### PR TITLE
chore(lint): make ESLint usable so CI can gate on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 ## Unreleased
 
+### Changed
+- **ESLint actually runs clean now** — the config reported 85 errors, 72 of them
+  `react/no-unknown-property` firing on react-three-fiber's three.js JSX in
+  `ModelViewer.tsx` (typed by `@react-three/fiber`, so `tsc` is the real check) and one
+  from a rule that was never registered. Added `eslint-plugin-react-hooks`
+  (`rules-of-hooks` as an error, `exhaustive-deps` as a warning — v7's `recommended` also
+  pulls in the React Compiler ruleset, which flags ~50 pre-existing patterns and deserves
+  its own pass), pointed the Node-globals override at `.mjs` scripts too, and ignored
+  Vite's gitignored timestamped config copies. Now 0 errors / 3 dependency-array
+  warnings, so lint can gate CI.
+
 ### Fixed
+- **Seven unescaped apostrophes** in the viewer's empty/error copy (`ViewerDialog.tsx`).
 - **Bikes that ship one mesh per part now load in the 3D viewer** — the viewer assumed
   every bike packs all four parts into a single `model.edf`, so a mod naming its meshes
   after the bike (e.g. `MX1OEM_1996_Honda_CR250`: `96cr250.edf`, `96cr250_fs.edf`,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,15 +1,18 @@
 import js from "@eslint/js";
 import globals from "globals";
 import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["dist", "src-tauri/target"] },
+  // Vite rewrites its config to a timestamped sibling on reload; it's gitignored
+  // build machinery, not source.
+  { ignores: ["dist", "src-tauri/target", "vite.config.ts.timestamp-*.mjs"] },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {
     // Standalone Node maintenance scripts run outside the browser bundle.
-    files: ["scripts/**/*.js"],
+    files: ["scripts/**/*.{js,mjs}"],
     languageOptions: { globals: globals.node },
   },
   {
@@ -18,12 +21,24 @@ export default tseslint.config(
       ecmaVersion: 2020,
       globals: globals.browser,
     },
-    plugins: { react },
+    plugins: { react, "react-hooks": reactHooks },
     rules: {
       ...react.configs.flat.recommended.rules,
+      // The two classic hook rules only. v7's `recommended` also enables the React
+      // Compiler ruleset (set-state-in-effect, immutability, …), which flags ~50
+      // pre-existing patterns across the app — worth its own pass, not a lint-config fix.
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn",
       "react/react-in-jsx-scope": "off",
       "react/prop-types": "off",
     },
     settings: { react: { version: "detect" } },
+  },
+  {
+    // react-three-fiber renders three.js objects as JSX (`<mesh castShadow>`,
+    // `<ambientLight intensity>`), which eslint-plugin-react judges against the DOM and
+    // flags wholesale. @react-three/fiber ships types for them, so tsc is the real check.
+    files: ["src/Components/Viewer/ModelViewer.tsx"],
+    rules: { "react/no-unknown-property": "off" },
   },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "@vitejs/plugin-react": "^4.3.3",
         "eslint": "^9.14.0",
         "eslint-plugin-react": "^7.37.2",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^15.12.0",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.13.0",
@@ -5381,6 +5382,26 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
       }
     },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
       "version": "2.0.0-next.7",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
@@ -5904,6 +5925,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/hls.js": {
@@ -8798,6 +8836,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@vitejs/plugin-react": "^4.3.3",
     "eslint": "^9.14.0",
     "eslint-plugin-react": "^7.37.2",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^15.12.0",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.13.0",

--- a/src/Components/Viewer/ViewerDialog.tsx
+++ b/src/Components/Viewer/ViewerDialog.tsx
@@ -280,7 +280,7 @@ export function ViewerDialog({
           {stockGearPart && gear && !loading && (
             <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center p-3">
               <span className="rounded-md bg-black/70 px-3 py-1.5 text-center text-xs text-white/90">
-                Shown on the game's stock {stockGearPart}. A paint made for a different
+                Shown on the game&apos;s stock {stockGearPart}. A paint made for a different
                 model may not line up perfectly.
               </span>
             </div>
@@ -288,17 +288,19 @@ export function ViewerDialog({
           {paintNoChange && !loading && (
             <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center p-3">
               <span className="rounded-md bg-black/70 px-3 py-1.5 text-center text-xs text-white/90">
-                None of this paint's textures are used by the parts shown here, so the
-                preview doesn't change. It may still paint the wheels or chain, which
-                this view doesn't render.
+                None of this paint&apos;s textures are used by the parts shown here, so the
+                preview doesn&apos;t change. It may still paint the wheels or chain, which
+                this view doesn&apos;t render.
               </span>
             </div>
           )}
           {bikeFailed && (
             <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-1 text-center">
-              <span className="text-sm font-medium text-foreground">Can't load bike model</span>
+              <span className="text-sm font-medium text-foreground">
+                Can&apos;t load bike model
+              </span>
               <span className="text-xs text-muted-foreground">
-                This bike's 3D model isn't in a format the viewer supports yet.
+                This bike&apos;s 3D model isn&apos;t in a format the viewer supports yet.
               </span>
             </div>
           )}


### PR DESCRIPTION
## Problem

`npm run lint` reported **85 errors**, but 80 of them were config faults rather than code defects — which meant lint carried no signal and couldn't gate CI.

- **72 × `react/no-unknown-property`**, all in `ModelViewer.tsx`: react-three-fiber renders three.js objects as JSX (`<mesh castShadow>`, `<ambientLight intensity>`), which `eslint-plugin-react` judges against the DOM.
- **1 × unknown rule**: a disable comment in `ViewerPanel.tsx` referenced `react-hooks/exhaustive-deps`, but the plugin was never installed.
- **4 × `no-undef`** for `process` / `console`: the Node-globals override targeted `scripts/**/*.js`, and the only script there is `.mjs`.
- **1 × `no-undef`** inside Vite's gitignored `vite.config.ts.timestamp-*.mjs` reload copy, which was being linted as source.

Genuine findings: 7 unescaped apostrophes.

## Fix

- Disable `react/no-unknown-property` for `ModelViewer.tsx` only — `@react-three/fiber` ships types for those props, so `tsc` is the real check there.
- Add `eslint-plugin-react-hooks` with `rules-of-hooks` (error) and `exhaustive-deps` (warn). **Not** the v7 `recommended` preset: it now bundles the React Compiler ruleset (`set-state-in-effect`, `immutability`, …), which flags ~50 pre-existing patterns app-wide. That's a real refactor and deserves its own pass, not a lint-config PR.
- Point the Node-globals override at `scripts/**/*.{js,mjs}`; ignore the Vite timestamp copies.
- Escape the 7 apostrophes in `ViewerDialog.tsx`.

## Result

**0 errors, 3 warnings.** The warnings are genuine dependency-array gaps in `ModDetail`, `Presets` and `ViewerDialog` — left visible rather than silenced, since they may well be deliberate.

`npm run lint`, `npm run typecheck` and `npm run build` all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)