### PR TITLE
feat(settings): lift the game picker out, and make a beta say so

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,12 @@ jobs:
           # Shop-less variant rather than failing, same as the sidecar step above.
           MXB_SHOP_API_HEADER: ${{ secrets.MXB_SHOP_API_HEADER }}
           MXB_SHOP_API_KEY: ${{ secrets.MXB_SHOP_API_KEY }}
+          # The tag this build came from, baked in by src-tauri/build.rs. tauri.conf.json
+          # carries the plain `0.8.0` and nothing here rewrites it, so the suffix that makes
+          # `v0.8.0-beta.1` a pre-release would otherwise be invisible to the running app —
+          # a beta install would call itself 0.8.0 and show no Beta badge. Only set for real
+          # tags: a workflow_dispatch build's ref_name is a branch, not a version.
+          MXB_RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
         with:
           tagName: ${{ github.ref_type == 'tag' && github.ref_name || format('v{0}', github.run_number) }}
           releaseName: "MXB App ${{ github.ref_type == 'tag' && github.ref_name || format('build-{0}', github.run_number) }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,21 @@
   that was never the shape they were drawn against. A paint whose model isn't installed still
   previews the way it did before.
 
+- **A beta build now says it's a beta.** The About box reads `v0.8.0-beta.1` with a **Beta**
+  badge beside it. The badge existed but could never fire: the packaged version is a plain
+  `0.8.0` and nothing wrote the tag's `-beta.1` suffix into the build, so a beta install
+  called itself the release it precedes.
+
 ### Changed
+- **The game picker moved out of the folder setting.** MX Bikes / GP Bikes now sits in its own
+  **Game** card at the top of Settings, above the folders it scopes, instead of inside the
+  card whose own title it changes. Builds that know one title don't show it at all.
+- **Switching to a game you haven't set up says what to do.** The folder row read a bare "Not
+  set" next to a **Change…** button; it now reads *Select a folder for GP Bikes* next to
+  **Set…**.
+- **"Join a server" is behind the Experimental toggle.** It launches the game with an
+  undocumented connect flag, so it belongs with the rest of the unfinished multiplayer surface
+  rather than being something you find by accident.
 - **The Library's 3D button says what it does.** The bare square on each row is now a
   labelled **View in 3D**.
 - **Settings spells out which folder to pick.** The app wants your MX Bikes folder — the one

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -14,8 +14,29 @@ fn main() {
     println!("cargo::rerun-if-changed=src/sidecar.rs");
 
     shop_credentials();
+    release_tag();
 
     tauri_build::build()
+}
+
+/// Bake in the git tag this build came from, when there is one.
+///
+/// `tauri.conf.json` carries a plain `x.y.z` and the release workflow never rewrites it, so
+/// `package_info().version` can't tell a `v0.8.0-beta.1` build from the `v0.8.0` that follows
+/// it. The tag is the only place that distinction exists — see `experimental_state`, which
+/// prefers this over the packaged version so a beta names itself.
+///
+/// Absent is the normal case (every local build), and `option_env!` then yields `None`.
+fn release_tag() {
+    // Without this, `Swatinem/rust-cache` in CI would reuse an object file compiled against
+    // the previous tag — same reason the shop credentials declare it below.
+    println!("cargo::rerun-if-env-changed=MXB_RELEASE_TAG");
+    if let Some(tag) = std::env::var("MXB_RELEASE_TAG")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+    {
+        println!("cargo::rustc-env=MXB_RELEASE_TAG={}", tag.trim());
+    }
 }
 
 /// Bake the shop-catalog API credential in, when the build has one.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2711,13 +2711,39 @@ fn launch_game(app: tauri::AppHandle) -> Result<gameproc::LaunchOutcome, String>
     gameproc::launch(&cfg).map_err(|e| format!("{e:#}"))
 }
 
+/// The version to *show*, which is the release tag when this build came from one.
+///
+/// `tauri.conf.json` carries a plain `x.y.z` that the release workflow never rewrites, so a
+/// build cut from `v0.8.0-beta.1` packages itself as `0.8.0` — indistinguishable from the
+/// full release that follows. The tag is baked in by `build.rs` (`MXB_RELEASE_TAG`) and is
+/// the only place the pre-release suffix survives.
+///
+/// Deliberately scoped to what the UI displays: the updater and the release showcase compare
+/// against `package_info().version` and must keep doing so.
+///
+/// A tag is only believed when it looks like a version, so a stray `MXB_RELEASE_TAG=main`
+/// can't put a branch name in the About box.
+fn release_version(packaged: String) -> String {
+    pick_release_version(option_env!("MXB_RELEASE_TAG"), packaged)
+}
+
+/// The rule behind [`release_version`], split out because `option_env!` resolves at compile
+/// time — testing it in place would mean a rebuild per case.
+fn pick_release_version(tag: Option<&str>, packaged: String) -> String {
+    tag.map(str::trim)
+        .map(|tag| tag.strip_prefix('v').unwrap_or(tag))
+        .filter(|tag| tag.starts_with(|c: char| c.is_ascii_digit()))
+        .map(str::to_string)
+        .unwrap_or(packaged)
+}
+
 /// Whether the unfinished multiplayer features should be shown, and whether this build is
 /// a pre-release. The frontend gates the Servers tab and the paint-sync UI on the first and
 /// badges the version with the second.
 #[tauri::command]
 fn experimental_state(app: tauri::AppHandle) -> serde_json::Value {
     let cfg = config::load_or_detect(&app).unwrap_or_default();
-    let version = app.package_info().version.to_string();
+    let version = release_version(app.package_info().version.to_string());
     serde_json::json!({
         "enabled": cfg.experimental_enabled(),
         // Set by the env var rather than the setting, so the UI can explain why the toggle
@@ -3785,6 +3811,48 @@ fn main() {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod release_version_tests {
+    use super::*;
+
+    /// The bug this exists for: a build cut from `v0.8.0-beta.1` packages itself as `0.8.0`,
+    /// so the Beta badge — which keys off a pre-release suffix — never fired on any beta.
+    #[test]
+    fn a_release_tag_carries_its_prerelease_suffix() {
+        assert_eq!(
+            pick_release_version(Some("v0.8.0-beta.1"), "0.8.0".into()),
+            "0.8.0-beta.1",
+        );
+    }
+
+    /// Local builds, and the `workflow_dispatch` runs that pass an empty tag.
+    #[test]
+    fn no_tag_leaves_the_packaged_version_alone() {
+        assert_eq!(pick_release_version(None, "0.8.0".into()), "0.8.0");
+        assert_eq!(pick_release_version(Some("  "), "0.8.0".into()), "0.8.0");
+    }
+
+    /// `github.ref_name` is a *branch* outside a tag push. Believing it would put "main" in
+    /// the About box, which reads as a broken build rather than a misconfigured workflow.
+    #[test]
+    fn a_tag_that_isnt_a_version_is_ignored() {
+        for junk in ["main", "chore/harden-release-binary", "vNext"] {
+            assert_eq!(
+                pick_release_version(Some(junk), "0.8.0".into()),
+                "0.8.0",
+                "{junk} should not have been believed",
+            );
+        }
+    }
+
+    /// The `v` is a tag convention, not part of the version — the UI adds its own.
+    #[test]
+    fn the_tags_v_prefix_is_optional() {
+        assert_eq!(pick_release_version(Some("0.9.0"), "0.8.0".into()), "0.9.0");
+        assert_eq!(pick_release_version(Some("v0.9.0"), "0.8.0".into()), "0.9.0");
+    }
 }
 
 #[cfg(test)]

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -65,6 +65,7 @@ const REPO_URL = "https://github.com/Frostn1/mxb-app";
 const DISCORD_URL = "https://discord.gg/3994Rr3ywb";
 
 export type SectionId =
+  | "game"
   | "folder"
   | "general"
   | "overlay"
@@ -72,6 +73,7 @@ export type SectionId =
   | "frostmod"
   | "about";
 const SECTIONS: { id: SectionId; label: TKey }[] = [
+  { id: "game", label: "game.label" },
   { id: "folder", label: "settings.gameFolder" },
   { id: "general", label: "settings.general" },
   { id: "overlay", label: "overlay.section" },
@@ -173,8 +175,10 @@ interface SettingsProps {
 
 export default function Settings({ initialSection, onShowWhatsNew }: SettingsProps) {
   const { t, locale, setLocale } = useI18n();
-  const { config, reloadConfig, game } = useConfig();
+  const { config, reloadConfig, game, games } = useConfig();
   const caps = game.caps;
+  // A build that only knows one title has nothing to switch between — see `GameSwitcher`.
+  const multiGame = games.length > 1;
   const platform = usePlatform();
   const isWindows = platform === "windows";
   const isMac = platform === "macos";
@@ -185,11 +189,20 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
   const { startTour } = useTour();
   const [version, setVersion] = useState("");
   const [experimental, setExperimentalState] = useState<ExperimentalState | null>(null);
+  // The packaged version is always a plain `x.y.z` — the release tag's pre-release suffix
+  // only survives in what the backend reports (see `release_version`), so a beta names
+  // itself here. `getVersion()` covers the moment before that call lands.
+  const shownVersion = experimental?.version || version;
   const [active, setActive] = useState<SectionId>(initialSection ?? "folder");
-  // FrostMod has no GP Bikes build, so its section isn't there to jump to either.
-  const sections = SECTIONS.filter((s) => s.id !== "frostmod" || caps.frostmod);
+  // FrostMod has no GP Bikes build, so its section isn't there to jump to either — and
+  // neither is the game picker when there's only one game to pick.
+  const sections = SECTIONS.filter(
+    (s) =>
+      (s.id !== "frostmod" || caps.frostmod) && (s.id !== "game" || multiGame),
+  );
   const [busy, setBusy] = useState(false);
   const refs = useRef<Record<SectionId, HTMLDivElement | null>>({
+    game: null,
     folder: null,
     general: null,
     overlay: null,
@@ -508,20 +521,32 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
             />
           </div>
 
+          {/* game — which title the app is driving. Its own card, above the folders it
+              scopes: everything below belongs to whatever is picked here, so it isn't a
+              property of the folder setting it used to sit inside. */}
+          {multiGame && (
+            <Section
+              title={t("game.label")}
+              desc={t("settings.gameDesc")}
+              innerRef={(el) => (refs.current.game = el)}
+            >
+              <GameSwitcher />
+            </Section>
+          )}
+
           {/* game folder */}
           <Section
             title={t("setup.modsFolder", { game: game.display })}
             desc={t("settings.modsFolderDesc")}
             innerRef={(el) => (refs.current.folder = el)}
           >
-            {/* Which title everything below belongs to. It sits at the top of this
-                section because it decides which game's folders the rest of it edits. */}
-            <GameSwitcher />
-            <div className="h-px bg-border" />
             <div className="flex gap-2">
               <div className="flex flex-1 items-center gap-2 rounded-lg border border-input bg-background px-3 py-2.5 font-mono text-[12px] text-muted-foreground">
+                {/* Named rather than a bare "Not set": switching to a title the player
+                    hasn't installed lands here, and "Not set" says neither what to set
+                    nor which game it's for. */}
                 <span className="flex-1 truncate" title={config.modsPath}>
-                  {config.modsPath || t("settings.notSet")}
+                  {config.modsPath || t("settings.selectFolderFor")}
                 </span>
                 {config.modsPath && (
                   <span className="flex flex-none items-center gap-1 font-sans text-[11px] font-semibold text-success">
@@ -530,7 +555,7 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
                 )}
               </div>
               <Button variant="outline" size="sm" onClick={changeFolder} disabled={busy}>
-                Change…
+                {config.modsPath ? t("settings.change") : t("settings.set")}
               </Button>
             </div>
             <button
@@ -959,7 +984,7 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
           {/* about */}
           <Section title={t("settings.about")} innerRef={(el) => (refs.current.about = el)}>
             <div className="flex items-center gap-3 text-[12px] text-muted-foreground">
-              <span>mxb-app {version && `v${version}`}</span>
+              <span>{shownVersion ? `mxb-app v${shownVersion}` : "mxb-app"}</span>
               {experimental?.prerelease && (
                 <span className="rounded-full bg-primary/15 px-2 py-0.5 text-[10.5px] font-semibold uppercase tracking-wide text-primary">
                   {t("settings.betaBadge")}

--- a/src/Components/Shell/GameSwitcher.tsx
+++ b/src/Components/Shell/GameSwitcher.tsx
@@ -41,41 +41,39 @@ export default function GameSwitcher() {
   };
 
   return (
-    <div className="pb-3">
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          disabled={busy}
-          className="flex w-full cursor-default items-center gap-2 rounded-lg border border-white/[0.07] px-3 py-2 text-left transition-colors hover:bg-foreground/[0.05] disabled:opacity-60"
-        >
-          <div className="flex min-w-0 flex-1 flex-col">
-            <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-              {t("game.label")}
-            </span>
-            <span className="truncate text-[12.5px] font-semibold">
-              {game.display}
-            </span>
-          </div>
-          {busy ? (
-            <Loader2 className="size-3.5 flex-none animate-spin text-muted-foreground" />
-          ) : (
-            <ChevronsUpDown className="size-3.5 flex-none text-muted-foreground" />
-          )}
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-[196px]">
-          <DropdownMenuLabel>{t("game.switch")}</DropdownMenuLabel>
-          {games.map((g) => (
-            <DropdownMenuItem key={g.id} onSelect={() => void pick(g.id)}>
-              <Check
-                className={cn(
-                  "size-3.5",
-                  g.id === game.id ? "opacity-100" : "opacity-0",
-                )}
-              />
-              <span>{g.display}</span>
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        disabled={busy}
+        className="flex w-full cursor-default items-center gap-2 rounded-lg border border-input bg-background px-3 py-2 text-left transition-colors hover:bg-foreground/[0.05] disabled:opacity-60"
+      >
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            {t("game.label")}
+          </span>
+          <span className="truncate text-[12.5px] font-semibold">
+            {game.display}
+          </span>
+        </div>
+        {busy ? (
+          <Loader2 className="size-3.5 flex-none animate-spin text-muted-foreground" />
+        ) : (
+          <ChevronsUpDown className="size-3.5 flex-none text-muted-foreground" />
+        )}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-[196px]">
+        <DropdownMenuLabel>{t("game.switch")}</DropdownMenuLabel>
+        {games.map((g) => (
+          <DropdownMenuItem key={g.id} onSelect={() => void pick(g.id)}>
+            <Check
+              className={cn(
+                "size-3.5",
+                g.id === game.id ? "opacity-100" : "opacity-0",
+              )}
+            />
+            <span>{g.display}</span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/src/Components/Shell/Sidebar.tsx
+++ b/src/Components/Shell/Sidebar.tsx
@@ -267,10 +267,13 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
           </span>
         </button>
 
-        {/* Join-by-address launches the game with `-directconnect`. Both the argv parser
-            offset it was found at and the default port it assumes are MX Bikes', so it
-            stays behind a capability until GP's are confirmed. */}
-        {caps.joinByAddress && (
+        {/* Join-by-address launches the game with `-directconnect`. Behind the experimental
+            toggle with the rest of the unfinished multiplayer surface: the flag is
+            undocumented by PiBoSo, so it's opt-in rather than something a player finds by
+            accident. Capability-gated on top — both the argv parser offset it was found at
+            and the default port it assumes are MX Bikes', so it waits until GP's are
+            confirmed. */}
+        {experimental && caps.joinByAddress && (
         <>
         <button
           onClick={() => setJoinOpen(true)}

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -497,6 +497,9 @@ export const de: Translation = {
     "Wohin Mods installiert werden. Wähle den Ordner, der die Ordner mods und profiles enthält \u2014 also den Ordner über mods, nicht den mods-Ordner selbst. Eine Änderung scannt deine Bibliothek neu.",
   "settings.insideModsFolder": "In deinem {{game}}-Ordner",
   "settings.notSet": "Nicht festgelegt",
+  "settings.selectFolderFor": "Ordner für {{game}} auswählen",
+  "settings.gameDesc":
+    "Welchen Titel MXB App steuert. Deine Ordner, deine Bibliothek und deine Presets gehören alle zu dem Spiel, das du hier auswählst.",
   "settings.change": "Ändern…",
   "settings.set": "Festlegen…",
   "settings.theme": "Design",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -477,6 +477,9 @@ export const en = {
     "Where mods are installed. Pick the folder that holds the mods and profiles folders \u2014 the one above mods, not the mods folder itself. Changing it re-scans your library.",
   "settings.insideModsFolder": "Inside your {{game}} folder",
   "settings.notSet": "Not set",
+  "settings.selectFolderFor": "Select a folder for {{game}}",
+  "settings.gameDesc":
+    "Which title MXB App is driving. Your folders, library and presets all belong to the game you pick here.",
   "settings.change": "Change…",
   "settings.set": "Set…",
   "settings.theme": "Theme",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -488,6 +488,9 @@ export const es: Translation = {
     "Donde se instalan los mods. Elige la carpeta que contiene las carpetas mods y profiles \u2014 la de encima de mods, no la carpeta mods en sí. Cambiarla vuelve a analizar tu biblioteca.",
   "settings.insideModsFolder": "Dentro de tu carpeta de {{game}}",
   "settings.notSet": "Sin definir",
+  "settings.selectFolderFor": "Selecciona una carpeta para {{game}}",
+  "settings.gameDesc":
+    "Qué juego está gestionando MXB App. Tus carpetas, tu biblioteca y tus presets pertenecen al juego que elijas aquí.",
   "settings.change": "Cambiar…",
   "settings.set": "Definir…",
   "settings.theme": "Tema",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -492,6 +492,9 @@ export const fr: Translation = {
     "Là où les mods sont installés. Choisissez le dossier qui contient les dossiers mods et profiles \u2014 celui au-dessus de mods, pas le dossier mods lui-même. Le modifier relance l'analyse de votre bibliothèque.",
   "settings.insideModsFolder": "Dans votre dossier {{game}}",
   "settings.notSet": "Non défini",
+  "settings.selectFolderFor": "Sélectionnez un dossier pour {{game}}",
+  "settings.gameDesc":
+    "Le jeu que MXB App pilote. Vos dossiers, votre bibliothèque et vos presets appartiennent tous au jeu choisi ici.",
   "settings.change": "Modifier…",
   "settings.set": "Définir…",
   "settings.theme": "Thème",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -484,6 +484,9 @@ export const it: Translation = {
     "Dove vengono installate le mod. Scegli la cartella che contiene le cartelle mods e profiles \u2014 quella sopra mods, non la cartella mods stessa. Cambiandola, la libreria viene riscansionata.",
   "settings.insideModsFolder": "Dentro la tua cartella {{game}}",
   "settings.notSet": "Non impostata",
+  "settings.selectFolderFor": "Seleziona una cartella per {{game}}",
+  "settings.gameDesc":
+    "Quale titolo sta gestendo MXB App. Cartelle, libreria e preset appartengono tutti al gioco che scegli qui.",
   "settings.change": "Cambia…",
   "settings.set": "Imposta…",
   "settings.theme": "Tema",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -488,6 +488,9 @@ export const ptBR: Translation = {
     "Onde os mods são instalados. Escolha a pasta que contém as pastas mods e profiles \u2014 a de cima de mods, não a pasta mods em si. Mudar isso faz uma nova varredura da biblioteca.",
   "settings.insideModsFolder": "Dentro da sua pasta do {{game}}",
   "settings.notSet": "Não definida",
+  "settings.selectFolderFor": "Selecione uma pasta para {{game}}",
+  "settings.gameDesc":
+    "Qual jogo o MXB App está gerenciando. Suas pastas, sua biblioteca e seus presets pertencem todos ao jogo escolhido aqui.",
   "settings.change": "Alterar…",
   "settings.set": "Definir…",
   "settings.theme": "Tema",


### PR DESCRIPTION
Four changes to the app's chrome, all fallout from MXB App now driving two PiBoSo titles.

## The game picker moved out of the folder setting

`GameSwitcher` was rendering *inside* the "MX Bikes folder" card — the control that scopes the whole app presented as a property of one folder setting, and changing the card's own title underneath itself. It now has its own **Game** card at the top of Settings, above the folders it scopes, with its own left-nav entry. Both hide when the build knows only one title.

Its `pb-3` wrapper (padding for the old inline home) is gone, and it moved from `border-white/[0.07]` to `border-input bg-background` to match the folder rows it now sits directly above.

## Switching to a game you haven't set up says what to do

The folder row read a bare **Not set** beside a hardcoded **Change…** — neither said what to set nor for which title. Now: *Select a folder for GP Bikes* beside **Set…**.

Most of that card was already game-aware for free — `interpolate` fills `{{game}}` from the ambient vars set in `App.tsx`, so the card title, picker dialogs and toasts already said "GP Bikes". These two were the only hardcoded spots.

## A beta build now says it's a beta

The Beta badge in About already existed but had **never fired**. `prerelease` is computed as `version.contains('-')` over `package_info().version`, which comes from `tauri.conf.json` — a plain `0.8.0` that the release workflow never rewrites. So a build cut from `v0.8.0-beta.1` reported itself as the release it precedes.

`release.yml` now passes `MXB_RELEASE_TAG` (real tags only — a `workflow_dispatch` run's `ref_name` is a branch), `build.rs` bakes it in, and `experimental_state` prefers it over the packaged version. About reads `mxb-app v0.8.0-beta.1` with the badge beside it.

Deliberately scoped to that one command: the updater and `Showcase/releases.ts` compare against the packaged version and must keep doing so.

## "Join a server" is behind the Experimental toggle

It launches the game with an undocumented connect flag, so it belongs with the rest of the unfinished multiplayer surface rather than being something a player finds by accident. The `experimental` state was already in `Sidebar` for the Servers nav entry.

## Notes

- No DB or schema changes.
- Two new i18n keys across all six locales (`Translation` is `Record<keyof typeof en, string>`, so a miss is a build failure).
- `CHANGELOG.md` updated in the existing `2026-08-08` section rather than opening a duplicate heading.

## Verification

`tsc` clean, eslint clean, `vite build` clean, `cargo check` clean. Four new unit tests cover the tag rule — suffix preserved, no tag falls back, a branch name like `main` is refused, `v` prefix optional. Confirmed `build.rs` actually emits: with `MXB_RELEASE_TAG=v0.9.0-beta.1` the build-script output carries `cargo::rustc-env=MXB_RELEASE_TAG=v0.9.0-beta.1`; without it, nothing.

Not run as an app — `tauri dev` is a ~13min debug build on this machine and MX Bikes is Windows-only, so the layout of the new card is the part that wants a human eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)