### PR TITLE
fix(browse): show GP Bikes mod pictures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2026-08-09 — v0.8.1 — GP Bikes' mod pictures
+
+A patch on top of v0.8.0 — everything that release added is still the news, and its notes are
+repeated below.
+
+### Fixed
+- **GP Bikes mods show their pictures in Browse.** Every card in the GP grid came up blank,
+  and so did the pictures inside a mod's page. The app fetches thumbnails through its own
+  cache rather than letting the page load them directly, and that cache only ever knew
+  mxb-mods.com and the store — gpb-mods.com wasn't on the list, so every GP image was refused
+  before it was ever requested. The list is now built from the games the app drives, so a
+  title's catalog can't be added without its pictures working.
+- **GP thumbnails are fetched as GP Bikes' own visitor.** They were going out through the
+  store's session, which holds cookies for a different site. The two catalogs keep separate
+  sessions on purpose — Cloudflare scopes a clearance to the host that issued it — and images
+  now follow the host they came from rather than whichever game is selected.
+
 ## 2026-08-09 — v0.8.0 — GP Bikes, the MXB Shop, and a dropzone that takes anything
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -33,25 +33,44 @@ EOF
     ;;
 esac
 
+# `## 2026-08-07 — v0.7.0 — Six languages, …` → the part after the version.
+release_name() {
+  "$here/changelog-section.sh" "$1" --heading | awk -F'—' '
+    NF >= 3 { s = $3; for (i = 4; i <= NF; i++) s = s "—" $i
+              gsub(/^[ \t]+|[ \t]+$/, "", s); print s }'
+}
+
+# One version's section under its own "What's new in …" heading.
+section_block() {
+  local ver="$1" lead="$2" body name title
+  body="$("$here/changelog-section.sh" "$ver")" || return 1
+  [ -n "$body" ] || return 1
+  name="$(release_name "$ver")"
+  title="$lead ${ver%%-*}"
+  [ -n "$name" ] && title="$title — $name"
+  printf '## %s\n\n%s\n\n---\n\n' "$title" "$body"
+}
+
 # A build with no changelog section (a `workflow_dispatch` test build, tagged
 # `v<run_number>`) still gets the download guidance — it just has nothing to announce.
-if section="$("$here/changelog-section.sh" "$TAG")" && [ -n "$section" ]; then
-  heading="$("$here/changelog-section.sh" "$TAG" --heading)"
-  # `## 2026-08-07 — v0.7.0 — Six languages, …` → the part after the version.
-  name="$(printf '%s' "$heading" | awk -F'—' '
-    NF >= 3 { s = $3; for (i = 4; i <= NF; i++) s = s "—" $i
-              gsub(/^[ \t]+|[ \t]+$/, "", s); print s }')"
-  title="What's new in ${TAG%%-*}"
-  [ -n "$name" ] && title="$title — $name"
-  cat <<EOF
-## $title
+section_block "$TAG" "What's new in" || true
 
-$section
-
----
-
-EOF
-fi
+# A patch is the same app as the `.0` it patches, so its page repeats that release's notes:
+# someone landing on v0.8.1 came for MXB App, not for the two lines that changed since v0.8.0,
+# and the features are what tells them whether they want it. Discord is deliberately left
+# alone — `notify-discord.sh` reads only the tag's own section, because re-dumping a whole
+# feature list into a chat channel for a patch is noise.
+version="${TAG#v}"
+version="${version%%-*}"
+case "$version" in
+  *.*.*)
+    patch="${version##*.}"
+    minor_zero="${version%.*}.0"
+    if [ "$patch" != "0" ]; then
+      section_block "v$minor_zero" "Everything new in" || true
+    fi
+    ;;
+esac
 
 cat <<'EOF'
 ## Which file do I download?

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "frost"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frost"
-version = "0.8.0"
+version = "0.8.1"
 description = "Frost — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/src/imgcache.rs
+++ b/src-tauri/src/imgcache.rs
@@ -29,18 +29,28 @@ pub const SCHEME: &str = "imgcache";
 /// Bumped when the on-disk layout changes, so old entries are dropped rather than misread.
 const CACHE_DIR: &str = "img-v1";
 
-/// Hosts we're willing to fetch from.
+/// The store's hosts. `mxbikes-shop.b-cdn.net` is its own Bunny pull zone, named in full
+/// rather than as `b-cdn.net` — that suffix is shared by every Bunny customer, and matching
+/// it would open the proxy to all of them. A few dozen product descriptions embed images
+/// from it.
+const SHOP_HOSTS: [&str; 2] = ["mxbikes-shop.com", "mxbikes-shop.b-cdn.net"];
+
+/// Is `host` one we're willing to fetch from?
 ///
 /// Not paranoia: the scheme handler will fetch whatever URL it's handed, so without this it
 /// would be a general-purpose proxy that any injected markup could aim anywhere.
-/// `mxbikes-shop.b-cdn.net` is the store's own Bunny pull zone, named in full rather than as
-/// `b-cdn.net` — that suffix is shared by every Bunny customer, and matching it would open the
-/// proxy to all of them. A few dozen product descriptions embed images from it.
-const ALLOWED_HOSTS: [&str; 3] = [
-    "mxb-mods.com",
-    "mxbikes-shop.com",
-    "mxbikes-shop.b-cdn.net",
-];
+///
+/// The catalogs come from the game table rather than a list written out here, because a list
+/// written out here is a list that gets forgotten: gpb-mods.com wasn't on it, so every GP
+/// Bikes thumbnail was refused and Browse showed a grid of blank cards. A third title's
+/// catalog is now covered the moment its `GameProfile` exists.
+fn is_allowed(host: &str) -> bool {
+    let under = |domain: &str| host == domain || host.ends_with(&format!(".{domain}"));
+    crate::game::Game::ALL
+        .iter()
+        .any(|g| under(g.profile().catalog.domain))
+        || SHOP_HOSTS.iter().any(|h| under(h))
+}
 
 /// Roughly a few thousand thumbnails. Generous, because the whole point is not refetching.
 const MAX_CACHE_BYTES: u64 = 256 * 1024 * 1024;
@@ -135,10 +145,7 @@ fn source_url(uri: &str) -> Option<String> {
         return None;
     }
     let host = url.host_str()?.to_ascii_lowercase();
-    let allowed = ALLOWED_HOSTS
-        .iter()
-        .any(|a| host == *a || host.ends_with(&format!(".{a}")));
-    allowed.then(|| url.to_string())
+    is_allowed(&host).then(|| url.to_string())
 }
 
 /// The `?w=` the caller asked for, if any.
@@ -348,14 +355,27 @@ fn touch(path: &Path) {
 
 /// Images are fetched with the same session as the catalog they belong to, so a
 /// `cf_clearance` earned for a site applies to its images too.
+///
+/// Which site that is comes from the URL's host, not from the active game: the two catalogs
+/// keep separate jars precisely because a clearance is scoped to the host that minted it, so
+/// serving a gpb-mods.com thumbnail through mxb-mods.com's session — or, as it did before,
+/// through the store's — sends a cookie that can only fail.
 fn client_for(url: &str) -> Option<&'static reqwest::Client> {
     static MXB: OnceLock<Option<reqwest::Client>> = OnceLock::new();
+    static GPB: OnceLock<Option<reqwest::Client>> = OnceLock::new();
     static SHOP: OnceLock<Option<reqwest::Client>> = OnceLock::new();
 
     let host = reqwest::Url::parse(url).ok()?.host_str()?.to_ascii_lowercase();
-    if host == "mxb-mods.com" || host.ends_with(".mxb-mods.com") {
-        MXB.get_or_init(|| crate::mxb_session::client_builder().build().ok())
+    let under = |domain: &str| host == domain || host.ends_with(&format!(".{domain}"));
+
+    let catalog = |slot: &'static OnceLock<Option<reqwest::Client>>, site| {
+        slot.get_or_init(|| crate::mxb_session::client_builder_for(site).build().ok())
             .as_ref()
+    };
+    if under(crate::mxb_session::MXB_SITE.domain) {
+        catalog(&MXB, &crate::mxb_session::MXB_SITE)
+    } else if under(crate::mxb_session::GPB_SITE.domain) {
+        catalog(&GPB, &crate::mxb_session::GPB_SITE)
     } else {
         SHOP.get_or_init(|| crate::shop_catalog_session::client_builder().build().ok())
             .as_ref()
@@ -520,9 +540,10 @@ mod tests {
     }
 
     #[test]
-    fn accepts_the_two_catalog_origins_and_their_cdns() {
+    fn accepts_the_catalog_origins_and_their_cdns() {
         for url in [
             "https://mxb-mods.com/wp-content/uploads/a.jpg",
+            "https://gpb-mods.com/wp-content/uploads/a.jpg",
             "https://mxbikes-shop.com/img/1.png",
             "https://cdn.mxbikes-shop.com/img/1.png",
             // The store's Bunny pull zone — where some product descriptions embed from.
@@ -530,6 +551,52 @@ mod tests {
         ] {
             assert_eq!(source_url(&encoded(url)).as_deref(), Some(url), "{url}");
         }
+    }
+
+    /// Every catalog the app can browse has to be fetchable, or that title's Browse is a
+    /// grid of blank cards — which is exactly what shipped for GP Bikes. Driven off the game
+    /// table so adding a title can't quietly leave its thumbnails refused.
+    #[test]
+    fn every_titles_catalog_is_fetchable() {
+        for game in crate::game::Game::ALL {
+            let url = format!(
+                "https://{}/wp-content/uploads/2026/01/thumb.jpg",
+                game.profile().catalog.domain,
+            );
+            assert_eq!(
+                source_url(&encoded(&url)).as_deref(),
+                Some(url.as_str()),
+                "{} browses {} — its images must load",
+                game.id(),
+                game.profile().catalog.domain,
+            );
+        }
+    }
+
+    /// End-to-end against the live catalog: take a real thumbnail off gpb-mods.com's API,
+    /// put it through the same three steps a `<img src="imgcache://…">` does — allowlist,
+    /// session-picked client, fetch — and check what comes back is a real image the cache
+    /// would serve. The unit tests above prove the allowlist; only this proves a GP Bikes
+    /// card actually gets pixels.
+    ///
+    /// Ignored by default because it hits the network. Run it with
+    /// `cargo test gp_bikes_thumbnails_really_load -- --ignored --nocapture`.
+    #[tokio::test]
+    #[ignore = "hits live gpb-mods.com"]
+    async fn gp_bikes_thumbnails_really_load() {
+        let api = "https://gpb-mods.com/wp-json/wp/v2/posts\
+                   ?categories=18&per_page=1&_embed=wp:featuredmedia";
+        let posts: serde_json::Value = reqwest::get(api).await.unwrap().json().await.unwrap();
+        let origin = posts[0]["_embedded"]["wp:featuredmedia"][0]["source_url"]
+            .as_str()
+            .expect("the catalog gives its posts a featured image")
+            .to_string();
+
+        let url = source_url(&encoded(&origin)).expect("a GP thumbnail must not be refused");
+        let bytes = fetch(&url).await.expect("and it must actually fetch");
+        let mime = sniff(&bytes).expect("what comes back has to be an image");
+        assert!(bytes.len() > 1024, "{mime} of only {} bytes", bytes.len());
+        println!("{origin}\n  -> {mime}, {} bytes", bytes.len());
     }
 
     /// The pull zone is allowed by its full name. `b-cdn.net` is Bunny's shared domain, so

--- a/src-tauri/src/mxb_session.rs
+++ b/src-tauri/src/mxb_session.rs
@@ -80,7 +80,15 @@ fn jar_for(site: &Site) -> Arc<Jar> {
 /// The mods client is built from this so its User-Agent, jar and timeouts cannot drift from
 /// the fetch WebView's. Callers add their own default headers.
 pub fn client_builder() -> reqwest::ClientBuilder {
-    let site = site();
+    client_builder_for(site())
+}
+
+/// A builder for a *named* catalog rather than the active one.
+///
+/// The image cache needs this: a thumbnail's host says which site it belongs to, and that is
+/// not always the game currently selected — a description can embed an image from either, and
+/// a fetch already in flight outlives a game switch.
+pub fn client_builder_for(site: &'static Site) -> reqwest::ClientBuilder {
     cookie_session::client_builder(site, jar_for(site))
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/imgcache.ts
+++ b/src/lib/imgcache.ts
@@ -53,7 +53,12 @@ export function cachedImage(
  * mod authors, which can point anywhere. Routing a host the handler refuses would turn an
  * image that loads today into one that can't load at all, so those are left alone.
  */
-const CACHEABLE_HOSTS = ["mxb-mods.com", "mxbikes-shop.com", "mxbikes-shop.b-cdn.net"];
+const CACHEABLE_HOSTS = [
+  "mxb-mods.com",
+  "gpb-mods.com",
+  "mxbikes-shop.com",
+  "mxbikes-shop.b-cdn.net",
+];
 
 /** Whether [`cachedImage`] would resolve to something the handler is willing to serve. */
 export function isCacheableImage(url: string): boolean {


### PR DESCRIPTION
## The problem

Every card in GP Bikes' Browse grid was blank, and so were the images inside a mod's page.

Thumbnails don't load from the page — they go through the app's own `imgcache://` scheme, which fetches, downscales and caches them in Rust. That handler will fetch whatever URL it's handed, so it holds an allowlist. The allowlist was a hand-written literal naming mxb-mods.com and the store; **gpb-mods.com was never added**, so every GP image was refused before a request was made.

Note the catalog itself was fine all along — gpb-mods.com serves a `featured_media` on every post, exactly as mxb-mods does. Nothing was missing upstream.

## The fix

- **The allowlist's catalogs come from `game::Game::ALL`**, not a literal list, so a title's catalog is covered the moment its `GameProfile` exists. The store's two hosts stay literal — `mxbikes-shop.b-cdn.net` is named in full because `b-cdn.net` is shared by every Bunny customer, and matching the suffix would hand the proxy to all of them.
- **Images are fetched with the session of the host they came from.** GP images were going out through the *store's* client, which holds cookies for a different site. The two catalogs keep separate jars precisely because a `cf_clearance` is scoped to the host that minted it. Adds `mxb_session::client_builder_for`, since the active game isn't necessarily the site a given image belongs to — a description can embed from either, and a fetch in flight outlives a game switch.
- `lib/imgcache.ts` mirrors the host list, which is what governs images embedded in mod descriptions.

## Verification

An end-to-end test against the live catalog takes a real thumbnail off gpb-mods.com's API and puts it through the same three steps a card does — allowlist, session-picked client, fetch:

```
https://gpb-mods.com/wp-content/uploads/2026/08/Gy9nMhjXQAA_ONF-scaled.webp
  -> image/webp, 250092 bytes
```

Both new tests were checked against the shipped behaviour first and fail there ("a GP thumbnail must not be refused"). 419 tests pass; typecheck clean.

The unit test is driven off the game table, so adding a title can't quietly leave its thumbnails refused again.

## Also in here

Version bumped to **0.8.1**, and `release-notes.sh` now repeats the `.0` release's notes on a patch tag — someone landing on v0.8.1 came for MXB App, not for the two lines that changed since v0.8.0. Discord is deliberately left alone; a patch announcement re-dumping the whole feature list into chat is noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)