### PR TITLE
chore(build): strip and harden release binaries; obfuscate endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026-08-08 — Unreleased
+
+### Changed
+- **Release binaries are stripped and hardened against reverse-engineering.** Added a
+  `[profile.release]` that strips the symbol table from every platform's artifact, builds with
+  fat LTO + a single codegen unit (functions inlined/merged so a decompiler can't recover clean
+  structure), and aborts on panic (no unwind tables). `opt-level` stays at 3 so the viewer's hot
+  paths aren't sacrificed. On Windows this also means no PDB is produced. Self-update is
+  unaffected — the updater signs file content after the build.
+- **Sensitive endpoint paths no longer appear in a `strings` dump.** Wired in `obfstr` and
+  XOR-obfuscated the runtime-built API paths and upload/download URLs (WordPress REST/admin-ajax
+  paths, pixeldrain upload, Google Drive resolver). Public host bases stay as-is — they're
+  visible in network traffic regardless and are bound into `const` config.
+
 ## 2026-08-08 — v0.7.1 — Browse works for blocked players, the model-swap crash is gone, and the Rider preview wears a real rider
 
 ### Added

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1353,6 +1353,7 @@ dependencies = [
  "mega",
  "notify",
  "notify-debouncer-mini",
+ "obfstr",
  "rayon",
  "regex",
  "reqwest 0.12.28",
@@ -2945,6 +2946,12 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "obfstr"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cf5f1acbf6ef57cef9d127e72c4afd01d6b08692616fd09afad7f7807d6eb78"
 
 [[package]]
 name = "objc2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -81,6 +81,9 @@ notify-debouncer-mini = "0.4"
 # Check an installed FrostMod binary against the digest its GitHub release advertises,
 # so an install that only half-applied can be spotted and repaired.
 sha2 = "0.10"
+# Compile-time string obfuscation: sensitive endpoints/hosts are XOR-encoded in the
+# binary and decoded on the stack at use, so they don't show up in a `strings` dump.
+obfstr = "0.4"
 
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!
@@ -94,3 +97,24 @@ tauri = { version = "2", features = ["test"] }
 # `#[tokio::test]` for the live network checks against mxb-mods.com. Dev-only, so the
 # shipped binary keeps the minimal `time`-only tokio it already had.
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }
+
+# Ship a hardened, hard-to-reverse binary. cargo defaults leave the symbol table in and
+# emit no debug info; this strips symbols and leans on the optimizer to erase structure.
+# opt-level stays at 3 so the viewer's hot paths aren't sacrificed for it.
+[profile.release]
+opt-level = 3
+# Remove the symbol table (and any debug symbols) from every platform's artifact, so a
+# profiler/decompiler sees `frost.exe+0x…` rather than function names.
+strip = "symbols"
+# Fat cross-crate LTO: inlines and merges functions across crate boundaries, which both
+# speeds up hot paths and dissolves the clean call structure a decompiler leans on.
+lto = "fat"
+# One codegen unit: maximal optimization, and fewer tidy module boundaries to recover.
+codegen-units = 1
+# Abort on panic: drops the unwinding tables and landing pads (smaller, less to read).
+# Safe here — nothing in the crate relies on catching a panic (no catch_unwind).
+panic = "abort"
+# No debug info: on Windows/MSVC this means no PDB is produced at all.
+debug = false
+# Strip the overflow-check branches from release too.
+overflow-checks = false

--- a/src-tauri/src/install.rs
+++ b/src-tauri/src/install.rs
@@ -1,5 +1,6 @@
 use crate::config::AppConfig;
 use futures_util::StreamExt;
+use obfstr::obfstr;
 use regex::Regex;
 use reqwest::Client;
 use scraper::{Html, Selector};
@@ -334,7 +335,10 @@ fn resolve_gdrive(url: &str) -> String {
     match id {
         // usercontent serves the bytes; large files still hit a virus-scan interstitial.
         Some(id) => {
-            format!("https://drive.usercontent.google.com/download?id={id}&export=download")
+            format!(
+                "{}?id={id}&export=download",
+                obfstr!("https://drive.usercontent.google.com/download")
+            )
         }
         None => url.to_string(),
     }
@@ -385,7 +389,8 @@ async fn resolve_gdrive_folder(client: &Client, url: &str) -> anyhow::Result<Str
         )
     })?;
     Ok(resolve_gdrive(&format!(
-        "https://drive.google.com/file/d/{}/view",
+        "{}/file/d/{}/view",
+        obfstr!("https://drive.google.com"),
         chosen.id
     )))
 }

--- a/src-tauri/src/mods/mxb.rs
+++ b/src-tauri/src/mods/mxb.rs
@@ -1,6 +1,7 @@
 use super::{DownloadOption, ModDetail, ModRating, ModSort, ModSource, ModSummary};
 use crate::mxb_session;
 use futures_util::StreamExt;
+use obfstr::obfstr;
 use regex::Regex;
 use reqwest::Client;
 use scraper::{Html, Selector};
@@ -456,7 +457,7 @@ async fn listing_response(
     category_id: u32,
     page: Page,
 ) -> anyhow::Result<(Fetched, Option<u32>)> {
-    let url = format!("{BASE}/wp-json/wp/v2/posts");
+    let url = format!("{BASE}{}", obfstr!("/wp-json/wp/v2/posts"));
     let mut params: Vec<(&str, String)> = vec![
         ("categories", category_id.to_string()),
         ("_embed", "wp:featuredmedia".to_string()),
@@ -537,7 +538,10 @@ async fn total_count(q: &str, category_id: u32) -> anyhow::Result<u32> {
 /// differences are `limit`/`offset` instead of `page`, and that paging past the end
 /// returns an empty list rather than a 400.
 async fn popular(category_id: u32, page: u32, range: &str) -> anyhow::Result<Vec<ModSummary>> {
-    let url = format!("{BASE}/wp-json/wordpress-popular-posts/v1/popular-posts");
+    let url = format!(
+        "{BASE}{}",
+        obfstr!("/wp-json/wordpress-popular-posts/v1/popular-posts")
+    );
     let per_page: u32 = PER_PAGE.parse().unwrap_or(24);
     let params: Vec<(&str, String)> = vec![
         ("taxonomy", "category".to_string()),
@@ -562,7 +566,7 @@ async fn popular(category_id: u32, page: u32, range: &str) -> anyhow::Result<Vec
 
 pub async fn detail(slug: &str) -> anyhow::Result<ModDetail> {
     // 1. Post metadata + description via the REST API.
-    let url = format!("{BASE}/wp-json/wp/v2/posts");
+    let url = format!("{BASE}{}", obfstr!("/wp-json/wp/v2/posts"));
     let params = vec![
         ("slug", slug.to_string()),
         ("_embed", "wp:featuredmedia".to_string()),
@@ -703,7 +707,7 @@ fn lock<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
 /// The rating plugin has no REST route; its front end reads scores from this admin-ajax
 /// action, which answers unauthenticated with `{voteCount, avgRating}`.
 async fn rating(id: u64) -> anyhow::Result<ModRating> {
-    let url = format!("{BASE}/wp-admin/admin-ajax.php");
+    let url = format!("{BASE}{}", obfstr!("/wp-admin/admin-ajax.php"));
     let form = [
         ("action", "load_results".to_string()),
         ("postID", id.to_string()),

--- a/src-tauri/src/upload.rs
+++ b/src-tauri/src/upload.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use obfstr::obfstr;
 use reqwest::Client;
 use serde::Deserialize;
 use std::path::Path;
@@ -33,7 +34,7 @@ async fn pixeldrain_upload(client: &Client, file: &Path) -> anyhow::Result<Strin
         .unwrap_or_else(|| "preset-bundle.zip".to_string());
 
     let resp = client
-        .put(format!("https://pixeldrain.com/api/file/{name}"))
+        .put(format!("{}/{name}", obfstr!("https://pixeldrain.com/api/file")))
         .body(bytes)
         .send()
         .await
@@ -48,7 +49,7 @@ async fn pixeldrain_upload(client: &Client, file: &Path) -> anyhow::Result<Strin
     match parsed.id {
         Some(id) if !id.is_empty() => {
             // Direct-download URL — the install downloader streams it as-is.
-            Ok(format!("https://pixeldrain.com/api/file/{id}"))
+            Ok(format!("{}/{id}", obfstr!("https://pixeldrain.com/api/file")))
         }
         _ => {
             let why = parsed.message.unwrap_or_else(|| format!("HTTP {status}"));


### PR DESCRIPTION
## What

Make shipped release artifacts hard to reverse-engineer.

### `[profile.release]` (the real win)
- `strip = "symbols"` — no symbol table on any platform's artifact (profiler/decompiler sees `frost.exe+0x…`, not function names).
- `lto = "fat"` + `codegen-units = 1` — functions inlined/merged across crate boundaries, dissolving the clean call structure a decompiler leans on (also faster hot paths).
- `panic = "abort"` — drops unwind tables/landing pads. Safe: the crate has no `catch_unwind`.
- `debug = false` — no PDB emitted on Windows.
- `opt-level = 3` kept, so the viewer texture work isn't sacrificed.

Self-update is unaffected — updater signatures are over file **content** and are produced after the build.

### String obfuscation (`obfstr`)
XOR-obfuscated the runtime-built endpoint strings so they don't appear in a `strings` dump:
- WordPress REST / admin-ajax paths — `mods/mxb.rs`
- pixeldrain upload — `upload.rs`
- Google Drive resolver — `install.rs`

Public host bases (`mxb-mods.com`, `mxbikes-shop.com`) left plain: they're visible in network traffic regardless, and they're bound into `const` config that `obfstr` (runtime-decoded) can't sit in without a brittle refactor.

## Scope note
This makes casual decompilation produce unreadable output and hides the API surface from `strings`. It does **not** stop a determined analyst with Ghidra/IDA — no shipped native binary can. The higher-value string-obfuscation target is the private sidecar repo (the decrypt/unlock IP), which is a separate follow-up.

## Verification
- `cargo check` clean (only pre-existing dead-code warnings).
- `cargo test --locked` — 247 passed, 30 ignored, 0 failed. The obfuscated builders produce byte-identical URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)