### PR TITLE
fix(overlay): close the overlay when focus moves to another app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@
   across it.
 - **A "Stock" option that showed a helmet in the wrong texture.** It's offered only where the
   mesh really carries the sheet that side's paints replace.
+- **The overlay's empty frame left sitting over the game.** Clicking back into MX Bikes with
+  the overlay open stopped drawing the panel but kept its window there — a box over the game
+  that still swallowed clicks. The overlay now closes itself when you click away, to the game
+  or to anything else, and the hotkey brings it straight back. Its own file picker doesn't
+  count, so importing a mod from the overlay no longer risks closing it.
 
 ## 2026-08-08 — v0.8.0 — GP Bikes, dedicated servers, and paint sync
 

--- a/src-tauri/src/gameproc.rs
+++ b/src-tauri/src/gameproc.rs
@@ -116,6 +116,7 @@ mod ffi {
         ) -> Handle;
         pub fn WaitForSingleObject(handle: Handle, ms: u32) -> u32;
         pub fn CloseHandle(handle: Handle) -> i32;
+        pub fn GetCurrentProcessId() -> u32;
     }
 
     /// `EnumWindows` callback: return 0 to stop the walk, non-zero to continue.
@@ -133,6 +134,7 @@ mod ffi {
     #[link(name = "user32")]
     extern "system" {
         pub fn EnumWindows(callback: EnumWindowsProc, lparam: isize) -> i32;
+        pub fn GetForegroundWindow() -> Handle;
         pub fn GetWindowRect(hwnd: Handle, rect: *mut Rect) -> i32;
         pub fn GetWindowThreadProcessId(hwnd: Handle, process_id: *mut u32) -> u32;
         pub fn IsWindowVisible(hwnd: Handle) -> i32;
@@ -282,6 +284,26 @@ pub fn focus_game() -> bool {
     }
 }
 
+/// Is the window the player is working in owned by some *other* process?
+///
+/// The overlay asks this after it loses focus, to tell "clicked back into the game"
+/// (or into any other app) apart from "opened our own file picker" — both take focus
+/// off the overlay, only the first means the player is done with it.
+#[cfg(windows)]
+pub fn foreground_is_another_app() -> bool {
+    // SAFETY: both calls are reads. No foreground window at all (the desktop is
+    // mid-switch) leaves `pid` at 0, which belongs to nobody and counts as neither.
+    unsafe {
+        let hwnd = ffi::GetForegroundWindow();
+        if hwnd.is_null() {
+            return false;
+        }
+        let mut pid = 0u32;
+        ffi::GetWindowThreadProcessId(hwnd, &mut pid);
+        pid != 0 && pid != ffi::GetCurrentProcessId()
+    }
+}
+
 /// Where the game's window sits on the desktop, in physical pixels
 /// (`left, top, right, bottom`).
 ///
@@ -376,6 +398,13 @@ pub fn focus_game() -> bool {
 /// Only Windows has an exclusive-fullscreen mode to be blocked by.
 #[cfg(not(windows))]
 pub fn is_exclusive_fullscreen() -> bool {
+    false
+}
+
+/// A dev machine has no game to click back into, and the overlay there is an ordinary
+/// window that behaves itself when it loses focus — so it never dismisses itself.
+#[cfg(not(windows))]
+pub fn foreground_is_another_app() -> bool {
     false
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3622,6 +3622,15 @@ fn main() {
             Ok(())
         })
         .on_window_event(|window, event| {
+            // The overlay is a HUD over a running game, so clicking back into the game
+            // has to put it away — an unfocused webview stops repainting and leaves an
+            // empty frame over the game that still eats clicks.
+            if let WindowEvent::Focused(false) = event {
+                if window.label() == overlay::LABEL {
+                    overlay::on_focus_lost(window.app_handle());
+                    return;
+                }
+            }
             if let WindowEvent::CloseRequested { api, .. } = event {
                 // Closing the overlay (Alt+F4, its own button) parks it rather than
                 // destroying it, so the next hotkey press doesn't rebuild the webview.

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -9,7 +9,9 @@
 //! What it deliberately does *not* do is draw inside the game's swapchain. Exclusive
 //! fullscreen therefore covers it — see [`fullscreen_hint`].
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
+use std::time::Duration;
 
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager, Runtime, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
@@ -30,6 +32,19 @@ const HEIGHT: f64 = 720.0;
 /// Emitted to the main window when the overlay is summoned but the game owns the
 /// screen exclusively, so the player finds out why nothing appeared.
 const FULLSCREEN_EVENT: &str = "overlay-fullscreen-blocked";
+
+/// How long to let a focus loss settle before deciding the player clicked away.
+///
+/// Windows deactivates us *before* it settles the new foreground window, so an
+/// immediate check still reads our own window and would never hide anything.
+const BLUR_SETTLE: Duration = Duration::from_millis(150);
+
+/// Counts the times the overlay has been put on screen.
+///
+/// A pending blur check reads this to tell "still the same showing" from "hidden and
+/// summoned again while we were waiting" — otherwise a fast hotkey press right after a
+/// click away would be answered by an overlay that closes itself 150ms later.
+static SHOWINGS: AtomicU64 = AtomicU64::new(0);
 
 /// What the Settings panel needs to describe the overlay's current state.
 #[derive(Debug, Clone, Serialize)]
@@ -131,8 +146,63 @@ pub fn toggle<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
     }
     center_over_game(&window);
     window.show().map_err(|e| format!("{e:#}"))?;
+    SHOWINGS.fetch_add(1, Ordering::SeqCst);
     let _ = window.set_focus();
     Ok(())
+}
+
+/// What the desktop looked like once a focus loss had settled.
+#[derive(Debug, Clone, Copy)]
+struct Blur {
+    /// The overlay is still on the same showing it was when focus left.
+    same_showing: bool,
+    /// It's still on the screen — something else may have put it away already.
+    visible: bool,
+    /// The player came back to it during the settle window.
+    refocused: bool,
+    /// Another process owns the foreground now.
+    foreground_is_another_app: bool,
+}
+
+/// Should a blurred overlay take itself off the screen?
+///
+/// Kept separate from the timing and the window handles so the rules can be tested:
+/// they're the whole reason this isn't just "hide on blur".
+fn should_dismiss(blur: Blur) -> bool {
+    blur.same_showing && blur.visible && !blur.refocused && blur.foreground_is_another_app
+}
+
+/// Put the overlay away when the player clicks back into the game.
+///
+/// Without this the window stays up unfocused, and an unfocused webview over a game
+/// that's repainting the screen stops being drawn — leaving its frame sitting on top of
+/// the game as an empty box that still swallows clicks. The window has to actually go.
+///
+/// Deliberately not fired on every blur: our own file picker (Browse → import) takes
+/// focus off the overlay too, and closing the window out from under a dialog it opened
+/// is worse than the bug. Hence the wait, and the check for *whose* window took over.
+pub fn on_focus_lost<R: Runtime>(app: &AppHandle<R>) {
+    let Some(window) = app.get_webview_window(LABEL) else {
+        return;
+    };
+    let showing = SHOWINGS.load(Ordering::SeqCst);
+    std::thread::spawn(move || {
+        std::thread::sleep(BLUR_SETTLE);
+        let blur = Blur {
+            same_showing: SHOWINGS.load(Ordering::SeqCst) == showing,
+            visible: window.is_visible().unwrap_or(false),
+            refocused: window.is_focused().unwrap_or(false),
+            foreground_is_another_app: gameproc::foreground_is_another_app(),
+        };
+        if !should_dismiss(blur) {
+            return;
+        }
+        // `dismiss`, not `hide`: focus is already wherever the player sent it, and
+        // dragging MX Bikes forward would fight the app they just switched to.
+        if let Err(e) = dismiss(window.app_handle()) {
+            log::warn!("overlay didn't close after losing focus: {e}");
+        }
+    });
 }
 
 /// Put the overlay over the game's window, wherever that is.
@@ -326,5 +396,66 @@ mod tests {
         let app = mock_app();
         dismiss(app.handle()).expect("nothing to dismiss is not a failure");
         assert!(app.get_webview_window(LABEL).is_none());
+    }
+
+    /// A blur with nothing else going on: the player clicked back into the game.
+    fn clicked_away() -> Blur {
+        Blur {
+            same_showing: true,
+            visible: true,
+            refocused: false,
+            foreground_is_another_app: true,
+        }
+    }
+
+    #[test]
+    fn clicking_back_into_the_game_closes_the_overlay() {
+        assert!(
+            should_dismiss(clicked_away()),
+            "an overlay left up unfocused is the empty box over the game",
+        );
+    }
+
+    /// Browse's import picker is a window of *our* process, and it deactivates the
+    /// overlay exactly like a click into the game does. Closing the overlay while its
+    /// own dialog is up would strand the player in a file picker with nothing behind it.
+    #[test]
+    fn our_own_file_picker_does_not_close_it() {
+        let blur = Blur {
+            foreground_is_another_app: false,
+            ..clicked_away()
+        };
+        assert!(!should_dismiss(blur));
+    }
+
+    #[test]
+    fn coming_back_during_the_settle_keeps_it_open() {
+        let blur = Blur {
+            refocused: true,
+            ..clicked_away()
+        };
+        assert!(!should_dismiss(blur));
+    }
+
+    /// The hotkey, Esc and the close button all hide the window themselves, and each
+    /// one blurs it on the way out. The pending check must not fire into that.
+    #[test]
+    fn an_already_hidden_overlay_is_left_alone() {
+        let blur = Blur {
+            visible: false,
+            ..clicked_away()
+        };
+        assert!(!should_dismiss(blur));
+    }
+
+    /// Click into the game, then hit the hotkey before the settle is up: the overlay
+    /// the player just summoned must not be closed by the previous showing's blur.
+    #[test]
+    fn a_resummon_during_the_settle_survives() {
+        let blur = Blur {
+            same_showing: false,
+            ..clicked_away()
+        };
+        assert!(!should_dismiss(blur));
     }
 }


### PR DESCRIPTION
## The bug

Clicking back into MX Bikes with the overlay open stopped drawing the panel but left its window there — an empty box over the game that still swallowed clicks. Nothing ever took the overlay off the screen on focus loss, and an unfocused WebView2 over a repainting game stops being drawn. The only ways out (hotkey, Esc, close button) all need the overlay to *have* focus.

## The fix

`WindowEvent::Focused(false)` on the overlay window now schedules a check; 150 ms later the overlay dismisses itself if the player really moved on.

Deliberately not a plain "hide on blur" — three guards, one test each:

| Situation | Why it must not close |
|---|---|
| Our own file picker (Browse → import) | It's a window of *our* process; closing the overlay out from under its own dialog is worse than the bug |
| Hotkey / Esc / close button, which blur on the way out | Already hidden — the pending check must not fire into that |
| Hotkey pressed during the 150 ms settle | A showing counter tells "same showing" from "re-summoned while we waited" |

`dismiss`, not `hide`: focus is already wherever the player sent it, so pulling MX Bikes forward would fight the app they just switched to.

- `overlay.rs` — the settle, the guards, and `should_dismiss` split out so the rules are testable
- `gameproc.rs` — `foreground_is_another_app()`: `GetForegroundWindow` → owning pid vs. our own
- `main.rs` — routes the focus event

No DB/schema changes.

## Verification

- `cargo test` — 389 passed, 0 failed, including 5 new tests over the dismissal rules
- `cargo check --target x86_64-pc-windows-gnu` — exit 0, no new warnings (macOS never builds the Win32 path)
- Behaviour over a live game needs a Windows box: overlay open → click into the game → panel and box both gone, hotkey brings it straight back; import picker leaves it up; alt-tab to another app closes it

## Notes

- macOS is a deliberate no-op — the overlay there stays an ordinary window
- In a dev build, opening DevTools on the overlay would now close it (DevTools is an `msedgewebview2.exe` window); release builds have none
- Still floats above the main app window if you alt-tab straight to it — same class, not this report, left alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
