### PR TITLE
chore(linux): ship a Linux build that can actually find the game

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ jobs:
           # macOS (Apple Silicon) build of the cross-platform download/extract UI.
           - platform: macos-latest
             args: "--target aarch64-apple-darwin"
+          # Linux, for players running MX Bikes under Proton. Pinned to 22.04, not
+          # `latest`: the AppImage inherits the builder's glibc as its floor, so
+          # building on a newer runner would refuse to start on older distros.
+          - platform: ubuntu-22.04
+            args: ""
 
     runs-on: ${{ matrix.platform }}
 
@@ -43,6 +48,20 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin' || '' }}
+
+      # Tauri links against the GTK/WebKit stack on Linux; `patchelf` is what the
+      # AppImage bundler uses to rewrite the runtime paths. Mirrors ci.yml.
+      - name: Install Linux system dependencies
+        if: startsWith(matrix.platform, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libsoup-3.0-dev \
+            patchelf
 
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2
@@ -108,7 +127,10 @@ jobs:
           gh release download "$TAG" -R "$REPO" -p latest.json -O latest.json --clobber || true
           for name in $(gh release view "$TAG" -R "$REPO" --json assets --jq '.assets[].name'); do
             case "$name" in
-              MXB.App_*.exe|MXB.App_*.dmg|MXB.App_*.exe.sig|MXB.App_*.dmg.sig)
+              # The .rpm is named `mxb-app-<ver>-1.x86_64.rpm` by convention and is
+              # deliberately left alone. latest.json's Linux entry points at the
+              # AppImage, and the sed below keeps it pointing at the renamed one.
+              MXB.App_*.exe|MXB.App_*.dmg|MXB.App_*.exe.sig|MXB.App_*.dmg.sig|MXB.App_*.AppImage|MXB.App_*.AppImage.sig|MXB.App_*.deb)
                 new="$(printf '%s' "$name" | sed -e 's/MXB\.App/MXB-App/' -e 's/_/-/g' -e 's/-setup//')"
                 [ "$name" = "$new" ] && continue
                 echo "rename: $name -> $new"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Linux builds.** Releases now produce an AppImage, a `.deb` and an `.rpm` alongside the
+  Windows and macOS installers, built on a third CI leg. The AppImage isn't optional —
+  it's the only Linux artifact the updater can use, so `latest.json` gets its
+  `linux-x86_64` entry from it. Pinned to Ubuntu 22.04 rather than `latest`, because an
+  AppImage inherits its builder's glibc as a floor and would otherwise refuse to start on
+  older distros.
+- **MX Bikes is found automatically under Proton.** The game runs as a Windows process
+  there, so it writes into the Wine prefix —
+  `steamapps/compatdata/655500/pfx/drive_c/users/steamuser/Documents/PiBoSo/MX Bikes` —
+  and never touches the real `~/Documents`. Detection checks the prefix first, and now
+  also finds Steam installed via Flatpak or snap, or at `~/.steam/root`.
+
+### Fixed
+- **Folder lookups no longer depend on how a name is capitalised.** Windows and macOS
+  don't care, so hardcoded lowercase `mods` / `profiles` always resolved. Under Proton the
+  filesystem is case-sensitive, and a folder the game or a mod archive created as `Mods`
+  was simply invisible. Resolution now falls back to a case-insensitive match, in the one
+  helper every `mods/...` path already goes through.
+
+### Changed
+- **Windows-only features are hidden rather than offered and broken on Linux.** The
+  FrostMod section — a Win32 DLL injected into the game — no longer appears, and can't be
+  asked to download two `.exe`/`.dll` files that would never run. Instant preset refresh
+  explains why it's unavailable instead of saying "Windows only" to a Windows user. The
+  setup screen shows the Proton path rather than `Documents\PiBoSo\MX Bikes`. The frontend
+  now asks the backend which OS it's on, instead of inferring it from `navigator.userAgent`
+  (which can spot a Mac and nothing else).
+- **Closing the window on Linux really closes it.** Close-to-tray relies on the tray
+  surviving, but Tauri doesn't receive tray clicks through libayatana-appindicator and a
+  stock GNOME desktop has no tray at all — hiding there could strand the window with no
+  way back.
+
 ## 2026-08-06 — v0.6.2 — mod-manager performance, Discord release announcements
 
 ### Added

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -94,7 +94,10 @@ fn looks_like_mods_dir(path: &str) -> bool {
     if path.trim().is_empty() || !dir.is_dir() {
         return false;
     }
-    dir.join("profiles").is_dir() || dir.join("mods").is_dir()
+    // Case-insensitive: under Proton these can come back as `Mods`/`Profiles` on a
+    // case-sensitive filesystem, and an exact match would reject a perfectly good folder.
+    crate::library::resolve_child(dir, "profiles").is_dir()
+        || crate::library::resolve_child(dir, "mods").is_dir()
 }
 
 /// The saved config, or one built on the spot when the MX Bikes folder sits where it
@@ -135,7 +138,13 @@ pub fn save(app: &AppHandle, cfg: &AppConfig) -> anyhow::Result<()> {
 
 pub fn finalize(mut cfg: AppConfig) -> AppConfig {
     if cfg.mods_path.trim().is_empty() {
-        if let Some(docs) = dirs_next::document_dir() {
+        // On Linux the game runs under Proton and writes into the Wine prefix, not the
+        // user's real Documents — check there first, since `document_dir()` would
+        // otherwise hand back a path MX Bikes has never written to (and often `None`,
+        // because it depends on `~/.config/user-dirs.dirs` existing).
+        if let Some(p) = detect_proton_mods_path() {
+            cfg.mods_path = p;
+        } else if let Some(docs) = dirs_next::document_dir() {
             cfg.mods_path = docs
                 .join("PiBoSo")
                 .join("MX Bikes")
@@ -151,6 +160,36 @@ pub fn finalize(mut cfg: AppConfig) -> AppConfig {
         }
     }
     cfg
+}
+
+/// MX Bikes' Steam AppID — names its Proton prefix under `steamapps/compatdata`.
+const MX_BIKES_APPID: &str = "655500";
+
+/// The MX Bikes user folder inside a Proton prefix.
+///
+/// Under Proton the game is a Windows process, so `Documents` is the prefix's fake
+/// `C:` drive — `compatdata/655500/pfx/drive_c/users/steamuser/Documents/PiBoSo/MX Bikes`
+/// — and nothing is ever written to the user's real `~/Documents`. Without this a Linux
+/// player lands on the setup screen with no working default to accept.
+///
+/// Returns the first prefix that actually looks like a mods dir, so a stale prefix from an
+/// uninstalled copy can't win over a real one.
+fn detect_proton_mods_path() -> Option<String> {
+    if cfg!(not(target_os = "linux")) {
+        return None;
+    }
+    for lib in steam_libraries() {
+        let candidate = lib
+            .join("steamapps")
+            .join("compatdata")
+            .join(MX_BIKES_APPID)
+            .join("pfx/drive_c/users/steamuser/Documents/PiBoSo/MX Bikes");
+        let as_str = candidate.to_string_lossy().into_owned();
+        if looks_like_mods_dir(&as_str) {
+            return Some(as_str);
+        }
+    }
+    None
 }
 
 /// Locate the MX Bikes install folder (the one containing `rider.pkz`) by scanning
@@ -195,7 +234,15 @@ fn steam_libraries() -> Vec<PathBuf> {
         if let Some(home) = dirs_next::home_dir() {
             push(&mut roots, home.join("Library/Application Support/Steam"));
             push(&mut roots, home.join(".steam/steam"));
+            push(&mut roots, home.join(".steam/root"));
             push(&mut roots, home.join(".local/share/Steam"));
+            // Flatpak and snap Steam keep their own home, so the paths above miss them
+            // entirely — which for a Flatpak user means no detection at all.
+            push(
+                &mut roots,
+                home.join(".var/app/com.valvesoftware.Steam/data/Steam"),
+            );
+            push(&mut roots, home.join("snap/steam/common/.local/share/Steam"));
         }
     }
 
@@ -321,5 +368,47 @@ mod tests {
                 "D:\\SteamLibrary".to_string(),
             ]
         );
+    }
+}
+
+#[cfg(test)]
+mod linux_paths_tests {
+    use super::*;
+
+    /// A Proton prefix laid out the way Steam actually makes one, checked through the
+    /// same `looks_like_mods_dir` gate detection uses. Runs on every OS: the layout is
+    /// what's under test, not the host.
+    #[test]
+    fn recognises_a_proton_prefix_layout() {
+        let root = std::env::temp_dir().join(format!("frost-proton-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let mods = root
+            .join("steamapps/compatdata")
+            .join(MX_BIKES_APPID)
+            .join("pfx/drive_c/users/steamuser/Documents/PiBoSo/MX Bikes");
+        std::fs::create_dir_all(mods.join("mods").join("bikes")).unwrap();
+        std::fs::create_dir_all(mods.join("profiles")).unwrap();
+
+        assert!(
+            looks_like_mods_dir(&mods.to_string_lossy()),
+            "the prefix's MX Bikes folder is a valid mods dir"
+        );
+        // And the path the app builds from a library root matches where Steam put it.
+        let built = root
+            .join("steamapps")
+            .join("compatdata")
+            .join(MX_BIKES_APPID)
+            .join("pfx/drive_c/users/steamuser/Documents/PiBoSo/MX Bikes");
+        assert_eq!(built, mods);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn proton_detection_is_linux_only() {
+        // On Windows/macOS the game is native and writes to the real Documents folder,
+        // so the prefix probe must never hijack detection there.
+        if cfg!(not(target_os = "linux")) {
+            assert!(detect_proton_mods_path().is_none());
+        }
     }
 }

--- a/src-tauri/src/frostmod_manage.rs
+++ b/src-tauri/src/frostmod_manage.rs
@@ -165,7 +165,13 @@ fn write_with_retry(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()>
 }
 
 /// Download `frostmod.exe` + `frostmod.dll` from the latest release; returns the tag.
+///
+/// Refused off Windows: FrostMod is a Win32 DLL injected into the game, so downloading it
+/// elsewhere just parks two unusable binaries in the app's data dir before `start()` bails.
 pub async fn install(app: &AppHandle) -> anyhow::Result<String> {
+    if cfg!(not(windows)) {
+        anyhow::bail!("FrostMod runs on Windows only");
+    }
     let rel = latest_release().await?;
     let dir = frostmod_dir(app);
     std::fs::create_dir_all(&dir)?;

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -13,10 +13,35 @@ pub struct InstalledMod {
     pub size: u64,
 }
 
+/// The child of `dir` named `seg`, matching case-insensitively when the exact name isn't
+/// there.
+///
+/// Windows and macOS don't care about case, so a hardcoded `"mods"` always resolved. Linux
+/// does: MX Bikes runs under Proton on a case-sensitive filesystem, where a folder the game
+/// or a mod archive created as `Mods` is a different path from `mods`, and every lookup
+/// silently missed. Falls back to the literal name so paths we're about to *create* still
+/// come out as written.
+pub fn resolve_child(dir: &Path, seg: &str) -> PathBuf {
+    let exact = dir.join(seg);
+    if exact.exists() {
+        return exact;
+    }
+    if let Ok(rd) = std::fs::read_dir(dir) {
+        for e in rd.flatten() {
+            if e.file_name().to_string_lossy().eq_ignore_ascii_case(seg) {
+                return e.path();
+            }
+        }
+    }
+    exact
+}
+
+/// Resolve `mods/bikes`-style relative paths under the MX Bikes folder. The single funnel
+/// for these lookups, so making it case-tolerant covers the whole app at once.
 pub fn mods_subdir(mods_path: &str, subpath: &str) -> PathBuf {
     let mut p = PathBuf::from(mods_path);
     for seg in subpath.split(['/', '\\']).filter(|s| !s.is_empty()) {
-        p.push(seg);
+        p = resolve_child(&p, seg);
     }
     p
 }
@@ -677,5 +702,47 @@ mod tests {
         assert!(res.is_err());
         assert!(outside.exists());
         let _ = fs::remove_dir_all(&root);
+    }
+}
+
+#[cfg(test)]
+mod path_case_tests {
+    use super::*;
+
+    /// True when the filesystem under `dir` distinguishes case (ext4 does, APFS/NTFS
+    /// as shipped do not) — the assertion only means something on the former.
+    fn case_sensitive_fs(dir: &Path) -> bool {
+        let probe = dir.join("CaseProbe");
+        std::fs::create_dir_all(&probe).unwrap();
+        !dir.join("caseprobe").exists()
+    }
+
+    #[test]
+    fn resolves_a_child_whose_case_differs() {
+        let root = std::env::temp_dir().join(format!("frost-case-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let sensitive = case_sensitive_fs(&root);
+        // What a Proton prefix or a mod archive can leave on a case-sensitive filesystem.
+        std::fs::create_dir_all(root.join("Mods").join("Bikes")).unwrap();
+
+        let got = mods_subdir(root.to_str().unwrap(), "mods/bikes");
+        assert!(got.is_dir(), "lookup found the real folder: {got:?}");
+        if sensitive {
+            assert!(got.ends_with("Bikes"), "kept the on-disk casing: {got:?}");
+        } else {
+            eprintln!("case-insensitive filesystem — the OS resolved it for us");
+        }
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn falls_back_to_the_literal_name_for_paths_we_create() {
+        let root = std::env::temp_dir().join(format!("frost-case-new-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let got = mods_subdir(root.to_str().unwrap(), "mods/tracks");
+        assert!(got.ends_with("tracks"), "nothing on disk yet, so use what we asked for");
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1470,6 +1470,17 @@ fn bike_preview_available() -> bool {
     cfg!(sidecar)
 }
 
+/// The OS we're running on — `"windows"`, `"macos"`, `"linux"`.
+///
+/// The frontend used to infer this from `navigator.userAgent`, which can tell a Mac from
+/// everything else and nothing more. Features that only exist on Windows (FrostMod, the
+/// live in-game refresh) need to know the difference between Windows and Linux, so it
+/// comes from the backend rather than adding `plugin-os` and a capability for one string.
+#[tauri::command]
+fn app_platform() -> &'static str {
+    std::env::consts::OS
+}
+
 #[tauri::command]
 fn set_run_in_background(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
     let mut cfg = config::load(&app).unwrap_or_default();
@@ -1924,7 +1935,12 @@ fn main() {
         .on_window_event(|window, event| {
             if let WindowEvent::CloseRequested { api, .. } = event {
                 let cfg = config::load(window.app_handle()).unwrap_or_default();
-                if cfg.run_in_background && !cfg!(debug_assertions) {
+                // Never on Linux: the tray runs through libayatana-appindicator, which
+                // doesn't deliver click events to Tauri and isn't present at all on a
+                // stock GNOME desktop. Hiding there can strand the window with no way
+                // back, so closing closes.
+                let tray_can_restore = cfg!(not(target_os = "linux"));
+                if cfg.run_in_background && tray_can_restore && !cfg!(debug_assertions) {
                     api.prevent_close();
                     let _ = window.hide();
                 }
@@ -1935,6 +1951,7 @@ fn main() {
             get_config,
             create_config,
             bike_preview_available,
+            app_platform,
             search_mods,
             get_mod_detail,
             get_installed_mods,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -34,7 +34,8 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["nsis", "app", "dmg"],
+    "targets": ["nsis", "app", "dmg", "appimage", "deb", "rpm"],
+    "category": "Game",
     "createUpdaterArtifacts": true,
     "licenseFile": "../LICENSE",
     "publisher": "Frost",

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "linux": {
+      "deb": {
+        "depends": ["libwebkit2gtk-4.1-0", "libgtk-3-0"]
+      },
+      "appimage": {
+        "bundleMediaFramework": false
+      }
+    }
+  }
+}

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -17,6 +17,7 @@ import {
   setWatchModsReload,
 } from "../../api/mods";
 import { useUpdate } from "../../Context/Update";
+import { usePlatform } from "../../lib/usePlatform";
 import { useConfig } from "../../Context/Config";
 import { useTheme, type ThemeMode } from "../../Context/Theme";
 import { useFrostmod } from "../../Context/FrostmodContext";
@@ -43,6 +44,7 @@ const SECTIONS: { id: SectionId; label: string }[] = [
 
 export default function Settings() {
   const { config, reloadConfig } = useConfig();
+  const isWindows = usePlatform() === "windows";
   const { theme, setTheme } = useTheme();
   const { running, reload, status, installing, checking, statusError, install, start, refreshStatus } =
     useFrostmod();
@@ -415,7 +417,11 @@ export default function Settings() {
             <div className="h-px bg-border" />
             <ToggleRow
               label="Instant preset refresh"
-              desc="When you apply a preset while MX Bikes is running, refresh the look in-game instantly — no restart or profile reselect. Windows only; if it can't, you'll be told to reselect your profile."
+              desc={
+                isWindows
+                  ? "When you apply a preset while MX Bikes is running, refresh the look in-game instantly — no restart or profile reselect. If it can't, you'll be told to reselect your profile."
+                  : "Refreshing the look in-game without a restart needs FrostMod, which is Windows-only — you'll be told to reselect your profile instead."
+              }
               checked={instantRefresh}
               onChange={toggleInstantRefresh}
             />
@@ -441,7 +447,10 @@ export default function Settings() {
             </div>
           </Section>
 
-          {/* frostmod */}
+          {/* frostmod — a Win32 DLL injected into the game, so it has nothing to do
+              anywhere else. Hidden rather than shown-and-disabled: every control in it
+              would fail, including one that downloads two Windows binaries. */}
+          {isWindows && (
           <Section
             title="FrostMod"
             innerRef={(el) => (refs.current.frostmod = el)}
@@ -555,6 +564,7 @@ export default function Settings() {
               </Button>
             </div>
           </Section>
+          )}
 
           {/* about */}
           <Section title="About & updates" innerRef={(el) => (refs.current.about = el)}>

--- a/src/Components/Setup/Setup.tsx
+++ b/src/Components/Setup/Setup.tsx
@@ -2,13 +2,26 @@ import { useEffect, useState } from "react";
 import { Snowflake, FolderOpen, Gamepad2, Loader2, Check } from "lucide-react";
 import { open as pickFolder } from "@tauri-apps/plugin-dialog";
 import { createConfig, detectGamePath } from "../../api/mods";
+import { usePlatform } from "../../lib/usePlatform";
 import { Button } from "@/Components/ui/button";
 
 interface SetupProps {
   onComplete: () => void;
 }
 
+/**
+ * Where MX Bikes keeps its user folder, per OS. On Linux the game runs under Proton and
+ * writes inside the Wine prefix, so pointing someone at `~/Documents` would send them
+ * looking in a folder MX Bikes has never touched.
+ */
+function hintFor(platform: string | null): string {
+  if (platform === "linux") return "steamapps/compatdata/655500/.../Documents/PiBoSo/MX Bikes";
+  if (platform === "macos") return "Documents/PiBoSo/MX Bikes";
+  return "Documents\\PiBoSo\\MX Bikes";
+}
+
 export default function Setup({ onComplete }: SetupProps) {
+  const defaultHint = hintFor(usePlatform());
   const [chosen, setChosen] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -103,10 +116,8 @@ export default function Setup({ onComplete }: SetupProps) {
           ) : (
             <p className="text-[12.5px] text-muted-foreground">
               MXB App will auto-detect your{" "}
-              <span className="font-mono text-foreground/80">
-                Documents\PiBoSo\MX Bikes
-              </span>{" "}
-              folder. You can also pick it yourself.
+              <span className="font-mono text-foreground/80">{defaultHint}</span> folder.
+              You can also pick it yourself.
             </p>
           )}
           <button

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -806,3 +806,9 @@ export function onPresetBundleProgress(
 ): Promise<UnlistenFn> {
   return listen<BundleProgress>("preset-bundle-progress", (event) => cb(event.payload));
 }
+
+/** `"windows"` | `"macos"` | `"linux"`. Features gated on the OS ask the backend rather
+ *  than guessing from `navigator.userAgent`, which can't tell Windows from Linux. */
+export function appPlatform(): Promise<string> {
+  return invoke<string>("app_platform");
+}

--- a/src/lib/usePlatform.ts
+++ b/src/lib/usePlatform.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import { appPlatform } from "../api/mods";
+
+/**
+ * The OS the app is running on, or `null` until the backend answers.
+ *
+ * Callers gate Windows-only features on `platform === "windows"`, so the brief `null`
+ * renders as "not Windows" — hiding a control for a moment is harmless, offering one that
+ * cannot work is not.
+ */
+export function usePlatform(): string | null {
+  const [platform, setPlatform] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    appPlatform()
+      .then((p) => !cancelled && setPlatform(p))
+      .catch(() => !cancelled && setPlatform(null));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return platform;
+}


### PR DESCRIPTION
Asked for in the launch-day comments ("Can you tell me if this works with Linux?"). Less work than it looks — the code already uses `#[cfg(windows)]`/`#[cfg(not(windows))]` throughout, so Linux takes the same arm macOS does, and `ci.yml` already builds and tests on ubuntu. What was missing is packaging and the Proton reality.

## Packaging

- `appimage`, `deb`, `rpm` added to bundle targets, plus a `Game` category and a `tauri.linux.conf.json` alongside the existing macOS one. **The AppImage is required, not a nicety**: with `createUpdaterArtifacts: true` it's the only Linux artifact the updater can derive `latest.json`'s `linux-x86_64` entry from.
- Third release leg on **ubuntu-22.04**, not `latest` — an AppImage inherits its builder's glibc as a floor, so building on a newer runner produces something that won't start on older distros. apt step mirrored from `ci.yml`.
- The finalize rename step covers the AppImage and `.deb` so `latest.json` keeps pointing at the renamed asset. The `.rpm` keeps its conventional `mxb-app-<ver>-1.x86_64.rpm` name.

## Making it actually work

**Proton paths — the functional heart.** MX Bikes is a Windows process under Proton, so it writes into the Wine prefix at `steamapps/compatdata/655500/pfx/drive_c/users/steamuser/Documents/PiBoSo/MX Bikes` and never touches the real `~/Documents`. Detection checks the prefix first; `dirs_next::document_dir()` would otherwise return a folder the game has never written to, and frequently `None`, since it depends on `~/.config/user-dirs.dirs`. Steam under Flatpak, snap and `~/.steam/root` is now found too.

**Case sensitivity.** Hardcoded lowercase `mods`/`profiles` always resolved on NTFS and APFS. On the case-sensitive filesystem a Proton prefix lives on, a folder created as `Mods` was simply invisible. Fixed in `library::mods_subdir` — the single helper every `mods/...` lookup already funnels through — rather than sprinkling call sites. Falls back to the literal name so paths we're about to *create* still come out as written.

**Windows-only features.** The FrostMod section is hidden rather than shown-and-broken; `install()` now refuses off Windows instead of parking two unusable binaries in the data dir. Instant preset refresh explains why it's unavailable rather than telling a Windows user "Windows only". Setup shows the Proton path. New `app_platform` command replaces the `navigator.userAgent` sniff, which could spot a Mac and nothing else — chosen over adding `plugin-os` plus a capability for one string.

**Close-to-tray is off on Linux.** Tauri doesn't receive tray clicks through libayatana-appindicator, and stock GNOME has no tray at all, so hiding on close could strand the window with no way back.

## Verification

- `cargo test` — 132 passed, 0 failed (4 new).
- **The whole suite re-run with `TMPDIR` on a case-sensitive APFS volume** created for the purpose — the closest thing to ext4 available here: 130 passed, 0 failed. The case-resolution test's `ends_with("Bikes")` assertion genuinely executes there; on ordinary APFS it's a no-op, so without this it would have been vacuous.
- Both tauri configs parse; `release.yml` parses and its matrix is `windows-latest, macos-latest, ubuntu-22.04`.
- `tsc --noEmit` clean, ESLint 0 errors.

**Not verified:** no real Linux machine and no real Proton prefix. CI going green proves it builds and packages, not that detection fires against a genuine install. Worth one manual check on a Linux box before this goes out in a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)