### PR TITLE
chore(release): tell people which file to download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,30 @@ jobs:
         with:
           tagName: ${{ github.ref_type == 'tag' && github.ref_name || format('v{0}', github.run_number) }}
           releaseName: "MXB App ${{ github.ref_type == 'tag' && github.ref_name || format('build-{0}', github.run_number) }}"
-          releaseBody: "See the assets below to download and install."
+          # Nearly everyone here is on Windows, and the asset list now runs to six
+          # files across three platforms — so lead with the one file most people
+          # want and describe the rest by extension. Extensions don't drift when the
+          # `finalize` job renames the assets, exact filenames would.
+          releaseBody: |
+            ## Which file do I download?
+
+            **Windows — download the `.exe`.** That's the installer, and it's what
+            almost everyone needs. Run it and you're done.
+
+            <details>
+            <summary>macOS and Linux</summary>
+
+            - **macOS (Apple Silicon)** — the `.dmg`.
+            - **Linux** — the `.AppImage` works on any distro: download, `chmod +x`, run
+              it. Prefer your package manager? `.deb` for Debian/Ubuntu, `.rpm` for
+              Fedora. Note MX Bikes itself runs through Proton on Linux.
+
+            </details>
+
+            The `.sig` and `.tar.gz` files are used by the in-app updater — you don't
+            need to download those.
+
+            ---
           # Publish straight away (not a draft) so the updater's `latest.json`
           # endpoint (releases/latest) resolves without a manual publish step.
           releaseDraft: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## Unreleased
 
 ### Added
+- **Releases now say which file to download.** The release body led with "See the assets
+  below", which was thin with three files and no help at all now there are six across
+  three platforms. It opens with the Windows `.exe` — what nearly everyone here needs —
+  and tucks macOS and Linux behind a fold, noting that the `.sig`/`.tar.gz` files are the
+  updater's and shouldn't be downloaded. The Discord announcement labels the Windows link
+  "start here" and gained a Linux (AppImage) link. Both describe files by extension, so
+  the rename step can't make them wrong.
 - **Linux builds.** Releases now produce an AppImage, a `.deb` and an `.rpm` alongside the
   Windows and macOS installers, built on a third CI leg. The AppImage isn't optional —
   it's the only Linux artifact the updater can use, so `latest.json` gets its

--- a/scripts/notify-discord.sh
+++ b/scripts/notify-discord.sh
@@ -113,6 +113,9 @@ fi
 # names rather than Tauri's `MXB.App_0.6.1_x64-setup.exe`.
 win="$(jq -r '[.assets[] | select(.name | test("\\.exe$"))] | first | .url // empty' <<<"$meta")"
 mac="$(jq -r '[.assets[] | select(.name | test("\\.dmg$"))] | first | .url // empty' <<<"$meta")"
+# The AppImage is the portable one that works on any distro, so it's the Linux link
+# worth putting in a chat message; .deb/.rpm are a click away on the release page.
+lin="$(jq -r '[.assets[] | select(.name | test("\\.AppImage$"))] | first | .url // empty' <<<"$meta")"
 
 icon="https://raw.githubusercontent.com/$REPO/$TAG/src-tauri/icons/icon.png"
 avatar="https://raw.githubusercontent.com/$REPO/main/src-tauri/icons/icon.png"
@@ -126,6 +129,7 @@ payload="$(jq -n \
   --arg ts "$published" \
   --arg win "$win" \
   --arg mac "$mac" \
+  --arg lin "$lin" \
   '{
     username: "MXB App",
     avatar_url: $avatar,
@@ -140,7 +144,7 @@ payload="$(jq -n \
       footer: { text: "MXB App • GitHub Releases" },
       fields: (
         (if $win != "" then [{
-          name: "⬇ Windows",
+          name: "⬇ Windows — start here",
           value: ("[" + ($win | split("/") | last) + "](" + $win + ")"),
           inline: true
         }] else [] end)
@@ -148,6 +152,12 @@ payload="$(jq -n \
         (if $mac != "" then [{
           name: "⬇ macOS (Apple Silicon)",
           value: ("[" + ($mac | split("/") | last) + "](" + $mac + ")"),
+          inline: true
+        }] else [] end)
+        +
+        (if $lin != "" then [{
+          name: "⬇ Linux (AppImage)",
+          value: ("[" + ($lin | split("/") | last) + "](" + $lin + ")"),
           inline: true
         }] else [] end)
       )


### PR DESCRIPTION
The release body was `"See the assets below to download and install."` — thin with three assets, and unhelpful now that Linux brings the count to six across three platforms. Nearly everyone using this is on Windows.

## Changes

**Release body** now opens with the Windows `.exe` and what to do with it, folds macOS and Linux into a `<details>` block, and states that the `.sig` / `.tar.gz` files belong to the in-app updater and shouldn't be downloaded — those are a common source of "which one is it?".

**Discord announcement** labels the Windows link "start here" and gains a Linux (AppImage) link, which the notifier never had.

Both refer to files **by extension**, not exact filename, so the `finalize` rename step can't leave the instructions pointing at something that no longer exists.

## Verification

- `release.yml` parses and the multi-line `releaseBody` round-trips intact.
- `notify-discord.sh v0.6.2 --print` produces valid JSON against the real release, Windows field first. The Linux field correctly omits itself, since v0.6.2 predates the AppImage — so the empty-asset branch is exercised.
- Asset selectors resolve against a 0.6.3-shaped asset list: `.exe`, `.dmg` and `.AppImage` all match, and `.exe.sig` is correctly *not* picked as the exe.
- `bash -n` clean.

Both surfaces only render on a real tagged release, so the first true end-to-end proof is the 0.6.3 release itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)