### PR TITLE
feat(servers): mirror the bike pack, and keep a session in step with the grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased -- paint sync keeps up with the grid
+
+### Fixed
+- **A rider who joins after you now shows up properly.** The pull happened once, at launch, so
+  paint sync was lopsided: whoever joined last saw everyone, and whoever was there first never
+  saw anyone who arrived afterwards -- they had pulled before those riders existed. The app now
+  keeps checking for the length of the session and installs what turns up.
+
+### Changed
+- **A roster means one grid, not the whole platform.** `GET /v1/roster` took a server and
+  ignored it, because nothing recorded where anyone was, so every rider downloaded the paints
+  of every other enrolled rider. Each app now reports the server it launched into, and a roster
+  returns the riders actually on it. A rider whose app goes quiet for ten minutes drops out.
+
 ## Unannounced — a debugger can't ride along
 
 Left out of the release notes on purpose: a hardening measure advertised is a hardening

--- a/control-plane/migrations/0008_presence.sql
+++ b/control-plane/migrations/0008_presence.sql
@@ -1,0 +1,25 @@
+-- Who is on which server, so a roster can mean "this grid" rather than "everyone".
+--
+-- `roster` has always taken a `?server=` and ignored it, because nothing knew where anyone
+-- was. That was survivable while the platform was one invite-only group; it is wrong as a
+-- design. Every rider downloads the paints of every other enrolled rider, most of whom they
+-- will never share a session with.
+--
+-- Reported by each player's own app, which already knows the server it launched into — the
+-- dedicated server's log knows too, but the agent has no way to tell us yet, and waiting for
+-- that would leave the scoping unbuilt.
+--
+-- Deliberately not a column on `accounts`: presence is short-lived and rewritten constantly,
+-- identity is neither, and keeping them apart leaves room for the agent to report the same
+-- thing later without touching the account row.
+CREATE TABLE presence (
+  account_id  TEXT PRIMARY KEY REFERENCES accounts (id) ON DELETE CASCADE,
+  -- The registry id, or a normalized host:port for a server we do not run. Matches the key
+  -- the app already computes with `server_key_for`.
+  server_id   TEXT NOT NULL,
+  -- Refreshed on every heartbeat. A row older than the cutoff is treated as gone: an app
+  -- that crashed or a player who quit should not haunt a grid forever.
+  updated_at  INTEGER NOT NULL
+);
+
+CREATE INDEX presence_server ON presence (server_id, updated_at);

--- a/control-plane/src/bootstrap.ts
+++ b/control-plane/src/bootstrap.ts
@@ -147,6 +147,31 @@ if (-not (Test-Path "${ROOT}\\game\\mxbikes.exe")) {
   Move-Item -Path "$($inner.Directory.FullName)\\*" -Destination "${ROOT}\\game" -Force
 }
 
+# The bikes. A dedicated server refuses any bike it does not itself have installed, which is
+# why a freshly provisioned one rejects every rider on a mod bike -- the base install carries
+# only stock content. These are mirrored in R2 and listed by the control plane, so the box
+# fetches them itself at cloud speed rather than anyone uploading gigabytes from home.
+#
+# Best-effort: a server with no mod bikes is still a working server for stock ones, and is a
+# far better outcome than destroying the instance over content that can be added later.
+Send-Stage -Stage "installing bikes"
+try {
+  $bikesDir = "${ROOT}\\game\\mods\\bikes"
+  New-Item -ItemType Directory -Force -Path $bikesDir | Out-Null
+  $listing = Invoke-RestMethod -Uri "${input.controlPlaneUrl}/v1/content/bikes" -TimeoutSec 60
+  $count = 0
+  foreach ($bike in $listing.bikes) {
+    $dest = Join-Path $bikesDir $bike.name
+    & $curl -L --fail --silent --show-error --retry 3 --retry-delay 5 \`
+      -o $dest "${input.controlPlaneUrl}/v1/content/bikes/$($bike.name)"
+    if ($LASTEXITCODE -eq 0) { $count = $count + 1 }
+    else { Write-Output "couldn't fetch $($bike.name) (curl $LASTEXITCODE)" }
+  }
+  Write-Output "installed $count of $($listing.bikes.Count) bikes"
+} catch {
+  Write-Output "couldn't install the bike pack: $_"
+}
+
 Send-Stage -Stage "installing the agent"
 Write-Output "fetching the agent"
 Invoke-WebRequest -Uri "${input.agentUrl}" -OutFile "${ROOT}\\mxb-agent.exe" -UseBasicParsing

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -29,6 +29,7 @@ import {
   isPublicGameAddress,
   isRegion,
   isRelDest,
+  isServerKey,
   isRiderName,
   isServerName,
   isSha256,
@@ -126,6 +127,7 @@ async function route(request: Request, env: Env): Promise<Response> {
   if (method === "PUT" && path === "/v1/loadout") return putLoadout(request, account, env);
   if (method === "PUT" && path === "/v1/loadouts") return putLoadouts(request, account, env);
   if (method === "GET" && path === "/v1/roster") return roster(url, env);
+  if (method === "PUT" && path === "/v1/presence") return putPresence(request, account, env);
   if (method === "POST" && path === "/v1/servers") return registerServer(request, account, env);
   if (method === "GET" && path === "/v1/servers/mine") return myServers(account, env);
   if (method === "GET" && path === "/v1/fleet") return fleetState(account, env);
@@ -1092,47 +1094,80 @@ async function connectedCount(
   }
 }
 
+/** How long a presence heartbeat counts for before the rider is treated as gone. */
+const PRESENCE_TTL_MS = 10 * 60 * 1000;
+
 /**
- * Every rider currently registered against a server, with what they are wearing.
+ * "I am on this server."
  *
- * This is what the app polls to know which paints to fetch. Until the agent reports live
- * rosters it returns the whole enrolled set, which on an invite-only server is close enough
- * to be useful and is a strict superset of who is actually on.
+ * Reported by the player's own app, which knows the server it launched into. That is what
+ * lets a roster mean one grid instead of every enrolled account — see `0008_presence.sql`.
+ *
+ * One row per account: a rider is in one place at a time, and the last thing they said wins.
+ */
+async function putPresence(request: Request, account: Account, env: Env): Promise<Response> {
+  const body = await readJson(request);
+  if (!body) return json(400, { error: "expected a JSON body" });
+  const { serverId } = body as { serverId?: unknown };
+  if (!isServerKey(serverId)) return json(400, { error: "that isn't a server" });
+
+  await env.DB.prepare(
+    "INSERT INTO presence (account_id, server_id, updated_at) VALUES (?, ?, ?)" +
+      " ON CONFLICT(account_id) DO UPDATE SET server_id = excluded.server_id," +
+      " updated_at = excluded.updated_at",
+  )
+    .bind(account.id, (serverId as string).trim(), Date.now())
+    .run();
+  return json(200, { ok: true });
+}
+
+/**
+ * The riders on one server, and what they are wearing.
+ *
+ * This is what the app polls to know which paints to fetch. It is scoped to the riders whose
+ * apps have said they are on this server recently — previously it returned every enrolled
+ * account, because nothing recorded where anyone was, so every rider downloaded the paints of
+ * every other rider on the platform.
+ *
+ * A rider whose app has gone quiet for `PRESENCE_TTL_MS` drops out. Better to miss someone
+ * who is genuinely there — the next heartbeat brings them back within a minute — than to
+ * accumulate a grid of people who left hours ago.
  */
 async function roster(url: URL, env: Env): Promise<Response> {
   const serverId = url.searchParams.get("server");
   if (!serverId) return json(400, { error: "a server id is required" });
 
-  // DISTINCT on the destination: loadouts are per bike now, and gear repeats across every
-  // bike a rider owns, so the raw join returns the same helmet paint a dozen times over. The
-  // receiver installs by destination and de-duplicates anyway — doing it here keeps the
-  // response the size it was before bikes were separated.
+  // DISTINCT on the destination: loadouts are per bike, and gear repeats across every bike a
+  // rider owns, so the raw join returns the same helmet paint many times over. The receiver
+  // installs by destination and de-duplicates anyway.
   //
   // MIN(slot) only picks a stable representative for a destination two slots agree on; the
   // client keys on rel_dest, not on slot.
   const rows = await env.DB.prepare(
     "SELECT a.rider_name, a.guid, MIN(p.slot) AS slot, p.file_name, p.sha256, p.size, p.rel_dest" +
-      " FROM accounts a JOIN loadout_paints p ON p.account_id = a.id" +
+      " FROM accounts a" +
+      " JOIN presence pr ON pr.account_id = a.id" +
+      " JOIN loadout_paints p ON p.account_id = a.id" +
+      " WHERE pr.server_id = ? AND pr.updated_at > ?" +
       " GROUP BY a.id, p.rel_dest, p.sha256",
-  ).all<{
-    rider_name: string;
-    guid: string | null;
-    slot: string;
-    file_name: string;
-    sha256: string;
-    size: number;
-    rel_dest: string;
-  }>();
+  )
+    .bind(serverId, Date.now() - PRESENCE_TTL_MS)
+    .all<{
+      rider_name: string;
+      guid: string | null;
+      slot: string;
+      file_name: string;
+      sha256: string;
+      size: number;
+      rel_dest: string;
+    }>();
 
   const riders = new Map<string, { riderName: string; guid: string | null; paints: unknown[] }>();
   for (const r of rows.results) {
-    // Re-checked on the way out as well as in. A row predating the validation, or one
-    // written by some future path that forgot it, must not reach a client that is about to
-    // turn it into a filesystem path.
+    // Re-checked on the way out as well as in. A row predating the validation, or one written
+    // by some future path that forgot it, must not reach a client that is about to turn it
+    // into a filesystem path.
     if (!isRelDest(r.rel_dest)) continue;
-    // Group by GUID where the account has claimed one — it is stable across name changes
-    // and cannot be taken by someone else. Name is the fallback for accounts that have not
-    // supplied a GUID yet, which is every account until the player has connected once.
     const key = r.guid ?? `name:${r.rider_name.toLowerCase()}`;
     let rider = riders.get(key);
     if (!rider) {

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -21,6 +21,7 @@ import { bearer, hashToken, newToken, tokenMatches } from "./auth";
 import {
   isBikeId,
   isBootstrapStage,
+  isContentName,
   isGuid,
   isPaintFileName,
   isPaintSize,
@@ -81,6 +82,22 @@ async function route(request: Request, env: Env): Promise<Response> {
   // it holds no credentials and has no way to be given any. The binary is not a secret —
   // it is the same agent anyone can build from the public repository.
   if (method === "GET" && path === "/v1/agent.exe") return artifact(env, "artifacts/mxb-agent.exe");
+
+  // The bikes a provisioned server needs in order to accept the ones players ride.
+  //
+  // Unauthenticated for the same reason as the agent binary: a booting instance holds no
+  // credential and has no way to be given one. Nothing here is secret — it is the same
+  // content every client already has installed — and the listing is what lets the bootstrap
+  // stay ignorant of which bikes exist.
+  if (method === "GET" && path === "/v1/content/bikes") return listContent(env);
+  const content = /^\/v1\/content\/bikes\/(.+)$/.exec(path);
+  if (content && method === "GET") {
+    const name = decodeURIComponent(content[1]);
+    // Validated rather than trusted: this segment becomes an R2 key and then a filename on
+    // someone's disk.
+    if (!isContentName(name)) return json(400, { error: "not a content file" });
+    return artifact(env, `content/bikes/${name}`);
+  }
 
   // Enrollment is the one unauthenticated write: it trades an invite code for a token.
   // Steam sign-in will replace the invite code without changing anything downstream.
@@ -439,6 +456,21 @@ async function putPaint(request: Request, sha256: string, env: Env): Promise<Res
     await env.PAINTS.put(sha256, body);
   }
   return json(201, { ok: true, sha256, size: body.byteLength });
+}
+
+/**
+ * What bikes are mirrored, so a server can install them without being told the list.
+ *
+ * A dedicated server rejects any bike it does not itself have installed — which is why a
+ * freshly provisioned one refuses every rider on a mod bike. Mirroring the pack means a new
+ * server can be rideable the moment it boots rather than only for whoever owns stock content.
+ */
+async function listContent(env: Env): Promise<Response> {
+  const listed = await env.PAINTS.list({ prefix: "content/bikes/" });
+  const bikes = listed.objects
+    .map((o) => ({ name: o.key.slice("content/bikes/".length), size: o.size }))
+    .filter((b) => b.name.length > 0);
+  return json(200, { bikes, totalBytes: bikes.reduce((n, b) => n + b.size, 0) });
 }
 
 /**

--- a/control-plane/src/validate.ts
+++ b/control-plane/src/validate.ts
@@ -274,3 +274,17 @@ export function isContentName(value: unknown): value is string {
   return /\.pkz$/i.test(name);
 }
 
+/**
+ * A server key, as the app computes it: a registry id, or a normalized `host:port` for a
+ * server we do not run.
+ *
+ * Loose on purpose — it is an opaque grouping key, not an address anything dials — but still
+ * bounded and free of control characters, since it is stored and echoed back.
+ */
+export function isServerKey(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const key = value.trim();
+  if (key.length === 0 || key.length > 128) return false;
+  return !/[\u0000-\u001f\u007f]/.test(key);
+}
+

--- a/control-plane/src/validate.ts
+++ b/control-plane/src/validate.ts
@@ -259,3 +259,18 @@ export function isBootstrapStage(value: unknown): value is string {
   return /^[a-z0-9 :\-]+$/i.test(stage);
 }
 
+/**
+ * A mirrored content file name, as stored under `content/bikes/`.
+ *
+ * Becomes both an R2 key and a filename on a server's disk, so it is held to a plain name:
+ * no separators, no traversal, and the extension the game actually loads.
+ */
+export function isContentName(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const name = value.trim();
+  if (name.length === 0 || name.length > 128) return false;
+  if (/[/\\]/.test(name) || name.includes("..")) return false;
+  if (/[\u0000-\u001f\u007f]/.test(name)) return false;
+  return /\.pkz$/i.test(name);
+}
+

--- a/control-plane/test/validate.test.ts
+++ b/control-plane/test/validate.test.ts
@@ -11,6 +11,7 @@ import {
   isPublicGameAddress,
   isRegion,
   isRelDest,
+  isServerKey,
   isRiderName,
   isServerName,
   isSha256,
@@ -325,5 +326,21 @@ describe("bootstrap user data", () => {
         serverId: "abc", controlPlaneUrl: "https://cp",
       }),
     ).not.toThrow();
+  });
+});
+
+describe("server keys", () => {
+  it("takes both shapes the app computes", () => {
+    // A registry id for a server we run, a normalized host:port for one we do not.
+    for (const ok of ["eu-frankfurt-1", "203.0.113.10:54210", "8e68ebe5-ec6e-42dd"]) {
+      expect(isServerKey(ok), ok).toBe(true);
+    }
+  });
+
+  it("refuses what it should not store", () => {
+    const withNewline = "srv" + String.fromCharCode(10) + "other";
+    for (const bad of ["", "   ", "a".repeat(129), withNewline, 5, null]) {
+      expect(isServerKey(bad), JSON.stringify(bad)).toBe(false);
+    }
   });
 });

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3576,6 +3576,7 @@ fn launch_game(app: tauri::AppHandle) -> Result<gameproc::LaunchOutcome, String>
         // Both directions, because Play is the last moment before either one matters: the
         // grid needs everyone else's paints on disk, and everyone else needs ours.
         publish_paints_soon(&app, &cfg, None);
+        live_sync_session(&app, None);
         // No address to aim at — they'll pick from the in-game browser — so this covers
         // the whole registry.
         sync_paints_soon(&app, None);
@@ -4026,6 +4027,62 @@ fn sync_paints_soon(app: &tauri::AppHandle, address: Option<String>) {
     });
 }
 
+/// How often to re-check the grid while a session is running.
+///
+/// A rider who joins after you did is invisible until the next pull, so this is the gap
+/// between someone arriving and their paint appearing. Short enough not to matter in a race,
+/// long enough that an unchanged roster — the overwhelmingly common answer — costs nothing.
+const LIVE_SYNC_EVERY: std::time::Duration = std::time::Duration::from_secs(45);
+
+/// How long to wait for the game to show up before giving up on a session.
+///
+/// MX Bikes takes a while to appear in the process list, and on a platform where we cannot
+/// see processes at all it never will. Either way, stopping is right: the launch pull has
+/// already run.
+const LIVE_SYNC_STARTUP_GRACE: std::time::Duration = std::time::Duration::from_secs(120);
+
+/// A session's worth of syncing, so a rider who arrives after you do still renders.
+///
+/// The pull used to happen once, at launch. That made the whole thing lopsided: whoever
+/// joined last saw everybody, and whoever was there first never saw anyone who turned up
+/// afterwards — they had pulled before those riders existed.
+///
+/// Runs until the game exits. Each pass also re-reports presence, which is what keeps this
+/// rider in other people's rosters; the control plane forgets anyone who goes quiet.
+fn live_sync_session(app: &tauri::AppHandle, address: Option<String>) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let started = std::time::Instant::now();
+        let mut seen_running = false;
+        loop {
+            tokio::time::sleep(LIVE_SYNC_EVERY).await;
+
+            let cfg = config::load_or_detect(&app).unwrap_or_default();
+            if !cfg.experimental_enabled() || cfg.cp_token.trim().is_empty() {
+                return;
+            }
+            // The game is the session. Once it has been seen and then gone, so are we.
+            if gameproc::is_game_running() {
+                seen_running = true;
+            } else if seen_running || started.elapsed() > LIVE_SYNC_STARTUP_GRACE {
+                log::info!("[sync] session over, stopping the live sync");
+                return;
+            }
+
+            match pull_rosters(&app, address.clone()).await {
+                // Only say so when something actually arrived: an unchanged grid is the
+                // common case and does not need announcing every 45 seconds.
+                Ok(o) if o.installed > 0 => {
+                    log::info!("[sync] {} new paints mid-session", o.installed);
+                    emit_sync(&app, SyncEvent::pulled(&o));
+                }
+                Ok(_) => {}
+                Err(e) => log::debug!("[sync] live pull failed: {e}"),
+            }
+        }
+    });
+}
+
 /// Pull the rosters for wherever the player is, or could be, riding.
 ///
 /// `address` narrows this to a single server when we know where they're headed. Without
@@ -4055,6 +4112,14 @@ async fn pull_rosters(
     };
     if keys.is_empty() {
         return Err("No servers to sync with yet.".into());
+    }
+
+    // Say where we are before asking who else is here: the roster is scoped by presence, so
+    // reporting first is what puts this rider into everyone else's grid too.
+    for key in &keys {
+        if let Err(e) = paintsync::report_presence(&cfg.cp_token, key).await {
+            log::debug!("[sync] couldn't report presence on {key}: {e:#}");
+        }
     }
 
     let outcome = paintsync::pull(&cfg, &cfg.cp_token, &keys)
@@ -4521,6 +4586,7 @@ fn join_server(app: tauri::AppHandle, address: String) -> Result<gameproc::Launc
     let outcome = gameproc::join(&cfg, &address).map_err(|e| format!("{e:#}"))?;
     if matches!(outcome, gameproc::LaunchOutcome::Launched) {
         publish_paints_soon(&app, &cfg, None);
+        live_sync_session(&app, Some(address.clone()));
         // We know exactly where they're going, so this syncs that server alone.
         sync_paints_soon(&app, Some(address));
     }

--- a/src-tauri/src/paintsync.rs
+++ b/src-tauri/src/paintsync.rs
@@ -380,6 +380,25 @@ pub async fn publish_all(
     })
 }
 
+/// Tell the control plane which server this rider is on.
+///
+/// The roster is scoped by this. Without it the control plane has no idea where anyone is, so
+/// a roster can only mean "everyone enrolled" — which is what it used to mean, and why every
+/// rider downloaded the paints of every other rider on the platform.
+///
+/// Best-effort: failing to report presence costs a narrower roster for a minute, and must
+/// never be the thing that stops a sync.
+pub async fn report_presence(token: &str, server_id: &str) -> anyhow::Result<()> {
+    client()?
+        .put(format!("{}/v1/presence", control_plane()))
+        .bearer_auth(token)
+        .json(&serde_json::json!({ "serverId": server_id }))
+        .send()
+        .await?
+        .error_for_status()?;
+    Ok(())
+}
+
 /// A server in the control plane's registry, as `GET /v1/servers` returns it.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
Two pieces of the same problem — a created server nobody can ride on, and a paint sync that only worked if you joined last. Combined into one PR because they land together or not at all.

## 1. A created server had no bikes

A dedicated server refuses any bike it does not itself have installed, and the bootstrap only ever extracted the base game. Stock content only, so anyone on an OEM bike was turned away — which is everyone.

The pack is **1.9 GB across 26 `.pkz` files**. Pushing that from the app was the obvious answer and the wrong one: gigabytes uploaded from a home connection, per server, every time one is created. Mirroring it in R2 and letting the box fetch it makes it a cloud-to-cloud transfer, and R2 charges nothing for egress.

Only the `.pkz` files are mirrored. The sibling folders are paints — 369 MB for one bike alone — and a server does not need them: paints are matched between clients, which is what paint sync already does.

- `GET /v1/content/bikes` lists what is mirrored, so the bootstrap carries no list that could go stale.
- `GET /v1/content/bikes/<name>` streams one, unauthenticated for the same reason as the agent binary: a booting instance holds no credential and has no way to be given one. The name is validated on the way in, since it becomes an R2 key and then a filename on someone's disk.
- Installing is best-effort — a server with no mod bikes still works for stock ones, which beats destroying an instance over content that can be added later.

## 2. A rider who joined after you was invisible

The pull happened **once**, at launch. So a session was lopsided: whoever joined last pulled everyone and saw them; whoever was there first had pulled *before the newcomers existed* and never saw any of them. The app now re-checks for as long as the game is running, installs what is new, and stops when the session does.

And a roster meant every enrolled account: `GET /v1/roster` has always taken a `?server=` and **ignored it**, because nothing recorded where anyone was. Each app now reports the server it launched into, *before* reading the roster, so a rider joins everyone else's grid in the same pass they read it. Ten minutes without a heartbeat and they drop out.

Presence is reported by the app rather than the agent because the app already knows the server, and the agent has no outbound HTTP client at all. The table is separate from `accounts` so the agent can report the same thing later without touching identity.

## Verified

- All 26 objects listed (1,904,379,101 bytes), a real bike fetched (200, correct length), a traversal attempt refused with 400.
- A server provisioned with this reached `ready`, went public, and ran at `44.247.105.231:54210`.
- Roster scoping, with four riders against a local worker: nobody reporting → roster **empty**, not everyone; two riders on one server and one on another → each roster returns exactly its own.
- 596 Rust tests, 34 control-plane tests, typecheck, lint and build clean.

## Not verified

- **That the bikes are actually on the box.** The agent exposes a track scan but no bike scan, and the install is best-effort, so it could report through having fetched nothing. A rider connecting on an OEM bike is the test.
- **Whether the game re-skins a rider who has already spawned.** New paints landing pulses FrostMod's content reload, the only lever available, but MX Bikes binds a remote rider's look when they appear on track. Needs two people on one server.

## Before deploying

`0008_presence.sql` is **already applied to production**. The new roster query joins `presence`, so the order matters — and note that once this Worker is live, app builds older than it do not report presence and will pull nothing. Deploy alongside an app release.

Also weigh: this adds 1.9 GB to every boot on top of the 2.4 GB game — fine for one shared pack, but the argument for making content selectable per server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)