### PR TITLE
feat(locker): let a model swap own its liveries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 ## 2026-08-07
 
 ### Added
+- **A model swap can say which liveries are its own.** MX Bikes gives a bike one flat
+  `paints/` folder and has no idea model swaps exist, so a Yami mesh running on a KTM
+  offered every KTM livery alongside the Yami ones — a long list where most entries were
+  drawn for a mesh that isn't on the bike. Each model in the Locker now has a livery
+  picker: tick the ones drawn for it and they become the only liveries the bike livery
+  slot offers while that model is active. Switching models switches the list. The liveries
+  belonging to an inactive model are also moved out of `paints/` into
+  `FrostMod Models/_paints/`, so MX Bikes' own paint picker stops listing them too — which
+  does mean a livery assigned to a model you've swapped away from renders as stock in-game
+  until you swap back. A livery no model claims stays on offer under every model, so a
+  bike you haven't assigned anything on behaves exactly as it did before, and shelved
+  liveries still show in the Library. The game holds its bike files open while it runs, so
+  assigning during a session reports the files it couldn't move rather than claiming a
+  clean filter.
 - **Star ratings on browse thumbnails.** A mod that people have rated on mxb-mods.com now
   shows its score on the card the same way the site does — five stars filled to the
   nearest half, the average, and the vote count — so a good mod is recognisable before you

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -423,6 +423,27 @@ fn dir_has_sound_markers(dir: &Path) -> bool {
     found.iter().all(|&f| f)
 }
 
+/// Whether these folder segments name a bike livery, and which bike owns it — `Some(None)`
+/// for a livery loose at the bikes root, `None` when it isn't a livery at all.
+///
+/// Liveries normally live in `<Bike>/paints/`. One assigned to a model swap waits in the
+/// shelf, `<Bike>/FrostMod Models/_paints/`, while that model is inactive — still the
+/// bike's livery, so still listed, or assigning one would make it vanish from the Library.
+fn paint_owner(segs: &[&str]) -> Option<Option<String>> {
+    let owner_at = |i: usize| segs.get(i).map(|s| s.to_string());
+    if let Some(pos) = segs.iter().position(|s| s.eq_ignore_ascii_case("paints")) {
+        return Some(pos.checked_sub(1).and_then(owner_at));
+    }
+    let pos = segs
+        .iter()
+        .position(|s| s.eq_ignore_ascii_case(crate::modelswap::PAINT_SHELF))?;
+    let parent = segs.get(pos.checked_sub(1)?)?;
+    if !parent.eq_ignore_ascii_case(crate::modelswap::LIB_DIR) {
+        return None;
+    }
+    Some(pos.checked_sub(2).and_then(owner_at))
+}
+
 fn scan_bikes(dir: &Path, sound_bikes: &[String]) -> Vec<LibraryEntry> {
     let mut out = Vec::new();
 
@@ -445,12 +466,9 @@ fn scan_bikes(dir: &Path, sound_bikes: &[String]) -> Vec<LibraryEntry> {
         }
         let folder = rel_folder(dir, p);
         let segs: Vec<&str> = folder.split('/').filter(|s| !s.is_empty()).collect();
-        let paints_pos = segs.iter().position(|s| s.eq_ignore_ascii_case("paints"));
 
-        if let Some(pos) = paints_pos {
-            // `<Bike>/paints/…` livery — owner is the segment before `paints`.
-            let parent = if pos > 0 { Some(segs[pos - 1].to_string()) } else { None };
-            out.push(make_entry(dir, p, "bikePaint", parent));
+        if let Some(owner) = paint_owner(&segs) {
+            out.push(make_entry(dir, p, "bikePaint", owner));
         } else if is_pkz {
             out.push(make_entry(dir, p, "bike", None));
         }
@@ -627,6 +645,23 @@ mod tests {
         let swap = cat(&v, "OEM2024.pkz").unwrap();
         assert_eq!(swap.category, "bikeModelSwap");
         assert_eq!(swap.parent.as_deref(), Some("KTM450"));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_shelved_livery_is_still_the_bikes_livery() {
+        // Assigned to an inactive model swap, so parked out of `paints/` — the Library
+        // must still list it, or assigning a livery would look like losing it.
+        let root = tmp("lib-shelved-paint");
+        let base = root.join("mods/bikes");
+        touch(&base.join("KTM450/model.edf"));
+        touch(&base.join("KTM450/paints/Red.pnt"));
+        touch(&base.join("KTM450/FrostMod Models/_paints/Yami Redbud.pnt"));
+
+        let v = scan_library(root.to_str().unwrap(), "mods/bikes", &[]).unwrap();
+        let shelved = cat(&v, "Yami Redbud.pnt").unwrap();
+        assert_eq!(shelved.category, "bikePaint");
+        assert_eq!(shelved.parent.as_deref(), Some("KTM450"));
         let _ = fs::remove_dir_all(&root);
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -271,6 +271,56 @@ async fn unbind_sound(app: tauri::AppHandle, bike: String, model: String) -> Res
     .map_err(|e| format!("unbind_sound task failed: {e}"))?
 }
 
+/// Outcome of assigning liveries to a model swap: the same live-refresh feedback a swap
+/// gives, plus what the reconcile couldn't do.
+#[derive(serde::Serialize)]
+struct PaintAssignOutcome {
+    /// Liveries that couldn't be moved. MX Bikes holds its bike files open while it runs,
+    /// so a reconcile mid-session leaves some liveries visible in-game — say so rather
+    /// than report a clean filter.
+    stuck: usize,
+    #[serde(flatten)]
+    swap: SwapApplyOutcome,
+}
+
+/// Every livery the bike owns, loose or shelved — the set the assignment picker offers.
+#[tauri::command]
+async fn list_bike_liveries(app: tauri::AppHandle, bike: String) -> Result<Vec<String>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
+        Ok(modelswap::bike_liveries(&cfg.mods_path, &bike))
+    })
+    .await
+    .map_err(|e| format!("list_bike_liveries task failed: {e}"))?
+}
+
+/// Replace the liveries a model swap owns, then move the bike's `paints/` folder to match
+/// — the liveries of an inactive model go to the shelf, where the game can't list them.
+#[tauri::command]
+async fn set_model_paints(
+    app: tauri::AppHandle,
+    bike: String,
+    model: String,
+    paints: Vec<String>,
+) -> Result<PaintAssignOutcome, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
+        let stuck = modelswap::set_model_paints(&cfg.mods_path, &bike, &model, &paints)
+            .map_err(|e| format!("{e:#}"))?;
+        Ok(PaintAssignOutcome {
+            stuck,
+            swap: SwapApplyOutcome {
+                content_reload: frostmod::signal_reload(),
+                game_running: gameproc::is_game_running(),
+                live_refresh: live_refresh(cfg.instant_refresh),
+                model_refresh: None, // the mesh didn't change, only which paints are there
+            },
+        })
+    })
+    .await
+    .map_err(|e| format!("set_model_paints task failed: {e}"))?
+}
+
 #[tauri::command]
 async fn detect_loose_swaps(app: tauri::AppHandle) -> Result<Vec<modelswap::LooseSwapBike>, String> {
     tauri::async_runtime::spawn_blocking(move || detect_loose_swaps_blocking(app))
@@ -2042,6 +2092,8 @@ fn main() {
             apply_sound_swap,
             bind_sound,
             unbind_sound,
+            list_bike_liveries,
+            set_model_paints,
             detect_loose_swaps,
             register_loose_swaps,
             detect_orphaned_setup,

--- a/src-tauri/src/modelswap.rs
+++ b/src-tauri/src/modelswap.rs
@@ -1,13 +1,23 @@
 use serde::Serialize;
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-const LIB_DIR: &str = "FrostMod Models";
+pub const LIB_DIR: &str = "FrostMod Models";
 const MARKER: &str = "_active.txt";
 const ORIGINAL: &str = "Original";
 /// Per-variant record of the filenames that variant owns, written whenever we park a
 /// set. Lets the reverse swap move back exactly what it moved out instead of guessing.
 const MANIFEST: &str = "_files.txt";
+/// Which liveries each model variant owns: variant name -> livery base names (no `.pnt`).
+/// The game has no notion of a model swap — every livery must sit in the one flat
+/// `<Bike>/paints/` folder — so ownership can only live beside the swaps themselves.
+const PAINT_ASSIGN: &str = "_paints.json";
+/// Where a livery waits while the model it belongs to is *not* active. Out of
+/// `<Bike>/paints/` means out of the game's paint list too, which is the point. One shelf
+/// per bike rather than one per variant, so a livery owned by two models has one home.
+pub const PAINT_SHELF: &str = "_paints";
+const PNT_EXT: &str = ".pnt";
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -19,6 +29,9 @@ pub struct ModelVariant {
     /// distinct from an incomplete set that has files but is missing `model.edf`.
     pub empty: bool,
     pub file_count: usize,
+    /// Liveries assigned to this variant, by base name. Empty means "no opinion" — the
+    /// bike's unassigned liveries are offered under every model.
+    pub paints: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -76,6 +89,18 @@ fn lib_dir(mods_path: &str, bike: &str) -> PathBuf {
 }
 fn variant_dir(mods_path: &str, bike: &str, name: &str) -> PathBuf {
     lib_dir(mods_path, bike).join(name)
+}
+fn paints_dir(mods_path: &str, bike: &str) -> PathBuf {
+    bike_dir(mods_path, bike).join("paints")
+}
+fn shelf_dir(mods_path: &str, bike: &str) -> PathBuf {
+    lib_dir(mods_path, bike).join(PAINT_SHELF)
+}
+
+/// The shelf lives inside `FrostMod Models/` but is not a model set. Every walk over that
+/// folder's children has to say so, or it reads as a variant named `_paints`.
+fn is_shelf(name: &str) -> bool {
+    name.eq_ignore_ascii_case(PAINT_SHELF)
 }
 
 fn is_simple_name(s: &str) -> bool {
@@ -176,7 +201,7 @@ fn files_known_to_other_variants(mods_path: &str, bike: &str, except: &[&str]) -
                 continue;
             }
             let name = e.file_name().to_string_lossy().to_string();
-            if except.iter().any(|x| x.eq_ignore_ascii_case(&name)) {
+            if is_shelf(&name) || except.iter().any(|x| x.eq_ignore_ascii_case(&name)) {
                 continue;
             }
             for f in read_manifest(&p).unwrap_or_else(|| set_files(&p)) {
@@ -261,22 +286,206 @@ fn move_one(src: &Path, dst: &Path) -> bool {
     false
 }
 
+// ---------------------------------------------------------------------------
+// Livery ownership
+//
+// A bike's liveries all have to live in one flat `<Bike>/paints/` folder — that is the
+// game's rule, and it knows nothing about model swaps. So a Yami model swapped onto a KTM
+// shows the Yami liveries and the KTM ones side by side, most of them wrong for whatever
+// mesh is currently on the bike.
+//
+// `_paints.json` records which liveries each variant owns. A livery no variant claims is
+// unassigned and stays on offer under every model — so a tree with no assignments behaves
+// exactly as it did before. `reconcile_paints` then makes the folder agree with the
+// record: liveries owned by some *other* model move to the shelf, the active model's move
+// back. The game lists what it finds, so shelving is what filters it in-game too.
+// ---------------------------------------------------------------------------
+
+/// variant name -> the liveries it owns, by base name (no `.pnt`).
+pub type PaintAssignments = BTreeMap<String, Vec<String>>;
+
+fn assign_path(mods_path: &str, bike: &str) -> PathBuf {
+    lib_dir(mods_path, bike).join(PAINT_ASSIGN)
+}
+
+pub fn load_paint_assignments(mods_path: &str, bike: &str) -> PaintAssignments {
+    match fs::read_to_string(assign_path(mods_path, bike)) {
+        Ok(text) => serde_json::from_str(&text).unwrap_or_default(),
+        Err(_) => PaintAssignments::new(),
+    }
+}
+
+fn save_paint_assignments(
+    mods_path: &str,
+    bike: &str,
+    assignments: &PaintAssignments,
+) -> anyhow::Result<()> {
+    let lib = lib_dir(mods_path, bike);
+    fs::create_dir_all(&lib)?;
+    fs::write(
+        assign_path(mods_path, bike),
+        serde_json::to_string_pretty(assignments)?,
+    )?;
+    Ok(())
+}
+
+fn strip_pnt(name: &str) -> &str {
+    match name.rsplit_once('.') {
+        Some((stem, ext)) if ext.eq_ignore_ascii_case("pnt") => stem,
+        _ => name,
+    }
+}
+
+/// The `.pnt` files directly in `dir`, as base names.
+fn liveries_in(dir: &Path) -> Vec<String> {
+    let mut out: Vec<String> = list_files(dir)
+        .into_iter()
+        .filter(|f| f.to_ascii_lowercase().ends_with(PNT_EXT))
+        .map(|f| strip_pnt(&f).to_string())
+        .collect();
+    out.sort_by_key(|s| s.to_lowercase());
+    out
+}
+
+/// Every livery the bike owns, wherever it currently sits — the loose `paints/` folder and
+/// the shelf both count, so assigning one doesn't make it disappear from the picker that
+/// assigns it.
+pub fn bike_liveries(mods_path: &str, bike: &str) -> Vec<String> {
+    let mut out = liveries_in(&paints_dir(mods_path, bike));
+    for name in liveries_in(&shelf_dir(mods_path, bike)) {
+        if !contains_ci(&out, &name) {
+            out.push(name);
+        }
+    }
+    out.sort_by_key(|s| s.to_lowercase());
+    out
+}
+
+/// The real filename of livery `base` inside `dir`, matched case-insensitively — the
+/// record stores what the user sees, the disk stores whatever the mod author typed.
+fn livery_file(dir: &Path, base: &str) -> Option<String> {
+    list_files(dir).into_iter().find(|f| {
+        f.to_ascii_lowercase().ends_with(PNT_EXT) && strip_pnt(f).eq_ignore_ascii_case(base)
+    })
+}
+
+/// Put every *assigned* livery where the active model says it belongs: owned by the active
+/// variant → loose in `paints/`; owned only by others → on the shelf. Liveries no variant
+/// claims are never touched.
+///
+/// Idempotent and order-independent, so it can be re-run after any drift. Returns how many
+/// liveries it could **not** move — MX Bikes holds these files open while it runs, so a
+/// reconcile mid-session legitimately fails and the caller has to say so rather than
+/// report a clean filter.
+pub fn reconcile_paints(mods_path: &str, bike: &str) -> usize {
+    let assignments = load_paint_assignments(mods_path, bike);
+    let paints = paints_dir(mods_path, bike);
+    let shelf = shelf_dir(mods_path, bike);
+
+    // Every livery an assignment has an opinion about: claimed by some variant, or sitting
+    // on the shelf — which only ever happens because it *was* claimed. Including the shelf
+    // is what brings a livery home once its last claim is dropped.
+    let mut subject: Vec<String> = Vec::new();
+    for name in assignments.values().flatten().cloned().chain(liveries_in(&shelf)) {
+        if !contains_ci(&subject, &name) {
+            subject.push(name);
+        }
+    }
+    if subject.is_empty() {
+        return 0;
+    }
+
+    let active = current_active(mods_path, bike);
+    let owned_by_active: Vec<String> = assignments
+        .iter()
+        .filter(|(v, _)| v.eq_ignore_ascii_case(&active))
+        .flat_map(|(_, paints)| paints.iter().cloned())
+        .collect();
+    let mut stuck = 0usize;
+
+    for base in &subject {
+        // Home is the loose folder unless someone else has claimed it and the active model
+        // hasn't — an unclaimed livery belongs on offer under every model.
+        let claimed = assignments.values().any(|p| contains_ci(p, base));
+        let (from, to) = if claimed && !contains_ci(&owned_by_active, base) {
+            (&paints, &shelf)
+        } else {
+            (&shelf, &paints)
+        };
+        let Some(file) = livery_file(from, base) else {
+            continue; // already where it belongs (or gone from the tree entirely)
+        };
+        if fs::create_dir_all(to).is_err() || !move_one(&from.join(&file), &to.join(&file)) {
+            stuck += 1;
+        }
+    }
+
+    // Don't leave an empty `_paints/` behind once nothing is shelved.
+    if shelf.is_dir() && list_files(&shelf).is_empty() {
+        let _ = fs::remove_dir(&shelf);
+    }
+    stuck
+}
+
+/// Replace the set of liveries owned by one variant, then make the folder match. An empty
+/// list drops the variant from the record entirely, so unassigning everything leaves the
+/// tree exactly as it was found.
+pub fn set_model_paints(
+    mods_path: &str,
+    bike: &str,
+    model: &str,
+    paints: &[String],
+) -> anyhow::Result<usize> {
+    if !is_simple_name(bike) || !is_simple_name(model) {
+        anyhow::bail!("invalid bike or model name");
+    }
+    if !dir_exists(&bike_dir(mods_path, bike)) {
+        anyhow::bail!("bike '{bike}' not found");
+    }
+    let mut assignments = load_paint_assignments(mods_path, bike);
+    let cleaned: Vec<String> = paints
+        .iter()
+        .map(|p| strip_pnt(p).to_string())
+        .filter(|p| !p.is_empty())
+        .collect();
+    if cleaned.is_empty() {
+        assignments.remove(model);
+    } else {
+        assignments.insert(model.to_string(), cleaned);
+    }
+    if assignments.is_empty() {
+        let _ = fs::remove_file(assign_path(mods_path, bike));
+    } else {
+        save_paint_assignments(mods_path, bike, &assignments)?;
+    }
+    Ok(reconcile_paints(mods_path, bike))
+}
+
 fn scan_variants(mods_path: &str, bike: &str) -> Vec<ModelVariant> {
     let active_label = {
         let a = read_active(mods_path, bike);
         if a.is_empty() { ORIGINAL.to_string() } else { a }
+    };
+    let assignments = load_paint_assignments(mods_path, bike);
+    let paints_of = |name: &str| -> Vec<String> {
+        assignments
+            .iter()
+            .find(|(v, _)| v.eq_ignore_ascii_case(name))
+            .map(|(_, p)| p.clone())
+            .unwrap_or_default()
     };
 
     // The active model set is the subset of the bike's loose files that belongs to the
     // model — not the whole folder (see `active_set_files`).
     let active_files = active_set_files(mods_path, bike, &active_label, &[]).len();
     let mut variants = vec![ModelVariant {
-        name: active_label.clone(),
-        active: true,
         // The active set is loose at the root — valid iff a mesh is there.
         valid: crate::bikefiles::dir_has_mesh(&bike_dir(mods_path, bike)),
         empty: active_files == 0,
         file_count: active_files,
+        paints: paints_of(&active_label),
+        name: active_label.clone(),
+        active: true,
     }];
 
     let mut others: Vec<ModelVariant> = Vec::new();
@@ -290,6 +499,9 @@ fn scan_variants(mods_path: &str, bike: &str) -> Vec<ModelVariant> {
                 Some(n) => n.to_string(),
                 None => continue,
             };
+            if is_shelf(&name) {
+                continue; // the livery shelf is not a model set
+            }
             if name.eq_ignore_ascii_case(&active_label) {
                 continue; // active is already row 0
             }
@@ -298,6 +510,7 @@ fn scan_variants(mods_path: &str, bike: &str) -> Vec<ModelVariant> {
                 valid: crate::bikefiles::dir_has_mesh(&p),
                 empty: files == 0,
                 file_count: files,
+                paints: paints_of(&name),
                 name,
                 active: false,
             });
@@ -389,6 +602,9 @@ pub fn apply_model_swap(mods_path: &str, bike: &str, target: &str) -> anyhow::Re
     write_manifest(&backup_dir, &root_files);
     write_manifest(&target_dir, &target_files);
     write_active(mods_path, bike, target)?;
+    // The model changed, so the liveries on offer changed with it. Best-effort: the swap
+    // itself has already happened, and `reconcile_paints` reports its own failures.
+    reconcile_paints(mods_path, bike);
     Ok(())
 }
 
@@ -433,7 +649,7 @@ fn orphaned_setup_for(mods_path: &str, bike: &str) -> Vec<(String, PathBuf)> {
     if let Ok(rd) = fs::read_dir(lib_dir(mods_path, bike)) {
         for e in rd.flatten() {
             let p = e.path();
-            if !p.is_dir() {
+            if !p.is_dir() || e.file_name().to_str().is_some_and(is_shelf) {
                 continue;
             }
             for f in set_files(&p) {
@@ -789,6 +1005,199 @@ mod tests {
         let mut v = list_files(p);
         v.sort();
         v
+    }
+
+    /// A KTM wearing a Yami model swap, with liveries drawn for each — the case the
+    /// feature exists for.
+    fn make_bike_with_liveries(mp: &str, bike: &str, liveries: &[&str]) {
+        make_bike(mp, bike, "model.edf");
+        touch(&variant_dir(mp, bike, "Yami").join("model.edf"));
+        for l in liveries {
+            touch(&paints_dir(mp, bike).join(format!("{l}.pnt")));
+        }
+    }
+    fn assign(mp: &str, bike: &str, model: &str, paints: &[&str]) -> usize {
+        let owned: Vec<String> = paints.iter().map(|s| s.to_string()).collect();
+        set_model_paints(mp, bike, model, &owned).unwrap()
+    }
+    fn loose_liveries(mp: &str, bike: &str) -> Vec<String> {
+        liveries_in(&paints_dir(mp, bike))
+    }
+    fn shelved_liveries(mp: &str, bike: &str) -> Vec<String> {
+        liveries_in(&shelf_dir(mp, bike))
+    }
+
+    #[test]
+    fn assigned_liveries_follow_the_active_model() {
+        let root = tmp("paint-follows-model");
+        let mp = root.to_str().unwrap();
+        make_bike_with_liveries(mp, "KTM450", &["Yami Redbud", "KTM Factory", "Plain White"]);
+
+        assign(mp, "KTM450", "Yami", &["Yami Redbud"]);
+        assign(mp, "KTM450", ORIGINAL, &["KTM Factory"]);
+
+        // Original is active, so only its livery — plus the unassigned one — is on offer.
+        assert_eq!(loose_liveries(mp, "KTM450"), ["KTM Factory", "Plain White"]);
+        assert_eq!(shelved_liveries(mp, "KTM450"), ["Yami Redbud"]);
+
+        apply_model_swap(mp, "KTM450", "Yami").unwrap();
+        assert_eq!(
+            loose_liveries(mp, "KTM450"),
+            ["Plain White", "Yami Redbud"],
+            "the Yami livery came back and the KTM one went away"
+        );
+        assert_eq!(shelved_liveries(mp, "KTM450"), ["KTM Factory"]);
+
+        apply_model_swap(mp, "KTM450", ORIGINAL).unwrap();
+        assert_eq!(loose_liveries(mp, "KTM450"), ["KTM Factory", "Plain White"]);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn an_unassigned_livery_is_never_moved() {
+        let root = tmp("paint-unassigned");
+        let mp = root.to_str().unwrap();
+        make_bike_with_liveries(mp, "KTM450", &["Yami Redbud", "Plain White"]);
+
+        assign(mp, "KTM450", "Yami", &["Yami Redbud"]);
+        apply_model_swap(mp, "KTM450", "Yami").unwrap();
+        apply_model_swap(mp, "KTM450", ORIGINAL).unwrap();
+
+        assert!(
+            loose_liveries(mp, "KTM450").contains(&"Plain White".to_string()),
+            "a livery no model claims stays on offer under every model"
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_bike_with_no_assignments_is_left_exactly_alone() {
+        let root = tmp("paint-untouched");
+        let mp = root.to_str().unwrap();
+        make_bike_with_liveries(mp, "KTM450", &["Red", "Blue"]);
+        let before = names_at(&paints_dir(mp, "KTM450"));
+
+        apply_model_swap(mp, "KTM450", "Yami").unwrap();
+
+        assert_eq!(names_at(&paints_dir(mp, "KTM450")), before, "nothing moved");
+        assert!(!shelf_dir(mp, "KTM450").exists(), "no shelf is created");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn reconcile_is_idempotent() {
+        let root = tmp("paint-idempotent");
+        let mp = root.to_str().unwrap();
+        make_bike_with_liveries(mp, "KTM450", &["Yami Redbud", "KTM Factory"]);
+        assign(mp, "KTM450", "Yami", &["Yami Redbud"]);
+
+        let after_first = loose_liveries(mp, "KTM450");
+        for _ in 0..3 {
+            assert_eq!(reconcile_paints(mp, "KTM450"), 0, "nothing left to move");
+        }
+        assert_eq!(loose_liveries(mp, "KTM450"), after_first);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_livery_owned_by_two_models_stays_under_either() {
+        let root = tmp("paint-shared");
+        let mp = root.to_str().unwrap();
+        make_bike_with_liveries(mp, "KTM450", &["Team Kit"]);
+        assign(mp, "KTM450", "Yami", &["Team Kit"]);
+        assign(mp, "KTM450", ORIGINAL, &["Team Kit"]);
+
+        assert_eq!(loose_liveries(mp, "KTM450"), ["Team Kit"]);
+        apply_model_swap(mp, "KTM450", "Yami").unwrap();
+        assert_eq!(
+            loose_liveries(mp, "KTM450"),
+            ["Team Kit"],
+            "a livery drawn for both models is never shelved"
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn unassigning_everything_restores_the_tree() {
+        let root = tmp("paint-unassign");
+        let mp = root.to_str().unwrap();
+        make_bike_with_liveries(mp, "KTM450", &["Yami Redbud", "KTM Factory"]);
+        let before = names_at(&paints_dir(mp, "KTM450"));
+
+        assign(mp, "KTM450", "Yami", &["Yami Redbud"]);
+        assert!(shelf_dir(mp, "KTM450").is_dir(), "shelved while assigned");
+        assign(mp, "KTM450", "Yami", &[]);
+
+        assert_eq!(names_at(&paints_dir(mp, "KTM450")), before, "every livery is back");
+        assert!(!shelf_dir(mp, "KTM450").exists(), "the empty shelf is tidied away");
+        assert!(
+            !assign_path(mp, "KTM450").exists(),
+            "the record goes too — nothing left to explain"
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn bike_liveries_sees_shelved_ones_too() {
+        // The picker that assigns liveries has to keep offering the ones it shelved.
+        let root = tmp("paint-listing");
+        let mp = root.to_str().unwrap();
+        make_bike_with_liveries(mp, "KTM450", &["Yami Redbud", "KTM Factory"]);
+        assign(mp, "KTM450", "Yami", &["Yami Redbud"]);
+
+        assert_eq!(bike_liveries(mp, "KTM450"), ["KTM Factory", "Yami Redbud"]);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn the_shelf_is_not_a_model_variant() {
+        let root = tmp("paint-shelf-not-variant");
+        let mp = root.to_str().unwrap();
+        make_bike_with_liveries(mp, "KTM450", &["Yami Redbud"]);
+        assign(mp, "KTM450", "Yami", &["Yami Redbud"]);
+        assert!(shelf_dir(mp, "KTM450").is_dir(), "the shelf exists to be mistaken for one");
+
+        let names: Vec<String> = scan_model_swaps(mp)[0]
+            .variants
+            .iter()
+            .map(|v| v.name.clone())
+            .collect();
+        assert!(!names.iter().any(|n| is_shelf(n)), "got variants: {names:?}");
+        assert!(detect_orphaned_setup(mp).is_empty(), "and it isn't damage either");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_reports_each_variants_liveries() {
+        let root = tmp("paint-scan");
+        let mp = root.to_str().unwrap();
+        make_bike_with_liveries(mp, "KTM450", &["Yami Redbud", "KTM Factory", "Plain White"]);
+        assign(mp, "KTM450", "Yami", &["Yami Redbud"]);
+        assign(mp, "KTM450", ORIGINAL, &["KTM Factory"]);
+
+        let bike = &scan_model_swaps(mp)[0];
+        let paints_of = |name: &str| {
+            bike.variants.iter().find(|v| v.name == name).unwrap().paints.clone()
+        };
+        assert_eq!(paints_of(ORIGINAL), ["KTM Factory"]);
+        assert_eq!(paints_of("Yami"), ["Yami Redbud"]);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_livery_case_mismatch_still_resolves() {
+        // The record stores what the picker showed; the disk stores what the author typed.
+        let root = tmp("paint-case");
+        let mp = root.to_str().unwrap();
+        make_bike_with_liveries(mp, "KTM450", &["Yami RedBud"]);
+        assign(mp, "KTM450", "Yami", &["yami redbud"]);
+
+        assert_eq!(
+            names_at(&shelf_dir(mp, "KTM450")),
+            ["Yami RedBud.pnt"],
+            "matched case-insensitively, moved under its real name"
+        );
+        let _ = fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/src/Components/Locker/AssignPaintsDialog.tsx
+++ b/src/Components/Locker/AssignPaintsDialog.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useMemo, useState } from "react";
+import { Check, Loader2, Palette } from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/Components/ui/dialog";
+import { Button } from "@/Components/ui/button";
+import { listBikeLiveries, setModelPaints } from "../../api/mods";
+import type { BikeModels, PaintAssignOutcome } from "../../types";
+
+/**
+ * Assigns a bike's liveries to one model swap.
+ *
+ * The game gives a bike a single flat `paints/` folder and knows nothing about model
+ * swaps, so every livery for every model shows up at once — most of them drawn for a mesh
+ * that isn't on the bike. Ticking a livery here says it belongs to this model: it's the
+ * only model that offers it, and while another model is active the file is moved out of
+ * `paints/` so the game doesn't list it either. A livery left unticked by every model
+ * belongs to none and stays on offer under all of them.
+ */
+export default function AssignPaintsDialog({
+  open,
+  onOpenChange,
+  bike,
+  model,
+  models,
+  onDone,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  bike: string;
+  /** The variant being edited. */
+  model: string;
+  /** The bike's full scan — used to show which other model already claims a livery. */
+  models: BikeModels;
+  /** Called after a successful save so the Locker can refresh. */
+  onDone?: () => void;
+}) {
+  const [liveries, setLiveries] = useState<string[] | null>(null);
+  // Seeded once at mount — the caller keys this dialog by bike + model, so opening it for
+  // another model remounts rather than reseeding mid-edit when a rescan lands.
+  const [picked, setPicked] = useState<Set<string>>(
+    () => new Set(models.variants.find((v) => v.name === model)?.paints ?? []),
+  );
+  const [saving, setSaving] = useState(false);
+
+  // Which *other* model claims each livery, so ticking one shows what it's taken from.
+  const claimedBy = useMemo(() => {
+    const m = new Map<string, string[]>();
+    for (const v of models.variants) {
+      if (v.name === model) continue;
+      for (const p of v.paints) m.set(p.toLowerCase(), [...(m.get(p.toLowerCase()) ?? []), v.name]);
+    }
+    return m;
+  }, [models, model]);
+
+  useEffect(() => {
+    let alive = true;
+    listBikeLiveries(bike)
+      .then((l) => alive && setLiveries(l))
+      .catch((e) => {
+        if (!alive) return;
+        toast.error(String(e).replace(/^Error:\s*/, ""));
+        setLiveries([]);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [bike]);
+
+  const toggle = (name: string) =>
+    setPicked((prev) => {
+      const next = new Set(prev);
+      if (!next.delete(name)) next.add(name);
+      return next;
+    });
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      const r = await setModelPaints(bike, model, [...picked]);
+      toast.success(summary(picked.size, model), { description: note(r) });
+      onOpenChange(false);
+      onDone?.();
+    } catch (e) {
+      toast.error(String(e).replace(/^Error:\s*/, ""));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !saving && onOpenChange(o)}>
+      <DialogContent className="max-w-lg" showClose={!saving}>
+        <DialogHeader>
+          <DialogTitle>Liveries for “{model}”</DialogTitle>
+          <DialogDescription>
+            Tick the liveries drawn for this model. They&apos;re the only ones offered
+            while it&apos;s active — and the ones belonging to another model are moved out
+            of <span className="font-mono text-faint">paints/</span>, so MX Bikes stops
+            listing them too. Leave a livery unticked everywhere and it stays available
+            under every model.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-72 min-h-24 overflow-y-auto rounded-lg border border-white/[0.07] bg-black/20">
+          {liveries === null ? (
+            <p className="py-8 text-center text-[12.5px] text-muted-foreground">
+              Reading liveries…
+            </p>
+          ) : liveries.length === 0 ? (
+            <p className="px-4 py-8 text-center text-[12.5px] text-muted-foreground">
+              This bike has no liveries yet — install one and it&apos;ll show up here.
+            </p>
+          ) : (
+            liveries.map((name) => {
+              const on = picked.has(name);
+              const others = claimedBy.get(name.toLowerCase()) ?? [];
+              return (
+                <button
+                  key={name}
+                  onClick={() => toggle(name)}
+                  disabled={saving}
+                  className={cn(
+                    "flex w-full items-center gap-2.5 border-b border-white/[0.05] px-3.5 py-2 text-left transition-colors last:border-b-0",
+                    on ? "bg-primary/[0.07]" : "hover:bg-white/[0.03]",
+                    saving && "pointer-events-none opacity-60",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "grid size-4 flex-none place-items-center rounded border",
+                      on ? "border-primary bg-primary/20" : "border-white/15",
+                    )}
+                  >
+                    {on && <Check className="size-3 text-primary" />}
+                  </span>
+                  <Palette className="size-3.5 flex-none text-foreground/30" strokeWidth={1.5} />
+                  <span className="min-w-0 flex-1 truncate text-[12.5px]">{name}</span>
+                  {others.length > 0 && (
+                    <span
+                      className="flex-none text-[10.5px] text-faint"
+                      title={`Also assigned to ${others.join(", ")}`}
+                    >
+                      {others.join(", ")}
+                    </span>
+                  )}
+                </button>
+              );
+            })
+          )}
+        </div>
+
+        <DialogFooter className="flex-col-reverse gap-2 sm:flex-row sm:justify-between">
+          <Button variant="ghost" size="sm" disabled={saving} onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button size="sm" disabled={saving || liveries === null} onClick={() => void save()}>
+            {saving && <Loader2 className="animate-spin" />}
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function summary(count: number, model: string): string {
+  return count === 0
+    ? `“${model}” no longer claims any livery.`
+    : `${count} liver${count === 1 ? "y" : "ies"} assigned to “${model}”.`;
+}
+
+/** What the shelving actually managed — MX Bikes holds these files open while it runs. */
+function note(r: PaintAssignOutcome): string {
+  if (r.stuck > 0) {
+    return `${r.stuck} livery file${r.stuck === 1 ? "" : "s"} couldn't be moved — close MX Bikes and hit Rescan, or they stay visible in-game.`;
+  }
+  return r.game_running
+    ? "Reselect your profile in MX Bikes to see the new list."
+    : "The game will show the new list next time it opens.";
+}

--- a/src/Components/Locker/Locker.tsx
+++ b/src/Components/Locker/Locker.tsx
@@ -11,6 +11,7 @@ import {
   Link2,
   Link2Off,
   Wrench,
+  Palette,
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
@@ -37,6 +38,7 @@ import type {
   SwapApplyOutcome,
 } from "../../types";
 import RegisterSwapsDialog from "./RegisterSwapsDialog";
+import AssignPaintsDialog from "./AssignPaintsDialog";
 
 /**
  * Locker — the app-side bike **model & sound swap** manager, twinned with FrostMod's
@@ -130,6 +132,8 @@ export default function Locker() {
   const [registerOpen, setRegisterOpen] = useState(false);
   // Bikes gutted by a pre-0.6.3 swap — their setup files are in a swap folder.
   const [orphaned, setOrphaned] = useState<OrphanedSetup[]>([]);
+  // The model swap whose liveries are being assigned, if the dialog is open.
+  const [assigning, setAssigning] = useState<{ bike: string; model: string } | null>(null);
 
   const load = useCallback(async () => {
     setError(null);
@@ -163,6 +167,9 @@ export default function Locker() {
   }, [load]);
 
   const looseCount = loose.reduce((n, b) => n + b.candidates.length, 0);
+  // Re-read from `rows` rather than snapshotting, so a save's refresh reaches the dialog.
+  const assigningModels =
+    (assigning && rows?.find((r) => r.bike === assigning.bike)?.models) || null;
 
   // Runs a mutation for `bike`, toasting success/failure and refreshing every scan.
   // `note` optionally appends live-refresh feedback derived from the result.
@@ -314,6 +321,7 @@ export default function Locker() {
                 onSoundSwap={onSoundSwap}
                 onBind={onBind}
                 onUnbind={onUnbind}
+                onAssignPaints={(model) => setAssigning({ bike: r.bike, model })}
               />
             ))}
           </div>
@@ -326,6 +334,18 @@ export default function Locker() {
         bikes={loose}
         onDone={() => void load()}
       />
+
+      {assigning && assigningModels && (
+        <AssignPaintsDialog
+          key={`${assigning.bike}:${assigning.model}`}
+          open
+          onOpenChange={(o) => !o && setAssigning(null)}
+          bike={assigning.bike}
+          model={assigning.model}
+          models={assigningModels}
+          onDone={() => void load()}
+        />
+      )}
     </div>
   );
 }
@@ -338,6 +358,7 @@ function BikeCard({
   onSoundSwap,
   onBind,
   onUnbind,
+  onAssignPaints,
 }: {
   row: Row;
   busy: boolean;
@@ -346,6 +367,7 @@ function BikeCard({
   onSoundSwap: (bike: string, target: string) => void;
   onBind: (bike: string, model: string, sound: string) => void;
   onUnbind: (bike: string, model: string, sound: string) => void;
+  onAssignPaints: (model: string) => void;
 }) {
   const { bike, models, sounds } = row;
   const modelCount = models?.variants.length ?? 0;
@@ -372,14 +394,22 @@ function BikeCard({
           hint={modelCount <= 1 ? "Only one model — install more to swap" : undefined}
         >
           {models.variants.map((v) => (
-            <VariantButton
-              key={v.name}
-              variant={v}
-              kind="model"
-              busy={busy}
-              disabled={disabled}
-              onClick={() => onModelSwap(bike, v.name)}
-            />
+            <div key={v.name} className="flex items-stretch gap-1.5">
+              <VariantButton
+                variant={v}
+                kind="model"
+                busy={busy}
+                disabled={disabled}
+                className="min-w-0 flex-1"
+                onClick={() => onModelSwap(bike, v.name)}
+              />
+              <PaintsButton
+                count={v.paints.length}
+                model={v.name}
+                disabled={disabled}
+                onClick={() => onAssignPaints(v.name)}
+              />
+            </div>
           ))}
         </SwapSection>
       )}
@@ -449,12 +479,51 @@ function SwapSection({
   );
 }
 
+/**
+ * Opens the livery assignment for one model swap. A separate control from the swap button
+ * beside it — assigning is not switching, and a button can't live inside a button.
+ */
+function PaintsButton({
+  count,
+  model,
+  disabled,
+  onClick,
+}: {
+  count: number;
+  model: string;
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      title={
+        count > 0
+          ? `${count} liver${count === 1 ? "y" : "ies"} assigned to “${model}” — only these show while it's active`
+          : `Pick the liveries drawn for “${model}”, so the others don't show while it's active`
+      }
+      className={cn(
+        "flex flex-none flex-col items-center justify-center gap-0.5 rounded-lg border px-2.5 transition-colors",
+        count > 0
+          ? "border-primary/30 bg-primary/[0.06] text-primary/80 hover:border-primary/50"
+          : "border-white/[0.07] text-muted-foreground hover:border-white/20 hover:text-foreground",
+        disabled && "pointer-events-none opacity-60",
+      )}
+    >
+      <Palette className="size-3.5" strokeWidth={1.75} />
+      {count > 0 && <span className="text-[10px] font-semibold leading-none">{count}</span>}
+    </button>
+  );
+}
+
 function VariantButton({
   variant: v,
   kind,
   busy,
   disabled,
   boundModels = [],
+  className,
   onClick,
 }: {
   variant: ModelVariant | SoundVariant;
@@ -462,6 +531,7 @@ function VariantButton({
   busy: boolean;
   disabled: boolean;
   boundModels?: string[];
+  className?: string;
   onClick: () => void;
 }) {
   const emptyLabel = kind === "model" ? "No model" : "Stock";
@@ -494,6 +564,7 @@ function VariantButton({
             ? "cursor-pointer border-white/[0.07] hover:border-white/20"
             : "border-white/[0.05] opacity-50",
         disabled && !v.active && "pointer-events-none opacity-60",
+        className,
       )}
     >
       <span className="flex size-4 flex-none items-center justify-center">

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -28,6 +28,7 @@ import type {
   Preset,
   PresetApplyOutcome,
   SwapApplyOutcome,
+  PaintAssignOutcome,
   ReloadOutcome,
   BundlePlan,
   BundleProgress,
@@ -204,6 +205,23 @@ export function scanModelSwaps(): Promise<BikeModels[]> {
 
 export function applyModelSwap(bike: string, target: string): Promise<SwapApplyOutcome> {
   return invoke<SwapApplyOutcome>("apply_model_swap", { bike, target });
+}
+
+/** Every livery the bike owns, whether loose in `paints/` or shelved by an assignment. */
+export function listBikeLiveries(bike: string): Promise<string[]> {
+  return invoke<string[]>("list_bike_liveries", { bike });
+}
+
+/**
+ * Replace the liveries a model swap owns. The bike's `paints/` folder is moved to match —
+ * an inactive model's liveries go to the shelf, out of the game's paint list too.
+ */
+export function setModelPaints(
+  bike: string,
+  model: string,
+  paints: string[],
+): Promise<PaintAssignOutcome> {
+  return invoke<PaintAssignOutcome>("set_model_paints", { bike, model, paints });
 }
 
 export function scanSoundSwaps(): Promise<BikeSounds[]> {

--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -83,6 +83,9 @@ export const ANY_MODEL = "*";
 export interface Scans {
   bikePaints: Record<string, string[]>; // bikeid → livery names
   modelSwaps: Record<string, string[]>; // bikeid → model-swap variant names
+  activeModel: Record<string, string>; // bikeid → the model swap currently on the bike
+  /** bikeid → variant name → the liveries that variant claims. See {@link forActiveModel}. */
+  modelPaints: Record<string, Record<string, string[]>>;
   helmets: string[];
   helmetPaints: Record<string, string[]>; // helmet model (or ANY_MODEL) → paints
   goggles: Record<string, string[]>; // helmet model / rider profile → goggles
@@ -118,6 +121,8 @@ export async function loadScans(): Promise<Scans> {
   const s: Scans = {
     bikePaints: {},
     modelSwaps: {},
+    activeModel: {},
+    modelPaints: {},
     helmets: [...targets.helmets],
     helmetPaints: {},
     goggles: {},
@@ -139,6 +144,10 @@ export async function loadScans(): Promise<Scans> {
     // mesh) is rejected by the backend, so offering it only produces a failed apply.
     const usable = b.variants.filter((v) => v.valid || v.empty).map((v) => v.name);
     if (usable.length) s.modelSwaps[b.bike] = usable;
+    s.activeModel[b.bike] = b.active;
+    // Every variant's claim, not just the active one's — a livery claimed by *any* model
+    // is one the others shouldn't offer.
+    s.modelPaints[b.bike] = Object.fromEntries(b.variants.map((v) => [v.name, v.paints]));
   }
   for (const e of rider) {
     const v = stripExt(e.name);
@@ -183,10 +192,37 @@ export async function loadScans(): Promise<Scans> {
  * asks by the `bikeid` written in `profile.ini`; those agree in case only by convention,
  * and an exact match silently yielded an empty dropdown whenever they didn't.
  */
-function forBike(map: Record<string, string[]>, bikeid: string): string[] {
-  if (map[bikeid]) return map[bikeid];
+function byBike<T>(map: Record<string, T>, bikeid: string): T | undefined {
+  if (map[bikeid] !== undefined) return map[bikeid];
   const hit = Object.keys(map).find((k) => k.toLowerCase() === bikeid.toLowerCase());
-  return hit ? map[hit] : [];
+  return hit === undefined ? undefined : map[hit];
+}
+
+function forBike(map: Record<string, string[]>, bikeid: string): string[] {
+  return byBike(map, bikeid) ?? [];
+}
+
+/**
+ * Narrow a bike's liveries to the ones that suit the model swap currently on it: the
+ * liveries that model claims, plus the ones no model claims at all.
+ *
+ * A bike wears one model at a time but its liveries all share the single `paints/` folder
+ * the game insists on, so a Yami mesh on a KTM otherwise offers every KTM livery too.
+ * Unclaimed liveries staying universal is the same rule {@link forModel} applies to gear
+ * paints installed without an owning model — and it means a bike nobody has assigned
+ * anything on behaves exactly as before.
+ */
+function forActiveModel(liveries: string[], bikeid: string, scans: Scans): string[] {
+  const claims = byBike(scans.modelPaints, bikeid);
+  if (!claims) return liveries;
+  const active = byBike(scans.activeModel, bikeid) ?? "";
+  const keyed = (name: string) =>
+    Object.entries(claims).find(([v]) => v.toLowerCase() === name.toLowerCase())?.[1] ?? [];
+
+  const lower = (names: string[]) => new Set(names.map((n) => n.toLowerCase()));
+  const mine = lower(keyed(active));
+  const spokenFor = lower(Object.values(claims).flat());
+  return liveries.filter((l) => mine.has(l.toLowerCase()) || !spokenFor.has(l.toLowerCase()));
 }
 
 /** Paints for `model`, plus any installed with no owning model folder. */
@@ -211,7 +247,7 @@ export function slotOptions(
   let opts: string[] = [];
   switch (slot.key) {
     case "paint":
-      opts = forBike(scans.bikePaints, bikeid);
+      opts = forActiveModel(forBike(scans.bikePaints, bikeid), bikeid, scans);
       break;
     case "modelSwap":
       opts = forBike(scans.modelSwaps, bikeid);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -129,6 +129,11 @@ export interface ModelVariant {
   empty: boolean;
   /** Number of top-level files in the set. */
   fileCount: number;
+  /**
+   * Liveries assigned to this model, by base name (no `.pnt`). Empty means the model
+   * has no opinion; a livery no model claims stays on offer under every model.
+   */
+  paints: string[];
 }
 
 /** A bike and every model it can be swapped between (active first). */
@@ -355,6 +360,18 @@ export interface SwapApplyOutcome {
    * it still no-ops unless the swapped bike is the one currently selected in-game.
    */
   model_refresh: CommandOutcome | null;
+}
+
+/**
+ * Outcome of assigning liveries to a model swap — a swap's live-refresh feedback plus
+ * what the shelving couldn't do.
+ */
+export interface PaintAssignOutcome extends SwapApplyOutcome {
+  /**
+   * Liveries that couldn't be moved. MX Bikes holds its bike files open while it runs,
+   * so these stay visible in-game until the game is closed and the bike rescanned.
+   */
+  stuck: number;
 }
 
 /** Install/version/running snapshot for the FrostMod settings panel. */


### PR DESCRIPTION
## Why

MX Bikes gives a bike one flat `paints/` folder and knows nothing about model swaps. So a Yami mesh running on a KTM offered every KTM livery alongside the Yami ones — a long list where most entries were drawn for a mesh that isn't on the bike.

## What

A model swap can now declare which liveries are its own.

**Ownership record.** `FrostMod Models/_paints.json` maps variant → livery names — the same shape as the `_bindings.json` sound bindings sitting next to it.

**Reconcile.** One idempotent pass makes the folder agree with the record: an inactive model's liveries move to the shelf, `FrostMod Models/_paints/`, and the active model's move back. It runs after every swap and every assignment edit. Liveries no model claims are never moved, so **a bike with no assignments behaves exactly as it did before**.

**In-game too.** Shelving a livery is what filters the game's own paint picker. The consequence, accepted deliberately: a livery assigned to a model you swap away from renders as stock in-game until you swap back.

**Honest about failure.** MX Bikes holds its bike files open while it runs, so moves are best-effort and counted — assigning mid-session reports what it couldn't move rather than claiming a clean filter. The Presets livery list filters on the *record*, not the folder, so it stays correct even when the shelving isn't.

## Notable details

- The shelf is excluded from the three walks that enumerate `FrostMod Models/` children, or it reads as a bogus model variant.
- `library.rs` learned the shelf holds liveries, so assigning one doesn't make it vanish from the Library.
- No DB changes — all state is on-disk beside the swaps it describes.

## Verification

166 Rust tests pass (10 new), `tsc` clean, lint clean (3 pre-existing warnings, none in new code), `bun run build` succeeds, no new clippy warnings.

New tests cover: assigned liveries following the active model; an unassigned livery never moving; a bike with no assignments left byte-for-byte alone; reconcile idempotence; a livery owned by two models staying put under either; unassigning everything restoring the tree; the shelf not appearing as a variant; case-mismatched livery names resolving; the Library still listing a shelved livery.

**Not yet exercised against a real MX Bikes install.** Worth walking through before merge:

1. Locker → a bike with a model swap → palette button → tick liveries → Save. `paints/` should hold only those plus unassigned ones; the rest in `FrostMod Models/_paints/`.
2. Presets → same bike → the **Bike livery** dropdown shows the same shortened list.
3. Swap models — folder and dropdown both flip.
4. Untick everything on every model — `paints/` back as it started, `_paints/` and `_paints.json` gone.
5. With the game running, assign something — the toast reports files it couldn't move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)