### PR TITLE
feat(frostmod): auto-reload game on external mods-folder changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
   the content folder is watched — never `profiles/` — so gameplay churn (replays, telemetry)
   never triggers a reload.
 
+### Fixed
+- **Locker swaps now refresh live in-game** — switching a bike's model or sound in the
+  Locker re-runs the game's look loader instantly (the same `instant_refresh` path presets
+  already used), so the swap shows up without reselecting your profile. The swap toast now
+  reports the refresh result. `apply_model_swap`/`apply_sound_swap` return a
+  `SwapApplyOutcome`, and the refresh step is shared with `presets_apply`.
+
 ## 2026-07-22 — v0.3.1 — folder downloads, library multi-select, full-height fix
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-07-23
+
+### Added
+- **Auto-reload on folder changes** — a debounced watcher on `<modsPath>/mods` signals
+  FrostMod to reload the game when tracks or bikes are added outside MXB App (e.g. a manual
+  download dropped into the folder). Toggleable in Settings → FrostMod, on by default. Only
+  the content folder is watched — never `profiles/` — so gameplay churn (replays, telemetry)
+  never triggers a reload.
+
 ## 2026-07-22 — v0.3.1 — folder downloads, library multi-select, full-height fix
 
 ### Added

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1321,6 +1321,8 @@ dependencies = [
  "image",
  "log",
  "mega",
+ "notify",
+ "notify-debouncer-mini",
  "rayon",
  "regex",
  "reqwest 0.12.28",
@@ -1341,6 +1343,15 @@ dependencies = [
  "unrar",
  "walkdir",
  "zip 2.4.2",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2172,6 +2183,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2361,6 +2392,26 @@ dependencies = [
  "bitflags 2.13.0",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
 ]
 
 [[package]]
@@ -2613,6 +2664,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
@@ -2699,6 +2762,36 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.13.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d40b221972a1fc5ef4d858a2f671fb34c75983eb385463dff3780eeff6a9d43"
+dependencies = [
+ "crossbeam-channel",
+ "log",
+ "notify",
+]
 
 [[package]]
 name = "nt-time"
@@ -5334,7 +5427,7 @@ checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.2",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
@@ -6330,6 +6423,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6377,6 +6479,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -6438,6 +6555,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6456,6 +6579,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6471,6 +6600,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6504,6 +6639,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6519,6 +6660,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6540,6 +6687,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6555,6 +6708,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -65,6 +65,10 @@ rayon = "1"
 anyhow = "1"
 # Move uninstalled mods to the OS Recycle Bin / Trash rather than deleting outright.
 trash = "5"
+# Watch the mods content folder so tracks/bikes dropped in outside the app still
+# trigger a FrostMod reload. Debounced so an extract burst yields one reload.
+notify = "6"
+notify-debouncer-mini = "0.4"
 
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -20,6 +20,9 @@ pub struct AppConfig {
     pub auto_run_frostmod: bool,
     /// Re-run the game's profile loader in place after applying a preset (Windows-only).
     pub instant_refresh: bool,
+    /// Watch `<mods_path>/mods` and signal FrostMod to reload when tracks/bikes are
+    /// added outside the app (e.g. a manual download dropped into the folder).
+    pub watch_mods_reload: bool,
 }
 
 impl Default for AppConfig {
@@ -32,6 +35,7 @@ impl Default for AppConfig {
             launch_at_startup: true,
             auto_run_frostmod: true,
             instant_refresh: true,
+            watch_mods_reload: true,
         }
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -135,14 +135,40 @@ fn scan_model_swaps_blocking(app: tauri::AppHandle) -> Result<Vec<modelswap::Bik
     Ok(modelswap::scan_model_swaps(&cfg.mods_path))
 }
 
+/// Outcome of a Locker model/sound swap — mirrors `PresetApplyOutcome` so the UI can
+/// report the same "refreshed live in-game" feedback the presets flow gives.
+#[derive(serde::Serialize)]
+struct SwapApplyOutcome {
+    content_reload: ReloadOutcome,
+    game_running: bool,
+    live_refresh: gameproc::LiveRefresh,
+}
+
+/// Re-run the game's look loader live if instant refresh is enabled, else report it off.
+fn live_refresh(enabled: bool) -> gameproc::LiveRefresh {
+    if enabled {
+        gameproc::refresh_look()
+    } else {
+        gameproc::LiveRefresh::Disabled
+    }
+}
+
 #[tauri::command]
-async fn apply_model_swap(app: tauri::AppHandle, bike: String, target: String) -> Result<(), String> {
+async fn apply_model_swap(
+    app: tauri::AppHandle,
+    bike: String,
+    target: String,
+) -> Result<SwapApplyOutcome, String> {
     tauri::async_runtime::spawn_blocking(move || apply_model_swap_blocking(app, bike, target))
         .await
         .map_err(|e| format!("apply_model_swap task failed: {e}"))?
 }
 
-fn apply_model_swap_blocking(app: tauri::AppHandle, bike: String, target: String) -> Result<(), String> {
+fn apply_model_swap_blocking(
+    app: tauri::AppHandle,
+    bike: String,
+    target: String,
+) -> Result<SwapApplyOutcome, String> {
     let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
     let prev = modelswap::current_active(&cfg.mods_path, &bike);
     modelswap::apply_model_swap(&cfg.mods_path, &bike, &target).map_err(|e| format!("{e:#}"))?;
@@ -151,8 +177,12 @@ fn apply_model_swap_blocking(app: tauri::AppHandle, bike: String, target: String
     if let Err(e) = soundmods::reconcile_after_model_swap(&cfg.mods_path, &bike, &prev, &target) {
         eprintln!("sound reconcile after model swap failed: {e:#}");
     }
-    frostmod::signal_reload();
-    Ok(())
+    let content_reload = frostmod::signal_reload();
+    Ok(SwapApplyOutcome {
+        content_reload,
+        game_running: gameproc::is_game_running(),
+        live_refresh: live_refresh(cfg.instant_refresh),
+    })
 }
 
 #[tauri::command]
@@ -166,12 +196,20 @@ async fn scan_sound_swaps(app: tauri::AppHandle) -> Result<Vec<soundmods::BikeSo
 }
 
 #[tauri::command]
-async fn apply_sound_swap(app: tauri::AppHandle, bike: String, target: String) -> Result<(), String> {
+async fn apply_sound_swap(
+    app: tauri::AppHandle,
+    bike: String,
+    target: String,
+) -> Result<SwapApplyOutcome, String> {
     tauri::async_runtime::spawn_blocking(move || {
         let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
         soundmods::apply_sound_swap(&cfg.mods_path, &bike, &target).map_err(|e| format!("{e:#}"))?;
-        frostmod::signal_reload();
-        Ok(())
+        let content_reload = frostmod::signal_reload();
+        Ok(SwapApplyOutcome {
+            content_reload,
+            game_running: gameproc::is_game_running(),
+            live_refresh: live_refresh(cfg.instant_refresh),
+        })
     })
     .await
     .map_err(|e| format!("apply_sound_swap task failed: {e}"))?
@@ -1556,15 +1594,10 @@ fn presets_apply(
             .map_err(|e| format!("Cosmetics applied, but the model swap failed: {e:#}"))?;
     }
     let content_reload = frostmod::signal_reload();
-    let live = if cfg.instant_refresh {
-        gameproc::refresh_look()
-    } else {
-        gameproc::LiveRefresh::Disabled
-    };
     Ok(PresetApplyOutcome {
         content_reload,
         game_running: gameproc::is_game_running(),
-        live_refresh: live,
+        live_refresh: live_refresh(cfg.instant_refresh),
     })
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,6 +12,7 @@ mod install;
 mod library;
 mod modelswap;
 mod mods;
+mod modwatch;
 mod paint;
 mod pkz;
 #[cfg(sidecar)]
@@ -25,6 +26,7 @@ use config::AppConfig;
 use frostmod::ReloadOutcome;
 use frostmod_manage::{FrostmodProcess, FrostmodStatus};
 use library::InstalledMod;
+use modwatch::ModWatcher;
 use mods::mxb::MxbModsSource;
 use mods::{ModDetail, ModSource, ModSummary};
 use tauri::{
@@ -45,9 +47,18 @@ fn get_config(app: tauri::AppHandle) -> AppConfig {
 }
 
 #[tauri::command]
-fn create_config(app: tauri::AppHandle, config: AppConfig) -> Result<bool, String> {
+fn create_config(
+    app: tauri::AppHandle,
+    watcher: State<ModWatcher>,
+    config: AppConfig,
+) -> Result<bool, String> {
     let cfg = config::finalize(config);
     config::save(&app, &cfg).map_err(|e| format!("{e:#}"))?;
+    // Begin watching straight away so a fresh setup doesn't need a restart before
+    // manual downloads reload the game.
+    if cfg.watch_mods_reload {
+        modwatch::start(&app, &watcher, &cfg.mods_path);
+    }
     Ok(true)
 }
 
@@ -1369,6 +1380,24 @@ fn set_instant_refresh(app: tauri::AppHandle, enabled: bool) -> Result<(), Strin
 }
 
 #[tauri::command]
+fn set_watch_mods_reload(
+    app: tauri::AppHandle,
+    state: State<ModWatcher>,
+    enabled: bool,
+) -> Result<(), String> {
+    let mut cfg = config::load(&app).unwrap_or_default();
+    cfg.watch_mods_reload = enabled;
+    config::save(&app, &cfg).map_err(|e| format!("{e:#}"))?;
+    // Start/stop the watcher live so the toggle takes effect without a restart.
+    if enabled {
+        modwatch::start(&app, &state, &cfg.mods_path);
+    } else {
+        modwatch::stop(&state);
+    }
+    Ok(())
+}
+
+#[tauri::command]
 async fn shop_login(app: tauri::AppHandle) -> Result<(), String> {
     if let Some(w) = app.get_webview_window("shop-login") {
         let _ = w.set_focus();
@@ -1621,6 +1650,7 @@ fn main() {
             None,
         ))
         .manage(FrostmodProcess::default())
+        .manage(ModWatcher::default())
         .manage(shop_session::ShopSession::default())
         .setup(|app| {
             log::info!("MXB App {} starting", env!("CARGO_PKG_VERSION"));
@@ -1672,6 +1702,10 @@ fn main() {
                     if cfg.auto_run_frostmod && frostmod_manage::is_installed(handle) {
                         let state = handle.state::<FrostmodProcess>();
                         let _ = frostmod_manage::start(handle, &state);
+                    }
+                    if cfg.watch_mods_reload {
+                        let watcher = handle.state::<ModWatcher>();
+                        modwatch::start(handle, &watcher, &cfg.mods_path);
                     }
                 }
             }
@@ -1728,6 +1762,7 @@ fn main() {
             set_launch_at_startup,
             set_auto_run_frostmod,
             set_instant_refresh,
+            set_watch_mods_reload,
             frostmod_reload,
             frostmod_running,
             frostmod_status,

--- a/src-tauri/src/modwatch.rs
+++ b/src-tauri/src/modwatch.rs
@@ -1,0 +1,114 @@
+//! Watch the mods **content** folder and ask FrostMod to reload when it changes.
+//!
+//! The in-app installer already signals a reload after it places a mod (see
+//! `install::notify_frostmod`). This module covers the other path: a track or bike
+//! the user downloads and drops into the folder themselves. A debounced recursive
+//! watcher on `<mods_path>/mods` pulses the same reload once the folder settles.
+//!
+//! We deliberately watch only `<mods_path>/mods` — where tracks/bikes live — and NOT
+//! the sibling `profiles/` folder, which churns constantly during gameplay (replays,
+//! telemetry, settings) and would otherwise fire reloads mid-race.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::Duration;
+
+use notify::{RecommendedWatcher, RecursiveMode};
+use notify_debouncer_mini::{new_debouncer, DebounceEventResult, Debouncer};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+
+/// Debounce window. Extracting/copying a track writes many files in a burst; we want
+/// a single reload once the folder settles, not one per file.
+const DEBOUNCE: Duration = Duration::from_millis(1500);
+
+/// Slug the folder watcher tags its `frostmod-reload` events with. In-app install
+/// handlers filter on their own slug, so this sentinel never collides with them.
+pub const WATCH_SLUG: &str = "__mods_watch__";
+
+/// Managed handle to the running watcher. `None` when disabled, when no mods path is
+/// configured, or when the content folder doesn't exist yet. Dropping the inner
+/// `Debouncer` stops its background thread.
+#[derive(Default)]
+pub struct ModWatcher(pub Mutex<Option<Debouncer<RecommendedWatcher>>>);
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WatchReload {
+    slug: &'static str,
+    outcome: crate::frostmod::ReloadOutcome,
+}
+
+/// The content root we watch: `<mods_path>/mods` holds `tracks/` and `bikes/`.
+fn watch_root(mods_path: &str) -> PathBuf {
+    Path::new(mods_path).join("mods")
+}
+
+/// Start (or restart) the watcher on `<mods_path>/mods`. Replaces any existing
+/// watcher. Best-effort: a blank path, a missing folder, or a watch error just
+/// leaves the watcher disabled and is logged.
+pub fn start(app: &AppHandle, state: &ModWatcher, mods_path: &str) {
+    stop(state);
+
+    if mods_path.trim().is_empty() {
+        return;
+    }
+    let root = watch_root(mods_path);
+    if !root.is_dir() {
+        log::info!("mods watcher: content folder not present yet, not watching: {}", root.display());
+        return;
+    }
+
+    let handle = app.clone();
+    let mut debouncer = match new_debouncer(DEBOUNCE, move |res: DebounceEventResult| match res {
+        Ok(events) if !events.is_empty() => on_change(&handle),
+        Ok(_) => {}
+        Err(e) => log::warn!("mods watcher: event error: {e:?}"),
+    }) {
+        Ok(d) => d,
+        Err(e) => {
+            log::warn!("mods watcher: could not create debouncer: {e}");
+            return;
+        }
+    };
+
+    if let Err(e) = debouncer.watcher().watch(&root, RecursiveMode::Recursive) {
+        log::warn!("mods watcher: could not watch {}: {e}", root.display());
+        return;
+    }
+
+    log::info!("mods watcher: watching {} for changes", root.display());
+    *state.0.lock().unwrap() = Some(debouncer);
+}
+
+/// Tear down the watcher, if any.
+pub fn stop(state: &ModWatcher) {
+    *state.0.lock().unwrap() = None;
+}
+
+/// A settled batch of changes landed in the mods folder — pulse FrostMod's reload and
+/// tell the UI so it can surface it. Fire-and-forget; `signal_reload` no-ops when
+/// FrostMod isn't running or off-Windows.
+fn on_change(app: &AppHandle) {
+    let outcome = crate::frostmod::signal_reload();
+    log::info!("mods watcher: folder changed -> reload {outcome:?}");
+    let _ = app.emit(
+        "frostmod-reload",
+        WatchReload {
+            slug: WATCH_SLUG,
+            outcome,
+        },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn watch_root_is_the_content_subfolder_not_the_root() {
+        // Must be `<mods_path>/mods`, never the root (which also holds churny profiles/).
+        assert_eq!(watch_root("/games/mxb"), PathBuf::from("/games/mxb").join("mods"));
+        assert!(watch_root("/games/mxb").ends_with("mods"));
+    }
+}

--- a/src/Components/Locker/Locker.tsx
+++ b/src/Components/Locker/Locker.tsx
@@ -28,6 +28,7 @@ import type {
   LooseSwapBike,
   ModelVariant,
   SoundVariant,
+  SwapApplyOutcome,
 } from "../../types";
 import RegisterSwapsDialog from "./RegisterSwapsDialog";
 
@@ -43,6 +44,22 @@ import RegisterSwapsDialog from "./RegisterSwapsDialog";
  * switching a model preserves the sound (and vice versa). A sound can optionally be
  * **bound** to a model swap, so activating that model pulls its sound along.
  */
+
+/** Trailing feedback for a swap toast — mirrors the presets "refreshed live in-game" note. */
+function swapNote(outcome: SwapApplyOutcome): string {
+  switch (outcome.live_refresh) {
+    case "refreshed":
+      return "Refreshed live in-game.";
+    case "failed":
+      return "Instant refresh failed — reselect your profile in-game to load it.";
+    default:
+      break;
+  }
+  if (outcome.game_running) {
+    return "Reselect your profile in MX Bikes to load the swap.";
+  }
+  return "Loads next time the game opens.";
+}
 
 /** One bike's row: its models (null for sound-only bikes) and its sounds (always present). */
 interface Row {
@@ -108,12 +125,18 @@ export default function Locker() {
   const looseCount = loose.reduce((n, b) => n + b.candidates.length, 0);
 
   // Runs a mutation for `bike`, toasting success/failure and refreshing every scan.
+  // `note` optionally appends live-refresh feedback derived from the result.
   const run = useCallback(
-    async (bike: string, ok: string, fn: () => Promise<void>) => {
+    async <T,>(
+      bike: string,
+      ok: string,
+      fn: () => Promise<T>,
+      note?: (result: T) => string,
+    ) => {
       setBusy(bike);
       try {
-        await fn();
-        toast.success(ok);
+        const result = await fn();
+        toast.success(note ? `${ok} ${note(result)}` : ok);
         await load();
       } catch (e) {
         toast.error(String(e).replace(/^Error:\s*/, ""));
@@ -125,9 +148,9 @@ export default function Locker() {
   );
 
   const onModelSwap = (bike: string, target: string) =>
-    run(bike, `Switched ${bike} model to “${target}”.`, () => applyModelSwap(bike, target));
+    run(bike, `Switched ${bike} model to “${target}”.`, () => applyModelSwap(bike, target), swapNote);
   const onSoundSwap = (bike: string, target: string) =>
-    run(bike, `Switched ${bike} sound to “${target}”.`, () => applySoundSwap(bike, target));
+    run(bike, `Switched ${bike} sound to “${target}”.`, () => applySoundSwap(bike, target), swapNote);
   const onBind = (bike: string, model: string, sound: string) =>
     run(bike, `Tied “${sound}” to model “${model}”.`, () => bindSound(bike, model, sound));
   const onUnbind = (bike: string, model: string, sound: string) =>

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -14,6 +14,7 @@ import {
   setLaunchAtStartup,
   setProfilesPath,
   setRunInBackground,
+  setWatchModsReload,
 } from "../../api/mods";
 import { useUpdate } from "../../Context/Update";
 import { useConfig } from "../../Context/Config";
@@ -63,10 +64,20 @@ export default function Settings() {
   const launchAtStartup = config.launchAtStartup ?? true;
   const autoRunFrostmod = config.autoRunFrostmod ?? true;
   const instantRefresh = config.instantRefresh ?? true;
+  const watchModsReload = config.watchModsReload ?? true;
 
   const toggleInstantRefresh = async (v: boolean) => {
     try {
       await setInstantRefresh(v);
+      await reloadConfig();
+    } catch (e) {
+      toast.error("Couldn't update setting", { description: String(e) });
+    }
+  };
+
+  const toggleWatchModsReload = async (v: boolean) => {
+    try {
+      await setWatchModsReload(v);
       await reloadConfig();
     } catch (e) {
       toast.error("Couldn't update setting", { description: String(e) });
@@ -512,6 +523,13 @@ export default function Settings() {
               desc="Start FrostMod in the background whenever MXB App opens."
               checked={autoRunFrostmod}
               onChange={toggleAutoRun}
+            />
+
+            <ToggleRow
+              label="Auto-reload on folder changes"
+              desc="Reload the game automatically when tracks or bikes are added to your mods folder — even downloaded manually outside MXB App."
+              checked={watchModsReload}
+              onChange={toggleWatchModsReload}
             />
 
             <div className="flex gap-2">

--- a/src/Context/Frostmod.tsx
+++ b/src/Context/Frostmod.tsx
@@ -12,6 +12,8 @@ import {
   frostmodStart,
   frostmodStatus,
   isFrostmodRunning,
+  MODS_WATCH_SLUG,
+  onFrostmodReload,
   reloadFrostmod,
 } from "../api/mods";
 import type { FrostmodStatus } from "../types";
@@ -65,6 +67,25 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
       clearInterval(id);
     };
   }, [probe, refreshStatus]);
+
+  // Surface reloads the mods-folder watcher triggers (a manual download dropped into
+  // the folder). In-app installs carry their own slug and toast, so we only react to
+  // the watcher's sentinel here.
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    void onFrostmodReload((p) => {
+      if (p.slug !== MODS_WATCH_SLUG) return;
+      if (p.outcome === "signaled") {
+        toast.success("New mods loaded", {
+          description: "FrostMod refreshed the game with your folder changes.",
+        });
+      }
+      void probe();
+    }).then((fn) => {
+      unlisten = fn;
+    });
+    return () => unlisten?.();
+  }, [probe]);
 
   const reload = useCallback(async () => {
     const outcome = await reloadFrostmod();

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -24,6 +24,7 @@ import type {
   GearPaints,
   Preset,
   PresetApplyOutcome,
+  SwapApplyOutcome,
   ReloadOutcome,
   BundlePlan,
   BundleProgress,
@@ -168,16 +169,16 @@ export function scanModelSwaps(): Promise<BikeModels[]> {
   return invoke<BikeModels[]>("scan_model_swaps");
 }
 
-export function applyModelSwap(bike: string, target: string): Promise<void> {
-  return invoke<void>("apply_model_swap", { bike, target });
+export function applyModelSwap(bike: string, target: string): Promise<SwapApplyOutcome> {
+  return invoke<SwapApplyOutcome>("apply_model_swap", { bike, target });
 }
 
 export function scanSoundSwaps(): Promise<BikeSounds[]> {
   return invoke<BikeSounds[]>("scan_sound_swaps");
 }
 
-export function applySoundSwap(bike: string, target: string): Promise<void> {
-  return invoke<void>("apply_sound_swap", { bike, target });
+export function applySoundSwap(bike: string, target: string): Promise<SwapApplyOutcome> {
+  return invoke<SwapApplyOutcome>("apply_sound_swap", { bike, target });
 }
 
 /** Tie a sound variant to a model swap so activating that model applies the sound. */

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -679,6 +679,14 @@ export function setInstantRefresh(enabled: boolean): Promise<void> {
   return invoke<void>("set_instant_refresh", { enabled });
 }
 
+/** Toggle watching the mods folder to reload the game on external changes. */
+export function setWatchModsReload(enabled: boolean): Promise<void> {
+  return invoke<void>("set_watch_mods_reload", { enabled });
+}
+
+/** Sentinel slug the backend tags folder-watch reloads with (vs in-app installs). */
+export const MODS_WATCH_SLUG = "__mods_watch__";
+
 /** Fires after each install with whether FrostMod picked the new mod up live. */
 export function onFrostmodReload(
   cb: (payload: FrostmodReload) => void,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -305,6 +305,13 @@ export interface PresetApplyOutcome {
   live_refresh: LiveRefresh;
 }
 
+/** Outcome of a Locker model/sound swap — same shape/feedback as a preset apply. */
+export interface SwapApplyOutcome {
+  content_reload: ReloadOutcome;
+  game_running: boolean;
+  live_refresh: LiveRefresh;
+}
+
 /** Install/version/running snapshot for the FrostMod settings panel. */
 export interface FrostmodStatus {
   /** `frostmod.exe` present in the app-managed folder. */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,11 @@ export interface Config {
   /** Auto-run FrostMod when the app opens (default true). */
   autoRunFrostmod?: boolean;
   instantRefresh?: boolean;
+  /**
+   * Watch `<modsPath>/mods` and reload the game when tracks/bikes are added outside
+   * MXB App (e.g. a manual download dropped into the folder). Default true.
+   */
+  watchModsReload?: boolean;
 }
 
 /** A track-mod as it appears in search results / browse grid. */


### PR DESCRIPTION
## What & why

Adds a **debounced filesystem watcher** on the mods content folder so tracks/bikes added **outside MXB App** — e.g. a track you download manually and drop into the folder — trigger the same FrostMod reload the in-app installer already fires. Toggleable in **Settings → FrostMod**, **on by default**.

## Key design decision

Watches only `<modsPath>/mods` (where `tracks/` and `bikes/` live), **not** the mods root — the root also holds `profiles/` (replays, telemetry, settings), which churns during gameplay and would cause reload storms mid-race.

## Changes

- **`modwatch.rs`** (new) — managed `ModWatcher`; debounced (1.5s) recursive watch; on a settled batch, calls `signal_reload()` and emits `frostmod-reload` with a sentinel slug.
- **`config.rs`** — new `watch_mods_reload: bool`, default `true` (existing configs pick it up ON via serde's container default).
- **`main.rs`** — module + managed state; `set_watch_mods_reload` command (starts/stops live); watcher started in `.setup()` and in `create_config` (no restart on first run).
- **Frontend** — `watchModsReload` type, `setWatchModsReload` API, Settings toggle, and a "New mods loaded" toast on folder-change reloads.
- **Deps** — `notify` 6 + `notify-debouncer-mini` 0.4.

## Verification

- `cargo check` clean (no new warnings); `modwatch` unit test passes; `tsc --noEmit` + eslint clean.
- ⚠️ `signal_reload()` is a no-op off-Windows — the in-game reload must be verified on Windows: with FrostMod running, drop a track into `…/MX Bikes/mods/tracks/` and confirm the game reloads + toast appears. Confirm no reload storms while riding, and that toggling off stops the watcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)