### PR TITLE
chore(release): consolidate the v0.7.1 changelog for beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## 2026-08-07 — a Cloudflare block on Browse can finally be diagnosed
+## 2026-08-07 — v0.7.1 — the Rider preview stops failing in silence, and a blocked Browse says why
+
+### Fixed
+- **The Rider preview no longer goes quiet when it fails to update.** If resolving the
+  rider hit an error — a missing profile, a gear file the loader couldn't read — the Rider
+  tab caught it and did nothing with it. The previous model stayed on screen, deliberately,
+  so the preview never blanks; but with no error anywhere that is indistinguishable from a
+  pick that genuinely changed nothing, and it made a real fault read as "changing this slot
+  does nothing". A failed resolve now raises a toast with the reason, leaves a badge on the
+  preview for as long as what you're looking at is out of date, and writes the error to the
+  console. The toast fires once per distinct message rather than once per pick, since a
+  persistent fault is re-hit on every slot edit.
 
 ### Changed
 - **When mxb-mods.com refuses us, the log now says enough to act on.** Browse failing with
@@ -20,19 +31,6 @@
   without being a Cloudflare interstitial said nothing at all. Both are logged.
 - **`MXB_LOG=debug` traces every mxb-mods.com request.** Off by default, because search runs
   on each keystroke and a line per keystroke would bury the failure worth reading.
-
-## 2026-08-07 — v0.7.1 — the Rider preview stops failing in silence
-
-### Fixed
-- **The Rider preview no longer goes quiet when it fails to update.** If resolving the
-  rider hit an error — a missing profile, a gear file the loader couldn't read — the Rider
-  tab caught it and did nothing with it. The previous model stayed on screen, deliberately,
-  so the preview never blanks; but with no error anywhere that is indistinguishable from a
-  pick that genuinely changed nothing, and it made a real fault read as "changing this slot
-  does nothing". A failed resolve now raises a toast with the reason, leaves a badge on the
-  preview for as long as what you're looking at is out of date, and writes the error to the
-  console. The toast fires once per distinct message rather than once per pick, since a
-  persistent fault is re-hit on every slot edit.
 
 ## 2026-08-07 — v0.7.0 — Race mode, an in-game overlay, and six languages
 


### PR DESCRIPTION
Changelog-only, ahead of tagging `v0.7.1-beta.2`.

`scripts/changelog-section.sh` resolves a pre-release tag to the section for the version it is a candidate for, so `v0.7.1-beta.2` reads the **v0.7.1** section. The Cloudflare diagnostics work from #58 had landed as its own unreleased section above it, which means the beta would have published release notes covering only the Rider preview fix — and none of the work the beta exists to test.

Folds that section into v0.7.1 and widens the heading to name both changes. No code changes; version stays 0.7.1.

Verified with `scripts/changelog-section.sh v0.7.1-beta.2 --summary`:

```
### Fixed
- **The Rider preview no longer goes quiet when it fails to update.**

### Changed
- **When mxb-mods.com refuses us, the log now says enough to act on.**
- **The 403 dialog carries a reference id.**
- **Two silent failures now speak up.**
- **`MXB_LOG=debug` traces every mxb-mods.com request.**
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)