### PR TITLE
fix(shop): stop a sign-in from signing the user straight back out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,6 +256,22 @@
   FrostMod away from anyone the check is wrong about.
 
 ### Fixed
+- **Signing in to the Shop no longer signs you straight back out.** A sign-in would land, show
+  the Purchases tab for a second, and drop to the signed-out screen again — every time, for
+  anyone whose stored session had gone stale. Your purchases are read out of a hidden browser
+  window that stays parked on the store, and nothing was closing that window when the session
+  underneath it changed: it kept the page it already had, which — after a failed read, or a
+  sign-out — was the store's own login form. So the very first thing a successful sign-in did
+  was re-read that form and conclude the session had expired. Signing in now drops the window
+  along with the old cookies, and re-loads the purchases page rather than trusting whatever was
+  on screen. The same window is also dropped whenever the store answers that you are signed
+  out, so one failed read can no longer make every attempt after it fail the same way.
+- **The Purchases tab no longer claims you are signed in when you aren't.** The app remembered
+  a sign-in in a file that could outlive the browser's cookies, so opening the tab rendered as
+  signed in, failed its first read, and flipped to signed out — the same flicker, with no
+  sign-in involved. The store telling us you are signed out now clears that record. Your
+  Cloudflare pass is deliberately kept, so signing back in doesn't have to sit through a fresh
+  challenge; **Log out** still clears everything, as it always did.
 - **The MX Bikes Shop sign-in no longer loops on "Verify you are human", and your purchases
   install again.** The store now puts a Cloudflare *managed* challenge in front of every page
   the signed-in half touches — the login form, the purchases list, and the file downloads

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4614,6 +4614,12 @@ async fn shop_login(app: tauri::AppHandle) -> Result<(), String> {
         "opening the shop login window at {target} (clearing first; jar held: {})",
         shop_session::cookie_names(&stale)
     );
+    // The hidden purchases window goes first, for the same reason sign-*out* drops it: it is a
+    // browser parked on a page belonging to the session about to be thrown away. Clearing the
+    // cookies out from under a window that stays up leaves it displaying the old DOM, and that
+    // DOM is what the read straight after this sign-in would return — the login form, read back
+    // as "your session expired", which signs the user out a moment after signing them in.
+    shop_fetch::close(&app);
     if let Some(main) = app.get_webview_window(MAIN_WINDOW) {
         if let Err(e) = main.clear_all_browsing_data() {
             log::warn!("could not clear stale cookies before sign-in: {e}");

--- a/src-tauri/src/mods/mxbshop.rs
+++ b/src-tauri/src/mods/mxbshop.rs
@@ -48,12 +48,20 @@ fn looks_like_challenge(html: &str) -> bool {
 pub async fn fetch_my_downloads(app: &AppHandle, reload: bool) -> anyhow::Result<Vec<ShopItem>> {
     let html = crate::shop_fetch::downloads_html(reload).await?;
 
+    // Both of the answers below mean the window we are reading is no longer any use — it is
+    // sitting on an interstitial, or on a login form — and both tell the user to sign in again.
+    // So both drop the session and the window with it (see [`crate::shop_session::forget`]).
+    // Leaving either in place is what turned one failed read into a permanent one: the marker
+    // kept claiming a session, and the window kept answering with the same page that disproved
+    // it, right through the next sign-in.
     if looks_like_challenge(&html) {
+        crate::shop_session::forget(app);
         anyhow::bail!("MX Bikes Shop is blocking the app (Cloudflare). Please sign in again.");
     }
 
     // EDD bounces an unauthenticated user to the WordPress login form.
     if html.contains("name=\"log\"") && html.contains("name=\"pwd\"") {
+        crate::shop_session::forget(app);
         anyhow::bail!("Your MX Bikes Shop session expired — please sign in again.");
     }
 

--- a/src-tauri/src/shop_fetch.rs
+++ b/src-tauri/src/shop_fetch.rs
@@ -73,6 +73,11 @@ struct Reply {
     id: u64,
     #[serde(default)]
     html: String,
+    /// `performance.timeOrigin` — the document's own identity, and the only cheap way to tell
+    /// a page that a navigation has actually *replaced* from the one that is still on screen
+    /// while the new one loads. See [`wait_until_ready`].
+    #[serde(default)]
+    origin: f64,
 }
 
 type Waiting = Mutex<std::collections::HashMap<u64, tokio::sync::oneshot::Sender<Reply>>>;
@@ -106,15 +111,28 @@ fn listen_for_results(app: &AppHandle) {
 /// The purchases page's HTML, read from the window that is already displaying it.
 ///
 /// `reload` re-navigates first, which is what "Refresh" has to mean — the DOM otherwise stays
-/// on whatever was fetched when the window opened.
+/// on whatever was fetched when the window opened. It is also what a *fresh sign-in* means: the
+/// window that is already up was loaded by whoever was signed in before, and reading it again
+/// would answer for the old session — or, when there was none, hand back the login form that
+/// EDD serves a signed-out visitor. That is the reload's real job, not just the button's.
 pub async fn downloads_html(reload: bool) -> anyhow::Result<String> {
     let app = app()?;
-    let window = ensure_window(app).await?;
+    // A window that was *just built* has already loaded the purchases page, freshly, as itself:
+    // there is no stale DOM for a reload to replace, and re-navigating would only make the user
+    // wait through a second load and a second challenge. This is the common case after a
+    // sign-in now, since signing in drops the old window.
+    let (window, freshly_built) = ensure_window(app).await?;
 
-    if reload {
+    if reload && !freshly_built {
+        // Which document is being replaced. `navigate` returns immediately and the *old* page
+        // stays live — and `readyState === 'complete'` — for as long as the new one takes to
+        // arrive, so a readiness check that couldn't tell them apart would pass at once and
+        // read the page we just navigated away from. `Err` here (still on a challenge, script
+        // not reachable) simply leaves the wait below unconstrained.
+        let previous = probe(&window).await.ok();
         let url = format!("{SHOP_BASE}{DOWNLOADS_PATH}");
         window.navigate(url.parse()?)?;
-        wait_until_ready(&window).await?;
+        wait_until_ready_replacing(&window, previous).await?;
     }
 
     static NEXT_ID: AtomicU64 = AtomicU64::new(1);
@@ -212,7 +230,7 @@ fn download_lock() -> &'static tokio::sync::Mutex<()> {
 /// `commit_drop` — moves at all.
 pub async fn download(app: &AppHandle, slug: &str, url: &str, dir: &Path) -> anyhow::Result<PathBuf> {
     let _guard = download_lock().lock().await;
-    let window = ensure_window(app).await?;
+    let (window, _) = ensure_window(app).await?;
 
     *lock(download_dir()) = Some(dir.to_path_buf());
     *lock(download_state()) = Download::default();
@@ -339,20 +357,29 @@ fn sanitize(name: &str) -> String {
 
 // ──────────────────────────────────── the window ────────────────────────────────────
 
+/// Whether the window that is up has been seen past Cloudflare's challenge.
+///
+/// Module-level rather than a local static inside [`ensure_window`], because [`close`] has to
+/// be able to clear it: it belongs to a particular window, and a stale `true` would let the
+/// *next* window be handed out before its own challenge had cleared.
+static READY: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
 /// Build the hidden window on first use and leave it up for the session.
-async fn ensure_window(app: &AppHandle) -> anyhow::Result<tauri::WebviewWindow> {
+///
+/// The flag says whether this call is what built it — which is the same question as "is the
+/// page it is showing freshly loaded, or left over from before", and so decides whether a
+/// caller asking to reload has anything to reload away from.
+async fn ensure_window(app: &AppHandle) -> anyhow::Result<(tauri::WebviewWindow, bool)> {
     static LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
     let _guard = LOCK.lock().await;
 
-    static READY: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-
     if let Some(existing) = app.get_webview_window(WINDOW) {
         if READY.load(Ordering::Relaxed) {
-            return Ok(existing);
+            return Ok((existing, false));
         }
         wait_until_ready(&existing).await?;
         READY.store(true, Ordering::Relaxed);
-        return Ok(existing);
+        return Ok((existing, false));
     }
 
     let url: tauri::Url = format!("{SHOP_BASE}{DOWNLOADS_PATH}").parse()?;
@@ -373,7 +400,7 @@ async fn ensure_window(app: &AppHandle) -> anyhow::Result<tauri::WebviewWindow> 
 
     wait_until_ready(&window).await?;
     READY.store(true, Ordering::Relaxed);
-    Ok(window)
+    Ok((window, true))
 }
 
 /// Wait for the page to be able to run our script.
@@ -383,11 +410,25 @@ async fn ensure_window(app: &AppHandle) -> anyhow::Result<tauri::WebviewWindow> 
 /// is — has to have cleared. Polling a one-line `eval` covers both, since the challenge page is
 /// replaced by the real one when it passes.
 async fn wait_until_ready(window: &tauri::WebviewWindow) -> anyhow::Result<()> {
+    wait_until_ready_replacing(window, None).await
+}
+
+/// [`wait_until_ready`], for a page a navigation has just been asked for.
+///
+/// `replacing` is the document that has to be *gone* before the window counts as ready —
+/// identified by its `performance.timeOrigin`, which is minted per document. Without it the
+/// check answers about whatever is still on screen, which after a `navigate` is the previous
+/// page: complete, past the challenge, and wrong.
+async fn wait_until_ready_replacing(
+    window: &tauri::WebviewWindow,
+    replacing: Option<f64>,
+) -> anyhow::Result<()> {
     let deadline = std::time::Instant::now() + READY_TIMEOUT;
     let mut last: Option<String> = None;
     while std::time::Instant::now() < deadline {
         match probe(window).await {
-            Ok(()) => return Ok(()),
+            Ok(origin) if Some(origin) != replacing => return Ok(()),
+            Ok(_) => last = Some("the page it was told to leave is still loaded".to_string()),
             Err(e) => last = Some(e.to_string()),
         }
         tokio::time::sleep(Duration::from_millis(250)).await;
@@ -407,24 +448,19 @@ async fn wait_until_ready(window: &tauri::WebviewWindow) -> anyhow::Result<()> {
 /// wrong, and quietly so: Cloudflare injects its `challenge-platform/scripts/jsd` script into
 /// *ordinary* pages as well when JS detections are on, so that string is no evidence of a
 /// challenge and the window would never be declared ready.
-async fn probe(window: &tauri::WebviewWindow) -> anyhow::Result<()> {
+///
+/// Answers with the document's `performance.timeOrigin`, so a caller that has just navigated
+/// can tell the page it asked for from the one it asked to leave.
+async fn probe(window: &tauri::WebviewWindow) -> anyhow::Result<f64> {
     const PROBE_ID: u64 = 0;
     let (tx, rx) = tokio::sync::oneshot::channel();
     lock(waiting()).insert(PROBE_ID, tx);
-    let js = format!(
-        "if (window.__TAURI_INTERNALS__ && document.readyState === 'complete' \
-         && typeof window._cf_chl_opt === 'undefined' \
-         && !/^just a moment/i.test(document.title || '')) {{ \
-         window.__TAURI_INTERNALS__.invoke\
-         ('plugin:event|emit', {{ event: {event}, payload: {{id:0}} }}); }}",
-        event = js_string(RESULT_EVENT)
-    );
-    if let Err(e) = window.eval(&js) {
+    if let Err(e) = window.eval(probe_script()) {
         lock(waiting()).remove(&PROBE_ID);
         return Err(anyhow::anyhow!("{e}"));
     }
     match tokio::time::timeout(Duration::from_millis(400), rx).await {
-        Ok(Ok(_)) => Ok(()),
+        Ok(Ok(reply)) => Ok(reply.origin),
         _ => {
             lock(waiting()).remove(&PROBE_ID);
             Err(anyhow::anyhow!("still on the challenge, or not ready yet"))
@@ -432,9 +468,31 @@ async fn probe(window: &tauri::WebviewWindow) -> anyhow::Result<()> {
     }
 }
 
-/// Drop the window, so the next use rebuilds it. Signing out has to do this, or a window that
-/// is still signed in keeps answering.
+/// The probe, as its own function so a test can hold it to what it has to say.
+fn probe_script() -> String {
+    format!(
+        "if (window.__TAURI_INTERNALS__ && document.readyState === 'complete' \
+         && typeof window._cf_chl_opt === 'undefined' \
+         && !/^just a moment/i.test(document.title || '')) {{ \
+         window.__TAURI_INTERNALS__.invoke\
+         ('plugin:event|emit', {{ event: {event}, \
+         payload: {{id:0, origin: performance.timeOrigin}} }}); }}",
+        event = js_string(RESULT_EVENT)
+    )
+}
+
+/// Drop the window, so the next use rebuilds it from a fresh navigation.
+///
+/// Signing *out* has to do this, or a window that is still signed in keeps answering. Signing
+/// *in* has to do it just as much, and that is the less obvious half: the window is a browser
+/// parked on a page, and the page it is parked on was loaded by whoever was signed in before —
+/// or, if the last read failed, is the login form EDD serves a signed-out visitor. Left up, it
+/// answers the very next read with that same stale DOM, so a sign-in that genuinely succeeded
+/// is reported back as "your session expired" and the app drops straight to signed-out again.
 pub fn close(app: &AppHandle) {
+    // Cleared before the close, not after: `READY` describes the window that is going away, and
+    // a `true` left behind would let the next one be handed out before its challenge cleared.
+    READY.store(false, Ordering::Relaxed);
     if let Some(win) = app.get_webview_window(WINDOW) {
         let _ = win.close();
     }
@@ -514,11 +572,37 @@ mod tests {
         let (tx, mut rx) = tokio::sync::oneshot::channel();
         lock(waiting()).insert(4242, tx);
 
-        deliver(Reply { id: 4243, html: "injected".into() });
+        deliver(Reply { id: 4243, html: "injected".into(), origin: 0.0 });
         assert!(rx.try_recv().is_err(), "a reply for another id must not resolve this request");
 
-        deliver(Reply { id: 4242, html: "ours".into() });
+        deliver(Reply { id: 4242, html: "ours".into(), origin: 0.0 });
         assert_eq!(rx.try_recv().unwrap().html, "ours");
+    }
+
+    /// The probe has to carry the document's identity back, or a reload cannot be told from the
+    /// page it is replacing — which is how a fresh sign-in ends up reading the previous
+    /// session's DOM and reporting itself as expired.
+    #[test]
+    fn the_probe_reports_which_document_answered() {
+        let js = probe_script();
+        assert!(js.contains("performance.timeOrigin"), "{js}");
+        // The two conditions that make this a readiness check rather than a liveness one.
+        assert!(js.contains("_cf_chl_opt"), "{js}");
+        assert!(js.contains("readyState"), "{js}");
+        assert!(js.contains(RESULT_EVENT), "{js}");
+    }
+
+    /// A reply is parsed from a remote page, so every field it may omit has to have a default —
+    /// the probe sends no `html`, and the page read sends no `origin`.
+    #[test]
+    fn a_reply_may_omit_everything_but_its_id() {
+        let probe: Reply = serde_json::from_str(r#"{"id":0,"origin":1234.5}"#).unwrap();
+        assert_eq!(probe.origin, 1234.5);
+        assert_eq!(probe.html, "");
+
+        let read: Reply = serde_json::from_str(r#"{"id":3,"html":"<html></html>"}"#).unwrap();
+        assert_eq!(read.origin, 0.0);
+        assert_eq!(read.html, "<html></html>");
     }
 
     #[test]

--- a/src-tauri/src/shop_session.rs
+++ b/src-tauri/src/shop_session.rs
@@ -71,6 +71,29 @@ pub fn load_session(app: &AppHandle) {
     log::info!("restored MX Bikes Shop session ({} cookies)", cookies.len());
 }
 
+/// Forget the sign-in, without touching the browser's cookies.
+///
+/// For the case where the store itself has told us we are signed out — the purchases page came
+/// back as the login form, or as Cloudflare's interstitial. Two things have to happen, and
+/// neither used to:
+///
+///  - The stored marker goes. Otherwise `shop_status` keeps answering `true` from a file that
+///    has outlived the browser's cookies, so every visit to the Purchases tab renders as signed
+///    in, fails its first read, and drops to signed out — the "logged in for a second" flicker,
+///    with no sign-in involved at all.
+///  - The hidden window goes, so the next read starts from a fresh navigation instead of the
+///    signed-out DOM that produced this.
+///
+/// What stays is the cookie jar. Those cookies are dead as a session, but the `cf_clearance`
+/// among them is not, and dropping it makes the next sign-in pay for a fresh managed challenge
+/// — the slowest and least reliable part of the whole flow. [`clear_session`] is the one that
+/// clears cookies, because "Log out" has to mean the account is really let go of.
+pub fn forget(app: &AppHandle) {
+    cookie_session::remove(app, &SITE);
+    app.state::<ShopSession>().set(false);
+    crate::shop_fetch::close(app);
+}
+
 pub fn clear_session(app: &AppHandle) {
     cookie_session::remove(app, &SITE);
     app.state::<ShopSession>().set(false);

--- a/src/Components/Shop/MyDownloads.tsx
+++ b/src/Components/Shop/MyDownloads.tsx
@@ -158,7 +158,10 @@ export default function MyDownloads({ refreshKey }: MyDownloadsProps) {
       if (ok) {
         setLoggedIn(true);
         toast.success(tRef.current("shop.signedIn"));
-        void loadDownloads();
+        // `reload`, like the Refresh buttons: the page is read out of a hidden window, and a
+        // sign-in is precisely the moment its contents stop being about the right person. A
+        // read that didn't say so would answer from the page the previous session left behind.
+        void loadDownloads(true);
       } else {
         toast.error(tRef.current("shop.sessionFailed"));
       }


### PR DESCRIPTION
Reported against the current beta: signing in to the Shop lands, shows Purchases for a second, and drops back to the signed-out screen — reproducibly, for anyone whose stored session had gone stale.

## What was happening

The purchases page is read out of a hidden WebView parked on the store (`shop-fetch`, added in #119, because Cloudflare's managed challenge means an HTTP client can't read those pages). Nothing dropped that window when the session underneath it changed, so it kept whatever page it already had — which after a failed read, or a sign-out, is the login form EDD serves a signed-out visitor.

1. The stored session goes stale. `shop_session.json` is a marker file that can outlive the browser's cookies, and `load_session` restores "signed in" from it unconditionally.
2. Opening Purchases renders as signed in, builds the hidden window, and loads the login form. `fetch_my_downloads` matches `name="log"`/`name="pwd"` → *"Your MX Bikes Shop session expired"* → the frontend's `/sign in|session/i` test flips the tab to signed out.
3. That window stays up on the login form, and `READY` stays `true`.
4. Signing in succeeds — cookies captured, `shop-auth` fires, the tab shows signed in. Then `loadDownloads()` runs with `reload=false`, so `ensure_window` hands back the **existing** window without re-navigating and re-reads the same stale form. *"Session expired"* → signed out again.

Once that window existed, every later attempt hit the same DOM, so the loop never broke on its own.

## Changes

- **`shop_login` closes the shop-fetch window before clearing the cookie jar** — the same order sign-out already used, and for the same reason: a window left up when its cookies go is a window displaying someone else's page.
- **`shop_session::forget`** — the store answering "signed out" now drops the stored marker *and* the window. Without the marker going, `shop_status` kept answering `true` from a file that had outlived the browser's cookies, so merely opening the tab rendered as signed in, failed its read, and flicked to signed out with no sign-in involved — the same flicker by a second route. Cookies are deliberately kept: they're dead as a session, but the `cf_clearance` among them isn't, and re-earning a managed challenge is the slowest part of the flow. **Log out** still clears everything.
- **A fresh sign-in reloads** instead of trusting what's on screen, and the reload waits for a genuinely new document. `navigate` returns immediately while the old page stays live and `readyState === 'complete'`, so the readiness probe was passing instantly and reading the page it had just left; it reports `performance.timeOrigin` now, which is minted per document.
- **A reload right after the window is built is skipped** — it has already loaded the page once, and a second navigation only buys a second challenge to sit through. This is the common path after a sign-in now, since signing in drops the window.
- **`READY` moves to module scope** so closing the window clears it, rather than handing the next window out as ready before its own challenge cleared.

## Testing

- `cargo test` — 554 pass. One pre-existing failure, `gearrepair::a_move_that_fails_part_way_puts_everything_back`: it sets a directory to `0o500` to force a move to fail, which root ignores. Confirmed it fails identically on a clean checkout of `main`.
- `npm run typecheck` and `npm run lint` — clean (the 2 lint warnings are pre-existing, in unrelated files).
- New unit tests cover the probe carrying the document's identity, and `Reply` tolerating each field the two callers omit.
- Not exercised end-to-end: the sign-in flow itself needs a display and store access, neither available in the dev container. The WebView behaviour is reasoned from the code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4FxuFXoyRGY3XpeKQtCkZ)_