### PR TITLE
chore(release): v0.6.0 — garage groundwork, CI gating, setup fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2026-08-06 — v0.6.0 — garage bike-switch groundwork, CI gating, first-run setup fixes
 
 ### Added
 - **Garage bike-switch — cross-platform groundwork.** First slice of letting a player

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frost",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frost",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.19",
         "@radix-ui/react-context-menu": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "frost"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frost"
-version = "0.5.1"
+version = "0.6.0"
 description = "Frost — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Minor bump to close out the `Unreleased` changelog section and cut a tagged build.

**Why 0.6.0 and not 1.0.0** — this release adds no new user-facing features over
v0.5.1, so 1.0.0 stays reserved for when the garage bike-switch actually ships a UI.

## Changes

Version bumped `0.5.1` → `0.6.0` across `package.json`, `package-lock.json`,
`src-tauri/Cargo.toml`, `src-tauri/Cargo.lock` and `src-tauri/tauri.conf.json`,
and the CHANGELOG's `Unreleased` section closed out as a dated `v0.6.0` entry.

## What ships in it

- **Garage bike-switch groundwork** — `bikeswap` module + FrostMod command channel.
  Backend only, no UI yet; offline and class-locked by design.
- **CI gating** on every push and PR.
- **Security** — swiper 14.0.7, clearing a critical prototype-pollution advisory that
  reached the shipped bundle through the mod-detail gallery.
- **Fixes** — first-run setup no longer replays each launch; changing the MX Bikes
  folder no longer resets other settings; bikes shipping one mesh per part now load
  in the 3D viewer.

No DB/schema changes.

## Verification

Every gate CI runs, green locally:

| Gate | Result |
|---|---|
| `npm run typecheck` | clean |
| `npm run lint` | 0 errors (3 known pre-existing `exhaustive-deps` warnings) |
| `npm run build` | OK |
| `cargo test --locked` | **122 passed, 0 failed**, 20 ignored (need a real MX Bikes asset) |

`--locked` passing confirms `Cargo.lock` is consistent rather than silently regenerated.

## After merge

Tag `v0.6.0` to trigger `release.yml`, which publishes the Windows `.exe` and macOS
`.dmg` and patches `latest.json` for the self-updater.

🤖 Generated with [Claude Code](https://claude.com/claude-code)