### PR TITLE
chore(release): v0.5.1 — patch bump after branch cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026-08-04 — v0.5.1 — repository housekeeping
+
+### Changed
+- **Patch version bump to 0.5.1** across `package.json`, `src-tauri/Cargo.toml` and
+  `src-tauri/tauri.conf.json` (plus both lockfiles). No app or runtime behaviour changes
+  since v0.5.0 — this release exists to tag a clean tree after the branch cleanup below.
+
+### Removed
+- **Stale branch cleanup** — deleted 13 local branches whose work is already in `main`
+  (including the `backup/pre-email-rewrite` history backup and the superseded duplicate of
+  the v0.5.0 commit), and the 7 matching branches on `origin`. `feature/garage-bike-switch`
+  is deliberately kept: it holds unmerged bike-switch groundwork.
+
 ## 2026-08-04 — v0.5.0 — mods-folder auto-reload, live locker swaps, showcase site
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frost",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frost",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.19",
         "@radix-ui/react-context-menu": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "frost"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frost"
-version = "0.5.0"
+version = "0.5.1"
 description = "Frost — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Patch release cutting a clean tree after pruning stale branches.

## What changed
- Version `0.5.0` → `0.5.1` in `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, plus `package-lock.json` and the `frost` entry in `src-tauri/Cargo.lock`.
- `CHANGELOG.md` entry for v0.5.1.

**No app or runtime behaviour changes since v0.5.0.** No DB/schema changes.

## Branch cleanup (already applied)
- Deleted 13 local branches already merged into `main`, plus `fix/viewer-header-close-overlap` (identical tree to the v0.5.0 commit).
- Deleted the 7 matching branches on `origin`, including `fix/helmet-boots-models-only` (pre-history-rewrite copy; its work is already in `main`).
- `feature/garage-bike-switch` is deliberately kept — it holds unmerged bike-switch groundwork.

## Note on the tag
`v0.5.1` is already pushed and points at this branch's commit. **Merge with a merge commit (not squash)** so the tag stays an ancestor of `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)