### PR TITLE
fix(presets): find profiles when the mods folder has been moved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2026-08-07
+
+### Fixed
+- **Presets no longer comes up blank when your mods folder lives somewhere else.**
+  `mxbikes.ini` lets you point the mods folder at another drive, but the game has no
+  equivalent redirect for profiles — it keeps writing those to
+  `Documents\PiBoSo\MX Bikes\profiles`. The app only ever looked at
+  `<mods folder>\profiles`, found nothing, and rendered an empty Presets tab with no
+  hint that a path was involved. It now falls back to the stock `Documents` folder when
+  the one beside your mods isn't there, and Settings shows the path it actually resolved
+  to instead of the one it assumed (#27).
+- **The empty Presets tab explains itself.** Instead of "launch the game once", it names
+  the folder it read, says outright when that folder doesn't exist, points at the
+  `mxbikes.ini` split as the likely cause, and offers a button straight to the Settings
+  picker.
+
 ## 2026-08-06 — v0.6.3 — model swaps stop breaking bikes, Linux builds
 
 ### Added

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -8,9 +8,9 @@ pub struct AppConfig {
     pub mods_path: String,
     /// MX Bikes install dir (`mxbikes.exe` + core `rider.pkz`); distinct from `mods_path`.
     pub game_path: String,
-    /// Override for the PiBoSo `profiles` folder. Empty (the normal case) means it
-    /// sits inside `mods_path` at `<mods_path>/profiles`. Set only for the edge case
-    /// where a player's profiles folder lives outside their MX Bikes folder.
+    /// Override for the PiBoSo `profiles` folder. Empty (the normal case) means it's
+    /// resolved from `mods_path` — see [`AppConfig::profiles_dir`]. Set it when the
+    /// resolver can't find the folder, e.g. profiles on a drive we don't probe.
     pub profiles_path: String,
     /// Hide to the tray on window close and keep running.
     pub run_in_background: bool,
@@ -52,16 +52,55 @@ impl Default for AppConfig {
 
 impl AppConfig {
     /// Folder that holds the per-player PiBoSo profiles (each a subdir with a
-    /// `profile.ini`). Defaults to `<mods_path>/profiles` — the normal, combined
-    /// layout — unless `profiles_path` overrides it for the split-folder edge case.
+    /// `profile.ini`).
+    ///
+    /// An explicit `profiles_path` always wins. Otherwise it's `<mods_path>/profiles`
+    /// — the normal, combined layout — falling back to the stock
+    /// `Documents\PiBoSo\MX Bikes\profiles` when that folder doesn't exist.
+    ///
+    /// The fallback is not exotic: `mxbikes.ini` lets a player point the *mods* folder
+    /// at another drive, and the game has no equivalent redirect for profiles, so it
+    /// keeps writing them to `Documents`. Anyone who uses that documented feature ends
+    /// up with a split layout, and without this the app looked for profiles in a folder
+    /// that never existed.
     pub fn profiles_dir(&self) -> PathBuf {
         let custom = self.profiles_path.trim();
-        if custom.is_empty() {
-            PathBuf::from(&self.mods_path).join("profiles")
-        } else {
-            PathBuf::from(custom)
+        if !custom.is_empty() {
+            return PathBuf::from(custom);
         }
+        // Case-tolerant join: under Proton the folder can come back as `Profiles`.
+        let primary = crate::library::resolve_child(Path::new(self.mods_path.trim()), "profiles");
+        resolve_profiles_dir(primary, || {
+            default_mx_bikes_dir().map(|d| d.join("profiles"))
+        })
     }
+}
+
+/// Pick between the profiles folder implied by `mods_path` and the stock PiBoSo one.
+///
+/// Only a *missing* primary hands over to the fallback — an existing folder is the
+/// player's, empty or not. When neither exists we still return the primary, so the
+/// path the UI reports is the one derived from the folder they picked.
+///
+/// `fallback` is a closure because working it out means scanning Steam libraries on
+/// Linux, and this runs on every preset read and write.
+fn resolve_profiles_dir(primary: PathBuf, fallback: impl FnOnce() -> Option<PathBuf>) -> PathBuf {
+    if primary.is_dir() {
+        return primary;
+    }
+    match fallback() {
+        Some(f) if f.is_dir() => f,
+        _ => primary,
+    }
+}
+
+/// The MX Bikes user folder where the game puts it when nothing has been moved: the
+/// Proton prefix on Linux, `Documents\PiBoSo\MX Bikes` elsewhere.
+fn default_mx_bikes_dir() -> Option<PathBuf> {
+    if let Some(p) = detect_proton_mods_path() {
+        return Some(PathBuf::from(p));
+    }
+    Some(dirs_next::document_dir()?.join("PiBoSo").join("MX Bikes"))
 }
 
 pub fn config_path(app: &AppHandle) -> PathBuf {
@@ -139,17 +178,11 @@ pub fn save(app: &AppHandle, cfg: &AppConfig) -> anyhow::Result<()> {
 pub fn finalize(mut cfg: AppConfig) -> AppConfig {
     if cfg.mods_path.trim().is_empty() {
         // On Linux the game runs under Proton and writes into the Wine prefix, not the
-        // user's real Documents — check there first, since `document_dir()` would
-        // otherwise hand back a path MX Bikes has never written to (and often `None`,
-        // because it depends on `~/.config/user-dirs.dirs` existing).
-        if let Some(p) = detect_proton_mods_path() {
-            cfg.mods_path = p;
-        } else if let Some(docs) = dirs_next::document_dir() {
-            cfg.mods_path = docs
-                .join("PiBoSo")
-                .join("MX Bikes")
-                .to_string_lossy()
-                .into_owned();
+        // user's real Documents — `default_mx_bikes_dir` checks there first, since
+        // `document_dir()` would otherwise hand back a path MX Bikes has never written
+        // to (and often `None`, because it depends on `~/.config/user-dirs.dirs`).
+        if let Some(dir) = default_mx_bikes_dir() {
+            cfg.mods_path = dir.to_string_lossy().into_owned();
         }
     }
     // Auto-detect the Steam game install (holds `rider.pkz`) so the 3D rider preview
@@ -285,9 +318,15 @@ mod tests {
 
     #[test]
     fn profiles_dir_defaults_to_mods_subfolder() {
+        let root = std::env::temp_dir().join(format!("frost-profiles-dir-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("profiles")).unwrap();
+
         let mut cfg = AppConfig::default();
-        cfg.mods_path = "/games/mxb".into();
-        assert_eq!(cfg.profiles_dir(), PathBuf::from("/games/mxb").join("profiles"));
+        cfg.mods_path = root.to_string_lossy().into_owned();
+        assert_eq!(cfg.profiles_dir(), root.join("profiles"));
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]
@@ -296,6 +335,43 @@ mod tests {
         cfg.mods_path = "/games/mxb".into();
         cfg.profiles_path = "/other/drive/profiles".into();
         assert_eq!(cfg.profiles_dir(), PathBuf::from("/other/drive/profiles"));
+    }
+
+    /// The `mxbikes.ini` split-layout case: mods on another drive, profiles still in
+    /// `Documents`. The primary folder doesn't exist, so the stock one takes over —
+    /// but only then, and only if it's really there.
+    #[test]
+    fn profiles_dir_falls_back_to_the_stock_folder_when_the_mods_one_is_missing() {
+        let root = std::env::temp_dir().join(format!("frost-profiles-fb-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let relocated = root.join("A/MX Bikes/profiles");
+        let stock = root.join("Documents/PiBoSo/MX Bikes/profiles");
+        std::fs::create_dir_all(&stock).unwrap();
+
+        // Primary missing, fallback present → fallback.
+        assert_eq!(
+            resolve_profiles_dir(relocated.clone(), || Some(stock.clone())),
+            stock
+        );
+
+        // Primary present → it wins, and the fallback isn't even worked out.
+        std::fs::create_dir_all(&relocated).unwrap();
+        assert_eq!(
+            resolve_profiles_dir(relocated.clone(), || {
+                panic!("fallback must not be consulted when the primary is there")
+            }),
+            relocated
+        );
+
+        // Neither exists → keep the primary, so the UI names the folder they picked.
+        let nowhere = root.join("gone/profiles");
+        assert_eq!(
+            resolve_profiles_dir(nowhere.clone(), || Some(root.join("also-gone"))),
+            nowhere
+        );
+        assert_eq!(resolve_profiles_dir(nowhere.clone(), || None), nowhere);
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1726,10 +1726,13 @@ fn presets_dir(app: &tauri::AppHandle) -> Result<std::path::PathBuf, String> {
         .map_err(|e| format!("{e:#}"))
 }
 
+/// The player's profiles, plus the folder they were read from and whether it exists —
+/// so an empty Presets tab can say *which* folder came up empty instead of leaving the
+/// player to guess that a path is involved at all.
 #[tauri::command]
-fn presets_list_profiles(app: tauri::AppHandle) -> Result<Vec<String>, String> {
+fn presets_list_profiles(app: tauri::AppHandle) -> Result<presets::ProfilesScan, String> {
     let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
-    Ok(presets::list_profiles(&cfg.profiles_dir()))
+    Ok(presets::scan_profiles(&cfg.profiles_dir()))
 }
 
 #[tauri::command]

--- a/src-tauri/src/presets.rs
+++ b/src-tauri/src/presets.rs
@@ -241,19 +241,48 @@ fn read_profile_ini(path: &Path) -> anyhow::Result<String> {
     Ok(decode_ini(&bytes).0)
 }
 
-pub fn list_profiles(profiles_dir: &Path) -> Vec<String> {
-    let mut out = Vec::new();
-    if let Ok(rd) = fs::read_dir(profiles_dir) {
-        for e in rd.flatten() {
-            if e.path().is_dir() && e.path().join("profile.ini").is_file() {
-                if let Some(n) = e.file_name().to_str() {
-                    out.push(n.to_string());
+/// The profiles folder as the app sees it: where it looked, whether that folder is
+/// even there, and what it found.
+///
+/// `exists` is the point of this type. A missing folder and a folder holding zero
+/// profiles both used to surface as an empty list, so the UI could only ever say
+/// "no profiles" — never "that folder isn't there", which is the far more common
+/// cause and the only one the player can act on.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfilesScan {
+    pub dir: String,
+    pub exists: bool,
+    pub profiles: Vec<String>,
+}
+
+pub fn scan_profiles(profiles_dir: &Path) -> ProfilesScan {
+    let mut profiles = Vec::new();
+    let exists = match fs::read_dir(profiles_dir) {
+        Ok(rd) => {
+            for e in rd.flatten() {
+                if e.path().is_dir() && e.path().join("profile.ini").is_file() {
+                    if let Some(n) = e.file_name().to_str() {
+                        profiles.push(n.to_string());
+                    }
                 }
             }
+            true
         }
+        // Unreadable counts as missing: either way there's nothing to list, and the
+        // folder can't be used as-is.
+        Err(_) => false,
+    };
+    profiles.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+    ProfilesScan {
+        dir: profiles_dir.to_string_lossy().into_owned(),
+        exists,
+        profiles,
     }
-    out.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
-    out
+}
+
+pub fn list_profiles(profiles_dir: &Path) -> Vec<String> {
+    scan_profiles(profiles_dir).profiles
 }
 
 pub fn list_bikes(profiles_dir: &Path, profile: &str) -> anyhow::Result<Vec<String>> {
@@ -448,6 +477,34 @@ KTM250=p_mx
         assert_eq!(list_profiles(&profiles), vec!["main"]);
         let bikes = list_bikes(&profiles, "main").unwrap();
         assert_eq!(bikes, vec!["KTM250", "YZ450F"]);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// A folder that isn't there and a folder with nothing in it both list zero
+    /// profiles — the scan has to tell them apart, since only the first one means
+    /// "you're pointed at the wrong place".
+    #[test]
+    fn scan_tells_a_missing_folder_from_an_empty_one() {
+        let root = tmp("scan");
+
+        let missing = root.join("not-here");
+        let scan = scan_profiles(&missing);
+        assert!(!scan.exists);
+        assert!(scan.profiles.is_empty());
+        assert_eq!(scan.dir, missing.to_string_lossy());
+
+        let empty = root.join("profiles");
+        fs::create_dir_all(&empty).unwrap();
+        let scan = scan_profiles(&empty);
+        assert!(scan.exists, "the folder is there, it just holds no profiles");
+        assert!(scan.profiles.is_empty());
+
+        // A subdir without a profile.ini isn't a profile, but the folder still exists.
+        fs::create_dir_all(empty.join("junk")).unwrap();
+        let scan = scan_profiles(&empty);
+        assert!(scan.exists);
+        assert!(scan.profiles.is_empty());
+
         let _ = fs::remove_dir_all(&root);
     }
 

--- a/src/Components/Dashboard/Dashboard.tsx
+++ b/src/Components/Dashboard/Dashboard.tsx
@@ -153,7 +153,11 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
           ) : view === "locker" ? (
             <Locker />
           ) : view === "presets" ? (
-            <Presets onOpenInRider={openInRider} onOpenLocker={() => setView("locker")} />
+            <Presets
+              onOpenInRider={openInRider}
+              onOpenLocker={() => setView("locker")}
+              onOpenSettings={() => setView("settings")}
+            />
           ) : view === "rider" ? (
             <RiderStudio initialLoadout={riderPreset} onLoaded={clearRiderPreset} />
           ) : (

--- a/src/Components/Presets/Presets.tsx
+++ b/src/Components/Presets/Presets.tsx
@@ -135,10 +135,19 @@ interface PresetsProps {
   onOpenInRider?: (loadout: Loadout) => void;
   /** Jump to the Locker — where model swaps have to be registered before they show here. */
   onOpenLocker?: () => void;
+  /** Jump to Settings — the profiles folder picker lives there. */
+  onOpenSettings?: () => void;
 }
 
-export default function Presets({ onOpenInRider, onOpenLocker }: PresetsProps = {}) {
+export default function Presets({
+  onOpenInRider,
+  onOpenLocker,
+  onOpenSettings,
+}: PresetsProps = {}) {
   const [profiles, setProfiles] = useState<string[]>([]);
+  /** Where the backend read profiles from, and whether that folder is even there.
+   *  Only used by the empty state, which is the one place it matters. */
+  const [profilesDir, setProfilesDir] = useState<{ dir: string; exists: boolean } | null>(null);
   const [profile, setProfile] = useState<string>("");
   const [bikes, setBikes] = useState<string[]>([]);
   const [bike, setBike] = useState<string>("");
@@ -165,15 +174,16 @@ export default function Presets({ onOpenInRider, onOpenLocker }: PresetsProps = 
   const load = useCallback(async () => {
     setError(null);
     try {
-      const [profs, presets, sc] = await Promise.all([
+      const [scan, presets, sc] = await Promise.all([
         presetsListProfiles(),
         presetsList(),
         loadScans(),
       ]);
-      setProfiles(profs);
+      setProfiles(scan.profiles);
+      setProfilesDir({ dir: scan.dir, exists: scan.exists });
       setSaved(presets);
       setScans(sc);
-      setProfile((p) => p || profs[0] || "");
+      setProfile((p) => p || scan.profiles[0] || "");
     } catch (e) {
       setError(String(e));
     }
@@ -342,7 +352,9 @@ export default function Presets({ onOpenInRider, onOpenLocker }: PresetsProps = 
     [scans, bike, loadout],
   );
 
-  const noProfiles = profiles.length === 0 && !error;
+  // Wait for the first scan before claiming there's nothing — otherwise the empty
+  // state flashes (naming no folder) on every mount.
+  const noProfiles = profilesDir !== null && profiles.length === 0 && !error;
 
   return (
     <div className="flex h-full flex-col">
@@ -374,9 +386,34 @@ export default function Presets({ onOpenInRider, onOpenLocker }: PresetsProps = 
       )}
 
       {noProfiles ? (
-        <div className="flex flex-1 items-center justify-center px-7 text-center text-[13px] text-muted-foreground">
-          No MX Bikes profiles found. Launch the game once so it creates a profile,
-          then refresh.
+        /* Name the folder we actually read. A blank tab used to be the only signal
+           that a path was involved at all — and when the mods folder has been moved
+           via `mxbikes.ini`, a wrong path is the likeliest reason we found nothing. */
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 px-7 text-center">
+          <div className="max-w-[440px] text-[13px] leading-relaxed text-muted-foreground">
+            {profilesDir && !profilesDir.exists
+              ? "No profiles folder here — this folder doesn’t exist:"
+              : "No MX Bikes profiles found in:"}
+            <div className="mt-2 break-all rounded-lg border border-border bg-card/40 px-3 py-2 font-mono text-[11.5px] text-foreground/80">
+              {profilesDir?.dir || "your MX Bikes folder"}
+            </div>
+            <p className="mt-2.5">
+              {profilesDir && !profilesDir.exists
+                ? "If you moved your mods folder (mxbikes.ini), your profiles stayed in Documents\\PiBoSo\\MX Bikes\\profiles — point the app at them in Settings."
+                : "Launch the game once so it creates a profile, then refresh — or point the app at the folder that holds your profiles."}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {onOpenSettings && (
+              <Button variant="outline" size="sm" onClick={onOpenSettings}>
+                Choose profiles folder…
+              </Button>
+            )}
+            <Button variant="ghost" size="sm" onClick={() => void load()}>
+              <RefreshCw className="size-3.5" />
+              Refresh
+            </Button>
+          </div>
         </div>
       ) : (
         <div className="flex min-h-0 flex-1 gap-5 overflow-hidden px-7 pb-6">

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import {
   countProfilesIn,
   detectGamePath,
+  presetsListProfiles,
   setAutoRunFrostmod,
   setGamePath,
   setInstantRefresh,
@@ -61,12 +62,28 @@ export default function Settings() {
     about: null,
   });
 
-  // The profiles folder normally lives *inside* the mods folder — surface that
-  // derived default path so the override reads as a customization of it.
+  // The folder the backend *actually* reads profiles from when there's no override.
+  // Usually `<modsPath>/profiles`, but it falls back to `Documents\PiBoSo\MX Bikes\
+  // profiles` when that one doesn't exist — show the resolved path so a fallback is
+  // visible here rather than something the player has to infer.
+  const [resolvedProfilesPath, setResolvedProfilesPath] = useState("");
+  useEffect(() => {
+    if (config.profilesPath) {
+      // An override is shown verbatim; nothing to resolve.
+      setResolvedProfilesPath("");
+      return;
+    }
+    presetsListProfiles()
+      .then((scan) => setResolvedProfilesPath(scan.dir))
+      .catch(() => setResolvedProfilesPath(""));
+  }, [config.modsPath, config.profilesPath]);
+
   const profilesSep = config.modsPath.includes("\\") ? "\\" : "/";
-  const defaultProfilesPath = config.modsPath
-    ? `${config.modsPath}${profilesSep}profiles`
-    : "Inside your MX Bikes folder";
+  const defaultProfilesPath =
+    resolvedProfilesPath ||
+    (config.modsPath
+      ? `${config.modsPath}${profilesSep}profiles`
+      : "Inside your MX Bikes folder");
 
   const runInBackground = config.runInBackground ?? true;
   const launchAtStartup = config.launchAtStartup ?? true;
@@ -324,9 +341,12 @@ export default function Settings() {
                 </span>
               </div>
               <p className="mt-1 text-[11.5px] leading-relaxed text-muted-foreground">
-                Presets read your profiles from here. By default it&apos;s the{" "}
+                Presets read your profiles from here — the path below is where the app
+                is looking right now. It&apos;s the{" "}
                 <span className="font-mono">profiles</span> folder inside your MX Bikes
-                folder — only change it if yours lives somewhere else.
+                folder, or your{" "}
+                <span className="font-mono">Documents\PiBoSo\MX Bikes</span> one if you
+                moved your mods folder. Set it only if yours is somewhere else.
               </p>
               <div className="mt-2 flex gap-2">
                 <div

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -338,8 +338,8 @@ export function detectGamePath(): Promise<string | null> {
 }
 
 /**
- * Override the PiBoSo `profiles` folder for the split-folder edge case. Pass an
- * empty string to clear it (falls back to `<modsPath>/profiles`).
+ * Override the PiBoSo `profiles` folder. Pass an empty string to clear it (back to
+ * the resolved default — see {@link presetsListProfiles}).
  */
 export function setProfilesPath(path: string): Promise<void> {
   return invoke<void>("set_profiles_path", { path });
@@ -750,8 +750,18 @@ export function onModsChanged(cb: () => void): Promise<UnlistenFn> {
   return onFrostmodReload(() => cb());
 }
 
-export function presetsListProfiles(): Promise<string[]> {
-  return invoke<string[]>("presets_list_profiles");
+/** The profiles folder as the backend resolved it, and what it holds. */
+export type ProfilesScan = {
+  /** Absolute path the profiles were read from. */
+  dir: string;
+  /** Whether that folder is actually there — an empty list means something different
+   *  when it isn't (wrong path) than when it is (game never made a profile). */
+  exists: boolean;
+  profiles: string[];
+};
+
+export function presetsListProfiles(): Promise<ProfilesScan> {
+  return invoke<ProfilesScan>("presets_list_profiles");
 }
 
 /** Bike ids present in a profile — the targets a loadout can be applied to. */


### PR DESCRIPTION
Fixes #27.

## The problem

`mxbikes.ini` lets a player point the **mods** folder at another drive. The game has no equivalent redirect for **profiles** — it keeps writing those to `Documents\PiBoSo\MX Bikes\profiles`. The app only ever looked at `<modsPath>/profiles`, found nothing, and rendered an empty Presets tab: no error, no warning, and nothing to suggest a path was involved. Setting `profilesPath` in Settings fixed it, but there was no way to discover that from the UI.

Two things combined: `profiles_dir()` was pure string joining, never checked against the filesystem, and `list_profiles` swallowed the `read_dir` error so a missing folder and an empty one were the same `Vec![]`.

## The fix

**Backend**
- `profiles_dir()` resolves rather than assumes: explicit override → `<modsPath>/profiles` if it exists → stock `Documents\PiBoSo\MX Bikes\profiles` if that exists → back to the primary, so the UI still names a sensible path. Only a *missing* primary hands over; an existing folder is the player's, empty or not.
- The fallback is a closure — computing it scans Steam libraries on Linux, and `profiles_dir()` runs on every preset read and write.
- `finalize` and the new fallback share one `default_mx_bikes_dir()` (Proton prefix on Linux, `Documents` elsewhere).
- New `presets::scan_profiles` returns `{ dir, exists, profiles }`; `list_profiles` is a wrapper, so `count_profiles_in` is unchanged.

**Frontend**
- The empty Presets tab names the folder it read, says outright when that folder doesn't exist, points at the `mxbikes.ini` split as the likely cause, and offers **Choose profiles folder…** straight through to Settings. It now also waits for the first scan, so it no longer flashes a pathless "no profiles" on mount.
- Settings shows the *resolved* profiles path instead of a derived `<modsPath>/profiles` guess, so an automatic fallback is visible rather than something to infer.
- The "edge case" framing is gone from the config doc comment — it's the automatic consequence of a documented feature.

## Not included

The issue's title also names the **Rider** tab. Rider doesn't read the profiles folder — its data comes from `scan_rider_targets` over `<modsPath>/mods/rider` — so this change can't affect it. That reporter's empty Rider tab has a different cause, most likely the same one as #26.

## Testing

- `cargo test` — 151 passed, including three new/updated cases: the split-layout fallback, primary-wins (the fallback closure panics if consulted), and missing-vs-empty in `scan_profiles`.
- `bun run build` (tsc + vite) clean; `eslint` shows only the 3 warnings already on `main`.
- Launched the dev app against a reproduction of the reporter's layout (mods folder relocated, no `profiles/` beside it, real profiles in `Documents`) — it started and picked up that config, but the run ended early on a dev-server port clash, so the Presets tab wasn't visually confirmed.

No DB/schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
