### PR TITLE
feat(garage): bike-switch groundwork — class model + FrostMod command channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
-## 2026-07-22 — v0.3.1 — folder downloads, library multi-select, full-height fix
+## 2026-07-23 — in-garage bike switch (groundwork)
+
+### Added
+- **Garage bike-switch — cross-platform groundwork.** First slice of letting a player
+  swap their whole bike mid-session (offline, restricted to the race's class) without
+  relogging or an admin restart:
+  - New `bikeswap` module reads a bike's id / display name / **class** (`[data] cat`)
+    from its `.ini`/`.cfg` (reusing the existing `cfg` parser), with class-matching that
+    mirrors the dedicated-server `[event] category` semantics (empty = Open,
+    `/`-separated list) and an installed-bike scanner. Unit-tested.
+  - New FrostMod **command channel**: `signal_swap_bike` writes a `frostmod_cmd.json`
+    command file and pulses a dedicated `Local\FrostModCommand` event (the reload event
+    is left untouched). Tauri commands `garage_scan_bikes` / `garage_swap_bike`.
+  - Pairs with FrostMod **Stage A** (observation-only) in the sibling repo, which logs
+    the game's bike-load calls to confirm the loader offset before any live swap.
+  - Online swapping is intentionally **out of scope** — the server is authoritative and
+    anti-cheat validates client integrity on join; this is offline/local only.
 
 ### Added
 - **Library multi-select** — a new **Select** mode turns cards into checkboxes so you can

--- a/src-tauri/src/bikeswap.rs
+++ b/src-tauri/src/bikeswap.rs
@@ -1,0 +1,270 @@
+//! In-garage bike switching — class model + identity reading (cross-platform core).
+//!
+//! Lets the player swap their whole bike mid-session (offline only) restricted to
+//! the race's class. This module is the platform-neutral half: it reads a bike's
+//! **identity** (id / display name / class) from its PiBoSo config files and decides
+//! **class membership**. The actual in-game load is driven by FrostMod (see
+//! `frostmod.rs` for the command channel); nothing here touches the running game.
+//!
+//! Where the fields come from (verified against an OEM bike):
+//!   `<Name>.ini`  `[info] name`  → display name
+//!                 `[data] cat`   → class/category, e.g. "Classic MX1 OEM"
+//!   `<Name>.cfg`  `ID = ...`     → bike ID (matches the folder; server `allowed_bikes`)
+//!
+//! Class matching mirrors the dedicated-server `[event] category` semantics: an empty
+//! spec means Open (any bike), and multiple categories are separated by `/`.
+
+use crate::{cfg, pkz};
+use serde::Serialize;
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BikeIdentity {
+    /// Bike ID from `<name>.cfg` `ID` — matches the folder name and the server's
+    /// `allowed_bikes` ids. Falls back to the folder/pkz stem when the cfg is missing.
+    pub id: String,
+    /// Human-readable name from `<name>.ini` `[info] name`. Falls back to the stem.
+    pub name: String,
+    /// Class/category from `<name>.ini` `[data] cat` (e.g. "Classic MX1 OEM").
+    /// Empty when the bike declares none (treated as unclassified).
+    pub class: String,
+    /// Absolute path to the bike folder or `.pkz`.
+    pub path: String,
+}
+
+/// Class/category from a bike `.ini`'s `[data] cat`. `cfg::parse` flattens section
+/// headers, so a flat `cat` lookup is correct. Empty when absent.
+pub fn class_from_ini(bytes: &[u8]) -> String {
+    cfg::parse(bytes).get("cat").unwrap_or("").trim().to_string()
+}
+
+/// Display name from a bike `.ini`'s `[info] name`. Empty when absent.
+pub fn name_from_ini(bytes: &[u8]) -> String {
+    cfg::parse(bytes).get("name").unwrap_or("").trim().to_string()
+}
+
+/// Bike ID from a bike `.cfg`'s top-level `ID`. `None` when absent. (Engine-mapping
+/// blocks also carry `id`, but those are nested, so a root lookup is unambiguous.)
+pub fn id_from_cfg(bytes: &[u8]) -> Option<String> {
+    let v = cfg::parse(bytes).get("id").unwrap_or("").trim().to_string();
+    (!v.is_empty()).then_some(v)
+}
+
+/// Case-insensitive, whitespace-trimmed class equality.
+pub fn class_eq(a: &str, b: &str) -> bool {
+    a.trim().eq_ignore_ascii_case(b.trim())
+}
+
+/// Does `bike_class` satisfy the race's `allowed` spec? Mirrors the server's
+/// `[event] category`: empty spec = Open (anything), otherwise a `/`-separated
+/// list where matching any member passes.
+pub fn class_matches(bike_class: &str, allowed: &str) -> bool {
+    let allowed = allowed.trim();
+    if allowed.is_empty() {
+        return true;
+    }
+    allowed.split('/').any(|c| class_eq(bike_class, c))
+}
+
+/// Bikes from `bikes` whose class satisfies `allowed`. Preserves input order.
+pub fn bikes_in_class<'a>(bikes: &'a [BikeIdentity], allowed: &str) -> Vec<&'a BikeIdentity> {
+    bikes.iter().filter(|b| class_matches(&b.class, allowed)).collect()
+}
+
+/// Read a bike's identity from a loose folder (`<dir>/<name>.ini` + `.cfg`) or a
+/// `.pkz` (entries matched by basename). Assumes the OEM convention that the ini/cfg
+/// basenames equal the folder/pkz stem. Returns `None` when the path is not a bike
+/// (neither config present) so non-bike folders don't surface; a bike missing only
+/// one file still resolves, falling back to the stem for absent fields.
+pub fn read_identity(path: &Path) -> Option<BikeIdentity> {
+    let (stem, ini, cfg_bytes) = if path.is_dir() {
+        let stem = path.file_name()?.to_string_lossy().into_owned();
+        let ini = std::fs::read(path.join(format!("{stem}.ini"))).ok();
+        let cfg = std::fs::read(path.join(format!("{stem}.cfg"))).ok();
+        (stem, ini, cfg)
+    } else {
+        let stem = path.file_stem()?.to_string_lossy().into_owned();
+        let ini = pkz::read_entry(path, &format!("{stem}.ini")).ok().flatten();
+        let cfg = pkz::read_entry(path, &format!("{stem}.cfg")).ok().flatten();
+        (stem, ini, cfg)
+    };
+
+    // Not a bike if neither config file is present.
+    if ini.is_none() && cfg_bytes.is_none() {
+        return None;
+    }
+
+    let class = ini.as_deref().map(class_from_ini).unwrap_or_default();
+    let name = ini
+        .as_deref()
+        .map(name_from_ini)
+        .filter(|n| !n.is_empty())
+        .unwrap_or_else(|| stem.clone());
+    let id = cfg_bytes
+        .as_deref()
+        .and_then(id_from_cfg)
+        .unwrap_or_else(|| stem.clone());
+
+    Some(BikeIdentity {
+        id,
+        name,
+        class,
+        path: path.to_string_lossy().into_owned(),
+    })
+}
+
+/// Scan installed bikes under `<mods_path>/mods/bikes` — each a loose folder or a
+/// `.pkz` — returning their identities sorted by display name. Non-bike entries are
+/// skipped. Reuses the same `mods/bikes` location as the library scanner.
+pub fn scan_installed_bikes(mods_path: &str) -> Vec<BikeIdentity> {
+    let dir = crate::library::mods_subdir(mods_path, "mods/bikes");
+    let mut out = Vec::new();
+    if let Ok(rd) = std::fs::read_dir(&dir) {
+        for e in rd.flatten() {
+            let p = e.path();
+            let is_candidate = p.is_dir()
+                || p.extension()
+                    .and_then(|x| x.to_str())
+                    .is_some_and(|x| x.eq_ignore_ascii_case("pkz"));
+            if is_candidate {
+                if let Some(b) = read_identity(&p) {
+                    out.push(b);
+                }
+            }
+        }
+    }
+    out.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_bike(dir: &std::path::Path, name: &str, cat: &str) {
+        let bd = dir.join(name);
+        std::fs::create_dir_all(&bd).unwrap();
+        std::fs::write(
+            bd.join(format!("{name}.ini")),
+            format!("[info]\nname = {name}\n[data]\ncat = {cat}\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            bd.join(format!("{name}.cfg")),
+            format!("type = bike\nID = {name}\n"),
+        )
+        .unwrap();
+    }
+
+    // Trimmed from a real OEM bike (MX1OEM_1996_Honda_CR250).
+    const CR250_INI: &[u8] = b"\
+[info]
+name = Honda CR250 1996
+short_name = OEM CR250 '96
+engine_type = 2 stroke
+
+[paint]
+default = 96STOCK
+
+[data]
+code = 0
+cat = Classic MX1 OEM
+
+[race]
+length = 30
+";
+
+    const CR250_CFG: &[u8] = b"\
+type = bike
+ID = MX1OEM_1996_Honda_CR250
+geom_id = 96cr250
+
+engine
+{
+    mapping0
+    {
+        id = 1996_cr250
+        name = CR
+    }
+}
+";
+
+    #[test]
+    fn reads_class_name_and_id_from_configs() {
+        assert_eq!(class_from_ini(CR250_INI), "Classic MX1 OEM");
+        assert_eq!(name_from_ini(CR250_INI), "Honda CR250 1996");
+        // The nested engine-mapping `id`/`name` must not shadow the top-level ID.
+        assert_eq!(id_from_cfg(CR250_CFG).as_deref(), Some("MX1OEM_1996_Honda_CR250"));
+    }
+
+    #[test]
+    fn missing_fields_are_empty_or_none() {
+        assert_eq!(class_from_ini(b"[info]\nname = x\n"), "");
+        assert_eq!(id_from_cfg(b"type = bike\n"), None);
+    }
+
+    #[test]
+    fn class_eq_is_trimmed_and_case_insensitive() {
+        assert!(class_eq(" Classic MX1 OEM ", "classic mx1 oem"));
+        assert!(!class_eq("MX1 OEM", "MX2 OEM"));
+    }
+
+    #[test]
+    fn class_matches_open_single_and_multi() {
+        // Empty spec = Open → anything passes.
+        assert!(class_matches("Classic MX1 OEM", ""));
+        assert!(class_matches("", "   "));
+        // Single category.
+        assert!(class_matches("MX2 OEM", "MX2 OEM"));
+        assert!(!class_matches("MX1 OEM", "MX2 OEM"));
+        // Slash-separated list (server multi-category event).
+        assert!(class_matches("MX2 OEM", "MX1 OEM/MX2 OEM"));
+        assert!(!class_matches("125", "MX1 OEM/MX2 OEM"));
+    }
+
+    #[test]
+    fn scan_reads_identities_skips_non_bikes_and_filters_by_class() {
+        let root = std::env::temp_dir().join(format!("frost-bikeswap-{}", std::process::id()));
+        let bikes = root.join("mods/bikes");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&bikes).unwrap();
+        tmp_bike(&bikes, "MX1_A", "MX1 OEM");
+        tmp_bike(&bikes, "MX2_B", "MX2 OEM");
+        tmp_bike(&bikes, "MX1_C", "MX1 OEM");
+        // A non-bike folder (no .ini/.cfg) must be skipped.
+        std::fs::create_dir_all(bikes.join("_screenshots")).unwrap();
+
+        let all = scan_installed_bikes(&root.to_string_lossy());
+        let names: Vec<&str> = all.iter().map(|b| b.id.as_str()).collect();
+        assert_eq!(names, vec!["MX1_A", "MX1_C", "MX2_B"], "sorted, non-bike skipped");
+
+        let mx1: Vec<&str> = bikes_in_class(&all, "MX1 OEM")
+            .iter()
+            .map(|b| b.id.as_str())
+            .collect();
+        assert_eq!(mx1, vec!["MX1_A", "MX1_C"]);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn bikes_in_class_filters_and_preserves_order() {
+        let mk = |id: &str, class: &str| BikeIdentity {
+            id: id.into(),
+            name: id.into(),
+            class: class.into(),
+            path: String::new(),
+        };
+        let bikes = vec![
+            mk("a", "MX1 OEM"),
+            mk("b", "MX2 OEM"),
+            mk("c", "MX1 OEM"),
+        ];
+        let got: Vec<&str> = bikes_in_class(&bikes, "MX1 OEM")
+            .iter()
+            .map(|b| b.id.as_str())
+            .collect();
+        assert_eq!(got, vec!["a", "c"]);
+    }
+}

--- a/src-tauri/src/frostmod.rs
+++ b/src-tauri/src/frostmod.rs
@@ -81,3 +81,95 @@ pub fn signal_reload() -> ReloadOutcome {
 pub fn is_running() -> bool {
     false
 }
+
+// ===========================================================================
+// Command channel — swap the active bike (offline, in-garage) via FrostMod.
+//
+// The reload event carries no payload, so a bike swap needs its own channel:
+// mxb-app writes a small JSON command file, then signals a DEDICATED event so
+// FrostMod can't confuse a swap with a mods rescan. FrostMod reads the file on
+// wake and dispatches the swap on its render thread, where its own offline +
+// in-garage guard runs (a rejected swap is logged there, not returned here —
+// this side is fire-and-forget). Must match the reader in frostmod.cpp.
+// ===========================================================================
+
+/// Name of FrostMod's command event. Must match frostmod.cpp exactly.
+#[cfg(windows)]
+const COMMAND_EVENT_NAME: &[u8] = b"Local\\FrostModCommand\0";
+
+/// Command file FrostMod reads when the command event fires. Same temp dir the
+/// DLL uses — `std::env::temp_dir()` resolves to the `%TEMP%` that FrostMod's
+/// `GetTempPathA` returns.
+fn command_file_path() -> std::path::PathBuf {
+    std::env::temp_dir().join("frostmod_cmd.json")
+}
+
+/// Serialize a swap-bike command. Kept pure (no I/O) so it can be unit-tested and
+/// so the on-disk contract with frostmod.cpp is exercised without a game.
+fn swap_command_json(bike_id: &str) -> String {
+    serde_json::json!({ "verb": "swap_bike", "bikeId": bike_id }).to_string()
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SwapOutcome {
+    /// Command file written and FrostMod signalled.
+    Signaled,
+    /// FrostMod isn't running (the command event doesn't exist).
+    NotRunning,
+    /// The command file couldn't be written.
+    WriteFailed,
+    /// Non-Windows dev build — can't talk to FrostMod.
+    Unsupported,
+}
+
+/// Ask FrostMod to swap the active bike to `bike_id`. Writes the command file
+/// first (so it's there before FrostMod wakes), then pulses the command event.
+/// Best-effort: the actual offline/in-garage decision happens inside FrostMod.
+#[cfg(windows)]
+pub fn signal_swap_bike(bike_id: &str) -> SwapOutcome {
+    if std::fs::write(command_file_path(), swap_command_json(bike_id)).is_err() {
+        return SwapOutcome::WriteFailed;
+    }
+    // SAFETY: valid NUL-terminated ANSI name; null return means the event doesn't
+    // exist (FrostMod not running) or access was denied.
+    let handle =
+        unsafe { ffi::OpenEventA(ffi::EVENT_MODIFY_STATE, 0, COMMAND_EVENT_NAME.as_ptr()) };
+    if handle.is_null() {
+        return SwapOutcome::NotRunning;
+    }
+    // SAFETY: `handle` is a valid event we just opened and close below.
+    let ok = unsafe { ffi::SetEvent(handle) } != 0;
+    unsafe { ffi::CloseHandle(handle) };
+    if ok {
+        SwapOutcome::Signaled
+    } else {
+        SwapOutcome::NotRunning
+    }
+}
+
+#[cfg(not(windows))]
+pub fn signal_swap_bike(_bike_id: &str) -> SwapOutcome {
+    // Still write the command file on dev builds so the contract can be inspected.
+    let _ = std::fs::write(command_file_path(), swap_command_json(_bike_id));
+    SwapOutcome::Unsupported
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn swap_command_json_shape_and_escaping() {
+        assert_eq!(
+            swap_command_json("MX2OEM_2023_KTM_250_SX-F"),
+            r#"{"bikeId":"MX2OEM_2023_KTM_250_SX-F","verb":"swap_bike"}"#
+        );
+        // Ids are arbitrary folder names — ensure quotes/backslashes are escaped.
+        assert_eq!(
+            swap_command_json(r#"a"b\c"#),
+            r#"{"bikeId":"a\"b\\c","verb":"swap_bike"}"#
+        );
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,7 @@
 // Prevents an additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod bikeswap;
 mod bundle;
 mod cfg;
 mod config;
@@ -1321,6 +1322,25 @@ fn frostmod_running() -> bool {
     frostmod::is_running()
 }
 
+/// Installed bikes with their class, for the garage bike-switch UI. The frontend
+/// filters this to the current race's class before offering a swap.
+#[tauri::command]
+async fn garage_scan_bikes(app: tauri::AppHandle) -> Result<Vec<bikeswap::BikeIdentity>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
+        Ok(bikeswap::scan_installed_bikes(&cfg.mods_path))
+    })
+    .await
+    .map_err(|e| format!("garage_scan_bikes task failed: {e}"))?
+}
+
+/// Ask FrostMod to swap the active bike (offline, in-garage). FrostMod enforces the
+/// offline/in-garage guard; this only sends the request.
+#[tauri::command]
+fn garage_swap_bike(bike_id: String) -> frostmod::SwapOutcome {
+    frostmod::signal_swap_bike(&bike_id)
+}
+
 #[tauri::command]
 async fn frostmod_status(app: tauri::AppHandle) -> FrostmodStatus {
     frostmod_manage::status(&app).await
@@ -1730,6 +1750,8 @@ fn main() {
             set_instant_refresh,
             frostmod_reload,
             frostmod_running,
+            garage_scan_bikes,
+            garage_swap_bike,
             frostmod_status,
             frostmod_install,
             frostmod_start,


### PR DESCRIPTION
## What

First cross-platform slice of in-garage bike switching — swapping a whole bike mid-session without relogging or an admin restart. **Offline only**, restricted to the race's class.

- **`bikeswap` module** — reads a bike's id / display name / **class** (`[data] cat`) from its `.ini`/`.cfg` via the existing `cfg` parser. `class_matches` mirrors the dedicated-server `[event] category` semantics (empty = Open, `/`-separated list); plus `scan_installed_bikes` and `read_identity`. Unit-tested.
- **FrostMod command channel** — `signal_swap_bike` writes a `frostmod_cmd.json` command file and pulses a dedicated `Local\FrostModCommand` event. The existing reload event is left untouched.
- **Tauri commands** — `garage_scan_bikes` / `garage_swap_bike`, registered in `main.rs`.

Online swapping is intentionally out of scope: the server is authoritative and anti-cheat validates client integrity on join.

## Context

This branch predates the CI workflow (#11), so it had never been checked by anything. Brought up to date with `main` and verified:

- `cargo test --locked` — **122 passed**, 0 failed (112 on `main` + 10 from this branch).
- typecheck / lint / build all exit 0.
- CI now runs it on Linux **and** Windows, which matters here: the command channel uses Windows event APIs.

`CHANGELOG.md` conflicted — this branch had filed its entry under a dated `2026-07-23` heading while `main` had accumulated an `## Unreleased` section. Folded into `Unreleased → Added`, keeping every entry from both sides.

## Worth knowing before merging

The commit's own note says Stage B (live replay, offline + garage-gated) and the bench UI follow **after runtime confirmation**, and this pairs with a FrostMod Stage-A observation hook in the sibling repo. So this lands the groundwork and the command channel — not a user-facing feature yet. Nothing in the UI calls `garage_swap_bike`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)