### PR TITLE
fix(browse): badge mods that are actually installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
-## 2026-08-06 — v0.6.3 — model swaps stop breaking bikes, Linux builds
+## 2026-08-07
+
+### Fixed
+- **Browse knows what you already have.** The "Installed" badge almost never appeared —
+  one reporter's library scored 19 of 96 tracks and **0 of 96** bikes and rider items,
+  all of them installed and working in-game. Two causes. Browse asked for installed mods
+  with a scan that keeps `.pkz` files only, so extracted track folders and every `.pnt`
+  paint were invisible; since the Bikes and Rider categories are mostly liveries and gear
+  paints, nothing in them could ever be badged. And it compared the site's post title to
+  the packaged filename as exact strings, which post titles never survive — they carry
+  author credits, release tags and notes like "(READ INSTRUCTIONS)". Browse now reads the
+  same full library scan the Library tab uses, and matches titles the way a person would:
+  one name spelled inside the other, or enough distinctive words in common. Careful
+  enough to still tell two colourways of the same bike apart. (#26)
 
 ### Added
 - **Releases now say which file to download.** The release body led with "See the assets

--- a/src-tauri/src/mods/mxb.rs
+++ b/src-tauri/src/mods/mxb.rs
@@ -472,6 +472,12 @@ mod tests {
     #[test]
     fn decodes_title_entities() {
         assert_eq!(decode_entities("Rock &#038; Roll &#8211; MX"), "Rock & Roll – MX");
+        // Hex entities too — flag emoji are common in track titles, and left raw they
+        // fold `x1f1ee` into the "already installed" comparison key (issue #26).
+        assert_eq!(
+            decode_entities("ARDAN318 &#8211; Sirkuit Goro assalam &#x1f1ee;&#x1f1e9;"),
+            "ARDAN318 – Sirkuit Goro assalam 🇮🇩",
+        );
     }
 
     #[test]

--- a/src/Components/Browse/Browse.tsx
+++ b/src/Components/Browse/Browse.tsx
@@ -5,11 +5,11 @@ import {
   MOD_TYPES,
   SEARCH_PAGE_SIZE,
   isLiveryContext,
-  normalizeModName,
   resolveQuickInstall,
   searchMods,
   type ModType,
 } from "../../api/mods";
+import type { InstalledIndex } from "../../lib/installedMatch";
 import type { ModSummary } from "../../types";
 import { useInstall } from "../../Context/Install";
 import ModCard from "./ModCard";
@@ -31,14 +31,14 @@ import { cn } from "@/lib/utils";
 
 interface BrowseProps {
   modType: ModType;
-  installedNames: Set<string>;
+  installed: InstalledIndex;
   onOpenMod: (slug: string, categoryId: number) => void;
   onChangeType: (type: ModType) => void;
 }
 
 export default function Browse({
   modType,
-  installedNames,
+  installed,
   onOpenMod,
   onChangeType,
 }: BrowseProps) {
@@ -63,8 +63,8 @@ export default function Browse({
   const selectionActive = selected.size > 0;
 
   const isInstalled = useCallback(
-    (mod: ModSummary) => installedNames.has(normalizeModName(mod.title)),
-    [installedNames],
+    (mod: ModSummary) => installed.has(mod.title),
+    [installed],
   );
 
   // Reset the category filter (and any selection) when the mod type changes —

--- a/src/Components/Dashboard/Dashboard.tsx
+++ b/src/Components/Dashboard/Dashboard.tsx
@@ -14,11 +14,15 @@ import { useConfig } from "../../Context/Config";
 import {
   DEFAULT_MOD_TYPE,
   MOD_TYPES,
-  getInstalledMods,
-  normalizeModName,
+  scanLibrary,
   setIntroSeen,
   type ModType,
 } from "../../api/mods";
+import {
+  EMPTY_INSTALLED_INDEX,
+  buildInstalledIndex,
+  type InstalledIndex,
+} from "../../lib/installedMatch";
 import type { Loadout } from "../../types";
 
 interface DashboardProps {
@@ -36,22 +40,22 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
   const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
   // Bumped after an install so the library re-scans.
   const [libraryVersion, setLibraryVersion] = useState(0);
-  // Normalized names of installed mods for the active type (for "in library" badges).
-  const [installedNames, setInstalledNames] = useState<Set<string>>(new Set());
+  // What's on disk for the active type, as a fuzzy lookup (for "in library" badges).
+  const [installed, setInstalled] = useState<InstalledIndex>(EMPTY_INSTALLED_INDEX);
   // A preset handed off from the Presets tab to load in the Rider tab (its
   // "View in Rider" button). Consumed once by the Rider view, then cleared.
   const [riderPreset, setRiderPreset] = useState<Loadout | null>(null);
 
+  // The full library scan, not `getInstalledMods` — that one sees `.pkz` files only, so
+  // extracted track folders and every `.pnt` paint/livery counted as "not installed".
   useEffect(() => {
     let cancelled = false;
-    getInstalledMods(modType.installSubpath)
-      .then((installed) => {
+    scanLibrary(modType.installSubpath)
+      .then((entries) => {
         if (cancelled) return;
-        setInstalledNames(
-          new Set(installed.map((m) => normalizeModName(m.name))),
-        );
+        setInstalled(buildInstalledIndex(entries.map((e) => e.name)));
       })
-      .catch(() => !cancelled && setInstalledNames(new Set()));
+      .catch(() => !cancelled && setInstalled(EMPTY_INSTALLED_INDEX));
     return () => {
       cancelled = true;
     };
@@ -131,13 +135,13 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
               slug={selectedSlug}
               modType={modType}
               categoryId={selectedCategoryId ?? modType.categoryId}
-              installedNames={installedNames}
+              installed={installed}
               onBack={() => setSelectedSlug(null)}
             />
           ) : view === "browse" ? (
             <Browse
               modType={modType}
-              installedNames={installedNames}
+              installed={installed}
               onOpenMod={openMod}
               onChangeType={changeType}
             />

--- a/src/Components/ModDetail/ModDetail.tsx
+++ b/src/Components/ModDetail/ModDetail.tsx
@@ -26,7 +26,6 @@ import {
   isSoundContext,
   riderProfileSub,
   riderPaintKind,
-  normalizeModName,
   resolveInitialFolder,
   scanRiderTargets,
   sortMirrors,
@@ -41,6 +40,7 @@ import type {
 } from "../../types";
 import InstallDialog, { type InstallChoice } from "./InstallDialog";
 import { useInstall } from "../../Context/Install";
+import type { InstalledIndex } from "../../lib/installedMatch";
 import { fileFormat, formatDate } from "../../lib/mods";
 import { Badge } from "@/Components/ui/badge";
 import { Button } from "@/Components/ui/button";
@@ -61,7 +61,7 @@ interface ModDetailProps {
   modType: ModType;
   /** Browse category the mod was opened under — drives bike-livery routing. */
   categoryId: number;
-  installedNames: Set<string>;
+  installed: InstalledIndex;
   onBack: () => void;
 }
 
@@ -94,7 +94,7 @@ export default function ModDetail({
   slug,
   modType,
   categoryId,
-  installedNames,
+  installed,
   onBack,
 }: ModDetailProps) {
   const livery = isLiveryContext(modType, categoryId);
@@ -105,7 +105,9 @@ export default function ModDetail({
   const paintKind = riderPaintKind(modType, categoryId);
   const [detail, setDetail] = useState<Detail | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
-  const [installed, setInstalled] = useState<InstalledMod[]>([]);
+  // The raw file list — only for destination folders and their counts. The badge uses
+  // the `installed` index prop, which also sees folders and paints.
+  const [installedFiles, setInstalledFiles] = useState<InstalledMod[]>([]);
   const [destOptions, setDestOptions] = useState<DestOption[]>([]);
   const [guess, setGuess] = useState("");
   const [suggestions, setSuggestions] = useState<string[]>([]);
@@ -138,7 +140,7 @@ export default function ModDetail({
         try {
           const inst = await getInstalledMods(modType.installSubpath);
           if (cancelled) return;
-          setInstalled(inst);
+          setInstalledFiles(inst);
           // Rider paints route into a model's/profile's folder; everything else
           // uses the generic (track/bike) destination logic.
           const dest =
@@ -150,7 +152,7 @@ export default function ModDetail({
           setGuess(dest.guess);
           setSuggestions(dest.suggestions);
         } catch {
-          setInstalled([]);
+          setInstalledFiles([]);
           setDestOptions([]);
         }
       })
@@ -162,9 +164,9 @@ export default function ModDetail({
 
   const folderCounts = useMemo(() => {
     const m = new Map<string, number>();
-    for (const it of installed) m.set(it.folder, (m.get(it.folder) ?? 0) + 1);
+    for (const it of installedFiles) m.set(it.folder, (m.get(it.folder) ?? 0) + 1);
     return m;
-  }, [installed]);
+  }, [installedFiles]);
 
   // "Official" mirror + metadata for the collapsed install panel.
   const mirrors = useMemo(() => (detail ? sortMirrors(detail) : []), [detail]);
@@ -179,8 +181,7 @@ export default function ModDetail({
     [modType, destOptions, guess, livery, sound, paintKind],
   );
 
-  const isInstalled =
-    detail !== null && installedNames.has(normalizeModName(detail.title));
+  const isInstalled = detail !== null && installed.has(detail.title);
 
   // Already have it? Confirm before overwriting; otherwise open the dialog.
   const openInstall = () => {

--- a/src/Components/Shop/Shop.tsx
+++ b/src/Components/Shop/Shop.tsx
@@ -2,15 +2,19 @@ import { useCallback, useEffect, useState } from "react";
 import { Store, LogOut, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import {
-  getInstalledMods,
-  normalizeModName,
   onShopAuth,
   shopLogin,
   shopLogout,
   shopMyDownloads,
   shopStatus,
+  scanLibrary,
   type ShopItem,
 } from "../../api/mods";
+import {
+  EMPTY_INSTALLED_INDEX,
+  buildInstalledIndex,
+  type InstalledIndex,
+} from "../../lib/installedMatch";
 import { useInstall } from "../../Context/Install";
 import ModCard from "../Browse/ModCard";
 import { Button } from "@/Components/ui/button";
@@ -24,7 +28,7 @@ interface ShopProps {
 export default function Shop({ refreshKey }: ShopProps) {
   const [loggedIn, setLoggedIn] = useState<boolean | null>(null);
   const [items, setItems] = useState<ShopItem[]>([]);
-  const [installedNames, setInstalledNames] = useState<Set<string>>(new Set());
+  const [installed, setInstalled] = useState<InstalledIndex>(EMPTY_INSTALLED_INDEX);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -80,12 +84,12 @@ export default function Shop({ refreshKey }: ShopProps) {
   // Keep the "installed" badges in sync with the tracks library.
   useEffect(() => {
     let cancelled = false;
-    getInstalledMods("mods/tracks")
-      .then((installed) => {
+    scanLibrary("mods/tracks")
+      .then((entries) => {
         if (cancelled) return;
-        setInstalledNames(new Set(installed.map((m) => normalizeModName(m.name))));
+        setInstalled(buildInstalledIndex(entries.map((e) => e.name)));
       })
-      .catch(() => !cancelled && setInstalledNames(new Set()));
+      .catch(() => !cancelled && setInstalled(EMPTY_INSTALLED_INDEX));
     return () => {
       cancelled = true;
     };
@@ -182,7 +186,7 @@ export default function Shop({ refreshKey }: ShopProps) {
                 key={item.id}
                 mod={item}
                 isBike={false}
-                installed={installedNames.has(normalizeModName(item.title))}
+                installed={installed.has(item.title)}
                 selected={false}
                 selectionActive={false}
                 onOpen={() => install(item)}

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -97,11 +97,12 @@ export const MOD_TYPES: ModType[] = [
 
 export const DEFAULT_MOD_TYPE = MOD_TYPES[0];
 
-/** Normalize a mod title or filename for fuzzy "already installed" matching. */
+/** Normalize a mod title or filename into a comparison key. `.pnt` is in the list
+ *  because paints and liveries are installed files too — see `lib/installedMatch`. */
 export function normalizeModName(s: string): string {
   return s
     .toLowerCase()
-    .replace(/\.(pkz|zip|rar|7z)$/i, "")
+    .replace(/\.(pkz|zip|rar|7z|pnt)$/i, "")
     .replace(/[^a-z0-9]+/g, "");
 }
 

--- a/src/lib/installedMatch.ts
+++ b/src/lib/installedMatch.ts
@@ -1,0 +1,135 @@
+/**
+ * Deciding whether a catalog listing is already on disk.
+ *
+ * The two sides never agree on spelling: a mxb-mods post title is prose — author
+ * credits, release tags, "(READ INSTRUCTIONS)" — while the file the author packaged
+ * is named whatever they felt like. Comparing them as equal strings badges almost
+ * nothing (see issue #26: 0 of 96 bikes), so this widens the comparison in three
+ * steps, each one only firing when it can't plausibly be a coincidence.
+ */
+
+import { normalizeModName } from "../api/mods";
+
+/**
+ * Words that carry no identity — they show up in half the catalog, so counting them
+ * as agreement makes unrelated mods look alike. Kept out of the token comparison;
+ * the whole-string comparison still sees them.
+ */
+const FILLER = new Set([
+  "the", "and", "for", "with", "by", "of", "to", "in", "on",
+  // Category noise: nearly every bike post says "bike", every track says "track".
+  "mx", "mxb", "mxbikes", "bike", "bikes", "track", "tracks", "rider", "gear",
+  "paint", "paints", "livery", "liveries", "skin", "skins", "helmet", "helmets",
+  "boot", "boots", "glove", "gloves", "kit", "gfx", "design", "designs",
+  // Release/version chatter.
+  "read", "instructions", "instruction", "pub", "public", "beta", "wip", "final",
+  "release", "released", "rerelease", "re", "update", "updated", "fix", "fixed",
+  "remake", "reworked", "rework", "edit", "version", "ver", "hd", "new", "old",
+  "rd", "round", "pack", "mod", "final",
+]);
+
+/** Alphanumeric runs of 2+ chars, filler dropped. `"WDR: SX '26"` → `["wdr", "sx", "26"]`. */
+function significantTokens(s: string): Set<string> {
+  const out = new Set<string>();
+  for (const t of s.toLowerCase().split(/[^a-z0-9]+/)) {
+    if (t.length >= 2 && !FILLER.has(t)) out.add(t);
+  }
+  return out;
+}
+
+/**
+ * Shortest key we'll accept as evidence on its own. Below this, substrings collide by
+ * chance — `"sx"` sits inside a third of the bike catalog.
+ */
+const MIN_CONTAINED_LEN = 6;
+
+/**
+ * How much of the *combined* vocabulary the two names must share. Union-based
+ * (Jaccard) rather than "fraction of the shorter side" on purpose: two liveries for
+ * the same bike by the same author share their bike and author tokens and would sail
+ * through the latter, but score ~0.43 here and are rejected.
+ */
+const MIN_TOKEN_OVERLAP = 0.6;
+
+/** At least this many shared tokens before overlap is meaningful at all. */
+const MIN_SHARED_TOKENS = 2;
+
+interface Indexed {
+  key: string;
+  tokens: Set<string>;
+}
+
+export interface InstalledIndex {
+  /** How many installed items back this index (0 = nothing scanned / scan failed). */
+  readonly size: number;
+  /** Whether a catalog title looks like something already on disk. */
+  has(title: string): boolean;
+}
+
+function jaccard(a: Set<string>, b: Set<string>): { shared: number; score: number } {
+  let shared = 0;
+  for (const t of a) if (b.has(t)) shared++;
+  const union = a.size + b.size - shared;
+  return { shared, score: union === 0 ? 0 : shared / union };
+}
+
+/**
+ * Build a lookup over installed file/folder names (`LibraryEntry.name` — packed
+ * `.pkz`, extracted track folders, and `.pnt` paints alike).
+ *
+ * Candidates are narrowed through an inverted token index, so checking a card costs
+ * the handful of entries that share a word with it rather than the whole library.
+ */
+export function buildInstalledIndex(names: Iterable<string>): InstalledIndex {
+  const entries: Indexed[] = [];
+  const keys = new Set<string>();
+  const byToken = new Map<string, number[]>();
+
+  for (const name of names) {
+    const key = normalizeModName(name);
+    if (!key) continue;
+    keys.add(key);
+    const tokens = significantTokens(name);
+    const i = entries.push({ key, tokens }) - 1;
+    for (const t of tokens) {
+      const bucket = byToken.get(t);
+      if (bucket) bucket.push(i);
+      else byToken.set(t, [i]);
+    }
+  }
+
+  const has = (title: string): boolean => {
+    const key = normalizeModName(title);
+    if (!key) return false;
+    if (keys.has(key)) return true;
+
+    const tokens = significantTokens(title);
+    const candidates = new Set<number>();
+    for (const t of tokens) {
+      for (const i of byToken.get(t) ?? []) candidates.add(i);
+    }
+
+    for (const i of candidates) {
+      const entry = entries[i];
+
+      // One name spelled inside the other — `Farm Mx` inside `Feulatracks_Farm_MX`.
+      // Guarded on length *and* on the shorter side carrying a real word, so a bare
+      // model number like `sxf250` can't match every livery for that bike.
+      const [short, long] =
+        key.length <= entry.key.length ? [key, entry.key] : [entry.key, key];
+      if (short.length >= MIN_CONTAINED_LEN && long.includes(short)) {
+        const shortTokens = short === key ? tokens : entry.tokens;
+        if (shortTokens.size > 0) return true;
+      }
+
+      const { shared, score } = jaccard(tokens, entry.tokens);
+      if (shared >= MIN_SHARED_TOKENS && score >= MIN_TOKEN_OVERLAP) return true;
+    }
+    return false;
+  };
+
+  return { size: entries.length, has };
+}
+
+/** Stand-in for "nothing scanned yet" — matches nothing. */
+export const EMPTY_INSTALLED_INDEX: InstalledIndex = buildInstalledIndex([]);

--- a/src/lib/installedMatch.ts
+++ b/src/lib/installedMatch.ts
@@ -10,6 +10,9 @@
 
 import { normalizeModName } from "../api/mods";
 
+/** Packaged-file extensions, stripped before a name is read as words. */
+const EXT = /\.(pkz|zip|rar|7z|pnt)$/i;
+
 /**
  * Words that carry no identity — they show up in half the catalog, so counting them
  * as agreement makes unrelated mods look alike. Kept out of the token comparison;
@@ -28,11 +31,29 @@ const FILLER = new Set([
   "rd", "round", "pack", "mod", "final",
 ]);
 
-/** Alphanumeric runs of 2+ chars, filler dropped. `"WDR: SX '26"` → `["wdr", "sx", "26"]`. */
+/**
+ * Model years are written both ways across the catalog — `2026 Yamaha CLUBMX` on the
+ * post, `27 FOX Pawtector Gloves` on the next one, and the packaged file picks whichever
+ * the author preferred. Folding a plausible model year onto its two-digit form lets those
+ * agree. Bounded to 2000–2035 so displacements (`85`, `250`, `450`) are never touched,
+ * and years stay distinguishing: `2026` and `2027` still disagree.
+ */
+function canonicalToken(t: string): string {
+  if (t.length === 4 && /^20[0-3][0-9]$/.test(t)) return t.slice(2);
+  return t;
+}
+
+/**
+ * Alphanumeric runs of 2+ chars, filler dropped. `"WDR: SX '26"` → `["wdr", "sx", "26"]`.
+ *
+ * The extension goes first: tokenizing `livery.pnt` yields a `pnt` no post title can ever
+ * contain, and since it counts toward the union it drags down the score of every paint —
+ * the very category that was scoring zero.
+ */
 function significantTokens(s: string): Set<string> {
   const out = new Set<string>();
-  for (const t of s.toLowerCase().split(/[^a-z0-9]+/)) {
-    if (t.length >= 2 && !FILLER.has(t)) out.add(t);
+  for (const t of s.toLowerCase().replace(EXT, "").split(/[^a-z0-9]+/)) {
+    if (t.length >= 2 && !FILLER.has(t)) out.add(canonicalToken(t));
   }
   return out;
 }
@@ -44,15 +65,48 @@ function significantTokens(s: string): Set<string> {
 const MIN_CONTAINED_LEN = 6;
 
 /**
- * How much of the *combined* vocabulary the two names must share. Union-based
- * (Jaccard) rather than "fraction of the shorter side" on purpose: two liveries for
- * the same bike by the same author share their bike and author tokens and would sail
- * through the latter, but score ~0.43 here and are rejected.
+ * A filename that reduces to one distinctive word may still stand for the whole mod —
+ * `HIDEAWAY_MX.pkz` for the post "HIDEAWAY MX – SC Designs" — but only if that word is
+ * long enough to be a name rather than a category. Measured on the live catalog: at this
+ * length the author-credit stubs (`Replica`, `Ben89`, `ZD`, `RED`) stay out, while the
+ * real one-word mod names come back in.
  */
-const MIN_TOKEN_OVERLAP = 0.6;
+const MIN_LONE_WORD_LEN = 10;
+
+/**
+ * How much of the *combined* vocabulary the two names must share. Union-based (Jaccard)
+ * rather than "fraction of the shorter side" on purpose: two liveries for the same bike
+ * by the same author share their bike and author tokens and would sail through the latter.
+ *
+ * Set high, because this is the blunt rule. Measured against the live catalog, a
+ * white/blue and a red/white livery of the same bike still score 0.67, and a Washougal
+ * and a RedBud kit for the same 2026 Yamaha score 0.60 — names differing only in the word
+ * that matters. So this fires on near-identical word sets, and the subset rule below
+ * carries the abbreviation cases it now leaves behind.
+ */
+const MIN_TOKEN_OVERLAP = 0.75;
 
 /** At least this many shared tokens before overlap is meaningful at all. */
 const MIN_SHARED_TOKENS = 2;
+
+/**
+ * The other real shape: the filename is an abbreviation of the post title, so every word
+ * it has appears in the title but the title says more —
+ * `ktm 85 2027 with hgs front and back pipe` ← `KTM_85_2027_HGS.pnt`. Scored as overlap
+ * that's only 0.57, because the words the title adds all count against it.
+ *
+ * Accepted when one side's words are wholly contained in the other's, there are enough of
+ * them to be distinctive, and they still account for half the longer name. The half rule
+ * is what stops a two-word stub from claiming a much longer title.
+ */
+const MIN_SUBSET_TOKENS = 3;
+const MIN_SUBSET_COVERAGE = 0.5;
+
+function subsetMatch(a: Set<string>, b: Set<string>, shared: number): boolean {
+  const [small, large] = a.size <= b.size ? [a, b] : [b, a];
+  if (shared !== small.size) return false;
+  return small.size >= MIN_SUBSET_TOKENS && small.size >= MIN_SUBSET_COVERAGE * large.size;
+}
 
 interface Indexed {
   key: string;
@@ -112,18 +166,27 @@ export function buildInstalledIndex(names: Iterable<string>): InstalledIndex {
     for (const i of candidates) {
       const entry = entries[i];
 
-      // One name spelled inside the other — `Farm Mx` inside `Feulatracks_Farm_MX`.
-      // Guarded on length *and* on the shorter side carrying a real word, so a bare
-      // model number like `sxf250` can't match every livery for that bike.
-      const [short, long] =
-        key.length <= entry.key.length ? [key, entry.key] : [entry.key, key];
-      if (short.length >= MIN_CONTAINED_LEN && long.includes(short)) {
-        const shortTokens = short === key ? tokens : entry.tokens;
-        if (shortTokens.size > 0) return true;
-      }
+      // One name spelled inside the other. The two directions are not equally trustworthy,
+      // so they carry different bars:
+      //
+      // *title inside filename* is the author prefixing their own name to the post title
+      //   — `Farm Mx` inside `Feulatracks_Farm_MX`. Reliable even for a one-word title.
+      // *filename inside title* is a fragment of the title, which may just be a common
+      //   word: a paint called `Replica.pnt` otherwise claimed every "… Replica" post in
+      //   the catalog. Needs two distinctive words, or one long enough to be a name.
+      const titleInFile = entry.key.includes(key);
+      const fileInTitle = key.includes(entry.key);
+      if (titleInFile && key.length >= MIN_CONTAINED_LEN && tokens.size >= 1) return true;
+      if (
+        fileInTitle &&
+        entry.key.length >= MIN_CONTAINED_LEN &&
+        (entry.tokens.size >= 2 || entry.key.length >= MIN_LONE_WORD_LEN)
+      )
+        return true;
 
       const { shared, score } = jaccard(tokens, entry.tokens);
       if (shared >= MIN_SHARED_TOKENS && score >= MIN_TOKEN_OVERLAP) return true;
+      if (subsetMatch(tokens, entry.tokens, shared)) return true;
     }
     return false;
   };


### PR DESCRIPTION
Fixes #26.

The **Installed** badge in Browse almost never appeared. On the reporter's library it caught 19 of 96 tracks and **0 of 96** bikes and rider items — all installed and working in-game.

## What was wrong

**Browse scanned the wrong thing.** The installed set came from `get_installed_mods` → `scan_mods`, which keeps `.pkz` files only. Extracted track folders and every `.pnt` paint were invisible, and since the Bikes and Rider categories are dominated by liveries and gear paints, nothing in them could ever be badged. That's the two zeroes — not the name matching. `scan_library`, which the Library tab already uses, understands folders, `.pnt`, paints and model swaps; `Dashboard` and `Shop` now use it.

**Matching was exact equality** on a stripped key, so the packaged filename had to equal the WordPress post title character for character. Post titles are prose — author credits, release tags, `(READ INSTRUCTIONS)` — so it practically never held.

**HTML entities needed no fix.** `decode_entities` has run on `title.rendered` for both search and detail since v0.1.0; the reporter's standalone reimplementation hit the REST API directly, so it saw raw entities the app never sees. Added a hex/emoji case to that test to keep it true.

## The matcher

New `src/lib/installedMatch.ts`. Four rules, each firing only where it can't plausibly be coincidence:

1. **Exact** normalized key (today's behaviour).
2. **Containment**, asymmetric. A *title inside a filename* is the author prefixing their own name — `Farm Mx` inside `Feulatracks_Farm_MX` — and is reliable even for a one-word title. A *filename inside a title* is a fragment that may just be a common word, so it needs two distinctive words or one long enough to be a name. Without that split, a paint named `Replica.pnt` claimed every "… Replica" post in the catalog.
3. **Token subset** — the filename is often an abbreviation of the title (`KTM_85_2027_HGS.pnt` for *"ktm 85 2027 with hgs front and back pipe"*), where every extra word the title adds counts *against* an overlap score. Needs 3+ words covering half the longer name.
4. **Jaccard overlap ≥ 0.75** as the blunt fallback, over significant tokens with filler dropped and model years folded (`2027` ≡ `27`, bounded to 2000–2035 so `85`/`250`/`450` are untouched).

An inverted token index keeps a card check proportional to the entries sharing a word with it, not to the whole library.

## Calibration against the live catalog

The thresholds are not guesses — the matcher was run over the **288 live mxb-mods listings** (96 each for tracks, bikes, rider). That surfaced a defect the hand-picked fixture never could: **the file extension was being tokenized**, so every `.pnt` carried a `pnt` token no title can contain, inflating the union and dragging down the score of every paint — precisely the categories reporting 0/96.

Fixing it also removed an accidental cushion: the overlap threshold had been calibrated against those inflated unions. Measured properly, a white/blue and a red/white livery of the same bike score **0.67**, and a Washougal and a RedBud kit for the same 2026 Yamaha score **0.60** — names differing only in the word that matters. Hence 0.75, with the subset rule carrying the abbreviation cases it gives up.

Final numbers on live data:

| measure | result |
|---|---|
| posts that badge their own installed file | 281 / 288 |
| cross-hits over 288 × 287 title/file pairs | 17 (0.02%) |
| issue's reported examples recovered | 6 / 6, no false positives |

The 17 remaining cross-hits are all closely-related variants — `26 FLY Kinetic` against `26 FLY Kinetic Mesh`, or two Redbull Quadlock Husqvarna kits. The 7 non-matches are files that reduce to an author credit alone (`ZD`, `RED`, `Ben89`), which shouldn't claim a track.

## Verification

- `cargo test --locked`: 151 passed, 0 failed.
- `npm run typecheck` clean, `eslint src scripts` 0 errors, `npm run build` succeeds.
- Merged `main` twice (#27, #28, #29, #30 landed during this work); `Dashboard.tsx` and `api/mods.ts` auto-merged cleanly and were re-checked by hand.

## Not in scope

- **Category-aware matching** — comparing Liveries posts only against `bikePaint` entries would cut the remaining cross-hits further, but needs the index to carry `LibraryEntry.category` and Browse to thread its active category down.
- **No JS test runner in this repo**, so the calibration harnesses aren't committed. Worth adding vitest if this logic grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)