### PR TITLE
fix(frostmod): follow the active game's folder, and refuse unsafe builds on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,27 @@
   (`boot_l` / `boot_r`), with the old measurement kept for meshes that don't say. The preview
   and the on-body render share the rule, so a boot can't look right in one and wrong in the
   other.
+## 2026-08-08 — FrostMod follows the game you're on
+
+### Fixed
+- **FrostMod now reads the mods folder of the game you're actually playing.** It was told
+  which game to attach to but not where that game's mods live, and its own default was MX
+  Bikes' folder whatever it attached to — so on GP Bikes its track manager, inactive-tracks
+  store and model swap all worked against MX Bikes' folders. The app knows the real folder
+  (including a moved one), so it now sends it.
+- **Switching game restarts FrostMod.** FrostMod reads which game to watch once, at launch,
+  and the app skips starting one when a FrostMod is already running — so switching to GP
+  Bikes left it waiting for MX Bikes forever while the status pill still read "running".
+  This also clears a FrostMod the app didn't launch, which is the case that made it look
+  like nothing was wrong.
+
+### Changed
+- **FrostMod builds that aren't safe on the current game are no longer offered for it.**
+  FrostMod v0.10.0 is the first that attaches to GP Bikes, but its mod reload runs MX
+  Bikes' internals there and takes the game down the first time it's used. On GP Bikes the
+  app now requires v0.11.0 or newer, updates to it automatically, and says so instead of
+  starting a build that would crash. MX Bikes is unaffected — every FrostMod ever released
+  was built for it.
 
 ## 2026-08-08 — paints preview on their own model, and helmets bind their goggles right
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,118 +1,15 @@
 # Changelog
 
-## 2026-08-08 — every gear paint in the picker, and boots on the right legs
-
-### Fixed
-- **Helmet and boots paint lists showed one source and hid the rest.** A gear model can carry
-  its paints in three places — packed inside its `.pkz`, loose in a folder of the same name
-  beside it, or shipped with the game — and the picker stopped at whichever it found first.
-  So a mod installed as a `.pkz` offered only the paint pack you'd added next to it and none
-  of its own, a mod installed as a folder offered only that folder, and the stock helmet and
-  boots offered nothing the game ships at all. Every source is now merged into one list, with
-  a paint that appears in more than one offered once.
-- **The Presets tab never asked a model what paints it carries.** It listed only what the
-  library scan found loose on disk, which is why the same helmet offered a different set of
-  paints in Presets than it did in Rider. Both tabs now read the same list, so they can't
-  disagree, and the "slots reference a mod that is not installed" count is taken from that
-  same list rather than contradicting the dropdown above it.
-- **A paint the picker offered could render as a different one.** With a model installed both
-  as a `.pkz` and as a folder, the viewer opened one of the two and quietly fell back to some
-  other paint when the name you picked lived in the other. It now looks in both.
-- **Boots on the wrong legs.** Which foot went on which side was decided by the two boot
-  meshes' lateral centres, which differ by about a centimetre and a half — each foot's own
-  asymmetry about the mirror plane it was copied across, not a left-right layout. That made it
-  a coin toss settled by how each author happened to build the mesh, so some boots came out
-  mirrored, buckles facing inward. The side is now read from the mesh's own node names
-  (`boot_l` / `boot_r`), with the old measurement kept for meshes that don't say. The preview
-  and the on-body render share the rule, so a boot can't look right in one and wrong in the
-  other.
-## 2026-08-08 — FrostMod follows the game you're on
-
-### Fixed
-- **FrostMod now reads the mods folder of the game you're actually playing.** It was told
-  which game to attach to but not where that game's mods live, and its own default was MX
-  Bikes' folder whatever it attached to — so on GP Bikes its track manager, inactive-tracks
-  store and model swap all worked against MX Bikes' folders. The app knows the real folder
-  (including a moved one), so it now sends it.
-- **Switching game restarts FrostMod.** FrostMod reads which game to watch once, at launch,
-  and the app skips starting one when a FrostMod is already running — so switching to GP
-  Bikes left it waiting for MX Bikes forever while the status pill still read "running".
-  This also clears a FrostMod the app didn't launch, which is the case that made it look
-  like nothing was wrong.
-
-### Changed
-- **FrostMod builds that aren't safe on the current game are no longer offered for it.**
-  FrostMod v0.10.0 is the first that attaches to GP Bikes, but its mod reload runs MX
-  Bikes' internals there and takes the game down the first time it's used. On GP Bikes the
-  app now requires v0.11.0 or newer, updates to it automatically, and says so instead of
-  starting a build that would crash. MX Bikes is unaffected — every FrostMod ever released
-  was built for it.
-
-## 2026-08-08 — paints preview on their own model, and helmets bind their goggles right
-
-### Added
-- **Opening a paint in 3D now shows the model it was painted for, wearing it.** Click a
-  livery, a helmet paint or a goggle paint and the viewer loads the bike or helmet it belongs
-  to and selects that paint in the picker, instead of draping the textures over a stock body
-  that was never the shape they were drawn against. A paint whose model isn't installed still
-  previews the way it did before.
-
-- **A beta build now says it's a beta.** The About box reads `v0.8.0-beta.1` with a **Beta**
-  badge beside it. The badge existed but could never fire: the packaged version is a plain
-  `0.8.0` and nothing wrote the tag's `-beta.1` suffix into the build, so a beta install
-  called itself the release it precedes.
-
-### Changed
-- **The game picker moved out of the folder setting.** MX Bikes / GP Bikes now sits in its own
-  **Game** card at the top of Settings, above the folders it scopes, instead of inside the
-  card whose own title it changes. Builds that know one title don't show it at all.
-- **Switching to a game you haven't set up says what to do.** The folder row read a bare "Not
-  set" next to a **Change…** button; it now reads *Select a folder for GP Bikes* next to
-  **Set…**.
-- **"Join a server" is behind the Experimental toggle.** It launches the game with an
-  undocumented connect flag, so it belongs with the rest of the unfinished multiplayer surface
-  rather than being something you find by accident.
-- **The Library's 3D button says what it does.** The bare square on each row is now a
-  labelled **View in 3D**.
-- **Settings spells out which folder to pick.** The app wants your MX Bikes folder — the one
-  holding `mods` and `profiles` — not the `mods` folder inside it, which is one click deeper
-  in the picker and easy to land on. The setting now says so, and picking `mods` by mistake
-  quietly resolves to the folder above it (Settings says which one it took) rather than
-  leaving you with a library that scans nothing and a path that looks perfectly reasonable.
-
-### Fixed
-- **Helmets whose goggles came out wearing the helmet's paint.** The Bell Moto 10 packs are
-  the clear case: shell, tear-off, lens and goggle frame each ended up in the wrong texture,
-  the goggle worst of all. Three faults behind it, all in how a model's textures are counted
-  and matched:
-  - A helmet needn't ship the sheet its paints replace, and the Moto 10 doesn't — it names
-    it and leaves the pixels to the `.pnt`. That slot was going uncounted, so every piece
-    was drawn from its neighbour's texture.
-  - A one-character texture name (the Oakley pack calls its goggle sheet `O`) was skipped
-    entirely, sliding everything after it by one.
-  - Which pieces are the goggles was decided from their names, and a helmet names its
-    goggle group after the goggle it ships — `Armega`, `Airbrake` — not "goggles". It is now
-    decided by which paint supplies the texture the piece is drawn from, which is the mod's
-    own answer.
-- **Pieces no paint covers keep their own look.** A tear-off film, a visor, anything an author
-  baked into the mesh and left out of the `.pnt` used to have the shell's paint stretched
-  across it.
-- **A "Stock" option that showed a helmet in the wrong texture.** It's offered only where the
-  mesh really carries the sheet that side's paints replace.
-- **The overlay's empty frame left sitting over the game.** Clicking back into MX Bikes with
-  the overlay open stopped drawing the panel but kept its window there — a box over the game
-  that still swallowed clicks. The overlay now closes itself when you click away, to the game
-  or to anything else, and the hotkey brings it straight back. Its own file picker doesn't
-  count, so importing a mod from the overlay no longer risks closing it.
-
 ## 2026-08-08 — v0.8.0 — GP Bikes, dedicated servers, and paint sync
 
 ### Added
-- **FrostMod's live mod reload now works for GP Bikes.** FrostMod v0.10.0 attaches to
-  `gpbikes.exe`, so the status panel, the reload button and the watch-the-folder auto-reload
-  are all available when GP Bikes is the active game — they were hidden before because
-  FrostMod only knew about MX Bikes. The app launches it with the game it's driving, which
-  is what makes it attach; without that it would sit running and never hook anything.
+- **FrostMod's live mod reload now works for GP Bikes.** The status panel, the reload button
+  and the watch-the-folder auto-reload are all available when GP Bikes is the active game —
+  they were hidden before because FrostMod only knew about MX Bikes. The app launches it
+  with the game it's driving and the folder that game's mods live in, which is what makes it
+  attach to the right process and read the right files. This needs **FrostMod v0.11.0 or
+  newer**: v0.10.0 attaches to GP Bikes but reloads using MX Bikes' internals, which crashes
+  it, so the app won't run that build there and updates you to one that works.
 - **The app now drives GP Bikes as well as MX Bikes.** First launch asks which game you're
   setting up before anything else, and the game picker lives in Settings from then on;
   picking a title points the whole app — Library, Manage, Presets, Browse and the
@@ -260,6 +157,16 @@
 - **Shop items now show the store's own description.** The catalog started carrying them
   today — every one of its 1311 products, screenshots and all — and the detail page shows it
   under **About**, the same way a Browse mod's description reads.
+- **Opening a paint in 3D now shows the model it was painted for, wearing it.** Click a
+  livery, a helmet paint or a goggle paint and the viewer loads the bike or helmet it belongs
+  to and selects that paint in the picker, instead of draping the textures over a stock body
+  that was never the shape they were drawn against. A paint whose model isn't installed still
+  previews the way it did before.
+
+- **A beta build now says it's a beta.** The About box reads `v0.8.0-beta.1` with a **Beta**
+  badge beside it. The badge existed but could never fire: the packaged version is a plain
+  `0.8.0` and nothing wrote the tag's `-beta.1` suffix into the build, so a beta install
+  called itself the release it precedes.
 
 ### Changed
 - **Features that don't apply to GP Bikes are hidden rather than half-working.** FrostMod
@@ -288,6 +195,28 @@
   them was being cleaned up for display the moment the catalog loaded — before the grid could
   paint, for 1311 products of which you open maybe two. That work now happens when you open an
   item.
+- **The game picker moved out of the folder setting.** MX Bikes / GP Bikes now sits in its own
+  **Game** card at the top of Settings, above the folders it scopes, instead of inside the
+  card whose own title it changes. Builds that know one title don't show it at all.
+- **Switching to a game you haven't set up says what to do.** The folder row read a bare "Not
+  set" next to a **Change…** button; it now reads *Select a folder for GP Bikes* next to
+  **Set…**.
+- **"Join a server" is behind the Experimental toggle.** It launches the game with an
+  undocumented connect flag, so it belongs with the rest of the unfinished multiplayer surface
+  rather than being something you find by accident.
+- **The Library's 3D button says what it does.** The bare square on each row is now a
+  labelled **View in 3D**.
+- **Settings spells out which folder to pick.** The app wants your MX Bikes folder — the one
+  holding `mods` and `profiles` — not the `mods` folder inside it, which is one click deeper
+  in the picker and easy to land on. The setting now says so, and picking `mods` by mistake
+  quietly resolves to the folder above it (Settings says which one it took) rather than
+  leaving you with a library that scans nothing and a path that looks perfectly reasonable.
+- **FrostMod builds that aren't safe on the current game are no longer offered for it.**
+  FrostMod v0.10.0 is the first that attaches to GP Bikes, but its mod reload runs MX
+  Bikes' internals there and takes the game down the first time it's used. On GP Bikes the
+  app now requires v0.11.0 or newer, updates to it automatically, and says so instead of
+  starting a build that would crash. MX Bikes is unaffected — every FrostMod ever released
+  was built for it.
 
 ### Fixed
 - **A config written by an older build lost track of which game was active.** Builds that
@@ -344,6 +273,62 @@
   and the app window has no address bar or Back button to escape with. They now open in your
   own browser and leave the app where it was. Browse descriptions had the same fault and are
   fixed with it.
+- **Helmets whose goggles came out wearing the helmet's paint.** The Bell Moto 10 packs are
+  the clear case: shell, tear-off, lens and goggle frame each ended up in the wrong texture,
+  the goggle worst of all. Three faults behind it, all in how a model's textures are counted
+  and matched:
+  - A helmet needn't ship the sheet its paints replace, and the Moto 10 doesn't — it names
+    it and leaves the pixels to the `.pnt`. That slot was going uncounted, so every piece
+    was drawn from its neighbour's texture.
+  - A one-character texture name (the Oakley pack calls its goggle sheet `O`) was skipped
+    entirely, sliding everything after it by one.
+  - Which pieces are the goggles was decided from their names, and a helmet names its
+    goggle group after the goggle it ships — `Armega`, `Airbrake` — not "goggles". It is now
+    decided by which paint supplies the texture the piece is drawn from, which is the mod's
+    own answer.
+- **Pieces no paint covers keep their own look.** A tear-off film, a visor, anything an author
+  baked into the mesh and left out of the `.pnt` used to have the shell's paint stretched
+  across it.
+- **A "Stock" option that showed a helmet in the wrong texture.** It's offered only where the
+  mesh really carries the sheet that side's paints replace.
+- **The overlay's empty frame left sitting over the game.** Clicking back into MX Bikes with
+  the overlay open stopped drawing the panel but kept its window there — a box over the game
+  that still swallowed clicks. The overlay now closes itself when you click away, to the game
+  or to anything else, and the hotkey brings it straight back. Its own file picker doesn't
+  count, so importing a mod from the overlay no longer risks closing it.
+- **FrostMod now reads the mods folder of the game you're actually playing.** It was told
+  which game to attach to but not where that game's mods live, and its own default was MX
+  Bikes' folder whatever it attached to — so on GP Bikes its track manager, inactive-tracks
+  store and model swap all worked against MX Bikes' folders. The app knows the real folder
+  (including a moved one), so it now sends it.
+- **Switching game restarts FrostMod.** FrostMod reads which game to watch once, at launch,
+  and the app skips starting one when a FrostMod is already running — so switching to GP
+  Bikes left it waiting for MX Bikes forever while the status pill still read "running".
+  This also clears a FrostMod the app didn't launch, which is the case that made it look
+  like nothing was wrong.
+- **Helmet and boots paint lists showed one source and hid the rest.** A gear model can carry
+  its paints in three places — packed inside its `.pkz`, loose in a folder of the same name
+  beside it, or shipped with the game — and the picker stopped at whichever it found first.
+  So a mod installed as a `.pkz` offered only the paint pack you'd added next to it and none
+  of its own, a mod installed as a folder offered only that folder, and the stock helmet and
+  boots offered nothing the game ships at all. Every source is now merged into one list, with
+  a paint that appears in more than one offered once.
+- **The Presets tab never asked a model what paints it carries.** It listed only what the
+  library scan found loose on disk, which is why the same helmet offered a different set of
+  paints in Presets than it did in Rider. Both tabs now read the same list, so they can't
+  disagree, and the "slots reference a mod that is not installed" count is taken from that
+  same list rather than contradicting the dropdown above it.
+- **A paint the picker offered could render as a different one.** With a model installed both
+  as a `.pkz` and as a folder, the viewer opened one of the two and quietly fell back to some
+  other paint when the name you picked lived in the other. It now looks in both.
+- **Boots on the wrong legs.** Which foot went on which side was decided by the two boot
+  meshes' lateral centres, which differ by about a centimetre and a half — each foot's own
+  asymmetry about the mirror plane it was copied across, not a left-right layout. That made it
+  a coin toss settled by how each author happened to build the mesh, so some boots came out
+  mirrored, buckles facing inward. The side is now read from the mesh's own node names
+  (`boot_l` / `boot_r`), with the old measurement kept for meshes that don't say. The preview
+  and the on-body render share the rule, so a boot can't look right in one and wrong in the
+  other.
 
 ### Notes
 - Instant profile refresh stays MX Bikes only. Unlike FrostMod's reload, it calls a

--- a/src-tauri/src/frostmod.rs
+++ b/src-tauri/src/frostmod.rs
@@ -232,6 +232,34 @@ pub fn model_refresh_is_safe(tag: Option<&str>) -> bool {
     }
 }
 
+/// The oldest FrostMod that is safe to run against GP Bikes.
+///
+/// Same shape as [`MODEL_REFRESH_MIN_VERSION`], and the same kind of reason. FrostMod
+/// v0.10.0 is the first build that attaches to `gpbikes.exe` at all — but its reload ran
+/// MX Bikes' step table inside GP Bikes, calling arbitrary functions and zeroing arbitrary
+/// globals, which crashed the game on the first reload. v0.11.0 gives GP Bikes its own
+/// table and refuses the reload outright for any title that has none.
+///
+/// So the floor is not "does this build know about GP Bikes" (v0.10.0 does) but "will this
+/// build avoid taking the game down" — which starts at v0.11.0.
+pub const GPB_MIN_VERSION: &str = "v0.11.0";
+
+/// Is the installed FrostMod, tagged `tag`, safe to offer for `game`?
+///
+/// MX Bikes is unaffected: every FrostMod that ever shipped was built for it. An
+/// unreadable tag is treated as unsafe for the same reason as `model_refresh_is_safe` —
+/// the cost of guessing wrong is a crash to desktop, not an over-cautious toast.
+pub fn supported_for_game(game: crate::game::Game, tag: Option<&str>) -> bool {
+    let min = match game {
+        crate::game::Game::Mxb => return true,
+        crate::game::Game::Gpb => GPB_MIN_VERSION,
+    };
+    match (tag.and_then(version_parts), version_parts(min)) {
+        (Some(have), Some(floor)) => have >= floor,
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -293,6 +321,48 @@ mod tests {
         assert!(!model_refresh_is_safe(Some("")));
         assert!(!model_refresh_is_safe(Some("nightly")));
         assert!(!model_refresh_is_safe(Some("v-broken-")));
+    }
+
+    /// Every FrostMod ever released was built for MX Bikes, so the GP floor must not
+    /// touch it — including builds too old to have heard of GP Bikes, and unreadable ones.
+    #[test]
+    fn mx_bikes_accepts_every_build() {
+        for tag in [Some("v0.9.9"), Some("v0.10.0"), Some("v0.11.0"), Some("nightly"), None] {
+            assert!(
+                supported_for_game(crate::game::Game::Mxb, tag),
+                "MX Bikes should accept {tag:?}"
+            );
+        }
+    }
+
+    /// The case this floor exists for: v0.10.0 is the first build that attaches to GP
+    /// Bikes, and its reload runs MX Bikes' offsets there. "Knows about GP Bikes" and
+    /// "is safe on GP Bikes" are different versions, and this is the gap between them.
+    #[test]
+    fn gp_bikes_rejects_the_build_that_crashes_it() {
+        assert!(!supported_for_game(crate::game::Game::Gpb, Some("v0.10.0")));
+        assert!(!supported_for_game(crate::game::Game::Gpb, Some("v0.10.0-rc1")));
+        assert!(!supported_for_game(crate::game::Game::Gpb, Some("v0.9.11")));
+        assert!(supported_for_game(crate::game::Game::Gpb, Some("v0.11.0")));
+        assert!(supported_for_game(crate::game::Game::Gpb, Some("v0.11.0-rc1")));
+        assert!(supported_for_game(crate::game::Game::Gpb, Some("v1.0.0")));
+    }
+
+    /// Same numeric-not-lexical trap the model-refresh floor documents: "v0.11.0" sorts
+    /// below "v0.9.11" as a string, and a GP floor is exactly where that would bite.
+    #[test]
+    fn the_gp_floor_compares_numerically() {
+        assert!(supported_for_game(crate::game::Game::Gpb, Some("v0.11.0")));
+        assert!(!supported_for_game(crate::game::Game::Gpb, Some("v0.9.99")));
+    }
+
+    /// An unreadable tag is a build we can't vouch for, and the cost of guessing wrong
+    /// here is the game going down — so GP Bikes withholds, as the model refresh does.
+    #[test]
+    fn gp_bikes_withholds_from_a_version_it_cannot_read() {
+        assert!(!supported_for_game(crate::game::Game::Gpb, None));
+        assert!(!supported_for_game(crate::game::Game::Gpb, Some("")));
+        assert!(!supported_for_game(crate::game::Game::Gpb, Some("nightly")));
     }
 
     #[test]

--- a/src-tauri/src/frostmod_manage.rs
+++ b/src-tauri/src/frostmod_manage.rs
@@ -34,6 +34,11 @@ pub struct FrostmodStatus {
     pub needs_repair: bool,
     /// Whether FrostMod is currently running (its reload event exists).
     pub running: bool,
+    /// Whether the installed build is safe to run against the active game. False means
+    /// "installed, but too old for this title" — see `frostmod::supported_for_game`. The
+    /// UI offers an update instead of a start; starting it anyway is what crashed GP
+    /// Bikes, so `start` refuses too.
+    pub supported_for_game: bool,
 }
 
 fn frostmod_dir(app: &AppHandle) -> PathBuf {
@@ -205,12 +210,19 @@ pub async fn status(app: &AppHandle) -> FrostmodStatus {
         _ => false,
     };
 
+    let active_game = crate::config::load(app)
+        .map(|c| c.active_game)
+        .unwrap_or_default();
+    let supported_for_game =
+        crate::frostmod::supported_for_game(active_game, version.as_deref());
+
     FrostmodStatus {
         installed,
         version,
         latest: rel.map(|r| r.tag_name),
         needs_repair,
         running: crate::frostmod::is_running(),
+        supported_for_game,
     }
 }
 
@@ -437,6 +449,19 @@ pub fn start(app: &AppHandle, state: &FrostmodProcess) -> anyhow::Result<bool> {
     if !exe.exists() {
         anyhow::bail!("FrostMod isn't installed yet");
     }
+    // Refuse to point a build at a title it isn't safe on. v0.10.0 attaches to GP Bikes
+    // and then offers an in-game reload that runs MX Bikes' offsets — starting it there
+    // hands the player a crash behind an F8 keypress. Updating is the fix, so say so.
+    let active_game = crate::config::load(app)
+        .map(|c| c.active_game)
+        .unwrap_or_default();
+    if !crate::frostmod::supported_for_game(active_game, installed_version(app).as_deref()) {
+        anyhow::bail!(
+            "This FrostMod build isn't safe on {} — update FrostMod to {} or newer.",
+            active_game.profile().display,
+            crate::frostmod::GPB_MIN_VERSION,
+        );
+    }
     // Refresh the curated filter before FrostMod loads it.
     ensure_serverfilter(app);
     // Nothing holds the previous binaries once the game that mapped them is gone,
@@ -447,10 +472,20 @@ pub fn start(app: &AppHandle, state: &FrostmodProcess) -> anyhow::Result<bool> {
     // "running" while reload silently did nothing. `--game` landed in FrostMod v0.10.0;
     // older binaries ignore an unknown flag and keep their MX Bikes default, which is the
     // right fallback for the only game they support.
-    let game = crate::config::load(app).map(|c| c.active_game).unwrap_or_default();
+    //
+    // `--mods` matters for the same reason and then some: FrostMod's own default was
+    // `Documents\PiBoSo\MX Bikes\mods` whatever `--game` said, so on GP Bikes its track
+    // manager and model swap operated on the wrong game's folders. We already know the
+    // real folder — the user may well have moved it — so send it rather than let FrostMod
+    // guess. Harmless on every FrostMod that ever shipped: `--mods` predates `--game`.
+    let cfg = crate::config::load(app).unwrap_or_default();
+    let mut args: Vec<&str> = vec!["--game", cfg.active_game.id()];
+    if !cfg.mods_path.is_empty() {
+        args.extend(["--mods", cfg.mods_path.as_str()]);
+    }
     let child = std::process::Command::new(&exe)
         .current_dir(frostmod_dir(app))
-        .args(["--game", game.id()])
+        .args(&args)
         .creation_flags(CREATE_NO_WINDOW)
         .spawn()?;
     *state.0.lock().unwrap() = Some(child);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2665,6 +2665,7 @@ fn list_games() -> Vec<game::GameInfo> {
 async fn set_active_game(
     app: tauri::AppHandle,
     watcher: State<'_, ModWatcher>,
+    frostmod_state: State<'_, FrostmodProcess>,
     game: game::Game,
 ) -> Result<AppConfig, String> {
     let mut cfg = config::load(&app).unwrap_or_default();
@@ -2678,6 +2679,18 @@ async fn set_active_game(
     // in the game we just left.
     if cfg.watch_mods_reload {
         modwatch::start(&app, &watcher, &cfg.mods_path);
+    }
+    // FrostMod reads `--game` and `--mods` once, at launch, and `start` no-ops while one
+    // is already running — so without this a switch leaves FrostMod waiting for the game
+    // we just left while the status pill still reads "running". `force_stop_exe` because
+    // the running one may not be ours to `stop`: a hand-launched frostmod.exe claims the
+    // same named event, and that is exactly how this was first reported.
+    if frostmod::is_running() {
+        frostmod_manage::stop(&frostmod_state);
+        frostmod_manage::force_stop_exe();
+        if let Err(e) = frostmod_manage::start(&app, &frostmod_state) {
+            log::warn!("could not restart FrostMod for {}: {e:#}", cfg.game().display);
+        }
     }
     Ok(cfg)
 }

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -872,9 +872,16 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
                       ? t("settings.updateCheckFailed")
                       : status?.needsRepair
                         ? t("settings.frostmodNeedsRepair")
-                        : status?.latest
-                          ? t("settings.latestVersion", { version: status.latest })
-                          : null}
+                        : // Ranked above "latest version" on purpose: a build too old for
+                          // this game can't run at all, which the version line alone
+                          // wouldn't explain.
+                          status?.installed && !status.supportedForGame
+                          ? t("settings.frostmodUnsupportedForGame", {
+                              game: game.display,
+                            })
+                          : status?.latest
+                            ? t("settings.latestVersion", { version: status.latest })
+                            : null}
                 </span>
               </div>
               <div className="flex items-center gap-1.5">
@@ -898,11 +905,18 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
                   // current on version alone; without this it'd sit on a disabled "Up to
                   // date" with no way to put the missing half in place.
                   const repairable = Boolean(status?.needsRepair);
+                  // Same idea for a build that's too old for the active title: it reads as
+                  // current on version alone, but can't be started, so the button has to
+                  // stay live to offer the update that fixes it.
+                  const unsupported = Boolean(
+                    status?.installed && !status.supportedForGame,
+                  );
                   // "Up to date" only when we actually confirmed the latest tag.
                   const confirmedCurrent =
                     status?.installed &&
                     !updatable &&
                     !repairable &&
+                    !unsupported &&
                     !statusError &&
                     status?.latest;
                   return (
@@ -920,9 +934,13 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
                             ? t("settings.updateTo", { version: status.latest ?? "" })
                             : repairable
                               ? t("settings.frostmodRepair")
-                              : statusError || !status?.latest
-                                ? t("settings.reinstallLatest")
-                                : t("settings.upToDate")}
+                              : // Already on the newest tag, but that tag is still too
+                                // old for this game — "Up to date" would be a lie.
+                                unsupported
+                                ? t("settings.frostmodUpdateRequired")
+                                : statusError || !status?.latest
+                                  ? t("settings.reinstallLatest")
+                                  : t("settings.upToDate")}
                     </Button>
                   );
                 })()}

--- a/src/Context/Frostmod.tsx
+++ b/src/Context/Frostmod.tsx
@@ -166,6 +166,11 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
   // press anything — and the binaries it's short of are the ones the game actually
   // loads. Repairing it unasked is the only thing that reaches those players.
   //
+  // So does `supportedForGame`: a build too old for the active title can't be started at
+  // all, and the player has no way to know why. Updating unasked is the fix — and if the
+  // newest release is still too old, the attempt is capped at one per session and the
+  // panel falls back to telling them.
+  //
   // Runs at most once per session; a failed status check (`statusError`) is skipped so
   // we only act on a confirmed snapshot, never an offline guess.
   const autoInstallTried = useRef(false);
@@ -173,7 +178,7 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
     if (
       !autoInstallTried.current &&
       status &&
-      (!status.installed || status.needsRepair) &&
+      (!status.installed || status.needsRepair || !status.supportedForGame) &&
       !statusError &&
       !installing
     ) {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -538,6 +538,9 @@ export const de: Translation = {
   "settings.frostmodNeedsRepair":
     "Die installierten Dateien passen nicht zu dieser Version — eine Neuinstallation behebt das.",
   "settings.frostmodRepair": "Installation reparieren",
+  "settings.frostmodUnsupportedForGame":
+    "Diese FrostMod-Version ist für {{game}} nicht sicher — aktualisiere sie, um FrostMod hier zu nutzen.",
+  "settings.frostmodUpdateRequired": "Update erforderlich",
   "settings.checkNewer": "Nach einer neueren FrostMod-Version suchen",
   "settings.working": "Wird ausgeführt…",
   "settings.installFrostmod": "FrostMod installieren",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -517,6 +517,9 @@ export const en = {
   "settings.frostmodNeedsRepair":
     "The installed files don't match this version — reinstalling fixes it.",
   "settings.frostmodRepair": "Repair install",
+  "settings.frostmodUnsupportedForGame":
+    "This FrostMod build isn't safe on {{game}} — update it to use FrostMod here.",
+  "settings.frostmodUpdateRequired": "Update required",
   "settings.checkNewer": "Check for a newer FrostMod",
   "settings.working": "Working…",
   "settings.installFrostmod": "Install FrostMod",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -529,6 +529,9 @@ export const es: Translation = {
   "settings.frostmodNeedsRepair":
     "Los archivos instalados no coinciden con esta versión — reinstalar lo arregla.",
   "settings.frostmodRepair": "Reparar instalación",
+  "settings.frostmodUnsupportedForGame":
+    "Esta versión de FrostMod no es segura en {{game}} — actualízala para usar FrostMod aquí.",
+  "settings.frostmodUpdateRequired": "Actualización necesaria",
   "settings.checkNewer": "Buscar una versión más reciente de FrostMod",
   "settings.working": "Trabajando…",
   "settings.installFrostmod": "Instalar FrostMod",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -534,6 +534,9 @@ export const fr: Translation = {
   "settings.frostmodNeedsRepair":
     "Les fichiers installés ne correspondent pas à cette version — une réinstallation corrige ça.",
   "settings.frostmodRepair": "Réparer l'installation",
+  "settings.frostmodUnsupportedForGame":
+    "Cette version de FrostMod n'est pas sûre sur {{game}} — mets-la à jour pour utiliser FrostMod ici.",
+  "settings.frostmodUpdateRequired": "Mise à jour requise",
   "settings.checkNewer": "Chercher une version plus récente de FrostMod",
   "settings.working": "Traitement…",
   "settings.installFrostmod": "Installer FrostMod",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -524,6 +524,9 @@ export const it: Translation = {
   "settings.frostmodNeedsRepair":
     "I file installati non corrispondono a questa versione — reinstallando si risolve.",
   "settings.frostmodRepair": "Ripara installazione",
+  "settings.frostmodUnsupportedForGame":
+    "Questa versione di FrostMod non è sicura su {{game}} — aggiornala per usare FrostMod qui.",
+  "settings.frostmodUpdateRequired": "Aggiornamento necessario",
   "settings.checkNewer": "Cerca una versione più recente di FrostMod",
   "settings.working": "Elaborazione…",
   "settings.installFrostmod": "Installa FrostMod",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -528,6 +528,9 @@ export const ptBR: Translation = {
   "settings.frostmodNeedsRepair":
     "Os arquivos instalados não batem com esta versão — reinstalar resolve.",
   "settings.frostmodRepair": "Reparar instalação",
+  "settings.frostmodUnsupportedForGame":
+    "Esta versão do FrostMod não é segura no {{game}} — atualize para usar o FrostMod aqui.",
+  "settings.frostmodUpdateRequired": "Atualização necessária",
   "settings.checkNewer": "Procurar uma versão mais nova do FrostMod",
   "settings.working": "Processando…",
   "settings.installFrostmod": "Instalar o FrostMod",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -542,6 +542,13 @@ export interface FrostmodStatus {
   needsRepair: boolean;
   /** FrostMod currently running (its reload event exists). */
   running: boolean;
+  /**
+   * The installed build is safe to run against the *active* game. False means
+   * "installed, but too old for this title" — FrostMod v0.10.0 attaches to GP Bikes and
+   * then reloads using MX Bikes' offsets, which crashes it. Updating is the fix, so offer
+   * that rather than a start; the backend refuses to launch it either way.
+   */
+  supportedForGame: boolean;
 }
 
 /** What an install landed, beyond succeeding. */


### PR DESCRIPTION
## Context

A tester ran MXB App v0.8.0-beta.1 on GP Bikes and the game crashed on reload. The FrostMod-side cause is [Frostn1/frostmod#6](https://github.com/Frostn1/frostmod/pull/6); this is everything the *app* got wrong, found in the same log.

## Fixed

**Wrong mods folder.** FrostMod was told which game to attach to but not where that game's mods live, and its own default was MX Bikes' folder whatever it attached to. The reporter's log shows it plainly — FrostMod logged `mods=…\PiBoSo\MX Bikes\mods` while the game scanned `…\PiBoSo\GP Bikes\mods\tracks`. So its track manager, inactive-tracks store and model swap all worked against the wrong game's folders.

We already know the real folder, including a moved one, so `start` now sends `--mods` alongside `--game`. `--mods` predates `--game`, so this is safe on every FrostMod that ever shipped — and it fixes the GP case without waiting on a FrostMod release.

**Stale FrostMod after a game switch.** FrostMod reads `--game`/`--mods` once at launch, and `start` no-ops while one is already running — so switching to GP Bikes left it waiting for MX Bikes forever while the status pill still read "running". `set_active_game` now restarts it, reusing the stop → `force_stop_exe` → start sequence from `frostmod_install`.

`force_stop_exe` is the important half: the running FrostMod may not be ours to `stop`. A hand-launched `frostmod.exe` claims the same named event, `is_running()` only checks whether that event opens, and that is exactly how this was first reported.

## Changed

**GP Bikes requires FrostMod v0.11.0.** v0.10.0 is the first build that attaches to GP Bikes, but its reload runs MX Bikes' internals there and takes the game down the first time it's used — so "knows about GP Bikes" and "is safe on GP Bikes" are different versions. `start` refuses below the floor, the app auto-updates to a build that works, and Settings says why instead of failing silently. MX Bikes is unaffected: every FrostMod ever released was built for it.

Reuses the `MODEL_REFRESH_MIN_VERSION` pattern in `frostmod.rs`, including its numeric-not-lexical comparison — which a GP floor is precisely where it would bite, since `v0.11.0` sorts below `v0.9.11` as a string. There's a test for that.

## Changelog

Second commit consolidates the three unreleased sections into v0.8.0. `scripts/changelog-section.sh` maps a pre-release tag to the section for the version it's a candidate for, so without this `v0.8.0-beta.2` would render release notes missing all of it. Purely structural — 354 bullets before, 354 after — except for correcting the v0.8.0 claim that GP Bikes' live reload works with FrostMod v0.10.0.

## Verification

- `cargo test` — 401 pass, including six new ones covering the floor
- `tsc --noEmit` and `eslint` clean
- New i18n keys in all six locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)