### PR TITLE
perf(library): stop a big mod collection from locking the machine up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,16 +33,20 @@
 ### Changed
 - **The folder watcher waits for a copy to finish, and says what it picked up.** It used
   to pulse a reload on every debounced burst, so dropping a folder of tracks in asked the
-  game to re-scan its content over and over while the files were still being written. It
-  now accumulates changes until the folder goes quiet (capped at 45s), skips half-written
-  downloads (`.crdownload`, `.part`, `.tmp`), and reports the affected mods — the toast
-  names them instead of announcing a bare reload.
-- **Groundwork for a scoped in-game reload.** The watcher reduces changed paths to the
-  mods they belong to (`tracks/Red Bud`) and hands that set to FrostMod over the existing
-  command channel as a new `reload_paths` verb, before pulsing the usual reload event.
-  A FrostMod that doesn't know the verb ignores the file and does its normal full reload,
-  so this is inert until the matching sibling-repo change lands — at which point the game
-  can reload just the new mods rather than everything.
+  game to re-scan its content over and over *while the files were still being written* —
+  a plausible cause of a track that only shows up after a full game restart. It now
+  accumulates changes until the folder goes quiet (3s, capped at 45s) and fires one
+  reload, skips half-written downloads (`.crdownload`, `.part`, `.tmp`), and collapses
+  every change inside a mod to one entry so an extracting track counts once, not
+  hundreds of times. The toast names what landed.
+  - Scoping the reload to just the new mods stays FrostMod's call — its reload already
+    rebuilds the content lists surgically, one list per frame. All this side owes it is
+    a single pulse, once the writes are done.
+- **The folder-watcher toast no longer claims more than it knows.** Signalling FrostMod
+  only tells us its reload event exists and was poked; FrostMod can still abort (offsets
+  mismatch on an unrecognised game build) or drop the request as re-entrant. The toast
+  now says the mods were *added* and that a reload was *asked for*, rather than
+  announcing that the game refreshed.
 
 ## 2026-08-06 — v0.6.1 — Rider tab gear slots
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## Unreleased — mod-manager performance
+
+### Fixed
+- **A large library no longer locks the machine up on first open, or after changing the
+  MX Bikes folder.** Two people hit the same wall from different directions — one on the
+  very first launch with a big collection, one every time they repointed the folder.
+  Both are the same storm:
+  - The Library renders a card per installed mod and every card asked for its metadata
+    the moment it mounted. Each request opens the `.pkz`, reads its descriptor, and
+    decodes the preview image to a full-size bitmap before shrinking it to a 192px
+    thumbnail — so a few hundred mods meant a few hundred simultaneous archive reads and
+    image decodes competing for the same disk and RAM. Cards now request metadata only
+    once they scroll into view, a few at a time.
+  - The backend now gates archive inspection to 2–4 at once no matter how many callers
+    arrive, and caps what a single preview decode may allocate. The gate is the real
+    safety net: no UI change can reopen the floodgates.
+  - Metadata cache entries were keyed on the mod's **absolute path**, so pointing the app
+    at a moved or copied MX Bikes folder invalidated every entry at once and re-inspected
+    the entire collection in one burst. They're now keyed on the file itself (name, size,
+    mtime), which survives a move.
+  - A freshly scanned library pulls everything already cached in a single round trip
+    instead of one request per card, so a library that's been opened before paints
+    without touching an archive at all.
+- **`Change…` on the MX Bikes folder no longer blocks the window** — `set_mods_path` ran
+  on the UI thread, where re-detecting the Steam install and restarting the watcher could
+  stall it.
+- **Scanning the tracks folder walks it once, not twice.** An extracted track's folder is
+  the mod, so the scan now stops descending at it rather than walking its (often
+  thousands of) interior files and comparing every path against every track found so far.
+
+### Changed
+- **The folder watcher waits for a copy to finish, and says what it picked up.** It used
+  to pulse a reload on every debounced burst, so dropping a folder of tracks in asked the
+  game to re-scan its content over and over while the files were still being written. It
+  now accumulates changes until the folder goes quiet (capped at 45s), skips half-written
+  downloads (`.crdownload`, `.part`, `.tmp`), and reports the affected mods — the toast
+  names them instead of announcing a bare reload.
+- **Groundwork for a scoped in-game reload.** The watcher reduces changed paths to the
+  mods they belong to (`tracks/Red Bud`) and hands that set to FrostMod over the existing
+  command channel as a new `reload_paths` verb, before pulsing the usual reload event.
+  A FrostMod that doesn't know the verb ignores the file and does its normal full reload,
+  so this is inert until the matching sibling-repo change lands — at which point the game
+  can reload just the new mods rather than everything.
+
 ## 2026-08-06 — v0.6.1 — Rider tab gear slots
 
 ### Fixed

--- a/src-tauri/src/frostmod.rs
+++ b/src-tauri/src/frostmod.rs
@@ -110,6 +110,12 @@ fn swap_command_json(bike_id: &str) -> String {
     serde_json::json!({ "verb": "swap_bike", "bikeId": bike_id }).to_string()
 }
 
+/// Serialize a scoped-reload command: the mods that changed, each as `<type>/<name>`
+/// relative to the content root (e.g. `tracks/Red Bud`).
+fn reload_paths_command_json(mods: &[String]) -> String {
+    serde_json::json!({ "verb": "reload_paths", "mods": mods }).to_string()
+}
+
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -156,6 +162,33 @@ pub fn signal_swap_bike(_bike_id: &str) -> SwapOutcome {
     SwapOutcome::Unsupported
 }
 
+/// Name the mods that changed, so FrostMod can reload just those instead of re-scanning
+/// the whole collection.
+///
+/// Advisory, and deliberately paired with — never a replacement for — the plain reload
+/// pulse that follows it: a FrostMod build that doesn't know the `reload_paths` verb
+/// ignores the file and still does its usual full reload. Best-effort throughout; a
+/// failed write or a missing event just means the scoping hint didn't land.
+pub fn signal_reload_paths(mods: &[String]) {
+    if mods.is_empty() {
+        return;
+    }
+    if std::fs::write(command_file_path(), reload_paths_command_json(mods)).is_err() {
+        return;
+    }
+    #[cfg(windows)]
+    {
+        // SAFETY: valid NUL-terminated ANSI name; a null return means FrostMod isn't
+        // running, in which case there's nothing to tell.
+        let handle =
+            unsafe { ffi::OpenEventA(ffi::EVENT_MODIFY_STATE, 0, COMMAND_EVENT_NAME.as_ptr()) };
+        if !handle.is_null() {
+            unsafe { ffi::SetEvent(handle) };
+            unsafe { ffi::CloseHandle(handle) };
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -170,6 +203,23 @@ mod tests {
         assert_eq!(
             swap_command_json(r#"a"b\c"#),
             r#"{"bikeId":"a\"b\\c","verb":"swap_bike"}"#
+        );
+    }
+
+    #[test]
+    fn reload_paths_command_carries_every_changed_mod() {
+        assert_eq!(
+            reload_paths_command_json(&["tracks/Red Bud".into(), "bikes/KTM450.pkz".into()]),
+            r#"{"mods":["tracks/Red Bud","bikes/KTM450.pkz"],"verb":"reload_paths"}"#
+        );
+    }
+
+    #[test]
+    fn reload_paths_escapes_mod_names() {
+        // Mod keys are folder names, so they can hold anything the filesystem allows.
+        assert_eq!(
+            reload_paths_command_json(&[r#"tracks/a"b\c"#.into()]),
+            r#"{"mods":["tracks/a\"b\\c"],"verb":"reload_paths"}"#
         );
     }
 }

--- a/src-tauri/src/frostmod.rs
+++ b/src-tauri/src/frostmod.rs
@@ -172,5 +172,4 @@ mod tests {
             r#"{"bikeId":"a\"b\\c","verb":"swap_bike"}"#
         );
     }
-
 }

--- a/src-tauri/src/frostmod.rs
+++ b/src-tauri/src/frostmod.rs
@@ -110,12 +110,6 @@ fn swap_command_json(bike_id: &str) -> String {
     serde_json::json!({ "verb": "swap_bike", "bikeId": bike_id }).to_string()
 }
 
-/// Serialize a scoped-reload command: the mods that changed, each as `<type>/<name>`
-/// relative to the content root (e.g. `tracks/Red Bud`).
-fn reload_paths_command_json(mods: &[String]) -> String {
-    serde_json::json!({ "verb": "reload_paths", "mods": mods }).to_string()
-}
-
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -162,33 +156,6 @@ pub fn signal_swap_bike(_bike_id: &str) -> SwapOutcome {
     SwapOutcome::Unsupported
 }
 
-/// Name the mods that changed, so FrostMod can reload just those instead of re-scanning
-/// the whole collection.
-///
-/// Advisory, and deliberately paired with — never a replacement for — the plain reload
-/// pulse that follows it: a FrostMod build that doesn't know the `reload_paths` verb
-/// ignores the file and still does its usual full reload. Best-effort throughout; a
-/// failed write or a missing event just means the scoping hint didn't land.
-pub fn signal_reload_paths(mods: &[String]) {
-    if mods.is_empty() {
-        return;
-    }
-    if std::fs::write(command_file_path(), reload_paths_command_json(mods)).is_err() {
-        return;
-    }
-    #[cfg(windows)]
-    {
-        // SAFETY: valid NUL-terminated ANSI name; a null return means FrostMod isn't
-        // running, in which case there's nothing to tell.
-        let handle =
-            unsafe { ffi::OpenEventA(ffi::EVENT_MODIFY_STATE, 0, COMMAND_EVENT_NAME.as_ptr()) };
-        if !handle.is_null() {
-            unsafe { ffi::SetEvent(handle) };
-            unsafe { ffi::CloseHandle(handle) };
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -206,20 +173,4 @@ mod tests {
         );
     }
 
-    #[test]
-    fn reload_paths_command_carries_every_changed_mod() {
-        assert_eq!(
-            reload_paths_command_json(&["tracks/Red Bud".into(), "bikes/KTM450.pkz".into()]),
-            r#"{"mods":["tracks/Red Bud","bikes/KTM450.pkz"],"verb":"reload_paths"}"#
-        );
-    }
-
-    #[test]
-    fn reload_paths_escapes_mod_names() {
-        // Mod keys are folder names, so they can hold anything the filesystem allows.
-        assert_eq!(
-            reload_paths_command_json(&[r#"tracks/a"b\c"#.into()]),
-            r#"{"mods":["tracks/a\"b\\c"],"verb":"reload_paths"}"#
-        );
-    }
 }

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -345,31 +345,31 @@ fn sort_entries(v: &mut [LibraryEntry]) {
     v.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
 }
 
+/// Extracted tracks and packaged `.pkz`, in one pass.
+///
+/// An extracted track's folder *is* the mod, so once its markers are found we stop
+/// descending: the interior can hold thousands of files, and any `.pkz` down there
+/// belongs to the track rather than being a mod of its own. Pruning is what keeps a
+/// large tracks folder from being walked twice over and every path compared against
+/// every track found so far.
 fn scan_tracks(dir: &Path) -> Vec<LibraryEntry> {
     let mut out = Vec::new();
-    let mut track_dirs: Vec<PathBuf> = Vec::new();
+    let mut walk = WalkDir::new(dir).into_iter();
 
-    for entry in WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
-        if !entry.file_type().is_dir() {
-            continue;
-        }
+    loop {
+        let entry = match walk.next() {
+            None => break,
+            Some(Err(_)) => continue,
+            Some(Ok(e)) => e,
+        };
         let p = entry.path();
-        if p == dir || track_dirs.iter().any(|t| p.starts_with(t)) {
-            continue;
-        }
-        if dir_has_track_markers(p) {
-            track_dirs.push(p.to_path_buf());
-            out.push(make_entry(dir, p, "track", None));
-        }
-    }
 
-    // Packaged `.pkz`, skipping any that live inside an extracted-track folder.
-    for entry in WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
-        if !entry.file_type().is_file() {
-            continue;
-        }
-        let p = entry.path();
-        if has_ext(p, "pkz") && !track_dirs.iter().any(|t| p.starts_with(t)) {
+        if entry.file_type().is_dir() {
+            if p != dir && dir_has_track_markers(p) {
+                out.push(make_entry(dir, p, "track", None));
+                walk.skip_current_dir();
+            }
+        } else if entry.file_type().is_file() && has_ext(p, "pkz") {
             out.push(make_entry(dir, p, "track", None));
         }
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -286,6 +286,26 @@ fn get_pkz_meta_blocking(app: tauri::AppHandle, path: String) -> Result<pkz::Pkz
     pkz::read_meta_cached(&app, &path).map_err(|e| format!("{e:#}"))
 }
 
+/// Metadata for many mods at once, but only for the ones already cached — `None` marks
+/// an entry the caller still has to request individually.
+///
+/// The Library asks for this first so a known collection paints in a single round trip
+/// instead of one request (and one archive read) per card.
+#[tauri::command]
+async fn get_pkz_meta_cached(
+    app: tauri::AppHandle,
+    paths: Vec<String>,
+) -> Result<Vec<Option<pkz::PkzMeta>>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        paths
+            .iter()
+            .map(|p| pkz::read_meta_if_cached(&app, p))
+            .collect()
+    })
+    .await
+    .map_err(|e| format!("get_pkz_meta_cached task failed: {e}"))
+}
+
 #[tauri::command]
 async fn get_pkz_preview(path: String) -> Result<Option<String>, String> {
     tauri::async_runtime::spawn_blocking(move || get_pkz_preview_blocking(path))
@@ -1386,10 +1406,14 @@ fn set_game_path(app: tauri::AppHandle, path: String) -> Result<(), String> {
 /// Point the app at a different MX Bikes folder; an empty string re-runs detection.
 /// Only the folder changes — unlike a full `create_config`, the rest of the settings
 /// (startup, tray, FrostMod, first-run state) are left alone.
+///
+/// Async so the switch runs off the UI thread: `finalize` can scan Steam libraries and
+/// restarting the watcher tears down its background thread, neither of which should be
+/// able to lock up the window.
 #[tauri::command]
-fn set_mods_path(
+async fn set_mods_path(
     app: tauri::AppHandle,
-    watcher: State<ModWatcher>,
+    watcher: State<'_, ModWatcher>,
     path: String,
 ) -> Result<(), String> {
     let mut cfg = config::load(&app).unwrap_or_default();
@@ -1915,6 +1939,7 @@ fn main() {
             get_mod_detail,
             get_installed_mods,
             scan_library,
+            get_pkz_meta_cached,
             get_pkz_meta,
             get_pkz_preview,
             unpack_paint,

--- a/src-tauri/src/modwatch.rs
+++ b/src-tauri/src/modwatch.rs
@@ -84,6 +84,10 @@ fn watch_root(mods_path: &str) -> PathBuf {
 }
 
 /// Changes seen since the last reload, plus when the most recent one landed.
+///
+/// All the coalescing lives here rather than in the settle thread, so "a copy in
+/// progress yields exactly one reload, once it's finished" is something tests can
+/// assert against a clock they control.
 #[derive(Default)]
 struct Pending {
     mods: BTreeSet<String>,
@@ -91,6 +95,35 @@ struct Pending {
     last_seen: Option<Instant>,
     /// A settle thread is already waiting on this batch.
     settling: bool,
+}
+
+impl Pending {
+    /// Fold a batch of changed mods in. Returns whether this batch is the one that
+    /// needs a settle thread started behind it — every later batch joins that one.
+    fn absorb(&mut self, keys: Vec<String>, now: Instant) -> bool {
+        self.mods.extend(keys);
+        self.first_seen.get_or_insert(now);
+        self.last_seen = Some(now);
+        let start = !self.settling;
+        self.settling = true;
+        start
+    }
+
+    /// The batch, once the folder has gone quiet — or once we've waited long enough
+    /// that a still-trickling download shouldn't hold the reload any longer. Taking it
+    /// resets the state, so the next change starts a fresh batch.
+    fn take_if_settled(&mut self, now: Instant) -> Option<Vec<String>> {
+        let since = |t: Option<Instant>| t.map(|t| now.saturating_duration_since(t));
+        let quiet = since(self.last_seen).is_none_or(|d| d >= SETTLE);
+        let overdue = since(self.first_seen).is_some_and(|d| d >= MAX_SETTLE);
+        if !quiet && !overdue {
+            return None;
+        }
+        if overdue && !quiet {
+            log::info!("mods watcher: still changing after {MAX_SETTLE:?} — reloading what's landed");
+        }
+        Some(std::mem::take(self).mods.into_iter().collect())
+    }
 }
 
 /// Start (or restart) the watcher on `<mods_path>/mods`. Replaces any existing
@@ -196,16 +229,10 @@ fn on_batch(
         return;
     }
 
-    let now = Instant::now();
-    let start_settling = {
-        let mut p = pending.lock().unwrap_or_else(|e| e.into_inner());
-        p.mods.extend(keys);
-        p.first_seen.get_or_insert(now);
-        p.last_seen = Some(now);
-        let start = !p.settling;
-        p.settling = true;
-        start
-    };
+    let start_settling = pending
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .absorb(keys, Instant::now());
 
     if start_settling {
         let app = app.clone();
@@ -222,32 +249,28 @@ fn settle_then_reload(app: AppHandle, pending: Arc<Mutex<Pending>>, live: Arc<At
         if !live.load(Ordering::SeqCst) {
             return;
         }
-
-        let mut p = pending.lock().unwrap_or_else(|e| e.into_inner());
-        let quiet = p.last_seen.map(|t| t.elapsed() >= SETTLE).unwrap_or(true);
-        let overdue = p.first_seen.map(|t| t.elapsed() >= MAX_SETTLE).unwrap_or(false);
-        if quiet || overdue {
-            if overdue && !quiet {
-                log::info!("mods watcher: still changing after {MAX_SETTLE:?} — reloading what's landed");
-            }
-            let taken = std::mem::take(&mut *p);
-            break taken.mods;
+        let settled = pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take_if_settled(Instant::now());
+        if let Some(mods) = settled {
+            break mods;
         }
     };
 
     if mods.is_empty() {
         return;
     }
-    reload(&app, mods.into_iter().collect());
+    reload(&app, mods);
 }
 
-/// Tell FrostMod which mods changed, then pulse the reload it already understands.
+/// Pulse FrostMod's reload once for the settled batch.
 ///
-/// Order matters: the command file is in place before the reload event fires, so a
-/// FrostMod that reads it can scope the rescan to those mods. One that doesn't simply
-/// ignores an unknown verb and does its usual full reload — no behaviour change.
+/// Scoping the reload to just these mods is FrostMod's call, not ours — its reload
+/// already rebuilds the content lists surgically, stepped a list per frame. All this
+/// side owes it is one pulse, after the writes are done. The mod names ride along to
+/// the UI only.
 fn reload(app: &AppHandle, mods: Vec<String>) {
-    crate::frostmod::signal_reload_paths(&mods);
     let outcome = crate::frostmod::signal_reload();
     log::info!("mods watcher: {} mod(s) changed -> reload {outcome:?}: {mods:?}", mods.len());
     let _ = app.emit(
@@ -298,6 +321,83 @@ mod tests {
         assert_eq!(mod_key(root, root), None);
         // Somewhere else entirely (a watcher restart racing a path change).
         assert_eq!(mod_key(root, Path::new("/elsewhere/x.pkz")), None);
+    }
+
+    /// A batch of changed mod keys, as `on_batch` would hand them over.
+    fn batch(keys: &[&str]) -> Vec<String> {
+        keys.iter().map(|k| k.to_string()).collect()
+    }
+
+    #[test]
+    fn a_copy_in_progress_yields_one_reload_once_it_finishes() {
+        // Dropping a folder of tracks in writes files for as long as the copy takes,
+        // and the debouncer hands us a batch throughout. Reloading on each one asks
+        // the game to rescan while the files are still being written — which is how a
+        // track ends up missing until the game is restarted.
+        let t0 = Instant::now();
+        let mut p = Pending::default();
+
+        assert!(p.absorb(batch(&["tracks/Red Bud"]), t0), "first batch starts settling");
+        assert!(
+            !p.absorb(batch(&["tracks/Iron Man"]), t0 + Duration::from_secs(1)),
+            "later batches join the one already settling — no second thread, no second reload",
+        );
+        // Still being written: nothing fires.
+        assert_eq!(p.take_if_settled(t0 + Duration::from_secs(2)), None);
+        assert_eq!(p.take_if_settled(t0 + Duration::from_secs(3)), None);
+
+        // Quiet for SETTLE after the *last* write — now, and only now, one reload
+        // carrying both tracks.
+        let settled = p
+            .take_if_settled(t0 + Duration::from_secs(1) + SETTLE)
+            .expect("fires once the folder goes quiet");
+        assert_eq!(settled, vec!["tracks/Iron Man", "tracks/Red Bud"]);
+    }
+
+    #[test]
+    fn every_change_inside_one_mod_collapses_to_a_single_entry() {
+        let t0 = Instant::now();
+        let mut p = Pending::default();
+        // An extracting track touches hundreds of files; the game only needs telling once.
+        p.absorb(batch(&["tracks/Red Bud"]), t0);
+        p.absorb(batch(&["tracks/Red Bud", "tracks/Red Bud"]), t0);
+        assert_eq!(p.take_if_settled(t0 + SETTLE), Some(vec!["tracks/Red Bud".into()]));
+    }
+
+    #[test]
+    fn a_download_that_never_settles_still_reloads_eventually() {
+        // A slow trickle would otherwise hold the reload forever.
+        let t0 = Instant::now();
+        let mut p = Pending::default();
+        p.absorb(batch(&["tracks/Slow"]), t0);
+
+        let mut t = t0;
+        for _ in 0..10 {
+            t += Duration::from_secs(1);
+            p.absorb(batch(&["tracks/Slow"]), t);
+            assert_eq!(p.take_if_settled(t), None, "never quiet, and not yet overdue");
+        }
+        assert!(
+            p.take_if_settled(t0 + MAX_SETTLE).is_some(),
+            "past the cap we act on what's landed",
+        );
+    }
+
+    #[test]
+    fn taking_a_batch_leaves_the_next_change_to_start_a_fresh_one() {
+        let t0 = Instant::now();
+        let mut p = Pending::default();
+        p.absorb(batch(&["tracks/First"]), t0);
+        assert!(p.take_if_settled(t0 + SETTLE).is_some());
+
+        // The settle thread has retired; the next drop must be able to start another.
+        let later = t0 + SETTLE + Duration::from_secs(60);
+        assert!(p.absorb(batch(&["tracks/Second"]), later), "a new batch settles on its own");
+        assert_eq!(
+            p.take_if_settled(later + SETTLE),
+            Some(vec!["tracks/Second".into()]),
+            "and carries only the new mod",
+        );
     }
 
     #[test]

--- a/src-tauri/src/modwatch.rs
+++ b/src-tauri/src/modwatch.rs
@@ -2,46 +2,95 @@
 //!
 //! The in-app installer already signals a reload after it places a mod (see
 //! `install::notify_frostmod`). This module covers the other path: a track or bike
-//! the user downloads and drops into the folder themselves. A debounced recursive
-//! watcher on `<mods_path>/mods` pulses the same reload once the folder settles.
+//! the user downloads and drops into the folder themselves. A recursive watcher on
+//! `<mods_path>/mods` pulses a reload once the folder has settled.
 //!
 //! We deliberately watch only `<mods_path>/mods` — where tracks/bikes live — and NOT
 //! the sibling `profiles/` folder, which churns constantly during gameplay (replays,
 //! telemetry, settings) and would otherwise fire reloads mid-race.
+//!
+//! Two things keep the reload from being a blunt instrument:
+//!
+//! * **Settling.** Copying a folder of tracks writes files for as long as the copy
+//!   takes, and the debouncer keeps handing us batches throughout. Reloading on each
+//!   one asks the game to re-scan its content over and over while it's still being
+//!   written. Instead we accumulate and wait for the folder to go quiet.
+//! * **Naming what changed.** Each changed path is reduced to the mod it belongs to,
+//!   and that set is handed to FrostMod through the command channel so a reload can be
+//!   scoped to the new mods rather than the whole collection. The plain reload event is
+//!   still pulsed afterwards, so a FrostMod that doesn't know the verb behaves exactly
+//!   as it does today.
 
-use std::path::{Path, PathBuf};
-use std::sync::Mutex;
-use std::time::Duration;
+use std::collections::BTreeSet;
+use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use notify::{RecommendedWatcher, RecursiveMode};
 use notify_debouncer_mini::{new_debouncer, DebounceEventResult, Debouncer};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter};
 
-/// Debounce window. Extracting/copying a track writes many files in a burst; we want
-/// a single reload once the folder settles, not one per file.
+/// Debounce window inside the watcher. Extracting a track writes many files in a
+/// burst; this collapses them into batches rather than one event per file.
 const DEBOUNCE: Duration = Duration::from_millis(1500);
+
+/// How long the folder must stay quiet before we call a change finished. Sized to
+/// outlast the gaps between files in a slow copy without making a single dropped-in
+/// `.pkz` feel sluggish.
+const SETTLE: Duration = Duration::from_secs(3);
+
+/// Upper bound on settling. A download that trickles in for minutes shouldn't hold
+/// the reload forever — past this we act on what has landed so far.
+const MAX_SETTLE: Duration = Duration::from_secs(45);
 
 /// Slug the folder watcher tags its `frostmod-reload` events with. In-app install
 /// handlers filter on their own slug, so this sentinel never collides with them.
 pub const WATCH_SLUG: &str = "__mods_watch__";
 
+/// Partial-write suffixes browsers and archivers leave behind. A reload triggered by
+/// one of these would fire against a file that isn't finished being written.
+const PARTIAL_SUFFIXES: [&str; 6] = [".tmp", ".part", ".partial", ".crdownload", ".download", ".!ut"];
+
+/// A watcher and the flag that retires it.
+pub struct Running {
+    /// Dropping the debouncer stops its background thread.
+    _debouncer: Debouncer<RecommendedWatcher>,
+    /// Cleared on stop. A settle thread can be mid-wait when the user switches folders
+    /// or turns auto-reload off, and it must not fire a reload for a watcher that's
+    /// already been retired.
+    live: Arc<AtomicBool>,
+}
+
 /// Managed handle to the running watcher. `None` when disabled, when no mods path is
-/// configured, or when the content folder doesn't exist yet. Dropping the inner
-/// `Debouncer` stops its background thread.
+/// configured, or when the content folder doesn't exist yet.
 #[derive(Default)]
-pub struct ModWatcher(pub Mutex<Option<Debouncer<RecommendedWatcher>>>);
+pub struct ModWatcher(pub Mutex<Option<Running>>);
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct WatchReload {
     slug: &'static str,
     outcome: crate::frostmod::ReloadOutcome,
+    /// The mods that changed, as `<type>/<name>` (e.g. `tracks/Red Bud`). Lets the UI
+    /// say what was picked up instead of announcing a bare reload.
+    mods: Vec<String>,
 }
 
 /// The content root we watch: `<mods_path>/mods` holds `tracks/` and `bikes/`.
 fn watch_root(mods_path: &str) -> PathBuf {
     Path::new(mods_path).join("mods")
+}
+
+/// Changes seen since the last reload, plus when the most recent one landed.
+#[derive(Default)]
+struct Pending {
+    mods: BTreeSet<String>,
+    first_seen: Option<Instant>,
+    last_seen: Option<Instant>,
+    /// A settle thread is already waiting on this batch.
+    settling: bool,
 }
 
 /// Start (or restart) the watcher on `<mods_path>/mods`. Replaces any existing
@@ -60,8 +109,16 @@ pub fn start(app: &AppHandle, state: &ModWatcher, mods_path: &str) {
     }
 
     let handle = app.clone();
+    let pending: Arc<Mutex<Pending>> = Arc::default();
+    let live = Arc::new(AtomicBool::new(true));
+    let watched = root.clone();
+
+    let batch_live = Arc::clone(&live);
     let mut debouncer = match new_debouncer(DEBOUNCE, move |res: DebounceEventResult| match res {
-        Ok(events) if !events.is_empty() => on_change(&handle),
+        Ok(events) if !events.is_empty() => {
+            let changed: Vec<PathBuf> = events.into_iter().map(|e| e.path).collect();
+            on_batch(&handle, &pending, &batch_live, &watched, changed);
+        }
         Ok(_) => {}
         Err(e) => log::warn!("mods watcher: event error: {e:?}"),
     }) {
@@ -78,25 +135,127 @@ pub fn start(app: &AppHandle, state: &ModWatcher, mods_path: &str) {
     }
 
     log::info!("mods watcher: watching {} for changes", root.display());
-    *state.0.lock().unwrap() = Some(debouncer);
+    *state.0.lock().unwrap() = Some(Running {
+        _debouncer: debouncer,
+        live,
+    });
 }
 
-/// Tear down the watcher, if any.
+/// Tear down the watcher, if any, and retire anything still settling behind it.
 pub fn stop(state: &ModWatcher) {
-    *state.0.lock().unwrap() = None;
+    if let Some(running) = state.0.lock().unwrap().take() {
+        running.live.store(false, Ordering::SeqCst);
+    }
 }
 
-/// A settled batch of changes landed in the mods folder — pulse FrostMod's reload and
-/// tell the UI so it can surface it. Fire-and-forget; `signal_reload` no-ops when
-/// FrostMod isn't running or off-Windows.
-fn on_change(app: &AppHandle) {
+/// Is this a half-written file we should ignore until the writer is done with it?
+fn is_partial(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    let lower = name.to_ascii_lowercase();
+    // Office/editor lock files and the archivers' scratch names.
+    lower.starts_with('~') || PARTIAL_SUFFIXES.iter().any(|s| lower.ends_with(s))
+}
+
+/// Reduce a changed path to the mod it belongs to: `<type>/<name>` relative to the
+/// watched root, e.g. `.../mods/tracks/Red Bud/Red Bud.pkz` -> `tracks/Red Bud`.
+///
+/// A change anywhere inside a mod names that mod, so a track being extracted file by
+/// file collapses to a single entry rather than hundreds.
+fn mod_key(root: &Path, path: &Path) -> Option<String> {
+    let rel = path.strip_prefix(root).ok()?;
+    let mut segs = rel.components().filter_map(|c| match c {
+        Component::Normal(s) => s.to_str(),
+        _ => None,
+    });
+    let kind = segs.next()?;
+    let name = segs.next()?;
+    Some(format!("{kind}/{name}"))
+}
+
+/// A debounced batch landed. Fold it into the pending set and make sure something is
+/// waiting for the folder to go quiet.
+fn on_batch(
+    app: &AppHandle,
+    pending: &Arc<Mutex<Pending>>,
+    live: &Arc<AtomicBool>,
+    root: &Path,
+    changed: Vec<PathBuf>,
+) {
+    if !live.load(Ordering::SeqCst) {
+        return;
+    }
+    let keys: Vec<String> = changed
+        .iter()
+        .filter(|p| !is_partial(p))
+        .filter_map(|p| mod_key(root, p))
+        .collect();
+    if keys.is_empty() {
+        // Everything in the batch was scratch files, or churn directly in the root.
+        return;
+    }
+
+    let now = Instant::now();
+    let start_settling = {
+        let mut p = pending.lock().unwrap_or_else(|e| e.into_inner());
+        p.mods.extend(keys);
+        p.first_seen.get_or_insert(now);
+        p.last_seen = Some(now);
+        let start = !p.settling;
+        p.settling = true;
+        start
+    };
+
+    if start_settling {
+        let app = app.clone();
+        let pending = Arc::clone(pending);
+        let live = Arc::clone(live);
+        std::thread::spawn(move || settle_then_reload(app, pending, live));
+    }
+}
+
+/// Wait for the mods folder to stop changing, then fire one reload for the whole batch.
+fn settle_then_reload(app: AppHandle, pending: Arc<Mutex<Pending>>, live: Arc<AtomicBool>) {
+    let mods = loop {
+        std::thread::sleep(SETTLE / 3);
+        if !live.load(Ordering::SeqCst) {
+            return;
+        }
+
+        let mut p = pending.lock().unwrap_or_else(|e| e.into_inner());
+        let quiet = p.last_seen.map(|t| t.elapsed() >= SETTLE).unwrap_or(true);
+        let overdue = p.first_seen.map(|t| t.elapsed() >= MAX_SETTLE).unwrap_or(false);
+        if quiet || overdue {
+            if overdue && !quiet {
+                log::info!("mods watcher: still changing after {MAX_SETTLE:?} — reloading what's landed");
+            }
+            let taken = std::mem::take(&mut *p);
+            break taken.mods;
+        }
+    };
+
+    if mods.is_empty() {
+        return;
+    }
+    reload(&app, mods.into_iter().collect());
+}
+
+/// Tell FrostMod which mods changed, then pulse the reload it already understands.
+///
+/// Order matters: the command file is in place before the reload event fires, so a
+/// FrostMod that reads it can scope the rescan to those mods. One that doesn't simply
+/// ignores an unknown verb and does its usual full reload — no behaviour change.
+fn reload(app: &AppHandle, mods: Vec<String>) {
+    crate::frostmod::signal_reload_paths(&mods);
     let outcome = crate::frostmod::signal_reload();
-    log::info!("mods watcher: folder changed -> reload {outcome:?}");
+    log::info!("mods watcher: {} mod(s) changed -> reload {outcome:?}: {mods:?}", mods.len());
     let _ = app.emit(
         "frostmod-reload",
         WatchReload {
             slug: WATCH_SLUG,
             outcome,
+            mods,
         },
     );
 }
@@ -110,5 +269,44 @@ mod tests {
         // Must be `<mods_path>/mods`, never the root (which also holds churny profiles/).
         assert_eq!(watch_root("/games/mxb"), PathBuf::from("/games/mxb").join("mods"));
         assert!(watch_root("/games/mxb").ends_with("mods"));
+    }
+
+    #[test]
+    fn a_change_anywhere_inside_a_mod_names_that_mod() {
+        let root = Path::new("/games/mxb/mods");
+        // Every file of an extracting track collapses onto one key.
+        assert_eq!(
+            mod_key(root, &root.join("tracks/Red Bud/Red Bud.map")).as_deref(),
+            Some("tracks/Red Bud"),
+        );
+        assert_eq!(
+            mod_key(root, &root.join("tracks/Red Bud/textures/dirt.tga")).as_deref(),
+            Some("tracks/Red Bud"),
+        );
+        // A packaged mod dropped straight into its type folder is its own key.
+        assert_eq!(
+            mod_key(root, &root.join("tracks/Red Bud.pkz")).as_deref(),
+            Some("tracks/Red Bud.pkz"),
+        );
+    }
+
+    #[test]
+    fn churn_outside_a_mod_yields_no_key() {
+        let root = Path::new("/games/mxb/mods");
+        // The type folder itself changing tells us nothing about which mod moved.
+        assert_eq!(mod_key(root, &root.join("tracks")), None);
+        assert_eq!(mod_key(root, root), None);
+        // Somewhere else entirely (a watcher restart racing a path change).
+        assert_eq!(mod_key(root, Path::new("/elsewhere/x.pkz")), None);
+    }
+
+    #[test]
+    fn half_written_downloads_are_ignored() {
+        assert!(is_partial(Path::new("/m/tracks/Red Bud.pkz.crdownload")));
+        assert!(is_partial(Path::new("/m/tracks/Red Bud.pkz.part")));
+        assert!(is_partial(Path::new("/m/tracks/RedBud.TMP")));
+        assert!(is_partial(Path::new("/m/tracks/~$scratch")));
+        // The finished article must still get through.
+        assert!(!is_partial(Path::new("/m/tracks/Red Bud.pkz")));
     }
 }

--- a/src-tauri/src/pkz.rs
+++ b/src-tauri/src/pkz.rs
@@ -1,10 +1,12 @@
 use anyhow::{bail, Context, Result};
 use base64::Engine;
+use image::ImageDecoder;
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::io::{Cursor, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
+use std::sync::{Condvar, Mutex, Once, OnceLock};
 use tauri::Manager;
 use walkdir::WalkDir;
 
@@ -16,6 +18,70 @@ const THUMB_MAX: u32 = 192;
 
 /// Longest edge of the full-size preview, in pixels.
 const PREVIEW_MAX: u32 = 1100;
+
+/// Ceiling on what a single preview decode may allocate. Track previews are often
+/// uncompressed TGAs, and one oversized file shouldn't be able to claim hundreds of
+/// megabytes just to end up as a 192px thumbnail.
+const MAX_DECODE_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Widest/tallest preview we'll decode. Anything bigger is a mistake in the mod, not
+/// something a card needs.
+const MAX_DECODE_EDGE: u32 = 8192;
+
+// ===========================================================================
+// Inspection gate
+//
+// Cracking a `.pkz` open is expensive: a seek-heavy read off disk, then a preview
+// image decoded to a full-size bitmap before it's downscaled. The Library renders a
+// card per installed mod and every card asks for its metadata at once, so a large
+// collection would otherwise fan out into hundreds of concurrent blocking tasks —
+// each holding tens of megabytes of decoded pixels and competing for the same disk.
+// That is enough to push the whole machine into swap, not just stall the app.
+//
+// A small permit count keeps the work bounded no matter how many callers pile in.
+// ===========================================================================
+
+struct Gate {
+    free: Mutex<usize>,
+    ready: Condvar,
+}
+
+static INSPECT_GATE: OnceLock<Gate> = OnceLock::new();
+
+fn gate() -> &'static Gate {
+    INSPECT_GATE.get_or_init(|| Gate {
+        // Two to four at a time: enough to keep a disk busy, few enough that the
+        // peak memory of concurrent image decodes stays bounded.
+        free: Mutex::new(
+            std::thread::available_parallelism()
+                .map(|n| n.get().clamp(2, 4))
+                .unwrap_or(2),
+        ),
+        ready: Condvar::new(),
+    })
+}
+
+/// Held for the duration of one archive inspection; releases its slot on drop.
+struct Permit(&'static Gate);
+
+impl Drop for Permit {
+    fn drop(&mut self) {
+        // Recover from poisoning rather than propagating it — a panic in one
+        // inspection must not wedge the gate for every later caller.
+        *self.0.free.lock().unwrap_or_else(|e| e.into_inner()) += 1;
+        self.0.ready.notify_one();
+    }
+}
+
+fn acquire() -> Permit {
+    let gate = gate();
+    let mut free = gate.free.lock().unwrap_or_else(|e| e.into_inner());
+    while *free == 0 {
+        free = gate.ready.wait(free).unwrap_or_else(|e| e.into_inner());
+    }
+    *free -= 1;
+    Permit(gate)
+}
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -35,54 +101,120 @@ pub struct PkzMeta {
 struct CacheEntry {
     mtime_ns: u128,
     size: u64,
+    /// File name the entry was built from. Guards the (vanishingly unlikely) case of
+    /// two different mods hashing to the same cache file.
+    #[serde(default)]
+    name: String,
     meta: PkzMeta,
 }
 
-pub fn read_meta_cached(app: &tauri::AppHandle, path: &str) -> Result<PkzMeta> {
-    let file_meta = std::fs::metadata(path).with_context(|| format!("stat {path}"))?;
-    let size = file_meta.len();
-    let mtime_ns = file_meta
-        .modified()
-        .ok()
-        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
+/// Identity of a mod file for caching purposes: its name, size and mtime.
+///
+/// Deliberately *not* its full path. Pointing the app at a different MX Bikes folder —
+/// a moved install, a second copy on another drive — used to change every key at once,
+/// so a warm library went cold and re-inspected every archive in one burst. Windows
+/// preserves both timestamps and sizes across a move or copy, so identity survives.
+#[derive(Clone, Copy)]
+struct Stamp {
+    size: u64,
+    mtime_ns: u128,
+}
 
-    let cache_file = cache_path(app, path);
-    if let Some(cf) = &cache_file {
-        if let Ok(bytes) = std::fs::read(cf) {
-            if let Ok(entry) = serde_json::from_slice::<CacheEntry>(&bytes) {
-                if entry.mtime_ns == mtime_ns && entry.size == size {
-                    return Ok(entry.meta);
-                }
-            }
-        }
+fn stamp(path: &str) -> Result<Stamp> {
+    let file_meta = std::fs::metadata(path).with_context(|| format!("stat {path}"))?;
+    Ok(Stamp {
+        size: file_meta.len(),
+        mtime_ns: file_meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_nanos())
+            .unwrap_or(0),
+    })
+}
+
+fn file_name_of(path: &str) -> String {
+    Path::new(path)
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+pub fn read_meta_cached(app: &tauri::AppHandle, path: &str) -> Result<PkzMeta> {
+    let stamp = stamp(path)?;
+    let cache_file = cache_path(app, path, stamp);
+    if let Some(meta) = cache_file.as_deref().and_then(|cf| read_cache(cf, path, stamp)) {
+        return Ok(meta);
+    }
+
+    // Only genuine misses queue for the disk + decode work.
+    let _permit = acquire();
+    // Someone ahead of us in the queue may have been inspecting this very file.
+    if let Some(meta) = cache_file.as_deref().and_then(|cf| read_cache(cf, path, stamp)) {
+        return Ok(meta);
     }
 
     let meta = read_meta(Path::new(path))?;
-
     if let Some(cf) = &cache_file {
-        if let Some(parent) = cf.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
-        let entry = CacheEntry {
-            mtime_ns,
-            size,
-            meta: meta.clone(),
-        };
-        if let Ok(bytes) = serde_json::to_vec(&entry) {
-            let _ = std::fs::write(cf, bytes);
-        }
+        write_cache(cf, path, stamp, &meta);
     }
-
     Ok(meta)
 }
 
-fn cache_path(app: &tauri::AppHandle, source: &str) -> Option<PathBuf> {
-    let dir = app.path().app_cache_dir().ok()?.join("pkz-meta");
+/// Metadata for `path` only if it's already cached — never opens the archive.
+///
+/// Lets the Library paint every card it has seen before in one pass, leaving the
+/// gated inspection above for the handful of entries that are genuinely new.
+pub fn read_meta_if_cached(app: &tauri::AppHandle, path: &str) -> Option<PkzMeta> {
+    let stamp = stamp(path).ok()?;
+    let cache_file = cache_path(app, path, stamp)?;
+    read_cache(&cache_file, path, stamp)
+}
+
+fn read_cache(cache_file: &Path, path: &str, stamp: Stamp) -> Option<PkzMeta> {
+    let bytes = std::fs::read(cache_file).ok()?;
+    let entry: CacheEntry = serde_json::from_slice(&bytes).ok()?;
+    let same_file =
+        entry.mtime_ns == stamp.mtime_ns && entry.size == stamp.size && entry.name == file_name_of(path);
+    same_file.then_some(entry.meta)
+}
+
+fn write_cache(cache_file: &Path, path: &str, stamp: Stamp, meta: &PkzMeta) {
+    if let Some(parent) = cache_file.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let entry = CacheEntry {
+        mtime_ns: stamp.mtime_ns,
+        size: stamp.size,
+        name: file_name_of(path),
+        meta: meta.clone(),
+    };
+    if let Ok(bytes) = serde_json::to_vec(&entry) {
+        let _ = std::fs::write(cache_file, bytes);
+    }
+}
+
+/// Bumped when the key changes shape, so stale entries are ignored rather than
+/// misread. The previous generation was keyed on the absolute path.
+const CACHE_DIR: &str = "pkz-meta-v2";
+
+fn cache_path(app: &tauri::AppHandle, source: &str, stamp: Stamp) -> Option<PathBuf> {
+    let cache_root = app.path().app_cache_dir().ok()?;
+    drop_stale_cache(&cache_root);
+
     let mut hasher = DefaultHasher::new();
-    source.hash(&mut hasher);
-    Some(dir.join(format!("{:016x}.json", hasher.finish())))
+    file_name_of(source).hash(&mut hasher);
+    stamp.size.hash(&mut hasher);
+    stamp.mtime_ns.hash(&mut hasher);
+    Some(cache_root.join(CACHE_DIR).join(format!("{:016x}.json", hasher.finish())))
+}
+
+/// Clear out the path-keyed generation once per run — nothing will ever read it again.
+fn drop_stale_cache(cache_root: &Path) {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let _ = std::fs::remove_dir_all(cache_root.join("pkz-meta"));
+    });
 }
 
 pub fn read_meta(path: &Path) -> Result<PkzMeta> {
@@ -90,6 +222,7 @@ pub fn read_meta(path: &Path) -> Result<PkzMeta> {
 }
 
 pub fn read_preview(path: &Path) -> Result<Option<String>> {
+    let _permit = acquire();
     let (_, image) = inspect(path)?;
     Ok(image.and_then(|(name, bytes)| make_thumbnail(&name, &bytes, PREVIEW_MAX)))
 }
@@ -356,12 +489,27 @@ fn image_score(name: &str) -> i32 {
     score
 }
 
+/// Allocation ceiling applied to every preview decode. Without it a single
+/// mis-authored image can claim far more memory than the thumbnail it produces.
+fn decode_limits() -> image::Limits {
+    let mut limits = image::Limits::no_limits();
+    limits.max_alloc = Some(MAX_DECODE_BYTES);
+    limits.max_image_width = Some(MAX_DECODE_EDGE);
+    limits.max_image_height = Some(MAX_DECODE_EDGE);
+    limits
+}
+
 fn make_thumbnail(name: &str, bytes: &[u8], max: u32) -> Option<String> {
     let img = if name.to_ascii_lowercase().ends_with(".tga") {
-        let dec = image::codecs::tga::TgaDecoder::new(Cursor::new(bytes)).ok()?;
+        let mut dec = image::codecs::tga::TgaDecoder::new(Cursor::new(bytes)).ok()?;
+        dec.set_limits(decode_limits()).ok()?;
         image::DynamicImage::from_decoder(dec).ok()?
     } else {
-        image::load_from_memory(bytes).ok()?
+        let mut reader = image::ImageReader::new(Cursor::new(bytes))
+            .with_guessed_format()
+            .ok()?;
+        reader.limits(decode_limits());
+        reader.decode().ok()?
     };
 
     // Drop to RGB — JPEG can't hold the alpha a TGA may decode to.
@@ -532,6 +680,81 @@ fn extract_plain(path: &Path, out_dir: &Path) -> Result<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    fn tmp_dir(name: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("frost-pkz-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn cached_metadata_survives_the_library_moving() {
+        let dir = tmp_dir("cache-move");
+        let cache_file = dir.join("entry.json");
+        let stamp = Stamp { size: 1234, mtime_ns: 999 };
+        let meta = PkzMeta {
+            name: Some("Red Bud".into()),
+            ..Default::default()
+        };
+        write_cache(&cache_file, "/old/mods/tracks/Red Bud.pkz", stamp, &meta);
+
+        // Same file, different folder: pointing the app at a moved MX Bikes install
+        // must not re-inspect every archive it already knows.
+        let hit = read_cache(&cache_file, "/new/drive/mods/tracks/Red Bud.pkz", stamp);
+        assert_eq!(hit.and_then(|m| m.name).as_deref(), Some("Red Bud"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_replaced_or_different_mod_is_not_a_cache_hit() {
+        let dir = tmp_dir("cache-miss");
+        let cache_file = dir.join("entry.json");
+        let stamp = Stamp { size: 1234, mtime_ns: 999 };
+        write_cache(&cache_file, "/mods/tracks/Red Bud.pkz", stamp, &PkzMeta::default());
+
+        // Updated in place — same name and path, new contents.
+        let resized = Stamp { size: 4321, ..stamp };
+        assert!(read_cache(&cache_file, "/mods/tracks/Red Bud.pkz", resized).is_none());
+        let retouched = Stamp { mtime_ns: 1000, ..stamp };
+        assert!(read_cache(&cache_file, "/mods/tracks/Red Bud.pkz", retouched).is_none());
+        // A different mod that happens to hash to the same cache file.
+        assert!(read_cache(&cache_file, "/mods/tracks/Other.pkz", stamp).is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn inspection_gate_bounds_concurrent_reads() {
+        // The Library asks for every card's metadata at once. Letting all of those
+        // open archives and decode previews simultaneously is what locked machines
+        // up, so the gate has to hold regardless of how many callers arrive.
+        let live = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+
+        let threads: Vec<_> = (0..32)
+            .map(|_| {
+                let (live, peak) = (Arc::clone(&live), Arc::clone(&peak));
+                std::thread::spawn(move || {
+                    let _permit = acquire();
+                    let now = live.fetch_add(1, Ordering::SeqCst) + 1;
+                    peak.fetch_max(now, Ordering::SeqCst);
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                    live.fetch_sub(1, Ordering::SeqCst);
+                })
+            })
+            .collect();
+        for t in threads {
+            t.join().unwrap();
+        }
+
+        let peak = peak.load(Ordering::SeqCst);
+        assert!(peak >= 1, "the gate must let work through at all");
+        assert!(peak <= 4, "at most 4 inspections at once, saw {peak}");
+    }
 
     /// `MXB_DUMP_PKZ='…/rider.pkz' cargo test dump_pkz_layout -- --ignored --nocapture`
     #[test]

--- a/src/Components/Library/Library.tsx
+++ b/src/Components/Library/Library.tsx
@@ -20,7 +20,6 @@ import { toast } from "sonner";
 import {
   MOD_TYPES,
   scanLibrary,
-  getPkzMeta,
   moveMod,
   revealInExplorer,
   uninstallMod,
@@ -28,6 +27,7 @@ import {
 } from "../../api/mods";
 import type { LibraryEntry, PkzMeta } from "../../types";
 import { displayName, folderLabel, formatBytes, formatLength } from "../../lib/mods";
+import { metaKey, peekMeta, primeMetaCache, requestMeta } from "../../lib/pkzMeta";
 import {
   CATEGORY_LABEL,
   SECTION_LABEL,
@@ -84,8 +84,6 @@ interface RowAction {
   separatorBefore?: boolean;
 }
 
-const metaCache = new Map<string, PkzMeta>();
-
 function LibraryCardBody({
   item,
   typeIcon: TypeIcon,
@@ -93,31 +91,41 @@ function LibraryCardBody({
   item: LibraryEntry;
   typeIcon: LucideIcon;
 }) {
-  const cacheKey = `${item.path}:${item.size}`;
-  const [meta, setMeta] = useState<PkzMeta | null>(
-    () => metaCache.get(cacheKey) ?? null,
-  );
+  const cacheKey = metaKey(item);
+  const [meta, setMeta] = useState<PkzMeta | null>(() => peekMeta(cacheKey) ?? null);
+  // The thumbnail tile doubles as the visibility probe for the card.
+  const [tile, setTile] = useState<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    const cached = metaCache.get(cacheKey);
+    const cached = peekMeta(cacheKey);
     if (cached) {
       setMeta(cached);
       return;
     }
-    let alive = true;
     setMeta(null);
-    getPkzMeta(item.path)
-      .then((m) => {
-        metaCache.set(cacheKey, m);
-        if (alive) setMeta(m);
-      })
-      .catch(() => {
-        /* leave the icon/size fallback in place */
-      });
+    if (!tile) return;
+
+    // Reading metadata means opening the archive and decoding its preview, so only
+    // the cards a player actually scrolls to are worth it. Asking for all of them the
+    // moment the grid renders is what made a large library lock the machine up.
+    let alive = true;
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((e) => e.isIntersecting)) return;
+        io.disconnect();
+        void requestMeta(item.path, cacheKey).then((m) => {
+          if (alive && m) setMeta(m);
+        });
+      },
+      // A little ahead of the viewport, so scrolling finds them already loaded.
+      { rootMargin: "400px" },
+    );
+    io.observe(tile);
     return () => {
       alive = false;
+      io.disconnect();
     };
-  }, [item.path, cacheKey]);
+  }, [item.path, cacheKey, tile]);
 
   const title = meta?.name?.trim() || displayName(item.name);
   const parts: string[] = [];
@@ -128,7 +136,10 @@ function LibraryCardBody({
 
   return (
     <>
-      <div className="relative grid h-12 w-[76px] flex-none place-items-center overflow-hidden rounded-md bg-gradient-to-br from-[#3a3f45] to-[#20242a] text-foreground/25">
+      <div
+        ref={setTile}
+        className="relative grid h-12 w-[76px] flex-none place-items-center overflow-hidden rounded-md bg-gradient-to-br from-[#3a3f45] to-[#20242a] text-foreground/25"
+      >
         {meta?.thumbnail ? (
           <img src={meta.thumbnail} alt="" className="h-full w-full object-cover" />
         ) : (
@@ -247,7 +258,11 @@ export default function Library({
     setLoading(true);
     setError(null);
     try {
-      setEntries(await scanLibrary(modType.installSubpath));
+      const scanned = await scanLibrary(modType.installSubpath);
+      // Pull everything already known in one round trip, so a library that's been
+      // opened before renders complete without touching a single archive.
+      await primeMetaCache(scanned);
+      setEntries(scanned);
     } catch (e) {
       setError(String(e));
     } finally {

--- a/src/Context/Frostmod.tsx
+++ b/src/Context/Frostmod.tsx
@@ -28,13 +28,12 @@ const POLL_MS = 5000;
  * the drop had been seen at all.
  */
 function watchDescription(mods: string[]): string {
-  if (mods.length === 0) {
-    return "FrostMod refreshed the game with your folder changes.";
-  }
+  const asked = "Asked FrostMod to reload the game.";
+  if (mods.length === 0) return asked;
   const names = mods.map((m) => displayName(m.split("/").pop() ?? m));
   const shown = names.slice(0, 3).join(", ");
   const rest = names.length - 3;
-  return rest > 0 ? `${shown} and ${rest} more` : shown;
+  return `${rest > 0 ? `${shown} and ${rest} more` : shown} — ${asked.toLowerCase()}`;
 }
 
 export function FrostmodProvider({ children }: { children: ReactNode }) {
@@ -92,9 +91,12 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
     void onFrostmodReload((p) => {
       if (p.slug !== MODS_WATCH_SLUG) return;
       if (p.outcome === "signaled") {
+        // "Added", not "loaded": signalling FrostMod only tells us its reload event
+        // exists and was poked — whether the game picked the mods up is FrostMod's to
+        // report, and claiming otherwise is what makes a failed reload so confusing.
         const mods = p.mods ?? [];
         toast.success(
-          mods.length === 1 ? "New mod loaded" : `${mods.length || "New"} mods loaded`,
+          mods.length === 1 ? "New mod added" : `${mods.length || "New"} mods added`,
           { description: watchDescription(mods) },
         );
       }

--- a/src/Context/Frostmod.tsx
+++ b/src/Context/Frostmod.tsx
@@ -17,9 +17,25 @@ import {
   reloadFrostmod,
 } from "../api/mods";
 import type { FrostmodStatus } from "../types";
+import { displayName } from "../lib/mods";
 import { FrostmodContext } from "./FrostmodContext";
 
 const POLL_MS = 5000;
+
+/**
+ * Name what the folder watcher picked up. The watcher reports mods as `<type>/<name>`;
+ * showing them beats a generic "your folder changed", which left people unsure whether
+ * the drop had been seen at all.
+ */
+function watchDescription(mods: string[]): string {
+  if (mods.length === 0) {
+    return "FrostMod refreshed the game with your folder changes.";
+  }
+  const names = mods.map((m) => displayName(m.split("/").pop() ?? m));
+  const shown = names.slice(0, 3).join(", ");
+  const rest = names.length - 3;
+  return rest > 0 ? `${shown} and ${rest} more` : shown;
+}
 
 export function FrostmodProvider({ children }: { children: ReactNode }) {
   const [running, setRunning] = useState<boolean | null>(null);
@@ -76,9 +92,11 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
     void onFrostmodReload((p) => {
       if (p.slug !== MODS_WATCH_SLUG) return;
       if (p.outcome === "signaled") {
-        toast.success("New mods loaded", {
-          description: "FrostMod refreshed the game with your folder changes.",
-        });
+        const mods = p.mods ?? [];
+        toast.success(
+          mods.length === 1 ? "New mod loaded" : `${mods.length || "New"} mods loaded`,
+          { description: watchDescription(mods) },
+        );
       }
       void probe();
     }).then((fn) => {

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -230,6 +230,15 @@ export function getPkzMeta(path: string): Promise<PkzMeta> {
   return invoke<PkzMeta>("get_pkz_meta", { path });
 }
 
+/**
+ * Metadata for many mods in one call, but only where it's already cached — a `null`
+ * marks an entry that still needs {@link getPkzMeta}. Lets a known library paint
+ * without opening a single archive.
+ */
+export function getPkzMetaCached(paths: string[]): Promise<(PkzMeta | null)[]> {
+  return invoke<(PkzMeta | null)[]>("get_pkz_meta_cached", { paths });
+}
+
 export function getPkzPreview(path: string): Promise<string | null> {
   return invoke<string | null>("get_pkz_preview", { path });
 }

--- a/src/lib/pkzMeta.ts
+++ b/src/lib/pkzMeta.ts
@@ -1,0 +1,100 @@
+import { getPkzMeta, getPkzMetaCached } from "../api/mods";
+import type { LibraryEntry, PkzMeta } from "../types";
+
+/**
+ * Shared store for mod metadata (name, author, thumbnail) read out of `.pkz` archives.
+ *
+ * Reading one means opening the archive and decoding its preview image, so a library
+ * of a few hundred mods can't simply ask for all of them at once — that fans out into
+ * hundreds of concurrent archive reads and image decodes, which is enough to bring a
+ * machine to its knees rather than just making the app slow.
+ *
+ * Three things keep it bounded:
+ *
+ * 1. {@link primeMetaCache} pulls everything already cached on disk in a single round
+ *    trip, so a library that has been opened before needs no archive reads at all.
+ * 2. Callers request the remainder only when the card is actually on screen.
+ * 3. {@link requestMeta} lets a few of those run at a time and shares in-flight work.
+ */
+
+const cache = new Map<string, PkzMeta>();
+const inflight = new Map<string, Promise<PkzMeta | null>>();
+
+/** Size is part of the key so replacing a mod in place invalidates its entry. */
+export function metaKey(entry: Pick<LibraryEntry, "path" | "size">): string {
+  return `${entry.path}:${entry.size}`;
+}
+
+/** Metadata already in hand, if any — never triggers a read. */
+export function peekMeta(key: string): PkzMeta | undefined {
+  return cache.get(key);
+}
+
+/**
+ * Fill the store from the on-disk cache for a freshly scanned library, in one call.
+ * Entries the backend hasn't inspected yet are simply left out. Never rejects — a
+ * failure here just means the cards fall back to requesting metadata individually.
+ */
+export async function primeMetaCache(entries: LibraryEntry[]): Promise<void> {
+  const wanted = entries.filter((e) => !cache.has(metaKey(e)));
+  if (wanted.length === 0) return;
+  try {
+    const metas = await getPkzMetaCached(wanted.map((e) => e.path));
+    metas.forEach((meta, i) => {
+      if (meta) cache.set(metaKey(wanted[i]), meta);
+    });
+  } catch {
+    /* fall back to per-card requests */
+  }
+}
+
+/** How many archives we ask the backend to open at once. */
+const MAX_PARALLEL = 3;
+
+let active = 0;
+const waiting: Array<() => void> = [];
+
+function acquire(): Promise<void> {
+  if (active < MAX_PARALLEL) {
+    active += 1;
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    waiting.push(() => {
+      active += 1;
+      resolve();
+    });
+  });
+}
+
+function release(): void {
+  active -= 1;
+  waiting.shift()?.();
+}
+
+/**
+ * Read a mod's metadata, queued behind whatever else is in flight. Resolves `null`
+ * when the archive can't be read — the caller keeps its icon-and-size fallback.
+ */
+export function requestMeta(path: string, key: string): Promise<PkzMeta | null> {
+  const cached = cache.get(key);
+  if (cached) return Promise.resolve(cached);
+
+  const pending = inflight.get(key);
+  if (pending) return pending;
+
+  const run = acquire()
+    .then(() => getPkzMeta(path))
+    .then((meta) => {
+      cache.set(key, meta);
+      return meta;
+    })
+    .catch(() => null)
+    .finally(() => {
+      release();
+      inflight.delete(key);
+    });
+
+  inflight.set(key, run);
+  return run;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -295,6 +295,9 @@ export type ReloadOutcome = "signaled" | "not_running" | "unsupported";
 export interface FrostmodReload {
   slug: string;
   outcome: ReloadOutcome;
+  /** Mods the folder watcher saw change, as `<type>/<name>`. Only the watcher sets
+   *  this — an in-app install already knows what it placed. */
+  mods?: string[];
 }
 
 export type LiveRefresh =


### PR DESCRIPTION
Two reports, same wall: one froze on first launch with a large collection, one froze every time they changed their mods location. Both are the same storm.

## The freeze

The Library renders a card per installed mod, and every card fired `getPkzMeta` the moment it mounted. Each request opens the `.pkz`, reads its descriptor, and decodes the preview image to a **full-size bitmap** before shrinking it to a 192px thumbnail — a 4096² TGA is ~67 MB resident. Nothing bounded the fan-out on either side, so a few hundred mods meant a few hundred concurrent archive reads and image decodes competing for the same disk and RAM. That's a whole-PC stall, not an app hang — and it matches "let it sit a while and then it worked", because the second pass hits a warm cache.

The mods-location freeze is the same storm with a different trigger: cache entries were keyed on the mod's **absolute path**, so repointing the folder invalidated every entry at once and re-inspected the entire collection.

- Cards request metadata only once they scroll into view (`IntersectionObserver`, 400px margin), throttled to 3 in flight.
- The backend gates archive inspection to 2–4 concurrent regardless of how many callers arrive, and caps what one preview decode may allocate. The gate is the real safety net — no UI change can reopen the floodgates.
- Cache keys move to file identity (name, size, mtime), which survives a move or copy. The old path-keyed generation is cleared once on startup.
- A freshly scanned library pulls everything already cached in one round trip instead of one request per card.
- `set_mods_path` was a sync command, i.e. running on the UI thread — now async.
- `scan_tracks` walked the tracks tree twice and compared every path against every track found so far; it's one pruned pass now.

## The folder watcher

It pulsed a reload on every debounced burst, so dropping a folder of tracks in asked the game to rescan *while the files were still being written* — a plausible cause of a track that only shows up after a full game restart.

- Accumulate changes until the folder goes quiet (3s, capped at 45s), then fire one reload.
- Skip half-written downloads (`.crdownload`, `.part`, `.tmp`).
- Collapse every change inside a mod to one entry, so an extracting track counts once rather than hundreds of times.
- Retire a settle thread when the watcher stops, so turning auto-reload off takes effect immediately.

Scoping the reload to just the new mods stays FrostMod's call — `RequestReload()` already rebuilds the content lists surgically, one list per frame. All this side owes it is a single pulse once the writes are done.

The watcher toast also stopped claiming more than it knows. Signalling only tells us FrostMod's reload event exists and was poked; FrostMod can still abort on an offsets mismatch or drop the request as re-entrant. It now says the mods were *added* and a reload was *asked for*.

## Testing

- 128 Rust tests pass (11 new), `npm run typecheck`, `npm run lint` and `npm run build` clean.
- New coverage: the inspection gate holds under 32 concurrent callers; cache hits survive a folder move and miss on a replaced file; the watcher's coalescing is asserted against an injected clock (one reload per copy, collapse-per-mod, the 45s cap, and a fresh batch after taking one).
- **Not tested:** the actual in-game reload, and the library scan against a real large mods folder — neither is reachable from CI. Worth confirming on a Windows box before release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVf783R9t3S3h8mQBQwL6d)_