### PR TITLE
chore(release): consolidate v0.8.0 and give it a What's New page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,123 +1,15 @@
 # Changelog
 
-## 2026-08-09
-
-### Fixed
-- **GP Bikes suits go where GP Bikes reads them.** Every rider install landed in `mods/rider`
-  itself — the game never opens that folder, so a suit you'd just installed was nowhere in
-  the game. Suit paints now default to `riders/<your rider model>/paints`, rider models to
-  `riders`, helmet paints to `helmets/<model>/paints` and riding styles to `animations`,
-  which is exactly the set the game's loader reads and nothing else.
-- **The rider picker offers your game's folders, not the other one's.** GP Bikes was being
-  shown MX Bikes' `boots`, `protections`, gloves, goggles and `default_mx` rider — none of
-  which exist there — while `riders` and `animations` were missing entirely. Each title now
-  lists its own, and the folder you last picked is remembered per game.
-- **A suit paint knows which rider model it's for.** gpb-mods files suits under the model
-  family they fit — Modern 1, Modern 2, MGP 21 — and that now picks the installed model,
-  instead of falling back to whichever folder you used last.
-- **Quick-install stops dumping rider mods in the root.** One-click and bulk installs from
-  the Browse grid never asked the rider logic at all, so a helmet, kit or suit installed that
-  way ignored every gear folder. Both games.
-- **A dropped GP suit isn't filed as boots.** GP's suits carry the boots' textures because
-  the boots are part of the rider model, and the drop classifier read that as a boot paint —
-  aiming it at a folder GP Bikes has no loader for. Suit, outfit and arm textures now read as
-  the rider's body, and gear hints for folders your game doesn't have are ignored.
-- **A dropped protection paint goes to `protections`.** The drop route was still aiming at
-  the old singular spelling the game stopped reading.
-- **Protection is drawn the right way up.** Every piece in the slot rendered on its side: the
-  viewer assumed protection was authored the way the rider's body is, and it isn't — it takes
-  the same up-axis as a helmet, turned a quarter turn about it. Read off the meshes rather
-  than assumed, and checked against the game's own chest protector and neck brace, a tactical
-  vest, a Leatt, long hair and two chains. The library's quick-view had the same fault and now
-  faces a piece forward too.
-- **Installed protections show up at all.** The game keeps them in `mods/rider/protections`;
-  the app looked in — and installed to — `protection`, so nothing you dropped in the game's
-  folder was offered in the picker, and nothing the app installed was visible to the game.
-  New installs go to the game's folder; the old one is still read, so anything already there
-  keeps working.
-- **A protection set wears all of its pieces.** The game's own "Full" is a chest protector
-  *and* the neck brace worn with it, and only one of the two was drawn — a different one from
-  one run to the next. Every piece a mod declares is now drawn, each bound to its own mesh's
-  textures.
-- **Stock protection isn't a grey shape any more.** "Full" and "Neck" ship no paint of their
-  own, and the loader had nothing to dress them in; they now wear the texture baked into their
-  mesh, the same way a paintless mod already did.
-- **Chains hang where they belong.** A mesh whose geometry is a single group was placed twice,
-  which put a chain 35 cm below the rider and off to one side — most of the protection
-  category is chains. Gear now lands exactly on the bounds its own file states.
-- **A protection that ships sealed files loads out of a `.pkz` too**, not only out of a folder.
-- **The expanded 3D preview gives the model the window.** The title bar was taking half of it,
-  because the dialog laid its two rows out as an even grid.
-
-## 2026-08-08 — content behind a folder link is found
-
-### Fixed
-- **Paint folders shared between models with a junction or symlink are read again.** If you
-  keep one set of liveries and point several rider models at it — `mklink /J` on Windows, a
-  symlink on Linux and macOS — the app walked straight past the shared folder and showed
-  nothing in it, while the game loaded it fine. The only way to use the app was a copy of
-  every rider and glove paint per model. It now follows the link, so one folder can serve
-  all six of your rider models, and the paint is listed under each of them.
-
-  The cause is the same everywhere it bit: a junction is a *link*, and a directory listing
-  reports it as one rather than as a folder, so a scan that trusted the listing never
-  looked inside. That affected every content scan, not just paints — the Library, Manage,
-  the mod-detail panel, preset bundles and paint sync all shared it.
-- **A content folder that lives on another drive and is linked into place is scanned.** The
-  split layout — `mods\tracks` (or `bikes`, or `rider`) junctioned to somewhere with room
-  for it — used to come up empty.
-- **Auto-reload notices changes made behind a link.** A recursive watch stops at a
-  junction, so dropping a paint into the shared folder never pulsed FrostMod. The folders
-  those links point at are now watched too, and a change in one names every mod pointing
-  at it.
-- **Bundling a preset whose gear folder contains a link no longer fails.** The linked
-  folder's contents are copied into the bundle as real files, since the far end of your
-  junction doesn't exist on the machine that opens it.
-
-Extracted archives are deliberately left alone: a link inside a download you didn't make is
-still refused, which is what stops an archive writing outside the folder it unpacks into.
-
-## 2026-08-08 — paints preview on their own model, and helmets bind their goggles right
+## 2026-08-09 — v0.8.0 — GP Bikes, the MXB Shop, and a dropzone that takes anything
 
 ### Added
+
 - **Opening a paint in 3D now shows the model it was painted for, wearing it.** Click a
   livery, a helmet paint or a goggle paint and the viewer loads the bike or helmet it belongs
   to and selects that paint in the picker, instead of draping the textures over a stock body
   that was never the shape they were drawn against. A paint whose model isn't installed still
   previews the way it did before.
 
-### Changed
-- **The Library's 3D button says what it does.** The bare square on each row is now a
-  labelled **View in 3D**.
-- **Settings spells out which folder to pick.** The app wants your MX Bikes folder — the one
-  holding `mods` and `profiles` — not the `mods` folder inside it, which is one click deeper
-  in the picker and easy to land on. The setting now says so, and picking `mods` by mistake
-  quietly resolves to the folder above it (Settings says which one it took) rather than
-  leaving you with a library that scans nothing and a path that looks perfectly reasonable.
-
-### Fixed
-- **Helmets whose goggles came out wearing the helmet's paint.** The Bell Moto 10 packs are
-  the clear case: shell, tear-off, lens and goggle frame each ended up in the wrong texture,
-  the goggle worst of all. Three faults behind it, all in how a model's textures are counted
-  and matched:
-  - A helmet needn't ship the sheet its paints replace, and the Moto 10 doesn't — it names
-    it and leaves the pixels to the `.pnt`. That slot was going uncounted, so every piece
-    was drawn from its neighbour's texture.
-  - A one-character texture name (the Oakley pack calls its goggle sheet `O`) was skipped
-    entirely, sliding everything after it by one.
-  - Which pieces are the goggles was decided from their names, and a helmet names its
-    goggle group after the goggle it ships — `Armega`, `Airbrake` — not "goggles". It is now
-    decided by which paint supplies the texture the piece is drawn from, which is the mod's
-    own answer.
-- **Pieces no paint covers keep their own look.** A tear-off film, a visor, anything an author
-  baked into the mesh and left out of the `.pnt` used to have the shell's paint stretched
-  across it.
-- **A "Stock" option that showed a helmet in the wrong texture.** It's offered only where the
-  mesh really carries the sheet that side's paints replace.
-
-## 2026-08-08 — v0.8.0 — GP Bikes, dedicated servers, and paint sync
-
-### Added
 - **FrostMod's live mod reload now works for GP Bikes.** The status panel, the reload button
   and the watch-the-folder auto-reload are all available when GP Bikes is the active game —
   they were hidden before because FrostMod only knew about MX Bikes. The app launches it
@@ -284,6 +176,15 @@ still refused, which is what stops an archive writing outside the folder it unpa
   called itself the release it precedes.
 
 ### Changed
+
+- **The Library's 3D button says what it does.** The bare square on each row is now a
+  labelled **View in 3D**.
+- **Settings spells out which folder to pick.** The app wants your MX Bikes folder — the one
+  holding `mods` and `profiles` — not the `mods` folder inside it, which is one click deeper
+  in the picker and easy to land on. The setting now says so, and picking `mods` by mistake
+  quietly resolves to the folder above it (Settings says which one it took) rather than
+  leaving you with a library that scans nothing and a path that looks perfectly reasonable.
+
 - **Features that don't apply to GP Bikes are hidden rather than half-working.** FrostMod
   is a compiled MX Bikes plugin, so its sidebar panel and settings section are hidden for
   GP Bikes and instant profile refresh is shown disabled with the reason. The 3D preview
@@ -334,6 +235,97 @@ still refused, which is what stops an archive writing outside the folder it unpa
   was built for it.
 
 ### Fixed
+
+- **GP Bikes suits go where GP Bikes reads them.** Every rider install landed in `mods/rider`
+  itself — the game never opens that folder, so a suit you'd just installed was nowhere in
+  the game. Suit paints now default to `riders/<your rider model>/paints`, rider models to
+  `riders`, helmet paints to `helmets/<model>/paints` and riding styles to `animations`,
+  which is exactly the set the game's loader reads and nothing else.
+- **The rider picker offers your game's folders, not the other one's.** GP Bikes was being
+  shown MX Bikes' `boots`, `protections`, gloves, goggles and `default_mx` rider — none of
+  which exist there — while `riders` and `animations` were missing entirely. Each title now
+  lists its own, and the folder you last picked is remembered per game.
+- **A suit paint knows which rider model it's for.** gpb-mods files suits under the model
+  family they fit — Modern 1, Modern 2, MGP 21 — and that now picks the installed model,
+  instead of falling back to whichever folder you used last.
+- **Quick-install stops dumping rider mods in the root.** One-click and bulk installs from
+  the Browse grid never asked the rider logic at all, so a helmet, kit or suit installed that
+  way ignored every gear folder. Both games.
+- **A dropped GP suit isn't filed as boots.** GP's suits carry the boots' textures because
+  the boots are part of the rider model, and the drop classifier read that as a boot paint —
+  aiming it at a folder GP Bikes has no loader for. Suit, outfit and arm textures now read as
+  the rider's body, and gear hints for folders your game doesn't have are ignored.
+- **A dropped protection paint goes to `protections`.** The drop route was still aiming at
+  the old singular spelling the game stopped reading.
+- **Protection is drawn the right way up.** Every piece in the slot rendered on its side: the
+  viewer assumed protection was authored the way the rider's body is, and it isn't — it takes
+  the same up-axis as a helmet, turned a quarter turn about it. Read off the meshes rather
+  than assumed, and checked against the game's own chest protector and neck brace, a tactical
+  vest, a Leatt, long hair and two chains. The library's quick-view had the same fault and now
+  faces a piece forward too.
+- **Installed protections show up at all.** The game keeps them in `mods/rider/protections`;
+  the app looked in — and installed to — `protection`, so nothing you dropped in the game's
+  folder was offered in the picker, and nothing the app installed was visible to the game.
+  New installs go to the game's folder; the old one is still read, so anything already there
+  keeps working.
+- **A protection set wears all of its pieces.** The game's own "Full" is a chest protector
+  *and* the neck brace worn with it, and only one of the two was drawn — a different one from
+  one run to the next. Every piece a mod declares is now drawn, each bound to its own mesh's
+  textures.
+- **Stock protection isn't a grey shape any more.** "Full" and "Neck" ship no paint of their
+  own, and the loader had nothing to dress them in; they now wear the texture baked into their
+  mesh, the same way a paintless mod already did.
+- **Chains hang where they belong.** A mesh whose geometry is a single group was placed twice,
+  which put a chain 35 cm below the rider and off to one side — most of the protection
+  category is chains. Gear now lands exactly on the bounds its own file states.
+- **A protection that ships sealed files loads out of a `.pkz` too**, not only out of a folder.
+- **The expanded 3D preview gives the model the window.** The title bar was taking half of it,
+  because the dialog laid its two rows out as an even grid.
+
+- **Paint folders shared between models with a junction or symlink are read again.** If you
+  keep one set of liveries and point several rider models at it — `mklink /J` on Windows, a
+  symlink on Linux and macOS — the app walked straight past the shared folder and showed
+  nothing in it, while the game loaded it fine. The only way to use the app was a copy of
+  every rider and glove paint per model. It now follows the link, so one folder can serve
+  all six of your rider models, and the paint is listed under each of them.
+
+  The cause is the same everywhere it bit: a junction is a *link*, and a directory listing
+  reports it as one rather than as a folder, so a scan that trusted the listing never
+  looked inside. That affected every content scan, not just paints — the Library, Manage,
+  the mod-detail panel, preset bundles and paint sync all shared it.
+- **A content folder that lives on another drive and is linked into place is scanned.** The
+  split layout — `mods\tracks` (or `bikes`, or `rider`) junctioned to somewhere with room
+  for it — used to come up empty.
+- **Auto-reload notices changes made behind a link.** A recursive watch stops at a
+  junction, so dropping a paint into the shared folder never pulsed FrostMod. The folders
+  those links point at are now watched too, and a change in one names every mod pointing
+  at it.
+- **Bundling a preset whose gear folder contains a link no longer fails.** The linked
+  folder's contents are copied into the bundle as real files, since the far end of your
+  junction doesn't exist on the machine that opens it.
+
+Extracted archives are deliberately left alone: a link inside a download you didn't make is
+still refused, which is what stops an archive writing outside the folder it unpacks into.
+
+- **Helmets whose goggles came out wearing the helmet's paint.** The Bell Moto 10 packs are
+  the clear case: shell, tear-off, lens and goggle frame each ended up in the wrong texture,
+  the goggle worst of all. Three faults behind it, all in how a model's textures are counted
+  and matched:
+  - A helmet needn't ship the sheet its paints replace, and the Moto 10 doesn't — it names
+    it and leaves the pixels to the `.pnt`. That slot was going uncounted, so every piece
+    was drawn from its neighbour's texture.
+  - A one-character texture name (the Oakley pack calls its goggle sheet `O`) was skipped
+    entirely, sliding everything after it by one.
+  - Which pieces are the goggles was decided from their names, and a helmet names its
+    goggle group after the goggle it ships — `Armega`, `Airbrake` — not "goggles". It is now
+    decided by which paint supplies the texture the piece is drawn from, which is the mod's
+    own answer.
+- **Pieces no paint covers keep their own look.** A tear-off film, a visor, anything an author
+  baked into the mesh and left out of the `.pnt` used to have the shell's paint stretched
+  across it.
+- **A "Stock" option that showed a helmet in the wrong texture.** It's offered only where the
+  mesh really carries the sheet that side's paints replace.
+
 - **A config written by an older build lost track of which game was active.** Builds that
   predate multi-game support read the config fine but rewrite it without `activeGame` and
   `games` — so running one once (a downgrade, or the shipped app alongside a newer build)
@@ -446,10 +438,12 @@ still refused, which is what stops an archive writing outside the folder it unpa
   other.
 
 ### Notes
+
 - Instant profile refresh stays MX Bikes only. Unlike FrostMod's reload, it calls a
   hardcoded `mxbikes.exe` function offset, and there's no GP equivalent yet.
 
 ### Security
+
 - A paint carries the destination it should be written to, and that path arrives from
   another player. It's validated twice — once by the service and again in the app before it
   becomes a real path — because only the second check actually protects a disk. Anything

--- a/src/Components/Showcase/releases.ts
+++ b/src/Components/Showcase/releases.ts
@@ -8,7 +8,19 @@
  * Adding a release means adding an entry here and its strings to every locale. Nothing
  * else knows about versions.
  */
-import { Monitor, Languages, ListOrdered, Play, Bike } from "lucide-react";
+import {
+  Monitor,
+  Languages,
+  ListOrdered,
+  Play,
+  Bike,
+  Gamepad2,
+  Store,
+  FolderInput,
+  Wand2,
+  Shield,
+  Gauge,
+} from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { TKey } from "../../i18n/context";
 
@@ -34,6 +46,21 @@ export interface Release {
 }
 
 export const RELEASES: Release[] = [
+  {
+    version: "0.8.0",
+    hero: {
+      icon: Gamepad2,
+      title: "showcase.v080.hero.title",
+      body: "showcase.v080.hero.body",
+    },
+    highlights: [
+      { icon: Store, text: "showcase.v080.shop" },
+      { icon: FolderInput, text: "showcase.v080.dropzone" },
+      { icon: Wand2, text: "showcase.v080.destinations" },
+      { icon: Shield, text: "showcase.v080.protection" },
+      { icon: Gauge, text: "showcase.v080.faster" },
+    ],
+  },
   {
     version: "0.7.0",
     hero: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -941,6 +941,19 @@ export const de: Translation = {
   "showcase.whileGameRunning": "während MX Bikes läuft",
   "showcase.releaseNotes": "Release Notes lesen",
   "showcase.gotIt": "Alles klar",
+  "showcase.v080.hero.title": "MXB App steuert jetzt auch GP Bikes",
+  "showcase.v080.hero.body":
+    "Wähl dein Spiel beim ersten Start, oder wechsle jederzeit in den Einstellungen — die ganze App folgt: Bibliothek, Verwalten, Presets, Play und ein Durchsuchen-Tab von gpb-mods.com. GPs Fahrer-Ordner werden als GPs gelesen, nicht als die von MX Bikes, und FrostMod lädt auch dort live nach. Jedes Spiel behält seine eigenen Ordner, dein MX-Bikes-Setup bleibt also unangetastet.",
+  "showcase.v080.shop":
+    "Ein Shop-Tab durchsucht mxbikes-shop.com und installiert deine Käufe, ohne die App zu verlassen.",
+  "showcase.v080.dropzone":
+    "Zieh irgendwas auf das Fenster. Die App erkennt, was jede Datei ist, zeigt wohin sie geht und was sie ersetzen würde, und lässt dich jede Zeile vorher umlegen.",
+  "showcase.v080.destinations":
+    "Mods landen in dem Ordner, den das Spiel wirklich liest — eine Lackierung auf ihrem Bike, ein Helm-Design auf seinem Helm, eine GP-Kombi auf deinem Fahrermodell.",
+  "showcase.v080.protection":
+    "Der Protektoren-Slot funktioniert: jedes Teil aufrecht und vollständig gezeichnet, und dort installiert, wo das Spiel danach sucht.",
+  "showcase.v080.faster":
+    "Vorschaubilder werden zwischengespeichert und in der gezeigten Größe gezeichnet — Durchsuchen und Shop öffnen deutlich schneller.",
   "showcase.v070.hero.title": "Ein Overlay im Spiel, auf einem Kürzel",
   "showcase.v070.hero.body": "Holt Preset, Locker und Browse über MX Bikes — ohne Alt-Tab. Esc gibt die Kontrolle sofort zurück, und ein hier gewähltes Preset landet in der Session, die du gerade fährst. Spiele randlos oder im Fenster: über exklusivem Vollbild lässt sich nichts zeichnen.",
   "showcase.v070.hero.action": "Overlay einrichten",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -899,6 +899,19 @@ export const en = {
   "showcase.whileGameRunning": "while MX Bikes is running",
   "showcase.releaseNotes": "Read the release notes",
   "showcase.gotIt": "Got it",
+  "showcase.v080.hero.title": "MXB App drives GP Bikes too",
+  "showcase.v080.hero.body":
+    "Pick your game at first launch, or switch any time in Settings — the whole app follows: Library, Manage, Presets, Play, and a Browse tab served by gpb-mods.com. GP's rider folders are read as GP's, not as MX Bikes', and FrostMod hot-reloads there as well. Each game keeps its own folders, so your MX Bikes setup is untouched.",
+  "showcase.v080.shop":
+    "A Shop tab browses mxbikes-shop.com and installs what you've bought, without leaving the app.",
+  "showcase.v080.dropzone":
+    "Drag anything onto the window. It works out what each file is, shows where it's going and what it would replace, and lets you re-file any row before it installs.",
+  "showcase.v080.destinations":
+    "Mods land in the folder the game actually reads — a livery on its bike, a helmet paint on its helmet, a GP suit on your rider model.",
+  "showcase.v080.protection":
+    "The protection slot works: every piece drawn upright and whole, and installed where the game looks for it.",
+  "showcase.v080.faster":
+    "Thumbnails are cached and drawn at the size they're shown, so Browse and the Shop open far quicker.",
   "showcase.v070.hero.title": "An in-game overlay, on a hotkey",
   "showcase.v070.hero.body": "Brings Presets, the Locker and Browse up over MX Bikes — no alt-tab. Esc hands control straight back, and a preset picked here lands on the session you're already riding. Run the game borderless or windowed: nothing can be drawn over exclusive fullscreen.",
   "showcase.v070.hero.action": "Set up the overlay",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -928,6 +928,19 @@ export const es: Translation = {
   "showcase.whileGameRunning": "mientras MX Bikes está abierto",
   "showcase.releaseNotes": "Leer las notas de la versión",
   "showcase.gotIt": "Entendido",
+  "showcase.v080.hero.title": "MXB App también maneja GP Bikes",
+  "showcase.v080.hero.body":
+    "Elige tu juego en el primer arranque, o cámbialo cuando quieras en Ajustes: toda la app lo sigue — Biblioteca, Gestionar, Presets, Jugar y una pestaña Explorar servida por gpb-mods.com. Las carpetas de piloto de GP se leen como las de GP, no como las de MX Bikes, y FrostMod también recarga en caliente allí. Cada juego guarda sus propias carpetas, así que tu configuración de MX Bikes queda intacta.",
+  "showcase.v080.shop":
+    "Una pestaña Tienda explora mxbikes-shop.com e instala lo que has comprado, sin salir de la app.",
+  "showcase.v080.dropzone":
+    "Arrastra lo que sea a la ventana. Deduce qué es cada archivo, muestra dónde va y qué reemplazaría, y te deja recolocar cualquier fila antes de instalar.",
+  "showcase.v080.destinations":
+    "Los mods aterrizan en la carpeta que el juego lee de verdad — una decoración en su moto, un gráfico de casco en su casco, un mono de GP en tu modelo de piloto.",
+  "showcase.v080.protection":
+    "La ranura de protecciones funciona: cada pieza dibujada derecha y entera, e instalada donde el juego la busca.",
+  "showcase.v080.faster":
+    "Las miniaturas se cachean y se dibujan al tamaño en que se muestran, así que Explorar y la Tienda abren mucho más rápido.",
   "showcase.v070.hero.title": "Un overlay en el juego, con un atajo",
   "showcase.v070.hero.body": "Abre Preset, Locker y Browse sobre MX Bikes — sin alt-tab. Esc devuelve el control al momento, y un preset elegido aquí cae en la sesión que ya estás rodando. Juega sin bordes o en ventana: sobre la pantalla completa exclusiva no se puede dibujar nada.",
   "showcase.v070.hero.action": "Configurar el overlay",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -930,6 +930,19 @@ export const fr: Translation = {
   "showcase.whileGameRunning": "pendant que MX Bikes tourne",
   "showcase.releaseNotes": "Lire les notes de version",
   "showcase.gotIt": "Compris",
+  "showcase.v080.hero.title": "MXB App gère aussi GP Bikes",
+  "showcase.v080.hero.body":
+    "Choisis ton jeu au premier lancement, ou change quand tu veux dans les Réglages : toute l'app suit — Bibliothèque, Gérer, Presets, Jouer, et un onglet Parcourir servi par gpb-mods.com. Les dossiers pilote de GP sont lus comme ceux de GP, pas comme ceux de MX Bikes, et FrostMod y recharge à chaud aussi. Chaque jeu garde ses propres dossiers : ta configuration MX Bikes n'est pas touchée.",
+  "showcase.v080.shop":
+    "Un onglet Boutique parcourt mxbikes-shop.com et installe ce que tu as acheté, sans quitter l'app.",
+  "showcase.v080.dropzone":
+    "Dépose n'importe quoi sur la fenêtre. L'app devine ce qu'est chaque fichier, montre où il va et ce qu'il remplacerait, et te laisse reclasser chaque ligne avant l'installation.",
+  "showcase.v080.destinations":
+    "Les mods atterrissent dans le dossier que le jeu lit vraiment — une déco sur sa moto, une déco de casque sur son casque, une combinaison GP sur ton modèle de pilote.",
+  "showcase.v080.protection":
+    "L'emplacement protections fonctionne : chaque pièce dessinée droite et entière, et installée là où le jeu la cherche.",
+  "showcase.v080.faster":
+    "Les vignettes sont mises en cache et dessinées à la taille affichée : Parcourir et la Boutique s'ouvrent bien plus vite.",
   "showcase.v070.hero.title": "Un overlay en jeu, sur un raccourci",
   "showcase.v070.hero.body": "Ouvre Preset, Locker et Browse par-dessus MX Bikes — sans alt-tab. Esc rend la main aussitôt, et un preset choisi ici arrive sur la session que tu es en train de rouler. Joue en sans bordure ou en fenêtre : rien ne peut s'afficher par-dessus le plein écran exclusif.",
   "showcase.v070.hero.action": "Configurer l'overlay",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -920,6 +920,19 @@ export const it: Translation = {
   "showcase.whileGameRunning": "mentre MX Bikes è in esecuzione",
   "showcase.releaseNotes": "Leggi le note di rilascio",
   "showcase.gotIt": "Ho capito",
+  "showcase.v080.hero.title": "MXB App gestisce anche GP Bikes",
+  "showcase.v080.hero.body":
+    "Scegli il gioco al primo avvio, o cambialo quando vuoi nelle Impostazioni: tutta l'app lo segue — Libreria, Gestisci, Preset, Play e una scheda Sfoglia servita da gpb-mods.com. Le cartelle pilota di GP vengono lette come quelle di GP, non di MX Bikes, e anche lì FrostMod ricarica al volo. Ogni gioco tiene le proprie cartelle, quindi la tua configurazione di MX Bikes resta intatta.",
+  "showcase.v080.shop":
+    "La scheda Shop naviga mxbikes-shop.com e installa ciò che hai acquistato, senza uscire dall'app.",
+  "showcase.v080.dropzone":
+    "Trascina qualsiasi cosa sulla finestra. Capisce cos'è ogni file, mostra dove finirà e cosa sostituirebbe, e ti lascia ricollocare ogni riga prima di installare.",
+  "showcase.v080.destinations":
+    "I mod finiscono nella cartella che il gioco legge davvero — una livrea sulla sua moto, una grafica casco sul suo casco, una tuta GP sul tuo modello pilota.",
+  "showcase.v080.protection":
+    "Lo slot protezioni funziona: ogni pezzo disegnato dritto e completo, e installato dove il gioco lo cerca.",
+  "showcase.v080.faster":
+    "Le anteprime sono in cache e disegnate alla dimensione mostrata, così Sfoglia e Shop si aprono molto più in fretta.",
   "showcase.v070.hero.title": "Un overlay in gioco, su una scorciatoia",
   "showcase.v070.hero.body": "Apre Preset, Locker e Browse sopra MX Bikes — senza alt-tab. Esc restituisce subito il controllo e un preset scelto qui arriva sulla sessione che stai già guidando. Gioca senza bordi o in finestra: sopra il fullscreen esclusivo non si può disegnare nulla.",
   "showcase.v070.hero.action": "Configura l'overlay",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -919,6 +919,19 @@ export const ptBR: Translation = {
   "showcase.whileGameRunning": "enquanto o MX Bikes está aberto",
   "showcase.releaseNotes": "Ler as notas da versão",
   "showcase.gotIt": "Entendi",
+  "showcase.v080.hero.title": "O MXB App também comanda o GP Bikes",
+  "showcase.v080.hero.body":
+    "Escolha seu jogo no primeiro início, ou troque quando quiser nas Configurações — o app inteiro acompanha: Biblioteca, Gerenciar, Presets, Jogar e uma aba Explorar servida pelo gpb-mods.com. As pastas de piloto do GP são lidas como do GP, não como as do MX Bikes, e o FrostMod recarrega ao vivo lá também. Cada jogo guarda suas próprias pastas, então sua configuração do MX Bikes fica intacta.",
+  "showcase.v080.shop":
+    "Uma aba Loja navega pelo mxbikes-shop.com e instala o que você comprou, sem sair do app.",
+  "showcase.v080.dropzone":
+    "Arraste qualquer coisa para a janela. Ele descobre o que é cada arquivo, mostra para onde vai e o que substituiria, e deixa você remanejar qualquer linha antes de instalar.",
+  "showcase.v080.destinations":
+    "Os mods caem na pasta que o jogo realmente lê — uma pintura na moto dela, uma pintura de capacete no capacete dele, um macacão de GP no seu modelo de piloto.",
+  "showcase.v080.protection":
+    "O slot de proteções funciona: cada peça desenhada em pé e inteira, e instalada onde o jogo procura.",
+  "showcase.v080.faster":
+    "As miniaturas ficam em cache e são desenhadas no tamanho exibido, então Explorar e a Loja abrem bem mais rápido.",
   "showcase.v070.hero.title": "Um overlay dentro do jogo, num atalho",
   "showcase.v070.hero.body": "Abre Preset, Locker e Browse por cima do MX Bikes — sem alt-tab. Esc devolve o controle na hora, e um preset escolhido aqui cai na sessão que você já está pilotando. Jogue sem bordas ou em janela: nada é desenhado por cima da tela cheia exclusiva.",
   "showcase.v070.hero.action": "Configurar o overlay",


### PR DESCRIPTION
Release prep for the full **v0.8.0** tag. `v0.8.0` has only ever been tagged as `beta.1`/`beta.2`, so the plain tag is what ships it to everyone through the updater.

- **CHANGELOG** — folds the three unreleased dated sections (the protection slot, the GP Bikes rider destinations, content behind folder links, paints previewing on their own model) into the `v0.8.0` section, and names the release for what it actually carries. `scripts/changelog-section.sh v0.8.0` is what composes the GitHub release body and the Discord announcement, so this is the file that has to be right before tagging.
- **What's New** — the showcase modal had no 0.8.0 entry, so the biggest release so far would have shipped announcing nothing. GP Bikes support is the hero; the Shop tab, the whole-window dropzone, install destinations, the protection slot and the thumbnail cache are the lines under it. Strings in all six locales (`tsc` enforces completeness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)