### PR TITLE
chore(release): v0.7.0 — six languages, an in-game overlay, right paint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# The Windows release leg runs `scripts/release-notes.sh` through Git Bash, which chokes
+# on CRLF (`$'\r': command not found`). Keep shell scripts LF wherever they're checked out.
+*.sh text eol=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ name: Release
 # Triggers on any tag like `v0.1.0`. You can also run it manually from the
 # Actions tab (workflow_dispatch) to build without tagging. Releases are
 # published, not drafted (`releaseDraft: false`).
+#
+# A tag with a suffix — `v0.7.0-beta.1`, `v0.7.0-rc.2` — builds the same three
+# platforms but publishes as a PRE-RELEASE: GitHub keeps it off `releases/latest`,
+# which is the endpoint the in-app updater reads, so existing installs are not
+# offered it and the Discord announcement is held back. Beta testers install it by
+# downloading the installer from the release page. Tagging the plain `v0.7.0`
+# afterwards is what ships it to everyone.
 
 on:
   push:
@@ -87,6 +94,21 @@ jobs:
         shell: bash
         run: bash .sidecar-src/sync.sh "$GITHUB_WORKSPACE"
 
+      # The release page should say what shipped, not only which file to download — so
+      # the body is composed from this tag's CHANGELOG section. Same section the Discord
+      # announcement reads, so the two can't drift apart.
+      - name: Compose release notes
+        id: notes
+        shell: bash
+        env:
+          TAG: ${{ github.ref_type == 'tag' && github.ref_name || format('v{0}', github.run_number) }}
+        run: |
+          {
+            echo 'body<<RELEASE_NOTES_EOF'
+            bash scripts/release-notes.sh "$TAG"
+            echo 'RELEASE_NOTES_EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and publish release
         uses: tauri-apps/tauri-action@v0
         env:
@@ -99,34 +121,18 @@ jobs:
         with:
           tagName: ${{ github.ref_type == 'tag' && github.ref_name || format('v{0}', github.run_number) }}
           releaseName: "MXB App ${{ github.ref_type == 'tag' && github.ref_name || format('build-{0}', github.run_number) }}"
-          # Nearly everyone here is on Windows, and the asset list now runs to six
-          # files across three platforms — so lead with the one file most people
-          # want and describe the rest by extension. Extensions don't drift when the
-          # `finalize` job renames the assets, exact filenames would.
-          releaseBody: |
-            ## Which file do I download?
-
-            **Windows — download the `.exe`.** That's the installer, and it's what
-            almost everyone needs. Run it and you're done.
-
-            <details>
-            <summary>macOS and Linux</summary>
-
-            - **macOS (Apple Silicon)** — the `.dmg`.
-            - **Linux** — the `.AppImage` works on any distro: download, `chmod +x`, run
-              it. Prefer your package manager? `.deb` for Debian/Ubuntu, `.rpm` for
-              Fedora. Note MX Bikes itself runs through Proton on Linux.
-
-            </details>
-
-            The `.sig` and `.tar.gz` files are used by the in-app updater — you don't
-            need to download those.
-
-            ---
+          # What shipped, then which file to download — worded in scripts/release-notes.sh.
+          # The download half describes files by extension, since exact filenames drift
+          # when the `finalize` job renames the assets.
+          releaseBody: ${{ steps.notes.outputs.body }}
           # Publish straight away (not a draft) so the updater's `latest.json`
           # endpoint (releases/latest) resolves without a manual publish step.
           releaseDraft: false
-          prerelease: false
+          # A suffixed tag (`v0.7.0-beta.1`) is a beta: same artifacts, but flagged
+          # pre-release so `releases/latest` — and with it every installed app's update
+          # check — stays on the last full release until the plain tag is cut.
+          # A manual `workflow_dispatch` build is never the release everyone should get.
+          prerelease: ${{ github.ref_type != 'tag' || contains(github.ref_name, '-') }}
           args: ${{ matrix.args }}
 
   # Tauri names bundles like `MXB.App_0.1.0_x64-setup.exe`, which reads as ugly/
@@ -171,10 +177,12 @@ jobs:
   # Announce the finished release in Discord. Runs after `finalize` so the download links
   # point at the renamed installers, and only for real tags on the canonical repo — forks
   # stay silent, and `workflow_dispatch` test builds (throwaway `v<run_number>` tags) don't
-  # spam the channel.
+  # spam the channel. Pre-release tags stay quiet too: a beta goes to the people who asked
+  # for it, and the channel hears about the version once, when everyone can have it.
+  # (`scripts/notify-discord.sh <tag> --print` renders the message without sending it.)
   notify:
     needs: finalize
-    if: ${{ github.repository == 'Frostn1/mxb-app' && github.ref_type == 'tag' }}
+    if: ${{ github.repository == 'Frostn1/mxb-app' && github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,201 +1,93 @@
 # Changelog
 
-## 2026-08-08
-
-### Fixed
-- **Bikes whose bodywork came out in the wrong texture.** A part's material index was read
-  as a position in the model's texture list in the order the exporter happened to write
-  them, which only matches on bikes that were written in material order. The 2023 Kawasaki
-  KX250/KX450 store `w_plate` between `metals` and `plastics`, so their entire bodywork
-  wore the blank number-plate texture and an installed paint changed nothing visible. The
-  model's own material table now decides, which also fixes the Yamaha YZ125/YZ250, where
-  the chassis and the engine had swapped textures. Neither reading is right on every bike,
-  so where they disagree the mesh breaks the tie: a part's UV layout only lines up with
-  the atlas it was drawn against, and each part is asked separately, since a bike's parts
-  need not agree — the YZ125's chassis reads through the table while its steering reads
-  straight off the texture order. That puts the KTM 125 SX back on its plastics too.
-- **The front fender and fork guards rendering in bare metal.** A mesh group can hold
-  several materials as contiguous ranges — a fork leg and the plastic guard on it, a
-  triple clamp and the fender — and we merged each group into one submesh, so every range
-  wore the first one's texture. Each range now binds its own.
-
-### Changed
-- **Library thumbnails show a bike's manufacturer logo.** A bike's 250x250 `logo.tga` was
-  losing a scoring tie to `team.tga`, a 32x64 strip, so bikes showed a coloured sliver. A
-  real preview image still wins where a mod ships one. Cached thumbnails are rebuilt.
-- **Hovering a name in the Library shows the full name, folder and location.** The row
-  truncates hard, and the folder id is what you need when matching a paint to its bike.
-
-## 2026-08-07
-## 2026-08-07 — six languages, a Play button, live model swaps
+## 2026-08-07 — v0.7.0 — Six languages, an in-game overlay, and bikes wearing the right paint
 
 ### Added
-- **Browse can sort by what people actually ride, not just what landed last.** The page
-  was locked to the catalog's own newest-first order, which buries a track that thousands
-  of people have downloaded for two years under whatever went up this morning. There's now
-  a sort next to the category filters: **Most popular**, **Popular this month**, **Popular
-  this week** (ranked by views on mxb-mods.com — *Trials more pits version* leads tracks
-  all-time at 1.25M) and **Oldest**, for digging back to the 2019 originals. Alphabetical
-  and recently-updated orders aren't offered: the site accepts those requests and then
-  ignores them, and a sort that silently does nothing is worse than one that isn't there.
-  The popular listings can't be searched, so they step aside while the search box has text
-  in it and the order falls back to newest.
-- **An in-game overlay, on a hotkey.** Everything the app does still meant leaving the
-  game to do it. Ctrl+Shift+M (rebindable in Settings → In-game overlay) now brings
-  Presets, the Locker and Browse up over MX Bikes in a floating panel; Esc closes it and
-  hands control straight back to the game. It's the same UI the main window uses, not a
-  cut-down copy, and it pays off because presets and model swaps already apply to a
-  *running* game — pick a gear set from the pits and it's on you, no restart, no alt-tab.
-  Mods downloaded from Browse still need the usual content reload before the game sees
-  them. One real limit: nothing can be drawn over a game in exclusive fullscreen, so set
-  MX Bikes to borderless or windowed — if you summon the overlay and it can't appear, the
-  main window tells you why rather than leaving you guessing. Translated into all six
-  languages alongside the rest of the app.
-- **MXB App is translated into Italian, Spanish, French, German and Brazilian
-  Portuguese.** Pick a language under Settings → Appearance; the choice persists, and
-  `System` follows the OS (a bare `pt` resolves to Brazilian, the only Portuguese we
-  ship). Every screen, dialog, toast and empty state is covered — 540 keys per language.
-  Terminology follows what the MX Bikes community actually says rather than dictionary
-  equivalents: `mod`, `setup`, `preset` and `Stock` stay as loanwords in every language,
-  while gear is translated (`casco`/`casque`/`Helm`, `maschera`/`masque`/`Brille` for
-  goggles, `livrea`/`déco`/`Lackierung` for a bike paint).
-- **Dates follow the app's language, not the OS's.** Picking Italian on an English
-  machine moves the Library's dates too, instead of leaving half the UI in English.
-- **The 3D preview now offers a gear model's stock paint, not just its liveries.** The
-  paint picker listed only the `.pnt` files a helmet, boots or protection packs, so a
-  piece that ships liveries had no way back to its own look — the textures embedded in
-  the mesh, which the preview ignored entirely. "Stock" now leads the list whenever the
-  mesh carries a texture, with a separate entry for a helmet's goggles, which are picked
-  independently of the shell. A paint reuses the mesh's texture names, so stock shell
-  plus painted goggles (and the reverse) is resolved before the textures reach the
-  viewer, which would otherwise show whichever image finished loading last. Preview only
-  — it never becomes a value in your loadout, since the game names a `.pnt` there and has
-  no word for "the model's own look".
+- **An in-game overlay, on a hotkey.** Ctrl+Shift+M (rebindable in Settings → In-game
+  overlay) brings Presets, the Locker and Browse up over MX Bikes in a floating panel; Esc
+  hands control straight back to the game. It's the same UI as the main window, and it pays
+  off because presets and model swaps already apply to a *running* game — pick a gear set
+  from the pits and it's on you, no restart. One limit: nothing can draw over a game in
+  exclusive fullscreen, so run MX Bikes borderless or windowed.
+- **MXB App speaks six languages** — English, Italian, Spanish, French, German and
+  Brazilian Portuguese. Pick one under Settings → Appearance, or leave it on `System` to
+  follow the OS. Every screen, dialog, toast and empty state is covered, and the wording
+  follows what the community actually says: `mod`, `setup`, `preset` and `Stock` stay as
+  loanwords, while gear is translated (`casco`, `casque`, `Helm`). Dates follow the app's
+  language too, so picking Italian doesn't leave half the UI in English.
+- **Browse can sort by what people actually ride.** New sort next to the category filters:
+  **Most popular**, **Popular this month**, **Popular this week** (by views on
+  mxb-mods.com) and **Oldest**, for digging back to the 2019 originals — instead of being
+  locked to newest-first, which buries a track thousands of people ride under whatever went
+  up this morning. The popular listings can't be searched, so they step aside while you're
+  typing in the search box.
+- **Star ratings on browse thumbnails.** Cards now carry the mxb-mods.com score — stars,
+  average and vote count — so a well-rated mod stands out before you open it. Unrated mods
+  show nothing rather than five empty stars, and ratings load after the cards appear, so
+  browsing never waits on them.
+- **A Play button that launches MX Bikes.** It's in the sidebar on every tab, and reads
+  "MX Bikes running" while the game is up so it can't start a second copy. Windows launches
+  the game directly — Steam copies and standalone alike — and Linux hands off to Steam,
+  since a Proton install is Steam's to start.
+- **A model swap now shows up in-game straight away.** Applying a swap in the Locker, or a
+  preset that carries one, re-applies the bike you have selected — no more switching bike
+  class away and back to see it. Needs FrostMod and the **Instant refresh** setting.
+- **The 3D preview offers a gear model's stock paint, not just its liveries.** A helmet or
+  boots that ship liveries had no way back to their own look. "Stock" now leads the paint
+  list whenever the mesh carries a texture, with a separate entry for a helmet's goggles.
+  Preview only — the game names a `.pnt` in your loadout and has no word for "the model's
+  own look".
 
 ### Fixed
-- **Picking a goggle paint now updates the 3D preview on its own.** The Rider tab's
-  preview re-resolves the model whenever a rider slot changes, but the list of slots it
-  watched never included the goggles — so choosing a lens did nothing on screen, and the
-  new paint only appeared once you touched some *other* slot (helmet paint, boots) and
-  dragged the goggles along with it. The backend had been reading the goggle paint
-  correctly the whole time; it was simply never asked to.
-- **Downloads that Google Drive refuses now say why, instead of "the host returned a web
-  page".** Hitting a popular mod (Flow Series #1 FlowiCompound, for one) gave a message
-  that blamed the page and told you to download it manually — but Drive was answering the
-  virus-scan confirm with a *Quota exceeded* page, so a browser hit the exact same wall
-  and the advice sent people in circles. The three Drive refusals we can name — download
-  limit, private file, deleted file — now come through with what actually happened and
-  what to do about it (for a quota block: copy the file to your own Drive and download
-  the copy, or wait a day). Anything unrecognised keeps the old wording.
-
-### Added
-- **Star ratings on browse thumbnails.** A mod that people have rated on mxb-mods.com now
-  shows its score on the card the same way the site does — five stars filled to the
-  nearest half, the average, and the vote count — so a good mod is recognisable before you
-  open it. Unrated mods show nothing rather than five empty stars, which would read as a
-  bad score instead of "nobody has voted yet". The scores aren't in the REST API the
-  listing comes from, so they're fetched separately per page (six requests at a time,
-  cached for ten minutes) after the cards have painted: browsing never waits on them, and
-  a score that fails to load simply doesn't appear.
-- **A Play button that launches MX Bikes.** Setting a bike up in the Locker meant
-  alt-tabbing to Steam or the desktop to actually ride it, even though the app already
-  knew where the game was installed and whether it was running. The sidebar now carries a
-  Play button above the FrostMod pill, visible from every tab; it flips to "MX Bikes
-  running" while the game is up, so it can't start a second copy. Windows runs
-  `mxbikes.exe` directly, which works for standalone (non-Steam) copies too and doesn't
-  need Steam open; Linux hands `steam://rungameid/655500` to the desktop, because a
-  Proton install is Steam's to set up. If the install folder isn't set or holds no
-  `mxbikes.exe`, the error says so and points at Settings.
-- **Swapping a model now changes it in-game instantly, on the bike you have selected.**
-  A model swap moved the files and re-ran the game's *customization* loader — which
-  reloads paints and gear but never the bike mesh, so the garage kept showing the old
-  model until you switched bike class away and back. The Locker now also asks FrostMod
-  to re-apply the bike (new `refresh_bike_model` command), which re-reads it from disk
-  and brings the new model up immediately. FrostMod acts only on the bike you currently
-  have selected, so swapping any other bike never disturbs what you're looking at.
-  Presets get the same treatment when they carry a model swap. Gated on the existing
-  **Instant refresh** setting, since it reaches into the running game.
-
-### Fixed
-- **Browse now clears mxb-mods.com's bot protection with a real browser instead of trying
-  to impersonate one.** A user on v0.6.3 still hit `403 Forbidden` on every browse, which
-  ruled out the header work shipped for v0.6.3 — that build already sent Chrome's exact
-  header set. What it couldn't send is Chrome's TLS and HTTP/2 fingerprint, which no header
-  can disguise, and Cloudflare weighs that against the caller's IP. That's why the same
-  binary is fine on one connection and refused on another; the site itself is not blocking
-  the app, and the affected user's normal browser loads mxb-mods.com fine.
-
-  So when the site refuses us, the app now opens a small mxb-mods.com window, lets
-  Cloudflare's check clear, keeps the `cf_clearance` it hands out, and retries the request
-  with it. The cookie is saved, so being blocked once doesn't mean being blocked again on
-  every launch. This is the mechanism the app already used to sign into the MX Bikes Shop,
-  now shared by both sites rather than written twice.
-  - A 403 no longer retries in place. Three identical requests from the same fingerprint
-    earn the same refusal, so the old loop only failed three times slower; 429 and 503 do
-    still retry, since those genuinely pass on their own.
-  - A Cloudflare interstitial served as a `200` now takes the same route as a 403 — it is
-    the same refusal wearing a success code.
-  - If the check window never gets a clearance, the log says so specifically. That
-    distinguishes "the browser was never challenged either" from "we got a cookie and it
-    still failed", which are different problems with different fixes.
-
-  Honest caveat, same as last time: this is still not reproducible here, so it's verified
-  by construction and tests rather than by watching it cure the reported fault.
-- **The Locker no longer claims a model swap "Refreshed live in-game" when it didn't.**
-  The note was derived purely from the look-loader call succeeding, which says nothing
-  about whether the mesh reloaded — so it read as done while the garage still showed the
-  old model. Model and sound swaps now report separately, and the model note reflects
-  what actually happened: refreshing now, FrostMod not running, or instant refresh off.
-### Fixed
-- **Browse knows what you already have.** The "Installed" badge almost never appeared —
-  one reporter's library scored 19 of 96 tracks and **0 of 96** bikes and rider items,
-  all of them installed and working in-game. Two causes. Browse asked for installed mods
-  with a scan that keeps `.pkz` files only, so extracted track folders and every `.pnt`
-  paint were invisible; since the Bikes and Rider categories are mostly liveries and gear
-  paints, nothing in them could ever be badged. And it compared the site's post title to
-  the packaged filename as exact strings, which post titles never survive — they carry
-  author credits, release tags and notes like "(READ INSTRUCTIONS)". Browse now reads the
-  same full library scan the Library tab uses, and matches titles the way a person would:
-  one name spelled inside the other, or enough distinctive words in common. Careful
-  enough to still tell two colourways of the same bike apart. (#26)
-- **Presets no longer comes up blank when your mods folder lives somewhere else.**
-  `mxbikes.ini` lets you point the mods folder at another drive, but the game has no
-  equivalent redirect for profiles — it keeps writing those to
-  `Documents\PiBoSo\MX Bikes\profiles`. The app only ever looked at
-  `<mods folder>\profiles`, found nothing, and rendered an empty Presets tab with no
-  hint that a path was involved. It now falls back to the stock `Documents` folder when
-  the one beside your mods isn't there, and Settings shows the path it actually resolved
-  to instead of the one it assumed (#27).
-- **The empty Presets tab explains itself.** Instead of "launch the game once", it names
-  the folder it read, says outright when that folder doesn't exist, points at the
-  `mxbikes.ini` split as the likely cause, and offers a button straight to the Settings
-  picker.
-- **A slot can be cleared back to stock again.** Empty is what the game writes for an
-  unmodded slot, and every layer already handled it — the trigger renders it as "Stock",
-  a cleared slot isn't flagged missing, and applying writes it through. Only the picker
-  couldn't produce it: there was no "none" option, no clear button, and an empty search
-  box commits nothing. Pick `full` for Protection once and the only ways back were the
-  game's own UI or hand-editing `profile.ini`. Every slot dropdown now leads with a
-  "Stock (none)" row that clears it. (#28)
+- **Bikes wearing the wrong texture on their bodywork.** A part's material was matched to
+  the texture list in whatever order the exporter wrote it, which only works on bikes
+  written in material order. The Kawasaki KX250/KX450 wore their blank number-plate texture
+  over the whole bike, so an installed paint changed nothing visible; the Yamaha
+  YZ125/YZ250 had chassis and engine swapped. The model's own material table now decides,
+  and where the two readings disagree the mesh breaks the tie per part — which keeps the
+  KTM 125 SX on its plastics.
+- **The front fender and fork guards rendering in bare metal.** One mesh group can hold
+  several materials — a fork leg and the plastic guard on it — and all of them wore the
+  first one's texture. Each range now binds its own.
+- **Picking a goggle paint updates the 3D preview on its own.** The preview watched every
+  rider slot except the goggles, so a new lens only appeared once you touched some *other*
+  slot. The paint was being read correctly all along; the preview was simply never asked.
+- **Browse gets past mxb-mods.com's bot protection.** When the site refuses the app, it now
+  opens a small mxb-mods.com window, lets the Cloudflare check clear, and reuses the
+  clearance afterwards — the same route already used to sign into the MX Bikes Shop.
+  Headers alone couldn't fix this, which is why the same build worked on one connection and
+  was refused on another. Honest caveat, as last release: the block isn't reproducible
+  here, so it's verified by construction rather than by watching it cure the fault.
+- **Browse knows what you already have.** The "Installed" badge almost never showed — one
+  library scored 0 of 96 bikes, every one of them installed. It counted packed `.pkz` files
+  only, missing extracted tracks and every paint, and compared post titles as exact
+  strings, which they never survive. It now reads the full Library scan and matches titles
+  the way a person would. (#26)
+- **Downloads that Google Drive refuses now say why.** Download limit, private file and
+  deleted file each come through with what happened and what to do — for a quota block,
+  copy the file to your own Drive or wait a day — instead of blaming the page and sending
+  you to download it manually into the same wall.
+- **Presets works when your mods folder lives somewhere else.** `mxbikes.ini` can move the
+  mods folder, but the game still writes profiles to `Documents`, so Presets came up blank.
+  It now falls back there, and Settings shows the path it actually resolved to. (#27)
+- **The empty Presets tab explains itself** — the folder it read, whether that folder
+  exists, the likely cause, and a button straight to the Settings picker.
+- **A slot can be cleared back to stock.** Every slot dropdown now leads with a "Stock
+  (none)" row. Before, picking `full` for Protection could only be undone in the game's own
+  UI or by hand-editing `profile.ini`. (#28)
+- **The Locker stops saying a swap "Refreshed live in-game" when it didn't.** Model and
+  sound swaps report separately now, and the model note says what actually happened:
+  refreshing, FrostMod not running, or instant refresh off.
 
 ### Changed
-- **Translations can't silently go missing.** Each locale is typed as
-  `Record<keyof typeof en, string>`, so a key that's absent from — or invented in — any
-  of the five translations is a compile error, not a runtime blank. `npm run typecheck`
-  passing is proof all six locales are complete and consistent. This is why the i18n
-  layer is ~120 lines of local code rather than i18next: a missing key can't reach a
-  build.
-- **Plurals use `Intl.PluralRules` rather than an `n === 1` check.** French treats 0 as
-  singular, so "0 fichier" now comes out correct without a special case, and languages
-  that don't split one/other the way English does still land right.
-- **Sentences that wrap markup are translated whole.** A `<Trans>` component splices
-  React nodes into placeholders, so word order stays the translator's choice — splitting
-  such a sentence into prefix/suffix strings would have hard-coded English grammar into
-  German and French. The same applies to the preset-apply and swap toasts, which were
-  English fragments and are now complete sentences.
-- **Nouns that read differently mid-sentence get their own key.** "Search tracks…" used
-  `label.toLowerCase()`, which produces broken German — its nouns are capitalized
-  everywhere — so mod types now carry a separate inline form.
+- **Library thumbnails show a bike's manufacturer logo** instead of a coloured sliver — its
+  `logo.tga` was losing a tie to `team.tga`, a 32x64 strip. A real preview image still wins
+  where a mod ships one, and cached thumbnails are rebuilt.
+- **Hovering a name in the Library shows the full name, folder and location** — the row
+  truncates hard, and the folder id is what you need to match a paint to its bike.
+- **Translations can't silently go missing.** Each locale is typed against English, so a
+  missing or invented key is a compile error rather than a runtime blank, and plurals go
+  through `Intl.PluralRules` — French treats 0 as singular, and now so do we.
 
 ## 2026-08-06 — v0.6.3 — model swaps stop breaking bikes, Linux builds
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frost",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frost",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.19",
         "@radix-ui/react-context-menu": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.6.3",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/scripts/changelog-section.sh
+++ b/scripts/changelog-section.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Print one release's section out of CHANGELOG.md.
+#
+#   scripts/changelog-section.sh <tag|version> [--heading] [--fold|--summary]
+#
+# Default output is the section's body — its `### Added` / `### Fixed` groups, verbatim.
+#   --heading  print the section's heading line instead of the body.
+#   --fold     join each bullet's hard-wrapped continuation lines back onto one line.
+#              The file wraps for readability; Discord renders those newlines literally.
+#   --summary  --fold, then cut each bullet down to its bold headline. Every item still
+#              appears — that's the point — but a release with twenty of them fits in a
+#              chat message. Implies --fold.
+#
+# A pre-release tag (`v0.7.0-beta.1`) reads the section for the version it's a candidate
+# for (`v0.7.0`), since the changelog records releases, not the builds leading up to one.
+#
+# Exits 1 with no output when that version has no section yet (an untagged build, or a
+# tag cut before the changelog was written) — callers fall back to their own wording.
+
+set -euo pipefail
+
+TAG=""
+MODE="body"
+FOLD=0
+SUMMARY=0
+for arg in "$@"; do
+  case "$arg" in
+    --heading) MODE="heading" ;;
+    --fold) FOLD=1 ;;
+    --summary) SUMMARY=1; FOLD=1 ;;
+    -*) echo "unknown option: $arg" >&2; exit 2 ;;
+    *) TAG="$arg" ;;
+  esac
+done
+
+if [ -z "$TAG" ]; then
+  echo "usage: $0 <tag|version> [--heading] [--fold|--summary]" >&2
+  exit 2
+fi
+
+if ! root="$(git rev-parse --show-toplevel 2>/dev/null)" || [ -z "$root" ]; then
+  root="$(cd "$(dirname "$0")/.." && pwd)"
+fi
+changelog="$root/CHANGELOG.md"
+[ -f "$changelog" ] || exit 1
+
+heading_for() {
+  # Escape regex metacharacters so `0.6.1` can't match `0x6y1`.
+  local ver_re
+  ver_re="$(printf '%s' "$1" | sed 's/[].[^$*\\/]/\\&/g')"
+  awk -v re="^## .*[[:space:]]v${ver_re}([[:space:]]|\$)" '$0 ~ re { print; exit }' "$changelog"
+}
+
+VERSION="${TAG#v}"
+heading="$(heading_for "$VERSION")"
+if [ -z "$heading" ] && [ "${VERSION%%-*}" != "$VERSION" ]; then
+  # `0.7.0-beta.1` has no section of its own; fall back to `0.7.0`.
+  VERSION="${VERSION%%-*}"
+  heading="$(heading_for "$VERSION")"
+fi
+[ -n "$heading" ] || exit 1
+
+if [ "$MODE" = "heading" ]; then
+  printf '%s\n' "$heading"
+  exit 0
+fi
+
+body="$(awk -v h="$heading" '
+  $0 == h              { seen = 1; next }
+  !seen                { next }
+  seen && /^## /       { exit }
+                       { print }
+' "$changelog" | sed -e '/./,$!d')"
+
+if [ "$FOLD" -eq 1 ]; then
+  body="$(printf '%s\n' "$body" | awk '
+    function flush() { if (buf != "") { print buf; buf = "" } }
+    /^[[:space:]]*$/     { flush(); print ""; next }
+    /^[[:space:]]*[-*] / { flush(); buf = $0; next }
+    /^#/                 { flush(); print; next }
+    buf != ""            { line = $0; sub(/^[[:space:]]+/, "", line); buf = buf " " line; next }
+                         { flush(); print }
+    END                  { flush() }
+  ')"
+fi
+
+if [ "$SUMMARY" -eq 1 ]; then
+  body="$(printf '%s\n' "$body" | awk '
+    # A sub-bullet elaborates the item above it, so it goes with the detail.
+    /^[[:space:]]+[-*] /                { next }
+    # Keep the bold headline the bullet opens with; drop the explanation after it.
+    match($0, /^- \*\*[^*]+\*\*/)       { print substr($0, 1, RLENGTH); next }
+                                        { print }
+  ')"
+fi
+
+# Trim trailing blank lines.
+printf '%s\n' "$body" | awk 'NF { for (i = 0; i < held; i++) print ""; held = 0; print; next } { held++ }'

--- a/scripts/notify-discord.sh
+++ b/scripts/notify-discord.sh
@@ -39,15 +39,8 @@ if [ "$PRINT_ONLY" -eq 0 ] && [ -z "$WEBHOOK" ]; then
   exit 0
 fi
 
-if ! root="$(git rev-parse --show-toplevel 2>/dev/null)" || [ -z "$root" ]; then
-  root="$(cd "$(dirname "$0")/.." && pwd)"
-fi
-changelog="$root/CHANGELOG.md"
-
-VERSION="${TAG#v}"
-# Escape regex metacharacters so `0.6.1` can't match `0x6y1`.
-ver_re="$(printf '%s' "$VERSION" | sed 's/[].[^$*\\/]/\\&/g')"
-head_re="^## .*[[:space:]]v${ver_re}([[:space:]]|\$)"
+here="$(cd "$(dirname "$0")" && pwd)"
+section="$here/changelog-section.sh"
 
 meta="$(gh release view "$TAG" -R "$REPO" --json name,body,url,publishedAt,assets)"
 rel_url="$(jq -r '.url' <<<"$meta")"
@@ -56,56 +49,45 @@ published="$(jq -r '.publishedAt' <<<"$meta")"
 # --- title -------------------------------------------------------------------------
 # Release headings look like `## 2026-08-06 — v0.6.1 — Rider tab gear slots`; the trailing
 # segment is the human name for the release and makes a much better title than the tag.
-heading=""
-subtitle=""
-if [ -f "$changelog" ]; then
-  heading="$(awk -v re="$head_re" '$0 ~ re { print; exit }' "$changelog")"
-  subtitle="$(printf '%s' "$heading" | awk -F'—' '
-    NF >= 3 {
-      s = $3
-      for (i = 4; i <= NF; i++) s = s "—" $i
-      gsub(/^[ \t]+|[ \t]+$/, "", s)
-      print s
-    }')"
-fi
+heading="$("$section" "$TAG" --heading || true)"
+subtitle="$(printf '%s' "$heading" | awk -F'—' '
+  NF >= 3 {
+    s = $3
+    for (i = 4; i <= NF; i++) s = s "—" $i
+    gsub(/^[ \t]+|[ \t]+$/, "", s)
+    print s
+  }')"
 
 title="MXB App $TAG"
 [ -n "$subtitle" ] && title="$title — $subtitle"
 
 # --- description -------------------------------------------------------------------
-# The changelog hard-wraps mid-sentence for readability in the file; Discord renders those
-# newlines literally, so fold continuation lines back onto their bullet before sending.
-body=""
-if [ -n "$heading" ]; then
-  body="$(awk -v re="$head_re" '
-    $0 ~ re              { seen = 1; next }
-    !seen                { next }
-    seen && /^## /       { exit }
-                         { print }
-  ' "$changelog" | awk '
-    function flush() { if (buf != "") { print buf; buf = "" } }
-    /^[[:space:]]*$/     { flush(); print ""; next }
-    /^[[:space:]]*[-*] / { flush(); buf = $0; next }
-    /^#/                 { flush(); print; next }
-    buf != ""            { line = $0; sub(/^[[:space:]]+/, "", line); buf = buf " " line; next }
-                         { flush(); print }
-    END                  { flush() }
-  ' | sed -e '/./,$!d')"
+# Discord caps embed descriptions at 4096 characters; stop short of that so the footer
+# link always has room. A release big enough to blow the cap gets its headlines instead
+# of the first N characters — every item still gets named, which a hard cut can't
+# promise, and the detail is one click away on the release page.
+#
+# `--fold` because the changelog hard-wraps mid-sentence for readability in the file and
+# Discord renders those newlines literally.
+limit=3500
+more="
+
+[Full notes, with the detail →]($rel_url)"
+
+body="$("$section" "$TAG" --fold || true)"
+
+if [ -n "$body" ] && [ "${#body}" -gt "$limit" ]; then
+  short="$("$section" "$TAG" --summary || true)"
+  [ -n "$short" ] && body="$short$more"
 fi
 
-# Trim trailing blank lines.
-body="$(printf '%s' "$body" | awk 'NF { blanks = 0; for (i = 0; i < held; i++) print ""; held = 0; print; next } { held++ }')"
+# Headlines alone still over the cap (a genuinely enormous release) — now it's a trim.
+if [ "${#body}" -gt "$limit" ]; then
+  body="${body:0:$limit}…$more"
+fi
 
 if [ -z "$body" ]; then
   body="A new version is out — see the release page for details."
-fi
-
-# Discord caps embed descriptions at 4096 characters; leave room for the footer link.
-limit=3500
-if [ "${#body}" -gt "$limit" ]; then
-  body="${body:0:$limit}…
-
-[Full changelog →]($rel_url)"
 fi
 
 # --- download links ------------------------------------------------------------------

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Compose the GitHub Release body for a tag.
+#
+#   scripts/release-notes.sh <tag>
+#
+# What's new first — the tag's CHANGELOG section, so the release page says what shipped
+# instead of only which file to download — then the download guidance. Used by
+# .github/workflows/release.yml, which passes the result to tauri-action as `releaseBody`,
+# so this file is the one place either half is worded.
+
+set -euo pipefail
+
+TAG="${1:-}"
+if [ -z "$TAG" ]; then
+  echo "usage: $0 <tag>" >&2
+  exit 2
+fi
+
+here="$(cd "$(dirname "$0")" && pwd)"
+
+# A suffixed tag (`v0.7.0-beta.1`) is a beta build of the version it names. Say so at the
+# top, because the one thing a tester needs to know is that nothing will arrive on its own.
+case "$TAG" in
+  *-*)
+    cat <<EOF
+> [!NOTE]
+> **This is a beta build of ${TAG%%-*}, for testing.** Installed copies of MXB App won't
+> be offered it by the updater — download the installer below to try it. The full release
+> follows once it's been checked over.
+
+EOF
+    ;;
+esac
+
+# A build with no changelog section (a `workflow_dispatch` test build, tagged
+# `v<run_number>`) still gets the download guidance — it just has nothing to announce.
+if section="$("$here/changelog-section.sh" "$TAG")" && [ -n "$section" ]; then
+  heading="$("$here/changelog-section.sh" "$TAG" --heading)"
+  # `## 2026-08-07 — v0.7.0 — Six languages, …` → the part after the version.
+  name="$(printf '%s' "$heading" | awk -F'—' '
+    NF >= 3 { s = $3; for (i = 4; i <= NF; i++) s = s "—" $i
+              gsub(/^[ \t]+|[ \t]+$/, "", s); print s }')"
+  title="What's new in ${TAG%%-*}"
+  [ -n "$name" ] && title="$title — $name"
+  cat <<EOF
+## $title
+
+$section
+
+---
+
+EOF
+fi
+
+cat <<'EOF'
+## Which file do I download?
+
+**Windows — download the `.exe`.** That's the installer, and it's what almost everyone
+needs. Run it and you're done.
+
+<details>
+<summary>macOS and Linux</summary>
+
+- **macOS (Apple Silicon)** — the `.dmg`.
+- **Linux** — the `.AppImage` works on any distro: download, `chmod +x`, run it. Prefer
+  your package manager? `.deb` for Debian/Ubuntu, `.rpm` for Fedora. Note MX Bikes itself
+  runs through Proton on Linux.
+
+</details>
+
+The `.sig` and `.tar.gz` files are used by the in-app updater — you don't need to download
+those.
+EOF

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "frost"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frost"
-version = "0.6.3"
+version = "0.7.0"
 description = "Frost — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Cuts **v0.7.0** and rebuilds how a release describes itself.

## Version
0.6.3 → 0.7.0 across `package.json`, `package-lock.json`, `Cargo.toml`, `Cargo.lock`, `tauri.conf.json`.

## Changelog
The unreleased entries had merged from parallel branches into three duplicate `### Fixed` headings spread over two dates. They're now one dated `v0.7.0` section — Added / Fixed / Changed — each item a bold headline plus a line or two. All 20 user-visible items kept; the four i18n implementation notes fold into one.

## Release notes
- **The release page never showed the changelog** — its body was only "which file do I download". `scripts/release-notes.sh` now composes the body from the tag's CHANGELOG section followed by the download guidance, and the workflow passes it to `tauri-action` as `releaseBody`.
- `scripts/changelog-section.sh` is the single extractor, shared with `notify-discord.sh`, so the release page and Discord can't drift. It resolves a pre-release tag (`v0.7.0-beta.1`) to its version's section.
- **Discord truncated at 3500 chars** — that cut v0.6.3's announcement mid-sentence and silently dropped four items. A release too big to send whole now sends every item's headline plus a link to the full notes.

## Pre-release flow
A suffixed tag (`v0.7.0-beta.1`) builds the same three platforms but publishes as a pre-release: off `releases/latest`, so no installed app is offered it and Discord stays quiet. Tagging the plain `v0.7.0` afterwards is what ships it to everyone. Manual `workflow_dispatch` builds are pre-releases too, so a throwaway `v<run_number>` release can't become the updater's "latest".

`.gitattributes` pins `*.sh` to LF — the Windows leg runs `release-notes.sh` through Git Bash, which breaks on CRLF.

## Verification
- `cargo test` 169 passed, 0 failed; `tsc --noEmit` clean; `eslint` 0 errors.
- Discord payload rendered against a stubbed release: valid JSON, 1213 chars, all 20 items present.
- The workflow's `$GITHUB_OUTPUT` heredoc round-trips the 7.5KB body intact; YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)