### PR TITLE
fix(viewer): say when the rider preview fails instead of going quiet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,15 @@
   own look".
 
 ### Fixed
+- **The Rider preview no longer goes quiet when it fails to update.** If resolving the
+  rider hit an error — a missing profile, a gear file the loader couldn't read — the Rider
+  tab caught it and did nothing with it. The previous model stayed on screen, deliberately,
+  so the preview never blanks; but with no error anywhere that is indistinguishable from a
+  pick that genuinely changed nothing, and it made a real fault read as "changing this slot
+  does nothing". A failed resolve now raises a toast with the reason, leaves a badge on the
+  preview for as long as what you're looking at is out of date, and writes the error to the
+  console. The toast fires once per distinct message rather than once per pick, since a
+  persistent fault is re-hit on every slot edit.
 - **Bikes wearing the wrong texture on their bodywork.** A part's material was matched to
   the texture list in whatever order the exporter wrote it, which only works on bikes
   written in material order. The Kawasaki KX250/KX450 wore their blank number-plate texture

--- a/src/Components/Viewer/ViewerPanel.tsx
+++ b/src/Components/Viewer/ViewerPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
-import { Maximize2, Bike, User, Box, Loader2 } from "lucide-react";
+import { Maximize2, Bike, User, Box, Loader2, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { Button } from "../ui/button";
 import { Dialog, DialogContent } from "../ui/dialog";
@@ -63,8 +64,14 @@ export function ViewerPanel({
   const [expanded, setExpanded] = useState(false);
   const [riderParts, setRiderParts] = useState<RiderPart[] | null>(null);
   const [loading, setLoading] = useState(false);
+  // A resolve that failed. Kept in state because the previous model stays on screen
+  // (see below) — without this the panel looks like the pick simply did nothing.
+  const [loadError, setLoadError] = useState<string | null>(null);
   // First resolve loads immediately; later slot edits are debounced so picks don't thrash the decoder.
   const firstLoad = useRef(true);
+  // Toast once per distinct message: a resolve runs on every slot edit, and a fault that
+  // persists (a missing profile) would otherwise raise one toast per pick.
+  const toasted = useRef<string | null>(null);
 
   // Drop any toggled-off gear before rendering (keep the body + everything else).
   const shownParts = hiddenParts?.length
@@ -97,16 +104,34 @@ export function ViewerPanel({
     setLoading(true);
     const delay = firstLoad.current ? 0 : 200;
     firstLoad.current = false;
-    const t = setTimeout(() => {
+    // Not `t` — that's the translator this scope needs for the failure toast.
+    const timer = setTimeout(() => {
       loadRiderModel(loadout)
         // Keep the previous model on screen until the new one is ready (and on failure) so it never blanks.
-        .then((m) => alive && setRiderParts(m.parts))
-        .catch(() => {})
+        .then((m) => {
+          if (!alive) return;
+          setRiderParts(m.parts);
+          setLoadError(null);
+          toasted.current = null;
+        })
+        // A failure used to be swallowed here. With the old model left on screen that is
+        // indistinguishable from a pick that resolved to the same look, so a real fault
+        // reads as "changing this slot does nothing". Say so instead.
+        .catch((e) => {
+          const msg = String(e).replace(/^Error:\s*/, "");
+          console.error("[viewer] rider resolve failed:", e);
+          if (!alive) return;
+          setLoadError(msg);
+          if (toasted.current !== msg) {
+            toasted.current = msg;
+            toast.error(t("viewer.riderLoadFailed"), { description: msg });
+          }
+        })
         .finally(() => alive && setLoading(false));
     }, delay);
     return () => {
       alive = false;
-      clearTimeout(t);
+      clearTimeout(timer);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [riderKey]);
@@ -124,11 +149,21 @@ export function ViewerPanel({
       <Loader2 className="h-6 w-6 animate-spin" />
       <span className="text-[12.5px]">{t("viewer.loadingRider")}</span>
     </div>
+  ) : loading ? (
+    <div className="pointer-events-none absolute right-3 top-3 flex items-center gap-1.5 rounded-md bg-black/55 px-2 py-1 text-[11px] text-white/85">
+      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+      {t("common.loading")}
+    </div>
   ) : (
-    loading && (
-      <div className="pointer-events-none absolute right-3 top-3 flex items-center gap-1.5 rounded-md bg-black/55 px-2 py-1 text-[11px] text-white/85">
-        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-        {t("common.loading")}
+    // Stale-model warning: what's on screen is the *previous* resolve, so the badge has to
+    // stay up (not a toast that fades) for as long as the model is out of date.
+    loadError && (
+      <div
+        title={loadError}
+        className="absolute right-3 top-3 flex max-w-[85%] items-center gap-1.5 rounded-md bg-destructive/90 px-2 py-1 text-[11px] text-destructive-foreground"
+      >
+        <AlertTriangle className="h-3.5 w-3.5 flex-none" />
+        <span className="truncate">{t("viewer.riderLoadFailed")}</span>
       </div>
     )
   );

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -264,6 +264,7 @@ export const de: Translation = {
   "viewer.loadingModel": "Modell wird geladen…",
   "viewer.loadingPaint": "Design wird geladen…",
   "viewer.loadingRider": "Fahrer wird geladen…",
+  "viewer.riderLoadFailed": "Vorschau ist veraltet — sie konnte nicht aktualisiert werden",
   "viewer.dragToRotate": "Ziehen zum Drehen",
   "viewer.scrollToZoom": "Scrollen zum Zoomen",
   "viewer.rightDragToPan": "Rechts ziehen zum Verschieben",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -252,6 +252,7 @@ export const en = {
   "viewer.loadingModel": "Loading model…",
   "viewer.loadingPaint": "Loading paint…",
   "viewer.loadingRider": "Loading rider…",
+  "viewer.riderLoadFailed": "Preview is out of date — it couldn't be updated",
   "viewer.dragToRotate": "Drag to rotate",
   "viewer.scrollToZoom": "Scroll to zoom",
   "viewer.rightDragToPan": "Right-drag to pan",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -259,6 +259,7 @@ export const es: Translation = {
   "viewer.loadingModel": "Cargando modelo…",
   "viewer.loadingPaint": "Cargando gráficos…",
   "viewer.loadingRider": "Cargando piloto…",
+  "viewer.riderLoadFailed": "La vista previa está desactualizada: no se pudo actualizar",
   "viewer.dragToRotate": "Arrastra para rotar",
   "viewer.scrollToZoom": "Desplaza para hacer zoom",
   "viewer.rightDragToPan": "Arrastra con el botón derecho para mover",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -262,6 +262,7 @@ export const fr: Translation = {
   "viewer.loadingModel": "Chargement du modèle…",
   "viewer.loadingPaint": "Chargement de la déco…",
   "viewer.loadingRider": "Chargement du pilote…",
+  "viewer.riderLoadFailed": "Aperçu obsolète — impossible de le mettre à jour",
   "viewer.dragToRotate": "Glisser pour pivoter",
   "viewer.scrollToZoom": "Molette pour zoomer",
   "viewer.rightDragToPan": "Clic droit glissé pour déplacer",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -257,6 +257,7 @@ export const it: Translation = {
   "viewer.loadingModel": "Caricamento modello…",
   "viewer.loadingPaint": "Caricamento grafica…",
   "viewer.loadingRider": "Caricamento pilota…",
+  "viewer.riderLoadFailed": "Anteprima non aggiornata — impossibile aggiornarla",
   "viewer.dragToRotate": "Trascina per ruotare",
   "viewer.scrollToZoom": "Scorri per zoomare",
   "viewer.rightDragToPan": "Trascina col destro per spostare",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -260,6 +260,7 @@ export const ptBR: Translation = {
   "viewer.loadingModel": "Carregando o modelo…",
   "viewer.loadingPaint": "Carregando a pintura…",
   "viewer.loadingRider": "Carregando o piloto…",
+  "viewer.riderLoadFailed": "A prévia está desatualizada — não foi possível atualizá-la",
   "viewer.dragToRotate": "Arraste para girar",
   "viewer.scrollToZoom": "Role para dar zoom",
   "viewer.rightDragToPan": "Arraste com o botão direito para mover",


### PR DESCRIPTION
Diagnostic groundwork for "switching goggles does nothing" on the **Rider tab**. Not a goggles fix — it turns a silent failure into a reportable one.

## What I ruled out first

The backend is **not** at fault. Built a faithful debug build and ran every installed helmet through *both* loaders — the rider one (`load_gear`) and the Library one (`load_gear_model`). All return genuinely different `goggle` image bytes per pick, with correct submesh bindings:

| Helmet | Bindings | Changes? |
|---|---|---|
| Airoh Aviator 3 Armega (34 goggles) | `Lens→goggle`, `goggle→goggle` | ✅ |
| Airoh Aviator 3 Oakley (25) | `goggle→goggle`, `lens→goggle` | ✅ |
| Airoh Aviator 3 Scott (40) | `goggle→goggle`, `lens→lens` | ✅ |
| TLD SE4 Oakley Airbrake **`.pkz`** (6) | `goggles→TLDSE4goggle` | ✅ |

Also confirmed `v0.7.0-beta.2` was built from `6eb01fc71`, which contains #48 — so it isn't a stale artifact, and the rider chain (`riderKey` → live loadout → `goggles_paint`) reads correctly.

## The actual problem

`ViewerPanel` caught every rejection from `load_rider_model` and threw it away:

```js
.then((m) => alive && setRiderParts(m.parts))
.catch(() => {})        // ← every failure, silently
```

The previous model stays on screen by design so the preview never blanks. But with nothing reported, **a real error is indistinguishable from a pick that resolved to the same look** — any fault reads as "changing this slot does nothing". That's exactly the report we have, and the reason it couldn't be placed.

## Change

- Failed resolve → toast with the reason, a badge on the preview for as long as the model is stale, and `console.error` so a repro is self-documenting.
- Toast deduped by message — a resolve runs on every slot edit, so a persistent fault would otherwise toast per pick.
- Renamed the debounce timeout `t` → `timer`; it shadowed the `t` from `useT()` that the toast needs in that scope.
- `viewer.riderLoadFailed` added in all six locales.

## Verification

`tsc --noEmit` clean · `eslint` clean · `vite build` clean

## Next

With this in, a repro on the Rider tab either shows a concrete error (and we have the cause), or shows none — which rules the frontend out and points at a helmet-specific case not present on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)