### PR TITLE
fix(installer): close the running app so a manual install can't loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,15 @@
 - **Picking a goggle paint updates the 3D preview on its own.** The preview watched every
   rider slot except the goggles, so a new lens only appeared once you touched some *other*
   slot. The paint was being read correctly all along; the preview was simply never asked.
+- **Installing a new version by hand no longer loops back to the "already installed"
+  page.** MXB App sits in the tray after you close its window, so an installer you started
+  yourself nearly always finds it running — and when the old uninstaller can't close it,
+  the installer bounces you back to that page instead of installing. It now closes the app
+  itself, WebView2 children and all, before anything is written or removed. The in-app
+  updater was never affected, which is why this only turned up on a manual install.
+  **Upgrading from 0.6.3 by hand?** That version's uninstaller predates the fix, so quit
+  MXB App from the tray first (right-click the tray icon → Quit) — once you're on 0.7.0,
+  it takes care of itself.
 - **Updating FrostMod with MX Bikes open no longer fails** with "the process cannot access
   the file… (os error 32)". Windows won't let a loaded `frostmod.dll` be overwritten, so no
   amount of retrying could outlast a running game. The old binaries are renamed aside

--- a/src-tauri/installer-hooks.nsh
+++ b/src-tauri/installer-hooks.nsh
@@ -1,0 +1,36 @@
+; Installer hooks — close a running MXB App before the installer or uninstaller touches
+; the install folder.
+;
+; MXB App hides to the tray when its window is closed and launches at login, so an
+; installer a user started by hand nearly always finds it running. Tauri's own
+; `CheckIfAppIsRunning` prompts and then kills the process by name, but two things go
+; wrong from there:
+;
+;   * the prompt's Cancel — and a kill that doesn't take — `Abort` the uninstaller, which
+;     makes the installer's `PageLeaveReinstall` bounce back to the "already installed"
+;     page. Run it again and you land on the same page: an install loop with no
+;     explanation, reported against v0.7.0-beta.1 upgrading from v0.6.3.
+;   * it kills `MXB App.exe` alone, leaving the WebView2 child processes to exit in their
+;     own time, so a file in the install folder can still be held when the copy starts.
+;
+; So close it ourselves first — whole process tree, no questions — and give Windows a
+; moment to release the handles. By the time Tauri's check runs there's nothing to find,
+; and no dialog appears. `/T` takes the WebView2 children with it; `/F` doesn't wait on a
+; window that is only in the tray.
+;
+; PREUNINSTALL matters as much as PREINSTALL: it's the *installed* build's uninstaller
+; that the next version's installer runs, so this is what stops the loop from recurring.
+
+!macro CloseRunningApp
+  nsExec::Exec 'taskkill /F /T /IM "${MAINBINARYNAME}.exe"'
+  Pop $0 ; 0 = closed it, 128 = wasn't running. Either is the state we want.
+  Sleep 700
+!macroend
+
+!macro NSIS_HOOK_PREINSTALL
+  !insertmacro CloseRunningApp
+!macroend
+
+!macro NSIS_HOOK_PREUNINSTALL
+  !insertmacro CloseRunningApp
+!macroend

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -53,6 +53,7 @@
     "windows": {
       "nsis": {
         "installMode": "currentUser",
+        "installerHooks": "installer-hooks.nsh",
         "installerIcon": "icons/icon.ico",
         "languages": ["English"]
       }


### PR DESCRIPTION
Installing `v0.7.0-beta.1` over `v0.6.3` by hand bounced between the "already installed" page and an uninstaller that never ran — and never installed the new version.

## Mechanism
From Tauri's NSIS template (tauri-cli v2.11.4):

1. `PageLeaveReinstall` runs the **old** uninstaller with `ExecWait`, then `Abort`s back to the page if it returned non-zero **or** `$INSTDIR\MXB App.exe` still exists. That abort is the loop.
2. The uninstaller returns non-zero exactly when it can't close a running app — `CheckIfAppIsRunning` aborts on Cancel and on a kill that doesn't take ([utils.nsh](https://github.com/tauri-apps/tauri/blob/tauri-cli-v2.11.4/crates/tauri-bundler/src/bundle/windows/nsis/utils.nsh#L62-L67)).
3. MXB App hides to the tray on close and launches at login — both on by default — so an installer started by hand nearly always finds it running.

The in-app updater passes `/UPDATE /P`, which skips those pages and kills without prompting. That's why this never surfaced: a pre-release isn't offered by the updater, so the beta was the first build installed by hand.

## Fix
`src-tauri/installer-hooks.nsh`, wired in with `nsis.installerHooks`. `NSIS_HOOK_PREINSTALL` and `NSIS_HOOK_PREUNINSTALL` both run `taskkill /F /T /IM "${MAINBINARYNAME}.exe"` and pause for handles to drop. `/T` takes the WebView2 children, which Tauri's by-name kill leaves behind.

`PREUNINSTALL` is the half that matters going forward — the *installed* build's uninstaller is what the next version's installer runs.

## Scope
This can't fix the 0.6.3 → 0.7.0 hop: 0.6.3's uninstaller is already on disk without the hook. Quit from the tray first for that one — the changelog entry says so. From 0.7.0 onward it's automatic.

## Verification
- Hook compiles under `makensis` in both an install and an uninstall section.
- `makensis -PPO` shows `${MAINBINARYNAME}` expanding to `taskkill /F /T /IM "MXB App.exe"` at insertion — worth proving, since the template `!include`s the hook file *before* it defines that name.
- The `nsis` config block validates against the schema shipped in `@tauri-apps/cli` 2.11.4.
- **Not verified on Windows** — no Windows machine here. The loop is diagnosed from the template's control flow, not reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)