### PR TITLE
fix(presets): share bundles through catbox, and keep dialogs in their window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 
-## 2026-08-09 — v0.9.0 — Servers you can create, paints everyone can see, and a paint studio
+## 2026-08-10
+
+### Fixed
+- **Sharing a preset as a full bundle works again.** Pixeldrain closed anonymous uploads, so
+  every "Create full bundle" packed its zip and then died on the upload with no code to show
+  for it. Bundles now go to catbox, which still takes them without an account and hands back
+  the download link directly — nothing to unwrap, and the import side needed no changes at
+  all. A bundle past catbox's 200 MB ceiling is now refused up front, with its size named,
+  instead of after the whole upload.
+- **The import dialog keeps its contents inside the window.** A dialog lays itself out as a
+  grid, and a grid column grows to fit whatever can't wrap — so once a full-bundle code was
+  pasted and a third button appeared in the footer, the column outgrew the dialog and took
+  the text box with it. Only reachable now that sharing produces bundle codes again. Fixed
+  for every dialog, not just this one; a footer with too many buttons wraps, and long mod
+  names break instead of shoving.
+
+### Changed
+- **Share and Expand look like the buttons they are.** Sharing a preset was one of four
+  identical grey glyphs on the card, and the 3D preview's expand control was a tooltip away
+  from invisible. Both now keep a background at rest.
 
 ### Added
 - **A paint designer, and one Studio instead of three tabs.** Designing a livery meant leaving

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2992,6 +2992,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minisign-verify"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4284,6 +4294,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -6279,6 +6290,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,6 +51,8 @@ reqwest = { version = "0.12", default-features = false, features = [
     "cookies",
     "gzip",
     "brotli",
+    # Preset bundles upload as a multipart form.
+    "multipart",
 ] }
 # `sync` for the mutex that stops two simultaneous 403s opening two clearance windows.
 tokio = { version = "1", features = ["time", "sync", "rt"] }

--- a/src-tauri/src/upload.rs
+++ b/src-tauri/src/upload.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use obfstr::obfstr;
+use reqwest::multipart::{Form, Part};
 use reqwest::Client;
-use serde::Deserialize;
 use std::path::Path;
 
 pub struct UploadRef {
@@ -10,50 +10,58 @@ pub struct UploadRef {
     pub size: u64,
 }
 
-const HOST: &str = "pixeldrain";
+const HOST: &str = "catbox";
+
+/// catbox refuses anything past this, so we stop before spending the upload.
+const MAX_BYTES: u64 = 200 * 1024 * 1024;
 
 pub async fn upload_file(client: &Client, file: &Path) -> anyhow::Result<UploadRef> {
     let size = std::fs::metadata(file).map(|m| m.len()).unwrap_or(0);
-    let url = pixeldrain_upload(client, file).await?;
+    if size > MAX_BYTES {
+        anyhow::bail!(
+            "This bundle is {:.0} MB — too large to share (the limit is {} MB). \
+             Share the plain code instead.",
+            size as f64 / (1024.0 * 1024.0),
+            MAX_BYTES / (1024 * 1024)
+        );
+    }
+    let url = catbox_upload(client, file).await?;
     Ok(UploadRef { url, host: HOST.to_string(), size })
 }
 
-#[derive(Deserialize)]
-struct PixeldrainResp {
-    id: Option<String>,
-    /// Present on failures (`{ success:false, message:"…" }`).
-    message: Option<String>,
-}
-
-/// pixeldrain.com — anonymous `PUT /api/file/{name}` returns `{ "id": "…" }`.
-async fn pixeldrain_upload(client: &Client, file: &Path) -> anyhow::Result<String> {
+/// catbox.moe — anonymous multipart POST whose response body *is* the direct download URL.
+async fn catbox_upload(client: &Client, file: &Path) -> anyhow::Result<String> {
     let bytes = std::fs::read(file).with_context(|| format!("reading {}", file.display()))?;
     let name = file
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_else(|| "preset-bundle.zip".to_string());
 
+    let form = Form::new().text("reqtype", "fileupload").part(
+        "fileToUpload",
+        Part::bytes(bytes).file_name(name).mime_str("application/zip")?,
+    );
+
     let resp = client
-        .put(format!("{}/{name}", obfstr!("https://pixeldrain.com/api/file")))
-        .body(bytes)
+        .post(obfstr!("https://catbox.moe/user/api.php"))
+        .multipart(form)
         .send()
         .await
-        .context("couldn't reach pixeldrain to upload the bundle")?;
+        .context("couldn't reach catbox to upload the bundle")?;
 
     let status = resp.status();
-    let parsed: PixeldrainResp = resp
-        .json()
+    let body = resp
+        .text()
         .await
-        .context("pixeldrain returned an unexpected response")?;
+        .context("catbox returned an unreadable response")?;
+    let body = body.trim();
 
-    match parsed.id {
-        Some(id) if !id.is_empty() => {
-            // Direct-download URL — the install downloader streams it as-is.
-            Ok(format!("{}/{id}", obfstr!("https://pixeldrain.com/api/file")))
-        }
-        _ => {
-            let why = parsed.message.unwrap_or_else(|| format!("HTTP {status}"));
-            anyhow::bail!("pixeldrain upload failed: {why}")
-        }
+    // Failures come back as plain prose, sometimes under a 200, so the URL is the only tell.
+    if body.starts_with("https://") {
+        Ok(body.to_string())
+    } else if body.is_empty() {
+        anyhow::bail!("catbox upload failed: HTTP {status}")
+    } else {
+        anyhow::bail!("catbox upload failed: {body}")
     }
 }

--- a/src/Components/Presets/Presets.tsx
+++ b/src/Components/Presets/Presets.tsx
@@ -18,7 +18,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
-import { Button } from "../ui/button";
+import { Button, CHIP } from "../ui/button";
 import HelpHint from "../ui/help-hint";
 import { Input } from "../ui/input";
 import { Switch } from "../ui/switch";
@@ -761,7 +761,7 @@ function PresetCard({
           <IconBtn title={t("presets.editNameOrOptions")} onClick={onEdit}>
             <Pencil className="size-3.5" />
           </IconBtn>
-          <IconBtn title={t("presets.share")} onClick={onShare}>
+          <IconBtn chip title={t("presets.share")} onClick={onShare}>
             <Share2 className="size-3.5" />
           </IconBtn>
           <IconBtn title={t("common.delete")} onClick={onDelete}>
@@ -781,16 +781,24 @@ function IconBtn({
   title,
   onClick,
   children,
+  chip = false,
 }: {
   title: string;
   onClick: () => void;
   children: React.ReactNode;
+  /** Keep a background at rest, so the action doesn't read as one more grey glyph. */
+  chip?: boolean;
 }) {
   return (
     <button
       title={title}
       onClick={onClick}
-      className="cursor-default rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+      className={cn(
+        "cursor-default rounded-md p-1.5 transition-colors",
+        chip
+          ? CHIP
+          : "text-muted-foreground hover:bg-foreground/[0.06] hover:text-foreground",
+      )}
     >
       {children}
     </button>
@@ -934,7 +942,7 @@ function ShareDialog({ preset, onClose }: { preset: Preset | null; onClose: () =
 
         {/* Full-bundle section */}
         {!isFull && (
-          <div className="rounded-lg border border-white/[0.07] bg-card/40 p-3 text-[12px]">
+          <div className="rounded-lg border border-white/[0.07] bg-card/40 p-3 text-[12px] break-words">
             <div className="flex items-center gap-1.5 font-semibold">
               <Package className="size-3.5" />
               Full bundle
@@ -1115,7 +1123,7 @@ function ImportDialog({
           </p>
         )}
         {preview && (
-          <div className="rounded-lg border border-white/[0.07] bg-card/40 p-2.5 text-[12px]">
+          <div className="rounded-lg border border-white/[0.07] bg-card/40 p-2.5 text-[12px] break-words">
             <div className="font-semibold">{preview.name}</div>
             <div className="text-muted-foreground">{loadoutSummary(preview.loadout)}</div>
             {hasBundle && (

--- a/src/Components/Viewer/ViewerPanel.tsx
+++ b/src/Components/Viewer/ViewerPanel.tsx
@@ -184,7 +184,7 @@ export function ViewerPanel({
           <div className="flex items-center gap-2">
             {!riderOnly && <ModeToggle mode={mode} onChange={setMode} />}
             <Button
-              variant="ghost"
+              variant="chip"
               size="icon"
               className="h-7 w-7"
               title={t("viewer.expand")}

--- a/src/Components/ui/button.tsx
+++ b/src/Components/ui/button.tsx
@@ -3,6 +3,11 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
+/// A ghost that keeps its background at rest, for an action that would otherwise read as
+/// decoration among neighbouring icons. Exported for buttons built outside `Button`.
+export const CHIP =
+  "bg-foreground/[0.10] text-foreground hover:bg-foreground/[0.18]";
+
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-default select-none",
   {
@@ -13,6 +18,7 @@ const buttonVariants = cva(
         outline:
           "border border-input text-foreground hover:bg-foreground/[0.06]",
         ghost: "text-muted-foreground hover:bg-foreground/[0.06] hover:text-foreground",
+        chip: CHIP,
         destructive:
           "bg-destructive text-destructive-foreground hover:brightness-105",
         link: "text-primary underline-offset-4 hover:underline",

--- a/src/Components/ui/dialog.tsx
+++ b/src/Components/ui/dialog.tsx
@@ -36,7 +36,10 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-md -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl border border-input bg-[var(--panel,var(--card))] p-5 shadow-[0_24px_60px_rgba(0,0,0,0.5)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        // `grid-cols-[minmax(0,1fr)]`: a grid track sizes to its widest item's min-content,
+        // so anything that can't wrap — a row of nowrap buttons, an unbreakable mod name —
+        // stretched the track past `max-w-md` and took every `w-full` child out with it.
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-md grid-cols-[minmax(0,1fr)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl border border-input bg-[var(--panel,var(--card))] p-5 shadow-[0_24px_60px_rgba(0,0,0,0.5)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         className,
       )}
       style={{ background: "var(--card)" }}
@@ -62,7 +65,9 @@ function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivEleme
 function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("flex justify-end gap-2 pt-1", className)}
+      // Wraps because buttons are nowrap: three of them (Cancel / Config only / Full
+      // import) don't fit `max-w-md` once one is mid-progress.
+      className={cn("flex flex-wrap justify-end gap-2 pt-1", className)}
       {...props}
     />
   );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -711,7 +711,7 @@ export interface Loadout {
 export interface BundleRef {
   /** Direct-download URL of the uploaded `.zip`. */
   url: string;
-  /** Host label (e.g. `pixeldrain`), shown in the import dialog. */
+  /** Host label (e.g. `catbox`), shown in the import dialog. */
   host: string;
   /** Bundle size in bytes. */
   size: number;


### PR DESCRIPTION
## Why

"Create full bundle" was dead. Not our bug — **pixeldrain closed anonymous uploads**, so the exact call the app makes now answers:

```
$ curl -T bundle.zip https://pixeldrain.com/api/file/bundle.zip
HTTP 401
{"success":false,"value":"authentication_required","message":"…provide an API key…"}
```

The zip got packed, the upload 401'd, and the user got no code. Staying meant shipping an API key inside a desktop binary and owning the quota behind it.

## Provider: catbox.moe

Anonymous multipart POST whose **response body *is* the direct download URL** — no JSON envelope, no `Deserialize` struct, no id-to-URL reassembly. Files are permanent and the link is already direct.

Import needed **no changes**: `resolve_direct_url` already falls through to "assume a direct file link", and the host label is data, so the dialog now reads "from catbox" without touching any of the six locales.

Two hardening bits worth a look in review:

- **200 MB guard before the upload**, not after — an oversized bundle fails instantly with its size named.
- **The response is validated as a URL.** Catbox reports failures as plain prose, sometimes under an HTTP 200. Without this we'd have stored the error text as the bundle link and failed much later, at download.

Enables `reqwest/multipart`, which pulls `mime_guess` + `unicase` transitively.

## Dialog overflow (came along for the ride)

`DialogContent` is a CSS grid, and **a grid track sizes to its widest item's min-content regardless of `max-width`**. The footer's `whitespace-nowrap` buttons — three of them once a bundle code is pasted, one of which grows to "Downloading bundle…" mid-import — plus unbreakable names like `Airoh_Aviator_3_Armega` stretched the track past the dialog and dragged the `w-full` textarea out with it.

Only reachable *because* sharing works again: no bundle code had ever existed to paste, so that footer had never rendered.

Fixed at the primitive (`grid-cols-[minmax(0,1fr)]` + a wrapping footer) so it can't recur in any other dialog — there's already a comment in `ViewerPanel.tsx` from someone else hitting this same grid behaviour.

## Visibility

New `chip` button variant — a ghost that keeps its background at rest — for the preset card's Share and the 3D preview's Expand, both of which read as decoration beside their neighbours. Colours live in one exported constant so the two call sites can't drift.

## Verification

- `cargo test` — **573 passed, 0 failed**; `tsc --noEmit` and `eslint` clean.
- **Live round-trip through the real client** (curl's multipart bytes aren't reqwest's, so this was replicated against the live endpoint): upload → direct URL → download HTTP 200, `content-type: application/zip`, **byte-identical**.
- Bundle create and full import **confirmed by hand in the running app** against a real mods tree.

Note: old share codes carrying pixeldrain links take the same download path they always did. If pixeldrain has gated downloads too, those codes were already dead and nothing here changes that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
