### PR TITLE
chore(release): consolidate the unreleased sections into v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,85 @@
 # Changelog
 
-## 2026-08-09 — The app spots the missing Windows component behind a dead FrostMod
+## 2026-08-09 — v0.9.0 — A paint studio, ReShade presets, and your Shop purchases
 
 ### Added
+- **A new Paints tab turns image files into paints the game loads.** MX Bikes reads a paint
+  as a packed container of compressed texture sheets, which no image editor writes — so
+  until now a livery drawn in GIMP or Photoshop had to go through somebody else's converter
+  before the game, or this app's 3D preview, would look at it. Pick the sheets (`.tga`,
+  `.png`, `.jpg`, `.bmp`, `.webp`), say what they're for, and the app builds the `.pnt` and
+  installs it where the game expects it: `mods/bikes/<Bike>/paints`,
+  `rider/helmets/<Helmet>/paints` or `goggles`, boots, protection, and a rider profile's
+  kit or gloves. Or save it to a folder of your own, to share.
+- **Unpack an existing paint into editable `.tga` sheets.** This is how you get a template
+  that actually fits the model: the sheets come out named the way the mesh binds them
+  (`livery`, `rider`, `shell`…), open in any editor, and go straight back in under the same
+  names. Extracted to `Documents\MXB App\Paint Templates\<paint>` and loaded into the studio
+  in one step, so the round trip is edit → **Reload from disk** → **Save paint**.
+- **Names are the part that decides whether a paint works, so the studio shows them.** A
+  `.pnt` supplies textures *by name* and the mesh binds whichever names it asked for — a
+  sheet called `livery` lands on the bodywork, the same sheet called `my_livery` lands
+  nowhere. The studio reads the names the paints already installed for that model use (from
+  their headers — no pixels decoded), lists them, and flags a sheet whose name isn't one of
+  them before you save.
+- **Preview what you just saved on the real model**, through the viewer the app already
+  has: a bike livery on its bike, a helmet or goggle paint on that helmet, a kit on the
+  rider.
+- **Sheets that aren't a power of two are resized to one, and say so.** MX Bikes is a
+  DirectX 9 title and its textures are powers of two throughout; a 1000×1000 export — which
+  GIMP will happily make — would otherwise be packed into a file the game refuses, and the
+  failure would land in-game rather than in the app.
+- **Pick a ReShade preset from Settings.** A new ReShade card lists every preset you have —
+  the ones the app installed and any already sitting loose in your game folder — and switching
+  between them is one click. There's an "Off" entry that runs no effects, so you can compare a
+  preset against the stock look without uninstalling anything.
+- **Browse and install ReShade presets like any other mod.** mxb-mods' ReShade Presets
+  category is now a tab in Browse. Installing one files the preset where the app can find it,
+  and puts any effects and lookup textures the download bundles where ReShade looks for them —
+  the usual reason a preset "does nothing" after a manual install.
+- **Drop a preset on the app.** A `.ini` or an archive of them is recognised as a ReShade
+  preset and goes straight to the right place.
+- **The app says when ReShade is installed for the wrong graphics API.** MX Bikes and GP Bikes
+  render with OpenGL, and ReShade's installer offers DirectX first — a DirectX install is
+  never loaded by the game and looks like ReShade simply not working. The card names that
+  specifically, and points at the fix.
+- **Presets warn when they need effects you don't have.** A preset that switches on a shader
+  that isn't installed renders without it and looks like it did nothing; the card lists what's
+  missing instead.
+
+  Getting ReShade itself is still a trip to reshade.me — it asks that its binaries not be
+  redistributed, so the app detects it and links out rather than bundling or downloading it.
+- **Install what you bought on the MX Bikes Shop, from inside the app.** The Shop tab now has
+  two halves — **Catalog**, the store's public listing as before, and **My purchases**, which
+  signs in to your own mxbikes-shop.com account and shows everything you've already paid for.
+  Cards carry the store's own artwork and author, a product that ships several files (PRO/AMS
+  and the like) is one card with a picker rather than several, and anything already in your
+  library is badged as installed.
+- **Purchases install through the same review sheet a drag-and-drop uses.** The file is
+  downloaded with a progress bar, then read to see what it actually contains, and the sheet
+  says where each piece will land and warns about collisions before anything is written.
+- **Presets can use a custom riding style.** The **Riding style** slot only ever offered the
+  two styles the game ships, so a style you had installed could not be picked — you could
+  type its name in by hand, but the preset then flagged it as a mod you were missing, never
+  packed it into a share code, and Manage was free to park it right before a race. The slot
+  now lists what is installed in `mods/rider/animations` alongside the stock `mx` and `sm`,
+  a shared preset carries the style with it like it already carries helmets and paints, and
+  Manage keeps it. **MX Bikes and GP Bikes both**, which is the point: the two games load
+  riding styles from the same folder and record the pick in the same `[riding_style]` line.
+- **MX Bikes lists riding styles in the Library**, in the Rider tab under their own heading,
+  and offers `mods/rider/animations` when you install one. GP Bikes already did both; MX
+  Bikes was treated as if it had no such folder, so a riding style installed there was
+  invisible to the app.
+- **FrostMod can be stopped from the app.** The sidebar pill and the FrostMod section in
+  Settings now offer a stop control while it's running, next to the reload and start ones —
+  until now the only way out was Task Manager or quitting the app from the tray. It stops
+  FrostMod whoever started it: a `frostmod.exe` left behind by an earlier session, or one
+  launched by hand, is no longer out of reach just because this app didn't spawn it. The app
+  waits for the process to actually go before saying it stopped, so a FrostMod that survives
+  the attempt (running elevated, or as another user) is reported rather than papered over with
+  a success message the status pill contradicts a second later. Stopping is a one-off — it
+  doesn't touch the "Run FrostMod automatically" setting, so the next app launch behaves as
+  configured.
 - **"msvcr90.dll was not found" is now something the app explains and fixes.** MX Bikes is
   a Visual C++ 2008 build, and it asks Windows for that runtime by manifest rather than by
   path — which resolves either machine-wide or out of a private copy sitting in the game
@@ -35,61 +112,6 @@
   FrostMod away from anyone the check is wrong about.
 
 ### Fixed
-- **Settings offers Stop for a FrostMod it didn't install.** The button was hidden unless
-  the app had put FrostMod there itself — so the one case that most needs a stop, a
-  `frostmod.exe` running that the app didn't start, had no button. The backend could
-  always kill it; only the button was missing. (The sidebar's stop control was unaffected.)
-
-## 2026-08-09
-
-### Fixed
-- **Browse keeps your place when you look at a mod and come back.** Opening a mod used to
-  throw away the search you typed, the category you picked, the sort order, every page you'd
-  loaded with "Load more" and how far you'd scrolled — Back dropped you at the top of a fresh,
-  unfiltered listing, which made working through a long category one mod at a time miserable.
-  The grid now sits exactly where you left it, down to the row of cards, and nothing is
-  re-fetched on the way back. It survives a trip to Library or Settings too, and the in-game
-  overlay behaves the same way.
-- **The Linux app opens to its interface instead of a white screen.** On SteamOS the window
-  appeared, the title bar drew, and the inside stayed blank with nothing in the terminal to
-  explain it. The AppImage carries its own copy of the web engine, and that engine tries to
-  hand frames to the graphics driver through a fast path the host's driver answers
-  differently than the one it was built against — so it drew nothing at all, silently. It now
-  takes the ordinary path by default, which paints on every machine and costs nothing anyone
-  will notice on a UI this static. A machine that handles the fast path can still ask for it
-  back with `WEBKIT_DISABLE_DMABUF_RENDERER=0`. The startup log now records which path a run
-  took, so the next report of a blank window can be read straight from the log.
-### Added
-- **Install what you bought on the MX Bikes Shop, from inside the app.** The Shop tab now has
-  two halves — **Catalog**, the store's public listing as before, and **My purchases**, which
-  signs in to your own mxbikes-shop.com account and shows everything you've already paid for.
-  Cards carry the store's own artwork and author, a product that ships several files (PRO/AMS
-  and the like) is one card with a picker rather than several, and anything already in your
-  library is badged as installed.
-- **Purchases install through the same review sheet a drag-and-drop uses.** The file is
-  downloaded with a progress bar, then read to see what it actually contains, and the sheet
-  says where each piece will land and warns about collisions before anything is written.
-- **Pick a ReShade preset from Settings.** A new ReShade card lists every preset you have —
-  the ones the app installed and any already sitting loose in your game folder — and switching
-  between them is one click. There's an "Off" entry that runs no effects, so you can compare a
-  preset against the stock look without uninstalling anything.
-- **Browse and install ReShade presets like any other mod.** mxb-mods' ReShade Presets
-  category is now a tab in Browse. Installing one files the preset where the app can find it,
-  and puts any effects and lookup textures the download bundles where ReShade looks for them —
-  the usual reason a preset "does nothing" after a manual install.
-- **Drop a preset on the app.** A `.ini` or an archive of them is recognised as a ReShade
-  preset and goes straight to the right place.
-- **The app says when ReShade is installed for the wrong graphics API.** MX Bikes and GP Bikes
-  render with OpenGL, and ReShade's installer offers DirectX first — a DirectX install is
-  never loaded by the game and looks like ReShade simply not working. The card names that
-  specifically, and points at the fix.
-- **Presets warn when they need effects you don't have.** A preset that switches on a shader
-  that isn't installed renders without it and looks like it did nothing; the card lists what's
-  missing instead.
-
-Getting ReShade itself is still a trip to reshade.me — it asks that its binaries not be
-redistributed, so the app detects it and links out rather than bundling or downloading it.
-### Fixed
 - **Helmets, boots and protection now install into a folder of their own.** A gear mod
   packaged as a `.pkz` — which is how locked mods are distributed — unpacks to a single
   folder, and the app was unwrapping it and dropping the contents straight into
@@ -101,30 +123,12 @@ redistributed, so the app detects it and links out rather than bundling or downl
   folder it will make (taken from the mod's own descriptor) and lists exactly what will
   move before you press Repair. Packaged `.pkz` models and models already filed correctly
   are left alone.
-- **A purchased bike or gear set no longer installs as if it were a track.** The old path
-  picked a destination by looking for keywords in the *product name* and otherwise assumed
-  tracks, so bikes, paints and gear were filed into a tracks-derived folder silently, with no
-  preview and no collision check. Destination now comes from the archive's contents.
-- **A mods folder you moved with `mxbikes.ini` now works.** Plenty of players keep their
-  content somewhere short like `C:\mods` — junctioning one rider paint into six model
-  folders needs paths that OneDrive and a deep `Documents` tree can't give you. The app
-  couldn't be pointed at such a folder: picking it silently rewrote your setting to the
-  drive root, and auto-detection went to `Documents\PiBoSo\MX Bikes` instead, found no
-  `mods` inside it, and came up missing gear, paints and bikes with nothing to explain why.
-  The folder you pick is now the folder used, whether it's the game folder or the mods
-  folder itself.
-- **The app reads `mxbikes.ini` to find a relocated mods folder on its own.** The game
-  already knows where your content is; setup now asks it instead of guessing. Profiles,
-  which don't move with the mods folder, are pinned to where they actually stayed.
-- **FrostMod was being handed the wrong folder.** It appends `\tracks` and `\bikes` to what
-  the app gives it, and the app was sending the folder one level above — so its track
-  manager and model swap were pointed at folders that don't exist. Affected everyone, not
-  just relocated setups; it just never announced itself.
-- **Settings says which folder mods are actually read from** when that isn't the obvious
-  `<picked>\mods`, and warns when the folder isn't there at all.
-## 2026-08-09 — Gear with no paint picked wears its own look
-
-### Fixed
+- **A packed gear item and a folder of the same name are now one item, not two.** A `.pkz`
+  helmet with paints installed loose beside it (which is where the game looks, and where the
+  studio writes) only ever showed one side of itself: whichever the loader resolved first.
+  A folder holding nothing but paints hid the archive entirely — the picker listed the new
+  paint alone and the preview lost the mesh it belonged to. Both are read now, the folder
+  winning a name clash because it's what was installed last.
 - **An empty paint slot shows the model's own look, not a paint you never chose.** The stock
   helmet came out bronze on the Rider tab while the Library showed that same helmet white
   under "Stock", and picking a helmet mod without naming a paint quietly dressed it in
@@ -137,24 +141,10 @@ redistributed, so the app detects it and links out rather than bundling or downl
   same question now, so the two views can't disagree about it again. A paint that *is* named
   but missing still falls back as it always did, and a mod that ships paints without baking a
   shell texture into its mesh keeps that fallback too, rather than turning up bare.
-## 2026-08-09 — custom riding styles
-
-### Added
-- **Presets can use a custom riding style.** The **Riding style** slot only ever offered the
-  two styles the game ships, so a style you had installed could not be picked — you could
-  type its name in by hand, but the preset then flagged it as a mod you were missing, never
-  packed it into a share code, and Manage was free to park it right before a race. The slot
-  now lists what is installed in `mods/rider/animations` alongside the stock `mx` and `sm`,
-  a shared preset carries the style with it like it already carries helmets and paints, and
-  Manage keeps it. **MX Bikes and GP Bikes both**, which is the point: the two games load
-  riding styles from the same folder and record the pick in the same `[riding_style]` line.
-- **MX Bikes lists riding styles in the Library**, in the Rider tab under their own heading,
-  and offers `mods/rider/animations` when you install one. GP Bikes already did both; MX
-  Bikes was treated as if it had no such folder, so a riding style installed there was
-  invisible to the app.
-## Unreleased
-
-### Fixed
+- **A purchased bike or gear set no longer installs as if it were a track.** The old path
+  picked a destination by looking for keywords in the *product name* and otherwise assumed
+  tracks, so bikes, paints and gear were filed into a tracks-derived folder silently, with no
+  preview and no collision check. Destination now comes from the archive's contents.
 - **Retrying a failed install no longer breaks the install.** Downloads are meant to run one
   at a time, but the Retry button on a failure went straight to the installer instead of the
   queue — so a second, impatient click started a *parallel* run of the same mod. Both runs
@@ -170,22 +160,6 @@ redistributed, so the app detects it and links out rather than bundling or downl
 - **One unreadable file no longer sinks a whole install.** A shortcut whose target has gone
   away, or a file an antivirus pulls out mid-install, used to fail everything that came with
   it. Those entries are skipped and noted in the log; the rest of the mod installs.
-## 2026-08-09 — stopping FrostMod from the app
-
-### Added
-- **FrostMod can be stopped from the app.** The sidebar pill and the FrostMod section in
-  Settings now offer a stop control while it's running, next to the reload and start ones —
-  until now the only way out was Task Manager or quitting the app from the tray. It stops
-  FrostMod whoever started it: a `frostmod.exe` left behind by an earlier session, or one
-  launched by hand, is no longer out of reach just because this app didn't spawn it. The app
-  waits for the process to actually go before saying it stopped, so a FrostMod that survives
-  the attempt (running elevated, or as another user) is reported rather than papered over with
-  a success message the status pill contradicts a second later. Stopping is a one-off — it
-  doesn't touch the "Run FrostMod automatically" setting, so the next app launch behaves as
-  configured.
-## 2026-08-09 — an installer that can always replace the app it's updating
-
-### Fixed
 - **Installing over a running copy no longer stops at "error opening file for writing".**
   The file it named, `frost.exe`, is the app's own program file, and Windows won't let
   anything overwrite a program image that is still held — which the app's often is, since it
@@ -203,48 +177,6 @@ redistributed, so the app detects it and links out rather than bundling or downl
   process tree with it, and the installer the app had just launched was part of that tree.
   It now closes the app alone; the browser processes that the tree kill was there for exit
   with it anyway.
-
-## Unreleased — paint studio: TGA in, `.pnt` out
-
-### Added
-- **A new Paints tab turns image files into paints the game loads.** MX Bikes reads a paint
-  as a packed container of compressed texture sheets, which no image editor writes — so
-  until now a livery drawn in GIMP or Photoshop had to go through somebody else's converter
-  before the game, or this app's 3D preview, would look at it. Pick the sheets (`.tga`,
-  `.png`, `.jpg`, `.bmp`, `.webp`), say what they're for, and the app builds the `.pnt` and
-  installs it where the game expects it: `mods/bikes/<Bike>/paints`,
-  `rider/helmets/<Helmet>/paints` or `goggles`, boots, protection, and a rider profile's
-  kit or gloves. Or save it to a folder of your own, to share.
-- **Unpack an existing paint into editable `.tga` sheets.** This is how you get a template
-  that actually fits the model: the sheets come out named the way the mesh binds them
-  (`livery`, `rider`, `shell`…), open in any editor, and go straight back in under the same
-  names. Extracted to `Documents\MXB App\Paint Templates\<paint>` and loaded into the studio
-  in one step, so the round trip is edit → **Reload from disk** → **Save paint**.
-- **Names are the part that decides whether a paint works, so the studio shows them.** A
-  `.pnt` supplies textures *by name* and the mesh binds whichever names it asked for — a
-  sheet called `livery` lands on the bodywork, the same sheet called `my_livery` lands
-  nowhere. The studio reads the names the paints already installed for that model use (from
-  their headers — no pixels decoded), lists them, and flags a sheet whose name isn't one of
-  them before you save.
-- **Preview what you just saved on the real model**, through the viewer the app already
-  has: a bike livery on its bike, a helmet or goggle paint on that helmet, a kit on the
-  rider.
-- **Sheets that aren't a power of two are resized to one, and say so.** MX Bikes is a
-  DirectX 9 title and its textures are powers of two throughout; a 1000×1000 export — which
-  GIMP will happily make — would otherwise be packed into a file the game refuses, and the
-  failure would land in-game rather than in the app.
-
-### Fixed
-- **A packed gear item and a folder of the same name are now one item, not two.** A `.pkz`
-  helmet with paints installed loose beside it (which is where the game looks, and where the
-  studio writes) only ever showed one side of itself: whichever the loader resolved first.
-  A folder holding nothing but paints hid the archive entirely — the picker listed the new
-  paint alone and the preview lost the mesh it belonged to. Both are read now, the folder
-  winning a name clash because it's what was installed last.
-
-## 2026-08-09
-
-### Fixed
 - **Opening MXB App while it's already running shows the window you had, instead of starting
   a second copy.** Closing the window parks the app in the tray rather than quitting it —
   that part is deliberate, it's what keeps FrostMod connected — but nothing stopped the next
@@ -254,6 +186,43 @@ redistributed, so the app detects it and links out rather than bundling or downl
   brings its window forward, the same as clicking the tray icon. Launch-at-login is covered
   too — the instance that started with Windows is the one your first launch of the day
   reveals, rather than the one it stacks on top of.
+- **A mods folder you moved with `mxbikes.ini` now works.** Plenty of players keep their
+  content somewhere short like `C:\mods` — junctioning one rider paint into six model
+  folders needs paths that OneDrive and a deep `Documents` tree can't give you. The app
+  couldn't be pointed at such a folder: picking it silently rewrote your setting to the
+  drive root, and auto-detection went to `Documents\PiBoSo\MX Bikes` instead, found no
+  `mods` inside it, and came up missing gear, paints and bikes with nothing to explain why.
+  The folder you pick is now the folder used, whether it's the game folder or the mods
+  folder itself.
+- **The app reads `mxbikes.ini` to find a relocated mods folder on its own.** The game
+  already knows where your content is; setup now asks it instead of guessing. Profiles,
+  which don't move with the mods folder, are pinned to where they actually stayed.
+- **FrostMod was being handed the wrong folder.** It appends `\tracks` and `\bikes` to what
+  the app gives it, and the app was sending the folder one level above — so its track
+  manager and model swap were pointed at folders that don't exist. Affected everyone, not
+  just relocated setups; it just never announced itself.
+- **Settings says which folder mods are actually read from** when that isn't the obvious
+  `<picked>\mods`, and warns when the folder isn't there at all.
+- **Settings offers Stop for a FrostMod it didn't install.** The button was hidden unless
+  the app had put FrostMod there itself — so the one case that most needs a stop, a
+  `frostmod.exe` running that the app didn't start, had no button. The backend could
+  always kill it; only the button was missing. (The sidebar's stop control was unaffected.)
+- **Browse keeps your place when you look at a mod and come back.** Opening a mod used to
+  throw away the search you typed, the category you picked, the sort order, every page you'd
+  loaded with "Load more" and how far you'd scrolled — Back dropped you at the top of a fresh,
+  unfiltered listing, which made working through a long category one mod at a time miserable.
+  The grid now sits exactly where you left it, down to the row of cards, and nothing is
+  re-fetched on the way back. It survives a trip to Library or Settings too, and the in-game
+  overlay behaves the same way.
+- **The Linux app opens to its interface instead of a white screen.** On SteamOS the window
+  appeared, the title bar drew, and the inside stayed blank with nothing in the terminal to
+  explain it. The AppImage carries its own copy of the web engine, and that engine tries to
+  hand frames to the graphics driver through a fast path the host's driver answers
+  differently than the one it was built against — so it drew nothing at all, silently. It now
+  takes the ordinary path by default, which paints on every machine and costs nothing anyone
+  will notice on a UI this static. A machine that handles the fast path can still ask for it
+  back with `WEBKIT_DISABLE_DMABUF_RENDERER=0`. The startup log now records which path a run
+  took, so the next report of a blank window can be read straight from the log.
 
 ## 2026-08-09 — v0.8.1 — GP Bikes' mod pictures
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.8.1",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "frost"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frost"
-version = "0.8.1"
+version = "0.9.0"
 description = "Frost — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/Components/Showcase/releases.ts
+++ b/src/Components/Showcase/releases.ts
@@ -20,6 +20,11 @@ import {
   Wand2,
   Shield,
   Gauge,
+  Palette,
+  Sparkles,
+  PersonStanding,
+  Wrench,
+  RefreshCw,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { TKey } from "../../i18n/context";
@@ -46,6 +51,21 @@ export interface Release {
 }
 
 export const RELEASES: Release[] = [
+  {
+    version: "0.9.0",
+    hero: {
+      icon: Palette,
+      title: "showcase.v090.hero.title",
+      body: "showcase.v090.hero.body",
+    },
+    highlights: [
+      { icon: Sparkles, text: "showcase.v090.reshade" },
+      { icon: Store, text: "showcase.v090.purchases" },
+      { icon: PersonStanding, text: "showcase.v090.ridingStyles" },
+      { icon: Wrench, text: "showcase.v090.frostmod" },
+      { icon: RefreshCw, text: "showcase.v090.updates" },
+    ],
+  },
   {
     version: "0.8.0",
     hero: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -983,6 +983,19 @@ export const de: Translation = {
   "showcase.whileGameRunning": "während MX Bikes läuft",
   "showcase.releaseNotes": "Release Notes lesen",
   "showcase.gotIt": "Alles klar",
+  "showcase.v090.hero.title": "Mach aus deinen Grafiken ein Design, das das Spiel lädt",
+  "showcase.v090.hero.body":
+    "Ein neuer Designs-Tab baut Designs aus ganz normalen Bilddateien — TGA, PNG, JPG — und installiert sie dort, wo das Spiel sucht: eine Bike-Lackierung, ein Helm- oder Brillen-Design, Kit oder Handschuhe deines Fahrers. Entpack ein vorhandenes Design, um eine Vorlage zu bekommen, die wirklich zum Modell passt, bearbeite sie in jedem Editor und leg sie direkt wieder ab. Das Studio prüft deine Dateinamen gegen die, die das Mesh bindet, bevor du speicherst, und zeigt das Ergebnis danach am echten Modell.",
+  "showcase.v090.reshade":
+    "ReShade-Presets im Programm durchsuchen, installieren und wechseln — mit einem Aus-Eintrag zum Vergleich mit dem Original-Look und einer Warnung, wenn einem Preset Effekte fehlen.",
+  "showcase.v090.purchases":
+    "Meine Käufe meldet dich bei deinem mxbikes-shop.com-Konto an und installiert, was du schon bezahlt hast — über dieselbe Übersicht wie beim Drag-and-drop.",
+  "showcase.v090.ridingStyles":
+    "Presets können einen selbst installierten Fahrstil nutzen, nicht nur die zwei aus dem Spiel — und ein geteiltes Preset nimmt ihn mit.",
+  "showcase.v090.frostmod":
+    "Wenn FrostMod an einer fehlenden Windows-Laufzeit scheitert, benennt die App sie in klaren Worten und installiert sie für dich. FrostMod lässt sich außerdem aus der App stoppen, egal wer es gestartet hat.",
+  "showcase.v090.updates":
+    "Ein Update über eine laufende Kopie scheitert nicht mehr an „Fehler beim Öffnen der Datei zum Schreiben“, und ein zweiter Start holt dein vorhandenes Fenster zurück statt eine zweite Kopie zu öffnen.",
   "showcase.v080.hero.title": "MXB App steuert jetzt auch GP Bikes",
   "showcase.v080.hero.body":
     "Wähl dein Spiel beim ersten Start, oder wechsle jederzeit in den Einstellungen — die ganze App folgt: Bibliothek, Verwalten, Presets, Play und ein Durchsuchen-Tab von gpb-mods.com. GPs Fahrer-Ordner werden als GPs gelesen, nicht als die von MX Bikes, und FrostMod lädt auch dort live nach. Jedes Spiel behält seine eigenen Ordner, dein MX-Bikes-Setup bleibt also unangetastet.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -942,6 +942,19 @@ export const en = {
   "showcase.whileGameRunning": "while MX Bikes is running",
   "showcase.releaseNotes": "Read the release notes",
   "showcase.gotIt": "Got it",
+  "showcase.v090.hero.title": "Turn your artwork into a paint the game loads",
+  "showcase.v090.hero.body":
+    "A new Paints tab builds paints out of ordinary image sheets — TGA, PNG, JPG — and installs them where the game looks: a bike livery, a helmet or goggle paint, a rider's kit or gloves. Unpack a paint you already have to get a template that actually fits the model, edit it in any editor, and put it straight back. The studio checks your sheet names against the ones the mesh binds before you save, then previews the result on the real model.",
+  "showcase.v090.reshade":
+    "Browse, install and switch ReShade presets from the app — with an Off entry to compare against the stock look, and a warning when a preset needs effects you don't have.",
+  "showcase.v090.purchases":
+    "My purchases signs in to your mxbikes-shop.com account and installs what you've already paid for, through the same review sheet a drag-and-drop uses.",
+  "showcase.v090.ridingStyles":
+    "Presets can use a riding style you installed, not just the two the game ships — and a shared preset carries it along.",
+  "showcase.v090.frostmod":
+    "When FrostMod dies on a missing Windows runtime, the app names it in plain language and installs it for you. FrostMod can also be stopped from the app, whoever started it.",
+  "showcase.v090.updates":
+    "Updating over a running copy no longer stops at \"error opening file for writing\", and launching the app twice brings back the window you had instead of a second copy.",
   "showcase.v080.hero.title": "MXB App drives GP Bikes too",
   "showcase.v080.hero.body":
     "Pick your game at first launch, or switch any time in Settings — the whole app follows: Library, Manage, Presets, Play, and a Browse tab served by gpb-mods.com. GP's rider folders are read as GP's, not as MX Bikes', and FrostMod hot-reloads there as well. Each game keeps its own folders, so your MX Bikes setup is untouched.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -971,6 +971,19 @@ export const es: Translation = {
   "showcase.whileGameRunning": "mientras MX Bikes está abierto",
   "showcase.releaseNotes": "Leer las notas de la versión",
   "showcase.gotIt": "Entendido",
+  "showcase.v090.hero.title": "Convierte tus imágenes en un diseño que el juego carga",
+  "showcase.v090.hero.body":
+    "Una nueva pestaña Diseños crea diseños a partir de imágenes corrientes — TGA, PNG, JPG — y los instala donde el juego los busca: una decoración de moto, un diseño de casco o de gafas, el kit o los guantes de tu piloto. Descomprime un diseño que ya tengas para conseguir una plantilla que encaje de verdad con el modelo, edítala en cualquier editor y devuélvela tal cual. El estudio comprueba tus nombres de archivo frente a los que usa la malla antes de guardar, y luego muestra el resultado sobre el modelo real.",
+  "showcase.v090.reshade":
+    "Explora, instala y cambia presets de ReShade desde la app — con una entrada Desactivado para comparar con el aspecto original, y un aviso cuando a un preset le faltan efectos.",
+  "showcase.v090.purchases":
+    "Mis compras entra en tu cuenta de mxbikes-shop.com e instala lo que ya has pagado, con la misma hoja de revisión que usa el arrastrar y soltar.",
+  "showcase.v090.ridingStyles":
+    "Los presets pueden usar un estilo de pilotaje que hayas instalado, no solo los dos del juego — y un preset compartido se lo lleva consigo.",
+  "showcase.v090.frostmod":
+    "Cuando FrostMod muere por una biblioteca de Windows que falta, la app la nombra en lenguaje claro y la instala por ti. FrostMod también se puede parar desde la app, lo haya arrancado quien lo haya arrancado.",
+  "showcase.v090.updates":
+    "Instalar sobre una copia en ejecución ya no se detiene en «error al abrir el archivo para escritura», y abrir la app dos veces recupera la ventana que tenías en lugar de crear una segunda copia.",
   "showcase.v080.hero.title": "MXB App también maneja GP Bikes",
   "showcase.v080.hero.body":
     "Elige tu juego en el primer arranque, o cámbialo cuando quieras en Ajustes: toda la app lo sigue — Biblioteca, Gestionar, Presets, Jugar y una pestaña Explorar servida por gpb-mods.com. Las carpetas de piloto de GP se leen como las de GP, no como las de MX Bikes, y FrostMod también recarga en caliente allí. Cada juego guarda sus propias carpetas, así que tu configuración de MX Bikes queda intacta.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -973,6 +973,19 @@ export const fr: Translation = {
   "showcase.whileGameRunning": "pendant que MX Bikes tourne",
   "showcase.releaseNotes": "Lire les notes de version",
   "showcase.gotIt": "Compris",
+  "showcase.v090.hero.title": "Transforme tes images en une déco que le jeu charge",
+  "showcase.v090.hero.body":
+    "Un nouvel onglet Décos fabrique des décos à partir de simples fichiers image — TGA, PNG, JPG — et les installe là où le jeu les cherche : une livrée de moto, une déco de casque ou de masque, la tenue ou les gants de ton pilote. Décompresse une déco existante pour obtenir un gabarit vraiment adapté au modèle, retouche-la dans n'importe quel éditeur et remets-la telle quelle. Le studio vérifie tes noms de fichiers face à ceux que le maillage utilise avant l'enregistrement, puis affiche le résultat sur le vrai modèle.",
+  "showcase.v090.reshade":
+    "Parcours, installe et change de preset ReShade depuis l'app — avec une entrée Aucun pour comparer au rendu d'origine, et un avertissement quand un preset réclame des effets que tu n'as pas.",
+  "showcase.v090.purchases":
+    "Mes achats se connecte à ton compte mxbikes-shop.com et installe ce que tu as déjà payé, via la même fiche de contrôle qu'un glisser-déposer.",
+  "showcase.v090.ridingStyles":
+    "Les presets peuvent utiliser un style de pilotage que tu as installé, pas seulement les deux du jeu — et un preset partagé l'emporte avec lui.",
+  "showcase.v090.frostmod":
+    "Quand FrostMod meurt sur une bibliothèque Windows manquante, l'app la nomme clairement et l'installe pour toi. FrostMod peut aussi être arrêté depuis l'app, quel que soit ce qui l'a lancé.",
+  "showcase.v090.updates":
+    "Installer par-dessus une copie en cours d'exécution ne bloque plus sur « erreur d'ouverture du fichier en écriture », et un second lancement ramène ta fenêtre au lieu d'ouvrir une deuxième copie.",
   "showcase.v080.hero.title": "MXB App gère aussi GP Bikes",
   "showcase.v080.hero.body":
     "Choisis ton jeu au premier lancement, ou change quand tu veux dans les Réglages : toute l'app suit — Bibliothèque, Gérer, Presets, Jouer, et un onglet Parcourir servi par gpb-mods.com. Les dossiers pilote de GP sont lus comme ceux de GP, pas comme ceux de MX Bikes, et FrostMod y recharge à chaud aussi. Chaque jeu garde ses propres dossiers : ta configuration MX Bikes n'est pas touchée.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -963,6 +963,19 @@ export const it: Translation = {
   "showcase.whileGameRunning": "mentre MX Bikes è in esecuzione",
   "showcase.releaseNotes": "Leggi le note di rilascio",
   "showcase.gotIt": "Ho capito",
+  "showcase.v090.hero.title": "Trasforma le tue immagini in una livrea che il gioco carica",
+  "showcase.v090.hero.body":
+    "Una nuova scheda Livree costruisce le livree da normali file immagine — TGA, PNG, JPG — e le installa dove il gioco le cerca: la livrea di una moto, la grafica di un casco o di una maschera, il completo o i guanti del tuo pilota. Estrai una livrea che hai già per ottenere un template che calza davvero sul modello, modificalo in qualsiasi editor e rimettilo dentro così com'è. Lo studio controlla i nomi dei tuoi file contro quelli che la mesh usa prima del salvataggio, poi mostra il risultato sul modello vero.",
+  "showcase.v090.reshade":
+    "Sfoglia, installa e cambia i preset ReShade dall'app — con una voce Nessuno per confrontare con l'aspetto originale, e un avviso quando a un preset mancano degli effetti.",
+  "showcase.v090.purchases":
+    "I miei acquisti accede al tuo account mxbikes-shop.com e installa ciò che hai già pagato, con lo stesso riepilogo usato dal trascinamento.",
+  "showcase.v090.ridingStyles":
+    "I preset possono usare uno stile di guida che hai installato, non solo i due del gioco — e un preset condiviso se lo porta dietro.",
+  "showcase.v090.frostmod":
+    "Quando FrostMod muore per una libreria di Windows mancante, l'app la indica in parole chiare e la installa per te. FrostMod si può anche fermare dall'app, chiunque lo abbia avviato.",
+  "showcase.v090.updates":
+    "Installare sopra una copia in esecuzione non si ferma più su «errore nell'apertura del file in scrittura», e un secondo avvio riporta la finestra che avevi invece di aprirne una seconda.",
   "showcase.v080.hero.title": "MXB App gestisce anche GP Bikes",
   "showcase.v080.hero.body":
     "Scegli il gioco al primo avvio, o cambialo quando vuoi nelle Impostazioni: tutta l'app lo segue — Libreria, Gestisci, Preset, Play e una scheda Sfoglia servita da gpb-mods.com. Le cartelle pilota di GP vengono lette come quelle di GP, non di MX Bikes, e anche lì FrostMod ricarica al volo. Ogni gioco tiene le proprie cartelle, quindi la tua configurazione di MX Bikes resta intatta.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -963,6 +963,19 @@ export const ptBR: Translation = {
   "showcase.whileGameRunning": "enquanto o MX Bikes está aberto",
   "showcase.releaseNotes": "Ler as notas da versão",
   "showcase.gotIt": "Entendi",
+  "showcase.v090.hero.title": "Transforme suas imagens numa pintura que o jogo carrega",
+  "showcase.v090.hero.body":
+    "Uma nova aba Pinturas monta pinturas a partir de arquivos de imagem comuns — TGA, PNG, JPG — e instala onde o jogo procura: a pintura de uma moto, de um capacete ou de um óculos, o kit ou as luvas do seu piloto. Descompacte uma pintura que você já tem para conseguir um molde que serve de verdade no modelo, edite em qualquer editor e devolva do mesmo jeito. O estúdio confere os nomes dos seus arquivos contra os que a malha usa antes de salvar, e depois mostra o resultado no modelo de verdade.",
+  "showcase.v090.reshade":
+    "Procure, instale e troque presets do ReShade pelo app — com uma opção Desligado para comparar com o visual original, e um aviso quando falta algum efeito que o preset precisa.",
+  "showcase.v090.purchases":
+    "Minhas compras entra na sua conta do mxbikes-shop.com e instala o que você já pagou, pela mesma tela de conferência que o arrastar e soltar usa.",
+  "showcase.v090.ridingStyles":
+    "Os presets podem usar um estilo de pilotagem que você instalou, não só os dois que vêm no jogo — e um preset compartilhado leva ele junto.",
+  "showcase.v090.frostmod":
+    "Quando o FrostMod morre por falta de um componente do Windows, o app diz qual é em português claro e instala pra você. O FrostMod também pode ser parado pelo app, não importa quem tenha iniciado.",
+  "showcase.v090.updates":
+    "Instalar por cima de uma cópia em execução não trava mais no «erro ao abrir o arquivo para gravação», e abrir o app duas vezes traz de volta a janela que você já tinha em vez de uma segunda cópia.",
   "showcase.v080.hero.title": "O MXB App também comanda o GP Bikes",
   "showcase.v080.hero.body":
     "Escolha seu jogo no primeiro início, ou troque quando quiser nas Configurações — o app inteiro acompanha: Biblioteca, Gerenciar, Presets, Jogar e uma aba Explorar servida pelo gpb-mods.com. As pastas de piloto do GP são lidas como do GP, não como as do MX Bikes, e o FrostMod recarrega ao vivo lá também. Cada jogo guarda suas próprias pastas, então sua configuração do MX Bikes fica intacta.",


### PR DESCRIPTION
Release prep for **v0.9.0-beta.1**. No product code — changelog, version, and the What's New page.

## Why

Everything merged since v0.8.1 sat in **nine** separate changelog sections — two headed `## Unreleased`, five sharing a `## 2026-08-09` date. `scripts/changelog-section.sh` looks a tag's section up by version, so `v0.9.0-beta.1` would have found nothing and both the release page and the Discord announcement would have fallen back to bare download guidance.

## What's in it

- **One `v0.9.0` section**, like `###` groups combined, every bullet kept. Verified the 36 bullet headlines before and after are the same set (`diff` of the sorted headline lists, no output).
- **0.9.0 in `package.json`, `tauri.conf.json`, `Cargo.toml` and the lockfile.** Minor, not patch: a studio that authors paints, ReShade preset management and installing your Shop purchases are new capability, not fixes.
- **A What's New page for 0.9.0** — the paint studio as the hero, five highlights (ReShade, Shop purchases, riding styles, the FrostMod runtime check, updates over a running copy), strings in all six locales. Nothing catches a missing entry, and only 0.8.0 and 0.7.0 were in the file.

## What ships in 0.9.0

Paint studio (TGA/PNG in, `.pnt` out, unpack to editable sheets, name checking, preview) · ReShade presets in Browse and Settings · Shop **My purchases** · custom riding styles in presets · stop FrostMod from the app · the msvcr90 runtime check behind a dead FrostMod · beta releases announced in the beta Discord channel · plus install/update fixes: retry no longer breaks an install, installing over a running copy works, a second launch reveals the window you had, gear installs into its own folder, `mxbikes.ini` mods folders, Browse keeps your place, the Linux blank window.

## Verified

- `changelog-section.sh v0.9.0-beta.1` resolves to the new section (heading, body and `--summary`).
- `notify-discord.sh v0.9.0-beta.1 --print` renders a beta embed from it that fits Discord's cap — 18194-char body falls to the 2631-char headline summary plus the link, as designed.
- `tsc --noEmit` clean; `eslint` clean apart from two warnings that are already on `main`.

Tag `v0.9.0-beta.1` goes on after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
