### PR TITLE
fix(browse): make the mods client look like the browser it claims to be

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Browse survives mxb-mods.com's bot protection better, and says something useful when
+  it doesn't.** A user hit `403 Forbidden` on every browse and got the raw reqwest text,
+  percent-encoded URL and all. The client claimed to be Chrome while sending none of
+  Chrome's headers — no `Accept-Encoding` at all, since reqwest's `gzip`/`brotli` features
+  weren't enabled — kept no cookies, and was rebuilt from scratch on every call.
+  - One client for the session, with a cookie jar so a `cf_clearance` is replayed rather
+    than arriving cold, and connection reuse so typing in the search box costs one TLS
+    handshake instead of one per keystroke — the traffic shape that invites rate limiting.
+  - The header set Chrome actually sends, a full four-part Chrome version (no browser
+    emits the `Chrome/126.0` form we were using), and gzip/brotli enabled.
+  - 403 / 429 / 503 retry with backoff instead of failing on the first refusal, and each
+    maps to a plain-English message with something to do about it.
+  - A Cloudflare interstitial served as a 200 no longer reads as "No download link was
+    found on this page" — it says the page was intercepted.
+
+  Honest caveat: the 403 is not reproducible from here (the current client gets 200s), so
+  this is a set of well-founded improvements rather than a confirmed cure. The clearer
+  error means the next report will say which of these it is.
+
 ## 2026-08-06 — v0.6.2 — mod-manager performance, Discord release announcements
 
 ### Added

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -133,6 +133,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +544,24 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -5430,7 +5460,19 @@ dependencies = [
  "mio 1.2.2",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5608,12 +5650,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags 2.13.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,11 +29,16 @@ walkdir = "2"
 # rustls: consistent modern TLS across platforms (native SChannel failed on
 # Windows). MediaFire downloads work directly with this client — its CDN no
 # longer blocks the rustls fingerprint (verified against a live 427 MB .pkz).
+# `gzip`/`brotli` are not just bandwidth: without them reqwest sends no
+# `Accept-Encoding` at all, which makes a client claiming to be Chrome look
+# nothing like Chrome to a bot filter.
 reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
     "stream",
     "json",
     "cookies",
+    "gzip",
+    "brotli",
 ] }
 tokio = { version = "1", features = ["time"] }
 futures-util = { version = "0.3", features = ["io"] }
@@ -73,3 +78,8 @@ notify-debouncer-mini = "0.4"
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!
 custom-protocol = ["tauri/custom-protocol"]
+
+[dev-dependencies]
+# `#[tokio::test]` for the live network checks against mxb-mods.com. Dev-only, so the
+# shipped binary keeps the minimal `time`-only tokio it already had.
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/src-tauri/src/install.rs
+++ b/src-tauri/src/install.rs
@@ -10,7 +10,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
 
-const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36";
+// Same string as `shop_session::UA`, kept in one place.
+use crate::shop_session::UA;
 const EMIT_EVERY_BYTES: u64 = 512 * 1024;
 
 #[derive(Debug, Clone, Serialize)]

--- a/src-tauri/src/mods/mxb.rs
+++ b/src-tauri/src/mods/mxb.rs
@@ -5,7 +5,11 @@ use scraper::{Html, Selector};
 use serde_json::Value;
 
 const BASE: &str = "https://mxb-mods.com";
-const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36";
+/// A full four-part version, unlike the `Chrome/126.0` form used elsewhere — real Chrome
+/// never sends a two-part version, and a UA that no browser would emit is itself a signal
+/// to a bot filter. Deliberately not `shop_session::UA`: that one has to keep matching the
+/// login WebView or the `cf_clearance` minted there stops verifying.
+const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.6778.140 Safari/537.36";
 const PER_PAGE: &str = "24";
 
 pub struct MxbModsSource;
@@ -25,11 +29,115 @@ impl ModSource for MxbModsSource {
     }
 }
 
+/// One client for the whole session, not one per call.
+///
+/// Two reasons beyond the obvious. It keeps a cookie jar, so if Cloudflare ever hands out
+/// a `cf_clearance` we replay it instead of arriving cold every time — the pattern
+/// `shop_session` already uses for the sibling domain. And it reuses connections, so a
+/// user typing in the search box costs one TLS handshake rather than one per keystroke,
+/// which is the sort of traffic shape that gets a client rate-limited in the first place.
+fn client() -> anyhow::Result<&'static Client> {
+    static CLIENT: std::sync::OnceLock<Result<Client, String>> = std::sync::OnceLock::new();
+    CLIENT
+        .get_or_init(|| build_client().map_err(|e| format!("{e:#}")))
+        .as_ref()
+        .map_err(|e| anyhow::anyhow!("{e}"))
+}
+
 fn build_client() -> anyhow::Result<Client> {
+    use reqwest::header::{HeaderMap, HeaderValue};
+    // What Chrome actually sends on a same-origin `fetch`. reqwest sends almost none of
+    // these on its own, so a request claiming to be Chrome didn't look like one.
+    let mut headers = HeaderMap::new();
+    for (k, v) in [
+        ("accept", "application/json, text/plain, */*"),
+        ("accept-language", "en-US,en;q=0.9"),
+        ("sec-fetch-site", "same-origin"),
+        ("sec-fetch-mode", "cors"),
+        ("sec-fetch-dest", "empty"),
+        ("referer", BASE),
+    ] {
+        headers.insert(k, HeaderValue::from_static(v));
+    }
     Ok(Client::builder()
         .user_agent(UA)
+        .default_headers(headers)
+        .cookie_store(true)
+        .connect_timeout(std::time::Duration::from_secs(15))
         .timeout(std::time::Duration::from_secs(30))
         .build()?)
+}
+
+/// Statuses worth trying again: Cloudflare hands out 403 on a bad bot score, 429 on rate
+/// limiting, and 503 while an interstitial is up. All three are commonly transient for a
+/// client that is not in fact a bot.
+fn worth_retrying(status: reqwest::StatusCode) -> bool {
+    matches!(status.as_u16(), 403 | 429 | 503)
+}
+
+/// `GET` with backoff over the transient blocks above. Transport errors retry too, which
+/// is what `install::get_with_retry` already does for download hosts.
+async fn get_with_retry(
+    url: &str,
+    params: &[(&str, String)],
+) -> anyhow::Result<reqwest::Response> {
+    const ATTEMPTS: u32 = 3;
+    let client = client()?;
+    let mut last_err: Option<anyhow::Error> = None;
+    for attempt in 1..=ATTEMPTS {
+        match client.get(url).query(params).send().await {
+            Ok(resp) if !worth_retrying(resp.status()) => return Ok(resp),
+            Ok(resp) => {
+                let status = resp.status();
+                if attempt == ATTEMPTS {
+                    return Ok(resp);
+                }
+                last_err = Some(anyhow::anyhow!("{status}"));
+            }
+            Err(e) => {
+                if attempt == ATTEMPTS {
+                    return Err(e.into());
+                }
+                last_err = Some(e.into());
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500 * attempt as u64)).await;
+    }
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("request failed")))
+}
+
+/// Turn a blocked response into something a person can act on. The raw reqwest `Display`
+/// ("HTTP status client error (403 Forbidden) for url (…)") told users nothing and shipped
+/// them a URL with percent-encoded query params.
+fn blocked_error(status: reqwest::StatusCode) -> anyhow::Error {
+    match status.as_u16() {
+        403 => anyhow::anyhow!(
+            "mxb-mods.com refused the request (403). Its bot protection sometimes blocks \
+             an app it doesn't recognise — wait a minute and hit Retry. If it keeps \
+             happening, opening mxb-mods.com in your browser first usually clears it."
+        ),
+        429 => anyhow::anyhow!(
+            "mxb-mods.com is rate-limiting us (429). Give it a minute, then hit Retry."
+        ),
+        503 => anyhow::anyhow!(
+            "mxb-mods.com is unavailable right now (503) — it may be behind a Cloudflare \
+             check. Try again shortly."
+        ),
+        _ => anyhow::anyhow!("mxb-mods.com returned {status}"),
+    }
+}
+
+/// A Cloudflare interstitial served with a 200, which would otherwise parse as an empty
+/// page — the quiet failure behind "No download link was found on this page".
+///
+/// Deliberately *not* keyed on `challenge-platform`: Cloudflare injects that script into
+/// ordinary pages too (verified — it appears once in a normal 212 KB mod page that parses
+/// fine), so matching it would condemn every mod page. The markers below only appear on
+/// the interstitial itself.
+fn is_challenge(html: &str) -> bool {
+    html.contains("cf-browser-verification")
+        || html.contains("cf_chl_opt")
+        || html.to_ascii_lowercase().contains("<title>just a moment")
 }
 
 pub async fn search(
@@ -37,7 +145,6 @@ pub async fn search(
     category_id: u32,
     page: u32,
 ) -> anyhow::Result<Vec<ModSummary>> {
-    let client = build_client()?;
     let url = format!("{BASE}/wp-json/wp/v2/posts");
 
     let mut params: Vec<(&str, String)> = vec![
@@ -52,12 +159,14 @@ pub async fn search(
         params.push(("search", q.to_string()));
     }
 
-    let resp = client.get(&url).query(&params).send().await?;
+    let resp = get_with_retry(&url, &params).await?;
     // WP returns 400 (rest_post_invalid_page_number) once you page past the end.
     if resp.status() == reqwest::StatusCode::BAD_REQUEST {
         return Ok(vec![]);
     }
-    let resp = resp.error_for_status()?;
+    if !resp.status().is_success() {
+        return Err(blocked_error(resp.status()));
+    }
     let posts: Vec<Value> = resp.json().await?;
 
     Ok(posts
@@ -67,20 +176,16 @@ pub async fn search(
 }
 
 pub async fn detail(slug: &str) -> anyhow::Result<ModDetail> {
-    let client = build_client()?;
-
     // 1. Post metadata + description via the REST API.
     let url = format!("{BASE}/wp-json/wp/v2/posts");
     let params = vec![
         ("slug", slug.to_string()),
         ("_embed", "wp:featuredmedia".to_string()),
     ];
-    let resp = client
-        .get(&url)
-        .query(&params)
-        .send()
-        .await?
-        .error_for_status()?;
+    let resp = get_with_retry(&url, &params).await?;
+    if !resp.status().is_success() {
+        return Err(blocked_error(resp.status()));
+    }
     let posts: Vec<Value> = resp.json().await?;
     let post = posts
         .into_iter()
@@ -110,14 +215,24 @@ pub async fn detail(slug: &str) -> anyhow::Result<ModDetail> {
 
     let description_html = strip_images(&content);
 
-    // 2. Download links + version from the rendered page HTML.
-    let (downloads, version) = match client.get(&link).send().await {
-        Ok(r) => {
-            let html = r.text().await.unwrap_or_default();
-            (parse_downloads(&html), parse_version(&html))
-        }
-        Err(_) => (Vec::new(), None),
-    };
+    // 2. Download links + version from the rendered page HTML. A block here used to be
+    // swallowed: a 403 is `Ok(resp)`, so its error body went to the parsers and produced
+    // zero downloads — the page then said "No download link was found on this page"
+    // rather than "we couldn't read the page". Surface it instead.
+    let resp = get_with_retry(&link, &[]).await?;
+    if !resp.status().is_success() {
+        return Err(blocked_error(resp.status()));
+    }
+    let html = resp.text().await.unwrap_or_default();
+    let (downloads, version) = (parse_downloads(&html), parse_version(&html));
+    // Only call it a challenge when the page also yielded nothing, so a marker that turns
+    // up in a page that actually parsed can never turn a working mod into an error.
+    if downloads.is_empty() && is_challenge(&html) {
+        anyhow::bail!(
+            "mxb-mods.com served a Cloudflare check instead of the mod page. Open \
+             mxb-mods.com in your browser once, then hit Retry."
+        );
+    }
 
     Ok(ModDetail {
         id,
@@ -393,3 +508,80 @@ mod tests {
         });
     }
 }
+
+#[cfg(test)]
+mod client_tests {
+    use super::*;
+
+    #[test]
+    fn retries_only_the_transient_blocks() {
+        for code in [403u16, 429, 503] {
+            assert!(worth_retrying(reqwest::StatusCode::from_u16(code).unwrap()), "{code}");
+        }
+        for code in [200u16, 400, 404, 500] {
+            assert!(!worth_retrying(reqwest::StatusCode::from_u16(code).unwrap()), "{code}");
+        }
+    }
+
+    #[test]
+    fn spots_a_cloudflare_interstitial() {
+        assert!(is_challenge("<title>Just a moment...</title>"));
+        assert!(is_challenge(r#"<form id="challenge-form" class="cf-browser-verification">"#));
+        assert!(is_challenge("window._cf_chl_opt = {};"));
+    }
+
+    #[test]
+    fn a_normal_page_is_not_a_challenge() {
+        // Cloudflare injects this script into ordinary pages; a real 212 KB mod page that
+        // parses fine contains it. Matching on it would break every mod detail view.
+        let real = r#"<title>MXB App - MXB-Mods.com</title>
+            <div class="download-container"><a href="https://x/f.pkz">Default</a></div>
+            <script src="/cdn-cgi/challenge-platform/h/b/scripts/jsd/main.js"></script>"#;
+        assert!(!is_challenge(real));
+        assert!(!parse_downloads(real).is_empty(), "and it still parses");
+    }
+
+    #[test]
+    fn blocked_errors_say_what_to_do() {
+        let msg = blocked_error(reqwest::StatusCode::FORBIDDEN).to_string();
+        assert!(msg.contains("403") && msg.contains("Retry"), "{msg}");
+        // The old text leaked a percent-encoded URL at the user; make sure we don't.
+        assert!(!msg.contains("wp-json"), "{msg}");
+    }
+
+    /// Live check against mxb-mods.com — the client this ships, not an approximation.
+    /// `cargo test live_ -- --ignored --nocapture`
+    #[tokio::test]
+    #[ignore]
+    async fn live_search_and_detail() {
+        let mods = search("", 22, 1).await.expect("search works");
+        eprintln!("search returned {} tracks", mods.len());
+        assert!(!mods.is_empty(), "the tracks category should not be empty");
+
+        let d = detail(&mods[0].slug).await.expect("detail works");
+        eprintln!("detail '{}': {} downloads, version {:?}", d.title, d.downloads.len(), d.version);
+        assert!(!d.title.is_empty());
+    }
+
+    /// The headers really do go out — proves the fix is on the wire, not just in source.
+    #[tokio::test]
+    #[ignore]
+    async fn live_sends_browser_headers() {
+        let body: serde_json::Value = client()
+            .unwrap()
+            .get("https://httpbin.org/headers")
+            .send()
+            .await
+            .expect("reachable")
+            .json()
+            .await
+            .expect("json");
+        let h = &body["headers"];
+        eprintln!("{}", serde_json::to_string_pretty(h).unwrap());
+        assert!(h["User-Agent"].as_str().unwrap().contains("Chrome/131.0.6778.140"));
+        assert!(h["Accept-Encoding"].as_str().unwrap().contains("gzip"));
+        assert!(h["Accept-Language"].as_str().is_some());
+        assert!(h["Sec-Fetch-Mode"].as_str().is_some());
+    }
+}
+

--- a/src/Components/Browse/Browse.tsx
+++ b/src/Components/Browse/Browse.tsx
@@ -281,9 +281,14 @@ export default function Browse({
 
       <div className="min-h-0 flex-1 overflow-y-auto px-7 pb-6">
         {error ? (
-          <div className="flex flex-col items-center gap-3 py-20 text-center">
-            <p className="text-[13px] text-destructive">
-              Couldn&apos;t load mods: {error}
+          <div className="mx-auto flex max-w-md flex-col items-center gap-3 py-20 text-center">
+            <p className="text-[13px] font-semibold text-destructive">
+              Couldn&apos;t load mods
+            </p>
+            {/* The backend now explains blocks in plain words; show that on its own line
+                rather than glued to the heading, and keep it selectable for bug reports. */}
+            <p className="select-text text-[12.5px] leading-relaxed text-muted-foreground">
+              {error.replace(/^Error:\s*/, "")}
             </p>
             <Button variant="outline" size="sm" onClick={() => setReloadKey((k) => k + 1)}>
               Retry


### PR DESCRIPTION
From the launch-day comments: one user got `403 Forbidden` on every browse, shown as the raw reqwest text — `HTTP status client error (403 Forbidden) for url (https://mxb-mods.com/wp-json/...&_embed=wp%3Afeaturedmedia)`.

## What was wrong

The client claimed to be Chrome and sent almost nothing Chrome sends. No `Accept-Encoding` at all — reqwest's `gzip`/`brotli` features were never enabled — no `Accept-Language`, no `Sec-Fetch-*`, no `Referer`. It kept no cookies, so a `cf_clearance` could never persist, and it was rebuilt from scratch on every call, meaning a fresh TLS handshake per keystroke in the search box.

## Changes

- **One session-wide client** with a cookie jar and connection reuse — the pattern `shop_session.rs` already uses for the sibling domain.
- **Real browser headers**, gzip/brotli enabled, and a full four-part Chrome version. No real browser emits the `Chrome/126.0` form we were sending, which is itself a signal. Kept deliberately separate from `shop_session::UA`, which has to keep matching the login WebView or the `cf_clearance` minted there stops verifying; `install.rs` now shares that constant instead of holding a third copy.
- **Retry 403/429/503 with backoff**, each mapping to a message with something to do about it.
- **Cloudflare interstitials served as 200** no longer feed their body to the parsers and surface as "No download link was found on this page".

## Caught while testing

Keying challenge detection on `challenge-platform` — which I copied from `mods/mxbshop.rs` — is wrong. Cloudflare injects that script into **ordinary** pages; it appears once in a normal 212 KB mod page that parses fine. Shipping it would have turned every mod detail view into an error. Detection now uses markers unique to the interstitial (`cf-browser-verification`, `cf_chl_opt`, `<title>just a moment`) and only fires when the page also yielded no downloads, with a regression test built from the real page. `mods/mxbshop.rs` carries the same latent flaw — left alone here, since it's a different domain and paired with a second condition.

## Verification

Live, against mxb-mods.com, using the client this actually ships:

```
live_sends_browser_headers ... ok
  Accept-Encoding: gzip,br
  Accept-Language: en-US,en;q=0.9
  Sec-Fetch-Mode: cors
  User-Agent: ...Chrome/131.0.6778.140 Safari/537.36

live_search_and_detail ... ok
  search returned 24 tracks
  detail 'Track 556': 1 downloads, version Some("Beta 19")
```

`cargo test` — 132 passed, 0 failed. `tsc --noEmit` and ESLint clean.

**Honest limitation:** I cannot reproduce the 403 from here — the *current* client also gets 200s, so the header theory is unconfirmed. These are well-founded improvements, not a proven cure. What is guaranteed is that the next report will name the failure instead of dumping a URL.

If it recurs, the real fix is a fallback: the category listing pages (`/?cat=22`) serve fine and carry post links, so Browse could scrape HTML when `/wp-json` is blocked. Happy to add that on request — it's beyond what was agreed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)