### PR TITLE
fix(viewer): bind each bike part to its real texture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 2026-08-08
+
+### Fixed
+- **Bikes whose bodywork came out in the wrong texture.** A part's material index was read
+  as a position in the model's texture list in the order the exporter happened to write
+  them, which only matches on bikes that were written in material order. The 2023 Kawasaki
+  KX250/KX450 store `w_plate` between `metals` and `plastics`, so their entire bodywork
+  wore the blank number-plate texture and an installed paint changed nothing visible. The
+  model's own material table now decides, which also fixes the Yamaha YZ125/YZ250, where
+  the chassis and the engine had swapped textures.
+- **The front fender and fork guards rendering in bare metal.** A mesh group can hold
+  several materials as contiguous ranges — a fork leg and the plastic guard on it, a
+  triple clamp and the fender — and we merged each group into one submesh, so every range
+  wore the first one's texture. Each range now binds its own.
+
+### Changed
+- **Library thumbnails show a bike's manufacturer logo.** A bike's 250x250 `logo.tga` was
+  losing a scoring tie to `team.tga`, a 32x64 strip, so bikes showed a coloured sliver. A
+  real preview image still wins where a mod ships one. Cached thumbnails are rebuilt.
+- **Hovering a name in the Library shows the full name, folder and location.** The row
+  truncates hard, and the folder id is what you need when matching a paint to its bike.
+
 ## 2026-08-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@
   KX250/KX450 store `w_plate` between `metals` and `plastics`, so their entire bodywork
   wore the blank number-plate texture and an installed paint changed nothing visible. The
   model's own material table now decides, which also fixes the Yamaha YZ125/YZ250, where
-  the chassis and the engine had swapped textures.
+  the chassis and the engine had swapped textures. Neither reading is right on every bike,
+  so where they disagree the mesh breaks the tie: a part's UV layout only lines up with
+  the atlas it was drawn against, and each part is asked separately, since a bike's parts
+  need not agree — the YZ125's chassis reads through the table while its steering reads
+  straight off the texture order. That puts the KTM 125 SX back on its plastics too.
 - **The front fender and fork guards rendering in bare metal.** A mesh group can hold
   several materials as contiguous ranges — a fork leg and the plastic guard on it, a
   triple clamp and the fender — and we merged each group into one submesh, so every range

--- a/src-tauri/src/edf.rs
+++ b/src-tauri/src/edf.rs
@@ -419,6 +419,97 @@ const MAT_STRIDE: usize = 56;
 const MAT_TEX_FROM_REC: usize = 44;
 const MAX_MATERIALS: usize = 64;
 
+/// Side of the square grid the UV-fit test works on. Coarse on purpose: it asks which
+/// atlas a part was drawn against, not where exactly, and stays cheap on a 4096² texture.
+pub const FIT_RES: usize = 128;
+
+/// The texels an artist actually drew on: those differing from the texture's dominant
+/// colour, which for a bike atlas is the flat backdrop its islands are laid out on.
+/// None when the texture won't inflate, or is so uniform there's nothing to match
+/// against — MX Bikes' `w_plate` is a blank overlay the game composites numbers onto.
+pub fn content_mask(b: &[u8], t: &EmbeddedTexture) -> Option<Vec<bool>> {
+    let rgba = inflate_texture(b, t)?;
+    let (w, h) = (t.width as usize, t.height as usize);
+    if w == 0 || h == 0 || rgba.len() < w * h * 4 {
+        return None;
+    }
+    // Nearest-neighbour down to FIT_RES, quantised so near-identical backdrop shades
+    // land in one bucket.
+    let mut cell = Vec::with_capacity(FIT_RES * FIT_RES);
+    let mut hist: std::collections::HashMap<(u8, u8, u8), usize> = Default::default();
+    for y in 0..FIT_RES {
+        for x in 0..FIT_RES {
+            let sx = x * w / FIT_RES;
+            let sy = y * h / FIT_RES;
+            let p = (sy * w + sx) * 4;
+            let q = (rgba[p] / 24, rgba[p + 1] / 24, rgba[p + 2] / 24);
+            *hist.entry(q).or_default() += 1;
+            cell.push(q);
+        }
+    }
+    let bg = hist.into_iter().max_by_key(|(_, n)| *n)?.0;
+    let mask: Vec<bool> = cell
+        .iter()
+        .map(|q| {
+            q.0.abs_diff(bg.0) as u32 + q.1.abs_diff(bg.1) as u32 + q.2.abs_diff(bg.2) as u32 > 1
+        })
+        .collect();
+    let inked = mask.iter().filter(|m| **m).count();
+    (inked * 20 > mask.len()).then_some(mask)
+}
+
+/// Which texels a triangle range samples, on the same grid. UVs wrap; a triangle that
+/// straddles a tile edge is skipped rather than smeared across the atlas.
+pub fn uv_coverage(node: &EdfNode, tri_start: u32, tri_count: u32) -> Vec<bool> {
+    let mut hit = vec![false; FIT_RES * FIT_RES];
+    let lo = tri_start as usize * 3;
+    let hi = (lo + tri_count as usize * 3).min(node.indices.len());
+    let at = |i: u32| -> (f32, f32) {
+        let k = i as usize * 2;
+        let (u, v) = (node.uvs[k], node.uvs[k + 1]);
+        (u.rem_euclid(1.0) * (FIT_RES - 1) as f32, v.rem_euclid(1.0) * (FIT_RES - 1) as f32)
+    };
+    for t in node.indices[lo..hi].chunks_exact(3) {
+        if t.iter().any(|i| (*i as usize) * 2 + 1 >= node.uvs.len()) {
+            continue;
+        }
+        let p = [at(t[0]), at(t[1]), at(t[2])];
+        let (x0, x1) = (
+            p.iter().fold(f32::MAX, |a, q| a.min(q.0)),
+            p.iter().fold(f32::MIN, |a, q| a.max(q.0)),
+        );
+        let (y0, y1) = (
+            p.iter().fold(f32::MAX, |a, q| a.min(q.1)),
+            p.iter().fold(f32::MIN, |a, q| a.max(q.1)),
+        );
+        let half = (FIT_RES / 2) as f32;
+        if x1 - x0 > half || y1 - y0 > half {
+            continue; // wrapped across the seam
+        }
+        let area = (p[1].0 - p[0].0) * (p[2].1 - p[0].1) - (p[2].0 - p[0].0) * (p[1].1 - p[0].1);
+        if area.abs() < 1e-6 {
+            continue;
+        }
+        for y in y0.floor().max(0.0) as usize..=(y1.ceil() as usize).min(FIT_RES - 1) {
+            for x in x0.floor().max(0.0) as usize..=(x1.ceil() as usize).min(FIT_RES - 1) {
+                let (px, py) = (x as f32 + 0.5, y as f32 + 0.5);
+                let w0 = (p[1].0 - p[0].0) * (py - p[0].1) - (px - p[0].0) * (p[1].1 - p[0].1);
+                let w1 = (p[2].0 - p[1].0) * (py - p[1].1) - (px - p[1].0) * (p[2].1 - p[1].1);
+                let w2 = (p[0].0 - p[2].0) * (py - p[2].1) - (px - p[2].0) * (p[0].1 - p[2].1);
+                let inside = if area > 0.0 {
+                    w0 >= 0.0 && w1 >= 0.0 && w2 >= 0.0
+                } else {
+                    w0 <= 0.0 && w1 <= 0.0 && w2 <= 0.0
+                };
+                if inside {
+                    hit[y * FIT_RES + x] = true;
+                }
+            }
+        }
+    }
+    hit
+}
+
 /// PARTIALLY VERIFIED — which colour texture each material draws from, by position in
 /// `embedded_textures`' colour list; None where the material carries no texture.
 ///

--- a/src-tauri/src/edf.rs
+++ b/src-tauri/src/edf.rs
@@ -410,6 +410,45 @@ pub struct EmbeddedTexture {
     pub data_len: usize, // compressed byte length
 }
 
+// Material table, right after the file header: | u32 count @ 0x1c | count records |,
+// each 56 bytes holding six 1.0f shading terms and, at +44, a ONE-BASED index into the
+// model's colour textures (0 = untextured). The mesh data starts where the table ends.
+const MAT_COUNT_OFF: usize = 0x1c;
+const MAT_TABLE_OFF: usize = 0x20;
+const MAT_STRIDE: usize = 56;
+const MAT_TEX_FROM_REC: usize = 44;
+const MAX_MATERIALS: usize = 64;
+
+/// PARTIALLY VERIFIED — which colour texture each material draws from, by position in
+/// `embedded_textures`' colour list; None where the material carries no texture.
+///
+/// Texture blobs are written in the exporter's order, not the material order — the
+/// KX250/KX450 store `w_plate` between `metals` and `plastics`, so reading a material
+/// index as a blob position puts the number plate over the bodywork. This table reads as
+/// a permutation on all 60 OEM bikes and is confirmed against UV layouts on the KX250,
+/// KX450 and YZ125 — but it disagrees with them on the KTM 125 SX, where material 0 is
+/// `plastics` and this claims `125_metals`. Empty when the header doesn't parse.
+pub fn material_slots(b: &[u8], colors: usize) -> Vec<Option<usize>> {
+    if b.len() < MAT_COUNT_OFF + 4 {
+        return Vec::new();
+    }
+    let count = u32le(b, MAT_COUNT_OFF) as usize;
+    if count == 0 || count > MAX_MATERIALS || MAT_TABLE_OFF + MAT_STRIDE * count > b.len() {
+        return Vec::new();
+    }
+    let mut out = Vec::with_capacity(count);
+    for k in 0..count {
+        let one_based = u32le(b, MAT_TABLE_OFF + MAT_STRIDE * k + MAT_TEX_FROM_REC) as usize;
+        // Past the colour list means this isn't the table we think it is — refuse the lot
+        // rather than bind half a bike from a misread header.
+        if one_based > colors {
+            return Vec::new();
+        }
+        out.push(one_based.checked_sub(1));
+    }
+    out
+}
+
 // Record layout from `width`: | width u32 | height u32 | md5[16] | u32 | data_size u32 | pad[8] | data |
 // data_size counts the 8 pad bytes, so payload = data_size - 8.
 const TEX_SIZE_FROM_W: usize = 28;
@@ -528,29 +567,36 @@ fn read_node(
         normals.push(f32le(b, normal_base + i * 12 + 8));
     }
 
-    let mut raw_subs = detect_submeshes(b, cands, iend, raw_tris, vc);
-    // A skinned mesh (rider body) is ONE group whose contiguous ranges are distinct
-    // materials; split it back out so each material can bind its own texture.
-    if raw_subs.len() == 1 && raw_subs[0].tri_count == raw_tris {
-        if let Some(ranges) = read_sub_group_ranges(b, raw_subs[0].block_off, raw_tris, vc) {
-            if ranges.len() > 1 {
-                let (name, block_off) = (raw_subs[0].name.clone(), raw_subs[0].block_off);
-                raw_subs = ranges
-                    .into_iter()
-                    .enumerate()
-                    .map(|(i, (ts, tc, vs2, vc2))| RawSub {
-                        name: name.clone(),
-                        tri_start: ts,
-                        tri_count: tc,
-                        block_off,
-                        vert_start: vs2,
-                        vert_count: vc2,
-                        mat: Some(i as u32),
-                    })
-                    .collect();
-            }
-        }
-    }
+    // A group can carry SEVERAL materials as contiguous ranges — a fork leg and the
+    // plastic guard strapped to it, a triple clamp and the front fender, a skinned rider
+    // body and its kit. Merging those into one submesh makes every range wear the first
+    // range's texture (the KX250's front fender comes out in bare metal), so split them
+    // back out and let each bind its own. Ranges number upward from the group's material.
+    let raw_subs: Vec<RawSub> = detect_submeshes(b, cands, iend, raw_tris, vc)
+        .into_iter()
+        .flat_map(|s| {
+            let ranges = read_sub_group_ranges(b, s.block_off, raw_tris, vc)
+                .filter(|r| r.len() > 1);
+            let Some(ranges) = ranges else { return vec![s] };
+            let base = s
+                .mat
+                .or_else(|| s.block_off.checked_sub(4).map(|o| u32le(b, o)))
+                .unwrap_or(0);
+            ranges
+                .into_iter()
+                .enumerate()
+                .map(|(i, (ts, tc, vs2, vc2))| RawSub {
+                    name: s.name.clone(),
+                    tri_start: ts,
+                    tri_count: tc,
+                    block_off: s.block_off,
+                    vert_start: vs2,
+                    vert_count: vc2,
+                    mat: Some(base + i as u32),
+                })
+                .collect()
+        })
+        .collect();
     // Covers the node when the submesh triangle counts sum to the raw total.
     let covers = !raw_subs.is_empty() && raw_subs.iter().map(|s| s.tri_count).sum::<usize>() == raw_tris;
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -629,11 +629,9 @@ fn bind_textures(
     node_part: &std::collections::HashMap<String, String>,
 ) {
     let embedded = edf::embedded_textures(edf_bytes);
-    // A submesh's material index selects its colour texture by position in the model's
-    // COLOUR-texture pool, in file order (verified against every OEM bike: plastics=0,
-    // metals=1, w_plate=2, …). The pool is every embedded texture that isn't a companion
-    // map — MX Bikes names those `_n` (normal), `_s` (specular) and `_r` (reflection).
-    // The pool must include gfx-referenced textures (chain, w_plate): the index counts
+    // The model's COLOUR textures, in file order — every embedded texture that isn't a
+    // companion map (MX Bikes names those `_n` normal, `_s` specular, `_r` reflection).
+    // The list keeps gfx-referenced textures (chain, w_plate): material indices count
     // them, so dropping any shifts every later material onto the wrong texture.
     let color: Vec<&edf::EmbeddedTexture> = embedded
         .iter()
@@ -642,12 +640,29 @@ fn bind_textures(
             !n.ends_with("_n") && !n.ends_with("_s") && !n.ends_with("_r")
         })
         .collect();
+    // material index -> colour texture. Set MXB_MAT_TABLE=0 to fall back to blob order.
+    let slots = match std::env::var("MXB_MAT_TABLE").as_deref() {
+        Ok("0") => Vec::new(),
+        _ => edf::material_slots(edf_bytes, color.len()),
+    };
 
     for n in nodes.iter_mut() {
         let part = node_part.get(&n.name.to_ascii_lowercase());
         let overrides = part.and_then(|p| gfx.get(p)).map(|p| &p.textures);
-        // A node with no submesh table is a single material — the primary body texture
-        // (plastics, by convention the first colour texture).
+        // A part that draws on ONE material numbers it 0 whichever material that is, so
+        // the index says nothing to look up — the YZ125 numbers its chassis' plastics 0
+        // and, in the rear suspension, its metals 0 too. Only a part that distinguishes
+        // materials at all gets resolved through the table.
+        let spread: std::collections::HashSet<u32> =
+            n.submeshes.iter().filter_map(|s| s.mat).collect();
+        let by_table = spread.len() > 1;
+        let texture_for = |mat: usize| -> Option<&edf::EmbeddedTexture> {
+            match slots.get(mat).filter(|_| by_table) {
+                Some(slot) => slot.and_then(|s| color.get(s)).copied(),
+                None => color.get(mat).copied(),
+            }
+        };
+        // A node with no submesh table is a single material — the first colour texture.
         n.texture = color.first().map(|t| t.name.clone());
         for sm in n.submeshes.iter_mut() {
             let group = sm.name.to_ascii_lowercase();
@@ -659,8 +674,8 @@ fn bind_textures(
                 sm.texture = Some(tex.clone());
                 continue;
             }
-            // 2. Ground truth: the material index picks the colour texture in file order.
-            if let Some(t) = sm.mat.and_then(|i| color.get(i as usize)) {
+            // 2. The material index picks its colour texture, via the table where usable.
+            if let Some(t) = sm.mat.and_then(|i| texture_for(i as usize)) {
                 sm.texture = Some(t.name.clone());
                 continue;
             }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -640,11 +640,28 @@ fn bind_textures(
             !n.ends_with("_n") && !n.ends_with("_s") && !n.ends_with("_r")
         })
         .collect();
-    // material index -> colour texture. Set MXB_MAT_TABLE=0 to fall back to blob order.
+    // Two readings of a material index compete: its position in the blob list above, and
+    // whatever the header's material table maps it to. Neither is right everywhere — blob
+    // order puts the number plate over the KX250's bodywork, the table puts the KTM 125
+    // SX's cables on it — so the mesh itself breaks the tie below, per part.
     let slots = match std::env::var("MXB_MAT_TABLE").as_deref() {
         Ok("0") => Vec::new(),
         _ => edf::material_slots(edf_bytes, color.len()),
     };
+    let disputed: Vec<usize> = (0..color.len())
+        .filter(|i| matches!(slots.get(*i), Some(Some(j)) if j != i))
+        .collect();
+    // Only the disputed textures get inflated, and only on the bikes that disagree.
+    let ink: std::collections::HashMap<usize, Vec<bool>> = disputed
+        .iter()
+        .flat_map(|i| [*i, slots[*i].unwrap_or(*i)])
+        .collect::<std::collections::BTreeSet<usize>>()
+        .into_iter()
+        .filter_map(|slot| {
+            let mask = color.get(slot).and_then(|t| edf::content_mask(edf_bytes, t))?;
+            Some((slot, mask))
+        })
+        .collect();
 
     for n in nodes.iter_mut() {
         let part = node_part.get(&n.name.to_ascii_lowercase());
@@ -652,10 +669,53 @@ fn bind_textures(
         // A part that draws on ONE material numbers it 0 whichever material that is, so
         // the index says nothing to look up — the YZ125 numbers its chassis' plastics 0
         // and, in the rear suspension, its metals 0 too. Only a part that distinguishes
-        // materials at all gets resolved through the table.
+        // materials at all is worth resolving.
         let spread: std::collections::HashSet<u32> =
             n.submeshes.iter().filter_map(|s| s.mat).collect();
-        let by_table = spread.len() > 1;
+        // Ask the geometry which reading it was drawn for: for every disputed material,
+        // how much of what this part samples lands on texels the artist actually inked.
+        // The parts of one bike need not agree — the YZ125's chassis reads through the
+        // table while its steering reads straight off the blob list.
+        let mut table_fit = 0f64;
+        let mut blob_fit = 0f64;
+        if spread.len() > 1 {
+            for mat in spread.iter().map(|m| *m as usize).filter(|m| disputed.contains(m)) {
+                let mut seen = vec![false; edf::FIT_RES * edf::FIT_RES];
+                for sm in n.submeshes.iter().filter(|s| s.mat == Some(mat as u32)) {
+                    for (dst, src) in seen
+                        .iter_mut()
+                        .zip(edf::uv_coverage(n, sm.tri_start, sm.tri_count))
+                    {
+                        *dst |= src;
+                    }
+                }
+                let area = seen.iter().filter(|s| **s).count();
+                if area == 0 {
+                    continue;
+                }
+                // A blank overlay (`w_plate`, which the game composites numbers onto) has
+                // no islands to land on and so scores nothing — it can only ever lose a
+                // comparison, never win one.
+                let landed = |slot: usize| {
+                    ink.get(&slot).map_or(0.0, |m| {
+                        seen.iter().zip(m).filter(|(s, i)| **s && **i).count() as f64
+                    })
+                };
+                let Some(Some(via_table)) = slots.get(mat).copied() else { continue };
+                table_fit += landed(via_table);
+                blob_fit += landed(mat);
+            }
+        }
+        let by_table = spread.len() > 1 && table_fit > blob_fit;
+        if table_fit != blob_fit {
+            log::info!(
+                "[viewer] node '{}' reads its materials through the {} (fit {:.0} vs {:.0})",
+                n.name,
+                if by_table { "material table" } else { "texture order" },
+                table_fit.max(blob_fit),
+                table_fit.min(blob_fit),
+            );
+        }
         let texture_for = |mat: usize| -> Option<&edf::EmbeddedTexture> {
             match slots.get(mat).filter(|_| by_table) {
                 Some(slot) => slot.and_then(|s| color.get(s)).copied(),

--- a/src-tauri/src/pkz.rs
+++ b/src-tauri/src/pkz.rs
@@ -196,7 +196,8 @@ fn write_cache(cache_file: &Path, path: &str, stamp: Stamp, meta: &PkzMeta) {
 
 /// Bumped when the key changes shape, so stale entries are ignored rather than
 /// misread. The previous generation was keyed on the absolute path.
-const CACHE_DIR: &str = "pkz-meta-v2";
+// v3: image ranking now prefers a bike's `logo.tga`, so v2 thumbnails are stale.
+const CACHE_DIR: &str = "pkz-meta-v3";
 
 fn cache_path(app: &tauri::AppHandle, source: &str, stamp: Stamp) -> Option<PathBuf> {
     let cache_root = app.path().app_cache_dir().ok()?;
@@ -209,11 +210,13 @@ fn cache_path(app: &tauri::AppHandle, source: &str, stamp: Stamp) -> Option<Path
     Some(cache_root.join(CACHE_DIR).join(format!("{:016x}.json", hasher.finish())))
 }
 
-/// Clear out the path-keyed generation once per run — nothing will ever read it again.
+/// Clear out superseded generations once per run — nothing will ever read them again.
 fn drop_stale_cache(cache_root: &Path) {
     static ONCE: Once = Once::new();
     ONCE.call_once(|| {
-        let _ = std::fs::remove_dir_all(cache_root.join("pkz-meta"));
+        for old in ["pkz-meta", "pkz-meta-v2"] {
+            let _ = std::fs::remove_dir_all(cache_root.join(old));
+        }
     });
 }
 
@@ -481,6 +484,12 @@ fn image_score(name: &str) -> i32 {
     }
     if n.contains("image") || n.contains("info") || n.contains("thumb") {
         score += 10;
+    }
+    // A bike ships its manufacturer mark as `logo.tga` — a real thumbnail, and far better
+    // than the `team.tga` strip (32x64 on the OEM Kawasaki) it would otherwise tie with.
+    // Below a genuine preview, which stays the first choice when the mod has one.
+    if n.contains("logo") {
+        score += 5;
     }
     // Browser-native formats are cheaper/safer to decode than TGA.
     if n.ends_with(".png") || n.ends_with(".jpg") || n.ends_with(".jpeg") {

--- a/src/Components/Library/Library.tsx
+++ b/src/Components/Library/Library.tsx
@@ -34,6 +34,7 @@ import {
   RIDER_SECTION_ORDER,
   categoryIcon,
 } from "./categories";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import LibraryDetail from "./LibraryDetail";
 import { ViewerDialog } from "../Viewer/ViewerDialog";
 import { entryViewerProps } from "../Viewer/entryViewer";
@@ -128,6 +129,8 @@ function LibraryCardBody({
   }, [item.path, cacheKey, tile]);
 
   const title = meta?.name?.trim() || displayName(item.name);
+  const folder = item.name;
+  const location = meta?.location?.trim();
   const parts: string[] = [];
   if (meta?.author) parts.push(`by ${meta.author}`);
   if (meta?.length) parts.push(formatLength(meta.length));
@@ -155,12 +158,18 @@ function LibraryCardBody({
         )}
       </div>
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span
-          className="truncate text-[13px] font-semibold"
-          title={meta?.location?.trim() || item.name}
-        >
-          {title}
-        </span>
+        {/* The row truncates hard at this width, so the hover carries the full name and
+            the folder it actually lives in — the id you need when matching paints. */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="w-fit max-w-full truncate text-[13px] font-semibold">{title}</span>
+          </TooltipTrigger>
+          <TooltipContent side="top" align="start" className="max-w-sm">
+            <p className="font-semibold">{title}</p>
+            {folder !== title && <p className="text-muted-foreground">{folder}</p>}
+            {location && <p className="text-muted-foreground">{location}</p>}
+          </TooltipContent>
+        </Tooltip>
         <span className="truncate text-[11px] text-muted-foreground" title={subtitle}>
           {subtitle}
         </span>


### PR DESCRIPTION
The 3D preview was putting the wrong texture on whole sections of some bikes. Reported against the 2023 Kawasaki KX250, where an installed paint appeared to do nothing.

## What was wrong

**Bodywork wearing the number-plate texture.** A submesh's material index was resolved as a position in the model's colour-texture list *in the order the exporter wrote the blobs*. Those two orders only coincide on bikes written in material order. The KX250/KX450 store `w_plate` between `metals` and `plastics`, so:

| submesh | is | bound to (before) |
| --- | --- | --- |
| `Frame Plastics` (8074 tris) | the entire bodywork | `w_plate` |
| `Frame Plastics.001` (488 tris) | number plates | `plastics` |
| `Swingarm` (2nd range) | chain guard | `w_plate` |

Nothing on the bike sampled `plastics`, so a paint that repaints it changed nothing — the reported symptom.

**Front fender in bare metal.** Separately, a mesh group can hold several materials as contiguous ranges — `Fork Upper.006` is 3056 + 5018 triangles, a triple clamp and the front fender. We merged each group into a single submesh, so every range inherited the first one's texture. Each range now binds its own, which also fixes the fork guards.

## How a part's texture is chosen now

Two readings of a material index compete: its position in the blob list, and whatever the mesh header's material table maps it to. **Neither is right on every bike** — blob order breaks the KX250, the table breaks the KTM 125 SX — so where they disagree, the geometry decides: a part's UV layout only lines up with the atlas it was drawn against, so each disputed material's UV footprint is scored against the texels the artist actually inked, and the reading that lands on more of them wins.

The decision is **per part, not per bike**, because a bike's parts need not agree: the YZ125's chassis reads through the table while its steering reads straight off the texture order, and both are confirmed against their UV layouts. Only disputed textures are inflated, and only on the 16 of 60 OEM bikes whose two readings differ at all.

## Verification

Bindings were checked by rasterising a part's UV triangles and outlining them over each candidate atlas — the correct texture is the one whose islands the outline traces. Confirmed on the KX250, KX450, YZ125 (chassis, forks, swingarm, steering) and the KTM 125 SX chassis.

Fleet sweep over all 60 installed OEM bikes: no bike binds a majority of its parts to the plate texture, and bikes whose two readings agree are untouched.

`cargo test` — 156 pass.

## Known gap

The **KTM 125 SX steering** still reads through the table and puts its cables on `w_plate`. The ink test can't separate a blank overlay — `w_plate` is transparent, a backdrop the game composites numbers onto — from a real atlas, so that one part can't be decided this way. Its chassis, swingarm and forks are correct. `MXB_MAT_TABLE=0` falls back to plain texture order for the whole app.

## Also here

- Library thumbnails prefer a bike's `logo.tga` (its manufacturer mark) over the 32x64 `team.tga` strip that was winning the scoring tie. A real preview image still wins. Thumbnail cache bumped to v3 so stale ones rebuild.
- Hovering a Library row shows the full name, folder id and location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)