### PR TITLE
fix(setup): stop replaying first-run setup on every launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,30 @@
   warnings, so lint can gate CI.
 
 ### Fixed
+- **First-run setup no longer replays on every launch.** Two pieces of first-run state
+  were stored in places that don't reliably survive a restart, and losing either one
+  put the user back at the start:
+  - *The setup screen.* `is_configured` was a bare "does `config.json` exist?" check, so
+    anything that took the file out — an app-data wipe, a config written under a
+    different Windows account, a half-written file, a failed save — dropped the user back
+    into setup with no way out but redoing it. Since that screen's default action only
+    runs auto-detection anyway, startup now re-detects instead: `config::load_or_detect`
+    rebuilds the config from `Documents\PiBoSo\MX Bikes` when it's recognizably an MX
+    Bikes folder (has `profiles/` or `mods/`), and setup appears only when that finds
+    nothing. A corrupt `config.json` is now a parse *error* that triggers the same
+    rebuild, rather than deserializing to an empty config that left the app pointed at
+    no folder at all. Startup logs the config path and whether it was found.
+  - *The intro slideshow and guided tour.* Both were gated on `localStorage` alone, which
+    the webview drops whenever its storage is cleared. They're now recorded in the config
+    (`welcomeSeen` / `tourDone`), with the old keys still honored and migrated on first
+    launch so nobody sees the intro twice.
+- **Changing the MX Bikes folder in Settings no longer resets everything else.** Both
+  "choose a different folder" and "re-detect" called `createConfig` with just the path,
+  and every field the frontend omitted was refilled from `AppConfig::default()` — so
+  picking a new folder also wiped the detected game install and reset launch-at-startup,
+  run-in-background, auto-run FrostMod, instant refresh and the mods watcher. They now
+  call a `set_mods_path` command that touches only the folder (and restarts the watcher),
+  matching how `set_game_path` and the other setting commands already behaved.
 - **Seven unescaped apostrophes** in the viewer's empty/error copy (`ViewerDialog.tsx`).
 - **Bikes that ship one mesh per part now load in the 3D viewer** — the viewer assumed
   every bike packs all four parts into a single `model.edf`, so a mod naming its meshes

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -23,6 +23,14 @@ pub struct AppConfig {
     /// Watch `<mods_path>/mods` and signal FrostMod to reload when tracks/bikes are
     /// added outside the app (e.g. a manual download dropped into the folder).
     pub watch_mods_reload: bool,
+    /// The intro slideshow has been dismissed. Kept here rather than in the webview's
+    /// `localStorage` so it survives that storage being cleared (WebView2 resets it on
+    /// an app-data wipe, and an OS shutdown can kill the tray-resident process before
+    /// it flushes) — losing it made the app re-run its first-run flow on every launch.
+    pub welcome_seen: bool,
+    /// The first-run guided tour has been finished or skipped. Persisted alongside
+    /// `welcome_seen`, for the same reason.
+    pub tour_done: bool,
 }
 
 impl Default for AppConfig {
@@ -36,6 +44,8 @@ impl Default for AppConfig {
             auto_run_frostmod: true,
             instant_refresh: true,
             watch_mods_reload: true,
+            welcome_seen: false,
+            tour_done: false,
         }
     }
 }
@@ -68,7 +78,50 @@ pub fn exists(app: &AppHandle) -> bool {
 pub fn load(app: &AppHandle) -> anyhow::Result<AppConfig> {
     let path = config_path(app);
     let text = std::fs::read_to_string(path)?;
-    Ok(serde_json::from_str(&text).unwrap_or_default())
+    // A truncated/corrupt file is an error, not a silent empty config: callers that
+    // can rebuild one (see `load_or_detect`) get the chance to, instead of the app
+    // coming up pointed at nothing.
+    Ok(serde_json::from_str(&text)?)
+}
+
+/// Whether `path` is really a player's MX Bikes folder — the game keeps `profiles/`
+/// there, and `mods/` shows up as soon as anything is installed. Checking for those
+/// rather than just "the folder exists" keeps auto-detection from quietly adopting an
+/// empty `Documents\PiBoSo\MX Bikes` for someone whose setup lives elsewhere; they
+/// still get the setup screen to point us at it.
+fn looks_like_mods_dir(path: &str) -> bool {
+    let dir = Path::new(path.trim());
+    if path.trim().is_empty() || !dir.is_dir() {
+        return false;
+    }
+    dir.join("profiles").is_dir() || dir.join("mods").is_dir()
+}
+
+/// The saved config, or one built on the spot when the MX Bikes folder sits where it
+/// normally does. Returns `None` only when there's genuinely nothing to go on — the
+/// one case where the setup screen has something to ask.
+///
+/// The setup screen never gathered more than this: its default action just runs the
+/// same detection. So when the config file goes missing — an app-data wipe, a config
+/// written under a different Windows account, a failed write — the app re-detects and
+/// carries on rather than walking the user through setup again on every launch.
+pub fn load_or_detect(app: &AppHandle) -> Option<AppConfig> {
+    if exists(app) {
+        match load(app) {
+            Ok(cfg) => return Some(cfg),
+            Err(e) => log::warn!("config.json unreadable ({e:#}) — re-detecting"),
+        }
+    }
+
+    let cfg = finalize(AppConfig::default());
+    if !looks_like_mods_dir(&cfg.mods_path) {
+        return None;
+    }
+    log::info!("no usable config — auto-detected MX Bikes folder: {}", cfg.mods_path);
+    if let Err(e) = save(app, &cfg) {
+        log::warn!("couldn't save the auto-detected config: {e:#}");
+    }
+    Some(cfg)
 }
 
 pub fn save(app: &AppHandle, cfg: &AppConfig) -> anyhow::Result<()> {
@@ -196,6 +249,54 @@ mod tests {
         cfg.mods_path = "/games/mxb".into();
         cfg.profiles_path = "/other/drive/profiles".into();
         assert_eq!(cfg.profiles_dir(), PathBuf::from("/other/drive/profiles"));
+    }
+
+    #[test]
+    fn only_a_real_mx_bikes_folder_is_adopted_automatically() {
+        let root = std::env::temp_dir()
+            .join(format!("frost-config-detect-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+
+        assert!(!looks_like_mods_dir(""));
+        assert!(!looks_like_mods_dir(&root.join("nope").to_string_lossy()));
+
+        // The folder exists but holds nothing of ours — don't assume it's the one.
+        let bare = root.join("bare");
+        std::fs::create_dir_all(&bare).unwrap();
+        assert!(!looks_like_mods_dir(&bare.to_string_lossy()));
+
+        // `profiles/` (the game writes it) or `mods/` (we do) makes it recognizable.
+        let played = root.join("played");
+        std::fs::create_dir_all(played.join("profiles")).unwrap();
+        assert!(looks_like_mods_dir(&played.to_string_lossy()));
+
+        let modded = root.join("modded");
+        std::fs::create_dir_all(modded.join("mods")).unwrap();
+        assert!(looks_like_mods_dir(&modded.to_string_lossy()));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn older_configs_keep_their_settings_and_default_the_new_flags() {
+        // A config written before the intro flags existed must still load — a parse
+        // failure now makes the app re-detect and overwrite it.
+        let cfg: AppConfig = serde_json::from_str(
+            r#"{"modsPath":"C:\\MXB","gamePath":"C:\\Steam\\MX Bikes","runInBackground":false}"#,
+        )
+        .expect("older config still parses");
+        assert_eq!(cfg.mods_path, "C:\\MXB");
+        assert_eq!(cfg.game_path, "C:\\Steam\\MX Bikes");
+        assert!(!cfg.run_in_background);
+        assert!(cfg.launch_at_startup, "unset fields fall back to the defaults");
+        assert!(!cfg.welcome_seen);
+        assert!(!cfg.tour_done);
+    }
+
+    #[test]
+    fn corrupt_config_is_an_error_not_an_empty_config() {
+        assert!(serde_json::from_str::<AppConfig>(r#"{"modsPath":"C:\\MX"#).is_err());
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -36,9 +36,12 @@ use tauri::{
 };
 use tauri_plugin_autostart::{MacosLauncher, ManagerExt};
 
+/// Whether the app is ready to use. Falls back to auto-detection when the config file
+/// is missing, so the setup screen only appears when the MX Bikes folder genuinely
+/// can't be found — not every time the saved config goes astray.
 #[tauri::command]
 fn is_configured(app: tauri::AppHandle) -> bool {
-    config::exists(&app)
+    config::load_or_detect(&app).is_some()
 }
 
 #[tauri::command]
@@ -52,7 +55,13 @@ fn create_config(
     watcher: State<ModWatcher>,
     config: AppConfig,
 ) -> Result<bool, String> {
-    let cfg = config::finalize(config);
+    let mut cfg = config::finalize(config);
+    // Setup only sends the folders, so carry over first-run state from any config
+    // that's already there — rewriting it would replay the intro and the tour.
+    if let Ok(prev) = config::load(&app) {
+        cfg.welcome_seen |= prev.welcome_seen;
+        cfg.tour_done |= prev.tour_done;
+    }
     config::save(&app, &cfg).map_err(|e| format!("{e:#}"))?;
     // Begin watching straight away so a fresh setup doesn't need a restart before
     // manual downloads reload the game.
@@ -1369,6 +1378,39 @@ fn set_game_path(app: tauri::AppHandle, path: String) -> Result<(), String> {
     config::save(&app, &cfg).map_err(|e| format!("{e:#}"))
 }
 
+/// Point the app at a different MX Bikes folder; an empty string re-runs detection.
+/// Only the folder changes — unlike a full `create_config`, the rest of the settings
+/// (startup, tray, FrostMod, first-run state) are left alone.
+#[tauri::command]
+fn set_mods_path(
+    app: tauri::AppHandle,
+    watcher: State<ModWatcher>,
+    path: String,
+) -> Result<(), String> {
+    let mut cfg = config::load(&app).unwrap_or_default();
+    cfg.mods_path = path;
+    let cfg = config::finalize(cfg);
+    config::save(&app, &cfg).map_err(|e| format!("{e:#}"))?;
+    if cfg.watch_mods_reload {
+        modwatch::start(&app, &watcher, &cfg.mods_path);
+    }
+    Ok(())
+}
+
+/// Remember that the intro slideshow / guided tour is done. No-ops before the config
+/// exists — writing one there would leave the app "configured" with no folder set;
+/// the webview flag covers that short window instead.
+#[tauri::command]
+fn set_intro_seen(app: tauri::AppHandle, welcome: bool, tour: bool) -> Result<(), String> {
+    if !config::exists(&app) {
+        return Ok(());
+    }
+    let mut cfg = config::load(&app).unwrap_or_default();
+    cfg.welcome_seen |= welcome;
+    cfg.tour_done |= tour;
+    config::save(&app, &cfg).map_err(|e| format!("{e:#}"))
+}
+
 /// Override the PiBoSo `profiles` folder for the split-folder edge case. An empty
 /// string clears the override, falling back to `<mods_path>/profiles`.
 #[tauri::command]
@@ -1791,35 +1833,42 @@ fn main() {
                 .build(app)?;
 
             let handle = app.handle();
-            if config::exists(handle) {
-                if let Ok(mut cfg) = config::load(handle) {
-                    // Auto-detect the MX Bikes install on launch for configs that
-                    // never got one (created before detection existed, or when the
-                    // game wasn't installed yet). Only fills a blank — never overrides
-                    // a manual pick — and persists it so the 3D rider preview works.
-                    if cfg.game_path.trim().is_empty() {
-                        if let Some(gp) = config::detect_game_path() {
-                            log::info!("auto-detected MX Bikes install: {gp}");
-                            cfg.game_path = gp;
-                            let _ = config::save(handle, &cfg);
-                        }
-                    }
-                    let manager = handle.autolaunch();
-                    let enabled = manager.is_enabled().unwrap_or(false);
-                    if cfg.launch_at_startup && !enabled {
-                        let _ = manager.enable();
-                    } else if !cfg.launch_at_startup && enabled {
-                        let _ = manager.disable();
-                    }
-                    if cfg.auto_run_frostmod && frostmod_manage::is_installed(handle) {
-                        let state = handle.state::<FrostmodProcess>();
-                        let _ = frostmod_manage::start(handle, &state);
-                    }
-                    if cfg.watch_mods_reload {
-                        let watcher = handle.state::<ModWatcher>();
-                        modwatch::start(handle, &watcher, &cfg.mods_path);
+            log::info!(
+                "config: {} ({})",
+                config::config_path(handle).display(),
+                if config::exists(handle) { "found" } else { "missing" },
+            );
+            // `load_or_detect` rebuilds a missing/unreadable config from the standard
+            // MX Bikes folder, so a lost config no longer means a trip through setup.
+            if let Some(mut cfg) = config::load_or_detect(handle) {
+                // Auto-detect the MX Bikes install on launch for configs that
+                // never got one (created before detection existed, or when the
+                // game wasn't installed yet). Only fills a blank — never overrides
+                // a manual pick — and persists it so the 3D rider preview works.
+                if cfg.game_path.trim().is_empty() {
+                    if let Some(gp) = config::detect_game_path() {
+                        log::info!("auto-detected MX Bikes install: {gp}");
+                        cfg.game_path = gp;
+                        let _ = config::save(handle, &cfg);
                     }
                 }
+                let manager = handle.autolaunch();
+                let enabled = manager.is_enabled().unwrap_or(false);
+                if cfg.launch_at_startup && !enabled {
+                    let _ = manager.enable();
+                } else if !cfg.launch_at_startup && enabled {
+                    let _ = manager.disable();
+                }
+                if cfg.auto_run_frostmod && frostmod_manage::is_installed(handle) {
+                    let state = handle.state::<FrostmodProcess>();
+                    let _ = frostmod_manage::start(handle, &state);
+                }
+                if cfg.watch_mods_reload {
+                    let watcher = handle.state::<ModWatcher>();
+                    modwatch::start(handle, &watcher, &cfg.mods_path);
+                }
+            } else {
+                log::info!("no MX Bikes folder found — showing first-run setup");
             }
             shop_session::load_session(handle);
             Ok(())
@@ -1868,6 +1917,8 @@ fn main() {
             uninstall_mod,
             reveal_in_explorer,
             set_game_path,
+            set_mods_path,
+            set_intro_seen,
             set_profiles_path,
             detect_game_path,
             count_profiles_in,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,12 +9,20 @@ import { FrostmodProvider } from "./Context/Frostmod";
 import { ConfigContext } from "./Context/Config";
 import { Toaster } from "@/Components/ui/sonner";
 import { TooltipProvider } from "@/Components/ui/tooltip";
-import { bikePreviewAvailable, getConfig, isConfigured } from "./api/mods";
+import { bikePreviewAvailable, getConfig, isConfigured, setIntroSeen } from "./api/mods";
+import { TOUR_DONE_KEY } from "./Components/Tour/Tour";
 import { UpdateProvider } from "./Context/Update";
 import UpdateBanner from "./Components/UpdateBanner/UpdateBanner";
 import type { Config } from "./types";
 
-/** Bumped when the intro tour changes enough to warrant showing it again. */
+/**
+ * Bumped when the intro tour changes enough to warrant showing it again.
+ *
+ * The saved config (`welcomeSeen`) is the real record — this only covers the window
+ * before one exists, i.e. while the setup screen is still up. Keeping it in the
+ * webview's storage alone is what made the intro replay after that storage was
+ * cleared.
+ */
 const WELCOME_SEEN_KEY = "mxb:welcomeSeen:v1";
 
 const App = () => {
@@ -23,18 +31,32 @@ const App = () => {
   // Whether this build can decode real bike geometry (optional local module). Fixed
   // at build time, so fetch it once at startup.
   const [bikePreview, setBikePreview] = useState(false);
-  const [showWelcome, setShowWelcome] = useState(
-    () => localStorage.getItem(WELCOME_SEEN_KEY) !== "1",
+  const [welcomeDismissed, setWelcomeDismissed] = useState(
+    () => localStorage.getItem(WELCOME_SEEN_KEY) === "1",
   );
+  const showWelcome = !welcomeDismissed && !config?.welcomeSeen;
 
   const dismissWelcome = useCallback(() => {
     localStorage.setItem(WELCOME_SEEN_KEY, "1");
-    setShowWelcome(false);
+    setWelcomeDismissed(true);
+    // No-ops when there's no config yet (dismissed from over the setup screen); the
+    // flag above holds until setup writes one, and the effect below persists it then.
+    void setIntroSeen({ welcome: true }).catch(() => {});
   }, []);
 
   const reloadConfig = useCallback(async () => {
     setConfig(await getConfig());
   }, []);
+
+  // Carry the old webview-only flags into the config once, so an existing install
+  // doesn't get shown the intro again the first time that storage is lost.
+  useEffect(() => {
+    if (!config) return;
+    const welcome =
+      !config.welcomeSeen && localStorage.getItem(WELCOME_SEEN_KEY) === "1";
+    const tour = !config.tourDone && localStorage.getItem(TOUR_DONE_KEY) === "1";
+    if (welcome || tour) void setIntroSeen({ welcome, tour }).catch(() => {});
+  }, [config]);
 
   useEffect(() => {
     (async () => {

--- a/src/Components/Dashboard/Dashboard.tsx
+++ b/src/Components/Dashboard/Dashboard.tsx
@@ -10,10 +10,12 @@ import ModDetail from "../ModDetail/ModDetail";
 import Settings from "../Settings/Settings";
 import Tour, { TourContext, TOUR_DONE_KEY } from "../Tour/Tour";
 import { InstallProvider } from "../../Context/Install";
+import { useConfig } from "../../Context/Config";
 import {
   DEFAULT_MOD_TYPE,
   getInstalledMods,
   normalizeModName,
+  setIntroSeen,
   type ModType,
 } from "../../api/mods";
 import type { Loadout } from "../../types";
@@ -25,6 +27,7 @@ interface DashboardProps {
 }
 
 const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
+  const { config } = useConfig();
   const [view, setView] = useState<DashboardView>("browse");
   const [modType, setModType] = useState<ModType>(DEFAULT_MOD_TYPE);
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
@@ -83,6 +86,9 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
   }, []);
   const endTour = useCallback(() => {
     localStorage.setItem(TOUR_DONE_KEY, "1");
+    // The config is the durable record — localStorage above is just the immediate
+    // gate, and it doesn't survive the webview's storage being cleared.
+    void setIntroSeen({ tour: true }).catch(() => {});
     setTourRun(false);
     navigate("browse");
   }, [navigate]);
@@ -91,9 +97,9 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
   // been dismissed, otherwise its spotlights sit behind the overlay and show nothing.
   useEffect(() => {
     if (welcomeActive) return;
-    if (localStorage.getItem(TOUR_DONE_KEY) === "1") return;
+    if (config.tourDone || localStorage.getItem(TOUR_DONE_KEY) === "1") return;
     startTour();
-  }, [welcomeActive, startTour]);
+  }, [welcomeActive, startTour, config.tourDone]);
 
   // Jump from Presets into the Rider tab with a preset loaded, to view it on the model.
   const openInRider = useCallback((lo: Loadout) => {

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -6,12 +6,12 @@ import { getVersion } from "@tauri-apps/api/app";
 import { toast } from "sonner";
 import {
   countProfilesIn,
-  createConfig,
   detectGamePath,
   setAutoRunFrostmod,
   setGamePath,
   setInstantRefresh,
   setLaunchAtStartup,
+  setModsPath,
   setProfilesPath,
   setRunInBackground,
   setWatchModsReload,
@@ -135,7 +135,7 @@ export default function Settings() {
     if (typeof picked !== "string") return;
     setBusy(true);
     try {
-      await createConfig({ modsPath: picked });
+      await setModsPath(picked);
       await reloadConfig();
       toast.success("Game folder updated", { description: "Your library will re-scan." });
     } catch (e) {
@@ -148,7 +148,7 @@ export default function Settings() {
   const detectAgain = async () => {
     setBusy(true);
     try {
-      await createConfig({ modsPath: "" });
+      await setModsPath("");
       await reloadConfig();
       toast.success("Re-detected your MX Bikes folder");
     } catch (e) {

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -116,6 +116,23 @@ export function createConfig(config: Config): Promise<boolean> {
   return invoke<boolean>("create_config", { config });
 }
 
+/** Change only the MX Bikes folder — an empty string re-runs auto-detection. Unlike
+ *  `createConfig`, the rest of the settings are preserved. */
+export function setModsPath(path: string): Promise<void> {
+  return invoke<void>("set_mods_path", { path });
+}
+
+/** Persist that the intro slideshow and/or the guided tour is done. */
+export function setIntroSeen(opts: {
+  welcome?: boolean;
+  tour?: boolean;
+}): Promise<void> {
+  return invoke<void>("set_intro_seen", {
+    welcome: opts.welcome ?? false,
+    tour: opts.tour ?? false,
+  });
+}
+
 /** Whether this build can decode real bike geometry for the 3D preview. Public
  *  builds without the optional local module return false, so the UI hides it. */
 export function bikePreviewAvailable(): Promise<boolean> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,11 @@ export interface Config {
    * MXB App (e.g. a manual download dropped into the folder). Default true.
    */
   watchModsReload?: boolean;
+  /** Intro slideshow already dismissed. Saved with the config (not in localStorage)
+   *  so clearing the webview's storage doesn't replay the first-run flow. */
+  welcomeSeen?: boolean;
+  /** First-run guided tour already finished or skipped. */
+  tourDone?: boolean;
 }
 
 /** A track-mod as it appears in search results / browse grid. */


### PR DESCRIPTION
Reported: the app walks the user through initial setup again on every real start. It stays open fine, but each fresh launch (e.g. after a reboot) prompts for setup.

## Cause

Both pieces of first-run state lived somewhere a restart can take away, and losing either one sends the user back to the beginning.

**The setup screen.** `is_configured` was a bare "does `config.json` exist?" check, so anything that removed the file put the user back into setup with no way out but redoing it — an app-data wipe, a config written under a different Windows account than the one autostart launches as, a truncated write. `config::load` also deserialized a corrupt file into an *empty* config, so the app could instead come up "configured" but pointed at no folder at all.

**The intro slideshow and guided tour.** Both were gated on `localStorage` alone, which the webview drops whenever its storage is cleared. A tray-resident process killed at OS shutdown can lose it too — which matches the report's shape (fine while it stays open, back to square one on a real start).

Since the report doesn't distinguish which screen is appearing and both were genuinely fragile, both are fixed.

## Changes

- **Startup re-detects instead of prompting.** `config::load_or_detect` rebuilds a missing or unreadable config from `Documents\PiBoSo\MX Bikes` — but only when that folder is recognizably an MX Bikes folder (has `profiles/` or `mods/`), so a new user with an unusual layout still gets the picker. Safe because the setup screen's own default action did nothing more than run that same detection.
- **A corrupt `config.json` is now a parse error** feeding the same rebuild, rather than silently becoming an empty config.
- **Intro and tour completion move into the config** (`welcomeSeen` / `tourDone`). The old localStorage keys are still honored and migrated on first launch, so nobody sees the intro an extra time.
- **Startup logs the config path and whether it was found** — if this recurs, that line names the exact path being checked, which would confirm or rule out the different-account theory.

## Unrelated bug fixed along the way

Settings → "choose a different folder" and "re-detect" called `createConfig` with only the path, so every field the frontend omitted was refilled from `AppConfig::default()`. Changing the mods folder silently wiped the detected game install and reset launch-at-startup, run-in-background, auto-run FrostMod, instant refresh and the mods watcher. Both now call a new `set_mods_path` command that touches only the folder and restarts the watcher, matching how `set_game_path` and the other setting commands already behaved.

## Verification

- `cargo test --locked` — 111 passed, 0 failed (3 new tests covering folder recognition, older-config compatibility, and corrupt-config handling)
- `npm run typecheck` — clean
- `npm run lint` — 0 errors (3 pre-existing `exhaustive-deps` warnings)
- `npm run build` — succeeds

The original wipe itself isn't reproducible from here — it depends on the reporter's machine state — so the fix is built to recover from it rather than to prevent whatever removed the file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xy684cRKd2jKxQLdQo3sbQ)_