### PR TITLE
chore(release): v0.6.3 — model swaps stop breaking bikes, Linux builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2026-08-06 — v0.6.3 — model swaps stop breaking bikes, Linux builds
 
 ### Added
 - **Releases now say which file to download.** The release body led with "See the assets

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frost",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frost",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.19",
         "@radix-ui/react-context-menu": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "frost"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frost"
-version = "0.6.2"
+version = "0.6.3"
 description = "Frost — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump and CHANGELOG close-out for v0.6.3. No functional changes — everything shipping here already merged via #20, #22, #23, #24.

- 0.6.2 → 0.6.3 across `package.json`, `package-lock.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `tauri.conf.json`.
- CHANGELOG `## Unreleased` → `## 2026-08-06 — v0.6.3 — model swaps stop breaking bikes, Linux builds`.

## What ships

- **Model swaps stop breaking bikes.** A swap used to park the bike's own setup files (`.hrc`/`.cfg`/`.geom`) into the swap folder, so the game stopped seeing the bike entirely. Bikes already damaged can be repaired from the Locker in one click.
- Bikes and swap sets whose mesh isn't literally `model.edf` are visible again; model swaps appear in Presets.
- Browse client sends real browser headers, retries a Cloudflare block, and explains one in plain words.
- Linux builds (AppImage / deb / rpm) with Proton path detection.
- Release notes say which file to download, Windows first.

Verified: `cargo test` 153 passed, 0 failed; `tsc --noEmit` clean.

## ⚠️ Do not tag until Actions is healthy

GitHub Actions is in a **major outage**, and the incident notes say webhook triggers are throttled so many push events aren't starting workflow runs. That already cost v0.6.2 its `finalize` and `notify` jobs (cancelled, twice).

`releaseBody`'s workflow uses `releaseDraft: false`, so tauri-action **publishes the release as soon as the first matrix leg finishes**. If the outage lets one leg through and cancels the others, a v0.6.3 release gets published with a `latest.json` missing the Windows entry — and since the updater endpoint resolves `releases/latest`, that would break auto-update for most users.

Merging this PR is safe. Pushing the `v0.6.3` tag is the step to hold until Actions is back, then confirm all three build legs succeeded before it's announced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)