### PR TITLE
fix(mxb): stop the clearance window being parked in the tray

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -42,6 +42,26 @@ use tauri::{
 };
 use tauri_plugin_autostart::{MacosLauncher, ManagerExt};
 
+/// The app window, as opposed to the transient ones the app opens alongside it (the
+/// overlay, the mxb-mods.com clearance check, the shop login). `tauri.conf.json` declares
+/// it without an explicit label, which is Tauri's default of `main`.
+const MAIN_WINDOW: &str = "main";
+
+/// The shop login WebView, opened on demand and closed once the session is captured.
+const SHOP_LOGIN_WINDOW: &str = "shop-login";
+
+/// Whether closing this window should park it in the tray rather than destroy it.
+///
+/// Only the main window. The transient ones are owned by the code that opened them, and
+/// hiding one instead of closing it keeps its label registered for the life of the
+/// process — the next attempt to build it then fails with "a webview with label `…`
+/// already exists" and never opens again. A tester hit exactly that on the mxb-mods.com
+/// clearance window: the first Cloudflare handshake worked, and every Retry afterwards
+/// silently did nothing.
+fn parks_in_tray(label: &str) -> bool {
+    label == MAIN_WINDOW
+}
+
 /// Whether the app is ready to use. Falls back to auto-detection when the config file
 /// is missing, so the setup screen only appears when the MX Bikes folder genuinely
 /// can't be found — not every time the saved config goes astray.
@@ -120,7 +140,10 @@ where
         }
     }
     if !mxb_session::handshake(app).await {
-        log::warn!("{what} stays blocked — no cf_clearance to retry with");
+        // Deliberately not "no cf_clearance to retry with": the handshake also returns
+        // false when it couldn't run at all, and a log that claimed an empty jar while
+        // the refusal line above it listed a `cf_clearance` sent a reader the wrong way.
+        log::warn!("{what} stays blocked — the handshake produced no new clearance");
         return Err(format!("{err:#}"));
     }
     match op().await {
@@ -2026,7 +2049,7 @@ fn set_watch_mods_reload(
 
 #[tauri::command]
 async fn shop_login(app: tauri::AppHandle) -> Result<(), String> {
-    if let Some(w) = app.get_webview_window("shop-login") {
+    if let Some(w) = app.get_webview_window(SHOP_LOGIN_WINDOW) {
         let _ = w.set_focus();
         return Ok(());
     }
@@ -2039,7 +2062,7 @@ async fn shop_login(app: tauri::AppHandle) -> Result<(), String> {
         .parse()
         .map_err(|e| format!("{e}"))?,
     );
-    let window = tauri::WebviewWindowBuilder::new(&app, "shop-login", url)
+    let window = tauri::WebviewWindowBuilder::new(&app, SHOP_LOGIN_WINDOW, url)
         .title("Sign in to MX Bikes Shop")
         .user_agent(shop_session::UA)
         .inner_size(520.0, 760.0)
@@ -2052,7 +2075,7 @@ async fn shop_login(app: tauri::AppHandle) -> Result<(), String> {
         // ~5 minutes at 500ms intervals, then give up (user can retry).
         for _ in 0..600u32 {
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-            let Some(win) = app.get_webview_window("shop-login") else {
+            let Some(win) = app.get_webview_window(SHOP_LOGIN_WINDOW) else {
                 break; // user closed the window before finishing
             };
             let cookies = shop_session::cookies_from_window(&win);
@@ -2580,6 +2603,10 @@ fn main() {
                     let _ = overlay::hide(window.app_handle());
                     return;
                 }
+                // Everything else — the clearance check, the shop login — closes for real.
+                if !parks_in_tray(window.label()) {
+                    return;
+                }
                 let cfg = config::load(window.app_handle()).unwrap_or_default();
                 // Never on Linux: the tray runs through libayatana-appindicator, which
                 // doesn't deliver click events to Tauri and isn't present at all on a
@@ -2686,6 +2713,33 @@ fn main() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod window_tests {
+    use super::*;
+
+    /// The regression a tester's log caught: the clearance window was being parked in the
+    /// tray on close, which left its label registered, so every handshake after the first
+    /// failed to build a window and Retry silently did nothing for the rest of the session.
+    ///
+    /// Only the main window may park. Every transient window has to close for real.
+    #[test]
+    fn only_the_main_window_parks_in_the_tray() {
+        assert!(parks_in_tray(MAIN_WINDOW));
+
+        for transient in [
+            mxb_session::WINDOW,
+            SHOP_LOGIN_WINDOW,
+            overlay::LABEL, // handled earlier by its own branch, but never by this one
+        ] {
+            assert!(
+                !parks_in_tray(transient),
+                "{transient} must be destroyed on close, not hidden — a stranded label \
+                 makes it unopenable for the life of the process"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/mxb_session.rs
+++ b/src-tauri/src/mxb_session.rs
@@ -34,7 +34,9 @@ const SITE: Site = Site {
     timeout: Duration::from_secs(30),
 };
 
-const WINDOW: &str = "mxb-clearance";
+/// Public so the window-event handler can tell this transient window from the main one —
+/// hiding it instead of closing it strands its label and breaks every later handshake.
+pub const WINDOW: &str = "mxb-clearance";
 
 /// How long we leave the window up. It normally closes in a few seconds — a managed
 /// challenge clears on its own — but the budget has to cover one that wants a click.
@@ -155,8 +157,26 @@ pub async fn handshake(app: &AppHandle) -> bool {
         jar_summary()
     );
 
+    // Closing is a request handled on the main thread, not something that has finished by
+    // the time `close()` returns — so building the replacement immediately races the
+    // teardown and loses with "a webview with label `mxb-clearance` already exists". Wait
+    // for the label to actually free. If it never does, something is holding the window
+    // open and building would fail anyway; say so rather than logging the confusing
+    // already-exists error.
     if let Some(existing) = app.get_webview_window(WINDOW) {
         let _ = existing.close();
+        let mut freed = false;
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            if app.get_webview_window(WINDOW).is_none() {
+                freed = true;
+                break;
+            }
+        }
+        if !freed {
+            log::error!("the previous mxb-mods.com check window would not close");
+            return false;
+        }
     }
 
     let url = match BASE.parse() {


### PR DESCRIPTION
## Why

A tester's log from the v0.7.1-beta.2 diagnostics build showed the Cloudflare handshake working **once** and then never again:

```
06:05:55  earned a cf_clearance for mxb-mods.com
06:06:06  ERROR could not open the mxb-mods.com check window:
          a webview with label `mxb-clearance` already exists
06:06:06  search stays blocked — no cf_clearance to retry with
```

That repeats for every attempt from then on. **Retry was a no-op for the rest of the session**, and a hidden mxb-mods.com webview sat in the process the whole time.

## Root cause

The global `CloseRequested` handler special-cased the overlay and then fell through to the close-to-tray branch for *every other* window. With `run_in_background` defaulting to true and a release build, closing the clearance window hit `prevent_close()` + `hide()` — so it was hidden, not destroyed, and its label stayed registered for the life of the process. `WebviewWindowBuilder` could never rebuild it.

`shop-login` had the same latent bug.

## Changes

- Only the main window parks in the tray. Transient windows close for real. Extracted as `parks_in_tray()` so a test pins it.
- Name the window labels — `MAIN_WINDOW`, `SHOP_LOGIN_WINDOW`, and a now-public `mxb_session::WINDOW` — instead of scattered literals.
- Wait for the old label to free before rebuilding in `handshake()`. `close()` is handled on the main thread and isn't finished when it returns, so building the replacement raced teardown and lost.
- Reword `no cf_clearance to retry with` — the handshake also returns false when it couldn't run, and the log claimed an empty jar while the refusal line above it plainly listed a `cf_clearance`.

## Verification

`cargo test` — 211 pass, 0 fail, including a new regression test asserting every transient window is destroyed rather than hidden. `cargo clippy --all-targets` unchanged at the 51-warning baseline.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)