### PR TITLE
fix(viewer): make the protection slot show what the mod actually is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 2026-08-07
+
+### Fixed
+- **Protection mods now show what they actually look like.** The protection slot is the
+  busiest and least conventional one on mxb-mods — chains, necklaces, hoodies, bibs,
+  backpacks, hair, the odd pickaxe — and unlike helmets and boots those mods bake their
+  look straight into the mesh instead of shipping a `.pnt`. The preview only ever looked
+  for a paint, so five of eight real mods pulled off the site came out as a featureless
+  grey shape. A piece with no paint to wear now wears the texture its own mesh carries,
+  each part bound to its own: a chest protector's shell and straps, or a chain's four baked
+  maps, land where the model says they go instead of all sharing one.
+- **A protection is drawn at the size it was made.** Every piece was being scaled to a
+  fixed fraction of the rider and re-centred on his chest, which inflated a thin necklace
+  to the proportions of a full vest and threw away the offset a chain or a hood is
+  deliberately authored to hang at. Protection is modelled in the rider's own frame, so
+  it's now placed as authored — its own size, its own offset — and the mount an `.hrc`
+  names is honoured.
+- **Mods that ship sealed loose files load.** A protection folder whose files are sealed
+  the way a `.pkz` seals its entries used to fail outright with "no gear mesh found"; those
+  now read like any other. Gear also follows the `gfx.cfg` → `.hrc` chain to find its mesh,
+  so a mod that names it for the piece (`neckbrace.edf`, `pickaxe.edf`) resolves instead of
+  relying on a guess from filenames, and stock gear whose folder doesn't use the slot's own
+  mesh name no longer comes up empty.
+- **Textures baked in Substance or Blender bind to the right mesh.** Maps exported under
+  the toolchain's names — `Vest_Normal` beside `Vest_BaseColor` — were counted as looks in
+  their own right, and since material indices count that list, every texture after one slid
+  onto the wrong part. That's why the Tactical Vest wore its pouch's normal map.
+
+### Changed
+- **Protection is no longer hidden by default in the Rider tab.** It was, back when it
+  rendered as a grey blob spanning the whole torso.
+
 ## 2026-08-07 — v0.7.1 — the Rider preview stops failing in silence
 
 ### Fixed

--- a/src-tauri/src/edf.rs
+++ b/src-tauri/src/edf.rs
@@ -542,9 +542,40 @@ pub fn material_slots(b: &[u8], colors: usize) -> Vec<Option<usize>> {
 
 /// Companion maps ride alongside a colour texture and are never the look itself — MX
 /// Bikes names them `_n` normal, `_s` specular, `_r` reflection.
+///
+/// Mods baked in Substance or Blender keep those maps under the exporter's own names
+/// instead (`Vest_Normal` beside `Vest_BaseColor`). Counting one of those as a colour
+/// texture doesn't just add a stray entry: material indices count this list, so every
+/// texture after it slides onto the wrong mesh — which is how the Tactical Vest came out
+/// wearing its pouch's normal map.
 pub fn is_companion_texture(name: &str) -> bool {
     let n = name.to_ascii_lowercase();
-    n.ends_with("_n") || n.ends_with("_s") || n.ends_with("_r")
+    // MX Bikes' own single-letter convention, plus the exporter names.
+    n.ends_with("_n") || n.ends_with("_s") || n.ends_with("_r") || is_exporter_companion(&n)
+}
+
+/// Companion maps under the names Substance and Blender give them, shared by every filter
+/// that has to tell a map from the look. Colour channels (`_basecolor`, `_diffuse`,
+/// `_albedo`) are deliberately absent — those ARE the look.
+pub fn is_exporter_companion(name: &str) -> bool {
+    let n = name.to_ascii_lowercase();
+    [
+        "_normal",
+        "_nrm",
+        "_roughness",
+        "_metallic",
+        "_metalness",
+        "_specular",
+        "_glossiness",
+        "_ao",
+        "_ambientocclusion",
+        "_bump",
+        "_height",
+        "_displacement",
+        "_opacity",
+    ]
+    .iter()
+    .any(|suffix| n.ends_with(suffix))
 }
 
 /// A model's COLOUR textures, in file order. Material indices count these — including the
@@ -1174,6 +1205,19 @@ fn submesh_transform(b: &[u8], name_off: usize, block_off: usize) -> Vec<Mat4> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Material indices count the colour textures, so a map counted among them slides every
+    // later texture onto the wrong mesh — the Tactical Vest wore its pouch's normal map.
+    #[test]
+    fn exporter_named_maps_are_companions_not_colour() {
+        for name in ["Vest_Normal", "chest_Roughness", "brace_AO", "pouch_metallic", "shell_n"] {
+            assert!(is_companion_texture(name), "'{name}' is a map");
+        }
+        // The look itself, however it's spelled.
+        for name in ["Vest_BaseColor", "chest_diffuse", "CK_A1", "bake1", "aphair"] {
+            assert!(!is_companion_texture(name), "'{name}' is the look");
+        }
+    }
 
     // Investigation aid: print an .edf's overall vertex bounds + node names.
     // MXB_EDF_FILE=/tmp/rider.edf cargo test edf_bounds -- --ignored --nocapture

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1075,6 +1075,7 @@ async fn load_stock_gear_model(
             .ok_or_else(|| "game path not set or rider.pkz not found".to_string())?;
         let folder = format!("rider/{}/{}", spec.pkz_kind, spec.default_name);
         let nodes = load_pkz_mesh(&pkz, &format!("{folder}/{}", spec.mesh))
+            .or_else(|| stock_gear_entry(&pkz, &folder).and_then(|e| load_pkz_mesh(&pkz, &e)))
             .ok_or_else(|| format!("stock {part} mesh not found in rider.pkz"))?;
         let textures = match paint_path.filter(|s| !s.is_empty()) {
             Some(p) => std::fs::read(&p)
@@ -1118,9 +1119,16 @@ fn gear_paints_at(path: &std::path::Path) -> Result<GearPaints, String> {
         out
     };
     // Names only — decoding the pixels is the load path's job, and this runs per picker.
+    // Resolved the same way the loader resolves it, so the picker can't offer a stock look
+    // that comes off a different mesh than the one drawn.
+    let scene = gear_mount(&files).scene;
     let embedded: Vec<String> = files
         .iter()
-        .find(|(n, _)| is_visible_gear_mesh(n))
+        .find(|(n, _)| {
+            let base = n.rsplit('/').next().unwrap_or(n);
+            scene.as_deref().is_some_and(|s| base.eq_ignore_ascii_case(s))
+        })
+        .or_else(|| files.iter().find(|(n, _)| is_visible_gear_mesh(n)))
         .map(|(_, d)| edf::embedded_textures(d).iter().map(|t| t.name.clone()).collect())
         .unwrap_or_default();
     Ok(GearPaints {
@@ -1228,9 +1236,12 @@ fn load_gear_model_blocking(
     files.extend(extra);
     let want = paint.filter(|s| !s.is_empty());
     let want_goggles = goggles.filter(|s| !s.is_empty());
-    let mut nodes = Vec::new();
-    // Kept so a stock request can read the mesh's own textures back out of it.
-    let mut mesh: Option<&Vec<u8>> = None;
+    // Which `.edf` is the visible one, in the mod's own words where it says so.
+    let mount = gear_mount(&files);
+    let scene = mount.scene.as_deref();
+    // Kept so a stock side can read the mesh's own textures back out of it.
+    let mut named_mesh: Option<&Vec<u8>> = None;
+    let mut first_mesh: Option<&Vec<u8>> = None;
     // Collect paint/goggle entries up front so we can prefer the requested one but always
     // fall back to the first available: a stale or unknown paint name must still show the
     // gear textured, never bare grey.
@@ -1239,11 +1250,10 @@ fn load_gear_model_blocking(
     for (name, data) in &files {
         let base = name.rsplit('/').next().unwrap_or(name).to_ascii_lowercase();
         if base.ends_with(".edf") {
-            if nodes.is_empty() && is_visible_gear_mesh(name) {
-                mesh = Some(data);
-                nodes = edf::parse(data);
-                edf::to_right_handed(&mut nodes);
-                keep_lod0(&mut nodes);
+            if scene.is_some_and(|s| base.eq_ignore_ascii_case(s)) {
+                named_mesh = Some(data);
+            } else if first_mesh.is_none() && is_visible_gear_mesh(name) {
+                first_mesh = Some(data);
             }
         } else if let Some(pname) = gear_folder_paint_name(name, "paints") {
             paints.push((pname, data));
@@ -1251,9 +1261,29 @@ fn load_gear_model_blocking(
             goggle_paints.push((gname, data));
         }
     }
+    // A mod that names a scene it doesn't ship still has a mesh in the folder; take it.
+    let mesh = named_mesh.or(first_mesh);
+    let mut nodes = mesh.map(|d| edf::parse(d)).unwrap_or_default();
+    edf::to_right_handed(&mut nodes);
+    keep_lod0(&mut nodes);
     if nodes.is_empty() {
         return Err(format!("no gear mesh found in {path}"));
     }
+    // The `.hrc` may seat the piece off its mount — the Leatt neck brace drops 11 cm — and
+    // the viewer draws gear where the mesh puts it, so bake it in rather than pass it on.
+    if let Some(pos) = mount.pos {
+        offset_nodes(&mut nodes, pos);
+    }
+    // With no `.pnt` to offer, the shell wears what the mesh already carries. Helmets and
+    // boots nearly always ship a paint, so this reads as an edge case there — on the
+    // protection slot it's the norm: a chain, a bib or a chest protector bakes its look into
+    // the `.edf` and ships an empty `paints/` folder. Asked for a paint that doesn't exist,
+    // the binder had nothing to hand each piece and the whole item came out bare grey.
+    //
+    // Only the shell. Unpainted goggles already have somewhere to go — they fall back to the
+    // shell's texture, which is where a helmet that doesn't paint them apart drew them — and
+    // a helmet whose shell paint repaints the goggles too would lose that to the mesh's own.
+    let stock = stock || paints.is_empty();
     // A stock side decodes nothing from `paints/` — the mesh already carries that texture.
     let main_pnt = (!stock)
         .then(|| pick_gear_paint(&paints, want.as_deref(), &part))
@@ -1313,6 +1343,56 @@ fn load_gear_model_blocking(
     Ok(RiderPart { part, nodes, textures: out })
 }
 
+/// What a gear item says about its own mesh.
+#[derive(Default)]
+struct GearMount {
+    /// The `.edf` named by `level0 { scene }`.
+    scene: Option<String>,
+    /// The `pos { x y z }` the `.hrc` seats that mesh at, in the game's own frame.
+    pos: Option<[f32; 3]>,
+}
+
+/// Follow `gfx.cfg` → `<piece>.hrc` → `level0 { scene }`, the same chain the game walks and
+/// the bike loader already uses.
+///
+/// Worth following on gear because a gear mesh is named for the piece rather than the slot —
+/// `neckbrace.edf`, `pickaxe.edf`, `protection.edf` all turn up in the protection folder —
+/// so which `.edf` is *the* one is the mod's answer to give, not ours to guess from filenames.
+fn gear_mount(files: &[(String, Vec<u8>)]) -> GearMount {
+    let find = |want: &str| -> Option<&Vec<u8>> {
+        files
+            .iter()
+            .find(|(n, _)| n.rsplit('/').next().unwrap_or(n).eq_ignore_ascii_case(want))
+            .map(|(_, d)| d)
+    };
+    // The `.hrc` sits under a block named for the piece — `armour`, `neckbrace`, whatever
+    // the author called it — so take the first block that names one at all.
+    let hrc_name = find("gfx.cfg")
+        .map(|d| cfg::parse(d))
+        .and_then(|c| c.blocks.values().find_map(|b| b.get("model").map(str::to_string)));
+    let Some(hrc) = hrc_name.as_deref().and_then(find).map(|d| cfg::parse(d)) else {
+        return GearMount::default();
+    };
+    let pos = hrc.block("pos").and_then(|p| {
+        let axis = |k: &str| p.get(k).and_then(|v| v.trim().parse::<f32>().ok());
+        Some([axis("x")?, axis("y")?, axis("z")?])
+    });
+    GearMount { scene: cfg::hrc_level0_scene(&hrc), pos }
+}
+
+/// Shift a mesh onto the mount its `.hrc` names. `pos` is written in the game's own frame,
+/// so it takes the same X flip [`edf::to_right_handed`] gave the vertices.
+fn offset_nodes(nodes: &mut [edf::EdfNode], pos: [f32; 3]) {
+    let d = [-pos[0], pos[1], pos[2]];
+    for n in nodes.iter_mut() {
+        for p in n.positions.chunks_exact_mut(3) {
+            for (v, delta) in p.iter_mut().zip(d) {
+                *v += delta;
+            }
+        }
+    }
+}
+
 /// The gear file carrying the visible mesh — not the `_s` shadow or the `c_` cockpit variant.
 fn is_visible_gear_mesh(name: &str) -> bool {
     let base = name.rsplit('/').next().unwrap_or(name).to_ascii_lowercase();
@@ -1320,10 +1400,13 @@ fn is_visible_gear_mesh(name: &str) -> bool {
 }
 
 /// Normal (`_n`) and reflection (`_r`) maps ride alongside a colour texture and are never
-/// the look itself. Mirrors the filter in `paint::extract_edf_textures`.
+/// the look itself. Mirrors the filter in `paint::extract_edf_textures`, and shares the
+/// exporter-spelled names with [`edf::is_companion_texture`] so the two can't drift.
+/// `_s` is left out on purpose: the mesh-side filter reads it as MX Bikes' specular map,
+/// but a `.pnt` may legitimately name a texture that way.
 fn is_companion_map(name: &str) -> bool {
     let n = name.to_ascii_lowercase();
-    n.ends_with("_n") || n.ends_with("_r")
+    n.ends_with("_n") || n.ends_with("_r") || edf::is_exporter_companion(&n)
 }
 
 /// Goggles (and their lens) are the one gear part painted separately from the shell —
@@ -1403,6 +1486,17 @@ fn bind_gear_submeshes(
     }
 }
 
+/// One loose file out of an unpacked gear folder, in the form the rest of the loader reads.
+///
+/// A mod that ships as a plain folder may still seal its individual files the way a `.pkz`
+/// seals its entries — the Tactical Vest on mxb-mods does, and read raw its `.edf` isn't a
+/// mesh at all, so the whole item failed with "no gear mesh found". Anything already plain
+/// passes straight through.
+fn read_gear_file(path: &std::path::Path) -> Option<Vec<u8>> {
+    let bytes = std::fs::read(path).ok()?;
+    Some(pkz::read_sidecar_blob(&bytes).unwrap_or(bytes))
+}
+
 fn read_gear_files(p: &std::path::Path) -> anyhow::Result<Vec<(String, Vec<u8>)>> {
     use anyhow::Context;
     if p.is_dir() {
@@ -1410,8 +1504,8 @@ fn read_gear_files(p: &std::path::Path) -> anyhow::Result<Vec<(String, Vec<u8>)>
         for entry in std::fs::read_dir(p).with_context(|| format!("read dir {p:?}"))? {
             let path = entry?.path();
             if path.is_file() {
-                if let (Some(name), Ok(bytes)) =
-                    (path.file_name().and_then(|n| n.to_str()), std::fs::read(&path))
+                if let (Some(name), Some(bytes)) =
+                    (path.file_name().and_then(|n| n.to_str()), read_gear_file(&path))
                 {
                     out.push((name.to_string(), bytes));
                 }
@@ -1421,8 +1515,8 @@ fn read_gear_files(p: &std::path::Path) -> anyhow::Result<Vec<(String, Vec<u8>)>
             if let Ok(rd) = std::fs::read_dir(p.join(sub)) {
                 for entry in rd.flatten() {
                     let path = entry.path();
-                    if let (Some(name), Ok(bytes)) =
-                        (path.file_name().and_then(|n| n.to_str()), std::fs::read(&path))
+                    if let (Some(name), Some(bytes)) =
+                        (path.file_name().and_then(|n| n.to_str()), read_gear_file(&path))
                     {
                         out.push((format!("{sub}/{name}"), bytes));
                     }
@@ -1503,8 +1597,15 @@ fn load_gear(
     let name = if model.is_empty() { spec.default_name } else { model };
     let pkz = resolve_game_pkz(cfg, "rider.pkz")?;
     let folder = format!("rider/{}/{}", spec.pkz_kind, name);
-    let entry = format!("{folder}/{}", spec.mesh);
-    let mut nodes = load_pkz_mesh(&pkz, &entry)?;
+    let named = format!("{folder}/{}", spec.mesh);
+    let (entry, mut nodes) = match load_pkz_mesh(&pkz, &named) {
+        Some(n) => (named, n),
+        None => {
+            let alt = stock_gear_entry(&pkz, &folder)?;
+            let n = load_pkz_mesh(&pkz, &alt)?;
+            (alt, n)
+        }
+    };
     let mut textures = load_pkz_paint(&pkz, &folder, "paints", paint);
     let main_side = GearSide::new(textures.iter().map(|t| t.name.clone()).collect());
     // Stock gear paints its goggles apart from the shell just as an installed helmet does:
@@ -1536,6 +1637,30 @@ fn load_gear(
         nodes,
         textures,
     })
+}
+
+/// The `.edf` a stock gear folder in `rider.pkz` actually carries, for the folders that
+/// don't answer to the slot's usual name.
+///
+/// Protection is where this bites: the slot expects `armour.edf`, which is the chest
+/// protector's name — the neck brace beside it is its own mesh, and asking for a name that
+/// isn't there left the slot silently empty rather than wrong, which is harder to notice.
+/// Only reached once the expected name has already missed.
+fn stock_gear_entry(pkz: &std::path::Path, folder: &str) -> Option<String> {
+    let prefix = format!("{}/", folder.replace('\\', "/").to_ascii_lowercase());
+    let mut found: Vec<String> = pkz::read_selected(pkz, |n| {
+        let n = n.replace('\\', "/").to_ascii_lowercase();
+        n.starts_with(&prefix) && is_visible_gear_mesh(&n)
+    })
+    .ok()?
+    .into_iter()
+    .map(|(n, _)| n.replace('\\', "/"))
+    .collect();
+    // Deterministic rather than archive-order, so the same folder always resolves the same.
+    found.sort_by_key(|n| n.to_ascii_lowercase());
+    let hit = found.into_iter().next()?;
+    log::info!("[rider] stock '{folder}' doesn't carry the slot's mesh; using '{hit}'");
+    Some(hit)
 }
 
 /// Loose `.pnt` files in a folder, named as a gear archive would carry them so the loader
@@ -2744,6 +2869,84 @@ mod gear_bind_tests {
         assert_eq!(s.supplies("STRAP").as_deref(), Some("strap")); // case-insensitive
         assert_eq!(s.supplies("visor"), None);
     }
+
+    // A paint baked out of Substance names its maps the exporter's way, and one of those
+    // taken for the look leaves the piece wearing a normal map.
+    #[test]
+    fn an_exporter_named_map_is_never_the_primary() {
+        let s = side(&["Vest_Normal", "Vest_BaseColor"]);
+        assert_eq!(s.primary.as_deref(), Some("Vest_BaseColor"));
+    }
+}
+
+#[cfg(test)]
+mod gear_mount_tests {
+    use super::{gear_mount, offset_nodes, edf};
+
+    fn files(entries: &[(&str, &str)]) -> Vec<(String, Vec<u8>)> {
+        entries.iter().map(|(n, d)| (n.to_string(), d.as_bytes().to_vec())).collect()
+    }
+
+    // A protection folder names its mesh for the piece, not the slot, so the loader has to
+    // ask rather than guess: `neckbrace.edf` sits beside the shadow mesh it must not pick.
+    #[test]
+    fn a_mod_names_its_own_mesh() {
+        let f = files(&[
+            ("gfx.cfg", "neckbrace\n{\n\tmodel = neckbrace.hrc\n}\n"),
+            ("neckbrace.hrc", "level0\n{\n\tscene = neckbrace.edf\n\tswitch = 0\n}\n"),
+        ]);
+        let m = gear_mount(&f);
+        assert_eq!(m.scene.as_deref(), Some("neckbrace.edf"));
+        assert_eq!(m.pos, None);
+    }
+
+    // The block in `gfx.cfg` is named for the piece, and authors don't agree on the word —
+    // `armour` and `neckbrace` both turn up on protection mods that ship `protection.edf`.
+    #[test]
+    fn the_block_name_doesnt_matter() {
+        let f = files(&[
+            ("gfx.cfg", "armour\n{\n\tmodel = protection.hrc\n}\n"),
+            ("protection.hrc", "level0\n{\n\tscene = protection.edf\n}\n"),
+        ]);
+        assert_eq!(gear_mount(&f).scene.as_deref(), Some("protection.edf"));
+    }
+
+    #[test]
+    fn an_hrc_can_seat_the_mesh_off_its_mount() {
+        let f = files(&[
+            ("gfx.cfg", "neckbrace\n{\n\tmodel = neckbrace.hrc\n}\n"),
+            (
+                "neckbrace.hrc",
+                "level0\n{\n\tscene = neckbrace.edf\n}\npos\n{\n\tx = 0\n\ty = -0.11\n\tz = 0\n}\n",
+            ),
+        ]);
+        assert_eq!(gear_mount(&f).pos, Some([0.0, -0.11, 0.0]));
+    }
+
+    // Most gear ships neither, and that's not an error — the loader falls back to scanning.
+    #[test]
+    fn a_mod_that_says_nothing_answers_nothing() {
+        let m = gear_mount(&files(&[("protection.edf", "EDF\0")]));
+        assert_eq!(m.scene, None);
+        assert_eq!(m.pos, None);
+    }
+
+    // `pos` is written in the game's frame, so it takes the same X flip the vertices got.
+    #[test]
+    fn the_mount_offset_flips_x_with_the_vertices() {
+        let mut nodes = vec![edf::EdfNode {
+            name: "protection".into(),
+            positions: vec![1.0, 2.0, 3.0],
+            uvs: Vec::new(),
+            normals: Vec::new(),
+            indices: Vec::new(),
+            submeshes: Vec::new(),
+            texture: None,
+            placed: false,
+        }];
+        offset_nodes(&mut nodes, [0.5, -0.11, 0.25]);
+        assert_eq!(nodes[0].positions, vec![0.5, 1.89, 3.25]);
+    }
 }
 
 #[cfg(test)]
@@ -2818,6 +3021,27 @@ mod viewer_tests {
                 super::edf::color_textures(d).into_iter().map(|t| t.name).collect();
             eprintln!("mesh colour textures: {names:?}");
         }
+        // Where the mesh sits in its own frame. Protection is authored in the rider's own
+        // space, so these bounds say whether a piece is a chest-wide vest or a thin chain
+        // — the difference a one-size fit erases.
+        if let Some((_, d)) = files.iter().find(|(n, _)| super::is_visible_gear_mesh(n)) {
+            let mut nodes = super::edf::parse(d);
+            super::edf::to_right_handed(&mut nodes);
+            for n in &nodes {
+                let mut lo = [f32::INFINITY; 3];
+                let mut hi = [f32::NEG_INFINITY; 3];
+                for v in n.positions.chunks_exact(3) {
+                    for k in 0..3 {
+                        lo[k] = lo[k].min(v[k]);
+                        hi[k] = hi[k].max(v[k]);
+                    }
+                }
+                eprintln!(
+                    "bounds  {:<16} x[{:.3},{:.3}] y[{:.3},{:.3}] z[{:.3},{:.3}]",
+                    n.name, lo[0], hi[0], lo[1], hi[1], lo[2], hi[2],
+                );
+            }
+        }
         // The names each side's first paint supplies — where each can actually land.
         let supplied = |folder: &str| -> std::collections::HashSet<String> {
             files
@@ -2828,26 +3052,48 @@ mod viewer_tests {
                 .unwrap_or_default()
         };
 
-        let part = super::load_gear_model_blocking(path.clone(), "helmet".into(), None, None, false, false, Vec::new())
+        // The slot this item is worn in. Gear behaves differently per slot — protection has
+        // no goggle side, and is the slot where a paintless mod is the norm rather than the
+        // exception — so the run is worth naming honestly.
+        let slot = std::env::var("MXB_REAL_GEAR_PART").unwrap_or_else(|_| "helmet".into());
+        let part = super::load_gear_model_blocking(path.clone(), slot.clone(), None, None, false, false, Vec::new())
             .expect("load gear");
         let have: std::collections::HashSet<String> =
             part.textures.iter().map(|t| t.name.to_ascii_lowercase()).collect();
+        // An item with no paint and nothing baked into its mesh has no look to wear — the
+        // Minecraft pickaxe on mxb-mods ships exactly that. Bare grey is the honest answer
+        // there, and the only case where an unbound piece isn't a bug.
+        let has_look = !paints.is_empty() || !have.is_empty();
         // Which texture each piece ended up wearing, by node so a goggle node that carries
         // no submeshes of its own shows up too.
         let mut worn: Vec<(String, String)> = Vec::new();
+        let mut bare = 0usize;
         for n in &part.nodes {
-            if n.submeshes.is_empty() {
-                let t = n.texture.as_ref().expect("node bound to a texture");
-                eprintln!("node    {:<10} -> {t}", n.name);
-                worn.push((n.name.clone(), t.clone()));
-                continue;
-            }
-            for s in &n.submeshes {
-                let t = s.texture.as_ref().expect("submesh bound to a texture");
-                eprintln!("submesh {:<10} (node {:<10}) -> {t}", s.name, n.name);
-                worn.push((format!("{}/{}", n.name, s.name), t.clone()));
+            let pieces: Vec<(String, &Option<String>)> = if n.submeshes.is_empty() {
+                vec![(n.name.clone(), &n.texture)]
+            } else {
+                n.submeshes
+                    .iter()
+                    .map(|s| (format!("{}/{}", n.name, s.name), &s.texture))
+                    .collect()
+            };
+            for (label, tex) in pieces {
+                match tex {
+                    Some(t) => {
+                        eprintln!("worn    {label:<28} -> {t}");
+                        worn.push((label, t.clone()));
+                    }
+                    None => {
+                        eprintln!("worn    {label:<28} -> (bare)");
+                        bare += 1;
+                    }
+                }
             }
         }
+        assert!(
+            !has_look || bare == 0,
+            "{bare} piece(s) left bare though the item ships a look",
+        );
         for (_, t) in &worn {
             assert!(have.contains(&t.to_ascii_lowercase()), "'{t}' is shipped");
         }
@@ -2878,7 +3124,7 @@ mod viewer_tests {
         let stock =
             super::load_gear_model_blocking(
                 path,
-                "helmet".into(),
+                slot,
                 None,
                 None,
                 true,

--- a/src/Components/Rider/RiderStudio.tsx
+++ b/src/Components/Rider/RiderStudio.tsx
@@ -46,7 +46,10 @@ export default function RiderStudio({ initialLoadout, onLoaded }: RiderStudioPro
   const [loadout, setLoadout] = useState<Loadout>(EMPTY_LOADOUT);
   const [name, setName] = useState("");
   const [busy, setBusy] = useState(false);
-  const [hidden, setHidden] = useState<RiderPart["part"][]>(["protection"]);
+  // Nothing hidden to start. Protection used to be, back when it came out of the loader as
+  // a grey blob scaled to the whole torso — with the piece drawn as authored there's no
+  // reason to hide the slot the rider tab is most often opened for.
+  const [hidden, setHidden] = useState<RiderPart["part"][]>([]);
   const [error, setError] = useState<string | null>(null);
   const [gearPaints, setGearPaints] = useState<Record<"helmet" | "boots" | "protection", GearPaints>>({
     helmet: EMPTY_GEAR_PAINTS,

--- a/src/Components/Viewer/ModelViewer.tsx
+++ b/src/Components/Viewer/ModelViewer.tsx
@@ -235,19 +235,28 @@ function useGearMaterials(part: RiderPart, tex: Map<string, THREE.Texture>) {
 function RiderGearMesh({
   part,
   anchor,
-  target,
+  target = 1,
   rot = GEAR_ROT,
   yaw = 0,
   alignY = "center",
   pitch = 0,
+  fit: fitMode = "box",
 }: {
   part: RiderPart;
   anchor: [number, number, number];
-  target: number;
+  /** Longest edge the bounding box is scaled to. Ignored when `fit` is `"native"`. */
+  target?: number;
   rot?: [number, number, number];
   yaw?: number;
   alignY?: "center" | "top" | "bottom";
   pitch?: number;
+  /**
+   * How the piece meets the body. `"box"` scales its bounding box to `target` and centres
+   * it on the anchor — right for a helmet or a boot, each authored around its own origin
+   * in its own frame. `"native"` hangs it off the anchor unscaled, at the size and offset
+   * it was authored at, and ignores `target`.
+   */
+  fit?: "box" | "native";
 }) {
   const texMap = useTextureMap(part.textures);
   const geoms = useBodyGeometries(part.nodes);
@@ -276,16 +285,19 @@ function RiderGearMesh({
   }, [geoms, target, rot, yaw, pitch]);
 
   if (!fit) return null;
-  const s = fit.scale;
+  // Native: the mesh already knows its own size and where it hangs off the mount, so the
+  // only thing left to do is put its origin on the anchor.
+  const s = fitMode === "native" ? 1 : fit.scale;
   // Shift so the requested bbox edge (not just the centre) lands on anchor[1].
   const alignShift =
     alignY === "bottom" ? fit.halfY * s : alignY === "top" ? -fit.halfY * s : 0;
+  const recentre = fitMode === "native" ? new THREE.Vector3() : fit.center;
   return (
     <group
       position={[
-        anchor[0] - fit.center.x * s,
-        anchor[1] - fit.center.y * s + alignShift,
-        anchor[2] - fit.center.z * s,
+        anchor[0] - recentre.x * s,
+        anchor[1] - recentre.y * s + alignShift,
+        anchor[2] - recentre.z * s,
       ]}
       scale={s}
     >
@@ -564,6 +576,10 @@ function RiderComposite({ parts }: { parts: RiderPart[] }) {
   // Boots hang their top edge on the body's floor (alignY="top"), nudged forward in Z.
   const footY = b ? b.lo[1] + 0.08 * h : 0.2;
   const bootZ = b ? cz + 0.16 * depth : cz;
+  // Where a protection's own origin sits on the body. Unlike a helmet or a boot, the whole
+  // slot shares one mount: a chest protector, a neck brace, a chain and a bib are all
+  // authored around the same point in the rider's own frame, so this anchor places every
+  // one of them and their own geometry does the rest.
   const protAnchor: [number, number, number] = b ? [cx, b.lo[1] + 0.62 * h, cz] : [0, 1.16, 0.03];
   const bootTarget = hasBody ? 0.44 * h : 0.32;
 
@@ -586,8 +602,16 @@ function RiderComposite({ parts }: { parts: RiderPart[] }) {
           alignY={hasBody ? "bottom" : "center"}
         />
       )}
+      {/* Native, not fitted: the protection slot spans a full chest protector and a thin
+          necklace, and scaling each to one size inflated the chain to vest proportions and
+          threw away the offset a piece like a chain or a hood hangs at deliberately. */}
       {!!protection?.nodes.length && (
-        <RiderGearMesh part={protection!} anchor={protAnchor} target={hasBody ? 0.42 * h : 0.62} rot={PROT_ROT} />
+        <RiderGearMesh
+          part={protection!}
+          anchor={protAnchor}
+          rot={PROT_ROT}
+          fit="native"
+        />
       )}
       {/* Two feet as separate nodes → split left/right; a single-node boot renders centred. */}
       {!!boots?.nodes.length &&


### PR DESCRIPTION
## Why

The protection slot is the busiest and least conventional gear slot on mxb-mods — chains, necklaces, hoodies, bibs, backpacks, hair, the odd pickaxe — and its mods are authored differently from helmets and boots. I pulled ten real mods from the site's protection category and ran each through the loader: **five of the first eight rendered as a featureless grey shape, and one didn't load at all.**

| Mod | Ships `.pnt`? | Mesh textures | Before | After |
|---|---|---|---|---|
| Leatt GPX + MSR Chest Protector | no | `CHST`, `tex` | grey | `neckbrace`→`CHST`, `neckbrace.001`→`tex` |
| JS7 Iced Out Chain | no | `bake1..4` | grey | four submeshes → their own bake |
| Forged Racewear (Iced / 2Icey) | no | `texture1` | grey | → `texture1` |
| Long Hair | no | `aphair` | grey | → `aphair` |
| NORMZ.Co Tactical Vest | no | `Pouch_/Vest_BaseColor` | **failed to load** | each submesh → its own |
| Alpinestars A1-Pro | yes | `CK_A1` | ok | ok |
| Cuban Necklace (`.pkz`) | yes (4) | `Gold_d` | ok | ok |
| Minecraft Pickaxe | no | *(none)* | grey | bare — it ships no texture at all |

## What changed

- **A shell with no `.pnt` wears the texture its own mesh carries**, each submesh bound to its own via the mesh's material readings. Protection mods bake their look into the `.edf` and ship an empty `paints/` folder, so asking only for a paint left the binder nothing to hand each piece. Scoped to the shell — unpainted goggles already fall back to the shell texture, which is where a helmet that doesn't paint them apart drew them.
- **Protection is drawn at native scale and offset** instead of fitted to a fraction of the rider and re-centred, which inflated a thin necklace to vest proportions and discarded the offset a chain or hood hangs at. The whole slot shares one mount in the rider's own frame, so the anchor places every piece and its own geometry does the rest.
- **Loose gear files sealed the way a `.pkz` seals its entries are read as such**, instead of failing the whole item with "no gear mesh found".
- **Gear follows `gfx.cfg` → `.hrc` → `level0 { scene }`** to find its mesh and honours the `pos` that seats it, so a mod naming its mesh for the piece (`neckbrace.edf`, `pickaxe.edf`) resolves rather than relying on a filename guess. Stock gear falls back off the slot's expected mesh name to whatever `.edf` the folder carries.
- **Companion maps exported under Substance/Blender names** (`Vest_Normal` beside `Vest_BaseColor`) are no longer counted as colour textures. Material indices count that list, so one miscounted slid every later texture onto the wrong mesh — that's why the Tactical Vest wore its pouch's normal map.
- **Protection is no longer hidden by default in the Rider tab.** It was, back when it rendered as a grey blob spanning the whole torso.

No DB or schema changes.

## Testing

- 213 Rust tests pass, 5 new (`gear_mount_tests`, exporter-companion filtering, `GearSide` primary).
- The `#[ignore]`d real-mod diagnostic run over all ten protection mods: every piece binds to a texture the item actually ships, the pickaxe excepted — it embeds none, and bare is the honest answer there.
- Three helmets with separate goggle paints (Shoei VFX-EVO Spy, Bell Moto 10 EKS/Scott) bind shell/goggle/lens exactly as before.
- `tsc --noEmit`, eslint and `npm run build` clean; clippy adds no new warnings.

## Reviewer notes

- **The companion-map fix reaches bikes.** `edf::color_textures` is shared with the bike loader, so any bike shipping exporter-named maps gets the same material-indexing correction. Same direction of fix, but it's the widest blast radius here.
- **Two stock-gear paths are reasoned, not observed** — no `rider.pkz` on macOS. `stock_gear_entry` finding `neck`'s own mesh, and the `.hrc` `pos` offset on a stock piece. Both are fallbacks that only run where the current code returns nothing at all.
- **The protection anchor is unchanged** at `b.lo[1] + 0.62 * h`. Native placement puts the mesh origin there rather than its bbox centre, and on the pieces measured those are within 2 cm — so a chest protector doesn't move; everything else just stops being rescaled. Moving the anchor would be a guess without `rider.pkz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)