### PR TITLE
fix(locker): stop a model swap from taking the bike with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Swapping a bike's model no longer takes the bike with it.** The swapper treated every
+  loose file in `mods/bikes/<Bike>/` as part of the model, so a swap carted the bike's own
+  setup — the `.hrc` files naming each part's mesh, plus `.cfg` and `.geom` — off into
+  `FrostMod Models/`. The game then couldn't see the bike at all, which is why a swapped
+  model "didn't show in game" and then the bike itself vanished from the list. A swap now
+  moves only the files a swap actually provides:
+  - Each parked set records what it owns in `_files.txt` on the way in, so the reverse
+    swap moves back exactly what it moved out instead of guessing.
+  - Before any manifest exists, the set is scoped to the meshes at the bike root plus
+    whatever that bike's other swap folders contain — self-scoping, and it leaves setup
+    files the swaps never mention exactly where the game expects them.
+  - A swap that legitimately ships its own `.hrc` still displaces the bike's, and still
+    gives it back when you swap away.
+- **Bikes already broken by this can be repaired in one click.** The Locker now spots a
+  bike with no `.hrc` at its root — nothing left to tell the game which mesh each part
+  uses — and offers to put the missing files back from the swap folder holding them. It
+  copies rather than moves, so repairing can't break the swap set they came from, and a
+  bike stripped bare (what swapping to an empty "no model" variant used to do) gets its
+  whole set back and its active marker corrected, rather than setup with no model. Bikes
+  that carry a packed `.pkz` inside their folder are left alone — a missing `.hrc` is
+  normal there, since the loose files only layer over the packed bike.
+- **Bikes and swaps whose mesh isn't called `model.edf` are visible again.** A bike may
+  split its mesh one `.edf` per part (`96cr250.edf`, `96cr250_st.edf`, …); the viewer
+  learned that in 0.5.2 but the swapper never did, so those bikes never appeared in the
+  Locker, their swap folders were never offered for registration, and applying one failed
+  with "missing its model.edf". Both sides now share one definition of a bike's files
+  (`bikefiles`) and accept any `.edf` as a mesh.
+- **Model swaps show up in Presets.** The scan keys on the bike's folder name while the
+  Presets slot asked by the `bikeid` in `profile.ini`; the two agree in case only by
+  convention, and any divergence silently produced an empty dropdown. The lookup is now
+  case-insensitive, for bike paints as well. Incomplete sets (files but no mesh) are no
+  longer offered, since applying one could only fail.
+
+### Changed
+- **The Locker says what to do when it finds nothing**, instead of only what's missing —
+  the two conditions a swap needs, and a Scan button — and the empty "Model swap" slot in
+  Presets now explains that swaps are registered in the Locker and links there.
+- **New swaps get noticed.** The startup prompt to file loose swap folders used to show
+  once ever; it now tracks which folders it has asked about, so a swap installed later
+  still gets offered. The Locker and Presets also re-scan when the mods folder changes,
+  rather than waiting for a manual Refresh.
+
 ## 2026-08-06 — v0.6.2 — mod-manager performance, Discord release announcements
 
 ### Added

--- a/src-tauri/src/bikefiles.rs
+++ b/src-tauri/src/bikefiles.rs
@@ -1,0 +1,81 @@
+//! What the files inside a bike folder are, by name.
+//!
+//! A bike folder is not one thing. Some of its files are the **mesh** the bike renders
+//! with (`model.edf` by convention, but a bike may split its mesh one-EDF-per-part —
+//! `96cr250.edf`, `96cr250_st.edf`, … — named by its `.hrc`). Others are the bike's
+//! **setup**: the `.hrc`s that say which mesh a part uses, plus `.cfg` and `.geom`.
+//! Those belong to the bike itself, not to any one model, and a model swap must leave
+//! them alone — moving them is what makes the game stop seeing the bike at all.
+//!
+//! Shared so the viewer (`gather_bike_files`) and the swapper (`modelswap`) agree.
+
+fn base_name(name: &str) -> String {
+    name.rsplit(['/', '\\']).next().unwrap_or(name).to_ascii_lowercase()
+}
+
+fn has_ext(name: &str, ext: &str) -> bool {
+    base_name(name).ends_with(ext)
+}
+
+/// A renderable mesh. Any `.edf` — `model.edf` is the convention, not a rule.
+pub fn is_mesh(name: &str) -> bool {
+    has_ext(name, ".edf")
+}
+
+/// True if the directory holds at least one mesh, i.e. it is a model set.
+pub fn dir_has_mesh(dir: &std::path::Path) -> bool {
+    match std::fs::read_dir(dir) {
+        Ok(rd) => rd.flatten().any(|e| {
+            e.path().is_file()
+                && e.file_name().to_str().is_some_and(is_mesh)
+        }),
+        Err(_) => false,
+    }
+}
+
+/// The bike's own setup, shared by every model: the `.hrc`s naming each part's scene,
+/// plus `.cfg` and `.geom`. Never part of a model set.
+pub fn is_bike_setup(name: &str) -> bool {
+    has_ext(name, ".hrc") || has_ext(name, ".cfg") || has_ext(name, ".geom")
+}
+
+/// Everything the viewer needs to read to draw a bike.
+pub fn is_viewer_file(name: &str) -> bool {
+    is_mesh(name) || is_bike_setup(name) || has_ext(name, ".tga") || has_ext(name, ".pnt")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mesh_is_any_edf() {
+        assert!(is_mesh("model.edf"));
+        assert!(is_mesh("96cr250.edf"));
+        assert!(is_mesh("96cr250_st.edf"));
+        assert!(is_mesh("MODEL.EDF"));
+        assert!(is_mesh("bikes/honda/96cr250.edf"));
+        assert!(!is_mesh("chassis.hrc"));
+        assert!(!is_mesh("model.edf.bak"));
+    }
+
+    #[test]
+    fn setup_files_are_not_model_files() {
+        for f in ["chassis.hrc", "bike.cfg", "wheel.geom", "STEER.HRC"] {
+            assert!(is_bike_setup(f), "{f}");
+            assert!(!is_mesh(f), "{f}");
+        }
+        for f in ["model.edf", "paint.tga", "livery.pnt"] {
+            assert!(!is_bike_setup(f), "{f}");
+        }
+    }
+
+    #[test]
+    fn viewer_file_covers_the_old_hardcoded_list() {
+        for f in ["a.edf", "a.tga", "a.pnt", "a.geom", "a.cfg", "a.hrc"] {
+            assert!(is_viewer_file(f), "{f}");
+        }
+        assert!(!is_viewer_file("readme.txt"));
+        assert!(!is_viewer_file("engine.scl"));
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,7 @@
 // Prevents an additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod bikefiles;
 mod bikeswap;
 mod bundle;
 mod cfg;
@@ -273,6 +274,28 @@ fn register_loose_swaps_blocking(
 ) -> Result<modelswap::RegisterReport, String> {
     let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
     modelswap::register_loose_swaps(&cfg.mods_path, move_files).map_err(|e| format!("{e:#}"))
+}
+
+#[tauri::command]
+async fn detect_orphaned_setup(
+    app: tauri::AppHandle,
+) -> Result<Vec<modelswap::OrphanedSetup>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
+        Ok(modelswap::detect_orphaned_setup(&cfg.mods_path))
+    })
+    .await
+    .map_err(|e| format!("detect_orphaned_setup task failed: {e}"))?
+}
+
+#[tauri::command]
+async fn repair_orphaned_setup(app: tauri::AppHandle, bike: String) -> Result<usize, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
+        modelswap::repair_orphaned_setup(&cfg.mods_path, &bike).map_err(|e| format!("{e:#}"))
+    })
+    .await
+    .map_err(|e| format!("repair_orphaned_setup task failed: {e}"))?
 }
 
 #[tauri::command]
@@ -684,17 +707,10 @@ fn installed_paints(source: &std::path::Path) -> Vec<(String, Vec<u8>)> {
     out
 }
 
-fn wanted_bike_file(name: &str) -> bool {
-    let bn = name.rsplit('/').next().unwrap_or(name).to_ascii_lowercase();
-    // Any `.edf`, not just `model.edf`: a bike may ship one mesh per part, named by
-    // its `.hrc` (see `scene_files_for_parts`). Shadow meshes ride along unused.
-    bn.ends_with(".edf")
-        || bn.ends_with(".tga")
-        || bn.ends_with(".pnt")
-        || bn.ends_with(".geom")
-        || bn.ends_with(".cfg")
-        || bn.ends_with(".hrc")
-}
+// Any `.edf`, not just `model.edf`: a bike may ship one mesh per part, named by its
+// `.hrc` (see `scene_files_for_parts`). Shadow meshes ride along unused. Shared with
+// `modelswap` so the swapper and the viewer classify the same files the same way.
+use bikefiles::is_viewer_file as wanted_bike_file;
 
 /// The bike's main mesh when the `.hrc`s can't say which it is: `model.edf` by
 /// convention, else the shortest non-shadow name — a per-part set like `96cr250.edf` /
@@ -1960,6 +1976,8 @@ fn main() {
             unbind_sound,
             detect_loose_swaps,
             register_loose_swaps,
+            detect_orphaned_setup,
+            repair_orphaned_setup,
             add_to_library,
             import_file,
             move_mod,
@@ -2009,48 +2027,6 @@ fn main() {
 
 #[cfg(test)]
 mod viewer_tests {
-    // TEMP DIAGNOSTIC — remove before commit.
-    #[test]
-    #[ignore]
-    fn tmp_dump_pools() {
-        let path = std::env::var("MXB_REAL_PKZ").expect("set MXB_REAL_PKZ");
-        let files = super::gather_bike_files(std::path::Path::new(&path)).expect("files");
-        for (name, data) in &files {
-            let bn = name.rsplit('/').next().unwrap_or(name).to_ascii_lowercase();
-            if !bn.ends_with(".edf") {
-                continue;
-            }
-            eprintln!("=== {bn} ({} bytes)", data.len());
-            if let Ok(dir) = std::env::var("MXB_DUMP_DIR") {
-                std::fs::write(std::path::Path::new(&dir).join(&bn), data).unwrap();
-            }
-            let embedded = crate::edf::embedded_textures(data);
-            for (i, t) in embedded.iter().enumerate() {
-                eprintln!("   embedded[{i}] {} {}x{}", t.name, t.width, t.height);
-            }
-            let color: Vec<&crate::edf::EmbeddedTexture> = embedded
-                .iter()
-                .filter(|t| {
-                    let n = t.name.to_ascii_lowercase();
-                    !n.ends_with("_n") && !n.ends_with("_s") && !n.ends_with("_r")
-                })
-                .collect();
-            for (i, t) in color.iter().enumerate() {
-                eprintln!("   color[{i}] {}", t.name);
-            }
-            let nodes = crate::edf::parse_with_levels(data, &[]);
-            for n in &nodes {
-                eprintln!("   node '{}' tex={:?}", n.name, n.texture);
-                for s in &n.submeshes {
-                    eprintln!("      sub '{}' mat={:?} tile={:?}", s.name, s.mat, s.uv_tile);
-                }
-            }
-        }
-        for (name, _) in &files {
-            eprintln!("file: {name}");
-        }
-    }
-
     #[test]
     #[ignore]
     fn bike_model_from_pkz() {

--- a/src-tauri/src/modelswap.rs
+++ b/src-tauri/src/modelswap.rs
@@ -5,7 +5,9 @@ use std::path::{Path, PathBuf};
 const LIB_DIR: &str = "FrostMod Models";
 const MARKER: &str = "_active.txt";
 const ORIGINAL: &str = "Original";
-const MODEL_EDF: &str = "model.edf";
+/// Per-variant record of the filenames that variant owns, written whenever we park a
+/// set. Lets the reverse swap move back exactly what it moved out instead of guessing.
+const MANIFEST: &str = "_files.txt";
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -126,8 +128,107 @@ fn list_files(dir: &Path) -> Vec<String> {
 fn dir_exists(p: &Path) -> bool {
     p.is_dir()
 }
-fn file_exists(p: &Path) -> bool {
-    p.is_file()
+fn is_bookkeeping(name: &str) -> bool {
+    name.eq_ignore_ascii_case(MANIFEST) || name.eq_ignore_ascii_case(MARKER)
+}
+
+/// The files a parked variant actually consists of — its own bookkeeping doesn't count.
+fn set_files(dir: &Path) -> Vec<String> {
+    list_files(dir)
+        .into_iter()
+        .filter(|f| !is_bookkeeping(f))
+        .collect()
+}
+
+fn read_manifest(dir: &Path) -> Option<Vec<String>> {
+    let text = fs::read_to_string(dir.join(MANIFEST)).ok()?;
+    let files: Vec<String> = text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect();
+    if files.is_empty() { None } else { Some(files) }
+}
+
+fn write_manifest(dir: &Path, files: &[String]) {
+    if files.is_empty() {
+        let _ = fs::remove_file(dir.join(MANIFEST));
+        return;
+    }
+    let _ = fs::create_dir_all(dir);
+    let _ = fs::write(dir.join(MANIFEST), format!("{}\n", files.join("\n")));
+}
+
+fn contains_ci(haystack: &[String], needle: &str) -> bool {
+    haystack.iter().any(|h| h.eq_ignore_ascii_case(needle))
+}
+
+/// Every filename mentioned by a *parked* variant other than `except`. Used to scope the
+/// very first swap of a bike, before any manifest exists: the files this bike's swaps
+/// deal with are exactly the files its swaps contain.
+fn files_known_to_other_variants(mods_path: &str, bike: &str, except: &[&str]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    if let Ok(rd) = fs::read_dir(lib_dir(mods_path, bike)) {
+        for e in rd.flatten() {
+            let p = e.path();
+            if !p.is_dir() {
+                continue;
+            }
+            let name = e.file_name().to_string_lossy().to_string();
+            if except.iter().any(|x| x.eq_ignore_ascii_case(&name)) {
+                continue;
+            }
+            for f in read_manifest(&p).unwrap_or_else(|| set_files(&p)) {
+                if !contains_ci(&out, &f) {
+                    out.push(f);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// The loose root files that belong to the **active model set** — never the whole folder.
+///
+/// A bike root holds far more than its model: the `.hrc`s naming each part's scene, plus
+/// `.cfg`/`.geom` and physics data. Parking all of it (what versions up to 0.6.1 did) is
+/// what made the bike itself vanish from the game. The set is resolved as:
+///
+/// 1. the active variant's manifest, when we wrote one on the way in;
+/// 2. otherwise every mesh at the root (a model swap always replaces the mesh) plus any
+///    file this bike's other parked variants contain — self-scoping, and it leaves setup
+///    the swaps never mention exactly where the game expects it.
+///
+/// `incoming` adds the files the arriving set would overwrite, which must be displaced
+/// whatever else is true. Sound files are excluded throughout: they swap independently
+/// (see `soundmods`), so a model swap must leave them at the root untouched.
+fn active_set_files(mods_path: &str, bike: &str, active: &str, incoming: &[String]) -> Vec<String> {
+    let root = bike_dir(mods_path, bike);
+    let root_files = list_files(&root);
+
+    let owned = match read_manifest(&variant_dir(mods_path, bike, active)) {
+        Some(m) => m,
+        None => {
+            let mut m: Vec<String> = root_files
+                .iter()
+                .filter(|f| crate::bikefiles::is_mesh(f))
+                .cloned()
+                .collect();
+            for f in files_known_to_other_variants(mods_path, bike, &[active]) {
+                if !contains_ci(&m, &f) {
+                    m.push(f);
+                }
+            }
+            m
+        }
+    };
+
+    root_files
+        .into_iter()
+        .filter(|f| !crate::soundmods::is_sound_file(f) && !is_bookkeeping(f))
+        .filter(|f| contains_ci(&owned, f) || contains_ci(incoming, f))
+        .collect()
 }
 
 fn move_set(src: &Path, dst: &Path, files: &[String]) -> bool {
@@ -166,17 +267,14 @@ fn scan_variants(mods_path: &str, bike: &str) -> Vec<ModelVariant> {
         if a.is_empty() { ORIGINAL.to_string() } else { a }
     };
 
-    // The active model set is the bike's loose files, excluding the sound set (which
-    // coexists at the root but is swapped independently).
-    let active_files = list_files(&bike_dir(mods_path, bike))
-        .into_iter()
-        .filter(|f| !crate::soundmods::is_sound_file(f))
-        .count();
+    // The active model set is the subset of the bike's loose files that belongs to the
+    // model — not the whole folder (see `active_set_files`).
+    let active_files = active_set_files(mods_path, bike, &active_label, &[]).len();
     let mut variants = vec![ModelVariant {
         name: active_label.clone(),
         active: true,
-        // The active set is the bike's loose files — valid iff model.edf is there.
-        valid: file_exists(&bike_dir(mods_path, bike).join(MODEL_EDF)),
+        // The active set is loose at the root — valid iff a mesh is there.
+        valid: crate::bikefiles::dir_has_mesh(&bike_dir(mods_path, bike)),
         empty: active_files == 0,
         file_count: active_files,
     }];
@@ -195,9 +293,9 @@ fn scan_variants(mods_path: &str, bike: &str) -> Vec<ModelVariant> {
             if name.eq_ignore_ascii_case(&active_label) {
                 continue; // active is already row 0
             }
-            let files = list_files(&p).len();
+            let files = set_files(&p).len();
             others.push(ModelVariant {
-                valid: file_exists(&p.join(MODEL_EDF)),
+                valid: crate::bikefiles::dir_has_mesh(&p),
                 empty: files == 0,
                 file_count: files,
                 name,
@@ -223,8 +321,10 @@ pub fn scan_model_swaps(mods_path: &str) -> Vec<BikeModels> {
                 Some(n) => n.to_string(),
                 None => continue,
             };
+            // Any mesh qualifies, not just `model.edf` — a bike may ship one EDF per
+            // part (`96cr250.edf`, `96cr250_st.edf`, …), and those were invisible here.
             let qualifies =
-                file_exists(&p.join(MODEL_EDF)) || dir_exists(&p.join(LIB_DIR));
+                crate::bikefiles::dir_has_mesh(&p) || dir_exists(&p.join(LIB_DIR));
             if bike.starts_with('.') || !qualifies {
                 continue;
             }
@@ -262,21 +362,17 @@ pub fn apply_model_swap(mods_path: &str, bike: &str, target: &str) -> anyhow::Re
         anyhow::bail!("model '{target}' not found");
     }
 
-    // The model set is every loose root file EXCEPT the sound set — engine sound and
-    // audio are swapped independently (see `soundmods`), so a model swap must leave
-    // them at the bike root untouched.
-    let root_files: Vec<String> = list_files(&root)
-        .into_iter()
-        .filter(|f| !crate::soundmods::is_sound_file(f))
-        .collect();
-    let target_files = list_files(&target_dir); // variant files to bring in
+    let target_files = set_files(&target_dir); // variant files to bring in
 
     // An empty variant (no files) is an intentional "no model" swap: back up the live
     // set and bring in nothing, leaving the bike without a model. A variant that *has*
-    // files but no model.edf is an incomplete set and is rejected.
-    if !target_files.is_empty() && !file_exists(&target_dir.join(MODEL_EDF)) {
-        anyhow::bail!("model '{target}' is missing its {MODEL_EDF}");
+    // files but no mesh at all is an incomplete set and is rejected.
+    if !target_files.is_empty() && !crate::bikefiles::dir_has_mesh(&target_dir) {
+        anyhow::bail!("model '{target}' has no mesh (.edf) — it looks like an incomplete set");
     }
+
+    // Only the files that belong to the model move. The bike's own setup stays put.
+    let root_files = active_set_files(mods_path, bike, &active_label, &target_files);
 
     // 1) Back up the current set into the library (all-or-nothing).
     if !root_files.is_empty() && !move_set(&root, &backup_dir, &root_files) {
@@ -288,22 +384,182 @@ pub fn apply_model_swap(mods_path: &str, bike: &str, target: &str) -> anyhow::Re
         anyhow::bail!("swap failed and was rolled back (see the model files)");
     }
 
+    // Record what each side owns, so the next swap moves exactly this back and never has
+    // to guess again.
+    write_manifest(&backup_dir, &root_files);
+    write_manifest(&target_dir, &target_files);
     write_active(mods_path, bike, target)?;
     Ok(())
 }
 
-fn dir_has_model_edf(p: &Path) -> bool {
-    file_exists(&p.join(MODEL_EDF))
+/// A bike whose setup files (`.hrc`/`.cfg`/`.geom`) were carried off into a swap folder
+/// by a version that treated the whole folder as the model set. The game can't see such
+/// a bike at all until they're back at the root.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrphanedSetup {
+    pub bike: String,
+    /// Filenames missing from the bike root that a parked variant still holds.
+    pub files: Vec<String>,
+}
+
+fn root_setup_files(mods_path: &str, bike: &str) -> Vec<String> {
+    list_files(&bike_dir(mods_path, bike))
+        .into_iter()
+        .filter(|f| crate::bikefiles::is_bike_setup(f) && !crate::soundmods::is_sound_file(f))
+        .collect()
+}
+
+/// Setup files a parked variant holds that the bike root is missing, paired with where to
+/// find them. Empty when nothing is wrong.
+///
+/// Gated on the unambiguous signature of the damage: not one `.hrc` at the bike root, so
+/// nothing tells the game which mesh each part uses. Without that gate a swap set that
+/// legitimately ships its own `.cfg` would look broken. Note this must *not* also require
+/// a mesh at the root — swapping to an empty "no model" variant under the old rule left
+/// the root with nothing at all, which is the worst case and the one worth catching.
+fn orphaned_setup_for(mods_path: &str, bike: &str) -> Vec<(String, PathBuf)> {
+    let root = bike_dir(mods_path, bike);
+    // A `.pkz` sitting in the bike folder is a packed fallback the loose files layer over,
+    // so having no `.hrc` of its own is normal there, not damage.
+    if list_files(&root).iter().any(|f| f.to_ascii_lowercase().ends_with(".pkz")) {
+        return Vec::new();
+    }
+    let at_root = root_setup_files(mods_path, bike);
+    if at_root.iter().any(|f| f.to_ascii_lowercase().ends_with(".hrc")) {
+        return Vec::new();
+    }
+    let mut out: Vec<(String, PathBuf)> = Vec::new();
+    if let Ok(rd) = fs::read_dir(lib_dir(mods_path, bike)) {
+        for e in rd.flatten() {
+            let p = e.path();
+            if !p.is_dir() {
+                continue;
+            }
+            for f in set_files(&p) {
+                if !crate::bikefiles::is_bike_setup(&f) || crate::soundmods::is_sound_file(&f) {
+                    continue;
+                }
+                if contains_ci(&at_root, &f) || out.iter().any(|(n, _)| n.eq_ignore_ascii_case(&f)) {
+                    continue;
+                }
+                out.push((f.clone(), p.join(&f)));
+            }
+        }
+    }
+    out.sort_by(|a, b| a.0.to_lowercase().cmp(&b.0.to_lowercase()));
+    out
+}
+
+pub fn detect_orphaned_setup(mods_path: &str) -> Vec<OrphanedSetup> {
+    let mut out = Vec::new();
+    if let Ok(rd) = fs::read_dir(bikes_root(mods_path)) {
+        for e in rd.flatten() {
+            if !e.path().is_dir() {
+                continue;
+            }
+            let bike = match e.file_name().to_str() {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+            if bike.starts_with('.') || !is_simple_name(&bike) {
+                continue;
+            }
+            let files: Vec<String> =
+                orphaned_setup_for(mods_path, &bike).into_iter().map(|(n, _)| n).collect();
+            if !files.is_empty() {
+                out.push(OrphanedSetup { bike, files });
+            }
+        }
+    }
+    out.sort_by(|a, b| a.bike.to_lowercase().cmp(&b.bike.to_lowercase()));
+    out
+}
+
+/// Put a gutted bike back together at its root. Deliberately a **copy**: the variant that
+/// holds the files keeps its own, so repairing can't break a swap set even if a file
+/// turned out to legitimately belong to it. Returns how many files were restored.
+///
+/// When the root was stripped bare — no mesh either, which is what swapping to an empty
+/// variant used to do — the donor variant's whole set comes back and it becomes the active
+/// model, so the bike is coherent again rather than setup-without-a-model.
+pub fn repair_orphaned_setup(mods_path: &str, bike: &str) -> anyhow::Result<usize> {
+    if !is_simple_name(bike) {
+        anyhow::bail!("invalid bike name");
+    }
+    let root = bike_dir(mods_path, bike);
+    if !dir_exists(&root) {
+        anyhow::bail!("bike '{bike}' not found");
+    }
+    let missing = orphaned_setup_for(mods_path, bike);
+    if missing.is_empty() {
+        anyhow::bail!("nothing to restore for '{bike}'");
+    }
+
+    // The variant holding most of the bike's setup is the one it came from.
+    let donor: Option<PathBuf> = {
+        let mut counts: Vec<(PathBuf, usize)> = Vec::new();
+        for (_, path) in &missing {
+            let dir = match path.parent() {
+                Some(d) => d.to_path_buf(),
+                None => continue,
+            };
+            match counts.iter_mut().find(|(p, _)| *p == dir) {
+                Some((_, n)) => *n += 1,
+                None => counts.push((dir, 1)),
+            }
+        }
+        counts.into_iter().max_by_key(|(_, n)| *n).map(|(p, _)| p)
+    };
+
+    let mut restore: Vec<(String, PathBuf)> = missing;
+    let stripped = !crate::bikefiles::dir_has_mesh(&root);
+    if stripped {
+        if let Some(d) = &donor {
+            for f in set_files(d) {
+                if !restore.iter().any(|(n, _)| n.eq_ignore_ascii_case(&f)) {
+                    restore.push((f.clone(), d.join(&f)));
+                }
+            }
+        }
+    }
+
+    let mut restored = 0usize;
+    for (name, src) in &restore {
+        let dst = root.join(name);
+        if dst.exists() {
+            continue;
+        }
+        if fs::copy(src, &dst).is_ok() {
+            restored += 1;
+        }
+    }
+    if restored == 0 {
+        anyhow::bail!("nothing to restore for '{bike}'");
+    }
+    // The root now mirrors the donor, so say so — otherwise the next swap would park the
+    // restored files under whatever name the stale marker happens to hold.
+    if stripped {
+        if let Some(name) = donor
+            .as_ref()
+            .and_then(|d| d.file_name())
+            .and_then(|n| n.to_str())
+        {
+            write_active(mods_path, bike, name)?;
+        }
+    }
+    Ok(restored)
 }
 
 const KIND_MODEL: &str = "model";
 const KIND_SOUND: &str = "sound";
 
-/// Classify a loose folder as a swappable set: a `model.edf` set (models win when a
-/// folder somehow has both) or a complete `engine.scl` + `sfx.cfg` sound set. Anything
-/// else (liveries, screenshots, junk) is `None` and ignored.
+/// Classify a loose folder as a swappable set: a mesh set — any `.edf`, since a bike may
+/// ship one per part (models win when a folder somehow has both) — or a complete
+/// `engine.scl` + `sfx.cfg` sound set. Anything else (liveries, screenshots, junk) is
+/// `None` and ignored.
 fn classify_set(p: &Path) -> Option<&'static str> {
-    if dir_has_model_edf(p) {
+    if crate::bikefiles::dir_has_mesh(p) {
         Some(KIND_MODEL)
     } else if crate::soundmods::is_sound_set(p) {
         Some(KIND_SOUND)
@@ -517,6 +773,371 @@ mod tests {
     fn touch(p: &Path) {
         fs::create_dir_all(p.parent().unwrap()).unwrap();
         fs::write(p, b"x").unwrap();
+    }
+    fn file_exists(p: &Path) -> bool {
+        p.is_file()
+    }
+
+    /// A realistic extracted bike: mesh + the setup files the game needs to see it.
+    fn make_bike(mp: &str, bike: &str, mesh: &str) {
+        touch(&bike_dir(mp, bike).join(mesh));
+        touch(&bike_dir(mp, bike).join("chassis.hrc"));
+        touch(&bike_dir(mp, bike).join("bike.cfg"));
+        touch(&bike_dir(mp, bike).join("wheel.geom"));
+    }
+    fn names_at(p: &Path) -> Vec<String> {
+        let mut v = list_files(p);
+        v.sort();
+        v
+    }
+
+    #[test]
+    fn swap_leaves_the_bikes_setup_files_at_the_root() {
+        // The 0.6.1 bug: every loose root file was parked, so the game lost the bike.
+        let root = tmp("keeps-setup");
+        let mp = root.to_str().unwrap();
+        make_bike(mp, "KTM450", "model.edf");
+        touch(&bike_dir(mp, "KTM450").join("body.tga"));
+        touch(&variant_dir(mp, "KTM450", "Factory").join("model.edf"));
+
+        apply_model_swap(mp, "KTM450", "Factory").unwrap();
+
+        let at_root = names_at(&bike_dir(mp, "KTM450"));
+        for keep in ["chassis.hrc", "bike.cfg", "wheel.geom"] {
+            assert!(at_root.contains(&keep.to_string()), "{keep} must stay: {at_root:?}");
+        }
+        assert!(at_root.contains(&"model.edf".to_string()), "the new mesh arrived");
+        let parked = names_at(&variant_dir(mp, "KTM450", ORIGINAL));
+        assert!(parked.contains(&"model.edf".to_string()), "old mesh parked");
+        assert!(!parked.contains(&"chassis.hrc".to_string()), "setup never parked");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn swap_round_trip_restores_the_original_set() {
+        let root = tmp("round-trip");
+        let mp = root.to_str().unwrap();
+        make_bike(mp, "KTM450", "model.edf");
+        fs::write(bike_dir(mp, "KTM450").join("model.edf"), b"stock").unwrap();
+        touch(&variant_dir(mp, "KTM450", "Factory").join("model.edf"));
+        touch(&variant_dir(mp, "KTM450", "Factory").join("factory.tga"));
+
+        let before = names_at(&bike_dir(mp, "KTM450"));
+        apply_model_swap(mp, "KTM450", "Factory").unwrap();
+        apply_model_swap(mp, "KTM450", ORIGINAL).unwrap();
+
+        assert_eq!(names_at(&bike_dir(mp, "KTM450")), before, "root is back to stock");
+        assert_eq!(
+            fs::read(bike_dir(mp, "KTM450").join("model.edf")).unwrap(),
+            b"stock",
+            "the original mesh came back, not the swap's"
+        );
+        assert_eq!(
+            names_at(&variant_dir(mp, "KTM450", "Factory")),
+            vec!["_files.txt", "factory.tga", "model.edf"],
+            "the swap is parked whole again"
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn per_part_edf_bike_scans_and_swaps() {
+        // A bike whose mesh is split per part has no `model.edf` at all — it used to be
+        // invisible to the Locker and rejected on apply.
+        let root = tmp("per-part");
+        let mp = root.to_str().unwrap();
+        make_bike(mp, "CR250", "96cr250.edf");
+        touch(&bike_dir(mp, "CR250").join("96cr250_st.edf"));
+        touch(&variant_dir(mp, "CR250", "OEM").join("96cr250.edf"));
+
+        let bikes = scan_model_swaps(mp);
+        assert_eq!(bikes.len(), 1, "per-part bike lists");
+        assert!(bikes[0].variants.iter().all(|v| v.valid), "both sets are valid");
+
+        apply_model_swap(mp, "CR250", "OEM").unwrap();
+        let at_root = names_at(&bike_dir(mp, "CR250"));
+        assert!(at_root.contains(&"chassis.hrc".to_string()));
+        // Every root mesh is part of the model set, including the part the swap omits.
+        assert!(!at_root.contains(&"96cr250_st.edf".to_string()));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn loose_per_part_set_is_detected_for_registration() {
+        let root = tmp("loose-per-part");
+        let mp = root.to_str().unwrap();
+        make_bike(mp, "CR250", "96cr250.edf");
+        touch(&bike_dir(mp, "CR250").join("OEM Replica").join("96cr250.edf"));
+
+        let found = detect_loose_swaps(mp);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].candidates[0].name, "OEM Replica");
+        assert_eq!(found[0].candidates[0].kind, KIND_MODEL);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn set_with_files_but_no_mesh_is_rejected() {
+        let root = tmp("no-mesh");
+        let mp = root.to_str().unwrap();
+        make_bike(mp, "KTM450", "model.edf");
+        touch(&variant_dir(mp, "KTM450", "Broken").join("readme.txt"));
+
+        let err = apply_model_swap(mp, "KTM450", "Broken").unwrap_err().to_string();
+        assert!(err.contains("no mesh"), "got: {err}");
+        assert!(
+            bike_dir(mp, "KTM450").join("chassis.hrc").is_file(),
+            "a rejected swap touches nothing"
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn detects_and_repairs_a_bike_gutted_by_an_older_version() {
+        let root = tmp("repair");
+        let mp = root.to_str().unwrap();
+        // Reproduce the damage: setup files sitting in the swap folder, missing at root.
+        touch(&bike_dir(mp, "KTM450").join("model.edf"));
+        for f in ["chassis.hrc", "bike.cfg", "wheel.geom"] {
+            touch(&variant_dir(mp, "KTM450", ORIGINAL).join(f));
+        }
+        touch(&variant_dir(mp, "KTM450", ORIGINAL).join("model.edf"));
+
+        let found = detect_orphaned_setup(mp);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].bike, "KTM450");
+        assert_eq!(found[0].files, vec!["bike.cfg", "chassis.hrc", "wheel.geom"]);
+
+        assert_eq!(repair_orphaned_setup(mp, "KTM450").unwrap(), 3);
+        for f in ["chassis.hrc", "bike.cfg", "wheel.geom"] {
+            assert!(bike_dir(mp, "KTM450").join(f).is_file(), "{f} restored");
+            assert!(
+                variant_dir(mp, "KTM450", ORIGINAL).join(f).is_file(),
+                "{f} left in the variant too — repair copies, it can't break a set"
+            );
+        }
+        assert!(detect_orphaned_setup(mp).is_empty(), "nothing left to repair");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_healthy_bike_is_not_flagged_for_repair() {
+        let root = tmp("healthy");
+        let mp = root.to_str().unwrap();
+        make_bike(mp, "KTM450", "model.edf");
+        // A swap that legitimately ships its own hrc, while the root has one too.
+        touch(&variant_dir(mp, "KTM450", "Factory").join("model.edf"));
+        touch(&variant_dir(mp, "KTM450", "Factory").join("chassis.hrc"));
+        // And one that ships a cfg the base bike never had — not damage, just a set.
+        touch(&variant_dir(mp, "KTM450", "Loud").join("model.edf"));
+        touch(&variant_dir(mp, "KTM450", "Loud").join("extra.cfg"));
+
+        assert!(detect_orphaned_setup(mp).is_empty());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn repairs_a_bike_stripped_bare_by_a_no_model_swap() {
+        // The state found in a real install: swapping to an empty variant under the old
+        // rule left the bike root with nothing but `paints/`, the whole bike parked under
+        // `Original`, and the marker pointing at the empty variant.
+        let root = tmp("stripped");
+        let mp = root.to_str().unwrap();
+        fs::create_dir_all(bike_dir(mp, "KTM450").join("paints")).unwrap();
+        for f in ["model.edf", "gfx.cfg", "chassis.hrc", "fsusp.hrc", "rsusp.hrc", "steer.hrc"] {
+            touch(&variant_dir(mp, "KTM450", ORIGINAL).join(f));
+        }
+        fs::create_dir_all(variant_dir(mp, "KTM450", "new model")).unwrap();
+        write_active(mp, "KTM450", "new model").unwrap();
+
+        let found = detect_orphaned_setup(mp);
+        assert_eq!(found.len(), 1, "a bike with nothing at its root is the worst case");
+        assert_eq!(found[0].bike, "KTM450");
+
+        assert_eq!(repair_orphaned_setup(mp, "KTM450").unwrap(), 6, "whole set restored");
+        let at_root = names_at(&bike_dir(mp, "KTM450"));
+        assert!(crate::bikefiles::dir_has_mesh(&bike_dir(mp, "KTM450")), "mesh is back");
+        for f in ["chassis.hrc", "fsusp.hrc", "rsusp.hrc", "steer.hrc", "gfx.cfg"] {
+            assert!(at_root.contains(&f.to_string()), "{f} restored: {at_root:?}");
+        }
+        assert_eq!(read_active(mp, "KTM450"), ORIGINAL, "the marker matches what's at root");
+        assert!(detect_orphaned_setup(mp).is_empty(), "nothing left to repair");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_packed_bike_with_swaps_is_not_flagged_for_repair() {
+        // No loose model at the root: the pkz provides it, so a missing hrc is normal.
+        let root = tmp("packed-not-flagged");
+        let mp = root.to_str().unwrap();
+        touch(&bike_dir(mp, "RM").join("RM.pkz"));
+        touch(&variant_dir(mp, "RM", "Factory").join("model.edf"));
+        touch(&variant_dir(mp, "RM", "Factory").join("chassis.hrc"));
+
+        assert!(detect_orphaned_setup(mp).is_empty());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_swaps_own_setup_file_is_displaced_and_restored() {
+        let root = tmp("swap-owns-hrc");
+        let mp = root.to_str().unwrap();
+        make_bike(mp, "KTM450", "model.edf");
+        fs::write(bike_dir(mp, "KTM450").join("chassis.hrc"), b"stock-hrc").unwrap();
+        touch(&variant_dir(mp, "KTM450", "Factory").join("model.edf"));
+        fs::write(variant_dir(mp, "KTM450", "Factory").join("chassis.hrc"), b"factory-hrc")
+            .unwrap();
+
+        apply_model_swap(mp, "KTM450", "Factory").unwrap();
+        assert_eq!(
+            fs::read(bike_dir(mp, "KTM450").join("chassis.hrc")).unwrap(),
+            b"factory-hrc",
+            "the swap's own hrc wins while it is active"
+        );
+        apply_model_swap(mp, "KTM450", ORIGINAL).unwrap();
+        assert_eq!(
+            fs::read(bike_dir(mp, "KTM450").join("chassis.hrc")).unwrap(),
+            b"stock-hrc",
+            "and the bike's own comes back"
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// Read-only sweep of a real MX Bikes folder: what the Locker would list, what it
+    /// would offer to register, and whether anything looks gutted. Touches nothing.
+    ///
+    /// MXB_REAL_BIKES=~/Projects/PiBoSo/"MX Bikes" \
+    ///   cargo test real_mods_tree_discovery -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn real_mods_tree_discovery() {
+        let Ok(mp) = std::env::var("MXB_REAL_BIKES") else {
+            eprintln!("set MXB_REAL_BIKES to the MX Bikes folder to run");
+            return;
+        };
+        let bikes = scan_model_swaps(&mp);
+        eprintln!("-- swappable bikes: {}", bikes.len());
+        for b in &bikes {
+            let vs: Vec<String> = b
+                .variants
+                .iter()
+                .map(|v| {
+                    format!(
+                        "{}{}{} ({} files)",
+                        v.name,
+                        if v.active { "*" } else { "" },
+                        if v.valid { "" } else { " !no-mesh" },
+                        v.file_count
+                    )
+                })
+                .collect();
+            eprintln!("   {} -> {}", b.bike, vs.join(", "));
+        }
+        eprintln!("-- loose sets offered for registration:");
+        for b in detect_loose_swaps(&mp) {
+            for c in &b.candidates {
+                eprintln!("   {}/{} [{}] {} files", b.bike, c.source, c.kind, c.file_count);
+            }
+        }
+        eprintln!("-- bikes flagged as gutted: {:?}", detect_orphaned_setup(&mp));
+    }
+
+    /// Repairs a real damaged bike, on a copy. Skips cleanly when the tree is healthy.
+    ///
+    /// MXB_REAL_BIKES=~/Documents/PiBoSo/"MX Bikes" \
+    ///   cargo test real_gutted_bike_is_repaired -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn real_gutted_bike_is_repaired() {
+        let Ok(src_root) = std::env::var("MXB_REAL_BIKES") else { return };
+        let Some(flagged) = detect_orphaned_setup(&src_root).into_iter().next() else {
+            eprintln!("no damaged bike in this tree — nothing to repair");
+            return;
+        };
+        eprintln!("repairing real bike: {} (missing {:?})", flagged.bike, flagged.files);
+
+        let root = tmp("real-repair");
+        let mp = root.to_str().unwrap();
+        copy_tree(&bike_dir(&src_root, &flagged.bike), &bike_dir(mp, &flagged.bike))
+            .expect("copy the damaged bike");
+        eprintln!("root before: {:?}", names_at(&bike_dir(mp, &flagged.bike)));
+
+        let n = repair_orphaned_setup(mp, &flagged.bike).expect("repair runs");
+        eprintln!("restored {n} files");
+        eprintln!("root after:  {:?}", names_at(&bike_dir(mp, &flagged.bike)));
+        eprintln!("active is now: {:?}", read_active(mp, &flagged.bike));
+
+        assert!(
+            detect_orphaned_setup(mp).is_empty(),
+            "the bike is no longer flagged as damaged"
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// End-to-end against a **real** extracted bike, because the whole defect was a wrong
+    /// assumption about what a real bike folder contains. Copies the bike into a scratch
+    /// mods tree, swaps it, and asserts the bike still resolves through the app's own
+    /// loader — `.hrc` → scene → `.edf`, the same chain the game walks. Under the old
+    /// "park every loose file" rule this fails: the `.hrc`s end up in the swap folder and
+    /// `gather_bike_files` can't find a bike at all.
+    ///
+    /// MXB_REAL_BIKES=~/Projects/PiBoSo/"MX Bikes" \
+    ///   cargo test real_bike_survives_a_model_swap -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn real_bike_survives_a_model_swap() {
+        let Ok(src_root) = std::env::var("MXB_REAL_BIKES") else {
+            eprintln!("set MXB_REAL_BIKES to the MX Bikes folder to run");
+            return;
+        };
+        let src_bikes = Path::new(&src_root).join("mods").join("bikes");
+        // Any extracted bike with a mesh and at least one .hrc will do.
+        let (bike, src_dir) = subdirs(&src_bikes)
+            .into_iter()
+            .find(|(_, p)| {
+                crate::bikefiles::dir_has_mesh(p)
+                    && list_files(p).iter().any(|f| f.to_ascii_lowercase().ends_with(".hrc"))
+            })
+            .expect("no extracted bike with a mesh + .hrc found");
+        eprintln!("using real bike: {bike}");
+
+        let root = tmp("real-bike");
+        let mp = root.to_str().unwrap();
+        let dst = bike_dir(mp, &bike);
+        copy_tree(&src_dir, &dst).expect("copy bike");
+        // A realistic swap set: an alternate mesh, nothing else.
+        let mesh = list_files(&dst)
+            .into_iter()
+            .find(|f| crate::bikefiles::is_mesh(f))
+            .expect("mesh");
+        let variant = variant_dir(mp, &bike, "Factory");
+        fs::create_dir_all(&variant).unwrap();
+        fs::copy(dst.join(&mesh), variant.join(&mesh)).expect("copy mesh into the variant");
+
+        let before = names_at(&dst);
+        eprintln!("root before: {before:?}");
+        let nodes_before = crate::load_bike_model_blocking(dst.to_string_lossy().to_string())
+            .expect("the bike loads before the swap")
+            .nodes
+            .len();
+        assert!(nodes_before > 0, "loader produced no nodes before the swap");
+
+        apply_model_swap(mp, &bike, "Factory").expect("swap applies");
+
+        let after = names_at(&dst);
+        eprintln!("root after:  {after:?}");
+        for f in before.iter().filter(|f| crate::bikefiles::is_bike_setup(f)) {
+            assert!(after.contains(f), "{f} must still be at the bike root after a swap");
+        }
+        let model =
+            crate::load_bike_model_blocking(dst.to_string_lossy().to_string())
+                .expect("the bike still loads after the swap");
+        assert_eq!(model.nodes.len(), nodes_before, "same parts resolve after the swap");
+
+        apply_model_swap(mp, &bike, ORIGINAL).expect("swap back");
+        assert_eq!(names_at(&dst), before, "swapping back restores the bike folder exactly");
+
+        let _ = fs::remove_dir_all(&root);
     }
 
     #[test]
@@ -873,3 +1494,4 @@ mod tests {
         let _ = fs::remove_dir_all(&root);
     }
 }
+

--- a/src/Components/Dashboard/Dashboard.tsx
+++ b/src/Components/Dashboard/Dashboard.tsx
@@ -141,7 +141,7 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
           ) : view === "locker" ? (
             <Locker />
           ) : view === "presets" ? (
-            <Presets onOpenInRider={openInRider} />
+            <Presets onOpenInRider={openInRider} onOpenLocker={() => setView("locker")} />
           ) : view === "rider" ? (
             <RiderStudio initialLoadout={riderPreset} onLoaded={clearRiderPreset} />
           ) : (

--- a/src/Components/Locker/Locker.tsx
+++ b/src/Components/Locker/Locker.tsx
@@ -10,6 +10,7 @@ import {
   FolderInput,
   Link2,
   Link2Off,
+  Wrench,
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
@@ -18,6 +19,9 @@ import {
   scanModelSwaps,
   applyModelSwap,
   detectLooseSwaps,
+  detectOrphanedSetup,
+  repairOrphanedSetup,
+  onModsChanged,
   scanSoundSwaps,
   applySoundSwap,
   bindSound,
@@ -28,6 +32,7 @@ import type {
   BikeSounds,
   LooseSwapBike,
   ModelVariant,
+  OrphanedSetup,
   SoundVariant,
   SwapApplyOutcome,
 } from "../../types";
@@ -102,17 +107,21 @@ export default function Locker() {
   // Model sets found sitting loose outside `FrostMod Models/` (banner + dialog).
   const [loose, setLoose] = useState<LooseSwapBike[]>([]);
   const [registerOpen, setRegisterOpen] = useState(false);
+  // Bikes gutted by a pre-0.6.3 swap — their setup files are in a swap folder.
+  const [orphaned, setOrphaned] = useState<OrphanedSetup[]>([]);
 
   const load = useCallback(async () => {
     setError(null);
     try {
-      const [models, sounds, detected] = await Promise.all([
+      const [models, sounds, detected, broken] = await Promise.all([
         scanModelSwaps(),
         scanSoundSwaps().catch(() => [] as BikeSounds[]),
         detectLooseSwaps().catch(() => [] as LooseSwapBike[]),
+        detectOrphanedSetup().catch(() => [] as OrphanedSetup[]),
       ]);
       setRows(mergeRows(models, sounds));
       setLoose(detected);
+      setOrphaned(broken);
     } catch (e) {
       setError(String(e));
       setRows([]);
@@ -121,6 +130,15 @@ export default function Locker() {
 
   useEffect(() => {
     void load();
+  }, [load]);
+
+  // Installing a mod or editing the folder changes what's swappable — pick it up without
+  // making the user hit Rescan (same watcher `Context/Frostmod` listens to).
+  useEffect(() => {
+    const un = onModsChanged(() => void load());
+    return () => {
+      void un.then((f) => f());
+    };
   }, [load]);
 
   const looseCount = loose.reduce((n, b) => n + b.candidates.length, 0);
@@ -147,6 +165,11 @@ export default function Locker() {
     },
     [load],
   );
+
+  const onRepair = (bike: string) =>
+    run(bike, `Restored ${bike}'s setup files.`, () => repairOrphanedSetup(bike), (n) =>
+      `${n} file${n === 1 ? "" : "s"} put back — the bike should load again.`,
+    );
 
   const onModelSwap = (bike: string, target: string) =>
     run(bike, `Switched ${bike} model to “${target}”.`, () => applyModelSwap(bike, target), swapNote);
@@ -176,6 +199,33 @@ export default function Locker() {
         </button>
       </header>
 
+      {orphaned.map((o) => (
+        <div
+          key={o.bike}
+          className="mx-7 mb-3.5 flex items-center gap-2.5 rounded-lg border border-destructive/30 bg-destructive/[0.07] px-3.5 py-2.5"
+        >
+          <Wrench className="size-4 flex-none text-destructive/80" />
+          <span className="min-w-0 flex-1 text-[12.5px] text-foreground/90">
+            <span className="font-semibold">{o.bike}</span> is missing its setup files — an
+            earlier version moved them into a swap folder, which stops the bike loading
+            in-game at all.{" "}
+            <span className="font-mono text-faint">{o.files.join(", ")}</span>
+          </span>
+          <button
+            onClick={() => void onRepair(o.bike)}
+            disabled={busy !== null}
+            className="flex flex-none items-center gap-1.5 rounded-md bg-destructive/15 px-2.5 py-1.5 text-[12px] font-semibold text-destructive transition-colors hover:bg-destructive/25 disabled:opacity-50"
+          >
+            {busy === o.bike ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <Wrench className="size-3.5" />
+            )}
+            Restore
+          </button>
+        </div>
+      ))}
+
       {looseCount > 0 && (
         <button
           onClick={() => setRegisterOpen(true)}
@@ -201,11 +251,32 @@ export default function Locker() {
         ) : rows === null ? (
           <p className="py-16 text-center text-[13px] text-muted-foreground">Scanning bikes…</p>
         ) : rows.length === 0 ? (
-          <p className="py-16 text-center text-[13px] text-muted-foreground">
-            No extracted bikes found. Swaps need a bike unpacked into
-            <span className="mx-1 font-mono text-faint">mods/bikes/&lt;Bike&gt;/</span>
-            (a loose <span className="font-mono text-faint">model.edf</span> or sound files).
-          </p>
+          <div className="mx-auto max-w-md py-14 text-[13px] text-muted-foreground">
+            <p className="mb-3 text-center text-foreground/90">No swappable bikes yet.</p>
+            <p className="mb-3">Two things have to be true before a swap can happen:</p>
+            <ol className="mb-4 list-decimal space-y-2 pl-5">
+              <li>
+                The bike is <span className="text-foreground/90">unpacked</span> into
+                <span className="mx-1 font-mono text-faint">mods/bikes/&lt;Bike&gt;/</span>—
+                a packed <span className="font-mono text-faint">.pkz</span> can&apos;t be
+                swapped.
+                Unpack one from the Library.
+              </li>
+              <li>
+                Each alternate model sits in its own folder inside that bike, holding a mesh
+                (<span className="font-mono text-faint">.edf</span>). Drop it anywhere in the
+                bike folder and hit Scan below — we&apos;ll offer to file it under
+                <span className="mx-1 font-mono text-faint">FrostMod Models/</span>.
+              </li>
+            </ol>
+            <button
+              onClick={() => void load()}
+              className="mx-auto flex items-center gap-1.5 rounded-lg border border-input bg-card px-3 py-2 text-[12.5px] transition-colors hover:text-foreground"
+            >
+              <RefreshCw className="size-3.5" />
+              Scan for swaps
+            </button>
+          </div>
         ) : (
           <div className="flex flex-col gap-4">
             {rows.map((r) => (

--- a/src/Components/Locker/LooseSwapPrompt.tsx
+++ b/src/Components/Locker/LooseSwapPrompt.tsx
@@ -3,28 +3,44 @@ import RegisterSwapsDialog from "./RegisterSwapsDialog";
 import { detectLooseSwaps } from "../../api/mods";
 import type { LooseSwapBike } from "../../types";
 
-/** Set once the launch prompt has been shown, so we don't nag on every startup. */
-const SEEN_KEY = "mxb:looseSwapsSeen:v1";
+/**
+ * The set of loose swaps we last prompted about. Keyed on the candidates themselves, not
+ * on "have we ever asked" — a swap installed months later is new information and deserves
+ * a prompt, while the same unregistered folders stay quiet across launches.
+ */
+const SEEN_KEY = "mxb:looseSwapsSeen:v2";
+
+/** Stable fingerprint of what's currently loose, so re-prompting tracks real changes. */
+function fingerprint(bikes: LooseSwapBike[]): string {
+  return bikes
+    .flatMap((b) => b.candidates.map((c) => `${b.bike}/${c.source}`))
+    .sort()
+    .join("|");
+}
 
 /**
- * On launch, scan for model-set folders sitting loose in the user's bikes and, the first
- * time any are found, offer to register them. After it's shown once the prompt snoozes
- * (the Model Swaps page keeps a persistent banner) so subsequent launches stay quiet.
+ * On launch, scan for model-set folders sitting loose in the user's bikes and offer to
+ * register them. Asks again whenever a *new* loose set turns up; otherwise it stays quiet
+ * and the Locker's persistent banner carries the reminder.
  */
 export default function LooseSwapPrompt() {
   const [bikes, setBikes] = useState<LooseSwapBike[]>([]);
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
-    if (localStorage.getItem(SEEN_KEY) === "1") return;
     let cancelled = false;
     (async () => {
       try {
         const found = await detectLooseSwaps();
         if (cancelled || found.length === 0) return;
+        const seen = new Set((localStorage.getItem(SEEN_KEY) ?? "").split("|").filter(Boolean));
+        const fresh = found.some((b) =>
+          b.candidates.some((c) => !seen.has(`${b.bike}/${c.source}`)),
+        );
+        if (!fresh) return;
         setBikes(found);
         setOpen(true);
-        localStorage.setItem(SEEN_KEY, "1"); // shown once — snooze from here on
+        localStorage.setItem(SEEN_KEY, fingerprint(found));
       } catch {
         // Detection is best-effort; a failure here should never block startup.
       }

--- a/src/Components/Presets/Presets.tsx
+++ b/src/Components/Presets/Presets.tsx
@@ -38,6 +38,7 @@ import {
   DialogDescription,
 } from "../ui/dialog";
 import {
+  onModsChanged,
   presetsListProfiles,
   presetsListBikes,
   presetsReadLoadout,
@@ -132,9 +133,11 @@ function applyNote(outcome: PresetApplyOutcome): string {
 
 interface PresetsProps {
   onOpenInRider?: (loadout: Loadout) => void;
+  /** Jump to the Locker — where model swaps have to be registered before they show here. */
+  onOpenLocker?: () => void;
 }
 
-export default function Presets({ onOpenInRider }: PresetsProps = {}) {
+export default function Presets({ onOpenInRider, onOpenLocker }: PresetsProps = {}) {
   const [profiles, setProfiles] = useState<string[]>([]);
   const [profile, setProfile] = useState<string>("");
   const [bikes, setBikes] = useState<string[]>([]);
@@ -178,6 +181,15 @@ export default function Presets({ onOpenInRider }: PresetsProps = {}) {
 
   useEffect(() => {
     void load();
+  }, [load]);
+
+  // Registering a swap in the Locker (or installing a mod) changes what these slots can
+  // offer — re-scan on the same signal instead of waiting for a manual Refresh.
+  useEffect(() => {
+    const un = onModsChanged(() => void load());
+    return () => {
+      void un.then((f) => f());
+    };
   }, [load]);
 
   useEffect(() => {
@@ -428,16 +440,36 @@ export default function Presets({ onOpenInRider }: PresetsProps = {}) {
                   )}
                 </div>
                 <div className="grid grid-cols-1 gap-x-4 gap-y-2.5 sm:grid-cols-2">
-                  {g.slots.map((slot) => (
-                    <SlotField
-                      key={slot.key}
-                      slot={slot}
-                      value={loadout[slot.key]}
-                      options={scans ? slotOptions(slot, bike, loadout, scans) : []}
-                      missing={scans ? isMissing(slot, bike, loadout, scans) : false}
-                      onChange={(v) => setSlot(slot.key, v)}
-                    />
-                  ))}
+                  {g.slots.map((slot) => {
+                    const options = scans ? slotOptions(slot, bike, loadout, scans) : [];
+                    return (
+                      <SlotField
+                        key={slot.key}
+                        slot={slot}
+                        value={loadout[slot.key]}
+                        options={options}
+                        missing={scans ? isMissing(slot, bike, loadout, scans) : false}
+                        hint={
+                          // "No matches." doesn't tell you a swap has to be registered
+                          // in the Locker before it can be picked here.
+                          slot.key === "modelSwap" && scans && options.length === 0 ? (
+                            <>
+                              No model swaps registered for this bike —{" "}
+                              <button
+                                type="button"
+                                onClick={onOpenLocker}
+                                className="underline underline-offset-2 hover:text-foreground"
+                              >
+                                set them up in the Locker
+                              </button>
+                              .
+                            </>
+                          ) : undefined
+                        }
+                        onChange={(v) => setSlot(slot.key, v)}
+                      />
+                    );
+                  })}
                 </div>
               </div>
             ))}

--- a/src/Components/Presets/SlotField.tsx
+++ b/src/Components/Presets/SlotField.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import { Combobox } from "../ui/combobox";
 import type { SlotDef } from "../../lib/presets";
 
@@ -12,12 +13,15 @@ export function SlotField({
   value,
   options,
   missing,
+  hint,
   onChange,
 }: {
   slot: SlotDef;
   value: string;
   options: string[];
   missing: boolean;
+  /** Shown under the field — says why it's empty when "No matches." wouldn't. */
+  hint?: React.ReactNode;
   onChange: (v: string) => void;
 }) {
   return (
@@ -34,6 +38,7 @@ export function SlotField({
         )}
       </span>
       <Combobox value={value} options={options} onChange={onChange} invalid={missing} />
+      {hint && <span className="text-[11px] leading-snug text-faint">{hint}</span>}
     </div>
   );
 }

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -4,6 +4,7 @@ import type {
   BikeModels,
   BikeSounds,
   LooseSwapBike,
+  OrphanedSetup,
   RegisterReport,
   Config,
   DownloadOption,
@@ -224,6 +225,19 @@ export function detectLooseSwaps(): Promise<LooseSwapBike[]> {
  */
 export function registerLooseSwaps(move: boolean): Promise<RegisterReport> {
   return invoke<RegisterReport>("register_loose_swaps", { moveFiles: move });
+}
+
+/**
+ * Bikes whose setup files were moved into a swap folder by a version that treated the
+ * whole bike folder as the model set — such a bike doesn't load in-game at all.
+ */
+export function detectOrphanedSetup(): Promise<OrphanedSetup[]> {
+  return invoke<OrphanedSetup[]>("detect_orphaned_setup");
+}
+
+/** Copy a gutted bike's setup files back to its root. Returns how many were restored. */
+export function repairOrphanedSetup(bike: string): Promise<number> {
+  return invoke<number>("repair_orphaned_setup", { bike });
 }
 
 export function getPkzMeta(path: string): Promise<PkzMeta> {
@@ -725,6 +739,15 @@ export function onFrostmodReload(
   cb: (payload: FrostmodReload) => void,
 ): Promise<UnlistenFn> {
   return listen<FrostmodReload>("frostmod-reload", (event) => cb(event.payload));
+}
+
+/**
+ * Fires whenever the mods folder gains content — an in-app install or a file dropped in
+ * and caught by the watcher. Screens that scan the folder use this to stay current
+ * instead of relying on the user to hit Rescan.
+ */
+export function onModsChanged(cb: () => void): Promise<UnlistenFn> {
+  return onFrostmodReload(() => cb());
 }
 
 export function presetsListProfiles(): Promise<string[]> {

--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -135,7 +135,10 @@ export async function loadScans(): Promise<Scans> {
     if (e.category === "bikePaint" && e.parent) push(s.bikePaints, e.parent, stripExt(e.name));
   }
   for (const b of swaps) {
-    if (b.variants.length) s.modelSwaps[b.bike] = b.variants.map((v) => v.name);
+    // Only offer sets that can actually be applied — an incomplete one (files but no
+    // mesh) is rejected by the backend, so offering it only produces a failed apply.
+    const usable = b.variants.filter((v) => v.valid || v.empty).map((v) => v.name);
+    if (usable.length) s.modelSwaps[b.bike] = usable;
   }
   for (const e of rider) {
     const v = stripExt(e.name);
@@ -175,6 +178,17 @@ export async function loadScans(): Promise<Scans> {
   return s;
 }
 
+/**
+ * Look a bike up in a scan map. The scans key on the on-disk folder name while the slot
+ * asks by the `bikeid` written in `profile.ini`; those agree in case only by convention,
+ * and an exact match silently yielded an empty dropdown whenever they didn't.
+ */
+function forBike(map: Record<string, string[]>, bikeid: string): string[] {
+  if (map[bikeid]) return map[bikeid];
+  const hit = Object.keys(map).find((k) => k.toLowerCase() === bikeid.toLowerCase());
+  return hit ? map[hit] : [];
+}
+
 /** Paints for `model`, plus any installed with no owning model folder. */
 function forModel(map: Record<string, string[]>, model: string): string[] {
   return [...(map[model] ?? []), ...(map[ANY_MODEL] ?? [])];
@@ -197,10 +211,10 @@ export function slotOptions(
   let opts: string[] = [];
   switch (slot.key) {
     case "paint":
-      opts = scans.bikePaints[bikeid] ?? [];
+      opts = forBike(scans.bikePaints, bikeid);
       break;
     case "modelSwap":
-      opts = scans.modelSwaps[bikeid] ?? [];
+      opts = forBike(scans.modelSwaps, bikeid);
       break;
     case "helmet":
       opts = scans.helmets;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -115,8 +115,8 @@ export interface ModelVariant {
   name: string;
   /** Whether this is the currently-active model. */
   active: boolean;
-  /** Whether the set has a `model.edf`. A set with files but no `model.edf` is
-   * incomplete and can't be applied; an empty set can (see `empty`). */
+  /** Whether the set has a mesh (any `.edf` — a bike may ship one per part). A set with
+   * files but no mesh is incomplete and can't be applied; an empty set can (see `empty`). */
   valid: boolean;
   /** No files at all — an intentional "no model" swap that removes the current model. */
   empty: boolean;
@@ -189,6 +189,17 @@ export interface RegisterReport {
   skipped: number;
   /** `FrostMod Models/` folders newly created on disk. */
   foldersCreated: number;
+}
+
+/**
+ * A bike whose setup files (`.hrc`/`.cfg`/`.geom`) were carried into a swap folder by a
+ * version that treated the whole bike folder as the model set. The game can't see such a
+ * bike at all until they're restored.
+ */
+export interface OrphanedSetup {
+  bike: string;
+  /** Filenames missing from the bike root that a parked variant still holds. */
+  files: string[];
 }
 
 /** A material group over a node's kept triangles (for per-part texturing). */


### PR DESCRIPTION
Closes the launch-day reports that a swapped model doesn't show in game — and that the bike itself then disappears.

## The bug

A bike root holds more than its model. A real extracted bike (`MX1OEM_2023_KTM_450_SX-F`) is:

```
model.edf  gfx.cfg  chassis.hrc  fsusp.hrc  rsusp.hrc  steer.hrc  paints/
```

The `.hrc` files are what tell the game which mesh each part uses. `apply_model_swap` treated **every** loose non-sound file as the model set, so a swap parked all of it under `FrostMod Models/` and brought back only the swap's mesh. Running the 0.6.1 rule against that real bike:

```
0.6.1 would park: [model.edf, gfx.cfg, rsusp.hrc, fsusp.hrc, chassis.hrc, steer.hrc]
root left with:   [model.edf]
```

Both reported symptoms, one defect: the swapped model doesn't render because its `.hrc` was parked, and the bike vanishes because its setup went with it.

## The fix

**A swap moves only what a swap provides.** Each parked set records what it owns in `_files.txt`, so the reverse swap moves back exactly what it moved out. Before any manifest exists, the set is the meshes at the root plus whatever the bike's *other* swap folders contain — self-scoping, and it leaves setup the swaps never mention exactly where the game expects it.

**One definition of a bike's files.** New `bikefiles` module, shared by the viewer and the swapper. This drops the literal `model.edf` gate, so bikes and swap sets whose mesh is split per part (`96cr250.edf`, `96cr250_st.edf`) now list, register and apply instead of being invisible — the viewer learned this in 0.5.2, the swapper never did.

**Repair for bikes already broken.** Detects a bike with no `.hrc` at its root and a swap folder holding them. Repair *copies*, so it can't break the set they came from; a bike stripped bare gets its whole set back and its active marker corrected. Bikes carrying a packed `.pkz` in their folder are skipped — a missing `.hrc` is normal there.

**Discovery.** The Presets `modelSwap` lookup was exact-case against `profile.ini`'s bikeid while the scan keys on the folder name — any divergence silently emptied the dropdown. Now case-insensitive (bike paints too), unusable variants filtered out, and an empty slot explains itself with a link to the Locker. The Locker's empty state says what to do, the startup prompt re-asks when *new* loose swaps appear rather than once ever, and both screens re-scan on the mods-folder watcher.

## Verification

- `cargo test` — 145 passed, 0 failed (13 new).
- **Real bike, real swap**: the KTM 450 SX-F round-trips with its root unchanged and still resolves through the app's loader with the same 4 parts.
- **Real damage, real repair**: a genuinely gutted bike found in a live install — root empty, whole bike under `Original`, marker pointing at an empty variant — is detected and fully restored (7 files, marker corrected), tested on a copy.
- `tsc --noEmit` clean; ESLint clean on the touched files; app launches clean in `tauri dev`.

Verification is on file state and the app's own loader, not the game rendering — the loader falls back to a mesh-name heuristic where the game would not, so in-game confirmation is still worth doing before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)