### PR TITLE
chore(deps): bump swiper to 14 for the critical advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: CI
+
+# Verification on every push to main and every PR. Release builds (release.yml) only
+# run on a tag, so without this nothing checks a change before it lands.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# A new push to the same branch supersedes the previous run.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    name: Frontend (typecheck, lint, build)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+  rust:
+    name: Rust (test) — ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Linux is the quick check; Windows is what ships, so it must pass there too.
+        platform: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # No `cargo fmt --check` gate: the tree has never been rustfmt'd (~170 sites across
+      # nearly every file), so a format pass wants its own commit — and one right now
+      # would conflict across the unmerged feature/garage-bike-switch work.
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      # The crate links against Tauri's webview stack, so a Linux build needs the
+      # system libs even when we're only running tests.
+      - name: Install Linux system dependencies
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libsoup-3.0-dev \
+            patchelf
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ./src-tauri -> target
+
+      - name: Run tests
+        working-directory: ./src-tauri
+        # Tests needing a real MX Bikes asset are `#[ignore]`d and stay skipped here.
+        run: cargo test --locked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@
   Vite's gitignored timestamped config copies. Now 0 errors / 3 dependency-array
   warnings, so lint can gate CI.
 
+### Security
+- **Bump swiper to 14.0.7** — clears a critical prototype-pollution advisory covering
+  6.5.1–12.1.1. Unlike the vite/rollup/esbuild advisories (build-time only), this one
+  ships: swiper drives the mod-detail image gallery. Major bump, but the API the gallery
+  uses (`modules`, `navigation`, `pagination`, `onSwiper`, `onSlideChange`, `slideTo`)
+  and the `swiper-button-*` / `swiper-pagination-bullet*` class names our CSS targets are
+  unchanged; no React peer-dependency constraint. Remaining audit findings are all
+  build-time tooling and don't reach the shipped bundle.
+
 ### Fixed
 - **Seven unescaped apostrophes** in the viewer's empty/error copy (`ViewerDialog.tsx`).
 - **Bikes that ship one mesh per part now load in the 3D viewer** — the viewer assumed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+- **CI verification on every push and PR** (`.github/workflows/ci.yml`) — nothing checked
+  a change before it landed: `release.yml` only runs on a version tag and `pages.yml` only
+  deploys the site. Two jobs now run on pushes to `main` and on every PR: frontend
+  (`npm ci` → typecheck → lint → build) and Rust (`cargo test --locked`) on both Linux and
+  Windows, since Windows is what ships. Tests needing a real MX Bikes asset stay
+  `#[ignore]`d. Verified the sidecar-less public variant — what CI actually builds —
+  compiles and passes (108 tests). No `cargo fmt --check` gate yet: the tree has never
+  been rustfmt'd, so that wants its own pass once `feature/garage-bike-switch` lands.
+
 ### Changed
 - **ESLint actually runs clean now** — the config reported 85 errors, 72 of them
   `react/no-unknown-property` firing on react-three-fiber's three.js JSX in

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "react-dom": "^18.3.1",
         "sass": "^1.80.6",
         "sonner": "^2.0.7",
-        "swiper": "^11.1.14",
+        "swiper": "^14.0.7",
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.2",
         "three": "^0.160.1",
@@ -8157,17 +8157,17 @@
       }
     },
     "node_modules/swiper": {
-      "version": "11.2.10",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.10.tgz",
-      "integrity": "sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ==",
+      "version": "14.0.7",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-14.0.7.tgz",
+      "integrity": "sha512-PDMY+8hNQBh4kAYdfKIF1GNS7u3hg4xl3NVKBey0rENnpUpTsiE/aCcbgpmm1PIf4RMI7loO3XhW9BdxLzQw0A==",
       "funding": [
         {
-          "type": "patreon",
-          "url": "https://www.patreon.com/swiperjs"
+          "type": "custom",
+          "url": "https://sponsors.nolimits4web.com"
         },
         {
-          "type": "open_collective",
-          "url": "http://opencollective.com/swiper"
+          "type": "github",
+          "url": "https://github.com/sponsors/nolimits4web"
         }
       ],
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-dom": "^18.3.1",
     "sass": "^1.80.6",
     "sonner": "^2.0.7",
-    "swiper": "^11.1.14",
+    "swiper": "^14.0.7",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.2",
     "three": "^0.160.1",


### PR DESCRIPTION
## Why

`swiper` 6.5.1–12.1.1 carries a **critical prototype-pollution advisory**, and we were on 11.x. Unlike the vite / rollup / esbuild findings — build-time tooling that never reaches the bundle — this one **ships**: swiper drives the mod-detail image gallery in `ModDetail.tsx`.

## Verification

It's a three-major jump (11 → 14), so I checked what the gallery actually depends on:

- **Subpaths still exported**: `swiper/react`, `swiper/modules`, `swiper/css`, `swiper/css/navigation`, `swiper/css/pagination`.
- **API unchanged**: `modules`, `navigation`, `pagination={{clickable:true}}`, `onSwiper`, `onSlideChange`, and `swiperRef.current?.slideTo(i)` all still present in v14's types.
- **No React peer constraint** — v14 declares no `peerDependencies`, so React 18 is fine.
- **Styling holds**: `.frost-gallery` in `index.css` targets `swiper-button-next` / `swiper-button-prev` / `swiper-pagination-bullet` / `swiper-pagination-bullet-active` / `--swiper-navigation-size`, and all five are still emitted by v14's stylesheets.

`npm run typecheck` and `npm run build` both pass.

## Remaining audit findings

All build-time only, none in the shipped bundle: `vite`, `rollup`, `esbuild`, and `brace-expansion` (the last arriving via the eslint toolchain in #10).

## Needs a visual check

A major version bump to a UI component — worth clicking through a mod's gallery once (arrows, pagination bullets, thumbnail click-to-jump) before this ships in a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)