### PR TITLE
fix(manage): let race mode clear the rider gear too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 2026-08-07
+
+### Fixed
+- **Race mode now clears the rider gear too.** Applying a race preset narrowed the bikes and
+  tracks the game could see and left the rider alone — every helmet, every boot, every
+  protection set and every gear livery you have installed still showed up in the game's
+  pickers, including the four hundred liveries sitting under the one helmet the preset
+  actually names. Manage only ever moved archives and extracted tracks, on the reasoning that
+  a loose `.pnt` costs nothing to mount; true, but mounting was never the point — a preset
+  that names one paint means the others should be out of sight. Race mode now takes rider gear
+  models and liveries out of the way alongside the rest, keeps exactly what the preset names,
+  and brings them all back on Restore all.
+
+### Added
+- **Helmets, Boots and Protection tabs in a preset's race content.** Next to Tracks and
+  Always keep, three panes list the gear models you have installed so you can tick the spares
+  worth keeping reachable — picking them by hand instead of leaving it all to what the preset
+  happens to name. Anything unticked steps aside for the race; the preset's own gear is kept
+  for you either way.
+
 ## 2026-08-07 — v0.7.1 — the Rider preview stops failing in silence, and a blocked Browse says why
 
 ### Fixed

--- a/src-tauri/src/bundle.rs
+++ b/src-tauri/src/bundle.rs
@@ -83,6 +83,23 @@ fn rel_dest(type_folder: &str, e: &LibraryEntry) -> String {
 }
 
 pub fn plan(cfg: &AppConfig, loadout: &Loadout) -> anyhow::Result<BundlePlan> {
+    let mut p = resolve(cfg, loadout)?;
+    dedup_assets(&mut p.assets);
+    p.total_size = p.assets.iter().map(|a| a.size).sum();
+    Ok(p)
+}
+
+/// The same resolution as [`plan`], with every asset still addressed in its own right.
+///
+/// [`plan`] collapses an asset into the folder that already contains it, because a zip that
+/// carries `rider/helmets/AGV` carries the liveries under it for free. Manage needs the
+/// opposite: it keeps that helmet by moving nothing at all, and decides livery by livery
+/// which ones the game still gets to offer — so the paint has to be named, not implied.
+pub fn plan_detailed(cfg: &AppConfig, loadout: &Loadout) -> anyhow::Result<BundlePlan> {
+    resolve(cfg, loadout)
+}
+
+fn resolve(cfg: &AppConfig, loadout: &Loadout) -> anyhow::Result<BundlePlan> {
     let bikes = library::scan_library(&cfg.mods_path, "mods/bikes", &[]).unwrap_or_default();
     let rider = library::scan_library(&cfg.mods_path, "mods/rider", &[]).unwrap_or_default();
     let tyres = library::scan_library(&cfg.mods_path, "mods/tyres", &[]).unwrap_or_default();
@@ -166,8 +183,6 @@ pub fn plan(cfg: &AppConfig, loadout: &Loadout) -> anyhow::Result<BundlePlan> {
             });
         }
     }
-
-    dedup_assets(&mut assets);
 
     let total_size = assets.iter().map(|a| a.size).sum();
     Ok(BundlePlan { assets, unresolved, total_size })

--- a/src-tauri/src/modstate.rs
+++ b/src-tauri/src/modstate.rs
@@ -6,6 +6,10 @@
 //! `<MX Bikes>/mxbapp_disabled`, mirroring its path under `mods` so putting it back is
 //! exact.
 //!
+//! Rider gear paints ride along for a different reason. A loose `.pnt` costs nothing to
+//! mount, but it is a row in the game's own gear pickers — and a preset that names one
+//! helmet paint means the other four hundred should be out of sight, not merely cheap.
+//!
 //! The mirrored path is the whole record. There's no manifest to fall out of step with the
 //! disk when app data is wiped, a folder is moved by hand, or two copies of the app run at
 //! once — restoring is just "walk the shadow tree and move everything back".
@@ -124,13 +128,41 @@ fn rel_of(mods_path: &str, abs: &Path) -> Option<String> {
     Some(rel.to_string_lossy().replace('\\', "/"))
 }
 
+/// Rider gear a player picks a *model* of in-game: helmets, boots, protection. Installed
+/// either as a folder or as a bare `.pkz`, and either way one row in the game's picker.
+pub const GEAR_MODEL_CATEGORIES: [&str; 3] = ["helmet", "boots", "protection"];
+
+/// Loose `.pnt` paints under `mods/rider` — the gear liveries the game lists once each.
+///
+/// Bike liveries are deliberately absent. They sit beside the model-swap and sound
+/// bookkeeping that tracks them by path, and narrowing which bikes exist is already the bike
+/// archive's job.
+const RIDER_PAINT_CATEGORIES: [&str; 6] = [
+    "helmetPaint",
+    "goggles",
+    "bootPaint",
+    "protectionPaint",
+    "gloves",
+    "outfit",
+];
+
 /// Whether a library entry is something we're willing to move.
 ///
-/// Archives and extracted tracks only. A loose `.pnt` paint, a `FrostMod Models` variant or
-/// a sound folder isn't mounted at boot, and moving one would desync the model-swap and
-/// sound bookkeeping that tracks it by path — all cost, no load-time gain.
+/// Three kinds of thing: archives the game mounts at boot, extracted tracks, and the rider
+/// gear (models and their paints) the game offers in its own pickers. The first two are what
+/// a load is waiting on; the third is what a race preset means when it says *this* helmet in
+/// *this* paint — everything else should be out of sight, not merely cheap.
+///
+/// Still excluded: a `FrostMod Models` variant, a sound folder, a bike livery and a rider
+/// profile, all of which are tracked by path elsewhere in the app and would desync if moved.
 fn is_candidate(e: &LibraryEntry) -> bool {
-    e.kind == "pkz" || (e.kind == "folder" && e.category == "track")
+    match e.kind.as_str() {
+        "pkz" => true,
+        "folder" => {
+            e.category == "track" || GEAR_MODEL_CATEGORIES.contains(&e.category.as_str())
+        }
+        _ => RIDER_PAINT_CATEGORIES.contains(&e.category.as_str()),
+    }
 }
 
 fn entry_from_library(mods_path: &str, e: &LibraryEntry, enabled: bool) -> Option<ModEntry> {
@@ -212,7 +244,7 @@ fn keep_keys(cfg: &AppConfig, preset: &Preset) -> (BTreeSet<String>, Vec<bundle:
     let mut keys = BTreeSet::new();
     let mut unresolved = Vec::new();
 
-    if let Ok(plan) = bundle::plan(cfg, &preset.loadout) {
+    if let Ok(plan) = bundle::plan_detailed(cfg, &preset.loadout) {
         for a in &plan.assets {
             keys.insert(key(&format!("mods/{}", a.rel_dest)));
         }
@@ -262,6 +294,12 @@ fn is_kept(keys: &BTreeSet<String>, rel: &str) -> bool {
     let k = key(rel);
     if keys.contains(&k) {
         return true;
+    }
+    // A paint is kept only when it is named outright. Falling through to the folder rule
+    // would let one kept helmet drag in every livery installed under it — the opposite of
+    // what choosing a paint means.
+    if k.ends_with(".pnt") {
+        return false;
     }
     keys.iter().any(|kept| k.starts_with(&format!("{kept}/")))
 }
@@ -465,7 +503,12 @@ pub fn restore_all(cfg: &AppConfig) -> StateOutcome {
     let mut rels: Vec<String> = Vec::new();
     for subpath in SUBPATHS {
         let leaf = subpath.trim_start_matches("mods/");
-        collect_parked(&shadow, &library::resolve_child(&shadow, leaf), &mut rels);
+        collect_parked(
+            &shadow,
+            &cfg.mods_path,
+            &library::resolve_child(&shadow, leaf),
+            &mut rels,
+        );
     }
 
     for rel in &rels {
@@ -483,37 +526,49 @@ pub fn restore_all(cfg: &AppConfig) -> StateOutcome {
     out
 }
 
-/// Collect what's parked under `dir` as `mods/…` rel paths. An extracted track folder is
-/// one item and isn't descended into; everything else yields its archives.
-fn collect_parked(shadow: &Path, dir: &Path, out: &mut Vec<String>) {
+/// Collect what's parked under `dir` as `mods/…` rel paths. A folder parked whole — an
+/// extracted track, a gear model — is one item and isn't descended into; everything else
+/// yields its archives and paints.
+fn collect_parked(shadow: &Path, mods_path: &str, dir: &Path, out: &mut Vec<String>) {
     let Ok(rd) = fs::read_dir(dir) else { return };
     for e in rd.flatten() {
         let p = e.path();
-        let is_pkz = p
-            .extension()
-            .and_then(|x| x.to_str())
-            .map(|x| x.eq_ignore_ascii_case("pkz"))
-            .unwrap_or(false);
+        let Some(rel) = rel_of(&shadow.to_string_lossy(), &p) else {
+            continue;
+        };
         if p.is_file() {
-            if is_pkz {
-                if let Some(rel) = rel_of(&shadow.to_string_lossy(), &p) {
-                    out.push(format!("mods/{rel}"));
-                }
+            if is_parked_file(&p) {
+                out.push(format!("mods/{rel}"));
             }
             continue;
         }
-        // A directory holding no subfolders of its own that we parked whole (an extracted
-        // track) is indistinguishable from a grouping folder by name alone — so descend,
-        // and let the leaf test below decide. `dir_is_parked_mod` keeps a track's interior
-        // from being enumerated file by file.
-        if dir_is_parked_mod(&p) {
-            if let Some(rel) = rel_of(&shadow.to_string_lossy(), &p) {
-                out.push(format!("mods/{rel}"));
-            }
+        // A directory we parked whole is indistinguishable from a grouping folder by name
+        // alone — so descend, and let the leaf test below decide. That test is what keeps a
+        // track's interior from being enumerated file by file.
+        //
+        // A gear model is the one folder that can be *half* parked: leave the helmet in
+        // place, park the liveries under it. When the enabled folder is still there, the
+        // shadow copy is only holding paints, so descend for those rather than queueing a
+        // whole-folder move that would collide with it.
+        let whole = if is_gear_model_dir(shadow, &p) {
+            !enabled_path(mods_path, &format!("mods/{rel}")).exists()
         } else {
-            collect_parked(shadow, &p, out);
+            dir_is_parked_mod(&p)
+        };
+        if whole {
+            out.push(format!("mods/{rel}"));
+        } else {
+            collect_parked(shadow, mods_path, &p, out);
         }
     }
+}
+
+/// A file that was parked in its own right: an archive or a gear paint.
+fn is_parked_file(p: &Path) -> bool {
+    p.extension()
+        .and_then(|x| x.to_str())
+        .map(|x| x.eq_ignore_ascii_case("pkz") || x.eq_ignore_ascii_case("pnt"))
+        .unwrap_or(false)
 }
 
 /// An extracted track parked in the shadow tree: a folder carrying the marker files the
@@ -534,6 +589,19 @@ fn dir_is_parked_mod(dir: &Path) -> bool {
         }
     }
     false
+}
+
+/// `<shadow>/rider/helmets/AGV` — a gear model, one level under its area folder.
+fn is_gear_model_dir(shadow: &Path, dir: &Path) -> bool {
+    let Ok(rel) = dir.strip_prefix(shadow) else {
+        return false;
+    };
+    let segs: Vec<String> = rel_segments(&rel.to_string_lossy())
+        .map(|s| s.to_lowercase())
+        .collect();
+    segs.len() == 3
+        && segs[0] == "rider"
+        && matches!(segs[1].as_str(), "helmets" | "boots" | "protection")
 }
 
 #[cfg(test)]
@@ -720,10 +788,10 @@ mod tests {
         let _ = fs::remove_dir_all(&root);
     }
 
-    /// Loose paints and model-swap sets aren't archives the game mounts at boot — Manage
+    /// Bike liveries and model-swap sets are tracked by path elsewhere in the app — Manage
     /// leaves them where they are.
     #[test]
-    fn leaves_loose_paints_and_swap_sets_alone() {
+    fn leaves_bike_liveries_and_swap_sets_alone() {
         let root = tmp("loose");
         touch(&root.join("mods/bikes/KTM450/paints/RedBud.pnt"));
         touch(&root.join("mods/bikes/KTM450/FrostMod Models/2024/bike.edf"));
@@ -732,6 +800,93 @@ mod tests {
 
         let names: Vec<String> = scan(&cfg, &[]).iter().map(|m| m.name.clone()).collect();
         assert_eq!(names, vec!["OEM Pack.pkz"]);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    fn gear_root(name: &str) -> PathBuf {
+        let root = tmp(name);
+        touch(&root.join("mods/rider/helmets/AGV/model.edf"));
+        touch(&root.join("mods/rider/helmets/AGV/paints/Wanted.pnt"));
+        touch(&root.join("mods/rider/helmets/AGV/paints/Other.pnt"));
+        touch(&root.join("mods/rider/helmets/AGV/goggles/Tinted.pnt"));
+        touch(&root.join("mods/rider/helmets/Fox/model.edf"));
+        touch(&root.join("mods/rider/boots/Alpinestars/model.edf"));
+        touch(&root.join("mods/rider/riders/default_mx/paints/Kit.pnt"));
+        root
+    }
+
+    fn helmet_preset(helmet: &str, paint: &str, keep: Vec<String>) -> Preset {
+        let loadout = Loadout {
+            helmet: helmet.into(),
+            helmet_paint: paint.into(),
+            ..Default::default()
+        };
+        preset_with("Race", loadout, PresetContent { tracks: vec![], keep })
+    }
+
+    fn preset_with(name: &str, loadout: Loadout, content: PresetContent) -> Preset {
+        Preset {
+            name: name.into(),
+            loadout,
+            bundle: None,
+            content: Some(content),
+        }
+    }
+
+    /// The gear a preset names is the gear the game should offer. Every other helmet, boot,
+    /// protection set and livery steps aside — including the other liveries of the very
+    /// helmet the preset keeps, which is what a chosen paint means.
+    #[test]
+    fn a_race_preset_leaves_only_the_gear_it_names() {
+        let root = gear_root("gear");
+        let cfg = cfg_at(&root);
+        let p = helmet_preset("AGV", "Wanted", vec![]);
+
+        let plan = plan(&cfg, &p, &[]);
+        let disabled: Vec<&str> = plan.disable.iter().map(|m| m.name.as_str()).collect();
+        for gone in ["Other.pnt", "Tinted.pnt", "Kit.pnt", "Fox", "Alpinestars"] {
+            assert!(disabled.contains(&gone), "{gone} should step aside: {disabled:?}");
+        }
+        assert!(!disabled.contains(&"Wanted.pnt"), "{disabled:?}");
+        assert!(!disabled.contains(&"AGV"), "{disabled:?}");
+
+        let out = apply(&cfg, &plan);
+        assert!(out.failed.is_empty(), "{:?}", out.failed);
+        assert!(root.join("mods/rider/helmets/AGV/paints/Wanted.pnt").is_file());
+        assert!(root.join("mods/rider/helmets/AGV/model.edf").is_file());
+        assert!(!root.join("mods/rider/helmets/AGV/paints/Other.pnt").exists());
+        assert!(!root.join("mods/rider/helmets/Fox").exists());
+        assert!(root
+            .join("mxbapp_disabled/rider/helmets/AGV/paints/Other.pnt")
+            .is_file());
+        assert!(root.join("mxbapp_disabled/rider/helmets/Fox/model.edf").is_file());
+
+        // A half-parked helmet — folder in place, liveries parked — restores its paints
+        // rather than colliding with the folder that never moved.
+        let back = restore_all(&cfg);
+        assert!(back.failed.is_empty(), "{:?}", back.failed);
+        assert!(root.join("mods/rider/helmets/AGV/paints/Other.pnt").is_file());
+        assert!(root.join("mods/rider/helmets/AGV/goggles/Tinted.pnt").is_file());
+        assert!(root.join("mods/rider/helmets/Fox/model.edf").is_file());
+        assert!(root.join("mods/rider/riders/default_mx/paints/Kit.pnt").is_file());
+        assert!(!root.join("mxbapp_disabled").exists());
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// Extra models pinned in the content dialog are kept alongside the preset's own, so a
+    /// player can still swap helmets mid-session without leaving race mode.
+    #[test]
+    fn pinned_gear_models_are_kept_too() {
+        let root = gear_root("pinned");
+        let cfg = cfg_at(&root);
+        let p = helmet_preset("AGV", "Wanted", vec!["mods/rider/helmets/Fox".into()]);
+
+        let plan = plan(&cfg, &p, &[]);
+        let disabled: Vec<&str> = plan.disable.iter().map(|m| m.name.as_str()).collect();
+        assert!(!disabled.contains(&"Fox"), "{disabled:?}");
+        assert!(disabled.contains(&"Alpinestars"), "{disabled:?}");
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/src/Components/Manage/ContentDialog.tsx
+++ b/src/Components/Manage/ContentDialog.tsx
@@ -12,22 +12,55 @@ import {
 } from "@/Components/ui/dialog";
 import { Segmented } from "@/Components/ui/segmented";
 import type { ModEntry, Preset, PresetContent } from "../../types";
-import { useT } from "../../i18n/context";
+import { useT, type TKey } from "../../i18n/context";
 import { displayName, formatBytes } from "../../lib/mods";
 import { categoryIcon } from "../Library/categories";
-import { contentOf, contentType } from "./Manage";
+import { contentOf } from "./Manage";
 
-type Pane = "tracks" | "keep";
+const PANES = ["tracks", "helmets", "boots", "protection", "keep"] as const;
+type Pane = (typeof PANES)[number];
+
+const PANE_LABEL: Record<Pane, TKey> = {
+  tracks: "manage.paneTracks",
+  helmets: "manage.paneHelmets",
+  boots: "manage.paneBoots",
+  protection: "manage.paneProtection",
+  keep: "manage.paneKeep",
+};
 
 /**
- * Pick the content a preset's race needs: the track(s) it's ridden on, and the mods to
- * keep enabled alongside them.
+ * Which pane a mod belongs in, decided by its path so it answers the same for a mod that
+ * has since been uninstalled.
  *
- * The two lists are deliberately separate. A track is *what this preset is for* and reads
- * on the row in the panel behind; the pinned list is the boring infrastructure a race
- * needs anyway (the OEM pack, a sound pack) and is set once and forgotten. Everything the
- * loadout itself references — paint, helmet, boots, model swap — resolves automatically at
- * apply time and doesn't belong in either list.
+ * `null` means it belongs in none of them: a gear livery is resolved from the loadout's own
+ * paint slots at apply time, so pinning one by hand would only be a way to get it wrong.
+ */
+function paneOfRel(rel: string): Pane | null {
+  const segs = rel.toLowerCase().split(/[\\/]/).filter(Boolean);
+  if (segs[segs.length - 1]?.endsWith(".pnt")) return null;
+  if (segs[1] === "tracks") return "tracks";
+  // `mods/rider/helmets/AGV` — a gear model, folder or archive, one level under its area.
+  if (segs[1] === "rider" && segs.length === 4) {
+    if (segs[2] === "helmets") return "helmets";
+    if (segs[2] === "boots") return "boots";
+    if (segs[2] === "protection") return "protection";
+  }
+  return "keep";
+}
+
+/**
+ * Pick the content a preset's race needs: the track(s) it's ridden on, the gear models to
+ * leave in the game's pickers, and the mods to keep enabled alongside them.
+ *
+ * The lists are deliberately separate. A track is *what this preset is for* and reads on the
+ * row in the panel behind. The gear panes are the intuitive half of race mode: the preset's
+ * own helmet, boots and protection are kept automatically, and these are the extras worth
+ * still being able to reach for — everything unticked steps aside instead of padding the
+ * in-game list. The pinned list is the boring infrastructure a race needs anyway (the OEM
+ * pack, a sound pack) and is set once and forgotten.
+ *
+ * Paints are in none of them: the loadout names the one it wants, and that one is resolved
+ * at apply time.
  */
 export function ContentDialog({
   preset,
@@ -62,17 +95,24 @@ export function ContentDialog({
   const shown = useMemo(() => {
     const q = search.trim().toLowerCase();
     return mods
-      .filter((m) => (pane === "tracks" ? contentType(m.rel) === "tracks" : true))
+      .filter((m) => paneOfRel(m.rel) === pane)
       .filter((m) => q === "" || m.name.toLowerCase().includes(q))
       .slice(0, 400);
   }, [mods, pane, search]);
 
   // A mod named by the preset but no longer installed still has to be visible — otherwise
-  // it's silently dropped the next time the content is saved.
+  // it's silently dropped the next time the content is saved. It shows in its own pane, so
+  // a stale helmet doesn't turn up under Tracks.
   const missing = useMemo(() => {
     const known = new Set(mods.map((m) => m.rel.toLowerCase()));
-    return selected.filter((rel) => !known.has(rel.toLowerCase()));
-  }, [mods, selected]);
+    return selected.filter(
+      (rel) => !known.has(rel.toLowerCase()) && paneOfRel(rel) === pane,
+    );
+  }, [mods, selected, pane]);
+
+  /** How many of this preset's picks land in `p` — the number on its tab. */
+  const countIn = (p: Pane) =>
+    (p === "tracks" ? tracks : keep).filter((rel) => paneOfRel(rel) === p).length;
 
   const toggle = (rel: string) =>
     setSelected((prev) =>
@@ -96,28 +136,17 @@ export function ContentDialog({
             size="sm"
             value={pane}
             onChange={(v) => setPane(v as Pane)}
-            options={[
-              {
-                value: "tracks",
-                label: (
-                  <span className="flex items-center gap-1.5">
-                    {t("manage.paneTracks")}
-                    <span className="text-muted-foreground">{tracks.length}</span>
-                  </span>
-                ),
-              },
-              {
-                value: "keep",
-                label: (
-                  <span className="flex items-center gap-1.5">
-                    {t("manage.paneKeep")}
-                    <span className="text-muted-foreground">{keep.length}</span>
-                  </span>
-                ),
-              },
-            ]}
+            options={PANES.map((p) => ({
+              value: p,
+              label: (
+                <span className="flex items-center gap-1.5">
+                  {t(PANE_LABEL[p])}
+                  <span className="text-muted-foreground">{countIn(p)}</span>
+                </span>
+              ),
+            }))}
           />
-          <div className="ml-auto flex w-[220px] items-center gap-2 rounded-lg border border-input bg-card px-3 py-1.5">
+          <div className="ml-auto flex w-[200px] items-center gap-2 rounded-lg border border-input bg-card px-3 py-1.5">
             <Search className="size-3.5 text-faint" />
             <input
               value={search}
@@ -129,7 +158,11 @@ export function ContentDialog({
         </div>
 
         <p className="text-[11.5px] text-muted-foreground">
-          {pane === "tracks" ? t("manage.paneTracksHint") : t("manage.paneKeepHint")}
+          {pane === "tracks"
+            ? t("manage.paneTracksHint")
+            : pane === "keep"
+              ? t("manage.paneKeepHint")
+              : t("manage.paneGearHint")}
         </p>
 
         <div className="flex max-h-[46vh] min-h-[220px] flex-col gap-1 overflow-y-auto pr-1">

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -868,10 +868,15 @@ export const de: Translation = {
   "manage.contentSaved": "Renninhalte für „{{name}}“ gespeichert.",
   "manage.contentTitle": "Renninhalte für „{{name}}“",
   "manage.contentBody":
-    "Lackierung, Ausrüstung und Model-Swap des Presets werden von allein gefunden. Hier steht, was ein Loadout nicht sagen kann: die Strecke und die Packs, die ein Rennen ohnehin braucht.",
+    "Lackierung, Ausrüstung und Model-Swap des Presets werden von allein gefunden. Hier steht der Rest: die Strecke, zusätzliche Ausrüstungsmodelle, die bleiben sollen, und die Packs, die ein Rennen ohnehin braucht.",
   "manage.paneTracks": "Strecken",
+  "manage.paneHelmets": "Helme",
+  "manage.paneBoots": "Stiefel",
+  "manage.paneProtection": "Protektoren",
   "manage.paneKeep": "Immer behalten",
   "manage.paneTracksHint": "Die Strecke (oder Strecken), für die dieses Preset gedacht ist.",
+  "manage.paneGearHint":
+    "Zusätzliche Modelle, die in der Auswahl des Spiels bleiben. Die Ausrüstung des Presets wird ohnehin behalten — hake hier an, worauf du sonst noch zugreifen möchtest. Alles ohne Haken tritt zur Seite.",
   "manage.paneKeepHint":
     "Mods, die aktiv bleiben, egal was sonst passiert — das OEM-Pack, das Bike dieses Presets, eine Sound-Mod.",
   "manage.notInstalled": "nicht installiert",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -825,10 +825,15 @@ export const en = {
   "manage.contentSaved": "Saved the race content for “{{name}}”.",
   "manage.contentTitle": "Race content for “{{name}}”",
   "manage.contentBody":
-    "The paint, gear and model swap in the preset are found automatically. This is for what a loadout can't say: the track, and the packs a race needs anyway.",
+    "The paint, gear and model swap in the preset are found automatically. This is for the rest: the track, the spare gear models worth keeping, and the packs a race needs anyway.",
   "manage.paneTracks": "Tracks",
+  "manage.paneHelmets": "Helmets",
+  "manage.paneBoots": "Boots",
+  "manage.paneProtection": "Protection",
   "manage.paneKeep": "Always keep",
   "manage.paneTracksHint": "The track (or tracks) this preset is for.",
+  "manage.paneGearHint":
+    "Extra models to leave in the game's picker. The preset's own gear is kept for you — tick anything else you still want to be able to reach for. Everything unticked steps aside.",
   "manage.paneKeepHint":
     "Mods to keep enabled whatever else goes — the OEM pack, a bike this preset rides, a sound mod.",
   "manage.notInstalled": "not installed",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -856,10 +856,15 @@ export const es: Translation = {
   "manage.contentSaved": "Contenido de carrera guardado para «{{name}}».",
   "manage.contentTitle": "Contenido de carrera de «{{name}}»",
   "manage.contentBody":
-    "La pintura, el equipo y el cambio de modelo del preset se encuentran solos. Esto es para lo que un loadout no puede decir: la pista y los packs que una carrera necesita igualmente.",
+    "La pintura, el equipo y el cambio de modelo del preset se encuentran solos. Esto es para el resto: la pista, los modelos de equipo de repuesto que quieras conservar y los packs que una carrera necesita igualmente.",
   "manage.paneTracks": "Pistas",
+  "manage.paneHelmets": "Cascos",
+  "manage.paneBoots": "Botas",
+  "manage.paneProtection": "Protecciones",
   "manage.paneKeep": "Mantener siempre",
   "manage.paneTracksHint": "La pista (o pistas) para las que es este preset.",
+  "manage.paneGearHint":
+    "Modelos extra que quedan en el selector del juego. El equipo del propio preset se mantiene solo: marca aquí lo demás que quieras seguir teniendo a mano. Todo lo que quede sin marcar se aparta.",
   "manage.paneKeepHint":
     "Mods que siguen activos pase lo que pase — el pack OEM, la moto de este preset, un mod de sonido.",
   "manage.notInstalled": "no instalado",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -858,10 +858,15 @@ export const fr: Translation = {
   "manage.contentSaved": "Contenu de course enregistré pour « {{name}} ».",
   "manage.contentTitle": "Contenu de course de « {{name}} »",
   "manage.contentBody":
-    "La déco, l'équipement et le model swap du preset sont trouvés tout seuls. Ceci sert à ce qu'un loadout ne peut pas dire : la piste, et les packs dont une course a besoin de toute façon.",
+    "La déco, l'équipement et le model swap du preset sont trouvés tout seuls. Ceci sert au reste : la piste, les modèles d'équipement à garder en plus, et les packs dont une course a besoin de toute façon.",
   "manage.paneTracks": "Pistes",
+  "manage.paneHelmets": "Casques",
+  "manage.paneBoots": "Bottes",
+  "manage.paneProtection": "Protections",
   "manage.paneKeep": "Toujours garder",
   "manage.paneTracksHint": "La piste (ou les pistes) à laquelle ce preset est destiné.",
+  "manage.paneGearHint":
+    "Modèles supplémentaires à laisser dans le sélecteur du jeu. L'équipement du preset est gardé automatiquement — cochez ici ce que vous voulez encore pouvoir choisir. Tout ce qui n'est pas coché s'écarte.",
   "manage.paneKeepHint":
     "Les mods qui restent actifs quoi qu'il arrive — le pack OEM, la moto de ce preset, un mod de son.",
   "manage.notInstalled": "pas installé",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -847,10 +847,15 @@ export const it: Translation = {
   "manage.contentSaved": "Contenuti gara salvati per “{{name}}”.",
   "manage.contentTitle": "Contenuti gara di “{{name}}”",
   "manage.contentBody":
-    "Livrea, attrezzatura e model swap del preset vengono trovati da soli. Qui va ciò che un loadout non può dire: la pista e i pacchetti che una gara richiede comunque.",
+    "Livrea, attrezzatura e model swap del preset vengono trovati da soli. Qui va il resto: la pista, i modelli di attrezzatura da tenere in più e i pacchetti che una gara richiede comunque.",
   "manage.paneTracks": "Piste",
+  "manage.paneHelmets": "Caschi",
+  "manage.paneBoots": "Stivali",
+  "manage.paneProtection": "Protezioni",
   "manage.paneKeep": "Sempre attive",
   "manage.paneTracksHint": "La pista (o le piste) per cui è pensato questo preset.",
+  "manage.paneGearHint":
+    "Modelli extra da lasciare nel selettore del gioco. L'attrezzatura del preset viene mantenuta da sola: spunta qui ciò che vuoi ancora poter scegliere. Tutto ciò che resta non spuntato si fa da parte.",
   "manage.paneKeepHint":
     "Mod da tenere attive qualunque cosa accada — il pacchetto OEM, la moto di questo preset, una mod audio.",
   "manage.notInstalled": "non installata",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -846,10 +846,15 @@ export const ptBR: Translation = {
   "manage.contentSaved": "Conteúdo de corrida salvo para “{{name}}”.",
   "manage.contentTitle": "Conteúdo de corrida de “{{name}}”",
   "manage.contentBody":
-    "A pintura, o equipamento e a troca de modelo do preset são encontrados sozinhos. Aqui fica o que um loadout não consegue dizer: a pista e os pacotes que uma corrida precisa de qualquer jeito.",
+    "A pintura, o equipamento e a troca de modelo do preset são encontrados sozinhos. Aqui fica o resto: a pista, os modelos de equipamento extras que valem a pena manter e os pacotes que uma corrida precisa de qualquer jeito.",
   "manage.paneTracks": "Pistas",
+  "manage.paneHelmets": "Capacetes",
+  "manage.paneBoots": "Botas",
+  "manage.paneProtection": "Proteções",
   "manage.paneKeep": "Manter sempre",
   "manage.paneTracksHint": "A pista (ou pistas) para as quais este preset serve.",
+  "manage.paneGearHint":
+    "Modelos extras para deixar no seletor do jogo. O equipamento do próprio preset é mantido sozinho — marque aqui o que você ainda quer poder escolher. Tudo o que ficar desmarcado sai do caminho.",
   "manage.paneKeepHint":
     "Mods que continuam ativos aconteça o que acontecer — o pacote OEM, a moto deste preset, um mod de som.",
   "manage.notInstalled": "não instalado",


### PR DESCRIPTION
## The bug

Applying a race preset narrowed the bikes and tracks the game could see and left the rider alone. Every helmet, boot, protection set and gear livery installed still showed up in the game's pickers — including the hundreds of liveries sitting under the one helmet the preset actually names.

`modstate::is_candidate` decided what race mode was allowed to move:

```rust
e.kind == "pkz" || (e.kind == "folder" && e.category == "track")
```

Archives and extracted tracks only. Bikes and tracks ship as `.pkz`, so those narrowed correctly. A helmet/boots/protection model is a *folder* and a livery is a loose `.pnt`, so neither was ever a candidate. The reasoning in the comment was load-time — "a loose `.pnt` isn't mounted at boot, all cost and no gain" — which is true but beside the point: they're still rows in the picker.

Two more bugs sat behind it, either of which would have made the obvious fix a no-op:

- `is_kept` keeps anything *inside* a kept folder. That rule exists for model-swap variants; applied to gear, keeping the helmet would have kept every livery under it.
- `bundle::plan` collapses an asset into the folder that contains it — right for a zip that carries `rider/helmets/AGV` and its paints for free, wrong here, and it was silently dropping the named paint's own key.

## What changed

**Backend** — `modstate.rs`, `bundle.rs`

- Rider gear models and liveries are now candidates. Bike liveries and `FrostMod Models` stay excluded: they're tracked by path elsewhere in the app and would desync if moved.
- A `.pnt` is kept only when named outright, so a kept helmet no longer drags its whole livery folder along.
- New `bundle::plan_detailed` — the same resolution without the folder collapse, since Manage keeps a helmet by moving nothing and decides livery by livery.
- Restore handles the new half-parked case (folder in place, liveries parked) instead of colliding with the folder that never moved.

**UI** — `ContentDialog.tsx`

- Panes are now `Tracks · Helmets · Boots · Protection · Always keep`, each with its own count, so spare models can be ticked by hand rather than left to whatever the preset happens to name.
- Gear picks share the existing `keep` list — no preset-schema change, no migration.
- Paints are excluded from the dialog entirely, which its own docstring already claimed.
- Strings added to all six locales.

No DB or schema changes.

## Verification

- 212 Rust tests pass, including two new ones: a preset leaves only the gear it names (and restores cleanly from half-parked), and pinned gear models survive alongside the preset's own.
- `tsc --noEmit` clean; clippy clean on the changed files.
- Needs a Windows pass in-game: race a preset naming one helmet + one paint, confirm the pickers show only those, tick a spare helmet under the new tab and confirm it survives, then Restore all and confirm every folder and livery is back at its exact path.

## Judgment call worth a look

A preset using stock gear (`helmet=default`) now parks every installed helmet, since nothing is named. That's the honest reading of race mode and the new tabs are the escape hatch — but it's a deliberate choice, not a fallout, and worth agreeing on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)