### PR TITLE
fix(install): make the failed-install banner open the mod's page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **A failed install is no longer a dead end once you've browsed away.** The failure
+  toast only offered Retry, and the error itself — the message, the destination picker,
+  the reinstall controls — lives on the mod's own page. Leave that page while the
+  download is running and the failure had nowhere to send you back to. The banner is now
+  the way back: clicking it reopens that mod's detail page, restoring the mod type the
+  install targeted so Browse and the detail page agree on folders and livery routing.
+  Retry and the dismiss X still do only their own job. Shop installs, which have no
+  browse page, keep the plain toast.
+
 ## 2026-08-06 — v0.6.2 — mod-manager performance, Discord release announcements
 
 ### Added

--- a/src/Components/Browse/Browse.tsx
+++ b/src/Components/Browse/Browse.tsx
@@ -95,7 +95,7 @@ export default function Browse({
           isLiveryContext(modType, categoryId),
         );
         if (res.ok) {
-          startInstall(res.params);
+          startInstall({ ...res.params, categoryId });
           toast.success(`Queued “${res.params.title}”`, {
             description: `Installing to ${res.params.destFolder || "root"}.`,
           });
@@ -137,7 +137,7 @@ export default function Browse({
             isLiveryContext(modType, categoryId),
           );
           if (res.ok) {
-            startInstall(res.params);
+            startInstall({ ...res.params, categoryId });
             queued++;
           } else {
             skipped.push(res.title);

--- a/src/Components/Dashboard/Dashboard.tsx
+++ b/src/Components/Dashboard/Dashboard.tsx
@@ -9,10 +9,11 @@ import Shop from "../Shop/Shop";
 import ModDetail from "../ModDetail/ModDetail";
 import Settings from "../Settings/Settings";
 import Tour, { TourContext, TOUR_DONE_KEY } from "../Tour/Tour";
-import { InstallProvider } from "../../Context/Install";
+import { InstallProvider, type ModTarget } from "../../Context/Install";
 import { useConfig } from "../../Context/Config";
 import {
   DEFAULT_MOD_TYPE,
+  MOD_TYPES,
   getInstalledMods,
   normalizeModName,
   setIntroSeen,
@@ -66,6 +67,17 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
     setSelectedCategoryId(categoryId);
   }, []);
 
+  // Jump straight to a mod's detail page from anywhere (the failed-install
+  // banner) — restores the mod type its install targeted, so Browse and the
+  // detail page agree on folders and livery routing.
+  const openModTarget = useCallback(({ slug, subpath, categoryId }: ModTarget) => {
+    const type = MOD_TYPES.find((t) => t.installSubpath === subpath);
+    if (type) setModType(type);
+    setSelectedCategoryId(categoryId ?? type?.categoryId ?? null);
+    setSelectedSlug(slug);
+    setView("browse");
+  }, []);
+
   const changeType = useCallback((t: ModType) => {
     setModType(t);
     setSelectedSlug(null);
@@ -110,7 +122,7 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
 
   return (
     <TourContext.Provider value={{ startTour }}>
-    <InstallProvider onInstalled={onInstalled}>
+    <InstallProvider onInstalled={onInstalled} onOpenMod={openModTarget}>
       <div className="flex min-h-0 flex-1">
         <Sidebar view={view} onNavigate={navigate} />
         <div className="min-h-0 min-w-0 flex-1 overflow-hidden">

--- a/src/Components/ModDetail/ModDetail.tsx
+++ b/src/Components/ModDetail/ModDetail.tsx
@@ -201,6 +201,7 @@ export default function ModDetail({
         title: detail.title,
         subpath: modType.installSubpath,
         destFolder,
+        categoryId,
         url: mirror.url,
         host: mirror.host,
       });
@@ -219,6 +220,7 @@ export default function ModDetail({
       title: detail.title,
       subpath: modType.installSubpath,
       destFolder: localStorage.getItem(destKey) ?? "",
+      categoryId,
       path: picked,
     });
   };

--- a/src/Context/Install.tsx
+++ b/src/Context/Install.tsx
@@ -8,6 +8,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { AlertTriangle, X } from "lucide-react";
 import { toast } from "sonner";
 import {
   addToLibrary,
@@ -31,7 +32,18 @@ interface StartParams {
   title: string;
   subpath: string;
   destFolder: string;
+  /** Browse category the mod was opened under — lets a failed install jump back
+   *  to its detail page with the right livery routing. */
+  categoryId?: number;
   source: InstallSource;
+}
+
+/** Where a failed install can send the user back to. Shop installs have no
+ *  browse page, so they get no target. */
+export interface ModTarget {
+  slug: string;
+  subpath: string;
+  categoryId?: number;
 }
 
 export interface ActiveInstall extends StartParams {
@@ -61,15 +73,21 @@ const InstallContext = createContext<InstallContextValue | null>(null);
 
 export function InstallProvider({
   onInstalled,
+  onOpenMod,
   children,
 }: {
   onInstalled?: () => void;
+  /** Navigate to a mod's detail page — used by the failure toast so a user who
+   *  browsed away can get back to the error and retry. */
+  onOpenMod?: (target: ModTarget) => void;
   children: ReactNode;
 }) {
   const [active, setActive] = useState<ActiveInstall | null>(null);
   const [queueLength, setQueueLength] = useState(0);
   const onInstalledRef = useRef(onInstalled);
   onInstalledRef.current = onInstalled;
+  const onOpenModRef = useRef(onOpenMod);
+  onOpenModRef.current = onOpenMod;
   const clearTimer = useRef<number | null>(null);
   // Installs run one at a time (the engine handles a single transfer); extra
   // requests wait in this queue and are drained sequentially.
@@ -143,11 +161,37 @@ export function InstallProvider({
       setActive((cur) =>
         cur && cur.slug === slug ? { ...cur, stage: "error", message } : cur,
       );
-      toast.error(`Install failed — ${title}`, {
-        description: message,
-        duration: Infinity,
-        action: { label: "Retry", onClick: () => void run(params) },
-      });
+      // Shop items have no browse page, so their failure stays a plain toast.
+      const target: ModTarget | null =
+        source.kind === "shop"
+          ? null
+          : { slug, subpath, categoryId: params.categoryId };
+      if (!target) {
+        toast.error(`Install failed — ${title}`, {
+          description: message,
+          duration: Infinity,
+          action: { label: "Retry", onClick: () => void run(params) },
+        });
+      } else {
+        toast.custom(
+          (id) => (
+            <InstallFailedToast
+              title={title}
+              message={message}
+              onOpen={() => {
+                toast.dismiss(id);
+                onOpenModRef.current?.(target);
+              }}
+              onRetry={() => {
+                toast.dismiss(id);
+                void run(params);
+              }}
+              onDismiss={() => toast.dismiss(id)}
+            />
+          ),
+          { duration: Infinity },
+        );
+      }
     } finally {
       unlisten();
       unlistenFrost();
@@ -219,6 +263,72 @@ export function InstallProvider({
 
   return (
     <InstallContext.Provider value={value}>{children}</InstallContext.Provider>
+  );
+}
+
+/** Persistent failure banner. The whole card is clickable — it reopens the mod's
+ *  page, where the error card and its retry/destination controls live. The
+ *  surrounding toast still carries the shared card chrome (background, border,
+ *  radius) from `Components/ui/sonner`; a custom toast only loses the padding and
+ *  the built-in close button, so this supplies those. */
+function InstallFailedToast({
+  title,
+  message,
+  onOpen,
+  onRetry,
+  onDismiss,
+}: {
+  title: string;
+  message: string;
+  onOpen: () => void;
+  onRetry: () => void;
+  onDismiss: () => void;
+}) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") onOpen();
+      }}
+      title="Open the mod's page"
+      className="group flex w-full cursor-default flex-col gap-1 rounded-xl px-4 py-3 transition-colors hover:bg-foreground/[0.04]"
+    >
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="mt-px size-3.5 flex-none text-destructive" />
+        <span className="flex-1 font-bold text-destructive">
+          Install failed — {title}
+        </span>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onDismiss();
+          }}
+          aria-label="Dismiss"
+          className="-mr-1 -mt-0.5 flex-none cursor-default rounded-full p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100"
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+      <span className="line-clamp-3 pl-[22px] text-[11.5px] text-muted-foreground">
+        {message}
+      </span>
+      <div className="mt-1.5 flex items-center justify-between gap-2 pl-[22px]">
+        <span className="text-[11px] text-muted-foreground">
+          Click to open the mod’s page
+        </span>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onRetry();
+          }}
+          className="flex-none cursor-default rounded-md bg-primary px-2 py-1 text-[11.5px] font-semibold text-primary-foreground transition-[filter] hover:brightness-110"
+        >
+          Retry
+        </button>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## What

Browsing away from a mod while its download runs left an install failure with nowhere to send you. The toast offered only **Retry**, while the error message, the destination picker and the reinstall controls all live on the mod's own detail page — *"if I leave the mod, and get the error, I can't access the mods page."*

The banner is now the way back.

- The failure toast is a clickable banner (`InstallFailedToast` in `src/Context/Install.tsx`). Clicking the card dismisses it and reopens that mod's detail page, where the existing error card and its controls are. **Retry** and the hover dismiss **X** stop propagation, so they still do only their own job.
- The browse `categoryId` is carried through the install, so the reopened page keeps its livery/sound routing. The mod type is resolved from the install's `installSubpath` — a bikes install that failed still lands on a bikes page after Browse has been switched to tracks.
- Shop installs have no browse page, so they keep the plain error toast.

The banner stays persistent (`duration: Infinity`) and inherits the shared toast chrome; a custom toast loses only the padding and the built-in close button, which the component supplies. Failure now reads from a red warning icon and title rather than the destructive border, which can't be overridden reliably on the inherited card.

No DB/schema changes.

## Verification

- `tsc --noEmit` clean; `eslint` clean on the touched files; `vite build` passes.
- `tauri dev` boots the app on this branch's code (`cargo check` clean).
- Manual pass to run through: fail an install (offline + quick-install from Browse), navigate away, click the banner → lands on that mod's page with the red error card; Retry and X don't navigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)