### PR TITLE
chore(release): v0.7.1-beta.1 — the Rider preview stops failing in silence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026-08-07 — v0.7.1 — the Rider preview stops failing in silence
+
+### Fixed
+- **The Rider preview no longer goes quiet when it fails to update.** If resolving the
+  rider hit an error — a missing profile, a gear file the loader couldn't read — the Rider
+  tab caught it and did nothing with it. The previous model stayed on screen, deliberately,
+  so the preview never blanks; but with no error anywhere that is indistinguishable from a
+  pick that genuinely changed nothing, and it made a real fault read as "changing this slot
+  does nothing". A failed resolve now raises a toast with the reason, leaves a badge on the
+  preview for as long as what you're looking at is out of date, and writes the error to the
+  console. The toast fires once per distinct message rather than once per pick, since a
+  persistent fault is re-hit on every slot edit.
+
 ## 2026-08-07 — v0.7.0 — Race mode, an in-game overlay, and six languages
 
 ### Added
@@ -61,15 +74,6 @@
   own look".
 
 ### Fixed
-- **The Rider preview no longer goes quiet when it fails to update.** If resolving the
-  rider hit an error — a missing profile, a gear file the loader couldn't read — the Rider
-  tab caught it and did nothing with it. The previous model stayed on screen, deliberately,
-  so the preview never blanks; but with no error anywhere that is indistinguishable from a
-  pick that genuinely changed nothing, and it made a real fault read as "changing this slot
-  does nothing". A failed resolve now raises a toast with the reason, leaves a badge on the
-  preview for as long as what you're looking at is out of date, and writes the error to the
-  console. The toast fires once per distinct message rather than once per pick, since a
-  persistent fault is re-hit on every slot edit.
 - **Bikes wearing the wrong texture on their bodywork.** A part's material was matched to
   the texture list in whatever order the exporter wrote it, which only works on bikes
   written in material order. The Kawasaki KX250/KX450 wore their blank number-plate texture

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "frost"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frost"
-version = "0.7.0"
+version = "0.7.1"
 description = "Frost — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Prep for a **quiet pre-release** carrying #56.

`v0.7.0` went GA (#55) while #56 was still in review, so the fix missed the tag by one merge. This files it under its own version rather than leaving it in the `v0.7.0` section, where it claimed to be part of a build that doesn't contain it.

## Changes

- **CHANGELOG** — new `v0.7.1` section; the Rider-preview entry moves there out of `v0.7.0`.
- **Version** — `0.7.1` in `package.json`, `tauri.conf.json`, `Cargo.toml`; `Cargo.lock` synced.

## Why a pre-release

The suffixed tag keeps it off `releases/latest`, so the in-app updater won't offer it and the `notify` job won't post to Discord (`!contains(github.ref_name, '-')`).

This build is an **instrument, not a fix** — it exists so a Rider-tab goggles repro either names a concrete error or rules the frontend out. It shouldn't go to everyone as a fix.

## Verified

`scripts/changelog-section.sh v0.7.1-beta.1` resolves to the new section (suffixed tags read the version they're a candidate for), and `--summary` renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)