### PR TITLE
chore(deps): bump postcss to 8.5.25 to clear GHSA advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-08-04
+
+### Security
+- **Bump postcss to 8.5.25** — pins the transitive `postcss` (pulled in by Vite) via an npm
+  `overrides` entry, clearing two GHSA advisories for path traversal / arbitrary `.map` file
+  disclosure through attacker-controlled `sourceMappingURL` in CSS comments. Build-time only;
+  the shipped app is unaffected.
+
 ## 2026-07-29 — v0.3.2 — presets: tolerate non-UTF-8 profile.ini
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frost",
-  "version": "0.1.6",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frost",
-      "version": "0.1.6",
+      "version": "0.3.2",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.19",
         "@radix-ui/react-context-menu": "^2.3.3",
@@ -6954,9 +6954,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -7245,9 +7245,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -7264,7 +7264,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "three": "^0.160.1",
     "tw-animate-css": "^1.4.0"
   },
+  "overrides": {
+    "postcss": "^8.5.25"
+  },
   "devDependencies": {
     "@eslint/js": "^9.14.0",
     "@tauri-apps/cli": "^2.1.0",


### PR DESCRIPTION
## Summary
Pins the transitive **postcss** (pulled in by Vite) to `^8.5.25` via an npm `overrides` entry, clearing two high-severity Dependabot alerts.

- **Path Traversal in source-map auto-loading** — arbitrary `.map` file disclosure via attacker-controlled `sourceMappingURL` in CSS comments (fixed in 8.5.18).
- Was resolving to **8.5.16** (via `vite@5.4.21`); now **8.5.25**.

Build-time dependency only — the shipped Tauri app is unaffected.

## Notes
- The other open Dependabot alerts on the repo are **stale**: `immutable` already resolves to 5.1.9 (above the vulnerable `<4.3.9` range) and `axios` isn't in the current dependency tree.

## Verify
- `npm ls postcss` → `8.5.25`.
- `npm audit` → no postcss advisory.
- `npm run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)