### PR TITLE
feat(i18n): translate the app into five languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 2026-08-07 — the app speaks six languages
+
+### Added
+- **MXB App is translated into Italian, Spanish, French, German and Brazilian
+  Portuguese.** Pick a language under Settings → Appearance; the choice persists, and
+  `System` follows the OS (a bare `pt` resolves to Brazilian, the only Portuguese we
+  ship). Every screen, dialog, toast and empty state is covered — 535 keys per language.
+  Terminology follows what the MX Bikes community actually says rather than dictionary
+  equivalents: `mod`, `setup`, `preset` and `Stock` stay as loanwords in every language,
+  while gear is translated (`casco`/`casque`/`Helm`, `maschera`/`masque`/`Brille` for
+  goggles, `livrea`/`déco`/`Lackierung` for a bike paint).
+- **Dates follow the app's language, not the OS's.** Picking Italian on an English
+  machine moves the Library's dates too, instead of leaving half the UI in English.
+
+### Changed
+- **Translations can't silently go missing.** Each locale is typed as
+  `Record<keyof typeof en, string>`, so a key that's absent from — or invented in — any
+  of the five translations is a compile error, not a runtime blank. `npm run typecheck`
+  passing is proof all six locales are complete and consistent. This is why the i18n
+  layer is ~120 lines of local code rather than i18next: a missing key can't reach a
+  build.
+- **Plurals use `Intl.PluralRules` rather than an `n === 1` check.** French treats 0 as
+  singular, so "0 fichier" now comes out correct without a special case, and languages
+  that don't split one/other the way English does still land right.
+- **Sentences that wrap markup are translated whole.** A `<Trans>` component splices
+  React nodes into placeholders, so word order stays the translator's choice — splitting
+  such a sentence into prefix/suffix strings would have hard-coded English grammar into
+  German and French. The same applies to the preset-apply toasts, which were an English
+  fragment ("Applied X to Y — {note}") and are now four complete sentences.
+- **Nouns that read differently mid-sentence get their own key.** "Search tracks…" used
+  `label.toLowerCase()`, which produces broken German — its nouns are capitalized
+  everywhere — so mod types now carry a separate inline form.
+
 ## 2026-08-06 — v0.6.3 — model swaps stop breaking bikes, Linux builds
 
 ### Added

--- a/src/Components/Browse/Browse.tsx
+++ b/src/Components/Browse/Browse.tsx
@@ -12,6 +12,7 @@ import {
 } from "../../api/mods";
 import type { ModSummary } from "../../types";
 import { useInstall } from "../../Context/Install";
+import { useT } from "../../i18n/context";
 import ModCard from "./ModCard";
 import { Segmented } from "@/Components/ui/segmented";
 import { Button } from "@/Components/ui/button";
@@ -42,6 +43,7 @@ export default function Browse({
   onOpenMod,
   onChangeType,
 }: BrowseProps) {
+  const t = useT();
   const [query, setQuery] = useState("");
   const [debounced, setDebounced] = useState("");
   const [categoryId, setCategoryId] = useState(modType.categoryId);
@@ -96,23 +98,25 @@ export default function Browse({
         );
         if (res.ok) {
           startInstall({ ...res.params, categoryId });
-          toast.success(`Queued “${res.params.title}”`, {
-            description: `Installing to ${res.params.destFolder || "root"}.`,
+          toast.success(t("browse.queued", { title: res.params.title }), {
+            description: t("browse.queuedDesc", {
+              folder: res.params.destFolder || t("browse.rootFolder"),
+            }),
           });
         } else if (res.reason === "blocked") {
-          toast.error(`“${res.title}” needs a browser download`, {
-            description: `${res.host} blocks in-app downloads — open its page to finish.`,
+          toast.error(t("browse.needsBrowser", { title: res.title }), {
+            description: t("browse.needsBrowserDesc", { host: res.host ?? "" }),
           });
         } else {
-          toast.error(`No download found for “${res.title}”`);
+          toast.error(t("browse.noDownload", { title: res.title }));
         }
       } catch (e) {
-        toast.error(`Couldn't quick-install “${mod.title}”`, {
+        toast.error(t("browse.quickInstallFailed", { title: mod.title }), {
           description: String(e),
         });
       }
     },
-    [modType, categoryId, startInstall],
+    [modType, categoryId, startInstall, t],
   );
 
   // Guard: if the mod is already installed, confirm before overwriting.
@@ -149,18 +153,18 @@ export default function Browse({
       setBulkBusy(false);
       clearSelection();
       if (queued > 0) {
-        toast.success(`Queued ${queued} mod${queued > 1 ? "s" : ""}`, {
+        toast.success(t("browse.queuedBulk", { count: queued }), {
           description: skipped.length
-            ? `${skipped.length} skipped — browser-only host.`
-            : "They'll install one after another.",
+            ? t("browse.queuedBulkSkipped", { count: skipped.length })
+            : t("browse.queuedBulkDesc"),
         });
       } else if (skipped.length) {
-        toast.error("Couldn't quick-install the selection", {
-          description: `All ${skipped.length} need a browser download.`,
+        toast.error(t("browse.bulkFailed"), {
+          description: t("browse.bulkFailedDesc", { count: skipped.length }),
         });
       }
     },
-    [modType, categoryId, startInstall, clearSelection],
+    [modType, categoryId, startInstall, clearSelection, t],
   );
 
   const bulkInstall = useCallback(() => {
@@ -232,25 +236,32 @@ export default function Browse({
     <div className="flex h-full flex-col">
       <header className="flex flex-none flex-col gap-4 px-7 pb-3.5 pt-5">
         <div className="flex items-center gap-3.5">
-          <h1 className="text-[21px] font-bold tracking-[-0.2px]">Browse</h1>
+          <h1 className="text-[21px] font-bold tracking-[-0.2px]">
+            {t("nav.browse")}
+          </h1>
           <HelpHint
-            title="Browse"
-            description="Discover and install mods from the online catalog — search, filter by type, and open a mod to download it into the game."
+            title={t("nav.browse")}
+            description={t("browse.help")}
           />
           <Segmented
             value={modType.id}
             onChange={(id) => {
-              const next = MOD_TYPES.find((t) => t.id === id);
+              const next = MOD_TYPES.find((mt) => mt.id === id);
               if (next) onChangeType(next);
             }}
-            options={MOD_TYPES.map((t) => ({ value: t.id, label: t.label }))}
+            options={MOD_TYPES.map((mt) => ({
+              value: mt.id,
+              label: t(mt.label),
+            }))}
           />
           <div className="ml-auto flex w-[280px] items-center gap-2 rounded-lg border border-input bg-card px-3 py-2">
             <Search className="size-3.5 text-faint" />
             <input
               value={query}
               onChange={(e) => setQuery(e.target.value)}
-              placeholder={`Search ${modType.label.toLowerCase()}…`}
+              placeholder={t("browse.searchPlaceholder", {
+                type: t(modType.labelInline),
+              })}
               className="w-full bg-transparent text-[12.5px] placeholder:text-faint focus:outline-none"
             />
           </div>
@@ -269,12 +280,12 @@ export default function Browse({
                     : "border border-input text-muted-foreground hover:text-foreground",
                 )}
               >
-                {c.label}
+                {t(c.label)}
               </button>
             );
           })}
           <span className="ml-auto self-center text-[11.5px] text-faint">
-            Sorted by newest
+            {t("browse.sortedByNewest")}
           </span>
         </div>
       </header>
@@ -283,7 +294,7 @@ export default function Browse({
         {error ? (
           <div className="mx-auto flex max-w-md flex-col items-center gap-3 py-20 text-center">
             <p className="text-[13px] font-semibold text-destructive">
-              Couldn&apos;t load mods
+              {t("browse.loadFailed")}
             </p>
             {/* The backend now explains blocks in plain words; show that on its own line
                 rather than glued to the heading, and keep it selectable for bug reports. */}
@@ -291,7 +302,7 @@ export default function Browse({
               {error.replace(/^Error:\s*/, "")}
             </p>
             <Button variant="outline" size="sm" onClick={() => setReloadKey((k) => k + 1)}>
-              Retry
+              {t("common.retry")}
             </Button>
           </div>
         ) : loading ? (
@@ -302,7 +313,7 @@ export default function Browse({
           </div>
         ) : mods.length === 0 ? (
           <p className="py-20 text-center text-[13px] text-muted-foreground">
-            No {modType.label.toLowerCase()} found.
+            {t("browse.empty", { type: t(modType.labelInline) })}
           </p>
         ) : (
           <>
@@ -324,7 +335,7 @@ export default function Browse({
             {hasMore && (
               <div className="flex justify-center pt-4">
                 <Button variant="outline" onClick={loadMore} disabled={loadingMore}>
-                  {loadingMore ? "Loading…" : "Load more"}
+                  {loadingMore ? t("common.loading") : t("browse.loadMore")}
                 </Button>
               </div>
             )}
@@ -335,14 +346,16 @@ export default function Browse({
       {selectionActive && (
         <div className="flex flex-none items-center gap-3 border-t border-white/[0.08] bg-window px-7 py-3">
           <span className="text-[12.5px] font-semibold">
-            {selected.size} selected
+            {t("browse.selectedCount", { count: selected.size })}
           </span>
           <Button size="sm" onClick={bulkInstall} disabled={bulkBusy}>
             <Download className="size-3.5" />
-            {bulkBusy ? "Queuing…" : `Quick install ${selected.size}`}
+            {bulkBusy
+              ? t("browse.queuing")
+              : t("browse.quickInstallCount", { count: selected.size })}
           </Button>
           <Button size="sm" variant="outline" onClick={selectAll} disabled={bulkBusy}>
-            Select all
+            {t("common.selectAll")}
           </Button>
           <Button
             size="sm"
@@ -351,7 +364,7 @@ export default function Browse({
             disabled={bulkBusy}
             className="ml-auto"
           >
-            <X className="size-3.5" /> Clear
+            <X className="size-3.5" /> {t("common.clear")}
           </Button>
         </div>
       )}
@@ -361,21 +374,24 @@ export default function Browse({
           <AlertDialogHeader>
             <AlertDialogTitle>
               {reinstall?.kind === "single"
-                ? `Reinstall “${reinstall.mod.title}”?`
-                : "Reinstall mods you already have?"}
+                ? t("browse.reinstallOne", { title: reinstall.mod.title })
+                : t("browse.reinstallMany")}
             </AlertDialogTitle>
             <AlertDialogDescription>
               {reinstall?.kind === "single"
-                ? "This mod is already in your library. Reinstalling downloads it again and overwrites the installed files."
-                : `${reinstall?.mods.filter(isInstalled).length ?? 0} of the ${
-                    reinstall?.mods.length ?? 0
-                  } selected are already installed. Continuing reinstalls and overwrites them.`}
+                ? t("browse.reinstallOneBody")
+                : t("browse.reinstallManyBody", {
+                    installed: reinstall?.mods.filter(isInstalled).length ?? 0,
+                    total: reinstall?.mods.length ?? 0,
+                  })}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
             <AlertDialogAction onClick={confirmReinstall}>
-              {reinstall?.kind === "single" ? "Reinstall" : "Reinstall all"}
+              {reinstall?.kind === "single"
+                ? t("browse.reinstall")
+                : t("browse.reinstallAll")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/Components/Browse/ModCard.tsx
+++ b/src/Components/Browse/ModCard.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/Components/ui/context-menu";
 import { cn } from "@/lib/utils";
 import { formatDateShort } from "../../lib/mods";
+import { useT } from "../../i18n/context";
 
 interface ModCardProps {
   mod: ModSummary;
@@ -42,6 +43,7 @@ export default function ModCard({
   onToggleSelect,
   onQuickInstall,
 }: ModCardProps) {
+  const t = useT();
   const [broken, setBroken] = useState(false);
   const Icon = isBike ? Bike : Mountain;
 
@@ -102,7 +104,7 @@ export default function ModCard({
               {installed && (
                 <Badge variant="success" className="flex-none">
                   <Check className="size-3" strokeWidth={3} />
-                  Installed
+                  {t("common.installed")}
                 </Badge>
               )}
             </div>
@@ -114,20 +116,21 @@ export default function ModCard({
       </ContextMenuTrigger>
       <ContextMenuContent>
         <ContextMenuItem onSelect={onQuickInstall}>
-          <Download className="size-4" /> {installed ? "Quick reinstall" : "Quick install"}
+          <Download className="size-4" />{" "}
+          {installed ? t("browse.quickReinstall") : t("browse.quickInstall")}
         </ContextMenuItem>
         <ContextMenuItem onSelect={onOpen}>
-          <Info className="size-4" /> Open details
+          <Info className="size-4" /> {t("browse.openDetails")}
         </ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem onSelect={onToggleSelect}>
           {selected ? (
             <>
-              <SquareCheck className="size-4" /> Deselect
+              <SquareCheck className="size-4" /> {t("common.deselect")}
             </>
           ) : (
             <>
-              <Square className="size-4" /> Select
+              <Square className="size-4" /> {t("common.select")}
             </>
           )}
         </ContextMenuItem>

--- a/src/Components/ErrorBoundary.tsx
+++ b/src/Components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
 import { AlertTriangle, RotateCcw } from "lucide-react";
+import { useT } from "../i18n/context";
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -13,6 +14,62 @@ interface ErrorBoundaryProps {
 
 interface ErrorBoundaryState {
   error: Error | null;
+}
+
+/* The fallbacks are function components purely so they can reach `useT()` — the
+   boundary itself has to stay a class, since only classes can catch. */
+
+function CompactFallback({ error, reset }: { error: Error; reset: () => void }) {
+  const t = useT();
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-3 p-6 text-center text-sm text-muted-foreground">
+      <AlertTriangle className="h-6 w-6 text-amber-500" />
+      <div>
+        <p className="font-medium text-foreground">{t("error.previewFailed")}</p>
+        <p className="mt-1 max-w-xs text-xs opacity-80">{error.message}</p>
+      </div>
+      <button
+        type="button"
+        onClick={reset}
+        className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+      >
+        <RotateCcw className="h-3.5 w-3.5" /> {t("common.tryAgain")}
+      </button>
+    </div>
+  );
+}
+
+function FullFallback({ error, reset }: { error: Error; reset: () => void }) {
+  const t = useT();
+  return (
+    <div className="flex h-screen w-screen flex-col items-center justify-center gap-4 bg-background p-8 text-center">
+      <AlertTriangle className="h-10 w-10 text-amber-500" />
+      <div className="max-w-md">
+        <h1 className="text-lg font-semibold text-foreground">
+          {t("error.somethingWentWrong")}
+        </h1>
+        <p className="mt-2 break-words text-sm text-muted-foreground">
+          {error.message || t("error.unexpected")}
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={reset}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+        >
+          <RotateCcw className="h-4 w-4" /> {t("common.tryAgain")}
+        </button>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground transition-colors hover:opacity-90"
+        >
+          {t("error.reloadApp")}
+        </button>
+      </div>
+    </div>
+  );
 }
 
 /**
@@ -49,52 +106,9 @@ export class ErrorBoundary extends Component<
     if (this.props.fallback) return this.props.fallback(error, this.reset);
 
     if (this.props.compact) {
-      return (
-        <div className="flex h-full w-full flex-col items-center justify-center gap-3 p-6 text-center text-sm text-muted-foreground">
-          <AlertTriangle className="h-6 w-6 text-amber-500" />
-          <div>
-            <p className="font-medium text-foreground">Preview failed to render</p>
-            <p className="mt-1 max-w-xs text-xs opacity-80">{error.message}</p>
-          </div>
-          <button
-            type="button"
-            onClick={this.reset}
-            className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent"
-          >
-            <RotateCcw className="h-3.5 w-3.5" /> Try again
-          </button>
-        </div>
-      );
+      return <CompactFallback error={error} reset={this.reset} />;
     }
 
-    return (
-      <div className="flex h-screen w-screen flex-col items-center justify-center gap-4 bg-background p-8 text-center">
-        <AlertTriangle className="h-10 w-10 text-amber-500" />
-        <div className="max-w-md">
-          <h1 className="text-lg font-semibold text-foreground">
-            Something went wrong
-          </h1>
-          <p className="mt-2 break-words text-sm text-muted-foreground">
-            {error.message || "An unexpected error occurred."}
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={this.reset}
-            className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
-          >
-            <RotateCcw className="h-4 w-4" /> Try again
-          </button>
-          <button
-            type="button"
-            onClick={() => window.location.reload()}
-            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground transition-colors hover:opacity-90"
-          >
-            Reload app
-          </button>
-        </div>
-      </div>
-    );
+    return <FullFallback error={error} reset={this.reset} />;
   }
 }

--- a/src/Components/Library/Library.tsx
+++ b/src/Components/Library/Library.tsx
@@ -27,6 +27,7 @@ import {
 } from "../../api/mods";
 import type { LibraryEntry, PkzMeta } from "../../types";
 import { displayName, folderLabel, formatBytes, formatLength } from "../../lib/mods";
+import { useT, type TFunc } from "../../i18n/context";
 import { metaKey, peekMeta, primeMetaCache, requestMeta } from "../../lib/pkzMeta";
 import {
   CATEGORY_LABEL,
@@ -91,6 +92,7 @@ function LibraryCardBody({
   item: LibraryEntry;
   typeIcon: LucideIcon;
 }) {
+  const t = useT();
   const cacheKey = metaKey(item);
   const [meta, setMeta] = useState<PkzMeta | null>(() => peekMeta(cacheKey) ?? null);
   // The thumbnail tile doubles as the visibility probe for the card.
@@ -129,10 +131,13 @@ function LibraryCardBody({
 
   const title = meta?.name?.trim() || displayName(item.name);
   const parts: string[] = [];
-  if (meta?.author) parts.push(`by ${meta.author}`);
+  if (meta?.author) parts.push(t("library.byAuthor", { author: meta.author }));
   if (meta?.length) parts.push(formatLength(meta.length));
   if (item.size) parts.push(formatBytes(item.size));
-  const subtitle = parts.join(" · ") || CATEGORY_LABEL[item.category] || folderLabel(item.folder);
+  const categoryKey = CATEGORY_LABEL[item.category];
+  const subtitle =
+    parts.join(" · ") ||
+    (categoryKey ? t(categoryKey) : folderLabel(item.folder));
 
   return (
     <>
@@ -148,7 +153,7 @@ function LibraryCardBody({
         {meta?.locked && (
           <span
             className="absolute bottom-0.5 right-0.5 rounded bg-black/60 p-0.5 text-white/75"
-            title="Locked — contents can't be read"
+            title={t("library.locked")}
           >
             <Lock className="size-3" />
           </span>
@@ -179,6 +184,7 @@ function buildSections(
   modType: ModType,
   entries: LibraryEntry[],
   search: string,
+  t: TFunc,
 ): Section[] {
   const q = search.trim().toLowerCase();
   const filtered = q
@@ -206,7 +212,7 @@ function buildSections(
       })
       .map((cat) => ({
         key: cat,
-        label: SECTION_LABEL[cat] ?? cat,
+        label: SECTION_LABEL[cat] ? t(SECTION_LABEL[cat]) : cat,
         items: byCat.get(cat)!,
       }));
   }
@@ -239,6 +245,7 @@ export default function Library({
   refreshKey,
   onChanged,
 }: LibraryProps) {
+  const t = useT();
   const [entries, setEntries] = useState<LibraryEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -288,8 +295,8 @@ export default function Library({
   );
 
   const sections = useMemo(
-    () => buildSections(modType, entries, search),
-    [modType, entries, search],
+    () => buildSections(modType, entries, search, t),
+    [modType, entries, search, t],
   );
 
   const visibleItems = useMemo(() => sections.flatMap((s) => s.items), [sections]);
@@ -330,7 +337,7 @@ export default function Library({
       await load();
       onChanged();
     } catch (e) {
-      toast.error("Couldn't move mod", { description: String(e) });
+      toast.error(t("library.moveFailed"), { description: String(e) });
     } finally {
       setBusy(false);
     }
@@ -344,11 +351,11 @@ export default function Library({
       if (detail?.path === item.path) setDetail(null);
       await load();
       onChanged();
-      toast.success(`${displayName(item.name)} uninstalled`, {
-        description: "Moved to the Recycle Bin.",
+      toast.success(t("library.uninstalledOne", { name: displayName(item.name) }), {
+        description: t("library.movedToBin"),
       });
     } catch (e) {
-      toast.error("Couldn't uninstall", { description: String(e) });
+      toast.error(t("library.uninstallFailed"), { description: String(e) });
     } finally {
       setBusy(false);
     }
@@ -373,12 +380,12 @@ export default function Library({
     onChanged();
     exitSelect();
     if (fail)
-      toast.error(`Uninstalled ${ok}, ${fail} failed`, {
-        description: "Some items couldn't be removed.",
+      toast.error(t("library.bulkUninstallPartial", { ok, fail }), {
+        description: t("library.someNotRemoved"),
       });
     else
-      toast.success(`${ok} item${ok === 1 ? "" : "s"} uninstalled`, {
-        description: "Moved to the Recycle Bin.",
+      toast.success(t("library.bulkUninstalled", { count: ok }), {
+        description: t("library.movedToBin"),
       });
     setBusy(false);
   };
@@ -400,14 +407,17 @@ export default function Library({
     await load();
     onChanged();
     exitSelect();
-    if (fail) toast.error(`Moved ${ok}, ${fail} failed`);
-    else toast.success(`Moved ${ok} item${ok === 1 ? "" : "s"} to ${folderLabel(toFolder)}`);
+    if (fail) toast.error(t("library.bulkMovePartial", { ok, fail }));
+    else
+      toast.success(
+        t("library.bulkMoved", { count: ok, folder: folderLabel(toFolder) }),
+      );
     setBusy(false);
   };
 
   const reveal = (item: LibraryEntry) =>
     revealInExplorer(item.path).catch((e) =>
-      toast.error("Couldn't open", { description: String(e) }),
+      toast.error(t("library.openFailed"), { description: String(e) }),
     );
 
   const rowActions = (item: LibraryEntry): RowAction[] => [
@@ -416,7 +426,7 @@ export default function Library({
           {
             key: "move",
             icon: FolderInput,
-            label: "Move to folder…",
+            label: t("library.moveToFolder"),
             onSelect: () => setMoveTarget(item),
           },
         ]
@@ -424,13 +434,13 @@ export default function Library({
     {
       key: "reveal",
       icon: FolderOpen,
-      label: "Show in Explorer",
+      label: t("library.showInExplorer"),
       onSelect: () => reveal(item),
     },
     {
       key: "uninstall",
       icon: Trash2,
-      label: "Uninstall…",
+      label: t("library.uninstallAction"),
       destructive: true,
       separatorBefore: true,
       onSelect: () => setUninstallTarget(item),
@@ -454,24 +464,23 @@ export default function Library({
         <>
       <header className="flex flex-none items-center gap-3.5 px-7 pb-3.5 pt-5">
         <div className="flex items-center gap-1.5">
-          <h1 className="text-[21px] font-bold tracking-[-0.2px]">Library</h1>
-          <HelpHint
-            title="Library"
-            description="Your installed mods. Review what's installed and remove ones you no longer want."
-          />
+          <h1 className="text-[21px] font-bold tracking-[-0.2px]">
+            {t("nav.library")}
+          </h1>
+          <HelpHint title={t("nav.library")} description={t("library.help")} />
         </div>
         <Segmented
           value={modType.id}
           onChange={(id) => {
-            const next = MOD_TYPES.find((t) => t.id === id);
+            const next = MOD_TYPES.find((mt) => mt.id === id);
             if (next) onChangeType(next);
           }}
-          options={MOD_TYPES.map((t) => ({
-            value: t.id,
+          options={MOD_TYPES.map((mt) => ({
+            value: mt.id,
             label: (
               <span className="flex items-center gap-1.5">
-                {t.label}
-                {t.id === modType.id && (
+                {t(mt.label)}
+                {mt.id === modType.id && (
                   <span className="text-muted-foreground">{visibleCount}</span>
                 )}
               </span>
@@ -483,7 +492,7 @@ export default function Library({
           <input
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search installed…"
+            placeholder={t("library.searchPlaceholder")}
             className="w-full bg-transparent text-[12.5px] placeholder:text-faint focus:outline-none"
           />
         </div>
@@ -493,10 +502,12 @@ export default function Library({
           onClick={() => (selectMode ? exitSelect() : setSelectMode(true))}
           disabled={loading}
         >
-          <ListChecks className="size-3.5" /> {selectMode ? "Done" : "Select"}
+          <ListChecks className="size-3.5" />{" "}
+          {selectMode ? t("common.done") : t("common.select")}
         </Button>
         <Button variant="outline" size="sm" onClick={load} disabled={loading || busy}>
-          <RefreshCw className={cn("size-3.5", loading && "animate-spin")} /> Rescan
+          <RefreshCw className={cn("size-3.5", loading && "animate-spin")} />{" "}
+          {t("locker.rescan")}
         </Button>
       </header>
 
@@ -507,13 +518,13 @@ export default function Library({
           </p>
         ) : loading ? (
           <p className="py-16 text-center text-[13px] text-muted-foreground">
-            Scanning your library…
+            {t("library.scanning")}
           </p>
         ) : sections.length === 0 ? (
           <p className="py-16 text-center text-[13px] text-muted-foreground">
             {entries.length === 0
-              ? `No ${modType.label.toLowerCase()} installed yet — head to Browse and add one.`
-              : "No matches."}
+              ? t("library.empty", { type: t(modType.labelInline) })
+              : t("library.noMatches")}
           </p>
         ) : (
           <div className="flex flex-col gap-6">
@@ -563,8 +574,8 @@ export default function Library({
                             <LibraryCardBody item={item} typeIcon={Icon} />
                             {!selectMode && canView3d && (
                               <button
-                                title="Quick 3D view"
-                                aria-label="Quick 3D view"
+                                title={t("library.quick3d")}
+                                aria-label={t("library.quick3d")}
                                 onClick={(e) => {
                                   e.stopPropagation();
                                   setView3d(item);
@@ -632,10 +643,10 @@ export default function Library({
             disabled={visibleCount === 0}
             className="cursor-default text-[12px] font-semibold text-primary transition-colors hover:brightness-110 disabled:opacity-40"
           >
-            {allSelected ? "Select none" : "Select all"}
+            {allSelected ? t("library.selectNone") : t("common.selectAll")}
           </button>
           <span className="text-[12.5px] text-muted-foreground">
-            {selected.size} selected
+            {t("browse.selectedCount", { count: selected.size })}
           </span>
           <div className="ml-auto flex items-center gap-2">
             <Button
@@ -644,7 +655,7 @@ export default function Library({
               disabled={selectedMovable.length === 0 || busy}
               onClick={() => setBulkMoveOpen(true)}
             >
-              <FolderInput className="size-3.5" /> Move
+              <FolderInput className="size-3.5" /> {t("library.move")}
               {selectedMovable.length > 0 ? ` (${selectedMovable.length})` : ""}
             </Button>
             <Button
@@ -653,7 +664,7 @@ export default function Library({
               disabled={selected.size === 0 || busy}
               onClick={() => setBulkUninstallOpen(true)}
             >
-              <Trash2 className="size-3.5" /> Uninstall
+              <Trash2 className="size-3.5" /> {t("library.uninstall")}
             </Button>
           </div>
         </div>
@@ -675,7 +686,7 @@ export default function Library({
 
       <MoveDialog
         open={Boolean(moveTarget)}
-        title="Move to folder"
+        title={t("library.moveDialogTitle")}
         subtitle={moveTarget ? displayName(moveTarget.name) : undefined}
         folders={allFolders}
         modType={modType}
@@ -686,8 +697,8 @@ export default function Library({
 
       <MoveDialog
         open={bulkMoveOpen}
-        title={`Move ${selectedMovable.length} item${selectedMovable.length === 1 ? "" : "s"}`}
-        subtitle="Choose a destination folder"
+        title={t("library.moveCount", { count: selectedMovable.length })}
+        subtitle={t("library.chooseDestination")}
         folders={allFolders}
         modType={modType}
         onClose={() => setBulkMoveOpen(false)}
@@ -701,16 +712,16 @@ export default function Library({
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              Uninstall {selected.size} item{selected.size === 1 ? "" : "s"}?
+              {t("library.confirmBulkUninstall", { count: selected.size })}
             </AlertDialogTitle>
             <AlertDialogDescription>
-              Each item is moved to the Recycle Bin — you can restore them from there.
+              {t("library.confirmBulkUninstallBody")}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
             <AlertDialogAction variant="destructive" onClick={doBulkUninstall}>
-              Uninstall {selected.size}
+              {t("library.uninstallCount", { count: selected.size })}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -723,19 +734,21 @@ export default function Library({
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              Uninstall {uninstallTarget && displayName(uninstallTarget.name)}?
+              {t("library.confirmUninstall", {
+                name: uninstallTarget ? displayName(uninstallTarget.name) : "",
+              })}
             </AlertDialogTitle>
             <AlertDialogDescription>
-              The item is moved to the Recycle Bin — you can restore it from there.
+              {t("library.confirmUninstallBody")}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
             <AlertDialogAction
               variant="destructive"
               onClick={() => uninstallTarget && doUninstall(uninstallTarget)}
             >
-              Uninstall
+              {t("library.uninstall")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -768,6 +781,7 @@ function MoveDialog({
   onClose: () => void;
   onPick: (folder: string) => void;
 }) {
+  const t = useT();
   const [creating, setCreating] = useState(false);
   const [name, setName] = useState("");
 
@@ -811,7 +825,9 @@ function MoveDialog({
                 if (e.key === "Escape") setCreating(false);
               }}
               placeholder={
-                modType.id === "bikes" ? "KTM450/paints" : "New folder name"
+                modType.id === "bikes"
+                  ? "KTM450/paints"
+                  : t("library.newFolderName")
               }
               className="rounded-md bg-transparent px-3 py-2 text-[12.5px] placeholder:text-faint focus:outline-none"
             />
@@ -820,13 +836,13 @@ function MoveDialog({
               onClick={() => setCreating(true)}
               className="flex cursor-default items-center gap-1.5 rounded-md px-3 py-2 text-[12.5px] font-semibold text-primary hover:bg-foreground/[0.06]"
             >
-              <Plus className="size-3.5" /> New folder…
+              <Plus className="size-3.5" /> {t("library.newFolder")}
             </button>
           )}
         </div>
         <DialogFooter>
           <Button variant="outline" size="sm" onClick={onClose}>
-            Cancel
+            {t("common.cancel")}
           </Button>
           {creating && (
             <Button
@@ -834,7 +850,7 @@ function MoveDialog({
               disabled={!name.trim()}
               onClick={() => name.trim() && onPick(name.trim())}
             >
-              Create &amp; move
+              {t("library.createAndMove")}
             </Button>
           )}
         </DialogFooter>

--- a/src/Components/Library/LibraryDetail.tsx
+++ b/src/Components/Library/LibraryDetail.tsx
@@ -21,6 +21,8 @@ import {
   formatLength,
 } from "../../lib/mods";
 import { CATEGORY_ICON, CATEGORY_LABEL, categoryIcon } from "./categories";
+import { Trans } from "../../i18n";
+import { useT } from "../../i18n/context";
 import { Button } from "@/Components/ui/button";
 
 interface LibraryDetailProps {
@@ -48,6 +50,7 @@ export default function LibraryDetail({
   onMove,
   onOpenEntry,
 }: LibraryDetailProps) {
+  const t = useT();
   const [meta, setMeta] = useState<PkzMeta | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
   const [lightbox, setLightbox] = useState(false);
@@ -91,15 +94,25 @@ export default function LibraryDetail({
   );
 
   const rows: [string, string][] = [];
-  if (meta?.author) rows.push(["Author", meta.author]);
-  if (meta?.length) rows.push(["Length", formatLength(meta.length)]);
-  if (meta?.altitude != null) rows.push(["Altitude", `${meta.altitude} m`]);
-  if (meta?.location) rows.push(["Location", meta.location]);
-  rows.push(["Type", CATEGORY_LABEL[entry.category] ?? "Mod"]);
-  if (entry.parent) rows.push(["Belongs to", entry.parent]);
-  rows.push(["Format", entry.kind === "folder" ? "Extracted folder" : entry.kind === "loose" ? "Paint file" : "Packaged .pkz"]);
-  if (entry.size) rows.push(["Size", formatBytes(entry.size)]);
-  rows.push(["Folder", folderLabel(entry.folder)]);
+  if (meta?.author) rows.push([t("libraryDetail.author"), meta.author]);
+  if (meta?.length) rows.push([t("libraryDetail.length"), formatLength(meta.length)]);
+  if (meta?.altitude != null) rows.push([t("libraryDetail.altitude"), `${meta.altitude} m`]);
+  if (meta?.location) rows.push([t("libraryDetail.location"), meta.location]);
+  rows.push([
+    t("libraryDetail.type"),
+    CATEGORY_LABEL[entry.category] ? t(CATEGORY_LABEL[entry.category]) : t("libraryDetail.mod"),
+  ]);
+  if (entry.parent) rows.push([t("libraryDetail.belongsTo"), entry.parent]);
+  rows.push([
+    t("libraryDetail.format"),
+    entry.kind === "folder"
+      ? t("libraryDetail.extractedFolder")
+      : entry.kind === "loose"
+        ? t("libraryDetail.paintFile")
+        : t("libraryDetail.packagedPkz"),
+  ]);
+  if (entry.size) rows.push([t("libraryDetail.size"), formatBytes(entry.size)]);
+  rows.push([t("libraryDetail.folder"), folderLabel(entry.folder)]);
 
   const canMove = entry.kind === "pkz";
 
@@ -191,15 +204,29 @@ export default function LibraryDetail({
                 <Lock className="mt-0.5 size-3.5 flex-none text-faint" />
                 {meta?.name?.trim() ? (
                   <span>
-                    This track is <b className="text-foreground/80">locked</b> by its
-                    creator. Its name, details and preview are shown here, but the files
-                    stay sealed — it can’t be unpacked or previewed in 3D.
+                    <Trans
+                      k="libraryDetail.lockedWithMeta"
+                      values={{
+                        locked: (
+                          <b className="text-foreground/80">
+                            {t("libraryDetail.lockedWord")}
+                          </b>
+                        ),
+                      }}
+                    />
                   </span>
                 ) : (
                   <span>
-                    This track is <b className="text-foreground/80">locked</b>, so
-                    its name, length and preview can’t be read from the file —
-                    only its filename and size.
+                    <Trans
+                      k="libraryDetail.lockedNoMeta"
+                      values={{
+                        locked: (
+                          <b className="text-foreground/80">
+                            {t("libraryDetail.lockedWord")}
+                          </b>
+                        ),
+                      }}
+                    />
                   </span>
                 )}
               </div>

--- a/src/Components/Library/categories.ts
+++ b/src/Components/Library/categories.ts
@@ -14,40 +14,43 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import type { LibraryCategory } from "../../types";
+import type { TKey } from "../../i18n";
 
-/** Human label per library category (section headers + detail "Type"). */
-export const CATEGORY_LABEL: Record<string, string> = {
-  track: "Track",
-  bike: "Bike",
-  bikePaint: "Livery",
-  bikeModelSwap: "Model swap",
-  sound: "Sound",
-  helmet: "Helmet",
-  helmetPaint: "Helmet paint",
-  goggles: "Goggles",
-  boots: "Boots",
-  bootPaint: "Boot paint",
-  protection: "Protection",
-  protectionPaint: "Protection paint",
-  gloves: "Gloves",
-  outfit: "Outfit / kit",
-  misc: "Other",
+/** Translation key per library category (section headers + detail "Type").
+ *  Singular — resolved with `t()` at render. */
+export const CATEGORY_LABEL: Record<string, TKey> = {
+  track: "category.track",
+  bike: "category.bike",
+  bikePaint: "category.bikePaint",
+  bikeModelSwap: "category.bikeModelSwap",
+  sound: "category.sound",
+  helmet: "category.helmet",
+  helmetPaint: "category.helmetPaint",
+  goggles: "category.goggles",
+  boots: "category.boots",
+  bootPaint: "category.bootPaint",
+  protection: "category.protection",
+  protectionPaint: "category.protectionPaint",
+  gloves: "category.gloves",
+  outfit: "category.outfit",
+  misc: "category.misc",
 };
 
-/** Section header label per category, used when grouping the Rider tab. */
-export const SECTION_LABEL: Record<string, string> = {
+/** Section header key per category, used when grouping the Rider tab. Plural in
+ *  English; other languages pluralize their own way inside the string. */
+export const SECTION_LABEL: Record<string, TKey> = {
   ...CATEGORY_LABEL,
-  bikePaint: "Liveries",
-  bikeModelSwap: "Model swaps",
-  sound: "Sounds",
-  helmet: "Helmets",
-  helmetPaint: "Helmet paints",
-  boots: "Boots",
-  bootPaint: "Boot paints",
-  protection: "Protection",
-  protectionPaint: "Protection paints",
-  gloves: "Gloves",
-  outfit: "Outfit / kit",
+  bikePaint: "section.bikePaint",
+  bikeModelSwap: "section.bikeModelSwap",
+  sound: "section.sound",
+  helmet: "section.helmet",
+  helmetPaint: "section.helmetPaint",
+  boots: "section.boots",
+  bootPaint: "section.bootPaint",
+  protection: "section.protection",
+  protectionPaint: "section.protectionPaint",
+  gloves: "section.gloves",
+  outfit: "section.outfit",
 };
 
 export const CATEGORY_ICON: Record<string, LucideIcon> = {

--- a/src/Components/Locker/Locker.tsx
+++ b/src/Components/Locker/Locker.tsx
@@ -37,6 +37,8 @@ import type {
   SwapApplyOutcome,
 } from "../../types";
 import RegisterSwapsDialog from "./RegisterSwapsDialog";
+import { Trans } from "../../i18n";
+import { useT, type TFunc } from "../../i18n/context";
 
 /**
  * Locker — the app-side bike **model & sound swap** manager, twinned with FrostMod's
@@ -52,19 +54,19 @@ import RegisterSwapsDialog from "./RegisterSwapsDialog";
  */
 
 /** Trailing feedback for a swap toast — mirrors the presets "refreshed live in-game" note. */
-function swapNote(outcome: SwapApplyOutcome): string {
+function swapNote(outcome: SwapApplyOutcome, t: TFunc): string {
   switch (outcome.live_refresh) {
     case "refreshed":
-      return "Refreshed live in-game.";
+      return t("locker.refreshedLive");
     case "failed":
-      return "Instant refresh failed — reselect your profile in-game to load it.";
+      return t("locker.refreshFailed");
     default:
       break;
   }
   if (outcome.game_running) {
-    return "Reselect your profile in MX Bikes to load the swap.";
+    return t("locker.reselectProfile");
   }
-  return "Loads next time the game opens.";
+  return t("locker.loadsNextTime");
 }
 
 /** One bike's row: its models (null for sound-only bikes) and its sounds (always present). */
@@ -100,6 +102,7 @@ function mergeRows(models: BikeModels[], sounds: BikeSounds[]): Row[] {
 }
 
 export default function Locker() {
+  const t = useT();
   const [rows, setRows] = useState<Row[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   // Bike name currently being mutated (disables its rows + spins the target).
@@ -167,35 +170,47 @@ export default function Locker() {
   );
 
   const onRepair = (bike: string) =>
-    run(bike, `Restored ${bike}'s setup files.`, () => repairOrphanedSetup(bike), (n) =>
-      `${n} file${n === 1 ? "" : "s"} put back — the bike should load again.`,
+    run(
+      bike,
+      t("locker.restored", { bike }),
+      () => repairOrphanedSetup(bike),
+      (n) => t("locker.restoredNote", { count: n }),
     );
 
   const onModelSwap = (bike: string, target: string) =>
-    run(bike, `Switched ${bike} model to “${target}”.`, () => applyModelSwap(bike, target), swapNote);
+    run(
+      bike,
+      t("locker.switchedModel", { bike, target }),
+      () => applyModelSwap(bike, target),
+      (o) => swapNote(o, t),
+    );
   const onSoundSwap = (bike: string, target: string) =>
-    run(bike, `Switched ${bike} sound to “${target}”.`, () => applySoundSwap(bike, target), swapNote);
+    run(
+      bike,
+      t("locker.switchedSound", { bike, target }),
+      () => applySoundSwap(bike, target),
+      (o) => swapNote(o, t),
+    );
   const onBind = (bike: string, model: string, sound: string) =>
-    run(bike, `Tied “${sound}” to model “${model}”.`, () => bindSound(bike, model, sound));
+    run(bike, t("locker.tied", { sound, model }), () => bindSound(bike, model, sound));
   const onUnbind = (bike: string, model: string, sound: string) =>
-    run(bike, `Untied “${sound}” from model “${model}”.`, () => unbindSound(bike, model));
+    run(bike, t("locker.untied", { sound, model }), () => unbindSound(bike, model));
 
   return (
     <div className="flex h-full flex-col">
       <header className="flex flex-none items-center gap-3.5 px-7 pb-3.5 pt-5">
         <div className="flex items-center gap-1.5">
-          <h1 className="text-[21px] font-bold tracking-[-0.2px]">Locker</h1>
-          <HelpHint
-            title="Locker"
-            description="Swap each bike's model and engine sound between the sets you've installed."
-          />
+          <h1 className="text-[21px] font-bold tracking-[-0.2px]">
+            {t("nav.locker")}
+          </h1>
+          <HelpHint title={t("nav.locker")} description={t("locker.help")} />
         </div>
         <button
           onClick={() => void load()}
           className="ml-auto flex items-center gap-1.5 rounded-lg border border-input bg-card px-3 py-2 text-[12.5px] text-muted-foreground transition-colors hover:text-foreground"
         >
           <RefreshCw className={cn("size-3.5", rows === null && "animate-spin")} />
-          Rescan
+          {t("locker.rescan")}
         </button>
       </header>
 
@@ -206,10 +221,15 @@ export default function Locker() {
         >
           <Wrench className="size-4 flex-none text-destructive/80" />
           <span className="min-w-0 flex-1 text-[12.5px] text-foreground/90">
-            <span className="font-semibold">{o.bike}</span> is missing its setup files — an
-            earlier version moved them into a swap folder, which stops the bike loading
-            in-game at all.{" "}
-            <span className="font-mono text-faint">{o.files.join(", ")}</span>
+            <Trans
+              k="locker.orphanBanner"
+              values={{
+                bike: <span className="font-semibold">{o.bike}</span>,
+                files: (
+                  <span className="font-mono text-faint">{o.files.join(", ")}</span>
+                ),
+              }}
+            />
           </span>
           <button
             onClick={() => void onRepair(o.bike)}
@@ -221,7 +241,7 @@ export default function Locker() {
             ) : (
               <Wrench className="size-3.5" />
             )}
-            Restore
+            {t("locker.restore")}
           </button>
         </div>
       ))}
@@ -233,14 +253,20 @@ export default function Locker() {
         >
           <AlertTriangle className="size-4 flex-none text-amber-500/80" />
           <span className="min-w-0 flex-1 text-[12.5px] text-foreground/90">
-            {looseCount} model / sound set{looseCount === 1 ? "" : "s"} found loose in your
-            bikes — register {looseCount === 1 ? "it" : "them"} into{" "}
-            <span className="font-mono text-faint">FrostMod Models</span> /{" "}
-            <span className="font-mono text-faint">Sounds</span>.
+            <Trans
+              k="locker.looseBanner"
+              count={looseCount}
+              values={{
+                modelsFolder: (
+                  <span className="font-mono text-faint">FrostMod Models</span>
+                ),
+                soundsFolder: <span className="font-mono text-faint">Sounds</span>,
+              }}
+            />
           </span>
           <span className="flex flex-none items-center gap-1.5 text-[12px] font-semibold text-amber-500/90">
             <FolderInput className="size-3.5" />
-            Register
+            {t("locker.register")}
           </span>
         </button>
       )}
@@ -249,24 +275,46 @@ export default function Locker() {
         {error ? (
           <p className="select-text py-16 text-center text-[13px] text-destructive">{error}</p>
         ) : rows === null ? (
-          <p className="py-16 text-center text-[13px] text-muted-foreground">Scanning bikes…</p>
+          <p className="py-16 text-center text-[13px] text-muted-foreground">
+            {t("locker.scanning")}
+          </p>
         ) : rows.length === 0 ? (
           <div className="mx-auto max-w-md py-14 text-[13px] text-muted-foreground">
-            <p className="mb-3 text-center text-foreground/90">No swappable bikes yet.</p>
-            <p className="mb-3">Two things have to be true before a swap can happen:</p>
+            <p className="mb-3 text-center text-foreground/90">
+              {t("locker.emptyTitle")}
+            </p>
+            <p className="mb-3">{t("locker.emptyIntro")}</p>
             <ol className="mb-4 list-decimal space-y-2 pl-5">
               <li>
-                The bike is <span className="text-foreground/90">unpacked</span> into
-                <span className="mx-1 font-mono text-faint">mods/bikes/&lt;Bike&gt;/</span>—
-                a packed <span className="font-mono text-faint">.pkz</span> can&apos;t be
-                swapped.
-                Unpack one from the Library.
+                <Trans
+                  k="locker.emptyRuleUnpacked"
+                  values={{
+                    unpacked: (
+                      <span className="text-foreground/90">
+                        {t("locker.unpacked")}
+                      </span>
+                    ),
+                    path: (
+                      <span className="mx-1 font-mono text-faint">
+                        mods/bikes/&lt;Bike&gt;/
+                      </span>
+                    ),
+                    pkz: <span className="font-mono text-faint">.pkz</span>,
+                  }}
+                />
               </li>
               <li>
-                Each alternate model sits in its own folder inside that bike, holding a mesh
-                (<span className="font-mono text-faint">.edf</span>). Drop it anywhere in the
-                bike folder and hit Scan below — we&apos;ll offer to file it under
-                <span className="mx-1 font-mono text-faint">FrostMod Models/</span>.
+                <Trans
+                  k="locker.emptyRuleMesh"
+                  values={{
+                    edf: <span className="font-mono text-faint">.edf</span>,
+                    folder: (
+                      <span className="mx-1 font-mono text-faint">
+                        FrostMod Models/
+                      </span>
+                    ),
+                  }}
+                />
               </li>
             </ol>
             <button
@@ -274,7 +322,7 @@ export default function Locker() {
               className="mx-auto flex items-center gap-1.5 rounded-lg border border-input bg-card px-3 py-2 text-[12.5px] transition-colors hover:text-foreground"
             >
               <RefreshCw className="size-3.5" />
-              Scan for swaps
+              {t("locker.scanForSwaps")}
             </button>
           </div>
         ) : (
@@ -322,6 +370,7 @@ function BikeCard({
   onBind: (bike: string, model: string, sound: string) => void;
   onUnbind: (bike: string, model: string, sound: string) => void;
 }) {
+  const t = useT();
   const { bike, models, sounds } = row;
   const modelCount = models?.variants.length ?? 0;
   const soundCount = sounds.variants.length;
@@ -335,7 +384,12 @@ function BikeCard({
         <div className="min-w-0">
           <div className="truncate text-[14px] font-semibold">{bike}</div>
           <div className="truncate text-[11px] text-muted-foreground">
-            {models ? `model “${models.active}”` : "no model swaps"} · sound “{sounds.active}”
+            {t("locker.summary", {
+              model: models
+                ? t("locker.modelNamed", { name: models.active })
+                : t("locker.noModelSwaps"),
+              sound: sounds.active,
+            })}
           </div>
         </div>
       </div>
@@ -343,8 +397,8 @@ function BikeCard({
       {models && (
         <SwapSection
           icon={<Bike className="size-3.5" strokeWidth={1.75} />}
-          label="Models"
-          hint={modelCount <= 1 ? "Only one model — install more to swap" : undefined}
+          label={t("locker.models")}
+          hint={modelCount <= 1 ? t("locker.onlyOneModel") : undefined}
         >
           {models.variants.map((v) => (
             <VariantButton
@@ -361,8 +415,8 @@ function BikeCard({
 
       <SwapSection
         icon={<Volume2 className="size-3.5" strokeWidth={1.75} />}
-        label="Sounds"
-        hint={soundCount <= 1 ? "Only Stock — install a sound mod to swap" : undefined}
+        label={t("locker.sounds")}
+        hint={soundCount <= 1 ? t("locker.onlyStock") : undefined}
       >
         {sounds.variants.map((v) => {
           // Models that pull this sound in when activated (a sound may back several).
@@ -439,7 +493,8 @@ function VariantButton({
   boundModels?: string[];
   onClick: () => void;
 }) {
-  const emptyLabel = kind === "model" ? "No model" : "Stock";
+  const t = useT();
+  const emptyLabel = kind === "model" ? t("locker.noModel") : t("locker.stock");
   // An empty set is applicable (revert to no-model / Stock); a set with files but
   // missing its required file is incomplete and stays disabled.
   const applicable = v.valid || v.empty;
@@ -450,16 +505,18 @@ function VariantButton({
       onClick={onClick}
       title={
         v.active
-          ? `Active ${kind}`
+          ? kind === "model"
+            ? t("locker.activeModel")
+            : t("locker.activeSound")
           : v.empty
             ? kind === "model"
-              ? "Switch to no model — removes the current model files"
-              : "Switch to Stock — removes the sound mod (built-in sound plays)"
+              ? t("locker.switchToNoModel")
+              : t("locker.switchToStock")
             : !v.valid
               ? kind === "model"
-                ? "This set has no model.edf"
-                : "This set is missing engine.scl or sfx.cfg"
-              : `Switch to ${v.name}`
+                ? t("locker.missingModelEdf")
+                : t("locker.missingSoundFiles")
+              : t("locker.switchTo", { name: v.name })
       }
       className={cn(
         "flex items-center gap-2 rounded-lg border px-3 py-2.5 text-left transition-colors",
@@ -497,14 +554,14 @@ function VariantButton({
         </span>
         <span className="flex items-center gap-1 text-[10.5px] text-faint">
           {v.active
-            ? "Active"
+            ? t("common.active")
             : v.empty
               ? emptyLabel
-              : `${v.fileCount} file${v.fileCount === 1 ? "" : "s"}`}
+              : t("swaps.fileCount", { count: v.fileCount })}
           {boundModels.length > 0 && (
             <span
               className="flex items-center gap-0.5 text-primary/70"
-              title={`Tied to model ${boundModels.join(", ")}`}
+              title={t("locker.tiedToModel", { models: boundModels.join(", ") })}
             >
               <Link2 className="size-3" />
               {boundModels.join(", ")}
@@ -533,6 +590,7 @@ function BindControl({
   onBind: (bike: string, model: string, sound: string) => void;
   onUnbind: (bike: string, model: string, sound: string) => void;
 }) {
+  const t = useT();
   return (
     <button
       disabled={disabled}
@@ -546,12 +604,14 @@ function BindControl({
       )}
       title={
         bound
-          ? `“${sound}” is tied to model “${model}” — it travels with that model. Click to untie.`
-          : `Tie the active sound “${sound}” to model “${model}” so switching to it pulls the sound in.`
+          ? t("locker.boundHint", { sound, model })
+          : t("locker.unboundHint", { sound, model })
       }
     >
       {bound ? <Link2Off className="size-3.5" /> : <Link2 className="size-3.5" />}
-      {bound ? `Untie “${sound}” from “${model}”` : `Tie “${sound}” to “${model}”`}
+      {bound
+        ? t("locker.untieAction", { sound, model })
+        : t("locker.tieAction", { sound, model })}
     </button>
   );
 }

--- a/src/Components/Locker/RegisterSwapsDialog.tsx
+++ b/src/Components/Locker/RegisterSwapsDialog.tsx
@@ -12,13 +12,17 @@ import {
 import { Button } from "@/Components/ui/button";
 import { registerLooseSwaps } from "../../api/mods";
 import type { LooseSwapBike, LooseSwapCandidate } from "../../types";
+import { Trans } from "../../i18n";
+import { useT, type TFunc } from "../../i18n/context";
 
-/** "2 model swaps and 1 sound mod" — omits a kind with zero, "sets" if somehow both are 0. */
-function summarize(models: number, sounds: number): string {
+/** "2 model swaps and 1 sound mod" — omits a kind with zero, "sets" if somehow both are 0.
+ *  The joiner is a key too; " and " is English, not punctuation. */
+function summarize(models: number, sounds: number, t: TFunc): string {
   const parts: string[] = [];
-  if (models) parts.push(`${models} model swap${models === 1 ? "" : "s"}`);
-  if (sounds) parts.push(`${sounds} sound mod${sounds === 1 ? "" : "s"}`);
-  return parts.join(" and ") || "0 sets";
+  if (models) parts.push(t("swaps.modelSets", { count: models }));
+  if (sounds) parts.push(t("swaps.soundSets", { count: sounds }));
+  if (parts.length === 2) return t("swaps.and", { a: parts[0], b: parts[1] });
+  return parts[0] ?? t("swaps.noSets");
 }
 
 /**
@@ -40,6 +44,7 @@ export default function RegisterSwapsDialog({
   /** Called after a successful register so callers can refresh their view. */
   onDone?: () => void;
 }) {
+  const t = useT();
   // Which action is running ("move" | "folders"), so we can spin the right button.
   const [busy, setBusy] = useState<"move" | "folders" | null>(null);
 
@@ -54,17 +59,16 @@ export default function RegisterSwapsDialog({
       if (move) {
         toast.success(
           r.registered > 0
-            ? `Registered ${r.registered} set${r.registered === 1 ? "" : "s"}.`
-            : "Nothing was moved.",
+            ? t("swaps.registered", { count: r.registered })
+            : t("swaps.nothingMoved"),
           r.skipped > 0
-            ? { description: `${r.skipped} skipped (name already in use).` }
+            ? { description: t("swaps.skipped", { count: r.skipped }) }
             : undefined,
         );
       } else {
-        toast.success(
-          `Created the library folder${r.foldersCreated === 1 ? "" : "s"} for ${r.bikes} bike${r.bikes === 1 ? "" : "s"}.`,
-          { description: "Your model / sound folders were left where they are." },
-        );
+        toast.success(t("swaps.foldersCreated", { count: r.bikes }), {
+          description: t("swaps.foldersCreatedDesc"),
+        });
       }
       onOpenChange(false);
       onDone?.();
@@ -79,13 +83,21 @@ export default function RegisterSwapsDialog({
     <Dialog open={open} onOpenChange={(o) => !busy && onOpenChange(o)}>
       <DialogContent className="max-w-lg" showClose={!busy}>
         <DialogHeader>
-          <DialogTitle>Found {summarize(models, sounds)}</DialogTitle>
+          <DialogTitle>
+            {t("swaps.foundTitle", { summary: summarize(models, sounds, t) })}
+          </DialogTitle>
           <DialogDescription>
-            These folders are sitting loose inside your bikes. Register them to move each
-            into the right library —{" "}
-            <span className="font-mono text-faint">FrostMod Models</span> for models,{" "}
-            <span className="font-mono text-faint">FrostMod Sounds</span> for sounds — so
-            they show up in the Locker.
+            <Trans
+              k="swaps.description"
+              values={{
+                modelsFolder: (
+                  <span className="font-mono text-faint">FrostMod Models</span>
+                ),
+                soundsFolder: (
+                  <span className="font-mono text-faint">FrostMod Sounds</span>
+                ),
+              }}
+            />
           </DialogDescription>
         </DialogHeader>
 
@@ -115,7 +127,7 @@ export default function RegisterSwapsDialog({
             disabled={!!busy}
             onClick={() => onOpenChange(false)}
           >
-            Later
+            {t("common.later")}
           </Button>
           <div className="flex flex-col gap-2 sm:flex-row">
             <Button
@@ -129,11 +141,11 @@ export default function RegisterSwapsDialog({
               ) : (
                 <FolderPlus />
               )}
-              Just create folders
+              {t("swaps.justCreateFolders")}
             </Button>
             <Button size="sm" disabled={!!busy} onClick={() => void run(true)}>
               {busy === "move" ? <Loader2 className="animate-spin" /> : <FolderInput />}
-              Register &amp; move
+              {t("swaps.registerAndMove")}
             </Button>
           </div>
         </DialogFooter>
@@ -144,16 +156,17 @@ export default function RegisterSwapsDialog({
 
 /** One candidate: a model (bike icon) or sound (speaker icon) set, name + file count. */
 function Chip({ candidate: c }: { candidate: LooseSwapCandidate }) {
+  const t = useT();
   const Icon = c.kind === "sound" ? Volume2 : Bike;
   return (
     <span
-      title={`${c.source} · ${c.kind}`}
+      title={`${c.source} · ${c.kind === "sound" ? t("category.sound") : t("swaps.model")}`}
       className="flex items-center gap-1.5 rounded-md bg-foreground/[0.06] px-2 py-0.5 text-[11px] text-foreground/80"
     >
       <Icon className="size-3 text-foreground/40" strokeWidth={1.5} />
       {c.name}
       <span className="text-faint">
-        {c.fileCount} file{c.fileCount === 1 ? "" : "s"}
+        {t("swaps.fileCount", { count: c.fileCount })}
       </span>
     </span>
   );

--- a/src/Components/ModDetail/InstallDialog.tsx
+++ b/src/Components/ModDetail/InstallDialog.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useState } from "react";
 import { ChevronDown, ChevronRight, Plus, Check, X, Search } from "lucide-react";
 import { Dialog, DialogContent } from "@/Components/ui/dialog";
 import { Button } from "@/Components/ui/button";
+import { useT } from "../../i18n/context";
+import { labelOf } from "../../i18n/core";
 import { Badge } from "@/Components/ui/badge";
 import { cn } from "@/lib/utils";
 import {
@@ -53,6 +55,7 @@ export default function InstallDialog({
   sound = false,
   onConfirm,
 }: InstallDialogProps) {
+  const t = useT();
   const mirrors = useMirrors(detail);
   const [folder, setFolder] = useState(initialFolder);
   const [folderOpen, setFolderOpen] = useState(false);
@@ -87,8 +90,10 @@ export default function InstallDialog({
 
   const folderLabel = useMemo(() => {
     if (creating && newFolder.trim()) return newFolder.trim();
-    return destOptions.find((o) => o.value === folder)?.label ?? folder ?? "(root)";
-  }, [creating, newFolder, destOptions, folder]);
+    const opt = destOptions.find((o) => o.value === folder);
+    if (opt) return labelOf(opt, t);
+    return folder || t("library.rootFolder");
+  }, [creating, newFolder, destOptions, folder, t]);
 
   // Probable destinations (ranked) resolved to options, best first.
   const suggestedOptions = useMemo(() => {
@@ -102,8 +107,8 @@ export default function InstallDialog({
   const filteredOptions = useMemo(() => {
     const q = folderSearch.trim().toLowerCase();
     if (!q) return destOptions;
-    return destOptions.filter((o) => o.label.toLowerCase().includes(q));
-  }, [folderSearch, destOptions]);
+    return destOptions.filter((o) => labelOf(o, t).toLowerCase().includes(q));
+  }, [folderSearch, destOptions, t]);
 
   const suggestedValues = useMemo(
     () => new Set(suggestedOptions.map((o) => o.value)),
@@ -113,7 +118,11 @@ export default function InstallDialog({
   const selectedMirror = mirrors[mirrorIdx];
   const thumb = detail.images[0];
   const subtitleType =
-    modType.id === "bikes" ? "Bike" : modType.id === "rider" ? "Rider" : "Track";
+    modType.id === "bikes"
+      ? t("category.bike")
+      : modType.id === "rider"
+        ? t("modType.rider")
+        : t("category.track");
 
   const commitNewFolder = () => {
     const v = newFolder.trim();
@@ -144,7 +153,7 @@ export default function InstallDialog({
             : "text-foreground/90 hover:bg-foreground/[0.06]",
         )}
       >
-        <span className="min-w-0 flex-1 truncate text-left">{o.label}</span>
+        <span className="min-w-0 flex-1 truncate text-left">{labelOf(o, t)}</span>
         <span className="flex flex-none items-center gap-2 text-[11px] text-faint">
           <span>{count} mods</span>
           {on && <Check className="size-3.5 text-primary" />}
@@ -195,7 +204,7 @@ export default function InstallDialog({
           {/* destination */}
           <section className="flex flex-col gap-2">
             <span className="text-[11px] font-bold uppercase tracking-[1.2px] text-faint">
-              Install to
+              {t("installDialog.installTo")}
             </span>
             <button
               onClick={() => setFolderOpen((v) => !v)}
@@ -207,7 +216,7 @@ export default function InstallDialog({
                 <b className="text-foreground">{folderLabel}</b>
               </span>
               <span className="flex flex-none items-center gap-1 text-[11px] text-muted-foreground">
-                Change <ChevronDown className="size-3" />
+                {t("installDialog.change")} <ChevronDown className="size-3" />
               </span>
             </button>
 
@@ -221,7 +230,9 @@ export default function InstallDialog({
                     value={folderSearch}
                     onChange={(e) => setFolderSearch(e.target.value)}
                     placeholder={
-                      modType.id === "bikes" ? "Search bikes…" : "Search folders…"
+                      modType.id === "bikes"
+                        ? t("installDialog.searchBikes")
+                        : t("installDialog.searchFolders")
                     }
                     className="w-full bg-transparent text-[12.5px] placeholder:text-faint focus:outline-none"
                   />
@@ -232,12 +243,12 @@ export default function InstallDialog({
                   {!folderSearch && suggestedOptions.length > 0 && (
                     <>
                       <div className="px-2 py-1 text-[10px] font-bold uppercase tracking-wider text-faint">
-                        Probably
+                        {t("installDialog.probably")}
                       </div>
                       {suggestedOptions.map(renderRow)}
                       <div className="mx-1.5 my-1 h-px bg-border" />
                       <div className="px-2 py-1 text-[10px] font-bold uppercase tracking-wider text-faint">
-                        All folders
+                        {t("installDialog.allFolders")}
                       </div>
                     </>
                   )}
@@ -247,7 +258,7 @@ export default function InstallDialog({
                   ).map(renderRow)}
                   {folderSearch && filteredOptions.length === 0 && (
                     <div className="px-3 py-4 text-center text-[12px] text-muted-foreground">
-                      No folder matches — create it below.
+                      {t("installDialog.noFolderMatch")}
                     </div>
                   )}
                 </div>
@@ -265,7 +276,9 @@ export default function InstallDialog({
                       }}
                       onBlur={commitNewFolder}
                       placeholder={
-                        modType.id === "bikes" ? "KTM450/paints" : "New folder name"
+                        modType.id === "bikes"
+                          ? "KTM450/paints"
+                          : t("library.newFolderName")
                       }
                       className="w-full rounded-md bg-transparent px-3 py-2 text-[12.5px] text-foreground placeholder:text-faint focus:outline-none"
                     />
@@ -277,14 +290,14 @@ export default function InstallDialog({
                       }}
                       className="flex w-full cursor-default items-center gap-1.5 rounded-md px-3 py-2 text-[12.5px] font-semibold text-primary hover:bg-foreground/[0.06]"
                     >
-                      <Plus className="size-3.5" /> New folder…
+                      <Plus className="size-3.5" /> {t("library.newFolder")}
                     </button>
                   )}
                 </div>
               </div>
             )}
             <span className="text-[11px] text-faint">
-              Remembered for {modType.label}
+              {t("installDialog.rememberedFor", { type: t(modType.label) })}
             </span>
           </section>
 
@@ -292,7 +305,9 @@ export default function InstallDialog({
           {mirrors.length > 0 && (
             <section className="flex flex-col gap-2">
               <span className="text-[11px] font-bold uppercase tracking-[1.2px] text-faint">
-                {sound ? "Download (per bike)" : "Download from"}
+                {sound
+                  ? t("installDialog.downloadPerBike")
+                  : t("installDialog.downloadFrom")}
               </span>
               <div className="flex flex-col gap-1.5">
                 {shownMirrors.map((m) => {
@@ -320,14 +335,14 @@ export default function InstallDialog({
                         <span className="text-[12.5px] font-semibold">{m.host}</span>
                         <span className="text-[11px] text-muted-foreground">
                           {blocked
-                            ? "Opens in browser — MXB App finishes the install"
+                            ? t("installDialog.opensInBrowser")
                             : sound
                               ? on
-                                ? "Matched to your bike"
-                                : "Different bike / pack"
+                                ? t("installDialog.matchedBike")
+                                : t("installDialog.differentBike")
                               : m.isDefault
-                                ? "Direct · fastest"
-                                : "Direct"}
+                                ? t("installDialog.directFastest")
+                                : t("installDialog.direct")}
                         </span>
                       </span>
                       {blocked ? (
@@ -355,8 +370,8 @@ export default function InstallDialog({
               {mirrors.length > 1 && (
                 <span className="text-[11px] text-faint">
                   {sound
-                    ? "Each download is a different bike — auto-selected to match your pick. Choose the “all bikes” pack for every bike at once."
-                    : "All mirrors contain the same file. If one fails, try the next."}
+                    ? t("installDialog.perBikeHint")
+                    : t("installDialog.mirrorsHint")}
                 </span>
               )}
             </section>
@@ -370,10 +385,12 @@ export default function InstallDialog({
             onClick={confirm}
             disabled={!selectedMirror}
           >
-            <span className="truncate">Install to {folderLabel}</span>
+            <span className="truncate">
+              {t("installDialog.installToFolder", { folder: folderLabel })}
+            </span>
           </Button>
           <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
+            {t("common.cancel")}
           </Button>
         </div>
       </DialogContent>

--- a/src/Components/ModDetail/ModDetail.tsx
+++ b/src/Components/ModDetail/ModDetail.tsx
@@ -15,6 +15,7 @@ import "swiper/css/navigation";
 import "swiper/css/pagination";
 import { open } from "@tauri-apps/plugin-shell";
 import { open as pickFile } from "@tauri-apps/plugin-dialog";
+import { useT, type TKey } from "../../i18n/context";
 import {
   buildDestinations,
   buildRiderDestinations,
@@ -65,12 +66,12 @@ interface ModDetailProps {
   onBack: () => void;
 }
 
-const CHAIN: { key: string; label: string }[] = [
-  { key: "resolving", label: "Resolve" },
-  { key: "downloading", label: "Download" },
-  { key: "extracting", label: "Extract" },
-  { key: "placing", label: "Place" },
-  { key: "reload", label: "Reload" },
+const CHAIN: { key: string; label: TKey }[] = [
+  { key: "resolving", label: "modDetail.stageResolve" },
+  { key: "downloading", label: "modDetail.stageDownload" },
+  { key: "extracting", label: "modDetail.stageExtract" },
+  { key: "placing", label: "modDetail.stagePlace" },
+  { key: "reload", label: "modDetail.stageReload" },
 ];
 
 function stageIndex(stage: InstallStage): number {
@@ -97,6 +98,7 @@ export default function ModDetail({
   installedNames,
   onBack,
 }: ModDetailProps) {
+  const t = useT();
   const livery = isLiveryContext(modType, categoryId);
   const sound = isSoundContext(modType, categoryId);
   // For rider kit/gloves, which profile sub-folder to target (`null` for gear paints).
@@ -211,7 +213,9 @@ export default function ModDetail({
   const chooseAndImport = async () => {
     const picked = await pickFile({
       multiple: false,
-      filters: [{ name: "Mod files", extensions: ["pkz", "zip", "rar", "7z"] }],
+      filters: [
+        { name: t("modDetail.modFiles"), extensions: ["pkz", "zip", "rar", "7z"] },
+      ],
     });
     if (typeof picked !== "string" || !detail) return;
     setBlocked(null);
@@ -374,10 +378,10 @@ export default function ModDetail({
                     className="flex-1"
                     onClick={() => setDialogOpen(true)}
                   >
-                    Try again
+                    {t("common.tryAgain")}
                   </Button>
                   <Button size="sm" variant="outline" onClick={copyError}>
-                    <Copy className="size-3.5" /> {copied ? "Copied" : "Copy"}
+                    <Copy className="size-3.5" /> {copied ? t("modDetail.copied") : t("modDetail.copy")}
                   </Button>
                 </div>
               </div>
@@ -394,18 +398,18 @@ export default function ModDetail({
             ) : primary ? (
               <>
                 <Button className="h-11 w-full text-[14px]" onClick={openInstall}>
-                  {isInstalled ? "Reinstall" : "Add to Library"}
+                  {isInstalled ? t("browse.reinstall") : t("modDetail.addToLibrary")}
                 </Button>
-                <Row label="Host" value={primary.host} />
+                <Row label={t("modDetail.host")} value={primary.host} />
                 <Row
-                  label="Installs to"
+                  label={t("modDetail.installsTo")}
                   value={`${modType.installSubpath.replace(/\//g, "\\")}\\`}
                   mono
                 />
               </>
             ) : (
               <p className="text-[12.5px] text-muted-foreground">
-                No download link was found on this page — open it on mxb-mods.com.
+                {t("modDetail.noDownloadLink")}
               </p>
             )}
           </div>
@@ -414,19 +418,25 @@ export default function ModDetail({
           <div className="flex items-center gap-2.5 rounded-[10px] border border-success/25 bg-success/[0.06] px-3 py-2.5">
             <span className="size-[7px] flex-none rounded-full bg-success" />
             <span className="text-[12px] text-success/90">
-              FrostMod will hot-reload the {modType.id === "rider" ? "rider" : modType.id === "bikes" ? "bike" : "track"} list
-              when this finishes.
+              {t("modDetail.frostmodHint", {
+                kind:
+                  modType.id === "rider"
+                    ? t("modDetail.kindRider")
+                    : modType.id === "bikes"
+                      ? t("modDetail.kindBike")
+                      : t("modDetail.kindTrack"),
+              })}
             </span>
           </div>
 
           {/* details */}
           <div className="flex flex-col gap-2.5 rounded-xl border border-white/[0.07] bg-card px-4 py-3.5">
             <span className="text-[11px] font-bold uppercase tracking-[1.2px] text-faint">
-              Details
+              {t("modDetail.details")}
             </span>
-            {format && <Row label="Format" value={format} mono />}
-            {mirrorNames && <Row label="Mirrors" value={mirrorNames} />}
-            <Row label="Type" value={modType.label} />
+            {format && <Row label={t("modDetail.format")} value={format} mono />}
+            {mirrorNames && <Row label={t("modDetail.mirrors")} value={mirrorNames} />}
+            <Row label={t("modDetail.type")} value={t(modType.label)} />
           </div>
         </div>
       </div>
@@ -449,21 +459,22 @@ export default function ModDetail({
       <AlertDialog open={confirmReinstall} onOpenChange={setConfirmReinstall}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Reinstall “{detail.title}”?</AlertDialogTitle>
+            <AlertDialogTitle>
+              {t("browse.reinstallOne", { title: detail.title })}
+            </AlertDialogTitle>
             <AlertDialogDescription>
-              This mod is already in your library. Reinstalling downloads it again
-              and overwrites the installed files.
+              {t("browse.reinstallOneBody")}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
             <AlertDialogAction
               onClick={() => {
                 setConfirmReinstall(false);
                 setDialogOpen(true);
               }}
             >
-              Reinstall
+              {t("browse.reinstall")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -483,16 +494,17 @@ function Breadcrumb({
   onBack: () => void;
   link: string | null;
 }) {
+  const t = useT();
   return (
     <div className="flex items-center gap-2 text-[12.5px] text-muted-foreground">
       <button
         onClick={onBack}
         className="flex cursor-default items-center gap-1 font-semibold text-primary hover:brightness-110"
       >
-        <ArrowLeft className="size-3.5" /> Browse
+        <ArrowLeft className="size-3.5" /> {t("nav.browse")}
       </button>
       <span className="text-faint">/</span>
-      <span>{modType.label}</span>
+      <span>{t(modType.label)}</span>
       <span className="text-faint">/</span>
       <span className="truncate text-foreground/85">{title}</span>
       {link && (
@@ -500,7 +512,7 @@ function Breadcrumb({
           onClick={() => open(link)}
           className="ml-auto flex cursor-default items-center gap-1 text-[12px] text-primary hover:brightness-110"
         >
-          View on mxb-mods.com <ExternalLink className="size-3" />
+          {t("modDetail.viewOnSite")} <ExternalLink className="size-3" />
         </button>
       )}
     </div>
@@ -544,17 +556,18 @@ function InstallProgress({
   received?: number;
   total?: number;
 }) {
+  const t = useT();
   const mb = (n?: number) => (n ? Math.round(n / 1e6) : 0);
   const label =
     stage === "done"
-      ? "Added to your library"
+      ? t("modDetail.addedToLibrary")
       : stage === "downloading"
-        ? "Downloading…"
+        ? t("update.downloading")
         : stage === "extracting"
-          ? "Extracting…"
+          ? t("modDetail.extracting")
           : stage === "placing"
-            ? "Adding to library…"
-            : "Resolving download…";
+            ? t("modDetail.addingToLibrary")
+            : t("modDetail.resolving");
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-baseline justify-between">
@@ -613,10 +626,13 @@ function BlockedHost({
   onOpen: () => void;
   onChoose: () => void;
 }) {
+  const t = useT();
   return (
     <div className="flex flex-col gap-3.5">
       <div className="flex flex-col gap-1">
-        <span className="text-[14px] font-bold">Finish in your browser</span>
+        <span className="text-[14px] font-bold">
+          {t("modDetail.finishInBrowser")}
+        </span>
         <span className="text-[12px] leading-relaxed text-muted-foreground">
           {host} only allows browser downloads. Download it, then point MXB App at
           the file to finish the install.

--- a/src/Components/Presets/Presets.tsx
+++ b/src/Components/Presets/Presets.tsx
@@ -62,6 +62,8 @@ import type {
   PresetApplyOutcome,
 } from "../../types";
 import { SlotField } from "./SlotField";
+import { Trans } from "../../i18n";
+import { useT, type TFunc, type TKey } from "../../i18n/context";
 import {
   SLOTS,
   SLOT_GROUPS,
@@ -80,18 +82,18 @@ function humanSize(bytes: number): string {
   return `${bytes} B`;
 }
 
-function phaseLabel(phase: BundlePhase): string {
+function phaseLabel(phase: BundlePhase, t: TFunc): string {
   switch (phase) {
     case "bundling":
-      return "Packaging assets…";
+      return t("presets.phaseBundling");
     case "uploading":
-      return "Uploading bundle…";
+      return t("presets.phaseUploading");
     case "downloading":
-      return "Downloading bundle…";
+      return t("presets.phaseDownloading");
     case "installing":
-      return "Installing assets…";
+      return t("presets.phaseInstalling");
     case "done":
-      return "Done";
+      return t("common.done");
   }
 }
 
@@ -116,19 +118,20 @@ async function copyText(text: string): Promise<boolean> {
   }
 }
 
-function applyNote(outcome: PresetApplyOutcome): string {
+/** Which whole-sentence toast an apply produced. A key, not a fragment: the
+ *  English "Applied X to Y — {note}" shape doesn't survive translation. */
+function applyNoteKey(outcome: PresetApplyOutcome): TKey {
   switch (outcome.live_refresh) {
     case "refreshed":
-      return "refreshed live in-game.";
+      return "presets.appliedRefreshed";
     case "failed":
-      return "saved — instant refresh failed, so reselect your profile in-game to load it.";
+      return "presets.appliedRefreshFailed";
     default:
       break;
   }
-  if (outcome.game_running) {
-    return "saved — reselect your profile in MX Bikes (Profile menu) to load the new look.";
-  }
-  return "saved — it loads next time the game opens.";
+  return outcome.game_running
+    ? "presets.appliedGameRunning"
+    : "presets.appliedNextTime";
 }
 
 interface PresetsProps {
@@ -138,6 +141,7 @@ interface PresetsProps {
 }
 
 export default function Presets({ onOpenInRider, onOpenLocker }: PresetsProps = {}) {
+  const t = useT();
   const [profiles, setProfiles] = useState<string[]>([]);
   const [profile, setProfile] = useState<string>("");
   const [bikes, setBikes] = useState<string[]>([]);
@@ -244,8 +248,8 @@ export default function Presets({ onOpenInRider, onOpenLocker }: PresetsProps = 
     setLoadout(preset.loadout);
     // Bring the builder (left column) into view on smaller layouts.
     window.scrollTo({ top: 0, behavior: "smooth" });
-    toast.info(`Editing “${preset.name}” — change anything, then Save changes.`);
-  }, []);
+    toast.info(t("presets.editing", { name: preset.name }));
+  }, [t]);
 
   const cancelEdit = useCallback(() => {
     setEditing(null);
@@ -255,7 +259,7 @@ export default function Presets({ onOpenInRider, onOpenLocker }: PresetsProps = 
   const onSave = useCallback(() => {
     const nm = name.trim();
     if (!nm) {
-      toast.error("Give the preset a name first.");
+      toast.error(t("presets.nameFirst"));
       return;
     }
     // Always confirm an edit (it rewrites a saved preset) or a name clash (it would
@@ -265,7 +269,7 @@ export default function Presets({ onOpenInRider, onOpenLocker }: PresetsProps = 
       return;
     }
     void commitSave();
-  }, [name, editing, nameClash]);
+  }, [name, editing, nameClash, t]);
 
   const commitSave = useCallback(async () => {
     const nm = name.trim();
@@ -285,34 +289,34 @@ export default function Presets({ onOpenInRider, onOpenLocker }: PresetsProps = 
       toast.success(
         wasEditing
           ? eq(wasEditing, nm)
-            ? `Updated preset “${nm}”.`
-            : `Renamed to “${nm}” and saved changes.`
-          : `Saved preset “${nm}”.`,
+            ? t("presets.updated", { name: nm })
+            : t("presets.renamed", { name: nm })
+          : t("presets.saved", { name: nm }),
       );
     } catch (e) {
       toast.error(String(e).replace(/^Error:\s*/, ""));
     } finally {
       setBusy(false);
     }
-  }, [name, loadout, editing, refreshSaved]);
+  }, [name, loadout, editing, refreshSaved, t]);
 
   const applyLoadout = useCallback(
     async (lo: Loadout, id: string, label: string) => {
       if (!profile || !bike) {
-        toast.error("Pick a profile and bike to apply to.");
+        toast.error(t("presets.pickProfileAndBike"));
         return;
       }
       setApplyingId(id);
       try {
         const outcome = await presetsApply(profile, bike, lo, makeActive);
-        toast.success(`Applied “${label}” to ${bike} — ${applyNote(outcome)}`);
+        toast.success(t(applyNoteKey(outcome), { label, bike }));
       } catch (e) {
         toast.error(String(e).replace(/^Error:\s*/, ""));
       } finally {
         setApplyingId(null);
       }
     },
-    [profile, bike, makeActive],
+    [profile, bike, makeActive, t],
   );
 
   const onShare = useCallback((preset: Preset) => {
@@ -348,10 +352,12 @@ export default function Presets({ onOpenInRider, onOpenLocker }: PresetsProps = 
     <div className="flex h-full flex-col">
       <header className="flex flex-none items-center gap-3.5 px-7 pb-3.5 pt-5">
         <div className="flex items-center gap-1.5">
-          <h1 className="text-[21px] font-bold tracking-[-0.2px]">Presets</h1>
+          <h1 className="text-[21px] font-bold tracking-[-0.2px]">
+            {t("nav.presets")}
+          </h1>
           <HelpHint
-            title="Presets"
-            description="Save a full rider look and load it onto a bike on command."
+            title={t("nav.presets")}
+            description={t("presets.help")}
           />
         </div>
         <div className="ml-auto flex items-center gap-2">
@@ -385,10 +391,12 @@ export default function Presets({ onOpenInRider, onOpenLocker }: PresetsProps = 
             {/* Target row */}
             <div className="flex flex-wrap items-end gap-3 rounded-xl border border-white/[0.07] bg-card/40 p-3.5">
               <label className="flex min-w-[140px] flex-col gap-1">
-                <span className="text-[11px] font-medium text-muted-foreground">Profile</span>
+                <span className="text-[11px] font-medium text-muted-foreground">
+                  {t("presets.profile")}
+                </span>
                 <Select value={profile} onValueChange={setProfile}>
                   <SelectTrigger>
-                    <SelectValue placeholder="Profile" />
+                    <SelectValue placeholder={t("presets.profile")} />
                   </SelectTrigger>
                   <SelectContent>
                     {profiles.map((p) => (
@@ -400,10 +408,12 @@ export default function Presets({ onOpenInRider, onOpenLocker }: PresetsProps = 
                 </Select>
               </label>
               <label className="flex min-w-[180px] flex-1 flex-col gap-1">
-                <span className="text-[11px] font-medium text-muted-foreground">Bike</span>
+                <span className="text-[11px] font-medium text-muted-foreground">
+                  {t("slotGroup.bike")}
+                </span>
                 <Select value={bike} onValueChange={setBike}>
                   <SelectTrigger>
-                    <SelectValue placeholder="Bike" />
+                    <SelectValue placeholder={t("slotGroup.bike")} />
                   </SelectTrigger>
                   <SelectContent>
                     {bikes.map((b) => (
@@ -425,7 +435,7 @@ export default function Presets({ onOpenInRider, onOpenLocker }: PresetsProps = 
               <div key={g.id} className="flex flex-col gap-2">
                 <div className="flex items-center gap-2">
                   <h2 className="text-[11px] font-semibold uppercase tracking-wide text-faint">
-                    {g.label}
+                    {t(g.label)}
                   </h2>
                   {g.id === "rider" && onOpenInRider && (
                     <Button
@@ -487,8 +497,17 @@ export default function Presets({ onOpenInRider, onOpenLocker }: PresetsProps = 
                 <div className="flex items-center gap-2 text-[12px]">
                   <Pencil className="size-3.5 flex-none text-primary" />
                   <span className="min-w-0 flex-1">
-                    Editing <span className="font-semibold">“{editing}”</span> — change
-                    the name or any slot, then <span className="font-semibold">Save changes</span>.
+                    <Trans
+                      k="presets.editingBanner"
+                      values={{
+                        name: <span className="font-semibold">“{editing}”</span>,
+                        save: (
+                          <span className="font-semibold">
+                            {t("presets.saveChanges")}
+                          </span>
+                        ),
+                      }}
+                    />
                   </span>
                   <button
                     onClick={cancelEdit}
@@ -524,13 +543,13 @@ export default function Presets({ onOpenInRider, onOpenLocker }: PresetsProps = 
                 <Input
                   value={name}
                   onChange={(e) => setName(e.target.value)}
-                  placeholder="Preset name…"
+                  placeholder={t("presets.namePlaceholder")}
                   className="h-9 max-w-[220px]"
                   onKeyDown={(e) => e.key === "Enter" && void onSave()}
                 />
                 <Button size="sm" onClick={() => onSave()} disabled={busy}>
                   {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Save className="size-3.5" />}
-                  {editing ? "Save changes" : "Save preset"}
+                  {editing ? t("presets.saveChanges") : t("presets.savePreset")}
                 </Button>
                 <Button
                   variant="outline"
@@ -629,6 +648,7 @@ function PresetCard({
   onDelete: () => void;
   onViewInRider?: () => void;
 }) {
+  const t = useT();
   return (
     <div
       className={cn(
@@ -639,7 +659,7 @@ function PresetCard({
       <div className="flex items-start justify-between gap-2">
         <button
           onClick={onLoad}
-          title="Load a copy into the builder"
+          title={t("presets.loadCopy")}
           className="min-w-0 flex-1 cursor-default text-left"
         >
           <div className="flex items-center gap-1.5">
@@ -656,17 +676,17 @@ function PresetCard({
         </button>
         <div className="flex flex-none items-center gap-0.5">
           {onViewInRider && (
-            <IconBtn title="View on rider" onClick={onViewInRider}>
+            <IconBtn title={t("presets.viewOnRider")} onClick={onViewInRider}>
               <User className="size-3.5" />
             </IconBtn>
           )}
-          <IconBtn title="Edit name or options" onClick={onEdit}>
+          <IconBtn title={t("presets.editNameOrOptions")} onClick={onEdit}>
             <Pencil className="size-3.5" />
           </IconBtn>
-          <IconBtn title="Share" onClick={onShare}>
+          <IconBtn title={t("presets.share")} onClick={onShare}>
             <Share2 className="size-3.5" />
           </IconBtn>
-          <IconBtn title="Delete" onClick={onDelete}>
+          <IconBtn title={t("common.delete")} onClick={onDelete}>
             <Trash2 className="size-3.5" />
           </IconBtn>
         </div>
@@ -718,8 +738,9 @@ function ConfirmSaveDialog({
   onConfirm: () => void;
   onCancel: () => void;
 }) {
+  const t = useT();
   const renamed = !!editing && editing.toLowerCase() !== newName.toLowerCase();
-  const title = editing ? "Save changes?" : "Replace preset?";
+  const title = editing ? t("presets.saveChangesQ") : t("presets.replaceQ");
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onCancel()}>
@@ -755,7 +776,7 @@ function ConfirmSaveDialog({
           </Button>
           <Button onClick={onConfirm} disabled={busy}>
             {busy ? <Loader2 className="size-4 animate-spin" /> : <Check className="size-4" />}
-            {editing ? "Save changes" : "Replace"}
+            {editing ? t("presets.saveChanges") : t("presets.replace")}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -764,6 +785,7 @@ function ConfirmSaveDialog({
 }
 
 function ShareDialog({ preset, onClose }: { preset: Preset | null; onClose: () => void }) {
+  const t = useT();
   const [copied, setCopied] = useState(false);
   const [configCode, setConfigCode] = useState<string | null>(null);
   const [fullCode, setFullCode] = useState<string | null>(null);
@@ -802,7 +824,7 @@ function ShareDialog({ preset, onClose }: { preset: Preset | null; onClose: () =
       const c = await presetBundleCreate(preset.name);
       setFullCode(c);
       setCopied(false);
-      toast.success("Full bundle uploaded — the code now includes the assets.");
+      toast.success(t("presets.bundleUploaded"));
     } catch (e) {
       toast.error(String(e).replace(/^Error:\s*/, ""));
     } finally {
@@ -810,7 +832,7 @@ function ShareDialog({ preset, onClose }: { preset: Preset | null; onClose: () =
       setCreating(false);
       setPhase(null);
     }
-  }, [preset]);
+  }, [preset, t]);
 
   return (
     <Dialog open={!!preset} onOpenChange={(o) => !o && onClose()}>
@@ -819,8 +841,8 @@ function ShareDialog({ preset, onClose }: { preset: Preset | null; onClose: () =
           <DialogTitle>Share “{preset?.name}”</DialogTitle>
           <DialogDescription>
             {isFull
-              ? "This code includes a downloadable asset bundle — the recipient picks Full import and gets everything, even with no mods installed."
-              : "Send this code to anyone. They import it under Presets → Import. They'll need the same mods installed for every part to show."}
+              ? t("presets.shareHintFull")
+              : t("presets.shareHintConfig")}
           </DialogDescription>
         </DialogHeader>
 
@@ -828,7 +850,7 @@ function ShareDialog({ preset, onClose }: { preset: Preset | null; onClose: () =
           readOnly
           value={code ?? ""}
           onFocus={(e) => e.currentTarget.select()}
-          placeholder="Generating code…"
+          placeholder={t("presets.generatingCode")}
           className="h-24 w-full resize-none rounded-lg border border-input bg-transparent p-2.5 font-mono text-[11px] leading-snug"
         />
 
@@ -842,7 +864,7 @@ function ShareDialog({ preset, onClose }: { preset: Preset | null; onClose: () =
             {plan && (
               <p className="mt-1 text-muted-foreground">
                 {plan.assets.length === 0
-                  ? "No installed assets to bundle — this look is all stock/fonts."
+                  ? t("presets.nothingToBundle")
                   : `Packages ${plan.assets.length} asset${plan.assets.length > 1 ? "s" : ""} (~${humanSize(plan.totalSize)}) so a recipient needs nothing installed.`}
                 {plan.unresolved.length > 0 && plan.assets.length > 0 && (
                   <>
@@ -868,7 +890,11 @@ function ShareDialog({ preset, onClose }: { preset: Preset | null; onClose: () =
               ) : (
                 <UploadCloud className="size-3.5" />
               )}
-              {creating ? (phase ? phaseLabel(phase) : "Working…") : "Create full bundle"}
+              {creating
+                ? phase
+                  ? phaseLabel(phase, t)
+                  : t("settings.working")
+                : t("presets.createFullBundle")}
             </Button>
           </div>
         )}
@@ -879,14 +905,20 @@ function ShareDialog({ preset, onClose }: { preset: Preset | null; onClose: () =
             onClick={async () => {
               if (code && (await copyText(code))) {
                 setCopied(true);
-                toast.success(isFull ? "Copied full-bundle code." : "Copied share code.");
+                toast.success(
+                  isFull ? t("presets.copiedFull") : t("presets.copiedShare"),
+                );
               } else {
-                toast.error("Couldn't copy — select the code and copy manually.");
+                toast.error(t("presets.copyFailed"));
               }
             }}
           >
             {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
-            {copied ? "Copied" : isFull ? "Copy full code" : "Copy code"}
+            {copied
+              ? t("modDetail.copied")
+              : isFull
+                ? t("presets.copyFullCode")
+                : t("presets.copyCode")}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -907,6 +939,7 @@ function ImportDialog({
   onClose: () => void;
   onImported: () => void;
 }) {
+  const t = useT();
   const [text, setText] = useState("");
   const [preview, setPreview] = useState<Preset | null>(null);
   const [previewErr, setPreviewErr] = useState<string | null>(null);
@@ -989,8 +1022,8 @@ function ImportDialog({
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <DialogTitle>Import preset</DialogTitle>
-          <DialogDescription>Paste a share code someone sent you.</DialogDescription>
+          <DialogTitle>{t("presets.importTitle")}</DialogTitle>
+          <DialogDescription>{t("presets.importBody")}</DialogDescription>
         </DialogHeader>
         <textarea
           value={text}
@@ -1012,9 +1045,14 @@ function ImportDialog({
               <p className="mt-1.5 flex items-start gap-1.5 text-[11.5px] text-emerald-500">
                 <Package className="mt-px size-3.5 flex-none" />
                 <span>
-                  Includes a full asset bundle (~{humanSize(preview.bundle!.size)} from{" "}
-                  {preview.bundle!.host}). Use <strong>Full import</strong> to download
-                  and install everything — no mods needed first.
+                  <Trans
+                    k="presets.bundleNotice"
+                    values={{
+                      size: humanSize(preview.bundle!.size),
+                      host: preview.bundle!.host,
+                      fullImport: <strong>{t("presets.fullImport")}</strong>,
+                    }}
+                  />
                 </span>
               </p>
             )}
@@ -1022,8 +1060,9 @@ function ImportDialog({
               <p className="mt-1.5 flex items-start gap-1.5 text-[11.5px] text-amber-500">
                 <AlertTriangle className="mt-px size-3.5 flex-none" />
                 <span>
-                  Missing mods: {missing.map((s) => s.label).join(", ")}. Install
-                  them for those parts to show.
+                  {t("presets.missingMods", {
+                    mods: missing.map((s) => t(s.label)).join(", "),
+                  })}
                 </span>
               </p>
             )}
@@ -1043,7 +1082,7 @@ function ImportDialog({
             ) : (
               <Download className="size-4" />
             )}
-            {hasBundle ? "Config only" : "Import"}
+            {hasBundle ? t("presets.configOnly") : t("presets.import")}
           </Button>
           {hasBundle && (
             <Button onClick={() => void onFullImport()} disabled={!preview || busy}>
@@ -1052,7 +1091,7 @@ function ImportDialog({
               ) : (
                 <Package className="size-4" />
               )}
-              {busy && phase ? phaseLabel(phase) : "Full import"}
+              {busy && phase ? phaseLabel(phase, t) : t("presets.fullImport")}
             </Button>
           )}
         </DialogFooter>

--- a/src/Components/Presets/SlotField.tsx
+++ b/src/Components/Presets/SlotField.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { Combobox } from "../ui/combobox";
 import type { SlotDef } from "../../lib/presets";
+import { useT } from "../../i18n/context";
 
 /**
  * One editable customization slot: a searchable **creatable** combobox over the
@@ -24,16 +25,17 @@ export function SlotField({
   hint?: React.ReactNode;
   onChange: (v: string) => void;
 }) {
+  const t = useT();
   return (
     <div className="flex flex-col gap-1">
       <span className="flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground">
-        {slot.label}
+        {t(slot.label)}
         {missing && (
           <span
-            title="This mod isn't installed — shows as stock in-game"
+            title={t("presets.missingHint")}
             className="rounded bg-amber-500/15 px-1 text-[9.5px] font-semibold uppercase text-amber-500"
           >
-            missing
+            {t("presets.missing")}
           </span>
         )}
       </span>

--- a/src/Components/Rider/RiderStudio.tsx
+++ b/src/Components/Rider/RiderStudio.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { RefreshCw, AlertTriangle, Save, Loader2 } from "lucide-react";
 import { toast } from "sonner";
+import { useT, type TKey } from "../../i18n/context";
 import { Button } from "../ui/button";
 import HelpHint from "../ui/help-hint";
 import { Input } from "../ui/input";
@@ -23,10 +24,10 @@ const EMPTY_GEAR_PAINTS: GearPaints = { paints: [], goggles: [] };
 
 const RIDER_GROUPS = SLOT_GROUPS.filter((g) => g.id !== "bike");
 
-const TOGGLES: { part: RiderPart["part"]; label: string }[] = [
-  { part: "helmet", label: "Helmet" },
-  { part: "protection", label: "Protection" },
-  { part: "boots", label: "Boots" },
+const TOGGLES: { part: RiderPart["part"]; label: TKey }[] = [
+  { part: "helmet", label: "category.helmet" },
+  { part: "protection", label: "category.protection" },
+  { part: "boots", label: "category.boots" },
 ];
 
 interface RiderStudioProps {
@@ -35,6 +36,7 @@ interface RiderStudioProps {
 }
 
 export default function RiderStudio({ initialLoadout, onLoaded }: RiderStudioProps) {
+  const t = useT();
   const [scans, setScans] = useState<Scans | null>(null);
   const [loadout, setLoadout] = useState<Loadout>(EMPTY_LOADOUT);
   const [name, setName] = useState("");
@@ -67,7 +69,7 @@ export default function RiderStudio({ initialLoadout, onLoaded }: RiderStudioPro
   const onSave = useCallback(async () => {
     const nm = name.trim();
     if (!nm) {
-      toast.error("Name this rider look first.");
+      toast.error(t("rider.nameFirst"));
       return;
     }
     setBusy(true);
@@ -80,7 +82,7 @@ export default function RiderStudio({ initialLoadout, onLoaded }: RiderStudioPro
     } finally {
       setBusy(false);
     }
-  }, [name, loadout]);
+  }, [name, loadout, t]);
 
   const load = useCallback(async () => {
     setError(null);
@@ -162,17 +164,19 @@ export default function RiderStudio({ initialLoadout, onLoaded }: RiderStudioPro
     <div className="flex h-full flex-col">
       <header className="flex flex-none items-center gap-3.5 px-7 pb-3.5 pt-5">
         <div className="flex items-center gap-1.5">
-          <h1 className="text-[21px] font-bold tracking-[-0.2px]">Rider</h1>
+          <h1 className="text-[21px] font-bold tracking-[-0.2px]">
+            {t("nav.rider")}
+          </h1>
           <HelpHint
-            title="Rider"
-            description="Dress the player model — helmet, goggles, outfit and boots together."
+            title={t("nav.rider")}
+            description={t("rider.help")}
           />
         </div>
         <div className="ml-auto flex items-center gap-2">
           <Input
             value={name}
             onChange={(e) => setName(e.target.value)}
-            placeholder="Name this rider…"
+            placeholder={t("rider.namePlaceholder")}
             className="h-8 w-[180px]"
             onKeyDown={(e) => e.key === "Enter" && void onSave()}
           />
@@ -200,12 +204,12 @@ export default function RiderStudio({ initialLoadout, onLoaded }: RiderStudioPro
           {/* Show-on-model toggles */}
           <div className="flex flex-wrap items-center gap-x-5 gap-y-2 rounded-xl border border-white/[0.07] bg-card/40 p-3.5">
             <span className="text-[11px] font-semibold uppercase tracking-wide text-faint">
-              Show on model
+              {t("rider.showOnModel")}
             </span>
             {TOGGLES.map(({ part, label }) => (
               <label key={part} className="flex items-center gap-2 text-[12px] text-muted-foreground">
                 <Switch checked={!hidden.includes(part)} onCheckedChange={() => toggle(part)} />
-                {label}
+                {t(label)}
               </label>
             ))}
           </div>
@@ -214,7 +218,7 @@ export default function RiderStudio({ initialLoadout, onLoaded }: RiderStudioPro
           {grouped.map((g) => (
             <div key={g.id} className="flex flex-col gap-2">
               <h2 className="text-[11px] font-semibold uppercase tracking-wide text-faint">
-                {g.label}
+                {t(g.label)}
               </h2>
               <div className="grid grid-cols-1 gap-x-4 gap-y-2.5 sm:grid-cols-2">
                 {g.slots.map((slot) => (

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -20,11 +20,20 @@ import { useUpdate } from "../../Context/Update";
 import { usePlatform } from "../../lib/usePlatform";
 import { useConfig } from "../../Context/Config";
 import { useTheme, type ThemeMode } from "../../Context/Theme";
+import { useI18n, type LocalePref, type TKey } from "../../i18n/context";
+import { LOCALE_OPTIONS } from "../../i18n/core";
 import { useFrostmod } from "../../Context/FrostmodContext";
 import { useTour } from "../Tour/Tour";
 import { Button } from "@/Components/ui/button";
 import HelpHint from "@/Components/ui/help-hint";
 import { Segmented } from "@/Components/ui/segmented";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/Components/ui/select";
 import { Switch } from "@/Components/ui/switch";
 import { cn } from "@/lib/utils";
 
@@ -34,15 +43,16 @@ const REPO_URL = "https://github.com/Frostn1/mxb-app";
 const DISCORD_URL = "https://discord.gg/3994Rr3ywb";
 
 type SectionId = "folder" | "general" | "appearance" | "frostmod" | "about";
-const SECTIONS: { id: SectionId; label: string }[] = [
-  { id: "folder", label: "Game folder" },
-  { id: "general", label: "General" },
-  { id: "appearance", label: "Appearance" },
-  { id: "frostmod", label: "FrostMod" },
-  { id: "about", label: "About & updates" },
+const SECTIONS: { id: SectionId; label: TKey }[] = [
+  { id: "folder", label: "settings.gameFolder" },
+  { id: "general", label: "settings.general" },
+  { id: "appearance", label: "settings.appearance" },
+  { id: "frostmod", label: "settings.frostmod" },
+  { id: "about", label: "settings.about" },
 ];
 
 export default function Settings() {
+  const { t, locale, setLocale } = useI18n();
   const { config, reloadConfig } = useConfig();
   const isWindows = usePlatform() === "windows";
   const { theme, setTheme } = useTheme();
@@ -66,7 +76,7 @@ export default function Settings() {
   const profilesSep = config.modsPath.includes("\\") ? "\\" : "/";
   const defaultProfilesPath = config.modsPath
     ? `${config.modsPath}${profilesSep}profiles`
-    : "Inside your MX Bikes folder";
+    : t("settings.insideModsFolder");
 
   const runInBackground = config.runInBackground ?? true;
   const launchAtStartup = config.launchAtStartup ?? true;
@@ -79,7 +89,7 @@ export default function Settings() {
       await setInstantRefresh(v);
       await reloadConfig();
     } catch (e) {
-      toast.error("Couldn't update setting", { description: String(e) });
+      toast.error(t("settings.updateFailed"), { description: String(e) });
     }
   };
 
@@ -88,7 +98,7 @@ export default function Settings() {
       await setWatchModsReload(v);
       await reloadConfig();
     } catch (e) {
-      toast.error("Couldn't update setting", { description: String(e) });
+      toast.error(t("settings.updateFailed"), { description: String(e) });
     }
   };
 
@@ -97,7 +107,7 @@ export default function Settings() {
       await setAutoRunFrostmod(v);
       await reloadConfig();
     } catch (e) {
-      toast.error("Couldn't update setting", { description: String(e) });
+      toast.error(t("settings.updateFailed"), { description: String(e) });
     }
   };
 
@@ -106,7 +116,7 @@ export default function Settings() {
       await setRunInBackground(v);
       await reloadConfig();
     } catch (e) {
-      toast.error("Couldn't update setting", { description: String(e) });
+      toast.error(t("settings.updateFailed"), { description: String(e) });
     }
   };
 
@@ -115,7 +125,7 @@ export default function Settings() {
       await setLaunchAtStartup(v);
       await reloadConfig();
     } catch (e) {
-      toast.error("Couldn't update startup setting", { description: String(e) });
+      toast.error(t("settings.startupUpdateFailed"), { description: String(e) });
     }
   };
 
@@ -135,16 +145,18 @@ export default function Settings() {
     const picked = await pickFolder({
       directory: true,
       multiple: false,
-      title: "Select your MX Bikes folder",
+      title: t("setup.pickModsFolder"),
     });
     if (typeof picked !== "string") return;
     setBusy(true);
     try {
       await setModsPath(picked);
       await reloadConfig();
-      toast.success("Game folder updated", { description: "Your library will re-scan." });
+      toast.success(t("settings.folderUpdated"), {
+        description: t("settings.folderUpdatedDesc"),
+      });
     } catch (e) {
-      toast.error("Couldn't set folder", { description: String(e) });
+      toast.error(t("settings.setFolderFailed"), { description: String(e) });
     } finally {
       setBusy(false);
     }
@@ -155,9 +167,9 @@ export default function Settings() {
     try {
       await setModsPath("");
       await reloadConfig();
-      toast.success("Re-detected your MX Bikes folder");
+      toast.success(t("settings.reDetected"));
     } catch (e) {
-      toast.error("Couldn't detect folder", { description: String(e) });
+      toast.error(t("settings.detectFolderFailed"), { description: String(e) });
     } finally {
       setBusy(false);
     }
@@ -167,18 +179,18 @@ export default function Settings() {
     const picked = await pickFolder({
       directory: true,
       multiple: false,
-      title: "Select your MX Bikes install folder (contains rider.pkz)",
+      title: t("settings.pickInstallFolder"),
     });
     if (typeof picked !== "string") return;
     setBusy(true);
     try {
       await setGamePath(picked);
       await reloadConfig();
-      toast.success("Game install set", {
-        description: "The 3D rider preview can now load the real body model.",
+      toast.success(t("settings.installSet"), {
+        description: t("settings.installSetDesc"),
       });
     } catch (e) {
-      toast.error("Couldn't set install folder", { description: String(e) });
+      toast.error(t("settings.setInstallFailed"), { description: String(e) });
     } finally {
       setBusy(false);
     }
@@ -189,16 +201,16 @@ export default function Settings() {
     try {
       const found = await detectGamePath();
       if (!found) {
-        toast.info("Couldn't find MX Bikes", {
-          description: "No Steam install detected — set the folder manually.",
+        toast.info(t("settings.installNotFound"), {
+          description: t("settings.installNotFoundDesc"),
         });
         return;
       }
       await setGamePath(found);
       await reloadConfig();
-      toast.success("Found your MX Bikes install", { description: found });
+      toast.success(t("settings.installFound"), { description: found });
     } catch (e) {
-      toast.error("Couldn't detect install folder", { description: String(e) });
+      toast.error(t("settings.detectInstallFailed"), { description: String(e) });
     } finally {
       setBusy(false);
     }
@@ -208,7 +220,7 @@ export default function Settings() {
     const picked = await pickFolder({
       directory: true,
       multiple: false,
-      title: "Select your MX Bikes profiles folder",
+      title: t("settings.pickProfilesFolder"),
     });
     if (typeof picked !== "string") return;
     setBusy(true);
@@ -217,17 +229,17 @@ export default function Settings() {
       await reloadConfig();
       const count = await countProfilesIn(picked).catch(() => 0);
       if (count > 0) {
-        toast.success("Profiles folder set", {
-          description: `Found ${count} profile${count === 1 ? "" : "s"}.`,
+        toast.success(t("settings.profilesSet"), {
+          description: t("settings.profilesFound", { count }),
         });
       } else {
         // Warn but keep the pick (per design) — they may be mid-setup.
-        toast.warning("No profiles found there", {
-          description: "Saved anyway, but preset creation needs a folder that holds your profile.ini folders.",
+        toast.warning(t("settings.noProfilesThere"), {
+          description: t("settings.noProfilesThereDesc"),
         });
       }
     } catch (e) {
-      toast.error("Couldn't set profiles folder", { description: String(e) });
+      toast.error(t("settings.setProfilesFailed"), { description: String(e) });
     } finally {
       setBusy(false);
     }
@@ -238,9 +250,9 @@ export default function Settings() {
     try {
       await setProfilesPath("");
       await reloadConfig();
-      toast.success("Reverted to the default profiles folder");
+      toast.success(t("settings.profilesReverted"));
     } catch (e) {
-      toast.error("Couldn't reset profiles folder", { description: String(e) });
+      toast.error(t("settings.resetProfilesFailed"), { description: String(e) });
     } finally {
       setBusy(false);
     }
@@ -248,10 +260,10 @@ export default function Settings() {
 
   const reloadGame = async () => {
     const outcome = await reload();
-    if (outcome === "signaled") toast.success("FrostMod reloaded the game.");
+    if (outcome === "signaled") toast.success(t("frostmod.reloadedGame"));
     else if (outcome === "not_running")
-      toast.info("FrostMod isn't running — start it to hot-reload mods.");
-    else toast.info("Reload isn't available on this platform.");
+      toast.info(t("settings.frostmodNotRunningHint"));
+    else toast.info(t("settings.reloadUnavailable"));
   };
 
   return (
@@ -268,7 +280,7 @@ export default function Settings() {
                 : "text-muted-foreground hover:text-foreground",
             )}
           >
-            {s.label}
+            {t(s.label)}
           </button>
         ))}
       </nav>
@@ -276,23 +288,25 @@ export default function Settings() {
       <div className="min-h-0 flex-1 overflow-y-auto px-2 py-5">
         <div className="flex max-w-[640px] flex-col gap-[18px]">
           <div className="flex items-center gap-1.5">
-            <h1 className="text-[21px] font-bold tracking-[-0.2px]">Settings</h1>
+            <h1 className="text-[21px] font-bold tracking-[-0.2px]">
+              {t("nav.settings")}
+            </h1>
             <HelpHint
-              title="Settings"
-              description="Configure your game folder, updates, and app preferences."
+              title={t("nav.settings")}
+              description={t("settings.help")}
             />
           </div>
 
           {/* game folder */}
           <Section
-            title="MX Bikes folder"
-            desc="Where mods are installed. Changing it re-scans your library."
+            title={t("setup.modsFolder")}
+            desc={t("settings.modsFolderDesc")}
             innerRef={(el) => (refs.current.folder = el)}
           >
             <div className="flex gap-2">
               <div className="flex flex-1 items-center gap-2 rounded-lg border border-input bg-background px-3 py-2.5 font-mono text-[12px] text-muted-foreground">
                 <span className="flex-1 truncate" title={config.modsPath}>
-                  {config.modsPath || "Not set"}
+                  {config.modsPath || t("settings.notSet")}
                 </span>
                 {config.modsPath && (
                   <span className="flex flex-none items-center gap-1 font-sans text-[11px] font-semibold text-success">
@@ -352,7 +366,7 @@ export default function Settings() {
                   )}
                 </div>
                 <Button variant="outline" size="sm" onClick={changeProfilesFolder} disabled={busy}>
-                  {config.profilesPath ? "Change…" : "Set…"}
+                  {config.profilesPath ? t("settings.change") : t("settings.set")}
                 </Button>
               </div>
               {config.profilesPath && (
@@ -378,7 +392,7 @@ export default function Settings() {
             <div className="flex gap-2">
               <div className="flex flex-1 items-center gap-2 rounded-lg border border-input bg-background px-3 py-2.5 font-mono text-[12px] text-muted-foreground">
                 <span className="flex-1 truncate" title={config.gamePath}>
-                  {config.gamePath || "Not set"}
+                  {config.gamePath || t("settings.notSet")}
                 </span>
                 {config.gamePath && (
                   <span className="flex flex-none items-center gap-1 font-sans text-[11px] font-semibold text-success">
@@ -387,7 +401,7 @@ export default function Settings() {
                 )}
               </div>
               <Button variant="outline" size="sm" onClick={changeGameFolder} disabled={busy}>
-                {config.gamePath ? "Change…" : "Set…"}
+                {config.gamePath ? t("settings.change") : t("settings.set")}
               </Button>
             </div>
             <button
@@ -400,27 +414,27 @@ export default function Settings() {
           </Section>
 
           {/* general / background */}
-          <Section title="General" innerRef={(el) => (refs.current.general = el)}>
+          <Section title={t("settings.general")} innerRef={(el) => (refs.current.general = el)}>
             <ToggleRow
-              label="Keep running in the background"
-              desc="Closing the window hides MXB App to the tray so FrostMod stays connected. Quit from the tray icon."
+              label={t("settings.runInBackground")}
+              desc={t("settings.runInBackgroundDesc")}
               checked={runInBackground}
               onChange={toggleBackground}
             />
             <div className="h-px bg-border" />
             <ToggleRow
-              label="Launch at startup"
-              desc="Start MXB App automatically when you log in."
+              label={t("settings.launchAtStartup")}
+              desc={t("settings.launchAtStartupDesc")}
               checked={launchAtStartup}
               onChange={toggleStartup}
             />
             <div className="h-px bg-border" />
             <ToggleRow
-              label="Instant preset refresh"
+              label={t("settings.instantRefresh")}
               desc={
                 isWindows
-                  ? "When you apply a preset while MX Bikes is running, refresh the look in-game instantly — no restart or profile reselect. If it can't, you'll be told to reselect your profile."
-                  : "Refreshing the look in-game without a restart needs FrostMod, which is Windows-only — you'll be told to reselect your profile instead."
+                  ? t("settings.instantRefreshDesc")
+                  : t("settings.instantRefreshWindowsOnly")
               }
               checked={instantRefresh}
               onChange={toggleInstantRefresh}
@@ -429,21 +443,49 @@ export default function Settings() {
 
           {/* appearance */}
           <Section
-            title="Appearance"
+            title={t("settings.appearance")}
             innerRef={(el) => (refs.current.appearance = el)}
           >
             <div className="flex items-center justify-between">
-              <span className="text-[12.5px] text-foreground/85">Theme</span>
+              <span className="text-[12.5px] text-foreground/85">
+                {t("settings.theme")}
+              </span>
               <Segmented
                 size="sm"
                 value={theme}
                 onChange={(v) => setTheme(v as ThemeMode)}
                 options={[
-                  { value: "light", label: "Light" },
-                  { value: "dark", label: "Dark" },
-                  { value: "system", label: "System" },
+                  { value: "light", label: t("settings.themeLight") },
+                  { value: "dark", label: t("settings.themeDark") },
+                  { value: "system", label: t("settings.themeSystem") },
                 ]}
               />
+            </div>
+
+            {/* A Select, not a Segmented control — seven options don't fit the
+                segmented track, and each is named in its own language so someone
+                who lands in a script they can't read can still get back out. */}
+            <div className="mt-3 flex items-center justify-between">
+              <span className="text-[12.5px] text-foreground/85">
+                {t("settings.language")}
+              </span>
+              <Select
+                value={locale}
+                onValueChange={(v) => setLocale(v as LocalePref)}
+              >
+                <SelectTrigger className="h-8 w-[180px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {LOCALE_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.value === "system"
+                        ? t("settings.languageSystem")
+                        : opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
           </Section>
 
@@ -452,7 +494,7 @@ export default function Settings() {
               would fail, including one that downloads two Windows binaries. */}
           {isWindows && (
           <Section
-            title="FrostMod"
+            title={t("settings.frostmod")}
             innerRef={(el) => (refs.current.frostmod = el)}
             titleRight={
               <span
@@ -468,10 +510,10 @@ export default function Settings() {
                   )}
                 />
                 {running === null
-                  ? "Checking…"
+                  ? t("settings.checking")
                   : running
-                    ? "Running · game connected"
-                    : "Not running"}
+                    ? t("settings.runningConnected")
+                    : t("settings.notRunning")}
               </span>
             }
           >
@@ -484,16 +526,18 @@ export default function Settings() {
               <div className="flex flex-col">
                 <span className="text-[12.5px] text-foreground/85">
                   {status?.installed
-                    ? `Installed${status.version ? ` · ${status.version}` : ""}`
-                    : "Not installed"}
+                    ? t("settings.frostmodInstalled", {
+                        suffix: status.version ? ` · ${status.version}` : "",
+                      })
+                    : t("settings.notInstalled")}
                 </span>
                 <span className="text-[11px] text-muted-foreground">
                   {checking
-                    ? "Checking GitHub for the latest release…"
+                    ? t("settings.checkingGitHub")
                     : statusError
-                      ? "Couldn't check for updates — offline or GitHub unavailable."
+                      ? t("settings.updateCheckFailed")
                       : status?.latest
-                        ? `Latest: ${status.latest}`
+                        ? t("settings.latestVersion", { version: status.latest })
                         : null}
                 </span>
               </div>
@@ -504,7 +548,7 @@ export default function Settings() {
                     size="icon"
                     onClick={() => refreshStatus()}
                     disabled={checking || installing}
-                    title="Check for a newer FrostMod"
+                    title={t("settings.checkNewer")}
                   >
                     <RefreshCw className={cn("size-3.5", checking && "animate-spin")} />
                   </Button>
@@ -525,14 +569,14 @@ export default function Settings() {
                       disabled={installing || checking || Boolean(confirmedCurrent)}
                     >
                       {installing
-                        ? "Working…"
+                        ? t("settings.working")
                         : !status?.installed
-                          ? "Install FrostMod"
+                          ? t("settings.installFrostmod")
                           : updatable
-                            ? `Update to ${status.latest}`
+                            ? t("settings.updateTo", { version: status.latest ?? "" })
                             : statusError || !status?.latest
-                              ? "Reinstall latest"
-                              : "Up to date"}
+                              ? t("settings.reinstallLatest")
+                              : t("settings.upToDate")}
                     </Button>
                   );
                 })()}
@@ -540,15 +584,15 @@ export default function Settings() {
             </div>
 
             <ToggleRow
-              label="Run FrostMod automatically"
-              desc="Start FrostMod in the background whenever MXB App opens."
+              label={t("settings.autoRunFrostmod")}
+              desc={t("settings.autoRunFrostmodDesc")}
               checked={autoRunFrostmod}
               onChange={toggleAutoRun}
             />
 
             <ToggleRow
-              label="Auto-reload on folder changes"
-              desc="Reload the game automatically when tracks or bikes are added to your mods folder — even downloaded manually outside MXB App."
+              label={t("settings.watchModsReload")}
+              desc={t("settings.watchModsReloadDesc")}
               checked={watchModsReload}
               onChange={toggleWatchModsReload}
             />
@@ -567,7 +611,7 @@ export default function Settings() {
           )}
 
           {/* about */}
-          <Section title="About & updates" innerRef={(el) => (refs.current.about = el)}>
+          <Section title={t("settings.about")} innerRef={(el) => (refs.current.about = el)}>
             <div className="flex items-center gap-3 text-[12px] text-muted-foreground">
               <span>mxb-app {version && `v${version}`}</span>
               <button
@@ -603,7 +647,7 @@ export default function Settings() {
             </div>
             <div className="flex flex-col gap-1 pt-1 text-[11.5px] text-faint">
               <div className="flex items-center gap-1.5">
-                <span>Made with</span>
+                <span>{t("settings.madeWith")}</span>
                 <span className="text-primary">❄</span>
                 <span>by</span>
                 <button

--- a/src/Components/Setup/Setup.tsx
+++ b/src/Components/Setup/Setup.tsx
@@ -3,6 +3,8 @@ import { Snowflake, FolderOpen, Gamepad2, Loader2, Check } from "lucide-react";
 import { open as pickFolder } from "@tauri-apps/plugin-dialog";
 import { createConfig, detectGamePath } from "../../api/mods";
 import { usePlatform } from "../../lib/usePlatform";
+import { Trans } from "../../i18n";
+import { useT } from "../../i18n/context";
 import { Button } from "@/Components/ui/button";
 
 interface SetupProps {
@@ -21,6 +23,7 @@ function hintFor(platform: string | null): string {
 }
 
 export default function Setup({ onComplete }: SetupProps) {
+  const t = useT();
   const defaultHint = hintFor(usePlatform());
   const [chosen, setChosen] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -67,7 +70,7 @@ export default function Setup({ onComplete }: SetupProps) {
     const picked = await pickFolder({
       directory: true,
       multiple: false,
-      title: "Select your MX Bikes folder",
+      title: t("setup.pickModsFolder"),
     });
     if (typeof picked === "string") setChosen(picked);
   };
@@ -76,7 +79,7 @@ export default function Setup({ onComplete }: SetupProps) {
     const picked = await pickFolder({
       directory: true,
       multiple: false,
-      title: "Select your MX Bikes install folder",
+      title: t("setup.pickInstallFolder"),
     });
     if (typeof picked === "string") {
       setGamePath(picked);
@@ -93,18 +96,17 @@ export default function Setup({ onComplete }: SetupProps) {
           </div>
           <div className="flex flex-col items-center gap-1.5">
             <h1 className="text-[26px] font-extrabold tracking-[-0.4px]">
-              Welcome to MXB App
+              {t("setup.title")}
             </h1>
             <p className="max-w-[380px] text-center text-[13.5px] leading-relaxed text-muted-foreground">
-              Browse mxb-mods, install with one click, and let FrostMod reload the
-              game for you.
+              {t("setup.tagline")}
             </p>
           </div>
         </div>
 
         <div className="flex w-full flex-col gap-2.5">
           <span className="text-[11.5px] font-bold uppercase tracking-[1px] text-faint">
-            MX Bikes folder
+            {t("setup.modsFolder")}
           </span>
           {chosen ? (
             <div className="flex items-center gap-2.5 rounded-[10px] border border-input bg-card px-3.5 py-3 font-mono text-[12.5px] text-muted-foreground">
@@ -115,27 +117,32 @@ export default function Setup({ onComplete }: SetupProps) {
             </div>
           ) : (
             <p className="text-[12.5px] text-muted-foreground">
-              MXB App will auto-detect your{" "}
-              <span className="font-mono text-foreground/80">{defaultHint}</span> folder.
-              You can also pick it yourself.
+              <Trans
+                k="setup.autoDetect"
+                values={{
+                  hint: (
+                    <span className="font-mono text-foreground/80">{defaultHint}</span>
+                  ),
+                }}
+              />
             </p>
           )}
           <button
             onClick={choose}
             className="cursor-default self-start text-[12px] font-semibold text-primary hover:brightness-110"
           >
-            {chosen ? "Choose a different folder…" : "Choose the folder manually…"}
+            {chosen ? t("setup.chooseDifferent") : t("setup.chooseManually")}
           </button>
         </div>
 
         <div className="flex w-full flex-col gap-2.5">
           <span className="text-[11.5px] font-bold uppercase tracking-[1px] text-faint">
-            MX Bikes install
+            {t("setup.gameInstall")}
           </span>
           {detecting ? (
             <div className="flex items-center gap-2.5 rounded-[10px] border border-input bg-card px-3.5 py-3 text-[12.5px] text-muted-foreground">
               <Loader2 className="size-4 flex-none animate-spin text-primary" />
-              <span>Looking for your MX Bikes install…</span>
+              <span>{t("setup.detecting")}</span>
             </div>
           ) : gamePath ? (
             <>
@@ -147,10 +154,10 @@ export default function Setup({ onComplete }: SetupProps) {
                 {gameAuto && (
                   <span
                     className="flex flex-none items-center gap-1 font-sans text-[11px] font-semibold text-primary"
-                    title="Detected automatically"
+                    title={t("setup.detectedAutomatically")}
                   >
                     <Check className="size-3.5" strokeWidth={2.5} />
-                    Found
+                    {t("setup.found")}
                   </span>
                 )}
               </div>
@@ -158,21 +165,19 @@ export default function Setup({ onComplete }: SetupProps) {
                 onClick={chooseGame}
                 className="cursor-default self-start text-[12px] font-semibold text-primary hover:brightness-110"
               >
-                Choose a different folder…
+                {t("setup.chooseDifferent")}
               </button>
             </>
           ) : (
             <>
               <p className="text-[12.5px] text-muted-foreground">
-                Couldn&apos;t find your MX Bikes install automatically — it powers
-                the
-                3D rider preview. Pick it manually, or set it later in Settings.
+                {t("setup.installNotFound")}
               </p>
               <button
                 onClick={chooseGame}
                 className="cursor-default self-start text-[12px] font-semibold text-primary hover:brightness-110"
               >
-                Choose the install folder manually…
+                {t("setup.chooseInstallManually")}
               </button>
             </>
           )}
@@ -189,7 +194,7 @@ export default function Setup({ onComplete }: SetupProps) {
           disabled={busy}
           onClick={() => finish(chosen ?? "")}
         >
-          {chosen ? "Start browsing mods" : "Detect & start browsing"}
+          {chosen ? t("setup.startBrowsing") : t("setup.detectAndStart")}
         </Button>
       </div>
     </div>

--- a/src/Components/Shell/Sidebar.tsx
+++ b/src/Components/Shell/Sidebar.tsx
@@ -13,6 +13,7 @@ import { cn } from "@/lib/utils";
 import { useFrostmod } from "../../Context/FrostmodContext";
 import { useInstall } from "../../Context/Install";
 import { displayName } from "../../lib/mods";
+import { useT, type TKey } from "../../i18n/context";
 
 export type DashboardView =
   | "browse"
@@ -28,18 +29,19 @@ interface SidebarProps {
   onNavigate: (view: DashboardView) => void;
 }
 
-const NAV: { id: DashboardView; label: string; icon: typeof Home }[] = [
-  { id: "browse", label: "Browse", icon: Home },
-  // { id: "shop", label: "Shop", icon: Store }, // hidden for now
-  { id: "library", label: "Library", icon: LibraryIcon },
-  { id: "locker", label: "Locker", icon: Bike },
-  { id: "presets", label: "Presets", icon: Shirt },
-  { id: "rider", label: "Rider", icon: User },
+const NAV: { id: DashboardView; label: TKey; icon: typeof Home }[] = [
+  { id: "browse", label: "nav.browse", icon: Home },
+  // { id: "shop", label: "nav.shop", icon: Store }, // hidden for now
+  { id: "library", label: "nav.library", icon: LibraryIcon },
+  { id: "locker", label: "nav.locker", icon: Bike },
+  { id: "presets", label: "nav.presets", icon: Shirt },
+  { id: "rider", label: "nav.rider", icon: User },
 ];
 
 const IN_PROGRESS = new Set(["resolving", "downloading", "extracting", "placing"]);
 
 export default function Sidebar({ view, onNavigate }: SidebarProps) {
+  const t = useT();
   const { running, reload, status, start } = useFrostmod();
   const { active, queueLength } = useInstall();
 
@@ -51,8 +53,8 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
 
   const onReload = async () => {
     const outcome = await reload();
-    if (outcome === "signaled") toast.success("FrostMod reloaded the game.");
-    else if (outcome === "not_running") toast.info("FrostMod isn't running.");
+    if (outcome === "signaled") toast.success(t("frostmod.reloadedGame"));
+    else if (outcome === "not_running") toast.info(t("frostmod.notRunningToast"));
   };
 
   return (
@@ -77,7 +79,7 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
               )}
             >
               <Icon className="size-4" />
-              <span>{label}</span>
+              <span>{t(label)}</span>
             </button>
           );
         })}
@@ -88,7 +90,7 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
           <div className="flex flex-col gap-[7px] rounded-[10px] border border-white/[0.07] bg-[color-mix(in_srgb,var(--card)_60%,var(--window))] px-3 py-2.5">
             <div className="flex items-baseline justify-between gap-2">
               <span className="truncate text-[11.5px] font-semibold text-foreground/85">
-                Installing “{displayName(active.title)}”
+                {t("sidebar.installing", { name: displayName(active.title) })}
               </span>
               {pct !== undefined && (
                 <span className="flex-none text-[10.5px] text-muted-foreground">
@@ -98,7 +100,7 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
             </div>
             {queueLength > 0 && (
               <span className="text-[10.5px] text-muted-foreground">
-                +{queueLength} queued
+                {t("sidebar.queued", { count: queueLength })}
               </span>
             )}
             <div className="h-[3px] overflow-hidden rounded-full bg-foreground/[0.08]">
@@ -126,15 +128,15 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
           />
           <span className="flex-1 text-[11.5px] text-muted-foreground">
             {running === null
-              ? "Checking FrostMod…"
+              ? t("frostmod.checking")
               : running
-                ? "FrostMod running"
-                : "FrostMod not running"}
+                ? t("frostmod.running")
+                : t("frostmod.notRunning")}
           </span>
           {running ? (
             <button
               onClick={onReload}
-              title="Reload game"
+              title={t("frostmod.reloadGame")}
               className="cursor-default text-muted-foreground transition-colors hover:text-foreground"
             >
               <RefreshCw className="size-3.5" />
@@ -143,7 +145,7 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
             status?.installed && (
               <button
                 onClick={start}
-                title="Start FrostMod"
+                title={t("frostmod.start")}
                 className="cursor-default text-primary transition-colors hover:brightness-110"
               >
                 <Play className="size-3.5" />
@@ -163,7 +165,7 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
           )}
         >
           <Settings className="size-4" />
-          <span>Settings</span>
+          <span>{t("nav.settings")}</span>
         </button>
       </div>
     </aside>

--- a/src/Components/Shop/Shop.tsx
+++ b/src/Components/Shop/Shop.tsx
@@ -12,6 +12,7 @@ import {
   type ShopItem,
 } from "../../api/mods";
 import { useInstall } from "../../Context/Install";
+import { useT, type TFunc } from "../../i18n/context";
 import ModCard from "../Browse/ModCard";
 import { Button } from "@/Components/ui/button";
 import { Skeleton } from "@/Components/ui/skeleton";
@@ -22,6 +23,7 @@ interface ShopProps {
 }
 
 export default function Shop({ refreshKey }: ShopProps) {
+  const t = useT();
   const [loggedIn, setLoggedIn] = useState<boolean | null>(null);
   const [items, setItems] = useState<ShopItem[]>([]);
   const [installedNames, setInstalledNames] = useState<Set<string>>(new Set());
@@ -66,16 +68,16 @@ export default function Shop({ refreshKey }: ShopProps) {
     const unlisten = onShopAuth((ok) => {
       if (ok) {
         setLoggedIn(true);
-        toast.success("Signed in to MX Bikes Shop");
+        toast.success(t("shop.signedIn"));
         void loadDownloads();
       } else {
-        toast.error("Couldn't capture your MX Bikes Shop session");
+        toast.error(t("shop.sessionFailed"));
       }
     });
     return () => {
       unlisten.then((fn) => fn());
     };
-  }, [loadDownloads]);
+  }, [loadDownloads, t]);
 
   // Keep the "installed" badges in sync with the tracks library.
   useEffect(() => {
@@ -94,11 +96,11 @@ export default function Shop({ refreshKey }: ShopProps) {
   const install = useCallback(
     (item: ShopItem) => {
       startShopInstall(item);
-      toast.success(`Queued “${item.title}”`, {
-        description: "Installing to your tracks folder.",
+      toast.success(t("browse.queued", { title: item.title }), {
+        description: t("shop.queuedDesc"),
       });
     },
-    [startShopInstall],
+    [startShopInstall, t],
   );
 
   const logout = useCallback(async () => {
@@ -112,21 +114,19 @@ export default function Shop({ refreshKey }: ShopProps) {
   if (loggedIn === false) {
     return (
       <div className="flex h-full flex-col">
-        <Header />
+        <Header t={t} />
         <div className="flex flex-1 flex-col items-center justify-center gap-4 px-7 text-center">
           <div className="grid size-14 place-items-center rounded-2xl bg-foreground/[0.06] text-foreground/50">
             <Store className="size-7" strokeWidth={1.5} />
           </div>
           <div className="flex max-w-sm flex-col gap-1.5">
-            <h2 className="text-[15px] font-semibold">Sign in to MX Bikes Shop</h2>
+            <h2 className="text-[15px] font-semibold">{t("shop.signInTitle")}</h2>
             <p className="text-[12.5px] text-muted-foreground">
-              Log in to mxbikes-shop.com to see and install the tracks
-              you&apos;ve purchased. We open the real site — your password never
-              touches this app.
+              {t("shop.signInBody")}
             </p>
           </div>
           <Button onClick={() => void shopLogin()}>
-            <Store className="size-4" /> Sign in
+            <Store className="size-4" /> {t("shop.signIn")}
           </Button>
         </div>
       </div>
@@ -136,6 +136,7 @@ export default function Shop({ refreshKey }: ShopProps) {
   return (
     <div className="flex h-full flex-col">
       <Header
+        t={t}
         right={
           loggedIn ? (
             <div className="ml-auto flex items-center gap-2">
@@ -145,10 +146,10 @@ export default function Shop({ refreshKey }: ShopProps) {
                 onClick={() => void loadDownloads()}
                 disabled={loading}
               >
-                <RefreshCw className="size-3.5" /> Refresh
+                <RefreshCw className="size-3.5" /> {t("common.refresh")}
               </Button>
               <Button variant="outline" size="sm" onClick={() => void logout()}>
-                <LogOut className="size-3.5" /> Log out
+                <LogOut className="size-3.5" /> {t("shop.logOut")}
               </Button>
             </div>
           ) : undefined
@@ -159,10 +160,10 @@ export default function Shop({ refreshKey }: ShopProps) {
         {error ? (
           <div className="flex flex-col items-center gap-3 py-20 text-center">
             <p className="text-[13px] text-destructive">
-              Couldn&apos;t load your downloads: {error}
+              {t("shop.loadFailed", { error })}
             </p>
             <Button variant="outline" size="sm" onClick={() => void loadDownloads()}>
-              Retry
+              {t("common.retry")}
             </Button>
           </div>
         ) : loading || loggedIn === null ? (
@@ -173,7 +174,7 @@ export default function Shop({ refreshKey }: ShopProps) {
           </div>
         ) : items.length === 0 ? (
           <p className="py-20 text-center text-[13px] text-muted-foreground">
-            No purchased downloads found on your account yet.
+            {t("shop.empty")}
           </p>
         ) : (
           <div className="grid grid-cols-4 gap-3.5">
@@ -197,11 +198,13 @@ export default function Shop({ refreshKey }: ShopProps) {
   );
 }
 
-function Header({ right }: { right?: React.ReactNode }) {
+function Header({ t, right }: { t: TFunc; right?: React.ReactNode }) {
   return (
     <header className="flex flex-none items-center gap-3.5 px-7 pb-3.5 pt-5">
-      <h1 className="text-[21px] font-bold tracking-[-0.2px]">Shop</h1>
-      <span className="text-[12.5px] text-muted-foreground">My Downloads</span>
+      <h1 className="text-[21px] font-bold tracking-[-0.2px]">{t("nav.shop")}</h1>
+      <span className="text-[12.5px] text-muted-foreground">
+        {t("shop.myDownloads")}
+      </span>
       {right}
     </header>
   );

--- a/src/Components/TitleBar/TitleBar.tsx
+++ b/src/Components/TitleBar/TitleBar.tsx
@@ -1,5 +1,6 @@
 import { Minus, Square, X } from "lucide-react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useT } from "../../i18n/context";
 import { cn } from "@/lib/utils";
 
 const appWindow = getCurrentWindow();
@@ -13,6 +14,7 @@ const IS_MAC = navigator.userAgent.includes("Mac");
 
 /** App brand + window controls. The whole bar is a drag region. */
 export default function TitleBar() {
+  const t = useT();
   return (
     <div
       data-tauri-drag-region
@@ -28,21 +30,21 @@ export default function TitleBar() {
         <div className="flex h-full">
           <button
             onClick={() => appWindow.minimize()}
-            title="Minimize"
+            title={t("window.minimize")}
             className="grid h-full w-[46px] cursor-default place-items-center text-muted-foreground transition-colors hover:bg-foreground/[0.06]"
           >
             <Minus className="size-4" />
           </button>
           <button
             onClick={() => appWindow.toggleMaximize()}
-            title="Maximize"
+            title={t("window.maximize")}
             className="grid h-full w-[46px] cursor-default place-items-center text-muted-foreground transition-colors hover:bg-foreground/[0.06]"
           >
             <Square className="size-[13px]" />
           </button>
           <button
             onClick={() => appWindow.close()}
-            title="Close"
+            title={t("window.close")}
             className="grid h-full w-[46px] cursor-default place-items-center text-muted-foreground transition-colors hover:bg-[#c4453c] hover:text-white"
           >
             <X className="size-4" />

--- a/src/Components/Tour/Tour.tsx
+++ b/src/Components/Tour/Tour.tsx
@@ -22,6 +22,7 @@ import {
 import type { LucideIcon } from "lucide-react";
 import { Button } from "@/Components/ui/button";
 import { cn } from "@/lib/utils";
+import { useT, type TKey } from "../../i18n/context";
 import type { DashboardView } from "../Shell/Sidebar";
 
 /** Bumped when the tour changes enough to warrant showing it again. */
@@ -41,68 +42,68 @@ interface Step {
   /** CSS selector of the element to spotlight. Omit for a centered, un-anchored step. */
   selector?: string;
   icon: LucideIcon;
-  title: string;
-  body: string;
+  title: TKey;
+  body: TKey;
 }
 
 const STEPS: Step[] = [
   {
     icon: Snowflake,
-    title: "Take a quick tour",
-    body: "A few seconds to see where everything lives. You can skip at any point.",
+    title: "tour.welcomeTour.title",
+    body: "tour.welcomeTour.body",
   },
   {
     view: "browse",
     selector: '[data-tour="browse"]',
     icon: Compass,
-    title: "Browse mods",
-    body: "Search mxb-mods.com right here and install any track, bike or paint with a single click.",
+    title: "tour.browse.title",
+    body: "tour.browse.body",
   },
   {
     view: "library",
     selector: '[data-tour="library"]',
     icon: LibraryIcon,
-    title: "Your library",
-    body: "Everything you've installed, in one place — update or remove mods without ever touching a zip file.",
+    title: "tour.library.title",
+    body: "tour.library.body",
   },
   {
     view: "locker",
     selector: '[data-tour="locker"]',
     icon: Bike,
-    title: "The locker",
-    body: "Swap bike models in and out. MXB App registers the pieces so the game picks them up.",
+    title: "tour.locker.title",
+    body: "tour.locker.body",
   },
   {
     view: "presets",
     selector: '[data-tour="presets"]',
     icon: Shirt,
-    title: "Presets",
-    body: "Save gear and paint loadouts, then apply a full look in one click — even while you're riding.",
+    title: "tour.presets.title",
+    body: "tour.presets.body",
   },
   {
     view: "rider",
     selector: '[data-tour="rider"]',
     icon: User,
-    title: "Rider studio",
-    body: "Preview your gear and paints on the 3D rider before you take them out on track.",
+    title: "tour.rider.title",
+    body: "tour.rider.body",
   },
   {
     selector: '[data-tour="frostmod"]',
     icon: RefreshCw,
-    title: "FrostMod, live",
-    body: "This shows FrostMod's status. It live-reloads MX Bikes after an install, so new content shows up without restarting the game.",
+    title: "tour.frostmod.title",
+    body: "tour.frostmod.body",
   },
   {
     view: "settings",
     selector: '[data-tour="settings"]',
     icon: SettingsIcon,
-    title: "Settings",
-    body: "Set your game folder, background behaviour and FrostMod options here. You can replay this tour from here too.",
+    title: "tour.settings.title",
+    body: "tour.settings.body",
   },
   {
     icon: Check,
-    title: "You're all set",
-    body: "That's the tour. Head to Browse and install your first mod.",
+    title: "tour.done.title",
+    body: "tour.done.body",
   },
 ];
 
@@ -142,6 +143,7 @@ interface TourProps {
 }
 
 export default function Tour({ navigate, onDone }: TourProps) {
+  const t = useT();
   const [index, setIndex] = useState(0);
   const [rect, setRect] = useState<Rect | null>(null);
   const bubbleRef = useRef<HTMLDivElement>(null);
@@ -172,10 +174,10 @@ export default function Tour({ navigate, onDone }: TourProps) {
       const r = el.getBoundingClientRect();
       setRect({ top: r.top, left: r.left, width: r.width, height: r.height });
     };
-    const t = window.setTimeout(measure, 70);
+    const timer = window.setTimeout(measure, 70);
     window.addEventListener("resize", measure);
     return () => {
-      window.clearTimeout(t);
+      window.clearTimeout(timer);
       window.removeEventListener("resize", measure);
     };
   }, [index, step.selector]);
@@ -220,8 +222,12 @@ export default function Tour({ navigate, onDone }: TourProps) {
             <Icon className="size-[22px]" strokeWidth={2.5} />
           </div>
           <div className="flex flex-col gap-1.5">
-            <h2 className="text-[17px] font-extrabold tracking-[-0.3px]">{step.title}</h2>
-            <p className="text-[13px] leading-relaxed text-muted-foreground">{step.body}</p>
+            <h2 className="text-[17px] font-extrabold tracking-[-0.3px]">
+              {t(step.title)}
+            </h2>
+            <p className="text-[13px] leading-relaxed text-muted-foreground">
+              {t(step.body)}
+            </p>
           </div>
         </div>
 
@@ -240,15 +246,15 @@ export default function Tour({ navigate, onDone }: TourProps) {
         <div className="flex items-center justify-between gap-3">
           {index > 0 ? (
             <Button variant="ghost" size="sm" onClick={back}>
-              <ArrowLeft /> Back
+              <ArrowLeft /> {t("common.back")}
             </Button>
           ) : (
             <Button variant="ghost" size="sm" onClick={onDone}>
-              Skip
+              {t("common.skip")}
             </Button>
           )}
           <Button size="sm" onClick={next}>
-            {isLast ? "Done" : "Next"}
+            {isLast ? t("common.done") : t("common.next")}
             {!isLast && <ArrowRight />}
           </Button>
         </div>

--- a/src/Components/UpdateBanner/UpdateBanner.tsx
+++ b/src/Components/UpdateBanner/UpdateBanner.tsx
@@ -1,12 +1,15 @@
 import { ArrowUpCircle, Loader2, X } from "lucide-react";
 import { Button } from "@/Components/ui/button";
 import { useUpdate } from "@/Context/Update";
+import { Trans } from "@/i18n";
+import { useT } from "@/i18n/context";
 
 /**
  * Slim, dismissible bar shown at the top of the app when a newer signed build
  * is available. Renders nothing when there's no update pending.
  */
 export default function UpdateBanner() {
+  const t = useT();
   const { available, installing, progress, install, dismiss } = useUpdate();
   if (!available) return null;
 
@@ -14,14 +17,20 @@ export default function UpdateBanner() {
     <div className="flex items-center gap-3 border-b border-primary/25 bg-primary/10 px-4 py-2 text-sm text-foreground">
       <ArrowUpCircle className="size-4 shrink-0 text-primary" />
       <span className="min-w-0 truncate">
-        <span className="font-semibold">MXB App v{available.version}</span> is
-        available.
+        <Trans
+          k="update.available"
+          values={{
+            version: (
+              <span className="font-semibold">MXB App v{available.version}</span>
+            ),
+          }}
+        />
         <span className="ml-1 text-muted-foreground">
           {installing
             ? progress != null
-              ? `Downloading… ${progress}%`
-              : "Downloading…"
-            : "Update to get the latest features and fixes."}
+              ? t("update.downloadingPct", { pct: progress })
+              : t("update.downloading")
+            : t("update.pitch")}
         </span>
       </span>
 
@@ -32,7 +41,7 @@ export default function UpdateBanner() {
           ) : (
             <ArrowUpCircle className="size-3.5" />
           )}
-          {installing ? "Updating…" : "Update & restart"}
+          {installing ? t("update.updating") : t("update.updateAndRestart")}
         </Button>
         <Button
           size="icon"
@@ -40,7 +49,7 @@ export default function UpdateBanner() {
           className="size-8"
           onClick={dismiss}
           disabled={installing}
-          aria-label="Dismiss update notification"
+          aria-label={t("update.dismiss")}
         >
           <X className="size-4" />
         </Button>

--- a/src/Components/Viewer/ModelViewer.tsx
+++ b/src/Components/Viewer/ModelViewer.tsx
@@ -6,6 +6,7 @@ import * as THREE from "three";
 import { cn } from "@/lib/utils";
 import type { EdfNode, PaintTexture, RiderPart } from "../../types";
 import { ErrorBoundary } from "../ErrorBoundary";
+import { useT } from "../../i18n/context";
 
 export type ViewerMode = "bike" | "rider";
 
@@ -727,10 +728,11 @@ function CameraRig({ solo }: { solo: boolean }) {
 // Legend for the OrbitControls gestures below — the canvas gives no other clue
 // that it's draggable. Kept muted so it reads as chrome, never competing with the model.
 function ControlsHint() {
+  const t = useT();
   const items = [
-    { Icon: Rotate3d, label: "Drag to rotate" },
-    { Icon: ZoomIn, label: "Scroll to zoom" },
-    { Icon: Move, label: "Right-drag to pan" },
+    { Icon: Rotate3d, label: t("viewer.dragToRotate") },
+    { Icon: ZoomIn, label: t("viewer.scrollToZoom") },
+    { Icon: Move, label: t("viewer.rightDragToPan") },
   ];
   return (
     <div className="pointer-events-none absolute bottom-2 left-2 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md bg-white/[0.06] px-2 py-1 text-[11px] leading-none text-white/45">

--- a/src/Components/Viewer/ViewerDialog.tsx
+++ b/src/Components/Viewer/ViewerDialog.tsx
@@ -11,6 +11,7 @@ import {
   listGearPaints,
 } from "../../api/mods";
 import type { PaintTexture, BikeModel, EdfNode, RiderPart, GearPaints } from "../../types";
+import { useT } from "../../i18n/context";
 
 interface ViewerDialogProps {
   open: boolean;
@@ -39,6 +40,7 @@ export function ViewerDialog({
   gearPart,
   stockGearPart,
 }: ViewerDialogProps) {
+  const t = useT();
   // A bike model → bike; gear/rider paint → rider. No user switch.
   const isBike = !!modelSource;
   const mode: ViewerMode = isBike ? "bike" : "rider";
@@ -224,12 +226,12 @@ export function ViewerDialog({
         <div className="flex flex-none items-center justify-between gap-3 border-b border-border px-4 py-2.5">
           <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
             <Box className="h-4 w-4 flex-none text-muted-foreground" />
-            <span className="truncate">{title ?? "3D Preview"}</span>
+            <span className="truncate">{title ?? t("viewer.preview3d")}</span>
           </div>
           <div className="flex flex-none items-center gap-2">
             {paintOptions.length > 0 && (
               <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                Paint
+                {t("viewer.paint")}
                 <select
                   value={paintIdx}
                   onChange={(e) => setPaintIdx(Number(e.target.value))}
@@ -245,7 +247,7 @@ export function ViewerDialog({
             )}
             {goggleOptions.length > 0 && (
               <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                Goggles
+                {t("category.goggles")}
                 <select
                   value={gogglesIdx}
                   onChange={(e) => setGogglesIdx(Number(e.target.value))}
@@ -261,7 +263,7 @@ export function ViewerDialog({
             )}
             <DialogClose className="rounded-md p-1 text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none">
               <X className="size-4" />
-              <span className="sr-only">Close</span>
+              <span className="sr-only">{t("common.close")}</span>
             </DialogClose>
           </div>
         </div>
@@ -308,7 +310,7 @@ export function ViewerDialog({
             <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-3 bg-black/40">
               <Loader2 className="h-6 w-6 animate-spin text-white/80" />
               <span className="text-sm text-white/80">
-                {loadingModel ? "Loading model…" : "Loading paint…"}
+                {loadingModel ? t("viewer.loadingModel") : t("viewer.loadingPaint")}
               </span>
               {/* Indeterminate bar so a slow decode/transfer never looks hung. */}
               <div className="h-1 w-52 overflow-hidden rounded-full bg-white/15">

--- a/src/Components/Viewer/ViewerPanel.tsx
+++ b/src/Components/Viewer/ViewerPanel.tsx
@@ -6,6 +6,7 @@ import { Dialog, DialogContent } from "../ui/dialog";
 import { ModelViewer, type ViewerMode } from "./ModelViewer";
 import { loadRiderModel } from "../../api/mods";
 import type { Loadout, RiderPart } from "../../types";
+import { useT } from "../../i18n/context";
 
 interface ViewerPanelProps {
   texture?: string | null;
@@ -22,12 +23,13 @@ function ModeToggle({
   mode: ViewerMode;
   onChange: (m: ViewerMode) => void;
 }) {
+  const t = useT();
   return (
     <div className="inline-flex rounded-md border border-border bg-background/60 p-0.5">
       {(
         [
-          { m: "bike" as const, icon: Bike, label: "Bike" },
-          { m: "rider" as const, icon: User, label: "Rider" },
+          { m: "bike" as const, icon: Bike, label: t("category.bike") },
+          { m: "rider" as const, icon: User, label: t("nav.rider") },
         ]
       ).map(({ m, icon: Icon, label }) => (
         <button
@@ -56,6 +58,7 @@ export function ViewerPanel({
   hiddenParts,
   className,
 }: ViewerPanelProps) {
+  const t = useT();
   const [mode, setMode] = useState<ViewerMode>(riderOnly ? "rider" : "bike");
   const [expanded, setExpanded] = useState(false);
   const [riderParts, setRiderParts] = useState<RiderPart[] | null>(null);
@@ -118,13 +121,13 @@ export function ViewerPanel({
   const overlay = riderFirstLoad ? (
     <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-2 text-muted-foreground">
       <Loader2 className="h-6 w-6 animate-spin" />
-      <span className="text-[12.5px]">Loading rider…</span>
+      <span className="text-[12.5px]">{t("viewer.loadingRider")}</span>
     </div>
   ) : (
     loading && (
       <div className="pointer-events-none absolute right-3 top-3 flex items-center gap-1.5 rounded-md bg-black/55 px-2 py-1 text-[11px] text-white/85">
         <Loader2 className="h-3.5 w-3.5 animate-spin" />
-        Loading…
+        {t("common.loading")}
       </div>
     )
   );
@@ -140,7 +143,7 @@ export function ViewerPanel({
         <div className="flex items-center justify-between border-b border-border px-3 py-2">
           <div className="flex items-center gap-2 text-sm font-medium">
             <Box className="h-4 w-4 text-muted-foreground" />
-            3D Preview
+            {t("viewer.preview3d")}
           </div>
           <div className="flex items-center gap-2">
             {!riderOnly && <ModeToggle mode={mode} onChange={setMode} />}
@@ -148,7 +151,7 @@ export function ViewerPanel({
               variant="ghost"
               size="icon"
               className="h-7 w-7"
-              title="Expand"
+              title={t("viewer.expand")}
               onClick={() => setExpanded(true)}
             >
               <Maximize2 className="h-4 w-4" />
@@ -172,7 +175,7 @@ export function ViewerPanel({
           <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
             <div className="flex items-center gap-2 text-sm font-medium">
               <Box className="h-4 w-4 text-muted-foreground" />
-              3D Preview
+              {t("viewer.preview3d")}
             </div>
             {!riderOnly && <ModeToggle mode={mode} onChange={setMode} />}
           </div>

--- a/src/Components/Welcome/Welcome.tsx
+++ b/src/Components/Welcome/Welcome.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Snowflake, ArrowLeft, ArrowRight } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+import { useT, type TKey } from "../../i18n/context";
 import { Button } from "@/Components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -11,8 +12,8 @@ interface WelcomeProps {
 
 interface Slide {
   icon: LucideIcon;
-  title: string;
-  body: string;
+  title: TKey;
+  body: TKey;
 }
 
 // Just the intro. The per-feature walkthrough (Browse, Library, FrostMod, …) is
@@ -21,12 +22,13 @@ interface Slide {
 const SLIDES: Slide[] = [
   {
     icon: Snowflake,
-    title: "Welcome to MXB App",
-    body: "Your mod manager for MX Bikes. Keep your tracks, bikes and paints organized in one place — no more zip files scattered across your desktop. We'll show you around in a few seconds.",
+    title: "welcome.intro.title",
+    body: "welcome.intro.body",
   },
 ];
 
 export default function Welcome({ onDone }: WelcomeProps) {
+  const t = useT();
   const [index, setIndex] = useState(0);
   const slide = SLIDES[index];
   const Icon = slide.icon;
@@ -44,10 +46,10 @@ export default function Welcome({ onDone }: WelcomeProps) {
           </div>
           <div className="flex flex-col items-center gap-2">
             <h1 className="text-center text-[24px] font-extrabold tracking-[-0.4px]">
-              {slide.title}
+              {t(slide.title)}
             </h1>
             <p className="min-h-[72px] max-w-[400px] text-center text-[13.5px] leading-relaxed text-muted-foreground">
-              {slide.body}
+              {t(slide.body)}
             </p>
           </div>
         </div>
@@ -68,21 +70,21 @@ export default function Welcome({ onDone }: WelcomeProps) {
 
         {SLIDES.length === 1 ? (
           <Button className="w-full" onClick={onDone}>
-            Get started
+            {t("welcome.getStarted")}
           </Button>
         ) : (
           <div className="flex w-full items-center justify-between gap-3">
             {index > 0 ? (
               <Button variant="ghost" onClick={back}>
-                <ArrowLeft /> Back
+                <ArrowLeft /> {t("common.back")}
               </Button>
             ) : (
               <Button variant="ghost" onClick={onDone}>
-                Skip
+                {t("common.skip")}
               </Button>
             )}
             <Button onClick={next}>
-              {isLast ? "Get started" : "Next"}
+              {isLast ? t("welcome.getStarted") : t("common.next")}
               {!isLast && <ArrowRight />}
             </Button>
           </div>

--- a/src/Components/ui/combobox.tsx
+++ b/src/Components/ui/combobox.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Check, ChevronsUpDown } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useT } from "@/i18n/context";
 import { Button } from "./button";
 import {
   Command,
@@ -33,10 +34,11 @@ export function Combobox({
   value,
   options,
   onChange,
-  placeholder = "Stock",
+  placeholder,
   invalid,
   className,
 }: ComboboxProps) {
+  const t = useT();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
 
@@ -70,20 +72,20 @@ export function Combobox({
             className,
           )}
         >
-          <span className="truncate">{value || placeholder}</span>
+          <span className="truncate">{value || placeholder || t("locker.stock")}</span>
           <ChevronsUpDown className="ml-1 h-3.5 w-3.5 flex-none opacity-50" />
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
         <Command>
           <CommandInput
-            placeholder="Search…"
+            placeholder={t("combobox.search")}
             value={query}
             onValueChange={setQuery}
             className="text-[12.5px]"
           />
           <CommandList>
-            {!canCreate && <CommandEmpty>No matches.</CommandEmpty>}
+            {!canCreate && <CommandEmpty>{t("library.noMatches")}</CommandEmpty>}
             <CommandGroup>
               {options.map((o) => (
                 <CommandItem
@@ -106,7 +108,7 @@ export function Combobox({
                   className="text-[12.5px]"
                 >
                   <Check className="mr-2 h-3.5 w-3.5 flex-none opacity-0" />
-                  Use “{q}”
+                  {t("combobox.use", { value: q })}
                 </CommandItem>
               )}
             </CommandGroup>

--- a/src/Components/ui/dialog.tsx
+++ b/src/Components/ui/dialog.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useT } from "@/i18n/context";
 
 const Dialog = DialogPrimitive.Root;
 const DialogTrigger = DialogPrimitive.Trigger;
@@ -27,7 +28,9 @@ const DialogContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
     showClose?: boolean;
   }
->(({ className, children, showClose = true, ...props }, ref) => (
+>(({ className, children, showClose = true, ...props }, ref) => {
+  const t = useT();
+  return (
   <DialogPrimitive.Portal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -43,12 +46,13 @@ const DialogContent = React.forwardRef<
       {showClose && (
         <DialogPrimitive.Close className="absolute right-4 top-4 rounded-md text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none">
           <X className="size-4" />
-          <span className="sr-only">Close</span>
+          <span className="sr-only">{t("common.close")}</span>
         </DialogPrimitive.Close>
       )}
     </DialogPrimitive.Content>
   </DialogPrimitive.Portal>
-));
+  );
+});
 DialogContent.displayName = "DialogContent";
 
 function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {

--- a/src/Context/Frostmod.tsx
+++ b/src/Context/Frostmod.tsx
@@ -18,6 +18,7 @@ import {
 } from "../api/mods";
 import type { FrostmodStatus } from "../types";
 import { displayName } from "../lib/mods";
+import { useT, type TFunc } from "../i18n/context";
 import { FrostmodContext } from "./FrostmodContext";
 
 const POLL_MS = 5000;
@@ -26,17 +27,22 @@ const POLL_MS = 5000;
  * Name what the folder watcher picked up. The watcher reports mods as `<type>/<name>`;
  * showing them beats a generic "your folder changed", which left people unsure whether
  * the drop had been seen at all.
+ *
+ * Takes `t` rather than lowercasing a translated sentence to splice it mid-phrase —
+ * that only works in languages that lowercase mid-sentence, which German doesn't.
  */
-function watchDescription(mods: string[]): string {
-  const asked = "Asked FrostMod to reload the game.";
-  if (mods.length === 0) return asked;
+function watchDescription(mods: string[], t: TFunc): string {
+  if (mods.length === 0) return t("frostmod.askedReload");
   const names = mods.map((m) => displayName(m.split("/").pop() ?? m));
   const shown = names.slice(0, 3).join(", ");
   const rest = names.length - 3;
-  return `${rest > 0 ? `${shown} and ${rest} more` : shown} — ${asked.toLowerCase()}`;
+  const list =
+    rest > 0 ? t("frostmod.andMore", { names: shown, count: rest }) : shown;
+  return t("frostmod.watchDesc", { names: list });
 }
 
 export function FrostmodProvider({ children }: { children: ReactNode }) {
+  const t = useT();
   const [running, setRunning] = useState<boolean | null>(null);
   const [status, setStatus] = useState<FrostmodStatus | null>(null);
   const [installing, setInstalling] = useState(false);
@@ -96,8 +102,10 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
         // report, and claiming otherwise is what makes a failed reload so confusing.
         const mods = p.mods ?? [];
         toast.success(
-          mods.length === 1 ? "New mod added" : `${mods.length || "New"} mods added`,
-          { description: watchDescription(mods) },
+          mods.length === 0
+            ? t("frostmod.newModsAdded")
+            : t("frostmod.modsAdded", { count: mods.length }),
+          { description: watchDescription(mods, t) },
         );
       }
       void probe();
@@ -105,7 +113,7 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
       unlisten = fn;
     });
     return () => unlisten?.();
-  }, [probe]);
+  }, [probe, t]);
 
   const reload = useCallback(async () => {
     const outcome = await reloadFrostmod();
@@ -117,12 +125,12 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
     try {
       const started = await frostmodStart();
       await probe();
-      if (started) toast.success("FrostMod started");
-      else toast.info("FrostMod is already running");
+      if (started) toast.success(t("frostmod.started"));
+      else toast.info(t("frostmod.alreadyRunning"));
     } catch (e) {
-      toast.error("Couldn't start FrostMod", { description: String(e) });
+      toast.error(t("frostmod.startFailed"), { description: String(e) });
     }
-  }, [probe]);
+  }, [probe, t]);
 
   const install = useCallback(async () => {
     setInstalling(true);
@@ -132,15 +140,15 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
       // which would race that restart and spawn a second instance.
       const version = await frostmodInstall();
       await refreshStatus();
-      toast.success(`FrostMod ${version} installed`, {
-        description: "It'll live-reload the game when you add mods.",
+      toast.success(t("frostmod.installedToast", { version }), {
+        description: t("frostmod.installedToastDesc"),
       });
     } catch (e) {
-      toast.error("Couldn't install FrostMod", { description: String(e) });
+      toast.error(t("frostmod.installFailed"), { description: String(e) });
     } finally {
       setInstalling(false);
     }
-  }, [refreshStatus]);
+  }, [refreshStatus, t]);
 
   // FrostMod is core to the app, so set it up automatically on first run instead
   // of prompting: once we learn it isn't installed, download + start it silently.

--- a/src/Context/Install.tsx
+++ b/src/Context/Install.tsx
@@ -19,6 +19,7 @@ import {
   type ShopItem,
 } from "../api/mods";
 import type { InstallStage, ReloadOutcome } from "../types";
+import { useT } from "../i18n/context";
 
 /** Where the bytes come from — a resolvable host, a file the user picked, or a
  * purchased item from the authenticated MX Bikes Shop. */
@@ -88,6 +89,11 @@ export function InstallProvider({
   onInstalledRef.current = onInstalled;
   const onOpenModRef = useRef(onOpenMod);
   onOpenModRef.current = onOpenMod;
+  // Held in a ref, like the callbacks above, so `run` keeps its empty dep list —
+  // switching language mid-transfer must not rebuild the installer.
+  const t = useT();
+  const tRef = useRef(t);
+  tRef.current = t;
   const clearTimer = useRef<number | null>(null);
   // Installs run one at a time (the engine handles a single transfer); extra
   // requests wait in this queue and are drained sequentially.
@@ -144,11 +150,11 @@ export function InstallProvider({
         cur && cur.slug === slug ? { ...cur, stage: "done" } : cur,
       );
       onInstalledRef.current?.();
-      toast.success(`${title} installed`, {
+      toast.success(tRef.current("install.installed", { title }), {
         description:
           frostOutcome === "signaled"
-            ? "Game reloaded via FrostMod — it's live now."
-            : "Added to your library.",
+            ? tRef.current("install.reloadedDesc")
+            : tRef.current("install.addedDesc"),
       });
       // Auto-retire the sidebar/detail card a few seconds after success.
       clearTimer.current = window.setTimeout(() => {
@@ -167,10 +173,13 @@ export function InstallProvider({
           ? null
           : { slug, subpath, categoryId: params.categoryId };
       if (!target) {
-        toast.error(`Install failed — ${title}`, {
+        toast.error(tRef.current("install.failed", { title }), {
           description: message,
           duration: Infinity,
-          action: { label: "Retry", onClick: () => void run(params) },
+          action: {
+            label: tRef.current("common.retry"),
+            onClick: () => void run(params),
+          },
         });
       } else {
         toast.custom(
@@ -284,6 +293,7 @@ function InstallFailedToast({
   onRetry: () => void;
   onDismiss: () => void;
 }) {
+  const t = useT();
   return (
     <div
       role="button"
@@ -292,20 +302,20 @@ function InstallFailedToast({
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") onOpen();
       }}
-      title="Open the mod's page"
+      title={t("install.openModPage")}
       className="group flex w-full cursor-default flex-col gap-1 rounded-xl px-4 py-3 transition-colors hover:bg-foreground/[0.04]"
     >
       <div className="flex items-start gap-2">
         <AlertTriangle className="mt-px size-3.5 flex-none text-destructive" />
         <span className="flex-1 font-bold text-destructive">
-          Install failed — {title}
+          {t("install.failed", { title })}
         </span>
         <button
           onClick={(e) => {
             e.stopPropagation();
             onDismiss();
           }}
-          aria-label="Dismiss"
+          aria-label={t("common.dismiss")}
           className="-mr-1 -mt-0.5 flex-none cursor-default rounded-full p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100"
         >
           <X className="size-3.5" />
@@ -316,7 +326,7 @@ function InstallFailedToast({
       </span>
       <div className="mt-1.5 flex items-center justify-between gap-2 pl-[22px]">
         <span className="text-[11px] text-muted-foreground">
-          Click to open the mod’s page
+          {t("install.clickToOpen")}
         </span>
         <button
           onClick={(e) => {
@@ -325,7 +335,7 @@ function InstallFailedToast({
           }}
           className="flex-none cursor-default rounded-md bg-primary px-2 py-1 text-[11.5px] font-semibold text-primary-foreground transition-[filter] hover:brightness-110"
         >
-          Retry
+          {t("common.retry")}
         </button>
       </div>
     </div>

--- a/src/Context/Update.tsx
+++ b/src/Context/Update.tsx
@@ -9,6 +9,7 @@ import {
 import { check as checkForUpdate, type Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { toast } from "sonner";
+import { useT } from "../i18n/context";
 
 /** The updater only works inside the Tauri runtime (no-op in the browser). */
 function inTauri(): boolean {
@@ -42,6 +43,7 @@ type UpdateContextValue = {
 const UpdateContext = createContext<UpdateContextValue | null>(null);
 
 export function UpdateProvider({ children }: { children: React.ReactNode }) {
+  const t = useT();
   const [available, setAvailable] = useState<Update | null>(null);
   const [installing, setInstalling] = useState(false);
   const [progress, setProgress] = useState<number | null>(null);
@@ -53,7 +55,7 @@ export function UpdateProvider({ children }: { children: React.ReactNode }) {
     try {
       const update = await checkForUpdate();
       if (!update) {
-        if (!silent) toast.success("You're on the latest version");
+        if (!silent) toast.success(t("update.onLatest"));
         setAvailable(null);
         return;
       }
@@ -64,11 +66,12 @@ export function UpdateProvider({ children }: { children: React.ReactNode }) {
       }
       setAvailable(update);
     } catch (e) {
-      if (!silent) toast.error("Couldn't check for updates", { description: String(e) });
+      if (!silent)
+        toast.error(t("update.checkFailed"), { description: String(e) });
     } finally {
       inFlight.current = false;
     }
-  }, []);
+  }, [t]);
 
   const install = useCallback(async () => {
     if (!available || installing) return;
@@ -93,11 +96,11 @@ export function UpdateProvider({ children }: { children: React.ReactNode }) {
       });
       await relaunch();
     } catch (e) {
-      toast.error("Update failed", { description: String(e) });
+      toast.error(t("update.failed"), { description: String(e) });
       setInstalling(false);
       setProgress(null);
     }
-  }, [available, installing]);
+  }, [available, installing, t]);
 
   const dismiss = useCallback(() => {
     if (available) localStorage.setItem(DISMISSED_UPDATE_KEY, available.version);

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -30,19 +30,26 @@ import type {
   BundlePlan,
   BundleProgress,
 } from "../types";
+import type { TKey } from "../i18n";
 
 /** Results per page (mirrors `PER_PAGE` in the Rust backend). */
 export const SEARCH_PAGE_SIZE = 24;
 
 export interface ModCategory {
   id: number;
-  label: string;
+  label: TKey;
 }
 
 /** A top-level kind of mod, with its filter categories and install folder. */
 export interface ModType {
   id: string;
-  label: string;
+  label: TKey;
+  /**
+   * The same noun as it reads *inside* a sentence ("Search tracks…").
+   * A separate key rather than `label.toLowerCase()` — German capitalizes its
+   * nouns everywhere, so lowercasing a translated label produces broken German.
+   */
+  labelInline: TKey;
   /** Parent WordPress category id (also the "All" filter). */
   categoryId: number;
   categories: ModCategory[];
@@ -53,44 +60,47 @@ export interface ModType {
 export const MOD_TYPES: ModType[] = [
   {
     id: "tracks",
-    label: "Tracks",
+    label: "modType.tracks",
+    labelInline: "modType.tracksInline",
     categoryId: 22,
     installSubpath: "mods/tracks",
     categories: [
-      { id: 22, label: "All" },
-      { id: 300, label: "Beginner" },
-      { id: 301, label: "Intermediate" },
-      { id: 302, label: "Pro" },
-      { id: 119, label: "Assets" },
+      { id: 22, label: "browseCat.all" },
+      { id: 300, label: "browseCat.beginner" },
+      { id: 301, label: "browseCat.intermediate" },
+      { id: 302, label: "browseCat.pro" },
+      { id: 119, label: "browseCat.assets" },
     ],
   },
   {
     id: "bikes",
-    label: "Bikes",
+    label: "modType.bikes",
+    labelInline: "modType.bikesInline",
     categoryId: 29,
     installSubpath: "mods/bikes",
     categories: [
-      { id: 29, label: "All" },
-      { id: 45, label: "New Bikes" },
-      { id: 37, label: "Liveries" },
-      { id: 46, label: "Sounds" },
+      { id: 29, label: "browseCat.all" },
+      { id: 45, label: "browseCat.newBikes" },
+      { id: 37, label: "browseCat.liveries" },
+      { id: 46, label: "browseCat.sounds" },
     ],
   },
   {
     id: "rider",
-    label: "Rider",
+    label: "modType.rider",
+    labelInline: "modType.riderInline",
     categoryId: 30,
     installSubpath: "mods/rider",
     categories: [
-      { id: 30, label: "All" },
-      { id: 35, label: "Rider Kit" },
-      { id: 313, label: "Helmets" },
-      { id: 127, label: "Helmet Paints" },
-      { id: 32, label: "Gloves" },
-      { id: 343, label: "Boots" },
-      { id: 126, label: "Boot Paints" },
-      { id: 36, label: "Protection" },
-      { id: 135, label: "Protection Paints" },
+      { id: 30, label: "browseCat.all" },
+      { id: 35, label: "browseCat.riderKit" },
+      { id: 313, label: "browseCat.helmets" },
+      { id: 127, label: "browseCat.helmetPaints" },
+      { id: 32, label: "browseCat.gloves" },
+      { id: 343, label: "browseCat.boots" },
+      { id: 126, label: "browseCat.bootPaints" },
+      { id: 36, label: "browseCat.protection" },
+      { id: 135, label: "browseCat.protectionPaints" },
     ],
   },
 ];
@@ -377,7 +387,15 @@ export function importFile(
 
 export interface DestOption {
   value: string;
+  /** A real folder name — shown verbatim, never translated. */
   label: string;
+  /**
+   * Set when the label is UI prose rather than a folder name ("Bikes (root)",
+   * "{{name}} — paints"). The folder name, when one is involved, rides in
+   * `labelVars.name` so the translation can put it where its language wants it.
+   */
+  labelKey?: TKey;
+  labelVars?: Record<string, string>;
 }
 
 const stripExt = (s: string) => s.replace(/\.(pkz|zip|rar|7z)$/i, "");
@@ -398,11 +416,15 @@ export function buildDestinations(
 ): { options: DestOption[]; guess: string; suggestions: string[] } {
   const seen = new Set<string>([""]);
   const options: DestOption[] = [
-    { value: "", label: modType.id === "bikes" ? "Bikes (root)" : "Tracks (root)" },
+    {
+      value: "",
+      label: "",
+      labelKey: modType.id === "bikes" ? "dest.bikesRoot" : "dest.tracksRoot",
+    },
   ];
-  const add = (value: string, label: string) => {
+  const add = (value: string, opt: Omit<DestOption, "value">) => {
     if (!seen.has(value)) {
-      options.push({ value, label });
+      options.push({ value, ...opt });
       seen.add(value);
     }
   };
@@ -412,8 +434,16 @@ export function buildDestinations(
   if (modType.id === "bikes") {
     const bikes = installed.filter((i) => i.folder === "");
     for (const b of bikes) {
-      add(stripExt(b.name), `${stripExt(b.name)} — bike folder`);
-      add(`${stripExt(b.name)}/paints`, `${stripExt(b.name)} — paints`);
+      add(stripExt(b.name), {
+        label: "",
+        labelKey: "dest.bikeFolder",
+        labelVars: { name: stripExt(b.name) },
+      });
+      add(`${stripExt(b.name)}/paints`, {
+        label: "",
+        labelKey: "dest.bikePaints",
+        labelVars: { name: stripExt(b.name) },
+      });
     }
 
     if (livery || sound) {
@@ -433,7 +463,7 @@ export function buildDestinations(
   }
 
   for (const f of [...new Set(installed.map((i) => i.folder))].sort((a, b) => a.localeCompare(b))) {
-    if (f) add(f, f);
+    if (f) add(f, { label: f });
   }
   return { options, guess, suggestions };
 }
@@ -477,9 +507,9 @@ export function buildRiderDestinations(
 ): { options: DestOption[]; guess: string; suggestions: string[] } {
   const seen = new Set<string>();
   const options: DestOption[] = [];
-  const add = (value: string, label: string) => {
+  const add = (value: string, labelKey: TKey, labelVars?: Record<string, string>) => {
     if (!seen.has(value)) {
-      options.push({ value, label });
+      options.push({ value, label: "", labelKey, labelVars });
       seen.add(value);
     }
   };
@@ -491,22 +521,22 @@ export function buildRiderDestinations(
     return s;
   };
 
-  add("helmets", "Helmets (new model)");
-  add("boots", "Boots (new model)");
-  add("protection", "Protection (new model)");
+  add("helmets", "dest.helmetsNewModel");
+  add("boots", "dest.bootsNewModel");
+  add("protection", "dest.protectionNewModel");
 
   const scoredPaints: { value: string; score: number; kind: GearPaintKind }[] = [];
   for (const h of targets.helmets) {
-    add(`helmets/${h}/paints`, `${h} · helmet paints`);
-    add(`helmets/${h}/goggles`, `${h} · goggles`);
+    add(`helmets/${h}/paints`, "dest.helmetPaintsFor", { name: h });
+    add(`helmets/${h}/goggles`, "dest.gogglesFor", { name: h });
     scoredPaints.push({ value: `helmets/${h}/paints`, score: score(h), kind: "helmets" });
   }
   for (const b of targets.boots) {
-    add(`boots/${b}/paints`, `${b} · boot paints`);
+    add(`boots/${b}/paints`, "dest.bootPaintsFor", { name: b });
     scoredPaints.push({ value: `boots/${b}/paints`, score: score(b), kind: "boots" });
   }
   for (const p of targets.protection) {
-    add(`protection/${p}/paints`, `${p} · protection paints`);
+    add(`protection/${p}/paints`, "dest.protectionPaintsFor", { name: p });
     scoredPaints.push({ value: `protection/${p}/paints`, score: score(p), kind: "protection" });
   }
 
@@ -514,8 +544,8 @@ export function buildRiderDestinations(
     (a, b) => a.toLowerCase().localeCompare(b.toLowerCase()),
   );
   for (const prof of profiles) {
-    add(`riders/${prof}/paints`, `${prof} · outfit / kit`);
-    add(`riders/${prof}/gloves`, `${prof} · gloves`);
+    add(`riders/${prof}/paints`, "dest.outfitFor", { name: prof });
+    add(`riders/${prof}/gloves`, "dest.glovesFor", { name: prof });
   }
 
   const kindPaints = paintKind

--- a/src/i18n/context.ts
+++ b/src/i18n/context.ts
@@ -1,0 +1,44 @@
+/**
+ * The i18n context and its hooks.
+ *
+ * Split from the provider for the same reason `Context/FrostmodContext.ts` is
+ * split from `Context/Frostmod.tsx`: Vite's Fast Refresh only hot-swaps a module
+ * whose exports are *all* React components. With the hooks living alongside
+ * `I18nProvider`, editing any locale file invalidated that module and forced a
+ * full page reload of the app — on the files a translator edits most.
+ *
+ * Import `useT` / `useI18n` from here; import `I18nProvider` / `Trans` from `..`.
+ */
+import { createContext, useContext } from "react";
+import type { Locale, LocalePref, TFunc } from "./core";
+
+export type {
+  Locale,
+  LocalePref,
+  TFunc,
+  TKey,
+  TVars,
+  Translation,
+} from "./core";
+
+export interface I18nContextValue {
+  /** The user's preference, `system` included. */
+  locale: LocalePref;
+  /** What's actually rendering right now. */
+  resolved: Locale;
+  setLocale: (pref: LocalePref) => void;
+  t: TFunc;
+}
+
+export const I18nContext = createContext<I18nContextValue | null>(null);
+
+export function useI18n() {
+  const ctx = useContext(I18nContext);
+  if (!ctx) throw new Error("useI18n must be used within I18nProvider");
+  return ctx;
+}
+
+/** The common case — just the translate function. */
+export function useT(): TFunc {
+  return useI18n().t;
+}

--- a/src/i18n/core.ts
+++ b/src/i18n/core.ts
@@ -1,0 +1,130 @@
+/**
+ * The non-React half of the i18n layer: dictionaries, key types, lookup and
+ * formatting.
+ *
+ * Kept separate from `index.tsx` because React Fast Refresh only hot-swaps a
+ * module whose exports are all components or hooks. With `LOCALE_OPTIONS` and
+ * friends living alongside `I18nProvider`, every edit to the i18n layer forced a
+ * full page reload in dev instead of a hot update.
+ */
+import { en } from "./locales/en";
+import { it } from "./locales/it";
+import { es } from "./locales/es";
+import { fr } from "./locales/fr";
+import { de } from "./locales/de";
+import { ptBR } from "./locales/pt-BR";
+
+export type Locale = "en" | "it" | "es" | "fr" | "de" | "pt-BR";
+/** What the user picked — `system` follows the OS. */
+export type LocalePref = Locale | "system";
+
+/**
+ * Every locale is typed against `en`, so `tsc` rejects a translation that is
+ * missing a key or invents one. That's the whole reason this is a local module
+ * and not i18next: a missing key can't reach a build.
+ */
+export type Translation = Record<keyof typeof en, string>;
+
+const DICTS: Record<Locale, Translation> = { en, it, es, fr, de, "pt-BR": ptBR };
+
+/** Listed in their own language — someone who lands in a language they can't
+ *  read still has to be able to find their way out. */
+export const LOCALE_OPTIONS: { value: LocalePref; label: string }[] = [
+  { value: "system", label: "System" },
+  { value: "en", label: "English" },
+  { value: "it", label: "Italiano" },
+  { value: "es", label: "Español" },
+  { value: "fr", label: "Français" },
+  { value: "de", label: "Deutsch" },
+  { value: "pt-BR", label: "Português (BR)" },
+];
+
+type Key = keyof typeof en;
+/** `"library.uninstalled_other"` → `"library.uninstalled"`, so the plural family
+ *  is addressable by its base name while staying type-checked. */
+type PluralBase<K> = K extends `${infer B}_other` ? B : never;
+export type TKey = Key | PluralBase<Key>;
+
+export type TVars = Record<string, string | number>;
+export type TFunc = (key: TKey, vars?: TVars) => string;
+
+export const STORAGE_KEY = "frost-locale";
+
+function isLocale(v: string): v is Locale {
+  return v in DICTS;
+}
+
+/**
+ * The active locale, mirrored outside React.
+ *
+ * `Intl` date formatting lives in pure helpers (`lib/mods`) that dozens of call
+ * sites use without a hook in scope. Reading the locale from here keeps those
+ * helpers signature-compatible while still following the in-app language rather
+ * than the OS one — picking Italian on an English machine has to move the dates
+ * too, or half the UI stays English.
+ */
+let activeLocale: Locale = "en";
+export function getLocale(): Locale {
+  return activeLocale;
+}
+export function setActiveLocale(locale: Locale) {
+  activeLocale = locale;
+}
+
+export function readStoredLocale(): LocalePref {
+  const v = localStorage.getItem(STORAGE_KEY);
+  if (v === "system" || (v && isLocale(v))) return v;
+  return "system";
+}
+
+/** Map an OS tag (`de-AT`, `pt`, `en-GB`) onto a locale we actually ship. */
+export function resolveSystemLocale(tag = navigator.language): Locale {
+  if (isLocale(tag)) return tag;
+  const base = tag.split("-")[0]?.toLowerCase() ?? "";
+  // Brazilian is the only Portuguese we ship — better than dropping `pt` to English.
+  if (base === "pt") return "pt-BR";
+  return isLocale(base) ? base : "en";
+}
+
+function lookup(
+  dict: Translation,
+  locale: Locale,
+  key: string,
+  vars?: TVars,
+): string | undefined {
+  const d = dict as Record<string, string | undefined>;
+  if (typeof vars?.count === "number") {
+    // Intl gets the per-language rules right where a `n === 1` check wouldn't —
+    // French, for one, treats 0 as singular.
+    const category = new Intl.PluralRules(locale).select(vars.count);
+    return d[`${key}_${category}`] ?? d[`${key}_other`] ?? d[key];
+  }
+  return d[key];
+}
+
+function interpolate(str: string, vars?: TVars): string {
+  if (!vars) return str;
+  return str.replace(/\{\{(\w+)\}\}/g, (whole, name: string) =>
+    name in vars ? String(vars[name]) : whole,
+  );
+}
+
+/** The uninterpolated string for a key, falling back to English. */
+export function template(locale: Locale, key: string, vars?: TVars): string {
+  const raw =
+    lookup(DICTS[locale], locale, key, vars) ?? lookup(en, "en", key, vars);
+  // The types make this unreachable; showing English beats showing a raw key.
+  return raw ?? key;
+}
+
+export function translate(locale: Locale, key: string, vars?: TVars): string {
+  return interpolate(template(locale, key, vars), vars);
+}
+
+/** Render a label that is either a real folder name or a translated phrase. */
+export function labelOf(
+  opt: { label: string; labelKey?: TKey; labelVars?: Record<string, string> },
+  t: TFunc,
+): string {
+  return opt.labelKey ? t(opt.labelKey, opt.labelVars) : opt.label;
+}

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -1,0 +1,118 @@
+/**
+ * The i18n components.
+ *
+ * This module exports **only** React components, which is what makes it a valid
+ * Fast Refresh boundary — so editing a locale file hot-updates instead of
+ * reloading the whole app. Keep it that way:
+ *
+ *   - hooks and the context  → `./context`
+ *   - dictionaries and pure functions → `./core`
+ *
+ * (The `export type` block below is erased at build time and doesn't count.)
+ */
+import { Fragment, useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  readStoredLocale,
+  resolveSystemLocale,
+  setActiveLocale,
+  STORAGE_KEY,
+  template,
+  translate,
+  type Locale,
+  type LocalePref,
+  type TFunc,
+  type TKey,
+} from "./core";
+import { I18nContext, useI18n } from "./context";
+
+export type {
+  Locale,
+  LocalePref,
+  TFunc,
+  TKey,
+  TVars,
+  Translation,
+} from "./core";
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocaleState] = useState<LocalePref>(readStoredLocale);
+  const [systemLocale, setSystemLocale] = useState<Locale>(() =>
+    resolveSystemLocale(),
+  );
+
+  // The webview reports a language change without a reload on some platforms.
+  useEffect(() => {
+    const onChange = () => setSystemLocale(resolveSystemLocale());
+    window.addEventListener("languagechange", onChange);
+    return () => window.removeEventListener("languagechange", onChange);
+  }, []);
+
+  const resolved: Locale = locale === "system" ? systemLocale : locale;
+
+  // Set during render, not in an effect: the pure formatters in `lib/mods` read
+  // it while this same render's children are producing their output.
+  setActiveLocale(resolved);
+
+  // Screen readers and CSS hyphenation both key off this.
+  useEffect(() => {
+    document.documentElement.lang = resolved;
+  }, [resolved]);
+
+  const setLocale = useCallback((pref: LocalePref) => {
+    localStorage.setItem(STORAGE_KEY, pref);
+    setLocaleState(pref);
+  }, []);
+
+  const t = useCallback<TFunc>(
+    (key, vars) => translate(resolved, key, vars),
+    [resolved],
+  );
+
+  const value = useMemo(
+    () => ({ locale, resolved, setLocale, t }),
+    [locale, resolved, setLocale, t],
+  );
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+/**
+ * A translated string with React nodes spliced into its placeholders.
+ *
+ * Needed wherever a sentence wraps styled markup (a path in mono, a bold name):
+ * splitting such a sentence into prefix/suffix keys would hard-code English word
+ * order, and German and French don't share it.
+ *
+ *   <Trans k="setup.autoDetect" values={{ hint: <code>{hint}</code> }} />
+ */
+export function Trans({
+  k,
+  values,
+  count,
+}: {
+  k: TKey;
+  values: Record<string, ReactNode>;
+  count?: number;
+}) {
+  const { resolved } = useI18n();
+  const raw = template(resolved, k, count === undefined ? undefined : { count });
+  const parts = raw.split(/(\{\{\w+\}\})/g);
+  return (
+    <>
+      {parts.map((part, i) => {
+        const match = /^\{\{(\w+)\}\}$/.exec(part);
+        if (!match) return part;
+        const name = match[1];
+        return (
+          <Fragment key={i}>
+            {name in values
+              ? values[name]
+              : count !== undefined && name === "count"
+                ? count
+                : part}
+          </Fragment>
+        );
+      })}
+    </>
+  );
+}

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1,0 +1,726 @@
+import type { Translation } from "..";
+
+/**
+ * German (informal "du" — this is a modding tool for a game community, not a bank).
+ *
+ * Community terminology rather than dictionary equivalents: `mod`, `Setup`,
+ * `Preset` and `Stock` stay as loanwords, while gear is translated — `Helm`,
+ * `Stiefel`, `Brille` for goggles, `Protektoren` for protection (the actual MX term,
+ * not "Schutz"), `Lackierung` for a bike paint.
+ *
+ * Note `modType.*Inline`: German capitalizes nouns *everywhere*, so these keep their
+ * capitals where English lowercases them mid-sentence. That's the whole reason the
+ * inline forms are separate keys rather than `label.toLowerCase()`.
+ *
+ * German runs ~30% longer than English — this is the locale that stresses layout.
+ * Product names (MXB App, FrostMod, MX Bikes) are never translated.
+ */
+export const de: Translation = {
+  // ── Allgemein ──────────────────────────────────────────────────────────────
+  "common.cancel": "Abbrechen",
+  "common.back": "Zurück",
+  "common.next": "Weiter",
+  "common.skip": "Überspringen",
+  "common.close": "Schließen",
+  "common.save": "Speichern",
+  "common.delete": "Löschen",
+  "common.rename": "Umbenennen",
+  "common.retry": "Erneut versuchen",
+  "common.tryAgain": "Erneut versuchen",
+  "common.loading": "Wird geladen…",
+  "common.installed": "Installiert",
+  "common.select": "Auswählen",
+  "common.deselect": "Abwählen",
+  "common.selectAll": "Alle auswählen",
+  "common.clear": "Leeren",
+  "common.done": "Fertig",
+  "common.apply": "Anwenden",
+  "common.remove": "Entfernen",
+  "common.open": "Öffnen",
+  "common.refresh": "Aktualisieren",
+  "common.dismiss": "Ausblenden",
+  "common.later": "Später",
+  "common.active": "Aktiv",
+
+  // ── Fenstersteuerung ───────────────────────────────────────────────────────
+  "window.minimize": "Minimieren",
+  "window.maximize": "Maximieren",
+  "window.close": "Schließen",
+
+  // ── Navigation ─────────────────────────────────────────────────────────────
+  "nav.browse": "Entdecken",
+  "nav.shop": "Shop",
+  "nav.library": "Bibliothek",
+  "nav.locker": "Spind",
+  "nav.presets": "Presets",
+  "nav.rider": "Fahrer",
+  "nav.settings": "Einstellungen",
+
+  "sidebar.installing": "„{{name}}“ wird installiert",
+  "sidebar.queued": "+{{count}} in der Warteschlange",
+
+  // ── FrostMod ───────────────────────────────────────────────────────────────
+  "frostmod.checking": "FrostMod wird geprüft…",
+  "frostmod.running": "FrostMod läuft",
+  "frostmod.notRunning": "FrostMod läuft nicht",
+  "frostmod.reloadGame": "Spiel neu laden",
+  "frostmod.start": "FrostMod starten",
+  "frostmod.reloadedGame": "FrostMod hat das Spiel neu geladen.",
+  "frostmod.notRunningToast": "FrostMod läuft nicht.",
+  "frostmod.started": "FrostMod gestartet",
+  "frostmod.alreadyRunning": "FrostMod läuft bereits",
+  "frostmod.startFailed": "FrostMod konnte nicht gestartet werden",
+  "frostmod.installedToast": "FrostMod {{version}} installiert",
+  "frostmod.installedToastDesc":
+    "Es lädt das Spiel live neu, sobald du Mods hinzufügst.",
+  "frostmod.installFailed": "FrostMod konnte nicht installiert werden",
+  "frostmod.newModsAdded": "Neue Mods hinzugefügt",
+  "frostmod.modsAdded_one": "Neuer Mod hinzugefügt",
+  "frostmod.modsAdded_other": "{{count}} Mods hinzugefügt",
+  "frostmod.askedReload": "FrostMod wurde zum Neuladen aufgefordert.",
+  "frostmod.andMore_one": "{{names}} und {{count}} weiterer",
+  "frostmod.andMore_other": "{{names}} und {{count}} weitere",
+  "frostmod.watchDesc":
+    "{{names}} — FrostMod wurde zum Neuladen aufgefordert.",
+
+  // ── Ersteinrichtung ────────────────────────────────────────────────────────
+  "setup.title": "Willkommen bei MXB App",
+  "setup.tagline":
+    "Durchstöbere mxb-mods, installiere mit einem Klick und lass FrostMod das Spiel für dich neu laden.",
+  "setup.modsFolder": "MX-Bikes-Ordner",
+  "setup.autoDetect":
+    "MXB App erkennt deinen Ordner {{hint}} automatisch. Du kannst ihn auch selbst auswählen.",
+  "setup.chooseManually": "Ordner manuell auswählen…",
+  "setup.chooseDifferent": "Anderen Ordner auswählen…",
+  "setup.gameInstall": "MX-Bikes-Installation",
+  "setup.detecting": "Deine MX-Bikes-Installation wird gesucht…",
+  "setup.found": "Gefunden",
+  "setup.detectedAutomatically": "Automatisch erkannt",
+  "setup.installNotFound":
+    "Deine MX-Bikes-Installation konnte nicht automatisch gefunden werden — sie liefert die 3D-Fahrervorschau. Wähle sie manuell aus oder lege sie später in den Einstellungen fest.",
+  "setup.chooseInstallManually":
+    "Installationsordner manuell auswählen…",
+  "setup.startBrowsing": "Mods entdecken",
+  "setup.detectAndStart": "Erkennen und loslegen",
+  "setup.pickModsFolder": "Wähle deinen MX-Bikes-Ordner",
+  "setup.pickInstallFolder": "Wähle deinen MX-Bikes-Installationsordner",
+
+  // ── Willkommen ─────────────────────────────────────────────────────────────
+  "welcome.intro.title": "Willkommen bei MXB App",
+  "welcome.intro.body":
+    "Dein Mod-Manager für MX Bikes. Halte Strecken, Motorräder und Lackierungen an einem Ort organisiert — keine ZIP-Dateien mehr über den ganzen Desktop verstreut. Wir zeigen dir das Wichtigste in ein paar Sekunden.",
+  "welcome.getStarted": "Los geht's",
+
+  // ── Presets ────────────────────────────────────────────────────────────────
+  "presets.missing": "fehlt",
+  "presets.missingHint":
+    "Dieser Mod ist nicht installiert — im Spiel erscheint er als Stock",
+  "presets.missingMods":
+    "Fehlende Mods: {{mods}}. Installiere sie, damit diese Teile angezeigt werden.",
+  "presets.help":
+    "Speichere einen kompletten Fahrer-Look und lade ihn auf Kommando auf ein Motorrad.",
+  "presets.profile": "Profil",
+  "presets.namePlaceholder": "Preset-Name…",
+  "presets.savePreset": "Preset speichern",
+  "presets.saveChanges": "Änderungen speichern",
+  "presets.saveChangesQ": "Änderungen speichern?",
+  "presets.replaceQ": "Preset ersetzen?",
+  "presets.replace": "Ersetzen",
+  "presets.loadCopy": "Kopie in den Editor laden",
+  "presets.viewOnRider": "Am Fahrer ansehen",
+  "presets.editNameOrOptions": "Name oder Optionen bearbeiten",
+  "presets.share": "Teilen",
+  "presets.nameFirst": "Gib dem Preset zuerst einen Namen.",
+  "presets.pickProfileAndBike":
+    "Wähle ein Profil und ein Motorrad zum Anwenden.",
+  "presets.updated": "Preset „{{name}}“ aktualisiert.",
+  "presets.renamed":
+    "In „{{name}}“ umbenannt und Änderungen gespeichert.",
+  "presets.saved": "Preset „{{name}}“ gespeichert.",
+  "presets.editing":
+    "„{{name}}“ wird bearbeitet — ändere, was du willst, und speichere dann.",
+  "presets.appliedRefreshed":
+    "„{{label}}“ auf {{bike}} angewendet — live im Spiel aktualisiert.",
+  "presets.appliedRefreshFailed":
+    "„{{label}}“ auf {{bike}} angewendet — gespeichert, aber die sofortige Aktualisierung ist fehlgeschlagen: wähle dein Profil im Spiel neu aus, um es zu laden.",
+  "presets.appliedGameRunning":
+    "„{{label}}“ auf {{bike}} angewendet — gespeichert. Wähle dein Profil in MX Bikes (Profilmenü) neu aus, um den neuen Look zu laden.",
+  "presets.appliedNextTime":
+    "„{{label}}“ auf {{bike}} angewendet — gespeichert. Es wird beim nächsten Start des Spiels geladen.",
+  "presets.phaseBundling": "Dateien werden verpackt…",
+  "presets.phaseUploading": "Paket wird hochgeladen…",
+  "presets.phaseDownloading": "Paket wird heruntergeladen…",
+  "presets.phaseInstalling": "Dateien werden installiert…",
+  "presets.bundleUploaded":
+    "Komplettpaket hochgeladen — der Code enthält jetzt auch die Dateien.",
+  "presets.shareHintFull":
+    "Dieser Code enthält ein herunterladbares Paket — der Empfänger wählt Vollständiger Import und bekommt alles, auch ganz ohne installierte Mods.",
+  "presets.shareHintConfig":
+    "Schick diesen Code an wen du willst. Importiert wird unter Presets → Importieren. Für jedes Teil werden dieselben Mods benötigt.",
+  "presets.generatingCode": "Code wird erzeugt…",
+  "presets.nothingToBundle":
+    "Keine installierten Dateien zum Verpacken — dieser Look besteht nur aus Stock/Schriften.",
+  "presets.createFullBundle": "Komplettpaket erstellen",
+  "presets.copiedFull": "Code mit Komplettpaket kopiert.",
+  "presets.copiedShare": "Teilen-Code kopiert.",
+  "presets.copyFailed":
+    "Kopieren nicht möglich — markiere den Code und kopiere ihn von Hand.",
+  "presets.copyFullCode": "Vollständigen Code kopieren",
+  "presets.copyCode": "Code kopieren",
+  "presets.importTitle": "Preset importieren",
+  "presets.importBody": "Füge einen Code ein, den dir jemand geschickt hat.",
+  "presets.configOnly": "Nur Konfiguration",
+  "presets.import": "Importieren",
+  "presets.fullImport": "Vollständiger Import",
+  "presets.editingBanner":
+    "{{name}} wird bearbeitet — ändere den Namen oder einen Slot und dann {{save}}.",
+  "presets.bundleNotice":
+    "Enthält ein komplettes Paket (~{{size}} von {{host}}). Nutze {{fullImport}}, um alles herunterzuladen und zu installieren — vorher werden keine Mods benötigt.",
+
+  // ── Preset-Slots ───────────────────────────────────────────────────────────
+  "slot.paint": "Motorrad-Lackierung",
+  "slot.modelSwap": "Modellwechsel",
+  "slot.bikeFont": "Startnummern-Schrift",
+  "slot.tyres": "Reifen",
+  "slot.rider": "Fahrerprofil",
+  "slot.suitPaint": "Outfit / Kit",
+  "slot.suitFont": "Outfit-Schrift",
+  "slot.glovesPaint": "Handschuhe",
+  "slot.ridingStyle": "Fahrstil",
+  "slot.helmet": "Helm",
+  "slot.helmetPaint": "Helm-Design",
+  "slot.gogglesPaint": "Brille",
+  "slot.boots": "Stiefel",
+  "slot.bootsPaint": "Stiefel-Design",
+  "slot.protection": "Protektoren",
+  "slot.protectionPaint": "Protektoren-Design",
+  "slotGroup.bike": "Motorrad",
+  "slotGroup.rider": "Fahrer",
+  "slotGroup.head": "Kopf",
+  "slotGroup.body": "Körper",
+
+  // ── Fahrer-Studio ──────────────────────────────────────────────────────────
+  "rider.help":
+    "Kleide das Fahrermodell ein — Helm, Brille, Outfit und Stiefel zusammen.",
+  "rider.namePlaceholder": "Diesem Fahrer einen Namen geben…",
+  "rider.nameFirst": "Gib diesem Fahrer-Look zuerst einen Namen.",
+  "rider.showOnModel": "Am Modell zeigen",
+
+  // ── Rundgang ───────────────────────────────────────────────────────────────
+  "tour.welcomeTour.title": "Mach einen kurzen Rundgang",
+  "tour.welcomeTour.body":
+    "Ein paar Sekunden, um zu sehen, wo alles liegt. Du kannst jederzeit abbrechen.",
+  "tour.browse.title": "Mods entdecken",
+  "tour.browse.body":
+    "Durchsuche mxb-mods.com direkt hier und installiere jede Strecke, jedes Motorrad und jede Lackierung mit einem einzigen Klick.",
+  "tour.library.title": "Deine Bibliothek",
+  "tour.library.body":
+    "Alles, was du installiert hast, an einem Ort — Mods aktualisieren oder entfernen, ohne je eine ZIP-Datei anzufassen.",
+  "tour.locker.title": "Der Spind",
+  "tour.locker.body":
+    "Tausche Motorradmodelle beliebig aus. MXB App registriert die Teile, damit das Spiel sie erkennt.",
+  "tour.presets.title": "Presets",
+  "tour.presets.body":
+    "Speichere Ausrüstungs- und Design-Kombinationen und wende einen kompletten Look mit einem Klick an — sogar während du fährst.",
+  "tour.rider.title": "Fahrer-Studio",
+  "tour.rider.body":
+    "Sieh dir Ausrüstung und Designs am 3D-Fahrer an, bevor du sie mit auf die Strecke nimmst.",
+  "tour.frostmod.title": "FrostMod, live",
+  "tour.frostmod.body":
+    "Hier siehst du den Status von FrostMod. Es lädt MX Bikes nach einer Installation live neu, sodass neue Inhalte ohne Neustart erscheinen.",
+  "tour.settings.title": "Einstellungen",
+  "tour.settings.body":
+    "Hier legst du deinen Spielordner, das Verhalten im Hintergrund und die FrostMod-Optionen fest. Diesen Rundgang kannst du von hier aus ebenfalls wiederholen.",
+  "tour.done.title": "Alles bereit",
+  "tour.done.body":
+    "Das war der Rundgang. Auf zu Entdecken und installiere deinen ersten Mod.",
+
+  // ── Fehler ─────────────────────────────────────────────────────────────────
+  "error.previewFailed": "Vorschau konnte nicht dargestellt werden",
+  "error.somethingWentWrong": "Etwas ist schiefgelaufen",
+  "error.unexpected": "Ein unerwarteter Fehler ist aufgetreten.",
+  "error.reloadApp": "App neu laden",
+
+  // ── Updates ────────────────────────────────────────────────────────────────
+  "update.available": "{{version}} ist verfügbar.",
+  "update.downloading": "Wird heruntergeladen…",
+  "update.downloadingPct": "Wird heruntergeladen… {{pct}} %",
+  "update.pitch":
+    "Aktualisiere, um die neuesten Funktionen und Fehlerbehebungen zu erhalten.",
+  "update.updating": "Wird aktualisiert…",
+  "update.updateAndRestart": "Aktualisieren und neu starten",
+  "update.dismiss": "Update-Benachrichtigung ausblenden",
+  "update.onLatest": "Du hast bereits die neueste Version",
+  "update.checkFailed": "Updates konnten nicht geprüft werden",
+  "update.failed": "Update fehlgeschlagen",
+
+  // ── 3D-Ansicht ─────────────────────────────────────────────────────────────
+  "viewer.preview3d": "3D-Vorschau",
+  "viewer.expand": "Vergrößern",
+  "viewer.paint": "Design",
+  "viewer.loadingModel": "Modell wird geladen…",
+  "viewer.loadingPaint": "Design wird geladen…",
+  "viewer.loadingRider": "Fahrer wird geladen…",
+  "viewer.dragToRotate": "Ziehen zum Drehen",
+  "viewer.scrollToZoom": "Scrollen zum Zoomen",
+  "viewer.rightDragToPan": "Rechts ziehen zum Verschieben",
+
+  // ── Combobox ───────────────────────────────────────────────────────────────
+  "combobox.search": "Suchen…",
+  "combobox.use": "„{{value}}“ verwenden",
+
+  // ── Mod-Typen ──────────────────────────────────────────────────────────────
+  "modType.tracks": "Strecken",
+  "modType.bikes": "Motorräder",
+  "modType.rider": "Fahrer",
+  // Deutsche Substantive werden immer großgeschrieben — auch mitten im Satz.
+  "modType.tracksInline": "Strecken",
+  "modType.bikesInline": "Motorräder",
+  "modType.riderInline": "Fahrerausrüstung",
+
+  // ── Kategoriefilter ────────────────────────────────────────────────────────
+  "browseCat.all": "Alle",
+  "browseCat.beginner": "Anfänger",
+  "browseCat.intermediate": "Fortgeschritten",
+  "browseCat.pro": "Profi",
+  "browseCat.assets": "Assets",
+  "browseCat.newBikes": "Neue Motorräder",
+  "browseCat.liveries": "Lackierungen",
+  "browseCat.sounds": "Sounds",
+  "browseCat.riderKit": "Fahrer-Kit",
+  "browseCat.helmets": "Helme",
+  "browseCat.helmetPaints": "Helm-Designs",
+  "browseCat.gloves": "Handschuhe",
+  "browseCat.boots": "Stiefel",
+  "browseCat.bootPaints": "Stiefel-Designs",
+  "browseCat.protection": "Protektoren",
+  "browseCat.protectionPaints": "Protektoren-Designs",
+
+  // ── Entdecken ──────────────────────────────────────────────────────────────
+  "browse.help":
+    "Entdecke und installiere Mods aus dem Online-Katalog — suchen, nach Typ filtern und einen Mod öffnen, um ihn ins Spiel zu laden.",
+  "browse.searchPlaceholder": "{{type}} suchen…",
+  "browse.sortedByNewest": "Neueste zuerst",
+  "browse.loadFailed": "Mods konnten nicht geladen werden",
+  "browse.empty": "Keine {{type}} gefunden.",
+  "browse.loadMore": "Mehr laden",
+  "browse.selectedCount": "{{count}} ausgewählt",
+  "browse.queuing": "Wird eingereiht…",
+  "browse.quickInstallCount": "{{count}} schnell installieren",
+  "browse.quickInstall": "Schnellinstallation",
+  "browse.quickReinstall": "Schnelle Neuinstallation",
+  "browse.openDetails": "Details öffnen",
+  "browse.reinstallOne": "„{{title}}“ neu installieren?",
+  "browse.reinstallMany": "Bereits vorhandene Mods neu installieren?",
+  "browse.reinstallOneBody":
+    "Dieser Mod ist bereits in deiner Bibliothek. Beim Neuinstallieren wird er erneut heruntergeladen und die installierten Dateien werden überschrieben.",
+  "browse.reinstallManyBody":
+    "{{installed}} der {{total}} ausgewählten sind bereits installiert. Wenn du fortfährst, werden sie neu installiert und überschrieben.",
+  "browse.reinstall": "Neu installieren",
+  "browse.reinstallAll": "Alle neu installieren",
+  "browse.queued": "„{{title}}“ eingereiht",
+  "browse.queuedDesc": "Wird in {{folder}} installiert.",
+  "browse.rootFolder": "Hauptordner",
+  "browse.needsBrowser":
+    "„{{title}}“ muss über den Browser heruntergeladen werden",
+  "browse.needsBrowserDesc":
+    "{{host}} blockiert Downloads in der App — öffne die Seite, um fertigzustellen.",
+  "browse.noDownload": "Kein Download für „{{title}}“ gefunden",
+  "browse.quickInstallFailed":
+    "„{{title}}“ konnte nicht schnell installiert werden",
+  "browse.queuedBulk_one": "{{count}} Mod eingereiht",
+  "browse.queuedBulk_other": "{{count}} Mods eingereiht",
+  "browse.queuedBulkDesc": "Sie werden nacheinander installiert.",
+  "browse.queuedBulkSkipped_one":
+    "{{count}} übersprungen — nur über den Browser verfügbar.",
+  "browse.queuedBulkSkipped_other":
+    "{{count}} übersprungen — nur über den Browser verfügbar.",
+  "browse.bulkFailed": "Die Auswahl konnte nicht schnell installiert werden",
+  "browse.bulkFailedDesc_one":
+    "Er muss über den Browser heruntergeladen werden.",
+  "browse.bulkFailedDesc_other":
+    "Alle {{count}} müssen über den Browser heruntergeladen werden.",
+
+  // ── Shop ───────────────────────────────────────────────────────────────────
+  "shop.myDownloads": "Meine Downloads",
+  "shop.signInTitle": "Bei MX Bikes Shop anmelden",
+  "shop.signInBody":
+    "Melde dich bei mxbikes-shop.com an, um deine gekauften Strecken zu sehen und zu installieren. Wir öffnen die echte Seite — dein Passwort kommt nie mit dieser App in Berührung.",
+  "shop.signIn": "Anmelden",
+  "shop.logOut": "Abmelden",
+  "shop.signedIn": "Bei MX Bikes Shop angemeldet",
+  "shop.sessionFailed":
+    "Deine MX-Bikes-Shop-Sitzung konnte nicht übernommen werden",
+  "shop.queuedDesc": "Wird in deinen Streckenordner installiert.",
+  "shop.loadFailed":
+    "Deine Downloads konnten nicht geladen werden: {{error}}",
+  "shop.empty": "Noch keine gekauften Downloads in deinem Konto gefunden.",
+
+  // ── Installationsdialog ────────────────────────────────────────────────────
+  "installDialog.installTo": "Installieren nach",
+  "installDialog.installToFolder": "Nach {{folder}} installieren",
+  "installDialog.change": "Ändern",
+  "installDialog.searchBikes": "Motorräder suchen…",
+  "installDialog.searchFolders": "Ordner suchen…",
+  "installDialog.probably": "Wahrscheinlich",
+  "installDialog.allFolders": "Alle Ordner",
+  "installDialog.noFolderMatch":
+    "Kein Ordner passt — lege ihn unten an.",
+  "installDialog.rememberedFor": "Gemerkt für {{type}}",
+  "installDialog.downloadFrom": "Herunterladen von",
+  "installDialog.downloadPerBike": "Download (pro Motorrad)",
+  "installDialog.opensInBrowser":
+    "Öffnet im Browser — MXB App schließt die Installation ab",
+  "installDialog.matchedBike": "Passend zu deinem Motorrad",
+  "installDialog.differentBike": "Anderes Motorrad / Paket",
+  "installDialog.directFastest": "Direkt · am schnellsten",
+  "installDialog.direct": "Direkt",
+  "installDialog.perBikeHint":
+    "Jeder Download ist ein anderes Motorrad — automatisch passend zu deiner Auswahl. Wähle das Paket „all bikes“, um alle auf einmal zu bekommen.",
+  "installDialog.mirrorsHint":
+    "Alle Spiegelserver enthalten dieselbe Datei. Wenn einer fehlschlägt, probiere den nächsten.",
+
+  // ── Bibliotheksdetails ─────────────────────────────────────────────────────
+  "libraryDetail.author": "Autor",
+  "libraryDetail.length": "Länge",
+  "libraryDetail.altitude": "Höhe",
+  "libraryDetail.location": "Ort",
+  "libraryDetail.type": "Typ",
+  "libraryDetail.mod": "Mod",
+  "libraryDetail.belongsTo": "Gehört zu",
+  "libraryDetail.format": "Format",
+  "libraryDetail.extractedFolder": "Entpackter Ordner",
+  "libraryDetail.paintFile": "Design-Datei",
+  "libraryDetail.packagedPkz": "Gepackte .pkz",
+  "libraryDetail.size": "Größe",
+  "libraryDetail.folder": "Ordner",
+  "libraryDetail.lockedWord": "gesperrt",
+  "libraryDetail.lockedWithMeta":
+    "Diese Strecke wurde von ihrem Ersteller {{locked}}. Name, Details und Vorschau werden hier angezeigt, die Dateien bleiben aber versiegelt — sie lässt sich weder entpacken noch in 3D ansehen.",
+  "libraryDetail.lockedNoMeta":
+    "Diese Strecke ist {{locked}}, deshalb lassen sich Name, Länge und Vorschau nicht aus der Datei lesen — nur Dateiname und Größe.",
+
+  // ── Mod-Seite ──────────────────────────────────────────────────────────────
+  "modDetail.stageResolve": "Auflösen",
+  "modDetail.stageDownload": "Herunterladen",
+  "modDetail.stageExtract": "Entpacken",
+  "modDetail.stagePlace": "Ablegen",
+  "modDetail.stageReload": "Neu laden",
+  "modDetail.modFiles": "Mod-Dateien",
+  "modDetail.copied": "Kopiert",
+  "modDetail.copy": "Kopieren",
+  "modDetail.addToLibrary": "Zur Bibliothek hinzufügen",
+  "modDetail.host": "Host",
+  "modDetail.installsTo": "Installiert nach",
+  "modDetail.noDownloadLink":
+    "Auf dieser Seite wurde kein Download-Link gefunden — öffne sie auf mxb-mods.com.",
+  "modDetail.frostmodHint":
+    "FrostMod lädt die Liste ({{kind}}) neu, sobald das fertig ist.",
+  "modDetail.kindRider": "Fahrer",
+  "modDetail.kindBike": "Motorräder",
+  "modDetail.kindTrack": "Strecken",
+  "modDetail.details": "Details",
+  "modDetail.format": "Format",
+  "modDetail.mirrors": "Spiegelserver",
+  "modDetail.type": "Typ",
+  "modDetail.addedToLibrary": "Zu deiner Bibliothek hinzugefügt",
+  "modDetail.extracting": "Wird entpackt…",
+  "modDetail.addingToLibrary": "Wird zur Bibliothek hinzugefügt…",
+  "modDetail.resolving": "Download wird aufgelöst…",
+  "modDetail.finishInBrowser": "Im Browser abschließen",
+  "modDetail.viewOnSite": "Auf mxb-mods.com ansehen",
+
+  // ── Einstellungen ──────────────────────────────────────────────────────────
+  "settings.help":
+    "Konfiguriere deinen Spielordner, Updates und App-Einstellungen.",
+  "settings.gameFolder": "Spielordner",
+  "settings.general": "Allgemein",
+  "settings.appearance": "Darstellung",
+  "settings.frostmod": "FrostMod",
+  "settings.about": "Info & Updates",
+  "settings.modsFolderDesc":
+    "Wohin Mods installiert werden. Eine Änderung scannt deine Bibliothek neu.",
+  "settings.insideModsFolder": "In deinem MX-Bikes-Ordner",
+  "settings.notSet": "Nicht festgelegt",
+  "settings.change": "Ändern…",
+  "settings.set": "Festlegen…",
+  "settings.theme": "Design",
+  "settings.themeLight": "Hell",
+  "settings.themeDark": "Dunkel",
+  "settings.themeSystem": "System",
+  "settings.language": "Sprache",
+  "settings.languageSystem": "System",
+  "settings.runInBackground": "Im Hintergrund weiterlaufen",
+  "settings.runInBackgroundDesc":
+    "Beim Schließen des Fensters läuft MXB App im Infobereich weiter, damit FrostMod verbunden bleibt. Beenden über das Symbol im Infobereich.",
+  "settings.launchAtStartup": "Beim Systemstart starten",
+  "settings.launchAtStartupDesc":
+    "MXB App automatisch starten, wenn du dich anmeldest.",
+  "settings.instantRefresh": "Sofortige Preset-Aktualisierung",
+  "settings.instantRefreshDesc":
+    "Wenn du ein Preset anwendest, während MX Bikes läuft, wird der Look sofort im Spiel aktualisiert — ohne Neustart und ohne das Profil neu auszuwählen. Falls das nicht klappt, wirst du gebeten, dein Profil neu auszuwählen.",
+  "settings.instantRefreshWindowsOnly":
+    "Den Look ohne Neustart im Spiel zu aktualisieren erfordert FrostMod, und das gibt es nur für Windows — du wirst stattdessen gebeten, dein Profil neu auszuwählen.",
+  "settings.autoRunFrostmod": "FrostMod automatisch starten",
+  "settings.autoRunFrostmodDesc":
+    "FrostMod im Hintergrund starten, sobald MXB App geöffnet wird.",
+  "settings.watchModsReload": "Automatisch neu laden bei Ordneränderungen",
+  "settings.watchModsReloadDesc":
+    "Das Spiel automatisch neu laden, wenn Strecken oder Motorräder in deinen Mod-Ordner kommen — auch wenn sie außerhalb von MXB App manuell heruntergeladen wurden.",
+  "settings.checking": "Wird geprüft…",
+  "settings.runningConnected": "Läuft · Spiel verbunden",
+  "settings.notRunning": "Läuft nicht",
+  "settings.frostmodInstalled": "Installiert{{suffix}}",
+  "settings.notInstalled": "Nicht installiert",
+  "settings.checkingGitHub":
+    "GitHub wird auf die neueste Version geprüft…",
+  "settings.updateCheckFailed":
+    "Updates konnten nicht geprüft werden — offline oder GitHub nicht erreichbar.",
+  "settings.latestVersion": "Neueste: {{version}}",
+  "settings.checkNewer": "Nach einer neueren FrostMod-Version suchen",
+  "settings.working": "Wird ausgeführt…",
+  "settings.installFrostmod": "FrostMod installieren",
+  "settings.updateTo": "Auf {{version}} aktualisieren",
+  "settings.reinstallLatest": "Neueste neu installieren",
+  "settings.upToDate": "Aktuell",
+  "settings.madeWith": "Gemacht mit",
+  "settings.updateFailed": "Einstellung konnte nicht geändert werden",
+  "settings.startupUpdateFailed":
+    "Autostart-Einstellung konnte nicht geändert werden",
+  "settings.folderUpdated": "Spielordner aktualisiert",
+  "settings.folderUpdatedDesc": "Deine Bibliothek wird neu gescannt.",
+  "settings.setFolderFailed": "Ordner konnte nicht festgelegt werden",
+  "settings.reDetected": "MX-Bikes-Ordner erneut erkannt",
+  "settings.detectFolderFailed": "Ordner konnte nicht erkannt werden",
+  "settings.pickInstallFolder":
+    "Wähle deinen MX-Bikes-Installationsordner (enthält rider.pkz)",
+  "settings.installSet": "Spielinstallation festgelegt",
+  "settings.installSetDesc":
+    "Die 3D-Fahrervorschau kann jetzt das echte Körpermodell laden.",
+  "settings.setInstallFailed":
+    "Installationsordner konnte nicht festgelegt werden",
+  "settings.installNotFound": "MX Bikes konnte nicht gefunden werden",
+  "settings.installNotFoundDesc":
+    "Keine Steam-Installation erkannt — lege den Ordner manuell fest.",
+  "settings.installFound": "Deine MX-Bikes-Installation wurde gefunden",
+  "settings.detectInstallFailed":
+    "Installationsordner konnte nicht erkannt werden",
+  "settings.pickProfilesFolder": "Wähle deinen MX-Bikes-Profilordner",
+  "settings.profilesSet": "Profilordner festgelegt",
+  "settings.profilesFound_one": "{{count}} Profil gefunden.",
+  "settings.profilesFound_other": "{{count}} Profile gefunden.",
+  "settings.noProfilesThere": "Dort wurden keine Profile gefunden",
+  "settings.noProfilesThereDesc":
+    "Trotzdem gespeichert, aber zum Erstellen von Presets wird ein Ordner benötigt, der deine profile.ini-Ordner enthält.",
+  "settings.setProfilesFailed":
+    "Profilordner konnte nicht festgelegt werden",
+  "settings.profilesReverted":
+    "Auf den Standard-Profilordner zurückgesetzt",
+  "settings.resetProfilesFailed":
+    "Profilordner konnte nicht zurückgesetzt werden",
+  "settings.frostmodNotRunningHint":
+    "FrostMod läuft nicht — starte es, um Mods live nachzuladen.",
+  "settings.reloadUnavailable":
+    "Neu laden ist auf dieser Plattform nicht verfügbar.",
+
+  // ── Bibliothek ─────────────────────────────────────────────────────────────
+  "library.help":
+    "Deine installierten Mods. Sieh nach, was installiert ist, und entferne, was du nicht mehr willst.",
+  "library.rootFolder": "(Hauptordner)",
+  "library.byAuthor": "von {{author}}",
+  "library.locked": "Gesperrt — Inhalt kann nicht gelesen werden",
+  "library.searchPlaceholder": "Installierte durchsuchen…",
+  "library.scanning": "Deine Bibliothek wird gescannt…",
+  "library.empty":
+    "Noch keine {{type}} installiert — geh zu Entdecken und füge etwas hinzu.",
+  "library.noMatches": "Keine Treffer.",
+  "library.quick3d": "Schnelle 3D-Ansicht",
+  "library.selectNone": "Auswahl aufheben",
+  "library.move": "Verschieben",
+  "library.uninstall": "Deinstallieren",
+  "library.uninstallAction": "Deinstallieren…",
+  "library.moveToFolder": "In Ordner verschieben…",
+  "library.showInExplorer": "Im Explorer anzeigen",
+  "library.moveDialogTitle": "In Ordner verschieben",
+  "library.moveCount_one": "{{count}} Element verschieben",
+  "library.moveCount_other": "{{count}} Elemente verschieben",
+  "library.chooseDestination": "Wähle einen Zielordner",
+  "library.newFolder": "Neuer Ordner…",
+  "library.newFolderName": "Name des neuen Ordners",
+  "library.createAndMove": "Erstellen und verschieben",
+  "library.confirmUninstall": "{{name}} deinstallieren?",
+  "library.confirmUninstallBody":
+    "Das Element wird in den Papierkorb verschoben — von dort kannst du es wiederherstellen.",
+  "library.confirmBulkUninstall_one": "{{count}} Element deinstallieren?",
+  "library.confirmBulkUninstall_other":
+    "{{count}} Elemente deinstallieren?",
+  "library.confirmBulkUninstallBody":
+    "Jedes Element wird in den Papierkorb verschoben — von dort kannst du sie wiederherstellen.",
+  "library.uninstallCount": "{{count}} deinstallieren",
+  "library.moveFailed": "Mod konnte nicht verschoben werden",
+  "library.uninstallFailed": "Deinstallation fehlgeschlagen",
+  "library.openFailed": "Konnte nicht geöffnet werden",
+  "library.uninstalledOne": "{{name}} deinstalliert",
+  "library.movedToBin": "In den Papierkorb verschoben.",
+  "library.someNotRemoved":
+    "Einige Elemente konnten nicht entfernt werden.",
+  "library.bulkUninstalled_one": "{{count}} Element deinstalliert",
+  "library.bulkUninstalled_other": "{{count}} Elemente deinstalliert",
+  "library.bulkUninstallPartial":
+    "{{ok}} deinstalliert, {{fail}} fehlgeschlagen",
+  "library.bulkMovePartial": "{{ok}} verschoben, {{fail}} fehlgeschlagen",
+  "library.bulkMoved_one": "{{count}} Element nach {{folder}} verschoben",
+  "library.bulkMoved_other":
+    "{{count}} Elemente nach {{folder}} verschoben",
+
+  // ── Spind ──────────────────────────────────────────────────────────────────
+  "locker.help":
+    "Wechsle Modell und Motorsound jedes Motorrads zwischen den Sets, die du installiert hast.",
+  "locker.rescan": "Neu scannen",
+  "locker.restore": "Wiederherstellen",
+  "locker.register": "Registrieren",
+  "locker.scanning": "Motorräder werden gescannt…",
+  "locker.scanForSwaps": "Nach Sets suchen",
+  "locker.orphanBanner":
+    "{{bike}} fehlen die Setup-Dateien — eine frühere Version hat sie in einen Swap-Ordner verschoben, wodurch das Motorrad im Spiel überhaupt nicht mehr lädt. {{files}}",
+  "locker.looseBanner_one":
+    "{{count}} Modell-/Sound-Set lose in deinen Motorrädern gefunden — registriere es in {{modelsFolder}} / {{soundsFolder}}.",
+  "locker.looseBanner_other":
+    "{{count}} Modell-/Sound-Sets lose in deinen Motorrädern gefunden — registriere sie in {{modelsFolder}} / {{soundsFolder}}.",
+  "locker.emptyTitle": "Noch keine tauschbaren Motorräder.",
+  "locker.emptyIntro":
+    "Zwei Dinge müssen zutreffen, damit ein Tausch möglich ist:",
+  "locker.unpacked": "entpackt",
+  "locker.emptyRuleUnpacked":
+    "Das Motorrad ist {{unpacked}} nach {{path}}— eine gepackte {{pkz}} lässt sich nicht tauschen. Entpacke eines über die Bibliothek.",
+  "locker.emptyRuleMesh":
+    "Jedes Alternativmodell liegt in einem eigenen Ordner innerhalb dieses Motorrads und enthält ein Mesh ({{edf}}). Lege es irgendwo im Motorradordner ab und klicke unten auf Suchen — wir bieten dir dann an, es unter {{folder}} einzuordnen.",
+  "locker.summary": "{{model}} · Sound „{{sound}}“",
+  "locker.modelNamed": "Modell „{{name}}“",
+  "locker.noModelSwaps": "keine Modellwechsel",
+  "locker.models": "Modelle",
+  "locker.sounds": "Sounds",
+  "locker.onlyOneModel":
+    "Nur ein Modell — installiere weitere zum Tauschen",
+  "locker.onlyStock":
+    "Nur Stock — installiere einen Sound-Mod zum Tauschen",
+  "locker.noModel": "Kein Modell",
+  "locker.stock": "Stock",
+  "locker.activeModel": "Aktives Modell",
+  "locker.activeSound": "Aktiver Sound",
+  "locker.switchToNoModel":
+    "Auf kein Modell wechseln — entfernt die aktuellen Modelldateien",
+  "locker.switchToStock":
+    "Auf Stock wechseln — entfernt den Sound-Mod (der Originalsound spielt)",
+  "locker.missingModelEdf": "Diesem Set fehlt model.edf",
+  "locker.missingSoundFiles":
+    "Diesem Set fehlt engine.scl oder sfx.cfg",
+  "locker.switchTo": "Auf {{name}} wechseln",
+  "locker.tiedToModel": "Verknüpft mit Modell {{models}}",
+  "locker.boundHint":
+    "„{{sound}}“ ist mit Modell „{{model}}“ verknüpft — er wandert mit diesem Modell mit. Zum Lösen klicken.",
+  "locker.unboundHint":
+    "Verknüpfe den aktiven Sound „{{sound}}“ mit Modell „{{model}}“, damit beim Wechsel dorthin auch der Sound mitkommt.",
+  "locker.tieAction": "„{{sound}}“ mit „{{model}}“ verknüpfen",
+  "locker.untieAction": "„{{sound}}“ von „{{model}}“ lösen",
+  "locker.restored": "Setup-Dateien von {{bike}} wiederhergestellt.",
+  "locker.restoredNote_one":
+    "{{count}} Datei zurückgelegt — das Motorrad sollte wieder laden.",
+  "locker.restoredNote_other":
+    "{{count}} Dateien zurückgelegt — das Motorrad sollte wieder laden.",
+  "locker.switchedModel":
+    "Modell von {{bike}} auf „{{target}}“ gewechselt.",
+  "locker.switchedSound":
+    "Sound von {{bike}} auf „{{target}}“ gewechselt.",
+  "locker.tied": "„{{sound}}“ mit Modell „{{model}}“ verknüpft.",
+  "locker.untied": "„{{sound}}“ von Modell „{{model}}“ gelöst.",
+  "locker.refreshedLive": "Live im Spiel aktualisiert.",
+  "locker.refreshFailed":
+    "Sofortige Aktualisierung fehlgeschlagen — wähle dein Profil im Spiel neu aus, um sie zu laden.",
+  "locker.reselectProfile":
+    "Wähle dein Profil in MX Bikes neu aus, um den Tausch zu laden.",
+  "locker.loadsNextTime":
+    "Wird beim nächsten Start des Spiels geladen.",
+
+  // ── Registrierung loser Sets ───────────────────────────────────────────────
+  "swaps.model": "Modell",
+  "swaps.modelSets_one": "{{count}} Modellwechsel",
+  "swaps.modelSets_other": "{{count}} Modellwechsel",
+  "swaps.soundSets_one": "{{count}} Sound-Mod",
+  "swaps.soundSets_other": "{{count}} Sound-Mods",
+  "swaps.and": "{{a}} und {{b}}",
+  "swaps.noSets": "0 Sets",
+  "swaps.foundTitle": "{{summary}} gefunden",
+  "swaps.description":
+    "Diese Ordner liegen lose in deinen Motorrädern. Registriere sie, um jeden in die richtige Bibliothek zu verschieben — {{modelsFolder}} für Modelle, {{soundsFolder}} für Sounds — damit sie im Spind auftauchen.",
+  "swaps.registered_one": "{{count}} Set registriert.",
+  "swaps.registered_other": "{{count}} Sets registriert.",
+  "swaps.nothingMoved": "Es wurde nichts verschoben.",
+  "swaps.skipped_one": "{{count}} übersprungen (Name bereits vergeben).",
+  "swaps.skipped_other":
+    "{{count}} übersprungen (Namen bereits vergeben).",
+  "swaps.foldersCreated_one":
+    "Bibliotheksordner für {{count}} Motorrad erstellt.",
+  "swaps.foldersCreated_other":
+    "Bibliotheksordner für {{count}} Motorräder erstellt.",
+  "swaps.foldersCreatedDesc":
+    "Deine Modell-/Sound-Ordner sind dort geblieben, wo sie waren.",
+  "swaps.justCreateFolders": "Nur Ordner erstellen",
+  "swaps.registerAndMove": "Registrieren und verschieben",
+  "swaps.fileCount_one": "{{count}} Datei",
+  "swaps.fileCount_other": "{{count}} Dateien",
+
+  // ── Installation ───────────────────────────────────────────────────────────
+  "install.installed": "{{title}} installiert",
+  "install.reloadedDesc":
+    "Spiel über FrostMod neu geladen — es ist jetzt aktiv.",
+  "install.addedDesc": "Zu deiner Bibliothek hinzugefügt.",
+  "install.failed": "Installation fehlgeschlagen — {{title}}",
+  "install.openModPage": "Die Mod-Seite öffnen",
+  "install.clickToOpen": "Klicken, um die Mod-Seite zu öffnen",
+
+  // ── Kategorien (Singular) ──────────────────────────────────────────────────
+  "category.track": "Strecke",
+  "category.bike": "Motorrad",
+  "category.bikePaint": "Lackierung",
+  "category.bikeModelSwap": "Modellwechsel",
+  "category.sound": "Sound",
+  "category.helmet": "Helm",
+  "category.helmetPaint": "Helm-Design",
+  "category.goggles": "Brille",
+  "category.boots": "Stiefel",
+  "category.bootPaint": "Stiefel-Design",
+  "category.protection": "Protektoren",
+  "category.protectionPaint": "Protektoren-Design",
+  "category.gloves": "Handschuhe",
+  "category.outfit": "Outfit / Kit",
+  "category.misc": "Sonstiges",
+
+  // ── Abschnittsüberschriften (Plural) ───────────────────────────────────────
+  "section.bikePaint": "Lackierungen",
+  "section.bikeModelSwap": "Modellwechsel",
+  "section.sound": "Sounds",
+  "section.helmet": "Helme",
+  "section.helmetPaint": "Helm-Designs",
+  "section.boots": "Stiefel",
+  "section.bootPaint": "Stiefel-Designs",
+  "section.protection": "Protektoren",
+  "section.protectionPaint": "Protektoren-Designs",
+  "section.gloves": "Handschuhe",
+  "section.outfit": "Outfit / Kit",
+
+  // ── Installationsziele ─────────────────────────────────────────────────────
+  "dest.bikesRoot": "Motorräder (Hauptordner)",
+  "dest.tracksRoot": "Strecken (Hauptordner)",
+  "dest.bikeFolder": "{{name}} — Motorradordner",
+  "dest.bikePaints": "{{name}} — Lackierungen",
+  "dest.helmetsNewModel": "Helme (neues Modell)",
+  "dest.bootsNewModel": "Stiefel (neues Modell)",
+  "dest.protectionNewModel": "Protektoren (neues Modell)",
+  "dest.helmetPaintsFor": "{{name}} · Helm-Designs",
+  "dest.gogglesFor": "{{name}} · Brille",
+  "dest.bootPaintsFor": "{{name}} · Stiefel-Designs",
+  "dest.protectionPaintsFor": "{{name}} · Protektoren-Designs",
+  "dest.outfitFor": "{{name}} · Outfit / Kit",
+  "dest.glovesFor": "{{name}} · Handschuhe",
+};

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1,0 +1,683 @@
+/**
+ * English — the source of truth.
+ *
+ * Every other locale is typed as `Record<keyof typeof en, string>`, so adding a
+ * key here makes `tsc` fail until all five translations supply it. Keys are
+ * flat and namespaced by screen.
+ *
+ * Plural families are `<key>_one` / `<key>_other` and are looked up by passing
+ * `{ count }`; `Intl.PluralRules` picks the form, so languages that don't split
+ * one/other the way English does still land correctly.
+ */
+export const en = {
+  // ── Generic, reused everywhere ─────────────────────────────────────────────
+  "common.cancel": "Cancel",
+  "common.back": "Back",
+  "common.next": "Next",
+  "common.skip": "Skip",
+  "common.close": "Close",
+  "common.save": "Save",
+  "common.delete": "Delete",
+  "common.rename": "Rename",
+  "common.retry": "Retry",
+  "common.tryAgain": "Try again",
+  "common.loading": "Loading…",
+  "common.installed": "Installed",
+  "common.select": "Select",
+  "common.deselect": "Deselect",
+  "common.selectAll": "Select all",
+  "common.clear": "Clear",
+  "common.done": "Done",
+  "common.apply": "Apply",
+  "common.remove": "Remove",
+  "common.open": "Open",
+  "common.refresh": "Refresh",
+  "common.dismiss": "Dismiss",
+  "common.later": "Later",
+  "common.active": "Active",
+
+  // ── Window controls ────────────────────────────────────────────────────────
+  "window.minimize": "Minimize",
+  "window.maximize": "Maximize",
+  "window.close": "Close",
+
+  // ── Sidebar navigation ─────────────────────────────────────────────────────
+  "nav.browse": "Browse",
+  "nav.shop": "Shop",
+  "nav.library": "Library",
+  "nav.locker": "Locker",
+  "nav.presets": "Presets",
+  "nav.rider": "Rider",
+  "nav.settings": "Settings",
+
+  "sidebar.installing": "Installing “{{name}}”",
+  "sidebar.queued": "+{{count}} queued",
+
+  // ── FrostMod status + actions ──────────────────────────────────────────────
+  "frostmod.checking": "Checking FrostMod…",
+  "frostmod.running": "FrostMod running",
+  "frostmod.notRunning": "FrostMod not running",
+  "frostmod.reloadGame": "Reload game",
+  "frostmod.start": "Start FrostMod",
+  "frostmod.reloadedGame": "FrostMod reloaded the game.",
+  "frostmod.notRunningToast": "FrostMod isn't running.",
+  "frostmod.started": "FrostMod started",
+  "frostmod.alreadyRunning": "FrostMod is already running",
+  "frostmod.startFailed": "Couldn't start FrostMod",
+  "frostmod.installedToast": "FrostMod {{version}} installed",
+  "frostmod.installedToastDesc":
+    "It'll live-reload the game when you add mods.",
+  "frostmod.installFailed": "Couldn't install FrostMod",
+  // Folder-watcher notifications.
+  "frostmod.newModsAdded": "New mods added",
+  "frostmod.modsAdded_one": "New mod added",
+  "frostmod.modsAdded_other": "{{count}} mods added",
+  "frostmod.askedReload": "Asked FrostMod to reload the game.",
+  "frostmod.andMore_one": "{{names}} and {{count}} more",
+  "frostmod.andMore_other": "{{names}} and {{count}} more",
+  "frostmod.watchDesc": "{{names}} — asked FrostMod to reload the game.",
+
+  // ── First-run setup ────────────────────────────────────────────────────────
+  "setup.title": "Welcome to MXB App",
+  "setup.tagline":
+    "Browse mxb-mods, install with one click, and let FrostMod reload the game for you.",
+  "setup.modsFolder": "MX Bikes folder",
+  "setup.autoDetect":
+    "MXB App will auto-detect your {{hint}} folder. You can also pick it yourself.",
+  "setup.chooseManually": "Choose the folder manually…",
+  "setup.chooseDifferent": "Choose a different folder…",
+  "setup.gameInstall": "MX Bikes install",
+  "setup.detecting": "Looking for your MX Bikes install…",
+  "setup.found": "Found",
+  "setup.detectedAutomatically": "Detected automatically",
+  "setup.installNotFound":
+    "Couldn't find your MX Bikes install automatically — it powers the 3D rider preview. Pick it manually, or set it later in Settings.",
+  "setup.chooseInstallManually": "Choose the install folder manually…",
+  "setup.startBrowsing": "Start browsing mods",
+  "setup.detectAndStart": "Detect & start browsing",
+  "setup.pickModsFolder": "Select your MX Bikes folder",
+  "setup.pickInstallFolder": "Select your MX Bikes install folder",
+
+  // ── Welcome slideshow ──────────────────────────────────────────────────────
+  "welcome.intro.title": "Welcome to MXB App",
+  "welcome.intro.body":
+    "Your mod manager for MX Bikes. Keep your tracks, bikes and paints organized in one place — no more zip files scattered across your desktop. We'll show you around in a few seconds.",
+  "welcome.getStarted": "Get started",
+
+  // ── Presets ────────────────────────────────────────────────────────────────
+  "presets.missing": "missing",
+  "presets.missingHint": "This mod isn't installed — shows as stock in-game",
+  "presets.missingMods":
+    "Missing mods: {{mods}}. Install them for those parts to show.",
+  "presets.help":
+    "Save a full rider look and load it onto a bike on command.",
+  "presets.profile": "Profile",
+  "presets.namePlaceholder": "Preset name…",
+  "presets.savePreset": "Save preset",
+  "presets.saveChanges": "Save changes",
+  "presets.saveChangesQ": "Save changes?",
+  "presets.replaceQ": "Replace preset?",
+  "presets.replace": "Replace",
+  "presets.loadCopy": "Load a copy into the builder",
+  "presets.viewOnRider": "View on rider",
+  "presets.editNameOrOptions": "Edit name or options",
+  "presets.share": "Share",
+  "presets.nameFirst": "Give the preset a name first.",
+  "presets.pickProfileAndBike": "Pick a profile and bike to apply to.",
+  "presets.updated": "Updated preset “{{name}}”.",
+  "presets.renamed": "Renamed to “{{name}}” and saved changes.",
+  "presets.saved": "Saved preset “{{name}}”.",
+  "presets.editing": "Editing “{{name}}” — change anything, then Save changes.",
+  // Whole sentences, not "Applied X — {fragment}": the split reads as English grammar.
+  "presets.appliedRefreshed":
+    "Applied “{{label}}” to {{bike}} — refreshed live in-game.",
+  "presets.appliedRefreshFailed":
+    "Applied “{{label}}” to {{bike}} — saved, but instant refresh failed, so reselect your profile in-game to load it.",
+  "presets.appliedGameRunning":
+    "Applied “{{label}}” to {{bike}} — saved. Reselect your profile in MX Bikes (Profile menu) to load the new look.",
+  "presets.appliedNextTime":
+    "Applied “{{label}}” to {{bike}} — saved. It loads next time the game opens.",
+  // Share / import.
+  "presets.phaseBundling": "Packaging assets…",
+  "presets.phaseUploading": "Uploading bundle…",
+  "presets.phaseDownloading": "Downloading bundle…",
+  "presets.phaseInstalling": "Installing assets…",
+  "presets.bundleUploaded":
+    "Full bundle uploaded — the code now includes the assets.",
+  "presets.shareHintFull":
+    "This code includes a downloadable asset bundle — the recipient picks Full import and gets everything, even with no mods installed.",
+  "presets.shareHintConfig":
+    "Send this code to anyone. They import it under Presets → Import. They'll need the same mods installed for every part to show.",
+  "presets.generatingCode": "Generating code…",
+  "presets.nothingToBundle":
+    "No installed assets to bundle — this look is all stock/fonts.",
+  "presets.createFullBundle": "Create full bundle",
+  "presets.copiedFull": "Copied full-bundle code.",
+  "presets.copiedShare": "Copied share code.",
+  "presets.copyFailed": "Couldn't copy — select the code and copy manually.",
+  "presets.copyFullCode": "Copy full code",
+  "presets.copyCode": "Copy code",
+  "presets.importTitle": "Import preset",
+  "presets.importBody": "Paste a share code someone sent you.",
+  "presets.configOnly": "Config only",
+  "presets.import": "Import",
+  "presets.fullImport": "Full import",
+  "presets.editingBanner":
+    "Editing {{name}} — change the name or any slot, then {{save}}.",
+  "presets.bundleNotice":
+    "Includes a full asset bundle (~{{size}} from {{host}}). Use {{fullImport}} to download and install everything — no mods needed first.",
+
+  // ── Preset / rider loadout slots ───────────────────────────────────────────
+  "slot.paint": "Bike livery",
+  "slot.modelSwap": "Model swap",
+  "slot.bikeFont": "Number font",
+  "slot.tyres": "Tyres",
+  "slot.rider": "Rider profile",
+  "slot.suitPaint": "Kit / suit",
+  "slot.suitFont": "Suit font",
+  "slot.glovesPaint": "Gloves",
+  "slot.ridingStyle": "Riding style",
+  "slot.helmet": "Helmet",
+  "slot.helmetPaint": "Helmet paint",
+  "slot.gogglesPaint": "Goggles",
+  "slot.boots": "Boots",
+  "slot.bootsPaint": "Boot paint",
+  "slot.protection": "Protection",
+  "slot.protectionPaint": "Protection paint",
+  "slotGroup.bike": "Bike",
+  "slotGroup.rider": "Rider",
+  "slotGroup.head": "Head",
+  "slotGroup.body": "Body",
+
+  // ── Rider studio ───────────────────────────────────────────────────────────
+  "rider.help":
+    "Dress the player model — helmet, goggles, outfit and boots together.",
+  "rider.namePlaceholder": "Name this rider…",
+  "rider.nameFirst": "Name this rider look first.",
+  "rider.showOnModel": "Show on model",
+
+  // ── Guided tour ────────────────────────────────────────────────────────────
+  "tour.welcomeTour.title": "Take a quick tour",
+  "tour.welcomeTour.body":
+    "A few seconds to see where everything lives. You can skip at any point.",
+  "tour.browse.title": "Browse mods",
+  "tour.browse.body":
+    "Search mxb-mods.com right here and install any track, bike or paint with a single click.",
+  "tour.library.title": "Your library",
+  "tour.library.body":
+    "Everything you've installed, in one place — update or remove mods without ever touching a zip file.",
+  "tour.locker.title": "The locker",
+  "tour.locker.body":
+    "Swap bike models in and out. MXB App registers the pieces so the game picks them up.",
+  "tour.presets.title": "Presets",
+  "tour.presets.body":
+    "Save gear and paint loadouts, then apply a full look in one click — even while you're riding.",
+  "tour.rider.title": "Rider studio",
+  "tour.rider.body":
+    "Preview your gear and paints on the 3D rider before you take them out on track.",
+  "tour.frostmod.title": "FrostMod, live",
+  "tour.frostmod.body":
+    "This shows FrostMod's status. It live-reloads MX Bikes after an install, so new content shows up without restarting the game.",
+  "tour.settings.title": "Settings",
+  "tour.settings.body":
+    "Set your game folder, background behaviour and FrostMod options here. You can replay this tour from here too.",
+  "tour.done.title": "You're all set",
+  "tour.done.body": "That's the tour. Head to Browse and install your first mod.",
+
+  // ── Error boundary ─────────────────────────────────────────────────────────
+  "error.previewFailed": "Preview failed to render",
+  "error.somethingWentWrong": "Something went wrong",
+  "error.unexpected": "An unexpected error occurred.",
+  "error.reloadApp": "Reload app",
+
+  // ── Updater banner ─────────────────────────────────────────────────────────
+  "update.available": "{{version}} is available.",
+  "update.downloading": "Downloading…",
+  "update.downloadingPct": "Downloading… {{pct}}%",
+  "update.pitch": "Update to get the latest features and fixes.",
+  "update.updating": "Updating…",
+  "update.updateAndRestart": "Update & restart",
+  "update.dismiss": "Dismiss update notification",
+  "update.onLatest": "You're on the latest version",
+  "update.checkFailed": "Couldn't check for updates",
+  "update.failed": "Update failed",
+
+  // ── 3D viewer ──────────────────────────────────────────────────────────────
+  "viewer.preview3d": "3D Preview",
+  "viewer.expand": "Expand",
+  "viewer.paint": "Paint",
+  "viewer.loadingModel": "Loading model…",
+  "viewer.loadingPaint": "Loading paint…",
+  "viewer.loadingRider": "Loading rider…",
+  "viewer.dragToRotate": "Drag to rotate",
+  "viewer.scrollToZoom": "Scroll to zoom",
+  "viewer.rightDragToPan": "Right-drag to pan",
+
+  // ── Combobox ───────────────────────────────────────────────────────────────
+  "combobox.search": "Search…",
+  "combobox.use": "Use “{{value}}”",
+
+  // ── Mod types (Browse / Library segmented control) ─────────────────────────
+  "modType.tracks": "Tracks",
+  "modType.bikes": "Bikes",
+  "modType.rider": "Rider",
+  // The same nouns as they read inside a sentence ("Search tracks…"). English
+  // lowercases them; languages that capitalize their nouns keep doing so.
+  "modType.tracksInline": "tracks",
+  "modType.bikesInline": "bikes",
+  "modType.riderInline": "rider gear",
+
+  // ── Browse category filters ────────────────────────────────────────────────
+  "browseCat.all": "All",
+  "browseCat.beginner": "Beginner",
+  "browseCat.intermediate": "Intermediate",
+  "browseCat.pro": "Pro",
+  "browseCat.assets": "Assets",
+  "browseCat.newBikes": "New Bikes",
+  "browseCat.liveries": "Liveries",
+  "browseCat.sounds": "Sounds",
+  "browseCat.riderKit": "Rider Kit",
+  "browseCat.helmets": "Helmets",
+  "browseCat.helmetPaints": "Helmet Paints",
+  "browseCat.gloves": "Gloves",
+  "browseCat.boots": "Boots",
+  "browseCat.bootPaints": "Boot Paints",
+  "browseCat.protection": "Protection",
+  "browseCat.protectionPaints": "Protection Paints",
+
+  // ── Browse ─────────────────────────────────────────────────────────────────
+  "browse.help":
+    "Discover and install mods from the online catalog — search, filter by type, and open a mod to download it into the game.",
+  "browse.searchPlaceholder": "Search {{type}}…",
+  "browse.sortedByNewest": "Sorted by newest",
+  "browse.loadFailed": "Couldn't load mods",
+  "browse.empty": "No {{type}} found.",
+  "browse.loadMore": "Load more",
+  "browse.selectedCount": "{{count}} selected",
+  "browse.queuing": "Queuing…",
+  "browse.quickInstallCount": "Quick install {{count}}",
+  "browse.quickInstall": "Quick install",
+  "browse.quickReinstall": "Quick reinstall",
+  "browse.openDetails": "Open details",
+  "browse.reinstallOne": "Reinstall “{{title}}”?",
+  "browse.reinstallMany": "Reinstall mods you already have?",
+  "browse.reinstallOneBody":
+    "This mod is already in your library. Reinstalling downloads it again and overwrites the installed files.",
+  "browse.reinstallManyBody":
+    "{{installed}} of the {{total}} selected are already installed. Continuing reinstalls and overwrites them.",
+  "browse.reinstall": "Reinstall",
+  "browse.reinstallAll": "Reinstall all",
+  "browse.queued": "Queued “{{title}}”",
+  "browse.queuedDesc": "Installing to {{folder}}.",
+  "browse.rootFolder": "root",
+  "browse.needsBrowser": "“{{title}}” needs a browser download",
+  "browse.needsBrowserDesc":
+    "{{host}} blocks in-app downloads — open its page to finish.",
+  "browse.noDownload": "No download found for “{{title}}”",
+  "browse.quickInstallFailed": "Couldn't quick-install “{{title}}”",
+  "browse.queuedBulk_one": "Queued {{count}} mod",
+  "browse.queuedBulk_other": "Queued {{count}} mods",
+  "browse.queuedBulkDesc": "They'll install one after another.",
+  "browse.queuedBulkSkipped_one": "{{count}} skipped — browser-only host.",
+  "browse.queuedBulkSkipped_other": "{{count}} skipped — browser-only host.",
+  "browse.bulkFailed": "Couldn't quick-install the selection",
+  "browse.bulkFailedDesc_one": "It needs a browser download.",
+  "browse.bulkFailedDesc_other": "All {{count}} need a browser download.",
+
+  // ── Shop (MX Bikes Shop — purchased downloads) ─────────────────────────────
+  "shop.myDownloads": "My Downloads",
+  "shop.signInTitle": "Sign in to MX Bikes Shop",
+  "shop.signInBody":
+    "Log in to mxbikes-shop.com to see and install the tracks you've purchased. We open the real site — your password never touches this app.",
+  "shop.signIn": "Sign in",
+  "shop.logOut": "Log out",
+  "shop.signedIn": "Signed in to MX Bikes Shop",
+  "shop.sessionFailed": "Couldn't capture your MX Bikes Shop session",
+  "shop.queuedDesc": "Installing to your tracks folder.",
+  "shop.loadFailed": "Couldn't load your downloads: {{error}}",
+  "shop.empty": "No purchased downloads found on your account yet.",
+
+  // ── Install dialog (destination + mirror picker) ───────────────────────────
+  "installDialog.installTo": "Install to",
+  "installDialog.installToFolder": "Install to {{folder}}",
+  "installDialog.change": "Change",
+  "installDialog.searchBikes": "Search bikes…",
+  "installDialog.searchFolders": "Search folders…",
+  "installDialog.probably": "Probably",
+  "installDialog.allFolders": "All folders",
+  "installDialog.noFolderMatch": "No folder matches — create it below.",
+  "installDialog.rememberedFor": "Remembered for {{type}}",
+  "installDialog.downloadFrom": "Download from",
+  "installDialog.downloadPerBike": "Download (per bike)",
+  "installDialog.opensInBrowser":
+    "Opens in browser — MXB App finishes the install",
+  "installDialog.matchedBike": "Matched to your bike",
+  "installDialog.differentBike": "Different bike / pack",
+  "installDialog.directFastest": "Direct · fastest",
+  "installDialog.direct": "Direct",
+  "installDialog.perBikeHint":
+    "Each download is a different bike — auto-selected to match your pick. Choose the “all bikes” pack for every bike at once.",
+  "installDialog.mirrorsHint":
+    "All mirrors contain the same file. If one fails, try the next.",
+
+  // ── Library detail panel ───────────────────────────────────────────────────
+  "libraryDetail.author": "Author",
+  "libraryDetail.length": "Length",
+  "libraryDetail.altitude": "Altitude",
+  "libraryDetail.location": "Location",
+  "libraryDetail.type": "Type",
+  "libraryDetail.mod": "Mod",
+  "libraryDetail.belongsTo": "Belongs to",
+  "libraryDetail.format": "Format",
+  "libraryDetail.extractedFolder": "Extracted folder",
+  "libraryDetail.paintFile": "Paint file",
+  "libraryDetail.packagedPkz": "Packaged .pkz",
+  "libraryDetail.size": "Size",
+  "libraryDetail.folder": "Folder",
+  "libraryDetail.lockedWord": "locked",
+  "libraryDetail.lockedWithMeta":
+    "This track is {{locked}} by its creator. Its name, details and preview are shown here, but the files stay sealed — it can't be unpacked or previewed in 3D.",
+  "libraryDetail.lockedNoMeta":
+    "This track is {{locked}}, so its name, length and preview can't be read from the file — only its filename and size.",
+
+  // ── Mod detail page ────────────────────────────────────────────────────────
+  "modDetail.stageResolve": "Resolve",
+  "modDetail.stageDownload": "Download",
+  "modDetail.stageExtract": "Extract",
+  "modDetail.stagePlace": "Place",
+  "modDetail.stageReload": "Reload",
+  "modDetail.modFiles": "Mod files",
+  "modDetail.copied": "Copied",
+  "modDetail.copy": "Copy",
+  "modDetail.addToLibrary": "Add to Library",
+  "modDetail.host": "Host",
+  "modDetail.installsTo": "Installs to",
+  "modDetail.noDownloadLink":
+    "No download link was found on this page — open it on mxb-mods.com.",
+  "modDetail.frostmodHint":
+    "FrostMod will hot-reload the {{kind}} list when this finishes.",
+  "modDetail.kindRider": "rider",
+  "modDetail.kindBike": "bike",
+  "modDetail.kindTrack": "track",
+  "modDetail.details": "Details",
+  "modDetail.format": "Format",
+  "modDetail.mirrors": "Mirrors",
+  "modDetail.type": "Type",
+  "modDetail.addedToLibrary": "Added to your library",
+  "modDetail.extracting": "Extracting…",
+  "modDetail.addingToLibrary": "Adding to library…",
+  "modDetail.resolving": "Resolving download…",
+  "modDetail.finishInBrowser": "Finish in your browser",
+  "modDetail.viewOnSite": "View on mxb-mods.com",
+
+  // ── Settings ───────────────────────────────────────────────────────────────
+  "settings.help": "Configure your game folder, updates, and app preferences.",
+  "settings.gameFolder": "Game folder",
+  "settings.general": "General",
+  "settings.appearance": "Appearance",
+  "settings.frostmod": "FrostMod",
+  "settings.about": "About & updates",
+  "settings.modsFolderDesc":
+    "Where mods are installed. Changing it re-scans your library.",
+  "settings.insideModsFolder": "Inside your MX Bikes folder",
+  "settings.notSet": "Not set",
+  "settings.change": "Change…",
+  "settings.set": "Set…",
+  "settings.theme": "Theme",
+  "settings.themeLight": "Light",
+  "settings.themeDark": "Dark",
+  "settings.themeSystem": "System",
+  "settings.language": "Language",
+  "settings.languageSystem": "System",
+  "settings.runInBackground": "Keep running in the background",
+  "settings.runInBackgroundDesc":
+    "Closing the window hides MXB App to the tray so FrostMod stays connected. Quit from the tray icon.",
+  "settings.launchAtStartup": "Launch at startup",
+  "settings.launchAtStartupDesc":
+    "Start MXB App automatically when you log in.",
+  "settings.instantRefresh": "Instant preset refresh",
+  "settings.instantRefreshDesc":
+    "When you apply a preset while MX Bikes is running, refresh the look in-game instantly — no restart or profile reselect. If it can't, you'll be told to reselect your profile.",
+  "settings.instantRefreshWindowsOnly":
+    "Refreshing the look in-game without a restart needs FrostMod, which is Windows-only — you'll be told to reselect your profile instead.",
+  "settings.autoRunFrostmod": "Run FrostMod automatically",
+  "settings.autoRunFrostmodDesc":
+    "Start FrostMod in the background whenever MXB App opens.",
+  "settings.watchModsReload": "Auto-reload on folder changes",
+  "settings.watchModsReloadDesc":
+    "Reload the game automatically when tracks or bikes are added to your mods folder — even downloaded manually outside MXB App.",
+  "settings.checking": "Checking…",
+  "settings.runningConnected": "Running · game connected",
+  "settings.notRunning": "Not running",
+  "settings.frostmodInstalled": "Installed{{suffix}}",
+  "settings.notInstalled": "Not installed",
+  "settings.checkingGitHub": "Checking GitHub for the latest release…",
+  "settings.updateCheckFailed":
+    "Couldn't check for updates — offline or GitHub unavailable.",
+  "settings.latestVersion": "Latest: {{version}}",
+  "settings.checkNewer": "Check for a newer FrostMod",
+  "settings.working": "Working…",
+  "settings.installFrostmod": "Install FrostMod",
+  "settings.updateTo": "Update to {{version}}",
+  "settings.reinstallLatest": "Reinstall latest",
+  "settings.upToDate": "Up to date",
+  "settings.madeWith": "Made with",
+  // Toasts.
+  "settings.updateFailed": "Couldn't update setting",
+  "settings.startupUpdateFailed": "Couldn't update startup setting",
+  "settings.folderUpdated": "Game folder updated",
+  "settings.folderUpdatedDesc": "Your library will re-scan.",
+  "settings.setFolderFailed": "Couldn't set folder",
+  "settings.reDetected": "Re-detected your MX Bikes folder",
+  "settings.detectFolderFailed": "Couldn't detect folder",
+  "settings.pickInstallFolder":
+    "Select your MX Bikes install folder (contains rider.pkz)",
+  "settings.installSet": "Game install set",
+  "settings.installSetDesc":
+    "The 3D rider preview can now load the real body model.",
+  "settings.setInstallFailed": "Couldn't set install folder",
+  "settings.installNotFound": "Couldn't find MX Bikes",
+  "settings.installNotFoundDesc":
+    "No Steam install detected — set the folder manually.",
+  "settings.installFound": "Found your MX Bikes install",
+  "settings.detectInstallFailed": "Couldn't detect install folder",
+  "settings.pickProfilesFolder": "Select your MX Bikes profiles folder",
+  "settings.profilesSet": "Profiles folder set",
+  "settings.profilesFound_one": "Found {{count}} profile.",
+  "settings.profilesFound_other": "Found {{count}} profiles.",
+  "settings.noProfilesThere": "No profiles found there",
+  "settings.noProfilesThereDesc":
+    "Saved anyway, but preset creation needs a folder that holds your profile.ini folders.",
+  "settings.setProfilesFailed": "Couldn't set profiles folder",
+  "settings.profilesReverted": "Reverted to the default profiles folder",
+  "settings.resetProfilesFailed": "Couldn't reset profiles folder",
+  "settings.frostmodNotRunningHint":
+    "FrostMod isn't running — start it to hot-reload mods.",
+  "settings.reloadUnavailable": "Reload isn't available on this platform.",
+
+  // ── Library (installed mods) ───────────────────────────────────────────────
+  "library.help":
+    "Your installed mods. Review what's installed and remove ones you no longer want.",
+  "library.rootFolder": "(root)",
+  "library.byAuthor": "by {{author}}",
+  "library.locked": "Locked — contents can't be read",
+  "library.searchPlaceholder": "Search installed…",
+  "library.scanning": "Scanning your library…",
+  "library.empty": "No {{type}} installed yet — head to Browse and add one.",
+  "library.noMatches": "No matches.",
+  "library.quick3d": "Quick 3D view",
+  "library.selectNone": "Select none",
+  "library.move": "Move",
+  "library.uninstall": "Uninstall",
+  "library.uninstallAction": "Uninstall…",
+  "library.moveToFolder": "Move to folder…",
+  "library.showInExplorer": "Show in Explorer",
+  "library.moveDialogTitle": "Move to folder",
+  "library.moveCount_one": "Move {{count}} item",
+  "library.moveCount_other": "Move {{count}} items",
+  "library.chooseDestination": "Choose a destination folder",
+  "library.newFolder": "New folder…",
+  "library.newFolderName": "New folder name",
+  "library.createAndMove": "Create & move",
+  "library.confirmUninstall": "Uninstall {{name}}?",
+  "library.confirmUninstallBody":
+    "The item is moved to the Recycle Bin — you can restore it from there.",
+  "library.confirmBulkUninstall_one": "Uninstall {{count}} item?",
+  "library.confirmBulkUninstall_other": "Uninstall {{count}} items?",
+  "library.confirmBulkUninstallBody":
+    "Each item is moved to the Recycle Bin — you can restore them from there.",
+  "library.uninstallCount": "Uninstall {{count}}",
+  // Toasts.
+  "library.moveFailed": "Couldn't move mod",
+  "library.uninstallFailed": "Couldn't uninstall",
+  "library.openFailed": "Couldn't open",
+  "library.uninstalledOne": "{{name}} uninstalled",
+  "library.movedToBin": "Moved to the Recycle Bin.",
+  "library.someNotRemoved": "Some items couldn't be removed.",
+  "library.bulkUninstalled_one": "{{count}} item uninstalled",
+  "library.bulkUninstalled_other": "{{count}} items uninstalled",
+  "library.bulkUninstallPartial": "Uninstalled {{ok}}, {{fail}} failed",
+  "library.bulkMovePartial": "Moved {{ok}}, {{fail}} failed",
+  "library.bulkMoved_one": "Moved {{count}} item to {{folder}}",
+  "library.bulkMoved_other": "Moved {{count}} items to {{folder}}",
+
+  // ── Locker (per-bike model + sound swaps) ──────────────────────────────────
+  "locker.help":
+    "Swap each bike's model and engine sound between the sets you've installed.",
+  "locker.rescan": "Rescan",
+  "locker.restore": "Restore",
+  "locker.register": "Register",
+  "locker.scanning": "Scanning bikes…",
+  "locker.scanForSwaps": "Scan for swaps",
+  "locker.orphanBanner":
+    "{{bike}} is missing its setup files — an earlier version moved them into a swap folder, which stops the bike loading in-game at all. {{files}}",
+  "locker.looseBanner_one":
+    "{{count}} model / sound set found loose in your bikes — register it into {{modelsFolder}} / {{soundsFolder}}.",
+  "locker.looseBanner_other":
+    "{{count}} model / sound sets found loose in your bikes — register them into {{modelsFolder}} / {{soundsFolder}}.",
+  "locker.emptyTitle": "No swappable bikes yet.",
+  "locker.emptyIntro": "Two things have to be true before a swap can happen:",
+  "locker.unpacked": "unpacked",
+  "locker.emptyRuleUnpacked":
+    "The bike is {{unpacked}} into {{path}}— a packed {{pkz}} can't be swapped. Unpack one from the Library.",
+  "locker.emptyRuleMesh":
+    "Each alternate model sits in its own folder inside that bike, holding a mesh ({{edf}}). Drop it anywhere in the bike folder and hit Scan below — we'll offer to file it under {{folder}}.",
+  "locker.summary": "{{model}} · sound “{{sound}}”",
+  "locker.modelNamed": "model “{{name}}”",
+  "locker.noModelSwaps": "no model swaps",
+  "locker.models": "Models",
+  "locker.sounds": "Sounds",
+  "locker.onlyOneModel": "Only one model — install more to swap",
+  "locker.onlyStock": "Only Stock — install a sound mod to swap",
+  "locker.noModel": "No model",
+  "locker.stock": "Stock",
+  "locker.activeModel": "Active model",
+  "locker.activeSound": "Active sound",
+  "locker.switchToNoModel": "Switch to no model — removes the current model files",
+  "locker.switchToStock":
+    "Switch to Stock — removes the sound mod (built-in sound plays)",
+  "locker.missingModelEdf": "This set has no model.edf",
+  "locker.missingSoundFiles": "This set is missing engine.scl or sfx.cfg",
+  "locker.switchTo": "Switch to {{name}}",
+  "locker.tiedToModel": "Tied to model {{models}}",
+  "locker.boundHint":
+    "“{{sound}}” is tied to model “{{model}}” — it travels with that model. Click to untie.",
+  "locker.unboundHint":
+    "Tie the active sound “{{sound}}” to model “{{model}}” so switching to it pulls the sound in.",
+  "locker.tieAction": "Tie “{{sound}}” to “{{model}}”",
+  "locker.untieAction": "Untie “{{sound}}” from “{{model}}”",
+  // Toasts.
+  "locker.restored": "Restored {{bike}}'s setup files.",
+  "locker.restoredNote_one":
+    "{{count}} file put back — the bike should load again.",
+  "locker.restoredNote_other":
+    "{{count}} files put back — the bike should load again.",
+  "locker.switchedModel": "Switched {{bike}} model to “{{target}}”.",
+  "locker.switchedSound": "Switched {{bike}} sound to “{{target}}”.",
+  "locker.tied": "Tied “{{sound}}” to model “{{model}}”.",
+  "locker.untied": "Untied “{{sound}}” from model “{{model}}”.",
+  "locker.refreshedLive": "Refreshed live in-game.",
+  "locker.refreshFailed":
+    "Instant refresh failed — reselect your profile in-game to load it.",
+  "locker.reselectProfile": "Reselect your profile in MX Bikes to load the swap.",
+  "locker.loadsNextTime": "Loads next time the game opens.",
+
+  // ── Loose model/sound swap registration ────────────────────────────────────
+  "swaps.model": "model",
+  "swaps.modelSets_one": "{{count}} model swap",
+  "swaps.modelSets_other": "{{count}} model swaps",
+  "swaps.soundSets_one": "{{count}} sound mod",
+  "swaps.soundSets_other": "{{count}} sound mods",
+  // " and " is English prose, not punctuation — each language joins its own way.
+  "swaps.and": "{{a}} and {{b}}",
+  "swaps.noSets": "0 sets",
+  "swaps.foundTitle": "Found {{summary}}",
+  "swaps.description":
+    "These folders are sitting loose inside your bikes. Register them to move each into the right library — {{modelsFolder}} for models, {{soundsFolder}} for sounds — so they show up in the Locker.",
+  "swaps.registered_one": "Registered {{count}} set.",
+  "swaps.registered_other": "Registered {{count}} sets.",
+  "swaps.nothingMoved": "Nothing was moved.",
+  "swaps.skipped_one": "{{count}} skipped (name already in use).",
+  "swaps.skipped_other": "{{count}} skipped (names already in use).",
+  "swaps.foldersCreated_one": "Created the library folders for {{count}} bike.",
+  "swaps.foldersCreated_other": "Created the library folders for {{count}} bikes.",
+  "swaps.foldersCreatedDesc":
+    "Your model / sound folders were left where they are.",
+  "swaps.justCreateFolders": "Just create folders",
+  "swaps.registerAndMove": "Register & move",
+  "swaps.fileCount_one": "{{count}} file",
+  "swaps.fileCount_other": "{{count}} files",
+
+  // ── Install pipeline (toasts + failure card) ───────────────────────────────
+  "install.installed": "{{title}} installed",
+  "install.reloadedDesc": "Game reloaded via FrostMod — it's live now.",
+  "install.addedDesc": "Added to your library.",
+  "install.failed": "Install failed — {{title}}",
+  "install.openModPage": "Open the mod's page",
+  "install.clickToOpen": "Click to open the mod's page",
+
+  // ── Library categories (singular — item "Type" label) ──────────────────────
+  "category.track": "Track",
+  "category.bike": "Bike",
+  "category.bikePaint": "Livery",
+  "category.bikeModelSwap": "Model swap",
+  "category.sound": "Sound",
+  "category.helmet": "Helmet",
+  "category.helmetPaint": "Helmet paint",
+  "category.goggles": "Goggles",
+  "category.boots": "Boots",
+  "category.bootPaint": "Boot paint",
+  "category.protection": "Protection",
+  "category.protectionPaint": "Protection paint",
+  "category.gloves": "Gloves",
+  "category.outfit": "Outfit / kit",
+  "category.misc": "Other",
+
+  // ── Library/Rider section headers (plural) ─────────────────────────────────
+  "section.bikePaint": "Liveries",
+  "section.bikeModelSwap": "Model swaps",
+  "section.sound": "Sounds",
+  "section.helmet": "Helmets",
+  "section.helmetPaint": "Helmet paints",
+  "section.boots": "Boots",
+  "section.bootPaint": "Boot paints",
+  "section.protection": "Protection",
+  "section.protectionPaint": "Protection paints",
+  "section.gloves": "Gloves",
+  "section.outfit": "Outfit / kit",
+
+  // ── Install destinations ───────────────────────────────────────────────────
+  "dest.bikesRoot": "Bikes (root)",
+  "dest.tracksRoot": "Tracks (root)",
+  "dest.bikeFolder": "{{name}} — bike folder",
+  "dest.bikePaints": "{{name}} — paints",
+  "dest.helmetsNewModel": "Helmets (new model)",
+  "dest.bootsNewModel": "Boots (new model)",
+  "dest.protectionNewModel": "Protection (new model)",
+  "dest.helmetPaintsFor": "{{name}} · helmet paints",
+  "dest.gogglesFor": "{{name}} · goggles",
+  "dest.bootPaintsFor": "{{name}} · boot paints",
+  "dest.protectionPaintsFor": "{{name}} · protection paints",
+  "dest.outfitFor": "{{name}} · outfit / kit",
+  "dest.glovesFor": "{{name}} · gloves",
+} as const;

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1,0 +1,714 @@
+import type { Translation } from "..";
+
+/**
+ * Spanish (neutral — avoids vos/vosotros so it reads naturally in both Spain and
+ * Latin America; uses "tú" throughout).
+ *
+ * Community terminology rather than dictionary equivalents: `mod`, `setup`,
+ * `preset` and `Stock` stay as loanwords, while gear is translated — `casco`,
+ * `botas`, `gafas` for goggles, `librea` for a bike paint.
+ *
+ * Product names (MXB App, FrostMod, MX Bikes) are never translated.
+ */
+export const es: Translation = {
+  // ── Genérico ───────────────────────────────────────────────────────────────
+  "common.cancel": "Cancelar",
+  "common.back": "Atrás",
+  "common.next": "Siguiente",
+  "common.skip": "Omitir",
+  "common.close": "Cerrar",
+  "common.save": "Guardar",
+  "common.delete": "Eliminar",
+  "common.rename": "Renombrar",
+  "common.retry": "Reintentar",
+  "common.tryAgain": "Reintentar",
+  "common.loading": "Cargando…",
+  "common.installed": "Instalado",
+  "common.select": "Seleccionar",
+  "common.deselect": "Deseleccionar",
+  "common.selectAll": "Seleccionar todo",
+  "common.clear": "Limpiar",
+  "common.done": "Hecho",
+  "common.apply": "Aplicar",
+  "common.remove": "Quitar",
+  "common.open": "Abrir",
+  "common.refresh": "Actualizar",
+  "common.dismiss": "Descartar",
+  "common.later": "Más tarde",
+  "common.active": "Activo",
+
+  // ── Controles de ventana ───────────────────────────────────────────────────
+  "window.minimize": "Minimizar",
+  "window.maximize": "Maximizar",
+  "window.close": "Cerrar",
+
+  // ── Navegación ─────────────────────────────────────────────────────────────
+  "nav.browse": "Explorar",
+  "nav.shop": "Tienda",
+  "nav.library": "Biblioteca",
+  "nav.locker": "Taquilla",
+  "nav.presets": "Presets",
+  "nav.rider": "Piloto",
+  "nav.settings": "Ajustes",
+
+  "sidebar.installing": "Instalando «{{name}}»",
+  "sidebar.queued": "+{{count}} en cola",
+
+  // ── FrostMod ───────────────────────────────────────────────────────────────
+  "frostmod.checking": "Comprobando FrostMod…",
+  "frostmod.running": "FrostMod activo",
+  "frostmod.notRunning": "FrostMod inactivo",
+  "frostmod.reloadGame": "Recargar el juego",
+  "frostmod.start": "Iniciar FrostMod",
+  "frostmod.reloadedGame": "FrostMod recargó el juego.",
+  "frostmod.notRunningToast": "FrostMod no está en ejecución.",
+  "frostmod.started": "FrostMod iniciado",
+  "frostmod.alreadyRunning": "FrostMod ya está en ejecución",
+  "frostmod.startFailed": "No se pudo iniciar FrostMod",
+  "frostmod.installedToast": "FrostMod {{version}} instalado",
+  "frostmod.installedToastDesc":
+    "Recargará el juego en caliente cuando añadas mods.",
+  "frostmod.installFailed": "No se pudo instalar FrostMod",
+  "frostmod.newModsAdded": "Nuevos mods añadidos",
+  "frostmod.modsAdded_one": "Nuevo mod añadido",
+  "frostmod.modsAdded_other": "{{count}} mods añadidos",
+  "frostmod.askedReload": "Se pidió a FrostMod que recargara el juego.",
+  "frostmod.andMore_one": "{{names}} y {{count}} más",
+  "frostmod.andMore_other": "{{names}} y {{count}} más",
+  "frostmod.watchDesc":
+    "{{names}} — se pidió a FrostMod que recargara el juego.",
+
+  // ── Configuración inicial ──────────────────────────────────────────────────
+  "setup.title": "Bienvenido a MXB App",
+  "setup.tagline":
+    "Explora mxb-mods, instala con un clic y deja que FrostMod recargue el juego por ti.",
+  "setup.modsFolder": "Carpeta de MX Bikes",
+  "setup.autoDetect":
+    "MXB App detectará automáticamente tu carpeta {{hint}}. También puedes elegirla tú.",
+  "setup.chooseManually": "Elegir la carpeta manualmente…",
+  "setup.chooseDifferent": "Elegir otra carpeta…",
+  "setup.gameInstall": "Instalación de MX Bikes",
+  "setup.detecting": "Buscando tu instalación de MX Bikes…",
+  "setup.found": "Encontrada",
+  "setup.detectedAutomatically": "Detectada automáticamente",
+  "setup.installNotFound":
+    "No se pudo encontrar automáticamente tu instalación de MX Bikes — es lo que alimenta la vista previa 3D del piloto. Elígela manualmente, o configúrala más tarde en Ajustes.",
+  "setup.chooseInstallManually":
+    "Elegir la carpeta de instalación manualmente…",
+  "setup.startBrowsing": "Empezar a explorar mods",
+  "setup.detectAndStart": "Detectar y empezar",
+  "setup.pickModsFolder": "Selecciona tu carpeta de MX Bikes",
+  "setup.pickInstallFolder":
+    "Selecciona tu carpeta de instalación de MX Bikes",
+
+  // ── Bienvenida ─────────────────────────────────────────────────────────────
+  "welcome.intro.title": "Bienvenido a MXB App",
+  "welcome.intro.body":
+    "Tu gestor de mods para MX Bikes. Mantén pistas, motos y gráficos organizados en un solo sitio — se acabaron los archivos zip repartidos por el escritorio. Te enseñamos todo en unos segundos.",
+  "welcome.getStarted": "Empezar",
+
+  // ── Presets ────────────────────────────────────────────────────────────────
+  "presets.missing": "falta",
+  "presets.missingHint":
+    "Este mod no está instalado — se verá como Stock en el juego",
+  "presets.missingMods":
+    "Mods que faltan: {{mods}}. Instálalos para ver esas piezas.",
+  "presets.help":
+    "Guarda un look completo de piloto y cárgalo en una moto cuando quieras.",
+  "presets.profile": "Perfil",
+  "presets.namePlaceholder": "Nombre del preset…",
+  "presets.savePreset": "Guardar preset",
+  "presets.saveChanges": "Guardar cambios",
+  "presets.saveChangesQ": "¿Guardar los cambios?",
+  "presets.replaceQ": "¿Reemplazar el preset?",
+  "presets.replace": "Reemplazar",
+  "presets.loadCopy": "Cargar una copia en el editor",
+  "presets.viewOnRider": "Ver en el piloto",
+  "presets.editNameOrOptions": "Editar nombre u opciones",
+  "presets.share": "Compartir",
+  "presets.nameFirst": "Primero dale un nombre al preset.",
+  "presets.pickProfileAndBike":
+    "Elige un perfil y una moto a los que aplicarlo.",
+  "presets.updated": "Preset «{{name}}» actualizado.",
+  "presets.renamed": "Renombrado a «{{name}}» y cambios guardados.",
+  "presets.saved": "Preset «{{name}}» guardado.",
+  "presets.editing":
+    "Editando «{{name}}» — cambia lo que quieras y guarda los cambios.",
+  "presets.appliedRefreshed":
+    "«{{label}}» aplicado a {{bike}} — actualizado en directo en el juego.",
+  "presets.appliedRefreshFailed":
+    "«{{label}}» aplicado a {{bike}} — guardado, pero falló la actualización instantánea: vuelve a seleccionar tu perfil en el juego para cargarlo.",
+  "presets.appliedGameRunning":
+    "«{{label}}» aplicado a {{bike}} — guardado. Vuelve a seleccionar tu perfil en MX Bikes (menú Perfil) para cargar el nuevo look.",
+  "presets.appliedNextTime":
+    "«{{label}}» aplicado a {{bike}} — guardado. Se cargará la próxima vez que abras el juego.",
+  "presets.phaseBundling": "Empaquetando los archivos…",
+  "presets.phaseUploading": "Subiendo el paquete…",
+  "presets.phaseDownloading": "Descargando el paquete…",
+  "presets.phaseInstalling": "Instalando los archivos…",
+  "presets.bundleUploaded":
+    "Paquete completo subido — el código ya incluye los archivos.",
+  "presets.shareHintFull":
+    "Este código incluye un paquete descargable — quien lo reciba elige Importación completa y lo obtiene todo, incluso sin mods instalados.",
+  "presets.shareHintConfig":
+    "Envía este código a quien quieras. Lo importa desde Presets → Importar. Necesitará los mismos mods instalados para que se vea cada pieza.",
+  "presets.generatingCode": "Generando el código…",
+  "presets.nothingToBundle":
+    "No hay archivos instalados que empaquetar — este look es todo Stock/fuentes.",
+  "presets.createFullBundle": "Crear paquete completo",
+  "presets.copiedFull": "Código con paquete completo copiado.",
+  "presets.copiedShare": "Código para compartir copiado.",
+  "presets.copyFailed":
+    "No se pudo copiar — selecciona el código y cópialo a mano.",
+  "presets.copyFullCode": "Copiar código completo",
+  "presets.copyCode": "Copiar código",
+  "presets.importTitle": "Importar preset",
+  "presets.importBody": "Pega un código que te hayan enviado.",
+  "presets.configOnly": "Solo configuración",
+  "presets.import": "Importar",
+  "presets.fullImport": "Importación completa",
+  "presets.editingBanner":
+    "Editando {{name}} — cambia el nombre o cualquier ranura y luego {{save}}.",
+  "presets.bundleNotice":
+    "Incluye un paquete completo (~{{size}} desde {{host}}). Usa {{fullImport}} para descargar e instalar todo — no hace falta tener mods antes.",
+
+  // ── Ranuras de preset ──────────────────────────────────────────────────────
+  "slot.paint": "Librea de la moto",
+  "slot.modelSwap": "Cambio de modelo",
+  "slot.bikeFont": "Fuente de dorsales",
+  "slot.tyres": "Neumáticos",
+  "slot.rider": "Perfil de piloto",
+  "slot.suitPaint": "Equipación / kit",
+  "slot.suitFont": "Fuente de la equipación",
+  "slot.glovesPaint": "Guantes",
+  "slot.ridingStyle": "Estilo de pilotaje",
+  "slot.helmet": "Casco",
+  "slot.helmetPaint": "Gráficos del casco",
+  "slot.gogglesPaint": "Gafas",
+  "slot.boots": "Botas",
+  "slot.bootsPaint": "Gráficos de las botas",
+  "slot.protection": "Protecciones",
+  "slot.protectionPaint": "Gráficos de las protecciones",
+  "slotGroup.bike": "Moto",
+  "slotGroup.rider": "Piloto",
+  "slotGroup.head": "Cabeza",
+  "slotGroup.body": "Cuerpo",
+
+  // ── Estudio del piloto ─────────────────────────────────────────────────────
+  "rider.help":
+    "Viste al modelo del piloto — casco, gafas, equipación y botas a la vez.",
+  "rider.namePlaceholder": "Pon nombre a este piloto…",
+  "rider.nameFirst": "Primero ponle nombre a este look.",
+  "rider.showOnModel": "Mostrar en el modelo",
+
+  // ── Visita guiada ──────────────────────────────────────────────────────────
+  "tour.welcomeTour.title": "Haz un recorrido rápido",
+  "tour.welcomeTour.body":
+    "Unos segundos para ver dónde está cada cosa. Puedes omitirlo cuando quieras.",
+  "tour.browse.title": "Explorar mods",
+  "tour.browse.body":
+    "Busca en mxb-mods.com desde aquí mismo e instala cualquier pista, moto o gráfico con un solo clic.",
+  "tour.library.title": "Tu biblioteca",
+  "tour.library.body":
+    "Todo lo que has instalado, en un solo sitio — actualiza o elimina mods sin tocar nunca un archivo zip.",
+  "tour.locker.title": "La taquilla",
+  "tour.locker.body":
+    "Cambia los modelos de las motos a tu gusto. MXB App registra las piezas para que el juego las reconozca.",
+  "tour.presets.title": "Presets",
+  "tour.presets.body":
+    "Guarda combinaciones de equipación y gráficos, y aplica un look completo con un clic — incluso mientras estás rodando.",
+  "tour.rider.title": "Estudio del piloto",
+  "tour.rider.body":
+    "Previsualiza tu equipación y tus gráficos sobre el piloto 3D antes de llevarlos a la pista.",
+  "tour.frostmod.title": "FrostMod, en directo",
+  "tour.frostmod.body":
+    "Aquí ves el estado de FrostMod. Recarga MX Bikes tras una instalación, así el contenido nuevo aparece sin reiniciar el juego.",
+  "tour.settings.title": "Ajustes",
+  "tour.settings.body":
+    "Aquí configuras tu carpeta de juego, el comportamiento en segundo plano y las opciones de FrostMod. También puedes repetir esta visita desde aquí.",
+  "tour.done.title": "Todo listo",
+  "tour.done.body":
+    "Fin del recorrido. Ve a Explorar e instala tu primer mod.",
+
+  // ── Errores ────────────────────────────────────────────────────────────────
+  "error.previewFailed": "No se pudo mostrar la vista previa",
+  "error.somethingWentWrong": "Algo salió mal",
+  "error.unexpected": "Se produjo un error inesperado.",
+  "error.reloadApp": "Recargar la aplicación",
+
+  // ── Actualizaciones ────────────────────────────────────────────────────────
+  "update.available": "{{version}} ya está disponible.",
+  "update.downloading": "Descargando…",
+  "update.downloadingPct": "Descargando… {{pct}} %",
+  "update.pitch":
+    "Actualiza para tener las últimas funciones y correcciones.",
+  "update.updating": "Actualizando…",
+  "update.updateAndRestart": "Actualizar y reiniciar",
+  "update.dismiss": "Descartar la notificación de actualización",
+  "update.onLatest": "Ya tienes la última versión",
+  "update.checkFailed": "No se pudieron comprobar las actualizaciones",
+  "update.failed": "La actualización falló",
+
+  // ── Visor 3D ───────────────────────────────────────────────────────────────
+  "viewer.preview3d": "Vista previa 3D",
+  "viewer.expand": "Ampliar",
+  "viewer.paint": "Gráficos",
+  "viewer.loadingModel": "Cargando modelo…",
+  "viewer.loadingPaint": "Cargando gráficos…",
+  "viewer.loadingRider": "Cargando piloto…",
+  "viewer.dragToRotate": "Arrastra para rotar",
+  "viewer.scrollToZoom": "Desplaza para hacer zoom",
+  "viewer.rightDragToPan": "Arrastra con el botón derecho para mover",
+
+  // ── Combobox ───────────────────────────────────────────────────────────────
+  "combobox.search": "Buscar…",
+  "combobox.use": "Usar «{{value}}»",
+
+  // ── Tipos de mod ───────────────────────────────────────────────────────────
+  "modType.tracks": "Pistas",
+  "modType.bikes": "Motos",
+  "modType.rider": "Piloto",
+  "modType.tracksInline": "pistas",
+  "modType.bikesInline": "motos",
+  "modType.riderInline": "equipación de piloto",
+
+  // ── Filtros de categoría ───────────────────────────────────────────────────
+  "browseCat.all": "Todo",
+  "browseCat.beginner": "Principiante",
+  "browseCat.intermediate": "Intermedio",
+  "browseCat.pro": "Pro",
+  "browseCat.assets": "Recursos",
+  "browseCat.newBikes": "Motos nuevas",
+  "browseCat.liveries": "Libreas",
+  "browseCat.sounds": "Sonidos",
+  "browseCat.riderKit": "Kit de piloto",
+  "browseCat.helmets": "Cascos",
+  "browseCat.helmetPaints": "Gráficos de casco",
+  "browseCat.gloves": "Guantes",
+  "browseCat.boots": "Botas",
+  "browseCat.bootPaints": "Gráficos de botas",
+  "browseCat.protection": "Protecciones",
+  "browseCat.protectionPaints": "Gráficos de protecciones",
+
+  // ── Explorar ───────────────────────────────────────────────────────────────
+  "browse.help":
+    "Descubre e instala mods del catálogo en línea — busca, filtra por tipo y abre un mod para descargarlo al juego.",
+  "browse.searchPlaceholder": "Buscar {{type}}…",
+  "browse.sortedByNewest": "Ordenados por más recientes",
+  "browse.loadFailed": "No se pudieron cargar los mods",
+  "browse.empty": "No se encontraron {{type}}.",
+  "browse.loadMore": "Cargar más",
+  "browse.selectedCount": "{{count}} seleccionados",
+  "browse.queuing": "Añadiendo a la cola…",
+  "browse.quickInstallCount": "Instalar rápido {{count}}",
+  "browse.quickInstall": "Instalación rápida",
+  "browse.quickReinstall": "Reinstalación rápida",
+  "browse.openDetails": "Abrir detalles",
+  "browse.reinstallOne": "¿Reinstalar «{{title}}»?",
+  "browse.reinstallMany": "¿Reinstalar los mods que ya tienes?",
+  "browse.reinstallOneBody":
+    "Este mod ya está en tu biblioteca. Al reinstalarlo se descarga de nuevo y se sobrescriben los archivos instalados.",
+  "browse.reinstallManyBody":
+    "{{installed}} de los {{total}} seleccionados ya están instalados. Si continúas se reinstalan y se sobrescriben.",
+  "browse.reinstall": "Reinstalar",
+  "browse.reinstallAll": "Reinstalar todo",
+  "browse.queued": "«{{title}}» en cola",
+  "browse.queuedDesc": "Instalando en {{folder}}.",
+  "browse.rootFolder": "raíz",
+  "browse.needsBrowser": "«{{title}}» requiere descarga desde el navegador",
+  "browse.needsBrowserDesc":
+    "{{host}} bloquea las descargas dentro de la app — abre su página para terminar.",
+  "browse.noDownload": "No se encontró descarga para «{{title}}»",
+  "browse.quickInstallFailed":
+    "No se pudo instalar rápido «{{title}}»",
+  "browse.queuedBulk_one": "{{count}} mod en cola",
+  "browse.queuedBulk_other": "{{count}} mods en cola",
+  "browse.queuedBulkDesc": "Se instalarán uno tras otro.",
+  "browse.queuedBulkSkipped_one":
+    "{{count}} omitido — host solo de navegador.",
+  "browse.queuedBulkSkipped_other":
+    "{{count}} omitidos — host solo de navegador.",
+  "browse.bulkFailed": "No se pudo instalar rápido la selección",
+  "browse.bulkFailedDesc_one":
+    "Requiere descarga desde el navegador.",
+  "browse.bulkFailedDesc_other":
+    "Los {{count}} requieren descarga desde el navegador.",
+
+  // ── Tienda ─────────────────────────────────────────────────────────────────
+  "shop.myDownloads": "Mis descargas",
+  "shop.signInTitle": "Inicia sesión en MX Bikes Shop",
+  "shop.signInBody":
+    "Inicia sesión en mxbikes-shop.com para ver e instalar las pistas que has comprado. Abrimos el sitio real — tu contraseña nunca pasa por esta aplicación.",
+  "shop.signIn": "Iniciar sesión",
+  "shop.logOut": "Cerrar sesión",
+  "shop.signedIn": "Sesión iniciada en MX Bikes Shop",
+  "shop.sessionFailed":
+    "No se pudo capturar tu sesión de MX Bikes Shop",
+  "shop.queuedDesc": "Instalando en tu carpeta de pistas.",
+  "shop.loadFailed": "No se pudieron cargar tus descargas: {{error}}",
+  "shop.empty": "Aún no hay descargas compradas en tu cuenta.",
+
+  // ── Diálogo de instalación ─────────────────────────────────────────────────
+  "installDialog.installTo": "Instalar en",
+  "installDialog.installToFolder": "Instalar en {{folder}}",
+  "installDialog.change": "Cambiar",
+  "installDialog.searchBikes": "Buscar motos…",
+  "installDialog.searchFolders": "Buscar carpetas…",
+  "installDialog.probably": "Probablemente",
+  "installDialog.allFolders": "Todas las carpetas",
+  "installDialog.noFolderMatch":
+    "Ninguna carpeta coincide — créala abajo.",
+  "installDialog.rememberedFor": "Recordado para {{type}}",
+  "installDialog.downloadFrom": "Descargar desde",
+  "installDialog.downloadPerBike": "Descarga (por moto)",
+  "installDialog.opensInBrowser":
+    "Se abre en el navegador — MXB App termina la instalación",
+  "installDialog.matchedBike": "Coincide con tu moto",
+  "installDialog.differentBike": "Moto / pack distinto",
+  "installDialog.directFastest": "Directo · el más rápido",
+  "installDialog.direct": "Directo",
+  "installDialog.perBikeHint":
+    "Cada descarga es una moto distinta — se selecciona automáticamente según tu elección. Elige el pack «all bikes» para todas las motos de una vez.",
+  "installDialog.mirrorsHint":
+    "Todos los espejos contienen el mismo archivo. Si uno falla, prueba el siguiente.",
+
+  // ── Detalles de biblioteca ─────────────────────────────────────────────────
+  "libraryDetail.author": "Autor",
+  "libraryDetail.length": "Longitud",
+  "libraryDetail.altitude": "Altitud",
+  "libraryDetail.location": "Ubicación",
+  "libraryDetail.type": "Tipo",
+  "libraryDetail.mod": "Mod",
+  "libraryDetail.belongsTo": "Pertenece a",
+  "libraryDetail.format": "Formato",
+  "libraryDetail.extractedFolder": "Carpeta extraída",
+  "libraryDetail.paintFile": "Archivo de gráficos",
+  "libraryDetail.packagedPkz": "Paquete .pkz",
+  "libraryDetail.size": "Tamaño",
+  "libraryDetail.folder": "Carpeta",
+  "libraryDetail.lockedWord": "bloqueada",
+  "libraryDetail.lockedWithMeta":
+    "Esta pista está {{locked}} por su creador. Su nombre, detalles y vista previa se muestran aquí, pero los archivos siguen sellados — no se puede extraer ni ver en 3D.",
+  "libraryDetail.lockedNoMeta":
+    "Esta pista está {{locked}}, así que su nombre, longitud y vista previa no se pueden leer del archivo — solo su nombre de archivo y su tamaño.",
+
+  // ── Página del mod ─────────────────────────────────────────────────────────
+  "modDetail.stageResolve": "Resolver",
+  "modDetail.stageDownload": "Descargar",
+  "modDetail.stageExtract": "Extraer",
+  "modDetail.stagePlace": "Colocar",
+  "modDetail.stageReload": "Recargar",
+  "modDetail.modFiles": "Archivos de mod",
+  "modDetail.copied": "Copiado",
+  "modDetail.copy": "Copiar",
+  "modDetail.addToLibrary": "Añadir a la biblioteca",
+  "modDetail.host": "Host",
+  "modDetail.installsTo": "Se instala en",
+  "modDetail.noDownloadLink":
+    "No se encontró ningún enlace de descarga en esta página — ábrela en mxb-mods.com.",
+  "modDetail.frostmodHint":
+    "FrostMod recargará la lista de {{kind}} cuando esto termine.",
+  "modDetail.kindRider": "piloto",
+  "modDetail.kindBike": "motos",
+  "modDetail.kindTrack": "pistas",
+  "modDetail.details": "Detalles",
+  "modDetail.format": "Formato",
+  "modDetail.mirrors": "Espejos",
+  "modDetail.type": "Tipo",
+  "modDetail.addedToLibrary": "Añadido a tu biblioteca",
+  "modDetail.extracting": "Extrayendo…",
+  "modDetail.addingToLibrary": "Añadiendo a la biblioteca…",
+  "modDetail.resolving": "Resolviendo la descarga…",
+  "modDetail.finishInBrowser": "Termina en tu navegador",
+  "modDetail.viewOnSite": "Ver en mxb-mods.com",
+
+  // ── Ajustes ────────────────────────────────────────────────────────────────
+  "settings.help":
+    "Configura tu carpeta de juego, las actualizaciones y las preferencias de la aplicación.",
+  "settings.gameFolder": "Carpeta del juego",
+  "settings.general": "General",
+  "settings.appearance": "Apariencia",
+  "settings.frostmod": "FrostMod",
+  "settings.about": "Acerca de y actualizaciones",
+  "settings.modsFolderDesc":
+    "Donde se instalan los mods. Cambiarla vuelve a analizar tu biblioteca.",
+  "settings.insideModsFolder": "Dentro de tu carpeta de MX Bikes",
+  "settings.notSet": "Sin definir",
+  "settings.change": "Cambiar…",
+  "settings.set": "Definir…",
+  "settings.theme": "Tema",
+  "settings.themeLight": "Claro",
+  "settings.themeDark": "Oscuro",
+  "settings.themeSystem": "Sistema",
+  "settings.language": "Idioma",
+  "settings.languageSystem": "Sistema",
+  "settings.runInBackground": "Seguir en segundo plano",
+  "settings.runInBackgroundDesc":
+    "Cerrar la ventana deja MXB App en la bandeja del sistema para que FrostMod siga conectado. Sal desde el icono de la bandeja.",
+  "settings.launchAtStartup": "Iniciar al arrancar",
+  "settings.launchAtStartupDesc":
+    "Inicia MXB App automáticamente al iniciar sesión.",
+  "settings.instantRefresh": "Actualización instantánea de presets",
+  "settings.instantRefreshDesc":
+    "Cuando aplicas un preset con MX Bikes en marcha, actualiza el look en el juego al instante — sin reiniciar ni volver a seleccionar el perfil. Si no puede, se te pedirá que vuelvas a seleccionar tu perfil.",
+  "settings.instantRefreshWindowsOnly":
+    "Actualizar el look en el juego sin reiniciar necesita FrostMod, que es solo para Windows — en su lugar se te pedirá que vuelvas a seleccionar tu perfil.",
+  "settings.autoRunFrostmod": "Ejecutar FrostMod automáticamente",
+  "settings.autoRunFrostmodDesc":
+    "Inicia FrostMod en segundo plano cada vez que abres MXB App.",
+  "settings.watchModsReload": "Recarga automática al cambiar la carpeta",
+  "settings.watchModsReloadDesc":
+    "Recarga el juego automáticamente cuando se añaden pistas o motos a tu carpeta de mods — incluso descargadas manualmente fuera de MXB App.",
+  "settings.checking": "Comprobando…",
+  "settings.runningConnected": "En ejecución · juego conectado",
+  "settings.notRunning": "Inactivo",
+  "settings.frostmodInstalled": "Instalado{{suffix}}",
+  "settings.notInstalled": "No instalado",
+  "settings.checkingGitHub":
+    "Comprobando la última versión en GitHub…",
+  "settings.updateCheckFailed":
+    "No se pudieron comprobar las actualizaciones — sin conexión o GitHub no disponible.",
+  "settings.latestVersion": "Última: {{version}}",
+  "settings.checkNewer": "Buscar una versión más reciente de FrostMod",
+  "settings.working": "Trabajando…",
+  "settings.installFrostmod": "Instalar FrostMod",
+  "settings.updateTo": "Actualizar a {{version}}",
+  "settings.reinstallLatest": "Reinstalar la última",
+  "settings.upToDate": "Actualizado",
+  "settings.madeWith": "Hecho con",
+  "settings.updateFailed": "No se pudo actualizar el ajuste",
+  "settings.startupUpdateFailed":
+    "No se pudo actualizar el inicio automático",
+  "settings.folderUpdated": "Carpeta del juego actualizada",
+  "settings.folderUpdatedDesc": "Tu biblioteca se volverá a analizar.",
+  "settings.setFolderFailed": "No se pudo definir la carpeta",
+  "settings.reDetected": "Carpeta de MX Bikes detectada de nuevo",
+  "settings.detectFolderFailed": "No se pudo detectar la carpeta",
+  "settings.pickInstallFolder":
+    "Selecciona tu carpeta de instalación de MX Bikes (contiene rider.pkz)",
+  "settings.installSet": "Instalación del juego definida",
+  "settings.installSetDesc":
+    "La vista previa 3D del piloto ya puede cargar el modelo real del cuerpo.",
+  "settings.setInstallFailed":
+    "No se pudo definir la carpeta de instalación",
+  "settings.installNotFound": "No se pudo encontrar MX Bikes",
+  "settings.installNotFoundDesc":
+    "No se detectó ninguna instalación de Steam — define la carpeta manualmente.",
+  "settings.installFound": "Instalación de MX Bikes encontrada",
+  "settings.detectInstallFailed":
+    "No se pudo detectar la carpeta de instalación",
+  "settings.pickProfilesFolder":
+    "Selecciona tu carpeta de perfiles de MX Bikes",
+  "settings.profilesSet": "Carpeta de perfiles definida",
+  "settings.profilesFound_one": "Se encontró {{count}} perfil.",
+  "settings.profilesFound_other": "Se encontraron {{count}} perfiles.",
+  "settings.noProfilesThere": "No se encontraron perfiles ahí",
+  "settings.noProfilesThereDesc":
+    "Se guardó igualmente, pero crear presets necesita una carpeta que contenga tus carpetas de profile.ini.",
+  "settings.setProfilesFailed":
+    "No se pudo definir la carpeta de perfiles",
+  "settings.profilesReverted":
+    "Se restauró la carpeta de perfiles predeterminada",
+  "settings.resetProfilesFailed":
+    "No se pudo restablecer la carpeta de perfiles",
+  "settings.frostmodNotRunningHint":
+    "FrostMod no está en ejecución — inícialo para recargar mods en caliente.",
+  "settings.reloadUnavailable":
+    "La recarga no está disponible en esta plataforma.",
+
+  // ── Biblioteca ─────────────────────────────────────────────────────────────
+  "library.help":
+    "Tus mods instalados. Revisa lo que tienes instalado y quita lo que ya no quieras.",
+  "library.rootFolder": "(raíz)",
+  "library.byAuthor": "de {{author}}",
+  "library.locked": "Bloqueado — no se puede leer el contenido",
+  "library.searchPlaceholder": "Buscar entre los instalados…",
+  "library.scanning": "Analizando tu biblioteca…",
+  "library.empty":
+    "Aún no hay {{type}} instaladas — ve a Explorar y añade alguna.",
+  "library.noMatches": "Sin resultados.",
+  "library.quick3d": "Vista 3D rápida",
+  "library.selectNone": "No seleccionar nada",
+  "library.move": "Mover",
+  "library.uninstall": "Desinstalar",
+  "library.uninstallAction": "Desinstalar…",
+  "library.moveToFolder": "Mover a una carpeta…",
+  "library.showInExplorer": "Mostrar en el explorador",
+  "library.moveDialogTitle": "Mover a una carpeta",
+  "library.moveCount_one": "Mover {{count}} elemento",
+  "library.moveCount_other": "Mover {{count}} elementos",
+  "library.chooseDestination": "Elige una carpeta de destino",
+  "library.newFolder": "Nueva carpeta…",
+  "library.newFolderName": "Nombre de la nueva carpeta",
+  "library.createAndMove": "Crear y mover",
+  "library.confirmUninstall": "¿Desinstalar {{name}}?",
+  "library.confirmUninstallBody":
+    "El elemento se mueve a la Papelera de reciclaje — puedes restaurarlo desde ahí.",
+  "library.confirmBulkUninstall_one": "¿Desinstalar {{count}} elemento?",
+  "library.confirmBulkUninstall_other":
+    "¿Desinstalar {{count}} elementos?",
+  "library.confirmBulkUninstallBody":
+    "Cada elemento se mueve a la Papelera de reciclaje — puedes restaurarlos desde ahí.",
+  "library.uninstallCount": "Desinstalar {{count}}",
+  "library.moveFailed": "No se pudo mover el mod",
+  "library.uninstallFailed": "No se pudo desinstalar",
+  "library.openFailed": "No se pudo abrir",
+  "library.uninstalledOne": "{{name}} desinstalado",
+  "library.movedToBin": "Movido a la Papelera de reciclaje.",
+  "library.someNotRemoved": "Algunos elementos no se pudieron quitar.",
+  "library.bulkUninstalled_one": "{{count}} elemento desinstalado",
+  "library.bulkUninstalled_other": "{{count}} elementos desinstalados",
+  "library.bulkUninstallPartial":
+    "{{ok}} desinstalados, {{fail}} fallidos",
+  "library.bulkMovePartial": "{{ok}} movidos, {{fail}} fallidos",
+  "library.bulkMoved_one": "{{count}} elemento movido a {{folder}}",
+  "library.bulkMoved_other": "{{count}} elementos movidos a {{folder}}",
+
+  // ── Taquilla ───────────────────────────────────────────────────────────────
+  "locker.help":
+    "Cambia el modelo y el sonido del motor de cada moto entre los sets que tengas instalados.",
+  "locker.rescan": "Volver a analizar",
+  "locker.restore": "Restaurar",
+  "locker.register": "Registrar",
+  "locker.scanning": "Analizando motos…",
+  "locker.scanForSwaps": "Buscar sets",
+  "locker.orphanBanner":
+    "A {{bike}} le faltan sus archivos de setup — una versión anterior los movió a una carpeta de swap, y eso impide por completo que la moto cargue en el juego. {{files}}",
+  "locker.looseBanner_one":
+    "{{count}} set de modelo / sonido encontrado suelto entre tus motos — regístralo en {{modelsFolder}} / {{soundsFolder}}.",
+  "locker.looseBanner_other":
+    "{{count}} sets de modelo / sonido encontrados sueltos entre tus motos — regístralos en {{modelsFolder}} / {{soundsFolder}}.",
+  "locker.emptyTitle": "Todavía no hay motos intercambiables.",
+  "locker.emptyIntro":
+    "Se tienen que cumplir dos condiciones para poder hacer un cambio:",
+  "locker.unpacked": "extraída",
+  "locker.emptyRuleUnpacked":
+    "La moto está {{unpacked}} en {{path}}— un {{pkz}} comprimido no se puede intercambiar. Extrae una desde la Biblioteca.",
+  "locker.emptyRuleMesh":
+    "Cada modelo alternativo va en su propia carpeta dentro de esa moto y contiene una malla ({{edf}}). Ponla en cualquier sitio dentro de la carpeta de la moto y pulsa Buscar abajo — te ofreceremos archivarla en {{folder}}.",
+  "locker.summary": "{{model}} · sonido «{{sound}}»",
+  "locker.modelNamed": "modelo «{{name}}»",
+  "locker.noModelSwaps": "sin cambios de modelo",
+  "locker.models": "Modelos",
+  "locker.sounds": "Sonidos",
+  "locker.onlyOneModel":
+    "Solo un modelo — instala más para poder cambiar",
+  "locker.onlyStock":
+    "Solo Stock — instala un mod de sonido para poder cambiar",
+  "locker.noModel": "Sin modelo",
+  "locker.stock": "Stock",
+  "locker.activeModel": "Modelo activo",
+  "locker.activeSound": "Sonido activo",
+  "locker.switchToNoModel":
+    "Cambiar a sin modelo — quita los archivos del modelo actual",
+  "locker.switchToStock":
+    "Cambiar a Stock — quita el mod de sonido (suena el original)",
+  "locker.missingModelEdf": "Este set no tiene model.edf",
+  "locker.missingSoundFiles": "A este set le falta engine.scl o sfx.cfg",
+  "locker.switchTo": "Cambiar a {{name}}",
+  "locker.tiedToModel": "Vinculado al modelo {{models}}",
+  "locker.boundHint":
+    "«{{sound}}» está vinculado al modelo «{{model}}» — viaja con ese modelo. Haz clic para desvincular.",
+  "locker.unboundHint":
+    "Vincula el sonido activo «{{sound}}» al modelo «{{model}}» para que al cambiar a él se traiga también el sonido.",
+  "locker.tieAction": "Vincular «{{sound}}» a «{{model}}»",
+  "locker.untieAction": "Desvincular «{{sound}}» de «{{model}}»",
+  "locker.restored": "Archivos de setup de {{bike}} restaurados.",
+  "locker.restoredNote_one":
+    "{{count}} archivo devuelto a su sitio — la moto debería cargar de nuevo.",
+  "locker.restoredNote_other":
+    "{{count}} archivos devueltos a su sitio — la moto debería cargar de nuevo.",
+  "locker.switchedModel":
+    "Modelo de {{bike}} cambiado a «{{target}}».",
+  "locker.switchedSound": "Sonido de {{bike}} cambiado a «{{target}}».",
+  "locker.tied": "«{{sound}}» vinculado al modelo «{{model}}».",
+  "locker.untied": "«{{sound}}» desvinculado del modelo «{{model}}».",
+  "locker.refreshedLive": "Actualizado en directo en el juego.",
+  "locker.refreshFailed":
+    "Falló la actualización instantánea — vuelve a seleccionar tu perfil en el juego para cargarla.",
+  "locker.reselectProfile":
+    "Vuelve a seleccionar tu perfil en MX Bikes para cargar el cambio.",
+  "locker.loadsNextTime":
+    "Se cargará la próxima vez que abras el juego.",
+
+  // ── Registro de sets sueltos ───────────────────────────────────────────────
+  "swaps.model": "modelo",
+  "swaps.modelSets_one": "{{count}} cambio de modelo",
+  "swaps.modelSets_other": "{{count}} cambios de modelo",
+  "swaps.soundSets_one": "{{count}} mod de sonido",
+  "swaps.soundSets_other": "{{count}} mods de sonido",
+  "swaps.and": "{{a}} y {{b}}",
+  "swaps.noSets": "0 sets",
+  "swaps.foundTitle": "Se encontraron {{summary}}",
+  "swaps.description":
+    "Estas carpetas están sueltas dentro de tus motos. Regístralas para mover cada una a la biblioteca correcta — {{modelsFolder}} para modelos, {{soundsFolder}} para sonidos — y que aparezcan en la Taquilla.",
+  "swaps.registered_one": "{{count}} set registrado.",
+  "swaps.registered_other": "{{count}} sets registrados.",
+  "swaps.nothingMoved": "No se movió nada.",
+  "swaps.skipped_one": "{{count}} omitido (nombre ya en uso).",
+  "swaps.skipped_other": "{{count}} omitidos (nombres ya en uso).",
+  "swaps.foldersCreated_one":
+    "Se crearon las carpetas de biblioteca para {{count}} moto.",
+  "swaps.foldersCreated_other":
+    "Se crearon las carpetas de biblioteca para {{count}} motos.",
+  "swaps.foldersCreatedDesc":
+    "Tus carpetas de modelo / sonido se quedaron donde estaban.",
+  "swaps.justCreateFolders": "Solo crear las carpetas",
+  "swaps.registerAndMove": "Registrar y mover",
+  "swaps.fileCount_one": "{{count}} archivo",
+  "swaps.fileCount_other": "{{count}} archivos",
+
+  // ── Instalación ────────────────────────────────────────────────────────────
+  "install.installed": "{{title}} instalado",
+  "install.reloadedDesc":
+    "Juego recargado con FrostMod — ya está activo.",
+  "install.addedDesc": "Añadido a tu biblioteca.",
+  "install.failed": "Fallo en la instalación — {{title}}",
+  "install.openModPage": "Abrir la página del mod",
+  "install.clickToOpen": "Haz clic para abrir la página del mod",
+
+  // ── Categorías (singular) ──────────────────────────────────────────────────
+  "category.track": "Pista",
+  "category.bike": "Moto",
+  "category.bikePaint": "Librea",
+  "category.bikeModelSwap": "Cambio de modelo",
+  "category.sound": "Sonido",
+  "category.helmet": "Casco",
+  "category.helmetPaint": "Gráficos del casco",
+  "category.goggles": "Gafas",
+  "category.boots": "Botas",
+  "category.bootPaint": "Gráficos de las botas",
+  "category.protection": "Protecciones",
+  "category.protectionPaint": "Gráficos de las protecciones",
+  "category.gloves": "Guantes",
+  "category.outfit": "Equipación / kit",
+  "category.misc": "Otros",
+
+  // ── Encabezados de sección (plural) ────────────────────────────────────────
+  "section.bikePaint": "Libreas",
+  "section.bikeModelSwap": "Cambios de modelo",
+  "section.sound": "Sonidos",
+  "section.helmet": "Cascos",
+  "section.helmetPaint": "Gráficos de casco",
+  "section.boots": "Botas",
+  "section.bootPaint": "Gráficos de botas",
+  "section.protection": "Protecciones",
+  "section.protectionPaint": "Gráficos de protecciones",
+  "section.gloves": "Guantes",
+  "section.outfit": "Equipación / kit",
+
+  // ── Destinos de instalación ────────────────────────────────────────────────
+  "dest.bikesRoot": "Motos (raíz)",
+  "dest.tracksRoot": "Pistas (raíz)",
+  "dest.bikeFolder": "{{name}} — carpeta de la moto",
+  "dest.bikePaints": "{{name}} — gráficos",
+  "dest.helmetsNewModel": "Cascos (modelo nuevo)",
+  "dest.bootsNewModel": "Botas (modelo nuevo)",
+  "dest.protectionNewModel": "Protecciones (modelo nuevo)",
+  "dest.helmetPaintsFor": "{{name}} · gráficos de casco",
+  "dest.gogglesFor": "{{name}} · gafas",
+  "dest.bootPaintsFor": "{{name}} · gráficos de botas",
+  "dest.protectionPaintsFor": "{{name}} · gráficos de protecciones",
+  "dest.outfitFor": "{{name}} · equipación / kit",
+  "dest.glovesFor": "{{name}} · guantes",
+};

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1,0 +1,716 @@
+import type { Translation } from "..";
+
+/**
+ * French.
+ *
+ * Community terminology rather than dictionary equivalents: `mod`, `setup`,
+ * `preset` and `Stock` stay as loanwords (that's what riders say), while gear is
+ * translated — `casque`, `bottes`, `masque` for goggles, `déco` for a paint.
+ *
+ * Note the plural forms: French `_one` covers **0 and 1**, which `Intl.PluralRules`
+ * handles for us — so "0 fichier" (singular) comes out correct without a special case.
+ *
+ * Product names (MXB App, FrostMod, MX Bikes) are never translated.
+ */
+export const fr: Translation = {
+  // ── Générique ──────────────────────────────────────────────────────────────
+  "common.cancel": "Annuler",
+  "common.back": "Retour",
+  "common.next": "Suivant",
+  "common.skip": "Passer",
+  "common.close": "Fermer",
+  "common.save": "Enregistrer",
+  "common.delete": "Supprimer",
+  "common.rename": "Renommer",
+  "common.retry": "Réessayer",
+  "common.tryAgain": "Réessayer",
+  "common.loading": "Chargement…",
+  "common.installed": "Installé",
+  "common.select": "Sélectionner",
+  "common.deselect": "Désélectionner",
+  "common.selectAll": "Tout sélectionner",
+  "common.clear": "Effacer",
+  "common.done": "Terminé",
+  "common.apply": "Appliquer",
+  "common.remove": "Retirer",
+  "common.open": "Ouvrir",
+  "common.refresh": "Actualiser",
+  "common.dismiss": "Ignorer",
+  "common.later": "Plus tard",
+  "common.active": "Actif",
+
+  // ── Contrôles de fenêtre ───────────────────────────────────────────────────
+  "window.minimize": "Réduire",
+  "window.maximize": "Agrandir",
+  "window.close": "Fermer",
+
+  // ── Navigation ─────────────────────────────────────────────────────────────
+  "nav.browse": "Parcourir",
+  "nav.shop": "Boutique",
+  "nav.library": "Bibliothèque",
+  "nav.locker": "Casier",
+  "nav.presets": "Presets",
+  "nav.rider": "Pilote",
+  "nav.settings": "Réglages",
+
+  "sidebar.installing": "Installation de « {{name}} »",
+  "sidebar.queued": "+{{count}} en attente",
+
+  // ── FrostMod ───────────────────────────────────────────────────────────────
+  "frostmod.checking": "Vérification de FrostMod…",
+  "frostmod.running": "FrostMod actif",
+  "frostmod.notRunning": "FrostMod inactif",
+  "frostmod.reloadGame": "Recharger le jeu",
+  "frostmod.start": "Démarrer FrostMod",
+  "frostmod.reloadedGame": "FrostMod a rechargé le jeu.",
+  "frostmod.notRunningToast": "FrostMod n'est pas en cours d'exécution.",
+  "frostmod.started": "FrostMod démarré",
+  "frostmod.alreadyRunning": "FrostMod est déjà en cours d'exécution",
+  "frostmod.startFailed": "Impossible de démarrer FrostMod",
+  "frostmod.installedToast": "FrostMod {{version}} installé",
+  "frostmod.installedToastDesc":
+    "Il rechargera le jeu à chaud dès que vous ajouterez des mods.",
+  "frostmod.installFailed": "Impossible d'installer FrostMod",
+  "frostmod.newModsAdded": "Nouveaux mods ajoutés",
+  "frostmod.modsAdded_one": "Nouveau mod ajouté",
+  "frostmod.modsAdded_other": "{{count}} mods ajoutés",
+  "frostmod.askedReload": "Demande de rechargement envoyée à FrostMod.",
+  "frostmod.andMore_one": "{{names}} et {{count}} autre",
+  "frostmod.andMore_other": "{{names}} et {{count}} autres",
+  "frostmod.watchDesc":
+    "{{names}} — demande de rechargement envoyée à FrostMod.",
+
+  // ── Configuration initiale ─────────────────────────────────────────────────
+  "setup.title": "Bienvenue dans MXB App",
+  "setup.tagline":
+    "Parcourez mxb-mods, installez en un clic, et laissez FrostMod recharger le jeu pour vous.",
+  "setup.modsFolder": "Dossier MX Bikes",
+  "setup.autoDetect":
+    "MXB App détectera automatiquement votre dossier {{hint}}. Vous pouvez aussi le choisir vous-même.",
+  "setup.chooseManually": "Choisir le dossier manuellement…",
+  "setup.chooseDifferent": "Choisir un autre dossier…",
+  "setup.gameInstall": "Installation de MX Bikes",
+  "setup.detecting": "Recherche de votre installation de MX Bikes…",
+  "setup.found": "Trouvée",
+  "setup.detectedAutomatically": "Détectée automatiquement",
+  "setup.installNotFound":
+    "Impossible de trouver automatiquement votre installation de MX Bikes — elle alimente l'aperçu 3D du pilote. Choisissez-la manuellement, ou définissez-la plus tard dans les Réglages.",
+  "setup.chooseInstallManually":
+    "Choisir le dossier d'installation manuellement…",
+  "setup.startBrowsing": "Commencer à parcourir les mods",
+  "setup.detectAndStart": "Détecter et commencer",
+  "setup.pickModsFolder": "Sélectionnez votre dossier MX Bikes",
+  "setup.pickInstallFolder":
+    "Sélectionnez votre dossier d'installation de MX Bikes",
+
+  // ── Bienvenue ──────────────────────────────────────────────────────────────
+  "welcome.intro.title": "Bienvenue dans MXB App",
+  "welcome.intro.body":
+    "Votre gestionnaire de mods pour MX Bikes. Gardez circuits, motos et décos organisés au même endroit — fini les fichiers zip éparpillés sur le bureau. On vous fait faire le tour en quelques secondes.",
+  "welcome.getStarted": "C'est parti",
+
+  // ── Presets ────────────────────────────────────────────────────────────────
+  "presets.missing": "manquant",
+  "presets.missingHint":
+    "Ce mod n'est pas installé — il apparaîtra en Stock dans le jeu",
+  "presets.missingMods":
+    "Mods manquants : {{mods}}. Installez-les pour voir ces éléments.",
+  "presets.help":
+    "Enregistrez un look de pilote complet et chargez-le sur une moto à la demande.",
+  "presets.profile": "Profil",
+  "presets.namePlaceholder": "Nom du preset…",
+  "presets.savePreset": "Enregistrer le preset",
+  "presets.saveChanges": "Enregistrer les modifications",
+  "presets.saveChangesQ": "Enregistrer les modifications ?",
+  "presets.replaceQ": "Remplacer le preset ?",
+  "presets.replace": "Remplacer",
+  "presets.loadCopy": "Charger une copie dans l'éditeur",
+  "presets.viewOnRider": "Voir sur le pilote",
+  "presets.editNameOrOptions": "Modifier le nom ou les options",
+  "presets.share": "Partager",
+  "presets.nameFirst": "Donnez d'abord un nom au preset.",
+  "presets.pickProfileAndBike":
+    "Choisissez un profil et une moto sur lesquels l'appliquer.",
+  "presets.updated": "Preset « {{name}} » mis à jour.",
+  "presets.renamed":
+    "Renommé en « {{name}} » et modifications enregistrées.",
+  "presets.saved": "Preset « {{name}} » enregistré.",
+  "presets.editing":
+    "Modification de « {{name}} » — changez ce que vous voulez, puis enregistrez.",
+  "presets.appliedRefreshed":
+    "« {{label}} » appliqué à {{bike}} — actualisé en direct dans le jeu.",
+  "presets.appliedRefreshFailed":
+    "« {{label}} » appliqué à {{bike}} — enregistré, mais l'actualisation instantanée a échoué : resélectionnez votre profil en jeu pour le charger.",
+  "presets.appliedGameRunning":
+    "« {{label}} » appliqué à {{bike}} — enregistré. Resélectionnez votre profil dans MX Bikes (menu Profil) pour charger le nouveau look.",
+  "presets.appliedNextTime":
+    "« {{label}} » appliqué à {{bike}} — enregistré. Il sera chargé à la prochaine ouverture du jeu.",
+  "presets.phaseBundling": "Préparation des fichiers…",
+  "presets.phaseUploading": "Envoi du paquet…",
+  "presets.phaseDownloading": "Téléchargement du paquet…",
+  "presets.phaseInstalling": "Installation des fichiers…",
+  "presets.bundleUploaded":
+    "Paquet complet envoyé — le code inclut désormais les fichiers.",
+  "presets.shareHintFull":
+    "Ce code inclut un paquet téléchargeable — le destinataire choisit Import complet et récupère tout, même sans aucun mod installé.",
+  "presets.shareHintConfig":
+    "Envoyez ce code à qui vous voulez. L'import se fait dans Presets → Importer. Il faudra les mêmes mods installés pour que tout s'affiche.",
+  "presets.generatingCode": "Génération du code…",
+  "presets.nothingToBundle":
+    "Aucun fichier installé à empaqueter — ce look est entièrement en Stock/polices.",
+  "presets.createFullBundle": "Créer un paquet complet",
+  "presets.copiedFull": "Code du paquet complet copié.",
+  "presets.copiedShare": "Code de partage copié.",
+  "presets.copyFailed":
+    "Copie impossible — sélectionnez le code et copiez-le manuellement.",
+  "presets.copyFullCode": "Copier le code complet",
+  "presets.copyCode": "Copier le code",
+  "presets.importTitle": "Importer un preset",
+  "presets.importBody": "Collez un code de partage qu'on vous a envoyé.",
+  "presets.configOnly": "Configuration seule",
+  "presets.import": "Importer",
+  "presets.fullImport": "Import complet",
+  "presets.editingBanner":
+    "Modification de {{name}} — changez le nom ou n'importe quel emplacement, puis {{save}}.",
+  "presets.bundleNotice":
+    "Inclut un paquet complet (~{{size}} depuis {{host}}). Utilisez {{fullImport}} pour tout télécharger et installer — aucun mod requis au préalable.",
+
+  // ── Emplacements de preset ─────────────────────────────────────────────────
+  "slot.paint": "Livrée moto",
+  "slot.modelSwap": "Changement de modèle",
+  "slot.bikeFont": "Police des numéros",
+  "slot.tyres": "Pneus",
+  "slot.rider": "Profil pilote",
+  "slot.suitPaint": "Tenue / kit",
+  "slot.suitFont": "Police de la tenue",
+  "slot.glovesPaint": "Gants",
+  "slot.ridingStyle": "Style de pilotage",
+  "slot.helmet": "Casque",
+  "slot.helmetPaint": "Déco casque",
+  "slot.gogglesPaint": "Masque",
+  "slot.boots": "Bottes",
+  "slot.bootsPaint": "Déco bottes",
+  "slot.protection": "Protections",
+  "slot.protectionPaint": "Déco protections",
+  "slotGroup.bike": "Moto",
+  "slotGroup.rider": "Pilote",
+  "slotGroup.head": "Tête",
+  "slotGroup.body": "Corps",
+
+  // ── Studio pilote ──────────────────────────────────────────────────────────
+  "rider.help":
+    "Habillez le modèle du pilote — casque, masque, tenue et bottes d'un seul coup.",
+  "rider.namePlaceholder": "Nommez ce pilote…",
+  "rider.nameFirst": "Nommez d'abord ce look de pilote.",
+  "rider.showOnModel": "Afficher sur le modèle",
+
+  // ── Visite guidée ──────────────────────────────────────────────────────────
+  "tour.welcomeTour.title": "Faites un tour rapide",
+  "tour.welcomeTour.body":
+    "Quelques secondes pour voir où se trouve chaque chose. Vous pouvez passer à tout moment.",
+  "tour.browse.title": "Parcourir les mods",
+  "tour.browse.body":
+    "Cherchez sur mxb-mods.com directement ici et installez n'importe quel circuit, moto ou déco en un seul clic.",
+  "tour.library.title": "Votre bibliothèque",
+  "tour.library.body":
+    "Tout ce que vous avez installé, au même endroit — mettez à jour ou supprimez des mods sans jamais toucher un fichier zip.",
+  "tour.locker.title": "Le casier",
+  "tour.locker.body":
+    "Changez les modèles de moto à volonté. MXB App enregistre les pièces pour que le jeu les reconnaisse.",
+  "tour.presets.title": "Presets",
+  "tour.presets.body":
+    "Enregistrez vos combinaisons d'équipement et de décos, puis appliquez un look complet en un clic — même en pleine session.",
+  "tour.rider.title": "Studio pilote",
+  "tour.rider.body":
+    "Prévisualisez votre équipement et vos décos sur le pilote 3D avant de les emmener sur la piste.",
+  "tour.frostmod.title": "FrostMod, en direct",
+  "tour.frostmod.body":
+    "Ceci affiche l'état de FrostMod. Il recharge MX Bikes à chaud après une installation, pour que le nouveau contenu apparaisse sans redémarrer le jeu.",
+  "tour.settings.title": "Réglages",
+  "tour.settings.body":
+    "Définissez ici votre dossier de jeu, le comportement en arrière-plan et les options FrostMod. Vous pouvez aussi rejouer cette visite depuis cet écran.",
+  "tour.done.title": "Tout est prêt",
+  "tour.done.body":
+    "La visite est terminée. Direction Parcourir pour installer votre premier mod.",
+
+  // ── Erreurs ────────────────────────────────────────────────────────────────
+  "error.previewFailed": "Impossible d'afficher l'aperçu",
+  "error.somethingWentWrong": "Une erreur est survenue",
+  "error.unexpected": "Une erreur inattendue s'est produite.",
+  "error.reloadApp": "Recharger l'application",
+
+  // ── Mises à jour ───────────────────────────────────────────────────────────
+  "update.available": "{{version}} est disponible.",
+  "update.downloading": "Téléchargement…",
+  "update.downloadingPct": "Téléchargement… {{pct}} %",
+  "update.pitch":
+    "Mettez à jour pour obtenir les dernières fonctionnalités et corrections.",
+  "update.updating": "Mise à jour…",
+  "update.updateAndRestart": "Mettre à jour et redémarrer",
+  "update.dismiss": "Ignorer la notification de mise à jour",
+  "update.onLatest": "Vous avez déjà la dernière version",
+  "update.checkFailed": "Impossible de vérifier les mises à jour",
+  "update.failed": "Échec de la mise à jour",
+
+  // ── Visualiseur 3D ─────────────────────────────────────────────────────────
+  "viewer.preview3d": "Aperçu 3D",
+  "viewer.expand": "Agrandir",
+  "viewer.paint": "Déco",
+  "viewer.loadingModel": "Chargement du modèle…",
+  "viewer.loadingPaint": "Chargement de la déco…",
+  "viewer.loadingRider": "Chargement du pilote…",
+  "viewer.dragToRotate": "Glisser pour pivoter",
+  "viewer.scrollToZoom": "Molette pour zoomer",
+  "viewer.rightDragToPan": "Clic droit glissé pour déplacer",
+
+  // ── Combobox ───────────────────────────────────────────────────────────────
+  "combobox.search": "Rechercher…",
+  "combobox.use": "Utiliser « {{value}} »",
+
+  // ── Types de mods ──────────────────────────────────────────────────────────
+  "modType.tracks": "Circuits",
+  "modType.bikes": "Motos",
+  "modType.rider": "Pilote",
+  "modType.tracksInline": "circuits",
+  "modType.bikesInline": "motos",
+  "modType.riderInline": "équipement pilote",
+
+  // ── Filtres de catégorie ───────────────────────────────────────────────────
+  "browseCat.all": "Tout",
+  "browseCat.beginner": "Débutant",
+  "browseCat.intermediate": "Intermédiaire",
+  "browseCat.pro": "Pro",
+  "browseCat.assets": "Ressources",
+  "browseCat.newBikes": "Nouvelles motos",
+  "browseCat.liveries": "Livrées",
+  "browseCat.sounds": "Sons",
+  "browseCat.riderKit": "Kit pilote",
+  "browseCat.helmets": "Casques",
+  "browseCat.helmetPaints": "Décos casque",
+  "browseCat.gloves": "Gants",
+  "browseCat.boots": "Bottes",
+  "browseCat.bootPaints": "Décos bottes",
+  "browseCat.protection": "Protections",
+  "browseCat.protectionPaints": "Décos protections",
+
+  // ── Parcourir ──────────────────────────────────────────────────────────────
+  "browse.help":
+    "Découvrez et installez des mods depuis le catalogue en ligne — cherchez, filtrez par type, et ouvrez un mod pour le télécharger dans le jeu.",
+  "browse.searchPlaceholder": "Rechercher des {{type}}…",
+  "browse.sortedByNewest": "Triés du plus récent",
+  "browse.loadFailed": "Impossible de charger les mods",
+  "browse.empty": "Aucun résultat pour {{type}}.",
+  "browse.loadMore": "Charger plus",
+  "browse.selectedCount": "{{count}} sélectionné(s)",
+  "browse.queuing": "Mise en file…",
+  "browse.quickInstallCount": "Installation rapide de {{count}}",
+  "browse.quickInstall": "Installation rapide",
+  "browse.quickReinstall": "Réinstallation rapide",
+  "browse.openDetails": "Ouvrir les détails",
+  "browse.reinstallOne": "Réinstaller « {{title}} » ?",
+  "browse.reinstallMany": "Réinstaller les mods que vous avez déjà ?",
+  "browse.reinstallOneBody":
+    "Ce mod est déjà dans votre bibliothèque. Le réinstaller le télécharge à nouveau et écrase les fichiers installés.",
+  "browse.reinstallManyBody":
+    "{{installed}} des {{total}} sélectionnés sont déjà installés. Continuer les réinstalle et les écrase.",
+  "browse.reinstall": "Réinstaller",
+  "browse.reinstallAll": "Tout réinstaller",
+  "browse.queued": "« {{title}} » en file d'attente",
+  "browse.queuedDesc": "Installation dans {{folder}}.",
+  "browse.rootFolder": "racine",
+  "browse.needsBrowser":
+    "« {{title}} » doit être téléchargé depuis le navigateur",
+  "browse.needsBrowserDesc":
+    "{{host}} bloque les téléchargements dans l'application — ouvrez sa page pour terminer.",
+  "browse.noDownload": "Aucun téléchargement trouvé pour « {{title}} »",
+  "browse.quickInstallFailed":
+    "Impossible d'installer rapidement « {{title}} »",
+  "browse.queuedBulk_one": "{{count}} mod en file d'attente",
+  "browse.queuedBulk_other": "{{count}} mods en file d'attente",
+  "browse.queuedBulkDesc": "Ils s'installeront l'un après l'autre.",
+  "browse.queuedBulkSkipped_one":
+    "{{count}} ignoré — hébergeur navigateur uniquement.",
+  "browse.queuedBulkSkipped_other":
+    "{{count}} ignorés — hébergeur navigateur uniquement.",
+  "browse.bulkFailed": "Impossible d'installer rapidement la sélection",
+  "browse.bulkFailedDesc_one":
+    "Il doit être téléchargé depuis le navigateur.",
+  "browse.bulkFailedDesc_other":
+    "Les {{count}} doivent être téléchargés depuis le navigateur.",
+
+  // ── Boutique ───────────────────────────────────────────────────────────────
+  "shop.myDownloads": "Mes téléchargements",
+  "shop.signInTitle": "Connectez-vous à MX Bikes Shop",
+  "shop.signInBody":
+    "Connectez-vous à mxbikes-shop.com pour voir et installer les circuits que vous avez achetés. Nous ouvrons le vrai site — votre mot de passe ne passe jamais par cette application.",
+  "shop.signIn": "Se connecter",
+  "shop.logOut": "Se déconnecter",
+  "shop.signedIn": "Connecté à MX Bikes Shop",
+  "shop.sessionFailed": "Impossible de récupérer votre session MX Bikes Shop",
+  "shop.queuedDesc": "Installation dans votre dossier circuits.",
+  "shop.loadFailed":
+    "Impossible de charger vos téléchargements : {{error}}",
+  "shop.empty": "Aucun téléchargement acheté trouvé sur votre compte.",
+
+  // ── Fenêtre d'installation ─────────────────────────────────────────────────
+  "installDialog.installTo": "Installer dans",
+  "installDialog.installToFolder": "Installer dans {{folder}}",
+  "installDialog.change": "Modifier",
+  "installDialog.searchBikes": "Rechercher une moto…",
+  "installDialog.searchFolders": "Rechercher un dossier…",
+  "installDialog.probably": "Probablement",
+  "installDialog.allFolders": "Tous les dossiers",
+  "installDialog.noFolderMatch":
+    "Aucun dossier ne correspond — créez-le ci-dessous.",
+  "installDialog.rememberedFor": "Mémorisé pour {{type}}",
+  "installDialog.downloadFrom": "Télécharger depuis",
+  "installDialog.downloadPerBike": "Téléchargement (par moto)",
+  "installDialog.opensInBrowser":
+    "S'ouvre dans le navigateur — MXB App termine l'installation",
+  "installDialog.matchedBike": "Associé à votre moto",
+  "installDialog.differentBike": "Moto / pack différent",
+  "installDialog.directFastest": "Direct · le plus rapide",
+  "installDialog.direct": "Direct",
+  "installDialog.perBikeHint":
+    "Chaque téléchargement correspond à une moto différente — sélectionné automatiquement selon votre choix. Choisissez le pack « all bikes » pour toutes les motos d'un coup.",
+  "installDialog.mirrorsHint":
+    "Tous les miroirs contiennent le même fichier. Si l'un échoue, essayez le suivant.",
+
+  // ── Détails de bibliothèque ────────────────────────────────────────────────
+  "libraryDetail.author": "Auteur",
+  "libraryDetail.length": "Longueur",
+  "libraryDetail.altitude": "Altitude",
+  "libraryDetail.location": "Lieu",
+  "libraryDetail.type": "Type",
+  "libraryDetail.mod": "Mod",
+  "libraryDetail.belongsTo": "Appartient à",
+  "libraryDetail.format": "Format",
+  "libraryDetail.extractedFolder": "Dossier extrait",
+  "libraryDetail.paintFile": "Fichier de déco",
+  "libraryDetail.packagedPkz": "Paquet .pkz",
+  "libraryDetail.size": "Taille",
+  "libraryDetail.folder": "Dossier",
+  "libraryDetail.lockedWord": "verrouillé",
+  "libraryDetail.lockedWithMeta":
+    "Ce circuit est {{locked}} par son créateur. Son nom, ses détails et son aperçu sont affichés ici, mais les fichiers restent scellés — il ne peut être ni extrait ni prévisualisé en 3D.",
+  "libraryDetail.lockedNoMeta":
+    "Ce circuit est {{locked}}, donc son nom, sa longueur et son aperçu ne peuvent pas être lus depuis le fichier — seulement son nom de fichier et sa taille.",
+
+  // ── Page de mod ────────────────────────────────────────────────────────────
+  "modDetail.stageResolve": "Résolution",
+  "modDetail.stageDownload": "Téléchargement",
+  "modDetail.stageExtract": "Extraction",
+  "modDetail.stagePlace": "Placement",
+  "modDetail.stageReload": "Rechargement",
+  "modDetail.modFiles": "Fichiers de mod",
+  "modDetail.copied": "Copié",
+  "modDetail.copy": "Copier",
+  "modDetail.addToLibrary": "Ajouter à la bibliothèque",
+  "modDetail.host": "Hébergeur",
+  "modDetail.installsTo": "Installe dans",
+  "modDetail.noDownloadLink":
+    "Aucun lien de téléchargement trouvé sur cette page — ouvrez-la sur mxb-mods.com.",
+  "modDetail.frostmodHint":
+    "FrostMod rechargera la liste des {{kind}} une fois terminé.",
+  "modDetail.kindRider": "pilotes",
+  "modDetail.kindBike": "motos",
+  "modDetail.kindTrack": "circuits",
+  "modDetail.details": "Détails",
+  "modDetail.format": "Format",
+  "modDetail.mirrors": "Miroirs",
+  "modDetail.type": "Type",
+  "modDetail.addedToLibrary": "Ajouté à votre bibliothèque",
+  "modDetail.extracting": "Extraction…",
+  "modDetail.addingToLibrary": "Ajout à la bibliothèque…",
+  "modDetail.resolving": "Résolution du téléchargement…",
+  "modDetail.finishInBrowser": "Terminez dans votre navigateur",
+  "modDetail.viewOnSite": "Voir sur mxb-mods.com",
+
+  // ── Réglages ───────────────────────────────────────────────────────────────
+  "settings.help":
+    "Configurez votre dossier de jeu, les mises à jour et les préférences de l'application.",
+  "settings.gameFolder": "Dossier de jeu",
+  "settings.general": "Général",
+  "settings.appearance": "Apparence",
+  "settings.frostmod": "FrostMod",
+  "settings.about": "À propos et mises à jour",
+  "settings.modsFolderDesc":
+    "Là où les mods sont installés. Le modifier relance l'analyse de votre bibliothèque.",
+  "settings.insideModsFolder": "Dans votre dossier MX Bikes",
+  "settings.notSet": "Non défini",
+  "settings.change": "Modifier…",
+  "settings.set": "Définir…",
+  "settings.theme": "Thème",
+  "settings.themeLight": "Clair",
+  "settings.themeDark": "Sombre",
+  "settings.themeSystem": "Système",
+  "settings.language": "Langue",
+  "settings.languageSystem": "Système",
+  "settings.runInBackground": "Continuer en arrière-plan",
+  "settings.runInBackgroundDesc":
+    "Fermer la fenêtre place MXB App dans la barre d'état pour que FrostMod reste connecté. Quittez depuis l'icône de la barre.",
+  "settings.launchAtStartup": "Lancer au démarrage",
+  "settings.launchAtStartupDesc":
+    "Démarrer MXB App automatiquement à votre connexion.",
+  "settings.instantRefresh": "Actualisation instantanée des presets",
+  "settings.instantRefreshDesc":
+    "Quand vous appliquez un preset pendant que MX Bikes tourne, actualise le look en jeu instantanément — sans redémarrage ni resélection de profil. Si ce n'est pas possible, il vous sera demandé de resélectionner votre profil.",
+  "settings.instantRefreshWindowsOnly":
+    "Actualiser le look en jeu sans redémarrer nécessite FrostMod, qui est réservé à Windows — il vous sera demandé de resélectionner votre profil à la place.",
+  "settings.autoRunFrostmod": "Lancer FrostMod automatiquement",
+  "settings.autoRunFrostmodDesc":
+    "Démarrer FrostMod en arrière-plan à chaque ouverture de MXB App.",
+  "settings.watchModsReload":
+    "Rechargement auto lors des changements de dossier",
+  "settings.watchModsReloadDesc":
+    "Recharger le jeu automatiquement quand des circuits ou des motos sont ajoutés à votre dossier de mods — même téléchargés manuellement hors de MXB App.",
+  "settings.checking": "Vérification…",
+  "settings.runningConnected": "En cours · jeu connecté",
+  "settings.notRunning": "Inactif",
+  "settings.frostmodInstalled": "Installé{{suffix}}",
+  "settings.notInstalled": "Non installé",
+  "settings.checkingGitHub":
+    "Vérification de la dernière version sur GitHub…",
+  "settings.updateCheckFailed":
+    "Impossible de vérifier les mises à jour — hors ligne ou GitHub indisponible.",
+  "settings.latestVersion": "Dernière : {{version}}",
+  "settings.checkNewer": "Chercher une version plus récente de FrostMod",
+  "settings.working": "Traitement…",
+  "settings.installFrostmod": "Installer FrostMod",
+  "settings.updateTo": "Mettre à jour vers {{version}}",
+  "settings.reinstallLatest": "Réinstaller la dernière",
+  "settings.upToDate": "À jour",
+  "settings.madeWith": "Fait avec",
+  "settings.updateFailed": "Impossible de mettre à jour le réglage",
+  "settings.startupUpdateFailed":
+    "Impossible de mettre à jour le lancement au démarrage",
+  "settings.folderUpdated": "Dossier de jeu mis à jour",
+  "settings.folderUpdatedDesc": "Votre bibliothèque va être réanalysée.",
+  "settings.setFolderFailed": "Impossible de définir le dossier",
+  "settings.reDetected": "Dossier MX Bikes détecté à nouveau",
+  "settings.detectFolderFailed": "Impossible de détecter le dossier",
+  "settings.pickInstallFolder":
+    "Sélectionnez votre dossier d'installation de MX Bikes (contient rider.pkz)",
+  "settings.installSet": "Installation du jeu définie",
+  "settings.installSetDesc":
+    "L'aperçu 3D du pilote peut désormais charger le vrai modèle du corps.",
+  "settings.setInstallFailed":
+    "Impossible de définir le dossier d'installation",
+  "settings.installNotFound": "Impossible de trouver MX Bikes",
+  "settings.installNotFoundDesc":
+    "Aucune installation Steam détectée — définissez le dossier manuellement.",
+  "settings.installFound": "Installation de MX Bikes trouvée",
+  "settings.detectInstallFailed":
+    "Impossible de détecter le dossier d'installation",
+  "settings.pickProfilesFolder":
+    "Sélectionnez votre dossier de profils MX Bikes",
+  "settings.profilesSet": "Dossier de profils défini",
+  "settings.profilesFound_one": "{{count}} profil trouvé.",
+  "settings.profilesFound_other": "{{count}} profils trouvés.",
+  "settings.noProfilesThere": "Aucun profil trouvé à cet endroit",
+  "settings.noProfilesThereDesc":
+    "Enregistré quand même, mais la création de presets nécessite un dossier contenant vos dossiers profile.ini.",
+  "settings.setProfilesFailed":
+    "Impossible de définir le dossier de profils",
+  "settings.profilesReverted": "Retour au dossier de profils par défaut",
+  "settings.resetProfilesFailed":
+    "Impossible de réinitialiser le dossier de profils",
+  "settings.frostmodNotRunningHint":
+    "FrostMod n'est pas actif — démarrez-le pour recharger les mods à chaud.",
+  "settings.reloadUnavailable":
+    "Le rechargement n'est pas disponible sur cette plateforme.",
+
+  // ── Bibliothèque ───────────────────────────────────────────────────────────
+  "library.help":
+    "Vos mods installés. Vérifiez ce qui est installé et retirez ce dont vous ne voulez plus.",
+  "library.rootFolder": "(racine)",
+  "library.byAuthor": "par {{author}}",
+  "library.locked": "Verrouillé — le contenu ne peut pas être lu",
+  "library.searchPlaceholder": "Rechercher parmi les installés…",
+  "library.scanning": "Analyse de votre bibliothèque…",
+  "library.empty":
+    "Aucun mod {{type}} installé — allez dans Parcourir pour en ajouter un.",
+  "library.noMatches": "Aucun résultat.",
+  "library.quick3d": "Aperçu 3D rapide",
+  "library.selectNone": "Tout désélectionner",
+  "library.move": "Déplacer",
+  "library.uninstall": "Désinstaller",
+  "library.uninstallAction": "Désinstaller…",
+  "library.moveToFolder": "Déplacer vers un dossier…",
+  "library.showInExplorer": "Afficher dans l'explorateur",
+  "library.moveDialogTitle": "Déplacer vers un dossier",
+  "library.moveCount_one": "Déplacer {{count}} élément",
+  "library.moveCount_other": "Déplacer {{count}} éléments",
+  "library.chooseDestination": "Choisissez un dossier de destination",
+  "library.newFolder": "Nouveau dossier…",
+  "library.newFolderName": "Nom du nouveau dossier",
+  "library.createAndMove": "Créer et déplacer",
+  "library.confirmUninstall": "Désinstaller {{name}} ?",
+  "library.confirmUninstallBody":
+    "L'élément est déplacé vers la Corbeille — vous pouvez le restaurer de là.",
+  "library.confirmBulkUninstall_one": "Désinstaller {{count}} élément ?",
+  "library.confirmBulkUninstall_other": "Désinstaller {{count}} éléments ?",
+  "library.confirmBulkUninstallBody":
+    "Chaque élément est déplacé vers la Corbeille — vous pouvez les restaurer de là.",
+  "library.uninstallCount": "Désinstaller {{count}}",
+  "library.moveFailed": "Impossible de déplacer le mod",
+  "library.uninstallFailed": "Impossible de désinstaller",
+  "library.openFailed": "Impossible d'ouvrir",
+  "library.uninstalledOne": "{{name}} désinstallé",
+  "library.movedToBin": "Déplacé vers la Corbeille.",
+  "library.someNotRemoved": "Certains éléments n'ont pas pu être retirés.",
+  "library.bulkUninstalled_one": "{{count}} élément désinstallé",
+  "library.bulkUninstalled_other": "{{count}} éléments désinstallés",
+  "library.bulkUninstallPartial": "{{ok}} désinstallés, {{fail}} en échec",
+  "library.bulkMovePartial": "{{ok}} déplacés, {{fail}} en échec",
+  "library.bulkMoved_one": "{{count}} élément déplacé vers {{folder}}",
+  "library.bulkMoved_other": "{{count}} éléments déplacés vers {{folder}}",
+
+  // ── Casier ─────────────────────────────────────────────────────────────────
+  "locker.help":
+    "Changez le modèle et le son moteur de chaque moto parmi les sets que vous avez installés.",
+  "locker.rescan": "Réanalyser",
+  "locker.restore": "Restaurer",
+  "locker.register": "Enregistrer",
+  "locker.scanning": "Analyse des motos…",
+  "locker.scanForSwaps": "Chercher des sets",
+  "locker.orphanBanner":
+    "Il manque à {{bike}} ses fichiers de setup — une version précédente les a déplacés dans un dossier de swap, ce qui empêche totalement la moto de se charger en jeu. {{files}}",
+  "locker.looseBanner_one":
+    "{{count}} set modèle / son trouvé en vrac dans vos motos — enregistrez-le dans {{modelsFolder}} / {{soundsFolder}}.",
+  "locker.looseBanner_other":
+    "{{count}} sets modèle / son trouvés en vrac dans vos motos — enregistrez-les dans {{modelsFolder}} / {{soundsFolder}}.",
+  "locker.emptyTitle": "Aucune moto échangeable pour l'instant.",
+  "locker.emptyIntro":
+    "Deux conditions doivent être réunies pour qu'un échange soit possible :",
+  "locker.unpacked": "extraite",
+  "locker.emptyRuleUnpacked":
+    "La moto est {{unpacked}} dans {{path}}— un {{pkz}} compressé ne peut pas être échangé. Extrayez-en une depuis la Bibliothèque.",
+  "locker.emptyRuleMesh":
+    "Chaque modèle alternatif se trouve dans son propre dossier à l'intérieur de cette moto et contient un maillage ({{edf}}). Déposez-le n'importe où dans le dossier de la moto et cliquez sur Chercher ci-dessous — nous proposerons de le ranger dans {{folder}}.",
+  "locker.summary": "{{model}} · son « {{sound}} »",
+  "locker.modelNamed": "modèle « {{name}} »",
+  "locker.noModelSwaps": "aucun changement de modèle",
+  "locker.models": "Modèles",
+  "locker.sounds": "Sons",
+  "locker.onlyOneModel":
+    "Un seul modèle — installez-en d'autres pour échanger",
+  "locker.onlyStock":
+    "Stock uniquement — installez un mod audio pour échanger",
+  "locker.noModel": "Aucun modèle",
+  "locker.stock": "Stock",
+  "locker.activeModel": "Modèle actif",
+  "locker.activeSound": "Son actif",
+  "locker.switchToNoModel":
+    "Passer à aucun modèle — retire les fichiers du modèle actuel",
+  "locker.switchToStock":
+    "Passer à Stock — retire le mod audio (le son d'origine est joué)",
+  "locker.missingModelEdf": "Ce set n'a pas de model.edf",
+  "locker.missingSoundFiles": "Il manque engine.scl ou sfx.cfg à ce set",
+  "locker.switchTo": "Passer à {{name}}",
+  "locker.tiedToModel": "Lié au modèle {{models}}",
+  "locker.boundHint":
+    "« {{sound}} » est lié au modèle « {{model}} » — il suit ce modèle. Cliquez pour délier.",
+  "locker.unboundHint":
+    "Liez le son actif « {{sound}} » au modèle « {{model}} » pour qu'y passer amène aussi le son.",
+  "locker.tieAction": "Lier « {{sound}} » à « {{model}} »",
+  "locker.untieAction": "Délier « {{sound}} » de « {{model}} »",
+  "locker.restored": "Fichiers de setup de {{bike}} restaurés.",
+  "locker.restoredNote_one":
+    "{{count}} fichier remis en place — la moto devrait se charger à nouveau.",
+  "locker.restoredNote_other":
+    "{{count}} fichiers remis en place — la moto devrait se charger à nouveau.",
+  "locker.switchedModel":
+    "Modèle de {{bike}} changé pour « {{target}} ».",
+  "locker.switchedSound": "Son de {{bike}} changé pour « {{target}} ».",
+  "locker.tied": "« {{sound}} » lié au modèle « {{model}} ».",
+  "locker.untied": "« {{sound}} » délié du modèle « {{model}} ».",
+  "locker.refreshedLive": "Actualisé en direct dans le jeu.",
+  "locker.refreshFailed":
+    "Actualisation instantanée échouée — resélectionnez votre profil en jeu pour la charger.",
+  "locker.reselectProfile":
+    "Resélectionnez votre profil dans MX Bikes pour charger l'échange.",
+  "locker.loadsNextTime":
+    "Sera chargé à la prochaine ouverture du jeu.",
+
+  // ── Enregistrement des sets en vrac ────────────────────────────────────────
+  "swaps.model": "modèle",
+  "swaps.modelSets_one": "{{count}} changement de modèle",
+  "swaps.modelSets_other": "{{count}} changements de modèle",
+  "swaps.soundSets_one": "{{count}} mod audio",
+  "swaps.soundSets_other": "{{count}} mods audio",
+  "swaps.and": "{{a}} et {{b}}",
+  "swaps.noSets": "0 set",
+  "swaps.foundTitle": "{{summary}} trouvé(s)",
+  "swaps.description":
+    "Ces dossiers traînent en vrac dans vos motos. Enregistrez-les pour déplacer chacun dans la bonne bibliothèque — {{modelsFolder}} pour les modèles, {{soundsFolder}} pour les sons — afin qu'ils apparaissent dans le Casier.",
+  "swaps.registered_one": "{{count}} set enregistré.",
+  "swaps.registered_other": "{{count}} sets enregistrés.",
+  "swaps.nothingMoved": "Rien n'a été déplacé.",
+  "swaps.skipped_one": "{{count}} ignoré (nom déjà utilisé).",
+  "swaps.skipped_other": "{{count}} ignorés (noms déjà utilisés).",
+  "swaps.foldersCreated_one":
+    "Dossiers de bibliothèque créés pour {{count}} moto.",
+  "swaps.foldersCreated_other":
+    "Dossiers de bibliothèque créés pour {{count}} motos.",
+  "swaps.foldersCreatedDesc":
+    "Vos dossiers modèle / son sont restés où ils étaient.",
+  "swaps.justCreateFolders": "Créer seulement les dossiers",
+  "swaps.registerAndMove": "Enregistrer et déplacer",
+  "swaps.fileCount_one": "{{count}} fichier",
+  "swaps.fileCount_other": "{{count}} fichiers",
+
+  // ── Installation ───────────────────────────────────────────────────────────
+  "install.installed": "{{title}} installé",
+  "install.reloadedDesc":
+    "Jeu rechargé via FrostMod — c'est actif maintenant.",
+  "install.addedDesc": "Ajouté à votre bibliothèque.",
+  "install.failed": "Échec de l'installation — {{title}}",
+  "install.openModPage": "Ouvrir la page du mod",
+  "install.clickToOpen": "Cliquez pour ouvrir la page du mod",
+
+  // ── Catégories (singulier) ─────────────────────────────────────────────────
+  "category.track": "Circuit",
+  "category.bike": "Moto",
+  "category.bikePaint": "Livrée",
+  "category.bikeModelSwap": "Changement de modèle",
+  "category.sound": "Son",
+  "category.helmet": "Casque",
+  "category.helmetPaint": "Déco casque",
+  "category.goggles": "Masque",
+  "category.boots": "Bottes",
+  "category.bootPaint": "Déco bottes",
+  "category.protection": "Protections",
+  "category.protectionPaint": "Déco protections",
+  "category.gloves": "Gants",
+  "category.outfit": "Tenue / kit",
+  "category.misc": "Autre",
+
+  // ── En-têtes de section (pluriel) ──────────────────────────────────────────
+  "section.bikePaint": "Livrées",
+  "section.bikeModelSwap": "Changements de modèle",
+  "section.sound": "Sons",
+  "section.helmet": "Casques",
+  "section.helmetPaint": "Décos casque",
+  "section.boots": "Bottes",
+  "section.bootPaint": "Décos bottes",
+  "section.protection": "Protections",
+  "section.protectionPaint": "Décos protections",
+  "section.gloves": "Gants",
+  "section.outfit": "Tenue / kit",
+
+  // ── Destinations d'installation ────────────────────────────────────────────
+  "dest.bikesRoot": "Motos (racine)",
+  "dest.tracksRoot": "Circuits (racine)",
+  "dest.bikeFolder": "{{name}} — dossier moto",
+  "dest.bikePaints": "{{name}} — décos",
+  "dest.helmetsNewModel": "Casques (nouveau modèle)",
+  "dest.bootsNewModel": "Bottes (nouveau modèle)",
+  "dest.protectionNewModel": "Protections (nouveau modèle)",
+  "dest.helmetPaintsFor": "{{name}} · décos casque",
+  "dest.gogglesFor": "{{name}} · masque",
+  "dest.bootPaintsFor": "{{name}} · décos bottes",
+  "dest.protectionPaintsFor": "{{name}} · décos protections",
+  "dest.outfitFor": "{{name}} · tenue / kit",
+  "dest.glovesFor": "{{name}} · gants",
+};

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1,0 +1,705 @@
+import type { Translation } from "..";
+
+/**
+ * Italian.
+ *
+ * Terminology follows what the MX Bikes community actually says rather than
+ * dictionary equivalents: `mod`, `setup`, `preset` and `Stock` stay as-is —
+ * they're the words riders use — while gear is translated (`casco`, `stivali`,
+ * `maschera` for goggles, `livrea` for a bike paint).
+ *
+ * Product names (MXB App, FrostMod, MX Bikes) are never translated.
+ */
+export const it: Translation = {
+  // ── Generico ───────────────────────────────────────────────────────────────
+  "common.cancel": "Annulla",
+  "common.back": "Indietro",
+  "common.next": "Avanti",
+  "common.skip": "Salta",
+  "common.close": "Chiudi",
+  "common.save": "Salva",
+  "common.delete": "Elimina",
+  "common.rename": "Rinomina",
+  "common.retry": "Riprova",
+  "common.tryAgain": "Riprova",
+  "common.loading": "Caricamento…",
+  "common.installed": "Installato",
+  "common.select": "Seleziona",
+  "common.deselect": "Deseleziona",
+  "common.selectAll": "Seleziona tutto",
+  "common.clear": "Svuota",
+  "common.done": "Fatto",
+  "common.apply": "Applica",
+  "common.remove": "Rimuovi",
+  "common.open": "Apri",
+  "common.refresh": "Aggiorna",
+  "common.dismiss": "Ignora",
+  "common.later": "Più tardi",
+  "common.active": "Attivo",
+
+  // ── Controlli finestra ─────────────────────────────────────────────────────
+  "window.minimize": "Riduci a icona",
+  "window.maximize": "Ingrandisci",
+  "window.close": "Chiudi",
+
+  // ── Navigazione ────────────────────────────────────────────────────────────
+  "nav.browse": "Esplora",
+  "nav.shop": "Shop",
+  "nav.library": "Libreria",
+  "nav.locker": "Armadietto",
+  "nav.presets": "Preset",
+  "nav.rider": "Pilota",
+  "nav.settings": "Impostazioni",
+
+  "sidebar.installing": "Installazione di “{{name}}”",
+  "sidebar.queued": "+{{count}} in coda",
+
+  // ── FrostMod ───────────────────────────────────────────────────────────────
+  "frostmod.checking": "Controllo di FrostMod…",
+  "frostmod.running": "FrostMod attivo",
+  "frostmod.notRunning": "FrostMod non attivo",
+  "frostmod.reloadGame": "Ricarica il gioco",
+  "frostmod.start": "Avvia FrostMod",
+  "frostmod.reloadedGame": "FrostMod ha ricaricato il gioco.",
+  "frostmod.notRunningToast": "FrostMod non è in esecuzione.",
+  "frostmod.started": "FrostMod avviato",
+  "frostmod.alreadyRunning": "FrostMod è già in esecuzione",
+  "frostmod.startFailed": "Impossibile avviare FrostMod",
+  "frostmod.installedToast": "FrostMod {{version}} installato",
+  "frostmod.installedToastDesc":
+    "Ricaricherà il gioco in tempo reale quando aggiungi mod.",
+  "frostmod.installFailed": "Impossibile installare FrostMod",
+  "frostmod.newModsAdded": "Nuove mod aggiunte",
+  "frostmod.modsAdded_one": "Nuova mod aggiunta",
+  "frostmod.modsAdded_other": "{{count}} mod aggiunte",
+  "frostmod.askedReload": "Richiesto a FrostMod di ricaricare il gioco.",
+  "frostmod.andMore_one": "{{names}} e altra {{count}}",
+  "frostmod.andMore_other": "{{names}} e altre {{count}}",
+  "frostmod.watchDesc":
+    "{{names}} — richiesto a FrostMod di ricaricare il gioco.",
+
+  // ── Configurazione iniziale ────────────────────────────────────────────────
+  "setup.title": "Benvenuto in MXB App",
+  "setup.tagline":
+    "Sfoglia mxb-mods, installa con un clic e lascia che sia FrostMod a ricaricare il gioco per te.",
+  "setup.modsFolder": "Cartella MX Bikes",
+  "setup.autoDetect":
+    "MXB App rileverà automaticamente la tua cartella {{hint}}. Puoi anche sceglierla tu.",
+  "setup.chooseManually": "Scegli la cartella manualmente…",
+  "setup.chooseDifferent": "Scegli un'altra cartella…",
+  "setup.gameInstall": "Installazione di MX Bikes",
+  "setup.detecting": "Ricerca dell'installazione di MX Bikes…",
+  "setup.found": "Trovata",
+  "setup.detectedAutomatically": "Rilevata automaticamente",
+  "setup.installNotFound":
+    "Non ho trovato automaticamente la tua installazione di MX Bikes — serve per l'anteprima 3D del pilota. Scegliela manualmente, oppure impostala più tardi nelle Impostazioni.",
+  "setup.chooseInstallManually":
+    "Scegli manualmente la cartella d'installazione…",
+  "setup.startBrowsing": "Inizia a sfogliare le mod",
+  "setup.detectAndStart": "Rileva e inizia",
+  "setup.pickModsFolder": "Seleziona la tua cartella MX Bikes",
+  "setup.pickInstallFolder": "Seleziona la cartella d'installazione di MX Bikes",
+
+  // ── Benvenuto ──────────────────────────────────────────────────────────────
+  "welcome.intro.title": "Benvenuto in MXB App",
+  "welcome.intro.body":
+    "Il tuo gestore di mod per MX Bikes. Tieni piste, moto e grafiche organizzate in un unico posto — niente più file zip sparsi sul desktop. Ti facciamo fare un giro in pochi secondi.",
+  "welcome.getStarted": "Iniziamo",
+
+  // ── Preset ─────────────────────────────────────────────────────────────────
+  "presets.missing": "mancante",
+  "presets.missingHint":
+    "Questa mod non è installata — in gioco apparirà come stock",
+  "presets.missingMods":
+    "Mod mancanti: {{mods}}. Installale per vedere quelle parti.",
+  "presets.help":
+    "Salva un look completo del pilota e caricalo su una moto quando vuoi.",
+  "presets.profile": "Profilo",
+  "presets.namePlaceholder": "Nome del preset…",
+  "presets.savePreset": "Salva preset",
+  "presets.saveChanges": "Salva modifiche",
+  "presets.saveChangesQ": "Salvare le modifiche?",
+  "presets.replaceQ": "Sostituire il preset?",
+  "presets.replace": "Sostituisci",
+  "presets.loadCopy": "Carica una copia nell'editor",
+  "presets.viewOnRider": "Vedi sul pilota",
+  "presets.editNameOrOptions": "Modifica nome o opzioni",
+  "presets.share": "Condividi",
+  "presets.nameFirst": "Prima dai un nome al preset.",
+  "presets.pickProfileAndBike": "Scegli un profilo e una moto a cui applicarlo.",
+  "presets.updated": "Preset “{{name}}” aggiornato.",
+  "presets.renamed": "Rinominato in “{{name}}” e modifiche salvate.",
+  "presets.saved": "Preset “{{name}}” salvato.",
+  "presets.editing":
+    "Stai modificando “{{name}}” — cambia quello che vuoi, poi salva le modifiche.",
+  "presets.appliedRefreshed":
+    "“{{label}}” applicato a {{bike}} — aggiornato in tempo reale nel gioco.",
+  "presets.appliedRefreshFailed":
+    "“{{label}}” applicato a {{bike}} — salvato, ma l'aggiornamento istantaneo non è riuscito: riseleziona il profilo in gioco per caricarlo.",
+  "presets.appliedGameRunning":
+    "“{{label}}” applicato a {{bike}} — salvato. Riseleziona il profilo in MX Bikes (menu Profilo) per caricare il nuovo look.",
+  "presets.appliedNextTime":
+    "“{{label}}” applicato a {{bike}} — salvato. Verrà caricato alla prossima apertura del gioco.",
+  "presets.phaseBundling": "Preparazione dei file…",
+  "presets.phaseUploading": "Caricamento del pacchetto…",
+  "presets.phaseDownloading": "Download del pacchetto…",
+  "presets.phaseInstalling": "Installazione dei file…",
+  "presets.bundleUploaded":
+    "Pacchetto completo caricato — ora il codice include anche i file.",
+  "presets.shareHintFull":
+    "Questo codice include un pacchetto scaricabile — chi lo riceve sceglie Importazione completa e ottiene tutto, anche senza mod installate.",
+  "presets.shareHintConfig":
+    "Manda questo codice a chi vuoi. Lo importa da Preset → Importa. Servono le stesse mod installate perché si veda ogni parte.",
+  "presets.generatingCode": "Generazione del codice…",
+  "presets.nothingToBundle":
+    "Nessun file installato da includere — questo look è tutto stock/font.",
+  "presets.createFullBundle": "Crea pacchetto completo",
+  "presets.copiedFull": "Codice con pacchetto completo copiato.",
+  "presets.copiedShare": "Codice di condivisione copiato.",
+  "presets.copyFailed":
+    "Impossibile copiare — seleziona il codice e copialo a mano.",
+  "presets.copyFullCode": "Copia codice completo",
+  "presets.copyCode": "Copia codice",
+  "presets.importTitle": "Importa preset",
+  "presets.importBody": "Incolla un codice che ti hanno mandato.",
+  "presets.configOnly": "Solo configurazione",
+  "presets.import": "Importa",
+  "presets.fullImport": "Importazione completa",
+  "presets.editingBanner":
+    "Stai modificando {{name}} — cambia il nome o qualsiasi slot, poi {{save}}.",
+  "presets.bundleNotice":
+    "Include un pacchetto completo (~{{size}} da {{host}}). Usa {{fullImport}} per scaricare e installare tutto — non serve avere già le mod.",
+
+  // ── Slot dei preset ────────────────────────────────────────────────────────
+  "slot.paint": "Livrea moto",
+  "slot.modelSwap": "Cambio modello",
+  "slot.bikeFont": "Font numeri",
+  "slot.tyres": "Gomme",
+  "slot.rider": "Profilo pilota",
+  "slot.suitPaint": "Completo / kit",
+  "slot.suitFont": "Font completo",
+  "slot.glovesPaint": "Guanti",
+  "slot.ridingStyle": "Stile di guida",
+  "slot.helmet": "Casco",
+  "slot.helmetPaint": "Grafica casco",
+  "slot.gogglesPaint": "Maschera",
+  "slot.boots": "Stivali",
+  "slot.bootsPaint": "Grafica stivali",
+  "slot.protection": "Protezioni",
+  "slot.protectionPaint": "Grafica protezioni",
+  "slotGroup.bike": "Moto",
+  "slotGroup.rider": "Pilota",
+  "slotGroup.head": "Testa",
+  "slotGroup.body": "Corpo",
+
+  // ── Studio pilota ──────────────────────────────────────────────────────────
+  "rider.help":
+    "Vesti il modello del pilota — casco, maschera, completo e stivali insieme.",
+  "rider.namePlaceholder": "Dai un nome a questo pilota…",
+  "rider.nameFirst": "Prima dai un nome a questo look.",
+  "rider.showOnModel": "Mostra sul modello",
+
+  // ── Tour guidato ───────────────────────────────────────────────────────────
+  "tour.welcomeTour.title": "Fai un giro veloce",
+  "tour.welcomeTour.body":
+    "Bastano pochi secondi per vedere dov'è ogni cosa. Puoi saltare quando vuoi.",
+  "tour.browse.title": "Sfoglia le mod",
+  "tour.browse.body":
+    "Cerca su mxb-mods.com direttamente da qui e installa qualsiasi pista, moto o grafica con un solo clic.",
+  "tour.library.title": "La tua libreria",
+  "tour.library.body":
+    "Tutto ciò che hai installato, in un unico posto — aggiorna o rimuovi le mod senza mai toccare un file zip.",
+  "tour.locker.title": "L'armadietto",
+  "tour.locker.body":
+    "Cambia i modelli delle moto quando vuoi. MXB App registra i pezzi in modo che il gioco li riconosca.",
+  "tour.presets.title": "Preset",
+  "tour.presets.body":
+    "Salva le combinazioni di equipaggiamento e grafiche, poi applica un look completo con un clic — anche mentre stai guidando.",
+  "tour.rider.title": "Studio pilota",
+  "tour.rider.body":
+    "Guarda l'anteprima del tuo equipaggiamento sul pilota 3D prima di portarlo in pista.",
+  "tour.frostmod.title": "FrostMod, in diretta",
+  "tour.frostmod.body":
+    "Qui vedi lo stato di FrostMod. Ricarica MX Bikes dopo un'installazione, così i nuovi contenuti compaiono senza riavviare il gioco.",
+  "tour.settings.title": "Impostazioni",
+  "tour.settings.body":
+    "Qui imposti la cartella di gioco, il comportamento in background e le opzioni di FrostMod. Da qui puoi anche rivedere questo tour.",
+  "tour.done.title": "È tutto pronto",
+  "tour.done.body":
+    "Il tour finisce qui. Vai su Esplora e installa la tua prima mod.",
+
+  // ── Errori ─────────────────────────────────────────────────────────────────
+  "error.previewFailed": "Impossibile mostrare l'anteprima",
+  "error.somethingWentWrong": "Qualcosa è andato storto",
+  "error.unexpected": "Si è verificato un errore imprevisto.",
+  "error.reloadApp": "Ricarica l'app",
+
+  // ── Aggiornamenti ──────────────────────────────────────────────────────────
+  "update.available": "{{version}} è disponibile.",
+  "update.downloading": "Download in corso…",
+  "update.downloadingPct": "Download in corso… {{pct}}%",
+  "update.pitch":
+    "Aggiorna per avere le ultime funzionalità e correzioni.",
+  "update.updating": "Aggiornamento…",
+  "update.updateAndRestart": "Aggiorna e riavvia",
+  "update.dismiss": "Ignora la notifica di aggiornamento",
+  "update.onLatest": "Hai già l'ultima versione",
+  "update.checkFailed": "Impossibile controllare gli aggiornamenti",
+  "update.failed": "Aggiornamento non riuscito",
+
+  // ── Visualizzatore 3D ──────────────────────────────────────────────────────
+  "viewer.preview3d": "Anteprima 3D",
+  "viewer.expand": "Ingrandisci",
+  "viewer.paint": "Grafica",
+  "viewer.loadingModel": "Caricamento modello…",
+  "viewer.loadingPaint": "Caricamento grafica…",
+  "viewer.loadingRider": "Caricamento pilota…",
+  "viewer.dragToRotate": "Trascina per ruotare",
+  "viewer.scrollToZoom": "Scorri per zoomare",
+  "viewer.rightDragToPan": "Trascina col destro per spostare",
+
+  // ── Combobox ───────────────────────────────────────────────────────────────
+  "combobox.search": "Cerca…",
+  "combobox.use": "Usa “{{value}}”",
+
+  // ── Tipi di mod ────────────────────────────────────────────────────────────
+  "modType.tracks": "Piste",
+  "modType.bikes": "Moto",
+  "modType.rider": "Pilota",
+  "modType.tracksInline": "piste",
+  "modType.bikesInline": "moto",
+  "modType.riderInline": "equipaggiamento pilota",
+
+  // ── Filtri categoria ───────────────────────────────────────────────────────
+  "browseCat.all": "Tutto",
+  "browseCat.beginner": "Principiante",
+  "browseCat.intermediate": "Intermedio",
+  "browseCat.pro": "Pro",
+  "browseCat.assets": "Risorse",
+  "browseCat.newBikes": "Nuove moto",
+  "browseCat.liveries": "Livree",
+  "browseCat.sounds": "Suoni",
+  "browseCat.riderKit": "Kit pilota",
+  "browseCat.helmets": "Caschi",
+  "browseCat.helmetPaints": "Grafiche casco",
+  "browseCat.gloves": "Guanti",
+  "browseCat.boots": "Stivali",
+  "browseCat.bootPaints": "Grafiche stivali",
+  "browseCat.protection": "Protezioni",
+  "browseCat.protectionPaints": "Grafiche protezioni",
+
+  // ── Esplora ────────────────────────────────────────────────────────────────
+  "browse.help":
+    "Scopri e installa mod dal catalogo online — cerca, filtra per tipo e apri una mod per scaricarla nel gioco.",
+  "browse.searchPlaceholder": "Cerca {{type}}…",
+  "browse.sortedByNewest": "Ordinate dalle più recenti",
+  "browse.loadFailed": "Impossibile caricare le mod",
+  "browse.empty": "Nessun risultato per {{type}}.",
+  "browse.loadMore": "Carica altre",
+  "browse.selectedCount": "{{count}} selezionate",
+  "browse.queuing": "Accodamento…",
+  "browse.quickInstallCount": "Installa rapidamente {{count}}",
+  "browse.quickInstall": "Installazione rapida",
+  "browse.quickReinstall": "Reinstallazione rapida",
+  "browse.openDetails": "Apri i dettagli",
+  "browse.reinstallOne": "Reinstallare “{{title}}”?",
+  "browse.reinstallMany": "Reinstallare le mod che hai già?",
+  "browse.reinstallOneBody":
+    "Questa mod è già nella tua libreria. Reinstallandola verrà scaricata di nuovo e i file installati saranno sovrascritti.",
+  "browse.reinstallManyBody":
+    "{{installed}} delle {{total}} selezionate sono già installate. Continuando verranno reinstallate e sovrascritte.",
+  "browse.reinstall": "Reinstalla",
+  "browse.reinstallAll": "Reinstalla tutto",
+  "browse.queued": "“{{title}}” in coda",
+  "browse.queuedDesc": "Installazione in {{folder}}.",
+  "browse.rootFolder": "principale",
+  "browse.needsBrowser": "“{{title}}” va scaricata dal browser",
+  "browse.needsBrowserDesc":
+    "{{host}} blocca i download nell'app — apri la sua pagina per completare.",
+  "browse.noDownload": "Nessun download trovato per “{{title}}”",
+  "browse.quickInstallFailed":
+    "Impossibile installare rapidamente “{{title}}”",
+  "browse.queuedBulk_one": "{{count}} mod in coda",
+  "browse.queuedBulk_other": "{{count}} mod in coda",
+  "browse.queuedBulkDesc": "Verranno installate una dopo l'altra.",
+  "browse.queuedBulkSkipped_one": "{{count}} saltata — host solo browser.",
+  "browse.queuedBulkSkipped_other": "{{count}} saltate — host solo browser.",
+  "browse.bulkFailed": "Impossibile installare rapidamente la selezione",
+  "browse.bulkFailedDesc_one": "Va scaricata dal browser.",
+  "browse.bulkFailedDesc_other":
+    "Tutte e {{count}} vanno scaricate dal browser.",
+
+  // ── Shop ───────────────────────────────────────────────────────────────────
+  "shop.myDownloads": "I miei download",
+  "shop.signInTitle": "Accedi a MX Bikes Shop",
+  "shop.signInBody":
+    "Accedi a mxbikes-shop.com per vedere e installare le piste che hai acquistato. Apriamo il sito vero — la tua password non passa mai da questa app.",
+  "shop.signIn": "Accedi",
+  "shop.logOut": "Esci",
+  "shop.signedIn": "Accesso a MX Bikes Shop effettuato",
+  "shop.sessionFailed":
+    "Impossibile recuperare la tua sessione MX Bikes Shop",
+  "shop.queuedDesc": "Installazione nella tua cartella piste.",
+  "shop.loadFailed": "Impossibile caricare i tuoi download: {{error}}",
+  "shop.empty": "Nessun download acquistato trovato sul tuo account.",
+
+  // ── Finestra d'installazione ───────────────────────────────────────────────
+  "installDialog.installTo": "Installa in",
+  "installDialog.installToFolder": "Installa in {{folder}}",
+  "installDialog.change": "Cambia",
+  "installDialog.searchBikes": "Cerca moto…",
+  "installDialog.searchFolders": "Cerca cartelle…",
+  "installDialog.probably": "Probabilmente",
+  "installDialog.allFolders": "Tutte le cartelle",
+  "installDialog.noFolderMatch":
+    "Nessuna cartella corrisponde — creala qui sotto.",
+  "installDialog.rememberedFor": "Ricordato per {{type}}",
+  "installDialog.downloadFrom": "Scarica da",
+  "installDialog.downloadPerBike": "Download (per moto)",
+  "installDialog.opensInBrowser":
+    "Si apre nel browser — MXB App completa l'installazione",
+  "installDialog.matchedBike": "Abbinato alla tua moto",
+  "installDialog.differentBike": "Moto / pacchetto diverso",
+  "installDialog.directFastest": "Diretto · il più veloce",
+  "installDialog.direct": "Diretto",
+  "installDialog.perBikeHint":
+    "Ogni download è una moto diversa — selezionato automaticamente in base alla tua scelta. Scegli il pacchetto “all bikes” per averle tutte in una volta.",
+  "installDialog.mirrorsHint":
+    "Tutti i mirror contengono lo stesso file. Se uno non funziona, prova il successivo.",
+
+  // ── Dettagli libreria ──────────────────────────────────────────────────────
+  "libraryDetail.author": "Autore",
+  "libraryDetail.length": "Lunghezza",
+  "libraryDetail.altitude": "Altitudine",
+  "libraryDetail.location": "Località",
+  "libraryDetail.type": "Tipo",
+  "libraryDetail.mod": "Mod",
+  "libraryDetail.belongsTo": "Appartiene a",
+  "libraryDetail.format": "Formato",
+  "libraryDetail.extractedFolder": "Cartella estratta",
+  "libraryDetail.paintFile": "File grafica",
+  "libraryDetail.packagedPkz": "Pacchetto .pkz",
+  "libraryDetail.size": "Dimensione",
+  "libraryDetail.folder": "Cartella",
+  "libraryDetail.lockedWord": "bloccata",
+  "libraryDetail.lockedWithMeta":
+    "Questa pista è {{locked}} dal suo creatore. Nome, dettagli e anteprima sono visibili qui, ma i file restano sigillati — non può essere estratta né vista in 3D.",
+  "libraryDetail.lockedNoMeta":
+    "Questa pista è {{locked}}, quindi nome, lunghezza e anteprima non si possono leggere dal file — solo nome file e dimensione.",
+
+  // ── Pagina mod ─────────────────────────────────────────────────────────────
+  "modDetail.stageResolve": "Risoluzione",
+  "modDetail.stageDownload": "Download",
+  "modDetail.stageExtract": "Estrazione",
+  "modDetail.stagePlace": "Posizionamento",
+  "modDetail.stageReload": "Ricarica",
+  "modDetail.modFiles": "File mod",
+  "modDetail.copied": "Copiato",
+  "modDetail.copy": "Copia",
+  "modDetail.addToLibrary": "Aggiungi alla libreria",
+  "modDetail.host": "Host",
+  "modDetail.installsTo": "Installa in",
+  "modDetail.noDownloadLink":
+    "Nessun link di download trovato in questa pagina — aprila su mxb-mods.com.",
+  "modDetail.frostmodHint":
+    "FrostMod ricaricherà l'elenco {{kind}} al termine.",
+  "modDetail.kindRider": "pilota",
+  "modDetail.kindBike": "moto",
+  "modDetail.kindTrack": "piste",
+  "modDetail.details": "Dettagli",
+  "modDetail.format": "Formato",
+  "modDetail.mirrors": "Mirror",
+  "modDetail.type": "Tipo",
+  "modDetail.addedToLibrary": "Aggiunta alla tua libreria",
+  "modDetail.extracting": "Estrazione…",
+  "modDetail.addingToLibrary": "Aggiunta alla libreria…",
+  "modDetail.resolving": "Risoluzione del download…",
+  "modDetail.finishInBrowser": "Completa nel browser",
+  "modDetail.viewOnSite": "Vedi su mxb-mods.com",
+
+  // ── Impostazioni ───────────────────────────────────────────────────────────
+  "settings.help":
+    "Configura la cartella di gioco, gli aggiornamenti e le preferenze dell'app.",
+  "settings.gameFolder": "Cartella di gioco",
+  "settings.general": "Generali",
+  "settings.appearance": "Aspetto",
+  "settings.frostmod": "FrostMod",
+  "settings.about": "Info e aggiornamenti",
+  "settings.modsFolderDesc":
+    "Dove vengono installate le mod. Cambiandola, la libreria viene riscansionata.",
+  "settings.insideModsFolder": "Dentro la tua cartella MX Bikes",
+  "settings.notSet": "Non impostata",
+  "settings.change": "Cambia…",
+  "settings.set": "Imposta…",
+  "settings.theme": "Tema",
+  "settings.themeLight": "Chiaro",
+  "settings.themeDark": "Scuro",
+  "settings.themeSystem": "Sistema",
+  "settings.language": "Lingua",
+  "settings.languageSystem": "Sistema",
+  "settings.runInBackground": "Continua in background",
+  "settings.runInBackgroundDesc":
+    "Chiudendo la finestra, MXB App resta nella barra di sistema così FrostMod rimane collegato. Esci dall'icona nella barra.",
+  "settings.launchAtStartup": "Avvia all'accensione",
+  "settings.launchAtStartupDesc":
+    "Avvia MXB App automaticamente quando accedi.",
+  "settings.instantRefresh": "Aggiornamento preset istantaneo",
+  "settings.instantRefreshDesc":
+    "Quando applichi un preset mentre MX Bikes è in esecuzione, aggiorna il look in gioco all'istante — senza riavvio né riselezione del profilo. Se non ci riesce, ti verrà chiesto di riselezionare il profilo.",
+  "settings.instantRefreshWindowsOnly":
+    "Aggiornare il look in gioco senza riavviare richiede FrostMod, che è solo per Windows — ti verrà invece chiesto di riselezionare il profilo.",
+  "settings.autoRunFrostmod": "Avvia FrostMod automaticamente",
+  "settings.autoRunFrostmodDesc":
+    "Avvia FrostMod in background ogni volta che apri MXB App.",
+  "settings.watchModsReload": "Ricarica automatica alle modifiche",
+  "settings.watchModsReloadDesc":
+    "Ricarica il gioco automaticamente quando piste o moto vengono aggiunte alla cartella mod — anche se scaricate manualmente fuori da MXB App.",
+  "settings.checking": "Controllo…",
+  "settings.runningConnected": "In esecuzione · gioco collegato",
+  "settings.notRunning": "Non in esecuzione",
+  "settings.frostmodInstalled": "Installato{{suffix}}",
+  "settings.notInstalled": "Non installato",
+  "settings.checkingGitHub": "Controllo dell'ultima release su GitHub…",
+  "settings.updateCheckFailed":
+    "Impossibile controllare gli aggiornamenti — offline o GitHub non raggiungibile.",
+  "settings.latestVersion": "Ultima: {{version}}",
+  "settings.checkNewer": "Cerca una versione più recente di FrostMod",
+  "settings.working": "Elaborazione…",
+  "settings.installFrostmod": "Installa FrostMod",
+  "settings.updateTo": "Aggiorna a {{version}}",
+  "settings.reinstallLatest": "Reinstalla l'ultima",
+  "settings.upToDate": "Aggiornato",
+  "settings.madeWith": "Fatto con",
+  "settings.updateFailed": "Impossibile aggiornare l'impostazione",
+  "settings.startupUpdateFailed":
+    "Impossibile aggiornare l'avvio automatico",
+  "settings.folderUpdated": "Cartella di gioco aggiornata",
+  "settings.folderUpdatedDesc": "La tua libreria verrà riscansionata.",
+  "settings.setFolderFailed": "Impossibile impostare la cartella",
+  "settings.reDetected": "Cartella MX Bikes rilevata di nuovo",
+  "settings.detectFolderFailed": "Impossibile rilevare la cartella",
+  "settings.pickInstallFolder":
+    "Seleziona la cartella d'installazione di MX Bikes (contiene rider.pkz)",
+  "settings.installSet": "Installazione di gioco impostata",
+  "settings.installSetDesc":
+    "L'anteprima 3D del pilota può ora caricare il modello reale del corpo.",
+  "settings.setInstallFailed":
+    "Impossibile impostare la cartella d'installazione",
+  "settings.installNotFound": "Impossibile trovare MX Bikes",
+  "settings.installNotFoundDesc":
+    "Nessuna installazione Steam rilevata — imposta la cartella manualmente.",
+  "settings.installFound": "Installazione di MX Bikes trovata",
+  "settings.detectInstallFailed":
+    "Impossibile rilevare la cartella d'installazione",
+  "settings.pickProfilesFolder":
+    "Seleziona la cartella dei profili di MX Bikes",
+  "settings.profilesSet": "Cartella dei profili impostata",
+  "settings.profilesFound_one": "Trovato {{count}} profilo.",
+  "settings.profilesFound_other": "Trovati {{count}} profili.",
+  "settings.noProfilesThere": "Nessun profilo trovato lì",
+  "settings.noProfilesThereDesc":
+    "Salvata comunque, ma per creare preset serve una cartella che contenga le cartelle dei tuoi profile.ini.",
+  "settings.setProfilesFailed":
+    "Impossibile impostare la cartella dei profili",
+  "settings.profilesReverted":
+    "Ripristinata la cartella dei profili predefinita",
+  "settings.resetProfilesFailed":
+    "Impossibile reimpostare la cartella dei profili",
+  "settings.frostmodNotRunningHint":
+    "FrostMod non è in esecuzione — avvialo per ricaricare le mod a caldo.",
+  "settings.reloadUnavailable":
+    "La ricarica non è disponibile su questa piattaforma.",
+
+  // ── Libreria ───────────────────────────────────────────────────────────────
+  "library.help":
+    "Le tue mod installate. Controlla cosa è installato e rimuovi ciò che non ti serve più.",
+  "library.rootFolder": "(principale)",
+  "library.byAuthor": "di {{author}}",
+  "library.locked": "Bloccato — il contenuto non è leggibile",
+  "library.searchPlaceholder": "Cerca tra le installate…",
+  "library.scanning": "Scansione della libreria…",
+  "library.empty":
+    "Nessuna mod {{type}} installata — vai su Esplora e aggiungine una.",
+  "library.noMatches": "Nessun risultato.",
+  "library.quick3d": "Anteprima 3D rapida",
+  "library.selectNone": "Deseleziona tutto",
+  "library.move": "Sposta",
+  "library.uninstall": "Disinstalla",
+  "library.uninstallAction": "Disinstalla…",
+  "library.moveToFolder": "Sposta nella cartella…",
+  "library.showInExplorer": "Mostra in Esplora file",
+  "library.moveDialogTitle": "Sposta nella cartella",
+  "library.moveCount_one": "Sposta {{count}} elemento",
+  "library.moveCount_other": "Sposta {{count}} elementi",
+  "library.chooseDestination": "Scegli una cartella di destinazione",
+  "library.newFolder": "Nuova cartella…",
+  "library.newFolderName": "Nome della nuova cartella",
+  "library.createAndMove": "Crea e sposta",
+  "library.confirmUninstall": "Disinstallare {{name}}?",
+  "library.confirmUninstallBody":
+    "L'elemento viene spostato nel Cestino — puoi ripristinarlo da lì.",
+  "library.confirmBulkUninstall_one": "Disinstallare {{count}} elemento?",
+  "library.confirmBulkUninstall_other": "Disinstallare {{count}} elementi?",
+  "library.confirmBulkUninstallBody":
+    "Ogni elemento viene spostato nel Cestino — puoi ripristinarli da lì.",
+  "library.uninstallCount": "Disinstalla {{count}}",
+  "library.moveFailed": "Impossibile spostare la mod",
+  "library.uninstallFailed": "Impossibile disinstallare",
+  "library.openFailed": "Impossibile aprire",
+  "library.uninstalledOne": "{{name}} disinstallata",
+  "library.movedToBin": "Spostata nel Cestino.",
+  "library.someNotRemoved": "Alcuni elementi non sono stati rimossi.",
+  "library.bulkUninstalled_one": "{{count}} elemento disinstallato",
+  "library.bulkUninstalled_other": "{{count}} elementi disinstallati",
+  "library.bulkUninstallPartial": "Disinstallati {{ok}}, {{fail}} falliti",
+  "library.bulkMovePartial": "Spostati {{ok}}, {{fail}} falliti",
+  "library.bulkMoved_one": "Spostato {{count}} elemento in {{folder}}",
+  "library.bulkMoved_other": "Spostati {{count}} elementi in {{folder}}",
+
+  // ── Armadietto ─────────────────────────────────────────────────────────────
+  "locker.help":
+    "Cambia il modello e il suono del motore di ogni moto tra i set che hai installato.",
+  "locker.rescan": "Riscansiona",
+  "locker.restore": "Ripristina",
+  "locker.register": "Registra",
+  "locker.scanning": "Scansione delle moto…",
+  "locker.scanForSwaps": "Cerca set da scambiare",
+  "locker.orphanBanner":
+    "A {{bike}} mancano i file di setup — una versione precedente li ha spostati in una cartella di swap, e questo impedisce del tutto il caricamento della moto in gioco. {{files}}",
+  "locker.looseBanner_one":
+    "{{count}} set modello / suono trovato sparso tra le tue moto — registralo in {{modelsFolder}} / {{soundsFolder}}.",
+  "locker.looseBanner_other":
+    "{{count}} set modello / suono trovati sparsi tra le tue moto — registrali in {{modelsFolder}} / {{soundsFolder}}.",
+  "locker.emptyTitle": "Ancora nessuna moto scambiabile.",
+  "locker.emptyIntro":
+    "Servono due condizioni prima che uno scambio sia possibile:",
+  "locker.unpacked": "estratta",
+  "locker.emptyRuleUnpacked":
+    "La moto è {{unpacked}} in {{path}}— un {{pkz}} compresso non può essere scambiato. Estraine una dalla Libreria.",
+  "locker.emptyRuleMesh":
+    "Ogni modello alternativo sta nella sua cartella dentro quella moto e contiene una mesh ({{edf}}). Mettila ovunque nella cartella della moto e premi Cerca qui sotto — ti proporremo di archiviarla in {{folder}}.",
+  "locker.summary": "{{model}} · suono “{{sound}}”",
+  "locker.modelNamed": "modello “{{name}}”",
+  "locker.noModelSwaps": "nessun cambio modello",
+  "locker.models": "Modelli",
+  "locker.sounds": "Suoni",
+  "locker.onlyOneModel": "Un solo modello — installane altri per scambiare",
+  "locker.onlyStock":
+    "Solo Stock — installa una mod audio per scambiare",
+  "locker.noModel": "Nessun modello",
+  "locker.stock": "Stock",
+  "locker.activeModel": "Modello attivo",
+  "locker.activeSound": "Suono attivo",
+  "locker.switchToNoModel":
+    "Passa a nessun modello — rimuove i file del modello attuale",
+  "locker.switchToStock":
+    "Passa a Stock — rimuove la mod audio (torna il suono originale)",
+  "locker.missingModelEdf": "Questo set non ha model.edf",
+  "locker.missingSoundFiles": "A questo set mancano engine.scl o sfx.cfg",
+  "locker.switchTo": "Passa a {{name}}",
+  "locker.tiedToModel": "Legato al modello {{models}}",
+  "locker.boundHint":
+    "“{{sound}}” è legato al modello “{{model}}” — segue quel modello. Clicca per slegarlo.",
+  "locker.unboundHint":
+    "Lega il suono attivo “{{sound}}” al modello “{{model}}” così passando a quel modello arriva anche il suono.",
+  "locker.tieAction": "Lega “{{sound}}” a “{{model}}”",
+  "locker.untieAction": "Slega “{{sound}}” da “{{model}}”",
+  "locker.restored": "Ripristinati i file di setup di {{bike}}.",
+  "locker.restoredNote_one":
+    "{{count}} file rimesso a posto — la moto dovrebbe caricarsi di nuovo.",
+  "locker.restoredNote_other":
+    "{{count}} file rimessi a posto — la moto dovrebbe caricarsi di nuovo.",
+  "locker.switchedModel":
+    "Modello di {{bike}} cambiato in “{{target}}”.",
+  "locker.switchedSound": "Suono di {{bike}} cambiato in “{{target}}”.",
+  "locker.tied": "“{{sound}}” legato al modello “{{model}}”.",
+  "locker.untied": "“{{sound}}” slegato dal modello “{{model}}”.",
+  "locker.refreshedLive": "Aggiornato in tempo reale nel gioco.",
+  "locker.refreshFailed":
+    "Aggiornamento istantaneo fallito — riseleziona il profilo in gioco per caricarlo.",
+  "locker.reselectProfile":
+    "Riseleziona il tuo profilo in MX Bikes per caricare lo scambio.",
+  "locker.loadsNextTime":
+    "Verrà caricato alla prossima apertura del gioco.",
+
+  // ── Registrazione set sparsi ───────────────────────────────────────────────
+  "swaps.model": "modello",
+  "swaps.modelSets_one": "{{count}} cambio modello",
+  "swaps.modelSets_other": "{{count}} cambi modello",
+  "swaps.soundSets_one": "{{count}} mod audio",
+  "swaps.soundSets_other": "{{count}} mod audio",
+  "swaps.and": "{{a}} e {{b}}",
+  "swaps.noSets": "0 set",
+  "swaps.foundTitle": "Trovati {{summary}}",
+  "swaps.description":
+    "Queste cartelle sono sparse dentro le tue moto. Registrale per spostarle ciascuna nella libreria giusta — {{modelsFolder}} per i modelli, {{soundsFolder}} per i suoni — così compaiono nell'Armadietto.",
+  "swaps.registered_one": "Registrato {{count}} set.",
+  "swaps.registered_other": "Registrati {{count}} set.",
+  "swaps.nothingMoved": "Non è stato spostato nulla.",
+  "swaps.skipped_one": "{{count}} saltato (nome già in uso).",
+  "swaps.skipped_other": "{{count}} saltati (nomi già in uso).",
+  "swaps.foldersCreated_one":
+    "Create le cartelle di libreria per {{count}} moto.",
+  "swaps.foldersCreated_other":
+    "Create le cartelle di libreria per {{count}} moto.",
+  "swaps.foldersCreatedDesc":
+    "Le tue cartelle modello / suono sono rimaste dove sono.",
+  "swaps.justCreateFolders": "Crea solo le cartelle",
+  "swaps.registerAndMove": "Registra e sposta",
+  "swaps.fileCount_one": "{{count}} file",
+  "swaps.fileCount_other": "{{count}} file",
+
+  // ── Installazione ──────────────────────────────────────────────────────────
+  "install.installed": "{{title}} installata",
+  "install.reloadedDesc":
+    "Gioco ricaricato tramite FrostMod — è già attiva.",
+  "install.addedDesc": "Aggiunta alla tua libreria.",
+  "install.failed": "Installazione fallita — {{title}}",
+  "install.openModPage": "Apri la pagina della mod",
+  "install.clickToOpen": "Clicca per aprire la pagina della mod",
+
+  // ── Categorie (singolare) ──────────────────────────────────────────────────
+  "category.track": "Pista",
+  "category.bike": "Moto",
+  "category.bikePaint": "Livrea",
+  "category.bikeModelSwap": "Cambio modello",
+  "category.sound": "Suono",
+  "category.helmet": "Casco",
+  "category.helmetPaint": "Grafica casco",
+  "category.goggles": "Maschera",
+  "category.boots": "Stivali",
+  "category.bootPaint": "Grafica stivali",
+  "category.protection": "Protezioni",
+  "category.protectionPaint": "Grafica protezioni",
+  "category.gloves": "Guanti",
+  "category.outfit": "Completo / kit",
+  "category.misc": "Altro",
+
+  // ── Intestazioni di sezione (plurale) ──────────────────────────────────────
+  "section.bikePaint": "Livree",
+  "section.bikeModelSwap": "Cambi modello",
+  "section.sound": "Suoni",
+  "section.helmet": "Caschi",
+  "section.helmetPaint": "Grafiche casco",
+  "section.boots": "Stivali",
+  "section.bootPaint": "Grafiche stivali",
+  "section.protection": "Protezioni",
+  "section.protectionPaint": "Grafiche protezioni",
+  "section.gloves": "Guanti",
+  "section.outfit": "Completo / kit",
+
+  // ── Destinazioni d'installazione ───────────────────────────────────────────
+  "dest.bikesRoot": "Moto (principale)",
+  "dest.tracksRoot": "Piste (principale)",
+  "dest.bikeFolder": "{{name}} — cartella moto",
+  "dest.bikePaints": "{{name}} — grafiche",
+  "dest.helmetsNewModel": "Caschi (nuovo modello)",
+  "dest.bootsNewModel": "Stivali (nuovo modello)",
+  "dest.protectionNewModel": "Protezioni (nuovo modello)",
+  "dest.helmetPaintsFor": "{{name}} · grafiche casco",
+  "dest.gogglesFor": "{{name}} · maschera",
+  "dest.bootPaintsFor": "{{name}} · grafiche stivali",
+  "dest.protectionPaintsFor": "{{name}} · grafiche protezioni",
+  "dest.outfitFor": "{{name}} · completo / kit",
+  "dest.glovesFor": "{{name}} · guanti",
+};

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1,0 +1,704 @@
+import type { Translation } from "..";
+
+/**
+ * Brazilian Portuguese (informal "você" — this is a modding tool for a game
+ * community).
+ *
+ * Community terminology rather than dictionary equivalents: `mod`, `setup`,
+ * `preset` and `Stock` stay as loanwords, while gear is translated — `capacete`,
+ * `botas`, `óculos` for goggles, `pintura` for a paint/livery.
+ *
+ * This is the only Portuguese we ship, so a plain `pt` OS tag resolves here
+ * (see `resolveSystemLocale`).
+ *
+ * Product names (MXB App, FrostMod, MX Bikes) are never translated.
+ */
+export const ptBR: Translation = {
+  // ── Genérico ───────────────────────────────────────────────────────────────
+  "common.cancel": "Cancelar",
+  "common.back": "Voltar",
+  "common.next": "Avançar",
+  "common.skip": "Pular",
+  "common.close": "Fechar",
+  "common.save": "Salvar",
+  "common.delete": "Excluir",
+  "common.rename": "Renomear",
+  "common.retry": "Tentar de novo",
+  "common.tryAgain": "Tentar de novo",
+  "common.loading": "Carregando…",
+  "common.installed": "Instalado",
+  "common.select": "Selecionar",
+  "common.deselect": "Desmarcar",
+  "common.selectAll": "Selecionar tudo",
+  "common.clear": "Limpar",
+  "common.done": "Pronto",
+  "common.apply": "Aplicar",
+  "common.remove": "Remover",
+  "common.open": "Abrir",
+  "common.refresh": "Atualizar",
+  "common.dismiss": "Dispensar",
+  "common.later": "Mais tarde",
+  "common.active": "Ativo",
+
+  // ── Controles da janela ────────────────────────────────────────────────────
+  "window.minimize": "Minimizar",
+  "window.maximize": "Maximizar",
+  "window.close": "Fechar",
+
+  // ── Navegação ──────────────────────────────────────────────────────────────
+  "nav.browse": "Explorar",
+  "nav.shop": "Loja",
+  "nav.library": "Biblioteca",
+  "nav.locker": "Armário",
+  "nav.presets": "Presets",
+  "nav.rider": "Piloto",
+  "nav.settings": "Configurações",
+
+  "sidebar.installing": "Instalando “{{name}}”",
+  "sidebar.queued": "+{{count}} na fila",
+
+  // ── FrostMod ───────────────────────────────────────────────────────────────
+  "frostmod.checking": "Verificando o FrostMod…",
+  "frostmod.running": "FrostMod ativo",
+  "frostmod.notRunning": "FrostMod inativo",
+  "frostmod.reloadGame": "Recarregar o jogo",
+  "frostmod.start": "Iniciar o FrostMod",
+  "frostmod.reloadedGame": "O FrostMod recarregou o jogo.",
+  "frostmod.notRunningToast": "O FrostMod não está em execução.",
+  "frostmod.started": "FrostMod iniciado",
+  "frostmod.alreadyRunning": "O FrostMod já está em execução",
+  "frostmod.startFailed": "Não foi possível iniciar o FrostMod",
+  "frostmod.installedToast": "FrostMod {{version}} instalado",
+  "frostmod.installedToastDesc":
+    "Ele recarrega o jogo na hora quando você adiciona mods.",
+  "frostmod.installFailed": "Não foi possível instalar o FrostMod",
+  "frostmod.newModsAdded": "Novos mods adicionados",
+  "frostmod.modsAdded_one": "Novo mod adicionado",
+  "frostmod.modsAdded_other": "{{count}} mods adicionados",
+  "frostmod.askedReload": "Pedimos ao FrostMod para recarregar o jogo.",
+  "frostmod.andMore_one": "{{names}} e mais {{count}}",
+  "frostmod.andMore_other": "{{names}} e mais {{count}}",
+  "frostmod.watchDesc":
+    "{{names}} — pedimos ao FrostMod para recarregar o jogo.",
+
+  // ── Configuração inicial ───────────────────────────────────────────────────
+  "setup.title": "Bem-vindo ao MXB App",
+  "setup.tagline":
+    "Explore o mxb-mods, instale com um clique e deixe o FrostMod recarregar o jogo pra você.",
+  "setup.modsFolder": "Pasta do MX Bikes",
+  "setup.autoDetect":
+    "O MXB App vai detectar sua pasta {{hint}} automaticamente. Você também pode escolher você mesmo.",
+  "setup.chooseManually": "Escolher a pasta manualmente…",
+  "setup.chooseDifferent": "Escolher outra pasta…",
+  "setup.gameInstall": "Instalação do MX Bikes",
+  "setup.detecting": "Procurando sua instalação do MX Bikes…",
+  "setup.found": "Encontrada",
+  "setup.detectedAutomatically": "Detectada automaticamente",
+  "setup.installNotFound":
+    "Não deu pra encontrar sua instalação do MX Bikes automaticamente — é ela que alimenta a prévia 3D do piloto. Escolha manualmente, ou defina depois nas Configurações.",
+  "setup.chooseInstallManually":
+    "Escolher a pasta de instalação manualmente…",
+  "setup.startBrowsing": "Começar a explorar mods",
+  "setup.detectAndStart": "Detectar e começar",
+  "setup.pickModsFolder": "Selecione sua pasta do MX Bikes",
+  "setup.pickInstallFolder": "Selecione sua pasta de instalação do MX Bikes",
+
+  // ── Boas-vindas ────────────────────────────────────────────────────────────
+  "welcome.intro.title": "Bem-vindo ao MXB App",
+  "welcome.intro.body":
+    "Seu gerenciador de mods do MX Bikes. Mantenha pistas, motos e pinturas organizadas em um só lugar — chega de arquivos zip espalhados pela área de trabalho. Em alguns segundos a gente te mostra tudo.",
+  "welcome.getStarted": "Começar",
+
+  // ── Presets ────────────────────────────────────────────────────────────────
+  "presets.missing": "faltando",
+  "presets.missingHint":
+    "Este mod não está instalado — aparece como Stock no jogo",
+  "presets.missingMods":
+    "Mods faltando: {{mods}}. Instale-os para essas partes aparecerem.",
+  "presets.help":
+    "Salve um visual completo do piloto e carregue numa moto quando quiser.",
+  "presets.profile": "Perfil",
+  "presets.namePlaceholder": "Nome do preset…",
+  "presets.savePreset": "Salvar preset",
+  "presets.saveChanges": "Salvar alterações",
+  "presets.saveChangesQ": "Salvar as alterações?",
+  "presets.replaceQ": "Substituir o preset?",
+  "presets.replace": "Substituir",
+  "presets.loadCopy": "Carregar uma cópia no editor",
+  "presets.viewOnRider": "Ver no piloto",
+  "presets.editNameOrOptions": "Editar nome ou opções",
+  "presets.share": "Compartilhar",
+  "presets.nameFirst": "Primeiro dê um nome ao preset.",
+  "presets.pickProfileAndBike": "Escolha um perfil e uma moto para aplicar.",
+  "presets.updated": "Preset “{{name}}” atualizado.",
+  "presets.renamed": "Renomeado para “{{name}}” e alterações salvas.",
+  "presets.saved": "Preset “{{name}}” salvo.",
+  "presets.editing":
+    "Editando “{{name}}” — mude o que quiser e depois salve as alterações.",
+  "presets.appliedRefreshed":
+    "“{{label}}” aplicado em {{bike}} — atualizado na hora dentro do jogo.",
+  "presets.appliedRefreshFailed":
+    "“{{label}}” aplicado em {{bike}} — salvo, mas a atualização instantânea falhou: selecione seu perfil de novo no jogo para carregar.",
+  "presets.appliedGameRunning":
+    "“{{label}}” aplicado em {{bike}} — salvo. Selecione seu perfil de novo no MX Bikes (menu Profile) para carregar o novo visual.",
+  "presets.appliedNextTime":
+    "“{{label}}” aplicado em {{bike}} — salvo. Carrega na próxima vez que o jogo abrir.",
+  "presets.phaseBundling": "Empacotando os arquivos…",
+  "presets.phaseUploading": "Enviando o pacote…",
+  "presets.phaseDownloading": "Baixando o pacote…",
+  "presets.phaseInstalling": "Instalando os arquivos…",
+  "presets.bundleUploaded":
+    "Pacote completo enviado — o código agora inclui os arquivos.",
+  "presets.shareHintFull":
+    "Este código inclui um pacote para download — quem receber escolhe Importação completa e recebe tudo, mesmo sem nenhum mod instalado.",
+  "presets.shareHintConfig":
+    "Mande este código para quem quiser. A importação é em Presets → Importar. A pessoa vai precisar dos mesmos mods instalados para tudo aparecer.",
+  "presets.generatingCode": "Gerando o código…",
+  "presets.nothingToBundle":
+    "Nenhum arquivo instalado para empacotar — este visual é todo Stock/fontes.",
+  "presets.createFullBundle": "Criar pacote completo",
+  "presets.copiedFull": "Código com pacote completo copiado.",
+  "presets.copiedShare": "Código de compartilhamento copiado.",
+  "presets.copyFailed":
+    "Não deu pra copiar — selecione o código e copie na mão.",
+  "presets.copyFullCode": "Copiar código completo",
+  "presets.copyCode": "Copiar código",
+  "presets.importTitle": "Importar preset",
+  "presets.importBody": "Cole um código que te mandaram.",
+  "presets.configOnly": "Só a configuração",
+  "presets.import": "Importar",
+  "presets.fullImport": "Importação completa",
+  "presets.editingBanner":
+    "Editando {{name}} — mude o nome ou qualquer slot e depois {{save}}.",
+  "presets.bundleNotice":
+    "Inclui um pacote completo (~{{size}} de {{host}}). Use {{fullImport}} para baixar e instalar tudo — não precisa ter mods antes.",
+
+  // ── Slots dos presets ──────────────────────────────────────────────────────
+  "slot.paint": "Pintura da moto",
+  "slot.modelSwap": "Troca de modelo",
+  "slot.bikeFont": "Fonte dos números",
+  "slot.tyres": "Pneus",
+  "slot.rider": "Perfil do piloto",
+  "slot.suitPaint": "Uniforme / kit",
+  "slot.suitFont": "Fonte do uniforme",
+  "slot.glovesPaint": "Luvas",
+  "slot.ridingStyle": "Estilo de pilotagem",
+  "slot.helmet": "Capacete",
+  "slot.helmetPaint": "Pintura do capacete",
+  "slot.gogglesPaint": "Óculos",
+  "slot.boots": "Botas",
+  "slot.bootsPaint": "Pintura das botas",
+  "slot.protection": "Proteções",
+  "slot.protectionPaint": "Pintura das proteções",
+  "slotGroup.bike": "Moto",
+  "slotGroup.rider": "Piloto",
+  "slotGroup.head": "Cabeça",
+  "slotGroup.body": "Corpo",
+
+  // ── Estúdio do piloto ──────────────────────────────────────────────────────
+  "rider.help":
+    "Vista o modelo do piloto — capacete, óculos, uniforme e botas de uma vez.",
+  "rider.namePlaceholder": "Dê um nome a este piloto…",
+  "rider.nameFirst": "Primeiro dê um nome a este visual.",
+  "rider.showOnModel": "Mostrar no modelo",
+
+  // ── Tour guiado ────────────────────────────────────────────────────────────
+  "tour.welcomeTour.title": "Faça um tour rápido",
+  "tour.welcomeTour.body":
+    "Alguns segundos para ver onde fica cada coisa. Você pode pular quando quiser.",
+  "tour.browse.title": "Explorar mods",
+  "tour.browse.body":
+    "Pesquise no mxb-mods.com aqui mesmo e instale qualquer pista, moto ou pintura com um clique só.",
+  "tour.library.title": "Sua biblioteca",
+  "tour.library.body":
+    "Tudo que você instalou, em um só lugar — atualize ou remova mods sem nunca mexer num arquivo zip.",
+  "tour.locker.title": "O armário",
+  "tour.locker.body":
+    "Troque os modelos das motos à vontade. O MXB App registra as peças para o jogo reconhecer.",
+  "tour.presets.title": "Presets",
+  "tour.presets.body":
+    "Salve combinações de equipamento e pinturas e aplique um visual completo com um clique — até enquanto você está pilotando.",
+  "tour.rider.title": "Estúdio do piloto",
+  "tour.rider.body":
+    "Veja a prévia do seu equipamento e das pinturas no piloto 3D antes de levar pra pista.",
+  "tour.frostmod.title": "FrostMod, ao vivo",
+  "tour.frostmod.body":
+    "Aqui você vê o status do FrostMod. Ele recarrega o MX Bikes depois de uma instalação, então o conteúdo novo aparece sem reiniciar o jogo.",
+  "tour.settings.title": "Configurações",
+  "tour.settings.body":
+    "Aqui você define sua pasta do jogo, o comportamento em segundo plano e as opções do FrostMod. Também dá pra rever este tour por aqui.",
+  "tour.done.title": "Tudo pronto",
+  "tour.done.body":
+    "O tour acabou. Vá em Explorar e instale seu primeiro mod.",
+
+  // ── Erros ──────────────────────────────────────────────────────────────────
+  "error.previewFailed": "Não foi possível exibir a prévia",
+  "error.somethingWentWrong": "Algo deu errado",
+  "error.unexpected": "Ocorreu um erro inesperado.",
+  "error.reloadApp": "Recarregar o app",
+
+  // ── Atualizações ───────────────────────────────────────────────────────────
+  "update.available": "{{version}} está disponível.",
+  "update.downloading": "Baixando…",
+  "update.downloadingPct": "Baixando… {{pct}}%",
+  "update.pitch":
+    "Atualize para receber os recursos e as correções mais recentes.",
+  "update.updating": "Atualizando…",
+  "update.updateAndRestart": "Atualizar e reiniciar",
+  "update.dismiss": "Dispensar o aviso de atualização",
+  "update.onLatest": "Você já está na versão mais recente",
+  "update.checkFailed": "Não foi possível verificar as atualizações",
+  "update.failed": "A atualização falhou",
+
+  // ── Visualizador 3D ────────────────────────────────────────────────────────
+  "viewer.preview3d": "Prévia 3D",
+  "viewer.expand": "Expandir",
+  "viewer.paint": "Pintura",
+  "viewer.loadingModel": "Carregando o modelo…",
+  "viewer.loadingPaint": "Carregando a pintura…",
+  "viewer.loadingRider": "Carregando o piloto…",
+  "viewer.dragToRotate": "Arraste para girar",
+  "viewer.scrollToZoom": "Role para dar zoom",
+  "viewer.rightDragToPan": "Arraste com o botão direito para mover",
+
+  // ── Combobox ───────────────────────────────────────────────────────────────
+  "combobox.search": "Pesquisar…",
+  "combobox.use": "Usar “{{value}}”",
+
+  // ── Tipos de mod ───────────────────────────────────────────────────────────
+  "modType.tracks": "Pistas",
+  "modType.bikes": "Motos",
+  "modType.rider": "Piloto",
+  "modType.tracksInline": "pistas",
+  "modType.bikesInline": "motos",
+  "modType.riderInline": "equipamento do piloto",
+
+  // ── Filtros de categoria ───────────────────────────────────────────────────
+  "browseCat.all": "Tudo",
+  "browseCat.beginner": "Iniciante",
+  "browseCat.intermediate": "Intermediário",
+  "browseCat.pro": "Pro",
+  "browseCat.assets": "Recursos",
+  "browseCat.newBikes": "Motos novas",
+  "browseCat.liveries": "Pinturas",
+  "browseCat.sounds": "Sons",
+  "browseCat.riderKit": "Kit do piloto",
+  "browseCat.helmets": "Capacetes",
+  "browseCat.helmetPaints": "Pinturas de capacete",
+  "browseCat.gloves": "Luvas",
+  "browseCat.boots": "Botas",
+  "browseCat.bootPaints": "Pinturas de botas",
+  "browseCat.protection": "Proteções",
+  "browseCat.protectionPaints": "Pinturas de proteções",
+
+  // ── Explorar ───────────────────────────────────────────────────────────────
+  "browse.help":
+    "Descubra e instale mods do catálogo online — pesquise, filtre por tipo e abra um mod para baixá-lo no jogo.",
+  "browse.searchPlaceholder": "Pesquisar {{type}}…",
+  "browse.sortedByNewest": "Ordenados pelos mais recentes",
+  "browse.loadFailed": "Não foi possível carregar os mods",
+  "browse.empty": "Nenhum resultado em {{type}}.",
+  "browse.loadMore": "Carregar mais",
+  "browse.selectedCount": "{{count}} selecionados",
+  "browse.queuing": "Colocando na fila…",
+  "browse.quickInstallCount": "Instalar {{count}} rapidamente",
+  "browse.quickInstall": "Instalação rápida",
+  "browse.quickReinstall": "Reinstalação rápida",
+  "browse.openDetails": "Abrir detalhes",
+  "browse.reinstallOne": "Reinstalar “{{title}}”?",
+  "browse.reinstallMany": "Reinstalar os mods que você já tem?",
+  "browse.reinstallOneBody":
+    "Este mod já está na sua biblioteca. Reinstalar baixa tudo de novo e sobrescreve os arquivos instalados.",
+  "browse.reinstallManyBody":
+    "{{installed}} dos {{total}} selecionados já estão instalados. Se continuar, eles serão reinstalados e sobrescritos.",
+  "browse.reinstall": "Reinstalar",
+  "browse.reinstallAll": "Reinstalar tudo",
+  "browse.queued": "“{{title}}” na fila",
+  "browse.queuedDesc": "Instalando em {{folder}}.",
+  "browse.rootFolder": "raiz",
+  "browse.needsBrowser": "“{{title}}” precisa ser baixado pelo navegador",
+  "browse.needsBrowserDesc":
+    "O {{host}} bloqueia downloads dentro do app — abra a página dele para concluir.",
+  "browse.noDownload": "Nenhum download encontrado para “{{title}}”",
+  "browse.quickInstallFailed":
+    "Não foi possível instalar “{{title}}” rapidamente",
+  "browse.queuedBulk_one": "{{count}} mod na fila",
+  "browse.queuedBulk_other": "{{count}} mods na fila",
+  "browse.queuedBulkDesc": "Eles serão instalados um depois do outro.",
+  "browse.queuedBulkSkipped_one":
+    "{{count}} ignorado — host só pelo navegador.",
+  "browse.queuedBulkSkipped_other":
+    "{{count}} ignorados — host só pelo navegador.",
+  "browse.bulkFailed": "Não foi possível instalar a seleção rapidamente",
+  "browse.bulkFailedDesc_one": "Ele precisa ser baixado pelo navegador.",
+  "browse.bulkFailedDesc_other":
+    "Todos os {{count}} precisam ser baixados pelo navegador.",
+
+  // ── Loja ───────────────────────────────────────────────────────────────────
+  "shop.myDownloads": "Meus downloads",
+  "shop.signInTitle": "Entre na MX Bikes Shop",
+  "shop.signInBody":
+    "Entre no mxbikes-shop.com para ver e instalar as pistas que você comprou. A gente abre o site de verdade — sua senha nunca passa por este app.",
+  "shop.signIn": "Entrar",
+  "shop.logOut": "Sair",
+  "shop.signedIn": "Conectado à MX Bikes Shop",
+  "shop.sessionFailed": "Não foi possível capturar sua sessão da MX Bikes Shop",
+  "shop.queuedDesc": "Instalando na sua pasta de pistas.",
+  "shop.loadFailed": "Não foi possível carregar seus downloads: {{error}}",
+  "shop.empty": "Nenhum download comprado encontrado na sua conta ainda.",
+
+  // ── Janela de instalação ───────────────────────────────────────────────────
+  "installDialog.installTo": "Instalar em",
+  "installDialog.installToFolder": "Instalar em {{folder}}",
+  "installDialog.change": "Alterar",
+  "installDialog.searchBikes": "Pesquisar motos…",
+  "installDialog.searchFolders": "Pesquisar pastas…",
+  "installDialog.probably": "Provavelmente",
+  "installDialog.allFolders": "Todas as pastas",
+  "installDialog.noFolderMatch":
+    "Nenhuma pasta corresponde — crie uma abaixo.",
+  "installDialog.rememberedFor": "Lembrado para {{type}}",
+  "installDialog.downloadFrom": "Baixar de",
+  "installDialog.downloadPerBike": "Download (por moto)",
+  "installDialog.opensInBrowser":
+    "Abre no navegador — o MXB App conclui a instalação",
+  "installDialog.matchedBike": "Combina com a sua moto",
+  "installDialog.differentBike": "Moto / pacote diferente",
+  "installDialog.directFastest": "Direto · o mais rápido",
+  "installDialog.direct": "Direto",
+  "installDialog.perBikeHint":
+    "Cada download é uma moto diferente — selecionado automaticamente conforme a sua escolha. Escolha o pacote “all bikes” para todas de uma vez.",
+  "installDialog.mirrorsHint":
+    "Todos os espelhos têm o mesmo arquivo. Se um falhar, tente o próximo.",
+
+  // ── Detalhes da biblioteca ─────────────────────────────────────────────────
+  "libraryDetail.author": "Autor",
+  "libraryDetail.length": "Extensão",
+  "libraryDetail.altitude": "Altitude",
+  "libraryDetail.location": "Local",
+  "libraryDetail.type": "Tipo",
+  "libraryDetail.mod": "Mod",
+  "libraryDetail.belongsTo": "Pertence a",
+  "libraryDetail.format": "Formato",
+  "libraryDetail.extractedFolder": "Pasta extraída",
+  "libraryDetail.paintFile": "Arquivo de pintura",
+  "libraryDetail.packagedPkz": "Pacote .pkz",
+  "libraryDetail.size": "Tamanho",
+  "libraryDetail.folder": "Pasta",
+  "libraryDetail.lockedWord": "bloqueada",
+  "libraryDetail.lockedWithMeta":
+    "Esta pista foi {{locked}} pelo criador. O nome, os detalhes e a prévia aparecem aqui, mas os arquivos continuam lacrados — não dá pra extrair nem ver em 3D.",
+  "libraryDetail.lockedNoMeta":
+    "Esta pista está {{locked}}, então o nome, a extensão e a prévia não podem ser lidos do arquivo — só o nome do arquivo e o tamanho.",
+
+  // ── Página do mod ──────────────────────────────────────────────────────────
+  "modDetail.stageResolve": "Resolver",
+  "modDetail.stageDownload": "Baixar",
+  "modDetail.stageExtract": "Extrair",
+  "modDetail.stagePlace": "Posicionar",
+  "modDetail.stageReload": "Recarregar",
+  "modDetail.modFiles": "Arquivos de mod",
+  "modDetail.copied": "Copiado",
+  "modDetail.copy": "Copiar",
+  "modDetail.addToLibrary": "Adicionar à biblioteca",
+  "modDetail.host": "Host",
+  "modDetail.installsTo": "Instala em",
+  "modDetail.noDownloadLink":
+    "Nenhum link de download encontrado nesta página — abra no mxb-mods.com.",
+  "modDetail.frostmodHint":
+    "O FrostMod vai recarregar a lista de {{kind}} quando isso terminar.",
+  "modDetail.kindRider": "piloto",
+  "modDetail.kindBike": "motos",
+  "modDetail.kindTrack": "pistas",
+  "modDetail.details": "Detalhes",
+  "modDetail.format": "Formato",
+  "modDetail.mirrors": "Espelhos",
+  "modDetail.type": "Tipo",
+  "modDetail.addedToLibrary": "Adicionado à sua biblioteca",
+  "modDetail.extracting": "Extraindo…",
+  "modDetail.addingToLibrary": "Adicionando à biblioteca…",
+  "modDetail.resolving": "Resolvendo o download…",
+  "modDetail.finishInBrowser": "Conclua no seu navegador",
+  "modDetail.viewOnSite": "Ver no mxb-mods.com",
+
+  // ── Configurações ──────────────────────────────────────────────────────────
+  "settings.help":
+    "Configure sua pasta do jogo, as atualizações e as preferências do app.",
+  "settings.gameFolder": "Pasta do jogo",
+  "settings.general": "Geral",
+  "settings.appearance": "Aparência",
+  "settings.frostmod": "FrostMod",
+  "settings.about": "Sobre e atualizações",
+  "settings.modsFolderDesc":
+    "Onde os mods são instalados. Mudar isso faz uma nova varredura da biblioteca.",
+  "settings.insideModsFolder": "Dentro da sua pasta do MX Bikes",
+  "settings.notSet": "Não definida",
+  "settings.change": "Alterar…",
+  "settings.set": "Definir…",
+  "settings.theme": "Tema",
+  "settings.themeLight": "Claro",
+  "settings.themeDark": "Escuro",
+  "settings.themeSystem": "Sistema",
+  "settings.language": "Idioma",
+  "settings.languageSystem": "Sistema",
+  "settings.runInBackground": "Continuar em segundo plano",
+  "settings.runInBackgroundDesc":
+    "Fechar a janela deixa o MXB App na bandeja do sistema para o FrostMod continuar conectado. Saia pelo ícone da bandeja.",
+  "settings.launchAtStartup": "Iniciar junto com o sistema",
+  "settings.launchAtStartupDesc":
+    "Abrir o MXB App automaticamente quando você fizer login.",
+  "settings.instantRefresh": "Atualização instantânea de presets",
+  "settings.instantRefreshDesc":
+    "Quando você aplica um preset com o MX Bikes aberto, atualiza o visual no jogo na hora — sem reiniciar nem reselecionar o perfil. Se não der, você será avisado para selecionar o perfil de novo.",
+  "settings.instantRefreshWindowsOnly":
+    "Atualizar o visual no jogo sem reiniciar precisa do FrostMod, que só existe no Windows — em vez disso você será avisado para selecionar o perfil de novo.",
+  "settings.autoRunFrostmod": "Iniciar o FrostMod automaticamente",
+  "settings.autoRunFrostmodDesc":
+    "Iniciar o FrostMod em segundo plano sempre que o MXB App abrir.",
+  "settings.watchModsReload": "Recarregar automaticamente ao mudar a pasta",
+  "settings.watchModsReloadDesc":
+    "Recarregar o jogo automaticamente quando pistas ou motos forem adicionadas à sua pasta de mods — mesmo baixadas manualmente fora do MXB App.",
+  "settings.checking": "Verificando…",
+  "settings.runningConnected": "Em execução · jogo conectado",
+  "settings.notRunning": "Não está em execução",
+  "settings.frostmodInstalled": "Instalado{{suffix}}",
+  "settings.notInstalled": "Não instalado",
+  "settings.checkingGitHub": "Verificando a última versão no GitHub…",
+  "settings.updateCheckFailed":
+    "Não foi possível verificar as atualizações — sem conexão ou GitHub indisponível.",
+  "settings.latestVersion": "Última: {{version}}",
+  "settings.checkNewer": "Procurar uma versão mais nova do FrostMod",
+  "settings.working": "Processando…",
+  "settings.installFrostmod": "Instalar o FrostMod",
+  "settings.updateTo": "Atualizar para {{version}}",
+  "settings.reinstallLatest": "Reinstalar a mais recente",
+  "settings.upToDate": "Atualizado",
+  "settings.madeWith": "Feito com",
+  "settings.updateFailed": "Não foi possível alterar a configuração",
+  "settings.startupUpdateFailed":
+    "Não foi possível alterar o início automático",
+  "settings.folderUpdated": "Pasta do jogo atualizada",
+  "settings.folderUpdatedDesc": "Sua biblioteca será varrida de novo.",
+  "settings.setFolderFailed": "Não foi possível definir a pasta",
+  "settings.reDetected": "Pasta do MX Bikes detectada de novo",
+  "settings.detectFolderFailed": "Não foi possível detectar a pasta",
+  "settings.pickInstallFolder":
+    "Selecione sua pasta de instalação do MX Bikes (contém rider.pkz)",
+  "settings.installSet": "Instalação do jogo definida",
+  "settings.installSetDesc":
+    "A prévia 3D do piloto já pode carregar o modelo real do corpo.",
+  "settings.setInstallFailed":
+    "Não foi possível definir a pasta de instalação",
+  "settings.installNotFound": "Não foi possível encontrar o MX Bikes",
+  "settings.installNotFoundDesc":
+    "Nenhuma instalação da Steam detectada — defina a pasta manualmente.",
+  "settings.installFound": "Instalação do MX Bikes encontrada",
+  "settings.detectInstallFailed":
+    "Não foi possível detectar a pasta de instalação",
+  "settings.pickProfilesFolder":
+    "Selecione sua pasta de perfis do MX Bikes",
+  "settings.profilesSet": "Pasta de perfis definida",
+  "settings.profilesFound_one": "{{count}} perfil encontrado.",
+  "settings.profilesFound_other": "{{count}} perfis encontrados.",
+  "settings.noProfilesThere": "Nenhum perfil encontrado aí",
+  "settings.noProfilesThereDesc":
+    "Salvamos mesmo assim, mas criar presets precisa de uma pasta que contenha as pastas dos seus profile.ini.",
+  "settings.setProfilesFailed":
+    "Não foi possível definir a pasta de perfis",
+  "settings.profilesReverted": "Voltou para a pasta de perfis padrão",
+  "settings.resetProfilesFailed":
+    "Não foi possível redefinir a pasta de perfis",
+  "settings.frostmodNotRunningHint":
+    "O FrostMod não está em execução — inicie ele para recarregar os mods na hora.",
+  "settings.reloadUnavailable":
+    "Recarregar não está disponível nesta plataforma.",
+
+  // ── Biblioteca ─────────────────────────────────────────────────────────────
+  "library.help":
+    "Seus mods instalados. Veja o que está instalado e remova o que não quiser mais.",
+  "library.rootFolder": "(raiz)",
+  "library.byAuthor": "de {{author}}",
+  "library.locked": "Bloqueado — não dá pra ler o conteúdo",
+  "library.searchPlaceholder": "Pesquisar entre os instalados…",
+  "library.scanning": "Varrendo sua biblioteca…",
+  "library.empty":
+    "Nenhuma mod de {{type}} instalada — vá em Explorar e adicione uma.",
+  "library.noMatches": "Nenhum resultado.",
+  "library.quick3d": "Prévia 3D rápida",
+  "library.selectNone": "Desmarcar tudo",
+  "library.move": "Mover",
+  "library.uninstall": "Desinstalar",
+  "library.uninstallAction": "Desinstalar…",
+  "library.moveToFolder": "Mover para uma pasta…",
+  "library.showInExplorer": "Mostrar no Explorador de Arquivos",
+  "library.moveDialogTitle": "Mover para uma pasta",
+  "library.moveCount_one": "Mover {{count}} item",
+  "library.moveCount_other": "Mover {{count}} itens",
+  "library.chooseDestination": "Escolha uma pasta de destino",
+  "library.newFolder": "Nova pasta…",
+  "library.newFolderName": "Nome da nova pasta",
+  "library.createAndMove": "Criar e mover",
+  "library.confirmUninstall": "Desinstalar {{name}}?",
+  "library.confirmUninstallBody":
+    "O item vai para a Lixeira — dá pra restaurar de lá.",
+  "library.confirmBulkUninstall_one": "Desinstalar {{count}} item?",
+  "library.confirmBulkUninstall_other": "Desinstalar {{count}} itens?",
+  "library.confirmBulkUninstallBody":
+    "Cada item vai para a Lixeira — dá pra restaurar de lá.",
+  "library.uninstallCount": "Desinstalar {{count}}",
+  "library.moveFailed": "Não foi possível mover o mod",
+  "library.uninstallFailed": "Não foi possível desinstalar",
+  "library.openFailed": "Não foi possível abrir",
+  "library.uninstalledOne": "{{name}} desinstalado",
+  "library.movedToBin": "Movido para a Lixeira.",
+  "library.someNotRemoved": "Alguns itens não puderam ser removidos.",
+  "library.bulkUninstalled_one": "{{count}} item desinstalado",
+  "library.bulkUninstalled_other": "{{count}} itens desinstalados",
+  "library.bulkUninstallPartial": "{{ok}} desinstalados, {{fail}} falharam",
+  "library.bulkMovePartial": "{{ok}} movidos, {{fail}} falharam",
+  "library.bulkMoved_one": "{{count}} item movido para {{folder}}",
+  "library.bulkMoved_other": "{{count}} itens movidos para {{folder}}",
+
+  // ── Armário ────────────────────────────────────────────────────────────────
+  "locker.help":
+    "Troque o modelo e o som do motor de cada moto entre os sets que você instalou.",
+  "locker.rescan": "Varrer de novo",
+  "locker.restore": "Restaurar",
+  "locker.register": "Registrar",
+  "locker.scanning": "Varrendo as motos…",
+  "locker.scanForSwaps": "Procurar sets",
+  "locker.orphanBanner":
+    "Faltam os arquivos de setup de {{bike}} — uma versão anterior moveu eles para uma pasta de swap, e isso impede a moto de carregar no jogo. {{files}}",
+  "locker.looseBanner_one":
+    "{{count}} set de modelo / som encontrado solto nas suas motos — registre ele em {{modelsFolder}} / {{soundsFolder}}.",
+  "locker.looseBanner_other":
+    "{{count}} sets de modelo / som encontrados soltos nas suas motos — registre eles em {{modelsFolder}} / {{soundsFolder}}.",
+  "locker.emptyTitle": "Ainda não há motos com troca disponível.",
+  "locker.emptyIntro":
+    "Duas coisas precisam ser verdade antes de uma troca acontecer:",
+  "locker.unpacked": "extraída",
+  "locker.emptyRuleUnpacked":
+    "A moto está {{unpacked}} em {{path}}— um {{pkz}} compactado não pode ser trocado. Extraia uma pela Biblioteca.",
+  "locker.emptyRuleMesh":
+    "Cada modelo alternativo fica na própria pasta dentro dessa moto e contém uma malha ({{edf}}). Coloque em qualquer lugar da pasta da moto e clique em Procurar abaixo — vamos oferecer arquivar em {{folder}}.",
+  "locker.summary": "{{model}} · som “{{sound}}”",
+  "locker.modelNamed": "modelo “{{name}}”",
+  "locker.noModelSwaps": "sem trocas de modelo",
+  "locker.models": "Modelos",
+  "locker.sounds": "Sons",
+  "locker.onlyOneModel": "Só um modelo — instale mais para poder trocar",
+  "locker.onlyStock": "Só Stock — instale um mod de som para poder trocar",
+  "locker.noModel": "Sem modelo",
+  "locker.stock": "Stock",
+  "locker.activeModel": "Modelo ativo",
+  "locker.activeSound": "Som ativo",
+  "locker.switchToNoModel":
+    "Mudar para nenhum modelo — remove os arquivos do modelo atual",
+  "locker.switchToStock":
+    "Mudar para Stock — remove o mod de som (toca o som original)",
+  "locker.missingModelEdf": "Este set não tem model.edf",
+  "locker.missingSoundFiles": "Falta engine.scl ou sfx.cfg neste set",
+  "locker.switchTo": "Mudar para {{name}}",
+  "locker.tiedToModel": "Vinculado ao modelo {{models}}",
+  "locker.boundHint":
+    "“{{sound}}” está vinculado ao modelo “{{model}}” — ele acompanha esse modelo. Clique para desvincular.",
+  "locker.unboundHint":
+    "Vincule o som ativo “{{sound}}” ao modelo “{{model}}” para que mudar pra ele traga o som junto.",
+  "locker.tieAction": "Vincular “{{sound}}” a “{{model}}”",
+  "locker.untieAction": "Desvincular “{{sound}}” de “{{model}}”",
+  "locker.restored": "Arquivos de setup de {{bike}} restaurados.",
+  "locker.restoredNote_one":
+    "{{count}} arquivo de volta no lugar — a moto deve carregar de novo.",
+  "locker.restoredNote_other":
+    "{{count}} arquivos de volta no lugar — a moto deve carregar de novo.",
+  "locker.switchedModel": "Modelo de {{bike}} mudado para “{{target}}”.",
+  "locker.switchedSound": "Som de {{bike}} mudado para “{{target}}”.",
+  "locker.tied": "“{{sound}}” vinculado ao modelo “{{model}}”.",
+  "locker.untied": "“{{sound}}” desvinculado do modelo “{{model}}”.",
+  "locker.refreshedLive": "Atualizado ao vivo dentro do jogo.",
+  "locker.refreshFailed":
+    "A atualização instantânea falhou — selecione seu perfil de novo no jogo para carregar.",
+  "locker.reselectProfile":
+    "Selecione seu perfil de novo no MX Bikes para carregar a troca.",
+  "locker.loadsNextTime": "Carrega na próxima vez que o jogo abrir.",
+
+  // ── Registro de sets soltos ────────────────────────────────────────────────
+  "swaps.model": "modelo",
+  "swaps.modelSets_one": "{{count}} troca de modelo",
+  "swaps.modelSets_other": "{{count}} trocas de modelo",
+  "swaps.soundSets_one": "{{count}} mod de som",
+  "swaps.soundSets_other": "{{count}} mods de som",
+  "swaps.and": "{{a}} e {{b}}",
+  "swaps.noSets": "0 sets",
+  "swaps.foundTitle": "Encontrados {{summary}}",
+  "swaps.description":
+    "Estas pastas estão soltas dentro das suas motos. Registre elas para mover cada uma para a biblioteca certa — {{modelsFolder}} para modelos, {{soundsFolder}} para sons — e aparecerem no Armário.",
+  "swaps.registered_one": "{{count}} set registrado.",
+  "swaps.registered_other": "{{count}} sets registrados.",
+  "swaps.nothingMoved": "Nada foi movido.",
+  "swaps.skipped_one": "{{count}} ignorado (nome já em uso).",
+  "swaps.skipped_other": "{{count}} ignorados (nomes já em uso).",
+  "swaps.foldersCreated_one":
+    "Pastas da biblioteca criadas para {{count}} moto.",
+  "swaps.foldersCreated_other":
+    "Pastas da biblioteca criadas para {{count}} motos.",
+  "swaps.foldersCreatedDesc":
+    "Suas pastas de modelo / som ficaram onde estavam.",
+  "swaps.justCreateFolders": "Só criar as pastas",
+  "swaps.registerAndMove": "Registrar e mover",
+  "swaps.fileCount_one": "{{count}} arquivo",
+  "swaps.fileCount_other": "{{count}} arquivos",
+
+  // ── Instalação ─────────────────────────────────────────────────────────────
+  "install.installed": "{{title}} instalado",
+  "install.reloadedDesc": "Jogo recarregado pelo FrostMod — já está valendo.",
+  "install.addedDesc": "Adicionado à sua biblioteca.",
+  "install.failed": "Falha na instalação — {{title}}",
+  "install.openModPage": "Abrir a página do mod",
+  "install.clickToOpen": "Clique para abrir a página do mod",
+
+  // ── Categorias (singular) ──────────────────────────────────────────────────
+  "category.track": "Pista",
+  "category.bike": "Moto",
+  "category.bikePaint": "Pintura",
+  "category.bikeModelSwap": "Troca de modelo",
+  "category.sound": "Som",
+  "category.helmet": "Capacete",
+  "category.helmetPaint": "Pintura do capacete",
+  "category.goggles": "Óculos",
+  "category.boots": "Botas",
+  "category.bootPaint": "Pintura das botas",
+  "category.protection": "Proteções",
+  "category.protectionPaint": "Pintura das proteções",
+  "category.gloves": "Luvas",
+  "category.outfit": "Uniforme / kit",
+  "category.misc": "Outros",
+
+  // ── Cabeçalhos de seção (plural) ───────────────────────────────────────────
+  "section.bikePaint": "Pinturas",
+  "section.bikeModelSwap": "Trocas de modelo",
+  "section.sound": "Sons",
+  "section.helmet": "Capacetes",
+  "section.helmetPaint": "Pinturas de capacete",
+  "section.boots": "Botas",
+  "section.bootPaint": "Pinturas de botas",
+  "section.protection": "Proteções",
+  "section.protectionPaint": "Pinturas de proteções",
+  "section.gloves": "Luvas",
+  "section.outfit": "Uniforme / kit",
+
+  // ── Destinos de instalação ─────────────────────────────────────────────────
+  "dest.bikesRoot": "Motos (raiz)",
+  "dest.tracksRoot": "Pistas (raiz)",
+  "dest.bikeFolder": "{{name}} — pasta da moto",
+  "dest.bikePaints": "{{name}} — pinturas",
+  "dest.helmetsNewModel": "Capacetes (modelo novo)",
+  "dest.bootsNewModel": "Botas (modelo novo)",
+  "dest.protectionNewModel": "Proteções (modelo novo)",
+  "dest.helmetPaintsFor": "{{name}} · pinturas de capacete",
+  "dest.gogglesFor": "{{name}} · óculos",
+  "dest.bootPaintsFor": "{{name}} · pinturas de botas",
+  "dest.protectionPaintsFor": "{{name}} · pinturas de proteções",
+  "dest.outfitFor": "{{name}} · uniforme / kit",
+  "dest.glovesFor": "{{name}} · luvas",
+};

--- a/src/lib/mods.ts
+++ b/src/lib/mods.ts
@@ -1,4 +1,5 @@
 /** Shared display helpers for mod names, dates, and folders. */
+import { getLocale, translate } from "../i18n/core";
 
 const MOD_EXT = /\.(pkz|zip|rar|7z|pnt)$/i;
 
@@ -9,14 +10,14 @@ export function displayName(name: string): string {
 
 /** Human folder label; the type root shows as "(root)". */
 export function folderLabel(folder: string): string {
-  return folder || "(root)";
+  return folder || translate(getLocale(), "library.rootFolder");
 }
 
-/** Compact "Jul 8, 2026" date. */
+/** Compact "Jul 8, 2026" date, in the app's language — not the OS's. */
 export function formatDate(iso: string): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return "";
-  return d.toLocaleDateString(undefined, {
+  return d.toLocaleDateString(getLocale(), {
     month: "short",
     day: "numeric",
     year: "numeric",
@@ -27,7 +28,7 @@ export function formatDate(iso: string): string {
 export function formatDateShort(iso: string): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return "";
-  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  return d.toLocaleDateString(getLocale(), { month: "short", day: "numeric" });
 }
 
 /** Best-guess file format (e.g. ".pkz") from a download URL. */

--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -1,4 +1,5 @@
 import type { BikeModels, LibraryEntry, Loadout } from "../types";
+import type { TKey } from "../i18n";
 import {
   scanLibrary,
   scanRiderTargets,
@@ -8,7 +9,8 @@ import {
 
 export interface SlotDef {
   key: keyof Loadout;
-  label: string;
+  /** Translation key — resolved with `t()` at render. */
+  label: TKey;
   group: "bike" | "rider" | "head" | "body";
   /** Which other slot this slot's options depend on (for dependent dropdowns). */
   dependsOn?: "bikeid" | "helmet" | "boots" | "protection" | "rider";
@@ -17,29 +19,34 @@ export interface SlotDef {
 }
 
 export const SLOTS: SlotDef[] = [
-  { key: "paint", label: "Bike livery", group: "bike", dependsOn: "bikeid" },
-  { key: "modelSwap", label: "Model swap", group: "bike", dependsOn: "bikeid" },
-  { key: "bikeFont", label: "Number font", group: "bike", freeText: true },
-  { key: "tyres", label: "Tyres", group: "bike" },
-  { key: "rider", label: "Rider profile", group: "rider" },
-  { key: "suitPaint", label: "Kit / suit", group: "rider", dependsOn: "rider" },
-  { key: "suitFont", label: "Suit font", group: "rider", freeText: true },
-  { key: "glovesPaint", label: "Gloves", group: "rider" },
-  { key: "ridingStyle", label: "Riding style", group: "rider" },
-  { key: "helmet", label: "Helmet", group: "head" },
-  { key: "helmetPaint", label: "Helmet paint", group: "head", dependsOn: "helmet" },
-  { key: "gogglesPaint", label: "Goggles", group: "head", dependsOn: "helmet" },
-  { key: "boots", label: "Boots", group: "body" },
-  { key: "bootsPaint", label: "Boot paint", group: "body", dependsOn: "boots" },
-  { key: "protection", label: "Protection", group: "body" },
-  { key: "protectionPaint", label: "Protection paint", group: "body", dependsOn: "protection" },
+  { key: "paint", label: "slot.paint", group: "bike", dependsOn: "bikeid" },
+  { key: "modelSwap", label: "slot.modelSwap", group: "bike", dependsOn: "bikeid" },
+  { key: "bikeFont", label: "slot.bikeFont", group: "bike", freeText: true },
+  { key: "tyres", label: "slot.tyres", group: "bike" },
+  { key: "rider", label: "slot.rider", group: "rider" },
+  { key: "suitPaint", label: "slot.suitPaint", group: "rider", dependsOn: "rider" },
+  { key: "suitFont", label: "slot.suitFont", group: "rider", freeText: true },
+  { key: "glovesPaint", label: "slot.glovesPaint", group: "rider" },
+  { key: "ridingStyle", label: "slot.ridingStyle", group: "rider" },
+  { key: "helmet", label: "slot.helmet", group: "head" },
+  { key: "helmetPaint", label: "slot.helmetPaint", group: "head", dependsOn: "helmet" },
+  { key: "gogglesPaint", label: "slot.gogglesPaint", group: "head", dependsOn: "helmet" },
+  { key: "boots", label: "slot.boots", group: "body" },
+  { key: "bootsPaint", label: "slot.bootsPaint", group: "body", dependsOn: "boots" },
+  { key: "protection", label: "slot.protection", group: "body" },
+  {
+    key: "protectionPaint",
+    label: "slot.protectionPaint",
+    group: "body",
+    dependsOn: "protection",
+  },
 ];
 
-export const SLOT_GROUPS: { id: SlotDef["group"]; label: string }[] = [
-  { id: "bike", label: "Bike" },
-  { id: "rider", label: "Rider" },
-  { id: "head", label: "Head" },
-  { id: "body", label: "Body" },
+export const SLOT_GROUPS: { id: SlotDef["group"]; label: TKey }[] = [
+  { id: "bike", label: "slotGroup.bike" },
+  { id: "rider", label: "slotGroup.rider" },
+  { id: "head", label: "slotGroup.head" },
+  { id: "body", label: "slotGroup.body" },
 ];
 
 export const EMPTY_LOADOUT: Loadout = {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,17 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import { ErrorBoundary } from "./Components/ErrorBoundary";
+import { I18nProvider } from "./i18n";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <ErrorBoundary label="root">
-      <App />
-    </ErrorBoundary>
+    {/* Outside the boundary's child so the boundary's own fallback copy is
+        translated too. */}
+    <I18nProvider>
+      <ErrorBoundary label="root">
+        <App />
+      </ErrorBoundary>
+    </I18nProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
Adds a translation layer and ships **Italian, Spanish, French, German and Brazilian Portuguese** alongside English — 535 keys each, covering every screen, dialog, toast and empty state.

Pick a language under **Settings → Appearance**. The choice persists; `System` follows the OS (a bare `pt` resolves to Brazilian, the only Portuguese we ship).

## How it's built

`src/i18n/` is split three ways so the module stays a valid Fast Refresh boundary:

| File | Holds |
|---|---|
| `core.ts` | dictionaries, lookup, plurals, formatting |
| `context.ts` | context + `useT` / `useI18n` |
| `index.tsx` | components only (`I18nProvider`, `Trans`) |

Without that split, editing any locale file force-reloaded the whole app — the files a translator touches most. This mirrors the existing `Context/FrostmodContext.ts` ⁄ `Context/Frostmod.tsx` split.

**No new dependency.** Each locale is typed `Record<keyof typeof en, string>`, so a key missing from — or invented in — any translation is a compile error rather than a runtime blank. A green `typecheck` is proof that all six locales are complete and consistent. That guarantee is the reason for ~120 lines of local code instead of i18next, where a missing key is a runtime miss plus a separate lint plugin.

## Decisions worth reviewing

- **Plurals use `Intl.PluralRules`, not `n === 1`.** French treats 0 as singular; the ~16 hand-rolled `${n} item${n === 1 ? "" : "s"}` sites this replaces got that wrong.
- **`<Trans>` for sentences that wrap markup**, splicing React nodes into placeholders so word order stays the translator's choice. Splitting into prefix/suffix strings would hard-code English grammar. Same reasoning turned the preset-apply toast from a fragment (`Applied X to Y — {note}`) into four whole sentences.
- **A separate inline noun form on mod types.** "Search tracks…" used `label.toLowerCase()`, which produces broken German — its nouns are capitalized everywhere.
- **Dates follow the in-app language, not the OS**, via a locale mirrored outside React so the pure helpers in `lib/mods` keep their signatures.
- **Terminology follows the MX Bikes community**, not the dictionary: `mod`, `setup`, `preset` and `Stock` stay as loanwords in every language; gear is translated (`casco`/`casque`/`Helm`, `maschera`/`masque`/`Brille` for goggles, `livrea`/`déco`/`Lackierung` for a bike paint).

## Verification

- `npm run typecheck` — clean. This is the real test: it proves no locale is missing a key.
- `npm run lint` — 3 warnings, byte-identical to `main`'s baseline. None introduced.
- Ran the app and switched languages; also confirmed with a live HMR check that editing a locale now hot-updates rather than reloading.

## Known gaps

- **German layout is unverified.** German runs ~30% longer than English — the 216px sidebar, the Browse segmented control (`Strecken / Motorräder / Fahrer`) and the Settings toggle rows are the likely clipping spots.
- **Rust-side error strings stay English.** ~150 strings in `src-tauri` reach the UI as `String(e)` toast descriptions. Deliberately scoped out.
- **Native-speaker review wanted** on "Locker" (rendered literally in all five) and German `Motorräder` vs. the shorter community `Bikes`.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)