### PR TITLE
fix(rider): install GP Bikes suits where the game reads them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 ## 2026-08-09
 
 ### Fixed
+- **GP Bikes suits go where GP Bikes reads them.** Every rider install landed in `mods/rider`
+  itself — the game never opens that folder, so a suit you'd just installed was nowhere in
+  the game. Suit paints now default to `riders/<your rider model>/paints`, rider models to
+  `riders`, helmet paints to `helmets/<model>/paints` and riding styles to `animations`,
+  which is exactly the set the game's loader reads and nothing else.
+- **The rider picker offers your game's folders, not the other one's.** GP Bikes was being
+  shown MX Bikes' `boots`, `protections`, gloves, goggles and `default_mx` rider — none of
+  which exist there — while `riders` and `animations` were missing entirely. Each title now
+  lists its own, and the folder you last picked is remembered per game.
+- **A suit paint knows which rider model it's for.** gpb-mods files suits under the model
+  family they fit — Modern 1, Modern 2, MGP 21 — and that now picks the installed model,
+  instead of falling back to whichever folder you used last.
+- **Quick-install stops dumping rider mods in the root.** One-click and bulk installs from
+  the Browse grid never asked the rider logic at all, so a helmet, kit or suit installed that
+  way ignored every gear folder. Both games.
+- **A dropped GP suit isn't filed as boots.** GP's suits carry the boots' textures because
+  the boots are part of the rider model, and the drop classifier read that as a boot paint —
+  aiming it at a folder GP Bikes has no loader for. Suit, outfit and arm textures now read as
+  the rider's body, and gear hints for folders your game doesn't have are ignored.
+- **A dropped protection paint goes to `protections`.** The drop route was still aiming at
+  the old singular spelling the game stopped reading.
 - **Protection is drawn the right way up.** Every piece in the slot rendered on its side: the
   viewer assumed protection was authored the way the rider's body is, and it isn't — it takes
   the same up-axis as a helmet, turned a quarter turn about it. Read off the meshes rather

--- a/src-tauri/src/dropzone.rs
+++ b/src-tauri/src/dropzone.rs
@@ -296,7 +296,50 @@ fn from_route_rule(rule: RouteRule) -> Option<Verdict> {
     }
 }
 
-const GEAR_DIRS: [&str; 4] = ["helmets", "boots", "protection", "riders"];
+/// What classifying and placing a drop are relative to: the mods folder to look in, and the
+/// title whose folder layout applies.
+///
+/// The title is carried rather than read from [`crate::game::active`] at each use so that the
+/// whole module is a function of its inputs — one drop is classified against one title, and a
+/// test can put either one in without touching process-wide state.
+#[derive(Clone, Copy)]
+struct Ctx<'a> {
+    mods_path: &'a str,
+    game: &'static crate::game::GameProfile,
+}
+
+impl<'a> Ctx<'a> {
+    fn new(mods_path: &'a str) -> Self {
+        Ctx {
+            mods_path,
+            game: crate::game::active(),
+        }
+    }
+
+    /// Does `dir` hold the rider folders this title reads — `helmets/`, `riders/`, and
+    /// whatever else it keeps gear in?
+    ///
+    /// Per-title rather than a fixed list because the two barely overlap: MX Bikes has
+    /// `boots` and `protections`, GP Bikes bakes both into the rider model and has
+    /// `animations` instead.
+    fn has_gear_dirs(&self, dir: &Path) -> bool {
+        std::iter::once(crate::game::RIDERS_DIR)
+            .chain(self.game.rider.areas.iter().map(|a| a.folder))
+            .any(|g| install::child_dir(dir, g).is_some())
+    }
+
+    /// Whether `area` is a folder this title actually keeps content in. `goggles` and
+    /// `gloves` are folders *inside* another one rather than areas of their own, so they're
+    /// answered by the layout flags instead.
+    fn has_area(&self, area: &str) -> bool {
+        let rider = &self.game.rider;
+        match area {
+            "gloves" => rider.gloves || rider.profile_extras.iter().any(|(f, _)| *f == area),
+            "goggles" => rider.areas.iter().any(|a| a.goggles),
+            _ => self.game.installable_areas().any(|a| a.folder == area),
+        }
+    }
+}
 
 // Link-following: what's being classified here is a folder the player dragged in from
 // their own disk, and a junction in it is theirs — see `crate::linkwalk`.
@@ -312,7 +355,7 @@ fn dirs_in(dir: &Path) -> Vec<PathBuf> {
 ///
 /// Returns `None` when the directory looks like a container of other things rather than a
 /// unit in its own right, which is the signal to look one level deeper.
-fn classify_typed(dir: &Path, mods_path: &str) -> Option<Verdict> {
+fn classify_typed(dir: &Path, ctx: Ctx) -> Option<Verdict> {
     // An extracted track: `.map`/`.trh`/… sitting next to each other.
     if library::dir_has_track_markers(dir) {
         return Some(Verdict::new(ContentKind::Track, DetectReason::TrackMarkers));
@@ -332,12 +375,9 @@ fn classify_typed(dir: &Path, mods_path: &str) -> Option<Verdict> {
         );
     }
 
-    // Rider gear ships as `helmets/`, `boots/`, `protection/`, `riders/` — one level below
-    // the `rider` category folder, so `plan_placement`'s CATEGORY_DIRS rule never sees it.
-    if GEAR_DIRS
-        .iter()
-        .any(|g| install::child_dir(dir, g).is_some())
-    {
+    // Rider gear ships as `helmets/`, `riders/`, … — one level below the `rider` category
+    // folder, so `plan_placement`'s CATEGORY_DIRS rule never sees it.
+    if ctx.has_gear_dirs(dir) {
         return Some(Verdict::new(ContentKind::RiderGear, DetectReason::GearFolders));
     }
 
@@ -356,7 +396,7 @@ fn classify_typed(dir: &Path, mods_path: &str) -> Option<Verdict> {
     // where it belongs.
     if subdirs.is_empty() {
         if let Some(pnt) = files.iter().find(|p| install::has_ext(p, "pnt")) {
-            return Some(classify_paint(pnt, mods_path));
+            return Some(classify_paint(pnt, ctx));
         }
     }
 
@@ -412,14 +452,25 @@ fn classify_pkz(pkz: &Path) -> Verdict {
     Verdict::new(ContentKind::Unknown, DetectReason::Unrecognised).ask()
 }
 
-/// Gear areas a paint's texture names can name.
+/// Texture names that mean "this paints the rider's body", so it belongs on a rider model
+/// rather than on a piece of gear.
+///
+/// `rider` is MX Bikes' name for the sheet. GP Bikes' rider models don't use it: Manu's calls
+/// the suit `Suit.tga`, the casual model calls the whole thing `Outfit.tga`, and both carry
+/// an `Arms.tga`. Checked before the gear hints below, which matters most on GP — its suits
+/// carry the boots' textures too (they're part of the model), so a suit tested for `boot`
+/// first would be filed as boots, in a folder GP Bikes has no loader for.
+const RIDER_BODY_TEXTURES: [&str; 4] = ["rider", "suit", "outfit", "arms"];
+
+/// Gear areas a paint's texture names can name, as `(texture hint, area folder)`. Hints for
+/// areas the active title lacks are skipped — see [`classify_paint`].
 const GEAR_TEXTURE_HINTS: [(&str, &str); 6] = [
     ("goggle", "goggles"),
     ("lens", "goggles"),
     ("helmet", "helmets"),
     ("boot", "boots"),
     ("glove", "gloves"),
-    ("chest", "protection"),
+    ("chest", crate::game::PROTECTION_AREAS[0]),
 ];
 
 /// Identify a loose `.pnt` from the textures inside it.
@@ -434,7 +485,7 @@ const GEAR_TEXTURE_HINTS: [(&str, &str); 6] = [
 /// of its kind when there is exactly one — with two, nothing in the file picks between them.
 ///
 /// Falls back to a bike paint, the commonest case by far.
-fn classify_paint(pnt: &Path, mods_path: &str) -> Verdict {
+fn classify_paint(pnt: &Path, ctx: Ctx) -> Verdict {
     let bike = || Verdict::new(ContentKind::BikePaint, DetectReason::LoosePaint).ask();
     let Ok(bytes) = std::fs::read(pnt) else {
         return bike();
@@ -454,21 +505,40 @@ fn classify_paint(pnt: &Path, mods_path: &str) -> Verdict {
         })
         .collect();
 
-    if names.iter().any(|n| n == "rider") {
-        return Verdict::new(ContentKind::RiderGear, DetectReason::RiderTexture)
-            .dest(format!("riders/{}/paints", STOCK_RIDER_PROFILES[0]));
+    if names.iter().any(|n| RIDER_BODY_TEXTURES.contains(&n.as_str())) {
+        let v = Verdict::new(ContentKind::RiderGear, DetectReason::RiderTexture);
+        // The model the game ships if it ships one, else the only one installed. GP Bikes
+        // ships none, so there its suits genuinely have to be asked about until a rider
+        // model exists to wear them.
+        return match (
+            ctx.game.rider.stock_profiles.first(),
+            library::scan_rider_targets(ctx.mods_path).profiles.as_slice(),
+        ) {
+            (Some(stock), _) => v.dest(profile_dest(stock, "paints")),
+            (None, [only]) => v.dest(profile_dest(only, "paints")),
+            _ => v.ask(),
+        };
     }
 
     for (hint, area) in GEAR_TEXTURE_HINTS {
         if !names.iter().any(|n| n.contains(hint)) {
             continue;
         }
+        // A hint for a folder this title doesn't have is not a match — it's a texture the
+        // rider model carries because the part is built into it. Skipping keeps looking
+        // rather than filing the paint somewhere the game will never read.
+        if !ctx.has_area(area) {
+            continue;
+        }
         let v = Verdict::new(ContentKind::RiderGear, DetectReason::GearTexture);
         // Gloves hang off a rider profile; the rest hang off a gear model.
         if area == "gloves" {
-            return v.dest(format!("riders/{}/gloves", STOCK_RIDER_PROFILES[0]));
+            return match ctx.game.rider.stock_profiles.first() {
+                Some(stock) => v.dest(profile_dest(stock, "gloves")),
+                None => v.ask(),
+            };
         }
-        let t = library::scan_rider_targets(mods_path);
+        let t = library::scan_rider_targets(ctx.mods_path);
         let models = match area {
             "helmets" | "goggles" => &t.helmets,
             "boots" => &t.boots,
@@ -485,11 +555,16 @@ fn classify_paint(pnt: &Path, mods_path: &str) -> Verdict {
     bike()
 }
 
+/// `riders/<model>/<sub>` — where everything worn on the rider itself lives.
+fn profile_dest(profile: &str, sub: &str) -> String {
+    format!("{}/{profile}/{sub}", crate::game::RIDERS_DIR)
+}
+
 /// Split a staged root into the units the user will see as rows.
 fn units_in(
     dir: &Path,
     mods_dir: &Path,
-    mods_path: &str,
+    ctx: Ctx,
     slug: &str,
     depth: usize,
 ) -> Vec<Unit> {
@@ -505,7 +580,7 @@ fn units_in(
     // not the wrapper, or a `Mod v2/` folder would hide the bike inside it.
     let base = install::unwrap_wrapper(dir);
 
-    if let Some(verdict) = classify_typed(&base, mods_path) {
+    if let Some(verdict) = classify_typed(&base, ctx) {
         return vec![Unit {
             path: base,
             verdict,
@@ -522,7 +597,7 @@ fn units_in(
                         .file_name()
                         .map(|n| n.to_string_lossy().into_owned())
                         .unwrap_or_else(|| slug.to_string());
-                    units_in(c, mods_dir, mods_path, &child_slug, depth + 1)
+                    units_in(c, mods_dir, ctx, &child_slug, depth + 1)
                 })
                 .collect();
             // Only accept the split if it actually identified something; otherwise a folder
@@ -564,66 +639,67 @@ fn bike_choices(mods_path: &str, paints: bool) -> Vec<DestChoice> {
         .collect()
 }
 
-/// Rider profiles that exist whether or not anything is installed — MX Bikes ships them, so
-/// an outfit always has somewhere to go even on an empty mods folder.
-const STOCK_RIDER_PROFILES: [&str; 2] = ["default_mx", "default_sm"];
-
 /// Gear destinations: every installed model, plus the fixed places new gear and outfits go.
+///
+/// Built from the active title's own layout, because the two games' rider folders barely
+/// overlap — offering GP Bikes a `boots` folder would file a mod where its loader never
+/// looks, and offering it `riders/default_mx` would invent a rider model that doesn't exist.
 ///
 /// This must never come back empty. An earlier version listed only what was installed, so on
 /// a fresh mods folder the picker opened onto "Nothing installed to put this on yet" and the
 /// row could not be corrected at all — a dead end for the one case that most needs a choice.
-fn gear_choices(mods_path: &str) -> Vec<DestChoice> {
-    let t = library::scan_rider_targets(mods_path);
+fn gear_choices(ctx: Ctx) -> Vec<DestChoice> {
+    let game = ctx.game;
+    let t = library::scan_rider_targets(ctx.mods_path);
     let mut out = Vec::new();
+    let mut choice = |value: String, label: String| {
+        out.push(DestChoice {
+            value,
+            label,
+            subpath: "mods/rider".into(),
+        })
+    };
 
-    for (area, models) in [
-        ("helmets", &t.helmets),
-        ("boots", &t.boots),
-        ("protection", &t.protection),
-    ] {
+    for area in game.installable_areas() {
+        let folder = area.folder;
+        let models = match folder {
+            "helmets" => &t.helmets,
+            "boots" => &t.boots,
+            "animations" => &t.animations,
+            _ => &t.protection,
+        };
         for m in models {
-            out.push(DestChoice {
-                value: format!("{area}/{m}/paints"),
-                label: format!("{m} — {area} paints"),
-                subpath: "mods/rider".into(),
-            });
-            if area == "helmets" {
-                out.push(DestChoice {
-                    value: format!("helmets/{m}/goggles"),
-                    label: format!("{m} — goggles"),
-                    subpath: "mods/rider".into(),
-                });
+            if area.paint_cat.is_some() {
+                choice(format!("{folder}/{m}/paints"), format!("{m} — {folder} paints"));
+            }
+            if area.goggles {
+                choice(format!("{folder}/{m}/goggles"), format!("{m} — goggles"));
             }
         }
     }
 
     let mut profiles: Vec<String> = t.profiles.clone();
-    for p in STOCK_RIDER_PROFILES {
+    for p in game.rider.stock_profiles {
         if !profiles.iter().any(|x| x.eq_ignore_ascii_case(p)) {
             profiles.push(p.to_string());
         }
     }
+    // MX Bikes wears a kit over its rider; GP Bikes' rider *is* the suit.
+    let worn = if game.rider.stock_profiles.is_empty() { "suit paints" } else { "outfit" };
     for p in &profiles {
-        out.push(DestChoice {
-            value: format!("riders/{p}/paints"),
-            label: format!("{p} — outfit"),
-            subpath: "mods/rider".into(),
-        });
-        out.push(DestChoice {
-            value: format!("riders/{p}/gloves"),
-            label: format!("{p} — gloves"),
-            subpath: "mods/rider".into(),
-        });
+        choice(profile_dest(p, "paints"), format!("{p} — {worn}"));
+        for (extra, _) in game.rider.profile_extras {
+            choice(profile_dest(p, extra), format!("{p} — {extra}"));
+        }
     }
 
     // Somewhere to put a brand new model, which by definition isn't installed yet.
-    for area in ["helmets", "boots", "protection"] {
-        out.push(DestChoice {
-            value: area.to_string(),
-            label: format!("{area} — new model"),
-            subpath: "mods/rider".into(),
-        });
+    choice(
+        crate::game::RIDERS_DIR.to_string(),
+        format!("{} — new rider model", crate::game::RIDERS_DIR),
+    );
+    for area in game.installable_areas() {
+        choice(area.folder.to_string(), format!("{} — new model", area.folder));
     }
     out
 }
@@ -658,9 +734,9 @@ fn folder_choices(mods_path: &str, subpath: &str) -> Vec<DestChoice> {
 }
 
 /// Everywhere a dropped item could plausibly go, for the rows we can't place ourselves.
-fn all_choices(mods_path: &str, paints: bool) -> Vec<DestChoice> {
-    let mut c = bike_choices(mods_path, paints);
-    c.extend(gear_choices(mods_path));
+fn all_choices(ctx: Ctx, paints: bool) -> Vec<DestChoice> {
+    let mut c = bike_choices(ctx.mods_path, paints);
+    c.extend(gear_choices(ctx));
     // Unidentified content still has to be placeable — offer the bare category roots so a
     // dropped file the classifier couldn't name can at least be filed by hand.
     for (label, subpath) in [
@@ -681,7 +757,7 @@ fn all_choices(mods_path: &str, paints: bool) -> Vec<DestChoice> {
 /// Resolve a unit into the row the user reviews.
 fn to_item(
     unit: Unit,
-    mods_path: &str,
+    ctx: Ctx,
     mods_dir: &Path,
     slug: &str,
     source_name: &str,
@@ -712,20 +788,20 @@ fn to_item(
         DetectReason::RiderTexture | DetectReason::GearTexture
     ) {
         // Textures already said it's worn, not ridden — lead with gear and profiles.
-        let mut c = gear_choices(mods_path);
-        c.extend(bike_choices(mods_path, true));
+        let mut c = gear_choices(ctx);
+        c.extend(bike_choices(ctx.mods_path, true));
         c
     } else if needs_choice {
-        all_choices(mods_path, matches!(verdict.kind, ContentKind::BikePaint))
+        all_choices(ctx, matches!(verdict.kind, ContentKind::BikePaint))
     } else if matches!(
         verdict.kind,
         ContentKind::BikePaint | ContentKind::SoundSet | ContentKind::RiderGear
     ) {
-        let mut c = bike_choices(mods_path, matches!(verdict.kind, ContentKind::BikePaint));
-        c.extend(gear_choices(mods_path));
+        let mut c = bike_choices(ctx.mods_path, matches!(verdict.kind, ContentKind::BikePaint));
+        c.extend(gear_choices(ctx));
         c
     } else {
-        folder_choices(mods_path, verdict.kind.subpath().unwrap_or("mods/misc"))
+        folder_choices(ctx.mods_path, verdict.kind.subpath().unwrap_or("mods/misc"))
     };
 
     let subpath = if needs_choice {
@@ -823,6 +899,7 @@ pub fn plan(mods_path: &str, paths: &[String]) -> anyhow::Result<DropPlan> {
         anyhow::bail!("no MX Bikes folder configured");
     }
     let mods_dir = library::mods_subdir(mods_path, "mods");
+    let ctx = Ctx::new(mods_path);
 
     let plan_id = next_id("drop");
     let work = install::staging_dir("drop");
@@ -861,8 +938,8 @@ pub fn plan(mods_path: &str, paths: &[String]) -> anyhow::Result<DropPlan> {
             }
         };
 
-        for unit in units_in(&root, &mods_dir, mods_path, &slug, 0) {
-            let (item, st) = to_item(unit, mods_path, &mods_dir, &slug, &name);
+        for unit in units_in(&root, &mods_dir, ctx, &slug, 0) {
+            let (item, st) = to_item(unit, ctx, &mods_dir, &slug, &name);
             staged.insert(item.id.clone(), st);
             items.push(item);
         }
@@ -1051,7 +1128,26 @@ pub fn sound_bikes(plan_id: &str, ids: &[String]) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::game::Game;
     use std::fs;
+
+    /// The title a test classifies against. Passed in rather than set process-wide, so a GP
+    /// Bikes case and an MX Bikes case can run side by side — which, since `cargo test` runs
+    /// them in parallel threads, they do.
+    fn ctx(game: Game, mods_path: &str) -> Ctx<'_> {
+        Ctx {
+            mods_path,
+            game: game.profile(),
+        }
+    }
+
+    fn mx(mods_path: &str) -> Ctx<'_> {
+        ctx(Game::Mxb, mods_path)
+    }
+
+    fn gpb(mods_path: &str) -> Ctx<'_> {
+        ctx(Game::Gpb, mods_path)
+    }
 
     fn tmp(name: &str) -> PathBuf {
         let p = std::env::temp_dir().join(format!("frost-dz-test-{name}-{}", std::process::id()));
@@ -1121,7 +1217,7 @@ mod tests {
         let root = tmp("track");
         write(&root.join("Hangtown.map"), "m");
         write(&root.join("Hangtown.trh"), "t");
-        let v = classify_typed(&root, "").expect("classified");
+        let v = classify_typed(&root, mx("")).expect("classified");
         let (kind, reason) = (v.kind, v.reason);
         assert_eq!(kind, ContentKind::Track);
         assert_eq!(reason, DetectReason::TrackMarkers);
@@ -1133,7 +1229,7 @@ mod tests {
         let bike = root.join("MX1OEM_2023");
         write(&bike.join("MX1OEM_2023.ini"), "[info]\nname = Test 450\n[data]\ncat = MX1\n");
         write(&bike.join("MX1OEM_2023.cfg"), "ID = MX1OEM_2023\n");
-        let v = classify_typed(&bike, "").expect("classified");
+        let v = classify_typed(&bike, mx("")).expect("classified");
         let (kind, reason, detail) = (v.kind, v.reason, v.detail.clone());
         assert_eq!(kind, ContentKind::Bike);
         assert_eq!(reason, DetectReason::BikeConfig);
@@ -1144,7 +1240,7 @@ mod tests {
     fn loose_paints_demand_a_bike() {
         let root = tmp("paints");
         write(&root.join("Blue.pnt"), "PNT\0");
-        let v = classify_typed(&root, "").expect("classified");
+        let v = classify_typed(&root, mx("")).expect("classified");
         let (kind, reason) = (v.kind, v.reason);
         assert_eq!(kind, ContentKind::BikePaint);
         assert_eq!(reason, DetectReason::LoosePaint);
@@ -1153,7 +1249,7 @@ mod tests {
             path: root.clone(),
             verdict: v,
         };
-        let (item, _) = to_item(unit, "", &root.join("mods"), "Blue", "Blue.pnt");
+        let (item, _) = to_item(unit, mx(""), &root.join("mods"), "Blue", "Blue.pnt");
         assert!(item.needs_choice, "nothing says which bike these paint");
         assert!(item.subpath.is_empty(), "must not guess a category");
     }
@@ -1162,7 +1258,7 @@ mod tests {
     fn gear_folders_route_to_rider() {
         let root = tmp("gear");
         write(&root.join("helmets/Airoh/paints/Red.pnt"), "PNT\0");
-        let v = classify_typed(&root, "").expect("classified");
+        let v = classify_typed(&root, mx("")).expect("classified");
         let (kind, reason) = (v.kind, v.reason);
         assert_eq!(kind, ContentKind::RiderGear);
         assert_eq!(reason, DetectReason::GearFolders);
@@ -1179,7 +1275,7 @@ mod tests {
         );
         write(&root.join("drop/MX1OEM_2023/MX1OEM_2023.cfg"), "ID = X\n");
 
-        let units = units_in(&root.join("drop"), &mods, "", "drop", 0);
+        let units = units_in(&root.join("drop"), &mods, mx(""), "drop", 0);
         let kinds: Vec<ContentKind> = units.iter().map(|u| u.verdict.kind).collect();
         assert!(kinds.contains(&ContentKind::Track), "{kinds:?}");
         assert!(kinds.contains(&ContentKind::Bike), "{kinds:?}");
@@ -1193,7 +1289,7 @@ mod tests {
         write(&root.join("drop/Hangtown v2/Hangtown.map"), "m");
         write(&root.join("drop/Hangtown v2/readme.txt"), "hi");
 
-        let units = units_in(&root.join("drop"), &mods, "", "drop", 0);
+        let units = units_in(&root.join("drop"), &mods, mx(""), "drop", 0);
         assert_eq!(units.len(), 1);
         assert_eq!(units[0].verdict.kind, ContentKind::Track);
     }
@@ -1204,7 +1300,7 @@ mod tests {
         let mods = root.join("mods");
         write(&root.join("drop/mods/tracks/Hangtown/Hangtown.map"), "m");
 
-        let units = units_in(&root.join("drop"), &mods, "", "drop", 0);
+        let units = units_in(&root.join("drop"), &mods, mx(""), "drop", 0);
         assert_eq!(units.len(), 1);
         assert_eq!(units[0].verdict.kind, ContentKind::ModsTree);
         assert_eq!(units[0].verdict.reason, DetectReason::ModsTree);
@@ -1216,7 +1312,7 @@ mod tests {
         write(&root.join("drop/frame.edf"), "\0\0\0");
 
         let mods = root.join("mods");
-        let units = units_in(&root.join("drop"), &mods, "", "drop", 0);
+        let units = units_in(&root.join("drop"), &mods, mx(""), "drop", 0);
         assert_eq!(units.len(), 1);
         assert_eq!(units[0].verdict.kind, ContentKind::Unknown);
 
@@ -1225,7 +1321,7 @@ mod tests {
                 path: units[0].path.clone(),
                 verdict: units[0].verdict.clone(),
             },
-            "",
+            mx(""),
             &mods,
             "frame",
             "frame.edf",
@@ -1446,7 +1542,7 @@ mod tests {
         assert_eq!(reason, DetectReason::TrackPackage);
 
         // And the same shape reached through the normal classifier.
-        let k = classify_typed(&root, "").expect("classified").kind;
+        let k = classify_typed(&root, mx("")).expect("classified").kind;
         assert_eq!(k, ContentKind::Track);
         let _ = fs::remove_dir_all(&root);
     }
@@ -1476,7 +1572,7 @@ mod tests {
     fn destinations_are_offered_even_on_an_empty_mods_folder() {
         let root = tmp("emptymods");
         let mods_path = root.to_string_lossy().into_owned();
-        let choices = all_choices(&mods_path, true);
+        let choices = all_choices(mx(&mods_path), true);
         assert!(!choices.is_empty(), "a picker with no options is a dead end");
         assert!(
             choices.iter().any(|c| c.value == "riders/default_mx/paints"),
@@ -1496,7 +1592,7 @@ mod tests {
         let pnt = root.join("Astars.pnt");
         write_pnt(&pnt, &["rider", "rider_n"]);
 
-        let v = classify_paint(&pnt, "");
+        let v = classify_paint(&pnt, mx(""));
         assert_eq!(v.kind, ContentKind::RiderGear);
         assert_eq!(v.reason, DetectReason::RiderTexture);
         assert!(!v.needs_choice, "an outfit has a real default");
@@ -1507,7 +1603,7 @@ mod tests {
                 path: root.clone(),
                 verdict: v,
             },
-            "",
+            mx(""),
             &mods,
             "Astars",
             "Astars.pnt",
@@ -1518,13 +1614,102 @@ mod tests {
         let _ = fs::remove_dir_all(&root);
     }
 
+    /// GP Bikes' suits carry the boots' textures, because the boots are part of the rider
+    /// model — `(S) Suit 1 + Boots Alpinestars` is one mesh. Tested for `boot` first, a suit
+    /// was filed as boots: a folder GP Bikes has no loader for, so the paint vanished from
+    /// the game while the app reported it installed.
+    #[test]
+    fn a_gp_suit_is_not_mistaken_for_boots() {
+        let root = tmp("gpsuit");
+        let mods_path = root.to_string_lossy().into_owned();
+        // Manu's Modern Rider, the model nearly every GP suit is made for.
+        fs::create_dir_all(root.join("mods/rider/riders/Modern Type 1/paints")).unwrap();
+        let pnt = root.join("Alpinestars.pnt");
+        write_pnt(&pnt, &["Suit", "Suit_n", "Boots", "Arms"]);
+
+        let v = classify_paint(&pnt, gpb(&mods_path));
+        assert_eq!(v.kind, ContentKind::RiderGear);
+        assert_eq!(v.reason, DetectReason::RiderTexture, "the suit is read before the boots");
+        assert_eq!(v.dest_folder, "riders/Modern Type 1/paints");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// With no rider model installed there is nowhere a GP suit will load from, and the app
+    /// must say so rather than invent MX Bikes' `default_mx` — which GP Bikes doesn't have.
+    #[test]
+    fn a_gp_suit_asks_when_no_rider_model_is_installed() {
+        let root = tmp("gpsuit-empty");
+        let mods_path = root.to_string_lossy().into_owned();
+        let pnt = root.join("Alpinestars.pnt");
+        write_pnt(&pnt, &["Suit", "Boots"]);
+
+        let v = classify_paint(&pnt, gpb(&mods_path));
+        assert!(v.needs_choice, "nothing installed can wear it");
+        assert!(v.dest_folder.is_empty());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// The picker is the user's way out of a wrong guess, so it must offer this title's
+    /// folders — and only those.
+    #[test]
+    fn gp_bikes_is_offered_its_own_folders_and_no_others() {
+        let root = tmp("gpchoices");
+        let mods_path = root.to_string_lossy().into_owned();
+        fs::create_dir_all(root.join("mods/rider/riders/Modern Type 1")).unwrap();
+        let values: Vec<String> = gear_choices(gpb(&mods_path))
+            .into_iter()
+            .map(|c| c.value)
+            .collect();
+
+        assert!(values.contains(&"riders/Modern Type 1/paints".to_string()), "{values:?}");
+        assert!(values.contains(&"riders".to_string()), "somewhere for a new rider model");
+        assert!(values.contains(&"animations".to_string()), "riding styles are GP content");
+        for absent in ["boots", "protections", "riders/default_mx/paints"] {
+            assert!(
+                !values.iter().any(|v| v.starts_with(absent)),
+                "GP Bikes never reads `{absent}`: {values:?}",
+            );
+        }
+        assert!(
+            !values.iter().any(|v| v.ends_with("/gloves") || v.ends_with("/goggles")),
+            "gloves are built into the suit, and road helmets have visors: {values:?}",
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// MX Bikes keeps every folder it had, including the ones GP lacks.
+    #[test]
+    fn mx_bikes_still_gets_its_full_set_of_gear_folders() {
+        let root = tmp("mxchoices");
+        let mods_path = root.to_string_lossy().into_owned();
+        let values: Vec<String> = gear_choices(mx(&mods_path))
+            .into_iter()
+            .map(|c| c.value)
+            .collect();
+
+        for expected in [
+            "helmets",
+            "boots",
+            "protections",
+            "riders/default_mx/paints",
+            "riders/default_mx/gloves",
+        ] {
+            assert!(values.contains(&expected.to_string()), "{expected} missing: {values:?}");
+        }
+        assert!(
+            !values.iter().any(|v| v == "protection"),
+            "the legacy spelling is read, never written: {values:?}",
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
     /// A bike paint is the fallback, and it still has to ask which bike.
     #[test]
     fn a_bike_paint_is_told_apart_from_an_outfit() {
         let root = tmp("bikepaint");
         let pnt = root.join("96STOCK.pnt");
         write_pnt(&pnt, &["framecompletemap", "wheels"]);
-        let v = classify_paint(&pnt, "");
+        let v = classify_paint(&pnt, mx(""));
         assert_eq!(v.kind, ContentKind::BikePaint);
         assert!(v.needs_choice, "nothing says which bike");
         let _ = fs::remove_dir_all(&root);
@@ -1539,10 +1724,10 @@ mod tests {
         let src = root.join("Hangtown");
         write(&src.join("Hangtown.map"), "m");
 
-        let units = units_in(&src, &mods, "", "Hangtown", 0);
+        let units = units_in(&src, &mods, mx(""), "Hangtown", 0);
         let (item, _) = to_item(
             units.into_iter().next().unwrap(),
-            "",
+            mx(""),
             &mods,
             "Hangtown",
             "Hangtown",

--- a/src-tauri/src/game.rs
+++ b/src-tauri/src/game.rs
@@ -86,6 +86,15 @@ impl Game {
 /// read — nothing is ever written to it.
 pub const PROTECTION_AREAS: &[&str] = &["protections", "protection"];
 
+/// The folder every title keeps its rider models in, under `mods/rider`.
+///
+/// MX Bikes calls what lives here a rider *profile* and hangs the kit, gloves and goggles off
+/// it; GP Bikes calls the same thing a rider *model* and bakes the boots and gloves into it,
+/// so its suits are `riders/<model>/paints`. Same folder, so it isn't a per-title constant —
+/// but it *is* a destination both games install into, which is why it's named rather than
+/// spelled out at each call site.
+pub const RIDERS_DIR: &str = "riders";
+
 /// One gear area under `mods/rider` — a folder of models, each of which may carry paints.
 pub struct RiderArea {
     /// Folder name under `mods/rider`.
@@ -98,6 +107,10 @@ pub struct RiderArea {
     /// The area's models can carry a `goggles/` folder alongside `paints/`. MX Bikes
     /// helmets do; GP Bikes' road helmets use visors and have no such folder.
     pub goggles: bool,
+    /// New content of this kind may be installed here. False only for a folder that is
+    /// read for what earlier versions put there — see MX Bikes' singular `protection`.
+    /// Scans use every area; the pickers offer only these.
+    pub installable: bool,
 }
 
 /// How `mods/rider` is laid out for a title.
@@ -109,6 +122,15 @@ pub struct RiderLayout {
     /// Subfolders inside `mods/rider/riders/<profile>/` beyond `paints`, as
     /// `(folder, library category)`.
     pub profile_extras: &'static [(&'static str, &'static str)],
+    /// Rider models the game itself ships, so a paint for one has somewhere to go on a mods
+    /// folder that is otherwise empty.
+    ///
+    /// Empty for GP Bikes, and that is the fact rather than an omission: nothing there
+    /// paints the stock rider. Every GP suit is made for a downloaded model — Manu's
+    /// "Modern Type 1", Bar's "(S) Suit 1 + Boots …" — and the catalog files them under
+    /// that model's name. Offering an invented default would send a suit to a folder the
+    /// game never reads.
+    pub stock_profiles: &'static [&'static str],
 }
 
 /// Features that only exist for some titles. Gating on these rather than on `Game`
@@ -191,18 +213,21 @@ pub static MXB: GameProfile = GameProfile {
                 model_cat: "helmet",
                 paint_cat: Some("helmetPaint"),
                 goggles: true,
+                installable: true,
             },
             RiderArea {
                 folder: "boots",
                 model_cat: "boots",
                 paint_cat: Some("bootPaint"),
                 goggles: false,
+                installable: true,
             },
             RiderArea {
                 folder: PROTECTION_AREAS[0],
                 model_cat: "protection",
                 paint_cat: Some("protectionPaint"),
                 goggles: false,
+                installable: true,
             },
             // The same slot under the name earlier versions installed to, so what they put
             // there still shows up in the library and the pickers.
@@ -211,10 +236,12 @@ pub static MXB: GameProfile = GameProfile {
                 model_cat: "protection",
                 paint_cat: Some("protectionPaint"),
                 goggles: false,
+                installable: false,
             },
         ],
         gloves: true,
         profile_extras: &[("gloves", "gloves"), ("goggles", "goggles")],
+        stock_profiles: &["default_mx", "default_sm"],
     },
     catalog: &crate::mxb_session::MXB_SITE,
     caps: Caps {
@@ -248,6 +275,7 @@ pub static GPB: GameProfile = GameProfile {
                 paint_cat: Some("helmetPaint"),
                 // Road helmets have visors, not goggles: no `goggles/` folder exists.
                 goggles: false,
+                installable: true,
             },
             // Riding-style animations. Models with nothing to paint, so no paint category
             // — a `.pnt` under here would be a stray.
@@ -256,6 +284,7 @@ pub static GPB: GameProfile = GameProfile {
                 model_cat: "animation",
                 paint_cat: None,
                 goggles: false,
+                installable: true,
             },
         ],
         // GP Bikes bakes gloves and boots into the rider model — the `riders` folder is
@@ -263,6 +292,7 @@ pub static GPB: GameProfile = GameProfile {
         // pick separately, so there are no folders for them.
         gloves: false,
         profile_extras: &[],
+        stock_profiles: &[],
     },
     catalog: &crate::mxb_session::GPB_SITE,
     caps: Caps {
@@ -286,6 +316,21 @@ pub static GPB: GameProfile = GameProfile {
 /// correctly-packed archive.
 pub const ALL_MODS_DIRS: [&str; 5] = ["bikes", "tracks", "rider", "tyres", "misc"];
 
+/// One gear area as the install pickers need it: where it is, and what may sit inside.
+///
+/// The library's own view of an area is [`RiderArea`], which also carries the categories a
+/// scan tags entries with. Those mean nothing to a picker, and the legacy folders a scan
+/// reads are not places to write — so what crosses to the frontend is this narrower thing.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RiderAreaInfo {
+    pub folder: &'static str,
+    /// Models here keep their liveries in `<model>/paints`.
+    pub paints: bool,
+    /// …and a `<model>/goggles` folder besides.
+    pub goggles: bool,
+}
+
 /// What the frontend needs to render the game switcher and gate features.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -296,16 +341,40 @@ pub struct GameInfo {
     /// Host of the catalog this title browses, e.g. `mxb-mods.com`. The UI names the site
     /// it is linking to, and naming the wrong one is worse than naming none.
     pub catalog_domain: &'static str,
+    /// The gear areas under `mods/rider` new content installs into, in the order to offer
+    /// them. Sent for the same reason `mods_dirs` is: the install picker has to name real
+    /// folders, and which ones exist is the title's fact, not the UI's.
+    pub rider_areas: Vec<RiderAreaInfo>,
+    /// Rider models the title ships — `riders/<name>` that exist before anything is
+    /// installed. Empty for GP Bikes; see [`RiderLayout::stock_profiles`].
+    pub rider_stock_profiles: &'static [&'static str],
+    /// Folders inside `riders/<model>/` beyond `paints` — MX Bikes' `gloves` and `goggles`.
+    pub rider_profile_extras: Vec<&'static str>,
     pub caps: Caps,
 }
 
 impl GameProfile {
+    /// The gear areas new content may be installed into, in profile order.
+    pub fn installable_areas(&'static self) -> impl Iterator<Item = &'static RiderArea> {
+        self.rider.areas.iter().filter(|a| a.installable)
+    }
+
     pub fn info(&'static self) -> GameInfo {
         GameInfo {
             id: self.id,
             display: self.display,
             mods_dirs: self.mods_dirs,
             catalog_domain: self.catalog.domain,
+            rider_areas: self
+                .installable_areas()
+                .map(|a| RiderAreaInfo {
+                    folder: a.folder,
+                    paints: a.paint_cat.is_some(),
+                    goggles: a.goggles,
+                })
+                .collect(),
+            rider_stock_profiles: self.rider.stock_profiles,
+            rider_profile_extras: self.rider.profile_extras.iter().map(|(f, _)| *f).collect(),
             caps: self.caps,
         }
     }
@@ -364,6 +433,47 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// The legacy singular `protection` is read so nothing already filed there vanishes,
+    /// but it is not a place to write: the game's loader asks for `protections`.
+    #[test]
+    fn the_legacy_protection_folder_is_never_installed_to() {
+        let mxb = Game::Mxb.profile();
+        assert!(
+            mxb.rider.areas.iter().any(|a| a.folder == PROTECTION_AREAS[1]),
+            "the old spelling is still scanned",
+        );
+        assert!(
+            !mxb.installable_areas().any(|a| a.folder == PROTECTION_AREAS[1]),
+            "…but nothing is offered it as a destination",
+        );
+    }
+
+    /// The install pickers are built from this list, so an MX-only folder appearing here
+    /// would be offered on GP Bikes — where the loader never opens it, leaving the mod
+    /// installed as far as the app is concerned and absent as far as the game is.
+    #[test]
+    fn gp_bikes_offers_only_the_folders_its_loader_reads() {
+        let gpb = Game::Gpb.profile().info();
+        let folders: Vec<&str> = gpb.rider_areas.iter().map(|a| a.folder).collect();
+        assert_eq!(folders, ["helmets", "animations"]);
+        for absent in ["boots", "protections", "protection", "gloves"] {
+            assert!(!folders.contains(&absent), "GP Bikes has no `{absent}` folder");
+        }
+        assert!(
+            gpb.rider_areas.iter().all(|a| !a.goggles),
+            "road helmets have visors, not goggles",
+        );
+        assert!(
+            !gpb.rider_areas.iter().any(|a| a.folder == "animations" && a.paints),
+            "riding styles have nothing to paint",
+        );
+        assert!(gpb.rider_profile_extras.is_empty(), "gloves are part of the suit");
+        assert!(
+            gpb.rider_stock_profiles.is_empty(),
+            "every GP suit is made for a downloaded rider model",
+        );
     }
 
     #[test]

--- a/src/Components/Browse/Browse.tsx
+++ b/src/Components/Browse/Browse.tsx
@@ -5,12 +5,12 @@ import {
   MOD_SORTS,
   SEARCH_PAGE_SIZE,
   getModRatings,
-  isLiveryContext,
   resolveQuickInstall,
   searchMods,
   type ModSort,
   type ModType,
 } from "../../api/mods";
+import { useConfig } from "../../Context/Config";
 import type { InstalledIndex } from "../../lib/installedMatch";
 import type { ModRating, ModSummary } from "../../types";
 import { useInstall } from "../../Context/Install";
@@ -56,6 +56,7 @@ export default function Browse({
   onChangeType,
 }: BrowseProps) {
   const t = useT();
+  const { game } = useConfig();
   const [query, setQuery] = useState("");
   const [debounced, setDebounced] = useState("");
   const [categoryId, setCategoryId] = useState(modType.categoryId);
@@ -116,11 +117,7 @@ export default function Browse({
   const doQuickInstall = useCallback(
     async (mod: ModSummary) => {
       try {
-        const res = await resolveQuickInstall(
-          mod.slug,
-          modType,
-          isLiveryContext(modType, categoryId),
-        );
+        const res = await resolveQuickInstall(mod.slug, modType, game, categoryId);
         if (res.ok) {
           startInstall({ ...res.params, categoryId });
           toast.success(t("browse.queued", { title: res.params.title }), {
@@ -141,7 +138,7 @@ export default function Browse({
         });
       }
     },
-    [modType, categoryId, startInstall, t],
+    [modType, categoryId, game, startInstall, t],
   );
 
   // Guard: if the mod is already installed, confirm before overwriting.
@@ -160,11 +157,7 @@ export default function Browse({
       const skipped: string[] = [];
       for (const mod of list) {
         try {
-          const res = await resolveQuickInstall(
-            mod.slug,
-            modType,
-            isLiveryContext(modType, categoryId),
-          );
+          const res = await resolveQuickInstall(mod.slug, modType, game, categoryId);
           if (res.ok) {
             startInstall({ ...res.params, categoryId });
             queued++;
@@ -189,7 +182,7 @@ export default function Browse({
         });
       }
     },
-    [modType, categoryId, startInstall, clearSelection, t],
+    [modType, categoryId, game, startInstall, clearSelection, t],
   );
 
   const bulkInstall = useCallback(() => {

--- a/src/Components/ModDetail/ModDetail.tsx
+++ b/src/Components/ModDetail/ModDetail.tsx
@@ -19,8 +19,7 @@ import {
   isBlockedDownload,
   isLiveryContext,
   isSoundContext,
-  riderProfileSub,
-  riderPaintKind,
+  riderTarget,
   resolveInitialFolder,
   scanBikeTargets,
   scanRiderTargets,
@@ -100,10 +99,13 @@ export default function ModDetail({
   const { game } = useConfig();
   const livery = isLiveryContext(modType, categoryId);
   const sound = isSoundContext(modType, categoryId);
-  // For rider kit/gloves, which profile sub-folder to target (`null` for gear paints).
-  const profileSub = riderProfileSub(modType, categoryId);
-  // For a gear paint (Boot/Helmet/Protection Paints), which model kind it targets.
-  const paintKind = riderPaintKind(modType, categoryId);
+  // Which rider folder this category installs into — a gear model's paints, something worn
+  // on the rider model, or a model of its own. `null` when the category doesn't say.
+  const rider = useMemo(
+    () => riderTarget(game, modType, categoryId),
+    [game, modType, categoryId],
+  );
+  const [derivedDest, setDerivedDest] = useState(false);
   const [detail, setDetail] = useState<Detail | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   // The raw file list — only for destination folders and their counts. The badge uses
@@ -131,6 +133,7 @@ export default function ModDetail({
     setDestOptions([]);
     setGuess("");
     setSuggestions([]);
+    setDerivedDest(false);
     getModDetail(slug)
       .then(async (d) => {
         if (cancelled) return;
@@ -144,11 +147,17 @@ export default function ModDetail({
           const bikeTargets =
             modType.id === "bikes" ? await scanBikeTargets().catch(() => []) : [];
           if (cancelled) return;
-          // Rider paints route into a model's/profile's folder; everything else
-          // uses the generic (track/bike) destination logic.
+          // Rider content routes into a gear model's, or the rider model's, own folder;
+          // everything else uses the generic (track/bike) destination logic.
           const dest =
             modType.id === "rider"
-              ? buildRiderDestinations(await scanRiderTargets(), d.title, profileSub, paintKind)
+              ? buildRiderDestinations(
+                  game,
+                  await scanRiderTargets(),
+                  d.title,
+                  d.categories,
+                  rider,
+                )
               : buildDestinations(
                   modType,
                   d.title,
@@ -162,6 +171,7 @@ export default function ModDetail({
           setDestOptions(dest.options);
           setGuess(dest.guess);
           setSuggestions(dest.suggestions);
+          setDerivedDest("derived" in dest && dest.derived === true);
         } catch {
           setInstalledFiles([]);
           setDestOptions([]);
@@ -171,7 +181,7 @@ export default function ModDetail({
     return () => {
       cancelled = true;
     };
-  }, [slug, modType, livery, sound]);
+  }, [slug, modType, livery, sound, game, rider]);
 
   const folderCounts = useMemo(() => {
     const m = new Map<string, number>();
@@ -186,10 +196,14 @@ export default function ModDetail({
   const format = primary ? fileFormat(primary.url) : null;
   const mirrorNames = [...new Set(mirrors.map((m) => m.host))].join(" · ");
 
-  const destKey = destStorageKey(modType);
+  const destKey = destStorageKey(game, modType);
   const initialFolder = useMemo(
-    () => resolveInitialFolder(modType, destOptions, guess, livery, sound, paintKind),
-    [modType, destOptions, guess, livery, sound, paintKind],
+    () =>
+      resolveInitialFolder(game, modType, destOptions, guess, livery, sound, {
+        target: rider,
+        derived: derivedDest,
+      }),
+    [game, modType, destOptions, guess, livery, sound, rider, derivedDest],
   );
 
   const isInstalled = detail !== null && installed.has(detail.title);

--- a/src/Components/Shop/MyDownloads.tsx
+++ b/src/Components/Shop/MyDownloads.tsx
@@ -26,6 +26,7 @@ import {
   type InstalledIndex,
 } from "../../lib/installedMatch";
 import { useInstall } from "../../Context/Install";
+import { useConfig } from "../../Context/Config";
 import { useT, type TFunc } from "../../i18n/context";
 import ModCard from "../Browse/ModCard";
 import { Button } from "@/Components/ui/button";
@@ -45,6 +46,7 @@ export default function MyDownloads({ refreshKey }: MyDownloadsProps) {
   const [error, setError] = useState<string | null>(null);
 
   const { startShopInstall } = useInstall();
+  const { game } = useConfig();
 
   const loadDownloads = useCallback(async () => {
     setLoading(true);
@@ -111,12 +113,12 @@ export default function MyDownloads({ refreshKey }: MyDownloadsProps) {
     async (item: ShopItem) => {
       // No picker here, so land it where the Browse dialog would have preselected rather
       // than always at the tracks root.
-      startShopInstall(item, await resolveTrackDest());
+      startShopInstall(item, await resolveTrackDest(game));
       toast.success(t("browse.queued", { title: item.title }), {
         description: t("shop.queuedDesc"),
       });
     },
-    [startShopInstall, t],
+    [startShopInstall, game, t],
   );
 
   const logout = useCallback(async () => {

--- a/src/Context/Config.ts
+++ b/src/Context/Config.ts
@@ -18,6 +18,13 @@ const MXB_FALLBACK: GameInfo = {
   display: "MX Bikes",
   modsDirs: ["bikes", "tracks", "rider", "tyres", "misc"],
   catalogDomain: "mxb-mods.com",
+  riderAreas: [
+    { folder: "helmets", paints: true, goggles: true },
+    { folder: "boots", paints: true, goggles: false },
+    { folder: "protections", paints: true, goggles: false },
+  ],
+  riderStockProfiles: ["default_mx", "default_sm"],
+  riderProfileExtras: ["gloves", "goggles"],
   caps: MXB_CAPS,
 };
 

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -331,12 +331,24 @@ export interface RiderTargets {
   helmets: string[];
   boots: string[];
   protection: string[];
+  /** GP Bikes riding-style animations. Always empty for MX Bikes. */
+  animations: string[];
+  /** What `mods/rider/riders` holds: MX Bikes' rider profiles, GP Bikes' rider models. */
   profiles: string[];
 }
 
 export function scanRiderTargets(): Promise<RiderTargets> {
   return invoke<RiderTargets>("scan_rider_targets");
 }
+
+/** What a failed scan stands in for: nothing installed, which every picker handles. */
+export const EMPTY_RIDER_TARGETS: RiderTargets = {
+  helmets: [],
+  boots: [],
+  protection: [],
+  animations: [],
+  profiles: [],
+};
 
 /**
  * Every bike a paint can be installed for — folders and `.pkz` packages under `mods/bikes`,
@@ -767,56 +779,180 @@ export function buildDestinations(
 
 export const STOCK_RIDER_PROFILES = ["default_mx", "default_sm"];
 
-const RIDER_KIT_CATEGORY_IDS = [35, 129, 52];
-const RIDER_GLOVES_CATEGORY_ID = 32;
+/**
+ * The folder both titles keep their rider models in, under `mods/rider`.
+ *
+ * MX Bikes calls what lives here a rider *profile* and hangs the kit, gloves and goggles off
+ * it. GP Bikes calls the same thing a rider *model*, bakes the boots and gloves into it, and
+ * keeps the suits at `riders/<model>/paints` — verified against the loader, which opens
+ * `rider\riders\<model>\paints\<paint>.pnt` and nothing else for a suit.
+ */
+const RIDERS_DIR = "riders";
+
+/** Where a rider category's content belongs, once we know which title's catalog it is. */
+export type RiderTarget =
+  /** A livery for one model in a gear area — `<area>/<model>/paints`. */
+  | { kind: "gearPaint"; area: string }
+  /** Something worn by the rider model itself — `riders/<model>/<sub>`. */
+  | { kind: "profile"; sub: string }
+  /** A model of its own, which by definition isn't installed yet — the area's root. */
+  | { kind: "newModel"; folder: string };
+
+const gearPaint = (area: string): RiderTarget => ({ kind: "gearPaint", area });
+const profileSub = (sub: string): RiderTarget => ({ kind: "profile", sub });
+const newModel = (folder: string): RiderTarget => ({ kind: "newModel", folder });
 
 /**
- * The folder under `mods/rider` a protection install goes to.
+ * What each catalog's rider categories install, per title.
  *
- * The game's own name for the slot, plural: it is what `rider.pkz` calls the folder and what
- * mods package themselves as. Earlier versions installed to the singular `protection`, which
- * the backend still *reads* so nothing already there disappears — but nothing is written
- * there any more, because the game never looks in it.
+ * The two sites run the same WordPress build but numbered their taxonomies independently, so
+ * an id means nothing without the title it came from — GP's **52** is Helmets › Replicas
+ * while MX's **52** is a rider kit. Keying by game is what keeps those apart.
+ *
+ * GP's Suit Paints tree (55) is deep: every child names the *rider model* the suit fits
+ * ("Modern 1", "MGP 21"), and each of those has Replicas and Personal Suits under it. They
+ * all install the same way, so the whole subtree maps to the suit slot and the model itself
+ * is worked out by `rankRiderProfiles`.
  */
-const PROTECTION_DIR = "protections";
-
-export type GearPaintKind = "helmets" | "boots" | "protection";
-
-const RIDER_PAINT_CATEGORY_KIND: Record<number, GearPaintKind> = {
-  127: "helmets",
-  126: "boots",
-  135: "protection",
+const RIDER_CATEGORIES_BY_GAME: Record<GameId, Record<number, RiderTarget>> = {
+  mxb: {
+    35: profileSub("paints"), // Rider Kit
+    129: profileSub("paints"),
+    52: profileSub("paints"),
+    32: profileSub("gloves"), // Gloves
+    313: newModel("helmets"), // Helmets (models)
+    127: gearPaint("helmets"), // Helmet Paints
+    343: newModel("boots"),
+    126: gearPaint("boots"), // Boot Paints
+    36: newModel("protections"),
+    135: gearPaint("protection"), // Protection Paints
+  },
+  gpb: {
+    54: newModel(RIDERS_DIR), // Rider Models
+    70: newModel("helmets"), // Helmet Models
+    51: gearPaint("helmets"), // Helmets, and its Replicas / Personal Paints
+    52: gearPaint("helmets"),
+    53: gearPaint("helmets"),
+    // Suit Paints, and every branch of it.
+    ...Object.fromEntries(
+      [55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67].map((id) => [
+        id,
+        profileSub("paints"),
+      ]),
+    ),
+  },
 };
 
-export function riderPaintKind(
+export interface RiderDestinations {
+  options: DestOption[];
+  /** The preselected folder. */
+  guess: string;
+  /** The post itself decided the guess (its categories or title named the model), rather
+   *  than a default standing in. Only then does the guess outrank a remembered folder. */
+  derived: boolean;
+  /** Ranked "probably this one" values, shown above the full list. */
+  suggestions: string[];
+}
+
+/** Where the mod being viewed belongs, or `null` when its category doesn't say. */
+export function riderTarget(
+  game: GameInfo,
   modType: ModType,
   categoryId: number | null | undefined,
-): GearPaintKind | null {
+): RiderTarget | null {
   if (modType.id !== "rider" || categoryId == null) return null;
-  return RIDER_PAINT_CATEGORY_KIND[categoryId] ?? null;
+  return RIDER_CATEGORIES_BY_GAME[game.id]?.[categoryId] ?? null;
 }
 
-export function riderProfileSub(
-  modType: ModType,
-  categoryId: number | null | undefined,
-): "paints" | "gloves" | null {
-  if (modType.id !== "rider") return null;
-  if (categoryId === RIDER_GLOVES_CATEGORY_ID) return "gloves";
-  if (categoryId != null && RIDER_KIT_CATEGORY_IDS.includes(categoryId)) return "paints";
-  return null;
+/** `RiderTargets` keys its lists by slot, which is what every other consumer wants; only
+ *  the pickers need them addressed by the folder they live in. */
+function modelsInArea(targets: RiderTargets, folder: string): string[] {
+  switch (folder) {
+    case "helmets":
+      return targets.helmets;
+    case "boots":
+      return targets.boots;
+    case "protections":
+      return targets.protection;
+    case "animations":
+      return targets.animations ?? [];
+    default:
+      return [];
+  }
 }
 
+/** The gear paint slot an area's paints fill — `RiderTarget.area`, which for protection is
+ *  the slot's name rather than its folder's. */
+function areaSlot(folder: string): string {
+  return folder === "protections" ? "protection" : folder;
+}
+
+const AREA_LABELS: Record<string, { newModel: TKey; paints?: TKey; goggles?: TKey }> = {
+  helmets: {
+    newModel: "dest.helmetsNewModel",
+    paints: "dest.helmetPaintsFor",
+    goggles: "dest.gogglesFor",
+  },
+  boots: { newModel: "dest.bootsNewModel", paints: "dest.bootPaintsFor" },
+  protections: { newModel: "dest.protectionNewModel", paints: "dest.protectionPaintsFor" },
+  animations: { newModel: "dest.animationsNewStyle" },
+};
+
+/** Digit runs, which the tokenizer drops as too short: `"MGP 21"` → `["21"]`. */
+const digitRuns = (s: string): string[] => s.match(/\d+/g) ?? [];
+
+/**
+ * Installed rider models ranked against a post, best first.
+ *
+ * The catalog files a GP suit under the model family it fits, so the post's own categories
+ * name the target: "Modern 1" is Manu's `Modern Type 1`. Those families differ from one
+ * another *only* by a number, which `tokens` drops as too short — hence the digit pass,
+ * which only ever breaks a tie between models that already share a word.
+ */
+function rankRiderProfiles(
+  profiles: string[],
+  title: string,
+  categories: string[],
+): string[] {
+  const wanted = tokens([...categories, title].join(" "));
+  const wantedDigits = new Set(categories.flatMap(digitRuns));
+  return profiles
+    .map((name) => {
+      let score = 0;
+      for (const t of tokens(name)) if (wanted.has(t)) score++;
+      if (score > 0 && digitRuns(name).some((d) => wantedDigits.has(d))) score += 2;
+      return { name, score };
+    })
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name))
+    .map((s) => s.name);
+}
+
+/**
+ * Every folder under `mods/rider` this title installs into, with a default.
+ *
+ * Driven by the title's own layout (`GameInfo.riderAreas`) rather than a fixed list, because
+ * the two games barely overlap here: offering GP Bikes a `boots` folder would file a mod
+ * somewhere its loader never looks, which reads as "installed" in the app and as missing in
+ * the game.
+ */
 export function buildRiderDestinations(
+  game: GameInfo,
   targets: RiderTargets,
   title: string,
-  profileSub: "paints" | "gloves" | null = null,
-  paintKind: GearPaintKind | null = null,
-): { options: DestOption[]; guess: string; suggestions: string[] } {
+  categories: string[] = [],
+  target: RiderTarget | null = null,
+): RiderDestinations {
   const seen = new Set<string>();
   const options: DestOption[] = [];
-  const add = (value: string, labelKey: TKey, labelVars?: Record<string, string>) => {
+  const add = (value: string, labelKey: TKey | null, labelVars?: Record<string, string>) => {
     if (!seen.has(value)) {
-      options.push({ value, label: "", labelKey, labelVars });
+      // A folder a future title adds has no phrasing of its own; its name is the honest label.
+      options.push(
+        labelKey
+          ? { value, label: "", labelKey, labelVars }
+          : { value, label: labelVars?.name ?? value },
+      );
       seen.add(value);
     }
   };
@@ -828,57 +964,91 @@ export function buildRiderDestinations(
     return s;
   };
 
-  add("helmets", "dest.helmetsNewModel");
-  add("boots", "dest.bootsNewModel");
-  add(PROTECTION_DIR, "dest.protectionNewModel");
-
-  const scoredPaints: { value: string; score: number; kind: GearPaintKind }[] = [];
-  for (const h of targets.helmets) {
-    add(`helmets/${h}/paints`, "dest.helmetPaintsFor", { name: h });
-    add(`helmets/${h}/goggles`, "dest.gogglesFor", { name: h });
-    scoredPaints.push({ value: `helmets/${h}/paints`, score: score(h), kind: "helmets" });
-  }
-  for (const b of targets.boots) {
-    add(`boots/${b}/paints`, "dest.bootPaintsFor", { name: b });
-    scoredPaints.push({ value: `boots/${b}/paints`, score: score(b), kind: "boots" });
-  }
-  for (const p of targets.protection) {
-    add(`${PROTECTION_DIR}/${p}/paints`, "dest.protectionPaintsFor", { name: p });
-    scoredPaints.push({
-      value: `${PROTECTION_DIR}/${p}/paints`,
-      score: score(p),
-      kind: "protection",
-    });
+  // Somewhere to put a brand new model, which by definition isn't installed yet.
+  add(RIDERS_DIR, "dest.riderModelsNew");
+  for (const area of game.riderAreas) {
+    add(area.folder, AREA_LABELS[area.folder]?.newModel ?? null, { name: area.folder });
   }
 
-  const profiles = [...new Set([...targets.profiles, ...STOCK_RIDER_PROFILES])].sort(
-    (a, b) => a.toLowerCase().localeCompare(b.toLowerCase()),
-  );
+  const scoredPaints: { value: string; score: number; area: string }[] = [];
+  for (const area of game.riderAreas) {
+    const labels = AREA_LABELS[area.folder];
+    for (const model of modelsInArea(targets, area.folder)) {
+      if (area.paints) {
+        const value = `${area.folder}/${model}/paints`;
+        add(value, labels?.paints ?? null, { name: model });
+        scoredPaints.push({ value, score: score(model), area: areaSlot(area.folder) });
+      }
+      if (area.goggles) {
+        add(`${area.folder}/${model}/goggles`, labels?.goggles ?? null, { name: model });
+      }
+    }
+  }
+
+  // The models the game ships exist whether or not anything is installed, so a paint for one
+  // always has somewhere to go. GP Bikes ships none that mods target — see `stock_profiles`.
+  const profiles = [
+    ...new Set([...targets.profiles, ...game.riderStockProfiles]),
+  ].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+  const rankedProfiles = rankRiderProfiles(profiles, title, categories);
+  // Both games keep these in the same folder; each has its own word for what's in it. MX
+  // Bikes' kit is worn *with* the boots and gloves, GP Bikes' suit has them built in.
+  const profilePaints: TKey = game.id === "gpb" ? "dest.suitPaintsFor" : "dest.outfitFor";
   for (const prof of profiles) {
-    add(`riders/${prof}/paints`, "dest.outfitFor", { name: prof });
-    add(`riders/${prof}/gloves`, "dest.glovesFor", { name: prof });
+    add(`${RIDERS_DIR}/${prof}/paints`, profilePaints, { name: prof });
+    for (const extra of game.riderProfileExtras) {
+      add(
+        `${RIDERS_DIR}/${prof}/${extra}`,
+        extra === "gloves" ? "dest.glovesFor" : "dest.gogglesFor",
+        { name: prof },
+      );
+    }
   }
 
-  const kindPaints = paintKind
-    ? scoredPaints.filter((s) => s.kind === paintKind)
-    : scoredPaints;
-  const topPaints = kindPaints
-    .filter((s) => s.score >= 1)
-    .sort((a, b) => b.score - a.score);
+  const areaPaints =
+    target?.kind === "gearPaint"
+      ? scoredPaints.filter((s) => s.area === target.area)
+      : scoredPaints;
+  const topPaints = areaPaints.filter((s) => s.score >= 1).sort((a, b) => b.score - a.score);
+
+  // The rider model a suit belongs on: the one the game ships if it ships one, else the
+  // installed model the post points at, else the best guess left — its first model.
+  const sub = target?.kind === "profile" ? target.sub : "paints";
+  const profileFor = (p: string) => `${RIDERS_DIR}/${p}/${sub}`;
+  const bestProfile =
+    game.riderStockProfiles[0] ?? rankedProfiles[0] ?? profiles[0] ?? null;
+
   const suggestions = [
     ...topPaints.slice(0, 4).map((s) => s.value),
-    ...profiles.map((p) => `riders/${p}/${profileSub ?? "paints"}`),
+    ...[...rankedProfiles, ...profiles].map(profileFor),
   ];
 
-  const guess = profileSub
-    ? `riders/${STOCK_RIDER_PROFILES[0]}/${profileSub}`
-    : paintKind
-      ? topPaints[0]?.value ?? (kindPaints.length === 1 ? kindPaints[0].value : "")
-      : topPaints[0] && topPaints[0].score >= 2
-        ? topPaints[0].value
-        : "";
+  let guess: string;
+  // Whether the post itself settled this, rather than a default standing in. A derived
+  // destination outranks the folder used last time — the same rule bike liveries follow,
+  // and for the same reason: this content is per model, so last time's folder was another
+  // model's.
+  let derived = false;
+  switch (target?.kind) {
+    case "profile":
+      // Never the `mods/rider` root: a suit dropped there is invisible to the game.
+      guess = bestProfile ? profileFor(bestProfile) : RIDERS_DIR;
+      derived = !game.riderStockProfiles.length && !!rankedProfiles[0];
+      break;
+    case "newModel":
+      // Structural, not a preference: a model belongs at its area's root, never inside
+      // another model's `paints`.
+      guess = target.folder;
+      derived = true;
+      break;
+    case "gearPaint":
+      guess = topPaints[0]?.value ?? (areaPaints.length === 1 ? areaPaints[0].value : "");
+      break;
+    default:
+      guess = topPaints[0] && topPaints[0].score >= 2 ? topPaints[0].value : "";
+  }
 
-  return { options, guess, suggestions };
+  return { options, guess, derived, suggestions: [...new Set(suggestions)] };
 }
 
 /**
@@ -929,19 +1099,37 @@ export function pickDownloadForBike(
   return best && best.score > 0 ? best.m : fallback();
 }
 
-export function destStorageKey(modType: ModType): string {
-  return `frost-dest-${modType.id}`;
+/**
+ * Where the last-used folder for a kind of mod is remembered.
+ *
+ * Keyed by title as well as kind: the two games' rider folders barely overlap, so an MX
+ * Bikes choice preselecting on GP Bikes would put a suit in `boots`.
+ */
+export function destStorageKey(game: GameInfo, modType: ModType): string {
+  return game.id === "mxb"
+    ? // The key MX Bikes has always used — renaming it would forget every existing choice.
+      `frost-dest-${modType.id}`
+    : `frost-dest-${game.id}-${modType.id}`;
+}
+
+/** `helmets/AGV/paints` → `helmets/*\/paints`. Two destinations of the same shape are
+ *  interchangeable choices; different shapes are different *kinds* of place, and a folder
+ *  remembered from one is no answer for the other. */
+function destShape(value: string): string {
+  const segs = value.split("/").filter(Boolean);
+  return segs.length > 1 ? `${segs[0]}/*/${segs[segs.length - 1]}` : (segs[0] ?? "");
 }
 
 export function resolveInitialFolder(
+  game: GameInfo,
   modType: ModType,
   destOptions: DestOption[],
   guess: string,
   livery = false,
   sound = false,
-  paintKind: GearPaintKind | null = null,
+  rider: { target: RiderTarget | null; derived: boolean } | null = null,
 ): string {
-  const remembered = localStorage.getItem(destStorageKey(modType)) ?? "";
+  const remembered = localStorage.getItem(destStorageKey(game, modType)) ?? "";
   const rememberedIsPaints = /\/paints$/i.test(remembered);
   // An empty remembered value can't be told apart from never having chosen — both read as
   // `""`. For tracks that's the root, the one destination worth talking someone out of, so
@@ -952,7 +1140,13 @@ export function resolveInitialFolder(
   // not this mod's. Whenever we could work out which bike this one is for — its categories
   // name it — that beats the memory. With no match at all, fall through and keep it.
   if (modType.id === "bikes" && (livery || sound) && guess) return guess;
-  if (paintKind && remembered && !remembered.startsWith(`${paintKind}/`)) return guess;
+  if (rider?.target) {
+    // The post named the model this is for; that outranks the last folder used.
+    if (rider.derived) return guess;
+    // Otherwise the memory stands, but only where it's the same kind of place: a helmet
+    // paint's folder is no home for a helmet model, nor a boot paint for a suit.
+    if (destShape(remembered) !== destShape(guess)) return guess;
+  }
   if (destOptions.some((o) => o.value === remembered)) return remembered;
   return guess;
 }
@@ -962,11 +1156,11 @@ export function resolveInitialFolder(
  * the purchase list. Same answer the Browse dialog would preselect: the remembered folder, or
  * the first one the library already has.
  */
-export async function resolveTrackDest(): Promise<string> {
+export async function resolveTrackDest(game: GameInfo): Promise<string> {
   const modType = DEFAULT_MOD_TYPE;
   const installed = await getInstalledMods(modType.installSubpath).catch(() => []);
   const { options, guess } = buildDestinations(modType, "", installed);
-  return resolveInitialFolder(modType, options, guess);
+  return resolveInitialFolder(game, modType, options, guess);
 }
 
 export interface QuickInstallParams {
@@ -982,10 +1176,19 @@ export type QuickInstallResult =
   | { ok: true; params: QuickInstallParams }
   | { ok: false; reason: "blocked" | "none"; title: string; host?: string };
 
+/**
+ * The folder a one-click install from the Browse grid uses — the same answer the install
+ * dialog would have preselected, worked out without opening it.
+ *
+ * Rider mods route through `buildRiderDestinations` exactly as the dialog does. They used to
+ * fall through the generic (track/bike) logic instead, which knows nothing of gear models and
+ * so filed every quick-installed helmet, kit and suit in the `mods/rider` root.
+ */
 export async function resolveQuickInstall(
   slug: string,
   modType: ModType,
-  livery = false,
+  game: GameInfo,
+  categoryId: number | null | undefined,
 ): Promise<QuickInstallResult> {
   const detail = await getModDetail(slug);
   const mirrors = sortMirrors(detail);
@@ -993,6 +1196,34 @@ export async function resolveQuickInstall(
   if (!primary) return { ok: false, reason: "none", title: detail.title };
   if (isBlockedDownload(primary))
     return { ok: false, reason: "blocked", title: detail.title, host: primary.host };
+
+  const livery = isLiveryContext(modType, categoryId);
+
+  if (modType.id === "rider") {
+    const target = riderTarget(game, modType, categoryId);
+    const targets = await scanRiderTargets().catch(() => EMPTY_RIDER_TARGETS);
+    const { options, guess, derived } = buildRiderDestinations(
+      game,
+      targets,
+      detail.title,
+      detail.categories,
+      target,
+    );
+    return {
+      ok: true,
+      params: {
+        slug,
+        title: detail.title,
+        subpath: modType.installSubpath,
+        destFolder: resolveInitialFolder(game, modType, options, guess, false, false, {
+          target,
+          derived,
+        }),
+        url: primary.url,
+        host: primary.host,
+      },
+    };
+  }
 
   let installed: InstalledMod[] = [];
   let bikeTargets: string[] = [];
@@ -1013,7 +1244,7 @@ export async function resolveQuickInstall(
     detail.categories,
     bikeTargets,
   );
-  const destFolder = resolveInitialFolder(modType, options, guess, livery);
+  const destFolder = resolveInitialFolder(game, modType, options, guess, livery);
 
   return {
     ok: true,

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -892,11 +892,14 @@ export const de: Translation = {
   "dest.helmetsNewModel": "Helme (neues Modell)",
   "dest.bootsNewModel": "Stiefel (neues Modell)",
   "dest.protectionNewModel": "Protektoren (neues Modell)",
+  "dest.riderModelsNew": "Fahrermodelle (neues Modell)",
+  "dest.animationsNewStyle": "Fahrstile (neue Animation)",
   "dest.helmetPaintsFor": "{{name}} · Helm-Designs",
   "dest.gogglesFor": "{{name}} · Brille",
   "dest.bootPaintsFor": "{{name}} · Stiefel-Designs",
   "dest.protectionPaintsFor": "{{name}} · Protektoren-Designs",
   "dest.outfitFor": "{{name}} · Outfit / Kit",
+  "dest.suitPaintsFor": "{{name}} · Kombi-Designs",
   "dest.glovesFor": "{{name}} · Handschuhe",
 
   // In-game overlay — the hotkey panel drawn over MX Bikes.

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -850,11 +850,14 @@ export const en = {
   "dest.helmetsNewModel": "Helmets (new model)",
   "dest.bootsNewModel": "Boots (new model)",
   "dest.protectionNewModel": "Protection (new model)",
+  "dest.riderModelsNew": "Rider models (new model)",
+  "dest.animationsNewStyle": "Riding styles (new animation)",
   "dest.helmetPaintsFor": "{{name}} · helmet paints",
   "dest.gogglesFor": "{{name}} · goggles",
   "dest.bootPaintsFor": "{{name}} · boot paints",
   "dest.protectionPaintsFor": "{{name}} · protection paints",
   "dest.outfitFor": "{{name}} · outfit / kit",
+  "dest.suitPaintsFor": "{{name}} · suit paints",
   "dest.glovesFor": "{{name}} · gloves",
 
   // In-game overlay — the hotkey panel drawn over MX Bikes.

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -879,11 +879,14 @@ export const es: Translation = {
   "dest.helmetsNewModel": "Cascos (modelo nuevo)",
   "dest.bootsNewModel": "Botas (modelo nuevo)",
   "dest.protectionNewModel": "Protecciones (modelo nuevo)",
+  "dest.riderModelsNew": "Modelos de piloto (modelo nuevo)",
+  "dest.animationsNewStyle": "Estilos de pilotaje (animación nueva)",
   "dest.helmetPaintsFor": "{{name}} · gráficos de casco",
   "dest.gogglesFor": "{{name}} · gafas",
   "dest.bootPaintsFor": "{{name}} · gráficos de botas",
   "dest.protectionPaintsFor": "{{name}} · gráficos de protecciones",
   "dest.outfitFor": "{{name}} · equipación / kit",
+  "dest.suitPaintsFor": "{{name}} · gráficos de mono",
   "dest.glovesFor": "{{name}} · guantes",
 
   // In-game overlay — the hotkey panel drawn over MX Bikes.

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -881,11 +881,14 @@ export const fr: Translation = {
   "dest.helmetsNewModel": "Casques (nouveau modèle)",
   "dest.bootsNewModel": "Bottes (nouveau modèle)",
   "dest.protectionNewModel": "Protections (nouveau modèle)",
+  "dest.riderModelsNew": "Modèles de pilote (nouveau modèle)",
+  "dest.animationsNewStyle": "Styles de pilotage (nouvelle animation)",
   "dest.helmetPaintsFor": "{{name}} · décos casque",
   "dest.gogglesFor": "{{name}} · masque",
   "dest.bootPaintsFor": "{{name}} · décos bottes",
   "dest.protectionPaintsFor": "{{name}} · décos protections",
   "dest.outfitFor": "{{name}} · tenue / kit",
+  "dest.suitPaintsFor": "{{name}} · décos combinaison",
   "dest.glovesFor": "{{name}} · gants",
 
   // In-game overlay — the hotkey panel drawn over MX Bikes.

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -871,11 +871,14 @@ export const it: Translation = {
   "dest.helmetsNewModel": "Caschi (nuovo modello)",
   "dest.bootsNewModel": "Stivali (nuovo modello)",
   "dest.protectionNewModel": "Protezioni (nuovo modello)",
+  "dest.riderModelsNew": "Modelli pilota (nuovo modello)",
+  "dest.animationsNewStyle": "Stili di guida (nuova animazione)",
   "dest.helmetPaintsFor": "{{name}} · grafiche casco",
   "dest.gogglesFor": "{{name}} · maschera",
   "dest.bootPaintsFor": "{{name}} · grafiche stivali",
   "dest.protectionPaintsFor": "{{name}} · grafiche protezioni",
   "dest.outfitFor": "{{name}} · completo / kit",
+  "dest.suitPaintsFor": "{{name}} · grafiche tuta",
   "dest.glovesFor": "{{name}} · guanti",
 
   // In-game overlay — the hotkey panel drawn over MX Bikes.

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -870,11 +870,14 @@ export const ptBR: Translation = {
   "dest.helmetsNewModel": "Capacetes (modelo novo)",
   "dest.bootsNewModel": "Botas (modelo novo)",
   "dest.protectionNewModel": "Proteções (modelo novo)",
+  "dest.riderModelsNew": "Modelos de piloto (modelo novo)",
+  "dest.animationsNewStyle": "Estilos de pilotagem (nova animação)",
   "dest.helmetPaintsFor": "{{name}} · pinturas de capacete",
   "dest.gogglesFor": "{{name}} · óculos",
   "dest.bootPaintsFor": "{{name}} · pinturas de botas",
   "dest.protectionPaintsFor": "{{name}} · pinturas de proteções",
   "dest.outfitFor": "{{name}} · uniforme / kit",
+  "dest.suitPaintsFor": "{{name}} · pinturas de macacão",
   "dest.glovesFor": "{{name}} · luvas",
 
   // In-game overlay — the hotkey panel drawn over MX Bikes.

--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -4,8 +4,8 @@ import {
   scanLibrary,
   scanRiderTargets,
   scanModelSwaps,
+  EMPTY_RIDER_TARGETS,
   STOCK_RIDER_PROFILES,
-  type RiderTargets,
 } from "../api/mods";
 
 export interface SlotDef {
@@ -152,7 +152,7 @@ export async function loadScans(): Promise<Scans> {
     scanLibrary("mods/rider").catch(() => [] as LibraryEntry[]),
     scanLibrary("mods/tyres").catch(() => [] as LibraryEntry[]),
     scanRiderTargets().catch(
-      () => ({ helmets: [], boots: [], protection: [], profiles: [] }) as RiderTargets,
+      () => EMPTY_RIDER_TARGETS,
     ),
     scanModelSwaps().catch(() => [] as BikeModels[]),
   ]);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,16 @@ export interface GameCaps {
   servers: boolean;
 }
 
+/** One gear folder under `mods/rider` that new content installs into. */
+export interface RiderArea {
+  /** Folder name, e.g. `helmets`. */
+  folder: string;
+  /** Models here keep their liveries in `<model>/paints`. */
+  paints: boolean;
+  /** …and a `<model>/goggles` folder besides. */
+  goggles: boolean;
+}
+
 /** One title the app can drive, as reported by `listGames()`. */
 export interface GameInfo {
   id: GameId;
@@ -29,6 +39,15 @@ export interface GameInfo {
   /** Host of this title's catalog, e.g. `mxb-mods.com`. Shown wherever the UI names
    *  the site it links out to. */
   catalogDomain: string;
+  /** Gear areas under `mods/rider`, in the order to offer them. The two titles share
+   *  almost nothing here — MX Bikes has boots and protection, GP Bikes bakes those into
+   *  the rider model and has riding-style animations instead. */
+  riderAreas: RiderArea[];
+  /** Rider models the title ships, so a paint has somewhere to go on an empty mods
+   *  folder. Empty for GP Bikes: every suit there is made for a downloaded model. */
+  riderStockProfiles: string[];
+  /** Folders inside `riders/<model>/` beyond `paints` — MX Bikes' `gloves`, `goggles`. */
+  riderProfileExtras: string[];
   caps: GameCaps;
 }
 


### PR DESCRIPTION
## The problem

Every GP Bikes rider install landed in `mods/rider` itself. The game never opens that folder, so a suit the app reported as installed was simply absent in game.

Verified against the unpacked `gpbikes.exe` — its loader reads exactly:

```
rider\riders\<model>\paints\<paint>.pnt      suit paints
rider\riders\<model>\{rider.ini,gfx.cfg}     rider models
rider\helmets\<model>\paints\<paint>.pnt     helmet paints
rider\animations\<style>\...                 riding styles
```

No `boots`, no `protections`, no `gloves`, no `goggles` — GP bakes those into the rider model.

## The cause

`buildRiderDestinations` was MX Bikes-shaped in two ways:

1. **Category ids.** It knew only mxb-mods' numbering, so gpb-mods' Rider Models (54), Suit Paints (55 and its whole Modern / Modern 1 / Modern 2 / MGP 21 subtree) and Helmets (51) mapped to nothing — the guess resolved to `""` and the install wrote to the category root. The two sites numbered their taxonomies independently, so GP's **52** is Helmets › Replicas where MX's **52** is a rider kit.
2. **Fixed folders.** It offered GP `boots`, `protections`, gloves, goggles and a `default_mx` rider that doesn't exist there, while never offering `riders` or `animations`.

Two more instances of the same defect turned up alongside it:

- **Quick-install** (single and bulk, from the Browse grid) never called the rider builder at all — it fell through the generic track/bike logic, so every quick-installed helmet, kit and suit ignored the gear folders. That one bit MX Bikes too.
- **The drop route** aimed GP suits at `boots/<model>/paints`: a GP suit carries the boots' textures because the boots are part of the rider model, and the `boot` texture hint matched before anything else did.

## The fix

- `game.rs` now states, per title, which rider areas take new content (`RiderArea::installable`) and which rider models the game ships (`RiderLayout::stock_profiles` — empty for GP, because every GP suit is made for a downloaded model). Surfaced on `GameInfo` next to `mods_dirs`, so the UI names real folders instead of a hardcoded list and a third title stays one `const`.
- A suit's target model is ranked from the post's own categories — the family names it, "Modern 1" → `Modern Type 1` — with a digit pass to break the tie those families would otherwise leave. A destination the post decided outranks the folder used last time, the same rule bike liveries already follow.
- The last-used folder is remembered per title. MX Bikes keeps its existing storage key, so no one's choice is forgotten.
- `classify_paint` reads `suit` / `outfit` / `arms` as the rider's body before testing the gear hints, and skips hints for folders the active title doesn't have. A dropped protection paint also stops aiming at the singular `protection` the game no longer reads.
- The dropzone takes the title as an argument rather than reading process-wide state — which is also what lets a GP case and an MX case be tested side by side under `cargo test`'s parallelism.

## Verification

- 418 Rust tests pass, including four new ones: a GP suit isn't filed as boots, a GP suit asks when no rider model is installed, GP is offered only its own folders, and MX still gets its full set (with the legacy `protection` read but never written).
- `npm run typecheck` and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)