### PR TITLE
chore(release): announce beta builds in the beta Discord channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,9 @@ name: Release
 # A tag with a suffix — `v0.7.0-beta.1`, `v0.7.0-rc.2` — builds the same three
 # platforms but publishes as a PRE-RELEASE: GitHub keeps it off `releases/latest`,
 # which is the endpoint the in-app updater reads, so existing installs are not
-# offered it and the Discord announcement is held back. Beta testers install it by
-# downloading the installer from the release page. Tagging the plain `v0.7.0`
-# afterwards is what ships it to everyone.
+# offered it. It's announced in the beta Discord channel rather than the release
+# one, and beta testers install it by downloading the installer from the release
+# page. Tagging the plain `v0.7.0` afterwards is what ships it to everyone.
 
 on:
   push:
@@ -189,12 +189,14 @@ jobs:
   # Announce the finished release in Discord. Runs after `finalize` so the download links
   # point at the renamed installers, and only for real tags on the canonical repo — forks
   # stay silent, and `workflow_dispatch` test builds (throwaway `v<run_number>` tags) don't
-  # spam the channel. Pre-release tags stay quiet too: a beta goes to the people who asked
-  # for it, and the channel hears about the version once, when everyone can have it.
+  # spam a channel, since their ref is a branch rather than a tag. Which channel is the tag's
+  # decision: a suffixed tag posts to the beta webhook, a plain one to the release webhook, so
+  # testers hear about a beta straight away while the release channel hears about a version
+  # once, when everyone can have it.
   # (`scripts/notify-discord.sh <tag> --print` renders the message without sending it.)
   notify:
     needs: finalize
-    if: ${{ github.repository == 'Frostn1/mxb-app' && github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
+    if: ${{ github.repository == 'Frostn1/mxb-app' && github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -206,6 +208,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          # Missing secret is a warning, not a failure — see the script.
+          # Missing secret is a warning, not a failure — see the script. The script picks one
+          # of the two by the tag and never falls back to the other.
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_BETA_WEBHOOK_URL: ${{ secrets.DISCORD_BETA_WEBHOOK_URL }}
         run: bash scripts/notify-discord.sh "${{ github.ref_name }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@
   missing in plain language, and installs it from Microsoft with one button.
 - **The warning goes where it'll be seen.** A bar at the top of the app, not just a line in
   Settings — nothing about the symptom suggests Settings is where to look.
+- **A beta now announces itself in the beta Discord channel.** Until now a suffixed tag
+  built and published quietly and testers only heard about it if someone told them, because
+  the announcement job skipped pre-releases outright. It runs for them now, and the tag
+  decides which channel it reaches: a beta posts to the beta webhook, a full release to the
+  release one, so testers hear immediately while everyone else still hears about a version
+  once — when the updater can actually hand it to them.
+  - The beta message says what it is before it says what's in it — a beta build of the
+    version it names, which the updater won't offer you, so install it from the links in the
+    message. Same fact the release page leads with. It's titled and coloured as a beta, and
+    reads the changelog section for the version it's a build of, so it carries that
+    release's headline once it's written and simply omits it before then.
+  - The beta webhook is its own `DISCORD_BETA_WEBHOOK_URL` secret and the script never falls
+    back from one webhook to the other: a beta landing in the channel every player watches
+    is worse than a beta nobody announced.
 
 ### Changed
 - **FrostMod still starts when a runtime is missing.** It's a warning, not a gate: we can't

--- a/scripts/notify-discord.sh
+++ b/scripts/notify-discord.sh
@@ -5,14 +5,19 @@
 #   scripts/notify-discord.sh <tag> [--print]
 #
 # Reads the release from GitHub and the matching section out of CHANGELOG.md, then posts
-# a single embed to the webhook in $DISCORD_WEBHOOK_URL. `--print` dumps the payload to
+# a single embed to the webhook for that kind of release. `--print` dumps the payload to
 # stdout instead of sending, so the message can be eyeballed without spamming the channel.
 #
+# A suffixed tag (`v0.8.0-beta.2`) is a beta: same embed, but it goes to the beta channel,
+# is titled and coloured as a beta, and opens by saying the updater won't hand it to you.
+#
 # Env:
-#   DISCORD_WEBHOOK_URL  webhook to post to. Empty -> warn and exit 0, so a missing secret
-#                        never fails a release that otherwise built and published fine.
-#   GH_TOKEN             passed through to `gh` (the workflow hands it GITHUB_TOKEN).
-#   REPO                 owner/name. Defaults to GITHUB_REPOSITORY, then Frostn1/mxb-app.
+#   DISCORD_WEBHOOK_URL       webhook for a full release.
+#   DISCORD_BETA_WEBHOOK_URL  webhook for a beta. Never falls back to the one above.
+#                             Either being empty -> warn and exit 0, so a missing secret
+#                             never fails a release that otherwise built and published fine.
+#   GH_TOKEN                  passed through to `gh` (the workflow hands it GITHUB_TOKEN).
+#   REPO                      owner/name. Defaults to GITHUB_REPOSITORY, then Frostn1/mxb-app.
 
 set -euo pipefail
 
@@ -32,10 +37,30 @@ if [ -z "$TAG" ]; then
 fi
 
 REPO="${REPO:-${GITHUB_REPOSITORY:-Frostn1/mxb-app}}"
-WEBHOOK="${DISCORD_WEBHOOK_URL:-}"
 
+# A suffixed tag (`v0.8.0-beta.2`) is a beta build of the version it names — the same test
+# release.yml uses to publish it as a pre-release, and release-notes.sh to head the release
+# page with a tester's note. It's announced in the beta channel: the people who asked for it
+# want to hear straight away, while everyone else should hear about the version once, when
+# the updater can actually hand it to them.
+case "$TAG" in
+  *-*) IS_BETA=1 ;;
+  *)   IS_BETA=0 ;;
+esac
+
+if [ "$IS_BETA" -eq 1 ]; then
+  WEBHOOK_VAR="DISCORD_BETA_WEBHOOK_URL"
+  WEBHOOK="${DISCORD_BETA_WEBHOOK_URL:-}"
+else
+  WEBHOOK_VAR="DISCORD_WEBHOOK_URL"
+  WEBHOOK="${DISCORD_WEBHOOK_URL:-}"
+fi
+
+# No falling back to the other webhook when one is missing: a beta announced in the release
+# channel is worse than a beta nobody announced, and the release channel is the one every
+# player watches.
 if [ "$PRINT_ONLY" -eq 0 ] && [ -z "$WEBHOOK" ]; then
-  echo "::warning::DISCORD_WEBHOOK_URL is not set — skipping the Discord announcement."
+  echo "::warning::$WEBHOOK_VAR is not set — skipping the Discord announcement."
   exit 0
 fi
 
@@ -60,6 +85,9 @@ subtitle="$(printf '%s' "$heading" | awk -F'—' '
 
 title="MXB App $TAG"
 [ -n "$subtitle" ] && title="$title — $subtitle"
+# `changelog-section.sh` reads a beta against the section for the version it's a build of, so
+# a beta borrows that release's headline once it's written and simply has none before then.
+[ "$IS_BETA" -eq 1 ] && title="🧪 Beta — $title"
 
 # --- description -------------------------------------------------------------------
 # Discord caps embed descriptions at 4096 characters; stop short of that so the footer
@@ -74,6 +102,17 @@ more="
 
 [Full notes, with the detail →]($rel_url)"
 
+# A beta says what it is before it says what's in it: the one thing a tester needs to know is
+# that nothing will arrive on its own. Same fact release-notes.sh leads the release page with,
+# so the two can't drift. It spends part of the cap, so the ladder below measures what's left.
+lede=""
+if [ "$IS_BETA" -eq 1 ]; then
+  lede="**Beta build of ${TAG%%-*} — for testing.** Installed copies won't be offered it by the updater; grab an installer below to try it. Tell us what breaks, and the full release follows.
+
+"
+  limit=$(( limit - ${#lede} ))
+fi
+
 body="$("$section" "$TAG" --fold || true)"
 
 if [ -n "$body" ] && [ "${#body}" -gt "$limit" ]; then
@@ -86,9 +125,17 @@ if [ "${#body}" -gt "$limit" ]; then
   body="${body:0:$limit}…$more"
 fi
 
+# A beta cut before its section is written is normal — it's the build the notes get written
+# from — so it gets the lede and a pointer rather than a claim about what's in it.
 if [ -z "$body" ]; then
-  body="A new version is out — see the release page for details."
+  if [ "$IS_BETA" -eq 1 ]; then
+    body="See the release page for what went into this build."
+  else
+    body="A new version is out — see the release page for details."
+  fi
 fi
+
+body="$lede$body"
 
 # --- download links ------------------------------------------------------------------
 # Matched after the `finalize` job's rename, so these are the pretty `MXB-App-0.6.1-x64.exe`
@@ -102,6 +149,15 @@ lin="$(jq -r '[.assets[] | select(.name | test("\\.AppImage$"))] | first | .url 
 icon="https://raw.githubusercontent.com/$REPO/$TAG/src-tauri/icons/icon.png"
 avatar="https://raw.githubusercontent.com/$REPO/main/src-tauri/icons/icon.png"
 
+# Amber down the side of a beta instead of the usual blue, and a footer that says so — the
+# two announcements sit in different channels, but plenty of people watch both.
+color=10276076
+footer="MXB App • GitHub Releases"
+if [ "$IS_BETA" -eq 1 ]; then
+  color=15246141   # 0xE8A33D
+  footer="MXB App • Beta • GitHub Releases"
+fi
+
 payload="$(jq -n \
   --arg title "$title" \
   --arg url "$rel_url" \
@@ -112,6 +168,8 @@ payload="$(jq -n \
   --arg win "$win" \
   --arg mac "$mac" \
   --arg lin "$lin" \
+  --argjson color "$color" \
+  --arg footer "$footer" \
   '{
     username: "MXB App",
     avatar_url: $avatar,
@@ -120,10 +178,10 @@ payload="$(jq -n \
       title: $title,
       url: $url,
       description: $desc,
-      color: 10276076,
+      color: $color,
       thumbnail: { url: $icon },
       timestamp: $ts,
-      footer: { text: "MXB App • GitHub Releases" },
+      footer: { text: $footer },
       fields: (
         (if $win != "" then [{
           name: "⬇ Windows — start here",
@@ -158,4 +216,8 @@ curl --fail-with-body -sS -X POST \
   -d "$payload" \
   "$WEBHOOK"
 
-echo "Announced $TAG to Discord."
+if [ "$IS_BETA" -eq 1 ]; then
+  echo "Announced beta $TAG to the beta Discord channel."
+else
+  echo "Announced $TAG to Discord."
+fi


### PR DESCRIPTION
A beta build published quietly. The `notify` job was gated with `!contains(github.ref_name, '-')`, so a suffixed tag built, published as a pre-release, and then said nothing anywhere — testers only found out if someone told them.

Betas now announce themselves, in their own channel. The release channel is unchanged: it still hears about a version once, when everyone can have it.

## What the tag decides

`scripts/notify-discord.sh` derives beta-ness from the tag suffix — the same test `release.yml` uses to publish a pre-release and `release-notes.sh` uses to head the release page with a tester's note — and picks the webhook from it:

| tag | webhook | embed |
| --- | --- | --- |
| `v0.8.0` | `DISCORD_WEBHOOK_URL` | unchanged |
| `v0.8.0-beta.2` | `DISCORD_BETA_WEBHOOK_URL` | `🧪 Beta —` title, amber, `• Beta •` footer, tester lede |

**No fallback between the two.** If the beta webhook is missing the script warns and exits 0, same as today's missing-secret behaviour — it does not reach for the other one. A beta landing in the channel every player watches is worse than a beta nobody announced.

The beta message says what it is before it says what's in it: a beta build of the version it names, which the updater won't offer you, so install it from the links below. Same fact the release page leads with, so the two can't drift. The lede's length comes off the 3500-char budget before the existing `--fold` → `--summary` → trim ladder, so it can't push the description past Discord's 4096 cap. A beta cut before its changelog section is written — normal, it's the build the notes get written from — points at the release page instead of claiming what shipped.

## Verified

Against real published releases, with `--print` (renders without sending):

- **Release channel untouched** — the `v0.8.1` payload is byte-identical before and after the change (`diff`, no output).
- `v0.8.0-beta.2`, `v0.7.1-beta.4`, `v0.7.0-beta.1` render with the beta title, colour and footer, the changelog section for the version they're a build of, and all three download links pointing at the renamed pre-release assets. Descriptions: 3597 / 2451 / 2056 chars, all under the cap.
- Missing-secret path warns and exits 0 for both kinds; a beta with only `DISCORD_WEBHOOK_URL` set refuses to post rather than falling back.
- A beta whose version has no changelog section yet: lede plus a pointer at the release page, and a title with no subtitle.
- Workflow YAML parses; `workflow_dispatch` builds still can't reach `notify` — their ref is a branch, not a tag.

## Secret

`DISCORD_BETA_WEBHOOK_URL` is set on this repo. The URL is not in the tree — the repo is public and a webhook URL is a post-anything-to-this-channel credential — and a read-only GET confirms it points at the **Beta Releases** channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
