### PR TITLE
perf(paint): unpack a paint in a fifth of a second, not four

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,19 @@
 - **FrostMod still starts when a runtime is missing.** It's a warning, not a gate: we can't
   tell from outside which PCs manage to inject anyway, and refusing to launch would take
   FrostMod away from anyone the check is wrong about.
+- **Opening a paint in the viewer is fast.** A gear paint is tens of megabytes of compressed
+  pixels — three 4096² sheets — and every one of them was inflated one after another, then
+  copied whole before being downscaled. They now inflate in parallel off a header walk that
+  reads the image table without touching a pixel, and the copy is gone. The roughness sheet
+  isn't decoded at all: the viewer samples a diffuse and a normal map, so that plane was 67 MB
+  allocated, resized, sent to the webview and turned into a mipmapped texture nothing binds.
+  Paints are also kept once decoded, so re-opening one or flicking back to it in the picker
+  costs nothing.
+- **Developer builds no longer run the paint decoder unoptimized.** `cargo`'s default leaves
+  every crate at `opt-level = 0` in a debug build, and essentially all of this work happens
+  inside `flate2` and `image`. Dependencies now build optimized and our own crate lightly so,
+  which is what made a locally-run app take seconds where the shipped one took a fraction of
+  one. Release builds are untouched.
 
 ### Fixed
 - **The MX Bikes Shop sign-in no longer loops on "Verify you are human", and your purchases

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -116,6 +116,19 @@ tauri = { version = "2", features = ["test"] }
 # shipped binary keeps the minimal `time`-only tokio it already had.
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }
 
+# `tauri dev` builds this profile, and cargo's default leaves everything at opt-level 0 —
+# which is fine for our own glue but not for the crates doing the heavy lifting. Unpacking one
+# 36 MB gear paint (three 4096² textures) spends nearly all its time inside `flate2`'s inflate
+# and `image`'s resize: 4.3 s unoptimized against 0.33 s optimized.
+[profile.dev]
+# The local crate too, but only lightly: a creator-sealed `.pnt` is decrypted a byte at a time
+# over the whole file before it is even parsed, and that loop is ours. Keeps debug info.
+opt-level = 1
+
+[profile.dev.package."*"]
+# Dependencies are never stepped through, and they're built once and then cached.
+opt-level = 3
+
 # Ship a hardened, hard-to-reverse binary. cargo defaults leave the symbol table in and
 # emit no debug info; this strips symbols and leans on the optimizer to erase structure.
 # opt-level stays at 3 so the viewer's hot paths aren't sacrificed for it.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -51,6 +51,9 @@ use frostmod::ReloadOutcome;
 use frostmod_manage::{FrostmodProcess, FrostmodStatus, InstallReport};
 use library::InstalledMod;
 use modwatch::ModWatcher;
+// Decoding a paint's textures is per-texture CPU work over no shared state, and every path
+// that does it wants the same treatment — so this sits here rather than in one function.
+use rayon::prelude::*;
 use profilewatch::ProfileWatcher;
 use mods::mxb::WpModsSource;
 use mods::{ModDetail, ModRating, ModSort, ModSource, ModSummary};
@@ -696,8 +699,44 @@ async fn unpack_paint(path: String) -> Result<Vec<paint::PaintTexture>, String> 
         .map_err(|e| format!("unpack_paint task failed: {e}"))?
 }
 
+/// Paints decoded for the viewer, so re-opening one doesn't inflate it a second time.
+///
+/// The picker re-runs this on every selection change and on every re-open, and a gear paint is
+/// tens of megabytes of DEFLATE — the pixels behind an entry, on the other hand, are small,
+/// because each is downscaled to 1024² before it is stored.
+const PAINT_CACHE_CAP: usize = 4;
+
+fn paint_cache() -> &'static std::sync::Mutex<lru::Lru<Vec<paint::PaintTexture>>> {
+    static CACHE: std::sync::OnceLock<std::sync::Mutex<lru::Lru<Vec<paint::PaintTexture>>>> =
+        std::sync::OnceLock::new();
+    CACHE.get_or_init(|| std::sync::Mutex::new(lru::Lru::new(PAINT_CACHE_CAP)))
+}
+
 fn unpack_paint_blocking(path: String) -> Result<Vec<paint::PaintTexture>, String> {
-    paint::unpack_file(std::path::Path::new(&path)).map_err(|e| format!("{e:#}"))
+    let t0 = std::time::Instant::now();
+    // Path *and* mtime, as the bike cache does, so a paint re-saved under the same name misses.
+    let key = bike_cache_key(&path);
+    if let Some(t) = paint_cache().lock().ok().and_then(|mut c| c.get(&key).cloned()) {
+        log::info!("unpack_paint {path}: cache hit ({:?})", t0.elapsed());
+        return Ok(t);
+    }
+
+    let textures = paint::unpack_file(std::path::Path::new(&path)).map_err(|e| format!("{e:#}"))?;
+    log::info!(
+        "unpack_paint {path}: {} texture(s) in {:?} | {:.1} MB resident in the texture store",
+        textures.len(),
+        t0.elapsed(),
+        texstore::resident_bytes() as f64 / (1024.0 * 1024.0),
+    );
+    if let Ok(mut c) = paint_cache().lock() {
+        // Cloning an entry copies names, sizes and tokens — never pixels, which stay in the
+        // texture store. The evicted paint's go with it; nothing else holds those tokens.
+        if let Some(dropped) = c.insert(key, textures.clone()) {
+            let tokens: Vec<String> = dropped.iter().map(|t| t.token.clone()).collect();
+            texstore::release(&tokens);
+        }
+    }
+    Ok(textures)
 }
 
 // ── Paint studio ────────────────────────────────────────────────────────────────────
@@ -1043,7 +1082,6 @@ async fn load_bike_model(source: String) -> Result<BikeModel, String> {
 }
 
 fn load_bike_model_blocking(source: String) -> Result<BikeModel, String> {
-    use rayon::prelude::*;
     let t0 = std::time::Instant::now();
     let key = bike_cache_key(&source);
     if let Some(m) = bike_cache().lock().ok().and_then(|mut c| c.get(&key).cloned()) {
@@ -1168,7 +1206,7 @@ fn load_bike_model_blocking(source: String) -> Result<BikeModel, String> {
                 (
                     BikePaint {
                         name: name.clone(),
-                        textures: pnt.par_iter().map(paint::to_texture).collect(),
+                        textures: pnt.into_par_iter().map(paint::into_texture).collect(),
                         changes_preview: false, // resolved below, once bindings are known
                     },
                     *shipped,
@@ -1915,7 +1953,7 @@ async fn load_stock_gear_model(
             Some(p) => std::fs::read(&p)
                 .ok()
                 .and_then(|d| paint::decode_any(&d).ok())
-                .map(|pnt| pnt.iter().map(paint::to_texture).collect())
+                .map(|pnt| pnt.into_par_iter().map(paint::into_texture).collect())
                 .unwrap_or_default(),
             // Nothing to preview → the stock look, which is what the mesh carries. Not the
             // first `.pnt` in the folder: that's a paint like any other, and picking it here
@@ -2278,7 +2316,7 @@ fn load_gear_model_blocking(
     let mut main_side = GearSide::new(names_of(&main_pnt));
     let mut goggle_side = GearSide::new(names_of(&goggle_pnt));
     let mut out: Vec<paint::PaintTexture> =
-        main_pnt.iter().chain(goggle_pnt.iter()).map(paint::to_texture).collect();
+        main_pnt.into_par_iter().chain(goggle_pnt).map(paint::into_texture).collect();
     // The look the model ships with, before any paint: the textures embedded in the meshes.
     if stock || stock_goggles {
         let mut embedded: Vec<paint::PaintTexture> = Vec::new();
@@ -2929,7 +2967,7 @@ fn loose_paint_named(
     let hit = files.iter().find(|(n, _)| {
         gear_folder_paint_name(n, folder).is_some_and(|p| p.eq_ignore_ascii_case(want))
     })?;
-    Some(paint::decode_any(&hit.1).ok()?.iter().map(paint::to_texture).collect())
+    Some(paint::decode_any(&hit.1).ok()?.into_par_iter().map(paint::into_texture).collect())
 }
 
 /// A paint the game itself ships, from `<folder>/<sub>/<paint>.pnt` — `sub` being `paints`
@@ -2953,7 +2991,7 @@ fn load_pkz_paint(
     read_pkz_entry(pkz, &format!("{folder}/{sub}/{paint}.pnt"))
         .or_else(|| read_pkz_first(pkz, &format!("{folder}/{sub}/"), ".pnt"))
         .and_then(|d| paint::decode_any(&d).ok())
-        .map(|p| p.iter().map(paint::to_texture).collect())
+        .map(|p| p.into_par_iter().map(paint::into_texture).collect())
         .unwrap_or_default()
 }
 
@@ -2993,7 +3031,8 @@ fn load_rider_paint(
     // resolves instead of silently dropping off the preview.
     let profile = rider_profile_or_stock(profile);
     let data = read_rider_paint_file(cfg, base, profile, sub, paint)?;
-    let textures: Vec<_> = paint::decode_any(&data).ok()?.iter().map(paint::to_texture).collect();
+    let textures: Vec<_> =
+        paint::decode_any(&data).ok()?.into_par_iter().map(paint::into_texture).collect();
     if textures.is_empty() {
         return None;
     }

--- a/src-tauri/src/paint.rs
+++ b/src-tauri/src/paint.rs
@@ -3,6 +3,7 @@ use flate2::read::DeflateDecoder;
 use flate2::write::DeflateEncoder;
 use flate2::Compression;
 use md5::{Digest, Md5};
+use rayon::prelude::*;
 use serde::Serialize;
 use std::io::{Cursor, Read, Write};
 use std::path::Path;
@@ -50,7 +51,18 @@ fn read_name(buf: &[u8], off: usize) -> Result<String> {
     Ok(String::from_utf8_lossy(&raw[..n]).into_owned())
 }
 
-pub fn decode(buf: &[u8]) -> Result<Vec<PntTexture>> {
+/// One image's header, and where its payload sits in the file.
+struct ImageHeader {
+    name: String,
+    width: u32,
+    height: u32,
+    /// The deflate payload's byte range within the whole `.pnt`.
+    data: std::ops::Range<usize>,
+}
+
+/// Walk the image table without inflating a pixel — the same walk [`texture_names`] does,
+/// keeping the payload ranges so the planes can then be inflated in any order.
+fn image_headers(buf: &[u8]) -> Result<Vec<ImageHeader>> {
     if buf.len() < HEADER_SIZE || &buf[..4] != MAGIC {
         bail!("not a .pnt file (bad magic)");
     }
@@ -68,34 +80,65 @@ pub fn decode(buf: &[u8]) -> Result<Vec<PntTexture>> {
         }
 
         let data_start = off + IMAGE_HEADER_SIZE + IMAGE_PADDING;
-        let comp_len = data_size - IMAGE_PADDING;
-        let data_end = data_start + comp_len;
+        let data_end = data_start + (data_size - IMAGE_PADDING);
         if data_end > buf.len() {
             bail!("texture {i} '{name}': payload runs past end of file");
         }
 
-        let mut rgba = Vec::with_capacity((width as usize) * (height as usize) * 4);
-        DeflateDecoder::new(&buf[data_start..data_end])
-            .read_to_end(&mut rgba)
-            .with_context(|| format!("inflate texture {i} '{name}'"))?;
-
-        let expected = (width as usize) * (height as usize) * 4;
-        if rgba.len() != expected {
-            bail!(
-                "texture {i} '{name}': inflated {} bytes, expected {expected} ({width}x{height} RGBA)",
-                rgba.len()
-            );
-        }
-
-        out.push(PntTexture {
+        out.push(ImageHeader {
             name,
             width,
             height,
-            rgba,
+            data: data_start..data_end,
         });
-        off = data_start + comp_len;
+        off = data_end;
     }
     Ok(out)
+}
+
+pub fn decode(buf: &[u8]) -> Result<Vec<PntTexture>> {
+    decode_where(buf, |_| true)
+}
+
+/// [`decode`], inflating only the textures `want` accepts.
+///
+/// The filter runs on the name, before any of that texture's pixels exist: a 4096² plane the
+/// caller is going to throw away otherwise costs a 67 MB allocation and its share of the
+/// inflate. Planes are independent, so they inflate in parallel — the payload ranges come off
+/// the header walk, which is the only part that has to be sequential.
+pub fn decode_where(
+    buf: &[u8],
+    want: impl Fn(&str) -> bool + Sync,
+) -> Result<Vec<PntTexture>> {
+    image_headers(buf)?
+        .into_par_iter()
+        .enumerate()
+        .filter(|(_, h)| want(&h.name))
+        .map(|(i, h)| {
+            let expected = (h.width as usize) * (h.height as usize) * 4;
+            let mut rgba = Vec::with_capacity(expected);
+            DeflateDecoder::new(&buf[h.data])
+                .read_to_end(&mut rgba)
+                .with_context(|| format!("inflate texture {i} '{}'", h.name))?;
+
+            if rgba.len() != expected {
+                bail!(
+                    "texture {i} '{}': inflated {} bytes, expected {expected} ({}x{} RGBA)",
+                    h.name,
+                    rgba.len(),
+                    h.width,
+                    h.height
+                );
+            }
+
+            Ok(PntTexture {
+                name: h.name,
+                width: h.width,
+                height: h.height,
+                rgba,
+            })
+        })
+        .collect()
 }
 
 /// The texture names a `.pnt` supplies, read from the headers alone.
@@ -135,13 +178,22 @@ pub fn texture_names_any(buf: &[u8]) -> Result<Vec<String>> {
 }
 
 pub fn decode_any(buf: &[u8]) -> Result<Vec<PntTexture>> {
+    decode_any_where(buf, |_| true)
+}
+
+/// [`decode_any`], for a caller that only wants some of the textures — the same pairing as
+/// [`decode`]/[`decode_where`].
+pub fn decode_any_where(
+    buf: &[u8],
+    want: impl Fn(&str) -> bool + Sync,
+) -> Result<Vec<PntTexture>> {
     if buf.len() >= 4 && &buf[..4] == MAGIC {
-        return decode(buf);
+        return decode_where(buf, want);
     }
     if let Some(plain) = crate::pkz::read_sidecar_blob(buf) {
-        return decode(&plain);
+        return decode_where(&plain, want);
     }
-    decode(buf)
+    decode_where(buf, want)
 }
 
 /// Whether `buf` is a paint stored in the open format this module also writes.
@@ -279,19 +331,35 @@ pub fn extract_edf_textures_where(
         .collect()
 }
 
-pub fn to_texture(t: &PntTexture) -> PaintTexture {
-    if t.width.max(t.height) > MAX_EDGE {
-        if let Some(img) = image::RgbaImage::from_raw(t.width, t.height, t.rgba.clone()) {
+/// A decoded texture, downscaled if it is larger than the viewer needs, moved into the
+/// texture store.
+///
+/// Takes the pixels rather than borrowing them: a 4096² plane is 67 MB, and copying one is
+/// the same order of work as the downscale it feeds.
+pub fn into_texture(t: PntTexture) -> PaintTexture {
+    let PntTexture {
+        name,
+        width,
+        height,
+        rgba,
+    } = t;
+    // `from_raw` takes the buffer and hands back nothing when it isn't `w*h*4`, so the length
+    // is checked here instead — a truncated plane then goes through verbatim, exactly as
+    // before, and the viewer renders it grey.
+    if width.max(height) > MAX_EDGE && rgba.len() == (width as usize) * (height as usize) * 4 {
+        if let Some(img) = image::RgbaImage::from_raw(width, height, rgba) {
             let scaled = image::DynamicImage::ImageRgba8(img).thumbnail(MAX_EDGE, MAX_EDGE);
             return store_rgba(
-                &t.name,
+                &name,
                 scaled.width(),
                 scaled.height(),
                 scaled.to_rgba8().into_raw(),
             );
         }
+        // Unreachable — the only thing `from_raw` rejects is the length checked above.
+        return store_rgba(&name, width, height, Vec::new());
     }
-    store_rgba(&t.name, t.width, t.height, t.rgba.clone())
+    store_rgba(&name, width, height, rgba)
 }
 
 pub fn decode_image(name: &str, bytes: &[u8]) -> Option<PaintTexture> {
@@ -304,14 +372,46 @@ pub fn decode_image(name: &str, bytes: &[u8]) -> Option<PaintTexture> {
     Some(store_rgba(name, w, h, rgba.into_raw()))
 }
 
+/// Whether the viewer can do anything with a texture of this name.
+///
+/// It samples a diffuse and — the one companion it does read — a `_n` normal map. Every other
+/// map is a full-size plane inflated, downscaled, shipped over IPC and turned into a mipmapped
+/// `DataTexture` that nothing ever binds: a gear paint's roughness sheet alone is 4096², and
+/// dropping it is the difference between allocating 67 MB and not.
+///
+/// Safe to drop rather than merely ignore, because the binder never points a submesh at one:
+/// [`crate::edf::is_companion_texture`] is what keeps them out of the declared list in the
+/// first place, and reusing it here is what stops the two notions drifting apart.
+fn viewer_binds(name: &str) -> bool {
+    !crate::edf::is_companion_texture(name) || name.to_ascii_lowercase().ends_with("_n")
+}
+
 pub fn unpack_file(path: &Path) -> Result<Vec<PaintTexture>> {
     let bytes = std::fs::read(path).with_context(|| format!("read {path:?}"))?;
-    Ok(decode_any(&bytes)?.iter().map(to_texture).collect())
+    Ok(decode_any_where(&bytes, viewer_binds)?
+        .into_par_iter()
+        .map(into_texture)
+        .collect())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// What opening a paint in the viewer actually costs, against a real one. Run under the
+    /// `dev` profile — that's what `tauri dev` builds, and it's where this was ever slow:
+    /// `MXB_PNT=<paint.pnt> cargo test --bins unpack_file_timing -- --ignored --nocapture`
+    #[test]
+    #[ignore]
+    fn unpack_file_timing() {
+        let path = std::env::var("MXB_PNT").expect("set MXB_PNT");
+        let t = std::time::Instant::now();
+        let texs = unpack_file(std::path::Path::new(&path)).expect("unpack");
+        eprintln!("unpack_file({path}) -> {} texture(s) in {:?}", texs.len(), t.elapsed());
+        for x in &texs {
+            eprintln!("  '{}' {}x{}", x.name, x.width, x.height);
+        }
+    }
 
     #[test]
     #[ignore]
@@ -445,14 +545,55 @@ mod tests {
     }
 
     #[test]
-    fn to_texture_stores_pixels_verbatim() {
-        let texs = decode(FIXTURE_PNT).unwrap();
-        let out = to_texture(&texs[0]);
+    fn into_texture_stores_pixels_verbatim() {
+        let mut texs = decode(FIXTURE_PNT).unwrap();
+        let out = into_texture(texs.remove(0));
         assert_eq!((out.width, out.height), (4, 4));
         assert_eq!(
             *crate::texstore::get(&out.token).expect("token resolves"),
             fixture_stored_pixels()
         );
+    }
+
+    /// The decode went parallel; the file format did not. Every texture must still come back
+    /// in the order the image table lists it — material indices count that list, so a shuffle
+    /// would silently move a paint's textures onto the wrong parts.
+    #[test]
+    fn decode_keeps_the_files_texture_order() {
+        let texs = [tex("livery", 4, 4), tex("livery_n", 2, 2), tex("plate", 8, 8)];
+        let bytes = encode("p", &texs).unwrap();
+        let out = decode(&bytes).expect("decode what we just encoded");
+        assert_eq!(
+            out.iter().map(|t| t.name.as_str()).collect::<Vec<_>>(),
+            ["livery", "livery_n", "plate"],
+        );
+        for (a, b) in out.iter().zip(&texs) {
+            assert_eq!((a.width, a.height, &a.rgba), (b.width, b.height, &b.rgba));
+        }
+    }
+
+    /// Filtering happens before the inflate, and it must not disturb what survives it.
+    #[test]
+    fn decode_where_skips_only_what_it_is_told_to() {
+        let texs = [tex("livery", 4, 4), tex("livery_n", 2, 2), tex("livery_r", 8, 8)];
+        let bytes = encode("p", &texs).unwrap();
+        let out = decode_where(&bytes, |n| !n.ends_with("_r")).expect("decode");
+        assert_eq!(
+            out.iter().map(|t| t.name.as_str()).collect::<Vec<_>>(),
+            ["livery", "livery_n"],
+        );
+        assert_eq!(out[1].rgba, texs[1].rgba, "the kept planes decode unchanged");
+    }
+
+    /// The viewer samples a diffuse and a `_n` normal map. Dropping `_n` would strip the
+    /// relief off every gear paint, which is exactly the mistake this filter invites.
+    #[test]
+    fn viewer_binds_keeps_the_normal_map_and_nothing_else() {
+        assert!(viewer_binds("rider"), "the livery itself");
+        assert!(viewer_binds("rider_n"), "the normal map the viewer binds");
+        assert!(!viewer_binds("rider_r"), "roughness");
+        assert!(!viewer_binds("rider_s"), "specular");
+        assert!(!viewer_binds("rider_roughness"), "the exporter's spelling");
     }
 
     #[test]


### PR DESCRIPTION
Opening a gear/rider paint in the viewer took seconds.

## Measured

Same machine, same real files, both dev builds (`unpack_file_timing`, added here as an ignored test):

| paint | before (`main`) | after |
|---|---|---|
| `Frost Graphite ALP 2.pnt` — 36 MB, three 4096² sheets | **4.07 s** | **0.197 s** |
| `Astars HRC SCENZ Grey.pnt` — 10.5 MB, sealed | **1.82 s** | **0.070 s** |

Re-opening the same paint is a cache hit at ~0 ms.

## What was wrong

**The `dev` profile had no tuning at all.** `tauri dev` builds it, and cargo's default leaves every crate at `opt-level = 0` — which is where essentially all of this work happens, inside `flate2`'s inflate and `image`'s resize. That was the bulk of the four seconds. Dependencies now build at 3 and our own crate at 1; a sealed `.pnt` is decrypted a byte at a time over the whole file before it is even parsed, and that loop is ours. `[profile.release]` is untouched.

**The decode also left real time on the floor, in every build:**

- Planes inflated one after another. `decode` now walks the image table first — the same walk `texture_names` does, touching no pixels — and keeps each payload's byte range, which is what lets the planes inflate in any order.
- Every decoded plane was copied before being downscaled: 67 MB per 4096² sheet, at all seven decode sites. `into_texture` replaces `to_texture` and moves the buffer instead.
- The roughness sheet was decoded and thrown away. The viewer binds a diffuse and `_n`; `_r` was 67 MB allocated, downscaled, sent over IPC and turned into a mipmapped `DataTexture` nothing samples.
- Nothing cached an unpacked paint, so the picker re-decoded on every selection change and every re-open.

## Two things worth a reviewer's eye

**Dropping companion maps is safe because of who else uses the predicate.** The filter reuses `edf::is_companion_texture` — the same one that keeps those names out of the binder's declared list in the first place — so a submesh is never pointed at one, and dropping them cannot leave a part grey. `_n` is the single exception and is deliberately kept, with a test pinning that.

**Texture order survives going parallel.** Material indices count that list, so a shuffle would silently move a paint's textures onto the wrong parts. `decode_keeps_the_files_texture_order` pins it.

## Verified

- 561 tests pass, including four new ones (order, filtering, `_n` survives, verbatim pixels).
- `cargo check --release` and `cargo check --target x86_64-pc-windows-gnu` both clean, no new warnings.

**Not yet verified — needs a human:** that a gear paint still *renders* identically in the viewer, normal map included. The `_n` map is the one companion this change deliberately keeps, and it's the thing most likely to break. Timings and tests say the pixels are right; nobody has looked at the model.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)