### PR TITLE
fix(presets): let a slot be cleared back to stock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-08-07
+
+### Fixed
+- **A slot can be cleared back to stock again.** Empty is what the game writes for an
+  unmodded slot, and every layer already handled it — the trigger renders it as "Stock",
+  a cleared slot isn't flagged missing, and applying writes it through. Only the picker
+  couldn't produce it: there was no "none" option, no clear button, and an empty search
+  box commits nothing. Pick `full` for Protection once and the only ways back were the
+  game's own UI or hand-editing `profile.ini`. Every slot dropdown now leads with a
+  "Stock (none)" row that clears it. (#28)
+
 ## 2026-08-06 — v0.6.3 — model swaps stop breaking bikes, Linux builds
 
 ### Added

--- a/src/Components/ui/combobox.tsx
+++ b/src/Components/ui/combobox.tsx
@@ -25,7 +25,8 @@ interface ComboboxProps {
 /**
  * A searchable **creatable** combobox: click the trigger to see every option, type
  * to filter, and — since the value can be a free-text font or a captured mod name not
- * in the list — commit whatever you typed via the "Use …" row. Built on the shadcn
+ * in the list — commit whatever you typed via the "Use …" row. The first row clears the
+ * slot back to the empty/stock value, which no amount of typing can produce. Built on the shadcn
  * Popover + Command (cmdk) primitives. cmdk lowercases the value it hands `onSelect`,
  * so each item commits its own original-cased string from the closure instead.
  */
@@ -85,6 +86,22 @@ export function Combobox({
           <CommandList>
             {!canCreate && <CommandEmpty>No matches.</CommandEmpty>}
             <CommandGroup>
+              {/*
+                Empty is a real value — it's what the game writes for an unmodded slot,
+                and the trigger already renders it as the placeholder. Without this row
+                a slot is one-way: once set, nothing typeable commits "" again.
+                The extra words in `value` are just cmdk filter fodder.
+              */}
+              <CommandItem
+                value={`__stock__ ${placeholder} none clear`}
+                onSelect={() => commit("")}
+                className="text-[12.5px]"
+              >
+                <Check
+                  className={cn("mr-2 h-3.5 w-3.5 flex-none", !value ? "opacity-100" : "opacity-0")}
+                />
+                <span className="truncate text-muted-foreground">{placeholder} (none)</span>
+              </CommandItem>
               {options.map((o) => (
                 <CommandItem
                   key={o}


### PR DESCRIPTION
Fixes #28.

## The problem

An empty slot value means "stock / none", and every layer already handles it — the
`Combobox` trigger renders an empty value as its `Stock` placeholder, `isMissing`
returns `false` for it, and `apply_loadout` writes it through `doc.set`, so clearing
round-trips and survives later saves. The game writes empty itself.

Only the input couldn't produce it. `BUILTINS` has no none entry, `canCreate` requires
a non-empty query so an empty search box commits nothing, and there was no clear
affordance. Set Protection to `full` once and the only ways back to stock were the
game's own UI or hand-editing `profile.ini`. This applies to every non-`freeText`
slot — stock goggles, a stock livery, no boot paint.

## The change

One file. A first row in every slot dropdown, `Stock (none)`, that calls the existing
`commit("")` — so it inherits the working write behaviour with no backend change.

- Carries the check mark when the slot is already empty, so the list shows current state
- Label is `{placeholder} (none)`, matching what the trigger already shows for empty
- cmdk `value` includes `stock none clear` so typing any of those finds it

`Combobox` has exactly one consumer, `SlotField`, used by both Presets and Rider, so
this covers every slot in both tabs.

## Notes

- **Model swap**: clearing `modelSwap` means "don't touch the active model" on apply
  (`main.rs` skips when empty) rather than reverting to Original. That's the existing
  behaviour for presets that never set a swap; reverting is the Locker's job.
- **Placement**: top, per the issue's argument that it shows up where people go looking.
  Side effect is that Enter on an empty search box now highlights this row rather than
  the first option.

## Verification

`tsc --noEmit`, `eslint` and `npm run build` all clean. No test framework in this repo.
Manually: set Protection to `full` → save → pick `Stock (none)` → save → `profile.ini`
has `<bikeid>=` with no value and the trigger reads "Stock".

🤖 Generated with [Claude Code](https://claude.com/claude-code)