### PR TITLE
fix(rider): offer every gear paint, and put boots on the right legs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 2026-08-08 — every gear paint in the picker, and boots on the right legs
+
+### Fixed
+- **Helmet and boots paint lists showed one source and hid the rest.** A gear model can carry
+  its paints in three places — packed inside its `.pkz`, loose in a folder of the same name
+  beside it, or shipped with the game — and the picker stopped at whichever it found first.
+  So a mod installed as a `.pkz` offered only the paint pack you'd added next to it and none
+  of its own, a mod installed as a folder offered only that folder, and the stock helmet and
+  boots offered nothing the game ships at all. Every source is now merged into one list, with
+  a paint that appears in more than one offered once.
+- **The Presets tab never asked a model what paints it carries.** It listed only what the
+  library scan found loose on disk, which is why the same helmet offered a different set of
+  paints in Presets than it did in Rider. Both tabs now read the same list, so they can't
+  disagree, and the "slots reference a mod that is not installed" count is taken from that
+  same list rather than contradicting the dropdown above it.
+- **A paint the picker offered could render as a different one.** With a model installed both
+  as a `.pkz` and as a folder, the viewer opened one of the two and quietly fell back to some
+  other paint when the name you picked lived in the other. It now looks in both.
+- **Boots on the wrong legs.** Which foot went on which side was decided by the two boot
+  meshes' lateral centres, which differ by about a centimetre and a half — each foot's own
+  asymmetry about the mirror plane it was copied across, not a left-right layout. That made it
+  a coin toss settled by how each author happened to build the mesh, so some boots came out
+  mirrored, buckles facing inward. The side is now read from the mesh's own node names
+  (`boot_l` / `boot_r`), with the old measurement kept for meshes that don't say. The preview
+  and the on-body render share the rule, so a boot can't look right in one and wrong in the
+  other.
+
 ## 2026-08-08 — paints preview on their own model, and helmets bind their goggles right
 
 ### Added

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1549,7 +1549,7 @@ async fn load_stock_gear_model(
     .map_err(|e| format!("load_stock_gear_model task failed: {e}"))?
 }
 
-#[derive(serde::Serialize)]
+#[derive(serde::Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct GearPaints {
     paints: Vec<String>,
@@ -1559,6 +1559,34 @@ struct GearPaints {
     /// the game names a `.pnt` there and has no word for "the model's own look".
     has_stock: bool,
     has_stock_goggles: bool,
+}
+
+impl GearPaints {
+    /// Fold another source's paints into this one.
+    ///
+    /// A name that turns up twice is the same look twice — a paint pack installed loose
+    /// beside the `.pkz` it was made for ships the same file names — so repeats are dropped
+    /// rather than offered as two choices.
+    fn absorb(&mut self, other: GearPaints) {
+        let merge = |into: &mut Vec<String>, more: Vec<String>| {
+            for n in more {
+                if !into.iter().any(|have| have.eq_ignore_ascii_case(&n)) {
+                    into.push(n);
+                }
+            }
+        };
+        merge(&mut self.paints, other.paints);
+        merge(&mut self.goggles, other.goggles);
+        self.has_stock |= other.has_stock;
+        self.has_stock_goggles |= other.has_stock_goggles;
+    }
+
+    /// Alphabetical across the merged set — sources arrive sorted individually, which on its
+    /// own would list one source after the other rather than one list of paints.
+    fn sort(&mut self) {
+        self.paints.sort_by_key(|s| s.to_lowercase());
+        self.goggles.sort_by_key(|s| s.to_lowercase());
+    }
 }
 
 fn gear_paints_at(path: &std::path::Path) -> Result<GearPaints, String> {
@@ -1629,33 +1657,91 @@ async fn list_installed_gear_paints(
     model: String,
 ) -> Result<GearPaints, String> {
     tauri::async_runtime::spawn_blocking(move || {
-        let empty = GearPaints {
-            paints: Vec::new(),
-            goggles: Vec::new(),
-            has_stock: false,
-            has_stock_goggles: false,
-        };
         if model.trim().is_empty() {
-            return Ok(empty);
+            return Ok(GearPaints::default());
         }
         let Some(spec) = GEAR.iter().find(|g| g.part == part) else {
-            return Ok(empty);
+            return Ok(GearPaints::default());
         };
         let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
-        let kind_dir = std::path::Path::new(&cfg.mods_path)
-            .join("mods")
-            .join("rider")
-            .join(spec.mods_kind);
-        let stem = model.trim_end_matches(".pkz");
-        for src in [kind_dir.join(stem), kind_dir.join(format!("{stem}.pkz"))] {
-            if src.exists() {
-                return gear_paints_at(&src);
-            }
-        }
-        Ok(empty)
+        Ok(gear_paints_for(&cfg, spec, &model))
     })
     .await
     .map_err(|e| format!("list_installed_gear_paints task failed: {e}"))?
+}
+
+/// Every paint a gear model can be worn in, from every place one can live.
+///
+/// A model reaches the game three ways, and more than one is true at once more often than
+/// not: an unpacked `<model>/` folder, a `<model>.pkz`, and — for the pieces the game itself
+/// ships — a folder inside `rider.pkz`. A paint pack for a packaged mod installs loose in a
+/// folder beside it, because nothing can write into the `.pkz`. So a picker that stopped at
+/// the first source it found showed one of those sets and never the other.
+fn gear_paints_for(cfg: &config::AppConfig, spec: &GearSpec, model: &str) -> GearPaints {
+    let stem = model.trim_end_matches(".pkz");
+    let kind_dir = std::path::Path::new(&cfg.mods_path)
+        .join("mods")
+        .join("rider")
+        .join(spec.mods_kind);
+    let mut out = GearPaints::default();
+    for src in [kind_dir.join(stem), kind_dir.join(format!("{stem}.pkz"))] {
+        if !src.exists() {
+            continue;
+        }
+        match gear_paints_at(&src) {
+            Ok(found) => out.absorb(found),
+            // One unreadable source must not cost the others their paints.
+            Err(e) => log::warn!("[rider] {} paints from {src:?}: {e}", spec.part),
+        }
+    }
+    // The game's own copy of the piece. This is all a stock name — `default`, `full`, `neck`
+    // — has instead of a folder, and a mod installed under a stock name gets both.
+    if let Some(pkz) = resolve_game_pkz(cfg, "rider.pkz") {
+        let folder = format!("rider/{}/{}", spec.pkz_kind, stem);
+        out.absorb(GearPaints {
+            paints: pkz_paint_names(&pkz, &folder, "paints"),
+            goggles: pkz_paint_names(&pkz, &folder, "goggles"),
+            // Whether the stock mesh has a look of its own is a question about the mesh, and
+            // answering it would mean pulling that mesh out of a 100 MB archive every time a
+            // picker opens. The installed sources above answer it where a "Stock" entry is
+            // actually offered.
+            ..GearPaints::default()
+        });
+    }
+    out.sort();
+    out
+}
+
+/// The `.pnt` names under `<folder>/<sub>/` inside a pkz, without reading a byte of pixels.
+///
+/// Names come out of the archive's own directory, which keeps this cheap enough to run every
+/// time a picker opens — the game's `rider.pkz` is around 100 MB, and reading it to list a
+/// dozen names would be felt. That shortcut is the same assumption [`read_pkz_first`] makes,
+/// that the game's own archives are plain zips, with the general reader behind it for
+/// anything else.
+fn pkz_paint_names(pkz: &std::path::Path, folder: &str, sub: &str) -> Vec<String> {
+    let prefix = format!("{folder}/{sub}/").to_ascii_lowercase();
+    let stem = |name: &str| -> Option<String> {
+        let n = name.replace('\\', "/");
+        let lower = n.to_ascii_lowercase();
+        if !lower.starts_with(&prefix) || !lower.ends_with(".pnt") {
+            return None;
+        }
+        let base = n.rsplit('/').next()?;
+        Some(base[..base.len() - ".pnt".len()].to_string())
+    };
+    if pkz::is_plain_zip(pkz) {
+        let Ok(file) = std::fs::File::open(pkz) else {
+            return Vec::new();
+        };
+        let Ok(zip) = zip::ZipArchive::new(file) else {
+            return Vec::new();
+        };
+        return zip.file_names().filter_map(stem).collect();
+    }
+    pkz::read_selected(pkz, |n| stem(n).is_some())
+        .map(|hits| hits.iter().filter_map(|(n, _)| stem(n)).collect())
+        .unwrap_or_default()
 }
 
 fn gear_folder_paint_name(entry: &str, folder: &str) -> Option<String> {
@@ -2111,9 +2197,20 @@ fn load_gear(
     }
 
     if !model.is_empty() {
-        for src in [kind_dir.join(stem), kind_dir.join(format!("{stem}.pkz"))] {
+        let sources = [kind_dir.join(stem), kind_dir.join(format!("{stem}.pkz"))];
+        for (i, src) in sources.iter().enumerate() {
             if !src.exists() {
                 continue;
+            }
+            // The same model can be installed both ways at once — a paint pack for a
+            // packaged mod has nowhere to go but a folder beside it — and only one of the
+            // two is opened here. Carry the named paint over from the other, so a name the
+            // picker offered can't quietly render as whichever paint happened to be first.
+            let mut extra = extra.clone();
+            let other = &sources[1 - i];
+            if other.exists() {
+                extra.extend(gear_paint_from(other, "paints", paint));
+                extra.extend(gear_paint_from(other, "goggles", goggles));
             }
             match load_gear_model_blocking(
                 src.to_string_lossy().into_owned(),
@@ -2123,7 +2220,7 @@ fn load_gear(
                 // The rider wears what the loadout names; "stock" is a preview-only choice.
                 false,
                 false,
-                extra.clone(),
+                extra,
             ) {
                 Ok(part) => {
                     log::info!("[rider] {} '{model}' loaded: {} nodes", spec.part, part.nodes.len());
@@ -2208,6 +2305,30 @@ fn stock_gear_entry(pkz: &std::path::Path, folder: &str) -> Option<String> {
     let hit = found.into_iter().next()?;
     log::info!("[rider] stock '{folder}' doesn't carry the slot's mesh; using '{hit}'");
     Some(hit)
+}
+
+/// One named `.pnt` out of a gear source — an unpacked folder or a `.pkz`, whichever it is —
+/// named the way a gear archive carries it so the loader reads it like any packed paint.
+///
+/// Just the one paint: a helmet folder holds dozens, and this runs to cover the *other*
+/// install of a model the loader already has open, so reading them all would be paying a
+/// hundred megabytes for a file it needs one of. No name wanted, or a source that doesn't
+/// carry it → nothing, and the loader falls back exactly as it did before.
+fn gear_paint_from(src: &std::path::Path, sub: &str, want: &str) -> Vec<(String, Vec<u8>)> {
+    if want.is_empty() {
+        return Vec::new();
+    }
+    let entry = format!("{sub}/{want}.pnt");
+    if src.is_dir() {
+        return std::fs::read(src.join(sub).join(format!("{want}.pnt")))
+            .map(|d| vec![(entry, d)])
+            .unwrap_or_default();
+    }
+    pkz::read_selected(src, |n| {
+        gear_folder_paint_name(n, sub).is_some_and(|p| p.eq_ignore_ascii_case(want))
+    })
+    .map(|hits| hits.into_iter().map(|(_, d)| (entry.clone(), d)).collect())
+    .unwrap_or_default()
 }
 
 /// Loose `.pnt` files in a folder, named as a gear archive would carry them so the loader
@@ -4031,6 +4152,58 @@ mod gear_mount_tests {
 }
 
 #[cfg(test)]
+mod gear_paint_merge_tests {
+    use super::GearPaints;
+
+    fn paints(names: &[&str]) -> GearPaints {
+        GearPaints {
+            paints: names.iter().map(|s| s.to_string()).collect(),
+            ..GearPaints::default()
+        }
+    }
+
+    // The whole point: a model installed as a `.pkz` *and* as a folder of extra paints
+    // offers both sets. Taking the first source is what showed one and hid the other.
+    #[test]
+    fn sources_add_up() {
+        let mut all = paints(&["Black", "Red"]);
+        all.absorb(paints(&["Purple White", "RDS Leopard"]));
+        all.sort();
+        assert_eq!(all.paints, ["Black", "Purple White", "RDS Leopard", "Red"]);
+    }
+
+    // A paint pack ships the same file names as the mod it was made for, so the same look
+    // arrives twice. Twice in a dropdown is a bug, not a choice.
+    #[test]
+    fn a_repeat_is_the_same_look_twice() {
+        let mut all = paints(&["Black", "Red"]);
+        all.absorb(paints(&["black", "Flo"]));
+        all.sort();
+        assert_eq!(all.paints, ["Black", "Flo", "Red"]);
+    }
+
+    // Each source sorts its own names; merged, they have to sort as one list rather than
+    // as one source appended to the next.
+    #[test]
+    fn the_merged_list_sorts_as_one() {
+        let mut all = paints(&["Alpha", "Zulu"]);
+        all.absorb(paints(&["Bravo"]));
+        all.sort();
+        assert_eq!(all.paints, ["Alpha", "Bravo", "Zulu"]);
+    }
+
+    // A "Stock" entry is worth offering as soon as any source's mesh carries its own look.
+    #[test]
+    fn stock_carries_across() {
+        let mut all = GearPaints::default();
+        all.absorb(GearPaints { has_stock: true, ..GearPaints::default() });
+        assert!(all.has_stock);
+        all.absorb(GearPaints::default());
+        assert!(all.has_stock, "a later source without one doesn't take it away");
+    }
+}
+
+#[cfg(test)]
 mod viewer_tests {
     #[test]
     #[ignore]
@@ -4288,6 +4461,76 @@ mod viewer_tests {
                 }
             }
         }
+    }
+
+    /// The picker's paint list against a real install: whatever any single source can
+    /// supply for a model, the merged list offers.
+    ///
+    /// `MXB_MODS=~/Documents/PiBoSo/MX\ Bikes MXB_GEAR_PART=boots \
+    ///   MXB_GEAR_MODEL='Fox Instinct 2.0 by Aeffertz' \
+    ///   cargo test gear_paints_merge_every_source -- --ignored --nocapture`
+    #[test]
+    #[ignore]
+    fn gear_paints_merge_every_source() {
+        let Ok(mods) = std::env::var("MXB_MODS") else {
+            eprintln!("set MXB_MODS to run");
+            return;
+        };
+        let part = std::env::var("MXB_GEAR_PART").unwrap_or_else(|_| "boots".into());
+        let Ok(model) = std::env::var("MXB_GEAR_MODEL") else {
+            eprintln!("set MXB_GEAR_MODEL to run");
+            return;
+        };
+        let cfg = crate::config::AppConfig { mods_path: mods.clone(), ..Default::default() };
+        let spec = super::GEAR.iter().find(|g| g.part == part).expect("a gear slot");
+
+        let merged = super::gear_paints_for(&cfg, spec, &model);
+        eprintln!("merged paints ({}): {:?}", merged.paints.len(), merged.paints);
+        eprintln!("merged goggles ({}): {:?}", merged.goggles.len(), merged.goggles);
+
+        let has = |set: &[String], want: &str| set.iter().any(|n| n.eq_ignore_ascii_case(want));
+
+        // Every source, asked on its own. Each one's paints have to survive the merge —
+        // taking the first source is exactly what dropped the others.
+        let kind_dir =
+            std::path::Path::new(&mods).join("mods").join("rider").join(spec.mods_kind);
+        let stem = model.trim_end_matches(".pkz");
+        let mut sources = 0;
+        for src in [kind_dir.join(stem), kind_dir.join(format!("{stem}.pkz"))] {
+            if !src.exists() {
+                continue;
+            }
+            sources += 1;
+            let alone = super::gear_paints_at(&src).expect("list one source");
+            eprintln!("  {src:?}: {:?}", alone.paints);
+            for p in &alone.paints {
+                assert!(has(&merged.paints, p), "'{p}' from {src:?} survives the merge");
+            }
+            for g in &alone.goggles {
+                assert!(has(&merged.goggles, g), "goggle '{g}' from {src:?} survives the merge");
+            }
+        }
+
+        // The game's own copy, which is all a stock name has and which nothing listed before.
+        if let Some(pkz) = super::resolve_game_pkz(&cfg, "rider.pkz") {
+            let folder = format!("rider/{}/{}", spec.pkz_kind, stem);
+            let stock = super::pkz_paint_names(&pkz, &folder, "paints");
+            eprintln!("  rider.pkz {folder}: {stock:?}");
+            if !stock.is_empty() {
+                sources += 1;
+            }
+            for p in &stock {
+                assert!(has(&merged.paints, p), "stock '{p}' survives the merge");
+            }
+        }
+        assert!(sources > 0, "'{model}' resolved to at least one source");
+        // Nothing is offered twice — a paint pack installed beside the mod it was made for
+        // ships the same names, and the same look twice is not two choices.
+        let mut seen: Vec<String> = merged.paints.iter().map(|s| s.to_lowercase()).collect();
+        let total = seen.len();
+        seen.sort();
+        seen.dedup();
+        assert_eq!(seen.len(), total, "no paint is offered twice");
     }
 
     #[test]

--- a/src/Components/Presets/Presets.tsx
+++ b/src/Components/Presets/Presets.tsx
@@ -70,12 +70,11 @@ import {
   slotsFor,
   EMPTY_LOADOUT,
   loadScans,
-  slotOptions,
-  isMissing,
   missingSlots,
   loadoutSummary,
   type Scans,
 } from "../../lib/presets";
+import { useGearPaints } from "../../lib/useGearPaints";
 
 function humanSize(bytes: number): string {
   if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
@@ -179,6 +178,10 @@ export default function Presets({
 
   const [sharePreset, setSharePreset] = useState<Preset | null>(null);
   const [importOpen, setImportOpen] = useState(false);
+
+  // The paints the chosen helmet, boots and protection carry — packed inside the model or
+  // shipped with the game — merged with the loose ones the library scan found.
+  const { optionsFor, missingFor } = useGearPaints(loadout);
 
   const setSlot = useCallback((key: keyof Loadout, value: string) => {
     setLoadout((prev) => ({ ...prev, [key]: value }));
@@ -384,9 +387,14 @@ export default function Presets({
     })).filter((g) => g.slots.length > 0);
   }, [slots]);
 
+  // Counted through the same lookup the dropdowns use, so a paint the pickers offer is
+  // never also reported as a mod you haven't installed.
   const builderMissing = useMemo(
-    () => (scans ? missingSlots(bike, loadout, scans).length : 0),
-    [scans, bike, loadout],
+    () =>
+      grouped
+        .flatMap((g) => g.slots)
+        .filter((s) => missingFor(s, bike, scans)).length,
+    [scans, bike, grouped, missingFor],
   );
 
   // Wait for the first scan before claiming there's nothing — otherwise the empty
@@ -521,14 +529,14 @@ export default function Presets({
                 </div>
                 <div className="grid grid-cols-1 gap-x-4 gap-y-2.5 sm:grid-cols-2">
                   {g.slots.map((slot) => {
-                    const options = scans ? slotOptions(slot, bike, loadout, scans) : [];
+                    const options = optionsFor(slot, bike, scans);
                     return (
                       <SlotField
                         key={slot.key}
                         slot={slot}
                         value={loadout[slot.key]}
                         options={options}
-                        missing={scans ? isMissing(slot, bike, loadout, scans) : false}
+                        missing={missingFor(slot, bike, scans)}
                         hint={
                           // "No matches." doesn't tell you a swap has to be registered
                           // in the Locker before it can be picked here.

--- a/src/Components/Rider/RiderStudio.tsx
+++ b/src/Components/Rider/RiderStudio.tsx
@@ -6,8 +6,8 @@ import { Button } from "../ui/button";
 import HelpHint from "../ui/help-hint";
 import { Input } from "../ui/input";
 import { Switch } from "../ui/switch";
-import type { GearPaints, Loadout, RiderPart } from "../../types";
-import { listInstalledGearPaints, presetsSave } from "../../api/mods";
+import type { Loadout, RiderPart } from "../../types";
+import { presetsSave } from "../../api/mods";
 import { ViewerPanel } from "../Viewer/ViewerPanel";
 import { SlotField } from "../Presets/SlotField";
 import {
@@ -15,17 +15,9 @@ import {
   SLOT_GROUPS,
   EMPTY_LOADOUT,
   loadScans,
-  slotOptions,
   type Scans,
-  type SlotDef,
 } from "../../lib/presets";
-
-const EMPTY_GEAR_PAINTS: GearPaints = {
-  paints: [],
-  goggles: [],
-  hasStock: false,
-  hasStockGoggles: false,
-};
+import { useGearPaints } from "../../lib/useGearPaints";
 
 const RIDER_GROUPS = SLOT_GROUPS.filter((g) => g.id !== "bike");
 
@@ -51,11 +43,8 @@ export default function RiderStudio({ initialLoadout, onLoaded }: RiderStudioPro
   // reason to hide the slot the rider tab is most often opened for.
   const [hidden, setHidden] = useState<RiderPart["part"][]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [gearPaints, setGearPaints] = useState<Record<"helmet" | "boots" | "protection", GearPaints>>({
-    helmet: EMPTY_GEAR_PAINTS,
-    boots: EMPTY_GEAR_PAINTS,
-    protection: EMPTY_GEAR_PAINTS,
-  });
+  // Paints the chosen models carry, merged with the loose ones the scan found.
+  const { optionsFor, missingFor } = useGearPaints(loadout);
 
   const setSlot = useCallback((key: keyof Loadout, value: string) => {
     setLoadout((prev) => ({ ...prev, [key]: value }));
@@ -111,57 +100,6 @@ export default function RiderStudio({ initialLoadout, onLoaded }: RiderStudioPro
   useEffect(() => {
     void load();
   }, [load]);
-
-  useEffect(() => {
-    let alive = true;
-    const grab = (part: RiderPart["part"], model: string) =>
-      listInstalledGearPaints(part, model).catch(() => EMPTY_GEAR_PAINTS);
-    Promise.all([
-      grab("helmet", loadout.helmet),
-      grab("boots", loadout.boots),
-      grab("protection", loadout.protection),
-    ]).then(([helmet, boots, protection]) => {
-      if (alive) setGearPaints({ helmet, boots, protection });
-    });
-    return () => {
-      alive = false;
-    };
-  }, [loadout.helmet, loadout.boots, loadout.protection]);
-
-  const packedFor = useCallback(
-    (key: keyof Loadout): string[] => {
-      switch (key) {
-        case "helmetPaint":
-          return gearPaints.helmet.paints;
-        case "gogglesPaint":
-          return gearPaints.helmet.goggles;
-        case "bootsPaint":
-          return gearPaints.boots.paints;
-        case "protectionPaint":
-          return gearPaints.protection.paints;
-        default:
-          return [];
-      }
-    },
-    [gearPaints],
-  );
-
-  const optionsFor = useCallback(
-    (slot: SlotDef): string[] => {
-      const base = scans ? slotOptions(slot, "", loadout, scans) : [];
-      return [...new Set([...base, ...packedFor(slot.key)])];
-    },
-    [scans, loadout, packedFor],
-  );
-
-  const missingFor = useCallback(
-    (slot: SlotDef): boolean => {
-      const val = loadout[slot.key];
-      if (slot.freeText || !val) return false;
-      return !optionsFor(slot).includes(val);
-    },
-    [loadout, optionsFor],
-  );
 
   const grouped = useMemo(
     () => RIDER_GROUPS.map((g) => ({ ...g, slots: SLOTS.filter((s) => s.group === g.id) })),
@@ -234,8 +172,8 @@ export default function RiderStudio({ initialLoadout, onLoaded }: RiderStudioPro
                     key={slot.key}
                     slot={slot}
                     value={loadout[slot.key]}
-                    options={optionsFor(slot)}
-                    missing={missingFor(slot)}
+                    options={optionsFor(slot, "", scans)}
+                    missing={missingFor(slot, "", scans)}
                     onChange={(v) => setSlot(slot.key, v)}
                   />
                 ))}

--- a/src/Components/Viewer/ModelViewer.tsx
+++ b/src/Components/Viewer/ModelViewer.tsx
@@ -366,10 +366,49 @@ function RiderGearMesh({
   );
 }
 
-// Boots ship both feet as separate nodes coincident at the ankle; split by their
-// native left-right (Y) centre, one to each side.
-function bootSides(part: RiderPart): { node: EdfNode; side: number }[] {
-  const withY = part.nodes.map((node) => {
+/**
+ * Which leg a boot node belongs on: −1 for the rider's right (−X), +1 for their left (+X).
+ *
+ * The rider faces +Z — the body's name and number planes, which sit on a rider's back, are
+ * at its most negative Z — and in a right-handed Y-up frame a figure facing +Z wears its
+ * left on +X.
+ *
+ * `null` where the mesh doesn't say, which the geometric split below then settles.
+ */
+function namedBootSide(node: EdfNode): number | null {
+  // The node's own name first, then its groups': a pair comes as `boot_l`/`boot_r`, or as
+  // one node holding `lboots`/`rboots`, and either alone identifies the foot.
+  for (const name of [node.name, ...node.submeshes.map((s) => s.name)]) {
+    // Drop the word the piece is named for, leaving the side marker to read on its own:
+    // `boot_l` → `_l`, `lboots` → `l`, `Boot_Right` → `_right`. Whole-word only, so
+    // `boot_lod0` and a group called `plastic` say nothing.
+    const rest = name.toLowerCase().replace(/boots?/g, "");
+    if (/(^|[^a-z])l(eft)?([^a-z]|$)/.test(rest)) return 1;
+    if (/(^|[^a-z])r(ight)?([^a-z]|$)/.test(rest)) return -1;
+  }
+  return null;
+}
+
+/**
+ * Boots ship both feet as separate nodes, near enough coincident at the ankle. Put each on
+ * the leg the mesh says it belongs to.
+ *
+ * The two nodes differ laterally by around a centimetre and a half — that's each foot's own
+ * asymmetry about the mirror plane it was copied across, not a left-right layout — so
+ * splitting them on that centre was a coin toss decided by how an author happened to bias
+ * the mesh, and came out mirrored on the mods that biased it the other way. Names are the
+ * mesh's own statement of which foot is which; the centre only settles a pair that has none.
+ */
+function bootSideOf(part: RiderPart): number[] {
+  const named = part.nodes.map(namedBootSide);
+  // Both feet named, and named as opposites — a lone "left", or two nodes both reading
+  // left, is a naming accident rather than an answer, and the geometry below is better
+  // evidence than half a statement.
+  if (named.length === 2 && named[0] !== null && named[1] !== null && named[0] !== named[1]) {
+    return named as number[];
+  }
+  // Nothing to read: fall back to the pair's own lateral centres, lower to the right.
+  const ys = part.nodes.map((node) => {
     let lo = Infinity;
     let hi = -Infinity;
     for (let i = 1; i < node.positions.length; i += 3) {
@@ -377,10 +416,16 @@ function bootSides(part: RiderPart): { node: EdfNode; side: number }[] {
       if (v < lo) lo = v;
       if (v > hi) hi = v;
     }
-    return { node, y: (lo + hi) / 2 };
+    return (lo + hi) / 2;
   });
-  withY.sort((a, b) => a.y - b.y);
-  return withY.map((w, i) => ({ node: w.node, side: i === 0 ? -1 : 1 }));
+  const lowest = ys.reduce((best, y, i) => (y < ys[best] ? i : best), 0);
+  return part.nodes.map((_, i) => (i === lowest ? -1 : 1));
+}
+
+/** The same split as [`bootSideOf`], paired back up with the nodes it describes. */
+function bootSides(part: RiderPart): { node: EdfNode; side: number }[] {
+  const sides = bootSideOf(part);
+  return part.nodes.map((node, i) => ({ node, side: sides[i] }));
 }
 
 function partBounds(nodes: EdfNode[]) {
@@ -562,11 +607,11 @@ function RiderGearSolo({ part }: { part: RiderPart }) {
       part.part === "boots" && boxes.length === 2 && !boxes.some((b) => b.isEmpty());
     if (pair) {
       const w = Math.max(boxes[0].max.x - boxes[0].min.x, boxes[1].max.x - boxes[1].min.x);
-      // Place each foot on its correct side (camera looks from +X).
-      const firstIsPlusX =
-        boxes[0].min.x + boxes[0].max.x >= boxes[1].min.x + boxes[1].max.x;
-      offsets[0] = (firstIsPlusX ? -1 : 1) * w * 0.55;
-      offsets[1] = (firstIsPlusX ? 1 : -1) * w * 0.55;
+      // Each foot to the side it belongs on — read off the mesh by the same rule the
+      // on-body render uses, so the preview and the rider can't disagree about a boot.
+      const sides = bootSideOf(part);
+      offsets[0] = sides[0] * w * 0.55;
+      offsets[1] = sides[1] * w * 0.55;
     }
     // Straighten each foot so its toe points forward instead of splaying in.
     const yaws = geoms.map((g) => (pair ? straightenYaw(g, rotM) : 0));
@@ -586,7 +631,7 @@ function RiderGearSolo({ part }: { part: RiderPart }) {
     const center = new THREE.Vector3();
     total.getCenter(center);
     return { scale: 1.1 / (Math.max(size.x, size.y, size.z) || 1), offsets, yaws, center };
-  }, [geoms, rot, part.part]);
+  }, [geoms, rot, part]);
   if (!layout) return null;
   return (
     <group scale={layout.scale}>

--- a/src/lib/useGearPaints.ts
+++ b/src/lib/useGearPaints.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useState } from "react";
+import type { GearPaints, Loadout, RiderPart } from "../types";
+import { listInstalledGearPaints } from "../api/mods";
+import { slotOptions, type Scans, type SlotDef } from "./presets";
+
+const EMPTY: GearPaints = {
+  paints: [],
+  goggles: [],
+  hasStock: false,
+  hasStockGoggles: false,
+};
+
+/** The gear slots whose paints live with the model rather than loose on disk. */
+type GearPart = Extract<RiderPart["part"], "helmet" | "boots" | "protection">;
+
+/**
+ * Every paint the chosen helmet, boots and protection can wear, merged with what the
+ * library scan found loose on disk.
+ *
+ * Two sources, because neither sees the other. The library scan walks folders, so it finds
+ * a paint pack installed loose — but never one packed inside a `<model>.pkz`, nor one the
+ * game itself ships. `list_installed_gear_paints` asks the model, which answers for those.
+ * A picker fed by only one of them shows one set and silently drops the other, which is
+ * what the Presets tab did until it grew this.
+ *
+ * Shared rather than written twice: the Rider tab merged them and Presets didn't, and one
+ * tab offering paints the other hides is exactly the drift worth designing out.
+ */
+export function useGearPaints(loadout: Loadout) {
+  const [paints, setPaints] = useState<Record<GearPart, GearPaints>>({
+    helmet: EMPTY,
+    boots: EMPTY,
+    protection: EMPTY,
+  });
+
+  const { helmet: helmetModel, boots: bootsModel, protection: protectionModel } = loadout;
+  useEffect(() => {
+    let alive = true;
+    const grab = (part: GearPart, model: string) =>
+      listInstalledGearPaints(part, model).catch(() => EMPTY);
+    Promise.all([
+      grab("helmet", helmetModel),
+      grab("boots", bootsModel),
+      grab("protection", protectionModel),
+    ]).then(([helmet, boots, protection]) => {
+      if (alive) setPaints({ helmet, boots, protection });
+    });
+    return () => {
+      alive = false;
+    };
+  }, [helmetModel, bootsModel, protectionModel]);
+
+  /** What the models themselves offer for a slot — nothing, for a slot they don't dress. */
+  const packedFor = useCallback(
+    (key: keyof Loadout): string[] => {
+      switch (key) {
+        case "helmetPaint":
+          return paints.helmet.paints;
+        case "gogglesPaint":
+          return paints.helmet.goggles;
+        case "bootsPaint":
+          return paints.boots.paints;
+        case "protectionPaint":
+          return paints.protection.paints;
+        default:
+          return [];
+      }
+    },
+    [paints],
+  );
+
+  /** A slot's full option list: what's installed loose, plus what the model carries. */
+  const optionsFor = useCallback(
+    (slot: SlotDef, bikeid: string, scans: Scans | null): string[] => {
+      const base = scans ? slotOptions(slot, bikeid, loadout, scans) : [];
+      return [...new Set([...base, ...packedFor(slot.key)])];
+    },
+    [loadout, packedFor],
+  );
+
+  /**
+   * Whether the slot names something none of those sources can supply.
+   *
+   * Never before the scan has landed: with nothing yet to check against, every filled slot
+   * would read as a mod you haven't installed, and the warning would flash on every mount.
+   */
+  const missingFor = useCallback(
+    (slot: SlotDef, bikeid: string, scans: Scans | null): boolean => {
+      const val = loadout[slot.key];
+      if (!scans || slot.freeText || !val) return false;
+      return !optionsFor(slot, bikeid, scans).includes(val);
+    },
+    [loadout, optionsFor],
+  );
+
+  return { optionsFor, missingFor };
+}


### PR DESCRIPTION
Two defects reported from the Presets tab: helmet and boots paint lists showing "either the extended or just the stock, but not both", and some boots rendering reversed on the legs.

## Paint lists showed one source and hid the rest

A gear model's paints can live in three places, and usually more than one is true at once:

| Where | Who puts them there |
|---|---|
| `mods/rider/<kind>/<model>/paints/` | a paint pack you install — the only place it *can* go, since nothing can write into a `.pkz` |
| `mods/rider/<kind>/<model>.pkz` | the mod itself |
| `rider.pkz` → `rider/<kind>/<name>/paints/` | the game, and all a stock name (`default`, `full`, `neck`) has |

Every listing path stopped at the first one that existed. Measured on a real install: the Fox Instinct boots' 5 packed paints were invisible behind the 2 loose ones beside them, and `helmet = default` listed nothing the game ships.

- `gear_paints_for` merges all three, deduped case-insensitively and sorted as one list
- `pkz_paint_names` takes names from the archive directory, so the ~100 MB `rider.pkz` costs nothing per picker (it's a plain zip; the general reader is still the fallback)
- **Presets never asked the model at all** — it listed only what the folder scan found, which is why the same helmet offered a different set there than in Rider. Both tabs now share one `useGearPaints` hook, and the "slots reference a mod that is not installed" count comes from that same list instead of contradicting the dropdown above it
- `load_gear` carries a named paint over from the other install of a model, so the picker can't offer something that renders as a different paint

## Boots on the wrong legs

The side was decided from the two boot meshes' lateral centres — which differ by **1.7 cm**, each foot's own asymmetry about the mirror plane it was copied across, not a left-right layout. A coin toss settled by how each author built the mesh, which is why only *some* boots came out mirrored. The mesh says it outright: nodes are `boot_l` / `boot_r`, groups `lboots` / `rboots`. That name now decides, with the old measurement kept for meshes that don't say. `RiderGearSolo` had a third, different rule of its own, so a boot could look right in the preview and wrong on the body; both now share one rule.

Which world side is the rider's left is measured, not assumed: the stock body's name/number planes sit at z −0.115 against bounds [−0.126, +0.110], so the body faces +Z and its left is +X. The same probe confirmed the boots' toes already point forward — the facing was never wrong, only the side.

## Verification

- 392 Rust tests pass, plus 4 new unit tests for the merge and an `#[ignore]`d real-asset test (`gear_paints_merge_every_source`) asserting that whatever any single source supplies survives the merge, with nothing offered twice
- Against a real install: Fox boots now list all 5 packed paints; `helmet = default` lists 5 stock paints + 4 goggles where it listed none; the Airoh helmet's 27 are unchanged
- A scratch tree with the mod installed **both** ways returns 7 = 5 packed + 2 loose
- The naming rule was exercised over 12 cases, including `boot_lod0` and `plastic`, which must say nothing
- `npm run typecheck` and `npm run lint` clean (3 pre-existing warnings)

**Not verified here:** screen recording is unavailable on this machine, so there's no screenshot of the render — the app builds and opens with a clean log, but the visual check is outstanding. And the only locally installed boots mod happens to give the same answer under both the old and new rules, so this machine can show no-regression but not the fix; that needs a mod that was previously mirrored.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
