### PR TITLE
chore(release): v0.6.2 — mod-manager performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased — mod-manager performance, Discord release announcements
+## 2026-08-06 — v0.6.2 — mod-manager performance, Discord release announcements
 
 ### Added
 - **Every tagged release now announces itself in Discord.** A new `notify` job runs after
@@ -16,8 +16,6 @@
   - The webhook is a credential and lives in the `DISCORD_WEBHOOK_URL` Actions secret,
     never in the repo. If it's missing the job warns and passes rather than failing a
     release that already built and published fine.
-
-### Added
 - **`Join the Discord` in Settings → About & updates**, opening the community invite in
   the system browser. The invite is permanent — a link that expires would leave a dead
   button in every already-shipped build.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
     never in the repo. If it's missing the job warns and passes rather than failing a
     release that already built and published fine.
 
+### Added
+- **`Join the Discord` in Settings → About & updates**, opening the community invite in
+  the system browser. The invite is permanent — a link that expires would leave a dead
+  button in every already-shipped build.
+
 ### Fixed
 - **A large library no longer locks the machine up on first open, or after changing the
   MX Bikes folder.** Two people hit the same wall from different directions — one on the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frost",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frost",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.19",
         "@radix-ui/react-context-menu": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "frost"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frost"
-version = "0.6.1"
+version = "0.6.2"
 description = "Frost — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Check, RefreshCw, ExternalLink, Play, Compass } from "lucide-react";
+import { Check, RefreshCw, ExternalLink, Play, Compass, MessagesSquare } from "lucide-react";
 import { open as pickFolder } from "@tauri-apps/plugin-dialog";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
 import { getVersion } from "@tauri-apps/api/app";
@@ -28,6 +28,9 @@ import { Switch } from "@/Components/ui/switch";
 import { cn } from "@/lib/utils";
 
 const REPO_URL = "https://github.com/Frostn1/mxb-app";
+// Permanent invite (no expiry, no use cap) — a link that dies leaves a dead button
+// in a shipped build, and the app can't be told about a new one without an update.
+const DISCORD_URL = "https://discord.gg/3994Rr3ywb";
 
 type SectionId = "folder" | "general" | "appearance" | "frostmod" | "about";
 const SECTIONS: { id: SectionId; label: string }[] = [
@@ -583,6 +586,9 @@ export default function Settings() {
               </Button>
               <Button variant="outline" size="sm" onClick={startTour}>
                 <Compass className="size-3.5" /> Replay tour
+              </Button>
+              <Button variant="outline" size="sm" onClick={() => openUrl(DISCORD_URL)}>
+                <MessagesSquare className="size-3.5" /> Join the Discord
               </Button>
             </div>
             <div className="flex flex-col gap-1 pt-1 text-[11.5px] text-faint">


### PR DESCRIPTION
Cuts **v0.6.2**. The performance work itself already landed on `main` in #17 — this bumps the version, dates the CHANGELOG section, and adds the Discord link.

## What ships

**Fixed — a large library no longer locks the machine up** on first open or after changing the MX Bikes folder. Every Library card fired `getPkzMeta` on mount, and each one decodes a preview to a full-size bitmap before thumbnailing it, so a few hundred mods meant a few hundred simultaneous archive reads and image decodes. Cards now load on scroll, the backend gates inspection to 2–4 regardless of caller count, decodes have an allocation cap, and cache keys moved from absolute path to file identity so repointing the folder no longer invalidates everything at once.

**Changed — the folder watcher waits for a copy to finish.** It coalesces until the folder goes quiet instead of pulsing mid-write, skips half-written downloads and collapses per-mod. The `reload_paths` verb is gone: scoping the reload is FrostMod's job, and its stepped rebuild already does it surgically.

**Added — `Join the Discord`** in Settings → About & updates, opening the invite via the shell plugin. Reuses the existing About section and the same `openUrl` path as the GitHub/Changelog links.

## Verification

Local, matching the CI gate: typecheck clean, lint 0 errors (3 pre-existing warnings, none added), build ok, `cargo test --locked` **128 passed / 0 failed**.

Two things checked rather than assumed:
- The invite resolves to guild "The MXB App" with `expires_at: null` — permanent, so it won't become a dead button in a shipped build.
- `shell:allow-open` is granted with no `plugins.shell.open` override, so the plugin's default URL regex accepts `discord.gg`. A scoped allowlist would have made the button silently no-op in a release build.

## After merge

Tag `v0.6.2` on the merge commit, matching v0.6.1. That fires `release.yml` (Windows + macOS bundles, published release, updater `latest.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)