### PR TITLE
fix(rider): repair a scattered gear model, never a paint pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 2026-08-09 — The gear repair no longer invents a helmet
+
+### Fixed
+- **"A helmets mod was installed loose" no longer fires on a paint pack.** The repair asked
+  to gather anything it found sitting in `mods/rider/helmets` — including a bare
+  `paints/`/`goggles/` pair, which is not a scattered helmet at all but liveries for one that
+  is already installed. Paints for a packaged helmet have nowhere else to live, since nothing
+  can be written inside a `.pkz`. Repairing them built a helmet out of the liveries: a folder
+  with no mesh, offered by every picker as a model, with the real helmet's paints filed under
+  a name the loader never looks for. The repair now only offers itself when a model is
+  genuinely there — a mesh in the gear areas, a descriptor for riding-style animations, which
+  ship no mesh and no paints either.
+- **Two mods scattered into one folder are left alone instead of fused.** Nothing on disk
+  says which mesh, config or livery came from which mod, so gathering them under one name
+  produced a model that never existed. Two descriptors in an area root is now a refusal, with
+  the reason in the log.
+- **A repair that fails part-way puts everything back.** It stopped at the first file that
+  wouldn't move — a file the running game holds open, on Windows — leaving the mesh gathered
+  and `paints/`/`goggles/` still in the area root, which shows the model *and* both strays in
+  the picker and reads as the repair having split the helmet up. It is now all-or-nothing.
+
 ## 2026-08-09 — Import from the Library
 
 ### Added

--- a/src-tauri/src/game.rs
+++ b/src-tauri/src/game.rs
@@ -341,6 +341,24 @@ pub fn is_rider_model_area(name: &str) -> bool {
     RIDER_MODEL_AREAS.iter().any(|a| a.eq_ignore_ascii_case(name))
 }
 
+/// Whether models in this area can be painted — i.e. whether a `paints/` folder found here
+/// means anything at all.
+///
+/// The union across titles, like [`is_rider_model_area`]: an area is paintable if any title
+/// gives it a paint category. Riding-style `animations` are the ones that aren't, and the
+/// difference matters to anything reasoning about stray `paints/` folders — in a paintable
+/// area they are liveries that belong to some model, and in a non-paintable one they cannot
+/// be liveries at all. See [`crate::gearrepair`], which is what asks.
+pub fn rider_area_is_paintable(name: &str) -> bool {
+    Game::ALL.iter().any(|g| {
+        g.profile()
+            .rider
+            .areas
+            .iter()
+            .any(|a| a.folder.eq_ignore_ascii_case(name) && a.paint_cat.is_some())
+    })
+}
+
 /// One gear area as the install pickers need it: where it is, and what may sit inside.
 ///
 /// The library's own view of an area is [`RiderArea`], which also carries the categories a
@@ -462,6 +480,18 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// The gear areas are paintable and riding styles are not. `gearrepair` leans on this to
+    /// tell a scattered model from a paint pack, and getting it backwards would either let it
+    /// invent a helmet out of liveries again or stop it repairing riding styles at all.
+    #[test]
+    fn only_gear_areas_are_paintable() {
+        for area in ["helmets", "boots", "protections", "protection"] {
+            assert!(rider_area_is_paintable(area), "{area} holds paints");
+        }
+        assert!(!rider_area_is_paintable("animations"), "riding styles have nothing to paint");
+        assert!(!rider_area_is_paintable("nonsense"), "and an unknown folder is not a claim");
     }
 
     /// `RIDER_MODEL_AREAS` only works as a recogniser if it really is the union — an area

--- a/src-tauri/src/gearrepair.rs
+++ b/src-tauri/src/gearrepair.rs
@@ -7,11 +7,19 @@
 //! models of their own, so the helmet picker fills up with entries called "paints".
 //!
 //! Installs before the placement fix in [`crate::install::gear_model_folder`] could leave
-//! exactly that, so finding it and undoing it is this module's whole job. It only ever moves
-//! things the game cannot read where they are:
+//! exactly that, so finding it and undoing it is this module's whole job — but only where a
+//! model is genuinely what got scattered. That is the entry condition, not a detail of the
+//! plan: see [`is_a_model`]. A `paints/`/`goggles/` pair with no mesh beside it is not a
+//! scattered helmet at all, it is a *paint pack*, and paints for a packaged helmet have
+//! nowhere else to live since nothing can write inside a `.pkz`. Gathering those would invent
+//! a helmet out of liveries — a folder with no mesh, offered by every picker as a model, with
+//! the real helmet's paints filed underneath where the loader will never look for them.
 //!
-//! * loose files in an area root — nothing there is loadable, whatever it is;
-//! * a `paints/` or `goggles/` folder in an area root — those belong to a model.
+//! Once a model is established, what moves with it is everything the game cannot read where
+//! it sits:
+//!
+//! * the loose files in the area root — nothing there is loadable, whatever it is;
+//! * a `paints/` or `goggles/` folder in the area root — those belong to a model.
 //!
 //! A `.pkz` is left alone: a packaged model *is* a valid entry in an area root. So is any
 //! other sub-folder, because that is a model already.
@@ -22,6 +30,39 @@ use std::path::{Path, PathBuf};
 /// The sub-folders a model carries. Found in an *area* root they are strays that belong to
 /// whichever model was scattered there — the game reads neither.
 const MODEL_SUBDIRS: [&str; 2] = ["paints", "goggles"];
+
+/// A gear model *is* its mesh, and a mesh is an `.edf`. The stem varies by mod — `helmet.edf`,
+/// `model.edf`, one per part — so the extension is the whole test.
+///
+/// Holds for sealed mods too: a creator-locked helmet is a folder of KCOL blobs that keep
+/// their real names, so its 32 MB `helmet.edf` is still an `.edf` to everything here.
+fn is_mesh(p: &Path) -> bool {
+    p.extension().is_some_and(|x| x.eq_ignore_ascii_case("edf"))
+}
+
+/// Whether these loose files are a model rather than a pile of paints.
+///
+/// In a paintable area the mesh is the proof, because the thing being ruled out — a paint
+/// pack — is made of exactly the files a model's own `paints/` would hold, and only the mesh
+/// separates them. Riding-style `animations` carry no mesh and no paints either: the game
+/// reads `animations/<name>/<name>.ini`, so the descriptor *is* the model there, and nothing
+/// in that area could be a livery to begin with.
+fn is_a_model(files: &[PathBuf], area: &str) -> bool {
+    if crate::game::rider_area_is_paintable(area) {
+        files.iter().any(|p| is_mesh(p))
+    } else {
+        !descriptors(files).is_empty()
+    }
+}
+
+/// A mod's descriptor `.ini`, one per mod. Two of them in one area root means two mods were
+/// scattered on top of each other, and nothing on disk says which file came from which.
+fn descriptors(files: &[PathBuf]) -> Vec<&PathBuf> {
+    files
+        .iter()
+        .filter(|p| p.extension().is_some_and(|x| x.eq_ignore_ascii_case("ini")))
+        .collect()
+}
 
 /// One area root that needs gathering, and what gathering it would move.
 #[derive(Debug, Clone, Serialize)]
@@ -50,9 +91,8 @@ fn is_model_subdir(name: &str) -> bool {
 /// `helmet.edf` would name every helmet ever recovered the same thing. With no `.ini` to
 /// read, say plainly that this was recovered rather than inventing a brand name.
 fn recovered_name(files: &[PathBuf], area: &str) -> String {
-    let ini = files
-        .iter()
-        .find(|p| p.extension().is_some_and(|x| x.eq_ignore_ascii_case("ini")))
+    let ini = descriptors(files)
+        .first()
         .and_then(|p| p.file_stem())
         .and_then(|s| s.to_str())
         .map(str::trim)
@@ -101,6 +141,36 @@ fn plan_area(dir: &Path, area: &str) -> Option<GearRepair> {
     // Deterministic, so the preview a user reads is the order the apply walks.
     files.sort();
     subdirs.sort();
+
+    // No model, nothing to gather. Most often this is a paint pack for a helmet that is
+    // already installed — commonly a packaged one, whose paints *have* to live outside the
+    // archive. Those belong under the helmet they paint; there is nothing here that says
+    // which, and filing them under a folder of their own would only bury them deeper. Left
+    // where they are, and said out loud, because it is the shape most likely to be reported.
+    if !is_a_model(&files, area) {
+        log::info!(
+            "[gearrepair] {area}: {} loose file(s) and {} stray folder(s), but nothing that \
+             proves a model — not a scattered install, left alone",
+            files.len(),
+            subdirs.len(),
+        );
+        return None;
+    }
+
+    // One descriptor is a mod naming itself. Several means several mods were emptied into
+    // the same folder, and no rule can say which mesh, paint or config came from which —
+    // gathering them under one name would fuse them into a model that never existed.
+    let inis = descriptors(&files);
+    if inis.len() > 1 {
+        log::warn!(
+            "[gearrepair] {area}: {} descriptors ({:?}) — more than one mod scattered here, \
+             so there is no safe way to gather them; left alone",
+            inis.len(),
+            inis.iter().filter_map(|p| p.file_name()).collect::<Vec<_>>(),
+        );
+        return None;
+    }
+
     let model = recovered_name(&files, area);
     let items = files
         .iter()
@@ -131,6 +201,16 @@ pub fn plan(mods_path: &str) -> Vec<GearRepair> {
 ///
 /// Re-planned rather than trusting the caller's copy: a preview can be minutes old, and the
 /// only thing worth acting on is what is in the folder now.
+///
+/// All-or-nothing. Stopping at the first failure used to leave the mesh gathered and
+/// `paints/`/`goggles/` still in the area root — the half-done state is *worse* than either
+/// end of it, because the pickers then show the model and both strays side by side, which
+/// reads as the repair having split the helmet in three. Windows makes that a live risk: a
+/// file the running game holds open refuses to move. So anything already moved goes back.
+///
+/// No cross-device fallback, deliberately: `dest` is always a child of `dir`, so a rename
+/// between them cannot cross a filesystem and copying would only add a way to half-write a
+/// 32 MB sealed mesh.
 pub fn apply_one(mods_path: &str, area: &str) -> anyhow::Result<usize> {
     use anyhow::Context;
     let base = crate::library::mods_subdir(mods_path, "mods/rider");
@@ -143,7 +223,7 @@ pub fn apply_one(mods_path: &str, area: &str) -> anyhow::Result<usize> {
     // fail on it — so `create_dir_all`, and a per-entry existence check below.
     std::fs::create_dir_all(&dest)
         .with_context(|| format!("create {dest:?}"))?;
-    let mut moved = 0;
+    let mut done: Vec<(PathBuf, PathBuf)> = Vec::new();
     for item in &plan.items {
         let from = dir.join(item);
         let to = dest.join(item);
@@ -151,11 +231,28 @@ pub fn apply_one(mods_path: &str, area: &str) -> anyhow::Result<usize> {
             log::warn!("[gearrepair] {area}: '{item}' already exists in {dest:?} — left alone");
             continue;
         }
-        std::fs::rename(&from, &to).with_context(|| format!("move {from:?} -> {to:?}"))?;
-        moved += 1;
+        if let Err(e) = std::fs::rename(&from, &to) {
+            rollback(&done);
+            return Err(anyhow::Error::new(e))
+                .with_context(|| format!("move {from:?} -> {to:?} (nothing was moved)"));
+        }
+        done.push((from, to));
     }
-    log::info!("[gearrepair] gathered {moved} entries into {dest:?}");
-    Ok(moved)
+    log::info!("[gearrepair] gathered {} entries into {dest:?}", done.len());
+    Ok(done.len())
+}
+
+/// Put back what a failed gather had already moved, best-effort.
+///
+/// In reverse, so the area root is rebuilt in the order it came apart. A rollback that itself
+/// fails is logged and no more: the original error is the one worth reporting, and there is
+/// nothing further this can do about a folder the OS won't let it touch.
+fn rollback(done: &[(PathBuf, PathBuf)]) {
+    for (from, to) in done.iter().rev() {
+        if let Err(e) = std::fs::rename(to, from) {
+            log::error!("[gearrepair] rollback failed: {to:?} -> {from:?}: {e}");
+        }
+    }
 }
 
 #[cfg(test)]
@@ -199,6 +296,107 @@ mod tests {
         assert!(!helmets.join("helmet.edf").exists(), "nothing left loose");
         assert!(!helmets.join("paints").exists(), "no stray `paints` sibling");
         assert!(plan(root.to_str().unwrap()).is_empty(), "and it stays tidy");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The shape this repair used to get wrong. A paint pack for a *packaged* helmet has
+    /// nowhere to live but outside the archive, so `paints/` and `goggles/` beside a `.pkz`
+    /// with no mesh anywhere is a normal thing to find — and gathering it would invent a
+    /// mesh-less helmet, offer it in every picker, and bury the real helmet's liveries under
+    /// a name the loader never looks for.
+    #[test]
+    fn a_paint_pack_with_no_mesh_is_never_gathered() {
+        let root = tmp("paintsonly");
+        let helmets = root.join("mods/rider/helmets");
+        touch(&helmets.join("Astars_SM10_EKS.pkz"));
+        touch(&helmets.join("paints/Red.pnt"));
+        touch(&helmets.join("goggles/Smoke.pnt"));
+
+        assert!(plan(root.to_str().unwrap()).is_empty(), "no mesh, so nothing to gather");
+        assert_eq!(apply_one(root.to_str().unwrap(), "helmets").unwrap(), 0);
+        assert!(helmets.join("paints/Red.pnt").exists(), "the pack is left exactly as found");
+        assert!(helmets.join("goggles/Smoke.pnt").exists());
+        assert!(!helmets.join("Recovered helmet").exists(), "and no helmet is invented");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Riding styles are models with no mesh — the game reads `animations/<name>/<name>.ini`
+    /// — and no paints either, so the mesh rule must not reach them. One scattered here is
+    /// still gathered, on the strength of its descriptor.
+    #[test]
+    fn a_scattered_riding_style_is_still_gathered() {
+        let root = tmp("animations");
+        let anims = root.join("mods/rider/animations");
+        touch(&anims.join("Scrub.ini"));
+        touch(&anims.join("scrub.cfg"));
+
+        let plans = plan(root.to_str().unwrap());
+        assert_eq!(plans.len(), 1, "a mesh-less area still repairs");
+        assert_eq!(plans[0].model, "Scrub");
+        assert_eq!(apply_one(root.to_str().unwrap(), "animations").unwrap(), 2);
+        assert!(anims.join("Scrub/Scrub.ini").exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A loose `.pnt` or two in the area root is the same story without the folders: paints,
+    /// misfiled, belonging to a helmet that already exists.
+    #[test]
+    fn loose_paints_alone_are_not_a_model() {
+        let root = tmp("loosepnt");
+        let helmets = root.join("mods/rider/helmets");
+        touch(&helmets.join("Red.pnt"));
+        touch(&helmets.join("Blue.pnt"));
+        assert!(plan(root.to_str().unwrap()).is_empty());
+        assert!(helmets.join("Red.pnt").exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Two mods emptied into the same area root. Both are scattered and both need gathering,
+    /// but nothing on disk says which mesh went with which descriptor — so gathering them
+    /// under one name would fuse two helmets into one that never existed. Refused instead.
+    #[test]
+    fn two_scattered_mods_are_left_alone_rather_than_fused() {
+        let root = tmp("twomods");
+        let helmets = root.join("mods/rider/helmets");
+        for f in ["Fox_V3.ini", "Airoh_Twist.ini", "helmet.edf", "gfx.cfg"] {
+            touch(&helmets.join(f));
+        }
+        assert!(plan(root.to_str().unwrap()).is_empty(), "two descriptors, no safe gather");
+        assert_eq!(apply_one(root.to_str().unwrap(), "helmets").unwrap(), 0);
+        assert!(helmets.join("helmet.edf").exists(), "and nothing moved");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A move that fails part-way must not leave the mesh gathered and the strays behind —
+    /// that state shows the model *and* `paints` in the picker, which is exactly what a
+    /// player reads as "the repair split my helmet up".
+    ///
+    /// Unix-only because it needs a rename to fail on demand: a directory with no write
+    /// permission of its own cannot be moved to a new parent, since the move has to rewrite
+    /// its `..`. Windows fails the same way for the real reason — a file the game holds open.
+    #[cfg(unix)]
+    #[test]
+    fn a_move_that_fails_part_way_puts_everything_back() {
+        use std::os::unix::fs::PermissionsExt;
+        let root = tmp("rollback");
+        let helmets = root.join("mods/rider/helmets");
+        touch(&helmets.join("Fox_V3.ini"));
+        touch(&helmets.join("helmet.edf"));
+        touch(&helmets.join("paints/Red.pnt"));
+        // Files sort before folders in the plan, so both move before this one refuses.
+        std::fs::set_permissions(helmets.join("paints"), std::fs::Permissions::from_mode(0o500))
+            .unwrap();
+
+        let err = apply_one(root.to_str().unwrap(), "helmets").unwrap_err();
+        assert!(format!("{err:#}").contains("nothing was moved"), "and it says so: {err:#}");
+
+        assert!(helmets.join("Fox_V3.ini").exists(), "descriptor back at the area root");
+        assert!(helmets.join("helmet.edf").exists(), "mesh back at the area root");
+        assert!(helmets.join("paints/Red.pnt").exists(), "strays never left");
+        assert!(!helmets.join("Fox_V3/helmet.edf").exists(), "and nothing is half-gathered");
+
+        std::fs::set_permissions(helmets.join("paints"), std::fs::Permissions::from_mode(0o700))
+            .unwrap();
         let _ = std::fs::remove_dir_all(&root);
     }
 


### PR DESCRIPTION
## The bug

The Rider tab's **"A helmets mod was installed loose"** banner offered to gather anything sitting in a `mods/rider` area root, with no check that a *model* was what got scattered.

A bare `paints/`/`goggles/` pair is not a scattered helmet. It is a **paint pack** for a helmet that is already installed — and for a packaged helmet that is the only place its liveries *can* live, since nothing can be written inside a `.pkz`.

Repairing it built a helmet out of the liveries: a mesh-less folder, offered by every picker as a model, with the real helmet's paints filed underneath a name the loader never reads.

## The fix

- **`is_a_model` is the entry condition for a plan**, not a detail of it. In a paintable area the mesh (`.edf`) is the proof — a paint pack is made of exactly the files a model's own `paints/` holds, and only the mesh separates them. Sealed mods are covered: a creator-locked helmet keeps its real file names.
- **Riding-style `animations` are the exception**, and would have been a regression from a plain "require a mesh" rule. They ship no mesh and no paints, and the game reads `animations/<name>/<name>.ini` — so there the descriptor *is* the model.
- **`game::rider_area_is_paintable`** is the discriminator, derived from the game profiles as a union across titles rather than naming `animations` by hand, guarded by a test — mirroring `is_rider_model_area` beside it.
- **Two descriptors in one area root is a refusal.** Nothing on disk says which mesh, config or livery came from which mod, so gathering them under one name fused them into a model that never existed.
- **`apply_one` is all-or-nothing.** Stopping at the first entry that wouldn't move — a file the running game holds open, on Windows — left the mesh gathered and the strays behind, which shows the model *and* `paints` in the picker and reads as the repair having split the helmet up. Anything already moved is rolled back. No copy fallback: the destination is always a child of the source folder, so a rename between them cannot cross a filesystem.

## Scope

No DB or schema changes. No frontend change — the banner renders what the scan reports, and the scan now reports less.

## Tests

Four new in `gearrepair` — a paint pack beside a `.pkz`, loose `.pnt`s alone, two mods scattered together, and a part-way failure rolling back — plus one in `game`. The rollback test is Unix-only, since it needs a rename that fails on demand; Windows fails the same way for the real reason.

Full suite: 542 passed, 0 failed. Clippy clean on both changed files.

## Not included

Paints orphaned in an area root with no matching helmet installed are now left alone and logged, not surfaced. Rescuing those needs a separate "these paints don't belong to any installed helmet — pick one" prompt, which is a new banner and destination picker rather than a change to any of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)