### PR TITLE
perf(viewer): stop encoding textures and rendering a parked model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 2026-08-08
+
+### Changed
+- **The 3D viewer stops eating the machine.** Every texture a preview showed was compressed
+  to a PNG and then base64'd into a text blob before it could cross to the viewer — seconds
+  of every core per bike, and a multi-megabyte string that then lived in the Rust cache, the
+  message to the frontend and the browser heap all at once. Worse, each paint carried its
+  own copy of the model's base textures, so a bike with several liveries held the same
+  pixels over and over. The pixels now stay put and the viewer is handed a reference,
+  fetching the raw bytes over a binary channel only for the paint it is actually drawing.
+  Nothing is encoded, nothing is turned into text, and a paint costs a handful of bytes
+  instead of a copy of the bike.
+- **The viewer no longer redraws a parked model 60 times a second.** Nothing in the scene
+  moves on its own, but the canvas was rendering continuously anyway, shadows and all — and
+  the Rider tab keeps one on screen for as long as that page is open. It now draws only when
+  something actually changes: you move the camera, a texture arrives, the model is reframed.
+  Rendering also stops oversampling to twice the screen's pixels for a preview-sized model.
+- **Switching paint no longer rebuilds the bike.** Changing livery threw away every part's
+  geometry and re-uploaded the whole model to the graphics card just to swap which image it
+  wore. Geometry and paint are now built separately, so a paint change only changes the
+  paint.
+- **The viewer's caches have a ceiling.** Parsed meshes were kept for the life of the app
+  and never released, and the bike cache emptied itself wholesale on its seventh entry —
+  throwing away the model you were looking at along with the rest. Both now keep the most
+  recently used and drop only the coldest, and a dropped bike releases its texture pixels
+  with it.
+
+### Fixed
+- **A paint with one unreadable texture no longer leaves the whole model untextured.** The
+  viewer waited for a fixed number of textures to arrive and one that failed to load never
+  arrived, so the count never completed and every part stayed grey. A texture that can't be
+  read is now skipped on its own, and the rest of the paint still shows.
+
 ## 2026-08-07 — v0.7.1 — the Rider preview stops failing in silence, and a blocked Browse says why
 
 ### Fixed

--- a/src-tauri/src/lru.rs
+++ b/src-tauri/src/lru.rs
@@ -1,0 +1,93 @@
+//! A bounded, least-recently-used map.
+//!
+//! The viewer caches parsed meshes and whole bike models so re-opening one is instant.
+//! Both used to grow without a real ceiling — the mesh cache had none at all, and the bike
+//! cache emptied itself wholesale once it hit six entries, throwing away the model you were
+//! looking at along with the rest. This keeps the recent ones and evicts only the coldest,
+//! handing the caller what it dropped so it can free anything hanging off it.
+
+use std::collections::{HashMap, VecDeque};
+
+pub struct Lru<V> {
+    map: HashMap<String, V>,
+    /// Coldest key first.
+    order: VecDeque<String>,
+    cap: usize,
+}
+
+impl<V> Lru<V> {
+    pub fn new(cap: usize) -> Self {
+        Self {
+            map: HashMap::new(),
+            order: VecDeque::new(),
+            cap: cap.max(1),
+        }
+    }
+
+    /// Look up `key`, marking it as the most recently used.
+    pub fn get(&mut self, key: &str) -> Option<&V> {
+        if !self.map.contains_key(key) {
+            return None;
+        }
+        self.touch(key);
+        self.map.get(key)
+    }
+
+    /// Insert `value`, returning whatever was evicted to make room for it.
+    pub fn insert(&mut self, key: String, value: V) -> Option<V> {
+        if self.map.insert(key.clone(), value).is_some() {
+            self.touch(&key);
+            return None; // replaced in place, nothing left the cache
+        }
+        self.order.push_back(key);
+        if self.map.len() > self.cap {
+            if let Some(coldest) = self.order.pop_front() {
+                return self.map.remove(&coldest);
+            }
+        }
+        None
+    }
+
+    fn touch(&mut self, key: &str) {
+        if let Some(i) = self.order.iter().position(|k| k == key) {
+            let k = self.order.remove(i).expect("index came from the deque");
+            self.order.push_back(k);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn evicts_the_coldest_entry() {
+        let mut lru = Lru::new(2);
+        assert!(lru.insert("a".into(), 1).is_none());
+        assert!(lru.insert("b".into(), 2).is_none());
+        assert_eq!(lru.insert("c".into(), 3), Some(1), "'a' was coldest");
+        assert!(lru.get("a").is_none());
+        assert_eq!(lru.get("b"), Some(&2));
+        assert_eq!(lru.get("c"), Some(&3));
+    }
+
+    #[test]
+    fn a_hit_keeps_an_entry_alive() {
+        let mut lru = Lru::new(2);
+        lru.insert("a".into(), 1);
+        lru.insert("b".into(), 2);
+        lru.get("a"); // 'a' is now the warm one
+        assert_eq!(lru.insert("c".into(), 3), Some(2), "'b' went instead");
+        assert_eq!(lru.get("a"), Some(&1));
+    }
+
+    #[test]
+    fn replacing_a_key_evicts_nothing() {
+        let mut lru = Lru::new(2);
+        lru.insert("a".into(), 1);
+        lru.insert("b".into(), 2);
+        assert_eq!(lru.insert("a".into(), 9), None);
+        assert_eq!(lru.get("a"), Some(&9));
+        assert_eq!(lru.get("b"), Some(&2), "both still resident");
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -13,6 +13,7 @@ mod frostmod_manage;
 mod gameproc;
 mod install;
 mod library;
+mod lru;
 mod modelswap;
 mod mods;
 mod modstate;
@@ -26,6 +27,7 @@ mod sidecar;
 mod presets;
 mod shop_session;
 mod soundmods;
+mod texstore;
 mod upload;
 
 use config::AppConfig;
@@ -457,6 +459,17 @@ fn unpack_paint_blocking(path: String) -> Result<Vec<paint::PaintTexture>, Strin
     paint::unpack_file(std::path::Path::new(&path)).map_err(|e| format!("{e:#}"))
 }
 
+/// Raw RGBA for a texture the viewer was handed a token for.
+///
+/// Returns an `ipc::Response`, which travels as `application/octet-stream` and lands in the
+/// webview as an `ArrayBuffer` — the pixels are never encoded, base64'd, or parsed as JSON
+/// on the way. The frontend feeds the buffer straight to a `THREE.DataTexture`. `async`
+/// keeps the copy off the main thread, as with every other command here.
+#[tauri::command]
+async fn texture_bytes(token: String) -> tauri::ipc::Response {
+    tauri::ipc::Response::new(texstore::bytes_or_missing(&token))
+}
+
 #[tauri::command]
 async fn unpack_pkz(path: String, out_dir: String) -> Result<Vec<String>, String> {
     tauri::async_runtime::spawn_blocking(move || unpack_pkz_blocking(path, out_dir))
@@ -484,10 +497,23 @@ struct BikeModel {
     paints: Vec<BikePaint>,
 }
 
-fn bike_cache() -> &'static std::sync::Mutex<std::collections::HashMap<String, BikeModel>> {
-    static CACHE: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<String, BikeModel>>> =
+impl BikeModel {
+    /// Every texture token the model holds, so evicting it can free the pixels too.
+    fn tokens(&self) -> Vec<String> {
+        self.paints
+            .iter()
+            .flat_map(|p| p.textures.iter().map(|t| t.token.clone()))
+            .collect()
+    }
+}
+
+/// Bikes are big (geometry plus every paint's pixels), so hold only the few most recent.
+const BIKE_CACHE_CAP: usize = 3;
+
+fn bike_cache() -> &'static std::sync::Mutex<lru::Lru<BikeModel>> {
+    static CACHE: std::sync::OnceLock<std::sync::Mutex<lru::Lru<BikeModel>>> =
         std::sync::OnceLock::new();
-    CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+    CACHE.get_or_init(|| std::sync::Mutex::new(lru::Lru::new(BIKE_CACHE_CAP)))
 }
 
 fn bike_cache_key(source: &str) -> String {
@@ -511,7 +537,7 @@ fn load_bike_model_blocking(source: String) -> Result<BikeModel, String> {
     use rayon::prelude::*;
     let t0 = std::time::Instant::now();
     let key = bike_cache_key(&source);
-    if let Some(m) = bike_cache().lock().ok().and_then(|c| c.get(&key).cloned()) {
+    if let Some(m) = bike_cache().lock().ok().and_then(|mut c| c.get(&key).cloned()) {
         log::info!("load_bike_model {source}: cache hit ({:?})", t0.elapsed());
         return Ok(m);
     }
@@ -642,7 +668,7 @@ fn load_bike_model_blocking(source: String) -> Result<BikeModel, String> {
         })
         .collect();
     let base_count = base.len();
-    let t_encode = t0.elapsed();
+    let t_textures = t0.elapsed();
 
     let bound: std::collections::HashSet<String> = nodes
         .iter()
@@ -687,12 +713,18 @@ fn load_bike_model_blocking(source: String) -> Result<BikeModel, String> {
         });
     }
 
+    let distinct_tex: std::collections::HashSet<&str> = paints
+        .iter()
+        .flat_map(|p| p.textures.iter().map(|t| t.token.as_str()))
+        .collect();
     log::info!(
-        "load_bike_model {source}: {} paint(s) + {base_count} base tex | read {t_read:?}, parse {:?}, encode {:?}, total {:?}",
+        "load_bike_model {source}: {} paint(s) + {base_count} base tex | read {t_read:?}, parse {:?}, decode {:?}, total {:?} | {} distinct texture(s), {:.1} MB resident in the texture store",
         paints.len(),
         t_parse - t_read,
-        t_encode - t_parse,
+        t_textures - t_parse,
         t0.elapsed(),
+        distinct_tex.len(),
+        texstore::resident_bytes() as f64 / (1024.0 * 1024.0),
     );
     for p in &paints {
         let mut names: Vec<&str> = p.textures.iter().map(|t| t.name.as_str()).collect();
@@ -720,10 +752,10 @@ fn load_bike_model_blocking(source: String) -> Result<BikeModel, String> {
 
     let model = BikeModel { nodes, paints };
     if let Ok(mut c) = bike_cache().lock() {
-        if c.len() >= 6 {
-            c.clear();
+        // The evicted bike's pixels go with it — nothing else references them.
+        if let Some(dropped) = c.insert(key, model.clone()) {
+            texstore::release(&dropped.tokens());
         }
-        c.insert(key, model.clone());
     }
     Ok(model)
 }
@@ -983,12 +1015,14 @@ fn tag_body_materials(nodes: &mut [edf::EdfNode]) {
     }
 }
 
-fn pkz_mesh_cache() -> &'static std::sync::Mutex<std::collections::HashMap<String, Vec<edf::EdfNode>>>
-{
-    static C: std::sync::OnceLock<
-        std::sync::Mutex<std::collections::HashMap<String, Vec<edf::EdfNode>>>,
-    > = std::sync::OnceLock::new();
-    C.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+/// Rider bodies and helmets are small next to a bike, and a session cycles through a
+/// handful of them, so this can hold more entries than the bike cache does.
+const MESH_CACHE_CAP: usize = 12;
+
+fn pkz_mesh_cache() -> &'static std::sync::Mutex<lru::Lru<Vec<edf::EdfNode>>> {
+    static C: std::sync::OnceLock<std::sync::Mutex<lru::Lru<Vec<edf::EdfNode>>>> =
+        std::sync::OnceLock::new();
+    C.get_or_init(|| std::sync::Mutex::new(lru::Lru::new(MESH_CACHE_CAP)))
 }
 
 fn keep_lod0(nodes: &mut Vec<edf::EdfNode>) {
@@ -998,7 +1032,7 @@ fn keep_lod0(nodes: &mut Vec<edf::EdfNode>) {
 
 fn load_pkz_mesh(pkz: &std::path::Path, entry: &str) -> Option<Vec<edf::EdfNode>> {
     let key = format!("{}:{}", bike_cache_key(&pkz.to_string_lossy()), entry);
-    if let Some(n) = pkz_mesh_cache().lock().ok().and_then(|c| c.get(&key).cloned()) {
+    if let Some(n) = pkz_mesh_cache().lock().ok().and_then(|mut c| c.get(&key).cloned()) {
         return Some(n);
     }
     let data = read_pkz_entry(pkz, entry)?;
@@ -2607,6 +2641,7 @@ fn main() {
             get_pkz_meta,
             get_pkz_preview,
             unpack_paint,
+            texture_bytes,
             unpack_pkz,
             load_bike_model,
             load_rider_model,

--- a/src-tauri/src/paint.rs
+++ b/src-tauri/src/paint.rs
@@ -7,10 +7,7 @@
 //! ```
 
 use anyhow::{bail, Context, Result};
-use base64::Engine;
 use flate2::read::DeflateDecoder;
-use image::codecs::png::{CompressionType, FilterType, PngEncoder};
-use image::{ExtendedColorType, ImageEncoder};
 use serde::Serialize;
 use std::io::{Cursor, Read};
 use std::path::Path;
@@ -36,7 +33,9 @@ pub struct PaintTexture {
     pub name: String,
     pub width: u32,
     pub height: u32,
-    pub png: String,
+    /// Names the pixels in [`crate::texstore`]. Cloning this struct is cheap, which is why
+    /// a paint can carry the model's whole base texture set without duplicating megabytes.
+    pub token: String,
 }
 
 fn read_u32(buf: &[u8], off: usize) -> Result<u32> {
@@ -116,15 +115,21 @@ pub fn decode_any(buf: &[u8]) -> Result<Vec<PntTexture>> {
     decode(buf) // not PNT and no sidecar reader for it → report bad magic
 }
 
-fn to_png_uri(tex: &PntTexture) -> Result<String> {
-    // Fast deflate + no row filter: encode speed over size.
-    let mut png = Vec::new();
-    PngEncoder::new_with_quality(&mut png, CompressionType::Fast, FilterType::NoFilter)
-        .write_image(&tex.rgba, tex.width, tex.height, ExtendedColorType::Rgba8)
-        .context("encode PNG")?;
-    let b64 = base64::engine::general_purpose::STANDARD.encode(&png);
-    Ok(format!("data:image/png;base64,{b64}"))
+/// Hand pixels to the store and describe them. The viewer reads RGBA straight into a
+/// `DataTexture`, so nothing is encoded here — this used to be a PNG compress plus a base64
+/// pass per texture, which is what made loading a bike peg every core for seconds.
+fn store_rgba(name: &str, width: u32, height: u32, rgba: Vec<u8>) -> PaintTexture {
+    PaintTexture {
+        name: name.to_string(),
+        width,
+        height,
+        token: crate::texstore::put(rgba),
+    }
 }
+
+/// Longest edge the viewer is given. Beyond this the extra pixels cost memory without
+/// showing on a preview-sized model.
+const MAX_EDGE: u32 = 1024;
 
 pub fn extract_edf_textures(edf: &[u8]) -> Vec<PaintTexture> {
     crate::edf::embedded_textures(edf)
@@ -139,49 +144,30 @@ pub fn extract_edf_textures(edf: &[u8]) -> Vec<PaintTexture> {
             let img = image::DynamicImage::ImageRgba8(image::RgbaImage::from_raw(
                 t.width, t.height, rgba,
             )?);
-            let scaled = img.thumbnail(1024, 1024);
-            let (sw, sh) = (scaled.width(), scaled.height());
-            let mut jpg = Vec::new();
-            image::DynamicImage::ImageRgb8(scaled.to_rgb8())
-                .write_to(&mut Cursor::new(&mut jpg), image::ImageFormat::Jpeg)
-                .ok()?;
-            let b64 = base64::engine::general_purpose::STANDARD.encode(&jpg);
-            Some(PaintTexture {
-                name: t.name.clone(),
-                width: sw,
-                height: sh,
-                png: format!("data:image/jpeg;base64,{b64}"),
-            })
+            let scaled = img.thumbnail(MAX_EDGE, MAX_EDGE);
+            Some(store_rgba(
+                &t.name,
+                scaled.width(),
+                scaled.height(),
+                scaled.to_rgba8().into_raw(),
+            ))
         })
         .collect()
 }
 
 pub fn to_texture(t: &PntTexture) -> PaintTexture {
-    const MAX: u32 = 1024;
-    if t.width.max(t.height) > MAX {
+    if t.width.max(t.height) > MAX_EDGE {
         if let Some(img) = image::RgbaImage::from_raw(t.width, t.height, t.rgba.clone()) {
-            let scaled = image::DynamicImage::ImageRgba8(img).thumbnail(MAX, MAX);
-            let (w, h) = (scaled.width(), scaled.height());
-            let scaled = PntTexture {
-                name: t.name.clone(),
-                width: w,
-                height: h,
-                rgba: scaled.to_rgba8().into_raw(),
-            };
-            return PaintTexture {
-                name: t.name.clone(),
-                width: w,
-                height: h,
-                png: to_png_uri(&scaled).unwrap_or_default(),
-            };
+            let scaled = image::DynamicImage::ImageRgba8(img).thumbnail(MAX_EDGE, MAX_EDGE);
+            return store_rgba(
+                &t.name,
+                scaled.width(),
+                scaled.height(),
+                scaled.to_rgba8().into_raw(),
+            );
         }
     }
-    PaintTexture {
-        name: t.name.clone(),
-        width: t.width,
-        height: t.height,
-        png: to_png_uri(t).unwrap_or_default(),
-    }
+    store_rgba(&t.name, t.width, t.height, t.rgba.clone())
 }
 
 pub fn decode_image(name: &str, bytes: &[u8]) -> Option<PaintTexture> {
@@ -191,33 +177,13 @@ pub fn decode_image(name: &str, bytes: &[u8]) -> Option<PaintTexture> {
         .and_then(|d| image::DynamicImage::from_decoder(d).ok())
         .or_else(|| image::load_from_memory(bytes).ok())?;
     let rgba = img.to_rgba8();
-    let tex = PntTexture {
-        name: name.to_string(),
-        width: rgba.width(),
-        height: rgba.height(),
-        rgba: rgba.into_raw(),
-    };
-    to_png_uri(&tex).ok().map(|png| PaintTexture {
-        name: tex.name,
-        width: tex.width,
-        height: tex.height,
-        png,
-    })
+    let (w, h) = (rgba.width(), rgba.height());
+    Some(store_rgba(name, w, h, rgba.into_raw()))
 }
 
 pub fn unpack_file(path: &Path) -> Result<Vec<PaintTexture>> {
     let bytes = std::fs::read(path).with_context(|| format!("read {path:?}"))?;
-    decode_any(&bytes)?
-        .iter()
-        .map(|t| {
-            Ok(PaintTexture {
-                name: t.name.clone(),
-                width: t.width,
-                height: t.height,
-                png: to_png_uri(t)?,
-            })
-        })
-        .collect()
+    Ok(decode_any(&bytes)?.iter().map(to_texture).collect())
 }
 
 #[cfg(test)]
@@ -276,8 +242,10 @@ mod tests {
         eprintln!("extracted {} texture(s) in {:?}", texs.len(), t.elapsed());
         assert!(!texs.is_empty(), "the model packs its own textures");
         for x in &texs {
-            eprintln!("  '{}' {}x{} uri_len={}", x.name, x.width, x.height, x.png.len());
-            assert!(x.width <= 1024 && x.height <= 1024 && x.png.len() > 100);
+            let px = crate::texstore::get(&x.token).expect("token resolves to pixels");
+            eprintln!("  '{}' {}x{} bytes={}", x.name, x.width, x.height, px.len());
+            assert!(x.width <= MAX_EDGE && x.height <= MAX_EDGE);
+            assert_eq!(px.len() as u32, x.width * x.height * 4, "RGBA, no padding");
         }
     }
 
@@ -287,10 +255,15 @@ mod tests {
     }
 
     #[test]
-    fn encodes_png_uri() {
+    fn to_texture_stores_pixels_verbatim() {
         let texs = decode(FIXTURE_PNT).unwrap();
-        let uri = to_png_uri(&texs[0]).unwrap();
-        assert!(uri.starts_with("data:image/png;base64,"));
+        let out = to_texture(&texs[0]);
+        assert_eq!((out.width, out.height), (4, 4));
+        // Under MAX_EDGE, so the pixels reach the viewer untouched — no resample, no encode.
+        assert_eq!(
+            *crate::texstore::get(&out.token).expect("token resolves"),
+            fixture_stored_pixels()
+        );
     }
 
     #[test]

--- a/src-tauri/src/texstore.rs
+++ b/src-tauri/src/texstore.rs
@@ -1,0 +1,149 @@
+//! Decoded texture pixels, held here instead of being shipped as text.
+//!
+//! Every texture the viewer shows used to travel to the webview as a
+//! `data:image/png;base64,…` string: a PNG encode per texture (seconds of every core on a
+//! bike with a handful of 1024² liveries), a 37% base64 tax on top, and a multi-megabyte
+//! string that then lived in the Rust cache, the JSON payload and the JS heap at once.
+//!
+//! Instead the raw RGBA stays in this store and the frontend gets a short token. It fetches
+//! the pixels over binary IPC (`texture_bytes`) and hands them straight to a
+//! `THREE.DataTexture`, so nothing is ever encoded or stringified.
+//!
+//! Ownership: `to_texture` is called once per texture per source load, so a token belongs
+//! to exactly one `bike_cache` entry — no refcounting. That entry calls [`release`] when it
+//! is evicted. Paths with no cache of their own (a gear `.pnt` re-decoded on every pick)
+//! rely on [`CAP_BYTES`] reaping the oldest blobs.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+/// Ceiling on resident pixels. Comfortably above the working set — three cached bikes at
+/// ~10 textures each is ~120 MB — so the eviction below only ever reaps blobs whose owner
+/// is long gone.
+const CAP_BYTES: usize = 384 * 1024 * 1024;
+
+/// Stand-in for a token that has been evicted: the same grey an untextured part wears, so a
+/// stale reference reads as "no texture" rather than throwing in the viewer.
+const MISSING_RGBA: [u8; 4] = [0xb7, 0xbc, 0xc4, 0xff];
+
+/// Row-major RGBA8, `width * height * 4` bytes, top-left origin. Dimensions are not kept
+/// here — the `PaintTexture` the frontend already holds is their single source of truth.
+type Blob = Vec<u8>;
+
+#[derive(Default)]
+struct Store {
+    blobs: HashMap<String, Arc<Blob>>,
+    /// Insertion order, for the cap below.
+    order: VecDeque<String>,
+    bytes: usize,
+}
+
+fn store() -> &'static Mutex<Store> {
+    static S: OnceLock<Mutex<Store>> = OnceLock::new();
+    S.get_or_init(|| Mutex::new(Store::default()))
+}
+
+fn next_token() -> String {
+    static N: AtomicU64 = AtomicU64::new(1);
+    format!("t{}", N.fetch_add(1, Ordering::Relaxed))
+}
+
+/// Take ownership of a texture's pixels and return the token that names them.
+pub fn put(rgba: Vec<u8>) -> String {
+    let token = next_token();
+    let size = rgba.len();
+    let Ok(mut s) = store().lock() else {
+        return token; // poisoned — the token resolves to grey, which beats panicking
+    };
+    s.bytes += size;
+    s.blobs.insert(token.clone(), Arc::new(rgba));
+    s.order.push_back(token.clone());
+
+    while s.bytes > CAP_BYTES {
+        let Some(oldest) = s.order.pop_front() else {
+            break;
+        };
+        if let Some(b) = s.blobs.remove(&oldest) {
+            s.bytes -= b.len();
+            log::warn!(
+                "texture store over {CAP_BYTES} bytes — dropped {oldest}; a viewer still \
+                 holding it will show grey"
+            );
+        }
+    }
+    token
+}
+
+pub fn get(token: &str) -> Option<Arc<Blob>> {
+    store().lock().ok()?.blobs.get(token).cloned()
+}
+
+/// Drop the pixels behind `tokens`, called when whatever owned them is evicted.
+pub fn release(tokens: &[String]) {
+    let Ok(mut guard) = store().lock() else {
+        return;
+    };
+    let s = &mut *guard;
+    for t in tokens {
+        if let Some(b) = s.blobs.remove(t) {
+            s.bytes -= b.len();
+        }
+    }
+    let blobs = &s.blobs;
+    s.order.retain(|t| blobs.contains_key(t));
+}
+
+/// Pixels for `token`, or a single grey pixel if it has been evicted. The frontend treats a
+/// buffer that doesn't match the texture's declared size as "no texture" and renders grey.
+pub fn bytes_or_missing(token: &str) -> Vec<u8> {
+    match get(token) {
+        Some(b) => b.as_ref().clone(),
+        None => {
+            log::warn!("texture {token} is no longer resident — serving grey");
+            MISSING_RGBA.to_vec()
+        }
+    }
+}
+
+/// Resident pixel bytes, for the load-timing log.
+pub fn resident_bytes() -> usize {
+    store().lock().map(|s| s.bytes).unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_pixels() {
+        let px = vec![1u8, 2, 3, 4, 5, 6, 7, 8];
+        let token = put(px.clone());
+        assert_eq!(*get(&token).expect("token resolves"), px);
+        assert_eq!(bytes_or_missing(&token), px);
+    }
+
+    #[test]
+    fn released_tokens_serve_grey() {
+        let token = put(vec![9u8; 4]);
+        release(std::slice::from_ref(&token));
+        assert!(get(&token).is_none());
+        assert_eq!(bytes_or_missing(&token), MISSING_RGBA.to_vec());
+    }
+
+    #[test]
+    fn releasing_keeps_the_byte_count_honest() {
+        let before = resident_bytes();
+        let token = put(vec![7u8; 4096]);
+        assert_eq!(resident_bytes(), before + 4096);
+        release(&[token]);
+        assert_eq!(resident_bytes(), before);
+    }
+
+    #[test]
+    fn tokens_are_unique() {
+        let a = put(vec![0u8; 4]);
+        let b = put(vec![0u8; 4]);
+        assert_ne!(a, b, "each put names its own pixels");
+    }
+}

--- a/src/Components/Viewer/ModelViewer.tsx
+++ b/src/Components/Viewer/ModelViewer.tsx
@@ -5,10 +5,56 @@ import { Move, Rotate3d, ZoomIn } from "lucide-react";
 import * as THREE from "three";
 import { cn } from "@/lib/utils";
 import type { EdfNode, PaintTexture, RiderPart } from "../../types";
+import { textureBytes } from "../../api/mods";
 import { ErrorBoundary } from "../ErrorBoundary";
 import { useT } from "../../i18n/context";
 
 export type ViewerMode = "bike" | "rider";
+
+/**
+ * Pull a texture's pixels over the binary IPC channel and wrap them in a `DataTexture`.
+ *
+ * The backend hands us raw RGBA rather than an encoded image, so there is no decode step
+ * here — but that also means none of `TextureLoader`'s defaults come along, and every
+ * sampler setting below has to be stated. `DataTexture` starts out nearest-filtered with no
+ * mipmaps, which would read as a hard, aliased livery.
+ */
+async function loadTexture(t: PaintTexture): Promise<THREE.DataTexture | null> {
+  let buf: ArrayBuffer;
+  try {
+    buf = await textureBytes(t.token);
+  } catch (e) {
+    console.warn(`[ModelViewer] texture '${t.name}' could not be fetched:`, e);
+    return null;
+  }
+  const expected = t.width * t.height * 4;
+  if (buf.byteLength !== expected) {
+    // The store dropped it (or something is badly out of step) — leave the part untextured
+    // rather than hand three.js a buffer it will read past the end of.
+    console.warn(
+      `[ModelViewer] texture '${t.name}' is ${buf.byteLength}B, expected ${expected}B`,
+    );
+    return null;
+  }
+  const tex = new THREE.DataTexture(
+    new Uint8Array(buf),
+    t.width,
+    t.height,
+    THREE.RGBAFormat,
+  );
+  tex.colorSpace = THREE.SRGBColorSpace;
+  // MX Bikes paints use a top-left UV origin, which is `DataTexture`'s own default.
+  tex.flipY = false;
+  // Wrap (not clamp): some islands run outside 0–1 (plates, tiled exhaust) and need it.
+  tex.wrapS = THREE.RepeatWrapping;
+  tex.wrapT = THREE.RepeatWrapping;
+  tex.magFilter = THREE.LinearFilter;
+  tex.minFilter = THREE.LinearMipmapLinearFilter;
+  tex.generateMipmaps = true;
+  tex.anisotropy = 4;
+  tex.needsUpdate = true;
+  return tex;
+}
 
 function useTextureMap(textures: PaintTexture[]): Map<string, THREE.Texture> {
   const [map, setMap] = useState<Map<string, THREE.Texture>>(new Map());
@@ -18,26 +64,28 @@ function useTextureMap(textures: PaintTexture[]): Map<string, THREE.Texture> {
       return;
     }
     let alive = true;
-    const loaded = new Map<string, THREE.Texture>();
-    let pending = textures.length;
-    const loader = new THREE.TextureLoader();
-    textures.forEach((t) =>
-      loader.load(t.png, (tex) => {
-        tex.colorSpace = THREE.SRGBColorSpace;
-        // MX Bikes paints use a top-left UV origin, so disable three.js' default flipY.
-        tex.flipY = false;
-        // Wrap (not clamp): some islands run outside 0–1 (plates, tiled exhaust) and need it.
-        tex.wrapS = THREE.RepeatWrapping;
-        tex.wrapT = THREE.RepeatWrapping;
-        tex.anisotropy = 4;
-        loaded.set(t.name.toLowerCase(), tex);
-        pending -= 1;
-        if (pending === 0 && alive) setMap(new Map(loaded));
-      }),
-    );
+    // Disposal hangs off this rather than off each texture as it lands, so every texture
+    // has exactly one owner no matter when the effect is torn down.
+    let settled: Map<string, THREE.Texture> | null = null;
+
+    void Promise.all(
+      // `all`, not a counter: a texture that fails to load used to leave the tally short,
+      // and the model stayed untextured forever instead of losing the one bad part.
+      textures.map(async (t) => [t.name.toLowerCase(), await loadTexture(t)] as const),
+    ).then((pairs) => {
+      const loaded = new Map<string, THREE.Texture>();
+      for (const [name, tex] of pairs) if (tex) loaded.set(name, tex);
+      if (!alive) {
+        loaded.forEach((tex) => tex.dispose());
+        return;
+      }
+      settled = loaded;
+      setMap(loaded);
+    });
+
     return () => {
       alive = false;
-      loaded.forEach((tex) => tex.dispose());
+      settled?.forEach((tex) => tex.dispose());
     };
   }, [textures]);
   return map;
@@ -50,26 +98,26 @@ function submeshTexture(
   return (texture && tex.get(texture.toLowerCase())) || null;
 }
 
-function useDataTexture(uri: string | null | undefined): THREE.Texture | null {
+/** A single texture, for the stand-in body and the loose gear pieces. */
+function useDataTexture(source: PaintTexture | null | undefined): THREE.Texture | null {
   const [tex, setTex] = useState<THREE.Texture | null>(null);
   const current = useRef<THREE.Texture | null>(null);
+  const token = source?.token;
 
   useEffect(() => {
-    if (!uri) {
+    if (!source) {
       current.current?.dispose();
       current.current = null;
       setTex(null);
       return;
     }
     let disposed = false;
-    new THREE.TextureLoader().load(uri, (t) => {
+    void loadTexture(source).then((t) => {
+      if (!t) return;
       if (disposed) {
         t.dispose();
         return;
       }
-      t.colorSpace = THREE.SRGBColorSpace;
-      t.flipY = false; // top-left UV origin — see `useTextureMap`.
-      t.anisotropy = 4;
       current.current?.dispose();
       current.current = t;
       setTex(t);
@@ -77,7 +125,10 @@ function useDataTexture(uri: string | null | undefined): THREE.Texture | null {
     return () => {
       disposed = true;
     };
-  }, [uri]);
+    // Keyed on the token: the same pixels never need re-fetching just because the object
+    // identity around them changed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
 
   useEffect(
     () => () => {
@@ -170,10 +221,10 @@ function RiderBody({
   );
 }
 
-function partPng(part: RiderPart | undefined, ...names: string[]): string | null {
+function partTexture(part: RiderPart | undefined, ...names: string[]): PaintTexture | null {
   if (!part?.textures.length) return null;
   const hit = part.textures.find((t) => names.includes(t.name.toLowerCase()));
-  return (hit ?? part.textures[0]).png;
+  return hit ?? part.textures[0];
 }
 
 // Helmet/protection are authored X-up; after to_right_handed negates X, up is −X,
@@ -250,7 +301,7 @@ function RiderGearMesh({
   pitch?: number;
 }) {
   const texMap = useTextureMap(part.textures);
-  const geoms = useBodyGeometries(part.nodes);
+  const geoms = useNodeGeometries(part.nodes);
   const mats = useGearMaterials(part, texMap);
 
   // Gear is authored around its own origin, so fit it onto the body. Measure in the
@@ -379,7 +430,14 @@ function straightenYaw(geom: THREE.BufferGeometry, rotM: THREE.Matrix4): number 
   return -Math.atan2(dx, dz);
 }
 
-function useBodyGeometries(nodes: EdfNode[]) {
+/**
+ * Turn parsed nodes into `BufferGeometry`, keyed on the nodes alone.
+ *
+ * Deliberately separate from the materials that dress them: geometry only changes when the
+ * model does, so a paint switch has no business rebuilding vertex buffers and re-uploading
+ * a whole bike to the GPU.
+ */
+function useNodeGeometries(nodes: EdfNode[]) {
   const geoms = useMemo(() => {
     return nodes.map((n) => {
       const g = new THREE.BufferGeometry();
@@ -444,7 +502,7 @@ function makeBodyMaterial(name: string | null | undefined, tex: Map<string, THRE
 
 function RiderBodyMesh({ part }: { part: RiderPart }) {
   const tex = useTextureMap(part.textures);
-  const geoms = useBodyGeometries(part.nodes);
+  const geoms = useNodeGeometries(part.nodes);
   // One material per submesh; a node with no submesh table takes a single suit material.
   const mats = useMemo(
     () =>
@@ -473,7 +531,7 @@ function RiderBodyMesh({ part }: { part: RiderPart }) {
 
 function RiderGearSolo({ part }: { part: RiderPart }) {
   const tex = useTextureMap(part.textures);
-  const geoms = useBodyGeometries(part.nodes);
+  const geoms = useNodeGeometries(part.nodes);
   const mats = useGearMaterials(part, tex);
   const rot =
     part.part === "boots" ? BOOT_ROT : part.part === "protection" ? PROT_ROT : GEAR_ROT;
@@ -539,8 +597,8 @@ function RiderComposite({ parts }: { parts: RiderPart[] }) {
   const helmet = byPart("helmet");
   const boots = byPart("boots");
   const protection = byPart("protection");
-  const suit = useDataTexture(partPng(byPart("suit"), "rider", "suit"));
-  const gloves = useDataTexture(partPng(byPart("gloves"), "gloves"));
+  const suit = useDataTexture(partTexture(byPart("suit"), "rider", "suit"));
+  const gloves = useDataTexture(partTexture(byPart("gloves"), "gloves"));
   const hasBody = !!body?.nodes.length;
   const hasHelmet = !!helmet?.nodes.length;
 
@@ -618,65 +676,42 @@ function RiderComposite({ parts }: { parts: RiderPart[] }) {
   );
 }
 
+function makeEdfMaterial(t: THREE.Texture | null) {
+  return new THREE.MeshStandardMaterial({
+    map: t ?? undefined,
+    color: t ? 0xffffff : 0xb7bcc4,
+    metalness: 0.2,
+    roughness: 0.55,
+    // Inconsistent winding — render both sides so the bike isn't see-through.
+    side: THREE.DoubleSide,
+  });
+}
+
 function useEdfMeshes(
   nodes: EdfNode[] | null | undefined,
   tex: Map<string, THREE.Texture>,
 ) {
-  const built = useMemo(() => {
-    if (!nodes?.length) return [];
-    return nodes.map((n) => {
-      const g = new THREE.BufferGeometry();
-      g.setAttribute(
-        "position",
-        new THREE.Float32BufferAttribute(Float32Array.from(n.positions), 3),
-      );
-      if (n.uvs.length)
-        g.setAttribute("uv", new THREE.Float32BufferAttribute(Float32Array.from(n.uvs), 2));
-      if (n.normals.length)
-        g.setAttribute(
-          "normal",
-          new THREE.Float32BufferAttribute(Float32Array.from(n.normals), 3),
-        );
-      g.setIndex(n.indices);
-      if (!n.normals.length) g.computeVertexNormals();
-      g.computeBoundingBox();
-      g.computeBoundingSphere();
+  const list = useMemo(() => nodes ?? [], [nodes]);
+  const geoms = useNodeGeometries(list);
 
-      const makeMat = (t: THREE.Texture | null) =>
-        new THREE.MeshStandardMaterial({
-          map: t ?? undefined,
-          color: t ? 0xffffff : 0xb7bcc4,
-          metalness: 0.2,
-          roughness: 0.55,
-          // Inconsistent winding — render both sides so the bike isn't see-through.
-          side: THREE.DoubleSide,
-        });
-
-      let materials: THREE.Material[];
-      if (n.submeshes.length) {
-        n.submeshes.forEach((sm, i) =>
-          g.addGroup(sm.triStart * 3, sm.triCount * 3, i),
-        );
-        materials = n.submeshes.map((sm) => makeMat(submeshTexture(sm.texture, tex)));
-      } else {
-        // No submesh table → whole-node binding (the model's primary body texture).
-        materials = [makeMat(submeshTexture(n.texture, tex))];
-      }
-      return { g, materials };
-    });
-  }, [nodes, tex]);
-
+  // Only the materials know about the paint. Building them alongside the geometry meant
+  // every livery switch tore down and rebuilt the bike's vertex buffers to change a map.
+  const materials = useMemo(
+    () =>
+      list.map((n) =>
+        n.submeshes.length
+          ? n.submeshes.map((sm) => makeEdfMaterial(submeshTexture(sm.texture, tex)))
+          : // No submesh table → whole-node binding (the model's primary body texture).
+            [makeEdfMaterial(submeshTexture(n.texture, tex))],
+      ),
+    [list, tex],
+  );
   useEffect(
-    () => () => {
-      built.forEach(({ g, materials }) => {
-        g.dispose();
-        materials.forEach((m) => m.dispose());
-      });
-    },
-    [built],
+    () => () => materials.forEach((a) => a.forEach((m) => m.dispose())),
+    [materials],
   );
 
-  return built;
+  return { geoms, materials };
 }
 
 // MX Bikes meshes are authored Y-up, +Z forward (three.js' convention) — no rotation.
@@ -687,14 +722,14 @@ function EdfMesh({
   nodes: EdfNode[];
   textures: Map<string, THREE.Texture>;
 }) {
-  const built = useEdfMeshes(nodes, textures);
+  const { geoms, materials } = useEdfMeshes(nodes, textures);
   return (
     <group>
-      {built.map(({ g, materials }, i) => (
+      {geoms.map((g, i) => (
         <mesh
           key={i}
           geometry={g}
-          material={materials.length === 1 ? materials[0] : materials}
+          material={materials[i].length === 1 ? materials[i][0] : materials[i]}
           castShadow
           receiveShadow
         />
@@ -711,6 +746,7 @@ function CameraRig({ solo }: { solo: boolean }) {
   const controls = useThree((s) => s.controls) as
     | { target: THREE.Vector3; update: () => void }
     | null;
+  const invalidate = useThree((s) => s.invalidate);
   useEffect(() => {
     const [x, y, z] = solo ? [1.25, 0.35, 1.7] : [2.6, 1.8, 3.2];
     camera.position.set(x, y, z);
@@ -721,7 +757,10 @@ function CameraRig({ solo }: { solo: boolean }) {
     } else {
       camera.lookAt(0, 0, 0);
     }
-  }, [solo, camera, controls]);
+    // Moving the camera by hand changes no React state, so under `frameloop="demand"`
+    // nothing would repaint and the reframe wouldn't show until the next interaction.
+    invalidate();
+  }, [solo, camera, controls, invalidate]);
   return null;
 }
 
@@ -748,7 +787,7 @@ function ControlsHint() {
 
 export interface ModelViewerProps {
   mode: ViewerMode;
-  texture?: string | null;
+  texture?: PaintTexture | null;
   textures?: PaintTexture[];
   nodes?: EdfNode[] | null;
   riderParts?: RiderPart[] | null;
@@ -780,9 +819,15 @@ export function ModelViewer({
         <Canvas
           className="h-full w-full"
           shadows
-          dpr={[1, 2]}
+          // Nothing in this scene animates, so drawing 60 shadowed frames a second at a
+          // parked model was pure burn — and the Rider Studio panel is mounted the whole
+          // time that page is open. On demand, a frame is drawn when React commits, when
+          // OrbitControls moves, and when `CameraRig` reframes; otherwise the GPU idles.
+          frameloop="demand"
+          // 2× on a retina panel quadruples the pixels for a preview-sized model.
+          dpr={[1, 1.5]}
           camera={{ position: [2.6, 1.8, 3.2], fov: 42 }}
-          onCreated={({ gl }) => {
+          onCreated={({ gl, invalidate }) => {
             // A lost GPU context otherwise leaves a black canvas; preventDefault lets the browser restore it.
             gl.domElement.addEventListener(
               "webglcontextlost",
@@ -792,6 +837,9 @@ export function ModelViewer({
               },
               false,
             );
+            // Restoring doesn't touch React state, so on demand nothing would redraw and
+            // the canvas would stay black until the next interaction.
+            gl.domElement.addEventListener("webglcontextrestored", () => invalidate(), false);
           }}
         >
           <color attach="background" args={["#0e0f13"]} />

--- a/src/Components/Viewer/ViewerDialog.tsx
+++ b/src/Components/Viewer/ViewerDialog.tsx
@@ -308,7 +308,7 @@ export function ViewerDialog({
         <div className="relative min-h-0 flex-1">
           <ModelViewer
             mode={mode}
-            texture={standInTex?.png ?? null}
+            texture={standInTex ?? null}
             textures={activeTextures}
             nodes={nodes}
             riderParts={riderParts}

--- a/src/Components/Viewer/ViewerPanel.tsx
+++ b/src/Components/Viewer/ViewerPanel.tsx
@@ -6,11 +6,11 @@ import { Button } from "../ui/button";
 import { Dialog, DialogContent } from "../ui/dialog";
 import { ModelViewer, type ViewerMode } from "./ModelViewer";
 import { loadRiderModel } from "../../api/mods";
-import type { Loadout, RiderPart } from "../../types";
+import type { Loadout, PaintTexture, RiderPart } from "../../types";
 import { useT } from "../../i18n/context";
 
 interface ViewerPanelProps {
-  texture?: string | null;
+  texture?: PaintTexture | null;
   loadout?: Loadout;
   riderOnly?: boolean;
   hiddenParts?: RiderPart["part"][];

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -309,6 +309,18 @@ export function unpackPaint(path: string): Promise<PaintTexture[]> {
   return invoke<PaintTexture[]>("unpack_paint", { path });
 }
 
+/**
+ * Raw RGBA for a {@link PaintTexture.token}, straight off the binary IPC channel.
+ *
+ * The backend answers with `application/octet-stream`, so this resolves to an
+ * `ArrayBuffer` rather than JSON — no base64 on the wire and no megabyte strings on the
+ * heap. A token whose pixels have been evicted comes back as a single grey pixel, which the
+ * caller spots by checking the length against the texture's declared size.
+ */
+export function textureBytes(token: string): Promise<ArrayBuffer> {
+  return invoke<ArrayBuffer>("texture_bytes", { token });
+}
+
 export function unpackPkz(path: string, outDir: string): Promise<string[]> {
   return invoke<string[]>("unpack_pkz", { path, outDir });
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -249,8 +249,12 @@ export interface PaintTexture {
   name: string;
   width: number;
   height: number;
-  /** `data:image/png;base64,…` — bind straight into a three.js texture loader. */
-  png: string;
+  /**
+   * Names the pixels held on the Rust side. Fetch them with {@link textureBytes} and build
+   * a `THREE.DataTexture` — the RGBA never crosses as text, so paints cost no encode and
+   * carrying the model's base textures on every paint costs no memory.
+   */
+  token: string;
 }
 
 /** One selectable paint (livery) for a bike: a name + its textures. */


### PR DESCRIPTION
## Why

The viewer was the app's CPU and memory problem, on both sides of the IPC boundary. From `MXB App.log`:

```
load_bike_model …Yamaha_YZ250.pkz: 2 paint(s) + 5 base tex |
  read 1.6s, parse 3.7s, encode 6.2s, total 11.6s
```

Four things were wrong:

1. **`encode` was 3–6s of every core pegged.** Each texture became a base64 PNG data URI, fanned out with rayon. Deliberately `CompressionType::Fast` + `NoFilter`, so a 1024² RGBA texture came out near-uncompressed (~3–4 MB), then base64 added another 37%.
2. **Every paint carried a full copy of every base texture** — multi-megabyte strings cloned N×M, then held three times over: the Rust cache, the JSON payload, and React state.
3. **The canvas rendered 60 fps forever at a static model,** shadows and all. Worst in Rider Studio, where the panel is mounted for as long as the page is open.
4. **`pkz_mesh_cache` was unbounded** — every mesh ever loaded retained for the process lifetime.

## What changed

**Textures no longer become text.** New `texstore` holds decoded RGBA; `PaintTexture` carries a token instead of a data URI. The new `texture_bytes` command returns `tauri::ipc::Response`, which travels as `application/octet-stream` and lands in the webview as an `ArrayBuffer` — straight into a `THREE.DataTexture`. No encode, no base64, no JSON blob.

`to_texture` and `extract_edf_textures` are the only producers of `PaintTexture`, so changing those two fixed all ~10 call sites. And with a paint's texture list now being cheap structs, problem 2 dissolved on its own.

**`frameloop="demand"`** on the Canvas, with explicit `invalidate()` on the two paths that change the picture without a React commit (`CameraRig`, WebGL context restore). Nothing in the scene animates. `dpr` capped at 1.5.

**Geometry split from materials** in the viewer, so a livery switch no longer tears down every `BufferGeometry` and re-uploads the bike. Reuses the rider path's existing geometry hook rather than adding another.

**New bounded LRU** behind both viewer caches — bikes at 3 (an evicted bike releases its pixels), meshes at 12.

**Instrumentation:** the load-timing log now reports distinct texture count and MB resident in the store, so before/after is measurable rather than eyeballed.

**Fixed on the way:** one unreadable texture left `useTextureMap`'s counter short, so the map never resolved and the model stayed permanently grey.

## Checks

`cargo check` / `cargo clippy` clean, 221 Rust tests pass (8 new across `texstore`/`lru`/`paint`), `tsc --noEmit` clean, eslint clean on every touched file, `npm run build` succeeds.

Not covered by automation: the runtime round-trip. The contract is traced in the crate source (`ipc::Response::new(Vec<u8>)` → `InvokeResponseBody::Raw` → `ipc-protocol.js` takes the `arrayBuffer()` branch), but it wants a real load to confirm.

## What to check by hand

- Open a bike from the Library — the `encode` phase should be gone from the log line.
- Cycle paints: liveries swap, parts still wear their own texture rather than a smeared primary diffuse.
- Switching goggles still changes the goggles.
- Rider Studio sits near 0% CPU untouched; orbiting repaints and settles again.
- Open several bikes and watch RSS plateau rather than climb.

Two spots worth a specific look: texture filtering (`DataTexture` defaults to nearest with no mipmaps, so linear/mipmaps/anisotropy are set by hand) and single gear textures, which now use `RepeatWrapping` where they previously got the default clamp.

## Out of scope

Geometry still crosses IPC as JSON `number[]` — roughly a million numbers per bike and a real chunk of the remaining `parse` time. Left for its own change to keep this reviewable.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)