### PR TITLE
fix(viewer): bind gear textures by slot, and preview a paint on its model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 2026-08-08 — paints preview on their own model, and helmets bind their goggles right
+
+### Added
+- **Opening a paint in 3D now shows the model it was painted for, wearing it.** Click a
+  livery, a helmet paint or a goggle paint and the viewer loads the bike or helmet it belongs
+  to and selects that paint in the picker, instead of draping the textures over a stock body
+  that was never the shape they were drawn against. A paint whose model isn't installed still
+  previews the way it did before.
+
+### Changed
+- **The Library's 3D button says what it does.** The bare square on each row is now a
+  labelled **View in 3D**.
+- **Settings spells out which folder to pick.** The app wants your MX Bikes folder — the one
+  holding `mods` and `profiles` — not the `mods` folder inside it, which is one click deeper
+  in the picker and easy to land on. The setting now says so, and picking `mods` by mistake
+  quietly resolves to the folder above it (Settings says which one it took) rather than
+  leaving you with a library that scans nothing and a path that looks perfectly reasonable.
+
+### Fixed
+- **Helmets whose goggles came out wearing the helmet's paint.** The Bell Moto 10 packs are
+  the clear case: shell, tear-off, lens and goggle frame each ended up in the wrong texture,
+  the goggle worst of all. Three faults behind it, all in how a model's textures are counted
+  and matched:
+  - A helmet needn't ship the sheet its paints replace, and the Moto 10 doesn't — it names
+    it and leaves the pixels to the `.pnt`. That slot was going uncounted, so every piece
+    was drawn from its neighbour's texture.
+  - A one-character texture name (the Oakley pack calls its goggle sheet `O`) was skipped
+    entirely, sliding everything after it by one.
+  - Which pieces are the goggles was decided from their names, and a helmet names its
+    goggle group after the goggle it ships — `Armega`, `Airbrake` — not "goggles". It is now
+    decided by which paint supplies the texture the piece is drawn from, which is the mod's
+    own answer.
+- **Pieces no paint covers keep their own look.** A tear-off film, a visor, anything an author
+  baked into the mesh and left out of the `.pnt` used to have the shell's paint stretched
+  across it.
+- **A "Stock" option that showed a helmet in the wrong texture.** It's offered only where the
+  mesh really carries the sheet that side's paints replace.
+
 ## 2026-08-08 — v0.8.0 — GP Bikes, dedicated servers, and paint sync
 
 ### Added

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -349,6 +349,39 @@ fn looks_like_mods_dir(path: &str) -> bool {
         || crate::library::resolve_child(dir, "mods").is_dir()
 }
 
+/// The parent of `path` when the pick is the `mods` folder rather than the game folder
+/// above it, else `None`.
+///
+/// What the app wants is the game's *user* folder — the one holding `mods/` and
+/// `profiles/`. In a folder picker the two are one click apart, and getting it wrong is
+/// invisible afterwards: every scan then looks under `<mods>/mods`, finds nothing, and the
+/// library comes up empty next to a path that reads perfectly reasonably in Settings.
+///
+/// The folder's contents decide it, not just its name — a mods tree is called `mods` by
+/// convention, but what identifies it is the type folders the game reads out of it, and an
+/// extracted one can arrive under any name at all.
+fn climb_out_of_mods(path: &str, game: &GameProfile) -> Option<PathBuf> {
+    let dir = Path::new(path.trim());
+    if path.trim().is_empty() || !dir.is_dir() {
+        return None;
+    }
+    // Already the game folder: it holds the `mods`/`profiles` children itself.
+    if looks_like_mods_dir(path) {
+        return None;
+    }
+    let named_mods = dir
+        .file_name()
+        .is_some_and(|n| n.to_string_lossy().eq_ignore_ascii_case("mods"));
+    let holds_type_folders = game
+        .mods_dirs
+        .iter()
+        .any(|k| crate::library::resolve_child(dir, k).is_dir());
+    if !named_mods && !holds_type_folders {
+        return None;
+    }
+    dir.parent().filter(|p| p.is_dir()).map(Path::to_path_buf)
+}
+
 /// The saved config, or one built on the spot when the MX Bikes folder sits where it
 /// normally does. Returns `None` only when there's genuinely nothing to go on — the
 /// one case where the setup screen has something to ask.
@@ -397,6 +430,18 @@ pub fn save(app: &AppHandle, cfg: &AppConfig) -> anyhow::Result<()> {
 
 pub fn finalize(mut cfg: AppConfig) -> AppConfig {
     let game = cfg.game();
+    // Picked one level too deep — take the folder above `mods`, which is the one every
+    // other path in the app is built from. Done here so it covers both ways in: first-run
+    // setup (`create_config`) and Change… in Settings (`set_mods_path`).
+    if let Some(up) = climb_out_of_mods(&cfg.mods_path, game) {
+        log::info!(
+            "{} folder was set to the mods folder ({}) — using the folder above it: {}",
+            game.display,
+            cfg.mods_path,
+            up.display()
+        );
+        cfg.mods_path = up.to_string_lossy().into_owned();
+    }
     // A folder that isn't there any more is worse than none: it reads as "configured",
     // so the app comes up on a dashboard scanning nothing instead of asking where the
     // game went. Covers a game uninstalled or moved, and a path a previous build adopted
@@ -714,6 +759,47 @@ mod tests {
         cfg.mods_path = root.to_string_lossy().into_owned();
         assert_eq!(cfg.profiles_dir(), root.join("profiles"));
 
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Picking `…/MX Bikes/mods` instead of `…/MX Bikes` — the folder one level down, and
+    /// the one a player is far more likely to have open when the picker appears.
+    #[test]
+    fn finalize_climbs_out_of_the_mods_folder() {
+        let root = std::env::temp_dir().join(format!("frost-climb-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let game = root.join("MX Bikes");
+        std::fs::create_dir_all(game.join("mods").join("bikes")).unwrap();
+        std::fs::create_dir_all(game.join("profiles")).unwrap();
+
+        let mut cfg = AppConfig::default();
+        cfg.mods_path = game.join("mods").to_string_lossy().into_owned();
+        let out = finalize(cfg);
+        assert_eq!(Path::new(&out.mods_path), game);
+
+        // An extracted tree under any other name is still recognised by what's inside it.
+        let odd = root.join("MX Bikes 2").join("Mods_backup");
+        std::fs::create_dir_all(odd.join("tracks")).unwrap();
+        let mut cfg = AppConfig::default();
+        cfg.mods_path = odd.to_string_lossy().into_owned();
+        assert_eq!(Path::new(&finalize(cfg).mods_path), odd.parent().unwrap());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The right folder must survive untouched, including the one case that looks like the
+    /// wrong one: a game folder that is itself *named* `mods`.
+    #[test]
+    fn finalize_leaves_the_game_folder_alone() {
+        let root = std::env::temp_dir().join(format!("frost-noclimb-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        for game in [root.join("MX Bikes"), root.join("mods")] {
+            std::fs::create_dir_all(game.join("mods").join("bikes")).unwrap();
+            std::fs::create_dir_all(game.join("profiles")).unwrap();
+            let mut cfg = AppConfig::default();
+            cfg.mods_path = game.to_string_lossy().into_owned();
+            assert_eq!(Path::new(&finalize(cfg).mods_path), game, "{}", game.display());
+        }
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src-tauri/src/edf.rs
+++ b/src-tauri/src/edf.rs
@@ -175,8 +175,8 @@ fn parse_impl(b: &[u8], level0: &[String]) -> Vec<EdfNode> {
     }
     let mut nodes = Vec::new();
     let cands = collect_sub_cands(b);
-    // Only needed to sanity-check a material's texture index, so count them once.
-    let colors = color_textures(b).len();
+    // Only needed to bound a material's texture index, so count them once.
+    let textures = embedded_textures(b).len();
     let mut o = HEADER_START;
 
     while o + 8 <= n {
@@ -205,7 +205,7 @@ fn parse_impl(b: &[u8], level0: &[String]) -> Vec<EdfNode> {
                     let iend = ic + 8 + tc * 12;
                     if let (true, Some(name)) = (ok, plausible_name(b, iend)) {
                         // `o` is the node's vertex-count word — its material table ends there.
-                        let mats = node_material_table(b, o, colors);
+                        let mats = node_material_table(b, o, textures);
                         nodes.push(read_node(b, &cands, vs, vc, raw, iend, tc, name, mats));
                         o = iend; // jump past this block
                         continue;
@@ -438,7 +438,12 @@ const MAX_MATERIALS: usize = 64;
 // A 56-byte material record: two bracketing 0.0 floats around six shading terms, a run of
 // zeroed words, and the one-based texture index. Strict on purpose — the table is found by
 // walking backwards, so a loose test would latch onto compressed texture bytes.
-fn valid_material_record(b: &[u8], o: usize, colors: usize) -> bool {
+//
+// `textures` is every embedded texture, companions included, because a material may name
+// one: the Bell Moto 10's fourth material points at `Racecraft_n`, its goggle's normal map.
+// Bounding the index by the colour list instead threw that whole table away, and with it
+// the evidence every *other* piece of that helmet is bound from.
+fn valid_material_record(b: &[u8], o: usize, textures: usize) -> bool {
     if o + MAT_STRIDE > b.len() {
         return false;
     }
@@ -453,15 +458,17 @@ fn valid_material_record(b: &[u8], o: usize, colors: usize) -> bool {
     if w(8) != 0 || w(9) != 0 || w(10) != 0 || w(12) != 0 || w(13) != 0 {
         return false;
     }
-    w(11) as usize <= colors
+    w(11) as usize <= textures
 }
 
-/// One node's material table: LOCAL material id -> position in the model's colour textures,
-/// None where that material carries no texture. Empty when the node has no readable table
-/// (shadow meshes, which are never painted).
+/// One node's material table: LOCAL material id -> position in the model's declared colour
+/// textures (see [`declared_colors`]), None where that material carries no texture. Empty
+/// when the node has no readable table (shadow meshes, which are never painted).
 ///
 /// `node_start` is the offset of the node's `u32` vertex count; the table ends exactly there.
-pub fn node_material_table(b: &[u8], node_start: usize, colors: usize) -> Vec<Option<usize>> {
+/// `textures` is how many textures the model embeds — only a bound on the index, since the
+/// slot a material names may be a texture the model declares without embedding.
+pub fn node_material_table(b: &[u8], node_start: usize, textures: usize) -> Vec<Option<usize>> {
     for count in 1..=MAX_MATERIALS {
         let Some(o) = node_start.checked_sub(4 + MAT_STRIDE * count) else {
             break;
@@ -469,7 +476,7 @@ pub fn node_material_table(b: &[u8], node_start: usize, colors: usize) -> Vec<Op
         if u32le(b, o) as usize != count {
             continue;
         }
-        if (0..count).all(|k| valid_material_record(b, o + 4 + MAT_STRIDE * k, colors)) {
+        if (0..count).all(|k| valid_material_record(b, o + 4 + MAT_STRIDE * k, textures)) {
             return (0..count)
                 .map(|k| {
                     let one = u32le(b, o + 4 + MAT_STRIDE * k + MAT_TEX_FROM_REC) as usize;
@@ -479,6 +486,63 @@ pub fn node_material_table(b: &[u8], node_start: usize, colors: usize) -> Vec<Op
         }
     }
     Vec::new()
+}
+
+/// The COLOUR textures a model declares, by name, in file order — the list material indices
+/// count. Companion maps are left out: the TLD SE4 helmet embeds `TLDSE4`, `TLDSE4_n`,
+/// `TLDSE4goggle`, `TLDSE4goggle_n` and binds its goggles with material 2, which is only the
+/// goggle sheet if the `_n` between them doesn't take a slot.
+///
+/// `external` names textures the model draws but does *not* embed — a paint supplies their
+/// pixels. They hold a slot all the same, and it is the slot's *position* that matters: the
+/// Bell Moto 10 ships no shell texture in its mesh, only the name of the one its paints
+/// supply, written ahead of the three it does embed. Counting the embedded three alone slid
+/// every material down one, and its goggles came out wearing the helmet's paint.
+///
+/// A name is only taken as a declaration where the model writes it in the clear — outside
+/// any texture payload, and terminated — so a name that happens to occur inside compressed
+/// pixels can't invent a slot.
+pub fn declared_colors(b: &[u8], external: &[String]) -> Vec<String> {
+    let embedded = embedded_textures(b);
+    let mut slots: Vec<(usize, String)> = embedded
+        .iter()
+        .filter(|t| !is_companion_texture(&t.name))
+        .map(|t| (t.data_off, t.name.clone()))
+        .collect();
+    for name in external {
+        if name.is_empty()
+            || embedded.iter().any(|t| t.name.eq_ignore_ascii_case(name))
+            || is_companion_texture(name)
+        {
+            continue;
+        }
+        if let Some(at) = declaration_offset(b, name, &embedded) {
+            slots.push((at, name.clone()));
+        }
+    }
+    slots.sort_by_key(|(at, _)| *at);
+    slots.into_iter().map(|(_, name)| name).collect()
+}
+
+/// Where the model writes `name` as a texture it draws but doesn't embed, if it does.
+fn declaration_offset(b: &[u8], name: &str, embedded: &[EmbeddedTexture]) -> Option<usize> {
+    let needle = name.as_bytes();
+    let mut from = 0usize;
+    while let Some(rel) = b[from..].windows(needle.len()).position(|w| w == needle) {
+        let at = from + rel;
+        let terminated = b.get(at + needle.len()) == Some(&0);
+        // The declaration is a word followed by the name, so the byte in front is that
+        // word's zero high byte — a much narrower target than "not a letter".
+        let starts_clean = at > 0 && b[at - 1] == 0;
+        let in_pixels = embedded
+            .iter()
+            .any(|t| at >= t.data_off && at < t.data_off + t.data_len);
+        if terminated && starts_clean && !in_pixels {
+            return Some(at);
+        }
+        from = at + 1;
+    }
+    None
 }
 
 /// Companion maps ride alongside a colour texture and are never the look itself — MX
@@ -538,7 +602,13 @@ const TEX_PAD_LEN: usize = 8;
 // Name's first char to `width`: either -100 or -104 depending on the record; probe both.
 const TEX_W_FROM_NAME: [usize; 2] = [100, 104];
 
-// A null-terminated embedded-texture name at `o`: 2-39 name-safe chars (may lead with a digit).
+// A null-terminated embedded-texture name at `o`: 1-39 name-safe chars (may lead with a digit).
+//
+// One character counts: the Bell Moto 10 "O" pack names its goggle sheet `O`, and skipping it
+// didn't just lose that texture — material indices count this list, so every slot after it
+// slid, and the helmet came out wearing its goggle's paint. The record's shape (both
+// dimensions from the fixed size set, eight zero pad bytes, a payload that fits the file) is
+// what rules out a stray letter, not the length of the name.
 fn tex_name(b: &[u8], o: usize) -> Option<String> {
     let mut e = o;
     while e < b.len() && e - o < 40 {
@@ -552,7 +622,7 @@ fn tex_name(b: &[u8], o: usize) -> Option<String> {
         e += 1;
     }
     let len = e - o;
-    (2..=39).contains(&len).then(|| String::from_utf8_lossy(&b[o..e]).into_owned())
+    (1..=39).contains(&len).then(|| String::from_utf8_lossy(&b[o..e]).into_owned())
 }
 
 // Enumerate every texture in a model.edf, in file order. Anchored on the name, then
@@ -1090,14 +1160,23 @@ mod tests {
     #[test]
     fn a_nodes_material_table_is_read_back_off_its_vertex_count() {
         let b = material_table_bytes(&[3, 1, 0], 512);
-        // One-based into the colour list, and 0 means the material carries no texture.
+        // One-based into the declared colours, and 0 means the material carries no texture.
         assert_eq!(node_material_table(&b, 512, 3), vec![Some(2), Some(0), None]);
     }
 
+    /// A model declares more texture slots than it embeds — the Bell Moto 10 leaves its
+    /// shell sheet to a `.pnt` and names it, then embeds three more. The table is still this
+    /// node's, and throwing it away costs every piece in the mesh its binding.
     #[test]
-    fn a_material_table_is_refused_when_it_overruns_the_colour_list() {
-        // Index 4 with only 3 colours isn't this node's table — better no table than a
-        // part bound from a misread one.
+    fn a_material_may_name_a_slot_past_the_embedded_textures() {
+        let b = material_table_bytes(&[1, 4], 512);
+        assert_eq!(node_material_table(&b, 512, 4), vec![Some(0), Some(3)]);
+    }
+
+    #[test]
+    fn a_material_table_is_refused_when_it_overruns_the_textures() {
+        // Index 4 with only 3 textures in the file isn't this node's table — better no
+        // table than a part bound from a misread one.
         let b = material_table_bytes(&[4], 512);
         assert!(node_material_table(&b, 512, 3).is_empty());
         assert_eq!(node_material_table(&b, 512, 4), vec![Some(3)]);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -902,7 +902,9 @@ fn bind_textures(
     gfx: &std::collections::HashMap<String, cfg::GfxPart>,
     node_part: &std::collections::HashMap<String, String>,
 ) {
-    let colors = edf::color_textures(edf_bytes);
+    // A bike embeds every texture it draws, its stock livery included, so it declares
+    // nothing beyond them.
+    let colors = edf::declared_colors(edf_bytes, &[]);
 
     for n in nodes.iter_mut() {
         let part = node_part.get(&n.name.to_ascii_lowercase());
@@ -911,12 +913,12 @@ fn bind_textures(
             log::warn!("[viewer] node '{}' has no material table — falling back", n.name);
         }
         // A material id is local to its node, so ask the node's own table.
-        let material_texture = |mat: Option<u32>| -> Option<&edf::EmbeddedTexture> {
+        let material_texture = |mat: Option<u32>| -> Option<&String> {
             let slot = n.materials.get(mat? as usize).copied().flatten()?;
             colors.get(slot)
         };
         // A node with no submesh table draws on its first material.
-        n.texture = material_texture(Some(0)).or_else(|| colors.first()).map(|t| t.name.clone());
+        n.texture = material_texture(Some(0)).or_else(|| colors.first()).cloned();
         for sm in n.submeshes.iter_mut() {
             let group = sm.name.to_ascii_lowercase();
             // 1. An explicit gfx texture (animated chain, number plate) is authoritative.
@@ -929,7 +931,7 @@ fn bind_textures(
             }
             // 2. The node's material table picks the colour texture this range was drawn on.
             if let Some(t) = material_texture(sm.mat) {
-                sm.texture = Some(t.name.clone());
+                sm.texture = Some(t.clone());
                 continue;
             }
             // 3. No material recorded → leave unbound so it renders neutral grey, never smeared.
@@ -1583,9 +1585,31 @@ fn gear_paints_at(path: &std::path::Path) -> Result<GearPaints, String> {
         .or_else(|| files.iter().find(|(n, _)| is_visible_gear_mesh(n)))
         .map(|(_, d)| edf::embedded_textures(d).iter().map(|t| t.name.clone()).collect())
         .unwrap_or_default();
+    // Whether a side has a stock look to offer: the mesh carries its own copy of the sheet
+    // that side's paints replace. Asking the paints, not the texture names, is what keeps a
+    // "Stock" entry off the Bell Moto 10 — it embeds a tear-off film and a goggle, but not
+    // the shell sheet its paints supply, so picking "Stock" there drew the helmet in a
+    // near-blank film. With nothing painted on a side at all, the mesh's own look is the only
+    // one there is, so anything it carries for that side counts.
+    let supplied = |folder: &str| {
+        paint_texture_names(
+            files
+                .iter()
+                .filter(|(n, _)| gear_folder_paint_name(n, folder).is_some())
+                .map(|(_, d)| d.as_slice()),
+        )
+    };
+    let has_stock = |folder: &str, goggle_side: bool| {
+        let paints = supplied(folder);
+        let mut usable = embedded.iter().filter(|n| !is_companion_map(n));
+        if paints.is_empty() {
+            return usable.any(|n| is_goggle_name(n) == goggle_side);
+        }
+        usable.any(|e| paints.iter().any(|p| p.eq_ignore_ascii_case(e)))
+    };
     Ok(GearPaints {
-        has_stock: embedded.iter().any(|n| !is_goggle_name(n) && !is_companion_map(n)),
-        has_stock_goggles: embedded.iter().any(|n| is_goggle_name(n) && !is_companion_map(n)),
+        has_stock: has_stock("paints", false),
+        has_stock_goggles: has_stock("goggles", true),
         paints: names("paints"),
         goggles: names("goggles"),
     })
@@ -1784,6 +1808,36 @@ fn load_gear_model_blocking(
                 .filter(|t| !taken.contains(&t.name.to_ascii_lowercase())),
         );
     }
+    // Which textures this item's paints supply, whichever one is picked — the names the mesh
+    // declares and leaves to a `.pnt`, and so part of the slot order its materials count.
+    // Read even when nothing is painted: a stock preview counts the same slots.
+    let declared =
+        paint_texture_names(paints.iter().chain(goggle_paints.iter()).map(|(_, d)| d.as_slice()));
+    bind_gear_submeshes(
+        &mut nodes,
+        mesh.map(|d| d.as_slice()),
+        &main_side,
+        &goggle_side,
+        &declared,
+    );
+    // Pieces the paints don't cover keep the mesh's own texture — a tear-off film, a visor,
+    // anything the author baked in and left out of the `.pnt`. The game draws those from the
+    // mesh, so they have to travel with it; without them the Bell Moto 10's tear-off had
+    // nothing to wear and took the helmet's paint across it. Decoded by name, so a mesh
+    // holding several 4K sheets only pays for the ones actually on screen.
+    let shipped: std::collections::HashSet<String> =
+        out.iter().map(|t| t.name.to_ascii_lowercase()).collect();
+    let worn: std::collections::HashSet<String> = nodes
+        .iter()
+        .flat_map(|n| n.texture.iter().chain(n.submeshes.iter().filter_map(|s| s.texture.as_ref())))
+        .map(|t| t.to_ascii_lowercase())
+        .filter(|t| !shipped.contains(t))
+        .collect();
+    if let (false, Some(d)) = (worn.is_empty(), mesh) {
+        out.extend(paint::extract_edf_textures_where(d, |n| {
+            worn.contains(&n.to_ascii_lowercase())
+        }));
+    }
     log::info!(
         "[viewer] {part}: paint={want:?} goggles={want_goggles:?} stock={stock}/{stock_goggles} \
          -> shell {:?}, goggles {:?} ({} textures)",
@@ -1791,7 +1845,6 @@ fn load_gear_model_blocking(
         goggle_side.primary,
         out.len(),
     );
-    bind_gear_submeshes(&mut nodes, mesh.map(|d| d.as_slice()), &main_side, &goggle_side);
     Ok(RiderPart { part, nodes, textures: out })
 }
 
@@ -1884,27 +1937,68 @@ fn pick_gear_paint(
     paint::decode_any(hit.or_else(|| paints.first())?.1).ok()
 }
 
+/// Every texture name a set of `.pnt` files supplies, deduplicated. Headers only — no pixels
+/// are inflated, so this stays cheap enough to run on every paint an item ships.
+fn paint_texture_names<'a>(paints: impl Iterator<Item = &'a [u8]>) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for data in paints {
+        for name in paint::texture_names_any(data).unwrap_or_default() {
+            if !out.iter().any(|n: &String| n.eq_ignore_ascii_case(&name)) {
+                out.push(name);
+            }
+        }
+    }
+    out
+}
+
+/// Which side of the item a piece belongs to, given the texture the mesh draws it from.
+///
+/// The paints decide it. A `.pnt` replaces textures *by name*, so the side that supplies
+/// the name a piece is drawn from is the side that piece is on — the mod's own answer,
+/// stated in its own files. Only when neither side claims the name (or the mesh names none)
+/// does the piece's spelling get a say.
+///
+/// It has to be this way round, because a helmet names its goggle group after the goggle it
+/// ships: the Bell Moto 10's goggle submeshes are called `Armega.001` and drawn from
+/// `Racecraft`, neither of which reads as "goggles" — so on names alone the whole goggle
+/// went out wearing the helmet's paint.
+fn on_goggle_side(emb: Option<&str>, spelled_goggle: bool, main: &GearSide, goggle: &GearSide) -> bool {
+    match emb {
+        Some(e) if goggle.supplies(e).is_some() => true,
+        Some(e) if main.supplies(e).is_some() => false,
+        _ => spelled_goggle,
+    }
+}
+
 /// Bind each submesh (or single-material node) to the texture it should wear: goggles take
 /// the goggle paint, everything else the shell paint.
 ///
-/// The mesh settles which is which — a submesh's material names the texture the model was
-/// drawn against, the same reading the bike viewer uses. A piece's own name is only
-/// evidence on top of that, because a helmet's goggle group is as often called `mask` or
-/// nothing at all, and just as often lives in a node of its own with no submeshes. A paint
-/// replaces textures by name, so a side wearing one it doesn't supply falls back to its
-/// primary; unmatched → `None`, so the frontend renders neutral grey rather than smearing
-/// another part's texture over it.
+/// The mesh settles which texture a piece was drawn against — a submesh's material names it,
+/// the same reading the bike viewer uses — and [`on_goggle_side`] settles whose texture that
+/// is. A paint replaces textures by name, so a side wearing one it doesn't supply falls back
+/// to its primary; unmatched → `None`, so the frontend renders neutral grey rather than
+/// smearing another part's texture over it.
 fn bind_gear_submeshes(
     nodes: &mut [edf::EdfNode],
     mesh: Option<&[u8]>,
     main: &GearSide,
     goggle: &GearSide,
+    // Every texture name the item's own paints supply — see `paint_texture_names`.
+    declared: &[String],
 ) {
-    let colors = mesh.map(edf::color_textures).unwrap_or_default();
+    let colors = mesh.map(|d| edf::declared_colors(d, declared)).unwrap_or_default();
+    // Names the mesh carries pixels for, so a piece no paint covers can keep its own look.
+    let embedded: Vec<String> = mesh
+        .map(|d| edf::embedded_textures(d).into_iter().map(|t| t.name).collect())
+        .unwrap_or_default();
+    let carried = |want: &str| embedded.iter().any(|n| n.eq_ignore_ascii_case(want));
     // What this side puts on a piece the mesh draws from `emb`.
     let wear = |emb: Option<&str>, goggles_here: bool| -> Option<String> {
         let (side, other) = if goggles_here { (goggle, main) } else { (main, goggle) };
         emb.and_then(|e| side.supplies(e))
+            // No paint replaces this one, but the mesh has it: that IS the piece's look, and
+            // it beats stretching the side's paint over something it was never drawn for.
+            .or_else(|| emb.filter(|e| carried(e)).map(str::to_string))
             .or_else(|| side.primary.clone())
             // A helmet whose goggles aren't painted apart still shows them — in the shell's
             // texture, which is where they were drawn.
@@ -1914,24 +2008,23 @@ fn bind_gear_submeshes(
         // A material id is local to its node — resolve it through that node's own table.
         let material_texture = |mat: Option<u32>| -> Option<&str> {
             let slot = node.materials.get(mat? as usize).copied().flatten()?;
-            colors.get(slot).map(|t| t.name.as_str())
+            colors.get(slot).map(String::as_str)
         };
         let node_goggle = is_goggle_name(&node.name);
         if node.submeshes.is_empty() {
-            // No submesh table means no material index to look up. Take the mesh's own
-            // colour texture for this side, so a goggle node isn't handed the shell's.
+            // No submesh table means no material index to look up. Take a texture from this
+            // side of the mesh, so a goggle node isn't handed the shell's.
             let emb = colors
                 .iter()
-                .map(|t| t.name.as_str())
-                .find(|n| is_goggle_name(n) == node_goggle);
+                .map(String::as_str)
+                .find(|n| on_goggle_side(Some(n), is_goggle_name(n), main, goggle) == node_goggle);
             node.texture = wear(emb, node_goggle);
             continue;
         }
         for sm in &mut node.submeshes {
             let emb = material_texture(sm.mat);
-            let goggles_here =
-                node_goggle || is_goggle_name(&sm.name) || emb.is_some_and(is_goggle_name);
-            sm.texture = wear(emb, goggles_here);
+            let spelled = node_goggle || is_goggle_name(&sm.name) || emb.is_some_and(is_goggle_name);
+            sm.texture = wear(emb, on_goggle_side(emb, spelled, main, goggle));
         }
     }
 }
@@ -2074,7 +2167,11 @@ fn load_gear(
     // Only a goggled piece needs the mesh's own materials read back, so only that pays for
     // the extra archive read — the nodes themselves stay cached.
     let mesh = (!goggles.is_empty()).then(|| read_pkz_entry(&pkz, &entry)).flatten();
-    bind_gear_submeshes(&mut nodes, mesh.as_deref(), &main_side, &goggle_side);
+    // The stock model's own paints are what it declares — both sides' names are already in
+    // hand here, decoded from `rider.pkz` above.
+    let declared: Vec<String> =
+        main_side.names.iter().chain(goggle_side.names.iter()).cloned().collect();
+    bind_gear_submeshes(&mut nodes, mesh.as_deref(), &main_side, &goggle_side, &declared);
     log::info!(
         "[rider] {} stock '{name}' loaded: {} nodes, tex={:?} goggles={:?}",
         spec.part,
@@ -2476,7 +2573,7 @@ async fn set_mods_path(
     app: tauri::AppHandle,
     watcher: State<'_, ModWatcher>,
     path: String,
-) -> Result<(), String> {
+) -> Result<String, String> {
     let mut cfg = config::load(&app).unwrap_or_default();
     cfg.mods_path = path;
     let cfg = config::finalize(cfg);
@@ -2484,7 +2581,10 @@ async fn set_mods_path(
     if cfg.watch_mods_reload {
         modwatch::start(&app, &watcher, &cfg.mods_path);
     }
-    Ok(())
+    // The folder actually adopted, which isn't always the one picked: detection fills a
+    // blank, and a pick of the `mods` folder resolves to the game folder above it. Settings
+    // says which it took, so a corrected pick is visible rather than silently different.
+    Ok(cfg.mods_path)
 }
 
 /// Remember that the intro slideshow / guided tour is done. No-ops before the config
@@ -3800,7 +3900,7 @@ mod gear_bind_tests {
     #[test]
     fn a_named_goggle_submesh_wears_the_goggle_paint() {
         let mut nodes = vec![node("helmet", &["shell", "goggle", "lens"])];
-        bind_gear_submeshes(&mut nodes, None, &side(&["hjc"]), &side(&["smoke"]));
+        bind_gear_submeshes(&mut nodes, None, &side(&["hjc"]), &side(&["smoke"]), &[]);
         assert_eq!(
             bound(&nodes),
             [Some("hjc".into()), Some("smoke".into()), Some("smoke".into())],
@@ -3812,7 +3912,7 @@ mod gear_bind_tests {
     #[test]
     fn a_goggle_node_without_submeshes_wears_the_goggle_paint() {
         let mut nodes = vec![node("helmet", &[]), node("goggles", &[])];
-        bind_gear_submeshes(&mut nodes, None, &side(&["hjc"]), &side(&["smoke"]));
+        bind_gear_submeshes(&mut nodes, None, &side(&["hjc"]), &side(&["smoke"]), &[]);
         assert_eq!(bound(&nodes), [Some("hjc".into()), Some("smoke".into())]);
     }
 
@@ -3820,7 +3920,7 @@ mod gear_bind_tests {
     #[test]
     fn a_submesh_inherits_its_node() {
         let mut nodes = vec![node("goggles", &["strap", "glass"])];
-        bind_gear_submeshes(&mut nodes, None, &side(&["hjc"]), &side(&["smoke"]));
+        bind_gear_submeshes(&mut nodes, None, &side(&["hjc"]), &side(&["smoke"]), &[]);
         assert_eq!(bound(&nodes), [Some("smoke".into()), Some("smoke".into())]);
     }
 
@@ -3828,7 +3928,7 @@ mod gear_bind_tests {
     #[test]
     fn unpainted_goggles_fall_back_to_the_shell() {
         let mut nodes = vec![node("helmet", &["shell", "goggle"])];
-        bind_gear_submeshes(&mut nodes, None, &side(&["hjc"]), &GearSide::default());
+        bind_gear_submeshes(&mut nodes, None, &side(&["hjc"]), &GearSide::default(), &[]);
         assert_eq!(bound(&nodes), [Some("hjc".into()), Some("hjc".into())]);
     }
 
@@ -3836,7 +3936,7 @@ mod gear_bind_tests {
     #[test]
     fn an_unpainted_shell_stays_bare() {
         let mut nodes = vec![node("helmet", &["shell", "goggle"])];
-        bind_gear_submeshes(&mut nodes, None, &GearSide::default(), &side(&["smoke"]));
+        bind_gear_submeshes(&mut nodes, None, &GearSide::default(), &side(&["smoke"]), &[]);
         assert_eq!(bound(&nodes), [None, Some("smoke".into())]);
     }
 
@@ -3998,9 +4098,41 @@ mod viewer_tests {
         // What the mesh itself draws each piece from — the reading the binder goes by, and
         // the one worth eyeballing when a helmet's goggles come out wearing the shell.
         if let Some((_, d)) = files.iter().find(|(n, _)| super::is_visible_gear_mesh(n)) {
-            let names: Vec<String> =
-                super::edf::color_textures(d).into_iter().map(|t| t.name).collect();
-            eprintln!("mesh colour textures: {names:?}");
+            // The slots as the loader counts them: what the mesh embeds, plus the sheets it
+            // leaves to a `.pnt`, in the order the model names them.
+            let declared = super::paint_texture_names(
+                files
+                    .iter()
+                    .filter(|(n, _)| {
+                        super::gear_folder_paint_name(n, "paints").is_some()
+                            || super::gear_folder_paint_name(n, "goggles").is_some()
+                    })
+                    .map(|(_, d)| d.as_slice()),
+            );
+            let colors = super::edf::declared_colors(d, &declared);
+            eprintln!("mesh colour textures: {colors:?}");
+            // Per piece, the texture the model was drawn against. This is the evidence the
+            // binder decides on, so when a piece ends up wearing the wrong side it says
+            // whether the reading was wrong or the choice made from it was.
+            for n in &super::edf::parse(d) {
+                eprintln!("mats    {:<28} {:?}", n.name, n.materials);
+                for sm in &n.submeshes {
+                    let emb = sm
+                        .mat
+                        .and_then(|m| n.materials.get(m as usize).copied().flatten())
+                        .and_then(|slot| colors.get(slot))
+                        .map(String::as_str);
+                    // The triangle count tells the pieces apart when their names don't: a
+                    // helmet shell dwarfs its lens, and both dwarf a tear-off film.
+                    eprintln!(
+                        "drawn   {:<28} mat={:?} tris={:<6} -> {}",
+                        format!("{}/{}", n.name, sm.name),
+                        sm.mat,
+                        sm.tri_count,
+                        emb.unwrap_or("(none)"),
+                    );
+                }
+            }
         }
         // Where the mesh sits in its own frame. Protection is authored in the rider's own
         // space, so these bounds say whether a piece is a chest-wide vest or a thin chain

--- a/src-tauri/src/paint.rs
+++ b/src-tauri/src/paint.rs
@@ -93,6 +93,42 @@ pub fn decode(buf: &[u8]) -> Result<Vec<PntTexture>> {
     Ok(out)
 }
 
+/// The texture names a `.pnt` supplies, read from the headers alone.
+///
+/// Every image header is a fixed size and states its payload's length, so the names can be
+/// walked without inflating a single pixel — which matters because they're wanted for their
+/// own sake: they name the textures a model declares and leaves to a paint, and that decides
+/// which slot each of its materials points at.
+pub fn texture_names(buf: &[u8]) -> Result<Vec<String>> {
+    if buf.len() < HEADER_SIZE || &buf[..4] != MAGIC {
+        bail!("not a .pnt file (bad magic)");
+    }
+    let count = read_u32(buf, HEADER_SIZE - 4)? as usize;
+    let mut out = Vec::with_capacity(count);
+    let mut off = HEADER_SIZE;
+    for _ in 0..count {
+        out.push(read_name(buf, off)?);
+        let data_size = read_u32(buf, off + NAME_SIZE + 8 + 16)? as usize;
+        if data_size < IMAGE_PADDING {
+            break;
+        }
+        off = off + IMAGE_HEADER_SIZE + data_size;
+    }
+    Ok(out)
+}
+
+/// [`texture_names`], for a `.pnt` that may be sealed — the same pairing as
+/// [`decode`]/[`decode_any`].
+pub fn texture_names_any(buf: &[u8]) -> Result<Vec<String>> {
+    if buf.len() >= 4 && &buf[..4] == MAGIC {
+        return texture_names(buf);
+    }
+    if let Some(plain) = crate::pkz::read_sidecar_blob(buf) {
+        return texture_names(&plain);
+    }
+    texture_names(buf)
+}
+
 pub fn decode_any(buf: &[u8]) -> Result<Vec<PntTexture>> {
     if buf.len() >= 4 && &buf[..4] == MAGIC {
         return decode(buf);

--- a/src/Components/Library/Library.tsx
+++ b/src/Components/Library/Library.tsx
@@ -590,9 +590,9 @@ export default function Library({
                                   e.stopPropagation();
                                   setView3d(item);
                                 }}
-                                className="flex-none cursor-default rounded-md p-1 text-faint transition-colors hover:bg-foreground/[0.06] hover:text-primary"
+                                className="flex flex-none cursor-default items-center gap-1 whitespace-nowrap rounded-md px-1.5 py-1 text-[11px] font-semibold text-faint transition-colors hover:bg-foreground/[0.06] hover:text-primary"
                               >
-                                <Box className="size-4" />
+                                <Box className="size-3.5" /> {t("library.quick3d")}
                               </button>
                             )}
                             {!selectMode && (
@@ -692,6 +692,8 @@ export default function Library({
         gearSource={view3dProps?.gearSource}
         gearPart={view3dProps?.gearPart}
         stockGearPart={view3dProps?.stockGearPart}
+        initialPaint={view3dProps?.initialPaint}
+        initialGoggles={view3dProps?.initialGoggles}
       />
 
       <MoveDialog

--- a/src/Components/Library/LibraryDetail.tsx
+++ b/src/Components/Library/LibraryDetail.tsx
@@ -323,6 +323,8 @@ export default function LibraryDetail({
         gearSource={view?.gearSource}
         gearPart={view?.gearPart}
         stockGearPart={view?.stockGearPart}
+        initialPaint={view?.initialPaint}
+        initialGoggles={view?.initialGoggles}
       />
     </div>
   );

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -356,10 +356,15 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
     if (typeof picked !== "string") return;
     setBusy(true);
     try {
-      await setModsPath(picked);
+      const adopted = await setModsPath(picked);
       await reloadConfig();
+      // Picking the `mods` folder is the common slip, and the backend quietly corrects it
+      // to the folder above. Say so — a path that isn't the one they chose looks like a bug.
+      const corrected = adopted && adopted !== picked;
       toast.success(t("settings.folderUpdated"), {
-        description: t("settings.folderUpdatedDesc"),
+        description: corrected
+          ? t("settings.folderUsedParent", { folder: adopted })
+          : t("settings.folderUpdatedDesc"),
       });
     } catch (e) {
       toast.error(t("settings.setFolderFailed"), { description: String(e) });

--- a/src/Components/Viewer/ViewerDialog.tsx
+++ b/src/Components/Viewer/ViewerDialog.tsx
@@ -23,6 +23,10 @@ interface ViewerDialogProps {
   gearSource?: string;
   gearPart?: RiderPart["part"];
   stockGearPart?: RiderPart["part"];
+  /** Open on this paint / goggle paint rather than the first in the list — set when a
+   *  paint was opened in 3D and the model shown is the one it belongs to. */
+  initialPaint?: string;
+  initialGoggles?: string;
 }
 
 const EMPTY_GEAR_PAINTS: GearPaints = {
@@ -42,6 +46,14 @@ function withStock(names: string[], hasStock: boolean): string[] {
   return hasStock ? ["Stock", ...names] : names;
 }
 
+/** Where `want` sits in a picker's list, or the first entry when it isn't in it — a paint
+ *  the model doesn't carry (or a list that hasn't loaded) leaves the picker where it was. */
+function indexOfName(names: string[], want?: string): number {
+  if (!want) return 0;
+  const i = names.findIndex((n) => n.toLowerCase() === want.toLowerCase());
+  return i < 0 ? 0 : i;
+}
+
 export function ViewerDialog({
   open,
   onOpenChange,
@@ -51,12 +63,19 @@ export function ViewerDialog({
   gearSource,
   gearPart,
   stockGearPart,
+  initialPaint,
+  initialGoggles,
 }: ViewerDialogProps) {
   const t = useT();
   // A bike model → bike; gear/rider paint → rider. No user switch.
   const isBike = !!modelSource;
   const mode: ViewerMode = isBike ? "bike" : "rider";
-  const [paintIdx, setPaintIdx] = useState(0);
+  // Null until the player picks: the selection falls back to `initialPaint`, and the
+  // names it matches against only arrive once the model (or its archive) has loaded.
+  // Deriving it rather than storing it is what lets a late-arriving list still land on
+  // the right paint without ever overriding a pick made in the meantime.
+  const [paintPick, setPaintPick] = useState<number | null>(null);
+  const [gogglesPick, setGogglesPick] = useState<number | null>(null);
   const [model, setModel] = useState<BikeModel | null>(null);
   const [loadingModel, setLoadingModel] = useState(false);
   // Gear-paint path (no bike model): textures unpacked straight from a `.pnt`.
@@ -65,11 +84,23 @@ export function ViewerDialog({
   const [bodyNodes, setBodyNodes] = useState<EdfNode[] | null>(null);
   const [gear, setGear] = useState<RiderPart | null>(null);
   const [gearPaints, setGearPaints] = useState<GearPaints>(EMPTY_GEAR_PAINTS);
-  const [gogglesIdx, setGogglesIdx] = useState(0);
   const [err, setErr] = useState<string | null>(null);
 
   const nodes = model?.nodes ?? null;
   const paints = model?.paints ?? [];
+
+  // The names behind each picker, in order — the labels shown are decorated versions of
+  // these, and matching happens here so a decoration can never break the match.
+  const paintNames = isBike
+    ? paints.map((p) => p.name)
+    : gearSource
+      ? withStock(gearPaints.paints, gearPaints.hasStock)
+      : paintPaths.map(paintLabel);
+  const goggleNames = gearSource
+    ? withStock(gearPaints.goggles, gearPaints.hasStockGoggles)
+    : [];
+  const paintIdx = paintPick ?? indexOfName(paintNames, initialPaint);
+  const gogglesIdx = gogglesPick ?? indexOfName(goggleNames, initialGoggles);
 
   // Load the real bike geometry + its paints once per open (cached backend-side).
   useEffect(() => {
@@ -88,11 +119,12 @@ export function ViewerDialog({
     };
   }, [open, modelSource]);
 
-  // Reset to the first paint each time it opens.
+  // Drop any pick each time it opens, so the next thing shown starts from its own paint
+  // rather than the index left behind by the last one.
   useEffect(() => {
     if (open) {
-      setPaintIdx(0);
-      setGogglesIdx(0);
+      setPaintPick(null);
+      setGogglesPick(null);
     }
   }, [open]);
 
@@ -236,16 +268,12 @@ export function ViewerDialog({
       ? byName(["livery", "bike_parts"]) ?? null
       : byName(["rider", "suit", "helmet", "gloves", "boots"]) ?? null;
 
-  // Paint dropdown options: a bike's paints, a gear item's packed paints, or loose `.pnt` candidates.
+  // Paint dropdown labels: a bike's paints carry a note when they can't move the preview.
   const paintOptions = isBike
-    ? paints.map((p) => (p.changesPreview ? p.name : `${p.name} — no change here`))
-    : gearSource
-      ? withStock(gearPaints.paints, gearPaints.hasStock)
-      : paintPaths.map(paintLabel);
+    ? paintNames.map((n, i) => (paints[i]?.changesPreview ? n : `${n} — no change here`))
+    : paintNames;
   // A helmet's goggles carry their own paint set (lens/strap) — a second picker.
-  const goggleOptions = gearSource
-    ? withStock(gearPaints.goggles, gearPaints.hasStockGoggles)
-    : [];
+  const goggleOptions = goggleNames;
   const paintNoChange = isBike && paints[paintIdx]?.changesPreview === false;
 
   const loading = loadingModel || loadingPaint;
@@ -271,7 +299,7 @@ export function ViewerDialog({
                 {t("viewer.paint")}
                 <select
                   value={paintIdx}
-                  onChange={(e) => setPaintIdx(Number(e.target.value))}
+                  onChange={(e) => setPaintPick(Number(e.target.value))}
                   className="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground"
                 >
                   {paintOptions.map((name, i) => (
@@ -287,7 +315,7 @@ export function ViewerDialog({
                 {t("category.goggles")}
                 <select
                   value={gogglesIdx}
-                  onChange={(e) => setGogglesIdx(Number(e.target.value))}
+                  onChange={(e) => setGogglesPick(Number(e.target.value))}
                   className="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground"
                 >
                   {goggleOptions.map((name, i) => (

--- a/src/Components/Viewer/entryViewer.ts
+++ b/src/Components/Viewer/entryViewer.ts
@@ -21,6 +21,29 @@ function ownerKey(entry: LibraryEntry): string {
 
 type GearSlot = "helmet" | "boots" | "protection";
 
+/** For each paint category, the model category that wears it. A paint's `parent` names
+ *  one of these, which is what lets a paint be shown on the thing it was painted for. */
+const PAINT_WEARER: Partial<Record<LibraryCategory, LibraryCategory>> = {
+  bikePaint: "bike",
+  helmetPaint: "helmet",
+  // A goggle paint belongs to the helmet whose folder it sits in.
+  goggles: "helmet",
+  bootPaint: "boots",
+  protectionPaint: "protection",
+};
+
+/** The installed model a paint belongs to, if it's in the library. */
+function wearerOf(
+  entry: LibraryEntry,
+  entries: LibraryEntry[],
+): LibraryEntry | undefined {
+  const wearer = PAINT_WEARER[entry.category];
+  if (!wearer || !entry.parent) return undefined;
+  return entries.find(
+    (e) => e.category === wearer && ownerKey(e) === entry.parent,
+  );
+}
+
 /** The `ViewerDialog` props that show a library entry in 3D. */
 export interface EntryViewerProps {
   mode: "bike" | "rider";
@@ -33,12 +56,21 @@ export interface EntryViewerProps {
   gearPart?: GearSlot;
   /** A loose gear paint whose own model may not be installed → the stock model slot. */
   stockGearPart?: GearSlot;
+  /** Paint to open on, by name — set when a paint was clicked and its model was found,
+   *  so the viewer shows that paint rather than whichever one sorts first. */
+  initialPaint?: string;
+  /** Same, for the goggle picker: a goggle paint selects there, not on the shell. */
+  initialGoggles?: string;
 }
 
 /**
  * Resolve the `ViewerDialog` props for a library entry, or `null` when it can't
  * be shown in 3D. Single source of truth shared by the library list's quick-view
  * button and the detail view's "View in 3D" — so the two never drift.
+ *
+ * A paint is shown on the model it was painted for whenever that model is installed:
+ * on its own a `.pnt` is a set of textures with nothing to wrap, and the stock body it
+ * used to fall back on isn't the shape the paint was drawn against.
  */
 export function entryViewerProps(
   entry: LibraryEntry,
@@ -55,6 +87,20 @@ export function entryViewerProps(
   // category renders as a bike. Without the module, offer no bike 3D view at all.
   if (!RIDER_CATS.has(entry.category) && !bikePreview) return null;
 
+  // A paint clicked in the library: show the model that wears it, with it selected.
+  // Both pickers resolve by name, so a paint the model doesn't pack (a loose `.pnt`
+  // dropped beside a `.pkz`) simply leaves the picker where it was.
+  const wearer = isPaint ? wearerOf(entry, entries) : undefined;
+  const onWearer = wearer ? entryViewerProps(wearer, entries, bikePreview) : null;
+  if (onWearer) {
+    return {
+      ...onWearer,
+      ...(entry.category === "goggles"
+        ? { initialGoggles: displayName(entry.name) }
+        : { initialPaint: displayName(entry.name) }),
+    };
+  }
+
   // A gear *model* entry (not a paint) previews on the rider in its own slot.
   const gearPart: GearSlot | undefined = isPaint
     ? undefined
@@ -65,7 +111,7 @@ export function entryViewerProps(
         : entry.category === "protection"
           ? "protection"
           : undefined;
-  // A loose gear *paint* previews on the game's stock model for that slot.
+  // A loose gear paint whose model isn't installed previews on the game's stock model.
   const stockGearPart: GearSlot | undefined =
     entry.category === "helmetPaint"
       ? "helmet"

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -235,9 +235,10 @@ export function createConfig(config: Config): Promise<boolean> {
 }
 
 /** Change only the MX Bikes folder — an empty string re-runs auto-detection. Unlike
- *  `createConfig`, the rest of the settings are preserved. */
-export function setModsPath(path: string): Promise<void> {
-  return invoke<void>("set_mods_path", { path });
+ *  `createConfig`, the rest of the settings are preserved. Resolves to the folder actually
+ *  adopted: picking the `mods` folder settles on the game folder above it. */
+export function setModsPath(path: string): Promise<string> {
+  return invoke<string>("set_mods_path", { path });
 }
 
 /** Persist that the intro slideshow and/or the guided tour is done. */

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -494,7 +494,7 @@ export const de: Translation = {
   "settings.about": "Info & Updates",
   "settings.whatsNew": "Was ist neu",
   "settings.modsFolderDesc":
-    "Wohin Mods installiert werden. Eine Änderung scannt deine Bibliothek neu.",
+    "Wohin Mods installiert werden. Wähle den Ordner, der die Ordner mods und profiles enthält \u2014 also den Ordner über mods, nicht den mods-Ordner selbst. Eine Änderung scannt deine Bibliothek neu.",
   "settings.insideModsFolder": "In deinem {{game}}-Ordner",
   "settings.notSet": "Nicht festgelegt",
   "settings.change": "Ändern…",
@@ -547,6 +547,8 @@ export const de: Translation = {
     "Autostart-Einstellung konnte nicht geändert werden",
   "settings.folderUpdated": "Spielordner aktualisiert",
   "settings.folderUpdatedDesc": "Deine Bibliothek wird neu gescannt.",
+  "settings.folderUsedParent":
+    "Das war der mods-Ordner \u2014 stattdessen wird der Ordner darüber verwendet: {{folder}}",
   "settings.setFolderFailed": "Ordner konnte nicht festgelegt werden",
   "settings.reDetected": "{{game}}-Ordner erneut erkannt",
   "settings.detectFolderFailed": "Ordner konnte nicht erkannt werden",
@@ -689,7 +691,7 @@ export const de: Translation = {
   "library.empty":
     "Noch keine {{type}} installiert — geh zu Entdecken und füge etwas hinzu.",
   "library.noMatches": "Keine Treffer.",
-  "library.quick3d": "Schnelle 3D-Ansicht",
+  "library.quick3d": "In 3D ansehen",
   "library.selectNone": "Auswahl aufheben",
   "library.move": "Verschieben",
   "library.uninstall": "Deinstallieren",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -474,7 +474,7 @@ export const en = {
   "settings.about": "About & updates",
   "settings.whatsNew": "What's new",
   "settings.modsFolderDesc":
-    "Where mods are installed. Changing it re-scans your library.",
+    "Where mods are installed. Pick the folder that holds the mods and profiles folders \u2014 the one above mods, not the mods folder itself. Changing it re-scans your library.",
   "settings.insideModsFolder": "Inside your {{game}} folder",
   "settings.notSet": "Not set",
   "settings.change": "Change…",
@@ -526,6 +526,8 @@ export const en = {
   "settings.startupUpdateFailed": "Couldn't update startup setting",
   "settings.folderUpdated": "Game folder updated",
   "settings.folderUpdatedDesc": "Your library will re-scan.",
+  "settings.folderUsedParent":
+    "That was the mods folder \u2014 used the folder above it: {{folder}}",
   "settings.setFolderFailed": "Couldn't set folder",
   "settings.reDetected": "Re-detected your {{game}} folder",
   "settings.detectFolderFailed": "Couldn't detect folder",
@@ -661,7 +663,7 @@ export const en = {
   "library.scanning": "Scanning your library…",
   "library.empty": "No {{type}} installed yet — head to Browse and add one.",
   "library.noMatches": "No matches.",
-  "library.quick3d": "Quick 3D view",
+  "library.quick3d": "View in 3D",
   "library.selectNone": "Select none",
   "library.move": "Move",
   "library.uninstall": "Uninstall",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -485,7 +485,7 @@ export const es: Translation = {
   "settings.about": "Acerca de y actualizaciones",
   "settings.whatsNew": "Novedades",
   "settings.modsFolderDesc":
-    "Donde se instalan los mods. Cambiarla vuelve a analizar tu biblioteca.",
+    "Donde se instalan los mods. Elige la carpeta que contiene las carpetas mods y profiles \u2014 la de encima de mods, no la carpeta mods en sí. Cambiarla vuelve a analizar tu biblioteca.",
   "settings.insideModsFolder": "Dentro de tu carpeta de {{game}}",
   "settings.notSet": "Sin definir",
   "settings.change": "Cambiar…",
@@ -538,6 +538,8 @@ export const es: Translation = {
     "No se pudo actualizar el inicio automático",
   "settings.folderUpdated": "Carpeta del juego actualizada",
   "settings.folderUpdatedDesc": "Tu biblioteca se volverá a analizar.",
+  "settings.folderUsedParent":
+    "Esa era la carpeta mods \u2014 se usó la carpeta superior: {{folder}}",
   "settings.setFolderFailed": "No se pudo definir la carpeta",
   "settings.reDetected": "Carpeta de {{game}} detectada de nuevo",
   "settings.detectFolderFailed": "No se pudo detectar la carpeta",
@@ -681,7 +683,7 @@ export const es: Translation = {
   "library.empty":
     "Aún no hay {{type}} instaladas — ve a Explorar y añade alguna.",
   "library.noMatches": "Sin resultados.",
-  "library.quick3d": "Vista 3D rápida",
+  "library.quick3d": "Ver en 3D",
   "library.selectNone": "No seleccionar nada",
   "library.move": "Mover",
   "library.uninstall": "Desinstalar",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -489,7 +489,7 @@ export const fr: Translation = {
   "settings.about": "À propos et mises à jour",
   "settings.whatsNew": "Nouveautés",
   "settings.modsFolderDesc":
-    "Là où les mods sont installés. Le modifier relance l'analyse de votre bibliothèque.",
+    "Là où les mods sont installés. Choisissez le dossier qui contient les dossiers mods et profiles \u2014 celui au-dessus de mods, pas le dossier mods lui-même. Le modifier relance l'analyse de votre bibliothèque.",
   "settings.insideModsFolder": "Dans votre dossier {{game}}",
   "settings.notSet": "Non défini",
   "settings.change": "Modifier…",
@@ -543,6 +543,8 @@ export const fr: Translation = {
     "Impossible de mettre à jour le lancement au démarrage",
   "settings.folderUpdated": "Dossier de jeu mis à jour",
   "settings.folderUpdatedDesc": "Votre bibliothèque va être réanalysée.",
+  "settings.folderUsedParent":
+    "C’était le dossier mods \u2014 le dossier au-dessus a été utilisé : {{folder}}",
   "settings.setFolderFailed": "Impossible de définir le dossier",
   "settings.reDetected": "Dossier {{game}} détecté à nouveau",
   "settings.detectFolderFailed": "Impossible de détecter le dossier",
@@ -685,7 +687,7 @@ export const fr: Translation = {
   "library.empty":
     "Aucun mod {{type}} installé — allez dans Parcourir pour en ajouter un.",
   "library.noMatches": "Aucun résultat.",
-  "library.quick3d": "Aperçu 3D rapide",
+  "library.quick3d": "Voir en 3D",
   "library.selectNone": "Tout désélectionner",
   "library.move": "Déplacer",
   "library.uninstall": "Désinstaller",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -481,7 +481,7 @@ export const it: Translation = {
   "settings.about": "Info e aggiornamenti",
   "settings.whatsNew": "Novità",
   "settings.modsFolderDesc":
-    "Dove vengono installate le mod. Cambiandola, la libreria viene riscansionata.",
+    "Dove vengono installate le mod. Scegli la cartella che contiene le cartelle mods e profiles \u2014 quella sopra mods, non la cartella mods stessa. Cambiandola, la libreria viene riscansionata.",
   "settings.insideModsFolder": "Dentro la tua cartella {{game}}",
   "settings.notSet": "Non impostata",
   "settings.change": "Cambia…",
@@ -533,6 +533,8 @@ export const it: Translation = {
     "Impossibile aggiornare l'avvio automatico",
   "settings.folderUpdated": "Cartella di gioco aggiornata",
   "settings.folderUpdatedDesc": "La tua libreria verrà riscansionata.",
+  "settings.folderUsedParent":
+    "Quella era la cartella mods \u2014 è stata usata la cartella sopra: {{folder}}",
   "settings.setFolderFailed": "Impossibile impostare la cartella",
   "settings.reDetected": "Cartella {{game}} rilevata di nuovo",
   "settings.detectFolderFailed": "Impossibile rilevare la cartella",
@@ -676,7 +678,7 @@ export const it: Translation = {
   "library.empty":
     "Nessuna mod {{type}} installata — vai su Esplora e aggiungine una.",
   "library.noMatches": "Nessun risultato.",
-  "library.quick3d": "Anteprima 3D rapida",
+  "library.quick3d": "Vedi in 3D",
   "library.selectNone": "Deseleziona tutto",
   "library.move": "Sposta",
   "library.uninstall": "Disinstalla",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -485,7 +485,7 @@ export const ptBR: Translation = {
   "settings.about": "Sobre e atualizações",
   "settings.whatsNew": "Novidades",
   "settings.modsFolderDesc":
-    "Onde os mods são instalados. Mudar isso faz uma nova varredura da biblioteca.",
+    "Onde os mods são instalados. Escolha a pasta que contém as pastas mods e profiles \u2014 a de cima de mods, não a pasta mods em si. Mudar isso faz uma nova varredura da biblioteca.",
   "settings.insideModsFolder": "Dentro da sua pasta do {{game}}",
   "settings.notSet": "Não definida",
   "settings.change": "Alterar…",
@@ -537,6 +537,8 @@ export const ptBR: Translation = {
     "Não foi possível alterar o início automático",
   "settings.folderUpdated": "Pasta do jogo atualizada",
   "settings.folderUpdatedDesc": "Sua biblioteca será varrida de novo.",
+  "settings.folderUsedParent":
+    "Essa era a pasta mods \u2014 foi usada a pasta acima dela: {{folder}}",
   "settings.setFolderFailed": "Não foi possível definir a pasta",
   "settings.reDetected": "Pasta do {{game}} detectada de novo",
   "settings.detectFolderFailed": "Não foi possível detectar a pasta",
@@ -679,7 +681,7 @@ export const ptBR: Translation = {
   "library.empty":
     "Nenhuma mod de {{type}} instalada — vá em Explorar e adicione uma.",
   "library.noMatches": "Nenhum resultado.",
-  "library.quick3d": "Prévia 3D rápida",
+  "library.quick3d": "Ver em 3D",
   "library.selectNone": "Desmarcar tudo",
   "library.move": "Mover",
   "library.uninstall": "Desinstalar",


### PR DESCRIPTION
## What

Four things, one thread running through most of them — the 3D viewer showing the wrong texture on the wrong piece.

### Helmets whose goggles wore the helmet's paint

The Bell Moto 10 packs are the clear case: shell, tear-off, lens and goggle frame each ended up in the texture belonging to the piece beside it. Reproduced against the real mods (Aeffertz's Armega and Oakley packs, pulled from mxb-mods). Three causes:

- **A model may declare a texture it doesn't embed.** The Moto 10 names its shell sheet and leaves the pixels to a `.pnt`. Material indices count that slot, so counting only the embedded textures slid every piece down by one. `edf::declared_colors` now seats each unembedded name where the model writes it. The names come from the `.pnt` headers alone (`paint::texture_names`) — no pixels inflated.
- **One-character texture names were skipped.** The Oakley pack calls its goggle sheet `O`; dropping it shifted everything after it. The record's shape (power-of-two dimensions, zero pad, payload fits) already rules out a stray letter.
- **Goggle-vs-shell was decided from piece names**, but a helmet names its goggle group after the goggle it ships — `Armega.001`, drawn from `Racecraft`. `on_goggle_side` now asks which side's paint supplies the texture a piece is drawn from, and only falls back to names when neither side claims it.

Two follow-ons: a piece no paint covers (tear-off, visor) keeps the mesh's own texture rather than having the shell's paint stretched over it, and "Stock" is offered only where the mesh really carries the sheet that side's paints replace.

### Clicking a paint previews it on its model

A `.pnt` on its own is a set of textures with nothing to wrap. `entryViewerProps` now resolves the paint's owner through its `parent` and returns that model's props plus the paint to open on. The picker index is derived from the wanted name rather than stored, so a list arriving after the dialog opens still lands right and a manual pick always wins.

### Library

The bare square on each row is now a labelled **View in 3D**.

### Settings

The folder the app wants is the one holding `mods` and `profiles`, not `mods` itself — one click deeper in the picker and easy to land on, after which every scan looks under `<mods>/mods` and the library comes up empty next to a path that reads fine. `config::finalize` climbs out of a pick one level too deep (by name, or by the type folders inside it), so first-run setup and Change… both land right; `set_mods_path` returns the folder adopted and Settings says which one it took. Description reworded in all six locales.

## Testing

- 388 Rust tests pass; `tsc` and `eslint` clean.
- Armega and Oakley Bell Moto 10: shell → `Bell Moto 10`, tear-off → `tearoff`, lens → `lens`, goggle → `Racecraft`/`O`.
- No change to TLD SE4, three Airoh Aviator variants, four Bell Moto 10s from the other pack, Fox Instinct boots, or the rider body end-to-end.
- Bike bindings byte-identical before/after on five OEM bikes (CRF450R, KX250, FC 450, CR250, RM250).
- New tests cover the mods-folder climb-out (and the folder that is *itself* named `mods`, which must be left alone) and a material naming a slot past the embedded textures.
- Not verified visually — screen capture is unavailable in this environment. Worth an eye on the Library row button at three-column width and a helmet paint opening on the right paint.

No DB changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)