### PR TITLE
fix(docs): correct supported mod types and MEGA host claims

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Release
 
 # Build signed-less desktop bundles and publish them to a GitHub Release.
 # Triggers on any tag like `v0.1.0`. You can also run it manually from the
-# Actions tab (workflow_dispatch) to produce a draft without tagging.
+# Actions tab (workflow_dispatch) to build without tagging. Releases are
+# published, not drafted (`releaseDraft: false`).
 
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@
 - **MEGA downloads** — the site and README claimed MEGA isn't automated. It is: MEGA links
   are fetched and decrypted in-app (`download_mega` in `src-tauri/src/install.rs`). Only
   MEGA *folder* links still need a manual grab, which the copy now states precisely.
+- **`.rar` archives** — both the site FAQ and README said `.rar` isn't supported. It is
+  (`extract_rar` via the `unrar` crate); `.pnt` files are placed as-is alongside `.pkz`.
+- **Installer formats** — the site download card and README offered an `.msi`. The bundle
+  targets are `nsis`/`app`/`dmg`, so Windows ships an `.exe` only.
+- **Release flow** — the README (and the workflow's own header comment) said releases are
+  drafted for manual publishing; `release.yml` sets `releaseDraft: false` and publishes.
+- **Stale roadmap** — rider gear/liveries and self-update are both shipped, so they moved
+  out of "coming next"; the download section now says the app updates itself, and the
+  tech-stack list names three.js / React Three Fiber behind the 3D previews.
 
 ## 2026-08-04 — v0.5.1 — repository housekeeping
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-08-04 — docs/site copy corrections
+
+### Fixed
+- **Supported mod types** — the site FAQ, feature list, meta description and README said
+  tracks only; tracks, bikes and rider gear are all first-class today (`MOD_TYPES` in
+  `src/api/mods.ts`), so the copy now says so and stops naming `mods/tracks` as the single
+  install target.
+- **MEGA downloads** — the site and README claimed MEGA isn't automated. It is: MEGA links
+  are fetched and decrypted in-app (`download_mega` in `src-tauri/src/install.rs`). Only
+  MEGA *folder* links still need a manual grab, which the copy now states precisely.
+
 ## 2026-08-04 — v0.5.1 — repository housekeeping
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -24,11 +24,14 @@ Tracks, bikes and rider gear are supported today; more mod types are planned.
 Grab the latest installer from the
 [**Releases**](https://github.com/Frostn1/mxb-app/releases) page:
 
-- **Windows** — `.msi` or `.exe` (recommended; MX Bikes runs on Windows).
+- **Windows** — `.exe` NSIS installer (recommended; MX Bikes runs on Windows).
 - **macOS** (Apple Silicon) — `.dmg`, for working on the download/extract UI.
 
 Builds are unsigned, so Windows SmartScreen / macOS Gatekeeper will warn on
 first launch — choose _Run anyway_ / right-click _Open_.
+
+You only install once: the app checks for new releases on launch (and every 6
+hours), then downloads and installs them on restart.
 
 ## How it works
 
@@ -38,8 +41,12 @@ first launch — choose _Run anyway_ / right-click _Open_.
 - **Downloads** are resolved per host — MediaFire, Google Drive and MEGA, direct
   links as-is. MEGA *folder* links are the exception (open the page to grab
   those manually).
-- **Archives**: `.zip` and `.7z` are extracted natively; `.pkz` files are placed
-  as-is. (`.rar` is not supported yet.)
+- **Archives**: `.zip`, `.7z` and `.rar` are extracted natively; already-packaged
+  `.pkz` / `.pnt` files are placed as-is.
+- **Live reload**: a debounced watcher on `<modsPath>/mods` signals FrostMod to
+  reload the game when mods are added — including ones installed outside the app.
+- **Self-update**: `tauri-plugin-updater` against the `latest.json` published with
+  each release; signature-verified, installs on restart.
 
 ## Tech stack
 
@@ -50,6 +57,9 @@ first launch — choose _Run anyway_ / right-click _Open_.
   (Radix primitives) for UI, [lucide](https://lucide.dev/) icons,
   [Sonner](https://sonner.emilkowal.ski/) toasts, and
   [Swiper](https://swiperjs.com/) for galleries
+- [three.js](https://threejs.org/) via
+  [React Three Fiber](https://r3f.docs.pmnd.rs/) + drei for the 3D rider and bike
+  previews
 
 ## Development
 
@@ -97,21 +107,16 @@ git tag v0.2.0
 git push origin v0.2.0
 ```
 
-The workflow produces a **draft** release with the installers attached — review
-it in the Releases tab and publish when ready. You can also trigger a build
-without tagging via **Actions → Release → Run workflow**.
+The workflow **publishes** the release with the installers attached
+(`releaseDraft: false`), renames the bundles to `MXB-App-<ver>-<arch>.<ext>` and
+patches `latest.json` so self-update keeps verifying. You can also trigger a
+build without tagging via **Actions → Release → Run workflow**.
 
 ## Roadmap
 
 Features coming next:
 
-- **Liveries** — browse and install **bike liveries** and **rider gear/kit**
-  (helmet, jersey, pants, boots), installed into each bike's `paints` folder and
-  the rider folders, with previews so you can see a livery before installing it.
-- **Auto-update** — the app updates itself in the background: it checks for a new
-  release on launch, downloads it, and installs on restart, so you're always on
-  the latest version without re-downloading the installer.
-- More mod types (assets, sounds, wheels, …) — the `ModSource` trait and category
-  ids already generalize beyond tracks.
-- An injected DLL that reads your in-game track list and one-click-installs the
-  tracks you're missing, then refreshes the game library.
+- More mod types (assets, wheels, …) — the `ModSource` trait and category ids
+  already generalize beyond tracks, bikes and rider gear.
+- Reading your in-game track list through FrostMod (which already handles the
+  live reload) to one-click-install the tracks you're missing.

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ single flow:
 
 > **Search a mod → open its page → click _Add to Library_ → done.**
 
-MXB App downloads the mod, extracts it, and drops the track files into your MX
-Bikes `mods/tracks` folder automatically.
+MXB App downloads the mod, extracts it, and drops the files into the matching MX
+Bikes `mods` folder automatically.
 
-Track mods are supported today; more mod types are planned.
+Tracks, bikes and rider gear are supported today; more mod types are planned.
 
 ## Download
 
@@ -35,8 +35,9 @@ first launch — choose _Run anyway_ / right-click _Open_.
 - **Catalog** comes from [mxb-mods.com](https://mxb-mods.com) via its public
   WordPress REST API (search, listings, images), behind a swappable `ModSource`
   trait in the Rust backend.
-- **Downloads** are resolved per host — MediaFire and Google Drive today, direct
-  links as-is. Mega isn't supported yet (open the page to grab it manually).
+- **Downloads** are resolved per host — MediaFire, Google Drive and MEGA, direct
+  links as-is. MEGA *folder* links are the exception (open the page to grab
+  those manually).
 - **Archives**: `.zip` and `.7z` are extracted natively; `.pkz` files are placed
   as-is. (`.rar` is not supported yet.)
 

--- a/site/index.html
+++ b/site/index.html
@@ -586,7 +586,7 @@
         <div class="section-head">
           <div class="kicker">Download</div>
           <h2>Get MXB App</h2>
-          <p>Grab the latest installer from the Releases page. Free and open source.</p>
+          <p>Grab the latest installer from the Releases page. Free and open source — after that, the app updates itself.</p>
         </div>
         <div class="dl-grid">
           <div class="platform">
@@ -594,7 +594,7 @@
               <svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 5.1 10.5 4v7.5H3zM10.5 12.5V20L3 18.9v-6.4zM11.5 3.85 21 2.5v9H11.5zM21 12.5v9l-9.5-1.35V12.5z"/></svg>
               Windows x64
             </div>
-            <div class="kind"><code>.msi</code> or <code>.exe</code> installer</div>
+            <div class="kind"><code>.exe</code> installer</div>
             <div class="badge">Recommended · MX Bikes runs on Windows</div>
             <a class="btn btn-primary" href="https://github.com/Frostn1/mxb-app/releases">Download for Windows</a>
           </div>
@@ -634,7 +634,7 @@
           </details>
           <details class="qa">
             <summary>What archive types can it extract?<svg class="chev" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></summary>
-            <p><code>.zip</code> and <code>.7z</code> are extracted natively, and packaged <code>.pkz</code> files are placed as-is. <code>.rar</code> isn't supported yet.</p>
+            <p><code>.zip</code>, <code>.7z</code> and <code>.rar</code> are extracted natively, and already-packaged <code>.pkz</code> / <code>.pnt</code> files are placed as-is.</p>
           </details>
           <details class="qa">
             <summary>Do I need Windows?<svg class="chev" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></summary>

--- a/site/index.html
+++ b/site/index.html
@@ -10,7 +10,7 @@
   <!-- Open Graph -->
   <meta property="og:type" content="website" />
   <meta property="og:title" content="MXB App — one-click mod manager for MX Bikes" />
-  <meta property="og:description" content="Search a mod → Add to Library → done. MXB App downloads, extracts, and drops track mods straight into your game." />
+  <meta property="og:description" content="Search a mod → Add to Library → done. MXB App downloads, extracts, and drops tracks, bikes and rider gear straight into your game." />
   <meta property="og:image" content="logo.svg" />
 
   <style>
@@ -507,7 +507,7 @@
           <div class="feature">
             <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></div>
             <h3>One-click install</h3>
-            <p>Add to Library and MXB App downloads the mod, extracts it, and drops the track files straight into your <code>mods/tracks</code> folder.</p>
+            <p>Add to Library and MXB App downloads the mod, extracts it, and drops the files straight into the right <code>mods</code> folder — tracks, bikes or rider.</p>
           </div>
           <div class="feature">
             <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></div>
@@ -537,7 +537,7 @@
           <div class="feature">
             <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></div>
             <h3>Multi-host downloads</h3>
-            <p>MediaFire and Google Drive links (including Drive folders) are resolved automatically, so you rarely touch a browser again.</p>
+            <p>MediaFire, Google Drive (including Drive folders) and MEGA links are resolved automatically, so you rarely touch a browser again.</p>
           </div>
           <div class="feature">
             <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg></div>
@@ -574,7 +574,7 @@
           <div class="step">
             <div class="num">3</div>
             <h3>Ride</h3>
-            <p>The track lands in your MX Bikes <code>mods/tracks</code> folder, ready to load.</p>
+            <p>The mod lands in the matching MX Bikes <code>mods</code> folder, ready to load.</p>
           </div>
         </div>
       </div>
@@ -626,11 +626,11 @@
         <div class="faq">
           <details class="qa" open>
             <summary>Which mods are supported?<svg class="chev" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></summary>
-            <p>Track mods are fully supported today — search, install, and manage them end to end. Model and sound swaps are handled in the Locker. More mod types are planned.</p>
+            <p>Tracks, bikes and rider gear are all supported — search, install, and manage them end to end. Bike model and sound swaps are handled in the Locker. More mod types are planned.</p>
           </details>
           <details class="qa">
             <summary>Which download hosts work?<svg class="chev" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></summary>
-            <p>MediaFire and Google Drive (including Drive folders) are resolved automatically, and direct links are downloaded as-is. MEGA isn't automated yet — the app opens the page so you can grab those manually.</p>
+            <p>MediaFire, Google Drive (including Drive folders) and MEGA are resolved automatically, and direct links are downloaded as-is. The one exception is a MEGA <em>folder</em> link — open the mod page to grab that one manually.</p>
           </details>
           <details class="qa">
             <summary>What archive types can it extract?<svg class="chev" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></summary>


### PR DESCRIPTION
A full pass over the public-facing copy (site, README, release workflow comments). Every claim was checked against the code before rewriting.

## Round 1 — reported mod types and MEGA

**Supported mod types** — the site FAQ, feature list, `og:description` and README all said track mods only. `MOD_TYPES` in `src/api/mods.ts:52-94` defines three first-class types: Tracks (`mods/tracks`), Bikes (`mods/bikes` — incl. liveries and sounds) and Rider (`mods/rider` — helmets, gloves, boots, protection and their paints).

**MEGA** — the site and README said MEGA isn't automated. It is: `src-tauri/src/install.rs:80-84` routes MEGA links to `download_mega_and_place`, which fetches and decrypts in-app. The only manual case is a MEGA *folder* link, which errors out at `install.rs:185` pointing the user at the mod page.

## Round 2 — audit of every remaining claim

| Claim | Reality |
| --- | --- |
| "`.rar` isn't supported yet" (site FAQ + README) | Supported — `extract_rar` via the `unrar` crate (`install.rs:598`), magic-byte detected at `:640`. `.pnt` is placed as-is like `.pkz`. |
| "`.msi` or `.exe` installer" (site card + README) | Bundle targets are `["nsis","app","dmg"]` (`tauri.conf.json:36`) — Windows ships an `.exe` only, no MSI is ever built. |
| Roadmap: "**Liveries** — coming next" | Shipped — Rider is a full mod type with the 3D preview. |
| Roadmap: "**Auto-update** — coming next" | Shipped — `src/Context/Update.tsx:108-110` checks on launch and every 6h, downloads, relaunches. |
| "The workflow produces a **draft** release" | `release.yml:85` sets `releaseDraft: false` — it publishes immediately. The workflow's own header comment said "draft" too; both fixed. |

Docs also gained shipped behaviour they never mentioned: FrostMod live reload and self-update under *How it works*, three.js / React Three Fiber in the tech stack, and a note on the site that the app updates itself after install.

**Verified correct, left alone:** Recycle Bin uninstalls (`library.rs:82`), byte-for-byte preset backups (`presets.rs:296`), multi-select uninstall/move, guided tour, MIT license, React 18, the `npm run` scripts, and the "not affiliated" disclaimer. The MX Bikes Shop integration is built but its nav entry is commented out (`Sidebar.tsx:33`), so the site correctly stays silent on it.

Documentation and marketing copy only — no code, behaviour or DB changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)