### PR TITLE
feat(library): install downloads without dragging them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-08-09 — Import from the Library
+
+### Added
+- **An Import button in the Library, for setups drag-and-drop never reaches.** Dropping a
+  download on the window stays the fast path, but the OS drop event doesn't arrive
+  everywhere — remote desktops and some shells eat it — and where it doesn't, there was no
+  other way to install a file you'd already downloaded. **Import → Choose files…** (or
+  **Choose a folder…**, for an unpacked track) stages exactly what a drop stages: same
+  classification, same review sheet showing where each piece lands, same collision
+  warnings, and nothing written until you confirm.
+
 ## 2026-08-09 — v0.9.0 — A paint studio, ReShade presets, and your Shop purchases
 
 ### Added

--- a/src/Components/Dropzone/DropZone.tsx
+++ b/src/Components/Dropzone/DropZone.tsx
@@ -1,10 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { Loader2, PackageOpen } from "lucide-react";
-import { toast } from "sonner";
-import { planDrop } from "../../api/mods";
 import { useDropReview } from "../../Context/DropReview";
 import { useT } from "../../i18n/context";
+import { useImport } from "./useImport";
 
 /**
  * Whole-window drop target.
@@ -14,31 +13,18 @@ import { useT } from "../../i18n/context";
  * even if it did, an HTML5 `File` carries no filesystem path, which is the only thing the
  * installer can work with.
  *
+ * That event is also the one part of this we don't control — where it never arrives, dropping
+ * silently does nothing. So the paths it yields go through `useImport`, shared with the
+ * Library's Import button, rather than a handler only a drop can reach.
+ *
  * Nothing is written when a drop lands. `planDrop` stages and classifies, and the review sheet
  * — owned by `DropReviewProvider`, since purchases stage plans too — takes it from there.
  */
 export default function DropZone() {
   const t = useT();
-  const { reviewPlan, reviewing } = useDropReview();
+  const { reviewing } = useDropReview();
+  const { stagePaths, staging } = useImport();
   const [hovering, setHovering] = useState(false);
-  const [scanning, setScanning] = useState(false);
-
-  const tRef = useRef(t);
-  tRef.current = t;
-  const reviewRef = useRef(reviewPlan);
-  reviewRef.current = reviewPlan;
-
-  const handlePaths = useCallback(async (paths: string[]) => {
-    if (paths.length === 0) return;
-    setScanning(true);
-    try {
-      reviewRef.current(await planDrop(paths));
-    } catch (e) {
-      toast.error(tRef.current("drop.scanFailed"), { description: String(e) });
-    } finally {
-      setScanning(false);
-    }
-  }, []);
 
   useEffect(() => {
     let unlisten: (() => void) | undefined;
@@ -50,7 +36,7 @@ export default function DropZone() {
           setHovering(true);
         } else if (event.payload.type === "drop") {
           setHovering(false);
-          void handlePaths(event.payload.paths);
+          void stagePaths(event.payload.paths);
         } else {
           setHovering(false);
         }
@@ -64,23 +50,25 @@ export default function DropZone() {
       cancelled = true;
       unlisten?.();
     };
-  }, [handlePaths]);
+  }, [stagePaths]);
 
-  if (!(hovering || scanning) || reviewing) return null;
+  // `staging` is this hook instance's own — a pick from the Library drives a separate one, and
+  // reports itself on its own button — so the overlay still only ever follows a drop.
+  if (!(hovering || staging) || reviewing) return null;
 
   return (
     <div className="pointer-events-none fixed inset-0 z-50 flex items-center justify-center bg-background/70 backdrop-blur-sm">
       <div className="flex flex-col items-center gap-3 rounded-2xl border-2 border-dashed border-primary/50 bg-card/80 px-12 py-10">
-        {scanning ? (
+        {staging ? (
           <Loader2 className="size-8 animate-spin text-primary" />
         ) : (
           <PackageOpen className="size-8 text-primary" />
         )}
         <div className="text-center">
           <p className="text-[15px] font-bold">
-            {scanning ? t("drop.scanning") : t("drop.dropHere")}
+            {staging ? t("drop.scanning") : t("drop.dropHere")}
           </p>
-          {!scanning && (
+          {!staging && (
             <p className="mt-0.5 text-[12px] text-muted-foreground">
               {t("drop.dropHint")}
             </p>

--- a/src/Components/Dropzone/useImport.ts
+++ b/src/Components/Dropzone/useImport.ts
@@ -1,0 +1,92 @@
+import { useCallback, useRef, useState } from "react";
+import { open as pickPaths } from "@tauri-apps/plugin-dialog";
+import { toast } from "sonner";
+import { planDrop } from "../../api/mods";
+import { useDropReview } from "../../Context/DropReview";
+import { useT } from "../../i18n/context";
+import type { TKey } from "../../i18n/core";
+
+/** What the drop pipeline recognises by name. Anything else still stages — the classifier
+ *  carries an unknown file through and asks where it goes — so the picker offers "all files"
+ *  alongside this, rather than hiding a download the user knows is a mod. */
+const MOD_EXTENSIONS = ["pkz", "zip", "rar", "7z", "pnt"];
+
+/**
+ * Turning filesystem paths into a staged plan, for review.
+ *
+ * Dragging is the fast way to produce paths, but it is not always available: a webview that
+ * never receives the OS drop event — remote desktop, some shells, a policy that eats it —
+ * leaves that user with no way to install a downloaded file at all. A picker produces the
+ * same list of paths, so both feed this one function and a picked file is staged, classified,
+ * reviewed and committed exactly like a dropped one.
+ */
+export function useImport() {
+  const { reviewPlan } = useDropReview();
+  const [staging, setStaging] = useState(false);
+
+  // Kept in refs so `stagePaths` is stable: `DropZone` re-subscribes to the OS drop event
+  // whenever its handler changes, and a fresh identity per render would churn the listener.
+  const t = useT();
+  const tRef = useRef(t);
+  tRef.current = t;
+  const reviewRef = useRef(reviewPlan);
+  reviewRef.current = reviewPlan;
+
+  /** Stage and classify these paths, then put the plan up for review. Reads only.
+   *  `failureKey` because the two entrances have to own their own failure: someone who
+   *  clicked Import never dropped anything. */
+  const stagePaths = useCallback(
+    async (paths: string[], failureKey: TKey = "drop.scanFailed") => {
+      if (paths.length === 0) return;
+      setStaging(true);
+      try {
+        reviewRef.current(await planDrop(paths));
+      } catch (e) {
+        toast.error(tRef.current(failureKey), { description: String(e) });
+      } finally {
+        setStaging(false);
+      }
+    },
+    [],
+  );
+
+  /**
+   * Ask for paths with a native picker, then stage them.
+   *
+   * Files and folders are separate modes because the OS dialog is one or the other: an
+   * unpacked track is a folder, a download is a file, and no single dialog offers both.
+   */
+  const pickAndImport = useCallback(
+    async (mode: "files" | "folder") => {
+      const picked = await pickPaths(
+        mode === "folder"
+          ? { directory: true, multiple: true }
+          : {
+              multiple: true,
+              filters: [
+                {
+                  name: tRef.current("import.modFiles"),
+                  extensions: MOD_EXTENSIONS,
+                },
+                { name: tRef.current("import.allFiles"), extensions: ["*"] },
+              ],
+            },
+      ).catch((e) => {
+        toast.error(tRef.current("import.pickFailed"), {
+          description: String(e),
+        });
+        return null;
+      });
+
+      // Cancelling the dialog is not a failure — it just yields nothing.
+      if (picked === null) return;
+      await stagePaths(
+        Array.isArray(picked) ? picked : [picked],
+        "import.readFailed",
+      );
+    },
+    [stagePaths],
+  );
+
+  return { stagePaths, pickAndImport, staging };
+}

--- a/src/Components/Library/Library.tsx
+++ b/src/Components/Library/Library.tsx
@@ -14,6 +14,10 @@ import {
   ListChecks,
   CheckCircle2,
   Circle,
+  PackagePlus,
+  FileArchive,
+  Folder,
+  Loader2,
   type LucideIcon,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -41,6 +45,7 @@ import LibraryDetail from "./LibraryDetail";
 import { ViewerDialog } from "../Viewer/ViewerDialog";
 import { entryViewerProps } from "../Viewer/entryViewer";
 import { useConfig } from "../../Context/Config";
+import { useImport } from "../Dropzone/useImport";
 import { Segmented } from "@/Components/ui/segmented";
 import { Button } from "@/Components/ui/button";
 import HelpHint from "@/Components/ui/help-hint";
@@ -256,6 +261,7 @@ export default function Library({
   onChanged,
 }: LibraryProps) {
   const t = useT();
+  const { pickAndImport, staging } = useImport();
   const [entries, setEntries] = useState<LibraryEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -519,6 +525,30 @@ export default function Library({
           <ListChecks className="size-3.5" />{" "}
           {selectMode ? t("common.done") : t("common.select")}
         </Button>
+        {/* The same install flow as dropping, for anyone the OS drop event never reaches —
+            and a discoverable one for anyone who never thought to drag a file here. */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="sm" disabled={staging}>
+              {staging ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <PackagePlus className="size-3.5" />
+              )}{" "}
+              {staging ? t("import.staging") : t("import.action")}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={() => void pickAndImport("files")}>
+              <FileArchive className="size-3.5" />
+              {t("import.pickFiles")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => void pickAndImport("folder")}>
+              <Folder className="size-3.5" />
+              {t("import.pickFolder")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
         <Button variant="outline" size="sm" onClick={load} disabled={loading || busy}>
           <RefreshCw className={cn("size-3.5", loading && "animate-spin")} />{" "}
           {t("locker.rescan")}

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1160,6 +1160,16 @@ export const de: Translation = {
   "drop.reason.reshadePreset": "Listet ReShade-Techniken auf",
   "drop.reason.unrecognised": "Nicht erkannt — du musst es zuordnen",
 
+  // ── Import (derselbe Ablauf wie Ablegen, nur per Auswahl) ──────────────────
+  "import.action": "Importieren",
+  "import.staging": "Wird gelesen …",
+  "import.pickFiles": "Dateien auswählen …",
+  "import.pickFolder": "Ordner auswählen …",
+  "import.modFiles": "Mods und Lackierungen",
+  "import.allFiles": "Alle Dateien",
+  "import.pickFailed": "Die Dateiauswahl konnte nicht geöffnet werden",
+  "import.readFailed": "Das Ausgewählte konnte nicht gelesen werden",
+
   // ── ReShade ────────────────────────────────────────────────────────────────
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Postprocessing-Presets — wie {{game}} auf dem Bildschirm aussieht.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1119,6 +1119,16 @@ export const en = {
   "drop.reason.reshadePreset": "Lists ReShade techniques",
   "drop.reason.unrecognised": "Not recognised — you'll need to place it",
 
+  // ── Import (the same install flow, reached by picking instead of dropping) ──
+  "import.action": "Import",
+  "import.staging": "Reading…",
+  "import.pickFiles": "Choose files…",
+  "import.pickFolder": "Choose a folder…",
+  "import.modFiles": "Mods and paints",
+  "import.allFiles": "All files",
+  "import.pickFailed": "Couldn't open the file picker",
+  "import.readFailed": "Couldn't read what you picked",
+
   // ── ReShade ────────────────────────────────────────────────────────────────
   // ReShade is a product name and stays untranslated everywhere, capital S included.
   "settings.reshade": "ReShade",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1148,6 +1148,16 @@ export const es: Translation = {
   "drop.reason.reshadePreset": "Enumera técnicas de ReShade",
   "drop.reason.unrecognised": "No reconocido — tendrás que colocarlo tú",
 
+  // ── Import (el mismo flujo que soltar, pero eligiendo) ─────────────────────
+  "import.action": "Importar",
+  "import.staging": "Leyendo…",
+  "import.pickFiles": "Elegir archivos…",
+  "import.pickFolder": "Elegir una carpeta…",
+  "import.modFiles": "Mods y pinturas",
+  "import.allFiles": "Todos los archivos",
+  "import.pickFailed": "No se pudo abrir el selector de archivos",
+  "import.readFailed": "No se pudo leer lo que elegiste",
+
   // ── ReShade ────────────────────────────────────────────────────────────────
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Ajustes de posprocesado — cómo se ve {{game}} en pantalla.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1150,6 +1150,16 @@ export const fr: Translation = {
   "drop.reason.reshadePreset": "Liste des techniques ReShade",
   "drop.reason.unrecognised": "Non reconnu — à vous de le placer",
 
+  // ── Import (le même flux que le dépôt, en le sélectionnant) ────────────────
+  "import.action": "Importer",
+  "import.staging": "Lecture…",
+  "import.pickFiles": "Choisir des fichiers…",
+  "import.pickFolder": "Choisir un dossier…",
+  "import.modFiles": "Mods et peintures",
+  "import.allFiles": "Tous les fichiers",
+  "import.pickFailed": "Impossible d'ouvrir le sélecteur de fichiers",
+  "import.readFailed": "Impossible de lire ce que vous avez choisi",
+
   // ── ReShade ────────────────────────────────────────────────────────────────
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Préréglages de post-traitement — le rendu de {{game}} à l'écran.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1140,6 +1140,16 @@ export const it: Translation = {
   "drop.reason.reshadePreset": "Elenca tecniche ReShade",
   "drop.reason.unrecognised": "Non riconosciuto — dovrai collocarlo tu",
 
+  // ── Import (lo stesso flusso del rilascio, ma scegliendo) ──────────────────
+  "import.action": "Importa",
+  "import.staging": "Lettura…",
+  "import.pickFiles": "Scegli i file…",
+  "import.pickFolder": "Scegli una cartella…",
+  "import.modFiles": "Mod e livree",
+  "import.allFiles": "Tutti i file",
+  "import.pickFailed": "Impossibile aprire il selettore di file",
+  "import.readFailed": "Impossibile leggere ciò che hai scelto",
+
   // ── ReShade ────────────────────────────────────────────────────────────────
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Preset di post-processing — l'aspetto di {{game}} a schermo.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1140,6 +1140,16 @@ export const ptBR: Translation = {
   "drop.reason.reshadePreset": "Lista técnicas do ReShade",
   "drop.reason.unrecognised": "Não reconhecido — você precisa colocá-lo",
 
+  // ── Import (o mesmo fluxo de soltar, mas escolhendo) ───────────────────────
+  "import.action": "Importar",
+  "import.staging": "Lendo…",
+  "import.pickFiles": "Escolher arquivos…",
+  "import.pickFolder": "Escolher uma pasta…",
+  "import.modFiles": "Mods e pinturas",
+  "import.allFiles": "Todos os arquivos",
+  "import.pickFailed": "Não foi possível abrir o seletor de arquivos",
+  "import.readFailed": "Não foi possível ler o que você escolheu",
+
   // ── ReShade ────────────────────────────────────────────────────────────────
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Presets de pós-processamento — como {{game}} aparece na tela.",


### PR DESCRIPTION
## Why

Dropping a file on the window is the only way into the installer, and the OS drop event is the one part of that flow the app doesn't control. Where it never arrives — remote desktop sessions, some shells, a policy that eats it — a downloaded mod cannot be installed at all, and nothing on screen says why. This came from a user hitting exactly that.

## What

An **Import** button in the Library header, next to Rescan:

- **Choose files…** — filtered to `.pkz .zip .rar .7z .pnt`, with "All files" available, because the classifier carries an unrecognised file through and asks where it goes rather than refusing it.
- **Choose a folder…** — for an unpacked track. Separate mode because the native dialog is files *or* directories, never both.

Both feed the same `planDrop` → review sheet → `commitDrop` path a drop uses.

## How

`DropReviewProvider` already owns the review sheet (drop and shop purchases both produce plans), so this adds a third producer rather than a parallel path. The plan-and-review step that `DropZone` held privately moves into `useImport`, and both entrances call it — a picked file is staged, classified, reviewed and committed exactly like a dropped one.

`stagePaths` takes the failure-message key so each entrance owns its own copy: someone who clicked Import never dropped anything.

No backend change — `dropzone::plan` already accepts arbitrary file and folder paths, and `dialog:allow-open` is already in the default capability.

## Verified

`tsc --noEmit`, `eslint` and `vite build` clean. Frontend-only; not run in the worktree, which lacks the sidecar files and would misreport paint decoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)