### PR TITLE
feat(servers): report bootstrap progress, and fix the four failures it exposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@
 ## Unreleased — a server that says what it's doing
 
 ### Fixed
+- **A provisioned server can actually download the game.** The bootstrap fetched the installer
+  with `Start-BitsTransfer`, which cannot work where it runs: EC2 user data executes as SYSTEM
+  at boot with no interactive session, and BITS refuses with `0x800704DD` -- "the user has not
+  logged on to the network". Every launch died at that step. It now uses `curl.exe` from
+  System32, which streams to disk without a session and retries on its own, and the size is
+  checked afterwards so a truncated download fails loudly rather than extracting into nonsense.
+  Found by launching a real one, and diagnosed in a single attempt because the instance now
+  reports its transcript before shutting down.
+
 - **A server whose name isn't plain Latin-1 can be created.** EC2 user data was encoded with
   `btoa`, which takes a "binary string" of one character per byte and throws on anything above
   U+00FF. Any server named with an emoji or a non-Latin script failed to launch with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@
 ## Unreleased — a server that says what it's doing
 
 ### Fixed
+- **A provisioned server's agent can read its own config.** `agent.json` was written by hand as
+  JSON inside a PowerShell here-string, and the install path interpolated with single
+  backslashes -- so the file said `"game_dir": "C:\mxb\\game"`, and `\m` is not a valid JSON
+  escape. The agent refused to parse it and exited immediately on every server ever
+  provisioned. It is now built with `ConvertTo-Json`, which escapes properly, and the file is
+  parsed once on the box before the agent is asked to.
+
 - **A provisioned server can actually download the game.** The bootstrap fetched the installer
   with `Start-BitsTransfer`, which cannot work where it runs: EC2 user data executes as SYSTEM
   at boot with no interactive session, and BITS refuses with `0x800704DD` -- "the user has not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
 
 ## Unreleased — a server that says what it's doing
 
+### Fixed
+- **A server whose name isn't plain Latin-1 can be created.** EC2 user data was encoded with
+  `btoa`, which takes a "binary string" of one character per byte and throws on anything above
+  U+00FF. Any server named with an emoji or a non-Latin script failed to launch with
+  `InvalidCharacterError` and nothing else to go on. Found by trying to launch a real one.
+
 ### Added
 - **A booting server now reports its progress, and its failure.** Creating a server launches a
   machine that runs a long script with nobody watching: no console, no key pair, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@
   enrolled in, which makes it the worst one to be quietly missing. Switching it back off
   stops the watcher rather than leaving it running.
 
+## Unreleased — a server that says what it's doing
+
+### Added
+- **A booting server now reports its progress, and its failure.** Creating a server launches a
+  machine that runs a long script with nobody watching: no console, no key pair, so
+  `C:\mxb-bootstrap.log` cannot be read from outside — and the script's own failure trap shuts
+  the instance down, which terminates it and destroys the log. A bootstrap that died at minute
+  twelve and one still downloading a 2 GB installer were indistinguishable: a server that never
+  turned up. The instance now posts each step to the control plane, and posts the tail of its
+  transcript *before* shutting down, so a failure leaves an explanation behind.
+- **"Create a server" says which step it is on** — `downloading the game`, `extracting the
+  game`, `installing the agent` — instead of spinning for a quarter of an hour with nothing to
+  show, and shows the reported error if the server gave up.
+- **`POST /v1/servers/:id/bootstrap`**, authenticated by the agent token the box already holds,
+  the same credential and the same refusal as `hello`. Stage names are validated and the stored
+  log is capped and kept only on failure.
+
 ## 2026-08-09 — v0.9.0 — Servers you can create, paints everyone can see, and a paint studio
 
 ### Added

--- a/control-plane/migrations/0007_bootstrap_progress.sql
+++ b/control-plane/migrations/0007_bootstrap_progress.sql
@@ -1,0 +1,17 @@
+-- Let a booting server say how it is getting on.
+--
+-- A provisioned instance runs ~150 lines of PowerShell with nobody watching: no console, no
+-- key pair, so no RDP and no way to read `C:\mxb-bootstrap.log`. Worse, every failure path
+-- ends in `Stop-Computer`, and the instance is launched with
+-- `InstanceInitiatedShutdownBehavior=terminate` — so a failure destroys the only record of
+-- why it failed. From the outside a broken bootstrap and a slow one look identical: a server
+-- that never arrives.
+--
+-- These three columns are where the box reports what it is doing, and what went wrong if it
+-- did. They double as the answer to "why has Create a server been spinning for ten minutes".
+
+ALTER TABLE servers ADD COLUMN bootstrap_stage TEXT;
+ALTER TABLE servers ADD COLUMN bootstrap_at INTEGER;
+-- The tail of the transcript, only ever written on failure. Capped by the Worker before it
+-- gets here; a runaway log is not worth a row nobody can read.
+ALTER TABLE servers ADD COLUMN bootstrap_log TEXT;

--- a/control-plane/src/aws.ts
+++ b/control-plane/src/aws.ts
@@ -125,6 +125,23 @@ export async function latestWindowsAmi(env: AwsEnv): Promise<string> {
   return ids[best];
 }
 
+/**
+ * Base64 for EC2 user data.
+ *
+ * Not `btoa`, which throws on any character above U+00FF — it takes a "binary string", one
+ * char per byte, so anything outside Latin-1 is not representable. The script carries prose
+ * comments and, more to the point, the operator's own server name: a name with an emoji or a
+ * CJK character would fail the launch with `InvalidCharacterError` and nothing else to go on.
+ *
+ * Encoding to UTF-8 first and base64-ing the bytes is what `btoa` was always standing in for.
+ */
+function base64Utf8(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary);
+}
+
 export interface LaunchSpec {
   /** Display name, used for the Name tag so the console is readable. */
   name: string;
@@ -158,7 +175,7 @@ export async function runInstance(
     "SecurityGroupId.1": spec.securityGroupId,
     InstanceInitiatedShutdownBehavior: "terminate",
     // Base64 is what EC2 expects here; the instance decodes it before running it.
-    UserData: btoa(spec.userData),
+    UserData: base64Utf8(spec.userData),
     "TagSpecification.1.ResourceType": "instance",
     "TagSpecification.1.Tag.1.Key": MANAGED_TAG.key,
     "TagSpecification.1.Tag.1.Value": MANAGED_TAG.value,

--- a/control-plane/src/bootstrap.ts
+++ b/control-plane/src/bootstrap.ts
@@ -174,16 +174,25 @@ $publicIp = Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/publ
 if (-not $publicIp) { throw "this instance has no public address" }
 Write-Output "public address is $publicIp"
 
-@"
-{
-  "token": "${input.agentToken}",
-  "listen": "0.0.0.0:${input.agentPort}",
-  "public_url": "http://$publicIp:${input.agentPort}",
-  "game_dir": "${ROOT}\\\\game",
-  "ini": "dedicated.ini",
-  "game_port": ${input.gamePort}
-}
-"@ | Set-Content -Path "${ROOT}\\agent.json" -Encoding ASCII
+# Built with ConvertTo-Json rather than written out by hand.
+#
+# It was hand-written, and it was never valid: the path interpolated as a single-backslash
+# "C:\\mxb", so the file said "game_dir": "C:\\mxb\\\\game" and \\m is not a JSON escape. The
+# agent refused to parse its own config on every server ever provisioned. Letting PowerShell
+# do the escaping removes the entire class of mistake, and it is the same thing Send-Stage
+# already relies on.
+@{
+  token = "${input.agentToken}"
+  listen = "0.0.0.0:${input.agentPort}"
+  public_url = "http://$publicIp:${input.agentPort}"
+  game_dir = "${ROOT}\\game"
+  ini = "dedicated.ini"
+  game_port = ${input.gamePort}
+} | ConvertTo-Json | Set-Content -Path "${ROOT}\\agent.json" -Encoding ASCII
+
+# Prove it parses here, rather than discovering it does not when the agent exits.
+try { Get-Content -Path "${ROOT}\\agent.json" -Raw | ConvertFrom-Json | Out-Null }
+catch { throw "the agent config we just wrote is not valid JSON: $_" }
 
 # The security group already gates what reaches the box; these rules are what let traffic
 # past Windows' own firewall once it is there.

--- a/control-plane/src/bootstrap.ts
+++ b/control-plane/src/bootstrap.ts
@@ -102,9 +102,22 @@ Set-Location "${ROOT}"
 
 Send-Stage -Stage "downloading the game"
 Write-Output "fetching the MX Bikes installer (about 2 GB)"
-# BITS rather than Invoke-WebRequest: IWR buffers the whole response in memory, and two
-# gigabytes of it on a small instance is how this step fails.
-Start-BitsTransfer -Source "${input.gameUrl}" -Destination "${ROOT}\\mxbikes-installer.exe"
+# curl.exe, which ships in System32 on Server 2019 and later.
+#
+# Not Invoke-WebRequest: it buffers the whole response in memory, and two gigabytes of that on
+# a small instance is how this step fails. And not Start-BitsTransfer, which was the first
+# choice for exactly that reason and cannot work here at all -- user data runs as SYSTEM at
+# boot with no interactive session, and BITS refuses with 0x800704DD, "the user has not logged
+# on to the network". curl streams straight to disk, needs no session, and retries by itself.
+$curl = "$env:SystemRoot\\System32\\curl.exe"
+if (-not (Test-Path $curl)) { throw "curl.exe is missing from System32" }
+& $curl -L --fail --silent --show-error --retry 5 --retry-delay 15 --retry-connrefused \`
+  -o "${ROOT}\\mxbikes-installer.exe" "${input.gameUrl}"
+if ($LASTEXITCODE -ne 0) { throw "downloading the installer failed (curl exit $LASTEXITCODE)" }
+$size = (Get-Item "${ROOT}\\mxbikes-installer.exe").Length
+Write-Output "installer downloaded: $size bytes"
+# A truncated download extracts into nonsense; anything this small is not the installer.
+if ($size -lt 1GB) { throw "the installer is only $size bytes, so the download did not finish" }
 
 Send-Stage -Stage "extracting the game"
 Write-Output "extracting the server files"

--- a/control-plane/src/bootstrap.ts
+++ b/control-plane/src/bootstrap.ts
@@ -79,7 +79,7 @@ function Send-Stage {
 # a half-built server that sits idle is the one outcome that quietly costs money.
 #
 # Which is why the transcript is sent *before* shutting down. There is no console on this box
-# and no key pair, so the log cannot be read from outside — and terminating destroys it.
+# and no key pair, so the log cannot be read from outside -- and terminating destroys it.
 # Without this, a bootstrap that failed at minute twelve and one still downloading look
 # identical from the outside: a server that never turns up.
 trap {
@@ -111,14 +111,14 @@ Write-Output "extracting the server files"
 # There is no separate dedicated-server download; the installer carries it and \`-extract\`
 # unpacks it to mxbikes.zip without installing anything.
 #
-# It exits 1 on SUCCESS. Treating that as failure — which every normal convention says to
-# do — leaves the bootstrap dead at the one step that actually worked, so the exit code is
+# It exits 1 on SUCCESS. Treating that as failure -- which every normal convention says to
+# do -- leaves the bootstrap dead at the one step that actually worked, so the exit code is
 # deliberately ignored and the *artifact* is what gets checked instead.
 $proc = Start-Process -FilePath "${ROOT}\\mxbikes-installer.exe" -ArgumentList "-extract" -WorkingDirectory "${ROOT}" -Wait -PassThru -NoNewWindow
 Write-Output "installer exited $($proc.ExitCode) (1 is normal here)"
 
 $zip = Get-ChildItem -Path "${ROOT}" -Filter "mxbikes*.zip" | Select-Object -First 1
-if (-not $zip) { throw "the installer produced no zip — extraction did not work" }
+if (-not $zip) { throw "the installer produced no zip -- extraction did not work" }
 Expand-Archive -Path $zip.FullName -DestinationPath "${ROOT}\\game" -Force
 
 if (-not (Test-Path "${ROOT}\\game\\mxbikes.exe")) {
@@ -148,7 +148,7 @@ track_layout =
 # The box's own public address, from the instance metadata service. IMDSv2 needs a token
 # first; v1 is disabled on hardened AMIs and the extra call costs nothing. Without this the
 # agent binds a wildcard, works out its address from the primary interface, and prints the
-# *private* IP — an address nobody outside the VPC can use.
+# *private* IP -- an address nobody outside the VPC can use.
 $imdsToken = Invoke-RestMethod -Method PUT -Uri "http://169.254.169.254/latest/api/token" \`
   -Headers @{ "X-aws-ec2-metadata-token-ttl-seconds" = "300" } -TimeoutSec 10
 $publicIp = Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/public-ipv4" \`
@@ -182,7 +182,7 @@ Start-ScheduledTask -TaskName "mxb-agent"
 Send-Stage -Stage "waiting for the agent"
 
 # Wait for the agent to actually answer before saying the server is up. /health is the one
-# route it serves without a token, and it is served before anything else is ready — which is
+# route it serves without a token, and it is served before anything else is ready -- which is
 # all this needs to know: the process is alive and listening.
 $ready = $false
 foreach ($attempt in 1..30) {
@@ -201,7 +201,7 @@ if (-not $ready) { throw "the agent never came up" }
 # boots, long after that row was written, and nothing else is in a position to report it.
 # Authenticated with the agent's own token, which only this instance and that row hold.
 #
-# Retried, because everything else has already succeeded by this point — a transient network
+# Retried, because everything else has already succeeded by this point -- a transient network
 # failure here would otherwise self-destruct a server that is up and running.
 $announced = $false
 foreach ($attempt in 1..5) {

--- a/control-plane/src/bootstrap.ts
+++ b/control-plane/src/bootstrap.ts
@@ -87,8 +87,13 @@ trap {
   Write-Output "bootstrap failed: $reason"
   try { Stop-Transcript } catch {}
   $tail = ""
-  try { $tail = Get-Content -Path "C:\\mxb-bootstrap.log" -Tail 150 -Raw } catch {}
-  Send-Stage -Stage "failed" -Ok $false -Log "$reason\`n$tail"
+  # -Tail and -Raw cannot be combined; asking for both throws, which the catch would swallow
+  # and leave this report with nothing in it but the throw message.
+  try { $tail = (Get-Content -Path "C:\\mxb-bootstrap.log" -Tail 200 | Out-String) } catch {}
+  # Whatever the agent itself said on the way out. Usually the actual answer.
+  $agentOut = ""
+  try { $agentOut = (Get-Content -Path "${ROOT}\\agent-out.txt","${ROOT}\\agent-err.txt" -ErrorAction SilentlyContinue | Out-String) } catch {}
+  Send-Stage -Stage "failed" -Ok $false -Log "$reason\`n--- agent output ---\`n$agentOut\`n--- transcript ---\`n$tail"
   Stop-Computer -Force
   exit 1
 }
@@ -191,6 +196,24 @@ $action = New-ScheduledTaskAction -Execute "${ROOT}\\mxb-agent.exe" -Argument "$
 $trigger = New-ScheduledTaskTrigger -AtStartup
 $principal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -RunLevel Highest
 Register-ScheduledTask -TaskName "mxb-agent" -Action $action -Trigger $trigger -Principal $principal -Force | Out-Null
+# Run it once in the foreground first, with its output captured.
+#
+# The scheduled task is what keeps the agent alive across reboots, but it swallows everything
+# the process says: when the agent failed to come up, all we learned was that it hadn't. This
+# runs it directly for a few seconds purely so that a refusal to start has somewhere to say
+# why -- a bad agent.json, a missing folder, a binary Defender took exception to.
+$probe = Start-Process -FilePath "${ROOT}\\mxb-agent.exe" -ArgumentList "${ROOT}\\agent.json" \`
+  -WorkingDirectory "${ROOT}" -PassThru -NoNewWindow \`
+  -RedirectStandardOutput "${ROOT}\\agent-out.txt" -RedirectStandardError "${ROOT}\\agent-err.txt"
+Start-Sleep -Seconds 8
+if ($probe.HasExited) {
+  $out = (Get-Content -Path "${ROOT}\\agent-out.txt","${ROOT}\\agent-err.txt" -ErrorAction SilentlyContinue | Out-String)
+  throw "the agent exited immediately (code $($probe.ExitCode)): $out"
+}
+# It runs. Stop this copy so the scheduled task owns the port rather than racing it.
+Stop-Process -Id $probe.Id -Force -ErrorAction SilentlyContinue
+Start-Sleep -Seconds 2
+
 Start-ScheduledTask -TaskName "mxb-agent"
 Send-Stage -Stage "waiting for the agent"
 
@@ -198,7 +221,7 @@ Send-Stage -Stage "waiting for the agent"
 # route it serves without a token, and it is served before anything else is ready -- which is
 # all this needs to know: the process is alive and listening.
 $ready = $false
-foreach ($attempt in 1..30) {
+foreach ($attempt in 1..45) {
   try {
     Invoke-RestMethod -Uri "http://127.0.0.1:${input.agentPort}/health" -TimeoutSec 5 | Out-Null
     $ready = $true
@@ -207,7 +230,13 @@ foreach ($attempt in 1..30) {
     Start-Sleep -Seconds 2
   }
 }
-if (-not $ready) { throw "the agent never came up" }
+if (-not $ready) {
+  $info = ""
+  try { $info = (Get-ScheduledTaskInfo -TaskName "mxb-agent" | Format-List | Out-String) } catch {}
+  $running = ""
+  try { $running = (Get-Process -Name "mxb-agent" -ErrorAction SilentlyContinue | Out-String) } catch {}
+  throw "the agent never answered on ${input.agentPort}. task info: $info process: $running"
+}
 
 # Tell the control plane where this server is. Until this call, the row it was created from
 # has an empty address and is published to nobody: the public IP is assigned while the box

--- a/control-plane/src/bootstrap.ts
+++ b/control-plane/src/bootstrap.ts
@@ -61,12 +61,34 @@ export function bootstrapScript(input: BootstrapInputs): string {
 $ErrorActionPreference = "Stop"
 Start-Transcript -Path "C:\\mxb-bootstrap.log" -Append
 
+# Say what we are doing, so a server that takes a quarter of an hour to arrive can show its
+# progress instead of an unexplained spinner. Best-effort by design: a report that fails must
+# never be the thing that fails a build which is otherwise working.
+function Send-Stage {
+  param([string] $Stage, [bool] $Ok = $true, [string] $Log = "")
+  try {
+    $payload = @{ stage = $Stage; ok = $Ok; log = $Log } | ConvertTo-Json -Compress
+    Invoke-RestMethod -Method POST -Uri "${input.controlPlaneUrl}/v1/servers/${input.serverId}/bootstrap" -Headers @{ "Authorization" = "Bearer ${input.agentToken}"; "Content-Type" = "application/json" } -Body $payload -TimeoutSec 15 | Out-Null
+  } catch {
+    Write-Output "couldn't report stage '$Stage': $_"
+  }
+}
+
 # Any unhandled failure below takes the instance down with it. Launched with
 # InstanceInitiatedShutdownBehavior=terminate, so this is self-destruction, not a pause:
 # a half-built server that sits idle is the one outcome that quietly costs money.
+#
+# Which is why the transcript is sent *before* shutting down. There is no console on this box
+# and no key pair, so the log cannot be read from outside — and terminating destroys it.
+# Without this, a bootstrap that failed at minute twelve and one still downloading look
+# identical from the outside: a server that never turns up.
 trap {
-  Write-Output "bootstrap failed: $_"
-  Stop-Transcript
+  $reason = "$_"
+  Write-Output "bootstrap failed: $reason"
+  try { Stop-Transcript } catch {}
+  $tail = ""
+  try { $tail = Get-Content -Path "C:\\mxb-bootstrap.log" -Tail 150 -Raw } catch {}
+  Send-Stage -Stage "failed" -Ok $false -Log "$reason\`n$tail"
   Stop-Computer -Force
   exit 1
 }
@@ -78,11 +100,13 @@ Set-Location "${ROOT}"
 # known to negotiate down and fail against modern endpoints.
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
+Send-Stage -Stage "downloading the game"
 Write-Output "fetching the MX Bikes installer (about 2 GB)"
 # BITS rather than Invoke-WebRequest: IWR buffers the whole response in memory, and two
 # gigabytes of it on a small instance is how this step fails.
 Start-BitsTransfer -Source "${input.gameUrl}" -Destination "${ROOT}\\mxbikes-installer.exe"
 
+Send-Stage -Stage "extracting the game"
 Write-Output "extracting the server files"
 # There is no separate dedicated-server download; the installer carries it and \`-extract\`
 # unpacks it to mxbikes.zip without installing anything.
@@ -105,6 +129,7 @@ if (-not (Test-Path "${ROOT}\\game\\mxbikes.exe")) {
   Move-Item -Path "$($inner.Directory.FullName)\\*" -Destination "${ROOT}\\game" -Force
 }
 
+Send-Stage -Stage "installing the agent"
 Write-Output "fetching the agent"
 Invoke-WebRequest -Uri "${input.agentUrl}" -OutFile "${ROOT}\\mxb-agent.exe" -UseBasicParsing
 
@@ -154,6 +179,7 @@ $trigger = New-ScheduledTaskTrigger -AtStartup
 $principal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -RunLevel Highest
 Register-ScheduledTask -TaskName "mxb-agent" -Action $action -Trigger $trigger -Principal $principal -Force | Out-Null
 Start-ScheduledTask -TaskName "mxb-agent"
+Send-Stage -Stage "waiting for the agent"
 
 # Wait for the agent to actually answer before saying the server is up. /health is the one
 # route it serves without a token, and it is served before anything else is ready — which is
@@ -192,6 +218,7 @@ foreach ($attempt in 1..5) {
 }
 if (-not $announced) { throw "couldn't tell the control plane this server is up" }
 
+Send-Stage -Stage "ready"
 Write-Output "bootstrap complete"
 Stop-Transcript
 </powershell>

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -20,6 +20,7 @@ import { bootstrapScript } from "./bootstrap";
 import { bearer, hashToken, newToken, tokenMatches } from "./auth";
 import {
   isBikeId,
+  isBootstrapStage,
   isGuid,
   isPaintFileName,
   isPaintSize,
@@ -31,6 +32,7 @@ import {
   isServerName,
   isSha256,
   isSlot,
+  MAX_BOOTSTRAP_LOG,
   MAX_PAINT_BYTES,
 } from "./validate";
 
@@ -95,6 +97,9 @@ async function route(request: Request, env: Env): Promise<Response> {
   // not by an account bearer — the machine holds no account and has no way to be given one.
   const hello = /^\/v1\/servers\/([A-Za-z0-9._-]{1,64})\/hello$/.exec(path);
   if (hello && method === "POST") return serverHello(request, hello[1], env);
+
+  const boot = /^\/v1\/servers\/([A-Za-z0-9._-]{1,64})\/bootstrap$/.exec(path);
+  if (boot && method === "POST") return serverBootstrap(request, boot[1], env);
 
   const account = await authenticate(request, env);
   if (!account) return json(401, { error: "unauthorized" });
@@ -732,16 +737,70 @@ async function provision(request: Request, account: Account, env: Env): Promise<
  * Idempotent: a bootstrap that retries, or an instance that reboots and announces itself
  * again, simply rewrites the same row.
  */
-async function serverHello(request: Request, id: string, env: Env): Promise<Response> {
-  const row = await env.DB.prepare(
-    "SELECT agent_token, instance_id FROM servers WHERE id = ?",
-  )
+/**
+ * Prove a request came from the box a row was provisioned for.
+ *
+ * The agent token is the only credential that machine has — it holds no account and there is
+ * no way to give it one. Shared by every route the box itself calls, so the answer to a wrong
+ * token cannot drift between them: an unknown id and a bad token return the same 403, which
+ * is what stops this being a way to discover which server ids exist.
+ */
+async function asProvisionedServer(
+  request: Request,
+  id: string,
+  env: Env,
+): Promise<{ instance_id: string | null } | null> {
+  const row = await env.DB.prepare("SELECT agent_token, instance_id FROM servers WHERE id = ?")
     .bind(id)
     .first<{ agent_token: string | null; instance_id: string | null }>();
-  // The same answer for an unknown id and a wrong token, so this can't be used to find out
-  // which server ids exist.
   const presented = bearer(request.headers.get("Authorization"));
   if (!row?.agent_token || !presented || !tokenMatches(row.agent_token, presented)) {
+    return null;
+  }
+  return { instance_id: row.instance_id };
+}
+
+/**
+ * A booting instance reporting what it is doing, and why it died if it did.
+ *
+ * Nothing else can tell you. The box has no console and no key pair, so `C:\mxb-bootstrap.log`
+ * is unreadable from outside — and the bootstrap's own failure trap shuts the machine down,
+ * which terminates it and takes the log with it. Before this, a bootstrap that failed at
+ * minute twelve and one still downloading looked exactly the same from here: nothing.
+ *
+ * Also what lets "Create a server" say `extracting the game` instead of spinning for a
+ * quarter of an hour with nothing to show.
+ */
+async function serverBootstrap(request: Request, id: string, env: Env): Promise<Response> {
+  if (!(await asProvisionedServer(request, id, env))) {
+    return json(403, { error: "not this server" });
+  }
+  const body = (await readJson(request)) as
+    | { stage?: unknown; ok?: unknown; log?: unknown }
+    | null;
+  if (!isBootstrapStage(body?.stage)) return json(400, { error: "that isn't a stage" });
+
+  // Kept only when something went wrong, and only the tail: this is a transcript written by a
+  // script, and there is no version of "store all of it" that ends well.
+  const log =
+    body?.ok === false && typeof body.log === "string"
+      ? body.log.slice(-MAX_BOOTSTRAP_LOG)
+      : null;
+
+  await env.DB.prepare(
+    "UPDATE servers SET bootstrap_stage = ?, bootstrap_at = ?, bootstrap_log = COALESCE(?, bootstrap_log)" +
+      " WHERE id = ?",
+  )
+    .bind((body!.stage as string).trim(), Date.now(), log, id)
+    .run();
+
+  console.log(JSON.stringify({ msg: "bootstrap", id, stage: body!.stage, failed: log !== null }));
+  return json(200, { ok: true });
+}
+
+async function serverHello(request: Request, id: string, env: Env): Promise<Response> {
+  const row = await asProvisionedServer(request, id, env);
+  if (!row) {
     return json(403, { error: "not this server" });
   }
 
@@ -785,7 +844,8 @@ function isPort(value: unknown): value is number {
 async function myServers(account: Account, env: Env): Promise<Response> {
   const rows = await env.DB.prepare(
     "SELECT id, name, region, address, agent_url, agent_token, instance_id, published," +
-      " created_at, idle_since FROM servers WHERE owner_account_id = ? ORDER BY created_at",
+      " created_at, idle_since, bootstrap_stage, bootstrap_at, bootstrap_log" +
+      " FROM servers WHERE owner_account_id = ? ORDER BY created_at",
   )
     .bind(account.id)
     .all<{
@@ -799,6 +859,9 @@ async function myServers(account: Account, env: Env): Promise<Response> {
       published: number;
       created_at: number;
       idle_since: number | null;
+      bootstrap_stage: string | null;
+      bootstrap_at: number | null;
+      bootstrap_log: string | null;
     }>();
 
   // Only ask EC2 when at least one row is a machine we launched; a player who only runs
@@ -834,6 +897,11 @@ async function myServers(account: Account, env: Env): Promise<Response> {
         idleMinutes: Number(env.MXB_IDLE_MINUTES ?? "20"),
         state: r.instance_id ? (instance?.state ?? "gone") : "self-hosted",
         publicIp: instance?.publicIp ?? null,
+        // What the box last said it was doing, and why it gave up if it did. The only
+        // window into a machine with no console.
+        bootstrapStage: r.bootstrap_stage,
+        bootstrapAt: r.bootstrap_at,
+        bootstrapLog: r.bootstrap_log,
       };
     }),
   });

--- a/control-plane/src/validate.ts
+++ b/control-plane/src/validate.ts
@@ -242,3 +242,20 @@ export function isBikeId(value: unknown): value is string {
   // players' apps read.
   return !/[/\\]/.test(id);
 }
+
+/** How much of a failed bootstrap's transcript is worth keeping. */
+export const MAX_BOOTSTRAP_LOG = 16 * 1024;
+
+/**
+ * A bootstrap stage name.
+ *
+ * Written by a script on a machine we launched, and read back into the app's UI, so it is
+ * held to being a short plain label rather than trusted because of where it came from.
+ */
+export function isBootstrapStage(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const stage = value.trim();
+  if (stage.length === 0 || stage.length > 64) return false;
+  return /^[a-z0-9 :\-]+$/i.test(stage);
+}
+

--- a/control-plane/test/validate.test.ts
+++ b/control-plane/test/validate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { bearer } from "../src/auth";
+import { bootstrapScript } from "../src/bootstrap";
 import {
   isBikeId,
   isBootstrapStage,
@@ -298,5 +299,31 @@ describe("bootstrap stages", () => {
     for (const bad of ["", "   ", "a".repeat(65), "stage\nnext", "<b>x</b>", "drop;table", 7, null]) {
       expect(isBootstrapStage(bad), JSON.stringify(bad)).toBe(false);
     }
+  });
+});
+
+describe("bootstrap user data", () => {
+  it("is plain ASCII, so a Windows host cannot misread it", () => {
+    // EC2 hands the decoded script to PowerShell 5.1, which reads a file with no BOM using
+    // the system codepage rather than UTF-8. Comments are harmless; a mangled command is not.
+    const script = bootstrapScript({
+      agentToken: "t", agentUrl: "https://cp/v1/agent.exe", gameUrl: "https://g/i.exe",
+      serverName: "Test", gamePort: 54210, agentPort: 8787,
+      serverId: "abc", controlPlaneUrl: "https://cp",
+    });
+    const offenders = [...new Set([...script].filter((c) => c.charCodeAt(0) > 127))];
+    expect(offenders, `non-ASCII in the script: ${JSON.stringify(offenders)}`).toEqual([]);
+  });
+
+  it("survives a server name outside Latin-1", () => {
+    // The name is the operator's, and it is interpolated into the script. `btoa` threw on
+    // anything above U+00FF, which failed the launch with nothing to go on.
+    expect(() =>
+      bootstrapScript({
+        agentToken: "t", agentUrl: "https://cp/v1/agent.exe", gameUrl: "https://g/i.exe",
+        serverName: "Sean 🏁 サーバー", gamePort: 54210, agentPort: 8787,
+        serverId: "abc", controlPlaneUrl: "https://cp",
+      }),
+    ).not.toThrow();
   });
 });

--- a/control-plane/test/validate.test.ts
+++ b/control-plane/test/validate.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { bearer } from "../src/auth";
 import {
   isBikeId,
+  isBootstrapStage,
   isGuid,
   isPaintFileName,
   isPaintSize,
@@ -272,6 +273,30 @@ describe("bike ids", () => {
       {},
     ]) {
       expect(isBikeId(bad), JSON.stringify(bad)).toBe(false);
+    }
+  });
+});
+
+describe("bootstrap stages", () => {
+  it("takes the labels the bootstrap actually sends", () => {
+    for (const ok of [
+      "starting up",
+      "downloading the game",
+      "extracting the game",
+      "installing the agent",
+      "waiting for the agent",
+      "ready",
+      "failed",
+    ]) {
+      expect(isBootstrapStage(ok), ok).toBe(true);
+    }
+  });
+
+  it("refuses anything that isn't a short plain label", () => {
+    // Written by a script on a machine we launched and read straight back into the app's UI,
+    // so it is checked rather than trusted for coming from our own instance.
+    for (const bad of ["", "   ", "a".repeat(65), "stage\nnext", "<b>x</b>", "drop;table", 7, null]) {
+      expect(isBootstrapStage(bad), JSON.stringify(bad)).toBe(false);
     }
   });
 });

--- a/src/Components/Servers/Servers.tsx
+++ b/src/Components/Servers/Servers.tsx
@@ -931,9 +931,30 @@ const CloudServerRow = ({
       {!ready ? (
         // The wait is minutes, not seconds — the bootstrap downloads a 2 GB installer. Saying
         // so is the difference between "still working" and "something has gone wrong".
-        <div className="mt-3 flex items-center gap-2 rounded-lg border border-white/[0.07] px-3 py-2 text-[12px] text-muted-foreground">
-          <Loader2 className="size-3.5 animate-spin" />
-          {t("servers.bootingWhy")}
+        <div className="mt-3 space-y-2">
+          <div className="flex items-center gap-2 rounded-lg border border-white/[0.07] px-3 py-2 text-[12px] text-muted-foreground">
+            <Loader2 className="size-3.5 animate-spin" />
+            {/* The box reports each step, so a ten-minute wait can say which part it is on
+                rather than spinning with nothing to show. */}
+            {server.bootstrapStage && server.bootstrapStage !== "failed"
+              ? t("servers.bootingStage", { stage: server.bootstrapStage })
+              : t("servers.bootingWhy")}
+          </div>
+          {/* A bootstrap that gave up used to take its own log down with it. This is that
+              log, which is the only thing that can say why. */}
+          {server.bootstrapStage === "failed" && (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3">
+              <div className="flex items-center gap-2 text-[12px] font-semibold">
+                <TriangleAlert className="size-3.5 flex-none text-destructive" />
+                {t("servers.bootFailed")}
+              </div>
+              {server.bootstrapLog && (
+                <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-all text-[11px] leading-relaxed text-muted-foreground">
+                  {server.bootstrapLog}
+                </pre>
+              )}
+            </div>
+          )}
         </div>
       ) : (
         <>

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -1991,6 +1991,16 @@ export interface CloudServer {
   /** `pending` | `running` | `stopping` | `stopped` | `gone` | `self-hosted`. */
   state: string;
   publicIp: string | null;
+  /**
+   * What the box last reported doing — `downloading the game`, `ready`, `failed`.
+   *
+   * The only window into a machine with no console and no key pair. A bootstrap that failed
+   * and one still downloading are otherwise indistinguishable from here.
+   */
+  bootstrapStage: string | null;
+  bootstrapAt: number | null;
+  /** The tail of the transcript, present only when the bootstrap gave up. */
+  bootstrapLog: string | null;
 }
 
 /** The servers the control plane runs for this account, and what it takes to drive them. */

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -776,6 +776,8 @@ export const de: Translation = {
   "sync.keptYours_other": "{{count}} Lackierungen wurden nicht angerührt",
   "sync.keptYoursWhy": "Ein anderer Fahrer nutzt denselben Dateinamen für eine andere Lackierung. Deine bleibt — die App überschreibt nie ein Design, das sie nicht selbst installiert hat. Du siehst diesen Fahrer in deiner Version.",
   "servers.booting": "Startet…",
+  "servers.bootingStage": "{{stage}}…",
+  "servers.bootFailed": "Dieser Server konnte seine Einrichtung nicht abschließen und hat sich abgeschaltet. Das hat er gemeldet:",
   "servers.bootingWhy": "Das Spiel wird auf der neuen Maschine installiert. Das dauert ein paar Minuten — der komplette Installer wird geladen.",
   "servers.shutsDown": "Schaltet ab",
   "servers.inUse": "In Benutzung",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -750,6 +750,8 @@ export const en = {
   "sync.keptYours_other": "{{count}} paints were left alone",
   "sync.keptYoursWhy": "Another rider uses the same file name for a different paint. Yours was kept — the app never overwrites a livery it didn't install. You'll see that rider in your version of it.",
   "servers.booting": "Starting up…",
+  "servers.bootingStage": "{{stage}}…",
+  "servers.bootFailed": "This server couldn't finish setting itself up, so it shut down. Here's what it reported:",
   "servers.bootingWhy": "Installing the game on the new machine. This takes a few minutes — it downloads the full installer.",
   "servers.shutsDown": "Shuts down",
   "servers.inUse": "In use",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -769,6 +769,8 @@ export const es: Translation = {
   "sync.keptYours_other": "{{count}} pinturas se dejaron intactas",
   "sync.keptYoursWhy": "Otro piloto usa el mismo nombre de archivo para una pintura distinta. La tuya se conservó — la app nunca sobrescribe una librea que no instaló. Verás a ese piloto con tu versión.",
   "servers.booting": "Arrancando…",
+  "servers.bootingStage": "{{stage}}…",
+  "servers.bootFailed": "Este servidor no pudo terminar de configurarse y se apagó. Esto es lo que informó:",
   "servers.bootingWhy": "Instalando el juego en la máquina nueva. Tarda unos minutos — descarga el instalador completo.",
   "servers.shutsDown": "Se apaga",
   "servers.inUse": "En uso",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -773,6 +773,8 @@ export const fr: Translation = {
   "sync.keptYours_other": "{{count}} peintures ont été laissées intactes",
   "sync.keptYoursWhy": "Un autre pilote utilise le même nom de fichier pour une peinture différente. La vôtre a été conservée — l'app n'écrase jamais une livrée qu'elle n'a pas installée. Vous verrez ce pilote dans votre version.",
   "servers.booting": "Démarrage…",
+  "servers.bootingStage": "{{stage}}…",
+  "servers.bootFailed": "Ce serveur n'a pas pu terminer son installation et s'est éteint. Voici ce qu'il a signalé :",
   "servers.bootingWhy": "Installation du jeu sur la nouvelle machine. Cela prend quelques minutes — l'installeur complet est téléchargé.",
   "servers.shutsDown": "S'éteint",
   "servers.inUse": "En cours d'utilisation",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -764,6 +764,8 @@ export const it: Translation = {
   "sync.keptYours_other": "{{count}} grafiche sono state lasciate intatte",
   "sync.keptYoursWhy": "Un altro pilota usa lo stesso nome file per una grafica diversa. La tua è stata mantenuta — l'app non sovrascrive mai una livrea che non ha installato. Vedrai quel pilota con la tua versione.",
   "servers.booting": "Avvio in corso…",
+  "servers.bootingStage": "{{stage}}…",
+  "servers.bootFailed": "Questo server non è riuscito a completare la configurazione e si è spento. Ecco cosa ha riportato:",
   "servers.bootingWhy": "Installazione del gioco sulla nuova macchina. Richiede qualche minuto — scarica l'installer completo.",
   "servers.shutsDown": "Si spegne",
   "servers.inUse": "In uso",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -768,6 +768,8 @@ export const ptBR: Translation = {
   "sync.keptYours_other": "{{count}} pinturas foram mantidas",
   "sync.keptYoursWhy": "Outro piloto usa o mesmo nome de arquivo para uma pintura diferente. A sua foi mantida — o app nunca sobrescreve uma pintura que não instalou. Você verá aquele piloto com a sua versão.",
   "servers.booting": "Iniciando…",
+  "servers.bootingStage": "{{stage}}…",
+  "servers.bootFailed": "Este servidor não conseguiu concluir a configuração e se desligou. Foi isto que ele relatou:",
   "servers.bootingWhy": "Instalando o jogo na máquina nova. Leva alguns minutos — ele baixa o instalador completo.",
   "servers.shutsDown": "Desliga",
   "servers.inUse": "Em uso",


### PR DESCRIPTION
Provisioning launches a Windows instance that runs ~150 lines of PowerShell with nobody
watching, and until now it either worked or vanished. This branch makes it report — and
then uses that reporting to fix the four things it immediately exposed, each found by an
actual launch.

## 1. Let a booting server say what it is doing, and why it failed

There is no console and no key pair, so `C:\mxb-bootstrap.log` cannot be read from outside
— and the script's own failure trap calls `Stop-Computer`, which on an instance launched
with `InstanceInitiatedShutdownBehavior=terminate` destroys the machine and the log with
it. From the outside, a bootstrap that failed at minute twelve and one still fetching a
2 GB installer look exactly alike: a server that never turns up.

That is the right shape for production — a half-built server must not sit there billing —
and the wrong shape for a script that had never once been executed. So the box reports
instead: a stage before each long step (which also gives **Create a server** something to
say during a ten-minute wait rather than an unexplained spinner), and, from inside the
trap, the tail of the transcript *before* it shuts down.

`POST /v1/servers/:id/bootstrap` is authenticated by the agent token already on the machine
— the only credential it has — sharing one `asProvisionedServer` check with `hello` so the
two cannot drift apart. An unknown id and a wrong token give the same 403, so this is not a
way to discover server ids. Stage names are validated rather than trusted for coming from
our own instance, since they are echoed straight back into the app's UI, and the log is
capped and kept only when something actually went wrong.

## 2. Encode user data as UTF-8, not as a Latin-1 binary string

The first attempt at a real launch failed before EC2 was ever called:

    InvalidCharacterError: btoa() can only operate on characters in the Latin1 range.

`btoa` takes a "binary string" — one character per byte — so anything above U+00FF throws.
The bootstrap carries prose comments and, far more importantly, the operator's own server
name: anyone naming a server with an emoji or a non-Latin script would have hit exactly
this with no clue why. Encoding to UTF-8 and base64-ing those bytes is what `btoa` was
standing in for all along.

The script itself is now plain ASCII as well, with a test keeping it that way — belt and
braces rather than the fix: EC2 hands the decoded file to PowerShell 5.1, which reads a
BOM-less file using the system codepage, so a non-ASCII character in a *command* would fail
far worse than one that throws.

## 3. Download the game with curl, because BITS cannot run at boot

The first real launch died here, and said so:

    0x800704DD -- The operation being requested was not performed because the
    user has not logged on to the network.

`Start-BitsTransfer` needs an interactive logon session. EC2 user data runs as SYSTEM at
boot, before anyone has logged on, so BITS was never going to work on this path — every
provisioned server would have failed at the same step.

The reasoning behind choosing it was right: `Invoke-WebRequest` buffers the whole response
in memory, and 2.5 GB of that on a t3.small is how the step fails the other way. `curl.exe`
has shipped in System32 since Server 2019, streams straight to disk, needs no session, and
retries by itself. The size is checked afterwards — a truncated download extracts into
nonsense and would otherwise surface several steps later, somewhere unrelated.

This took one attempt to diagnose rather than several, because of change 1. That change
earned itself on its first outing.

## 4. Make a failed bootstrap actually say why

The second launch got to the last step and reported "the agent never came up", not a line
more. Two faults behind that.

The transcript never arrived: `Get-Content -Tail N -Raw` asks for two mutually exclusive
things, so it threw, and the surrounding catch — there so a missing log could not stop the
report — swallowed it. Every failure report was destined to contain the throw message and
nothing else, precisely the outcome this reporting was added to prevent.

And the agent is started by a scheduled task, which discards whatever the process says on
its way out. A malformed `agent.json`, a missing folder, an unsigned executable Defender
objected to — all identical from outside. The agent is now run once in the foreground
first, stdout and stderr captured to files, purely to give a refusal somewhere to be
recorded. If it exits within eight seconds the bootstrap fails immediately with the reason
rather than after a minute of polling with none. That copy is stopped before the scheduled
task starts so the two never race for the port, and the failure path carries the agent's
own output, the task's last result, and the transcript. The poll goes 60 → 90 seconds: an
unsigned binary being scanned on first execution is plausibly slow rather than broken.

## 5. Build agent.json instead of hand-writing it

The third launch reached the agent and got the answer in one line:

    couldn't parse C:\mxb\agent.json: invalid escape at line 5 column 19

The config was assembled as JSON text inside a PowerShell here-string, with the install root
interpolated as `C:\mxb` — one backslash. So the file contained `"game_dir": "C:\mxb\\game"`,
and `\m` is not a JSON escape. The agent has therefore never been able to read its own
config on any provisioned server; this was waiting under every launch that got far enough
to reach it, and nothing before today ever did.

`ConvertTo-Json` does the escaping, removing the whole class of mistake rather than this one
instance of it — and it is what `Send-Stage` was already relying on a few lines above. The
file is parsed once on the box straight after being written, so a config that cannot be read
fails where it was created rather than as an unexplained exit later.

---

### Notes for the reviewer

- Migration `control-plane/migrations/0007_bootstrap_progress.sql` **has already been applied
  to the production D1 database, and the Worker is already deployed.** Nothing to run on merge.
- Rebased onto `main` after #116. The CHANGELOG conflict resolved to both `Unreleased`
  sections kept, this branch's below the one from #116; the branch's obsolete
  `The gear repair no longer invents a helmet` heading was dropped because `main` has since
  folded that content into the `v0.9.0` section.
- `Servers.tsx` auto-merged with #116's scroll fix and default-region change; both verified
  still present.

**Verified green:** `cargo test --locked` 547 passed / 0 failed; `npm run typecheck`,
`npm run lint` (0 errors, the 2 pre-existing warnings), `npm run build`; control-plane
`wrangler types`, `tsc --noEmit`, `vitest run` 32 passed (4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
