### PR TITLE
feat(shell): add a Play button that launches MX Bikes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026-08-07
+
+### Added
+- **A Play button that launches MX Bikes.** Setting a bike up in the Locker meant
+  alt-tabbing to Steam or the desktop to actually ride it, even though the app already
+  knew where the game was installed and whether it was running. The sidebar now carries a
+  Play button above the FrostMod pill, visible from every tab; it flips to "MX Bikes
+  running" while the game is up, so it can't start a second copy. Windows runs
+  `mxbikes.exe` directly, which works for standalone (non-Steam) copies too and doesn't
+  need Steam open; Linux hands `steam://rungameid/655500` to the desktop, because a
+  Proton install is Steam's to set up. If the install folder isn't set or holds no
+  `mxbikes.exe`, the error says so and points at Settings.
+
 ## 2026-08-06 — v0.6.3 — model swaps stop breaking bikes, Linux builds
 
 ### Added

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -162,8 +162,9 @@ pub fn finalize(mut cfg: AppConfig) -> AppConfig {
     cfg
 }
 
-/// MX Bikes' Steam AppID — names its Proton prefix under `steamapps/compatdata`.
-const MX_BIKES_APPID: &str = "655500";
+/// MX Bikes' Steam AppID — names its Proton prefix under `steamapps/compatdata`, and
+/// addresses the game in the `steam://rungameid/…` URL the Linux launcher uses.
+pub const MX_BIKES_APPID: &str = "655500";
 
 /// The MX Bikes user folder inside a Proton prefix.
 ///

--- a/src-tauri/src/gameproc.rs
+++ b/src-tauri/src/gameproc.rs
@@ -1,11 +1,12 @@
 use serde::Serialize;
 
+use crate::config::AppConfig;
+
 /// Customization loader `fcn.1400ecd00` minus PE image base `0x140000000`.
 #[cfg(windows)]
 const LOADER_OFFSET: usize = 0x000e_cd00;
 
 /// The game's main executable (matched case-insensitively).
-#[cfg(windows)]
 const GAME_EXE: &str = "mxbikes.exe";
 
 // Non-Windows builds only construct `Unsupported`/`Disabled`.
@@ -227,4 +228,144 @@ pub fn is_game_running() -> bool {
 #[cfg(not(windows))]
 pub fn refresh_look() -> LiveRefresh {
     LiveRefresh::Unsupported
+}
+
+/// What happened when the user pressed Play.
+// macOS dev builds only ever construct `AlreadyRunning` (the launch bails first).
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LaunchOutcome {
+    /// We started the game.
+    Launched,
+    /// MX Bikes was already up — we left it alone rather than spawning a second copy.
+    AlreadyRunning,
+}
+
+/// The MX Bikes install folder and its `mxbikes.exe`, for launching.
+///
+/// Falls back to Steam detection when `gamePath` is blank: the setting only ever gets
+/// filled by that same detector, so an install we can find is one we can launch even if
+/// the config predates the setting.
+fn resolve_exe(cfg: &AppConfig) -> anyhow::Result<(std::path::PathBuf, std::path::PathBuf)> {
+    let dir = match cfg.game_path.trim() {
+        "" => crate::config::detect_game_path().ok_or_else(|| {
+            anyhow::anyhow!(
+                "MX Bikes install folder isn't set — set it in Settings, under MX Bikes install folder."
+            )
+        })?,
+        p => p.to_string(),
+    };
+    let dir = std::path::PathBuf::from(dir);
+    let exe = crate::library::resolve_child(&dir, GAME_EXE);
+    if !exe.is_file() {
+        anyhow::bail!(
+            "Couldn't find {GAME_EXE} in {} — check the MX Bikes install folder in Settings.",
+            dir.display()
+        );
+    }
+    Ok((dir, exe))
+}
+
+/// Start MX Bikes, unless it's already running.
+///
+/// Windows runs the exe directly rather than going through `steam://`: that works for
+/// standalone (non-Steam) copies too, and doesn't need Steam to be up. Under Proton the
+/// exe isn't ours to spawn — Steam has to set up the prefix — so Linux hands the Steam
+/// URL to the desktop instead.
+pub fn launch(cfg: &AppConfig) -> anyhow::Result<LaunchOutcome> {
+    if is_game_running() {
+        return Ok(LaunchOutcome::AlreadyRunning);
+    }
+    let (dir, exe) = resolve_exe(cfg)?;
+    log::info!("launching MX Bikes: {}", exe.display());
+
+    #[cfg(windows)]
+    {
+        // No CREATE_NO_WINDOW here (unlike the headless FrostMod child) — the game
+        // draws its own window and hiding the console would gain nothing.
+        std::process::Command::new(&exe)
+            .current_dir(&dir)
+            .spawn()
+            .map_err(|e| anyhow::anyhow!("Couldn't start {}: {e}", exe.display()))?;
+        Ok(LaunchOutcome::Launched)
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let _ = dir;
+        let url = format!("steam://rungameid/{}", crate::config::MX_BIKES_APPID);
+        std::process::Command::new("xdg-open")
+            .arg(&url)
+            .spawn()
+            .map_err(|e| anyhow::anyhow!("Couldn't ask Steam to launch MX Bikes ({url}): {e}"))?;
+        Ok(LaunchOutcome::Launched)
+    }
+
+    #[cfg(not(any(windows, target_os = "linux")))]
+    {
+        let _ = dir;
+        anyhow::bail!("Launching MX Bikes is supported on Windows and Linux only")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("frost-launch-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn finds_the_exe_in_the_configured_folder() {
+        let dir = temp_dir("found");
+        std::fs::write(dir.join(GAME_EXE), b"stub").unwrap();
+
+        let mut cfg = AppConfig::default();
+        cfg.game_path = dir.to_string_lossy().into_owned();
+        let (found_dir, exe) = resolve_exe(&cfg).expect("a folder holding mxbikes.exe launches");
+        assert_eq!(found_dir, dir);
+        assert_eq!(exe, dir.join(GAME_EXE));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Proton installs on a case-sensitive filesystem can hold `MXBikes.exe`; an exact
+    /// match would call a perfectly good install missing.
+    #[test]
+    fn matches_the_exe_case_insensitively() {
+        let dir = temp_dir("case");
+        std::fs::write(dir.join("MXBikes.exe"), b"stub").unwrap();
+
+        let mut cfg = AppConfig::default();
+        cfg.game_path = dir.to_string_lossy().into_owned();
+        // The name it comes back under depends on the host filesystem's case rules
+        // (macOS resolves the exact join); what matters is that it resolves at all.
+        let (_, exe) = resolve_exe(&cfg).expect("a differently-cased exe still resolves");
+        assert!(exe
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .eq_ignore_ascii_case(GAME_EXE));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_folder_without_the_exe_says_where_to_fix_it() {
+        let dir = temp_dir("empty");
+
+        let mut cfg = AppConfig::default();
+        cfg.game_path = dir.to_string_lossy().into_owned();
+        let err = resolve_exe(&cfg).expect_err("no exe means no launch");
+        let msg = format!("{err:#}");
+        assert!(msg.contains(GAME_EXE), "names what's missing: {msg}");
+        assert!(msg.contains("Settings"), "points at the fix: {msg}");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1536,6 +1536,21 @@ fn frostmod_running() -> bool {
     frostmod::is_running()
 }
 
+/// Start MX Bikes from the Play button in the sidebar.
+#[tauri::command]
+fn launch_game(app: tauri::AppHandle) -> Result<gameproc::LaunchOutcome, String> {
+    // `load_or_detect`, not `load`: a missing config file shouldn't turn Play into an
+    // error when the install is sitting exactly where the detector looks.
+    let cfg = config::load_or_detect(&app).unwrap_or_default();
+    gameproc::launch(&cfg).map_err(|e| format!("{e:#}"))
+}
+
+/// Is MX Bikes running? Polled by the sidebar so Play can show the live state.
+#[tauri::command]
+fn game_running() -> bool {
+    gameproc::is_game_running()
+}
+
 /// Installed bikes with their class, for the garage bike-switch UI. The frontend
 /// filters this to the current race's class before offering a swap.
 #[tauri::command]
@@ -2019,6 +2034,8 @@ fn main() {
             frostmod_install,
             frostmod_start,
             frostmod_stop,
+            launch_game,
+            game_running,
             shop_login,
             shop_status,
             shop_logout,

--- a/src/Components/Shell/Sidebar.tsx
+++ b/src/Components/Shell/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import {
   Home,
   Library as LibraryIcon,
@@ -7,12 +8,16 @@ import {
   Settings,
   RefreshCw,
   Play,
+  Loader2,
+  Gamepad2,
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useFrostmod } from "../../Context/FrostmodContext";
 import { useInstall } from "../../Context/Install";
 import { displayName } from "../../lib/mods";
+import { launchGame } from "../../api/mods";
+import { useGameRunning } from "../../lib/useGameRunning";
 
 export type DashboardView =
   | "browse"
@@ -39,9 +44,43 @@ const NAV: { id: DashboardView; label: string; icon: typeof Home }[] = [
 
 const IN_PROGRESS = new Set(["resolving", "downloading", "extracting", "placing"]);
 
+/** MX Bikes takes a while to show up in the process list; stop saying "Starting…" after this. */
+const STARTING_TIMEOUT_MS = 15000;
+
 export default function Sidebar({ view, onNavigate }: SidebarProps) {
   const { running, reload, status, start } = useFrostmod();
   const { active, queueLength } = useInstall();
+  const { running: gameRunning, refresh: refreshGame } = useGameRunning();
+  const [starting, setStarting] = useState(false);
+
+  // Drop out of "Starting…" once the game shows up — or once it's clear it isn't going
+  // to, so a launch that failed silently doesn't leave the button stuck.
+  useEffect(() => {
+    if (!starting) return;
+    if (gameRunning) {
+      setStarting(false);
+      return;
+    }
+    const id = setTimeout(() => setStarting(false), STARTING_TIMEOUT_MS);
+    return () => clearTimeout(id);
+  }, [starting, gameRunning]);
+
+  const onPlay = async () => {
+    setStarting(true);
+    try {
+      const outcome = await launchGame();
+      if (outcome === "already_running") {
+        toast.info("MX Bikes is already running");
+        setStarting(false);
+      } else {
+        toast.success("Launching MX Bikes…");
+      }
+    } catch (e) {
+      toast.error("Couldn't launch MX Bikes", { description: String(e) });
+      setStarting(false);
+    }
+    refreshGame();
+  };
 
   const installing = active && IN_PROGRESS.has(active.stage);
   const pct =
@@ -113,6 +152,30 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
             </div>
           </div>
         )}
+
+        <button
+          data-tour="play"
+          onClick={onPlay}
+          disabled={gameRunning || starting}
+          title={gameRunning ? "MX Bikes is running" : "Launch MX Bikes"}
+          className={cn(
+            "flex cursor-default items-center justify-center gap-2 rounded-lg px-3 py-2.5 text-[13.5px] font-semibold transition-colors",
+            gameRunning || starting
+              ? "border border-white/[0.07] text-muted-foreground"
+              : "bg-primary text-primary-foreground hover:brightness-105 active:brightness-95",
+          )}
+        >
+          {gameRunning ? (
+            <Gamepad2 className="size-4 text-success" />
+          ) : starting ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <Play className="size-4" />
+          )}
+          <span>
+            {gameRunning ? "MX Bikes running" : starting ? "Starting…" : "Play"}
+          </span>
+        </button>
 
         <div
           data-tour="frostmod"

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -12,6 +12,7 @@ import type {
   FrostmodStatus,
   InstalledMod,
   InstallProgress,
+  LaunchOutcome,
   LibraryEntry,
   Loadout,
   ModDetail,
@@ -695,6 +696,16 @@ export function reloadFrostmod(): Promise<ReloadOutcome> {
 /** Is FrostMod currently running on this PC? */
 export function isFrostmodRunning(): Promise<boolean> {
   return invoke<boolean>("frostmod_running");
+}
+
+/** Start MX Bikes. Resolves to `already_running` when the game is already up. */
+export function launchGame(): Promise<LaunchOutcome> {
+  return invoke<LaunchOutcome>("launch_game");
+}
+
+/** Is MX Bikes currently running? Always false off Windows — the probe is Win32-only. */
+export function isGameRunning(): Promise<boolean> {
+  return invoke<boolean>("game_running");
 }
 
 /** Install/version/running snapshot (hits GitHub for the latest tag). */

--- a/src/lib/useGameRunning.ts
+++ b/src/lib/useGameRunning.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { isGameRunning } from "../api/mods";
+
+/** Same cadence as the FrostMod probe in `Context/Frostmod.tsx`. */
+const POLL_MS = 5000;
+
+/**
+ * Whether MX Bikes is running, polled in the background.
+ *
+ * Kept out of `FrostmodProvider` on purpose: that context tracks FrostMod's own process,
+ * and the game is a separate thing to watch. `refresh` is exposed so a launch can check
+ * straight away instead of waiting out the interval.
+ *
+ * Note the probe is Win32-only, so off Windows this is permanently `false` — a Linux
+ * player sees Play rather than "MX Bikes running", which is harmless: the backend still
+ * routes through Steam, which focuses the running game instead of starting a second one.
+ */
+export function useGameRunning(): { running: boolean; refresh: () => void } {
+  const [running, setRunning] = useState(false);
+  const mounted = useRef(true);
+
+  const refresh = useCallback(() => {
+    isGameRunning()
+      .then((r) => mounted.current && setRunning(r))
+      .catch(() => mounted.current && setRunning(false));
+  }, []);
+
+  useEffect(() => {
+    mounted.current = true;
+    refresh();
+    const id = setInterval(refresh, POLL_MS);
+    return () => {
+      mounted.current = false;
+      clearInterval(id);
+    };
+  }, [refresh]);
+
+  return { running, refresh };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -311,6 +311,9 @@ export interface FrostmodReload {
   mods?: string[];
 }
 
+/** Result of pressing Play. `already_running` means we deliberately did nothing. */
+export type LaunchOutcome = "launched" | "already_running";
+
 export type LiveRefresh =
   | "refreshed"
   | "failed"


### PR DESCRIPTION
## What

A **Play** button in the sidebar, above the FrostMod pill and visible from every tab. Setting a bike up in the Locker meant alt-tabbing to Steam or the desktop to actually ride it — even though the app already knew where the game was installed and whether it was running.

Three states: **Play** → **Starting…** (spinner, disabled, 15s cap so a launch that fails silently can't wedge the button) → **MX Bikes running** (muted, disabled, so it can't start a second copy).

## How

- `gameproc::launch` lives next to the process probe that already owned "everything about the game process". It returns `AlreadyRunning` when `is_game_running()` says the game is up, rather than spawning a second copy.
- Install resolution reuses what's already there: `config::detect_game_path()` when `gamePath` is blank, and `library::resolve_child` for a case-insensitive `mxbikes.exe` match (a Proton install on a case-sensitive filesystem can hold `MXBikes.exe`).
- **Windows** spawns the exe directly rather than going through `steam://` — that covers standalone, non-Steam copies too, and doesn't need Steam open. No `CREATE_NO_WINDOW` here (unlike the headless FrostMod child): the game draws its own window.
- **Linux** hands `steam://rungameid/655500` to `xdg-open`, because under Proton the prefix is Steam's to set up and the exe isn't ours to spawn. **macOS** bails with a plain message instead of pretending.
- A missing install folder or a missing exe produces a user-facing error that points at Settings, not a raw io error.
- New `launch_game` / `game_running` commands. `useGameRunning` polls the latter every 5s — the same cadence as the FrostMod probe, and deliberately kept out of `FrostmodProvider`, which tracks a different process.

No DB/schema changes.

## Known limitation

`is_game_running()` is Win32-only and returns `false` elsewhere, so on Linux the button stays on **Play** even while the game is up. Clicking again is harmless — Steam focuses the running game rather than starting a second one.

## Verification

- `cargo test` — 152 pass, including three new ones covering exe found / case-insensitive match / missing-exe error text.
- `bun run build` (tsc + vite) and `eslint` clean.
- Both were re-run against this commit in a detached worktree, so the build is verified standalone.
- **Still needs a Windows check**: Play starts the game and the button flips to "MX Bikes running" within ~5s; clearing the install folder in Settings makes it error with the "set it in Settings" message. macOS can only exercise the error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)