### PR TITLE
feat(frostmod): detect and install the missing Visual C++ runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 2026-08-09 — The app spots the missing Windows component behind a dead FrostMod
+
+### Added
+- **"msvcr90.dll was not found" is now something the app explains and fixes.** MX Bikes is
+  a Visual C++ 2008 build, and it asks Windows for that runtime by manifest rather than by
+  path — which resolves either machine-wide or out of a private copy sitting in the game
+  folder. On a PC living on the second one the game launches perfectly while nothing loaded
+  from anywhere else can find the runtime, and FrostMod is loaded from somewhere else. The
+  result was the worst kind of bug report: the game works, FrostMod doesn't, and Windows
+  puts a bare error box over the screen that names a DLL and nothing else. The app now
+  checks for that runtime, and for the newer one `frostmod.dll` itself needs, says which is
+  missing in plain language, and installs it from Microsoft with one button.
+- **The warning goes where it'll be seen.** A bar at the top of the app, not just a line in
+  Settings — nothing about the symptom suggests Settings is where to look.
+
+### Changed
+- **FrostMod still starts when a runtime is missing.** It's a warning, not a gate: we can't
+  tell from outside which PCs manage to inject anyway, and refusing to launch would take
+  FrostMod away from anyone the check is wrong about.
+
+### Fixed
+- **Settings offers Stop for a FrostMod it didn't install.** The button was hidden unless
+  the app had put FrostMod there itself — so the one case that most needs a stop, a
+  `frostmod.exe` running that the app didn't start, had no button. The backend could
+  always kill it; only the button was missing. (The sidebar's stop control was unaffected.)
+
 ## 2026-08-09
 
 ### Fixed

--- a/src-tauri/src/frostmod_manage.rs
+++ b/src-tauri/src/frostmod_manage.rs
@@ -6,7 +6,7 @@ use tauri::{AppHandle, Manager};
 
 /// FrostMod's GitHub repo — releases carry `frostmod.exe` + `frostmod.dll`.
 const REPO: &str = "Frostn1/frostmod";
-const UA: &str = "mxb-app";
+pub const UA: &str = "mxb-app";
 
 /// The binaries a FrostMod release has to ship. Both land or neither does — a new
 /// `frostmod.exe` beside an old `frostmod.dll` is a worse state than not updating.
@@ -39,6 +39,14 @@ pub struct FrostmodStatus {
     /// UI offers an update instead of a start; starting it anyway is what crashed GP
     /// Bikes, so `start` refuses too.
     pub supported_for_game: bool,
+    /// Visual C++ runtimes this machine is short of. Empty is the normal case (and always
+    /// the case off Windows). Non-empty means FrostMod will very likely fail to attach with
+    /// a bare "…dll was not found" box over the game — see `crate::vcruntime`.
+    ///
+    /// Unlike the flags above this does **not** gate `start`: we can't prove from out here
+    /// which machines inject fine, and refusing to launch would take FrostMod away from
+    /// anyone the detection is wrong about. It's a warning with a fix attached.
+    pub missing_runtimes: Vec<crate::vcruntime::Runtime>,
 }
 
 fn frostmod_dir(app: &AppHandle) -> PathBuf {
@@ -223,6 +231,7 @@ pub async fn status(app: &AppHandle) -> FrostmodStatus {
         needs_repair,
         running: crate::frostmod::is_running(),
         supported_for_game,
+        missing_runtimes: crate::vcruntime::missing(),
     }
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -39,6 +39,7 @@ mod shop_session;
 mod soundmods;
 mod texstore;
 mod upload;
+mod vcruntime;
 
 use config::AppConfig;
 use frostmod::ReloadOutcome;
@@ -3613,6 +3614,21 @@ async fn frostmod_install(
     Ok(report)
 }
 
+/// Install a Visual C++ runtime `frostmod_status` reported missing.
+///
+/// Raises a UAC prompt — Microsoft's redistributables require admin, and only the shell
+/// can ask. A declined prompt comes back as `cancelled`, not an error, so the UI can fall
+/// back to handing over the download link instead of reading as broken.
+#[tauri::command]
+async fn frostmod_install_runtime(
+    app: tauri::AppHandle,
+    runtime: vcruntime::Runtime,
+) -> Result<vcruntime::InstallOutcome, String> {
+    vcruntime::install(&app, runtime)
+        .await
+        .map_err(|e| format!("{e:#}"))
+}
+
 #[tauri::command]
 fn frostmod_start(app: tauri::AppHandle, state: State<FrostmodProcess>) -> Result<bool, String> {
     frostmod_manage::start(&app, &state).map_err(|e| format!("{e:#}"))
@@ -4434,6 +4450,7 @@ fn main() {
             garage_swap_bike,
             frostmod_status,
             frostmod_install,
+            frostmod_install_runtime,
             frostmod_start,
             frostmod_stop,
             launch_game,

--- a/src-tauri/src/vcruntime.rs
+++ b/src-tauri/src/vcruntime.rs
@@ -1,0 +1,468 @@
+//! Visual C++ runtime preflight for the FrostMod chain.
+//!
+//! Two different runtimes have to be present before FrostMod can attach to the game,
+//! and when either is missing Windows says so with a bare "the code execution cannot
+//! proceed because <something>.dll was not found" box over the game — a message with no
+//! path from the error to the fix.
+//!
+//! **VC90 (Visual C++ 2008).** `mxbikes.exe` and `gpbikes.exe` are x64 PiBoSo builds that
+//! import `MSVCR90.dll`. They don't import it by path: their manifest requests it as a
+//! side-by-side assembly (`Microsoft.VC90.CRT`, amd64, publicKeyToken `1fc8b3b9a1e18e3b`).
+//! That resolves either machine-wide out of `WinSxS`, *or* out of a private copy sitting
+//! in the game folder — and on a machine living on the second one, the game launches fine
+//! while nothing loaded from outside the game folder can resolve `MSVCR90`. Which is
+//! exactly what FrostMod is: an absolute path under `%LOCALAPPDATA%`, injected with
+//! `CreateRemoteThread` + `LoadLibraryA`. Game works, FrostMod doesn't, and the two look
+//! unrelated to the player.
+//!
+//! **VC140 (Visual C++ 2015–2022).** `frostmod.dll` is a modern MSVC build, so it needs
+//! `vcruntime140` / `msvcp140` / the UCRT. Same failure, different DLL in the dialog.
+//!
+//! We detect both, and can install either. Detection is deliberately conservative: when
+//! we can't tell, we report nothing missing. Telling a working player their PC is broken
+//! is worse than staying quiet.
+
+// Detection and installation are Windows-only by construction; everywhere else this module
+// compiles down to `missing() -> []` and the rest of it reads as dead. Left visible, that's
+// a handful of warnings on every macOS build, which only teaches us to skim past them.
+#![cfg_attr(not(windows), allow(dead_code))]
+
+use serde::{Deserialize, Serialize};
+
+/// A Visual C++ runtime the FrostMod chain depends on.
+///
+/// `Deserialize` too: the UI names one of these when it asks us to install it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Runtime {
+    /// Visual C++ 2008 (`MSVCR90`) — what the *game* imports.
+    Vc90,
+    /// Visual C++ 2015–2022 (`vcruntime140` / `msvcp140`) — what `frostmod.dll` imports.
+    Vc140,
+}
+
+/// What an install attempt actually did.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InstallOutcome {
+    /// Installed, and re-detection confirms the runtime is now present.
+    Installed,
+    /// The user dismissed the UAC prompt. Not an error — offer the manual link.
+    Cancelled,
+}
+
+/// The WinSxS directory name every VC90 CRT assembly starts with. Real entries look like
+/// `amd64_microsoft.vc90.crt_1fc8b3b9a1e18e3b_9.0.30729.9635_none_08e793bfa83a89b5`.
+///
+/// The architecture prefix is load-bearing: an `x86_…` assembly is present on plenty of
+/// machines and does nothing for a 64-bit game. So is anchoring at the start — WinSxS also
+/// carries `amd64_policy.9.0.microsoft.vc90.crt_…` publisher-policy entries, which are
+/// redirection rules, not the CRT.
+const VC90_SXS_PREFIX: &str = "amd64_microsoft.vc90.crt_1fc8b3b9a1e18e3b_";
+
+/// The DLLs the 2015–2022 redistributable puts in `System32`.
+const VC140_DLLS: [&str; 2] = ["vcruntime140.dll", "msvcp140.dll"];
+
+/// An installer under this is a captive-portal login page or a truncated download, not a
+/// redistributable. The real ones are ~5 MB (VC90) and ~25 MB (VC140).
+const MIN_INSTALLER_BYTES: usize = 1024 * 1024;
+
+impl Runtime {
+    /// Microsoft's official download. Both were HEAD-checked when this landed; both are
+    /// permanent URLs Microsoft publishes for redistribution.
+    pub fn url(self) -> &'static str {
+        match self {
+            // Visual C++ 2008 SP1 redistributable, x64.
+            Runtime::Vc90 => "https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x64.exe",
+            // Evergreen "latest supported x64" link — always the current 2015–2022 build.
+            Runtime::Vc140 => "https://aka.ms/vs/17/release/vc_redist.x64.exe",
+        }
+    }
+
+    /// Silent-install switches. These differ by installer generation and are not
+    /// interchangeable: the 2008 package is an IExpress/MSI wrapper that takes `/q`, while
+    /// the 2015–2022 package is a Burn bundle that wants `/install /quiet /norestart` and
+    /// treats a bare `/q` as unknown.
+    pub fn installer_args(self) -> &'static str {
+        match self {
+            Runtime::Vc90 => "/q /norestart",
+            Runtime::Vc140 => "/install /quiet /norestart",
+        }
+    }
+
+    /// Filename to stage the download under.
+    fn installer_name(self) -> &'static str {
+        match self {
+            Runtime::Vc90 => "vcredist_x64_2008.exe",
+            Runtime::Vc140 => "vc_redist.x64.exe",
+        }
+    }
+}
+
+/// Does any of these WinSxS entry names name the amd64 VC90 CRT assembly?
+///
+/// Split out from the directory walk so the matching rule — the part with the actual
+/// judgement in it — is testable on any platform.
+fn names_contain_vc90<I, S>(names: I) -> bool
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    names
+        .into_iter()
+        .any(|n| n.as_ref().to_ascii_lowercase().starts_with(VC90_SXS_PREFIX))
+}
+
+/// Is the payload we downloaded plausibly a Windows installer?
+fn looks_like_installer(bytes: &[u8]) -> bool {
+    bytes.len() >= MIN_INSTALLER_BYTES && bytes.starts_with(b"MZ")
+}
+
+#[cfg(windows)]
+fn windir() -> std::path::PathBuf {
+    std::env::var_os("WINDIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from(r"C:\Windows"))
+}
+
+/// Walk `WinSxS` looking for the VC90 CRT.
+///
+/// Returns `true` ("present") when the directory can't be read at all. We'd rather miss a
+/// real problem than raise a false alarm on a machine we simply couldn't inspect.
+#[cfg(windows)]
+fn vc90_present() -> bool {
+    let sxs = windir().join("WinSxS");
+    match std::fs::read_dir(&sxs) {
+        Ok(entries) => names_contain_vc90(
+            entries
+                .filter_map(|e| e.ok())
+                .map(|e| e.file_name().to_string_lossy().into_owned()),
+        ),
+        Err(e) => {
+            log::warn!("could not read {} ({e}) — assuming VC90 is present", sxs.display());
+            true
+        }
+    }
+}
+
+/// The 2015–2022 runtime installs into `System32` rather than WinSxS. This process is
+/// x64, so `System32` is the genuine 64-bit directory — no WOW64 redirection to unpick.
+#[cfg(windows)]
+fn vc140_present() -> bool {
+    let sys32 = windir().join("System32");
+    VC140_DLLS.iter().all(|dll| sys32.join(dll).exists())
+}
+
+/// Cached detection result. Walking WinSxS means enumerating tens of thousands of entries,
+/// and the *absent* case — the one a player in trouble hits — is the one that walks all of
+/// them. The answer only changes when we install something, and `invalidate` covers that.
+#[cfg(windows)]
+static CACHE: std::sync::Mutex<Option<Vec<Runtime>>> = std::sync::Mutex::new(None);
+
+/// Drop the cached probe so the next `missing()` re-reads the disk.
+#[cfg(windows)]
+fn invalidate() {
+    if let Ok(mut c) = CACHE.lock() {
+        *c = None;
+    }
+}
+
+/// Which runtimes the FrostMod chain needs and this machine doesn't have.
+#[cfg(windows)]
+pub fn missing() -> Vec<Runtime> {
+    if let Ok(cache) = CACHE.lock() {
+        if let Some(hit) = cache.as_ref() {
+            return hit.clone();
+        }
+    }
+    let mut out = Vec::new();
+    if !vc90_present() {
+        out.push(Runtime::Vc90);
+    }
+    if !vc140_present() {
+        out.push(Runtime::Vc140);
+    }
+    if !out.is_empty() {
+        log::info!("missing Visual C++ runtimes: {out:?}");
+    }
+    if let Ok(mut cache) = CACHE.lock() {
+        *cache = Some(out.clone());
+    }
+    out
+}
+
+/// Nothing to detect off Windows — FrostMod only runs there.
+#[cfg(not(windows))]
+pub fn missing() -> Vec<Runtime> {
+    Vec::new()
+}
+
+// ===========================================================================
+// Elevated install
+// ===========================================================================
+
+#[cfg(windows)]
+mod ffi {
+    use std::os::raw::c_void;
+
+    pub type Handle = *mut c_void;
+
+    /// `SHELLEXECUTEINFOW`. Field order and the two implicit padding slots (after
+    /// `n_show` and after `dw_hot_key`) match the Win32 x64 layout under `repr(C)`.
+    #[repr(C)]
+    pub struct ShellExecuteInfoW {
+        pub cb_size: u32,
+        pub f_mask: u32,
+        pub hwnd: Handle,
+        pub lp_verb: *const u16,
+        pub lp_file: *const u16,
+        pub lp_parameters: *const u16,
+        pub lp_directory: *const u16,
+        pub n_show: i32,
+        pub h_inst_app: Handle,
+        pub lp_id_list: *mut c_void,
+        pub lp_class: *const u16,
+        pub hkey_class: Handle,
+        pub dw_hot_key: u32,
+        pub h_icon_or_monitor: Handle,
+        pub h_process: Handle,
+    }
+
+    extern "system" {
+        pub fn ShellExecuteExW(info: *mut ShellExecuteInfoW) -> i32;
+        pub fn WaitForSingleObject(handle: Handle, millis: u32) -> u32;
+        pub fn CloseHandle(handle: Handle) -> i32;
+        pub fn GetLastError() -> u32;
+    }
+
+    /// Hand back the process handle so we can wait on it.
+    pub const SEE_MASK_NOCLOSEPROCESS: u32 = 0x0000_0040;
+    /// We aren't pumping messages on this thread; without it the call can return before
+    /// the shell has finished with our string buffers.
+    pub const SEE_MASK_NOASYNC: u32 = 0x0000_0100;
+    pub const SW_HIDE: i32 = 0;
+    pub const WAIT_TIMEOUT: u32 = 0x0000_0102;
+    /// The user dismissed the UAC prompt.
+    pub const ERROR_CANCELLED: u32 = 1223;
+}
+
+/// Give a stuck installer a bound rather than hanging the command forever. A declined UAC
+/// prompt doesn't reach this — `ShellExecuteExW` fails immediately with `ERROR_CANCELLED`.
+#[cfg(windows)]
+const INSTALL_TIMEOUT_MS: u32 = 10 * 60 * 1000;
+
+#[cfg(windows)]
+fn wide(s: &std::ffi::OsStr) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt;
+    s.encode_wide().chain(std::iter::once(0)).collect()
+}
+
+/// Run an installer elevated and wait for it to finish.
+///
+/// `std::process::Command` cannot do this: it goes through `CreateProcess`, which refuses
+/// an executable manifested `requireAdministrator` with `ERROR_ELEVATION_REQUIRED` (740)
+/// instead of prompting. Only the shell raises the UAC dialog, so it has to be
+/// `ShellExecuteExW` with the `runas` verb.
+///
+/// Returns `Ok(false)` when the user declined the prompt.
+#[cfg(windows)]
+fn run_elevated(exe: &std::path::Path, args: &str) -> anyhow::Result<bool> {
+    let verb = wide(std::ffi::OsStr::new("runas"));
+    let file = wide(exe.as_os_str());
+    let params = wide(std::ffi::OsStr::new(args));
+
+    let mut info = ffi::ShellExecuteInfoW {
+        cb_size: std::mem::size_of::<ffi::ShellExecuteInfoW>() as u32,
+        f_mask: ffi::SEE_MASK_NOCLOSEPROCESS | ffi::SEE_MASK_NOASYNC,
+        hwnd: std::ptr::null_mut(),
+        lp_verb: verb.as_ptr(),
+        lp_file: file.as_ptr(),
+        lp_parameters: params.as_ptr(),
+        lp_directory: std::ptr::null(),
+        n_show: ffi::SW_HIDE,
+        h_inst_app: std::ptr::null_mut(),
+        lp_id_list: std::ptr::null_mut(),
+        lp_class: std::ptr::null(),
+        hkey_class: std::ptr::null_mut(),
+        dw_hot_key: 0,
+        h_icon_or_monitor: std::ptr::null_mut(),
+        h_process: std::ptr::null_mut(),
+    };
+
+    // SAFETY: `info` is a correctly sized, fully initialised SHELLEXECUTEINFOW, and every
+    // string pointer refers to a NUL-terminated buffer that outlives the call.
+    let ok = unsafe { ffi::ShellExecuteExW(&mut info) } != 0;
+    if !ok {
+        let err = unsafe { ffi::GetLastError() };
+        if err == ffi::ERROR_CANCELLED {
+            return Ok(false);
+        }
+        anyhow::bail!("Windows wouldn't start the installer (error {err})");
+    }
+
+    if info.h_process.is_null() {
+        // Shouldn't happen with SEE_MASK_NOCLOSEPROCESS, but without a handle we can't
+        // claim it finished — and re-detection below is what actually decides.
+        return Ok(true);
+    }
+    // SAFETY: `h_process` is a live process handle the shell handed us; closed below.
+    let waited = unsafe { ffi::WaitForSingleObject(info.h_process, INSTALL_TIMEOUT_MS) };
+    unsafe { ffi::CloseHandle(info.h_process) };
+    if waited == ffi::WAIT_TIMEOUT {
+        anyhow::bail!("the installer is still running after 10 minutes — finish it in the window Windows opened, then check again");
+    }
+    // The exit code is deliberately ignored: these packages return 3010 for "installed,
+    // reboot pending" and 1638 for "a newer one is already here", both of which are fine.
+    // Whether the runtime is actually there now is settled by re-detection.
+    Ok(true)
+}
+
+/// Download Microsoft's redistributable and install it, then prove it worked.
+#[cfg(windows)]
+pub async fn install(app: &tauri::AppHandle, runtime: Runtime) -> anyhow::Result<InstallOutcome> {
+    use tauri::Manager;
+
+    let dir = app
+        .path()
+        .app_local_data_dir()
+        .map_err(|e| anyhow::anyhow!("could not resolve the app data dir: {e}"))?
+        .join("runtime");
+    std::fs::create_dir_all(&dir)?;
+    let staged = dir.join(runtime.installer_name());
+
+    let client = reqwest::Client::builder()
+        .user_agent(crate::frostmod_manage::UA)
+        .build()?;
+    let bytes = client
+        .get(runtime.url())
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
+    // A download that didn't land is worth catching before we ask for admin rights.
+    if !looks_like_installer(&bytes) {
+        anyhow::bail!(
+            "The download from Microsoft didn't arrive intact ({} bytes) — nothing was installed. Check your connection and try again.",
+            bytes.len()
+        );
+    }
+    std::fs::write(&staged, &bytes)?;
+
+    let args = runtime.installer_args();
+    let path = staged.clone();
+    // ShellExecuteExW + the wait are blocking, and this is running on the async runtime.
+    let accepted = tauri::async_runtime::spawn_blocking(move || run_elevated(&path, args))
+        .await
+        .map_err(|e| anyhow::anyhow!("the installer task failed: {e}"))??;
+
+    let _ = std::fs::remove_file(&staged);
+
+    if !accepted {
+        return Ok(InstallOutcome::Cancelled);
+    }
+
+    // Trust the disk, not the installer's exit code.
+    invalidate();
+    if missing().contains(&runtime) {
+        anyhow::bail!(
+            "The installer ran but Windows still can't find the component. A restart usually finishes it off."
+        );
+    }
+    log::info!("installed Visual C++ runtime {runtime:?}");
+    Ok(InstallOutcome::Installed)
+}
+
+#[cfg(not(windows))]
+pub async fn install(
+    _app: &tauri::AppHandle,
+    _runtime: Runtime,
+) -> anyhow::Result<InstallOutcome> {
+    anyhow::bail!("Visual C++ runtimes only apply on Windows")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Real WinSxS entry names, as they appear on a machine that has the assembly.
+    #[test]
+    fn matches_a_real_vc90_assembly_folder() {
+        assert!(names_contain_vc90([
+            "amd64_microsoft.windows.common-controls_6595b64144ccf1df_6.0.22621.1_none_9f6e2b2b",
+            "amd64_microsoft.vc90.crt_1fc8b3b9a1e18e3b_9.0.30729.9635_none_08e793bfa83a89b5",
+        ]));
+    }
+
+    /// NTFS is case-insensitive and the casing of these entries isn't ours to rely on.
+    #[test]
+    fn matching_ignores_case() {
+        assert!(names_contain_vc90([
+            "AMD64_Microsoft.VC90.CRT_1FC8B3B9A1E18E3B_9.0.30729.6161_none_08e7a8e6a52ec5b5",
+        ]));
+    }
+
+    /// The x86 CRT is on plenty of machines and does nothing for a 64-bit game, so it must
+    /// not read as "present".
+    #[test]
+    fn x86_assembly_does_not_count() {
+        assert!(!names_contain_vc90([
+            "x86_microsoft.vc90.crt_1fc8b3b9a1e18e3b_9.0.30729.9635_none_508ef7e4bcbbe589",
+        ]));
+    }
+
+    /// Publisher-policy entries are redirection rules, not the CRT itself. They sit right
+    /// next to the real thing and share most of the name.
+    #[test]
+    fn publisher_policy_does_not_count() {
+        assert!(!names_contain_vc90([
+            "amd64_policy.9.0.microsoft.vc90.crt_1fc8b3b9a1e18e3b_9.0.30729.9635_none_a0b4c0f2",
+        ]));
+    }
+
+    #[test]
+    fn an_empty_or_unrelated_winsxs_reads_as_absent() {
+        assert!(!names_contain_vc90(Vec::<String>::new()));
+        assert!(!names_contain_vc90([
+            "amd64_microsoft.vc80.crt_1fc8b3b9a1e18e3b_8.0.50727.9585_none_88df89932faf0bf6",
+            "msil_system.web_b03f5f7f11d50a3a_4.0.15805.0_none_b3a4e5c9",
+        ]));
+    }
+
+    /// The two packages take different switches; swapping them silently does nothing.
+    #[test]
+    fn each_runtime_carries_its_own_silent_switches() {
+        assert_eq!(Runtime::Vc90.installer_args(), "/q /norestart");
+        assert_eq!(Runtime::Vc140.installer_args(), "/install /quiet /norestart");
+        assert_ne!(Runtime::Vc90.url(), Runtime::Vc140.url());
+    }
+
+    /// A captive-portal HTML page returns 200 and is not an installer.
+    #[test]
+    fn rejects_a_payload_that_isnt_an_installer() {
+        let html = b"<!doctype html><html>sign in to continue</html>".repeat(1000);
+        assert!(!looks_like_installer(&html));
+        // Right magic, far too small — a truncated download.
+        let mut stub = b"MZ".to_vec();
+        stub.resize(4096, 0);
+        assert!(!looks_like_installer(&stub));
+    }
+
+    #[test]
+    fn accepts_a_plausible_installer() {
+        let mut exe = b"MZ".to_vec();
+        exe.resize(MIN_INSTALLER_BYTES + 1, 0);
+        assert!(looks_like_installer(&exe));
+    }
+
+    /// The UI keys off these strings; renaming a variant would silently break the banner.
+    #[test]
+    fn runtimes_serialize_as_the_ui_expects() {
+        assert_eq!(serde_json::to_string(&Runtime::Vc90).unwrap(), "\"vc90\"");
+        assert_eq!(serde_json::to_string(&Runtime::Vc140).unwrap(), "\"vc140\"");
+        assert_eq!(
+            serde_json::to_string(&InstallOutcome::Cancelled).unwrap(),
+            "\"cancelled\""
+        );
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { TOUR_DONE_KEY } from "./Components/Tour/Tour";
 import { useI18n } from "./i18n/context";
 import { setAmbientVars } from "./i18n/core";
 import { UpdateProvider } from "./Context/Update";
+import RuntimeBanner from "./Components/RuntimeBanner/RuntimeBanner";
 import UpdateBanner from "./Components/UpdateBanner/UpdateBanner";
 import type { Config, GameId, GameInfo } from "./types";
 
@@ -148,6 +149,10 @@ const App = () => {
               <div className="h-[42px] flex-none">
                 <TitleBar />
               </div>
+              {/* Above the update banner on purpose: one is a broken state the player
+                  can fix right now, the other is an offer. Updating the app wouldn't
+                  put the missing runtime on their PC anyway. */}
+              <RuntimeBanner />
               <UpdateBanner />
               <main className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background text-foreground">
                 {ready && (

--- a/src/Components/RuntimeBanner/RuntimeBanner.tsx
+++ b/src/Components/RuntimeBanner/RuntimeBanner.tsx
@@ -1,0 +1,72 @@
+import { AlertTriangle, Download, Loader2, X } from "lucide-react";
+import { Button } from "@/Components/ui/button";
+import { useFrostmod } from "@/Context/FrostmodContext";
+import { Trans } from "@/i18n";
+import { useT } from "@/i18n/context";
+
+/**
+ * Slim bar shown when Windows is missing a Visual C++ runtime the FrostMod chain needs.
+ *
+ * This is the one problem the app can't fix behind the player's back: installing a
+ * Microsoft redistributable needs admin rights, so it has to be a button they press. It
+ * earns a banner rather than living only in Settings because the symptom — FrostMod
+ * silently failing to attach, or a bare "…dll was not found" box over the game — gives no
+ * hint that Settings is where to look.
+ *
+ * Renders nothing when there's nothing missing, which is the overwhelmingly common case.
+ */
+export default function RuntimeBanner() {
+  const t = useT();
+  const { runtimeWarning, installingRuntime, installRuntime, dismissRuntimeWarning } =
+    useFrostmod();
+  if (!runtimeWarning) return null;
+
+  // vc90 is the *game's* runtime and vc140 is FrostMod's own, so they need different
+  // sentences — "MX Bikes needs this" and "FrostMod needs this" aren't interchangeable
+  // when one of the two is visibly working.
+  const isGameRuntime = runtimeWarning === "vc90";
+  const bodyKey = isGameRuntime ? "runtime.bannerGame" : "runtime.bannerFrostmod";
+  const nameKey = isGameRuntime
+    ? "runtime.componentVc90"
+    : "runtime.componentVc140";
+
+  return (
+    <div className="flex items-center gap-3 border-b border-amber-500/25 bg-amber-500/10 px-4 py-2 text-sm text-foreground">
+      <AlertTriangle className="size-4 shrink-0 text-amber-500" />
+      <span className="min-w-0 truncate">
+        <Trans
+          k={bodyKey}
+          values={{
+            what: <span className="font-semibold">{t(nameKey)}</span>,
+          }}
+        />
+        <span className="ml-1 text-muted-foreground">{t("runtime.pitch")}</span>
+      </span>
+
+      <div className="ml-auto flex shrink-0 items-center gap-1.5">
+        <Button
+          size="sm"
+          onClick={() => void installRuntime(runtimeWarning)}
+          disabled={installingRuntime}
+        >
+          {installingRuntime ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <Download className="size-3.5" />
+          )}
+          {installingRuntime ? t("runtime.installing") : t("runtime.fixIt")}
+        </Button>
+        <Button
+          size="icon"
+          variant="ghost"
+          className="size-8"
+          onClick={dismissRuntimeWarning}
+          disabled={installingRuntime}
+          aria-label={t("runtime.dismiss")}
+        >
+          <X className="size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -185,7 +185,7 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
   const isWindows = platform === "windows";
   const isMac = platform === "macos";
   const { theme, setTheme } = useTheme();
-  const { running, reload, status, installing, checking, statusError, install, start, stop, refreshStatus } =
+  const { running, reload, status, installing, checking, statusError, install, start, stop, refreshStatus, missingRuntime, installRuntime, installingRuntime } =
     useFrostmod();
   const { check: checkForUpdates } = useUpdate();
   const { startTour } = useTour();
@@ -902,7 +902,12 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
                     ? t("settings.checkingGitHub")
                     : statusError
                       ? t("settings.updateCheckFailed")
-                      : status?.needsRepair
+                      : // Above everything else: a missing Visual C++ runtime stops
+                        // FrostMod attaching at all, and no amount of repairing or
+                        // updating FrostMod puts one on the machine.
+                        missingRuntime
+                        ? t("settings.frostmodRuntimeMissing")
+                        : status?.needsRepair
                         ? t("settings.frostmodNeedsRepair")
                         : // Ranked above "latest version" on purpose: a build too old for
                           // this game can't run at all, which the version line alone
@@ -917,6 +922,20 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
                 </span>
               </div>
               <div className="flex items-center gap-1.5">
+                {/* Its own button rather than a mode of the one below: the FrostMod
+                    install and the Windows component are separate things to fix, and
+                    someone can genuinely need both. */}
+                {missingRuntime && (
+                  <Button
+                    size="sm"
+                    onClick={() => void installRuntime(missingRuntime)}
+                    disabled={installingRuntime}
+                  >
+                    {installingRuntime
+                      ? t("runtime.installing")
+                      : t("runtime.fixIt")}
+                  </Button>
+                )}
                 {status?.installed && (
                   <Button
                     variant="ghost"
@@ -994,16 +1013,22 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
             />
 
             <div className="flex gap-2">
-              {status?.installed &&
-                (running ? (
-                  <Button variant="outline" size="sm" onClick={stop}>
-                    <Square className="size-3.5" /> {t("frostmod.stop")}
-                  </Button>
-                ) : (
+              {/* Stop is offered whenever FrostMod is running, installed by us or not —
+                  `frostmod_stop` kills a hand-launched `frostmod.exe` too, and gating it
+                  on `installed` left the one case that needs it most (something running
+                  that we didn't put there) with no button at all. Start still needs an
+                  install to start. */}
+              {running ? (
+                <Button variant="outline" size="sm" onClick={stop}>
+                  <Square className="size-3.5" /> {t("frostmod.stop")}
+                </Button>
+              ) : (
+                status?.installed && (
                   <Button variant="default" size="sm" onClick={start}>
                     <Play className="size-3.5" /> {t("frostmod.start")}
                   </Button>
-                ))}
+                )
+              )}
               <Button variant="outline" size="sm" onClick={reloadGame} disabled={!running}>
                 <RefreshCw className="size-3.5" /> Reload game now
               </Button>

--- a/src/Context/Frostmod.tsx
+++ b/src/Context/Frostmod.tsx
@@ -7,8 +7,10 @@ import {
   type ReactNode,
 } from "react";
 import { toast } from "sonner";
+import { open as openUrl } from "@tauri-apps/plugin-shell";
 import {
   frostmodInstall,
+  frostmodInstallRuntime,
   frostmodStart,
   frostmodStatus,
   frostmodStop,
@@ -16,8 +18,9 @@ import {
   MODS_WATCH_SLUG,
   onFrostmodReload,
   reloadFrostmod,
+  RUNTIME_DOWNLOAD_URL,
 } from "../api/mods";
-import type { FrostmodStatus } from "../types";
+import type { FrostmodStatus, VcRuntime } from "../types";
 import { displayName } from "../lib/mods";
 import { useT, type TFunc } from "../i18n/context";
 import { FrostmodContext } from "./FrostmodContext";
@@ -49,6 +52,8 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
   const [installing, setInstalling] = useState(false);
   const [checking, setChecking] = useState(false);
   const [statusError, setStatusError] = useState(false);
+  const [installingRuntime, setInstallingRuntime] = useState(false);
+  const [runtimeDismissed, setRuntimeDismissed] = useState(false);
   const mounted = useRef(true);
 
   const probe = useCallback(async () => {
@@ -177,6 +182,49 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
     }
   }, [refreshStatus, t]);
 
+  const installRuntime = useCallback(
+    async (runtime: VcRuntime) => {
+      setInstallingRuntime(true);
+      try {
+        const outcome = await frostmodInstallRuntime(runtime);
+        await refreshStatus();
+        if (outcome === "installed") {
+          toast.success(t("runtime.installed"), {
+            description: t("runtime.installedDesc"),
+          });
+        } else {
+          // Declining the admin prompt isn't a failure — but nothing was fixed either,
+          // so hand over the download rather than leaving them at the same dead end.
+          toast.info(t("runtime.cancelled"), {
+            description: t("runtime.cancelledDesc"),
+          });
+          void openUrl(RUNTIME_DOWNLOAD_URL[runtime]);
+        }
+      } catch (e) {
+        toast.error(t("runtime.installFailed"), {
+          description: String(e),
+          action: {
+            label: t("runtime.downloadManually"),
+            onClick: () => void openUrl(RUNTIME_DOWNLOAD_URL[runtime]),
+          },
+        });
+      } finally {
+        setInstallingRuntime(false);
+      }
+    },
+    [refreshStatus, t],
+  );
+
+  // Only ever surface one at a time: two banners stacked over the app is noise, and the
+  // game's own runtime (vc90) is the one that produces the error people actually report,
+  // so `missingRuntimes` order (vc90 first) decides.
+  const missingRuntime = status?.missingRuntimes?.[0] ?? null;
+  // The banner respects a dismissal; the Settings panel deliberately doesn't. Dismissing
+  // a bar you didn't understand shouldn't also erase the one place that explains it.
+  const runtimeWarning = runtimeDismissed ? null : missingRuntime;
+
+  const dismissRuntimeWarning = useCallback(() => setRuntimeDismissed(true), []);
+
   // FrostMod is core to the app, so set it up automatically on first run instead
   // of prompting: once we learn it isn't installed, download + start it silently.
   //
@@ -189,6 +237,11 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
   // all, and the player has no way to know why. Updating unasked is the fix — and if the
   // newest release is still too old, the attempt is capped at one per session and the
   // panel falls back to telling them.
+  //
+  // `missingRuntimes` is deliberately NOT in here. Reinstalling FrostMod cannot put a
+  // Visual C++ runtime on the machine, so auto-installing on that flag would download
+  // FrostMod again to no effect — and the flag would still be set afterwards. It needs
+  // the user's admin consent anyway, so it stays a banner they press.
   //
   // Runs at most once per session; a failed status check (`statusError`) is skipped so
   // we only act on a confirmed snapshot, never an offline guess.
@@ -219,8 +272,13 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
       install,
       start,
       stop,
+      installingRuntime,
+      installRuntime,
+      dismissRuntimeWarning,
+      runtimeWarning,
+      missingRuntime,
     }),
-    [running, status, installing, checking, statusError, reload, probe, refreshStatus, install, start, stop],
+    [running, status, installing, checking, statusError, reload, probe, refreshStatus, install, start, stop, installingRuntime, installRuntime, dismissRuntimeWarning, runtimeWarning, missingRuntime],
   );
 
   return (

--- a/src/Context/FrostmodContext.ts
+++ b/src/Context/FrostmodContext.ts
@@ -1,5 +1,5 @@
 import { createContext, useContext } from "react";
-import type { FrostmodStatus, ReloadOutcome } from "../types";
+import type { FrostmodStatus, ReloadOutcome, VcRuntime } from "../types";
 
 export interface FrostmodContextValue {
   /** Whether FrostMod is currently running (polled). `null` until first probe. */
@@ -20,6 +20,22 @@ export interface FrostmodContextValue {
   refreshStatus: () => Promise<void>;
   /** Download the latest FrostMod, then start it. */
   install: () => Promise<void>;
+  /** True while a Visual C++ runtime install is in flight. */
+  installingRuntime: boolean;
+  /**
+   * Install a missing Visual C++ runtime. Prompts for admin via Windows; resolves either
+   * way, and opens Microsoft's download page if the prompt was declined.
+   */
+  installRuntime: (runtime: VcRuntime) => Promise<void>;
+  /** Hide the runtime banner for this session (the Settings panel keeps showing it). */
+  dismissRuntimeWarning: () => void;
+  /** What the banner should warn about — `null` once dismissed this session. */
+  runtimeWarning: VcRuntime | null;
+  /**
+   * The runtime that's actually missing, dismissal or not. Settings uses this: hiding a
+   * bar you didn't understand shouldn't also erase the panel that explains it.
+   */
+  missingRuntime: VcRuntime | null;
   /** Launch FrostMod now if it isn't already running. */
   start: () => Promise<void>;
   /** Stop FrostMod now, whether or not this app started it. */

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -15,6 +15,8 @@ import type {
   FrostmodInstallReport,
   FrostmodReload,
   FrostmodStatus,
+  RuntimeInstallOutcome,
+  VcRuntime,
   InstalledMod,
   InstallProgress,
   LaunchOutcome,
@@ -1398,6 +1400,26 @@ export function frostmodStatus(): Promise<FrostmodStatus> {
 export function frostmodInstall(): Promise<FrostmodInstallReport> {
   return invoke<FrostmodInstallReport>("frostmod_install");
 }
+
+/** Install a Visual C++ runtime `frostmodStatus` reported missing.
+ *
+ *  Raises a Windows UAC prompt — Microsoft's redistributables need admin rights. A
+ *  declined prompt resolves to `"cancelled"` rather than throwing, so the caller can
+ *  offer the manual download instead of reporting a failure. */
+export function frostmodInstallRuntime(
+  runtime: VcRuntime,
+): Promise<RuntimeInstallOutcome> {
+  return invoke<RuntimeInstallOutcome>("frostmod_install_runtime", { runtime });
+}
+
+/** Where to send someone whose UAC prompt we can't raise (or who declined it).
+ *
+ *  Microsoft's own direct downloads, the same ones the backend fetches — a download page
+ *  would make them pick an architecture, and picking x86 here fixes nothing. */
+export const RUNTIME_DOWNLOAD_URL: Record<VcRuntime, string> = {
+  vc90: "https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x64.exe",
+  vc140: "https://aka.ms/vs/17/release/vc_redist.x64.exe",
+};
 
 /** Launch the managed FrostMod process if it isn't already running. */
 export function frostmodStart(): Promise<boolean> {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -261,6 +261,26 @@ export const de: Translation = {
   "update.updateAndRestart": "Aktualisieren und neu starten",
   "update.dismiss": "Update-Benachrichtigung ausblenden",
   "update.onLatest": "Du hast bereits die neueste Version",
+
+  // ── Fehlende Visual-C++-Laufzeit ───────────────────────────────────────────
+  "runtime.componentVc90": "Microsoft Visual C++ 2008 (x64)",
+  "runtime.componentVc140": "Microsoft Visual C++ 2015–2022 (x64)",
+  "runtime.bannerGame":
+    "MX Bikes braucht {{what}}, bevor FrostMod sich einklinken kann.",
+  "runtime.bannerFrostmod": "FrostMod braucht {{what}}, um zu laufen.",
+  "runtime.pitch":
+    "Sonst zeigt Windows stattdessen den Fehler „dll was not found“. In Sekunden behoben.",
+  "runtime.fixIt": "Installieren",
+  "runtime.installing": "Wird installiert…",
+  "runtime.dismiss": "Hinweis ausblenden",
+  "runtime.installed": "Komponente installiert",
+  "runtime.installedDesc":
+    "FrostMod sollte das Spiel jetzt erreichen. Starte MX Bikes neu, falls es schon läuft.",
+  "runtime.cancelled": "Es wurde nichts installiert",
+  "runtime.cancelledDesc":
+    "Windows braucht dafür deine Erlaubnis. Der Download von Microsoft wird stattdessen geöffnet.",
+  "runtime.installFailed": "Komponente konnte nicht installiert werden",
+  "runtime.downloadManually": "Selbst herunterladen",
   "update.checkFailed": "Updates konnten nicht geprüft werden",
   "update.failed": "Update fehlgeschlagen",
 
@@ -541,6 +561,8 @@ export const de: Translation = {
   "settings.updateCheckFailed":
     "Updates konnten nicht geprüft werden — offline oder GitHub nicht erreichbar.",
   "settings.latestVersion": "Neueste: {{version}}",
+  "settings.frostmodRuntimeMissing":
+    "Windows fehlt eine Visual-C++-Komponente, die FrostMod braucht — installiere sie, um den Fehler „dll was not found“ loszuwerden.",
   "settings.frostmodNeedsRepair":
     "Die installierten Dateien passen nicht zu dieser Version — eine Neuinstallation behebt das.",
   "settings.frostmodRepair": "Installation reparieren",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -249,6 +249,25 @@ export const en = {
   "update.updateAndRestart": "Update & restart",
   "update.dismiss": "Dismiss update notification",
   "update.onLatest": "You're on the latest version",
+
+  // ── Missing Visual C++ runtime ─────────────────────────────────────────────
+  "runtime.componentVc90": "Microsoft Visual C++ 2008 (x64)",
+  "runtime.componentVc140": "Microsoft Visual C++ 2015–2022 (x64)",
+  "runtime.bannerGame": "MX Bikes needs {{what}} before FrostMod can load into it.",
+  "runtime.bannerFrostmod": "FrostMod needs {{what}} to run.",
+  "runtime.pitch":
+    "Without it Windows shows a \"dll was not found\" error instead. Takes seconds to fix.",
+  "runtime.fixIt": "Install it",
+  "runtime.installing": "Installing…",
+  "runtime.dismiss": "Dismiss this warning",
+  "runtime.installed": "Component installed",
+  "runtime.installedDesc":
+    "FrostMod should reach the game now. Restart MX Bikes if it's already open.",
+  "runtime.cancelled": "Nothing was installed",
+  "runtime.cancelledDesc":
+    "Windows needs your permission to install it. Opening Microsoft's download instead.",
+  "runtime.installFailed": "Couldn't install the component",
+  "runtime.downloadManually": "Download it yourself",
   "update.checkFailed": "Couldn't check for updates",
   "update.failed": "Update failed",
 
@@ -520,6 +539,8 @@ export const en = {
   "settings.updateCheckFailed":
     "Couldn't check for updates — offline or GitHub unavailable.",
   "settings.latestVersion": "Latest: {{version}}",
+  "settings.frostmodRuntimeMissing":
+    "Windows is missing a Visual C++ component FrostMod needs — install it to stop the \"dll was not found\" error.",
   "settings.frostmodNeedsRepair":
     "The installed files don't match this version — reinstalling fixes it.",
   "settings.frostmodRepair": "Repair install",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -255,6 +255,26 @@ export const es: Translation = {
   "update.updateAndRestart": "Actualizar y reiniciar",
   "update.dismiss": "Descartar la notificación de actualización",
   "update.onLatest": "Ya tienes la última versión",
+
+  // ── Falta el runtime de Visual C++ ─────────────────────────────────────────
+  "runtime.componentVc90": "Microsoft Visual C++ 2008 (x64)",
+  "runtime.componentVc140": "Microsoft Visual C++ 2015–2022 (x64)",
+  "runtime.bannerGame":
+    "MX Bikes necesita {{what}} antes de que FrostMod pueda entrar en el juego.",
+  "runtime.bannerFrostmod": "FrostMod necesita {{what}} para funcionar.",
+  "runtime.pitch":
+    "Sin esto Windows muestra el error «dll was not found». Se arregla en segundos.",
+  "runtime.fixIt": "Instalarlo",
+  "runtime.installing": "Instalando…",
+  "runtime.dismiss": "Descartar este aviso",
+  "runtime.installed": "Componente instalado",
+  "runtime.installedDesc":
+    "FrostMod ya debería llegar al juego. Reinicia MX Bikes si lo tienes abierto.",
+  "runtime.cancelled": "No se instaló nada",
+  "runtime.cancelledDesc":
+    "Windows necesita tu permiso para instalarlo. Abriendo la descarga de Microsoft.",
+  "runtime.installFailed": "No se pudo instalar el componente",
+  "runtime.downloadManually": "Descargarlo tú mismo",
   "update.checkFailed": "No se pudieron comprobar las actualizaciones",
   "update.failed": "La actualización falló",
 
@@ -532,6 +552,8 @@ export const es: Translation = {
   "settings.updateCheckFailed":
     "No se pudieron comprobar las actualizaciones — sin conexión o GitHub no disponible.",
   "settings.latestVersion": "Última: {{version}}",
+  "settings.frostmodRuntimeMissing":
+    "A Windows le falta un componente de Visual C++ que FrostMod necesita — instálalo para quitar el error «dll was not found».",
   "settings.frostmodNeedsRepair":
     "Los archivos instalados no coinciden con esta versión — reinstalar lo arregla.",
   "settings.frostmodRepair": "Reparar instalación",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -258,6 +258,26 @@ export const fr: Translation = {
   "update.updateAndRestart": "Mettre à jour et redémarrer",
   "update.dismiss": "Ignorer la notification de mise à jour",
   "update.onLatest": "Vous avez déjà la dernière version",
+
+  // ── Runtime Visual C++ manquant ────────────────────────────────────────────
+  "runtime.componentVc90": "Microsoft Visual C++ 2008 (x64)",
+  "runtime.componentVc140": "Microsoft Visual C++ 2015–2022 (x64)",
+  "runtime.bannerGame":
+    "MX Bikes a besoin de {{what}} pour que FrostMod puisse s'y greffer.",
+  "runtime.bannerFrostmod": "FrostMod a besoin de {{what}} pour fonctionner.",
+  "runtime.pitch":
+    "Sans ça, Windows affiche l'erreur « dll was not found ». Réglé en quelques secondes.",
+  "runtime.fixIt": "L'installer",
+  "runtime.installing": "Installation…",
+  "runtime.dismiss": "Masquer cet avertissement",
+  "runtime.installed": "Composant installé",
+  "runtime.installedDesc":
+    "FrostMod devrait maintenant atteindre le jeu. Relancez MX Bikes s'il est déjà ouvert.",
+  "runtime.cancelled": "Rien n'a été installé",
+  "runtime.cancelledDesc":
+    "Windows a besoin de votre autorisation. Ouverture du téléchargement Microsoft à la place.",
+  "runtime.installFailed": "Impossible d'installer le composant",
+  "runtime.downloadManually": "Le télécharger soi-même",
   "update.checkFailed": "Impossible de vérifier les mises à jour",
   "update.failed": "Échec de la mise à jour",
 
@@ -537,6 +557,8 @@ export const fr: Translation = {
   "settings.updateCheckFailed":
     "Impossible de vérifier les mises à jour — hors ligne ou GitHub indisponible.",
   "settings.latestVersion": "Dernière : {{version}}",
+  "settings.frostmodRuntimeMissing":
+    "Il manque à Windows un composant Visual C++ dont FrostMod a besoin — installez-le pour faire disparaître l'erreur « dll was not found ».",
   "settings.frostmodNeedsRepair":
     "Les fichiers installés ne correspondent pas à cette version — une réinstallation corrige ça.",
   "settings.frostmodRepair": "Réparer l'installation",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -254,6 +254,26 @@ export const it: Translation = {
   "update.updateAndRestart": "Aggiorna e riavvia",
   "update.dismiss": "Ignora la notifica di aggiornamento",
   "update.onLatest": "Hai già l'ultima versione",
+
+  // ── Runtime Visual C++ mancante ────────────────────────────────────────────
+  "runtime.componentVc90": "Microsoft Visual C++ 2008 (x64)",
+  "runtime.componentVc140": "Microsoft Visual C++ 2015–2022 (x64)",
+  "runtime.bannerGame":
+    "MX Bikes ha bisogno di {{what}} prima che FrostMod possa agganciarsi.",
+  "runtime.bannerFrostmod": "FrostMod ha bisogno di {{what}} per funzionare.",
+  "runtime.pitch":
+    "Senza, Windows mostra l'errore «dll was not found». Si risolve in pochi secondi.",
+  "runtime.fixIt": "Installalo",
+  "runtime.installing": "Installazione…",
+  "runtime.dismiss": "Nascondi questo avviso",
+  "runtime.installed": "Componente installato",
+  "runtime.installedDesc":
+    "Ora FrostMod dovrebbe raggiungere il gioco. Riavvia MX Bikes se è già aperto.",
+  "runtime.cancelled": "Non è stato installato nulla",
+  "runtime.cancelledDesc":
+    "Windows ha bisogno del tuo permesso. Apro invece il download di Microsoft.",
+  "runtime.installFailed": "Impossibile installare il componente",
+  "runtime.downloadManually": "Scaricalo da solo",
   "update.checkFailed": "Impossibile controllare gli aggiornamenti",
   "update.failed": "Aggiornamento non riuscito",
 
@@ -527,6 +547,8 @@ export const it: Translation = {
   "settings.updateCheckFailed":
     "Impossibile controllare gli aggiornamenti — offline o GitHub non raggiungibile.",
   "settings.latestVersion": "Ultima: {{version}}",
+  "settings.frostmodRuntimeMissing":
+    "A Windows manca un componente Visual C++ che serve a FrostMod — installalo per togliere l'errore «dll was not found».",
   "settings.frostmodNeedsRepair":
     "I file installati non corrispondono a questa versione — reinstallando si risolve.",
   "settings.frostmodRepair": "Ripara installazione",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -257,6 +257,26 @@ export const ptBR: Translation = {
   "update.updateAndRestart": "Atualizar e reiniciar",
   "update.dismiss": "Dispensar o aviso de atualização",
   "update.onLatest": "Você já está na versão mais recente",
+
+  // ── Runtime do Visual C++ ausente ──────────────────────────────────────────
+  "runtime.componentVc90": "Microsoft Visual C++ 2008 (x64)",
+  "runtime.componentVc140": "Microsoft Visual C++ 2015–2022 (x64)",
+  "runtime.bannerGame":
+    "O MX Bikes precisa do {{what}} antes que o FrostMod consiga entrar nele.",
+  "runtime.bannerFrostmod": "O FrostMod precisa do {{what}} para funcionar.",
+  "runtime.pitch":
+    "Sem isso o Windows mostra o erro \"dll was not found\". Leva segundos para resolver.",
+  "runtime.fixIt": "Instalar",
+  "runtime.installing": "Instalando…",
+  "runtime.dismiss": "Dispensar este aviso",
+  "runtime.installed": "Componente instalado",
+  "runtime.installedDesc":
+    "O FrostMod já deve alcançar o jogo. Reinicie o MX Bikes se ele estiver aberto.",
+  "runtime.cancelled": "Nada foi instalado",
+  "runtime.cancelledDesc":
+    "O Windows precisa da sua permissão. Abrindo o download da Microsoft no lugar.",
+  "runtime.installFailed": "Não foi possível instalar o componente",
+  "runtime.downloadManually": "Baixar por conta própria",
   "update.checkFailed": "Não foi possível verificar as atualizações",
   "update.failed": "A atualização falhou",
 
@@ -531,6 +551,8 @@ export const ptBR: Translation = {
   "settings.updateCheckFailed":
     "Não foi possível verificar as atualizações — sem conexão ou GitHub indisponível.",
   "settings.latestVersion": "Última: {{version}}",
+  "settings.frostmodRuntimeMissing":
+    "Falta ao Windows um componente do Visual C++ que o FrostMod precisa — instale-o para acabar com o erro \"dll was not found\".",
   "settings.frostmodNeedsRepair":
     "Os arquivos instalados não batem com esta versão — reinstalar resolve.",
   "settings.frostmodRepair": "Reparar instalação",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -621,7 +621,23 @@ export interface FrostmodStatus {
    * that rather than a start; the backend refuses to launch it either way.
    */
   supportedForGame: boolean;
+  /**
+   * Visual C++ runtimes this PC is short of. Empty is the normal case, and always the
+   * case off Windows.
+   *
+   * `vc90` is what the *game* imports (`MSVCR90`) and `vc140` what `frostmod.dll` does.
+   * Either being absent means FrostMod will most likely fail to attach with a bare
+   * "…dll was not found" box over the game. Unlike the flags above this doesn't stop
+   * FrostMod starting — it's a warning with a one-click fix attached.
+   */
+  missingRuntimes: VcRuntime[];
 }
+
+/** A Visual C++ runtime the FrostMod chain needs. Matches `vcruntime::Runtime`. */
+export type VcRuntime = "vc90" | "vc140";
+
+/** What a runtime install did. `cancelled` is the user dismissing the UAC prompt. */
+export type RuntimeInstallOutcome = "installed" | "cancelled";
 
 /** What an install landed, beyond succeeding. */
 export interface FrostmodInstallReport {


### PR DESCRIPTION
## Why

A user reported MX Bikes launching fine on its own, but throwing *"the code execution cannot proceed because msvcr90.dll was not found"* whenever FrostMod was running.

`mxbikes.exe` and `gpbikes.exe` are x64 PiBoSo builds that import `MSVCR90.dll` — the Visual C++ **2008** CRT — and they don't import it by path. Their manifest requests it as a side-by-side assembly (`Microsoft.VC90.CRT`, amd64, token `1fc8b3b9a1e18e3b`). That resolves either machine-wide from `WinSxS` **or** from a private copy sitting in the game folder. On a PC living on the second one, the game runs perfectly while nothing loaded from *outside* the game folder can resolve MSVCR90 — which is exactly what FrostMod is, injected from `%LOCALAPPDATA%` via `CreateRemoteThread` + `LoadLibraryA`.

So: game works, FrostMod doesn't, and Windows puts a bare error box over the screen that names a DLL and nothing else. The app had nothing to say about it, and it installs/starts FrostMod silently — so the status pill read "running" while the player stared at an error with no route to a fix except asking us.

## What

- **`src-tauri/src/vcruntime.rs`** (new) — detects **VC90** by scanning `WinSxS` for a directory starting `amd64_microsoft.vc90.crt_1fc8b3b9a1e18e3b_`, which is what the loader actually resolves against (beats guessing uninstall-registry GUIDs, which differ per redist build). The `amd64_` anchor is load-bearing: an `x86_` assembly is on plenty of machines and does nothing for a 64-bit game, and `amd64_policy.9.0.…` entries are redirection rules, not the CRT. Detects **VC140** — what `frostmod.dll` itself imports — via `System32`.
- Installs either one from Microsoft over HTTPS. Elevation goes through `ShellExecuteExW` with the `runas` verb: `std::process::Command` uses `CreateProcess`, which refuses a `requireAdministrator` installer with `ERROR_ELEVATION_REQUIRED` (740) rather than prompting.
- **Success is proved by re-running detection, not by exit code** — these packages return 3010 ("reboot pending") and 1638 ("newer already present") on outcomes that are fine.
- Detection is deliberately conservative: an unreadable `WinSxS` reports *present*. Telling a working player their PC is broken is worse than staying quiet.
- Surfaced as a **top banner** (reusing the `UpdateBanner` shape, mounted above it) **plus a Settings line and Fix button**, extending the existing `needsRepair` / `supportedForGame` status-flag pattern rather than growing a parallel diagnostics concept. 14 keys across all six locales.

### Two judgment calls

**Warning, not a gate** — FrostMod still starts. We can't prove from outside which machines inject fine, and blocking would regress anyone the detection is wrong about.

**Excluded from the auto-install effect** — that effect reinstalls FrostMod on a problem flag, and reinstalling FrostMod cannot put an OS runtime on the machine. Wiring it in would redownload FrostMod to no effect, with the flag still set afterwards.

## Also

Settings was hiding **Stop** unless the app had installed FrostMod itself — so the case that most needs a stop, a `frostmod.exe` running that the app didn't start, had no button. The backend has always killed a hand-launched one; only the button was missing. The sidebar control was unaffected.

## Verified

- `cargo test` — 463 passed, 0 failed (9 new, covering the WinSxS matcher, the per-package installer switches, and the payload sanity check).
- **`cargo check --target x86_64-pc-windows-gnu` — 0 errors, no warnings from `vcruntime.rs`.** The FFI struct layout, the `ShellExecuteExW` externs and every `cfg(windows)` branch genuinely compile rather than being skipped on macOS.
- `tsc --noEmit` clean, `bun run build` clean, eslint 2 warnings both pre-existing.

## Not verified

None of the Windows **runtime** behaviour — the UAC prompt, the `WinSxS` walk against a real directory, or whether the install clears the fault. Compiling is not running. Worth checking on a Windows box: banner appears and FrostMod still starts; Fix → UAC → banner clears without a manual refresh; cancelling UAC opens Microsoft's download and nothing reads as broken.

Honest caveat: this makes the failure legible and fixable, but it doesn't *prove* a missing runtime was the reporting user's root cause — the dialog text never named the failing module. If his machine reports nothing missing, that kills the runtime theory and points at the injector's activation context in the frostmod repo, which is out of scope here.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)