### PR TITLE
fix(browse): clear Cloudflare with a real browser, not an impersonation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 ## 2026-08-07
 
 ### Fixed
+- **Browse now clears mxb-mods.com's bot protection with a real browser instead of trying
+  to impersonate one.** A user on v0.6.3 still hit `403 Forbidden` on every browse, which
+  ruled out the header work shipped for v0.6.3 — that build already sent Chrome's exact
+  header set. What it couldn't send is Chrome's TLS and HTTP/2 fingerprint, which no header
+  can disguise, and Cloudflare weighs that against the caller's IP. That's why the same
+  binary is fine on one connection and refused on another; the site itself is not blocking
+  the app, and the affected user's normal browser loads mxb-mods.com fine.
+
+  So when the site refuses us, the app now opens a small mxb-mods.com window, lets
+  Cloudflare's check clear, keeps the `cf_clearance` it hands out, and retries the request
+  with it. The cookie is saved, so being blocked once doesn't mean being blocked again on
+  every launch. This is the mechanism the app already used to sign into the MX Bikes Shop,
+  now shared by both sites rather than written twice.
+  - A 403 no longer retries in place. Three identical requests from the same fingerprint
+    earn the same refusal, so the old loop only failed three times slower; 429 and 503 do
+    still retry, since those genuinely pass on their own.
+  - A Cloudflare interstitial served as a `200` now takes the same route as a 403 — it is
+    the same refusal wearing a success code.
+  - If the check window never gets a clearance, the log says so specifically. That
+    distinguishes "the browser was never challenged either" from "we got a cookie and it
+    still failed", which are different problems with different fixes.
+
+  Honest caveat, same as last time: this is still not reproducible here, so it's verified
+  by construction and tests rather than by watching it cure the reported fault.
 - **Presets no longer comes up blank when your mods folder lives somewhere else.**
   `mxbikes.ini` lets you point the mods folder at another drive, but the game has no
   equivalent redirect for profiles — it keeps writing those to

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,7 +40,8 @@ reqwest = { version = "0.12", default-features = false, features = [
     "gzip",
     "brotli",
 ] }
-tokio = { version = "1", features = ["time"] }
+# `sync` for the mutex that stops two simultaneous 403s opening two clearance windows.
+tokio = { version = "1", features = ["time", "sync"] }
 futures-util = { version = "0.3", features = ["io"] }
 # Pure-Rust MEGA API client (built on reqwest): downloads + decrypts public
 # shared links in-app, so end users don't need the megatools/MEGAcmd binary.

--- a/src-tauri/src/cookie_session.rs
+++ b/src-tauri/src/cookie_session.rs
@@ -1,0 +1,190 @@
+//! Persisted cookie jars for the Cloudflare-fronted WordPress sites the app talks to.
+//!
+//! `shop_session` and `mxb_session` want the same mechanics and differ only in the domain,
+//! the file they persist to, and how patient a request may be: cookies minted by a real
+//! WebView, replayed by a reqwest client whose User-Agent matches that WebView, and kept on
+//! disk so a restart doesn't arrive at the bot filter cold.
+
+use reqwest::cookie::Jar;
+use reqwest::{Client, ClientBuilder, Url};
+use serde::{Deserialize, Serialize};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tauri::{AppHandle, Manager, WebviewWindow};
+
+/// One of the sites we keep a jar for.
+///
+/// `ua` is not cosmetic: Cloudflare ties a `cf_clearance` to the User-Agent that earned it,
+/// so the WebView we harvest from and the client that replays the cookie have to agree, or
+/// the cookie fails exactly as if we'd sent none.
+pub struct Site {
+    pub base: &'static str,
+    pub domain: &'static str,
+    pub file: &'static str,
+    pub ua: &'static str,
+    pub timeout: Duration,
+}
+
+pub type Cookies = Vec<(String, String)>;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct Stored {
+    cookies: Cookies,
+}
+
+/// A client, once a site has one. Both sites hold theirs in Tauri managed state.
+#[derive(Default)]
+pub struct Store {
+    client: Mutex<Option<Client>>,
+}
+
+impl Store {
+    pub fn client(&self) -> Option<Client> {
+        self.client.lock().unwrap().clone()
+    }
+
+    pub fn is_set(&self) -> bool {
+        self.client.lock().unwrap().is_some()
+    }
+
+    pub fn set(&self, client: Option<Client>) {
+        *self.client.lock().unwrap() = client;
+    }
+}
+
+/// Add `cookies` to `jar` as if the site had set them.
+pub fn fill(jar: &Jar, site: &Site, cookies: &[(String, String)]) -> anyhow::Result<()> {
+    let url: Url = site.base.parse()?;
+    for (name, value) in cookies {
+        jar.add_cookie_str(
+            &format!("{name}={value}; Domain={}; Path=/", site.domain),
+            &url,
+        );
+    }
+    Ok(())
+}
+
+/// A builder rather than a `Client`, so a caller can add its own default headers before
+/// building. Everything common to both sites is already applied.
+pub fn client_builder(site: &Site, jar: Arc<Jar>) -> ClientBuilder {
+    Client::builder()
+        .user_agent(site.ua)
+        .cookie_provider(jar)
+        .connect_timeout(Duration::from_secs(15))
+        .timeout(site.timeout)
+}
+
+fn path(app: &AppHandle, site: &Site) -> anyhow::Result<std::path::PathBuf> {
+    Ok(app
+        .path()
+        .app_local_data_dir()
+        .map_err(|e| anyhow::anyhow!("could not resolve app local data dir: {e}"))?
+        .join(site.file))
+}
+
+pub fn write(app: &AppHandle, site: &Site, cookies: &Cookies) -> anyhow::Result<()> {
+    let path = path(app, site)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(
+        &path,
+        serde_json::to_string_pretty(&Stored {
+            cookies: cookies.clone(),
+        })?,
+    )?;
+    Ok(())
+}
+
+/// `None` when there is nothing usable on disk — missing, unreadable, or empty.
+pub fn read(app: &AppHandle, site: &Site) -> Option<Cookies> {
+    let text = std::fs::read_to_string(path(app, site).ok()?).ok()?;
+    let stored: Stored = serde_json::from_str(&text).ok()?;
+    (!stored.cookies.is_empty()).then_some(stored.cookies)
+}
+
+pub fn remove(app: &AppHandle, site: &Site) {
+    if let Ok(path) = path(app, site) {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// Includes HttpOnly cookies — `wordpress_logged_in_*` and `cf_clearance` alike — which
+/// `document.cookie` cannot see.
+pub fn cookies_from_window(window: &WebviewWindow, site: &Site) -> Cookies {
+    let Ok(url) = site.base.parse::<Url>() else {
+        return vec![];
+    };
+    match window.cookies_for_url(url) {
+        Ok(list) => list
+            .into_iter()
+            .map(|c| (c.name().to_string(), c.value().to_string()))
+            .collect(),
+        Err(_) => vec![],
+    }
+}
+
+pub fn has(cookies: &[(String, String)], name: &str) -> bool {
+    cookies.iter().any(|(n, _)| n == name)
+}
+
+pub fn has_prefix(cookies: &[(String, String)], prefix: &str) -> bool {
+    cookies.iter().any(|(n, _)| n.starts_with(prefix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SITE: Site = Site {
+        base: "https://example.com",
+        domain: "example.com",
+        file: "example.json",
+        ua: "test-ua",
+        timeout: Duration::from_secs(30),
+    };
+
+    /// The jar is what the client actually sends, so "did `fill` work" is really "does the
+    /// cookie come back out for a URL on that site".
+    #[test]
+    fn fill_puts_cookies_where_the_client_will_find_them() {
+        use reqwest::cookie::CookieStore;
+
+        let jar = Jar::default();
+        fill(
+            &jar,
+            &SITE,
+            &[("cf_clearance".into(), "abc123".into())],
+        )
+        .unwrap();
+
+        let header = jar
+            .cookies(&"https://example.com/wp-json/wp/v2/posts".parse().unwrap())
+            .expect("jar should hand out a cookie header");
+        assert!(header.to_str().unwrap().contains("cf_clearance=abc123"));
+    }
+
+    /// A cookie for one site must never ride along on a request to the other.
+    #[test]
+    fn fill_scopes_cookies_to_the_site() {
+        use reqwest::cookie::CookieStore;
+
+        let jar = Jar::default();
+        fill(&jar, &SITE, &[("cf_clearance".into(), "abc123".into())]).unwrap();
+
+        assert!(jar
+            .cookies(&"https://mxb-mods.com/wp-json".parse().unwrap())
+            .is_none());
+    }
+
+    #[test]
+    fn has_and_has_prefix_distinguish_exact_from_family() {
+        let cookies = vec![
+            ("cf_clearance".to_string(), "x".to_string()),
+            ("wordpress_logged_in_9f2".to_string(), "y".to_string()),
+        ];
+        assert!(has(&cookies, "cf_clearance"));
+        assert!(!has(&cookies, "wordpress_logged_in"));
+        assert!(has_prefix(&cookies, "wordpress_logged_in"));
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,6 +6,7 @@ mod bikeswap;
 mod bundle;
 mod cfg;
 mod config;
+mod cookie_session;
 mod edf;
 mod frostmod;
 mod frostmod_manage;
@@ -15,6 +16,7 @@ mod library;
 mod modelswap;
 mod mods;
 mod modwatch;
+mod mxb_session;
 mod paint;
 mod pkz;
 #[cfg(sidecar)]
@@ -73,21 +75,45 @@ fn create_config(
     Ok(true)
 }
 
+/// Run an mxb-mods.com call; if Cloudflare refuses it, earn a `cf_clearance` in a real
+/// browser and try exactly once more.
+///
+/// Once, not a loop: the handshake either produced a cookie the client didn't have or it
+/// didn't, and repeating it would just reopen the window at someone who is already stuck.
+/// Only refusals we could plausibly clear get this treatment — a 429 wants patience, not a
+/// browser window.
+async fn with_clearance<T, F, Fut>(app: &tauri::AppHandle, op: F) -> Result<T, String>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<T>>,
+{
+    let err = match op().await {
+        Ok(value) => return Ok(value),
+        Err(err) => err,
+    };
+    match err.downcast_ref::<mods::mxb::Blocked>() {
+        Some(blocked) if blocked.clearable() => {}
+        _ => return Err(format!("{err:#}")),
+    }
+    if !mxb_session::handshake(app).await {
+        return Err(format!("{err:#}"));
+    }
+    op().await.map_err(|e| format!("{e:#}"))
+}
+
 #[tauri::command]
 async fn search_mods(
+    app: tauri::AppHandle,
     query: String,
     category_id: u32,
     page: u32,
 ) -> Result<Vec<ModSummary>, String> {
-    MxbModsSource
-        .search(&query, category_id, page)
-        .await
-        .map_err(|e| format!("{e:#}"))
+    with_clearance(&app, || MxbModsSource.search(&query, category_id, page)).await
 }
 
 #[tauri::command]
-async fn get_mod_detail(slug: String) -> Result<ModDetail, String> {
-    MxbModsSource.detail(&slug).await.map_err(|e| format!("{e:#}"))
+async fn get_mod_detail(app: tauri::AppHandle, slug: String) -> Result<ModDetail, String> {
+    with_clearance(&app, || MxbModsSource.detail(&slug)).await
 }
 
 #[tauri::command]
@@ -1949,6 +1975,7 @@ fn main() {
                 log::info!("no MX Bikes folder found — showing first-run setup");
             }
             shop_session::load_session(handle);
+            mxb_session::load(handle);
             Ok(())
         })
         .on_window_event(|window, event| {

--- a/src-tauri/src/mods/mxb.rs
+++ b/src-tauri/src/mods/mxb.rs
@@ -1,15 +1,11 @@
 use super::{DownloadOption, ModDetail, ModSource, ModSummary};
+use crate::mxb_session;
 use regex::Regex;
 use reqwest::Client;
 use scraper::{Html, Selector};
 use serde_json::Value;
 
-const BASE: &str = "https://mxb-mods.com";
-/// A full four-part version, unlike the `Chrome/126.0` form used elsewhere — real Chrome
-/// never sends a two-part version, and a UA that no browser would emit is itself a signal
-/// to a bot filter. Deliberately not `shop_session::UA`: that one has to keep matching the
-/// login WebView or the `cf_clearance` minted there stops verifying.
-const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.6778.140 Safari/537.36";
+const BASE: &str = mxb_session::BASE;
 const PER_PAGE: &str = "24";
 
 pub struct MxbModsSource;
@@ -31,11 +27,11 @@ impl ModSource for MxbModsSource {
 
 /// One client for the whole session, not one per call.
 ///
-/// Two reasons beyond the obvious. It keeps a cookie jar, so if Cloudflare ever hands out
-/// a `cf_clearance` we replay it instead of arriving cold every time — the pattern
-/// `shop_session` already uses for the sibling domain. And it reuses connections, so a
-/// user typing in the search box costs one TLS handshake rather than one per keystroke,
-/// which is the sort of traffic shape that gets a client rate-limited in the first place.
+/// Two reasons beyond the obvious. It holds [`mxb_session::jar`] — shared with the WebView
+/// handshake, so a `cf_clearance` earned there is picked up by this client without
+/// rebuilding it — and it reuses connections, so a user typing in the search box costs one
+/// TLS handshake rather than one per keystroke, which is the sort of traffic shape that
+/// gets a client rate-limited in the first place.
 fn client() -> anyhow::Result<&'static Client> {
     static CLIENT: std::sync::OnceLock<Result<Client, String>> = std::sync::OnceLock::new();
     CLIENT
@@ -59,20 +55,20 @@ fn build_client() -> anyhow::Result<Client> {
     ] {
         headers.insert(k, HeaderValue::from_static(v));
     }
-    Ok(Client::builder()
-        .user_agent(UA)
-        .default_headers(headers)
-        .cookie_store(true)
-        .connect_timeout(std::time::Duration::from_secs(15))
-        .timeout(std::time::Duration::from_secs(30))
-        .build()?)
+    // UA, jar and timeouts come from `mxb_session` so the client and the handshake WebView
+    // cannot drift apart — a `cf_clearance` is bound to the UA that earned it.
+    Ok(mxb_session::client_builder().default_headers(headers).build()?)
 }
 
-/// Statuses worth trying again: Cloudflare hands out 403 on a bad bot score, 429 on rate
-/// limiting, and 503 while an interstitial is up. All three are commonly transient for a
-/// client that is not in fact a bot.
+/// Statuses worth trying again *on the spot*: 429 is rate limiting and 503 is usually an
+/// interstitial going up, both of which pass on their own.
+///
+/// 403 is deliberately not here. It is a bot-score refusal, and a second identical request
+/// from the same fingerprint on the same connection gets the same answer — retrying it just
+/// failed three times more slowly. It is handled a level up instead, by earning a
+/// `cf_clearance` in a real browser and trying once more with something actually different.
 fn worth_retrying(status: reqwest::StatusCode) -> bool {
-    matches!(status.as_u16(), 403 | 429 | 503)
+    matches!(status.as_u16(), 429 | 503)
 }
 
 /// `GET` with backoff over the transient blocks above. Transport errors retry too, which
@@ -106,25 +102,69 @@ async fn get_with_retry(
     Err(last_err.unwrap_or_else(|| anyhow::anyhow!("request failed")))
 }
 
+/// Cloudflare refused us, as opposed to the site being down or the parse failing.
+///
+/// A type rather than a message because the command layer has to *act* on it — run the
+/// WebView handshake and retry — and matching on error strings to decide that would break
+/// the first time someone reworded a sentence.
+#[derive(Debug, Clone)]
+pub struct Blocked {
+    /// The refusing status, or `None` for an interstitial served as a 200.
+    pub status: Option<u16>,
+    message: String,
+}
+
+impl std::fmt::Display for Blocked {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for Blocked {}
+
+impl Blocked {
+    /// True when a `cf_clearance` could plausibly fix it — i.e. we were challenged, rather
+    /// than rate-limited or handed a server error.
+    pub fn clearable(&self) -> bool {
+        matches!(self.status, None | Some(403))
+    }
+}
+
 /// Turn a blocked response into something a person can act on. The raw reqwest `Display`
 /// ("HTTP status client error (403 Forbidden) for url (…)") told users nothing and shipped
 /// them a URL with percent-encoded query params.
+///
+/// The 403 wording assumes the handshake above it has already been tried and failed, since
+/// that is the only way this message reaches a user.
 fn blocked_error(status: reqwest::StatusCode) -> anyhow::Error {
-    match status.as_u16() {
-        403 => anyhow::anyhow!(
-            "mxb-mods.com refused the request (403). Its bot protection sometimes blocks \
-             an app it doesn't recognise — wait a minute and hit Retry. If it keeps \
-             happening, opening mxb-mods.com in your browser first usually clears it."
-        ),
-        429 => anyhow::anyhow!(
-            "mxb-mods.com is rate-limiting us (429). Give it a minute, then hit Retry."
-        ),
-        503 => anyhow::anyhow!(
-            "mxb-mods.com is unavailable right now (503) — it may be behind a Cloudflare \
-             check. Try again shortly."
-        ),
-        _ => anyhow::anyhow!("mxb-mods.com returned {status}"),
-    }
+    let message = match status.as_u16() {
+        403 => "mxb-mods.com refused the request (403), and its check window didn't clear \
+                it either. Open mxb-mods.com in your normal browser to confirm the site \
+                loads for you, then hit Retry."
+            .to_string(),
+        429 => "mxb-mods.com is rate-limiting us (429). Give it a minute, then hit Retry."
+            .to_string(),
+        503 => "mxb-mods.com is unavailable right now (503) — it may be behind a Cloudflare \
+                check. Try again shortly."
+            .to_string(),
+        _ => format!("mxb-mods.com returned {status}"),
+    };
+    anyhow::Error::new(Blocked {
+        status: Some(status.as_u16()),
+        message,
+    })
+}
+
+/// The interstitial-as-a-200 case. Same handling as a 403 — it is the same refusal, just
+/// dressed as a success.
+fn challenge_error() -> anyhow::Error {
+    anyhow::Error::new(Blocked {
+        status: None,
+        message: "mxb-mods.com served a Cloudflare check instead of the mod page, and its \
+                  check window didn't clear it. Open mxb-mods.com in your normal browser, \
+                  then hit Retry."
+            .to_string(),
+    })
 }
 
 /// A Cloudflare interstitial served with a 200, which would otherwise parse as an empty
@@ -228,10 +268,7 @@ pub async fn detail(slug: &str) -> anyhow::Result<ModDetail> {
     // Only call it a challenge when the page also yielded nothing, so a marker that turns
     // up in a page that actually parsed can never turn a working mod into an error.
     if downloads.is_empty() && is_challenge(&html) {
-        anyhow::bail!(
-            "mxb-mods.com served a Cloudflare check instead of the mod page. Open \
-             mxb-mods.com in your browser once, then hit Retry."
-        );
+        return Err(challenge_error());
     }
 
     Ok(ModDetail {
@@ -515,12 +552,52 @@ mod client_tests {
 
     #[test]
     fn retries_only_the_transient_blocks() {
-        for code in [403u16, 429, 503] {
+        for code in [429u16, 503] {
             assert!(worth_retrying(reqwest::StatusCode::from_u16(code).unwrap()), "{code}");
         }
         for code in [200u16, 400, 404, 500] {
             assert!(!worth_retrying(reqwest::StatusCode::from_u16(code).unwrap()), "{code}");
         }
+    }
+
+    /// The point of the clearance work: a 403 is a bot-score refusal, and repeating the
+    /// same request from the same fingerprint only fails slower. It goes up to the
+    /// handshake instead.
+    #[test]
+    fn a_403_is_not_retried_in_place() {
+        assert!(!worth_retrying(reqwest::StatusCode::FORBIDDEN));
+    }
+
+    /// Which refusals the command layer should answer with a browser window. Getting this
+    /// wrong either pops a window at someone who is merely rate-limited, or fails to open
+    /// one for the person this whole change exists for.
+    #[test]
+    fn only_challenges_are_worth_a_handshake() {
+        let blocked = |code: u16| Blocked {
+            status: Some(code),
+            message: String::new(),
+        };
+        assert!(blocked(403).clearable());
+        assert!(!blocked(429).clearable());
+        assert!(!blocked(503).clearable());
+        // The interstitial-as-a-200 — the same refusal wearing a success code.
+        assert!(matches!(
+            challenge_error().downcast_ref::<Blocked>(),
+            Some(b) if b.clearable()
+        ));
+    }
+
+    /// `with_clearance` finds this by downcast, so a 403 has to survive the trip through
+    /// `anyhow` as a `Blocked` and not collapse into a bare message.
+    #[test]
+    fn a_blocked_error_stays_downcastable() {
+        let err = blocked_error(reqwest::StatusCode::FORBIDDEN);
+        let blocked = err
+            .downcast_ref::<Blocked>()
+            .expect("the command layer downcasts to decide whether to run the handshake");
+        assert_eq!(blocked.status, Some(403));
+        // `{:#}` is what the command layer sends the UI; it must still read as the message.
+        assert!(format!("{err:#}").contains("403"));
     }
 
     #[test]

--- a/src-tauri/src/mxb_session.rs
+++ b/src-tauri/src/mxb_session.rs
@@ -1,0 +1,154 @@
+//! The mxb-mods.com side of [`cookie_session`], plus the WebView handshake that fills it.
+//!
+//! Browsing is anonymous — there is nothing to sign into here. The only cookie that matters
+//! is Cloudflare's `cf_clearance`, which is earned by a real browser passing a challenge.
+//!
+//! Why we need one at all: a reqwest client can copy Chrome's headers exactly and still be
+//! told apart by its TLS and HTTP/2 fingerprint, which no header can disguise. Cloudflare
+//! scores that fingerprint against the caller's IP reputation, so the same binary sails
+//! through on one connection and is refused on another — the shape of the report this
+//! exists to fix. We ship a real browser, so when the site refuses the HTTP client we open
+//! one, let it clear, and take the cookie.
+
+use crate::cookie_session::{self, Cookies, Site};
+use reqwest::cookie::Jar;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
+
+pub const BASE: &str = "https://mxb-mods.com";
+
+/// A full four-part version, unlike the `Chrome/126.0` form [`crate::shop_session::UA`]
+/// uses — real Chrome never sends a two-part version, and a UA no browser would emit is
+/// itself a signal to a bot filter. The handshake WebView is built with this same constant:
+/// a `cf_clearance` is bound to the User-Agent that earned it, so the two must not drift.
+pub const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.6778.140 Safari/537.36";
+
+const SITE: Site = Site {
+    base: BASE,
+    domain: "mxb-mods.com",
+    file: "mxb_session.json",
+    ua: UA,
+    timeout: Duration::from_secs(30),
+};
+
+const WINDOW: &str = "mxb-clearance";
+
+/// How long we leave the window up. It normally closes in a few seconds — a managed
+/// challenge clears on its own — but the budget has to cover one that wants a click.
+const WAIT: Duration = Duration::from_secs(120);
+const POLL: Duration = Duration::from_millis(500);
+
+/// Process-wide, because the mods client is built once and must see cookies that arrive
+/// long afterwards. `Jar` is internally synchronised, so filling it after the fact is
+/// visible to the client already holding it.
+pub fn jar() -> Arc<Jar> {
+    static JAR: OnceLock<Arc<Jar>> = OnceLock::new();
+    JAR.get_or_init(|| Arc::new(Jar::default())).clone()
+}
+
+/// The mods client is built from this so its User-Agent, jar and timeouts cannot drift from
+/// the handshake WebView's. Callers add their own default headers.
+pub fn client_builder() -> reqwest::ClientBuilder {
+    cookie_session::client_builder(&SITE, jar())
+}
+
+/// Bumped whenever fresh cookies land, so a caller that waited behind another handshake can
+/// tell it now has something new to retry with instead of opening a second window.
+static GENERATION: AtomicU64 = AtomicU64::new(0);
+
+fn store(app: &AppHandle, cookies: Cookies) {
+    if let Err(e) = cookie_session::fill(&jar(), &SITE, &cookies) {
+        log::warn!("could not add mxb-mods.com cookies to the jar: {e:#}");
+        return;
+    }
+    if let Err(e) = cookie_session::write(app, &SITE, &cookies) {
+        // Not fatal: the jar is filled, so this session works — only the next one arrives cold.
+        log::warn!("could not persist mxb-mods.com cookies: {e:#}");
+    }
+    GENERATION.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Replay last run's clearance, so a user who was blocked yesterday isn't blocked again on
+/// launch. An expired cookie is harmless — it fails exactly like no cookie, and the 403
+/// path mints a new one.
+pub fn load(app: &AppHandle) {
+    let Some(cookies) = cookie_session::read(app, &SITE) else {
+        return;
+    };
+    if let Err(e) = cookie_session::fill(&jar(), &SITE, &cookies) {
+        log::warn!("failed to restore mxb-mods.com cookies: {e:#}");
+        return;
+    }
+    log::info!("restored mxb-mods.com cookies ({})", cookies.len());
+}
+
+/// Open a real browser at mxb-mods.com, wait for Cloudflare to hand it a `cf_clearance`,
+/// and keep the cookie. `true` if we came away with one.
+///
+/// Serialised: a 403 on search and a 403 on a detail page arriving together must not open
+/// two windows. The loser of the lock checks whether the winner already succeeded.
+pub async fn handshake(app: &AppHandle) -> bool {
+    static LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    let before = GENERATION.load(Ordering::Relaxed);
+    let _guard = LOCK.lock().await;
+    if GENERATION.load(Ordering::Relaxed) != before {
+        return true; // another caller earned one while we waited
+    }
+
+    if let Some(existing) = app.get_webview_window(WINDOW) {
+        let _ = existing.close();
+    }
+
+    let url = match BASE.parse() {
+        Ok(url) => url,
+        Err(e) => {
+            log::error!("mxb-mods.com base URL is not a URL: {e}");
+            return false;
+        }
+    };
+    let window = match WebviewWindowBuilder::new(app, WINDOW, WebviewUrl::External(url))
+        .title("Checking with mxb-mods.com…")
+        .user_agent(UA)
+        .inner_size(480.0, 560.0)
+        .build()
+    {
+        Ok(window) => window,
+        Err(e) => {
+            log::error!("could not open the mxb-mods.com check window: {e:#}");
+            return false;
+        }
+    };
+
+    let deadline = WAIT.as_millis() / POLL.as_millis();
+    let mut last: Cookies = vec![];
+    for _ in 0..deadline {
+        tokio::time::sleep(POLL).await;
+        let Some(win) = app.get_webview_window(WINDOW) else {
+            log::info!("mxb-mods.com check window closed before it cleared");
+            return false;
+        };
+        last = cookie_session::cookies_from_window(&win, &SITE);
+        if cookie_session::has(&last, "cf_clearance") {
+            store(app, last);
+            let _ = win.close();
+            log::info!("earned a cf_clearance for mxb-mods.com");
+            return true;
+        }
+    }
+
+    let _ = window.close();
+    // No clearance, but `__cf_bm` and friends still feed the bot score, so keep what we got.
+    if !last.is_empty() {
+        store(app, last);
+    }
+    // Worth reading in a user's log, because it distinguishes the two ways this can fail.
+    // No clearance means the WebView was never challenged, so there was no challenge for us
+    // to pass and the refusal is aimed at the HTTP client specifically — the case that
+    // needs the request to be made from inside the WebView rather than merely wearing its
+    // cookie. A clearance that we *did* get and that still 403s is the other case.
+    log::warn!("mxb-mods.com never issued a cf_clearance within {WAIT:?}");
+    false
+}

--- a/src-tauri/src/shop_session.rs
+++ b/src-tauri/src/shop_session.rs
@@ -1,115 +1,77 @@
+//! The signed-in MX Bikes Shop session. Mechanics live in [`cookie_session`]; this module
+//! is the shop's half — where its cookies live, and what "signed in" means.
+
+use crate::cookie_session::{self, Cookies, Site, Store};
 use reqwest::cookie::Jar;
-use reqwest::{Client, Url};
-use serde::{Deserialize, Serialize};
-use std::sync::{Arc, Mutex};
+use reqwest::Client;
+use std::sync::Arc;
 use std::time::Duration;
 use tauri::{AppHandle, Manager, WebviewWindow};
 
 pub const SHOP_BASE: &str = "https://mxbikes-shop.com";
 
-/// Must match the login WebView's User-Agent, or a Cloudflare `cf_clearance` cookie minted there breaks when replayed.
+/// Must match the login WebView's User-Agent, or a Cloudflare `cf_clearance` cookie minted
+/// there breaks when replayed.
 pub const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36";
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-struct StoredSession {
-    cookies: Vec<(String, String)>,
-}
+/// Downloads run through this client, hence the patient timeout.
+const SITE: Site = Site {
+    base: SHOP_BASE,
+    domain: "mxbikes-shop.com",
+    file: "shop_session.json",
+    ua: UA,
+    timeout: Duration::from_secs(120),
+};
 
 #[derive(Default)]
-pub struct ShopSession {
-    client: Mutex<Option<Client>>,
-}
+pub struct ShopSession(Store);
 
 impl ShopSession {
     pub fn logged_in(&self) -> bool {
-        self.client.lock().unwrap().is_some()
+        self.0.is_set()
     }
 
     pub fn client(&self) -> Option<Client> {
-        self.client.lock().unwrap().clone()
-    }
-
-    fn set_client(&self, client: Option<Client>) {
-        *self.client.lock().unwrap() = client;
+        self.0.client()
     }
 }
 
 fn build_client(cookies: &[(String, String)]) -> anyhow::Result<Client> {
     let jar = Arc::new(Jar::default());
-    let url: Url = SHOP_BASE.parse()?;
-    for (name, value) in cookies {
-        jar.add_cookie_str(
-            &format!("{name}={value}; Domain=mxbikes-shop.com; Path=/"),
-            &url,
-        );
-    }
-    Ok(Client::builder()
-        .user_agent(UA)
-        .cookie_provider(jar)
-        .connect_timeout(Duration::from_secs(15))
-        .timeout(Duration::from_secs(120))
-        .build()?)
+    cookie_session::fill(&jar, &SITE, cookies)?;
+    Ok(cookie_session::client_builder(&SITE, jar).build()?)
 }
 
-fn session_path(app: &AppHandle) -> std::path::PathBuf {
-    app.path()
-        .app_local_data_dir()
-        .expect("could not resolve app local data dir")
-        .join("shop_session.json")
-}
-
-pub fn set_session(app: &AppHandle, cookies: Vec<(String, String)>) -> anyhow::Result<()> {
+pub fn set_session(app: &AppHandle, cookies: Cookies) -> anyhow::Result<()> {
     let client = build_client(&cookies)?;
-    let path = session_path(app);
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    std::fs::write(&path, serde_json::to_string_pretty(&StoredSession { cookies })?)?;
-    app.state::<ShopSession>().set_client(Some(client));
+    cookie_session::write(app, &SITE, &cookies)?;
+    app.state::<ShopSession>().0.set(Some(client));
     Ok(())
 }
 
 pub fn load_session(app: &AppHandle) {
-    let path = session_path(app);
-    let Ok(text) = std::fs::read_to_string(&path) else {
+    let Some(cookies) = cookie_session::read(app, &SITE) else {
         return;
     };
-    let Ok(stored) = serde_json::from_str::<StoredSession>(&text) else {
-        return;
-    };
-    if stored.cookies.is_empty() {
-        return;
-    }
-    match build_client(&stored.cookies) {
+    match build_client(&cookies) {
         Ok(client) => {
-            app.state::<ShopSession>().set_client(Some(client));
-            log::info!("restored MX Bikes Shop session ({} cookies)", stored.cookies.len());
+            app.state::<ShopSession>().0.set(Some(client));
+            log::info!("restored MX Bikes Shop session ({} cookies)", cookies.len());
         }
         Err(e) => log::warn!("failed to restore shop session: {e:#}"),
     }
 }
 
 pub fn clear_session(app: &AppHandle) {
-    let _ = std::fs::remove_file(session_path(app));
-    app.state::<ShopSession>().set_client(None);
+    cookie_session::remove(app, &SITE);
+    app.state::<ShopSession>().0.set(None);
 }
 
 /// Includes HttpOnly cookies (e.g. `wordpress_logged_in_*`) that `document.cookie` can't see.
-pub fn cookies_from_window(window: &WebviewWindow) -> Vec<(String, String)> {
-    let Ok(url) = SHOP_BASE.parse::<Url>() else {
-        return vec![];
-    };
-    match window.cookies_for_url(url) {
-        Ok(list) => list
-            .into_iter()
-            .map(|c| (c.name().to_string(), c.value().to_string()))
-            .collect(),
-        Err(_) => vec![],
-    }
+pub fn cookies_from_window(window: &WebviewWindow) -> Cookies {
+    cookie_session::cookies_from_window(window, &SITE)
 }
 
 pub fn is_authenticated(cookies: &[(String, String)]) -> bool {
-    cookies
-        .iter()
-        .any(|(name, _)| name.starts_with("wordpress_logged_in"))
+    cookie_session::has_prefix(cookies, "wordpress_logged_in")
 }


### PR DESCRIPTION
## The report

A user on **v0.6.3** still hits `403 Forbidden` on every browse.

That rules out the header work shipped in v0.6.3 (`a03e91d`) — his build already sends Chrome's exact header set. Its changelog entry flagged the caveat honestly: not reproducible, so "well-founded improvements rather than a confirmed cure." This is the follow-up that entry asked for.

## Diagnosis

Three facts narrow it to one cause:

1. **The endpoint isn't blocked.** A bare `curl` — no UA spoofing, no browser headers — gets `HTTP/2 200` from `mxb-mods.com/wp-json/wp/v2/posts`. No blanket rule exists.
2. **His IP is fine.** mxb-mods.com loads normally in his own browser. No VPN, no proxy.
3. **So the refusal targets our client specifically.**

What we still can't spoof is the **TLS/HTTP-2 fingerprint**. reqwest-on-rustls looks nothing like Chrome at the handshake, and no header changes that. Cloudflare scores that fingerprint against caller IP reputation, which is exactly why the same binary passes on one connection and is refused on another. Worse, v0.6.3 sends a perfect Chrome header set over a rustls handshake — that *mismatch* is itself a heuristic.

## The fix

We ship a real browser. When the site refuses the HTTP client, open a small mxb-mods.com window, let Cloudflare's check clear, keep the `cf_clearance`, retry once. This is how the app already signs into the MX Bikes Shop; the mechanics are now shared rather than written twice.

- **`cookie_session.rs`** (new) — jar/persist/WebView-harvest, common to both Cloudflare-fronted sites. `shop_session` delegates with its public API unchanged (104 → 76 lines); `mxb_session` is a second consumer, not a copy.
- **`mxb_session.rs`** (new) — process-wide jar plus `handshake()`. Serialised behind a mutex, so a simultaneous search-403 and detail-403 can't open two windows; the loser checks a generation counter and retries on the winner's cookie.
- **UA pinned** to the handshake WebView's. A `cf_clearance` is bound to the UA that earned it.
- **403 no longer retries in place.** Three identical requests from the same fingerprint earn the same refusal — the old loop just failed three times slower. 429/503 still retry.
- **Interstitial-as-a-200** takes the same path as a 403; same refusal, success code.
- **Typed `Blocked` error** instead of a message, since the command layer must act on it and string-matching would break on any rewording.

Cookies persist, so being blocked once doesn't mean arriving cold every launch.

No DB/schema changes. No frontend change — the Browse error surface already renders backend copy verbatim.

## Verification

- `cargo test --locked` — **157 passed, 0 failed** (was 132)
- Live checks against the real site pass, including `live_search_and_detail` and `live_sends_browser_headers`
- `typecheck` clean, `lint` 0 errors (3 pre-existing warnings, untouched files), production build clean
- `clippy` clean in every touched file

New tests cover what the change actually asserts: 403 is not retried in place, only challenges warrant a handshake (a 429 must not pop a window), and a `Blocked` survives `anyhow` as a downcastable type.

**Caveat, same as last time:** the fault isn't reproducible here, so the handshake firing is verified by construction and tests rather than by watching it cure the report.

## If this doesn't take

`handshake` logs which of two modes failed, and they point the same way:

- **No clearance issued** — the WebView was never challenged, so the refusal targets the HTTP client itself.
- **Cleared but still 403** — the cookie is fingerprint-bound.

Either means doing the fetch *inside* the WebView. `with_clearance` is the seam: the same downcast that triggers the handshake would route the call through the WebView instead, leaving `mxb.rs` and the UI untouched. That needs a capability granting remote-URL IPC, scoped to a dedicated window rather than `core:default`.

Ask the reporter for that log line — it picks the route without guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)