### PR TITLE
feat(viewer): offer a gear model's stock paint in the 3D preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026-08-07
+
+### Added
+- **The 3D preview now offers a gear model's stock paint, not just its liveries.** The
+  paint picker listed only the `.pnt` files a helmet, boots or protection packs, so a
+  piece that ships liveries had no way back to its own look — the textures embedded in
+  the mesh, which the preview ignored entirely. "Stock" now leads the list whenever the
+  mesh carries a texture, with a separate entry for a helmet's goggles, which are picked
+  independently of the shell. A paint reuses the mesh's texture names, so stock shell
+  plus painted goggles (and the reverse) is resolved before the textures reach the
+  viewer, which would otherwise show whichever image finished loading last. Preview only
+  — it never becomes a value in your loadout, since the game names a `.pnt` there and has
+  no word for "the model's own look".
+
 ## 2026-08-06 — v0.6.3 — model swaps stop breaking bikes, Linux builds
 
 ### Added

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -963,9 +963,20 @@ async fn load_gear_model(
     part: String,
     paint: Option<String>,
     goggles: Option<String>,
+    // Show the mesh's own textures instead of a `.pnt` — the stock look. Separate flags
+    // because a helmet's goggles are picked independently of its shell.
+    stock: Option<bool>,
+    stock_goggles: Option<bool>,
 ) -> Result<RiderPart, String> {
     tauri::async_runtime::spawn_blocking(move || {
-        load_gear_model_blocking(path, part, paint, goggles)
+        load_gear_model_blocking(
+            path,
+            part,
+            paint,
+            goggles,
+            stock.unwrap_or(false),
+            stock_goggles.unwrap_or(false),
+        )
     })
     .await
     .map_err(|e| format!("load_gear_model task failed: {e}"))?
@@ -1011,6 +1022,11 @@ async fn load_stock_gear_model(
 struct GearPaints {
     paints: Vec<String>,
     goggles: Vec<String>,
+    /// The mesh carries its own shell / goggle texture, so a "Stock" entry is worth
+    /// offering next to the packed paints. Preview-only — never a loadout value, since
+    /// the game names a `.pnt` there and has no word for "the model's own look".
+    has_stock: bool,
+    has_stock_goggles: bool,
 }
 
 fn gear_paints_at(path: &std::path::Path) -> Result<GearPaints, String> {
@@ -1024,7 +1040,15 @@ fn gear_paints_at(path: &std::path::Path) -> Result<GearPaints, String> {
         out.dedup();
         out
     };
+    // Names only — decoding the pixels is the load path's job, and this runs per picker.
+    let embedded: Vec<String> = files
+        .iter()
+        .find(|(n, _)| is_visible_gear_mesh(n))
+        .map(|(_, d)| edf::embedded_textures(d).iter().map(|t| t.name.clone()).collect())
+        .unwrap_or_default();
     Ok(GearPaints {
+        has_stock: embedded.iter().any(|n| !is_goggle_name(n) && !is_companion_map(n)),
+        has_stock_goggles: embedded.iter().any(|n| is_goggle_name(n) && !is_companion_map(n)),
         paints: names("paints"),
         goggles: names("goggles"),
     })
@@ -1044,7 +1068,12 @@ async fn list_installed_gear_paints(
     model: String,
 ) -> Result<GearPaints, String> {
     tauri::async_runtime::spawn_blocking(move || {
-        let empty = GearPaints { paints: Vec::new(), goggles: Vec::new() };
+        let empty = GearPaints {
+            paints: Vec::new(),
+            goggles: Vec::new(),
+            has_stock: false,
+            has_stock_goggles: false,
+        };
         if model.trim().is_empty() {
             return Ok(empty);
         }
@@ -1095,12 +1124,16 @@ fn load_gear_model_blocking(
     part: String,
     paint: Option<String>,
     goggles: Option<String>,
+    stock: bool,
+    stock_goggles: bool,
 ) -> Result<RiderPart, String> {
     let p = std::path::Path::new(&path);
     let files = read_gear_files(p).map_err(|e| format!("{e:#}"))?;
     let want = paint.filter(|s| !s.is_empty());
     let want_goggles = goggles.filter(|s| !s.is_empty());
     let mut nodes = Vec::new();
+    // Kept so a stock request can read the mesh's own textures back out of it.
+    let mut mesh: Option<&Vec<u8>> = None;
     // Collect paint/goggle entries up front so we can prefer the requested one but always
     // fall back to the first available: a stale or unknown paint name must still show the
     // gear textured, never bare grey.
@@ -1109,8 +1142,8 @@ fn load_gear_model_blocking(
     for (name, data) in &files {
         let base = name.rsplit('/').next().unwrap_or(name).to_ascii_lowercase();
         if base.ends_with(".edf") {
-            // Take the visible mesh: skip the `_s` shadow and `c_` cockpit variants.
-            if nodes.is_empty() && !base.ends_with("_s.edf") && !base.starts_with("c_") {
+            if nodes.is_empty() && is_visible_gear_mesh(name) {
+                mesh = Some(data);
                 nodes = edf::parse(data);
                 edf::to_right_handed(&mut nodes);
                 keep_lod0(&mut nodes);
@@ -1125,14 +1158,80 @@ fn load_gear_model_blocking(
         return Err(format!("no gear mesh found in {path}"));
     }
     let mut textures: Vec<paint::PntTexture> = Vec::new();
-    let main_tex = pick_gear_paint(&paints, want.as_deref(), &mut textures);
-    let goggle_tex = pick_gear_paint(&goggle_paints, want_goggles.as_deref(), &mut textures);
-    if want.is_some() && main_tex.is_none() && !paints.is_empty() {
+    // A stock side decodes nothing from `paints/` — the mesh already carries that texture.
+    let main_tex = (!stock)
+        .then(|| pick_gear_paint(&paints, want.as_deref(), &mut textures))
+        .flatten();
+    let goggle_tex = (!stock_goggles)
+        .then(|| pick_gear_paint(&goggle_paints, want_goggles.as_deref(), &mut textures))
+        .flatten();
+    if want.is_some() && main_tex.is_none() && !stock && !paints.is_empty() {
         log::warn!("[rider] {part} paint {want:?} not found; used first of {} packed", paints.len());
     }
+    let mut out: Vec<paint::PaintTexture> = textures.iter().map(paint::to_texture).collect();
+    // The look the model ships with, before any paint: the textures embedded in the mesh.
+    let (mut stock_main, mut stock_goggle) = (None, None);
+    if stock || stock_goggles {
+        let embedded = mesh.map(|d| paint::extract_edf_textures(d)).unwrap_or_default();
+        for t in &embedded {
+            let slot = if is_goggle_name(&t.name) { &mut stock_goggle } else { &mut stock_main };
+            slot.get_or_insert_with(|| t.name.clone());
+        }
+        if stock && stock_main.is_none() {
+            log::warn!("[rider] {part} has no stock texture in its mesh — showing it bare");
+        }
+        // A paint reuses the mesh's texture names (that's how it replaces them), so with
+        // one side stock and the other painted the two sets collide. Resolve it here: the
+        // stock side's embedded texture wins, the painted side keeps its `.pnt`. The
+        // frontend maps textures by name and would otherwise show whichever image
+        // happened to finish loading last.
+        let mut claimed: Vec<String> = Vec::new();
+        if stock {
+            claimed.extend(stock_main.clone());
+        }
+        if stock_goggles {
+            claimed.extend(stock_goggle.clone());
+        }
+        let claimed: Vec<String> = claimed.iter().map(|s| s.to_ascii_lowercase()).collect();
+        out.retain(|t| !claimed.contains(&t.name.to_ascii_lowercase()));
+        let taken: std::collections::HashSet<String> =
+            out.iter().map(|t| t.name.to_ascii_lowercase()).collect();
+        out.extend(
+            embedded
+                .into_iter()
+                .filter(|t| !taken.contains(&t.name.to_ascii_lowercase())),
+        );
+    }
+    let main_tex = if stock { stock_main } else { main_tex };
+    let goggle_tex = if stock_goggles { stock_goggle } else { goggle_tex };
+    log::info!(
+        "[viewer] {part}: paint={want:?} goggles={want_goggles:?} stock={stock}/{stock_goggles} \
+         -> shell {main_tex:?}, goggles {goggle_tex:?} ({} textures)",
+        out.len(),
+    );
     bind_gear_submeshes(&mut nodes, main_tex.as_deref(), goggle_tex.as_deref());
-    let textures = textures.iter().map(paint::to_texture).collect();
-    Ok(RiderPart { part, nodes, textures })
+    Ok(RiderPart { part, nodes, textures: out })
+}
+
+/// The gear file carrying the visible mesh — not the `_s` shadow or the `c_` cockpit variant.
+fn is_visible_gear_mesh(name: &str) -> bool {
+    let base = name.rsplit('/').next().unwrap_or(name).to_ascii_lowercase();
+    base.ends_with(".edf") && !base.ends_with("_s.edf") && !base.starts_with("c_")
+}
+
+/// Normal (`_n`) and reflection (`_r`) maps ride alongside a colour texture and are never
+/// the look itself. Mirrors the filter in `paint::extract_edf_textures`.
+fn is_companion_map(name: &str) -> bool {
+    let n = name.to_ascii_lowercase();
+    n.ends_with("_n") || n.ends_with("_r")
+}
+
+/// Goggles (and their lens) are the one gear part painted separately from the shell —
+/// the same test decides which submesh wears which texture, and which embedded texture
+/// is the stock goggle.
+fn is_goggle_name(name: &str) -> bool {
+    let n = name.to_ascii_lowercase();
+    n.contains("goggle") || n.contains("lens")
 }
 
 /// Pick a gear paint by name, else the first available so the piece is always textured.
@@ -1161,9 +1260,7 @@ fn bind_gear_submeshes(nodes: &mut [edf::EdfNode], main_tex: Option<&str>, goggl
             continue;
         }
         for sm in &mut node.submeshes {
-            let n = sm.name.to_ascii_lowercase();
-            let is_goggle = n.contains("goggle") || n.contains("lens");
-            sm.texture = if is_goggle {
+            sm.texture = if is_goggle_name(&sm.name) {
                 goggle_tex.or(main_tex).map(str::to_string)
             } else {
                 main_tex.map(str::to_string)
@@ -1237,6 +1334,9 @@ fn load_gear(
                 spec.part.to_string(),
                 Some(paint.to_string()),
                 Some(goggles.to_string()),
+                // The rider wears what the loadout names; "stock" is a preview-only choice.
+                false,
+                false,
             ) {
                 Ok(part) => {
                     log::info!("[rider] {} '{model}' loaded: {} nodes", spec.part, part.nodes.len());
@@ -2107,7 +2207,7 @@ mod viewer_tests {
         eprintln!("paints ({}): {:?}", paints.len(), &paints[..paints.len().min(4)]);
         eprintln!("goggles ({}): {:?}", goggles.len(), &goggles[..goggles.len().min(4)]);
 
-        let part = super::load_gear_model_blocking(path, "helmet".into(), None, None)
+        let part = super::load_gear_model_blocking(path.clone(), "helmet".into(), None, None, false, false)
             .expect("load gear");
         let have: std::collections::HashSet<String> =
             part.textures.iter().map(|t| t.name.to_ascii_lowercase()).collect();
@@ -2128,6 +2228,59 @@ mod viewer_tests {
         if !goggles.is_empty() {
             let (shell, goggle) = (shell.expect("a shell submesh"), goggle.expect("a goggle submesh"));
             assert_ne!(shell, goggle, "goggles bind their own texture, not the shell's");
+        }
+
+        // Stock: the same mesh wearing the textures embedded in it, not a packed `.pnt`.
+        let listed = super::gear_paints_at(std::path::Path::new(&path)).expect("list paints");
+        eprintln!("has_stock={} goggles={}", listed.has_stock, listed.has_stock_goggles);
+        if !listed.has_stock {
+            eprintln!("this piece embeds no textures — no stock entry to check");
+            return;
+        }
+        let stock =
+            super::load_gear_model_blocking(path, "helmet".into(), None, None, true, listed.has_stock_goggles)
+                .expect("load stock gear");
+        let embedded: std::collections::HashSet<String> =
+            stock.textures.iter().map(|t| t.name.to_ascii_lowercase()).collect();
+        assert!(
+            !paints.iter().any(|p| embedded.contains(&p.to_ascii_lowercase())),
+            "a stock preview decodes no packed paint",
+        );
+        let mut bound = 0;
+        for n in &stock.nodes {
+            for s in &n.submeshes {
+                let t = s.texture.as_ref().expect("stock submesh bound to a texture");
+                eprintln!("stock submesh {:<10} -> {t}", s.name);
+                assert!(embedded.contains(&t.to_ascii_lowercase()), "'{t}' is embedded in the mesh");
+                bound += 1;
+            }
+        }
+        assert!(bound > 0, "stock bound at least one submesh");
+
+        // Mixed: stock shell, painted goggles. A paint reuses the mesh's texture names, so
+        // this is where the two sets would collide and the viewer would pick at random.
+        if let Some(g) = goggles.first() {
+            let mixed = super::load_gear_model_blocking(
+                std::env::var("MXB_REAL_GEAR").unwrap(),
+                "helmet".into(),
+                None,
+                Some(g.clone()),
+                true,
+                false,
+            )
+            .expect("load mixed gear");
+            let mut names: Vec<String> =
+                mixed.textures.iter().map(|t| t.name.to_ascii_lowercase()).collect();
+            names.sort_unstable();
+            let total = names.len();
+            names.dedup();
+            assert_eq!(names.len(), total, "one texture per name, so binding is unambiguous");
+            for n in &mixed.nodes {
+                for s in &n.submeshes {
+                    let t = s.texture.as_ref().expect("mixed submesh bound to a texture");
+                    assert!(names.contains(&t.to_ascii_lowercase()), "'{t}' is available");
+                }
+            }
         }
     }
 

--- a/src/Components/Rider/RiderStudio.tsx
+++ b/src/Components/Rider/RiderStudio.tsx
@@ -19,7 +19,12 @@ import {
   type SlotDef,
 } from "../../lib/presets";
 
-const EMPTY_GEAR_PAINTS: GearPaints = { paints: [], goggles: [] };
+const EMPTY_GEAR_PAINTS: GearPaints = {
+  paints: [],
+  goggles: [],
+  hasStock: false,
+  hasStockGoggles: false,
+};
 
 const RIDER_GROUPS = SLOT_GROUPS.filter((g) => g.id !== "bike");
 

--- a/src/Components/Viewer/ViewerDialog.tsx
+++ b/src/Components/Viewer/ViewerDialog.tsx
@@ -24,9 +24,21 @@ interface ViewerDialogProps {
   stockGearPart?: RiderPart["part"];
 }
 
+const EMPTY_GEAR_PAINTS: GearPaints = {
+  paints: [],
+  goggles: [],
+  hasStock: false,
+  hasStockGoggles: false,
+};
+
 function paintLabel(path: string): string {
   const base = path.replace(/\\/g, "/").split("/").pop() ?? path;
   return base.replace(/\.pnt$/i, "");
+}
+
+/** The model's own look leads the picker, ahead of the paints it packs. */
+function withStock(names: string[], hasStock: boolean): string[] {
+  return hasStock ? ["Stock", ...names] : names;
 }
 
 export function ViewerDialog({
@@ -50,7 +62,7 @@ export function ViewerDialog({
   const [loadingPaint, setLoadingPaint] = useState(false);
   const [bodyNodes, setBodyNodes] = useState<EdfNode[] | null>(null);
   const [gear, setGear] = useState<RiderPart | null>(null);
-  const [gearPaints, setGearPaints] = useState<GearPaints>({ paints: [], goggles: [] });
+  const [gearPaints, setGearPaints] = useState<GearPaints>(EMPTY_GEAR_PAINTS);
   const [gogglesIdx, setGogglesIdx] = useState(0);
   const [err, setErr] = useState<string | null>(null);
 
@@ -135,21 +147,26 @@ export function ViewerDialog({
   // Gear ships paints inside the archive — read them out for the picker.
   useEffect(() => {
     if (!open || !gearSource) {
-      setGearPaints({ paints: [], goggles: [] });
+      setGearPaints(EMPTY_GEAR_PAINTS);
       return;
     }
     let alive = true;
     listGearPaints(gearSource)
       .then((p) => alive && setGearPaints(p))
-      .catch(() => alive && setGearPaints({ paints: [], goggles: [] }));
+      .catch(() => alive && setGearPaints(EMPTY_GEAR_PAINTS));
     return () => {
       alive = false;
     };
   }, [open, gearSource]);
 
+  // A gear model's own textures are a choice of their own next to its packed paints, so
+  // "Stock" leads each list when the mesh carries one — and shifts the packed names by one.
+  const gearStock = gearPaints.hasStock && paintIdx === 0;
+  const gearStockGoggles = gearPaints.hasStockGoggles && gogglesIdx === 0;
+
   // The gear item to show: an installed gear model, or the stock model for a loose paint.
-  const gearPaint = gearPaints.paints[paintIdx];
-  const gogglePaint = gearPaints.goggles[gogglesIdx];
+  const gearPaint = gearPaints.paints[paintIdx - (gearPaints.hasStock ? 1 : 0)];
+  const gogglePaint = gearPaints.goggles[gogglesIdx - (gearPaints.hasStockGoggles ? 1 : 0)];
   useEffect(() => {
     if (!open || isBike) {
       setGear(null);
@@ -157,7 +174,14 @@ export function ViewerDialog({
     }
     let load: Promise<RiderPart> | null = null;
     if (gearSource && gearPart) {
-      load = loadGearModel(gearSource, gearPart, gearPaint, gogglePaint);
+      load = loadGearModel(
+        gearSource,
+        gearPart,
+        gearPaint,
+        gogglePaint,
+        gearStock,
+        gearStockGoggles,
+      );
     } else if (stockGearPart && gearPath) {
       load = loadStockGearModel(stockGearPart, gearPath);
     }
@@ -174,7 +198,18 @@ export function ViewerDialog({
     return () => {
       alive = false;
     };
-  }, [open, isBike, gearSource, gearPart, gearPaint, gogglePaint, stockGearPart, gearPath]);
+  }, [
+    open,
+    isBike,
+    gearSource,
+    gearPart,
+    gearPaint,
+    gogglePaint,
+    gearStock,
+    gearStockGoggles,
+    stockGearPart,
+    gearPath,
+  ]);
 
   // Rider parts for the viewer: the real body (skinned when previewing a paint) plus any gear.
   const riderParts = useMemo<RiderPart[] | null>(() => {
@@ -203,10 +238,12 @@ export function ViewerDialog({
   const paintOptions = isBike
     ? paints.map((p) => (p.changesPreview ? p.name : `${p.name} — no change here`))
     : gearSource
-      ? gearPaints.paints
+      ? withStock(gearPaints.paints, gearPaints.hasStock)
       : paintPaths.map(paintLabel);
   // A helmet's goggles carry their own paint set (lens/strap) — a second picker.
-  const goggleOptions = gearSource ? gearPaints.goggles : [];
+  const goggleOptions = gearSource
+    ? withStock(gearPaints.goggles, gearPaints.hasStockGoggles)
+    : [];
   const paintNoChange = isBike && paints[paintIdx]?.changesPreview === false;
 
   const loading = loadingModel || loadingPaint;

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -282,8 +282,18 @@ export function loadGearModel(
   part: RiderPart["part"],
   paint?: string,
   goggles?: string,
+  /** Show the mesh's own texture instead of a `.pnt` — the stock look, per side. */
+  stock = false,
+  stockGoggles = false,
 ): Promise<RiderPart> {
-  return invoke<RiderPart>("load_gear_model", { path, part, paint, goggles });
+  return invoke<RiderPart>("load_gear_model", {
+    path,
+    part,
+    paint,
+    goggles,
+    stock,
+    stockGoggles,
+  });
 }
 
 export function listGearPaints(path: string): Promise<GearPaints> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -265,6 +265,10 @@ export interface RiderModel {
 export interface GearPaints {
   paints: string[];
   goggles: string[];
+  /** The mesh carries its own texture, so the preview can offer a "Stock" entry
+   *  alongside the packed paints. Preview-only — never a loadout value. */
+  hasStock: boolean;
+  hasStockGoggles: boolean;
 }
 
 export interface PkzMeta {


### PR DESCRIPTION
The gear paint picker listed only the `.pnt` files a helmet, boots or protection packs. A piece that ships liveries had no way back to its own look — the textures embedded in its mesh, which the preview ignored entirely.

"Stock" now leads each picker whenever the mesh carries a texture, with a separate entry for a helmet's goggles, since those are picked independently of the shell.

## How it works

- `list_gear_paints` reports `hasStock` / `hasStockGoggles`, read from the visible mesh's embedded texture names — names only, no decoding (0.6 ms of an 80 ms listing, which is dominated by reading the archive and was already happening).
- `load_gear_model` takes a `stock` flag per side. A stock side decodes no `.pnt` at all and binds the mesh's own texture instead.
- A paint replaces the mesh's textures *by name* — that's how it works — so with one side stock and the other painted, the two sets collide. The frontend maps textures by name and resolves duplicates by whichever image finished loading last, so the winner is decided server-side: the stock side's embedded texture, the painted side's `.pnt`.
- Preview only. `hasStock` never becomes a loadout value: the game names a `.pnt` in the profile and has no word for "the model's own look". Rider Studio's dropdowns are untouched.

## Verification

- `cargo test`: 149 passed, 0 failed. `tsc --noEmit` and eslint clean.
- `gear_model_from_pkz` extended to cover stock and the mixed case, run against real gear:
  - **TLD SE4 - Oakley Airbrake** (14 paints, 6 goggle paints) — stock binds `TLD se4 → TLDSE4` and `goggles → TLDSE4goggle` from the mesh; the mixed case asserts one texture per name, which is exactly what fails without the collision fix.
  - **Fox Instinct boots** (5 paints, no goggles) — stock binds both boot submeshes to `fox`; no goggles picker.
- Ran the app from a worktree and opened a helmet preview. The new `[viewer]` log line confirms the frontend wiring end to end:

```
[viewer] helmet: paint=None goggles=None stock=true/true -> shell Some("airoh_aviator_3"), goggles Some("lens") (3 textures)
```

Picker index 0 became a stock request on both sides, and the mesh's own shell and lens textures were bound.

No DB/schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)