### PR TITLE
feat(install): pick a paint's bike from the post's categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## 2026-08-08 — Unreleased
 
+### Added
+- **The install picker works out which bike a paint is for.** mxb-mods files every livery
+  under a category per bike it fits ("2023 KTM 450 SX-F OEM") — far more precise than the post
+  title it used to guess from. Those categories are now read off the post and matched against
+  your bikes, so the right one is preselected under "Probably" instead of whichever bike you
+  painted last. Checked against the whole catalog: the correct bike comes first for all 107
+  OEM models.
+- **OEM bikes can be picked as a destination at all.** Their files live inside the game's
+  locked archive, so nothing of them is on disk until they're painted and the picker never
+  listed them — a paint for one had to have its bike id typed by hand. Bike folders and the
+  bike ids in your profile are now offered alongside packaged `.pkz` bikes.
+
+### Fixed
+- **A paint dropped on a bike's root folder no longer vanishes.** MX Bikes only loads liveries
+  from `<Bike>/paints/`, but the picker also offers the bike's root (where sounds and model
+  swaps go) and would happily install a `.pnt` there — the install reported success and the
+  paint never appeared in game. It's now redirected into that bike's `paints/`.
+- **The install progress steps read as English again.** The Resolve → Download → Extract →
+  Place → Reload chain printed its raw translation keys (`modDetail.stageResolve`) in every
+  language — the labels were the only `TKey` in the app rendered without going through `t()`.
+  All five locales already had the strings.
+- **Tracks default to a folder you already use instead of the root.** Once the tracks library
+  has any folder, the first one is preselected rather than dumping another `.pkz` loose at the
+  root. Applies to Browse installs and to MX Bikes Shop purchases, which always went to the
+  root.
+
 ### Changed
 - **Release binaries are stripped and hardened against reverse-engineering.** Added a
   `[profile.release]` that strips the symbol table from every platform's artifact, builds with

--- a/src-tauri/src/install.rs
+++ b/src-tauri/src/install.rs
@@ -761,8 +761,21 @@ pub(crate) fn place_mod(
 
     // Plain placement into the type folder, honoring the chosen destination sub-folder.
     let mut type_dir = mods_dir.join(type_folder);
-    for seg in dest_folder.split(['/', '\\']).filter(|s| !s.is_empty()) {
+    let segs: Vec<&str> = dest_folder.split(['/', '\\']).filter(|s| !s.is_empty()).collect();
+    for seg in &segs {
         type_dir.push(sanitize(seg));
+    }
+
+    // A bike livery only loads from `<Bike>/paints/`. The picker offers a bike's root as a
+    // destination too — that's where sounds and model swaps go — so a paint chosen there
+    // would land one folder high and never show up in game. Drop it into `paints/` instead:
+    // a loose `.pnt` at a bike root does nothing whatever, so this can only help.
+    if type_folder.eq_ignore_ascii_case("bikes")
+        && !segs.is_empty()
+        && !segs[segs.len() - 1].eq_ignore_ascii_case("paints")
+        && is_loose_paint_drop(&unwrapped)
+    {
+        type_dir.push("paints");
     }
     // Extracted tracks need their own folder; loose bike paints don't.
     let wrap_loose = type_folder.eq_ignore_ascii_case("tracks");
@@ -858,6 +871,27 @@ pub fn sound_bikes_in(extracted: &Path) -> Vec<String> {
         }
     }
     out
+}
+
+/// Bare paints, ready to drop into a `paints/` folder: at least one `.pnt` sitting loose in
+/// `base`, and no `.pkz`. The `.pkz` matters — it's a packaged bike or model set, which
+/// belongs at the bike's root, and an archive that ships both is the package, not the paint.
+fn is_loose_paint_drop(base: &Path) -> bool {
+    let mut has_paint = false;
+    let Ok(rd) = std::fs::read_dir(base) else {
+        return false;
+    };
+    for e in rd.filter_map(|e| e.ok()) {
+        if !e.file_type().map(|t| t.is_file()).unwrap_or(false) {
+            continue;
+        }
+        let path = e.path();
+        if has_ext(&path, "pkz") {
+            return false;
+        }
+        has_paint |= has_ext(&path, "pnt");
+    }
+    has_paint
 }
 
 fn contains_paints_bundle(base: &Path) -> bool {
@@ -1388,6 +1422,71 @@ mod tests {
         assert!(mods
             .join("bikes/MX1OEM_2023_KTM_450_SX-F/paints/cool.pnt")
             .exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn loose_livery_chosen_against_a_bike_root_lands_in_paints() {
+        // The picker offers `<Bike>` as well as `<Bike>/paints` (sounds and model swaps need
+        // the root), and `resolveInitialFolder` will preselect the root when that's what was
+        // remembered. A `.pnt` left there is invisible to the game.
+        let root = place_tmp("livery-bike-root");
+        let ex = root.join("ex");
+        touch(&ex.join("cool.pnt"));
+        touch(&ex.join("preview.jpg")); // paints ship a thumbnail; it travels along
+        let mods = root.join("mods");
+        place_mod(&ex, &mods, "bikes", "MX1OEM_2023_KTM_450_SX-F", "cool-livery").unwrap();
+        assert!(mods
+            .join("bikes/MX1OEM_2023_KTM_450_SX-F/paints/cool.pnt")
+            .exists());
+        assert!(!mods
+            .join("bikes/MX1OEM_2023_KTM_450_SX-F/cool.pnt")
+            .exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn bike_package_chosen_against_a_bike_root_stays_at_the_root() {
+        // A `.pkz` is a bike or model set — the root is exactly where it belongs.
+        let root = place_tmp("pkz-bike-root");
+        let ex = root.join("ex");
+        touch(&ex.join("FrostMod Models.pkz"));
+        let mods = root.join("mods");
+        place_mod(&ex, &mods, "bikes", "MX1OEM_2023_KTM_450_SX-F", "swap").unwrap();
+        assert!(mods
+            .join("bikes/MX1OEM_2023_KTM_450_SX-F/FrostMod Models.pkz")
+            .exists());
+        assert!(!mods.join("bikes/MX1OEM_2023_KTM_450_SX-F/paints").exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn paints_destination_is_not_doubled_up() {
+        let root = place_tmp("livery-already-paints");
+        let ex = root.join("ex");
+        touch(&ex.join("cool.pnt"));
+        let mods = root.join("mods");
+        place_mod(&ex, &mods, "bikes", "MX1OEM_2023_KTM_450_SX-F/paints", "slug").unwrap();
+        assert!(mods
+            .join("bikes/MX1OEM_2023_KTM_450_SX-F/paints/cool.pnt")
+            .exists());
+        assert!(!mods
+            .join("bikes/MX1OEM_2023_KTM_450_SX-F/paints/paints")
+            .exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn loose_paint_at_the_bikes_root_is_left_alone() {
+        // No bike was chosen, so there's no `paints` folder to redirect into — inventing
+        // `bikes/paints` would be just as dead and harder to find.
+        let root = place_tmp("livery-no-bike");
+        let ex = root.join("ex");
+        touch(&ex.join("cool.pnt"));
+        let mods = root.join("mods");
+        place_mod(&ex, &mods, "bikes", "", "slug").unwrap();
+        assert!(mods.join("bikes/cool.pnt").exists());
+        assert!(!mods.join("bikes/paints").exists());
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -183,36 +183,65 @@ pub struct RiderTargets {
     pub profiles: Vec<String>,
 }
 
-pub fn scan_rider_targets(mods_path: &str) -> RiderTargets {
-    let base = mods_subdir(mods_path, "mods/rider");
-    let models_in = |sub: &str| -> Vec<String> {
-        let mut out = Vec::new();
-        if let Ok(rd) = fs::read_dir(base.join(sub)) {
-            for e in rd.flatten() {
-                let path = e.path();
-                if path.is_dir() {
-                    if let Some(n) = e.file_name().to_str() {
-                        out.push(n.to_string());
-                    }
-                } else if path.extension().is_some_and(|x| x.eq_ignore_ascii_case("pkz")) {
-                    if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-                        out.push(stem.to_string());
-                    }
+/// Installable content sitting directly in `dir`, by the name you'd address it as: a
+/// sub-folder verbatim, a `.pkz` by its stem. Sorted, case-insensitively deduped.
+fn models_in(dir: &Path) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Ok(rd) = fs::read_dir(dir) {
+        for e in rd.flatten() {
+            let path = e.path();
+            if path.is_dir() {
+                if let Some(n) = e.file_name().to_str() {
+                    out.push(n.to_string());
+                }
+            } else if path.extension().is_some_and(|x| x.eq_ignore_ascii_case("pkz")) {
+                if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                    out.push(stem.to_string());
                 }
             }
         }
-        out.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
-        out.dedup();
-        out
-    };
+    }
+    sort_dedup(&mut out);
+    out
+}
+
+/// Sort case-insensitively and drop repeats that differ only in case — the same bike
+/// reached as a folder and as a bike id must not be offered twice.
+fn sort_dedup(v: &mut Vec<String>) {
+    v.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+    v.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
+}
+
+pub fn scan_rider_targets(mods_path: &str) -> RiderTargets {
+    let base = mods_subdir(mods_path, "mods/rider");
     RiderTargets {
-        helmets: models_in("helmets"),
-        boots: models_in("boots"),
-        protection: models_in("protection"),
+        helmets: models_in(&base.join("helmets")),
+        boots: models_in(&base.join("boots")),
+        protection: models_in(&base.join("protection")),
         // A rider model can be packed as `riders/<name>.pkz` just as gear can, and a
         // profile the picker never lists is a model nobody can wear.
-        profiles: models_in("riders"),
+        profiles: models_in(&base.join("riders")),
     }
+}
+
+/// Every bike a paint could be installed for.
+///
+/// Two sources, because neither is complete on its own. `mods/bikes` has the mod bikes —
+/// a `.pkz` package or an unpacked folder. OEM bikes have neither: their files live inside
+/// the game's locked archive, so until someone installs a paint for one there is nothing of
+/// it on disk at all. The profile is where their ids can still be read, since the game
+/// writes a line per bike it knows.
+pub fn scan_bike_targets(mods_path: &str, profiles_dir: &Path) -> Vec<String> {
+    let mut out = models_in(&mods_subdir(mods_path, "mods/bikes"));
+    for profile in crate::presets::list_profiles(profiles_dir) {
+        // A profile we can't read is one source short, never an error — the folders above
+        // still stand on their own.
+        if let Ok(bikes) = crate::presets::list_bikes(profiles_dir, &profile) {
+            out.extend(bikes);
+        }
+    }
+    sort_dedup(&mut out);
+    out
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -578,6 +607,45 @@ mod tests {
 
     fn cat<'a>(v: &'a [LibraryEntry], name: &str) -> Option<&'a LibraryEntry> {
         v.iter().find(|e| e.name.eq_ignore_ascii_case(name))
+    }
+
+    #[test]
+    fn bike_targets_merge_disk_folders_with_profile_bike_ids() {
+        let root = tmp("bike-targets");
+        let bikes = root.join("mods/bikes");
+        touch(&bikes.join("CLUBMX YZ450F.pkz")); // packaged mod bike
+        touch(&bikes.join("MX1OEM_2023_KTM_450_SX-F/paints/red.pnt")); // OEM, paints only
+        // Same bike again by id — the profile must not double it up.
+        touch(
+            &root.join("profiles/Rider One/profile.ini"),
+        );
+        fs::write(
+            root.join("profiles/Rider One/profile.ini"),
+            "[rider]\nMX1OEM_2023_KTM_450_SX-F=default_mx\nMX2OEM_2023_KTM_250_SX-F=default_mx\n",
+        )
+        .unwrap();
+
+        let out = scan_bike_targets(root.to_str().unwrap(), &root.join("profiles"));
+
+        assert_eq!(
+            out,
+            vec![
+                "CLUBMX YZ450F".to_string(),
+                "MX1OEM_2023_KTM_450_SX-F".to_string(),
+                // Never touched the disk — only the profile knows this one exists.
+                "MX2OEM_2023_KTM_250_SX-F".to_string(),
+            ]
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn bike_targets_survive_a_missing_profiles_folder() {
+        let root = tmp("bike-targets-noprofiles");
+        touch(&root.join("mods/bikes/Some Bike.pkz"));
+        let out = scan_bike_targets(root.to_str().unwrap(), &root.join("nope"));
+        assert_eq!(out, vec!["Some Bike".to_string()]);
+        let _ = fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -249,6 +249,18 @@ fn scan_rider_targets_blocking(app: tauri::AppHandle) -> Result<library::RiderTa
 }
 
 #[tauri::command]
+async fn scan_bike_targets(app: tauri::AppHandle) -> Result<Vec<String>, String> {
+    tauri::async_runtime::spawn_blocking(move || scan_bike_targets_blocking(app))
+        .await
+        .map_err(|e| format!("scan_bike_targets task failed: {e}"))?
+}
+
+fn scan_bike_targets_blocking(app: tauri::AppHandle) -> Result<Vec<String>, String> {
+    let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
+    Ok(library::scan_bike_targets(&cfg.mods_path, &cfg.profiles_dir()))
+}
+
+#[tauri::command]
 async fn scan_model_swaps(app: tauri::AppHandle) -> Result<Vec<modelswap::BikeModels>, String> {
     tauri::async_runtime::spawn_blocking(move || scan_model_swaps_blocking(app))
         .await
@@ -3137,6 +3149,7 @@ fn main() {
             list_gear_paints,
             list_installed_gear_paints,
             scan_rider_targets,
+            scan_bike_targets,
             scan_model_swaps,
             apply_model_swap,
             scan_sound_swaps,

--- a/src-tauri/src/mods/mod.rs
+++ b/src-tauri/src/mods/mod.rs
@@ -85,6 +85,10 @@ pub struct ModDetail {
     pub images: Vec<String>,
     pub version: Option<String>,
     pub downloads: Vec<DownloadOption>,
+    /// The post's category names, verbatim ("2023 KTM 450 SX-F OEM", "Liveries", "KTM").
+    /// A livery's model category names the bike it's for far more precisely than its title
+    /// does, which is what the install picker ranks destinations by.
+    pub categories: Vec<String>,
 }
 
 #[allow(async_fn_in_trait)]

--- a/src-tauri/src/mods/mxb.rs
+++ b/src-tauri/src/mods/mxb.rs
@@ -567,9 +567,11 @@ async fn popular(category_id: u32, page: u32, range: &str) -> anyhow::Result<Vec
 pub async fn detail(slug: &str) -> anyhow::Result<ModDetail> {
     // 1. Post metadata + description via the REST API.
     let url = format!("{BASE}{}", obfstr!("/wp-json/wp/v2/posts"));
+    // `wp:term` rides along in the same request — the categories it brings back are what
+    // tell the install picker which bike a livery is for.
     let params = vec![
         ("slug", slug.to_string()),
-        ("_embed", "wp:featuredmedia".to_string()),
+        ("_embed", "wp:featuredmedia,wp:term".to_string()),
     ];
     let resp = get_with_retry(&url, &params).await?;
     if !resp.is_success() {
@@ -636,6 +638,7 @@ pub async fn detail(slug: &str) -> anyhow::Result<ModDetail> {
         images,
         version,
         downloads,
+        categories: term_names(&post),
     })
 }
 
@@ -769,6 +772,30 @@ fn featured_image(p: &Value) -> Option<String> {
         .get("source_url")?
         .as_str()
         .map(str::to_string)
+}
+
+/// Every term name `_embed=wp:term` brought back, flattened across taxonomies.
+///
+/// The site files a mod under one category per bike it fits ("2023 KTM 450 SX-F OEM") on top
+/// of the browse categories ("Liveries") and the manufacturer ("KTM"), so the caller gets a
+/// mixed bag and decides what's distinctive. Order follows the site's own.
+fn term_names(post: &Value) -> Vec<String> {
+    let mut out: Vec<String> = post
+        .get("_embedded")
+        .and_then(|e| e.get("wp:term"))
+        .and_then(Value::as_array)
+        .map(|groups| {
+            groups
+                .iter()
+                .filter_map(Value::as_array)
+                .flatten()
+                .filter_map(|t| t.get("name").and_then(Value::as_str))
+                .map(decode_entities)
+                .collect()
+        })
+        .unwrap_or_default();
+    dedup(&mut out);
+    out
 }
 
 fn decode_entities(s: &str) -> String {
@@ -917,6 +944,34 @@ fn dedup(v: &mut Vec<String>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn reads_every_embedded_term_name() {
+        // Shape of `_embed=wp:term` on a real livery post: one group per taxonomy, the
+        // second empty because the site files nothing under tags.
+        let post: Value = serde_json::from_str(
+            r#"{"_embedded":{"wp:term":[[
+                 {"taxonomy":"category","name":"2023 KTM 450 SX-F OEM"},
+                 {"taxonomy":"category","name":"Liveries"},
+                 {"taxonomy":"category","name":"KTM"},
+                 {"taxonomy":"category","name":"Ren&#038;s Bikes"}
+               ],[]]}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            term_names(&post),
+            vec![
+                "2023 KTM 450 SX-F OEM",
+                "Liveries",
+                "KTM",
+                // Entities decoded, same as the title.
+                "Ren&s Bikes",
+            ]
+        );
+
+        // A post fetched without `_embed`, or one with no terms, must not blow up.
+        assert!(term_names(&serde_json::json!({})).is_empty());
+    }
 
     #[test]
     fn parses_default_download_container() {

--- a/src/Components/ModDetail/ModDetail.tsx
+++ b/src/Components/ModDetail/ModDetail.tsx
@@ -28,6 +28,7 @@ import {
   riderProfileSub,
   riderPaintKind,
   resolveInitialFolder,
+  scanBikeTargets,
   scanRiderTargets,
   sortMirrors,
   type DestOption,
@@ -143,12 +144,25 @@ export default function ModDetail({
           const inst = await getInstalledMods(modType.installSubpath);
           if (cancelled) return;
           setInstalledFiles(inst);
+          // OEM bikes own no file until they're painted, so the scan of `mods/bikes` can't
+          // see them — the backend reads their ids out of the profile as well.
+          const bikeTargets =
+            modType.id === "bikes" ? await scanBikeTargets().catch(() => []) : [];
+          if (cancelled) return;
           // Rider paints route into a model's/profile's folder; everything else
           // uses the generic (track/bike) destination logic.
           const dest =
             modType.id === "rider"
               ? buildRiderDestinations(await scanRiderTargets(), d.title, profileSub, paintKind)
-              : buildDestinations(modType, d.title, inst, livery, sound);
+              : buildDestinations(
+                  modType,
+                  d.title,
+                  inst,
+                  livery,
+                  sound,
+                  d.categories,
+                  bikeTargets,
+                );
           if (cancelled) return;
           setDestOptions(dest.options);
           setGuess(dest.guess);
@@ -606,7 +620,7 @@ function InstallProgress({
               )}
             >
               {i < idx && "✓ "}
-              {s.label}
+              {t(s.label)}
             </span>
             {i < CHAIN.length - 1 && <span>→</span>}
           </span>

--- a/src/Components/Shop/Shop.tsx
+++ b/src/Components/Shop/Shop.tsx
@@ -8,6 +8,7 @@ import {
   shopMyDownloads,
   shopStatus,
   scanLibrary,
+  resolveTrackDest,
   type ShopItem,
 } from "../../api/mods";
 import {
@@ -98,8 +99,10 @@ export default function Shop({ refreshKey }: ShopProps) {
   }, [refreshKey, loggedIn]);
 
   const install = useCallback(
-    (item: ShopItem) => {
-      startShopInstall(item);
+    async (item: ShopItem) => {
+      // No picker here, so land it where the Browse dialog would have preselected rather
+      // than always at the tracks root.
+      startShopInstall(item, await resolveTrackDest());
       toast.success(t("browse.queued", { title: item.title }), {
         description: t("shop.queuedDesc"),
       });

--- a/src/Context/Install.tsx
+++ b/src/Context/Install.tsx
@@ -64,8 +64,9 @@ interface InstallContextValue {
     p: Omit<StartParams, "source"> & { url: string; host: string },
   ) => void;
   startImport: (p: Omit<StartParams, "source"> & { path: string }) => void;
-  /** Install a purchased MX Bikes Shop track (to the tracks root). */
-  startShopInstall: (item: ShopItem) => void;
+  /** Install a purchased MX Bikes Shop track. Defaults to the tracks root when the caller
+   *  hasn't resolved a folder (see `resolveTrackDest`). */
+  startShopInstall: (item: ShopItem, destFolder?: string) => void;
   /** Clear a finished (done/error) install card. */
   clear: () => void;
 }
@@ -245,12 +246,12 @@ export function InstallProvider({
   );
 
   const startShopInstall: InstallContextValue["startShopInstall"] = useCallback(
-    (item) =>
+    (item, destFolder = "") =>
       enqueue({
         slug: item.slug,
         title: item.title,
         subpath: "mods/tracks",
-        destFolder: "",
+        destFolder,
         source: { kind: "shop", item },
       }),
     [enqueue],

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -237,6 +237,16 @@ export function scanRiderTargets(): Promise<RiderTargets> {
   return invoke<RiderTargets>("scan_rider_targets");
 }
 
+/**
+ * Every bike a paint can be installed for — folders and `.pkz` packages under `mods/bikes`,
+ * plus the bike ids read out of the player's profiles. OEM bikes only exist inside the game's
+ * locked archive, so the profile is the only place their id can be found until someone
+ * installs a paint for one.
+ */
+export function scanBikeTargets(): Promise<string[]> {
+  return invoke<string[]>("scan_bike_targets");
+}
+
 export function scanModelSwaps(): Promise<BikeModels[]> {
   return invoke<BikeModels[]>("scan_model_swaps");
 }
@@ -467,12 +477,91 @@ const tokens = (s: string) =>
       .filter((t) => t.length >= 2),
   );
 
+/**
+ * Below this many significant words a category is a grouping, not a machine — "KTM", "OEM",
+ * "Beta 18". Matching on those would nominate every bike of the brand.
+ */
+const MIN_CATEGORY_TOKENS = 3;
+
+/**
+ * How much of a category's vocabulary the bike has to account for.
+ *
+ * The two spellings never line up exactly: the site writes `2023 KTM 450 SX-F OEM`, the game
+ * calls the same bike `MX1OEM_2023_KTM_450_SX-F`, and the class prefix swallows the "OEM".
+ * Four words of five is the real shape of a hit. Measured against the live catalog, 0.75 is
+ * also where the near-misses stop: a 250 scores 0.6 against a 450's category, and noise like
+ * "AMA SX 2024" scores 0.67 against any bike of that year.
+ */
+const MIN_CATEGORY_COVERAGE = 0.75;
+
+/** Compare rank tuples element by element; higher is better. */
+function cmpRank(a: number[], b: number[]): number {
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return a[i] - b[i];
+  return 0;
+}
+
+/**
+ * The bikes a post's categories point at, best first.
+ *
+ * mxb-mods files a livery under one category per bike it fits — "2023 KTM 250 SX-F OEM",
+ * "2023 KTM 350 SX-F OEM" — which says outright what the title ("Suzuki made by
+ * KindConcepts") only gestures at. Against the live catalog this puts the right bike first
+ * for every one of the 107 OEM models.
+ */
+export function bikesFromCategories(bikes: string[], categories: string[]): string[] {
+  const ranked = new Map<string, number[]>();
+  for (const cat of categories) {
+    const ct = tokens(cat);
+    if (ct.size < MIN_CATEGORY_TOKENS) continue;
+    // "OEM" is the site's word for stock; the bike spells it into its class prefix instead.
+    const core = normalizeModName(cat.replace(/oem/gi, ""));
+    for (const bike of bikes) {
+      const bt = tokens(bike);
+      let shared = 0;
+      for (const t of ct) if (bt.has(t)) shared++;
+      if (shared / ct.size < MIN_CATEGORY_COVERAGE) continue;
+
+      // Tie-break between siblings that share every word the tokenizer keeps: `250 SX` and
+      // `250 SX-F` differ only by an "F" too short to be a token, but the run-together form
+      // still tells them apart — `…250sxf` contains `…250sx`, not the other way round.
+      const norm = normalizeModName(bike);
+      const rank = [shared, norm.includes(core) ? 1 : 0, -norm.length];
+      const prev = ranked.get(bike);
+      if (!prev || cmpRank(rank, prev) > 0) ranked.set(bike, rank);
+    }
+  }
+  return [...ranked.entries()]
+    .sort(([an, a], [bn, b]) => cmpRank(b, a) || an.localeCompare(bn))
+    .map(([name]) => name);
+}
+
+/**
+ * Every bike the picker can offer, merging what the backend found (folders, packages and
+ * profile bike ids) with the packages this scan saw. Case-insensitive, so a bike reached both
+ * ways is listed once.
+ */
+function bikeNames(installed: InstalledMod[], targets: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const roots = installed.filter((i) => i.folder === "").map((i) => stripExt(i.name));
+  for (const name of [...roots, ...targets]) {
+    const key = name.toLowerCase();
+    if (name && !seen.has(key)) {
+      seen.add(key);
+      out.push(name);
+    }
+  }
+  return out.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+}
+
 export function buildDestinations(
   modType: ModType,
   title: string,
   installed: InstalledMod[],
   livery = false,
   sound = false,
+  categories: string[] = [],
+  bikeTargets: string[] = [],
 ): { options: DestOption[]; guess: string; suggestions: string[] } {
   const seen = new Set<string>([""]);
   const options: DestOption[] = [
@@ -492,39 +581,51 @@ export function buildDestinations(
   let guess = "";
   const suggestions: string[] = [];
   if (modType.id === "bikes") {
-    const bikes = installed.filter((i) => i.folder === "");
+    const bikes = bikeNames(installed, bikeTargets);
     for (const b of bikes) {
-      add(stripExt(b.name), {
-        label: "",
-        labelKey: "dest.bikeFolder",
-        labelVars: { name: stripExt(b.name) },
-      });
-      add(`${stripExt(b.name)}/paints`, {
-        label: "",
-        labelKey: "dest.bikePaints",
-        labelVars: { name: stripExt(b.name) },
-      });
+      add(b, { label: "", labelKey: "dest.bikeFolder", labelVars: { name: b } });
+      add(`${b}/paints`, { label: "", labelKey: "dest.bikePaints", labelVars: { name: b } });
     }
 
     if (livery || sound) {
+      // A sound replaces the bike itself, so it goes to the bike's root; a paint only ever
+      // loads out of `paints/`.
+      const dest = (bike: string) => (sound ? bike : `${bike}/paints`);
+
+      // The categories name the bike; the title is only ever a hint, so it ranks below them
+      // and stays as the fallback for a post nobody categorised.
+      const named = bikesFromCategories(bikes, categories);
       const tt = tokens(title);
       const scored = bikes
-        .map((b) => {
+        .map((bike) => {
           let score = 0;
-          for (const t of tokens(b.name)) if (tt.has(t)) score++;
-          const value = sound ? stripExt(b.name) : `${stripExt(b.name)}/paints`;
-          return { value, score };
+          for (const t of tokens(bike)) if (tt.has(t)) score++;
+          return { bike, score };
         })
         .filter((s) => s.score >= 1)
         .sort((a, b) => b.score - a.score);
-      suggestions.push(...scored.slice(0, 5).map((s) => s.value));
-      if (scored[0] && scored[0].score >= 2) guess = scored[0].value;
+
+      const ranked = [...named, ...scored.slice(0, 5).map((s) => s.bike)];
+      suggestions.push(...new Set(ranked.map(dest)));
+      guess = named[0]
+        ? dest(named[0])
+        : scored[0] && scored[0].score >= 2
+          ? dest(scored[0].bike)
+          : "";
     }
   }
 
   for (const f of [...new Set(installed.map((i) => i.folder))].sort((a, b) => a.localeCompare(b))) {
     if (f) add(f, { label: f });
   }
+
+  // Tracks live in folders — a series, a season, a pack — and the root is where they're
+  // hardest to find again. Once the library has any folder at all, that's a likelier home
+  // for the next track than the root the picker used to fall back to.
+  if (modType.id === "tracks" && !guess) {
+    guess = options.find((o) => o.value)?.value ?? "";
+  }
+
   return { options, guess, suggestions };
 }
 
@@ -683,11 +784,30 @@ export function resolveInitialFolder(
 ): string {
   const remembered = localStorage.getItem(destStorageKey(modType)) ?? "";
   const rememberedIsPaints = /\/paints$/i.test(remembered);
+  // An empty remembered value can't be told apart from never having chosen — both read as
+  // `""`. For tracks that's the root, the one destination worth talking someone out of, so
+  // let the guess (the first existing folder) have it.
+  if (modType.id === "tracks" && !remembered && guess) return guess;
   if (modType.id === "bikes" && rememberedIsPaints && !livery) return guess;
-  if (modType.id === "bikes" && sound && guess) return guess;
+  // Liveries and sounds are *per bike*, so the folder used last time is the previous bike's,
+  // not this mod's. Whenever we could work out which bike this one is for — its categories
+  // name it — that beats the memory. With no match at all, fall through and keep it.
+  if (modType.id === "bikes" && (livery || sound) && guess) return guess;
   if (paintKind && remembered && !remembered.startsWith(`${paintKind}/`)) return guess;
   if (destOptions.some((o) => o.value === remembered)) return remembered;
   return guess;
+}
+
+/**
+ * Where a track goes when there's no picker to ask — the MX Bikes Shop installs straight from
+ * the purchase list. Same answer the Browse dialog would preselect: the remembered folder, or
+ * the first one the library already has.
+ */
+export async function resolveTrackDest(): Promise<string> {
+  const modType = DEFAULT_MOD_TYPE;
+  const installed = await getInstalledMods(modType.installSubpath).catch(() => []);
+  const { options, guess } = buildDestinations(modType, "", installed);
+  return resolveInitialFolder(modType, options, guess);
 }
 
 export interface QuickInstallParams {
@@ -716,12 +836,24 @@ export async function resolveQuickInstall(
     return { ok: false, reason: "blocked", title: detail.title, host: primary.host };
 
   let installed: InstalledMod[] = [];
+  let bikeTargets: string[] = [];
   try {
     installed = await getInstalledMods(modType.installSubpath);
   } catch {
     installed = [];
   }
-  const { options, guess } = buildDestinations(modType, detail.title, installed, livery);
+  if (modType.id === "bikes") {
+    bikeTargets = await scanBikeTargets().catch(() => []);
+  }
+  const { options, guess } = buildDestinations(
+    modType,
+    detail.title,
+    installed,
+    livery,
+    false,
+    detail.categories,
+    bikeTargets,
+  );
   const destFolder = resolveInitialFolder(modType, options, guess, livery);
 
   return {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -79,6 +79,12 @@ export interface ModDetail {
   /** e.g. "Beta 19", when the page states it. */
   version: string | null;
   downloads: DownloadOption[];
+  /**
+   * The post's category names ("2023 KTM 450 SX-F OEM", "Liveries", "KTM"). A livery is
+   * filed under one category per bike it fits, which names its target far more precisely
+   * than the title does — see `bikesFromCategories` in `api/mods`.
+   */
+  categories: string[];
 }
 
 /** An installed `.pkz` mod file found under the type's folder (at any depth). */


### PR DESCRIPTION
## Why

Installing a bike livery went wrong in two ways that both ended with a paint the player couldn't find.

**The picker didn't know which bike the paint was for.** It ranked destinations by token overlap with the *post title* — prose like "Suzuki made by KindConcepts". mxb-mods actually files every livery under a category per bike it fits ("2023 KTM 250 SX-F OEM", "2023 KTM 350 SX-F OEM"), which names the target outright, and we were throwing that away.

**OEM bikes couldn't be selected at all.** Their files live inside the game's locked archive, so `mods/bikes` holds at most a `paints/` folder for them — and `library::scan_mods` only yields `.pkz` *files*. Every OEM bike was missing from the destination list, so a paint for one meant typing `MX2OEM_2023_KTM_250_SX-F/paints` by hand.

**And a paint aimed at a bike's root silently did nothing.** MX Bikes only reads liveries from `<Bike>/paints/`. The picker offers the bike root too (correct for sounds and model swaps), `resolveInitialFolder` would even preselect it, and `place_mod` wrote the `.pnt` there. The install reported success; the paint never appeared in game.

## What changed

- `_embed` also asks for `wp:term` — same request, no extra round trip — and `ModDetail` carries the category names to the frontend.
- `bikesFromCategories` ranks bikes by how much of a category's vocabulary they account for (≥3 tokens, ≥75% coverage), tie-breaking siblings like `250 SX` / `250 SX-F` on the run-together form, since the `-F` is too short to survive tokenizing.
- `library::scan_bike_targets` merges bike folders and `.pkz` stems under `mods/bikes` with the bike ids read from the player's profiles — the only place an unpainted OEM bike's id exists. Reuses the `models_in` helper that already did exactly this for rider gear.
- A category match now beats the remembered folder for liveries and sounds, which are per-bike: the remembered one is the *previous* bike's.
- `place_mod` redirects a loose `.pnt` into `<Bike>/paints`, mirroring the sound-mod rule directly above it that strips a trailing `paints`. A `.pkz` payload still lands at the root.

Two fixes found while testing this, folded in rather than left behind:

- Tracks default to the first existing folder instead of the root — in Browse, and in the Shop, which hardcoded `destFolder: ""`.
- The install progress chain printed its raw translation keys (`modDetail.stageResolve`) in **every** language. Its labels were the only `TKey` in the app rendered without `t()`; all five locales already had the strings.

## Verification

`cargo test` — 250 pass, including 4 new placement cases and 2 for `scan_bike_targets`; the existing sound-placement tests still pass, which is what proves the redirect didn't steal their path. `typecheck`, `lint` and `build` clean.

The matcher was checked against the live catalog rather than by eye. Bundled standalone and run over all 300 categories and 107 OEM models: **the right bike ranks first for 106/106** real model categories (the 107th is "Honda OEM", a manufacturer grouping, correctly rejected), and only 2 of 193 non-model categories nominate anything — both A-KIT categories pointing at the GasGas they're built on.

Then run against a real library (53 installed bikes) and 12 real livery posts: 6 resolved to the exact bike, and the other 6 carry only manufacturer categories ("Bikes | KTM | Liveries | Others") so they correctly fall back to title scoring — those are 85cc mod bikes with no OEM model category.

Manually confirmed in the app: Honda and Yamaha posts preselect correctly, a paint aimed at a bike root lands in `paints/`, and tracks default to an existing folder.

## Note for the GP Bikes branch

A config written by the multi-game branch carries `activeGame` / `games`, which `AppConfig` on `main` doesn't know about. It reads them fine but drops them on write, so any settings change from a `main` build deletes the block. Worth teaching `AppConfig` to preserve unknown keys over there — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
