### PR TITLE
feat(browse): show star ratings on mod thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-08-07
+
+### Added
+- **Star ratings on browse thumbnails.** A mod that people have rated on mxb-mods.com now
+  shows its score on the card the same way the site does — five stars filled to the
+  nearest half, the average, and the vote count — so a good mod is recognisable before you
+  open it. Unrated mods show nothing rather than five empty stars, which would read as a
+  bad score instead of "nobody has voted yet". The scores aren't in the REST API the
+  listing comes from, so they're fetched separately per page (six requests at a time,
+  cached for ten minutes) after the cards have painted: browsing never waits on them, and
+  a score that fails to load simply doesn't appear.
+
 ## 2026-08-06 — v0.6.3 — model swaps stop breaking bikes, Linux builds
 
 ### Added

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -30,7 +30,7 @@ use frostmod_manage::{FrostmodProcess, FrostmodStatus};
 use library::InstalledMod;
 use modwatch::ModWatcher;
 use mods::mxb::MxbModsSource;
-use mods::{ModDetail, ModSource, ModSummary};
+use mods::{ModDetail, ModRating, ModSource, ModSummary};
 use tauri::{
     menu::{Menu, MenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
@@ -83,6 +83,13 @@ async fn search_mods(
         .search(&query, category_id, page)
         .await
         .map_err(|e| format!("{e:#}"))
+}
+
+/// Community scores for the mods currently on screen, keyed by post id. Ids the site
+/// wouldn't answer for are left out rather than erroring — the cards just show no stars.
+#[tauri::command]
+async fn get_mod_ratings(ids: Vec<u64>) -> std::collections::HashMap<u64, ModRating> {
+    mods::mxb::ratings(&ids).await
 }
 
 #[tauri::command]
@@ -1970,6 +1977,7 @@ fn main() {
             app_platform,
             search_mods,
             get_mod_detail,
+            get_mod_ratings,
             get_installed_mods,
             scan_library,
             get_pkz_meta_cached,

--- a/src-tauri/src/mods/mod.rs
+++ b/src-tauri/src/mods/mod.rs
@@ -16,6 +16,16 @@ pub struct ModSummary {
     pub category_id: u32,
 }
 
+/// A mod's community score on mxb-mods.com — the same average and vote count the
+/// site prints under each listing thumbnail.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModRating {
+    /// Mean score out of 5. Meaningless when `count` is 0.
+    pub average: f32,
+    pub count: u32,
+}
+
 /// One download choice on a mod page. Hosts vary (Google Drive, MediaFire, …).
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/mods/mxb.rs
+++ b/src-tauri/src/mods/mxb.rs
@@ -1,8 +1,12 @@
-use super::{DownloadOption, ModDetail, ModSource, ModSummary};
+use super::{DownloadOption, ModDetail, ModRating, ModSource, ModSummary};
+use futures_util::StreamExt;
 use regex::Regex;
 use reqwest::Client;
 use scraper::{Html, Selector};
 use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 const BASE: &str = "https://mxb-mods.com";
 /// A full four-part version, unlike the `Chrome/126.0` form used elsewhere — real Chrome
@@ -245,6 +249,100 @@ pub async fn detail(slug: &str) -> anyhow::Result<ModDetail> {
         version,
         downloads,
     })
+}
+
+/// How long a fetched rating is trusted. Votes trickle in over days, so a stale score is
+/// harmless — but re-browsing a category shouldn't re-ask the site for the same 24 posts.
+const RATING_TTL: Duration = Duration::from_secs(10 * 60);
+
+/// Ratings cost one request each, so a page of results is a burst. Six at a time keeps
+/// that burst well under what the REST search already does in one shot.
+const RATING_CONCURRENCY: usize = 6;
+
+fn rating_cache() -> &'static Mutex<HashMap<u64, (ModRating, Instant)>> {
+    static CACHE: std::sync::OnceLock<Mutex<HashMap<u64, (ModRating, Instant)>>> =
+        std::sync::OnceLock::new();
+    CACHE.get_or_init(Default::default)
+}
+
+/// Scores for a batch of post ids, as the site's rating plugin reports them.
+///
+/// Ids we couldn't fetch are simply absent from the map: a rating is decoration on a mod
+/// card, so a blocked or slow request must never surface as a browsing error. That's also
+/// why this skips `get_with_retry` — one attempt each, no piling on a site that's already
+/// unhappy.
+pub async fn ratings(ids: &[u64]) -> HashMap<u64, ModRating> {
+    let mut out = HashMap::new();
+    let mut missing = Vec::new();
+    {
+        let cache = lock(rating_cache());
+        let now = Instant::now();
+        for &id in ids {
+            match cache.get(&id) {
+                Some((r, at)) if now.duration_since(*at) < RATING_TTL => {
+                    out.insert(id, *r);
+                }
+                _ => missing.push(id),
+            }
+        }
+    }
+    missing.sort_unstable();
+    missing.dedup();
+
+    let fetched: Vec<(u64, ModRating)> = futures_util::stream::iter(
+        missing
+            .into_iter()
+            .map(|id| async move { rating(id).await.ok().map(|r| (id, r)) }),
+    )
+    .buffer_unordered(RATING_CONCURRENCY)
+    .filter_map(|r| async move { r })
+    .collect()
+    .await;
+
+    {
+        let mut cache = lock(rating_cache());
+        let now = Instant::now();
+        for (id, r) in &fetched {
+            cache.insert(*id, (*r, now));
+        }
+    }
+    out.extend(fetched);
+    out
+}
+
+/// A poisoned rating cache is not worth taking the app down for — the worst case is one
+/// stale entry written by a thread that panicked mid-insert.
+fn lock<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// The rating plugin has no REST route; its front end reads scores from this admin-ajax
+/// action, which answers unauthenticated with `{voteCount, avgRating}`.
+async fn rating(id: u64) -> anyhow::Result<ModRating> {
+    let url = format!("{BASE}/wp-admin/admin-ajax.php");
+    let resp = client()?
+        .post(&url)
+        .form(&[("action", "load_results".to_string()), ("postID", id.to_string())])
+        .send()
+        .await?;
+    if !resp.status().is_success() {
+        anyhow::bail!("{}", resp.status());
+    }
+    let v: Value = resp.json().await?;
+    Ok(ModRating {
+        average: number(v.get("avgRating")).unwrap_or(0.0) as f32,
+        count: number(v.get("voteCount")).unwrap_or(0.0).max(0.0) as u32,
+    })
+}
+
+/// WordPress plugins are casual about JSON types — the same field comes back as a number
+/// on one post and a string on another.
+fn number(v: Option<&Value>) -> Option<f64> {
+    match v? {
+        Value::Number(n) => n.as_f64(),
+        Value::String(s) => s.trim().parse().ok(),
+        _ => None,
+    }
 }
 
 fn summary_from_post(p: &Value, category_id: u32) -> Option<ModSummary> {

--- a/src/Components/Browse/Browse.tsx
+++ b/src/Components/Browse/Browse.tsx
@@ -1,16 +1,17 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Search, Download, X } from "lucide-react";
 import { toast } from "sonner";
 import {
   MOD_TYPES,
   SEARCH_PAGE_SIZE,
+  getModRatings,
   isLiveryContext,
   normalizeModName,
   resolveQuickInstall,
   searchMods,
   type ModType,
 } from "../../api/mods";
-import type { ModSummary } from "../../types";
+import type { ModRating, ModSummary } from "../../types";
 import { useInstall } from "../../Context/Install";
 import ModCard from "./ModCard";
 import { Segmented } from "@/Components/ui/segmented";
@@ -46,6 +47,11 @@ export default function Browse({
   const [debounced, setDebounced] = useState("");
   const [categoryId, setCategoryId] = useState(modType.categoryId);
   const [mods, setMods] = useState<ModSummary[]>([]);
+  const [ratings, setRatings] = useState<Map<number, ModRating>>(new Map());
+  // Ids we've already asked about, so a mod the site had no answer for isn't re-requested
+  // on every render. Cleared when the listing is rebuilt (the Rust side caches, so asking
+  // again after a category switch costs nothing).
+  const askedForRatings = useRef<Set<number>>(new Set());
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -198,6 +204,7 @@ export default function Browse({
     setLoading(true);
     setError(null);
     setPage(1);
+    askedForRatings.current = new Set();
     searchMods(debounced, categoryId, 1)
       .then((res) => {
         if (cancelled) return;
@@ -210,6 +217,29 @@ export default function Browse({
       cancelled = true;
     };
   }, [debounced, categoryId, reloadKey]);
+
+  // Scores aren't part of the search response — they come in a second pass keyed by post
+  // id, for whatever is on screen. Never awaited by the grid: cards paint immediately and
+  // stars appear a moment later, and a failure just leaves them off.
+  useEffect(() => {
+    const wanted = mods.map((m) => m.id).filter((id) => !askedForRatings.current.has(id));
+    if (wanted.length === 0) return;
+    for (const id of wanted) askedForRatings.current.add(id);
+    let cancelled = false;
+    getModRatings(wanted)
+      .then((res) => {
+        if (cancelled) return;
+        setRatings((prev) => {
+          const next = new Map(prev);
+          for (const [id, rating] of Object.entries(res)) next.set(Number(id), rating);
+          return next;
+        });
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [mods]);
 
   const loadMore = useCallback(async () => {
     const next = page + 1;
@@ -311,6 +341,7 @@ export default function Browse({
                 <ModCard
                   key={m.id}
                   mod={m}
+                  rating={ratings.get(m.id)}
                   isBike={isBike}
                   installed={isInstalled(m)}
                   selected={selected.has(m.slug)}

--- a/src/Components/Browse/ModCard.tsx
+++ b/src/Components/Browse/ModCard.tsx
@@ -8,7 +8,8 @@ import {
   SquareCheck,
   Square,
 } from "lucide-react";
-import type { ModSummary } from "../../types";
+import type { ModRating, ModSummary } from "../../types";
+import RatingStars from "./RatingStars";
 import { Badge } from "@/Components/ui/badge";
 import {
   ContextMenu,
@@ -22,6 +23,8 @@ import { formatDateShort } from "../../lib/mods";
 
 interface ModCardProps {
   mod: ModSummary;
+  /** The site's score, when it has one. Undefined until the ratings request lands. */
+  rating?: ModRating;
   installed: boolean;
   isBike: boolean;
   selected: boolean;
@@ -34,6 +37,7 @@ interface ModCardProps {
 
 export default function ModCard({
   mod,
+  rating,
   installed,
   isBike,
   selected,
@@ -90,6 +94,13 @@ export default function ModCard({
             >
               <Check className="size-3.5" strokeWidth={3} />
             </span>
+            {/* Unrated mods get nothing at all — five empty stars would read as a bad
+                score rather than as "nobody has voted yet". */}
+            {rating && rating.count > 0 && (
+              <span className="absolute bottom-1.5 left-1.5 rounded-md bg-black/65 px-1.5 py-[3px] shadow-sm backdrop-blur-[2px]">
+                <RatingStars rating={rating} />
+              </span>
+            )}
           </div>
           <div className="flex flex-col gap-1 px-3 py-2.5">
             <div className="flex items-center gap-1.5">

--- a/src/Components/Browse/RatingStars.tsx
+++ b/src/Components/Browse/RatingStars.tsx
@@ -1,0 +1,50 @@
+import { Star } from "lucide-react";
+import type { ModRating } from "../../types";
+
+/** mxb-mods.com prints one decimal ("3.7"), and drops the ".0" on whole numbers. */
+function formatAverage(average: number): string {
+  return average.toFixed(1).replace(/\.0$/, "");
+}
+
+/**
+ * The site's own rating readout: five stars filled to the nearest half, then the average
+ * and the vote count. Rendered as a gold layer clipped over a dim one — a half star is a
+ * clip at 50%, so there's no separate half-star glyph to keep aligned with the full one.
+ */
+export default function RatingStars({ rating }: { rating: ModRating }) {
+  const rounded = Math.round(Math.min(rating.average, 5) * 2) / 2;
+  const stars = Array.from({ length: 5 });
+
+  return (
+    <span
+      className="flex items-center gap-1 text-[10.5px] font-semibold text-white/85"
+      title={`${formatAverage(rating.average)} out of 5 — ${rating.count} ${
+        rating.count === 1 ? "rating" : "ratings"
+      } on mxb-mods.com`}
+    >
+      <span className="relative inline-flex">
+        <span className="flex gap-px text-white/25">
+          {stars.map((_, i) => (
+            <Star key={i} className="size-[11px]" fill="currentColor" strokeWidth={0} />
+          ))}
+        </span>
+        <span
+          className="absolute inset-y-0 left-0 flex gap-px overflow-hidden text-[#ffc531]"
+          style={{ width: `${(rounded / 5) * 100}%` }}
+          aria-hidden
+        >
+          {stars.map((_, i) => (
+            <Star
+              key={i}
+              className="size-[11px] flex-none"
+              fill="currentColor"
+              strokeWidth={0}
+            />
+          ))}
+        </span>
+      </span>
+      {formatAverage(rating.average)}
+      <span className="font-normal text-white/60">({rating.count})</span>
+    </span>
+  );
+}

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -15,6 +15,7 @@ import type {
   LibraryEntry,
   Loadout,
   ModDetail,
+  ModRating,
   ModSummary,
   PkzMeta,
   PaintTexture,
@@ -150,6 +151,12 @@ export function searchMods(
 
 export function getModDetail(slug: string): Promise<ModDetail> {
   return invoke<ModDetail>("get_mod_detail", { slug });
+}
+
+/** Community scores for the given post ids, keyed by id. Ids the site didn't answer for
+ *  are absent — ratings decorate a card, so a miss shows no stars rather than an error. */
+export function getModRatings(ids: number[]): Promise<Record<string, ModRating>> {
+  return invoke<Record<string, ModRating>>("get_mod_ratings", { ids });
 }
 
 export function getInstalledMods(subpath: string): Promise<InstalledMod[]> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,6 +40,13 @@ export interface ModSummary {
   categoryId: number;
 }
 
+/** A mod's community score on mxb-mods.com, as shown under the site's own thumbnails. */
+export interface ModRating {
+  /** Mean score out of 5 — only meaningful when `count` is above zero. */
+  average: number;
+  count: number;
+}
+
 /** One download choice on a mod page (hosts vary: Google Drive, MediaFire, …). */
 export interface DownloadOption {
   url: string;


### PR DESCRIPTION
Mod cards in Browse now show the mxb-mods.com score the site itself prints under its listing thumbnails — five stars filled to the nearest half, the average, and the vote count.

## How it works

Ratings aren't in the WP REST API our listing comes from (not in `meta`, not in `acf`, no REST route). The site runs the Rate My Post plugin, whose front end reads scores from an unauthenticated admin-ajax action keyed by post id — the same ids `search_mods` already returns:

```
POST /wp-admin/admin-ajax.php  action=load_results&postID=187811
→ {"voteCount":1,"avgRating":4}
```

That's used rather than scraping the theme's archive HTML, which pages 16-at-a-time against our 24 and would misalign.

- `get_mod_ratings(ids)` fans out over the existing UA/cookie client at six requests in flight, cached 10 minutes. One attempt per id, no retry — a missing star isn't worth extra load on a site that's already unhappy.
- Ids the site won't answer for are omitted rather than raised, so a rating hiccup can never surface as a browsing error.
- Browse fetches in a second pass after the cards have painted; the grid never waits on it. Ids already asked about aren't re-requested, so a miss can't loop.
- Unrated mods show nothing at all — five empty stars would read as a bad score rather than "no votes yet".

## Scope

Browse cards only. Shop comes from the other domain and has no ratings; Library/Locker are local files. The mod detail page is untouched.

## Verified

- `cargo check`, `tsc --noEmit`, `eslint`, `vite build` all clean.
- Endpoint checked live before any code was written: post `187811` returns `4 (1)`, matching what the site prints on its own listing card for that mod.
- App built and ran from the worktree for ~15 minutes of hands-on use with no panic and nothing rating-related in the logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
