### PR TITLE
chore(ci): verify every push and PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: CI
+
+# Verification on every push to main and every PR. Release builds (release.yml) only
+# run on a tag, so without this nothing checks a change before it lands.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# A new push to the same branch supersedes the previous run.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    name: Frontend (typecheck, lint, build)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+  rust:
+    name: Rust (test) — ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Linux is the quick check; Windows is what ships, so it must pass there too.
+        platform: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # No `cargo fmt --check` gate: the tree has never been rustfmt'd (~170 sites across
+      # nearly every file), so a format pass wants its own commit — and one right now
+      # would conflict across the unmerged feature/garage-bike-switch work.
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      # The crate links against Tauri's webview stack, so a Linux build needs the
+      # system libs even when we're only running tests.
+      - name: Install Linux system dependencies
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libsoup-3.0-dev \
+            patchelf
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ./src-tauri -> target
+
+      - name: Run tests
+        working-directory: ./src-tauri
+        # Tests needing a real MX Bikes asset are `#[ignore]`d and stay skipped here.
+        run: cargo test --locked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+- **CI verification on every push and PR** (`.github/workflows/ci.yml`) — nothing checked
+  a change before it landed: `release.yml` only runs on a version tag and `pages.yml` only
+  deploys the site. Two jobs now run on pushes to `main` and on every PR: frontend
+  (`npm ci` → typecheck → lint → build) and Rust (`cargo test --locked`) on both Linux and
+  Windows, since Windows is what ships. Tests needing a real MX Bikes asset stay
+  `#[ignore]`d. Verified the sidecar-less public variant — what CI actually builds —
+  compiles and passes (108 tests). No `cargo fmt --check` gate yet: the tree has never
+  been rustfmt'd, so that wants its own pass once `feature/garage-bike-switch` lands.
+
 ### Changed
 - **ESLint actually runs clean now** — the config reported 85 errors, 72 of them
   `react/no-unknown-property` firing on react-three-fiber's three.js JSX in


### PR DESCRIPTION
## Problem

Nothing verified a change before it landed. `release.yml` only runs on a `v*` tag, and `pages.yml` only deploys the site — so PRs merged with **zero** automated checks.

## Change

New `.github/workflows/ci.yml`, on pushes to `main`, on every PR, and manually dispatchable:

| job | runs on | steps |
|---|---|---|
| frontend | ubuntu | `npm ci` → typecheck → lint → build |
| rust | ubuntu + windows | `cargo test --locked` |

- **Windows is in the matrix** because it's the shipped platform, so the suite has to pass there too. Linux additionally needs Tauri's webview system libs to compile at all.
- Concurrency group cancels superseded runs on the same ref; `permissions: contents: read`.
- Tests needing a real MX Bikes asset stay `#[ignore]`d.

## No `cargo fmt --check` gate

Deliberate. The tree has never been rustfmt'd — **~170 diff sites across nearly every file** — so the gate would fail on its first run. A format pass wants its own commit, and doing it now would conflict across the unmerged `feature/garage-bike-switch` work. Worth revisiting once that lands.

## Verification

Checked against a **sidecar-less git worktree** — the public variant CI actually builds, since the optional module is gitignored and only fetched by `release.yml`. It compiles and passes **108 tests** (the 4 sidecar tests don't exist without the module; 112 locally with it).

This PR's own checks are the live proof the workflow works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)