### PR TITLE
feat(overlay): add an "Open full app" button beside the close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-08-07 — a way out of the overlay that isn't the game
+
+### Added
+- **"Open full app" in the in-game overlay.** The overlay carries Presets, the Locker and
+  Browse; Rider, the Library and Settings only exist in the main window, and the only way
+  there was to close the overlay — which drops you back into the game — and then alt-tab.
+  A button next to the close X now puts the overlay away and brings the main window
+  forward instead, keeping the focus where you asked for it rather than handing it back to
+  MX Bikes on the way out.
+
 ## 2026-08-07 — v0.7.0 — Six languages, an in-game overlay, and bikes wearing the right paint
 
 ### Added

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1862,6 +1862,16 @@ fn overlay_hide(app: tauri::AppHandle) -> Result<(), String> {
     overlay::hide(&app)
 }
 
+/// The overlay's "Open full app" button: put the overlay away and bring the main
+/// window forward. Deliberately not `overlay::hide` — that hands focus back to MX
+/// Bikes, which is the opposite of what someone leaving for the full app wants.
+#[tauri::command]
+fn overlay_open_main(app: tauri::AppHandle) -> Result<(), String> {
+    overlay::dismiss(&app)?;
+    show_main(&app);
+    Ok(())
+}
+
 #[tauri::command]
 fn overlay_state(app: tauri::AppHandle) -> overlay::OverlayState {
     overlay::state(&config::load(&app).unwrap_or_default())
@@ -2332,6 +2342,7 @@ fn main() {
             set_instant_refresh,
             overlay_toggle,
             overlay_hide,
+            overlay_open_main,
             overlay_state,
             set_overlay_enabled,
             set_overlay_hotkey,

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -130,11 +130,20 @@ fn center_over_game<R: Runtime>(window: &WebviewWindow<R>) {
     let _ = window.set_position(tauri::PhysicalPosition::new(x, y));
 }
 
-/// Hide the overlay and return keyboard focus to MX Bikes.
-pub fn hide<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
+/// Take the overlay off the screen, leaving the foreground where it lands.
+///
+/// Separate from [`hide`] for the "Open full app" button: focus is on its way to the
+/// main window, so pulling MX Bikes forward on the way out would only fight it.
+pub fn dismiss<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
     if let Some(window) = app.get_webview_window(LABEL) {
         window.hide().map_err(|e| format!("{e:#}"))?;
     }
+    Ok(())
+}
+
+/// Hide the overlay and return keyboard focus to MX Bikes.
+pub fn hide<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
+    dismiss(app)?;
     // Order matters: the game can't take the foreground while our window still holds it.
     gameproc::focus_game();
     Ok(())
@@ -252,6 +261,15 @@ mod tests {
     fn hiding_a_never_opened_overlay_is_harmless() {
         let app = mock_app();
         hide(app.handle()).expect("nothing to hide is not a failure");
+        assert!(app.get_webview_window(LABEL).is_none());
+    }
+
+    /// "Open full app" routes through `dismiss` before the main window is raised, and
+    /// it too can fire with no overlay window built yet.
+    #[test]
+    fn dismissing_a_never_opened_overlay_is_harmless() {
+        let app = mock_app();
+        dismiss(app.handle()).expect("nothing to dismiss is not a failure");
         assert!(app.get_webview_window(LABEL).is_none());
     }
 }

--- a/src/Components/Overlay/Overlay.tsx
+++ b/src/Components/Overlay/Overlay.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Bike, Home, Shirt, X } from "lucide-react";
+import { Bike, ExternalLink, Home, Shirt, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Toaster } from "@/Components/ui/sonner";
 import { TooltipProvider } from "@/Components/ui/tooltip";
@@ -20,6 +20,7 @@ import {
   getOverlayState,
   isConfigured,
   overlayHide,
+  overlayOpenMain,
 } from "../../api/mods";
 import type { Config } from "../../types";
 
@@ -82,6 +83,12 @@ export default function Overlay() {
 
   const dismiss = useCallback(() => {
     void overlayHide().catch(() => {});
+  }, []);
+
+  // Rider, Library and Settings live only in the main window, so the overlay needs a
+  // way out that doesn't drop the player back into the game to go find it.
+  const openFullApp = useCallback(() => {
+    void overlayOpenMain().catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -169,6 +176,14 @@ export default function Overlay() {
                       {t("overlay.toClose", { hotkey: prettyHotkey(hotkey) })}
                     </span>
                   )}
+                  <button
+                    onClick={openFullApp}
+                    title={t("overlay.openMainTitle")}
+                    className="flex h-8 cursor-default items-center gap-1.5 rounded-lg px-2.5 text-[12.5px] font-medium text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+                  >
+                    <ExternalLink className="size-3.5" />
+                    <span>{t("overlay.openMain")}</span>
+                  </button>
                   <button
                     onClick={dismiss}
                     title={t("overlay.closeTitle")}

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -831,6 +831,11 @@ export function overlayHide(): Promise<void> {
   return invoke<void>("overlay_hide");
 }
 
+/** Close the overlay and bring the main MXB App window to the front. */
+export function overlayOpenMain(): Promise<void> {
+  return invoke<void>("overlay_open_main");
+}
+
 export function setOverlayEnabled(enabled: boolean): Promise<void> {
   return invoke<void>("set_overlay_enabled", { enabled });
 }

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -793,6 +793,8 @@ export const de: Translation = {
   "overlay.registerFailed": "Overlay-Tastenkürzel konnte nicht registriert werden",
   "overlay.toClose": "{{hotkey}} zum Schließen",
   "overlay.closeTitle": "Overlay schließen (Esc)",
+  "overlay.openMain": "Vollständige App öffnen",
+  "overlay.openMainTitle": "Overlay schließen und das Hauptfenster von MXB App öffnen",
   "overlay.needsSetup": "Richte MXB App zuerst im Hauptfenster fertig ein — sie muss wissen, wo dein MX-Bikes-Ordner liegt.",
   "overlay.fullscreenBlocked": "Das Overlay kann nicht über exklusivem Vollbild erscheinen",
   "overlay.fullscreenBlockedDesc": "Stelle MX Bikes unter Options → Video auf randlos oder Fenstermodus und drücke das Kürzel erneut.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -750,6 +750,8 @@ export const en = {
   "overlay.registerFailed": "Overlay hotkey couldn't be registered",
   "overlay.toClose": "{{hotkey}} to close",
   "overlay.closeTitle": "Close overlay (Esc)",
+  "overlay.openMain": "Open full app",
+  "overlay.openMainTitle": "Close the overlay and open the main MXB App window",
   "overlay.needsSetup": "Finish setting up MXB App in its main window first — it needs to know where your MX Bikes folder is.",
   "overlay.fullscreenBlocked": "The overlay can't show over exclusive fullscreen",
   "overlay.fullscreenBlockedDesc": "Set MX Bikes to borderless or windowed in Options → Video, then try the shortcut again.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -781,6 +781,8 @@ export const es: Translation = {
   "overlay.registerFailed": "No se pudo registrar el atajo del overlay",
   "overlay.toClose": "{{hotkey}} para cerrar",
   "overlay.closeTitle": "Cerrar overlay (Esc)",
+  "overlay.openMain": "Abrir la app completa",
+  "overlay.openMainTitle": "Cierra el overlay y abre la ventana principal de MXB App",
   "overlay.needsSetup": "Termina de configurar MXB App en su ventana principal — necesita saber dónde está tu carpeta de MX Bikes.",
   "overlay.fullscreenBlocked": "El overlay no puede mostrarse sobre la pantalla completa exclusiva",
   "overlay.fullscreenBlockedDesc": "Pon MX Bikes en modo sin bordes o en ventana desde Options → Video y vuelve a pulsar el atajo.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -783,6 +783,8 @@ export const fr: Translation = {
   "overlay.registerFailed": "Impossible d'enregistrer le raccourci de l'overlay",
   "overlay.toClose": "{{hotkey}} pour fermer",
   "overlay.closeTitle": "Fermer l'overlay (Esc)",
+  "overlay.openMain": "Ouvrir l'app complète",
+  "overlay.openMainTitle": "Ferme l'overlay et ouvre la fenêtre principale de MXB App",
   "overlay.needsSetup": "Termine d'abord la configuration de MXB App dans sa fenêtre principale — elle doit savoir où se trouve ton dossier MX Bikes.",
   "overlay.fullscreenBlocked": "L'overlay ne peut pas s'afficher par-dessus le plein écran exclusif",
   "overlay.fullscreenBlockedDesc": "Passe MX Bikes en sans bordure ou en fenêtre dans Options → Video, puis réessaie le raccourci.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -772,6 +772,8 @@ export const it: Translation = {
   "overlay.registerFailed": "Impossibile registrare la scorciatoia dell'overlay",
   "overlay.toClose": "{{hotkey}} per chiudere",
   "overlay.closeTitle": "Chiudi overlay (Esc)",
+  "overlay.openMain": "Apri l'app completa",
+  "overlay.openMainTitle": "Chiudi l'overlay e apri la finestra principale di MXB App",
   "overlay.needsSetup": "Completa prima la configurazione di MXB App nella finestra principale — deve sapere dov'è la tua cartella MX Bikes.",
   "overlay.fullscreenBlocked": "L'overlay non può apparire sopra il fullscreen esclusivo",
   "overlay.fullscreenBlockedDesc": "Imposta MX Bikes senza bordi o in finestra in Options → Video, poi riprova con la scorciatoia.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -771,6 +771,8 @@ export const ptBR: Translation = {
   "overlay.registerFailed": "Não foi possível registrar o atalho do overlay",
   "overlay.toClose": "{{hotkey}} para fechar",
   "overlay.closeTitle": "Fechar overlay (Esc)",
+  "overlay.openMain": "Abrir o app completo",
+  "overlay.openMainTitle": "Fecha o overlay e abre a janela principal do MXB App",
   "overlay.needsSetup": "Termine a configuração do MXB App na janela principal primeiro — ele precisa saber onde fica a sua pasta do MX Bikes.",
   "overlay.fullscreenBlocked": "O overlay não aparece por cima da tela cheia exclusiva",
   "overlay.fullscreenBlockedDesc": "Deixe o MX Bikes em sem bordas ou em janela nas Options → Video e tente o atalho de novo.",


### PR DESCRIPTION
## What

The in-game overlay's header gets an **Open full app** button, immediately left of the close X.

The overlay carries Presets, the Locker and Browse. Rider, the Library and Settings only exist in the main window, and until now the only way there was to close the overlay — which deliberately hands focus back to MX Bikes — and then alt-tab out of the game you were just put back into. One button now does it in one step.

## How

- New `overlay_open_main` command: hides the overlay, then raises the main window through the existing `show_main`.
- It does **not** reuse `overlay::hide`. That one ends with `gameproc::focus_game()`, which would pull MX Bikes to the foreground and fight the window you just asked for. `overlay.rs` therefore splits into `dismiss` (hide the window, leave the foreground alone) and `hide` (`dismiss` + focus the game), so Esc and the close X behave exactly as before.
- `overlay.openMain` / `overlay.openMainTitle` added to all six locales.

## Verification

- `tsc --noEmit` clean; `eslint` clean in the touched files (3 pre-existing warnings elsewhere).
- `cargo test overlay` — 8/8, including a new `dismissing_a_never_opened_overlay_is_harmless` (the button can fire from a stale frontend before the window is ever built).
- **Not verified, needs a Windows pass:** the focus handoff itself. `focus_game`/`show_main` are Windows behaviour and this was developed on macOS. Please check that clicking the button brings the main window up over the game rather than flashing MX Bikes back to the front.

No DB/schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)