### PR TITLE
fix(scan): follow folder links so shared paint folders are found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 2026-08-08 — content behind a folder link is found
+
+### Fixed
+- **Paint folders shared between models with a junction or symlink are read again.** If you
+  keep one set of liveries and point several rider models at it — `mklink /J` on Windows, a
+  symlink on Linux and macOS — the app walked straight past the shared folder and showed
+  nothing in it, while the game loaded it fine. The only way to use the app was a copy of
+  every rider and glove paint per model. It now follows the link, so one folder can serve
+  all six of your rider models, and the paint is listed under each of them.
+
+  The cause is the same everywhere it bit: a junction is a *link*, and a directory listing
+  reports it as one rather than as a folder, so a scan that trusted the listing never
+  looked inside. That affected every content scan, not just paints — the Library, Manage,
+  the mod-detail panel, preset bundles and paint sync all shared it.
+- **A content folder that lives on another drive and is linked into place is scanned.** The
+  split layout — `mods\tracks` (or `bikes`, or `rider`) junctioned to somewhere with room
+  for it — used to come up empty.
+- **Auto-reload notices changes made behind a link.** A recursive watch stops at a
+  junction, so dropping a paint into the shared folder never pulsed FrostMod. The folders
+  those links point at are now watched too, and a change in one names every mod pointing
+  at it.
+- **Bundling a preset whose gear folder contains a link no longer fails.** The linked
+  folder's contents are copied into the bundle as real files, since the far end of your
+  junction doesn't exist on the machine that opens it.
+
+Extracted archives are deliberately left alone: a link inside a download you didn't make is
+still refused, which is what stops an archive writing outside the folder it unpacks into.
+
 ## 2026-08-08 — paints preview on their own model, and helmets bind their goggles right
 
 ### Added

--- a/src-tauri/src/bundle.rs
+++ b/src-tauri/src/bundle.rs
@@ -249,7 +249,7 @@ fn dedup_assets(assets: &mut Vec<AssetRef>) {
 
 fn dir_size_deep(dir: &Path) -> u64 {
     let mut total = 0;
-    for e in walkdir::WalkDir::new(dir).into_iter().flatten() {
+    for e in crate::linkwalk::walk(dir).into_iter().flatten() {
         if e.file_type().is_file() {
             total += e.metadata().map(|m| m.len()).unwrap_or(0);
         }
@@ -378,18 +378,11 @@ fn rel_to_native(rel: &str) -> PathBuf {
     p
 }
 
+/// Copy an asset folder into the bundle, resolving any links inside it — a bundle is for
+/// someone else's machine, where the far end of the sender's junction doesn't exist. See
+/// [`crate::linkwalk::copy_tree`].
 fn copy_tree(src: &Path, dst: &Path) -> anyhow::Result<()> {
-    std::fs::create_dir_all(dst)?;
-    for entry in std::fs::read_dir(src)? {
-        let entry = entry?;
-        let target = dst.join(entry.file_name());
-        if entry.file_type()?.is_dir() {
-            copy_tree(&entry.path(), &target)?;
-        } else {
-            std::fs::copy(entry.path(), &target)?;
-        }
-    }
-    Ok(())
+    Ok(crate::linkwalk::copy_tree(src, dst)?)
 }
 
 fn zip_dir(root: &Path, zip_path: &Path) -> anyhow::Result<()> {

--- a/src-tauri/src/dropzone.rs
+++ b/src-tauri/src/dropzone.rs
@@ -298,30 +298,14 @@ fn from_route_rule(rule: RouteRule) -> Option<Verdict> {
 
 const GEAR_DIRS: [&str; 4] = ["helmets", "boots", "protection", "riders"];
 
+// Link-following: what's being classified here is a folder the player dragged in from
+// their own disk, and a junction in it is theirs — see `crate::linkwalk`.
 fn files_in(dir: &Path) -> Vec<PathBuf> {
-    let Ok(rd) = std::fs::read_dir(dir) else {
-        return Vec::new();
-    };
-    let mut v: Vec<PathBuf> = rd
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
-        .map(|e| e.path())
-        .collect();
-    v.sort();
-    v
+    crate::linkwalk::files(dir)
 }
 
 fn dirs_in(dir: &Path) -> Vec<PathBuf> {
-    let Ok(rd) = std::fs::read_dir(dir) else {
-        return Vec::new();
-    };
-    let mut v: Vec<PathBuf> = rd
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
-        .map(|e| e.path())
-        .collect();
-    v.sort();
-    v
+    crate::linkwalk::subdirs(dir)
 }
 
 /// Identify a directory that `plan_placement` had no opinion about.

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -1,9 +1,9 @@
 use crate::game::GameProfile;
+use crate::linkwalk;
 use serde::Serialize;
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
-use walkdir::WalkDir;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -142,7 +142,7 @@ pub fn scan_mods(mods_path: &str, subpath: &str) -> anyhow::Result<Vec<Installed
     }
 
     let mut items = Vec::new();
-    for entry in WalkDir::new(&dir).into_iter().filter_map(|e| e.ok()) {
+    for entry in linkwalk::walk(&dir).into_iter().filter_map(|e| e.ok()) {
         if !entry.file_type().is_file() {
             continue;
         }
@@ -403,7 +403,7 @@ fn sort_entries(v: &mut [LibraryEntry]) {
 /// every track found so far.
 fn scan_tracks(dir: &Path) -> Vec<LibraryEntry> {
     let mut out = Vec::new();
-    let mut walk = WalkDir::new(dir).into_iter();
+    let mut walk = linkwalk::walk(dir).into_iter();
 
     loop {
         let entry = match walk.next() {
@@ -457,7 +457,7 @@ fn scan_bikes(dir: &Path, sound_bikes: &[String]) -> Vec<LibraryEntry> {
         }
     }
 
-    for entry in WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
+    for entry in linkwalk::walk(dir).into_iter().filter_map(|e| e.ok()) {
         if !entry.file_type().is_file() {
             continue;
         }
@@ -554,7 +554,7 @@ fn scan_rider(dir: &Path, game: &GameProfile) -> Vec<LibraryEntry> {
 
 fn scan_generic(dir: &Path) -> Vec<LibraryEntry> {
     let mut out = Vec::new();
-    for entry in WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
+    for entry in linkwalk::walk(dir).into_iter().filter_map(|e| e.ok()) {
         if entry.file_type().is_file() && has_ext(entry.path(), "pkz") {
             out.push(make_entry(dir, entry.path(), "misc", None));
         }
@@ -698,6 +698,71 @@ mod tests {
         let swap = cat(&v, "OEM2024.pkz").unwrap();
         assert_eq!(swap.category, "bikeModelSwap");
         assert_eq!(swap.parent.as_deref(), Some("KTM450"));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// The shared-paints layout, which is what a player with six rider models and one set
+    /// of liveries actually has on disk: the `paints` folders are links to a single folder
+    /// living somewhere else entirely. The game reads them; before this the app didn't,
+    /// and the only way to use it was six copies of every paint.
+    #[cfg(unix)]
+    #[test]
+    fn finds_paints_in_a_folder_that_is_really_a_link() {
+        let root = tmp("lib-linked-paints");
+        let shared = root.join("D_drive/Shared Paints");
+        touch(&shared.join("Frost.pnt"));
+
+        let bikes = root.join("mods/bikes");
+        touch(&bikes.join("KTM450/model.edf"));
+        std::os::unix::fs::symlink(&shared, bikes.join("KTM450/paints")).unwrap();
+
+        let v = scan_library(root.to_str().unwrap(), "mods/bikes", &[], &crate::game::MXB).unwrap();
+        let paint = cat(&v, "Frost.pnt").expect("the livery behind the link is found");
+        assert_eq!(paint.category, "bikePaint");
+        assert_eq!(paint.parent.as_deref(), Some("KTM450"));
+        assert_eq!(
+            paint.folder, "KTM450/paints",
+            "and is addressed where it appears in the tree, not where it's stored",
+        );
+
+        // Same folder, reached through two rider models — each must list it.
+        let riders = root.join("mods/rider/riders");
+        for who in ["Male", "Female"] {
+            fs::create_dir_all(riders.join(who)).unwrap();
+            std::os::unix::fs::symlink(&shared, riders.join(who).join("paints")).unwrap();
+        }
+        let v = scan_library(root.to_str().unwrap(), "mods/rider", &[], &crate::game::MXB).unwrap();
+        let owners: Vec<&str> = v
+            .iter()
+            .filter(|e| e.name == "Frost.pnt")
+            .filter_map(|e| e.parent.as_deref())
+            .collect();
+        assert_eq!(owners, vec!["Female", "Male"], "one paint, worn by both models");
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// A whole content folder moved to another drive and linked back in — the split
+    /// layout, rather than a single shared leaf.
+    #[cfg(unix)]
+    #[test]
+    fn scans_a_type_folder_that_lives_on_another_drive() {
+        let root = tmp("lib-linked-tracks");
+        let elsewhere = root.join("D_drive/tracks");
+        touch(&elsewhere.join("Packed.pkz"));
+        touch(&elsewhere.join("Loose Track/Loose.map"));
+        fs::create_dir_all(root.join("mods")).unwrap();
+        std::os::unix::fs::symlink(&elsewhere, root.join("mods/tracks")).unwrap();
+
+        let v = scan_library(root.to_str().unwrap(), "mods/tracks", &[], &crate::game::MXB).unwrap();
+        assert!(cat(&v, "Packed.pkz").is_some());
+        assert!(cat(&v, "Loose Track").is_some_and(|e| e.category == "track"));
+
+        // And the plain `.pkz` listing Manage reads is the same tree.
+        let mods = scan_mods(root.to_str().unwrap(), "mods/tracks").unwrap();
+        assert_eq!(mods.len(), 1);
+        assert_eq!(mods[0].name, "Packed.pkz");
+
         let _ = fs::remove_dir_all(&root);
     }
 

--- a/src-tauri/src/linkwalk.rs
+++ b/src-tauri/src/linkwalk.rs
@@ -1,0 +1,328 @@
+//! Walking content folders a player has stitched together with links.
+//!
+//! A mods tree is not always a plain tree. One set of paints shared across six rider
+//! models is six `…/riders/<model>/paints` entries pointing at a single folder that lives
+//! somewhere else — a directory junction on Windows, a symlink on Linux and macOS. Both
+//! are *links*, and a link is exactly what a directory entry reports itself as:
+//! `DirEntry::file_type().is_dir()` is **false** for a junction, and `WalkDir` won't
+//! descend through one unless it's told to. So every scanner that asked the directory
+//! *entry* what it was walked straight past the shared folder, and its paints were
+//! invisible in the app while the game loaded them perfectly well.
+//!
+//! Asking the *path* instead — `Path::is_dir`, `read_dir` — follows the link and gets the
+//! answer the player expects. The helpers here are the following-side versions of the
+//! walks the content scanners do, so the app sees the same tree the game does.
+//!
+//! Deliberately scoped to content already sitting on the player's disk. Freshly extracted
+//! archives stay on the *non*-following side (see `install::purge_escapees`): a link
+//! inside a downloaded `.zip` is a stranger's idea of where our files should go, and
+//! following one is how an archive writes outside the folder it was extracted into.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+/// A recursive walk over the player's own content that descends through directory links.
+///
+/// Cycles are walkdir's problem rather than ours: with `follow_links` on, a link that
+/// points at one of its own ancestors is reported as an `Err` for that entry instead of
+/// being followed round forever — and every caller already drops walk errors. Entry types
+/// come from the link's *target*, so `file_type().is_dir()` finally answers the question
+/// callers were actually asking.
+pub fn walk(dir: &Path) -> WalkDir {
+    WalkDir::new(dir).follow_links(true)
+}
+
+/// [`walk`], stopping `max_depth` levels below `dir`.
+pub fn walk_depth(dir: &Path, max_depth: usize) -> WalkDir {
+    walk(dir).max_depth(max_depth)
+}
+
+/// Whether `path` is itself a link: a symlink, or a junction on Windows.
+///
+/// `symlink_metadata` is the point — plain `metadata` resolves the link and would answer
+/// about the target.
+pub fn is_link(path: &Path) -> bool {
+    std::fs::symlink_metadata(path)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+}
+
+/// The immediate children of `dir` that are directories, links to directories included.
+/// Sorted, so a scan of the same folder always comes out in the same order.
+pub fn subdirs(dir: &Path) -> Vec<PathBuf> {
+    children(dir, |p| p.is_dir())
+}
+
+/// The immediate children of `dir` that are files, links to files included.
+pub fn files(dir: &Path) -> Vec<PathBuf> {
+    children(dir, |p| p.is_file())
+}
+
+fn children(dir: &Path, keep: impl Fn(&Path) -> bool) -> Vec<PathBuf> {
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut out: Vec<PathBuf> = rd
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| keep(p))
+        .collect();
+    out.sort();
+    out
+}
+
+/// Directory links under `root`, as `(link, target)` pairs — the shape a caller needs to
+/// treat the far end as if it sat where the link does.
+///
+/// Bounded twice over, because this runs against a folder whose size is the player's
+/// business: `max_depth` keeps it out of a track's interior (the links that matter are
+/// shallow — `bikes/<bike>/paints`, `rider/riders/<model>/paints`), and `cap` stops a
+/// pathological tree from turning into thousands of watch registrations.
+///
+/// Links pointing back inside `root` are left out: whatever is at the far end is already
+/// part of the tree being walked, so treating it as external would double-count it.
+pub fn dir_links(root: &Path, max_depth: usize, cap: usize) -> Vec<(PathBuf, PathBuf)> {
+    let root_real = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let mut out = Vec::new();
+    // Not `walk`: this one is looking *for* the links, so it must see them rather than
+    // transparently step through them.
+    for entry in WalkDir::new(root)
+        .max_depth(max_depth)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let link = entry.path();
+        if !is_link(link) {
+            continue;
+        }
+        // A link to a file, or one whose target has since gone away.
+        if !link.is_dir() {
+            continue;
+        }
+        let Ok(target) = std::fs::canonicalize(link) else {
+            continue;
+        };
+        if target.starts_with(&root_real) {
+            continue;
+        }
+        out.push((link.to_path_buf(), target));
+        if out.len() >= cap {
+            log::warn!(
+                "more than {cap} directory links under {} — ignoring the rest",
+                root.display()
+            );
+            break;
+        }
+    }
+    out
+}
+
+/// Copy `src` to `dst`, materialising directory links into real folders.
+///
+/// The point of the copy decides this: what's being built is a bundle for someone else's
+/// machine, where the far end of a junction doesn't exist. Copying the link itself (or,
+/// as the entry-type version did, handing a directory to `fs::copy` and failing the whole
+/// bundle) ships a preset with a hole in it.
+///
+/// Self-referential links are the hazard that comes with following them, so the chain of
+/// directories currently open is tracked and one that reappears is skipped rather than
+/// descended into again.
+pub fn copy_tree(src: &Path, dst: &Path) -> std::io::Result<()> {
+    let mut open = HashSet::new();
+    copy_tree_inner(src, dst, &mut open)
+}
+
+fn copy_tree_inner(src: &Path, dst: &Path, open: &mut HashSet<PathBuf>) -> std::io::Result<()> {
+    // The identity of a folder is where it really is, not the path we reached it by —
+    // otherwise a two-link cycle looks like two different folders every time round.
+    let id = std::fs::canonicalize(src).unwrap_or_else(|_| src.to_path_buf());
+    if !open.insert(id.clone()) {
+        log::warn!("skipping {} — a link points back into a folder already being copied", src.display());
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)?.flatten() {
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        // `from.is_dir()`, not `entry.file_type()`: a junction is a directory to everyone
+        // except the directory entry describing it.
+        if from.is_dir() {
+            copy_tree_inner(&from, &to, open)?;
+        } else if from.is_file() {
+            std::fs::copy(&from, &to)?;
+        }
+        // Anything else — a broken link, a device node — is not content and is left out.
+    }
+
+    open.remove(&id);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Cross-platform in principle, unix-only in practice: making a link on Windows needs
+    /// either developer mode or `mklink /J`, neither of which a test run can assume.
+    #[cfg(unix)]
+    fn link_dir(target: &Path, link: &Path) {
+        std::os::unix::fs::symlink(target, link).expect("make a directory link");
+    }
+
+    fn tmp(name: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("frost-linkwalk-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn touch(p: &Path) {
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(p, b"x").unwrap();
+    }
+
+    /// The reported bug in miniature: one shared folder, several models pointing at it.
+    #[cfg(unix)]
+    #[test]
+    fn walks_into_a_linked_folder() {
+        let root = tmp("walk");
+        let shared = root.join("Shared Paints");
+        touch(&shared.join("Frost.pnt"));
+
+        let tree = root.join("mods/rider/riders");
+        std::fs::create_dir_all(tree.join("Male")).unwrap();
+        std::fs::create_dir_all(tree.join("Female")).unwrap();
+        link_dir(&shared, &tree.join("Male/paints"));
+        link_dir(&shared, &tree.join("Female/paints"));
+
+        let found: Vec<String> = walk(&tree)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().is_file())
+            .filter_map(|e| e.path().strip_prefix(&tree).ok().map(|p| p.to_string_lossy().into_owned()))
+            .collect();
+        assert!(found.contains(&"Male/paints/Frost.pnt".to_string()), "{found:?}");
+        assert!(found.contains(&"Female/paints/Frost.pnt".to_string()), "{found:?}");
+
+        // And the plain walk is what missed them — the regression this guards.
+        let plain = WalkDir::new(&tree)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().is_file())
+            .count();
+        assert_eq!(plain, 0, "a non-following walk sees nothing behind the link");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A link pointing at one of its own ancestors must end the walk, not run forever.
+    #[cfg(unix)]
+    #[test]
+    fn a_link_that_points_at_its_own_parent_terminates() {
+        let root = tmp("cycle");
+        let tree = root.join("bikes/KTM");
+        touch(&tree.join("model.edf"));
+        link_dir(&root.join("bikes"), &tree.join("loop"));
+
+        let files = walk(&root.join("bikes"))
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().is_file())
+            .count();
+        assert!(files >= 1, "the real file is still found");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn subdirs_and_files_see_through_links() {
+        let root = tmp("children");
+        let elsewhere = root.join("elsewhere");
+        touch(&elsewhere.join("Red.pnt"));
+        let here = root.join("here");
+        std::fs::create_dir_all(&here).unwrap();
+        link_dir(&elsewhere, &here.join("paints"));
+        link_dir(&elsewhere.join("Red.pnt"), &here.join("Blue.pnt"));
+
+        assert_eq!(subdirs(&here), vec![here.join("paints")]);
+        assert_eq!(files(&here), vec![here.join("Blue.pnt")]);
+        assert!(is_link(&here.join("paints")));
+        assert!(!is_link(&elsewhere));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dir_links_reports_the_far_end_and_ignores_links_that_stay_inside() {
+        let root = tmp("links");
+        let outside = root.join("outside");
+        touch(&outside.join("Frost.pnt"));
+        let tree = root.join("mods");
+        std::fs::create_dir_all(tree.join("bikes/KTM")).unwrap();
+        link_dir(&outside, &tree.join("bikes/KTM/paints"));
+        // A link that lands back inside the tree is already being walked.
+        link_dir(&tree.join("bikes/KTM"), &tree.join("bikes/Copy"));
+
+        let links = dir_links(&tree, 4, 16);
+        assert_eq!(links.len(), 1, "{links:?}");
+        assert_eq!(links[0].0, tree.join("bikes/KTM/paints"));
+        assert_eq!(links[0].1, std::fs::canonicalize(&outside).unwrap());
+
+        // Too deep to reach with a shallower budget.
+        assert!(dir_links(&tree, 2, 16).is_empty());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_tree_materialises_linked_folders() {
+        let root = tmp("copy");
+        let shared = root.join("shared");
+        touch(&shared.join("Frost.pnt"));
+        let src = root.join("src");
+        touch(&src.join("model.edf"));
+        link_dir(&shared, &src.join("paints"));
+
+        let dst = root.join("dst");
+        copy_tree(&src, &dst).expect("copy");
+        assert!(dst.join("model.edf").is_file());
+        assert!(dst.join("paints/Frost.pnt").is_file(), "the link's contents came along");
+        assert!(!is_link(&dst.join("paints")), "and arrived as a real folder");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Following links means a cycle is reachable; the copy must stop rather than fill the
+    /// disk with an ever-deeper tree.
+    #[cfg(unix)]
+    #[test]
+    fn copy_tree_stops_at_a_cycle() {
+        let root = tmp("copy-cycle");
+        let src = root.join("src");
+        touch(&src.join("a.txt"));
+        link_dir(&src, &src.join("self"));
+
+        let dst = root.join("dst");
+        copy_tree(&src, &dst).expect("copy");
+        assert!(dst.join("a.txt").is_file(), "the real content is copied");
+        assert!(!dst.join("self").exists(), "the folder pointing back at itself is skipped");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn children_of_a_missing_folder_are_empty_not_an_error() {
+        let root = tmp("missing");
+        assert!(subdirs(&root.join("nope")).is_empty());
+        assert!(files(&root.join("nope")).is_empty());
+        assert!(!is_link(&root.join("nope")));
+        assert!(dir_links(&root.join("nope"), 4, 16).is_empty());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,6 +16,7 @@ mod gameproc;
 mod imgcache;
 mod install;
 mod library;
+mod linkwalk;
 mod lru;
 mod modelswap;
 mod mods;

--- a/src-tauri/src/modwatch.rs
+++ b/src-tauri/src/modwatch.rs
@@ -53,6 +53,20 @@ pub const WATCH_SLUG: &str = "__mods_watch__";
 /// one of these would fire against a file that isn't finished being written.
 const PARTIAL_SUFFIXES: [&str; 6] = [".tmp", ".part", ".partial", ".crdownload", ".download", ".!ut"];
 
+/// How deep to look for folders that are really links to somewhere else.
+///
+/// A recursive watch does not cross a junction — `ReadDirectoryChangesW` stops at a
+/// reparse point — so a player who shares one paints folder between rider models gets no
+/// events for it unless the target is watched in its own right. Four levels reaches every
+/// place such a link is put in practice (`bikes/<bike>/paints`,
+/// `rider/riders/<model>/paints`, `rider/helmets/<helmet>/goggles`) without descending
+/// into a track's interior looking for one.
+const LINK_DEPTH: usize = 4;
+
+/// Upper bound on the extra watches. Each is a real OS handle; a tree with more links
+/// than this is doing something we shouldn't try to keep up with.
+const LINK_CAP: usize = 64;
+
 /// A watcher and the flag that retires it.
 pub struct Running {
     /// Dropping the debouncer stops its background thread.
@@ -145,12 +159,16 @@ pub fn start(app: &AppHandle, state: &ModWatcher, mods_path: &str) {
     let pending: Arc<Mutex<Pending>> = Arc::default();
     let live = Arc::new(AtomicBool::new(true));
     let watched = root.clone();
+    // Folders inside the tree that really live somewhere else. Resolved before the
+    // debouncer is built because its callback needs them to name what changed.
+    let links = crate::linkwalk::dir_links(&root, LINK_DEPTH, LINK_CAP);
+    let event_links = links.clone();
 
     let batch_live = Arc::clone(&live);
     let mut debouncer = match new_debouncer(DEBOUNCE, move |res: DebounceEventResult| match res {
         Ok(events) if !events.is_empty() => {
             let changed: Vec<PathBuf> = events.into_iter().map(|e| e.path).collect();
-            on_batch(&handle, &pending, &batch_live, &watched, changed);
+            on_batch(&handle, &pending, &batch_live, &watched, &event_links, changed);
         }
         Ok(_) => {}
         Err(e) => log::warn!("mods watcher: event error: {e:?}"),
@@ -165,6 +183,20 @@ pub fn start(app: &AppHandle, state: &ModWatcher, mods_path: &str) {
     if let Err(e) = debouncer.watcher().watch(&root, RecursiveMode::Recursive) {
         log::warn!("mods watcher: could not watch {}: {e}", root.display());
         return;
+    }
+
+    // One watch per distinct target: six rider models sharing a paints folder is six
+    // links and one place to watch.
+    let mut targets: Vec<&PathBuf> = links.iter().map(|(_, t)| t).collect();
+    targets.sort();
+    targets.dedup();
+    for target in targets {
+        match debouncer.watcher().watch(target, RecursiveMode::Recursive) {
+            Ok(()) => log::info!("mods watcher: also watching linked folder {}", target.display()),
+            // Best-effort, exactly like the root: a target we can't watch costs the
+            // auto-reload for that folder, not the watcher.
+            Err(e) => log::warn!("mods watcher: could not watch {}: {e}", target.display()),
+        }
     }
 
     log::info!("mods watcher: watching {} for changes", root.display());
@@ -207,6 +239,31 @@ fn mod_key(root: &Path, path: &Path) -> Option<String> {
     Some(format!("{kind}/{name}"))
 }
 
+/// Every mod a changed path belongs to.
+///
+/// Usually exactly one. More than one when the change landed in a folder several mods
+/// link to — dropping a livery into a shared paints folder changes it for all six rider
+/// models pointing at it, and each of them needs naming. The path arrives as the watcher
+/// saw it (under the link's *target*), so it's put back where it appears in the tree
+/// before being reduced.
+fn mod_keys(root: &Path, links: &[(PathBuf, PathBuf)], path: &Path) -> Vec<String> {
+    if let Some(key) = mod_key(root, path) {
+        return vec![key];
+    }
+    let mut out = Vec::new();
+    for (link, target) in links {
+        let Ok(rest) = path.strip_prefix(target) else {
+            continue;
+        };
+        if let Some(key) = mod_key(root, &link.join(rest)) {
+            if !out.contains(&key) {
+                out.push(key);
+            }
+        }
+    }
+    out
+}
+
 /// A debounced batch landed. Fold it into the pending set and make sure something is
 /// waiting for the folder to go quiet.
 fn on_batch(
@@ -214,6 +271,7 @@ fn on_batch(
     pending: &Arc<Mutex<Pending>>,
     live: &Arc<AtomicBool>,
     root: &Path,
+    links: &[(PathBuf, PathBuf)],
     changed: Vec<PathBuf>,
 ) {
     if !live.load(Ordering::SeqCst) {
@@ -222,7 +280,7 @@ fn on_batch(
     let keys: Vec<String> = changed
         .iter()
         .filter(|p| !is_partial(p))
-        .filter_map(|p| mod_key(root, p))
+        .flat_map(|p| mod_keys(root, links, p))
         .collect();
     if keys.is_empty() {
         // Everything in the batch was scratch files, or churn directly in the root.
@@ -321,6 +379,36 @@ mod tests {
         assert_eq!(mod_key(root, root), None);
         // Somewhere else entirely (a watcher restart racing a path change).
         assert_eq!(mod_key(root, Path::new("/elsewhere/x.pkz")), None);
+    }
+
+    /// A livery dropped into a folder that several rider models link to changes all of
+    /// them, and the watcher sees it at the target's own path — outside the tree.
+    #[test]
+    fn a_change_behind_a_link_names_every_mod_pointing_at_it() {
+        let root = Path::new("/games/mxb/mods");
+        let shared = PathBuf::from("/paints/shared");
+        let links = vec![
+            (root.join("rider/riders/Male/paints"), shared.clone()),
+            (root.join("rider/riders/Female/paints"), shared.clone()),
+            (root.join("bikes/KTM 450/paints"), PathBuf::from("/paints/bikes")),
+        ];
+
+        assert_eq!(
+            mod_keys(root, &links, &shared.join("Frost.pnt")),
+            vec!["rider/riders"],
+            "the change is placed back in the tree — both models reduce to the same key",
+        );
+        assert_eq!(
+            mod_keys(root, &links, Path::new("/paints/bikes/Frost.pnt")),
+            vec!["bikes/KTM 450"],
+        );
+        // A path inside the tree still resolves directly, without consulting the links.
+        assert_eq!(
+            mod_keys(root, &links, &root.join("tracks/Red Bud/x.map")),
+            vec!["tracks/Red Bud"],
+        );
+        // And something that is neither still yields nothing.
+        assert!(mod_keys(root, &links, Path::new("/elsewhere/x.pkz")).is_empty());
     }
 
     /// A batch of changed mod keys, as `on_batch` would hand them over.

--- a/src-tauri/src/pkz.rs
+++ b/src-tauri/src/pkz.rs
@@ -8,7 +8,6 @@ use std::io::{Cursor, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::{Condvar, Mutex, Once, OnceLock};
 use tauri::Manager;
-use walkdir::WalkDir;
 
 /// ZIP local-file-header magic ("PK\x03\x04").
 const ZIP_MAGIC: [u8; 4] = [0x50, 0x4b, 0x03, 0x04];
@@ -307,8 +306,7 @@ fn inspect_zip(path: &Path) -> Result<(PkzMeta, Option<(String, Vec<u8>)>)> {
 fn inspect_dir(dir: &Path) -> Result<(PkzMeta, Option<(String, Vec<u8>)>)> {
     // Walk a few levels deep — enough to find the `.ini` and a preview.
     let mut rels: Vec<(String, PathBuf)> = Vec::new();
-    for entry in WalkDir::new(dir)
-        .max_depth(3)
+    for entry in crate::linkwalk::walk_depth(dir, 3)
         .into_iter()
         .filter_map(|e| e.ok())
     {


### PR DESCRIPTION
## The bug

A player who keeps one set of liveries and points several rider models at it — `mklink /J` on Windows, a symlink on Linux and macOS — saw nothing in the app, while the game loaded the folder fine. The only way to use the app was to keep a copy of every rider and glove paint per model.

Reported by a player running six rider models off one shared paints folder, who found that restoring the default layout made the app work again — which is the tell: with no links in the tree, nothing was being skipped.

## Why

A junction is a *link*, and a directory listing says so. `DirEntry::file_type()` reports `is_symlink()` for a junction and never `is_dir()`, and `WalkDir` won't descend through one unless told to. Every scan that trusted the listing walked straight past the linked folder. Asking the *path* instead — `Path::is_dir`, `read_dir` — follows the link and gets the answer the game gets.

So this was never only a paints problem: the Library, Manage, the mod-detail panel, preset bundles and paint sync all read through those same walks.

## The change

New `src-tauri/src/linkwalk.rs` holds the following-side versions of those walks. Wired into:

- **`library.rs`** — all four scans (mods, tracks, bikes, generic). Covers `<bike>/paints` junctioned at a shared folder, and a whole type folder (`mods\tracks`, `bikes`, `rider`) moved to another drive and linked back in.
- **`pkz.rs`** — `inspect_dir`, the mod-detail panel's read of an extracted mod.
- **`bundle.rs`** — folder sizes, and a copy that materialises a linked folder into the bundle. Previously it handed a directory to `fs::copy` and failed the whole preset.
- **`dropzone.rs`** — classifying a folder the player dragged in.
- **`modwatch.rs`** — a recursive watch stops at a reparse point, so auto-reload never saw a paint dropped into the shared folder. Link targets are now watched in their own right, and a change in one names every mod pointing at it.

Cycle safety comes with following links: `walkdir` reports an ancestor loop as an error rather than recursing, and `linkwalk::copy_tree` tracks the chain of folders currently open and skips one that reappears.

## Deliberately out of scope

Archive extraction stays on the non-following side. A link inside a downloaded `.zip` is a stranger's idea of where our files should go, and `install::purge_escapees` exists to refuse it. One consequence, called out rather than quietly shipped: dragging in a folder that *contains* a junction still won't install what's behind it, because that path shares `walk_merge`/`walk_plain` with archive staging. Making it follow links safely means reworking that security boundary, which wants its own change.

## Testing

`cargo test` — 394 passed, 0 failed, 30 ignored (the pre-existing `#[ignore]`d tests needing real MX Bikes assets).

New tests:
- `library::finds_paints_in_a_folder_that_is_really_a_link` — builds the reported layout (one shared folder, a bike and two rider models pointing at it) and asserts the paint is listed under each owner, addressed where it appears in the tree rather than where it's stored.
- `library::scans_a_type_folder_that_lives_on_another_drive` — the split layout, through both `scan_library` and `scan_mods`.
- `modwatch::a_change_behind_a_link_names_every_mod_pointing_at_it`.
- Seven in `linkwalk`, including one asserting a plain walk finds nothing in the same tree (the regression guard), loop termination, and the copy stopping at a cycle.

The symlink tests are `#[cfg(unix)]` — creating a junction on the Windows runner needs privileges CI doesn't have — but the code path under test is the one junctions take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgQbgvLJMLUtToskEmyPwZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgQbgvLJMLUtToskEmyPwZ)_