### PR TITLE
fix(viewer): re-resolve the rider preview when goggle paint changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
   — it never becomes a value in your loadout, since the game names a `.pnt` there and has
   no word for "the model's own look".
 ### Fixed
+- **Picking a goggle paint now updates the 3D preview on its own.** The Rider tab's
+  preview re-resolves the model whenever a rider slot changes, but the list of slots it
+  watched never included the goggles — so choosing a lens did nothing on screen, and the
+  new paint only appeared once you touched some *other* slot (helmet paint, boots) and
+  dragged the goggles along with it. The backend had been reading the goggle paint
+  correctly the whole time; it was simply never asked to.
 - **Downloads that Google Drive refuses now say why, instead of "the host returned a web
   page".** Hitting a popular mod (Flow Series #1 FlowiCompound, for one) gave a message
   that blamed the page and told you to download it manually — but Drive was answering the

--- a/src/Components/Viewer/ViewerPanel.tsx
+++ b/src/Components/Viewer/ViewerPanel.tsx
@@ -74,6 +74,7 @@ export function ViewerPanel({
         loadout.rider,
         loadout.helmet,
         loadout.helmetPaint,
+        loadout.gogglesPaint,
         loadout.boots,
         loadout.bootsPaint,
         loadout.protection,


### PR DESCRIPTION
## What

Selecting a goggle paint in the **Rider** tab did nothing to the 3D preview. The new paint only showed up once you changed some *other* slot — pick goggles, then switch helmet paint, and the goggles would finally swap too.

## Why

`ViewerPanel` derives a `riderKey` from every rider-affecting slot and re-resolves the model when it changes. `gogglesPaint` was never in that list:

```
loadout.rider, loadout.helmet, loadout.helmetPaint,
loadout.boots, loadout.bootsPaint,
loadout.protection, loadout.protectionPaint,
loadout.suitPaint, loadout.glovesPaint
```

So a goggles-only change left the key identical and the effect never fired. Touching another slot moved the key and carried the pending goggle paint along — which is what made it look like an ordering quirk between goggles and helmet.

The backend was never at fault: `load_rider_model` already reads `goggles_paint`. It just wasn't being asked.

## Scope

One line. `ViewerPanel` has a single consumer — the Rider tab (`RiderStudio.tsx:241`) — so that is the whole blast radius. The Library's "View in 3D" goes through `ViewerDialog`, which resolves entries by path and was never affected.

## Verification

- `tsc --noEmit` clean.
- Ran the app from a worktree build. Backend logs confirm the re-resolve now fires on a goggles-only change (helmet paint held constant across each pair):

```
paint=Some("MONSTER JA21") goggles=None
paint=Some("MONSTER JA21") goggles=Some("100% Digi Purple")   <- fires now
paint=Some("PUSH Blue")    goggles=Some("100% Digi Purple")
paint=Some("PUSH Blue")    goggles=Some("100% CLARK")          <- fires now
paint=Some("PUSH Blue")    goggles=Some("Oakley Crackle")      <- fires now
```

- Confirmed visually in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)