### PR TITLE
feat(locker): refresh a swapped model live on the selected bike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 2026-08-07
+
+### Added
+- **Swapping a model now changes it in-game instantly, on the bike you have selected.**
+  A model swap moved the files and re-ran the game's *customization* loader — which
+  reloads paints and gear but never the bike mesh, so the garage kept showing the old
+  model until you switched bike class away and back. The Locker now also asks FrostMod
+  to re-apply the bike (new `refresh_bike_model` command), which re-reads it from disk
+  and brings the new model up immediately. FrostMod acts only on the bike you currently
+  have selected, so swapping any other bike never disturbs what you're looking at.
+  Presets get the same treatment when they carry a model swap. Gated on the existing
+  **Instant refresh** setting, since it reaches into the running game.
+
+### Fixed
+- **The Locker no longer claims a model swap "Refreshed live in-game" when it didn't.**
+  The note was derived purely from the look-loader call succeeding, which says nothing
+  about whether the mesh reloaded — so it read as done while the garage still showed the
+  old model. Model and sound swaps now report separately, and the model note reflects
+  what actually happened: refreshing now, FrostMod not running, or instant refresh off.
+
 ## 2026-08-06 — v0.6.3 — model swaps stop breaking bikes, Linux builds
 
 ### Added

--- a/src-tauri/src/frostmod.rs
+++ b/src-tauri/src/frostmod.rs
@@ -83,14 +83,21 @@ pub fn is_running() -> bool {
 }
 
 // ===========================================================================
-// Command channel — swap the active bike (offline, in-garage) via FrostMod.
+// Command channel — payload-carrying commands to FrostMod.
 //
-// The reload event carries no payload, so a bike swap needs its own channel:
-// mxb-app writes a small JSON command file, then signals a DEDICATED event so
-// FrostMod can't confuse a swap with a mods rescan. FrostMod reads the file on
-// wake and dispatches the swap on its render thread, where its own offline +
-// in-garage guard runs (a rejected swap is logged there, not returned here —
-// this side is fire-and-forget). Must match the reader in frostmod.cpp.
+// The reload event carries no payload, so anything needing an argument (a bike
+// id) needs its own channel: mxb-app writes a small JSON command file, then
+// signals a DEDICATED event so FrostMod can't confuse a command with a mods
+// rescan. FrostMod reads the file on wake and dispatches on its render thread
+// (refusals are logged there, not returned here — this side is fire-and-forget).
+// Must match `HandleFrostModCommand` in frostmod.cpp, verb names included.
+//
+// Verbs:
+//   `refresh_bike_model` — re-apply the named bike so a just-swapped model shows
+//       in the garage without the class-switch away-and-back. FrostMod no-ops
+//       unless that bike is the one currently selected.
+//   `swap_bike` — switch the active bike outright. NOT implemented in FrostMod
+//       yet (Stage B); it logs and ignores.
 // ===========================================================================
 
 /// Name of FrostMod's command event. Must match frostmod.cpp exactly.
@@ -104,16 +111,16 @@ fn command_file_path() -> std::path::PathBuf {
     std::env::temp_dir().join("frostmod_cmd.json")
 }
 
-/// Serialize a swap-bike command. Kept pure (no I/O) so it can be unit-tested and
-/// so the on-disk contract with frostmod.cpp is exercised without a game.
-fn swap_command_json(bike_id: &str) -> String {
-    serde_json::json!({ "verb": "swap_bike", "bikeId": bike_id }).to_string()
+/// Serialize a command. Kept pure (no I/O) so it can be unit-tested and so the
+/// on-disk contract with frostmod.cpp is exercised without a game.
+fn command_json(verb: &str, bike_id: &str) -> String {
+    serde_json::json!({ "verb": verb, "bikeId": bike_id }).to_string()
 }
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum SwapOutcome {
+pub enum CommandOutcome {
     /// Command file written and FrostMod signalled.
     Signaled,
     /// FrostMod isn't running (the command event doesn't exist).
@@ -124,36 +131,48 @@ pub enum SwapOutcome {
     Unsupported,
 }
 
-/// Ask FrostMod to swap the active bike to `bike_id`. Writes the command file
-/// first (so it's there before FrostMod wakes), then pulses the command event.
-/// Best-effort: the actual offline/in-garage decision happens inside FrostMod.
+/// Write the command file (so it's there before FrostMod wakes), then pulse the
+/// command event. Best-effort: FrostMod decides whether to act.
 #[cfg(windows)]
-pub fn signal_swap_bike(bike_id: &str) -> SwapOutcome {
-    if std::fs::write(command_file_path(), swap_command_json(bike_id)).is_err() {
-        return SwapOutcome::WriteFailed;
+fn send_command(json: String) -> CommandOutcome {
+    if std::fs::write(command_file_path(), json).is_err() {
+        return CommandOutcome::WriteFailed;
     }
     // SAFETY: valid NUL-terminated ANSI name; null return means the event doesn't
     // exist (FrostMod not running) or access was denied.
     let handle =
         unsafe { ffi::OpenEventA(ffi::EVENT_MODIFY_STATE, 0, COMMAND_EVENT_NAME.as_ptr()) };
     if handle.is_null() {
-        return SwapOutcome::NotRunning;
+        return CommandOutcome::NotRunning;
     }
     // SAFETY: `handle` is a valid event we just opened and close below.
     let ok = unsafe { ffi::SetEvent(handle) } != 0;
     unsafe { ffi::CloseHandle(handle) };
     if ok {
-        SwapOutcome::Signaled
+        CommandOutcome::Signaled
     } else {
-        SwapOutcome::NotRunning
+        CommandOutcome::NotRunning
     }
 }
 
 #[cfg(not(windows))]
-pub fn signal_swap_bike(_bike_id: &str) -> SwapOutcome {
+fn send_command(json: String) -> CommandOutcome {
     // Still write the command file on dev builds so the contract can be inspected.
-    let _ = std::fs::write(command_file_path(), swap_command_json(_bike_id));
-    SwapOutcome::Unsupported
+    let _ = std::fs::write(command_file_path(), json);
+    CommandOutcome::Unsupported
+}
+
+/// Ask FrostMod to swap the active bike to `bike_id`.
+/// NOTE: FrostMod does not implement this verb yet — it logs and ignores it.
+pub fn signal_swap_bike(bike_id: &str) -> CommandOutcome {
+    send_command(command_json("swap_bike", bike_id))
+}
+
+/// Ask FrostMod to re-apply `bike_id` so a just-swapped model shows in the garage
+/// straight away. A no-op inside FrostMod unless that bike is the selected one, so
+/// this is safe to fire after every model swap.
+pub fn signal_refresh_model(bike_id: &str) -> CommandOutcome {
+    send_command(command_json("refresh_bike_model", bike_id))
 }
 
 #[cfg(test)]
@@ -163,13 +182,23 @@ mod tests {
     #[test]
     fn swap_command_json_shape_and_escaping() {
         assert_eq!(
-            swap_command_json("MX2OEM_2023_KTM_250_SX-F"),
+            command_json("swap_bike", "MX2OEM_2023_KTM_250_SX-F"),
             r#"{"bikeId":"MX2OEM_2023_KTM_250_SX-F","verb":"swap_bike"}"#
         );
         // Ids are arbitrary folder names — ensure quotes/backslashes are escaped.
+        // frostmod.cpp's JsonStringField unescapes \" and \\ to match.
         assert_eq!(
-            swap_command_json(r#"a"b\c"#),
+            command_json("swap_bike", r#"a"b\c"#),
             r#"{"bikeId":"a\"b\\c","verb":"swap_bike"}"#
+        );
+    }
+
+    #[test]
+    fn refresh_command_json_uses_the_verb_frostmod_dispatches_on() {
+        // The verb string is the contract with HandleFrostModCommand in frostmod.cpp.
+        assert_eq!(
+            command_json("refresh_bike_model", "MX1OEM_1996_Honda_CR250"),
+            r#"{"bikeId":"MX1OEM_1996_Honda_CR250","verb":"refresh_bike_model"}"#
         );
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -153,6 +153,10 @@ struct SwapApplyOutcome {
     content_reload: ReloadOutcome,
     game_running: bool,
     live_refresh: gameproc::LiveRefresh,
+    /// Model swaps only (`None` for sound). `live_refresh` re-runs the *customization*
+    /// loader, which reloads paints/gear but never the mesh — the model needs FrostMod
+    /// to re-apply the bike. See `frostmod::signal_refresh_model`.
+    model_refresh: Option<frostmod::CommandOutcome>,
 }
 
 /// Re-run the game's look loader live if instant refresh is enabled, else report it off.
@@ -162,6 +166,13 @@ fn live_refresh(enabled: bool) -> gameproc::LiveRefresh {
     } else {
         gameproc::LiveRefresh::Disabled
     }
+}
+
+/// Ask FrostMod to re-apply `bike` so a just-swapped model shows live. `None` when
+/// instant refresh is off — the same switch that gates `live_refresh`, since both
+/// reach into the running game.
+fn model_refresh_cmd(enabled: bool, bike: &str) -> Option<frostmod::CommandOutcome> {
+    enabled.then(|| frostmod::signal_refresh_model(bike))
 }
 
 #[tauri::command]
@@ -189,10 +200,16 @@ fn apply_model_swap_blocking(
         eprintln!("sound reconcile after model swap failed: {e:#}");
     }
     let content_reload = frostmod::signal_reload();
+    // Ask FrostMod to re-apply the bike so the new model shows in the garage without a
+    // class switch away-and-back. Only acts if `bike` is the selected one (decided
+    // inside FrostMod, which is the only side that knows). Gated on the same
+    // instant-refresh setting as the look refresh — both poke the live game.
+    let model_refresh = model_refresh_cmd(cfg.instant_refresh, &bike);
     Ok(SwapApplyOutcome {
         content_reload,
         game_running: gameproc::is_game_running(),
         live_refresh: live_refresh(cfg.instant_refresh),
+        model_refresh,
     })
 }
 
@@ -220,6 +237,7 @@ async fn apply_sound_swap(
             content_reload,
             game_running: gameproc::is_game_running(),
             live_refresh: live_refresh(cfg.instant_refresh),
+            model_refresh: None, // a sound swap doesn't touch the model
         })
     })
     .await
@@ -1551,7 +1569,7 @@ async fn garage_scan_bikes(app: tauri::AppHandle) -> Result<Vec<bikeswap::BikeId
 /// Ask FrostMod to swap the active bike (offline, in-garage). FrostMod enforces the
 /// offline/in-garage guard; this only sends the request.
 #[tauri::command]
-fn garage_swap_bike(bike_id: String) -> frostmod::SwapOutcome {
+fn garage_swap_bike(bike_id: String) -> frostmod::CommandOutcome {
     frostmod::signal_swap_bike(&bike_id)
 }
 
@@ -1759,6 +1777,9 @@ struct PresetApplyOutcome {
     content_reload: ReloadOutcome,
     game_running: bool,
     live_refresh: gameproc::LiveRefresh,
+    /// Set only when the preset actually performed a model swap — see the note on
+    /// `SwapApplyOutcome::model_refresh`.
+    model_refresh: Option<frostmod::CommandOutcome>,
 }
 
 #[tauri::command]
@@ -1773,16 +1794,20 @@ fn presets_apply(
     presets::apply_loadout(&cfg.profiles_dir(), &profile, &bikeid, &loadout, make_active)
         .map_err(|e| format!("{e:#}"))?;
     let want = loadout.model_swap.trim();
+    let mut model_refresh = None;
     if !want.is_empty() && !want.eq_ignore_ascii_case(&modelswap::current_active(&cfg.mods_path, &bikeid))
     {
         modelswap::apply_model_swap(&cfg.mods_path, &bikeid, want)
             .map_err(|e| format!("Cosmetics applied, but the model swap failed: {e:#}"))?;
+        // Same reason as the Locker path: the look loader won't reload the mesh.
+        model_refresh = model_refresh_cmd(cfg.instant_refresh, &bikeid);
     }
     let content_reload = frostmod::signal_reload();
     Ok(PresetApplyOutcome {
         content_reload,
         game_running: gameproc::is_game_running(),
         live_refresh: live_refresh(cfg.instant_refresh),
+        model_refresh,
     })
 }
 

--- a/src/Components/Locker/Locker.tsx
+++ b/src/Components/Locker/Locker.tsx
@@ -51,20 +51,41 @@ import RegisterSwapsDialog from "./RegisterSwapsDialog";
  * **bound** to a model swap, so activating that model pulls its sound along.
  */
 
-/** Trailing feedback for a swap toast — mirrors the presets "refreshed live in-game" note. */
-function swapNote(outcome: SwapApplyOutcome): string {
+/**
+ * Trailing feedback for a swap toast.
+ *
+ * Models and sounds get different notes because they refresh by different routes.
+ * `live_refresh` re-runs the game's *customization* loader — that reloads paints and
+ * gear but never the bike mesh, so it says nothing about whether a swapped model is
+ * visible. A model only appears live if FrostMod re-applies the bike (`model_refresh`),
+ * which it does solely for the bike you currently have selected.
+ */
+function swapNote(kind: "model" | "sound", outcome: SwapApplyOutcome): string {
+  if (!outcome.game_running) return "Loads next time the game opens.";
+
+  if (kind === "model") {
+    switch (outcome.model_refresh) {
+      case "signaled":
+        return "Refreshing in-game — if it's your selected bike, it changes now.";
+      case "not_running":
+        return "Run FrostMod to see model swaps live — for now, reselect the bike in-game.";
+      case "write_failed":
+        return "Couldn't reach FrostMod — reselect the bike in-game to load it.";
+      case "unsupported":
+        return "Live model refresh is Windows-only — reselect the bike in-game.";
+      default: // null — instant refresh is switched off in Settings
+        return "Reselect the bike in MX Bikes to load it (instant refresh is off).";
+    }
+  }
+
   switch (outcome.live_refresh) {
     case "refreshed":
       return "Refreshed live in-game.";
     case "failed":
       return "Instant refresh failed — reselect your profile in-game to load it.";
     default:
-      break;
+      return "Reselect your profile in MX Bikes to load the swap.";
   }
-  if (outcome.game_running) {
-    return "Reselect your profile in MX Bikes to load the swap.";
-  }
-  return "Loads next time the game opens.";
 }
 
 /** One bike's row: its models (null for sound-only bikes) and its sounds (always present). */
@@ -172,9 +193,13 @@ export default function Locker() {
     );
 
   const onModelSwap = (bike: string, target: string) =>
-    run(bike, `Switched ${bike} model to “${target}”.`, () => applyModelSwap(bike, target), swapNote);
+    run(bike, `Switched ${bike} model to “${target}”.`, () => applyModelSwap(bike, target), (r) =>
+      swapNote("model", r),
+    );
   const onSoundSwap = (bike: string, target: string) =>
-    run(bike, `Switched ${bike} sound to “${target}”.`, () => applySoundSwap(bike, target), swapNote);
+    run(bike, `Switched ${bike} sound to “${target}”.`, () => applySoundSwap(bike, target), (r) =>
+      swapNote("sound", r),
+    );
   const onBind = (bike: string, model: string, sound: string) =>
     run(bike, `Tied “${sound}” to model “${model}”.`, () => bindSound(bike, model, sound));
   const onUnbind = (bike: string, model: string, sound: string) =>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -318,10 +318,19 @@ export type LiveRefresh =
   | "disabled"
   | "unsupported";
 
+/** Result of a payload-carrying command sent to FrostMod (see `frostmod.rs`). */
+export type CommandOutcome =
+  | "signaled"
+  | "not_running"
+  | "write_failed"
+  | "unsupported";
+
 export interface PresetApplyOutcome {
   content_reload: ReloadOutcome;
   game_running: boolean;
   live_refresh: LiveRefresh;
+  /** Set only when the preset performed a model swap. See `SwapApplyOutcome`. */
+  model_refresh: CommandOutcome | null;
 }
 
 /** Outcome of a Locker model/sound swap — same shape/feedback as a preset apply. */
@@ -329,6 +338,13 @@ export interface SwapApplyOutcome {
   content_reload: ReloadOutcome;
   game_running: boolean;
   live_refresh: LiveRefresh;
+  /**
+   * Model swaps only (`null` for sound). `live_refresh` re-runs the game's
+   * *customization* loader — that reloads paints/gear but never the mesh, so the
+   * model needs FrostMod to re-apply the bike. `signaled` means FrostMod was asked;
+   * it still no-ops unless the swapped bike is the one currently selected in-game.
+   */
+  model_refresh: CommandOutcome | null;
 }
 
 /** Install/version/running snapshot for the FrostMod settings panel. */


### PR DESCRIPTION
Swapping a model moved the files and re-ran the game's *customization* loader — which reloads paints and gear but **never the bike mesh**. So the garage kept showing the old model until you switched bike class away and back, while the toast reported "Refreshed live in-game" purely because that call succeeded.

## What changed
- After a model swap the Locker asks FrostMod to **re-apply the bike** (new `refresh_bike_model` verb on the existing command channel). FrostMod replays the game's own bike-apply call, which re-reads the bike from disk, and acts **only on the bike currently selected in-game** — the side that knows. Swapping any other bike never disturbs what you're looking at.
- Presets get the same treatment when they carry a model swap.
- Gated on the existing **Instant refresh** setting, since it reaches into the running game exactly like the look refresh does.
- Model and sound swaps now report **separately**, so the model note reflects what actually happened: refreshing now, FrostMod not running, or instant refresh off.
- `SwapOutcome` → `CommandOutcome` — it is no longer swap-specific.

## Requires the paired FrostMod change
Frostn1/frostmod#1. Without it the command file is written and nothing reads it — the app side has been writing to `Local\FrostModCommand` since the garage-switch groundwork, but FrostMod only ever created `Local\FrostModReload`, so that contract was dead. This PR is inert until that one lands.

## Checks
`cargo build` clean, **150 tests pass** (2 covering the command JSON contract, which is the on-disk contract with `HandleFrostModCommand`), `tsc --noEmit` clean, eslint clean.

No DB/schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)