### PR TITLE
feat(mxb): fetch the catalog from inside the WebView when Cloudflare refuses us

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 2026-08-08 — Browse works for players Cloudflare was blocking
+
+### Fixed
+- **Browse loads for players mxb-mods.com was refusing.** Some players got nothing but
+  "mxb-mods.com refused the request (403)", and until now the app's answer was to open a
+  check window, let Cloudflare's challenge clear, and reuse the cookie it earned. A tester's
+  log proved that can't work: the challenge cleared in about a second, the cookie was sent
+  correctly, and the site refused us anyway — Cloudflare ties that cookie to the exact
+  browser connection that earned it, and the app's own downloader isn't that. So the app now
+  moves the *request* into the browser instead of moving the cookie out of it. When
+  mxb-mods.com refuses the fast path, the same request is re-run inside a hidden window on
+  the site's own page and everything carries on from there, for the rest of the session. The
+  visible "Checking with mxb-mods.com…" popup is gone entirely — nothing appears on screen.
+- **Retry works more than once.** Closing the old check window parked it in the tray instead
+  of destroying it, which left its name taken, so every attempt after the first failed to
+  open one and Retry quietly did nothing for the rest of the session. The shop login window
+  had the same fault. Only the main window parks in the tray now.
+
+### Changed
+- Mod downloads are untouched by any of this — they come from MediaFire, Google Drive and
+  MEGA, never from mxb-mods.com.
+
 ## 2026-08-07 — v0.7.1 — the Rider preview stops failing in silence, and a blocked Browse says why
 
 ### Fixed

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1348,7 +1348,6 @@ dependencies = [
  "flate2",
  "futures-util",
  "html-escape",
- "http",
  "image",
  "log",
  "mega",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -94,7 +94,3 @@ tauri = { version = "2", features = ["test"] }
 # `#[tokio::test]` for the live network checks against mxb-mods.com. Dev-only, so the
 # shipped binary keeps the minimal `time`-only tokio it already had.
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }
-# Builds the synthetic Cloudflare 403 the refusal diagnostics are tested against — a real
-# one can't be provoked locally, since it is scored on IP and TLS fingerprint. `reqwest`
-# already depends on this; naming it here just makes it importable from tests.
-http = "1"

--- a/src-tauri/capabilities/mxb-fetch.json
+++ b/src-tauri/capabilities/mxb-fetch.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "mxb-fetch",
+  "description": "The hidden mxb-mods.com window that runs catalog fetches in a real browser, for users whose HTTP client Cloudflare refuses. This is the only capability granted to a REMOTE origin, so it is deliberately the narrowest one in the app: permission to emit an event, and nothing else — no shell, dialog, filesystem, updater, process or window control. A central guard in main.rs (`ipc_allowed`) additionally rejects every IPC call from this window except the single event emit, because app commands registered with generate_handler! are not covered by this ACL.",
+  "webviews": ["mxb-fetch"],
+  "remote": {
+    "urls": ["https://mxb-mods.com"]
+  },
+  "permissions": ["core:event:allow-emit"]
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -17,6 +17,7 @@ mod modelswap;
 mod mods;
 mod modstate;
 mod modwatch;
+mod mxb_fetch;
 mod mxb_session;
 mod overlay;
 mod paint;
@@ -62,6 +63,23 @@ fn parks_in_tray(label: &str) -> bool {
     label == MAIN_WINDOW
 }
 
+/// Whether a window may make this IPC call.
+///
+/// Exists for one window. [`mxb_fetch`] parks a hidden webview on the *remote* mxb-mods.com
+/// origin, and giving it a capability is what lets its page hand fetch results back. But a
+/// capability grants IPC in general, and the commands registered with `generate_handler!`
+/// are not covered by the permission ACL — so without this, script on mxb-mods.com could
+/// call `create_config`, `install_mod` or anything else the app exposes.
+///
+/// So that window gets an allowlist of exactly one call: emitting the result event. Every
+/// other window is unaffected and keeps whatever its own capability file grants.
+fn ipc_allowed(label: &str, command: &str) -> bool {
+    if label != mxb_fetch::WINDOW {
+        return true;
+    }
+    command == "plugin:event|emit"
+}
+
 /// Whether the app is ready to use. Falls back to auto-detection when the config file
 /// is missing, so the setup screen only appears when the MX Bikes folder genuinely
 /// can't be found — not every time the saved config goes astray.
@@ -104,15 +122,20 @@ fn create_config(
     Ok(true)
 }
 
-/// Run an mxb-mods.com call; if Cloudflare refuses it, earn a `cf_clearance` in a real
-/// browser and try exactly once more.
+/// Run an mxb-mods.com call; if Cloudflare refuses it, run it again from inside a real
+/// browser and keep using that transport for the rest of the session.
 ///
-/// Once, not a loop: the handshake either produced a cookie the client didn't have or it
-/// didn't, and repeating it would just reopen the window at someone who is already stuck.
-/// Only refusals we could plausibly clear get this treatment — a 429 wants patience, not a
-/// browser window.
+/// This used to earn a `cf_clearance` in a WebView and replay the cookie through the HTTP
+/// client. A tester's log showed why that can't work: the challenge cleared in about a
+/// second, the cookie was sent correctly, and Cloudflare served the interstitial to reqwest
+/// anyway — a clearance is bound to the TLS fingerprint that earned it. So instead of moving
+/// the cookie to the request, we move the request to the browser. See [`mxb_fetch`].
+///
+/// Once, not a loop: the second attempt is on a different transport, so if that is refused
+/// too, trying a third time changes nothing. Only refusals a browser could plausibly satisfy
+/// get this treatment — a 429 wants patience, not another request.
 async fn with_clearance<T, F, Fut>(
-    app: &tauri::AppHandle,
+    _app: &tauri::AppHandle,
     what: &str,
     op: F,
 ) -> Result<T, String>
@@ -127,7 +150,7 @@ where
     match err.downcast_ref::<mods::mxb::Blocked>() {
         Some(blocked) if blocked.clearable() => {
             log::info!(
-                "{what} blocked ({}) — trying to earn a cf_clearance",
+                "{what} blocked ({}) — retrying it from inside the WebView",
                 blocked
                     .status
                     .map_or_else(|| "interstitial".to_string(), |s| s.to_string())
@@ -135,27 +158,23 @@ where
         }
         // Not clearable, or not a block at all — a parse failure, a timeout, a 429.
         _ => {
-            log::warn!("{what} failed and a browser window wouldn't help: {err:#}");
+            log::warn!("{what} failed and a browser wouldn't help: {err:#}");
             return Err(format!("{err:#}"));
         }
     }
-    if !mxb_session::handshake(app).await {
-        // Deliberately not "no cf_clearance to retry with": the handshake also returns
-        // false when it couldn't run at all, and a log that claimed an empty jar while
-        // the refusal line above it listed a `cf_clearance` sent a reader the wrong way.
-        log::warn!("{what} stays blocked — the handshake produced no new clearance");
-        return Err(format!("{err:#}"));
-    }
+    // Latches for the session: once this client's fingerprint has been refused on this
+    // network, every later request would be refused the same way, so there is nothing to
+    // gain from trying the HTTP client again first.
+    mods::mxb::use_webview();
     match op().await {
         Ok(value) => {
-            log::info!("{what} succeeded on the retry with a fresh cf_clearance");
+            log::info!("{what} succeeded through the WebView");
             Ok(value)
         }
-        // The interesting failure: we passed the challenge in a real browser, replayed the
-        // cookie it earned, and were refused anyway. That is a fingerprint refusal aimed at
-        // the HTTP client, not something another window would fix.
+        // Report the browser's failure, not the original 403 — if the site is refusing a
+        // real browser too, "open mxb-mods.com and hit Retry" is the wrong advice.
         Err(e) => {
-            log::warn!("{what} refused again even with a fresh cf_clearance: {e:#}");
+            log::warn!("{what} failed through the WebView too: {e:#}");
             Err(format!("{e:#}"))
         }
     }
@@ -2592,6 +2611,9 @@ fn main() {
             }
             shop_session::load_session(handle);
             mxb_session::load(handle);
+            // Only registers the result listener and stashes the handle — the hidden window
+            // isn't built until something is actually refused.
+            mxb_fetch::init(handle);
             Ok(())
         })
         .on_window_event(|window, event| {
@@ -2619,7 +2641,12 @@ fn main() {
                 }
             }
         })
-        .invoke_handler(tauri::generate_handler![
+        // Wrapped rather than passed straight in: `ipc_allowed` closes the hole that giving
+        // the hidden mxb-mods.com window a capability would otherwise open. See its doc.
+        .invoke_handler({
+            // The macro is generic over the runtime; naming `Wry` here is what lets the
+            // wrapper below infer what it is wrapping.
+            let handler: fn(tauri::ipc::Invoke<tauri::Wry>) -> bool = tauri::generate_handler![
             is_configured,
             get_config,
             create_config,
@@ -2709,8 +2736,21 @@ fn main() {
             mods_state_set,
             mods_state_delete,
             mods_state_apply,
-            mods_state_restore_all
-        ])
+                mods_state_restore_all
+            ];
+            move |invoke: tauri::ipc::Invoke<tauri::Wry>| {
+                let (label, command) = (
+                    invoke.message.webview().label().to_string(),
+                    invoke.message.command().to_string(),
+                );
+                if !ipc_allowed(&label, &command) {
+                    log::warn!("refused IPC '{command}' from the '{label}' window");
+                    invoke.resolver.reject("not permitted from this window");
+                    return true;
+                }
+                handler(invoke)
+            }
+        })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
@@ -2729,7 +2769,7 @@ mod window_tests {
         assert!(parks_in_tray(MAIN_WINDOW));
 
         for transient in [
-            mxb_session::WINDOW,
+            mxb_fetch::WINDOW,
             SHOP_LOGIN_WINDOW,
             overlay::LABEL, // handled earlier by its own branch, but never by this one
         ] {
@@ -2738,6 +2778,42 @@ mod window_tests {
                 "{transient} must be destroyed on close, not hidden — a stranded label \
                  makes it unopenable for the life of the process"
             );
+        }
+    }
+
+    /// The security boundary. The fetch window runs a *remote* origin — mxb-mods.com's own
+    /// page — and its capability grants IPC, which `generate_handler!` commands are not
+    /// gated by. So it gets exactly one call and nothing else; if this test ever goes green
+    /// on a second command, script on mxb-mods.com can drive that command.
+    #[test]
+    fn the_remote_fetch_window_may_only_emit_its_result() {
+        assert!(ipc_allowed(mxb_fetch::WINDOW, "plugin:event|emit"));
+
+        for forbidden in [
+            "create_config",
+            "install_mod",
+            "mods_state_delete",
+            "get_config",
+            "plugin:shell|open",
+            "plugin:dialog|open",
+            "plugin:event|listen",
+            "plugin:process|restart",
+        ] {
+            assert!(
+                !ipc_allowed(mxb_fetch::WINDOW, forbidden),
+                "mxb-mods.com script must not be able to call {forbidden}"
+            );
+        }
+    }
+
+    /// ...and the guard must not touch anything else. The app's own windows keep whatever
+    /// their capability files grant.
+    #[test]
+    fn the_apps_own_windows_are_unaffected_by_the_guard() {
+        for label in [MAIN_WINDOW, overlay::LABEL, SHOP_LOGIN_WINDOW] {
+            for command in ["create_config", "install_mod", "plugin:event|emit"] {
+                assert!(ipc_allowed(label, command), "{label} / {command}");
+            }
         }
     }
 }

--- a/src-tauri/src/mods/mxb.rs
+++ b/src-tauri/src/mods/mxb.rs
@@ -76,12 +76,83 @@ fn worth_retrying(status: reqwest::StatusCode) -> bool {
     matches!(status.as_u16(), 429 | 503)
 }
 
+/// One response, read into memory, independent of which transport produced it.
+///
+/// The reqwest client and the WebView bridge return the same shape so everything downstream
+/// — the parsers, the `X-WP-Total` paging, the refusal diagnostics — is transport-agnostic.
+/// Owned rather than borrowed because the WebView hands back a decoded body, not a stream;
+/// that is affordable here because mxb-mods.com only ever serves us JSON and HTML. Actual
+/// mod downloads go to MediaFire/Drive/Mega and never come through this path.
+pub struct Fetched {
+    pub status: u16,
+    /// Lowercased header names. Same-origin `fetch` exposes every header, so this is as
+    /// complete over the bridge as it is over reqwest.
+    pub headers: HashMap<String, String>,
+    pub body: String,
+    /// The URL that actually answered, for the refusal log.
+    pub url: String,
+}
+
+impl Fetched {
+    fn is_success(&self) -> bool {
+        (200..300).contains(&self.status)
+    }
+
+    pub fn header(&self, name: &str) -> Option<&str> {
+        self.headers.get(name).map(String::as_str)
+    }
+
+    fn json<T: serde::de::DeserializeOwned>(&self) -> anyhow::Result<T> {
+        Ok(serde_json::from_str(&self.body)?)
+    }
+}
+
+/// Which transport this session uses for mxb-mods.com.
+///
+/// Starts on the HTTP client, which is faster and is what nearly every user needs. A
+/// Cloudflare refusal latches it to the WebView for the rest of the session — see
+/// [`use_webview`]. Never latches back: a client that has been refused once on a given IP
+/// and fingerprint will be refused again, and flapping between transports would just
+/// reintroduce the failure on every request.
+static WEBVIEW_TRANSPORT: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Route every mxb-mods.com request through the WebView from here on.
+pub fn use_webview() {
+    if !WEBVIEW_TRANSPORT.swap(true, std::sync::atomic::Ordering::Relaxed) {
+        log::info!("switching mxb-mods.com traffic to the WebView for the rest of this session");
+    }
+}
+
+/// `MXB_FORCE_WEBVIEW=1` starts on the bridge instead of falling back to it. The only way to
+/// exercise this path on a machine Cloudflare is happy with, and a support switch for a user
+/// who is blocked from the first request.
+fn forced_to_webview() -> bool {
+    static FORCED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FORCED.get_or_init(|| {
+        let on = matches!(
+            std::env::var("MXB_FORCE_WEBVIEW").unwrap_or_default().as_str(),
+            "1" | "true" | "yes"
+        );
+        if on {
+            log::info!("MXB_FORCE_WEBVIEW is set — all mxb-mods.com traffic goes via the WebView");
+        }
+        on
+    })
+}
+
+fn on_webview() -> bool {
+    forced_to_webview() || WEBVIEW_TRANSPORT.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 /// `GET` with backoff over the transient blocks above. Transport errors retry too, which
 /// is what `install::get_with_retry` already does for download hosts.
-async fn get_with_retry(
-    url: &str,
-    params: &[(&str, String)],
-) -> anyhow::Result<reqwest::Response> {
+async fn get_with_retry(url: &str, params: &[(&str, String)]) -> anyhow::Result<Fetched> {
+    if on_webview() {
+        // No backoff loop here: the bridge is a real browser, so a 429/503 it gets is one
+        // the site means, and it has its own timeout.
+        return crate::mxb_fetch::get(url, params).await;
+    }
+
     const ATTEMPTS: u32 = 3;
     let client = client()?;
     let mut last_err: Option<anyhow::Error> = None;
@@ -91,18 +162,19 @@ async fn get_with_retry(
             Ok(resp) if !worth_retrying(resp.status()) => {
                 // Debug, not info: search runs on every keystroke, and a line per keystroke
                 // would bury the one failure worth reading. `MXB_LOG=debug` turns it on.
+                let fetched = into_fetched(resp).await;
                 log::debug!(
                     "GET {} -> {} in {:?}",
                     path_of(url),
-                    resp.status().as_u16(),
+                    fetched.status,
                     started.elapsed()
                 );
-                return Ok(resp);
+                return Ok(fetched);
             }
             Ok(resp) => {
                 let status = resp.status();
                 if attempt == ATTEMPTS {
-                    return Ok(resp);
+                    return Ok(into_fetched(resp).await);
                 }
                 log::warn!(
                     "GET {} -> {} (attempt {attempt}/{ATTEMPTS}), retrying in {}ms",
@@ -127,6 +199,25 @@ async fn get_with_retry(
         tokio::time::sleep(std::time::Duration::from_millis(500 * attempt as u64)).await;
     }
     Err(last_err.unwrap_or_else(|| anyhow::anyhow!("request failed")))
+}
+
+/// Read a reqwest response into the transport-agnostic shape. A body that won't decode
+/// becomes an empty one rather than an error — the status and headers are still worth
+/// having, and that is exactly the case the refusal diagnostics exist to report.
+async fn into_fetched(resp: reqwest::Response) -> Fetched {
+    let status = resp.status().as_u16();
+    let url = resp.url().to_string();
+    let headers = resp
+        .headers()
+        .iter()
+        .filter_map(|(k, v)| v.to_str().ok().map(|v| (k.as_str().to_string(), v.to_string())))
+        .collect();
+    Fetched {
+        status,
+        headers,
+        body: resp.text().await.unwrap_or_default(),
+        url,
+    }
 }
 
 /// The path part of a URL, for logs. The full URL is mostly a constant prefix plus
@@ -174,8 +265,8 @@ impl Blocked {
 /// `ray` is Cloudflare's `cf-ray` id for the refused request. It goes on the end because it
 /// is the one token that identifies this specific block on Cloudflare's side — a screenshot
 /// carrying it can be diagnosed without asking anyone to find their log file.
-fn blocked_error(status: reqwest::StatusCode, ray: Option<&str>) -> anyhow::Error {
-    let message = match status.as_u16() {
+fn blocked_error(status: u16, ray: Option<&str>) -> anyhow::Error {
+    let message = match status {
         403 => "mxb-mods.com refused the request (403), and its check window didn't clear \
                 it either. Open mxb-mods.com in your normal browser to confirm the site \
                 loads for you, then hit Retry."
@@ -188,11 +279,11 @@ fn blocked_error(status: reqwest::StatusCode, ray: Option<&str>) -> anyhow::Erro
         _ => format!("mxb-mods.com returned {status}"),
     };
     let message = match ray {
-        Some(ray) if !ray.is_empty() => format!("{message}\n\nRef: {ray}"),
+        Some(ray) if !ray.is_empty() && ray != "-" => format!("{message}\n\nRef: {ray}"),
         _ => message,
     };
     anyhow::Error::new(Blocked {
-        status: Some(status.as_u16()),
+        status: Some(status),
         message,
     })
 }
@@ -205,27 +296,27 @@ fn blocked_error(status: reqwest::StatusCode, ray: Option<&str>) -> anyhow::Erro
 /// which says *how* Cloudflare decided, the cookies we actually sent, and the error body —
 /// Cloudflare puts the block reason in there ("Sorry, you have been blocked", `Error 1015`),
 /// and we were dropping it on the floor.
-async fn refusal(what: &str, resp: reqwest::Response) -> anyhow::Error {
-    let status = resp.status();
-    // From the response, so it is the URL actually refused after any redirect — and just
-    // the path, since the rest is a constant prefix plus percent-encoded query noise.
-    let path = resp.url().path().to_string();
-    let ray = header(&resp, "cf-ray");
-    // Cloned because reading the body consumes the response the headers are borrowed from.
-    let headers = resp.headers().clone();
-    let jar = mxb_session::jar_summary();
-    let body = resp.text().await.unwrap_or_default();
-    log::warn!("{}", refusal_line(what, &path, status, &headers, &jar, &body));
-
-    blocked_error(status, Some(&ray))
-}
-
-fn header(resp: &reqwest::Response, name: &str) -> String {
-    resp.headers()
-        .get(name)
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("-")
-        .to_string()
+fn refusal(what: &str, resp: &Fetched) -> anyhow::Error {
+    // Just the path: the rest is a constant prefix plus percent-encoded query noise.
+    let path = resp
+        .url
+        .split_once("://")
+        .and_then(|(_, rest)| rest.split_once('/'))
+        .map_or_else(|| resp.url.clone(), |(_, p)| format!("/{p}"));
+    let path = path.split('?').next().unwrap_or(&path).to_string();
+    let ray = resp.header("cf-ray").unwrap_or("-").to_string();
+    log::warn!(
+        "{}",
+        refusal_line(
+            what,
+            &path,
+            resp.status,
+            &resp.headers,
+            &mxb_session::jar_summary(),
+            &resp.body,
+        )
+    );
+    blocked_error(resp.status, Some(&ray))
 }
 
 /// The line itself, built separately from the logging so a test can pin what a user ends up
@@ -233,21 +324,15 @@ fn header(resp: &reqwest::Response, name: &str) -> String {
 fn refusal_line(
     what: &str,
     path: &str,
-    status: reqwest::StatusCode,
-    headers: &reqwest::header::HeaderMap,
+    status: u16,
+    headers: &HashMap<String, String>,
     jar: &str,
     body: &str,
 ) -> String {
-    let h = |name: &str| {
-        headers
-            .get(name)
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("-")
-    };
+    let h = |name: &str| headers.get(name).map_or("-", String::as_str);
     format!(
-        "mxb-mods refused {what} ({path}, {}) — cf-ray={} cf-mitigated={} server={} \
+        "mxb-mods refused {what} ({path}, {status}) — cf-ray={} cf-mitigated={} server={} \
          retry-after={}; jar: {jar}; body: {}",
-        status.as_u16(),
         h("cf-ray"),
         h("cf-mitigated"),
         h("server"),
@@ -346,17 +431,19 @@ enum Page {
 async fn listing(q: &str, category_id: u32, page: Page) -> anyhow::Result<Vec<ModSummary>> {
     let (resp, _) = listing_response(q, category_id, page).await?;
     // WP returns 400 (rest_post_invalid_page_number) once you page past the end.
-    if resp.status() == reqwest::StatusCode::BAD_REQUEST {
+    if resp.status == 400 {
         // Any *other* 400 also lands here and reads to the user as "no results", so say in
         // the log which one it was rather than letting a real error look like an empty page.
-        let body = resp.text().await.unwrap_or_default();
-        log::info!("catalog returned 400 — treating as the end of the listing: {}", snippet(&body));
+        log::info!(
+            "catalog returned 400 — treating as the end of the listing: {}",
+            snippet(&resp.body)
+        );
         return Ok(vec![]);
     }
-    if !resp.status().is_success() {
-        return Err(refusal("the catalog listing", resp).await);
+    if !resp.is_success() {
+        return Err(refusal("the catalog listing", &resp));
     }
-    let posts: Vec<Value> = resp.json().await?;
+    let posts: Vec<Value> = resp.json()?;
     Ok(posts
         .iter()
         .filter_map(|p| summary_from_post(p, category_id))
@@ -368,7 +455,7 @@ async fn listing_response(
     q: &str,
     category_id: u32,
     page: Page,
-) -> anyhow::Result<(reqwest::Response, Option<u32>)> {
+) -> anyhow::Result<(Fetched, Option<u32>)> {
     let url = format!("{BASE}/wp-json/wp/v2/posts");
     let mut params: Vec<(&str, String)> = vec![
         ("categories", category_id.to_string()),
@@ -388,11 +475,7 @@ async fn listing_response(
         params.push(("search", q.to_string()));
     }
     let resp = get_with_retry(&url, &params).await?;
-    let total = resp
-        .headers()
-        .get("x-wp-total")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.parse::<u32>().ok());
+    let total = resp.header("x-wp-total").and_then(|v| v.parse::<u32>().ok());
     Ok((resp, total))
 }
 
@@ -440,8 +523,8 @@ async fn total_count(q: &str, category_id: u32) -> anyhow::Result<u32> {
     }
     // One post is enough to read the header off; the body is discarded.
     let (resp, total) = listing_response(q, category_id, Page::Offset { skip: 0, take: 1 }).await?;
-    if !resp.status().is_success() {
-        return Err(refusal("the catalog post count", resp).await);
+    if !resp.is_success() {
+        return Err(refusal("the catalog post count", &resp));
     }
     let total = total.ok_or_else(|| anyhow::anyhow!("the catalog didn't report a post count"))?;
     lock(total_cache()).insert(key, (total, Instant::now()));
@@ -467,10 +550,10 @@ async fn popular(category_id: u32, page: u32, range: &str) -> anyhow::Result<Vec
     ];
 
     let resp = get_with_retry(&url, &params).await?;
-    if !resp.status().is_success() {
-        return Err(refusal("the popular listing", resp).await);
+    if !resp.is_success() {
+        return Err(refusal("the popular listing", &resp));
     }
-    let posts: Vec<Value> = resp.json().await?;
+    let posts: Vec<Value> = resp.json()?;
     Ok(posts
         .iter()
         .filter_map(|p| summary_from_post(p, category_id))
@@ -485,10 +568,10 @@ pub async fn detail(slug: &str) -> anyhow::Result<ModDetail> {
         ("_embed", "wp:featuredmedia".to_string()),
     ];
     let resp = get_with_retry(&url, &params).await?;
-    if !resp.status().is_success() {
-        return Err(refusal("mod metadata", resp).await);
+    if !resp.is_success() {
+        return Err(refusal("mod metadata", &resp));
     }
-    let posts: Vec<Value> = resp.json().await?;
+    let posts: Vec<Value> = resp.json()?;
     let post = posts
         .into_iter()
         .next()
@@ -522,10 +605,10 @@ pub async fn detail(slug: &str) -> anyhow::Result<ModDetail> {
     // zero downloads — the page then said "No download link was found on this page"
     // rather than "we couldn't read the page". Surface it instead.
     let resp = get_with_retry(&link, &[]).await?;
-    if !resp.status().is_success() {
-        return Err(refusal("the mod page", resp).await);
+    if !resp.is_success() {
+        return Err(refusal("the mod page", &resp));
     }
-    let html = resp.text().await.unwrap_or_default();
+    let html = resp.body;
     let (downloads, version) = (parse_downloads(&html), parse_version(&html));
     // Only call it a challenge when the page also yielded nothing, so a marker that turns
     // up in a page that actually parsed can never turn a working mod into an error.
@@ -621,15 +704,21 @@ fn lock<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
 /// action, which answers unauthenticated with `{voteCount, avgRating}`.
 async fn rating(id: u64) -> anyhow::Result<ModRating> {
     let url = format!("{BASE}/wp-admin/admin-ajax.php");
-    let resp = client()?
-        .post(&url)
-        .form(&[("action", "load_results".to_string()), ("postID", id.to_string())])
-        .send()
-        .await?;
-    if !resp.status().is_success() {
-        anyhow::bail!("{}", resp.status());
+    let form = [
+        ("action", "load_results".to_string()),
+        ("postID", id.to_string()),
+    ];
+    // Ratings go over whichever transport the session settled on too — otherwise a blocked
+    // user gets their mods back but every card silently loses its stars.
+    let resp = if on_webview() {
+        crate::mxb_fetch::post(&url, &form).await?
+    } else {
+        into_fetched(client()?.post(&url).form(&form).send().await?).await
+    };
+    if !resp.is_success() {
+        anyhow::bail!("{}", resp.status);
     }
-    let v: Value = resp.json().await?;
+    let v: Value = resp.json()?;
     Ok(ModRating {
         average: number(v.get("avgRating")).unwrap_or(0.0) as f32,
         count: number(v.get("voteCount")).unwrap_or(0.0).max(0.0) as u32,
@@ -961,7 +1050,7 @@ mod client_tests {
     /// `anyhow` as a `Blocked` and not collapse into a bare message.
     #[test]
     fn a_blocked_error_stays_downcastable() {
-        let err = blocked_error(reqwest::StatusCode::FORBIDDEN, None);
+        let err = blocked_error(403, None);
         let blocked = err
             .downcast_ref::<Blocked>()
             .expect("the command layer downcasts to decide whether to run the handshake");
@@ -993,7 +1082,7 @@ mod client_tests {
 
     #[test]
     fn blocked_errors_say_what_to_do() {
-        let msg = blocked_error(reqwest::StatusCode::FORBIDDEN, None).to_string();
+        let msg = blocked_error(403, None).to_string();
         assert!(msg.contains("403") && msg.contains("Retry"), "{msg}");
         // The old text leaked a percent-encoded URL at the user; make sure we don't.
         assert!(!msg.contains("wp-json"), "{msg}");
@@ -1005,36 +1094,63 @@ mod client_tests {
     /// Cloudflare's side, so it has to survive into the text the UI renders.
     #[test]
     fn a_ray_id_rides_along_on_the_message() {
-        let err = blocked_error(reqwest::StatusCode::FORBIDDEN, Some("8f2a1c9d4e5b6a07"));
+        let err = blocked_error(403, Some("8f2a1c9d4e5b6a07"));
         let msg = format!("{err:#}");
         assert!(msg.contains("Ref: 8f2a1c9d4e5b6a07"), "{msg}");
         assert!(msg.contains("403") && msg.contains("Retry"), "{msg}");
         // An absent header reads as "-" upstream; that must not reach the user as a ref.
-        assert!(!blocked_error(reqwest::StatusCode::FORBIDDEN, Some(""))
+        assert!(!blocked_error(403, Some(""))
             .to_string()
             .contains("Ref:"));
+    }
+
+    fn refused(status: u16, headers: &[(&str, &str)], body: &str) -> Fetched {
+        Fetched {
+            status,
+            headers: headers
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            body: body.to_string(),
+            url: "https://mxb-mods.com/wp-json/wp/v2/posts?categories=22".to_string(),
+        }
     }
 
     /// A real 403 can't be provoked locally — it's scored on IP and TLS fingerprint — so
     /// the response is synthesised. What's under test is that the diagnostic path reads the
     /// headers, still produces a `Blocked` the command layer can act on, and carries the ray.
-    #[tokio::test]
-    async fn a_refused_response_becomes_a_blocked_error_with_its_ray() {
-        let raw = http::Response::builder()
-            .status(403)
-            .header("cf-ray", "8f2a1c9d4e5b6a07-LHR")
-            .header("cf-mitigated", "challenge")
-            .header("server", "cloudflare")
-            .body("Sorry, you have been blocked")
-            .unwrap();
-        let err = refusal("the catalog listing", reqwest::Response::from(raw)).await;
+    #[test]
+    fn a_refused_response_becomes_a_blocked_error_with_its_ray() {
+        let resp = refused(
+            403,
+            &[
+                ("cf-ray", "8f2a1c9d4e5b6a07-LHR"),
+                ("cf-mitigated", "challenge"),
+                ("server", "cloudflare"),
+            ],
+            "Sorry, you have been blocked",
+        );
+        let err = refusal("the catalog listing", &resp);
 
         let blocked = err
             .downcast_ref::<Blocked>()
             .expect("a refusal must stay actionable by the command layer");
         assert_eq!(blocked.status, Some(403));
-        assert!(blocked.clearable(), "a 403 should still trigger the handshake");
+        assert!(
+            blocked.clearable(),
+            "a 403 should still send the command layer to the WebView"
+        );
         assert!(format!("{err:#}").contains("Ref: 8f2a1c9d4e5b6a07-LHR"));
+    }
+
+    /// The refusal log names the endpoint, not the whole URL with its query string — the
+    /// catalog API and the rendered mod page sit behind different Cloudflare rules, and
+    /// that distinction is the first thing to read off a report.
+    #[test]
+    fn the_refused_path_is_reported_without_query_noise() {
+        let err = refusal("the catalog listing", &refused(403, &[], ""));
+        // Nothing to reference, so no dangling Ref.
+        assert!(!format!("{err:#}").contains("Ref:"));
     }
 
     /// What a user actually pastes into Discord. Everything a diagnosis needs has to be on
@@ -1043,15 +1159,19 @@ mod client_tests {
     /// `cargo test the_refusal_line -- --nocapture` prints it.
     #[test]
     fn the_refusal_line_carries_a_whole_diagnosis() {
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert("cf-ray", "8f2a1c9d4e5b6a07-LHR".parse().unwrap());
-        headers.insert("cf-mitigated", "challenge".parse().unwrap());
-        headers.insert("server", "cloudflare".parse().unwrap());
+        let headers: HashMap<String, String> = [
+            ("cf-ray", "8f2a1c9d4e5b6a07-LHR"),
+            ("cf-mitigated", "challenge"),
+            ("server", "cloudflare"),
+        ]
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
 
         let line = refusal_line(
             "the catalog listing",
             "/wp-json/wp/v2/posts",
-            reqwest::StatusCode::FORBIDDEN,
+            403,
             &headers,
             "__cf_bm (no cf_clearance)",
             "<html>\n  <h1>Sorry, you have been blocked</h1>\n</html>",

--- a/src-tauri/src/mxb_fetch.rs
+++ b/src-tauri/src/mxb_fetch.rs
@@ -1,0 +1,464 @@
+//! Fetching mxb-mods.com from inside a real browser, for the users Cloudflare refuses.
+//!
+//! [`crate::mxb_session`] exists because Cloudflare sometimes challenges our HTTP client, and
+//! it answers that by earning a `cf_clearance` in a WebView and replaying the cookie. A
+//! tester's log showed the limit of that approach: the challenge cleared in about a second,
+//! the cookie was harvested and sent correctly, and Cloudflare served the interstitial to
+//! reqwest anyway. A `cf_clearance` is bound to the TLS/HTTP2 fingerprint of the connection
+//! that earned it, and rustls does not fingerprint like the WebView's Chrome — so the cookie
+//! is not portable between them, and no amount of cookie work fixes it.
+//!
+//! What does fix it is not sending the request from Rust at all. This module keeps a hidden
+//! WebView parked on the mxb-mods.com origin and runs `fetch()` inside it: same-origin, real
+//! browser, real fingerprint, the site's own cookies. Cloudflare cannot tell it from a tab,
+//! because it isn't one.
+//!
+//! Only text comes back this way — the catalog JSON and mod-page HTML. Mod downloads resolve
+//! to MediaFire/Drive/Mega and never touch this path, so no large binary is ever marshalled
+//! through JavaScript.
+
+use crate::mods::mxb::Fetched;
+use crate::mxb_session;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+use tauri::{AppHandle, Listener, Manager, WebviewUrl, WebviewWindowBuilder};
+
+/// The window the fetches run in. Public because the window-event handler and the IPC guard
+/// both have to recognise it — it is the one webview allowed to talk to us from a remote
+/// origin, and the one that must never be parked in the tray.
+pub const WINDOW: &str = "mxb-fetch";
+
+/// The event the injected script emits its result on. Also public for the guard: this is the
+/// only IPC the fetch window is permitted to perform.
+pub const RESULT_EVENT: &str = "mxb-fetch:done";
+
+/// How long a single fetch may take. Generous, because the very first one also pays for
+/// Cloudflare's challenge clearing in the background.
+const TIMEOUT: Duration = Duration::from_secs(45);
+
+/// How long to wait for the page to be ready to run script after the window is built.
+const READY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Set once from `setup`. The mods code is a set of free functions with no handle to thread
+/// through — `search`, `detail` and `ratings` would all have to grow an `AppHandle`
+/// parameter, along with everything between them and the command layer, to avoid this.
+static APP: OnceLock<AppHandle> = OnceLock::new();
+
+pub fn init(app: &AppHandle) {
+    let _ = APP.set(app.clone());
+    listen_for_results(app);
+}
+
+fn app() -> anyhow::Result<&'static AppHandle> {
+    APP.get()
+        .ok_or_else(|| anyhow::anyhow!("the WebView fetch bridge was never initialised"))
+}
+
+/// Requests still waiting on a reply, by id.
+fn waiting() -> &'static Mutex<HashMap<u64, tokio::sync::oneshot::Sender<Reply>>> {
+    static WAITING: OnceLock<Mutex<HashMap<u64, tokio::sync::oneshot::Sender<Reply>>>> =
+        OnceLock::new();
+    WAITING.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn lock<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// What the injected script sends back.
+///
+/// `error` carries a network-level failure — a `fetch` that rejected rather than a request
+/// that was answered — so those stay distinguishable from an HTTP error status.
+#[derive(Debug, Deserialize)]
+struct Reply {
+    id: u64,
+    #[serde(default)]
+    status: u16,
+    #[serde(default)]
+    headers: HashMap<String, String>,
+    #[serde(default)]
+    body: String,
+    #[serde(default)]
+    url: String,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+/// Route a reply to whoever is waiting for it.
+///
+/// An id we did not issue is dropped. That is the guard against the remote page inventing
+/// results: mxb-mods.com script can emit whatever it likes on this event, and the worst it
+/// achieves is a debug line.
+fn deliver(reply: Reply) {
+    let Some(tx) = lock(waiting()).remove(&reply.id) else {
+        log::debug!("ignoring a WebView fetch result for unknown id {}", reply.id);
+        return;
+    };
+    let _ = tx.send(reply);
+}
+
+fn listen_for_results(app: &AppHandle) {
+    app.listen(RESULT_EVENT, |event| {
+        match serde_json::from_str::<Reply>(event.payload()) {
+            Ok(reply) => deliver(reply),
+            // Never panic on a payload from a remote page.
+            Err(e) => log::warn!("unreadable WebView fetch result: {e}"),
+        }
+    });
+}
+
+pub async fn get(url: &str, params: &[(&str, String)]) -> anyhow::Result<Fetched> {
+    let full = with_query(url, params);
+    run(&full, None).await
+}
+
+pub async fn post(url: &str, form: &[(&str, String)]) -> anyhow::Result<Fetched> {
+    run(url, Some(&encode_form(form))).await
+}
+
+/// `application/x-www-form-urlencoded`, matching what `reqwest`'s `.form()` sends, so the
+/// two transports look identical to the site.
+fn encode_form(form: &[(&str, String)]) -> String {
+    form.iter()
+        .map(|(k, v)| format!("{}={}", urlencode(k), urlencode(v)))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+fn with_query(url: &str, params: &[(&str, String)]) -> String {
+    if params.is_empty() {
+        return url.to_string();
+    }
+    let q = params
+        .iter()
+        .map(|(k, v)| format!("{}={}", urlencode(k), urlencode(v)))
+        .collect::<Vec<_>>()
+        .join("&");
+    let sep = if url.contains('?') { '&' } else { '?' };
+    format!("{url}{sep}{q}")
+}
+
+/// Percent-encoding for the characters that actually turn up in these queries — search
+/// terms, slugs and numbers. Deliberately conservative: anything not unreserved is escaped.
+fn urlencode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.as_bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(*b as char)
+            }
+            b' ' => out.push_str("%20"),
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+async fn run(url: &str, body: Option<&str>) -> anyhow::Result<Fetched> {
+    let app = app()?;
+    let window = ensure_window(app).await?;
+
+    static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    lock(waiting()).insert(id, tx);
+
+    let started = std::time::Instant::now();
+    if let Err(e) = window.eval(script(id, url, body)) {
+        lock(waiting()).remove(&id);
+        return Err(anyhow::anyhow!("could not run the fetch in the WebView: {e}"));
+    }
+
+    let reply = match tokio::time::timeout(TIMEOUT, rx).await {
+        Ok(Ok(reply)) => reply,
+        // The sender is only dropped if the map is cleared out from under us.
+        Ok(Err(_)) => {
+            return Err(anyhow::anyhow!("the WebView fetch was cancelled"));
+        }
+        Err(_) => {
+            lock(waiting()).remove(&id);
+            return Err(anyhow::anyhow!(
+                "the WebView did not answer within {TIMEOUT:?} — {url}"
+            ));
+        }
+    };
+
+    if let Some(error) = reply.error {
+        return Err(anyhow::anyhow!("the WebView could not reach {url}: {error}"));
+    }
+
+    log::debug!(
+        "webview GET {} -> {} in {:?}",
+        url.strip_prefix(mxb_session::BASE).unwrap_or(url),
+        reply.status,
+        started.elapsed()
+    );
+
+    Ok(Fetched {
+        status: reply.status,
+        headers: reply.headers,
+        body: reply.body,
+        url: if reply.url.is_empty() {
+            url.to_string()
+        } else {
+            reply.url
+        },
+    })
+}
+
+/// The script run inside the page.
+///
+/// `credentials: "include"` so the site's own cookies ride along, and header names are
+/// lowercased to match what [`Fetched`] callers look up. `withGlobalTauri` is off, so the
+/// result goes back through the IPC primitive rather than `window.__TAURI__`.
+fn script(id: u64, url: &str, body: Option<&str>) -> String {
+    let init = match body {
+        Some(body) => format!(
+            "{{method:'POST',credentials:'include',\
+             headers:{{'content-type':'application/x-www-form-urlencoded'}},body:{}}}",
+            js_string(body)
+        ),
+        None => "{credentials:'include'}".to_string(),
+    };
+    format!(
+        r#"(function(){{
+  var send = function(p) {{
+    p.id = {id};
+    // The object itself, not a JSON string of it — Tauri encodes the payload, and
+    // stringifying first would land a quoted string where a struct is expected.
+    window.__TAURI_INTERNALS__.invoke('plugin:event|emit', {{
+      event: {event}, payload: p
+    }});
+  }};
+  try {{
+    fetch({url}, {init}).then(function(r) {{
+      return r.text().then(function(t) {{
+        var h = {{}};
+        r.headers.forEach(function(v, k) {{ h[k.toLowerCase()] = v; }});
+        send({{ status: r.status, headers: h, body: t, url: r.url }});
+      }});
+    }}).catch(function(e) {{ send({{ error: String(e) }}); }});
+  }} catch (e) {{ send({{ error: String(e) }}); }}
+}})();"#,
+        event = js_string(RESULT_EVENT),
+        url = js_string(url),
+    )
+}
+
+/// A JS string literal. The URLs here are ours, but they carry user-typed search terms, and
+/// a quote or backslash reaching `eval` unescaped would break the script — or worse.
+fn js_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
+            // `</script` inside a string literal would still end a script block.
+            '<' => out.push_str("\\u003C"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04X}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Build the hidden window on first use and leave it up for the session.
+///
+/// Serialised, so two requests arriving together don't both try to build it.
+async fn ensure_window(app: &AppHandle) -> anyhow::Result<tauri::WebviewWindow> {
+    static LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+    let _guard = LOCK.lock().await;
+
+    // Readiness is tracked separately from existence: a window that was built but never
+    // came good must not be handed out as if it were working, or every fetch through it
+    // times out 45 seconds at a time.
+    static READY: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+    if let Some(existing) = app.get_webview_window(WINDOW) {
+        if READY.load(Ordering::Relaxed) {
+            return Ok(existing);
+        }
+        wait_until_ready(&existing).await?;
+        READY.store(true, Ordering::Relaxed);
+        return Ok(existing);
+    }
+
+    let url: tauri::Url = mxb_session::BASE.parse()?;
+    log::info!("opening the hidden mxb-mods.com fetch window");
+    let window = WebviewWindowBuilder::new(app, WINDOW, WebviewUrl::External(url))
+        .title("mxb-mods.com")
+        .user_agent(mxb_session::UA)
+        // Not `visible(false)`: WebView2 can throttle a window it considers fully hidden,
+        // and a throttled timer here reads as the site being slow. One pixel, parked well
+        // off-screen, stays a live window without ever being seen.
+        .inner_size(1.0, 1.0)
+        .position(-32000.0, -32000.0)
+        .skip_taskbar(true)
+        .decorations(false)
+        .focused(false)
+        .build()?;
+
+    wait_until_ready(&window).await?;
+    READY.store(true, Ordering::Relaxed);
+    Ok(window)
+}
+
+/// Wait for the page to be able to run our script.
+///
+/// Two things have to be true: the IPC primitive has to be injected, and Cloudflare's
+/// challenge — which the window will be served on first navigation, exactly as the visible
+/// clearance window is — has to have cleared. Polling a one-line `eval` covers both, since
+/// the challenge page is replaced by the real one when it passes.
+async fn wait_until_ready(window: &tauri::WebviewWindow) -> anyhow::Result<()> {
+    let deadline = std::time::Instant::now() + READY_TIMEOUT;
+    let mut last: Option<String> = None;
+    while std::time::Instant::now() < deadline {
+        match probe(window).await {
+            Ok(()) => return Ok(()),
+            Err(e) => last = Some(e.to_string()),
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    Err(anyhow::anyhow!(
+        "the hidden mxb-mods.com window never became ready{}",
+        last.map(|e| format!(" ({e})")).unwrap_or_default()
+    ))
+}
+
+/// One round-trip that proves script can run and reach us. Doubles as the check that
+/// `__TAURI_INTERNALS__` still exists — if a Tauri upgrade renames it, this fails here with
+/// a clear message instead of every fetch timing out.
+async fn probe(window: &tauri::WebviewWindow) -> anyhow::Result<()> {
+    const PROBE_ID: u64 = 0;
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    lock(waiting()).insert(PROBE_ID, tx);
+    let js = format!(
+        "if (window.__TAURI_INTERNALS__) {{ window.__TAURI_INTERNALS__.invoke\
+         ('plugin:event|emit', {{ event: {event}, payload: {{id:0,status:204}} }}); }}",
+        event = js_string(RESULT_EVENT)
+    );
+    if let Err(e) = window.eval(&js) {
+        lock(waiting()).remove(&PROBE_ID);
+        return Err(anyhow::anyhow!("{e}"));
+    }
+    match tokio::time::timeout(Duration::from_millis(400), rx).await {
+        Ok(Ok(_)) => Ok(()),
+        _ => {
+            lock(waiting()).remove(&PROBE_ID);
+            Err(anyhow::anyhow!("no answer from the page yet"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A search term with a quote in it reaches `eval` — it must not be able to close the
+    /// string literal it sits in.
+    #[test]
+    fn js_strings_escape_what_would_break_out() {
+        assert_eq!(js_string(r#"a"b"#), r#""a\"b""#);
+        assert_eq!(js_string(r"a\b"), r#""a\\b""#);
+        assert_eq!(js_string("a\nb"), r#""a\nb""#);
+        // A closing script tag inside a literal still ends a script block in HTML parsing.
+        assert!(!js_string("</script>").contains('<'));
+    }
+
+    #[test]
+    fn the_script_carries_the_id_url_and_event() {
+        let js = script(42, "https://mxb-mods.com/wp-json/wp/v2/posts?page=2", None);
+        assert!(js.contains("p.id = 42;"), "{js}");
+        assert!(js.contains("wp-json/wp/v2/posts?page=2"), "{js}");
+        assert!(js.contains(RESULT_EVENT), "{js}");
+        assert!(js.contains("credentials:'include'"), "{js}");
+        assert!(!js.contains("method:'POST'"), "a GET must not claim to be a POST");
+        // Tauri encodes the payload itself. Stringifying first lands a quoted string where
+        // the listener expects a struct, and every reply is dropped as unreadable — which
+        // is exactly what the first run of this bridge did.
+        assert!(
+            !js.contains("JSON.stringify"),
+            "the payload must be the object, not a JSON string of it: {js}"
+        );
+    }
+
+    #[test]
+    fn a_post_carries_its_form_body() {
+        let js = script(7, "https://mxb-mods.com/wp-admin/admin-ajax.php", Some("a=1&b=2"));
+        assert!(js.contains("method:'POST'"), "{js}");
+        assert!(js.contains("a=1&b=2"), "{js}");
+        assert!(js.contains("x-www-form-urlencoded"), "{js}");
+    }
+
+    #[test]
+    fn queries_are_encoded_the_way_the_site_expects() {
+        let params = [("search", "supercross 26".to_string()), ("page", "2".to_string())];
+        let url = with_query("https://mxb-mods.com/wp-json/wp/v2/posts", &params);
+        assert_eq!(
+            url,
+            "https://mxb-mods.com/wp-json/wp/v2/posts?search=supercross%2026&page=2"
+        );
+        // An existing query string is appended to, not replaced.
+        assert!(with_query("https://x/y?a=1", &params).contains("?a=1&search="));
+        assert_eq!(with_query("https://x/y", &[]), "https://x/y");
+    }
+
+    #[test]
+    fn form_encoding_matches_reqwests() {
+        let form = [
+            ("action", "load_results".to_string()),
+            ("postID", "1234".to_string()),
+        ];
+        assert_eq!(encode_form(&form), "action=load_results&postID=1234");
+    }
+
+    /// The remote page can emit anything it likes on this event. A result for an id we never
+    /// issued has to be dropped, not delivered to whoever happens to be waiting.
+    #[test]
+    fn a_reply_for_an_unknown_id_is_dropped() {
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+        lock(waiting()).insert(9001, tx);
+
+        deliver(Reply {
+            id: 9002,
+            status: 200,
+            headers: HashMap::new(),
+            body: "injected".into(),
+            url: String::new(),
+            error: None,
+        });
+        assert!(
+            rx.try_recv().is_err(),
+            "a reply for another id must not resolve this request"
+        );
+
+        deliver(Reply {
+            id: 9001,
+            status: 200,
+            headers: HashMap::new(),
+            body: "ours".into(),
+            url: String::new(),
+            error: None,
+        });
+        assert_eq!(rx.try_recv().unwrap().body, "ours");
+    }
+
+    /// Malformed JSON from the page must not panic the listener.
+    #[test]
+    fn an_unreadable_payload_is_survivable() {
+        assert!(serde_json::from_str::<Reply>("not json").is_err());
+        // Missing optional fields are fine; only the id is required.
+        let r: Reply = serde_json::from_str(r#"{"id":3}"#).unwrap();
+        assert_eq!(r.id, 3);
+        assert_eq!(r.status, 0);
+    }
+}

--- a/src-tauri/src/mxb_session.rs
+++ b/src-tauri/src/mxb_session.rs
@@ -1,29 +1,33 @@
-//! The mxb-mods.com side of [`cookie_session`], plus the WebView handshake that fills it.
+//! The mxb-mods.com side of [`cookie_session`]: the identity the HTTP client browses under.
 //!
-//! Browsing is anonymous — there is nothing to sign into here. The only cookie that matters
-//! is Cloudflare's `cf_clearance`, which is earned by a real browser passing a challenge.
+//! Browsing is anonymous — there is nothing to sign into here. The only cookie that ever
+//! mattered is Cloudflare's `cf_clearance`, and this module used to open a WebView, let the
+//! challenge clear, and replay the cookie it earned into the reqwest client.
 //!
-//! Why we need one at all: a reqwest client can copy Chrome's headers exactly and still be
-//! told apart by its TLS and HTTP/2 fingerprint, which no header can disguise. Cloudflare
-//! scores that fingerprint against the caller's IP reputation, so the same binary sails
-//! through on one connection and is refused on another — the shape of the report this
-//! exists to fix. We ship a real browser, so when the site refuses the HTTP client we open
-//! one, let it clear, and take the cookie.
+//! That no longer exists, because a tester's log proved it cannot work: the challenge cleared
+//! in about a second, the cookie was sent correctly, and Cloudflare served the interstitial to
+//! reqwest anyway. A `cf_clearance` is bound to the TLS/HTTP2 fingerprint of the connection
+//! that earned it, and rustls does not fingerprint like the WebView's Chrome — so the cookie
+//! is not portable between them. The answer is to move the *request* into the browser instead;
+//! see [`crate::mxb_fetch`].
+//!
+//! What remains is the jar the client browses with — ordinary `Set-Cookie` handling, plus
+//! anything an older version left on disk — and the UA the bridge is built with, kept here so
+//! the two cannot drift.
 
-use crate::cookie_session::{self, Cookies, Site};
+use crate::cookie_session::{self, Site};
 use reqwest::cookie::Jar;
 use reqwest::Url;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
-use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri::AppHandle;
 
 pub const BASE: &str = "https://mxb-mods.com";
 
 /// A full four-part version, unlike the `Chrome/126.0` form [`crate::shop_session::UA`]
 /// uses — real Chrome never sends a two-part version, and a UA no browser would emit is
-/// itself a signal to a bot filter. The handshake WebView is built with this same constant:
-/// a `cf_clearance` is bound to the User-Agent that earned it, so the two must not drift.
+/// itself a signal to a bot filter. [`crate::mxb_fetch`]'s WebView is built with this same
+/// constant, so the HTTP client and the browser present as the same visitor.
 pub const UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.6778.140 Safari/537.36";
 
 const SITE: Site = Site {
@@ -34,15 +38,6 @@ const SITE: Site = Site {
     timeout: Duration::from_secs(30),
 };
 
-/// Public so the window-event handler can tell this transient window from the main one —
-/// hiding it instead of closing it strands its label and breaks every later handshake.
-pub const WINDOW: &str = "mxb-clearance";
-
-/// How long we leave the window up. It normally closes in a few seconds — a managed
-/// challenge clears on its own — but the budget has to cover one that wants a click.
-const WAIT: Duration = Duration::from_secs(120);
-const POLL: Duration = Duration::from_millis(500);
-
 /// Process-wide, because the mods client is built once and must see cookies that arrive
 /// long afterwards. `Jar` is internally synchronised, so filling it after the fact is
 /// visible to the client already holding it.
@@ -52,7 +47,7 @@ pub fn jar() -> Arc<Jar> {
 }
 
 /// The mods client is built from this so its User-Agent, jar and timeouts cannot drift from
-/// the handshake WebView's. Callers add their own default headers.
+/// the fetch WebView's. Callers add their own default headers.
 pub fn client_builder() -> reqwest::ClientBuilder {
     cookie_session::client_builder(&SITE, jar())
 }
@@ -97,25 +92,9 @@ fn summarize(jar: &Jar, url: &Url) -> String {
     format!("{}{cleared}", names.join(", "))
 }
 
-/// Bumped whenever fresh cookies land, so a caller that waited behind another handshake can
-/// tell it now has something new to retry with instead of opening a second window.
-static GENERATION: AtomicU64 = AtomicU64::new(0);
-
-fn store(app: &AppHandle, cookies: Cookies) {
-    if let Err(e) = cookie_session::fill(&jar(), &SITE, &cookies) {
-        log::warn!("could not add mxb-mods.com cookies to the jar: {e:#}");
-        return;
-    }
-    if let Err(e) = cookie_session::write(app, &SITE, &cookies) {
-        // Not fatal: the jar is filled, so this session works — only the next one arrives cold.
-        log::warn!("could not persist mxb-mods.com cookies: {e:#}");
-    }
-    GENERATION.fetch_add(1, Ordering::Relaxed);
-}
-
-/// Replay last run's clearance, so a user who was blocked yesterday isn't blocked again on
-/// launch. An expired cookie is harmless — it fails exactly like no cookie, and the 403
-/// path mints a new one.
+/// Replay whatever an earlier version of the app left on disk. Nothing writes this file any
+/// more — the handshake that used to fill it is gone — but an existing clearance still costs
+/// nothing to send, and an expired one fails exactly like no cookie.
 pub fn load(app: &AppHandle) {
     let Some(cookies) = cookie_session::read(app, &SITE) else {
         return;
@@ -124,8 +103,8 @@ pub fn load(app: &AppHandle) {
         log::warn!("failed to restore mxb-mods.com cookies: {e:#}");
         return;
     }
-    // Whether a clearance came back matters more than how many cookies did: without one we
-    // start the session already expecting the handshake.
+    // Whether a clearance came back matters more than how many cookies did — it is the first
+    // thing to check against a refusal line further down the log.
     log::info!(
         "restored mxb-mods.com cookies ({}, {})",
         cookies.len(),
@@ -137,110 +116,6 @@ pub fn load(app: &AppHandle) {
     );
 }
 
-/// Open a real browser at mxb-mods.com, wait for Cloudflare to hand it a `cf_clearance`,
-/// and keep the cookie. `true` if we came away with one.
-///
-/// Serialised: a 403 on search and a 403 on a detail page arriving together must not open
-/// two windows. The loser of the lock checks whether the winner already succeeded.
-pub async fn handshake(app: &AppHandle) -> bool {
-    static LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
-    let before = GENERATION.load(Ordering::Relaxed);
-    let _guard = LOCK.lock().await;
-    if GENERATION.load(Ordering::Relaxed) != before {
-        log::info!("another caller earned a cf_clearance while we waited — not opening a window");
-        return true; // another caller earned one while we waited
-    }
-
-    log::info!(
-        "opening the mxb-mods.com check window (jar currently holds: {})",
-        jar_summary()
-    );
-
-    // Closing is a request handled on the main thread, not something that has finished by
-    // the time `close()` returns — so building the replacement immediately races the
-    // teardown and loses with "a webview with label `mxb-clearance` already exists". Wait
-    // for the label to actually free. If it never does, something is holding the window
-    // open and building would fail anyway; say so rather than logging the confusing
-    // already-exists error.
-    if let Some(existing) = app.get_webview_window(WINDOW) {
-        let _ = existing.close();
-        let mut freed = false;
-        for _ in 0..20 {
-            tokio::time::sleep(Duration::from_millis(50)).await;
-            if app.get_webview_window(WINDOW).is_none() {
-                freed = true;
-                break;
-            }
-        }
-        if !freed {
-            log::error!("the previous mxb-mods.com check window would not close");
-            return false;
-        }
-    }
-
-    let url = match BASE.parse() {
-        Ok(url) => url,
-        Err(e) => {
-            log::error!("mxb-mods.com base URL is not a URL: {e}");
-            return false;
-        }
-    };
-    let window = match WebviewWindowBuilder::new(app, WINDOW, WebviewUrl::External(url))
-        .title("Checking with mxb-mods.com…")
-        .user_agent(UA)
-        .inner_size(480.0, 560.0)
-        .build()
-    {
-        Ok(window) => window,
-        Err(e) => {
-            log::error!("could not open the mxb-mods.com check window: {e:#}");
-            return false;
-        }
-    };
-
-    let deadline = WAIT.as_millis() / POLL.as_millis();
-    let mut last: Cookies = vec![];
-    for _ in 0..deadline {
-        tokio::time::sleep(POLL).await;
-        let Some(win) = app.get_webview_window(WINDOW) else {
-            log::info!("mxb-mods.com check window closed before it cleared");
-            return false;
-        };
-        last = cookie_session::cookies_from_window(&win, &SITE);
-        if cookie_session::has(&last, "cf_clearance") {
-            store(app, last);
-            let _ = win.close();
-            log::info!("earned a cf_clearance for mxb-mods.com");
-            return true;
-        }
-    }
-
-    let _ = window.close();
-    let names: Vec<String> = last.iter().map(|(n, _)| n.clone()).collect();
-    // No clearance, but `__cf_bm` and friends still feed the bot score, so keep what we got.
-    if !last.is_empty() {
-        store(app, last);
-    }
-    // Worth reading in a user's log, because it distinguishes the two ways this can fail.
-    // No clearance means the WebView was never challenged, so there was no challenge for us
-    // to pass and the refusal is aimed at the HTTP client specifically — the case that
-    // needs the request to be made from inside the WebView rather than merely wearing its
-    // cookie. A clearance that we *did* get and that still 403s is the other case.
-    //
-    // The names it *did* end up with separate those further: `cf_chl_*` means a challenge
-    // was served and we sat through it without passing, while nothing but `__cf_bm` means
-    // the browser was never challenged at all.
-    log::warn!(
-        "mxb-mods.com never issued a cf_clearance within {WAIT:?} (window ended with: {})",
-        if names.is_empty() {
-            "no cookies".to_string()
-        } else {
-            names.join(", ")
-        }
-    );
-    false
-}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Stacked on #66 (the window fix), which it branches from. Merge that first.

## Why

The beta.2 diagnostics were added to answer one question, and a tester's log answered it:

```
06:05:55  earned a cf_clearance for mxb-mods.com
06:05:55  mxb-mods refused the catalog listing (/wp-json/wp/v2/posts, 403)
          cf-ray=a27c55073e85659d-EWR cf-mitigated=challenge
          jar: … cf_clearance …   body: "<title>Just a moment...</title>"
06:05:55  search refused again even with a fresh cf_clearance
```

The handshake **works and does not help**. The challenge cleared in about a second, the cookie was harvested and replayed correctly, and Cloudflare served the interstitial to reqwest anyway. `cf_clearance` is bound to the TLS/HTTP2 fingerprint of the connection that earned it, and rustls doesn't fingerprint like the WebView's Chrome — the cookie simply isn't portable between them.

So: move the *request* into the browser instead of moving the cookie out of it. We already ship a browser.

## How

- **`mxb_fetch`** — a hidden WebView parked on the mxb-mods.com origin running same-origin `fetch()`, result returned over a Tauri event. Built lazily, only once something is actually refused. Sized 1×1 offscreen rather than `visible(false)`, because WebView2 can throttle a window it considers fully hidden.
- **A `Fetched { status, headers, body, url }` seam** so reqwest and the bridge are interchangeable. Parsers untouched. Same-origin fetch exposes every header, so `X-WP-Total` (needed by oldest-first paging) survives.
- **reqwest stays the fast path.** A clearable refusal latches the session to the bridge and never latches back — the same fingerprint on the same network gets refused again, so flapping would just reintroduce the failure per request. `MXB_FORCE_WEBVIEW=1` starts on it.
- **Removed the handshake apparatus this replaces.** Once `with_clearance` stopped calling it, `handshake`/`store`/the generation counter/the clearance window were dead code. `mxb_session` keeps the jar, UA and `jar_summary`. The visible "Checking with mxb-mods.com…" popup is gone.
- **Ratings ride the same transport**, so a blocked player no longer gets their mods back with every star missing.

## Security — the part worth reviewing directly

`capabilities/mxb-fetch.json` is the only capability in the app granted to a **remote** origin. It holds `core:event:allow-emit` and nothing else — no shell, dialog, fs, updater, process or window control.

That alone isn't enough: **a capability enables IPC generally, and commands registered with `generate_handler!` are not covered by the permission ACL.** Without a guard, script on mxb-mods.com could call `create_config` or `install_mod`. So `ipc_allowed()` wraps the handler and permits that window exactly one call, rejecting and logging everything else. Replies carrying an id we never issued are dropped, so a hostile page can only emit noise.

Two tests pin this, including an explicit list of commands that must stay refused. If `the_remote_fetch_window_may_only_emit_its_result` ever passes for a second command, that command is reachable from mxb-mods.com.

## Verification

`MXB_FORCE_WEBVIEW=1 MXB_LOG=debug` against the live site — every request through the bridge:

```
MXB_FORCE_WEBVIEW is set — all mxb-mods.com traffic goes via the WebView
opening the hidden mxb-mods.com fetch window
webview GET /wp-json/wp/v2/posts?categories=22&…&page=1 -> 200 in 857ms
webview GET /wp-admin/admin-ajax.php -> 200 in 527ms      (×24)
```

26 requests, all 200, **zero warnings or errors**. The 24 rating lookups only fire for cards already rendered, so the grid populated. `x-wp-total: 1547` confirmed intact through the bridge.

`cargo test` — 221 pass, 0 fail. `cargo clippy --all-targets` at the 51-warning baseline.

**Not verified:** the mod-detail path was never clicked — screen recording is blocked in my environment so I couldn't drive the UI. It goes through the identical seam and differs only in reading the body as HTML rather than JSON, but I didn't watch it work. Worth one click.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)