### PR TITLE
feat(servers): join a server by address from the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2026-08-07 — join a server by address
+
+### Added
+- **Join a server straight from the app.** A new *Join a server* button in the sidebar takes
+  a server address and starts MX Bikes already connected to it, rather than launching the
+  game and leaving you to find the server in the in-game WORLD list. The game has carried an
+  undocumented `-directconnect` flag all along — PiBoSo documents only `-dedicated` and
+  `-clientport` — which reads the address from the argument that follows it. A bare host gets
+  the dedicated server's default port, 54210.
+
+  The address is validated in the Rust command rather than in the UI, because it ends up on
+  the game's command line: anything that could smuggle a second argument past us — embedded
+  whitespace, a leading `-` — is rejected there, so a pasted address can't quietly turn into
+  a different flag. The connect flag is only read at startup, so asking to join while MX
+  Bikes is already running says so instead of appearing to work.
+
 ## 2026-08-07 — v0.7.1 — the Rider preview stops failing in silence, and a blocked Browse says why
 
 ### Fixed

--- a/src-tauri/src/gameproc.rs
+++ b/src-tauri/src/gameproc.rs
@@ -9,6 +9,22 @@ const LOADER_OFFSET: usize = 0x000e_cd00;
 /// The game's main executable (matched case-insensitively).
 const GAME_EXE: &str = "mxbikes.exe";
 
+/// The flag that makes a fresh game process connect straight to a server.
+///
+/// Undocumented: PiBoSo's docs list only `-dedicated` and `-clientport`, but the argv
+/// parser at `0x140133640` (image base `0x140000000`) also handles `-directconnect` and a
+/// sibling `-connect`. Each takes the *next* argv as a string, copies it to a global, and
+/// sets a startup-mode enum — 2 for `-directconnect`, 3 for `-connect`.
+///
+/// Which of the two we want, and the exact address form the game expects, still need
+/// confirming against the in-game `log.txt` on Windows. Both live here as single constants
+/// so that test flips one line rather than reshaping the call site.
+const CONNECT_FLAG: &str = "-directconnect";
+
+/// Port used when an address doesn't carry one. The dedicated server's default, and what
+/// every published MX Bikes server address omits.
+const DEFAULT_SERVER_PORT: u16 = 54210;
+
 // Non-Windows builds only construct `Unsupported`/`Disabled`.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -413,19 +429,96 @@ fn resolve_exe(cfg: &AppConfig) -> anyhow::Result<(std::path::PathBuf, std::path
 /// exe isn't ours to spawn — Steam has to set up the prefix — so Linux hands the Steam
 /// URL to the desktop instead.
 pub fn launch(cfg: &AppConfig) -> anyhow::Result<LaunchOutcome> {
+    launch_with(cfg, None)
+}
+
+/// Start MX Bikes and connect it straight to `address`, unless it's already running.
+///
+/// The game only reads the connect flag at startup, so a running copy can't be steered
+/// into a server — the caller gets [`LaunchOutcome::AlreadyRunning`] and has to close it
+/// first.
+pub fn join(cfg: &AppConfig, address: &str) -> anyhow::Result<LaunchOutcome> {
+    let address = parse_server_address(address)?;
+    launch_with(cfg, Some(&address))
+}
+
+/// Normalize a user-supplied server address into the `host:port` form the connect flag
+/// takes, filling in [`DEFAULT_SERVER_PORT`] when it's left off.
+///
+/// Deliberately strict, because the result is handed to the game as a command-line
+/// argument: anything that could smuggle a *second* argument past us — whitespace, a
+/// leading `-` — has to be rejected here, or a pasted address could quietly turn into
+/// another flag entirely.
+pub fn parse_server_address(input: &str) -> anyhow::Result<String> {
+    let raw = input.trim();
+    if raw.is_empty() {
+        anyhow::bail!("Enter a server address, like 203.0.113.10:54210.");
+    }
+    // MX Bikes networking is IPv4-only, so a bracketed literal is a mistake worth naming
+    // rather than letting it fail as an unresolvable host.
+    if raw.starts_with('[') {
+        anyhow::bail!("MX Bikes servers are IPv4 only — use an address like 203.0.113.10:54210.");
+    }
+
+    let (host, port) = match raw.rsplit_once(':') {
+        Some((host, port)) => {
+            let parsed: u16 = port
+                .parse()
+                .ok()
+                .filter(|p| *p > 0)
+                .ok_or_else(|| anyhow::anyhow!("\"{port}\" isn't a valid port — expected 1-65535."))?;
+            (host, parsed)
+        }
+        None => (raw, DEFAULT_SERVER_PORT),
+    };
+
+    if host.is_empty() {
+        anyhow::bail!("Enter a server address, like 203.0.113.10:54210.");
+    }
+    if host.starts_with('-') {
+        anyhow::bail!("\"{host}\" isn't a valid server address.");
+    }
+    if !host
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-')
+    {
+        anyhow::bail!(
+            "\"{host}\" isn't a valid server address — use an IP or hostname, like 203.0.113.10:54210."
+        );
+    }
+
+    Ok(format!("{host}:{port}"))
+}
+
+/// The argv entries that make the game join `address`.
+///
+/// Two separate entries, not `flag=value`: the parser matches the flag and then reads the
+/// *following* argv as the address.
+fn connect_args(address: &str) -> [String; 2] {
+    [CONNECT_FLAG.to_string(), address.to_string()]
+}
+
+/// Shared body of [`launch`] and [`join`] — `address` is already normalized.
+fn launch_with(cfg: &AppConfig, address: Option<&str>) -> anyhow::Result<LaunchOutcome> {
     if is_game_running() {
         return Ok(LaunchOutcome::AlreadyRunning);
     }
     let (dir, exe) = resolve_exe(cfg)?;
-    log::info!("launching MX Bikes: {}", exe.display());
+    match address {
+        Some(addr) => log::info!("launching MX Bikes into {addr}: {}", exe.display()),
+        None => log::info!("launching MX Bikes: {}", exe.display()),
+    }
 
     #[cfg(windows)]
     {
         // No CREATE_NO_WINDOW here (unlike the headless FrostMod child) — the game
         // draws its own window and hiding the console would gain nothing.
-        std::process::Command::new(&exe)
-            .current_dir(&dir)
-            .spawn()
+        let mut cmd = std::process::Command::new(&exe);
+        cmd.current_dir(&dir);
+        if let Some(addr) = address {
+            cmd.args(connect_args(addr));
+        }
+        cmd.spawn()
             .map_err(|e| anyhow::anyhow!("Couldn't start {}: {e}", exe.display()))?;
         Ok(LaunchOutcome::Launched)
     }
@@ -433,7 +526,16 @@ pub fn launch(cfg: &AppConfig) -> anyhow::Result<LaunchOutcome> {
     #[cfg(target_os = "linux")]
     {
         let _ = dir;
-        let url = format!("steam://rungameid/{}", crate::config::MX_BIKES_APPID);
+        // Steam takes launch arguments after a `//` separator. Under Proton this is the
+        // only way to reach the exe's argv, since Steam — not us — spawns it.
+        let url = match address {
+            Some(addr) => format!(
+                "steam://rungameid/{}//{}",
+                crate::config::MX_BIKES_APPID,
+                connect_args(addr).join(" ")
+            ),
+            None => format!("steam://rungameid/{}", crate::config::MX_BIKES_APPID),
+        };
         std::process::Command::new("xdg-open")
             .arg(&url)
             .spawn()
@@ -443,7 +545,7 @@ pub fn launch(cfg: &AppConfig) -> anyhow::Result<LaunchOutcome> {
 
     #[cfg(not(any(windows, target_os = "linux")))]
     {
-        let _ = dir;
+        let _ = (dir, address);
         anyhow::bail!("Launching MX Bikes is supported on Windows and Linux only")
     }
 }
@@ -457,6 +559,51 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[test]
+    fn fills_in_the_default_port_when_the_address_omits_one() {
+        assert_eq!(parse_server_address("203.0.113.10").unwrap(), "203.0.113.10:54210");
+        assert_eq!(parse_server_address("mx.example.com").unwrap(), "mx.example.com:54210");
+    }
+
+    #[test]
+    fn keeps_an_explicit_port_and_trims_surrounding_space() {
+        assert_eq!(parse_server_address("  203.0.113.10:9000  ").unwrap(), "203.0.113.10:9000");
+    }
+
+    #[test]
+    fn rejects_addresses_that_could_smuggle_a_second_argument() {
+        // The whole point of validating: each of these would otherwise reach the game's
+        // argv parser as an extra flag rather than as part of the address.
+        for bad in ["203.0.113.10 -mod evil", "-directconnect", "203.0.113.10:54210 -log"] {
+            assert!(
+                parse_server_address(bad).is_err(),
+                "{bad:?} must not survive validation"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_empty_and_malformed_ports() {
+        for bad in ["", "   ", "203.0.113.10:", "203.0.113.10:0", "203.0.113.10:99999", ":54210"] {
+            assert!(parse_server_address(bad).is_err(), "{bad:?} must not survive validation");
+        }
+    }
+
+    #[test]
+    fn names_ipv6_rather_than_failing_on_lookup() {
+        let err = parse_server_address("[::1]:54210").unwrap_err().to_string();
+        assert!(err.contains("IPv4"), "expected an IPv4-only message, got {err:?}");
+    }
+
+    #[test]
+    fn passes_the_flag_and_address_as_separate_argv_entries() {
+        // `flag=value` would be read as one argument and never matched.
+        assert_eq!(
+            connect_args("203.0.113.10:54210"),
+            ["-directconnect".to_string(), "203.0.113.10:54210".to_string()]
+        );
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1876,6 +1876,16 @@ fn launch_game(app: tauri::AppHandle) -> Result<gameproc::LaunchOutcome, String>
     gameproc::launch(&cfg).map_err(|e| format!("{e:#}"))
 }
 
+/// Start MX Bikes and connect it straight to a server.
+///
+/// The game reads the connect flag only at startup, so this reports `already_running`
+/// rather than trying to steer a copy that's already up.
+#[tauri::command]
+fn join_server(app: tauri::AppHandle, address: String) -> Result<gameproc::LaunchOutcome, String> {
+    let cfg = config::load_or_detect(&app).unwrap_or_default();
+    gameproc::join(&cfg, &address).map_err(|e| format!("{e:#}"))
+}
+
 /// Is MX Bikes running? Polled by the sidebar so Play can show the live state.
 #[tauri::command]
 fn game_running() -> bool {
@@ -2658,6 +2668,7 @@ fn main() {
             frostmod_start,
             frostmod_stop,
             launch_game,
+            join_server,
             game_running,
             shop_login,
             shop_status,

--- a/src/Components/Shell/JoinServerDialog.tsx
+++ b/src/Components/Shell/JoinServerDialog.tsx
@@ -1,0 +1,99 @@
+import { useState, type FormEvent } from "react";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/Components/ui/dialog";
+import { Input } from "@/Components/ui/input";
+import { Button } from "@/Components/ui/button";
+import { joinServer } from "../../api/mods";
+import { useT } from "../../i18n/context";
+
+/** Remembers the last address, so rejoining a regular server is one keystroke. */
+const LAST_ADDRESS_KEY = "mxb:lastServerAddress";
+
+interface JoinServerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Lets the sidebar refresh its running-state probe once the game is up. */
+  onJoined?: () => void;
+}
+
+/**
+ * Join a server by address: the app starts MX Bikes with the connect flag so the game
+ * lands in the server directly, instead of the player hunting for it in the in-game list.
+ *
+ * The address is validated in the Rust command rather than here — it ends up on the
+ * game's command line, so the check has to sit next to the spawn, not in a UI that a
+ * future caller might bypass. Its messages are what this shows on failure.
+ */
+const JoinServerDialog = ({
+  open,
+  onOpenChange,
+  onJoined,
+}: JoinServerDialogProps) => {
+  const t = useT();
+  const [address, setAddress] = useState(
+    () => localStorage.getItem(LAST_ADDRESS_KEY) ?? "",
+  );
+  const [joining, setJoining] = useState(false);
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (joining || !address.trim()) return;
+    setJoining(true);
+    try {
+      const outcome = await joinServer(address);
+      if (outcome === "already_running") {
+        toast.info(t("join.alreadyRunning"));
+      } else {
+        localStorage.setItem(LAST_ADDRESS_KEY, address.trim());
+        toast.success(t("join.launching", { address: address.trim() }));
+        onOpenChange(false);
+        onJoined?.();
+      }
+    } catch (e) {
+      toast.error(t("join.failed"), { description: String(e) });
+    }
+    setJoining(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <form onSubmit={onSubmit}>
+          <DialogHeader>
+            <DialogTitle>{t("join.title")}</DialogTitle>
+            <DialogDescription>{t("join.desc")}</DialogDescription>
+          </DialogHeader>
+
+          <label className="mt-4 block text-[12.5px] text-muted-foreground">
+            {t("join.address")}
+            <Input
+              autoFocus
+              value={address}
+              spellCheck={false}
+              onChange={(e) => setAddress(e.target.value)}
+              placeholder="203.0.113.10:54210"
+              className="mt-1.5"
+            />
+          </label>
+
+          <DialogFooter className="mt-5">
+            <Button type="submit" disabled={joining || !address.trim()}>
+              {joining && <Loader2 className="size-4 animate-spin" />}
+              {joining ? t("join.joining") : t("join.action")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default JoinServerDialog;

--- a/src/Components/Shell/Sidebar.tsx
+++ b/src/Components/Shell/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Loader2,
   Gamepad2,
   SlidersHorizontal,
+  Plug,
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
@@ -20,6 +21,7 @@ import { displayName } from "../../lib/mods";
 import { useT, type TKey } from "../../i18n/context";
 import { launchGame } from "../../api/mods";
 import { useGameRunning } from "../../lib/useGameRunning";
+import JoinServerDialog from "./JoinServerDialog";
 
 export type DashboardView =
   | "browse"
@@ -57,6 +59,7 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
   const { active, queueLength } = useInstall();
   const { running: gameRunning, refresh: refreshGame } = useGameRunning();
   const [starting, setStarting] = useState(false);
+  const [joinOpen, setJoinOpen] = useState(false);
 
   // Drop out of "Starting…" once the game shows up — or once it's clear it isn't going
   // to, so a launch that failed silently doesn't leave the button stuck.
@@ -185,6 +188,27 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
                 : t("game.play")}
           </span>
         </button>
+
+        <button
+          onClick={() => setJoinOpen(true)}
+          disabled={gameRunning}
+          title={gameRunning ? t("game.running") : t("join.title")}
+          className={cn(
+            "flex cursor-default items-center justify-center gap-2 rounded-lg border border-white/[0.07] px-3 py-1.5 text-[12px] font-medium transition-colors",
+            gameRunning
+              ? "text-muted-foreground"
+              : "text-foreground/80 hover:bg-white/[0.04]",
+          )}
+        >
+          <Plug className="size-3.5" />
+          <span>{t("join.title")}</span>
+        </button>
+
+        <JoinServerDialog
+          open={joinOpen}
+          onOpenChange={setJoinOpen}
+          onJoined={refreshGame}
+        />
 
         <div
           data-tour="frostmod"

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -780,6 +780,17 @@ export function launchGame(): Promise<LaunchOutcome> {
   return invoke<LaunchOutcome>("launch_game");
 }
 
+/**
+ * Start MX Bikes connected straight to `address` (`host` or `host:port`; the port
+ * defaults to 54210).
+ *
+ * Resolves to `already_running` when the game is already up — the connect flag is only
+ * read at startup, so a running copy can't be steered into a server.
+ */
+export function joinServer(address: string): Promise<LaunchOutcome> {
+  return invoke<LaunchOutcome>("join_server", { address });
+}
+
 /** Is MX Bikes currently running? Always false off Windows — the probe is Win32-only. */
 export function isGameRunning(): Promise<boolean> {
   return invoke<boolean>("game_running");

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -543,6 +543,16 @@ export const de: Translation = {
   "game.alreadyRunning": "MX Bikes läuft bereits",
   "game.launching": "MX Bikes wird gestartet…",
   "game.launchFailed": "MX Bikes konnte nicht gestartet werden",
+  "join.title": "Server beitreten",
+  "join.desc":
+    "Gib eine Serveradresse ein, um MX Bikes direkt damit verbunden zu starten.",
+  "join.address": "Serveradresse",
+  "join.action": "Beitreten",
+  "join.joining": "Verbinden…",
+  "join.launching": "Verbinde mit {{address}}…",
+  "join.alreadyRunning":
+    "Schließe zuerst MX Bikes — ein laufendes Spiel kann nicht zu einem Server geschickt werden.",
+  "join.failed": "Diesem Server konnte nicht beigetreten werden",
 
   // ── Vom ersten Durchlauf übersehene Strings (mehrzeiliges JSX) ─────────────
   "libraryDetail.noEmbedded": "Für dieses Element wurden keine eingebetteten Details gefunden.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -515,6 +515,16 @@ export const en = {
   "game.alreadyRunning": "MX Bikes is already running",
   "game.launching": "Launching MX Bikes…",
   "game.launchFailed": "Couldn't launch MX Bikes",
+  "join.title": "Join a server",
+  "join.desc":
+    "Enter a server address to start MX Bikes connected straight to it.",
+  "join.address": "Server address",
+  "join.action": "Join",
+  "join.joining": "Joining…",
+  "join.launching": "Joining {{address}}…",
+  "join.alreadyRunning":
+    "Close MX Bikes first — a running game can't be sent to a server.",
+  "join.failed": "Couldn't join that server",
 
   // ── Strings the multi-line JSX sweep initially missed ──────────────────────
   "libraryDetail.noEmbedded": "No embedded details were found for this item.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -536,6 +536,16 @@ export const es: Translation = {
   "game.alreadyRunning": "MX Bikes ya está en ejecución",
   "game.launching": "Iniciando MX Bikes…",
   "game.launchFailed": "No se pudo iniciar MX Bikes",
+  "join.title": "Unirse a un servidor",
+  "join.desc":
+    "Introduce la dirección de un servidor para iniciar MX Bikes conectado directamente a él.",
+  "join.address": "Dirección del servidor",
+  "join.action": "Unirse",
+  "join.joining": "Conectando…",
+  "join.launching": "Conectando a {{address}}…",
+  "join.alreadyRunning":
+    "Cierra MX Bikes primero — un juego ya iniciado no se puede enviar a un servidor.",
+  "join.failed": "No se pudo unir a ese servidor",
 
   // ── Cadenas que el primer barrido no vio (JSX multilínea) ─────────────────
   "libraryDetail.noEmbedded": "No se encontraron detalles incrustados para este elemento.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -540,6 +540,16 @@ export const fr: Translation = {
   "game.alreadyRunning": "MX Bikes est déjà en cours d'exécution",
   "game.launching": "Lancement de MX Bikes…",
   "game.launchFailed": "Impossible de lancer MX Bikes",
+  "join.title": "Rejoindre un serveur",
+  "join.desc":
+    "Saisissez l'adresse d'un serveur pour lancer MX Bikes en vous y connectant directement.",
+  "join.address": "Adresse du serveur",
+  "join.action": "Rejoindre",
+  "join.joining": "Connexion…",
+  "join.launching": "Connexion à {{address}}…",
+  "join.alreadyRunning":
+    "Fermez d'abord MX Bikes — un jeu déjà lancé ne peut pas être envoyé vers un serveur.",
+  "join.failed": "Impossible de rejoindre ce serveur",
 
   // ── Chaînes manquées par le premier balayage (JSX multi-lignes) ────────────
   "libraryDetail.noEmbedded": "Aucun détail intégré n'a été trouvé pour cet élément.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -530,6 +530,16 @@ export const it: Translation = {
   "game.alreadyRunning": "MX Bikes è già in esecuzione",
   "game.launching": "Avvio di MX Bikes…",
   "game.launchFailed": "Impossibile avviare MX Bikes",
+  "join.title": "Entra in un server",
+  "join.desc":
+    "Inserisci l'indirizzo di un server per avviare MX Bikes collegandoti direttamente.",
+  "join.address": "Indirizzo del server",
+  "join.action": "Entra",
+  "join.joining": "Connessione…",
+  "join.launching": "Connessione a {{address}}…",
+  "join.alreadyRunning":
+    "Chiudi prima MX Bikes — un gioco già avviato non può essere collegato a un server.",
+  "join.failed": "Impossibile entrare in quel server",
 
   // ── Stringhe sfuggite alla prima scansione (JSX su più righe) ──────────────
   "libraryDetail.noEmbedded": "Nessun dettaglio incorporato trovato per questo elemento.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -533,6 +533,16 @@ export const ptBR: Translation = {
   "game.alreadyRunning": "O MX Bikes já está em execução",
   "game.launching": "Iniciando o MX Bikes…",
   "game.launchFailed": "Não foi possível iniciar o MX Bikes",
+  "join.title": "Entrar em um servidor",
+  "join.desc":
+    "Informe o endereço de um servidor para iniciar o MX Bikes conectado diretamente a ele.",
+  "join.address": "Endereço do servidor",
+  "join.action": "Entrar",
+  "join.joining": "Conectando…",
+  "join.launching": "Conectando a {{address}}…",
+  "join.alreadyRunning":
+    "Feche o MX Bikes primeiro — um jogo em execução não pode ser enviado para um servidor.",
+  "join.failed": "Não foi possível entrar nesse servidor",
 
   // ── Textos que a primeira varredura não pegou (JSX em várias linhas) ──────
   "libraryDetail.noEmbedded": "Nenhum detalhe embutido foi encontrado para este item.",


### PR DESCRIPTION
First step of the dedicated-servers project (plan: `tasks/mxb-servers.md`).

Adds a **Join a server** button to the sidebar: enter a server address, and the app starts MX Bikes already connected to it — no hunting for the server in the in-game WORLD list.

## How it works

MX Bikes has an undocumented `-directconnect` flag. PiBoSo documents only `-dedicated` and `-clientport`, but the argv parser at `0x140133640` (image base `0x140000000`) also handles `-directconnect` and a sibling `-connect`. Each reads the **next argv** as a string, copies it to a global, and sets a startup-mode enum — 2 for `-directconnect`, 3 for `-connect`. The flag and address are therefore passed as two separate argv entries, not `flag=value`.

This also means we never need PiBoSo's master server: for our own servers we know the address, so direct-connect bypasses discovery entirely.

## Notes for review

- **Validation lives in Rust, not the UI.** The address ends up on the game's command line, so `203.0.113.10 -mod evil` has to be rejected next to the spawn rather than in a dialog a future caller could bypass. A bare host gets the default port 54210.
- `launch()` and the new `join()` share a `launch_with()` body — the existing Play path is unchanged.
- `join.*` keys added to all six locales; every locale is typed against `en`, so partial keys wouldn't compile.

## Verified

9 gameproc tests pass (6 new): default-port fill-in, explicit port, trimming, argument-smuggling rejection, malformed ports, the IPv4-only message, and the two-argv shape. `typecheck` clean; `lint` and `cargo check` show only pre-existing warnings in untouched files.

## Not yet verified

**The join has not been exercised against a real server** — built on macOS with no game install. Confirmed: the flag exists and takes the next argv as a string. Assumed: the address is `host:port`, and `-directconnect` (mode 2) is the right one of the pair.

To settle it on Windows:

```
mxbikes.exe -log -directconnect <a-real-server>:54210
```

then read `log.txt`. If it fails, try `-connect` with an address and with a server name. `CONNECT_FLAG` and the address format are single constants in `gameproc.rs` so the fix is one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)