### PR TITLE
fix(viewer): read a rider part's material through its own node's table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026-08-08
+
+### Fixed
+- **The app builds again, and the rider wears the right textures.** Two changes landed
+  together that couldn't both be right: one gave every mesh part its own material table,
+  because an id counts into the table of the part that owns it and means nothing outside
+  it; the other added the custom-rider binder, written against the whole-model reading
+  that the first change deleted. The merge kept both, so `main` stopped compiling. The
+  rider binder now reads each part's id through its own node's table, the same way the
+  bike and gear viewers do — which is also the correct behaviour, not just the compiling
+  one: under the old reading every part resolved its ids through the first node's table,
+  which is what smeared one part's texture across another's geometry. Covered by a test
+  that pins two parts using the same local id to mean different textures.
+
 ## 2026-08-07
 
 ### Fixed

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1076,20 +1076,31 @@ fn stand_body_upright(nodes: &mut [edf::EdfNode]) {
 /// the gloves first and the suit last. So a fixed index→slot map is one model memorised —
 /// it already swaps face and gloves on the supermoto rider, and on a custom model it smears
 /// the glove texture across the whole body. Read the name the model was drawn against
-/// instead, the same reading the bike and gear viewers take.
+/// instead, the same reading the bike and gear viewers take — through each node's own
+/// material table, since an id counts into the table of the part that owns it and means
+/// nothing outside it (see `bind_textures`).
 fn bind_body_submeshes(nodes: &mut [edf::EdfNode], mesh: &[u8]) {
-    let readings = edf::MaterialReadings::new(mesh);
-    if readings.color.is_empty() {
+    let colors = edf::color_textures(mesh);
+    if colors.is_empty() {
         // A mesh whose texture table doesn't parse tells us nothing; the stock layout is
         // still right for the model the app has always shown.
         return tag_body_materials(nodes);
     }
+    bind_body_to_colors(nodes, &colors);
+}
+
+/// The binding itself, split out so a test can drive it without a mesh blob: reading a
+/// material id through the wrong node's table is the failure worth pinning down, and it
+/// needs two nodes whose tables disagree, not a parseable `.edf`.
+fn bind_body_to_colors(nodes: &mut [edf::EdfNode], colors: &[edf::EmbeddedTexture]) {
     for node in nodes.iter_mut() {
-        let fit = readings.fit(node);
-        for sm in &mut node.submeshes {
+        // Disjoint field borrows: the node's table is read while its submeshes are written.
+        let materials = &node.materials;
+        for sm in node.submeshes.iter_mut() {
             let emb = sm
                 .mat
-                .and_then(|m| readings.texture(m as usize, &fit))
+                .and_then(|m| materials.get(m as usize).copied().flatten())
+                .and_then(|slot| colors.get(slot))
                 .map(|t| t.name.as_str());
             sm.texture = Some(body_slot(emb));
         }
@@ -3290,6 +3301,67 @@ mod viewer_tests {
         }
         // A material that names no texture still has to render as something.
         assert_eq!(super::body_slot(None), "rider");
+    }
+
+    /// A material id is LOCAL to the node that owns it, so the same id must resolve to
+    /// different textures in different parts of one mesh.
+    ///
+    /// This is the invariant the per-part material-table fix established, and the one the
+    /// rider binder lost: it was still resolving ids through a whole-model reading, which
+    /// is what put one part's texture on another's geometry.
+    #[test]
+    fn a_body_part_resolves_its_material_through_its_own_table() {
+        fn tex(name: &str) -> super::edf::EmbeddedTexture {
+            super::edf::EmbeddedTexture {
+                name: name.into(),
+                width: 4,
+                height: 4,
+                data_off: 0,
+                data_len: 0,
+            }
+        }
+        fn sm(mat: u32) -> super::edf::Submesh {
+            super::edf::Submesh {
+                name: "range".into(),
+                tri_start: 0,
+                tri_count: 1,
+                texture: None,
+                uv_tile: None,
+                mat: Some(mat),
+            }
+        }
+        fn node(materials: Vec<Option<usize>>, mats: &[u32]) -> super::edf::EdfNode {
+            super::edf::EdfNode {
+                name: "part".into(),
+                positions: Vec::new(),
+                uvs: Vec::new(),
+                normals: Vec::new(),
+                indices: Vec::new(),
+                submeshes: mats.iter().map(|m| sm(*m)).collect(),
+                texture: None,
+                placed: false,
+                materials,
+            }
+        }
+
+        let colors = [tex("rider"), tex("gloves"), tex("w_number")];
+        // Both parts draw on local id 0 — and mean different textures by it.
+        let mut nodes = vec![
+            node(vec![Some(0)], &[0]),           // body  -> rider
+            node(vec![Some(1)], &[0]),           // hands -> gloves
+            node(vec![Some(2), None], &[0, 1]),  // plate -> hidden decal, then untextured
+        ];
+        super::bind_body_to_colors(&mut nodes, &colors);
+
+        assert_eq!(nodes[0].submeshes[0].texture.as_deref(), Some("rider"));
+        assert_eq!(
+            nodes[1].submeshes[0].texture.as_deref(),
+            Some("gloves"),
+            "id 0 read through the first node's table would smear the suit onto the hands"
+        );
+        assert_eq!(nodes[2].submeshes[0].texture.as_deref(), Some("hide"));
+        // An untextured material, and an id past the end of the table, both still render.
+        assert_eq!(nodes[2].submeshes[1].texture.as_deref(), Some("rider"));
     }
 
     /// The bug this replaced: material indices count into the model's own texture list, and


### PR DESCRIPTION
## `main` doesn't compile

```
error[E0433]: cannot find `MaterialReadings` in `edf`
    --> src/main.rs:1081:25
```

Two changes landed together that couldn't both be right, and the merge kept both:

- **#62** ("give every part its own material table") established that a material id counts into the table of the **node that owns it** — an id means nothing outside its part — and deleted the whole-model reading (`MaterialReadings`, `MaterialFit`, `material_slots`) along with the tie-break it existed for.
- **#60** ("let the preview wear a custom rider model") added `bind_body_submeshes`, written against that whole-model reading.

`edf.rs` came through without the type; `main.rs` came through still calling it. CI on `main` has been red since the #63 merge.

## The fix

The rider binder resolves each submesh's id through its owning node's table, exactly as `bind_textures` already does for bikes and gear.

This is the **correct** behaviour, not merely the compiling one. Under the old reading every part resolved its ids through the first node's table, which is precisely what put one part's texture on another part's geometry — the bug #62 was written to fix. The rider binder was the one caller that didn't get migrated.

## Test

`bind_body_submeshes` needs a parseable `.edf` to reach its binding, so the binding is split into `bind_body_to_colors(nodes, colors)` — the invariant needs two nodes whose tables disagree, not a mesh blob.

The new test pins two parts that both use local id `0` and mean different textures by it. I verified it fails against the old whole-model reading before landing the fix:

```
assertion `left == right` failed: id 0 read through the first node's table
would smear the suit onto the hands
  left: Some("rider")
 right: Some("gloves")
```

221 tests pass (was 220, on a tree that didn't build).

## Note

Found while landing #65 (the FrostMod model-refresh crash fix), whose Rust CI is red purely because GitHub builds the merge commit against this break. #65 needs no changes of its own — it should go green once this lands.

No DB/schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)