### PR TITLE
fix(rider): install a gear model into a folder of its own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@
 Getting ReShade itself is still a trip to reshade.me — it asks that its binaries not be
 redistributed, so the app detects it and links out rather than bundling or downloading it.
 ### Fixed
+- **Helmets, boots and protection now install into a folder of their own.** A gear mod
+  packaged as a `.pkz` — which is how locked mods are distributed — unpacks to a single
+  folder, and the app was unwrapping it and dropping the contents straight into
+  `mods/rider/helmets`. The game only loads a model as `helmets/<Model>/…`, so the helmet
+  became unloadable and invisible: it never appeared in the Rider tab's picker, and the
+  `paints` and `goggles` folders it arrived with were listed there in its place.
+- **The Rider tab offers to gather a gear mod that was installed loose.** Anything already
+  scattered by the above stays broken until it's moved, so the tab now spots it, names the
+  folder it will make (taken from the mod's own descriptor) and lists exactly what will
+  move before you press Repair. Packaged `.pkz` models and models already filed correctly
+  are left alone.
 - **A mods folder you moved with `mxbikes.ini` now works.** Plenty of players keep their
   content somewhere short like `C:\mods` — junctioning one rider paint into six model
   folders needs paths that OneDrive and a deep `Documents` tree can't give you. The app

--- a/src-tauri/src/game.rs
+++ b/src-tauri/src/game.rs
@@ -326,6 +326,21 @@ pub static GPB: GameProfile = GameProfile {
 /// correctly-packed archive.
 pub const ALL_MODS_DIRS: [&str; 5] = ["bikes", "tracks", "rider", "tyres", "misc"];
 
+/// Every folder under `mods/rider` that holds *models*, each model a folder of its own.
+///
+/// The union across titles, for the reason [`ALL_MODS_DIRS`] is one: its job is recognition
+/// — deciding whether a chosen destination names an *area* (so what is being installed is a
+/// new model, which needs a folder) or names a model already (so the content merges into
+/// it). Routing stays per-game. `riders` is listed too: a profile is a folder of files
+/// exactly as a helmet is, even though it carries no [`RiderArea`] of its own.
+pub const RIDER_MODEL_AREAS: [&str; 6] =
+    ["helmets", "boots", "protections", "protection", "animations", "riders"];
+
+/// Whether `name` is one of [`RIDER_MODEL_AREAS`], case-insensitively.
+pub fn is_rider_model_area(name: &str) -> bool {
+    RIDER_MODEL_AREAS.iter().any(|a| a.eq_ignore_ascii_case(name))
+}
+
 /// One gear area as the install pickers need it: where it is, and what may sit inside.
 ///
 /// The library's own view of an area is [`RiderArea`], which also carries the categories a
@@ -444,6 +459,23 @@ mod tests {
                     ALL_MODS_DIRS.contains(dir),
                     "{} has a `{dir}` folder that ALL_MODS_DIRS doesn't list",
                     g.id(),
+                );
+            }
+        }
+    }
+
+    /// `RIDER_MODEL_AREAS` only works as a recogniser if it really is the union — an area
+    /// it doesn't list would have a new model installed loose into the area folder instead
+    /// of into a folder of its own.
+    #[test]
+    fn rider_model_areas_covers_every_game() {
+        for g in Game::ALL {
+            for area in g.profile().rider.areas {
+                assert!(
+                    is_rider_model_area(area.folder),
+                    "{} has a `{}` area that RIDER_MODEL_AREAS doesn't list",
+                    g.id(),
+                    area.folder,
                 );
             }
         }

--- a/src-tauri/src/gearrepair.rs
+++ b/src-tauri/src/gearrepair.rs
@@ -1,0 +1,258 @@
+//! Gathering a gear model that was installed loose into the folder it needs.
+//!
+//! The game reads a model as a folder — `mods/rider/helmets/<Model>/helmet.edf` — and every
+//! picker in this app lists the folders an area holds. A model whose files sit directly in
+//! the area root is therefore invisible twice over: the game can't load it, and the app
+//! can't offer it. Worse, the `paints/` and `goggles/` folders that came with it are read as
+//! models of their own, so the helmet picker fills up with entries called "paints".
+//!
+//! Installs before the placement fix in [`crate::install::gear_model_folder`] could leave
+//! exactly that, so finding it and undoing it is this module's whole job. It only ever moves
+//! things the game cannot read where they are:
+//!
+//! * loose files in an area root — nothing there is loadable, whatever it is;
+//! * a `paints/` or `goggles/` folder in an area root — those belong to a model.
+//!
+//! A `.pkz` is left alone: a packaged model *is* a valid entry in an area root. So is any
+//! other sub-folder, because that is a model already.
+
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+/// The sub-folders a model carries. Found in an *area* root they are strays that belong to
+/// whichever model was scattered there — the game reads neither.
+const MODEL_SUBDIRS: [&str; 2] = ["paints", "goggles"];
+
+/// One area root that needs gathering, and what gathering it would move.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GearRepair {
+    /// The area folder under `mods/rider`, e.g. `helmets`.
+    pub area: String,
+    /// The folder the loose content will be gathered into.
+    pub model: String,
+    /// Absolute path of that folder, so the frontend can name it exactly.
+    pub dest: String,
+    /// What moves, by name, in the order it will move. Preview and apply read the same list.
+    pub items: Vec<String>,
+}
+
+/// Whether a directory entry is a model sub-folder that shouldn't be at an area root.
+fn is_model_subdir(name: &str) -> bool {
+    MODEL_SUBDIRS.iter().any(|s| s.eq_ignore_ascii_case(name))
+}
+
+/// The name to gather under.
+///
+/// A gear mod's descriptor `.ini` is named for the mod (`Astars_SM10_EKS.ini`), which is the
+/// name its author chose and the one the picker should show. Nothing else in the folder
+/// carries it — the mesh, the `.hrc` and `cameras.cfg` are all named for the slot, so
+/// `helmet.edf` would name every helmet ever recovered the same thing. With no `.ini` to
+/// read, say plainly that this was recovered rather than inventing a brand name.
+fn recovered_name(files: &[PathBuf], area: &str) -> String {
+    let ini = files
+        .iter()
+        .find(|p| p.extension().is_some_and(|x| x.eq_ignore_ascii_case("ini")))
+        .and_then(|p| p.file_stem())
+        .and_then(|s| s.to_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    match ini {
+        Some(name) => crate::install::sanitize(name),
+        // `helmets` → `helmet`; `protections` → `protection`. Crude, and only ever seen by
+        // someone whose mod shipped no descriptor at all.
+        None => format!("Recovered {}", area.strip_suffix('s').unwrap_or(area)),
+    }
+}
+
+/// What gathering `dir` would move, or `None` when it is already tidy.
+fn plan_area(dir: &Path, area: &str) -> Option<GearRepair> {
+    let rd = std::fs::read_dir(dir).ok()?;
+    let (mut files, mut subdirs) = (Vec::new(), Vec::new());
+    for e in rd.flatten() {
+        let p = e.path();
+        let Some(name) = p.file_name().and_then(|n| n.to_str()).map(str::to_string) else {
+            continue;
+        };
+        // `fs::metadata` on the path, not `DirEntry::file_type`/`DirEntry::metadata`: both of
+        // those describe the link itself, so a symlinked `paints/` reads as neither dir nor
+        // file and would be skipped without a word. A mods tree assembled out of symlinks is
+        // normal here — that's what `linkwalk` exists for.
+        match std::fs::metadata(&p) {
+            Ok(t) if t.is_dir() => {
+                if is_model_subdir(&name) {
+                    subdirs.push((name, p));
+                }
+            }
+            Ok(t) if t.is_file() => {
+                // A packaged model belongs here; junk is not worth moving and not worth
+                // reporting as if it were someone's helmet.
+                let packaged = p.extension().is_some_and(|x| x.eq_ignore_ascii_case("pkz"));
+                if !packaged && !crate::install::is_junk(&name) {
+                    files.push(p);
+                }
+            }
+            _ => {}
+        }
+    }
+    if files.is_empty() && subdirs.is_empty() {
+        return None;
+    }
+    // Deterministic, so the preview a user reads is the order the apply walks.
+    files.sort();
+    subdirs.sort();
+    let model = recovered_name(&files, area);
+    let items = files
+        .iter()
+        .filter_map(|p| p.file_name()?.to_str().map(str::to_string))
+        .chain(subdirs.iter().map(|(n, _)| n.clone()))
+        .collect();
+    Some(GearRepair {
+        area: area.to_string(),
+        model: model.clone(),
+        dest: dir.join(&model).to_string_lossy().into_owned(),
+        items,
+    })
+}
+
+/// Every gear area under `mods/rider` holding content the game can't reach where it is.
+pub fn plan(mods_path: &str) -> Vec<GearRepair> {
+    let base = crate::library::mods_subdir(mods_path, "mods/rider");
+    crate::game::RIDER_MODEL_AREAS
+        .iter()
+        // A profile is picked by name from `riders/` and its own loose files are read there,
+        // so that area is not scattered in the sense this repairs.
+        .filter(|a| !a.eq_ignore_ascii_case("riders"))
+        .filter_map(|area| plan_area(&base.join(area), area))
+        .collect()
+}
+
+/// Carry out one plan, returning how many entries moved.
+///
+/// Re-planned rather than trusting the caller's copy: a preview can be minutes old, and the
+/// only thing worth acting on is what is in the folder now.
+pub fn apply_one(mods_path: &str, area: &str) -> anyhow::Result<usize> {
+    use anyhow::Context;
+    let base = crate::library::mods_subdir(mods_path, "mods/rider");
+    let dir = base.join(area);
+    let Some(plan) = plan_area(&dir, area) else {
+        return Ok(0);
+    };
+    let dest = dir.join(&plan.model);
+    // A second run after a half-finished first one must merge into the folder it made, not
+    // fail on it — so `create_dir_all`, and a per-entry existence check below.
+    std::fs::create_dir_all(&dest)
+        .with_context(|| format!("create {dest:?}"))?;
+    let mut moved = 0;
+    for item in &plan.items {
+        let from = dir.join(item);
+        let to = dest.join(item);
+        if to.exists() {
+            log::warn!("[gearrepair] {area}: '{item}' already exists in {dest:?} — left alone");
+            continue;
+        }
+        std::fs::rename(&from, &to).with_context(|| format!("move {from:?} -> {to:?}"))?;
+        moved += 1;
+    }
+    log::info!("[gearrepair] gathered {moved} entries into {dest:?}");
+    Ok(moved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp(tag: &str) -> PathBuf {
+        let p = std::env::temp_dir().join(format!("frost-gearrepair-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&p);
+        p
+    }
+
+    fn touch(p: &Path) {
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(p, b"x").unwrap();
+    }
+
+    /// The shape a pre-fix install left behind: the mesh loose in the area root with the
+    /// model's `paints/` and `goggles/` beside it, named from the descriptor `.ini`.
+    #[test]
+    fn gathers_a_scattered_helmet_under_its_own_name() {
+        let root = tmp("scattered");
+        let helmets = root.join("mods/rider/helmets");
+        for f in ["gfx.cfg", "helmet.edf", "helmet.hrc", "Astars_SM10_EKS.ini"] {
+            touch(&helmets.join(f));
+        }
+        touch(&helmets.join("paints/Red.pnt"));
+        touch(&helmets.join("goggles/Smoke.pnt"));
+
+        let plans = plan(root.to_str().unwrap());
+        assert_eq!(plans.len(), 1, "one area needs gathering");
+        assert_eq!(plans[0].model, "Astars_SM10_EKS", "named from the descriptor");
+        assert_eq!(plans[0].area, "helmets");
+
+        let moved = apply_one(root.to_str().unwrap(), "helmets").unwrap();
+        assert_eq!(moved, 6);
+        let model = helmets.join("Astars_SM10_EKS");
+        assert!(model.join("helmet.edf").exists());
+        assert!(model.join("paints/Red.pnt").exists());
+        assert!(model.join("goggles/Smoke.pnt").exists());
+        assert!(!helmets.join("helmet.edf").exists(), "nothing left loose");
+        assert!(!helmets.join("paints").exists(), "no stray `paints` sibling");
+        assert!(plan(root.to_str().unwrap()).is_empty(), "and it stays tidy");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A packaged model and a properly-installed one are what a healthy area looks like.
+    /// Neither is loose content, so neither is touched — and nothing is reported.
+    #[test]
+    fn a_tidy_area_is_left_alone() {
+        let root = tmp("tidy");
+        let helmets = root.join("mods/rider/helmets");
+        touch(&helmets.join("Fox V3/helmet.edf"));
+        touch(&helmets.join("Fox V3/paints/Blue.pnt"));
+        touch(&helmets.join("Airoh.pkz"));
+        touch(&helmets.join("readme.txt"));
+        assert!(plan(root.to_str().unwrap()).is_empty());
+        assert_eq!(apply_one(root.to_str().unwrap(), "helmets").unwrap(), 0);
+        assert!(helmets.join("Airoh.pkz").exists(), "a packaged model stays put");
+        assert!(helmets.join("Fox V3/helmet.edf").exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// No descriptor to read. Still gathered — loose files are unloadable either way — but
+    /// named for what happened rather than after `helmet.edf`, which would name them all
+    /// alike.
+    #[test]
+    fn names_the_folder_plainly_when_no_descriptor_shipped() {
+        let root = tmp("noini");
+        let boots = root.join("mods/rider/boots");
+        touch(&boots.join("gfx.cfg"));
+        touch(&boots.join("boots.edf"));
+        let plans = plan(root.to_str().unwrap());
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].model, "Recovered boot");
+        apply_one(root.to_str().unwrap(), "boots").unwrap();
+        assert!(boots.join("Recovered boot/boots.edf").exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Applying twice must not throw away the second copy of a name — leave it and say so,
+    /// rather than overwriting what is already filed.
+    #[test]
+    fn a_name_that_already_exists_is_never_overwritten() {
+        let root = tmp("collide");
+        let helmets = root.join("mods/rider/helmets");
+        touch(&helmets.join("Fox.ini"));
+        touch(&helmets.join("helmet.edf"));
+        touch(&helmets.join("Fox/helmet.edf"));
+        std::fs::write(helmets.join("Fox/helmet.edf"), b"the one already filed").unwrap();
+        apply_one(root.to_str().unwrap(), "helmets").unwrap();
+        assert_eq!(
+            std::fs::read(helmets.join("Fox/helmet.edf")).unwrap(),
+            b"the one already filed",
+            "the filed model wins"
+        );
+        assert!(helmets.join("helmet.edf").exists(), "and the loose one is still there");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/src-tauri/src/install.rs
+++ b/src-tauri/src/install.rs
@@ -986,6 +986,9 @@ pub(crate) fn plan_placement(
     for seg in &segs {
         type_dir.push(sanitize(seg));
     }
+    if let Some(name) = gear_model_folder(type_folder, &segs, extracted, &unwrapped, slug) {
+        type_dir.push(name);
+    }
 
     // A bike livery only loads from `<Bike>/paints/`. The picker offers a bike's root as a
     // destination too — that's where sounds and model swaps go — so a paint chosen there
@@ -1009,6 +1012,45 @@ pub(crate) fn plan_placement(
             wrap_loose,
         },
     )
+}
+
+/// The folder a whole gear model needs under its area, or `None` when this placement isn't
+/// installing one.
+///
+/// A gear model *is* a folder: the game loads `helmets/<Model>/helmet.edf`, and every picker
+/// lists the folders an area contains. But the destination offered for a new model is the
+/// bare area (`helmets`), and [`unwrap_wrapper`] has by then stripped the mod's own folder —
+/// which is exactly the shape a packaged `.pkz` extracts to. Without this the model's files
+/// landed loose in `mods/rider/helmets`, where nothing lists them and nothing can load them,
+/// and the area picked up `paints`/`goggles` as if those were models of their own.
+///
+/// Named as the mod named itself, because that name is what the pickers will show. A mod
+/// that ships its files bare has only the slug to go on.
+///
+/// Two placements are deliberately left alone. A paint drop names the model it belongs to
+/// (`helmets/<Model>/paints`), so it is more than one segment and merges as before. And an
+/// archive packed area-first — a `helmets/` folder holding the models — is already in the
+/// shape the destination expects; wrapping it would bury the models a level down.
+fn gear_model_folder(
+    type_folder: &str,
+    segs: &[&str],
+    extracted: &Path,
+    unwrapped: &Path,
+    slug: &str,
+) -> Option<String> {
+    if !type_folder.eq_ignore_ascii_case("rider") {
+        return None;
+    }
+    let [area] = segs else { return None };
+    if !crate::game::is_rider_model_area(area) {
+        return None;
+    }
+    let own = (unwrapped != extracted)
+        .then(|| unwrapped.file_name()?.to_str())
+        .flatten()
+        .filter(|n| !crate::game::is_rider_model_area(n));
+    let name = sanitize(own.unwrap_or(slug));
+    (!name.trim().is_empty()).then_some(name)
 }
 
 pub(crate) fn place_mod(
@@ -1735,6 +1777,68 @@ mod tests {
         place_mod(&ex, &mods, "rider", "riders/default_mx/paints", "kit").unwrap();
         assert!(mods.join("rider/riders/default_mx/paints/kit.pnt").exists());
         assert!(!mods.join("bikes/default_mx").exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A packaged helmet extracts to a single `<Model>/` folder, which `unwrap_wrapper`
+    /// strips — and the destination offered for a new model is the bare area. Together
+    /// those scattered the mesh and its `paints/` straight into `mods/rider/helmets`,
+    /// where the game can't load it and the picker lists `paints` as a helmet.
+    #[test]
+    fn a_new_gear_model_keeps_a_folder_of_its_own() {
+        let root = place_tmp("gear-model-folder");
+        let ex = root.join("ex");
+        touch(&ex.join("Astars_SM10_EKS/gfx.cfg"));
+        touch(&ex.join("Astars_SM10_EKS/helmet.edf"));
+        touch(&ex.join("Astars_SM10_EKS/paints/Red.pnt"));
+        touch(&ex.join("Astars_SM10_EKS/goggles/Smoke.pnt"));
+        let mods = root.join("mods");
+        place_mod(&ex, &mods, "rider", "helmets", "astars-sm10").unwrap();
+
+        let model = mods.join("rider/helmets/Astars_SM10_EKS");
+        assert!(model.join("helmet.edf").exists(), "the mesh is under the model's own name");
+        assert!(model.join("gfx.cfg").exists());
+        assert!(model.join("paints/Red.pnt").exists(), "paints travel with the model");
+        assert!(model.join("goggles/Smoke.pnt").exists());
+        assert!(
+            !mods.join("rider/helmets/helmet.edf").exists(),
+            "nothing is left loose in the area folder"
+        );
+        assert!(
+            !mods.join("rider/helmets/paints").exists(),
+            "`paints` must not become a sibling of the models — the picker reads it as one"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Nothing to take the name from, so the slug is what's left. Still a folder: loose
+    /// files in the area root are unloadable however they got there.
+    #[test]
+    fn a_bare_gear_model_is_named_from_the_slug() {
+        let root = place_tmp("gear-model-slug");
+        let ex = root.join("ex");
+        touch(&ex.join("gfx.cfg"));
+        touch(&ex.join("boots.edf"));
+        let mods = root.join("mods");
+        place_mod(&ex, &mods, "rider", "boots", "tech-10").unwrap();
+        assert!(mods.join("rider/boots/tech-10/boots.edf").exists());
+        assert!(!mods.join("rider/boots/boots.edf").exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Packed area-first: the archive's `helmets/` already *is* the destination, so its
+    /// children are the models. Wrapping that would bury every one of them a level down.
+    #[test]
+    fn an_area_first_archive_is_not_wrapped_again() {
+        let root = place_tmp("gear-area-first");
+        let ex = root.join("ex");
+        touch(&ex.join("helmets/Fox V3/gfx.cfg"));
+        touch(&ex.join("helmets/Fox V3/helmet.edf"));
+        let mods = root.join("mods");
+        place_mod(&ex, &mods, "rider", "helmets", "fox-v3").unwrap();
+        assert!(mods.join("rider/helmets/Fox V3/helmet.edf").exists());
+        assert!(!mods.join("rider/helmets/helmets").exists(), "no doubled area folder");
+        assert!(!mods.join("rider/helmets/fox-v3").exists(), "no slug folder over the models");
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -13,6 +13,7 @@ mod frostmod;
 mod frostmod_manage;
 mod game;
 mod gameproc;
+mod gearrepair;
 mod imgcache;
 mod install;
 mod library;
@@ -348,6 +349,29 @@ async fn scan_rider_targets(app: tauri::AppHandle) -> Result<library::RiderTarge
 fn scan_rider_targets_blocking(app: tauri::AppHandle) -> Result<library::RiderTargets, String> {
     let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
     Ok(library::scan_rider_targets(&cfg.mods_path))
+}
+
+/// Gear areas holding a model the game can't reach, because its files sit loose in the area
+/// root instead of in a folder. See [`gearrepair`] for how that happened and what moves.
+#[tauri::command]
+async fn scan_gear_repairs(app: tauri::AppHandle) -> Result<Vec<gearrepair::GearRepair>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
+        Ok(gearrepair::plan(&cfg.mods_path))
+    })
+    .await
+    .map_err(|e| format!("scan_gear_repairs task failed: {e}"))?
+}
+
+/// Gather one area's loose content into a folder of its own. Returns how many entries moved.
+#[tauri::command]
+async fn repair_gear_area(app: tauri::AppHandle, area: String) -> Result<usize, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
+        gearrepair::apply_one(&cfg.mods_path, &area).map_err(|e| format!("{e:#}"))
+    })
+    .await
+    .map_err(|e| format!("repair_gear_area task failed: {e}"))?
 }
 
 #[tauri::command]
@@ -4461,6 +4485,8 @@ fn main() {
             paint_studio_extract,
             paint_studio_hints,
             scan_rider_targets,
+            scan_gear_repairs,
+            repair_gear_area,
             scan_bike_targets,
             scan_model_swaps,
             apply_model_swap,
@@ -5073,6 +5099,7 @@ mod viewer_tests {
             }
         }
     }
+
 
     #[test]
     #[ignore]

--- a/src/Components/Rider/RiderStudio.tsx
+++ b/src/Components/Rider/RiderStudio.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { RefreshCw, AlertTriangle, Save, Loader2 } from "lucide-react";
+import { RefreshCw, AlertTriangle, Save, Loader2, FolderInput } from "lucide-react";
 import { toast } from "sonner";
 import { useT, type TKey } from "../../i18n/context";
 import { Button } from "../ui/button";
@@ -7,7 +7,12 @@ import HelpHint from "../ui/help-hint";
 import { Input } from "../ui/input";
 import { Switch } from "../ui/switch";
 import type { Loadout, RiderPart } from "../../types";
-import { presetsSave } from "../../api/mods";
+import {
+  presetsSave,
+  scanGearRepairs,
+  repairGearArea,
+  type GearRepair,
+} from "../../api/mods";
 import { ViewerPanel } from "../Viewer/ViewerPanel";
 import { SlotField } from "../Presets/SlotField";
 import {
@@ -43,6 +48,11 @@ export default function RiderStudio({ initialLoadout, onLoaded }: RiderStudioPro
   // reason to hide the slot the rider tab is most often opened for.
   const [hidden, setHidden] = useState<RiderPart["part"][]>([]);
   const [error, setError] = useState<string | null>(null);
+  // Gear installed loose in an area root — see `gearrepair` on the Rust side. Surfaced here
+  // because this is the tab where the damage shows: the model is missing from its picker and
+  // `paints` is offered in its place.
+  const [repairs, setRepairs] = useState<GearRepair[]>([]);
+  const [repairing, setRepairing] = useState<string | null>(null);
   // Paints the chosen models carry, merged with the loose ones the scan found.
   const { optionsFor, missingFor } = useGearPaints(loadout);
 
@@ -95,11 +105,37 @@ export default function RiderStudio({ initialLoadout, onLoaded }: RiderStudioPro
     } catch (e) {
       setError(String(e));
     }
+    // Never fatal: a mods folder that can't be inspected for this is still a mods folder,
+    // and the tab has to open either way.
+    setRepairs(await scanGearRepairs().catch(() => []));
   }, []);
 
   useEffect(() => {
     void load();
   }, [load]);
+
+  const onRepair = useCallback(
+    async (r: GearRepair) => {
+      setRepairing(r.area);
+      try {
+        const moved = await repairGearArea(r.area);
+        toast.success(
+          moved
+            ? t("rider.repairDone", { count: moved, model: r.model })
+            : t("rider.repairNothing"),
+        );
+        // Re-scan rather than dropping the banner locally: gathering changes what the
+        // pickers can offer, and the model that was invisible a moment ago is the whole
+        // point of having done it.
+        await load();
+      } catch (e) {
+        toast.error(String(e).replace(/^Error:\s*/, ""));
+      } finally {
+        setRepairing(null);
+      }
+    },
+    [load, t],
+  );
 
   const grouped = useMemo(
     () => RIDER_GROUPS.map((g) => ({ ...g, slots: SLOTS.filter((s) => s.group === g.id) })),
@@ -143,6 +179,42 @@ export default function RiderStudio({ initialLoadout, onLoaded }: RiderStudioPro
           {error}
         </div>
       )}
+
+      {repairs.map((r) => (
+        <div
+          key={r.area}
+          className="mx-7 mb-3 flex items-start gap-2.5 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 text-[12.5px]"
+        >
+          <FolderInput className="mt-0.5 size-4 flex-none text-amber-500" />
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span className="font-semibold">
+              {t("rider.repairTitle", { area: r.area })}
+            </span>
+            <span className="text-muted-foreground">
+              {t("rider.repairBody", { area: r.area, model: r.model })}
+            </span>
+            {/* The exact list, because this moves files on disk and the person clicking
+                should be able to see what it will touch before it does. */}
+            <span className="truncate text-[11px] text-faint" title={r.items.join(", ")}>
+              {r.items.join(", ")}
+            </span>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            className="flex-none"
+            disabled={repairing !== null}
+            onClick={() => void onRepair(r)}
+          >
+            {repairing === r.area ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <FolderInput className="size-3.5" />
+            )}
+            {t("rider.repairAction")}
+          </Button>
+        </div>
+      ))}
 
       <div className="flex min-h-0 flex-1 gap-5 overflow-hidden px-7 pb-6">
         {/* Picker column */}

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -371,6 +371,26 @@ export function scanRiderTargets(): Promise<RiderTargets> {
   return invoke<RiderTargets>("scan_rider_targets");
 }
 
+/** A gear area whose model was installed loose in the area root instead of in a folder. */
+export interface GearRepair {
+  /** The area folder under `mods/rider` — `helmets`, `boots`, … */
+  area: string;
+  /** The folder the loose content will be gathered into. */
+  model: string;
+  dest: string;
+  /** What moves, by name. */
+  items: string[];
+}
+
+export function scanGearRepairs(): Promise<GearRepair[]> {
+  return invoke<GearRepair[]>("scan_gear_repairs");
+}
+
+/** Gather one area's loose content into its own folder; resolves with the entries moved. */
+export function repairGearArea(area: string): Promise<number> {
+  return invoke<number>("repair_gear_area", { area });
+}
+
 /** What a failed scan stands in for: nothing installed, which every picker handles. */
 export const EMPTY_RIDER_TARGETS: RiderTargets = {
   helmets: [],

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -216,6 +216,13 @@ export const de: Translation = {
   "rider.namePlaceholder": "Diesem Fahrer einen Namen geben…",
   "rider.nameFirst": "Gib diesem Fahrer-Look zuerst einen Namen.",
   "rider.showOnModel": "Am Modell zeigen",
+  "rider.repairTitle": "Ein {{area}}-Mod wurde lose installiert",
+  "rider.repairBody":
+    "Seine Dateien liegen direkt in {{area}} statt in einem Ordner — weder das Spiel noch diese App können ihn so laden. In „{{model}}“ zusammenfassen?",
+  "rider.repairAction": "Reparieren",
+  "rider.repairDone_one": "{{count}} Datei in „{{model}}“ zusammengefasst.",
+  "rider.repairDone_other": "{{count}} Dateien in „{{model}}“ zusammengefasst.",
+  "rider.repairNothing": "Es gibt nichts mehr zusammenzufassen.",
 
   // ── Rundgang ───────────────────────────────────────────────────────────────
   "tour.welcomeTour.title": "Mach einen kurzen Rundgang",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -206,6 +206,13 @@ export const en = {
   "rider.namePlaceholder": "Name this rider…",
   "rider.nameFirst": "Name this rider look first.",
   "rider.showOnModel": "Show on model",
+  "rider.repairTitle": "A {{area}} mod was installed loose",
+  "rider.repairBody":
+    "Its files sit directly in {{area}} instead of in a folder, so neither the game nor this app can load it. Gather them into “{{model}}”?",
+  "rider.repairAction": "Repair",
+  "rider.repairDone_one": "Gathered {{count}} file into “{{model}}”.",
+  "rider.repairDone_other": "Gathered {{count}} files into “{{model}}”.",
+  "rider.repairNothing": "Nothing left to gather.",
 
   // ── Guided tour ────────────────────────────────────────────────────────────
   "tour.welcomeTour.title": "Take a quick tour",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -210,6 +210,13 @@ export const es: Translation = {
   "rider.namePlaceholder": "Pon nombre a este piloto…",
   "rider.nameFirst": "Primero ponle nombre a este look.",
   "rider.showOnModel": "Mostrar en el modelo",
+  "rider.repairTitle": "Un mod de {{area}} se instaló suelto",
+  "rider.repairBody":
+    "Sus archivos están directamente en {{area}} en vez de en una carpeta, así que ni el juego ni esta app pueden cargarlo. ¿Recogerlos en “{{model}}”?",
+  "rider.repairAction": "Reparar",
+  "rider.repairDone_one": "Se recogió {{count}} archivo en “{{model}}”.",
+  "rider.repairDone_other": "Se recogieron {{count}} archivos en “{{model}}”.",
+  "rider.repairNothing": "No queda nada por recoger.",
 
   // ── Visita guiada ──────────────────────────────────────────────────────────
   "tour.welcomeTour.title": "Haz un recorrido rápido",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -213,6 +213,13 @@ export const fr: Translation = {
   "rider.namePlaceholder": "Nommez ce pilote…",
   "rider.nameFirst": "Nommez d'abord ce look de pilote.",
   "rider.showOnModel": "Afficher sur le modèle",
+  "rider.repairTitle": "Un mod {{area}} a été installé en vrac",
+  "rider.repairBody":
+    "Ses fichiers sont directement dans {{area}} au lieu d'un dossier, donc ni le jeu ni cette app ne peuvent le charger. Les rassembler dans « {{model}} » ?",
+  "rider.repairAction": "Réparer",
+  "rider.repairDone_one": "{{count}} fichier rassemblé dans « {{model}} ».",
+  "rider.repairDone_other": "{{count}} fichiers rassemblés dans « {{model}} ».",
+  "rider.repairNothing": "Plus rien à rassembler.",
 
   // ── Visite guidée ──────────────────────────────────────────────────────────
   "tour.welcomeTour.title": "Faites un tour rapide",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -209,6 +209,13 @@ export const it: Translation = {
   "rider.namePlaceholder": "Dai un nome a questo pilota…",
   "rider.nameFirst": "Prima dai un nome a questo look.",
   "rider.showOnModel": "Mostra sul modello",
+  "rider.repairTitle": "Un mod in {{area}} è stato installato sparso",
+  "rider.repairBody":
+    "I suoi file stanno direttamente in {{area}} invece che in una cartella, quindi né il gioco né questa app possono caricarlo. Raccoglierli in “{{model}}”?",
+  "rider.repairAction": "Ripara",
+  "rider.repairDone_one": "Raccolto {{count}} file in “{{model}}”.",
+  "rider.repairDone_other": "Raccolti {{count}} file in “{{model}}”.",
+  "rider.repairNothing": "Non c'è più niente da raccogliere.",
 
   // ── Tour guidato ───────────────────────────────────────────────────────────
   "tour.welcomeTour.title": "Fai un giro veloce",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -212,6 +212,13 @@ export const ptBR: Translation = {
   "rider.namePlaceholder": "Dê um nome a este piloto…",
   "rider.nameFirst": "Primeiro dê um nome a este visual.",
   "rider.showOnModel": "Mostrar no modelo",
+  "rider.repairTitle": "Um mod de {{area}} foi instalado solto",
+  "rider.repairBody":
+    "Os arquivos dele estão direto em {{area}} em vez de numa pasta, então nem o jogo nem este app conseguem carregá-lo. Juntar tudo em “{{model}}”?",
+  "rider.repairAction": "Reparar",
+  "rider.repairDone_one": "{{count}} arquivo juntado em “{{model}}”.",
+  "rider.repairDone_other": "{{count}} arquivos juntados em “{{model}}”.",
+  "rider.repairNothing": "Não sobrou nada para juntar.",
 
   // ── Tour guiado ────────────────────────────────────────────────────────────
   "tour.welcomeTour.title": "Faça um tour rápido",


### PR DESCRIPTION
## The bug

A gear mod packaged as a `.pkz` — which is how locked mods are distributed — extracts to a single `<Model>/` folder. `unwrap_wrapper` strips that, and the destination offered for a new model is the bare area (`helmets`). Together they dropped the mesh, `gfx.cfg` and the model's `paints/` and `goggles/` straight into `mods/rider/helmets`.

The game only loads a model as `helmets/<Model>/…`, and every picker lists the *folders* an area holds. So the helmet was unloadable and unlistable — and `paints`/`goggles` were offered in the helmet picker in its place.

Reproduced with a real sealed helmet (Astars SM10 EKS — every file a locked container, including a 32 MB `helmet.edf`), in a **release** build:

```
picker BEFORE repair: ["goggles", "paints"]
plans: [("helmets", "Astars_SM10_EKS")]
moved 9 entries
picker AFTER repair:  ["Astars_SM10_EKS"]
loaded: 1 nodes, 3 textures
  helmet/Astars_SM10 -> Some("Astars")
  helmet/goggle      -> Some("goggle")
  helmet/goggle      -> Some("lens")
```

## The fix

**Installer** — `gear_model_folder` gives the model its folder back, named as the mod named itself (that name is what the picker shows), falling back to the slug. Two placements are deliberately left alone: a paint drop already names its model (`helmets/<Model>/paints`), and an archive packed area-first is already in the destination's shape — wrapping it would bury every model a level down. `game::RIDER_MODEL_AREAS` is the recogniser, a union across titles guarded by a test, mirroring `ALL_MODS_DIRS`.

**Repair** — new `gearrepair` module for what earlier installs already scattered. It moves only what the game cannot read where it is: loose files in an area root, and a stray `paints/`/`goggles/`. A `.pkz` stays (a packaged model is valid there), as does any other sub-folder (already a model) and junk. The folder is named from the mod's `.ini`, the only file carrying the author's name — `helmet.edf` would name every recovery alike. A name already filed is never overwritten.

**UI** — the Rider tab lists exactly what will move before it moves, since this touches disk. Keys in all six locales, `_one`/`_other` on the count.

## Checks

494 Rust tests (9 new), `tsc` clean, eslint clean, clippy clean on the changed files, frontend builds.

## Worth a reviewer's eye

- The repair moves files on disk — worth trying on a copy of a mods folder first.
- No descriptor `.ini` → the folder is named `Recovered helmet`.
- `riders` is excluded from the repair: a profile's loose files are read where they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
