### PR TITLE
feat(frostmod): turn on live reload for GP Bikes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026-08-08 — FrostMod works on GP Bikes
+
+### Added
+- **FrostMod's live mod reload now works for GP Bikes.** FrostMod v0.10.0 attaches to
+  `gpbikes.exe`, so the status panel, the reload button and the watch-the-folder auto-reload
+  are all available when GP Bikes is the active game — they were hidden before because
+  FrostMod only knew about MX Bikes. The app launches it with the game it's driving, which
+  is what makes it attach; without that it would sit running and never hook anything.
+
+### Notes
+- Instant profile refresh stays MX Bikes only. Unlike FrostMod's reload, it calls a
+  hardcoded `mxbikes.exe` function offset, and there's no GP equivalent yet.
+
 ## 2026-08-08 — GP Bikes support
 
 ### Added

--- a/src-tauri/src/frostmod_manage.rs
+++ b/src-tauri/src/frostmod_manage.rs
@@ -442,8 +442,15 @@ pub fn start(app: &AppHandle, state: &FrostmodProcess) -> anyhow::Result<bool> {
     // Nothing holds the previous binaries once the game that mapped them is gone,
     // so a start is a good moment to clear what the last update had to leave behind.
     sweep_retired(&frostmod_dir(app));
+    // Tell FrostMod which game to wait for. Without this it defaults to `mxbikes.exe`, so
+    // on GP Bikes it would sit running and never attach — the status pill would say
+    // "running" while reload silently did nothing. `--game` landed in FrostMod v0.10.0;
+    // older binaries ignore an unknown flag and keep their MX Bikes default, which is the
+    // right fallback for the only game they support.
+    let game = crate::config::load(app).map(|c| c.active_game).unwrap_or_default();
     let child = std::process::Command::new(&exe)
         .current_dir(frostmod_dir(app))
+        .args(["--game", game.id()])
         .creation_flags(CREATE_NO_WINDOW)
         .spawn()?;
     *state.0.lock().unwrap() = Some(child);

--- a/src-tauri/src/game.rs
+++ b/src-tauri/src/game.rs
@@ -108,11 +108,12 @@ pub struct RiderLayout {
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Caps {
-    /// FrostMod, the in-process mod loader. It is a compiled **MX Bikes** plugin; there
-    /// is no GP Bikes build, so hot reload and its status panel don't apply there.
+    /// FrostMod, the in-process mod loader. Attaches to either title as of FrostMod
+    /// v0.10.0 — launched with `--game <id>`, see `frostmod_manage::start`.
     pub frostmod: bool,
     /// Re-run the game's profile loader in place after applying a preset. Implemented by
-    /// poking `mxbikes.exe` memory, so it is as MX-Bikes-specific as FrostMod.
+    /// calling a hardcoded `mxbikes.exe` function offset (`gameproc::LOADER_OFFSET`), which
+    /// is that binary's alone — unlike FrostMod's reload, this has no GP equivalent yet.
     pub instant_refresh: bool,
     /// The 3D preview (Locker / Rider / bike preview). GP Bikes uses the same `.edf`
     /// meshes, but its bike part names and rider rig need their own bindings — not in
@@ -248,7 +249,7 @@ pub static GPB: GameProfile = GameProfile {
     },
     catalog: &crate::mxb_session::GPB_SITE,
     caps: Caps {
-        frostmod: false,
+        frostmod: true,
         instant_refresh: false,
         viewer: false,
         shop: false,
@@ -308,6 +309,16 @@ mod tests {
         }
     }
 
+    /// These ids are passed to FrostMod as `frostmod.exe --game <id>`, so they are a
+    /// cross-repo contract: they must match the `id` field on FrostMod's `GameOffsets`
+    /// (frostmod `src/offsets.h`). Renaming one here silently stops FrostMod attaching —
+    /// it would fall back to its MX Bikes default and look "running" but do nothing.
+    #[test]
+    fn ids_match_what_frostmod_expects() {
+        assert_eq!(Game::Mxb.id(), "mxb");
+        assert_eq!(Game::Gpb.id(), "gpb");
+    }
+
     /// A config naming a title this build doesn't have must still open — on MX Bikes,
     /// the title every existing install is already using.
     #[test]
@@ -341,8 +352,7 @@ mod tests {
     #[test]
     fn gp_bikes_has_no_mx_only_features() {
         let caps = Game::Gpb.profile().caps;
-        assert!(!caps.frostmod, "FrostMod is an MX Bikes plugin");
-        assert!(!caps.instant_refresh, "instant refresh pokes mxbikes.exe");
+        assert!(!caps.instant_refresh, "instant refresh calls an mxbikes.exe offset");
         assert!(!caps.shop, "mxbikes-shop.com is MX Bikes only");
         assert!(!caps.manage, "Manage is MX Bikes only for now");
         assert!(!caps.join_by_address, "GP's connect flag and port are unconfirmed");


### PR DESCRIPTION
[FrostMod v0.10.0](https://github.com/Frostn1/frostmod/releases/tag/v0.10.0) attaches to `gpbikes.exe` and reloads its mods, so the capability that hid its panel and reload button for GP Bikes doesn't need to be off any more.

## What's here

- **Launch `frostmod.exe --game <id>`** with the game the app is driving. This is the part that actually matters. With no argument FrostMod waits for `mxbikes.exe`, so on GP Bikes it would sit running while the status pill said "running" and reload silently did nothing — a worse failure than the feature being hidden. Older FrostMod binaries ignore the unknown flag and keep their MX Bikes default, which is the correct fallback for the only game they support.
- `caps.frostmod` → `true` for GP Bikes. That surfaces the sidebar panel, the reload button, the settings section, and swaps the mod-detail hint back from "restart the game" to "FrostMod will hot-reload".
- `caps.instant_refresh` **stays false**. Unlike FrostMod's reload it calls a hardcoded `mxbikes.exe` function offset (`gameproc::LOADER_OFFSET`), and there is no GP equivalent yet.
- A test pinning the id strings. They cross a repo boundary now — `--game <id>` has to match the `id` field on FrostMod's `GameOffsets` in `src/offsets.h`. A rename here would quietly stop FrostMod attaching rather than fail loudly, so it's worth a test that says so.

No config or schema changes.

## Testing

- `cargo test` — 382 pass, 0 fail.
- **`cargo check --target x86_64-pc-windows-gnu`** — the spawn site is `#[cfg(windows)]`, so a macOS check skips it entirely. Cross-checked against a Windows target so the edit is actually compiled, not just reasoned about.
- `tsc --noEmit` clean, build succeeds.

Not verified against a real GP Bikes install (none available here). The end-to-end check is: switch to GP Bikes, start FrostMod, drop a `.pkz` into `Documents\PiBoSo\GP Bikes\mods\tracks`, and confirm it appears in-game without a restart. Worth confirming MX Bikes still attaches too, since the spawn now always passes `--game`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)