### PR TITLE
feat: preset editing, onboarding tour, rider loading, and public/full build split

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,22 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      # Pull in the optional local module from the private repo so published builds
+      # can decode real bike geometry. Read-only deploy key (SIDECAR_DEPLOY_KEY);
+      # gated to the canonical repo so forks build the public (sidecar-less) variant.
+      - name: Fetch private sidecar module
+        if: ${{ github.repository == 'Frostn1/mxb-app' }}
+        uses: actions/checkout@v4
+        with:
+          repository: Frostn1/mxbapp-private
+          ssh-key: ${{ secrets.SIDECAR_DEPLOY_KEY }}
+          path: .sidecar-src
+
+      - name: Apply sidecar module
+        if: ${{ github.repository == 'Frostn1/mxb-app' }}
+        shell: bash
+        run: bash .sidecar-src/sync.sh "$GITHUB_WORKSPACE"
+
       - name: Build and publish release
         uses: tauri-apps/tauri-action@v0
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ bun.lock
 
 # Local-only security/IP architecture docs — never publish to the public repo
 docs/secure-content/
+
+# CI-only checkout of the private sidecar module (see .github/workflows/release.yml)
+/.sidecar-src/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-08-04
+
+### Changed
+- **Setup surfaces the MX Bikes install path** — first-run onboarding now actively
+  scans for your Steam MX Bikes install (the folder with `rider.pkz`, powering the 3D
+  rider preview) and shows the detected path with a "Found" badge, or a manual folder
+  picker when it can't be found. The chosen/confirmed path is saved on completion. The
+  path was already auto-detected silently; this makes it visible and correctable during
+  install.
+
 ## 2026-07-29 — v0.3.2 — presets: tolerate non-UTF-8 profile.ini
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## 2026-08-04
 
 ### Added
+- **First-run guided tour** — an interactive spotlight walkthrough that runs once on
+  first launch (after Setup), highlighting the Browse, Library, Locker, Presets, Rider,
+  FrostMod status, and Settings areas with anchored coach-mark bubbles and driving the
+  navigation as it goes. Layered on top of the existing Welcome carousel (reused, not
+  replaced), gated on a `mxb:tourDone:v1` flag so it shows once for everyone, and
+  replayable anytime via a "Replay tour" button in Settings → About.
 - **Per-screen help hints** — a small `?` icon beside each screen's title (Browse,
   Library, Locker, Presets, Rider, Settings) opens a popover explaining what the screen
   does. Reuses the existing popover component. The redundant inline header subtitles on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 2026-08-04
 
+### Added
+- **Per-screen help hints** — a small `?` icon beside each screen's title (Browse,
+  Library, Locker, Presets, Rider, Settings) opens a popover explaining what the screen
+  does. Reuses the existing popover component. The redundant inline header subtitles on
+  Locker, Presets, and Rider were removed now that the same copy lives in the hint.
+
 ### Changed
 - **Setup surfaces the MX Bikes install path** — first-run onboarding now actively
   scans for your Steam MX Bikes install (the folder with `rider.pkz`, powering the 3D

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   Library, Locker, Presets, Rider, Settings) opens a popover explaining what the screen
   does. Reuses the existing popover component. The redundant inline header subtitles on
   Locker, Presets, and Rider were removed now that the same copy lives in the hint.
+- **Edit saved presets after creation** — each saved preset has an Edit action that
+  loads it into the builder in an explicit "editing" mode; you can rename it or change
+  any slot, and saving asks for confirmation (spelling out an update, a rename, or a
+  replace) before writing.
 
 ### Changed
 - **Setup surfaces the MX Bikes install path** — first-run onboarding now actively
@@ -15,6 +19,17 @@
   picker when it can't be found. The chosen/confirmed path is saved on completion. The
   path was already auto-detected silently; this makes it visible and correctable during
   install.
+- **Game install path auto-detected on launch** — if the MX Bikes install folder was
+  never set (e.g. the game was installed after first setup), it's now detected and saved
+  on startup, so the 3D rider preview works without a manual pick.
+- **Rider preview shows a loading state** — while the rider model resolves for the first
+  time, the preview shows "Loading rider…" instead of a placeholder body.
+- **Bike 3D preview requires the optional decoder module** — builds compiled without the
+  optional local module now hide the bike 3D preview entirely instead of showing an empty
+  one; official release builds include the module. Rider/gear previews are unaffected.
+- **UI cleanup** — the Shop tab is hidden for now, the app title moved into the sidebar
+  header (above Browse), Settings moved to the bottom of the sidebar, and the title bar
+  logo was removed.
 
 ## 2026-07-29 — v0.3.2 — presets: tolerate non-UTF-8 profile.ini
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1282,6 +1282,14 @@ fn count_profiles_in(path: String) -> usize {
     presets::list_profiles(std::path::Path::new(&path)).len()
 }
 
+/// Whether this build can decode real bike geometry (the optional local module is
+/// compiled in). Public builds without it return `false`, so the UI hides the bike
+/// 3D preview instead of showing a broken/empty one.
+#[tauri::command]
+fn bike_preview_available() -> bool {
+    cfg!(sidecar)
+}
+
 #[tauri::command]
 fn set_run_in_background(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
     let mut cfg = config::load(&app).unwrap_or_default();
@@ -1661,7 +1669,18 @@ fn main() {
 
             let handle = app.handle();
             if config::exists(handle) {
-                if let Ok(cfg) = config::load(handle) {
+                if let Ok(mut cfg) = config::load(handle) {
+                    // Auto-detect the MX Bikes install on launch for configs that
+                    // never got one (created before detection existed, or when the
+                    // game wasn't installed yet). Only fills a blank — never overrides
+                    // a manual pick — and persists it so the 3D rider preview works.
+                    if cfg.game_path.trim().is_empty() {
+                        if let Some(gp) = config::detect_game_path() {
+                            log::info!("auto-detected MX Bikes install: {gp}");
+                            cfg.game_path = gp;
+                            let _ = config::save(handle, &cfg);
+                        }
+                    }
                     let manager = handle.autolaunch();
                     let enabled = manager.is_enabled().unwrap_or(false);
                     if cfg.launch_at_startup && !enabled {
@@ -1691,6 +1710,7 @@ fn main() {
             is_configured,
             get_config,
             create_config,
+            bike_preview_available,
             search_mods,
             get_mod_detail,
             get_installed_mods,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { FrostmodProvider } from "./Context/Frostmod";
 import { ConfigContext } from "./Context/Config";
 import { Toaster } from "@/Components/ui/sonner";
 import { TooltipProvider } from "@/Components/ui/tooltip";
-import { getConfig, isConfigured } from "./api/mods";
+import { bikePreviewAvailable, getConfig, isConfigured } from "./api/mods";
 import { UpdateProvider } from "./Context/Update";
 import UpdateBanner from "./Components/UpdateBanner/UpdateBanner";
 import type { Config } from "./types";
@@ -20,6 +20,9 @@ const WELCOME_SEEN_KEY = "mxb:welcomeSeen:v1";
 const App = () => {
   const [ready, setReady] = useState(false);
   const [config, setConfig] = useState<Config | null>(null);
+  // Whether this build can decode real bike geometry (optional local module). Fixed
+  // at build time, so fetch it once at startup.
+  const [bikePreview, setBikePreview] = useState(false);
   const [showWelcome, setShowWelcome] = useState(
     () => localStorage.getItem(WELCOME_SEEN_KEY) !== "1",
   );
@@ -36,6 +39,7 @@ const App = () => {
   useEffect(() => {
     (async () => {
       try {
+        bikePreviewAvailable().then(setBikePreview).catch(() => {});
         if (await isConfigured()) await reloadConfig();
       } catch (err) {
         console.error("Startup failed", err);
@@ -76,7 +80,7 @@ const App = () => {
               <main className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background text-foreground">
                 {ready &&
                   (config ? (
-                    <ConfigContext.Provider value={{ config, reloadConfig }}>
+                    <ConfigContext.Provider value={{ config, reloadConfig, bikePreview }}>
                       <Dashboard />
                     </ConfigContext.Provider>
                   ) : (

--- a/src/Components/Browse/Browse.tsx
+++ b/src/Components/Browse/Browse.tsx
@@ -15,6 +15,7 @@ import { useInstall } from "../../Context/Install";
 import ModCard from "./ModCard";
 import { Segmented } from "@/Components/ui/segmented";
 import { Button } from "@/Components/ui/button";
+import HelpHint from "@/Components/ui/help-hint";
 import { Skeleton } from "@/Components/ui/skeleton";
 import {
   AlertDialog,
@@ -232,6 +233,10 @@ export default function Browse({
       <header className="flex flex-none flex-col gap-4 px-7 pb-3.5 pt-5">
         <div className="flex items-center gap-3.5">
           <h1 className="text-[21px] font-bold tracking-[-0.2px]">Browse</h1>
+          <HelpHint
+            title="Browse"
+            description="Discover and install mods from the online catalog — search, filter by type, and open a mod to download it into the game."
+          />
           <Segmented
             value={modType.id}
             onChange={(id) => {

--- a/src/Components/Dashboard/Dashboard.tsx
+++ b/src/Components/Dashboard/Dashboard.tsx
@@ -8,6 +8,7 @@ import Browse from "../Browse/Browse";
 import Shop from "../Shop/Shop";
 import ModDetail from "../ModDetail/ModDetail";
 import Settings from "../Settings/Settings";
+import Tour, { TourContext, TOUR_DONE_KEY } from "../Tour/Tour";
 import { InstallProvider } from "../../Context/Install";
 import {
   DEFAULT_MOD_TYPE,
@@ -66,6 +67,22 @@ const Dashboard = () => {
     setSelectedSlug(null);
   }, []);
 
+  // First-run interactive tour — shown once, gated on a localStorage flag. Also
+  // re-triggerable from Settings via the TourContext below.
+  const [tourRun, setTourRun] = useState(
+    () => localStorage.getItem(TOUR_DONE_KEY) !== "1",
+  );
+  const startTour = useCallback(() => {
+    setView("browse");
+    setSelectedSlug(null);
+    setTourRun(true);
+  }, []);
+  const endTour = useCallback(() => {
+    localStorage.setItem(TOUR_DONE_KEY, "1");
+    setTourRun(false);
+    navigate("browse");
+  }, [navigate]);
+
   // Jump from Presets into the Rider tab with a preset loaded, to view it on the model.
   const openInRider = useCallback((lo: Loadout) => {
     setRiderPreset(lo);
@@ -74,6 +91,7 @@ const Dashboard = () => {
   const clearRiderPreset = useCallback(() => setRiderPreset(null), []);
 
   return (
+    <TourContext.Provider value={{ startTour }}>
     <InstallProvider onInstalled={onInstalled}>
       <div className="flex min-h-0 flex-1">
         <Sidebar view={view} onNavigate={navigate} />
@@ -113,7 +131,9 @@ const Dashboard = () => {
           )}
         </div>
       </div>
+      {tourRun && <Tour navigate={navigate} onDone={endTour} />}
     </InstallProvider>
+    </TourContext.Provider>
   );
 };
 

--- a/src/Components/Library/Library.tsx
+++ b/src/Components/Library/Library.tsx
@@ -37,8 +37,10 @@ import {
 import LibraryDetail from "./LibraryDetail";
 import { ViewerDialog } from "../Viewer/ViewerDialog";
 import { entryViewerProps } from "../Viewer/entryViewer";
+import { useConfig } from "../../Context/Config";
 import { Segmented } from "@/Components/ui/segmented";
 import { Button } from "@/Components/ui/button";
+import HelpHint from "@/Components/ui/help-hint";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -302,7 +304,8 @@ export default function Library({
     [selectedEntries],
   );
 
-  const view3dProps = view3d ? entryViewerProps(view3d, entries) : null;
+  const { bikePreview } = useConfig();
+  const view3dProps = view3d ? entryViewerProps(view3d, entries, bikePreview) : null;
 
   const doMove = async (item: LibraryEntry, toFolder: string) => {
     setBusy(true);
@@ -435,7 +438,13 @@ export default function Library({
       ) : (
         <>
       <header className="flex flex-none items-center gap-3.5 px-7 pb-3.5 pt-5">
-        <h1 className="text-[21px] font-bold tracking-[-0.2px]">Library</h1>
+        <div className="flex items-center gap-1.5">
+          <h1 className="text-[21px] font-bold tracking-[-0.2px]">Library</h1>
+          <HelpHint
+            title="Library"
+            description="Your installed mods. Review what's installed and remove ones you no longer want."
+          />
+        </div>
         <Segmented
           value={modType.id}
           onChange={(id) => {
@@ -505,7 +514,7 @@ export default function Library({
                   {section.items.map((item) => {
                     const actions = rowActions(item);
                     const Icon = categoryIcon(item.category);
-                    const canView3d = entryViewerProps(item, entries) !== null;
+                    const canView3d = entryViewerProps(item, entries, bikePreview) !== null;
                     const isSel = selected.has(item.path);
                     return (
                       <ContextMenu key={item.path}>

--- a/src/Components/Library/LibraryDetail.tsx
+++ b/src/Components/Library/LibraryDetail.tsx
@@ -13,6 +13,7 @@ import { getPkzMeta, getPkzPreview, type ModType } from "../../api/mods";
 import type { LibraryEntry, PkzMeta } from "../../types";
 import { ViewerDialog } from "../Viewer/ViewerDialog";
 import { entryViewerProps } from "../Viewer/entryViewer";
+import { useConfig } from "../../Context/Config";
 import {
   displayName,
   folderLabel,
@@ -83,7 +84,11 @@ export default function LibraryDetail({
     return [...byCat.entries()];
   }, [entries, entry]);
 
-  const view = useMemo(() => entryViewerProps(entry, entries), [entry, entries]);
+  const { bikePreview } = useConfig();
+  const view = useMemo(
+    () => entryViewerProps(entry, entries, bikePreview),
+    [entry, entries, bikePreview],
+  );
 
   const rows: [string, string][] = [];
   if (meta?.author) rows.push(["Author", meta.author]);

--- a/src/Components/Locker/Locker.tsx
+++ b/src/Components/Locker/Locker.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import HelpHint from "@/Components/ui/help-hint";
 import {
   scanModelSwaps,
   applyModelSwap,
@@ -136,10 +137,13 @@ export default function Locker() {
   return (
     <div className="flex h-full flex-col">
       <header className="flex flex-none items-center gap-3.5 px-7 pb-3.5 pt-5">
-        <h1 className="text-[21px] font-bold tracking-[-0.2px]">Locker</h1>
-        <p className="text-[12.5px] text-muted-foreground">
-          Swap each bike’s model and engine sound between the sets you’ve installed.
-        </p>
+        <div className="flex items-center gap-1.5">
+          <h1 className="text-[21px] font-bold tracking-[-0.2px]">Locker</h1>
+          <HelpHint
+            title="Locker"
+            description="Swap each bike's model and engine sound between the sets you've installed."
+          />
+        </div>
         <button
           onClick={() => void load()}
           className="ml-auto flex items-center gap-1.5 rounded-lg border border-input bg-card px-3 py-2 text-[12.5px] text-muted-foreground transition-colors hover:text-foreground"

--- a/src/Components/Presets/Presets.tsx
+++ b/src/Components/Presets/Presets.tsx
@@ -13,9 +13,13 @@ import {
   Package,
   UploadCloud,
   User,
+  Pencil,
+  X,
 } from "lucide-react";
 import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 import { Button } from "../ui/button";
+import HelpHint from "../ui/help-hint";
 import { Input } from "../ui/input";
 import { Switch } from "../ui/switch";
 import {
@@ -143,6 +147,10 @@ export default function Presets({ onOpenInRider }: PresetsProps = {}) {
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [applyingId, setApplyingId] = useState<string | null>(null);
+  // Editing an existing preset: holds the ORIGINAL name so we can rename (save new
+  // + delete old) and confirm the change. null means we're creating a new preset.
+  const [editing, setEditing] = useState<string | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   const [sharePreset, setSharePreset] = useState<Preset | null>(null);
   const [importOpen, setImportOpen] = useState(false);
@@ -207,24 +215,74 @@ export default function Presets({ onOpenInRider }: PresetsProps = {}) {
     setSaved(await presetsList());
   }, []);
 
-  const onSave = useCallback(async () => {
+  const eq = (a: string, b: string) => a.toLowerCase() === b.toLowerCase();
+
+  // Does saving under the typed name replace a *different* existing preset (not the
+  // one we're editing)? That's a destructive overwrite worth confirming.
+  const nameClash = useMemo(() => {
+    const nm = name.trim();
+    if (!nm) return false;
+    return saved.some((p) => eq(p.name, nm) && !(editing && eq(p.name, editing)));
+  }, [name, saved, editing]);
+
+  // Enter edit mode: pull the preset into the builder and prime the name field.
+  const onEdit = useCallback((preset: Preset) => {
+    setEditing(preset.name);
+    setName(preset.name);
+    setLoadout(preset.loadout);
+    // Bring the builder (left column) into view on smaller layouts.
+    window.scrollTo({ top: 0, behavior: "smooth" });
+    toast.info(`Editing “${preset.name}” — change anything, then Save changes.`);
+  }, []);
+
+  const cancelEdit = useCallback(() => {
+    setEditing(null);
+    setName("");
+  }, []);
+
+  const onSave = useCallback(() => {
     const nm = name.trim();
     if (!nm) {
       toast.error("Give the preset a name first.");
       return;
     }
+    // Always confirm an edit (it rewrites a saved preset) or a name clash (it would
+    // replace someone else's preset). A brand-new, non-clashing name saves directly.
+    if (editing || nameClash) {
+      setConfirmOpen(true);
+      return;
+    }
+    void commitSave();
+  }, [name, editing, nameClash]);
+
+  const commitSave = useCallback(async () => {
+    const nm = name.trim();
+    if (!nm) return;
     setBusy(true);
+    setConfirmOpen(false);
     try {
       await presetsSave({ name: nm, loadout });
+      // Renamed while editing → drop the old entry so it isn't duplicated.
+      if (editing && !eq(editing, nm)) {
+        await presetsDelete(editing);
+      }
       await refreshSaved();
+      const wasEditing = editing;
+      setEditing(null);
       setName("");
-      toast.success(`Saved preset “${nm}”.`);
+      toast.success(
+        wasEditing
+          ? eq(wasEditing, nm)
+            ? `Updated preset “${nm}”.`
+            : `Renamed to “${nm}” and saved changes.`
+          : `Saved preset “${nm}”.`,
+      );
     } catch (e) {
       toast.error(String(e).replace(/^Error:\s*/, ""));
     } finally {
       setBusy(false);
     }
-  }, [name, loadout, refreshSaved]);
+  }, [name, loadout, editing, refreshSaved]);
 
   const applyLoadout = useCallback(
     async (lo: Loadout, id: string, label: string) => {
@@ -277,10 +335,13 @@ export default function Presets({ onOpenInRider }: PresetsProps = {}) {
   return (
     <div className="flex h-full flex-col">
       <header className="flex flex-none items-center gap-3.5 px-7 pb-3.5 pt-5">
-        <h1 className="text-[21px] font-bold tracking-[-0.2px]">Presets</h1>
-        <p className="hidden text-[12.5px] text-muted-foreground sm:block">
-          Save a full look and load it onto a bike on command.
-        </p>
+        <div className="flex items-center gap-1.5">
+          <h1 className="text-[21px] font-bold tracking-[-0.2px]">Presets</h1>
+          <HelpHint
+            title="Presets"
+            description="Save a full rider look and load it onto a bike on command."
+          />
+        </div>
         <div className="ml-auto flex items-center gap-2">
           <Button variant="outline" size="sm" onClick={() => setImportOpen(true)}>
             <Download className="size-3.5" />
@@ -382,7 +443,29 @@ export default function Presets({ onOpenInRider }: PresetsProps = {}) {
             ))}
 
             {/* Race number + save row */}
-            <div className="flex flex-col gap-3 rounded-xl border border-white/[0.07] bg-card/40 p-3.5">
+            <div
+              className={cn(
+                "flex flex-col gap-3 rounded-xl border p-3.5",
+                editing
+                  ? "border-primary/40 bg-primary/[0.06]"
+                  : "border-white/[0.07] bg-card/40",
+              )}
+            >
+              {editing && (
+                <div className="flex items-center gap-2 text-[12px]">
+                  <Pencil className="size-3.5 flex-none text-primary" />
+                  <span className="min-w-0 flex-1">
+                    Editing <span className="font-semibold">“{editing}”</span> — change
+                    the name or any slot, then <span className="font-semibold">Save changes</span>.
+                  </span>
+                  <button
+                    onClick={cancelEdit}
+                    className="flex flex-none cursor-default items-center gap-1 rounded-md px-1.5 py-0.5 text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+                  >
+                    <X className="size-3.5" /> Cancel
+                  </button>
+                </div>
+              )}
               <div className="flex flex-wrap items-center gap-3">
                 <label className="flex items-center gap-2">
                   <span className="text-[11px] font-medium text-muted-foreground">Race #</span>
@@ -413,9 +496,9 @@ export default function Presets({ onOpenInRider }: PresetsProps = {}) {
                   className="h-9 max-w-[220px]"
                   onKeyDown={(e) => e.key === "Enter" && void onSave()}
                 />
-                <Button size="sm" onClick={() => void onSave()} disabled={busy}>
+                <Button size="sm" onClick={() => onSave()} disabled={busy}>
                   {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Save className="size-3.5" />}
-                  Save preset
+                  {editing ? "Save changes" : "Save preset"}
                 </Button>
                 <Button
                   variant="outline"
@@ -450,8 +533,10 @@ export default function Presets({ onOpenInRider }: PresetsProps = {}) {
                   preset={p}
                   applying={applyingId === p.name}
                   disabled={applyingId !== null}
+                  editing={editing !== null && editing.toLowerCase() === p.name.toLowerCase()}
                   onApply={() => void applyLoadout(p.loadout, p.name, p.name)}
                   onLoad={() => setLoadout(p.loadout)}
+                  onEdit={() => onEdit(p)}
                   onShare={() => onShare(p)}
                   onDelete={() => void onDelete(p)}
                   onViewInRider={
@@ -464,6 +549,16 @@ export default function Presets({ onOpenInRider }: PresetsProps = {}) {
         </div>
       )}
 
+      <ConfirmSaveDialog
+        open={confirmOpen}
+        editing={editing}
+        newName={name.trim()}
+        loadout={loadout}
+        replacesOther={nameClash}
+        busy={busy}
+        onConfirm={() => void commitSave()}
+        onCancel={() => setConfirmOpen(false)}
+      />
       <ShareDialog preset={sharePreset} onClose={() => setSharePreset(null)} />
       <ImportDialog
         open={importOpen}
@@ -483,8 +578,10 @@ function PresetCard({
   preset,
   applying,
   disabled,
+  editing,
   onApply,
   onLoad,
+  onEdit,
   onShare,
   onDelete,
   onViewInRider,
@@ -492,21 +589,35 @@ function PresetCard({
   preset: Preset;
   applying: boolean;
   disabled: boolean;
+  editing: boolean;
   onApply: () => void;
   onLoad: () => void;
+  onEdit: () => void;
   onShare: () => void;
   onDelete: () => void;
   onViewInRider?: () => void;
 }) {
   return (
-    <div className="flex flex-col gap-2 rounded-xl border border-white/[0.07] bg-card/50 p-3">
+    <div
+      className={cn(
+        "flex flex-col gap-2 rounded-xl border p-3",
+        editing ? "border-primary/50 bg-primary/[0.06]" : "border-white/[0.07] bg-card/50",
+      )}
+    >
       <div className="flex items-start justify-between gap-2">
         <button
           onClick={onLoad}
-          title="Load into the builder"
+          title="Load a copy into the builder"
           className="min-w-0 flex-1 cursor-default text-left"
         >
-          <div className="truncate text-[13px] font-semibold">{preset.name}</div>
+          <div className="flex items-center gap-1.5">
+            <span className="truncate text-[13px] font-semibold">{preset.name}</span>
+            {editing && (
+              <span className="flex-none rounded-full bg-primary/15 px-1.5 py-[1px] text-[9.5px] font-semibold uppercase tracking-wide text-primary">
+                Editing
+              </span>
+            )}
+          </div>
           <div className="truncate text-[11px] text-muted-foreground">
             {loadoutSummary(preset.loadout)}
           </div>
@@ -517,6 +628,9 @@ function PresetCard({
               <User className="size-3.5" />
             </IconBtn>
           )}
+          <IconBtn title="Edit name or options" onClick={onEdit}>
+            <Pencil className="size-3.5" />
+          </IconBtn>
           <IconBtn title="Share" onClick={onShare}>
             <Share2 className="size-3.5" />
           </IconBtn>
@@ -550,6 +664,70 @@ function IconBtn({
     >
       {children}
     </button>
+  );
+}
+
+function ConfirmSaveDialog({
+  open,
+  editing,
+  newName,
+  loadout,
+  replacesOther,
+  busy,
+  onConfirm,
+  onCancel,
+}: {
+  open: boolean;
+  editing: string | null;
+  newName: string;
+  loadout: Loadout;
+  replacesOther: boolean;
+  busy: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const renamed = !!editing && editing.toLowerCase() !== newName.toLowerCase();
+  const title = editing ? "Save changes?" : "Replace preset?";
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onCancel()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            {editing
+              ? renamed
+                ? `This renames “${editing}” to “${newName}” and saves your current slots.`
+                : `This overwrites “${editing}” with your current slots.`
+              : `A preset named “${newName}” already exists — this replaces it with your current slots.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="rounded-lg border border-white/[0.07] bg-card/40 p-2.5 text-[12px]">
+          <div className="font-semibold">{newName}</div>
+          <div className="text-muted-foreground">{loadoutSummary(loadout)}</div>
+        </div>
+
+        {editing && renamed && replacesOther && (
+          <p className="flex items-start gap-1.5 text-[11.5px] text-amber-500">
+            <AlertTriangle className="mt-px size-3.5 flex-none" />
+            <span>
+              Another preset is already named “{newName}” — saving will overwrite it too.
+            </span>
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onCancel} disabled={busy}>
+            Cancel
+          </Button>
+          <Button onClick={onConfirm} disabled={busy}>
+            {busy ? <Loader2 className="size-4 animate-spin" /> : <Check className="size-4" />}
+            {editing ? "Save changes" : "Replace"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/src/Components/Rider/RiderStudio.tsx
+++ b/src/Components/Rider/RiderStudio.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { RefreshCw, AlertTriangle, Save, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "../ui/button";
+import HelpHint from "../ui/help-hint";
 import { Input } from "../ui/input";
 import { Switch } from "../ui/switch";
 import type { GearPaints, Loadout, RiderPart } from "../../types";
@@ -153,10 +154,13 @@ export default function RiderStudio({ initialLoadout, onLoaded }: RiderStudioPro
   return (
     <div className="flex h-full flex-col">
       <header className="flex flex-none items-center gap-3.5 px-7 pb-3.5 pt-5">
-        <h1 className="text-[21px] font-bold tracking-[-0.2px]">Rider</h1>
-        <p className="hidden text-[12.5px] text-muted-foreground lg:block">
-          Dress the player model — helmet, goggles, outfit and boots together.
-        </p>
+        <div className="flex items-center gap-1.5">
+          <h1 className="text-[21px] font-bold tracking-[-0.2px]">Rider</h1>
+          <HelpHint
+            title="Rider"
+            description="Dress the player model — helmet, goggles, outfit and boots together."
+          />
+        </div>
         <div className="ml-auto flex items-center gap-2">
           <Input
             value={name}

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Check, RefreshCw, ExternalLink, Play } from "lucide-react";
+import { Check, RefreshCw, ExternalLink, Play, Compass } from "lucide-react";
 import { open as pickFolder } from "@tauri-apps/plugin-dialog";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
 import { getVersion } from "@tauri-apps/api/app";
@@ -19,7 +19,9 @@ import { useUpdate } from "../../Context/Update";
 import { useConfig } from "../../Context/Config";
 import { useTheme, type ThemeMode } from "../../Context/Theme";
 import { useFrostmod } from "../../Context/FrostmodContext";
+import { useTour } from "../Tour/Tour";
 import { Button } from "@/Components/ui/button";
+import HelpHint from "@/Components/ui/help-hint";
 import { Segmented } from "@/Components/ui/segmented";
 import { Switch } from "@/Components/ui/switch";
 import { cn } from "@/lib/utils";
@@ -41,6 +43,7 @@ export default function Settings() {
   const { running, reload, status, installing, checking, statusError, install, start, refreshStatus } =
     useFrostmod();
   const { check: checkForUpdates } = useUpdate();
+  const { startTour } = useTour();
   const [version, setVersion] = useState("");
   const [active, setActive] = useState<SectionId>("folder");
   const [busy, setBusy] = useState(false);
@@ -256,7 +259,13 @@ export default function Settings() {
 
       <div className="min-h-0 flex-1 overflow-y-auto px-2 py-5">
         <div className="flex max-w-[640px] flex-col gap-[18px]">
-          <h1 className="text-[21px] font-bold tracking-[-0.2px]">Settings</h1>
+          <div className="flex items-center gap-1.5">
+            <h1 className="text-[21px] font-bold tracking-[-0.2px]">Settings</h1>
+            <HelpHint
+              title="Settings"
+              description="Configure your game folder, updates, and app preferences."
+            />
+          </div>
 
           {/* game folder */}
           <Section
@@ -543,7 +552,7 @@ export default function Settings() {
                 Changelog
               </button>
             </div>
-            <div>
+            <div className="flex gap-2">
               <Button
                 variant="outline"
                 size="sm"
@@ -553,6 +562,9 @@ export default function Settings() {
                 }}
               >
                 <RefreshCw className="size-3.5" /> Check for updates
+              </Button>
+              <Button variant="outline" size="sm" onClick={startTour}>
+                <Compass className="size-3.5" /> Replay tour
               </Button>
             </div>
             <div className="flex flex-col gap-1 pt-1 text-[11.5px] text-faint">

--- a/src/Components/Setup/Setup.tsx
+++ b/src/Components/Setup/Setup.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
-import { Snowflake, FolderOpen } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Snowflake, FolderOpen, Gamepad2, Loader2, Check } from "lucide-react";
 import { open as pickFolder } from "@tauri-apps/plugin-dialog";
-import { createConfig } from "../../api/mods";
+import { createConfig, detectGamePath } from "../../api/mods";
 import { Button } from "@/Components/ui/button";
 
 interface SetupProps {
@@ -13,11 +13,36 @@ export default function Setup({ onComplete }: SetupProps) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // MX Bikes install (Steam) folder — auto-detected on mount so the 3D rider
+  // preview works out of the box, with a manual fallback when detection misses.
+  const [detecting, setDetecting] = useState(true);
+  const [gamePath, setGamePath] = useState<string | null>(null);
+  const [gameAuto, setGameAuto] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    detectGamePath()
+      .then((found) => {
+        if (cancelled) return;
+        if (found) {
+          setGamePath(found);
+          setGameAuto(true);
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setDetecting(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const finish = async (modsPath: string) => {
     setBusy(true);
     setError(null);
     try {
-      await createConfig({ modsPath });
+      await createConfig({ modsPath, gamePath: gamePath ?? "" });
       onComplete();
     } catch (e) {
       setError(String(e));
@@ -32,6 +57,18 @@ export default function Setup({ onComplete }: SetupProps) {
       title: "Select your MX Bikes folder",
     });
     if (typeof picked === "string") setChosen(picked);
+  };
+
+  const chooseGame = async () => {
+    const picked = await pickFolder({
+      directory: true,
+      multiple: false,
+      title: "Select your MX Bikes install folder",
+    });
+    if (typeof picked === "string") {
+      setGamePath(picked);
+      setGameAuto(false);
+    }
   };
 
   return (
@@ -78,6 +115,56 @@ export default function Setup({ onComplete }: SetupProps) {
           >
             {chosen ? "Choose a different folder…" : "Choose the folder manually…"}
           </button>
+        </div>
+
+        <div className="flex w-full flex-col gap-2.5">
+          <span className="text-[11.5px] font-bold uppercase tracking-[1px] text-faint">
+            MX Bikes install
+          </span>
+          {detecting ? (
+            <div className="flex items-center gap-2.5 rounded-[10px] border border-input bg-card px-3.5 py-3 text-[12.5px] text-muted-foreground">
+              <Loader2 className="size-4 flex-none animate-spin text-primary" />
+              <span>Looking for your MX Bikes install…</span>
+            </div>
+          ) : gamePath ? (
+            <>
+              <div className="flex items-center gap-2.5 rounded-[10px] border border-input bg-card px-3.5 py-3 font-mono text-[12.5px] text-muted-foreground">
+                <Gamepad2 className="size-4 flex-none text-primary" />
+                <span className="flex-1 truncate" title={gamePath}>
+                  {gamePath}
+                </span>
+                {gameAuto && (
+                  <span
+                    className="flex flex-none items-center gap-1 font-sans text-[11px] font-semibold text-primary"
+                    title="Detected automatically"
+                  >
+                    <Check className="size-3.5" strokeWidth={2.5} />
+                    Found
+                  </span>
+                )}
+              </div>
+              <button
+                onClick={chooseGame}
+                className="cursor-default self-start text-[12px] font-semibold text-primary hover:brightness-110"
+              >
+                Choose a different folder…
+              </button>
+            </>
+          ) : (
+            <>
+              <p className="text-[12.5px] text-muted-foreground">
+                Couldn&apos;t find your MX Bikes install automatically — it powers
+                the
+                3D rider preview. Pick it manually, or set it later in Settings.
+              </p>
+              <button
+                onClick={chooseGame}
+                className="cursor-default self-start text-[12px] font-semibold text-primary hover:brightness-110"
+              >
+                Choose the install folder manually…
+              </button>
+            </>
+          )}
         </div>
 
         {error && (

--- a/src/Components/Shell/Sidebar.tsx
+++ b/src/Components/Shell/Sidebar.tsx
@@ -1,6 +1,5 @@
 import {
   Home,
-  Store,
   Library as LibraryIcon,
   Bike,
   Shirt,
@@ -11,7 +10,6 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
-import { useConfig } from "../../Context/Config";
 import { useFrostmod } from "../../Context/FrostmodContext";
 import { useInstall } from "../../Context/Install";
 import { displayName } from "../../lib/mods";
@@ -32,26 +30,16 @@ interface SidebarProps {
 
 const NAV: { id: DashboardView; label: string; icon: typeof Home }[] = [
   { id: "browse", label: "Browse", icon: Home },
-  { id: "shop", label: "Shop", icon: Store },
+  // { id: "shop", label: "Shop", icon: Store }, // hidden for now
   { id: "library", label: "Library", icon: LibraryIcon },
   { id: "locker", label: "Locker", icon: Bike },
   { id: "presets", label: "Presets", icon: Shirt },
   { id: "rider", label: "Rider", icon: User },
-  { id: "settings", label: "Settings", icon: Settings },
 ];
 
 const IN_PROGRESS = new Set(["resolving", "downloading", "extracting", "placing"]);
 
-/** Short "…\PiBoSo\MX Bikes" form of a long game path. */
-function shortPath(p: string): string {
-  if (!p) return "Not set";
-  const parts = p.split(/[/\\]/).filter(Boolean);
-  const tail = parts.slice(-2).join("\\");
-  return parts.length > 2 ? `…\\${tail}` : tail;
-}
-
 export default function Sidebar({ view, onNavigate }: SidebarProps) {
-  const { config } = useConfig();
   const { running, reload, status, start } = useFrostmod();
   const { active, queueLength } = useInstall();
 
@@ -69,12 +57,17 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
 
   return (
     <aside className="flex w-[216px] flex-none flex-col border-r border-white/[0.06] bg-window px-2.5 pb-3 pt-3.5">
+      <div className="px-3 pb-3 text-[13px] font-bold tracking-[0.2px]">
+        MXB App
+      </div>
+
       <nav className="flex flex-col gap-0.5">
         {NAV.map(({ id, label, icon: Icon }) => {
           const activeNav = view === id;
           return (
             <button
               key={id}
+              data-tour={id}
               onClick={() => onNavigate(id)}
               className={cn(
                 "flex cursor-default items-center gap-2.5 rounded-lg px-3 py-2.5 text-[13.5px] transition-colors",
@@ -121,7 +114,10 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
           </div>
         )}
 
-        <div className="flex items-center gap-2 rounded-[10px] border border-white/[0.07] px-3 py-2">
+        <div
+          data-tour="frostmod"
+          className="flex items-center gap-2 rounded-[10px] border border-white/[0.07] px-3 py-2"
+        >
           <span
             className={cn(
               "size-[7px] flex-none rounded-full",
@@ -156,12 +152,19 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
           )}
         </div>
 
-        <div
-          className="truncate px-1 font-mono text-[10px] text-faint"
-          title={config.modsPath}
+        <button
+          data-tour="settings"
+          onClick={() => onNavigate("settings")}
+          className={cn(
+            "flex cursor-default items-center gap-2.5 rounded-lg px-3 py-2.5 text-[13.5px] transition-colors",
+            view === "settings"
+              ? "bg-accent font-semibold text-accent-foreground"
+              : "font-medium text-muted-foreground hover:bg-foreground/[0.05] hover:text-foreground",
+          )}
         >
-          {shortPath(config.modsPath)}
-        </div>
+          <Settings className="size-4" />
+          <span>Settings</span>
+        </button>
       </div>
     </aside>
   );

--- a/src/Components/TitleBar/TitleBar.tsx
+++ b/src/Components/TitleBar/TitleBar.tsx
@@ -1,4 +1,4 @@
-import { Minus, Square, X, Snowflake } from "lucide-react";
+import { Minus, Square, X } from "lucide-react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { cn } from "@/lib/utils";
 
@@ -22,12 +22,7 @@ export default function TitleBar() {
         IS_MAC ? "pl-[82px]" : "pl-4",
       )}
     >
-      <div className="flex items-center gap-2.5" data-tauri-drag-region>
-        <div className="grid size-[18px] place-items-center rounded-[5px] bg-gradient-to-br from-[#9ccfec] to-[#5d8fb0] text-[#0d0f12]">
-          <Snowflake className="size-3" strokeWidth={2.5} />
-        </div>
-        <span className="text-[13px] font-bold tracking-[0.2px]">MXB App</span>
-      </div>
+      <div data-tauri-drag-region />
 
       {!IS_MAC && (
         <div className="flex h-full">

--- a/src/Components/Tour/Tour.tsx
+++ b/src/Components/Tour/Tour.tsx
@@ -1,0 +1,258 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import {
+  Snowflake,
+  Compass,
+  Library as LibraryIcon,
+  Bike,
+  Shirt,
+  User,
+  RefreshCw,
+  Settings as SettingsIcon,
+  Check,
+  ArrowLeft,
+  ArrowRight,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { Button } from "@/Components/ui/button";
+import { cn } from "@/lib/utils";
+import type { DashboardView } from "../Shell/Sidebar";
+
+/** Bumped when the tour changes enough to warrant showing it again. */
+export const TOUR_DONE_KEY = "mxb:tourDone:v1";
+
+interface TourContextValue {
+  /** Restart the interactive tour from the beginning (e.g. the Settings button). */
+  startTour: () => void;
+}
+
+export const TourContext = createContext<TourContextValue>({ startTour: () => {} });
+export const useTour = () => useContext(TourContext);
+
+interface Step {
+  /** View to switch to before highlighting, so the real screen sits behind the spotlight. */
+  view?: DashboardView;
+  /** CSS selector of the element to spotlight. Omit for a centered, un-anchored step. */
+  selector?: string;
+  icon: LucideIcon;
+  title: string;
+  body: string;
+}
+
+const STEPS: Step[] = [
+  {
+    icon: Snowflake,
+    title: "Take a quick tour",
+    body: "A few seconds to see where everything lives. You can skip at any point.",
+  },
+  {
+    view: "browse",
+    selector: '[data-tour="browse"]',
+    icon: Compass,
+    title: "Browse mods",
+    body: "Search mxb-mods.com right here and install any track, bike or paint with a single click.",
+  },
+  {
+    view: "library",
+    selector: '[data-tour="library"]',
+    icon: LibraryIcon,
+    title: "Your library",
+    body: "Everything you've installed, in one place — update or remove mods without ever touching a zip file.",
+  },
+  {
+    view: "locker",
+    selector: '[data-tour="locker"]',
+    icon: Bike,
+    title: "The locker",
+    body: "Swap bike models in and out. MXB App registers the pieces so the game picks them up.",
+  },
+  {
+    view: "presets",
+    selector: '[data-tour="presets"]',
+    icon: Shirt,
+    title: "Presets",
+    body: "Save gear and paint loadouts, then apply a full look in one click — even while you're riding.",
+  },
+  {
+    view: "rider",
+    selector: '[data-tour="rider"]',
+    icon: User,
+    title: "Rider studio",
+    body: "Preview your gear and paints on the 3D rider before you take them out on track.",
+  },
+  {
+    selector: '[data-tour="frostmod"]',
+    icon: RefreshCw,
+    title: "FrostMod, live",
+    body: "This shows FrostMod's status. It live-reloads MX Bikes after an install, so new content shows up without restarting the game.",
+  },
+  {
+    view: "settings",
+    selector: '[data-tour="settings"]',
+    icon: SettingsIcon,
+    title: "Settings",
+    body: "Set your game folder, background behaviour and FrostMod options here. You can replay this tour from here too.",
+  },
+  {
+    icon: Check,
+    title: "You're all set",
+    body: "That's the tour. Head to Browse and install your first mod.",
+  },
+];
+
+interface Rect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+const BUBBLE_W = 340;
+const PAD = 8; // spotlight padding around the target
+const GAP = 16; // gap between spotlight and bubble
+
+/** Where to place the bubble given the spotlight rect and the bubble's own height
+ *  (centered when there's no rect). Vertically centres on the target, then clamps so
+ *  the whole bubble stays inside the viewport — important for low targets. */
+function bubbleStyle(rect: Rect | null, bubbleH: number): React.CSSProperties {
+  if (typeof window === "undefined" || !rect) {
+    return { left: "50%", top: "50%", transform: "translate(-50%, -50%)" };
+  }
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  // Prefer the right of the target (the nav sits on the left); flip if it won't fit.
+  let left = rect.left + rect.width + GAP;
+  if (left + BUBBLE_W > vw - GAP) left = rect.left - BUBBLE_W - GAP;
+  left = Math.max(GAP, Math.min(left, vw - BUBBLE_W - GAP));
+  const h = bubbleH || 320;
+  let top = rect.top + rect.height / 2 - h / 2;
+  top = Math.max(GAP, Math.min(top, vh - h - GAP));
+  return { left, top };
+}
+
+interface TourProps {
+  navigate: (v: DashboardView) => void;
+  onDone: () => void;
+}
+
+export default function Tour({ navigate, onDone }: TourProps) {
+  const [index, setIndex] = useState(0);
+  const [rect, setRect] = useState<Rect | null>(null);
+  const bubbleRef = useRef<HTMLDivElement>(null);
+  const [bubbleH, setBubbleH] = useState(0);
+  const step = STEPS[index];
+  const Icon = step.icon;
+  const isLast = index === STEPS.length - 1;
+
+  // Switch to the step's view first, so the correct screen renders behind the spotlight.
+  useLayoutEffect(() => {
+    if (step.view) navigate(step.view);
+  }, [index, step.view, navigate]);
+
+  // Measure the target after the view switch has had a frame to lay out; keep it
+  // in sync with window resizes. Un-anchored steps clear the rect (centered bubble).
+  useEffect(() => {
+    if (!step.selector) {
+      setRect(null);
+      return;
+    }
+    const selector = step.selector;
+    const measure = () => {
+      const el = document.querySelector(selector);
+      if (!el) {
+        setRect(null);
+        return;
+      }
+      const r = el.getBoundingClientRect();
+      setRect({ top: r.top, left: r.left, width: r.width, height: r.height });
+    };
+    const t = window.setTimeout(measure, 70);
+    window.addEventListener("resize", measure);
+    return () => {
+      window.clearTimeout(t);
+      window.removeEventListener("resize", measure);
+    };
+  }, [index, step.selector]);
+
+  // Measure the bubble so it can be centred on its target and clamped to the viewport.
+  useLayoutEffect(() => {
+    if (bubbleRef.current) setBubbleH(bubbleRef.current.offsetHeight);
+  }, [index, rect]);
+
+  const next = () => (isLast ? onDone() : setIndex((i) => i + 1));
+  const back = () => setIndex((i) => Math.max(0, i - 1));
+
+  return (
+    <div className="fixed inset-0 z-[60]">
+      {/* Click-blocker: keeps the app behind the tour non-interactive. Also carries the
+          dim for centered steps that have no spotlight cut-out. */}
+      <div className={cn("absolute inset-0", !rect && "bg-black/70")} />
+
+      {/* Spotlight: a padded rounded rect whose massive box-shadow dims everything else.
+          pointer-events-none so it never intercepts clicks; it animates between targets. */}
+      {rect && (
+        <div
+          className="pointer-events-none absolute rounded-xl outline outline-2 outline-white/70 transition-all duration-300 ease-out"
+          style={{
+            top: rect.top - PAD,
+            left: rect.left - PAD,
+            width: rect.width + PAD * 2,
+            height: rect.height + PAD * 2,
+            boxShadow: "0 0 0 9999px rgba(0,0,0,0.66)",
+          }}
+        />
+      )}
+
+      {/* Coach-mark bubble */}
+      <div
+        ref={bubbleRef}
+        className="absolute flex w-[340px] flex-col gap-5 rounded-2xl border border-input bg-card p-6 shadow-2xl transition-all duration-300 ease-out"
+        style={bubbleStyle(rect, bubbleH)}
+      >
+        <div className="flex flex-col gap-3">
+          <div className="grid size-11 place-items-center rounded-[13px] bg-gradient-to-br from-[#9ccfec] to-[#5d8fb0] text-[#0d0f12]">
+            <Icon className="size-[22px]" strokeWidth={2.5} />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <h2 className="text-[17px] font-extrabold tracking-[-0.3px]">{step.title}</h2>
+            <p className="text-[13px] leading-relaxed text-muted-foreground">{step.body}</p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          {STEPS.map((_, i) => (
+            <span
+              key={i}
+              className={cn(
+                "h-1.5 rounded-full transition-all",
+                i === index ? "w-4 bg-primary" : "w-1.5 bg-foreground/20",
+              )}
+            />
+          ))}
+        </div>
+
+        <div className="flex items-center justify-between gap-3">
+          {index > 0 ? (
+            <Button variant="ghost" size="sm" onClick={back}>
+              <ArrowLeft /> Back
+            </Button>
+          ) : (
+            <Button variant="ghost" size="sm" onClick={onDone}>
+              Skip
+            </Button>
+          )}
+          <Button size="sm" onClick={next}>
+            {isLast ? "Done" : "Next"}
+            {!isLast && <ArrowRight />}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/Components/Viewer/ViewerPanel.tsx
+++ b/src/Components/Viewer/ViewerPanel.tsx
@@ -107,12 +107,26 @@ export function ViewerPanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [riderKey]);
 
-  // Non-blocking spinner over the canvas while a model resolves; the current model stays visible.
-  const spinner = loading && (
-    <div className="pointer-events-none absolute right-3 top-3 flex items-center gap-1.5 rounded-md bg-black/55 px-2 py-1 text-[11px] text-white/85">
-      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-      Loading…
+  // While the rider model is resolving for the first time, show a clear centered
+  // "Loading" state instead of the placeholder rider (see `riderLoading` passed to
+  // the viewer). Once a model is on screen, a re-resolve only gets the corner chip
+  // so the current model stays visible.
+  const riderFirstLoad = loading && mode === "rider" && !shownParts?.length;
+  // Suppress the stand-in rider while loading, but never hide the bike stand-in.
+  const riderLoading = mode === "rider" && loading;
+
+  const overlay = riderFirstLoad ? (
+    <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-2 text-muted-foreground">
+      <Loader2 className="h-6 w-6 animate-spin" />
+      <span className="text-[12.5px]">Loading rider…</span>
     </div>
+  ) : (
+    loading && (
+      <div className="pointer-events-none absolute right-3 top-3 flex items-center gap-1.5 rounded-md bg-black/55 px-2 py-1 text-[11px] text-white/85">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        Loading…
+      </div>
+    )
   );
 
   return (
@@ -146,9 +160,10 @@ export function ViewerPanel({
             mode={mode}
             texture={texture}
             riderParts={shownParts}
+            loading={riderLoading}
             className="absolute inset-0"
           />
-          {spinner}
+          {overlay}
         </div>
       </div>
 
@@ -166,9 +181,10 @@ export function ViewerPanel({
             mode={mode}
             texture={texture}
             riderParts={shownParts}
+            loading={riderLoading}
             className="absolute inset-0"
           />
-            {spinner}
+            {overlay}
           </div>
         </DialogContent>
       </Dialog>

--- a/src/Components/Viewer/entryViewer.ts
+++ b/src/Components/Viewer/entryViewer.ts
@@ -43,11 +43,17 @@ export interface EntryViewerProps {
 export function entryViewerProps(
   entry: LibraryEntry,
   entries: LibraryEntry[],
+  bikePreview = true,
 ): EntryViewerProps | null {
   const isPaint = entry.kind === "loose" && /\.pnt$/i.test(entry.name);
   const viewable =
     entry.category === "bike" || RIDER_CATS.has(entry.category) || isPaint;
   if (!viewable) return null;
+
+  // A bike (or bike paint) previews from a locked archive that only the optional
+  // local module can decode. Mirror the `mode` computed below: anything not a rider
+  // category renders as a bike. Without the module, offer no bike 3D view at all.
+  if (!RIDER_CATS.has(entry.category) && !bikePreview) return null;
 
   // A gear *model* entry (not a paint) previews on the rider in its own slot.
   const gearPart: GearSlot | undefined = isPaint

--- a/src/Components/ui/help-hint.tsx
+++ b/src/Components/ui/help-hint.tsx
@@ -1,0 +1,47 @@
+import { CircleHelp } from "lucide-react";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@/Components/ui/popover";
+import { cn } from "@/lib/utils";
+
+interface HelpHintProps {
+  /** Short heading — usually the screen name. */
+  title: string;
+  /** One or two sentences explaining what the screen is for. */
+  description: string;
+  className?: string;
+}
+
+/**
+ * A small "?" icon that opens a popover explaining what the current screen
+ * does. Drop it into a screen's header, right after the <h1>.
+ */
+export default function HelpHint({ title, description, className }: HelpHintProps) {
+  return (
+    <Popover>
+      <PopoverTrigger
+        aria-label={`About ${title}`}
+        className={cn(
+          "flex cursor-default items-center text-muted-foreground/70 outline-none transition-colors hover:text-foreground focus-visible:text-foreground",
+          className,
+        )}
+      >
+        <CircleHelp className="size-[15px]" />
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-64">
+        <PopoverHeader>
+          <PopoverTitle>{title}</PopoverTitle>
+          <PopoverDescription className="text-[12.5px] leading-relaxed">
+            {description}
+          </PopoverDescription>
+        </PopoverHeader>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/Context/Config.ts
+++ b/src/Context/Config.ts
@@ -5,11 +5,15 @@ export interface ConfigContextValue {
   config: Config;
   /** Re-read the saved config (e.g. after the user changes the game folder). */
   reloadConfig: () => Promise<void>;
+  /** This build can decode real bike geometry (optional local module compiled in).
+   *  False on public builds → hide the bike 3D preview. */
+  bikePreview: boolean;
 }
 
 export const ConfigContext = createContext<ConfigContextValue>({
   config: { modsPath: "" },
   reloadConfig: async () => {},
+  bikePreview: false,
 });
 
 export function useConfig() {

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -115,6 +115,12 @@ export function createConfig(config: Config): Promise<boolean> {
   return invoke<boolean>("create_config", { config });
 }
 
+/** Whether this build can decode real bike geometry for the 3D preview. Public
+ *  builds without the optional local module return false, so the UI hides it. */
+export function bikePreviewAvailable(): Promise<boolean> {
+  return invoke<boolean>("bike_preview_available");
+}
+
 export function searchMods(
   query: string,
   categoryId: number,


### PR DESCRIPTION
## Summary

Bundles this session's UX work with the onboarding tour, and completes the split
public/full build so the app is buildable by anyone while official releases keep the
optional bike-decoder module.

### Features & UX
- **Editable presets** — rename or change options after creation via an explicit
  "editing" mode, with a confirmation step (update / rename / replace).
- **Rider preview loading state** — shows "Loading rider…" on first load instead of a
  placeholder body.
- **Game install path auto-detected on launch** when it was never set.
- **Onboarding tour + per-screen help hints** (`?` popovers) and setup surfacing the
  detected MX Bikes install path.
- **UI cleanup** — Shop tab hidden, app title moved into the sidebar header, Settings
  moved to the sidebar bottom, title-bar logo removed.

### Build split (public vs full)
- New `bike_preview_available` command (`cfg!(sidecar)`); the UI hides the bike 3D
  preview when the optional local module isn't compiled in, so **anyone can build the
  public repo** and get a working app.
- **Official release builds include the module**: `release.yml` fetches it from the
  private `Frostn1/mxbapp-private` repo via a **read-only deploy key**, gated to the
  canonical repo so forks build the public variant. Nothing private lands in this repo.

## Verification
- `npm run typecheck` and `cargo check` pass.
- `release.yml` validated; `sync.sh` drop-in tested locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
