### PR TITLE
fix(browse): keep the grid where you left it after a mod visit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## 2026-08-09
 
 ### Fixed
+- **Browse keeps your place when you look at a mod and come back.** Opening a mod used to
+  throw away the search you typed, the category you picked, the sort order, every page you'd
+  loaded with "Load more" and how far you'd scrolled — Back dropped you at the top of a fresh,
+  unfiltered listing, which made working through a long category one mod at a time miserable.
+  The grid now sits exactly where you left it, down to the row of cards, and nothing is
+  re-fetched on the way back. It survives a trip to Library or Settings too, and the in-game
+  overlay behaves the same way.
 - **The Linux app opens to its interface instead of a white screen.** On SteamOS the window
   appeared, the title bar drew, and the inside stayed blank with nothing in the terminal to
   explain it. The AppImage carries its own copy of the web engine, and that engine tries to

--- a/src/Components/Browse/Browse.tsx
+++ b/src/Components/Browse/Browse.tsx
@@ -1,18 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import { Search, Download, X, ArrowUpDown } from "lucide-react";
 import { toast } from "sonner";
-import {
-  MOD_SORTS,
-  SEARCH_PAGE_SIZE,
-  getModRatings,
-  resolveQuickInstall,
-  searchMods,
-  type ModSort,
-  type ModType,
-} from "../../api/mods";
+import { resolveQuickInstall, type ModSort, type ModType } from "../../api/mods";
 import { useConfig } from "../../Context/Config";
 import type { InstalledIndex } from "../../lib/installedMatch";
-import type { ModRating, ModSummary } from "../../types";
+import type { ModListing } from "../../lib/useModListing";
+import type { ModSummary } from "../../types";
 import { useInstall } from "../../Context/Install";
 import { useT } from "../../i18n/context";
 import ModCard from "./ModCard";
@@ -43,6 +36,12 @@ interface BrowseProps {
   modType: ModType;
   /** The active game's browse tree — the catalogs differ per title. */
   modTypes: ModType[];
+  /**
+   * Filters, fetched pages and scroll offset. Owned by `useModBrowsing` above this
+   * component, which is what lets it survive a trip into a mod's detail page — see
+   * `useModListing`.
+   */
+  listing: ModListing;
   installed: InstalledIndex;
   onOpenMod: (slug: string, categoryId: number) => void;
   onChangeType: (type: ModType) => void;
@@ -51,29 +50,35 @@ interface BrowseProps {
 export default function Browse({
   modType,
   modTypes,
+  listing,
   installed,
   onOpenMod,
   onChangeType,
 }: BrowseProps) {
   const t = useT();
   const { game } = useConfig();
-  const [query, setQuery] = useState("");
-  const [debounced, setDebounced] = useState("");
-  const [categoryId, setCategoryId] = useState(modType.categoryId);
-  const [sort, setSort] = useState<ModSort>("newest");
-  const [mods, setMods] = useState<ModSummary[]>([]);
-  const [ratings, setRatings] = useState<Map<number, ModRating>>(new Map());
-  // Ids we've already asked about, so a mod the site had no answer for isn't re-requested
-  // on every render. Cleared when the listing is rebuilt (the Rust side caches, so asking
-  // again after a category switch costs nothing).
-  const askedForRatings = useRef<Set<number>>(new Set());
-  const [page, setPage] = useState(1);
-  const [hasMore, setHasMore] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [reloadKey, setReloadKey] = useState(0);
-  const [selected, setSelected] = useState<Map<string, ModSummary>>(new Map());
+  const {
+    query,
+    setQuery,
+    categoryId,
+    setCategoryId,
+    setSort,
+    sortOptions,
+    activeSort,
+    mods,
+    ratings,
+    hasMore,
+    loading,
+    loadingMore,
+    error,
+    reload,
+    loadMore,
+    selected,
+    toggleSelect,
+    clearSelection,
+    selectAll,
+    scrollTop,
+  } = listing;
   const [bulkBusy, setBulkBusy] = useState(false);
   // A pending reinstall the user must confirm (they already have these mods).
   const [reinstall, setReinstall] = useState<
@@ -83,35 +88,19 @@ export default function Browse({
   const { startInstall } = useInstall();
   const selectionActive = selected.size > 0;
 
-  // The popular listings are ranked by views by a part of the site that takes no search
-  // term, so they step aside while the box has text in it and the order falls back to
-  // newest — the control always names the order actually on screen. The pick itself is
-  // kept, so clearing the search puts it back.
-  const sortOptions = MOD_SORTS.filter((s) => !s.noSearch || !debounced);
-  const activeSort = sortOptions.some((s) => s.value === sort) ? sort : "newest";
+  // The grid scroller. Its offset is kept in `listing` rather than here, so opening a mod
+  // and coming back — which unmounts this component — lands on the same row of cards.
+  const grid = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    // Before paint, so the lazy thumbnails load for the row we're actually on and there
+    // is no jump from the top.
+    if (grid.current) grid.current.scrollTop = scrollTop.current;
+  }, [scrollTop]);
 
   const isInstalled = useCallback(
     (mod: ModSummary) => installed.has(mod.title),
     [installed],
   );
-
-  // Reset the category filter (and any selection) when the mod type changes —
-  // selection + quick-install resolve against the current type's folders.
-  useEffect(() => {
-    setCategoryId(modType.categoryId);
-    setSelected(new Map());
-  }, [modType]);
-
-  const toggleSelect = useCallback((mod: ModSummary) => {
-    setSelected((prev) => {
-      const next = new Map(prev);
-      if (next.has(mod.slug)) next.delete(mod.slug);
-      else next.set(mod.slug, mod);
-      return next;
-    });
-  }, []);
-
-  const clearSelection = useCallback(() => setSelected(new Map()), []);
 
   // Silent quick-install: resolve the mirror + folder, then enqueue.
   const doQuickInstall = useCallback(
@@ -200,78 +189,6 @@ export default function Browse({
     else void doBulkInstall(pending.mods);
   }, [reinstall, doQuickInstall, doBulkInstall]);
 
-  const selectAll = useCallback(() => {
-    setSelected((prev) => {
-      const next = new Map(prev);
-      for (const m of mods) next.set(m.slug, m);
-      return next;
-    });
-  }, [mods]);
-
-  // Debounce the search input so we don't hammer the API on every keystroke.
-  useEffect(() => {
-    const t = setTimeout(() => setDebounced(query.trim()), 350);
-    return () => clearTimeout(t);
-  }, [query]);
-
-  // (Re)load the first page whenever the query, category or sort changes.
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    setPage(1);
-    askedForRatings.current = new Set();
-    searchMods(debounced, categoryId, 1, activeSort)
-      .then((res) => {
-        if (cancelled) return;
-        setMods(res);
-        setHasMore(res.length >= SEARCH_PAGE_SIZE);
-      })
-      .catch((e) => !cancelled && setError(String(e)))
-      .finally(() => !cancelled && setLoading(false));
-    return () => {
-      cancelled = true;
-    };
-  }, [debounced, categoryId, activeSort, reloadKey]);
-
-  // Scores aren't part of the search response — they come in a second pass keyed by post
-  // id, for whatever is on screen. Never awaited by the grid: cards paint immediately and
-  // stars appear a moment later, and a failure just leaves them off.
-  useEffect(() => {
-    const wanted = mods.map((m) => m.id).filter((id) => !askedForRatings.current.has(id));
-    if (wanted.length === 0) return;
-    for (const id of wanted) askedForRatings.current.add(id);
-    let cancelled = false;
-    getModRatings(wanted)
-      .then((res) => {
-        if (cancelled) return;
-        setRatings((prev) => {
-          const next = new Map(prev);
-          for (const [id, rating] of Object.entries(res)) next.set(Number(id), rating);
-          return next;
-        });
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, [mods]);
-
-  const loadMore = useCallback(async () => {
-    const next = page + 1;
-    setLoadingMore(true);
-    try {
-      const res = await searchMods(debounced, categoryId, next, activeSort);
-      setMods((prev) => [...prev, ...res]);
-      setHasMore(res.length >= SEARCH_PAGE_SIZE);
-      setPage(next);
-    } catch (e) {
-      setError(String(e));
-    } finally {
-      setLoadingMore(false);
-    }
-  }, [debounced, categoryId, activeSort, page]);
-
   const isBike = modType.id === "bikes";
 
   return (
@@ -346,7 +263,11 @@ export default function Browse({
         </div>
       </header>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-7 pb-6">
+      <div
+        ref={grid}
+        onScroll={(e) => (scrollTop.current = e.currentTarget.scrollTop)}
+        className="min-h-0 flex-1 overflow-y-auto px-7 pb-6"
+      >
         {error ? (
           <div className="mx-auto flex max-w-md flex-col items-center gap-3 py-20 text-center">
             <p className="text-[13px] font-semibold text-destructive">
@@ -357,7 +278,7 @@ export default function Browse({
             <p className="select-text text-[12.5px] leading-relaxed text-muted-foreground">
               {error.replace(/^Error:\s*/, "")}
             </p>
-            <Button variant="outline" size="sm" onClick={() => setReloadKey((k) => k + 1)}>
+            <Button variant="outline" size="sm" onClick={reload}>
               {t("common.retry")}
             </Button>
           </div>

--- a/src/Components/Dashboard/Dashboard.tsx
+++ b/src/Components/Dashboard/Dashboard.tsx
@@ -40,6 +40,7 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
     modType,
     modTypes,
     changeType,
+    listing,
     selectedSlug,
     selectedCategoryId,
     installed,
@@ -136,6 +137,7 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
             <Browse
               modType={modType}
               modTypes={modTypes}
+              listing={listing}
               installed={installed}
               onOpenMod={openMod}
               onChangeType={changeType}

--- a/src/Components/Overlay/Overlay.tsx
+++ b/src/Components/Overlay/Overlay.tsx
@@ -82,6 +82,7 @@ export default function Overlay() {
     modType,
     modTypes,
     changeType,
+    listing,
     selectedSlug,
     selectedCategoryId,
     installed,
@@ -271,6 +272,7 @@ export default function Overlay() {
                             <Browse
                               modType={modType}
                               modTypes={modTypes}
+                              listing={listing}
                               installed={installed}
                               onOpenMod={openMod}
                               onChangeType={changeType}

--- a/src/lib/useModBrowsing.ts
+++ b/src/lib/useModBrowsing.ts
@@ -6,6 +6,7 @@ import {
   buildInstalledIndex,
   type InstalledIndex,
 } from "./installedMatch";
+import { useModListing } from "./useModListing";
 import type { ModTarget } from "../Context/Install";
 
 /**
@@ -32,6 +33,9 @@ export function useModBrowsing(
   const [libraryVersion, setLibraryVersion] = useState(0);
   // What's on disk for the active type, as a fuzzy lookup (for "in library" badges).
   const [installed, setInstalled] = useState<InstalledIndex>(EMPTY_INSTALLED_INDEX);
+  // The grid's own state — filters, fetched pages, scroll offset. Held here, above the
+  // Browse/ModDetail swap, so opening a mod and coming back lands on the same screen.
+  const listing = useModListing(modType);
 
   // Follow a game switch. The two catalogs don't share category ids, so carrying the old
   // `modType` over would query the new site with the old site's numbers and come back
@@ -92,6 +96,8 @@ export function useModBrowsing(
     /** The active game's browse tree — what the type selector offers. */
     modTypes,
     changeType,
+    /** Everything the browse grid renders from — see `useModListing`. */
+    listing,
     selectedSlug,
     selectedCategoryId,
     installed,

--- a/src/lib/useModListing.ts
+++ b/src/lib/useModListing.ts
@@ -1,0 +1,175 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  MOD_SORTS,
+  SEARCH_PAGE_SIZE,
+  getModRatings,
+  searchMods,
+  type ModSort,
+  type ModType,
+} from "../api/mods";
+import type { ModRating, ModSummary } from "../types";
+
+/**
+ * What the browse grid is showing: the filters, the pages fetched under them, and where
+ * the user was scrolled to.
+ *
+ * It lives here rather than inside `Browse` because `Browse` is unmounted whenever a mod
+ * detail page opens — it and `ModDetail` are the two arms of one ternary in both the
+ * Dashboard and the overlay. State held in the component would be thrown away on the way
+ * in and refetched from page 1 on the way back, losing the search, the category, the sort,
+ * every "load more" page and the scroll offset. Held here, by a hook that `useModBrowsing`
+ * calls *above* that swap, nothing unmounts: coming back re-renders the grid that is
+ * already in memory, with no refetch at all.
+ */
+export function useModListing(modType: ModType) {
+  const [query, setQuery] = useState("");
+  const [debounced, setDebounced] = useState("");
+  const [categoryId, setCategoryId] = useState(modType.categoryId);
+  const [sort, setSort] = useState<ModSort>("newest");
+  const [mods, setMods] = useState<ModSummary[]>([]);
+  const [ratings, setRatings] = useState<Map<number, ModRating>>(new Map());
+  // Ids we've already asked about, so a mod the site had no answer for isn't re-requested
+  // on every render. Cleared when the listing is rebuilt (the Rust side caches, so asking
+  // again after a category switch costs nothing).
+  const askedForRatings = useRef<Set<number>>(new Set());
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+  const [selected, setSelected] = useState<Map<string, ModSummary>>(new Map());
+  // Where the grid was scrolled to, for `Browse` to put back on its next mount. A ref
+  // rather than state: it changes on every scroll frame and nothing renders from it.
+  const scrollTop = useRef(0);
+
+  // The popular listings are ranked by views by a part of the site that takes no search
+  // term, so they step aside while the box has text in it and the order falls back to
+  // newest — the control always names the order actually on screen. The pick itself is
+  // kept, so clearing the search puts it back.
+  const sortOptions = MOD_SORTS.filter((s) => !s.noSearch || !debounced);
+  const activeSort = sortOptions.some((s) => s.value === sort) ? sort : "newest";
+
+  // Reset the category filter (and any selection) when the mod type changes —
+  // selection + quick-install resolve against the current type's folders.
+  useEffect(() => {
+    setCategoryId(modType.categoryId);
+    setSelected(new Map());
+    scrollTop.current = 0;
+  }, [modType]);
+
+  const toggleSelect = useCallback((mod: ModSummary) => {
+    setSelected((prev) => {
+      const next = new Map(prev);
+      if (next.has(mod.slug)) next.delete(mod.slug);
+      else next.set(mod.slug, mod);
+      return next;
+    });
+  }, []);
+
+  const clearSelection = useCallback(() => setSelected(new Map()), []);
+
+  const selectAll = useCallback(() => {
+    setSelected((prev) => {
+      const next = new Map(prev);
+      for (const m of mods) next.set(m.slug, m);
+      return next;
+    });
+  }, [mods]);
+
+  // Debounce the search input so we don't hammer the API on every keystroke.
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(query.trim()), 350);
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  // (Re)load the first page whenever the query, category or sort changes.
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setPage(1);
+    askedForRatings.current = new Set();
+    // A different listing starts at the top; the offset we were holding belongs to the
+    // old one.
+    scrollTop.current = 0;
+    searchMods(debounced, categoryId, 1, activeSort)
+      .then((res) => {
+        if (cancelled) return;
+        setMods(res);
+        setHasMore(res.length >= SEARCH_PAGE_SIZE);
+      })
+      .catch((e) => !cancelled && setError(String(e)))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [debounced, categoryId, activeSort, reloadKey]);
+
+  // Scores aren't part of the search response — they come in a second pass keyed by post
+  // id, for whatever is on screen. Never awaited by the grid: cards paint immediately and
+  // stars appear a moment later, and a failure just leaves them off.
+  useEffect(() => {
+    const wanted = mods.map((m) => m.id).filter((id) => !askedForRatings.current.has(id));
+    if (wanted.length === 0) return;
+    for (const id of wanted) askedForRatings.current.add(id);
+    let cancelled = false;
+    getModRatings(wanted)
+      .then((res) => {
+        if (cancelled) return;
+        setRatings((prev) => {
+          const next = new Map(prev);
+          for (const [id, rating] of Object.entries(res)) next.set(Number(id), rating);
+          return next;
+        });
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [mods]);
+
+  const loadMore = useCallback(async () => {
+    const next = page + 1;
+    setLoadingMore(true);
+    try {
+      const res = await searchMods(debounced, categoryId, next, activeSort);
+      setMods((prev) => [...prev, ...res]);
+      setHasMore(res.length >= SEARCH_PAGE_SIZE);
+      setPage(next);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [debounced, categoryId, activeSort, page]);
+
+  const reload = useCallback(() => setReloadKey((k) => k + 1), []);
+
+  return {
+    query,
+    setQuery,
+    categoryId,
+    setCategoryId,
+    setSort,
+    /** The orders offered right now: the popular ones drop out during a search. */
+    sortOptions,
+    /** The order on screen, which is `newest` when the pick isn't currently offered. */
+    activeSort,
+    mods,
+    ratings,
+    hasMore,
+    loading,
+    loadingMore,
+    error,
+    reload,
+    loadMore,
+    selected,
+    toggleSelect,
+    clearSelection,
+    selectAll,
+    scrollTop,
+  };
+}
+
+export type ModListing = ReturnType<typeof useModListing>;


### PR DESCRIPTION
## What

Opening a mod from Browse and pressing Back used to throw away the search text, the category pill, the sort order, every page loaded with "Load more", the selection and the scroll position — you landed at the top of a freshly-fetched, unfiltered listing.

The cause is structural: `Browse` and `ModDetail` are the two arms of one ternary in both `Dashboard` and `Overlay`, so opening a mod **unmounts** `Browse`, and all of that state was `useState` inside it.

## How

- New `src/lib/useModListing.ts` owns the filters, fetched pages, ratings, selection and a `scrollTop` ref, plus the four effects lifted verbatim out of `Browse` (debounce, type-change reset, page-1 load, ratings pass).
- `useModBrowsing` calls it and returns `listing`. That hook already sits *above* the swap in both windows, so nothing it holds unmounts — coming back re-renders the grid still in memory and fires **no request at all**.
- `Browse` keeps only its install machinery and reads the listing from one prop (−126 lines net). Its scroll container records the offset on scroll and restores it in a `useLayoutEffect` before paint, so lazy thumbnails load for the right row and there is no jump.
- One prop added at each call site; the in-game overlay gets the same fix.

Because the state now lives above the whole view switch, Browse also keeps its place across a visit to Library/Presets/Settings.

Unchanged: a mod-type switch still resets the category pill and selection (and now the scroll) while keeping the search text; a game switch still remaps the type the same way.

No DB or schema changes.

## Verification

- `bun run typecheck` and `bun run lint` clean (only pre-existing warnings in untouched files).
- Throwaway React harness with the backend mocked and calls counted, all passing: a detail round-trip fires **zero** extra `search_mods` calls and keeps query/category/sort/48 loaded cards/scroll offset; a mod-type switch resets category, selection and scroll and refetches under the new category; a filter change refetches exactly once and returns to the top.
- Manual: search + category + sort + two "Load more" pages + scrolled halfway, open a mod, Back — same screen, no loading skeletons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)