### PR TITLE
chore(release): consolidate the v0.9.0 notes and announce bundle sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,48 +1,13 @@
 # Changelog
 
-## 2026-08-10
+## Unannounced — servers and paint sync
 
-### Fixed
-- **Sharing a preset as a full bundle works again.** Pixeldrain closed anonymous uploads, so
-  every "Create full bundle" packed its zip and then died on the upload with no code to show
-  for it. Bundles now go to catbox, which still takes them without an account and hands back
-  the download link directly — nothing to unwrap, and the import side needed no changes at
-  all. A bundle past catbox's 200 MB ceiling is now refused up front, with its size named,
-  instead of after the whole upload.
-- **The import dialog keeps its contents inside the window.** A dialog lays itself out as a
-  grid, and a grid column grows to fit whatever can't wrap — so once a full-bundle code was
-  pasted and a third button appeared in the footer, the column outgrew the dialog and took
-  the text box with it. Only reachable now that sharing produces bundle codes again. Fixed
-  for every dialog, not just this one; a footer with too many buttons wraps, and long mod
-  names break instead of shoving.
-
-### Changed
-- **Share and Expand look like the buttons they are.** Sharing a preset was one of four
-  identical grey glyphs on the card, and the 3D preview's expand control was a tooltip away
-  from invisible. Both now keep a background at rest.
+These ship in the app but are deliberately left out of the release notes: both need an
+account on the control plane, which is invite-only, so announcing them would advertise
+something almost nobody can use yet. They fold into the notes of whichever release opens
+them up.
 
 ### Added
-- **A paint designer, and one Studio instead of three tabs.** Designing a livery meant leaving
-  for a web editor, exporting a `.tga`, packing it, launching, looking, and starting over —
-  the loop was long enough that most of it happened blind. The **Designer** closes it: start
-  from a paint already installed for the model (which is how the sheets arrive named the way
-  the mesh binds them), stack images and text on top, drag them around, and **the bike or
-  rider beside you wears the drawing as you draw it**. Save writes the packed `.pnt` the game
-  reads, through the same destination picker, overwrite prompt and folder rules Paints already
-  used. No brushes and no filters — pixels still come from wherever you like drawing them;
-  this places them and knows where they go.
-- **Designer, Paints and Rider now live under one Studio tab**, switched by a segmented
-  control. They were three sidebar entries answering three halves of one question, and the
-  sidebar had started listing features rather than places; it's back to seven entries.
-- **The Studio works under GP Bikes too.** Building a `.pnt` is the same job for either title —
-  same container, same encoder, same folders — and only the 3D preview needs part bindings GP
-  Bikes doesn't have yet. So Designer and Paints are both there, the preview says plainly why
-  it isn't, and the Rider tab (which *is* the rig) stays MX Bikes-only. Paint destinations are
-  read from the game's own rider layout rather than listed in the app, so GP Bikes is offered
-  its three — bike livery, helmet, rider kit — instead of MX Bikes' boots and protection
-  folders it has no use for.
-- **The sidebar collapses to icons**, and the Designer's sheets/layers rail folds away, for
-  when the canvas and the model are what you want the width for.
 - **Create a server from the app.** The control plane launches an EC2 instance, installs
   the dedicated server and the agent on it, and the server appears in the Servers page. The
   app holds no cloud credentials — a desktop binary can be unpacked, and a key inside one
@@ -109,6 +74,161 @@
   unauthenticated by necessity; the bucket itself stays private.
 - **A guided-tour step for the Servers page**, and a help hint on it. Every other screen had
   one.
+
+### Changed
+- **Nothing runs unattended.** Four separate things have to fail before a server can bill
+  indefinitely: a cap of 2 concurrent instances counted *from EC2 rather than our own
+  records*; destruction after 20 minutes with nobody connected; termination of any instance
+  no database row points at; and a hard maximum lifetime that catches everything else — a
+  hung bootstrap, an agent that never started, a failure nobody has thought of.
+  Instances also launch with `InstanceInitiatedShutdownBehavior=terminate`, and the
+  bootstrap's failure trap shuts the machine down, so a half-built server destroys itself
+  rather than sitting idle on the bill.
+- **A server is only advertised once we can reach it.** The control plane calls the agent's
+  unauthenticated `/health` before publishing; an unreachable one is recorded and stays
+  manageable, but is kept out of everyone's picker. A list full of servers nobody can
+  connect to is worse than a short list. This can't prove the *game* port is open — that's
+  UDP, and a Worker can't send one — so "reachable" means the host answers.
+- **Addresses pointing into private space are refused outright**, before any request is
+  made. The control plane fetches an operator-supplied URL, which makes it a
+  request-forgery surface: `127.0.0.1`, RFC1918, carrier-grade NAT and the `169.254.169.254`
+  metadata address are all rejected, as is any URL carrying credentials, a path or a query.
+- **Join a server offers the servers we know about**, instead of an empty box wanting an IP
+  address. The control plane has held a registry of them since the first migration and
+  nothing ever showed it, so the answer to "where do I get the address" was nowhere in the
+  app. Typing one is still there, for a server that isn't listed.
+- **The server registry is public.** It was bearer-only, which meant the players most in
+  need of a list — the ones who have never joined a server and have no address to type —
+  were the only ones who couldn't see it. It returns the same name, region and address a
+  server browser shows; `agent_url` is still withheld, so no admin API is advertised.
+- **Adding a server shows one field, not four.** The pairing code carries the address and
+  the token and the host supplies the name, so the manual fields sit behind a disclosure
+  rather than implying they all need filling in — and the form now says where the code is
+  printed.
+- **Adding a server checks it before saving it**, and takes the server's name from the host
+  rather than asking you to invent one. A wrong address or token now fails at the form
+  instead of becoming a row that never loads.
+- **The enroll panel says where an invite code comes from**, with a button through to the
+  Discord. Invites are issued by hand and the field previously explained none of that.
+- **Your rider name is picked from your MX Bikes profiles**, not typed. It had to match the
+  game exactly and nothing checked that it did, which made a silent no-op the most likely
+  outcome of enrolling. Typing is still there when no profiles are found.
+- **Your GUID is claimed automatically** the first time one of your servers sees you
+  connect — the app reads it from the server's log, where the game writes it next to your
+  name. You can't read it off your own machine, so asking you to type it never made sense.
+  The manual field is still there, one click away, for anyone not running a server.
+- **Join a server is behind the Experimental switch**, with the rest of the multiplayer
+  work. It rides on an undocumented connect flag, so it shouldn't sit under Play for
+  everyone while that's still unconfirmed.
+- **Publishing a whole profile costs one library scan, not one per bike.** Resolving a look
+  walks `mods/bikes` recursively — every livery installed — and the publish path did that once
+  per bike plus once per uploaded file. Loadouts are now planned in a batch against a single
+  walk, and the upload takes its bytes from the files already hashed.
+- **`GET /v1/fleet` no longer hands every enrolled account the address of every server.** The
+  running count stays public to everyone, because that is what the concurrency cap is measured
+  against; the instance list is scoped to its owner.
+- **The on-screen description of paint sync matches what it does.** It promised automatic
+  publishing on every look change before that was true.
+
+### Fixed
+- **Your look is published even if you never open the Locker.** Publishing only ever ran off
+  a preset apply, so the commonest path there is — enroll, press Play — sent nothing at all,
+  and the player appeared to everyone else in default gear with no indication anything was
+  wrong. It now publishes when you enroll, when the app starts, when you press Play or Join,
+  and whenever a preset is applied.
+- **Changing your kit in the game's own garage publishes it.** MX Bikes writes the same
+  `profile.ini` the app does; nothing was listening. A watcher on that file now catches it,
+  filtered to `profile.ini` alone so the replay and telemetry churn a session produces can't
+  set it off. Redundant fires cost nothing: the look is hashed and an unchanged one is never
+  sent.
+- **Switching Experimental on now starts watching for look changes straight away.** The
+  watcher that notices you changing kit in the game's own garage was only ever started when
+  the app launched, so turning the feature on left it stopped until the next restart — the
+  app kept publishing when you applied a preset or pressed Play, but a change made in the
+  garage went unnoticed for the rest of the session. That is the session you have just
+  enrolled in, which makes it the worst one to be quietly missing. Switching it back off
+  stops the watcher rather than leaving it running.
+- **Every bike is published, not just the last one touched.** Storage held one loadout per
+  account — `loadout_paints` had no bike dimension at all — so publishing a second bike
+  deleted the first. A rider looked right on whichever bike the app last saw and default on
+  every other. Both tables are rebuilt keyed by bike, and the app sends them together.
+- **The sync no longer overwrites liveries you made yourself.** Any local paint whose name
+  matched an incoming one was replaced, including your own artwork. It now records what it
+  installs and will only ever replace that; anything else is yours and is kept, and reported.
+  Two riders using one file name for different paints installs neither, rather than letting
+  whichever roster answered first decide what everyone sees.
+- **A server created from the app can now be reached.** Provisioning launched a machine and
+  then lost it: the response carried no address and no token, nothing ever filled either in,
+  and the row stayed unpublished forever — so the server could not be joined, managed or even
+  deleted, only waited out by the idle reaper. The instance now announces itself once its
+  agent answers, which fills in its address and puts it in the join picker.
+- **A server whose name isn't plain Latin-1 can be created.** EC2 user data was encoded with
+  `btoa`, which takes a "binary string" of one character per byte and throws on anything above
+  U+00FF. Any server named with an emoji or a non-Latin script failed to launch with
+  `InvalidCharacterError` and nothing else to go on. Found by trying to launch a real one.
+- **A provisioned server can actually download the game.** The bootstrap fetched the installer
+  with `Start-BitsTransfer`, which cannot work where it runs: EC2 user data executes as SYSTEM
+  at boot with no interactive session, and BITS refuses with `0x800704DD` — "the user has not
+  logged on to the network". Every launch died at that step. It now uses `curl.exe` from
+  System32, which streams to disk without a session and retries on its own, and the size is
+  checked afterwards so a truncated download fails loudly rather than extracting into nonsense.
+  Found by launching a real one, and diagnosed in a single attempt because the instance now
+  reports its transcript before shutting down.
+- **A provisioned server's agent can read its own config.** `agent.json` was written by hand as
+  JSON inside a PowerShell here-string, and the install path interpolated with single
+  backslashes — so the file said `"game_dir": "C:\mxb\\game"`, and `\m` is not a valid JSON
+  escape. The agent refused to parse it and exited immediately on every server ever
+  provisioned. It is now built with `ConvertTo-Json`, which escapes properly, and the file is
+  parsed once on the box before the agent is asked to.
+- **The idle reaper could never have reaped anything.** It read the agent address from a
+  column that provisioning cannot fill in — EC2 assigns the public IP while the instance
+  boots, long after the row is written — so every provisioned server looked permanently
+  unreachable and was skipped forever. It now takes the address from EC2's own view.
+- **Paint sync no longer syncs one hard-coded server.** The Servers page asked for
+  `eu-frankfurt-1` by name regardless of where you were riding; it now resolves the server
+  you actually joined, matching a registered one by address or falling back to the address
+  itself.
+- **The agent's track list no longer offers things that aren't tracks.** A folder tracks are
+  filed into (`EU`) and the interior of an extracted one (`data`) both came back as
+  selectable names, and picking either would have restarted the server into nothing. It now
+  uses the same marker files the app's own library scanner keys on, and stops descending
+  once it has found a track.
+
+## 2026-08-10 — v0.9.0 — A studio for paints, the Shop installing what you bought, and presets that carry their own mods
+
+### Added
+- **Share a preset as a complete bundle, not just a code.** A share code carries the *names*
+  of what a look is made of, which is no use to someone who owns none of it — they get your
+  preset and a list of things to go and find. **Create full bundle** in the Share dialog
+  gathers every asset the loadout actually references — bike livery, helmet and its paint,
+  goggles, suit, gloves, boots, protection, tyres, even a model-swap variant — zips them into
+  a `mods/`-shaped tree with the preset beside them, and puts the download inside the code.
+  **Full import** at the other end unpacks the lot into the folders the game reads, so a rider
+  with an empty mods folder ends up wearing exactly what you built, first try. Folders are
+  resolved as they're gathered, so a bundle carries real files rather than links pointing at
+  your disk. A bundle over 200 MB is refused up front, with its size named, instead of after
+  the upload.
+- **A paint designer, and one Studio instead of three tabs.** Designing a livery meant leaving
+  for a web editor, exporting a `.tga`, packing it, launching, looking, and starting over —
+  the loop was long enough that most of it happened blind. The **Designer** closes it: start
+  from a paint already installed for the model (which is how the sheets arrive named the way
+  the mesh binds them), stack images and text on top, drag them around, and **the bike or
+  rider beside you wears the drawing as you draw it**. Save writes the packed `.pnt` the game
+  reads, through the same destination picker, overwrite prompt and folder rules Paints already
+  used. No brushes and no filters — pixels still come from wherever you like drawing them;
+  this places them and knows where they go.
+- **Designer, Paints and Rider now live under one Studio tab**, switched by a segmented
+  control. They were three sidebar entries answering three halves of one question, and the
+  sidebar had started listing features rather than places; it's back to seven entries.
+- **The Studio works under GP Bikes too.** Building a `.pnt` is the same job for either title —
+  same container, same encoder, same folders — and only the 3D preview needs part bindings GP
+  Bikes doesn't have yet. So Designer and Paints are both there, the preview says plainly why
+  it isn't, and the Rider tab (which *is* the rig) stays MX Bikes-only. Paint destinations are
+  read from the game's own rider layout rather than listed in the app, so GP Bikes is offered
+  its three — bike livery, helmet, rider kit — instead of MX Bikes' boots and protection
+  folders it has no use for.
+- **The sidebar collapses to icons**, and the Designer's sheets/layers rail folds away, for
+  when the canvas and the model are what you want the width for.
 - **A new Paints tab turns image files into paints the game loads.** MX Bikes reads a paint
   as a packed container of compressed texture sheets, which no image editor writes — so
   until now a livery drawn in GIMP or Photoshop had to go through somebody else's converter
@@ -238,65 +358,15 @@
   old fuzzy match as a fallback.
 
 ### Changed
+- **Share and Expand look like the buttons they are.** Sharing a preset was one of four
+  identical grey glyphs on the card, and the 3D preview's expand control was a tooltip away
+  from invisible. Both now keep a background at rest.
 - The 3D viewer can be handed textures the backend has never seen, which is what lets the
   Designer's canvas appear on real geometry. Everything else still arrives by token, unchanged.
 - Switching between the Studio's tabs no longer throws away what you were doing in the one you
   left.
 - Sheets unpacked in Paints can be sent straight to the Designer to draw on, rather than
   unpacked a second time.
-- **Nothing runs unattended.** Four separate things have to fail before a server can bill
-  indefinitely: a cap of 2 concurrent instances counted *from EC2 rather than our own
-  records*; destruction after 20 minutes with nobody connected; termination of any instance
-  no database row points at; and a hard maximum lifetime that catches everything else — a
-  hung bootstrap, an agent that never started, a failure nobody has thought of.
-  Instances also launch with `InstanceInitiatedShutdownBehavior=terminate`, and the
-  bootstrap's failure trap shuts the machine down, so a half-built server destroys itself
-  rather than sitting idle on the bill.
-- **A server is only advertised once we can reach it.** The control plane calls the agent's
-  unauthenticated `/health` before publishing; an unreachable one is recorded and stays
-  manageable, but is kept out of everyone's picker. A list full of servers nobody can
-  connect to is worse than a short list. This can't prove the *game* port is open — that's
-  UDP, and a Worker can't send one — so "reachable" means the host answers.
-- **Addresses pointing into private space are refused outright**, before any request is
-  made. The control plane fetches an operator-supplied URL, which makes it a
-  request-forgery surface: `127.0.0.1`, RFC1918, carrier-grade NAT and the `169.254.169.254`
-  metadata address are all rejected, as is any URL carrying credentials, a path or a query.
-- **Join a server offers the servers we know about**, instead of an empty box wanting an IP
-  address. The control plane has held a registry of them since the first migration and
-  nothing ever showed it, so the answer to "where do I get the address" was nowhere in the
-  app. Typing one is still there, for a server that isn't listed.
-- **The server registry is public.** It was bearer-only, which meant the players most in
-  need of a list — the ones who have never joined a server and have no address to type —
-  were the only ones who couldn't see it. It returns the same name, region and address a
-  server browser shows; `agent_url` is still withheld, so no admin API is advertised.
-- **Adding a server shows one field, not four.** The pairing code carries the address and
-  the token and the host supplies the name, so the manual fields sit behind a disclosure
-  rather than implying they all need filling in — and the form now says where the code is
-  printed.
-- **Adding a server checks it before saving it**, and takes the server's name from the host
-  rather than asking you to invent one. A wrong address or token now fails at the form
-  instead of becoming a row that never loads.
-- **The enroll panel says where an invite code comes from**, with a button through to the
-  Discord. Invites are issued by hand and the field previously explained none of that.
-- **Your rider name is picked from your MX Bikes profiles**, not typed. It had to match the
-  game exactly and nothing checked that it did, which made a silent no-op the most likely
-  outcome of enrolling. Typing is still there when no profiles are found.
-- **Your GUID is claimed automatically** the first time one of your servers sees you
-  connect — the app reads it from the server's log, where the game writes it next to your
-  name. You can't read it off your own machine, so asking you to type it never made sense.
-  The manual field is still there, one click away, for anyone not running a server.
-- **Join a server is behind the Experimental switch**, with the rest of the multiplayer
-  work. It rides on an undocumented connect flag, so it shouldn't sit under Play for
-  everyone while that's still unconfirmed.
-- **Publishing a whole profile costs one library scan, not one per bike.** Resolving a look
-  walks `mods/bikes` recursively — every livery installed — and the publish path did that once
-  per bike plus once per uploaded file. Loadouts are now planned in a batch against a single
-  walk, and the upload takes its bytes from the files already hashed.
-- **`GET /v1/fleet` no longer hands every enrolled account the address of every server.** The
-  running count stays public to everyone, because that is what the concurrency cap is measured
-  against; the instance list is scoped to its owner.
-- **The on-screen description of paint sync matches what it does.** It promised automatic
-  publishing on every look change before that was true.
 - **FrostMod still starts when a runtime is missing.** It's a warning, not a gate: we can't
   tell from outside which PCs manage to inject anyway, and refusing to launch would take
   FrostMod away from anyone the check is wrong about.
@@ -315,6 +385,11 @@
   one. Release builds are untouched.
 
 ### Fixed
+- **A dialog keeps its contents inside its own window.** A dialog lays itself out as a grid,
+  and a grid column grows to fit whatever inside it refuses to wrap — so a footer carrying a
+  third button, or a mod name with no spaces in it, quietly pushed the text box out past the
+  dialog's edge. Fixed for every dialog at once rather than the one it was noticed in: a
+  crowded footer wraps, and long names break instead of shoving.
 - **Dropping paints no longer leaves the review sheet spinning.** Working out what a dropped
   `.pnt` is comes down to one question — which model does it paint? — and the file answers it
   in its texture names: an outfit carries `rider`, a bike livery carries `framecompletemap`.
@@ -384,68 +459,6 @@
   like an app that had simply hung. It now reports the failure and closes the dead window, and
   writes which cookies the window ended up with (names only, never values) so a log says
   whether the challenge ever cleared.
-- **Your look is published even if you never open the Locker.** Publishing only ever ran off
-  a preset apply, so the commonest path there is — enroll, press Play — sent nothing at all,
-  and the player appeared to everyone else in default gear with no indication anything was
-  wrong. It now publishes when you enroll, when the app starts, when you press Play or Join,
-  and whenever a preset is applied.
-- **Changing your kit in the game's own garage publishes it.** MX Bikes writes the same
-  `profile.ini` the app does; nothing was listening. A watcher on that file now catches it,
-  filtered to `profile.ini` alone so the replay and telemetry churn a session produces can't
-  set it off. Redundant fires cost nothing: the look is hashed and an unchanged one is never
-  sent.
-- **Switching Experimental on now starts watching for look changes straight away.** The
-  watcher that notices you changing kit in the game's own garage was only ever started when
-  the app launched, so turning the feature on left it stopped until the next restart — the
-  app kept publishing when you applied a preset or pressed Play, but a change made in the
-  garage went unnoticed for the rest of the session. That is the session you have just
-  enrolled in, which makes it the worst one to be quietly missing. Switching it back off
-  stops the watcher rather than leaving it running.
-- **Every bike is published, not just the last one touched.** Storage held one loadout per
-  account — `loadout_paints` had no bike dimension at all — so publishing a second bike
-  deleted the first. A rider looked right on whichever bike the app last saw and default on
-  every other. Both tables are rebuilt keyed by bike, and the app sends them together.
-- **The sync no longer overwrites liveries you made yourself.** Any local paint whose name
-  matched an incoming one was replaced, including your own artwork. It now records what it
-  installs and will only ever replace that; anything else is yours and is kept, and reported.
-  Two riders using one file name for different paints installs neither, rather than letting
-  whichever roster answered first decide what everyone sees.
-- **A server created from the app can now be reached.** Provisioning launched a machine and
-  then lost it: the response carried no address and no token, nothing ever filled either in,
-  and the row stayed unpublished forever — so the server could not be joined, managed or even
-  deleted, only waited out by the idle reaper. The instance now announces itself once its
-  agent answers, which fills in its address and puts it in the join picker.
-- **A server whose name isn't plain Latin-1 can be created.** EC2 user data was encoded with
-  `btoa`, which takes a "binary string" of one character per byte and throws on anything above
-  U+00FF. Any server named with an emoji or a non-Latin script failed to launch with
-  `InvalidCharacterError` and nothing else to go on. Found by trying to launch a real one.
-- **A provisioned server can actually download the game.** The bootstrap fetched the installer
-  with `Start-BitsTransfer`, which cannot work where it runs: EC2 user data executes as SYSTEM
-  at boot with no interactive session, and BITS refuses with `0x800704DD` — "the user has not
-  logged on to the network". Every launch died at that step. It now uses `curl.exe` from
-  System32, which streams to disk without a session and retries on its own, and the size is
-  checked afterwards so a truncated download fails loudly rather than extracting into nonsense.
-  Found by launching a real one, and diagnosed in a single attempt because the instance now
-  reports its transcript before shutting down.
-- **A provisioned server's agent can read its own config.** `agent.json` was written by hand as
-  JSON inside a PowerShell here-string, and the install path interpolated with single
-  backslashes — so the file said `"game_dir": "C:\mxb\\game"`, and `\m` is not a valid JSON
-  escape. The agent refused to parse it and exited immediately on every server ever
-  provisioned. It is now built with `ConvertTo-Json`, which escapes properly, and the file is
-  parsed once on the box before the agent is asked to.
-- **The idle reaper could never have reaped anything.** It read the agent address from a
-  column that provisioning cannot fill in — EC2 assigns the public IP while the instance
-  boots, long after the row is written — so every provisioned server looked permanently
-  unreachable and was skipped forever. It now takes the address from EC2's own view.
-- **Paint sync no longer syncs one hard-coded server.** The Servers page asked for
-  `eu-frankfurt-1` by name regardless of where you were riding; it now resolves the server
-  you actually joined, matching a registered one by address or falling back to the address
-  itself.
-- **The agent's track list no longer offers things that aren't tracks.** A folder tracks are
-  filed into (`EU`) and the interior of an extracted one (`data`) both came back as
-  selectable names, and picking either would have restarted the server into nothing. It now
-  uses the same marker files the app's own library scanner keys on, and stops descending
-  once it has found a track.
 - **Helmets, boots and protection now install into a folder of their own.** A gear mod
   packaged as a `.pkz` — which is how locked mods are distributed — unpacks to a single
   folder, and the app was unwrapping it and dropping the contents straight into

--- a/src/Components/Showcase/releases.ts
+++ b/src/Components/Showcase/releases.ts
@@ -25,6 +25,7 @@ import {
   PersonStanding,
   Wrench,
   RefreshCw,
+  Package,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { TKey } from "../../i18n/context";
@@ -59,8 +60,9 @@ export const RELEASES: Release[] = [
       body: "showcase.v090.hero.body",
     },
     highlights: [
-      { icon: Sparkles, text: "showcase.v090.reshade" },
+      { icon: Package, text: "showcase.v090.bundles" },
       { icon: Store, text: "showcase.v090.purchases" },
+      { icon: Sparkles, text: "showcase.v090.reshade" },
       { icon: PersonStanding, text: "showcase.v090.ridingStyles" },
       { icon: Wrench, text: "showcase.v090.frostmod" },
       { icon: RefreshCw, text: "showcase.v090.updates" },

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1091,6 +1091,8 @@ export const de: Translation = {
     "Ein neuer Designs-Tab baut Designs aus ganz normalen Bilddateien — TGA, PNG, JPG — und installiert sie dort, wo das Spiel sucht: eine Bike-Lackierung, ein Helm- oder Brillen-Design, Kit oder Handschuhe deines Fahrers. Entpack ein vorhandenes Design, um eine Vorlage zu bekommen, die wirklich zum Modell passt, bearbeite sie in jedem Editor und leg sie direkt wieder ab. Das Studio prüft deine Dateinamen gegen die, die das Mesh bindet, bevor du speicherst, und zeigt das Ergebnis danach am echten Modell.",
   "showcase.v090.reshade":
     "ReShade-Presets im Programm durchsuchen, installieren und wechseln — mit einem Aus-Eintrag zum Vergleich mit dem Original-Look und einer Warnung, wenn einem Preset Effekte fehlen.",
+  "showcase.v090.bundles":
+    "Teile ein Preset als Komplettpaket — der Code trägt die Mods selbst: Lackierung, Helm und Brille, Kluft, Handschuhe, Stiefel, Reifen. Vollständiger Import legt jede Datei dorthin, wo das Spiel sie liest, sodass auch jemand mit leerem Mods-Ordner am Ende genau das trägt, was du gebaut hast.",
   "showcase.v090.purchases":
     "Meine Käufe meldet dich bei deinem mxbikes-shop.com-Konto an und installiert, was du schon bezahlt hast — über dieselbe Übersicht wie beim Drag-and-drop.",
   "showcase.v090.ridingStyles":

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1050,6 +1050,8 @@ export const en = {
     "A new Paints tab builds paints out of ordinary image sheets — TGA, PNG, JPG — and installs them where the game looks: a bike livery, a helmet or goggle paint, a rider's kit or gloves. Unpack a paint you already have to get a template that actually fits the model, edit it in any editor, and put it straight back. The studio checks your sheet names against the ones the mesh binds before you save, then previews the result on the real model.",
   "showcase.v090.reshade":
     "Browse, install and switch ReShade presets from the app — with an Off entry to compare against the stock look, and a warning when a preset needs effects you don't have.",
+  "showcase.v090.bundles":
+    "Share a preset as a full bundle and the code carries the mods themselves — livery, helmet and goggles, kit, gloves, boots, tyres. Full import puts every file where the game reads it, so someone with an empty mods folder still ends up wearing exactly what you built.",
   "showcase.v090.purchases":
     "My purchases signs in to your mxbikes-shop.com account and installs what you've already paid for, through the same review sheet a drag-and-drop uses.",
   "showcase.v090.ridingStyles":

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1079,6 +1079,8 @@ export const es: Translation = {
     "Una nueva pestaña Diseños crea diseños a partir de imágenes corrientes — TGA, PNG, JPG — y los instala donde el juego los busca: una decoración de moto, un diseño de casco o de gafas, el kit o los guantes de tu piloto. Descomprime un diseño que ya tengas para conseguir una plantilla que encaje de verdad con el modelo, edítala en cualquier editor y devuélvela tal cual. El estudio comprueba tus nombres de archivo frente a los que usa la malla antes de guardar, y luego muestra el resultado sobre el modelo real.",
   "showcase.v090.reshade":
     "Explora, instala y cambia presets de ReShade desde la app — con una entrada Desactivado para comparar con el aspecto original, y un aviso cuando a un preset le faltan efectos.",
+  "showcase.v090.bundles":
+    "Comparte un preset como paquete completo y el código lleva los propios mods: decoración, casco y gafas, equipación, guantes, botas y neumáticos. Importación completa deja cada archivo donde el juego lo lee, así que alguien con la carpeta de mods vacía acaba llevando exactamente lo que creaste.",
   "showcase.v090.purchases":
     "Mis compras entra en tu cuenta de mxbikes-shop.com e instala lo que ya has pagado, con la misma hoja de revisión que usa el arrastrar y soltar.",
   "showcase.v090.ridingStyles":

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1081,6 +1081,8 @@ export const fr: Translation = {
     "Un nouvel onglet Décos fabrique des décos à partir de simples fichiers image — TGA, PNG, JPG — et les installe là où le jeu les cherche : une livrée de moto, une déco de casque ou de masque, la tenue ou les gants de ton pilote. Décompresse une déco existante pour obtenir un gabarit vraiment adapté au modèle, retouche-la dans n'importe quel éditeur et remets-la telle quelle. Le studio vérifie tes noms de fichiers face à ceux que le maillage utilise avant l'enregistrement, puis affiche le résultat sur le vrai modèle.",
   "showcase.v090.reshade":
     "Parcours, installe et change de preset ReShade depuis l'app — avec une entrée Aucun pour comparer au rendu d'origine, et un avertissement quand un preset réclame des effets que tu n'as pas.",
+  "showcase.v090.bundles":
+    "Partage un preset en paquet complet : le code emporte les mods eux-mêmes — déco, casque et masque, tenue, gants, bottes, pneus. Import complet place chaque fichier là où le jeu le lit, si bien qu'une personne au dossier mods vide porte exactement ce que tu as monté.",
   "showcase.v090.purchases":
     "Mes achats se connecte à ton compte mxbikes-shop.com et installe ce que tu as déjà payé, via la même fiche de contrôle qu'un glisser-déposer.",
   "showcase.v090.ridingStyles":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1071,6 +1071,8 @@ export const it: Translation = {
     "Una nuova scheda Livree costruisce le livree da normali file immagine — TGA, PNG, JPG — e le installa dove il gioco le cerca: la livrea di una moto, la grafica di un casco o di una maschera, il completo o i guanti del tuo pilota. Estrai una livrea che hai già per ottenere un template che calza davvero sul modello, modificalo in qualsiasi editor e rimettilo dentro così com'è. Lo studio controlla i nomi dei tuoi file contro quelli che la mesh usa prima del salvataggio, poi mostra il risultato sul modello vero.",
   "showcase.v090.reshade":
     "Sfoglia, installa e cambia i preset ReShade dall'app — con una voce Nessuno per confrontare con l'aspetto originale, e un avviso quando a un preset mancano degli effetti.",
+  "showcase.v090.bundles":
+    "Condividi un preset come pacchetto completo: il codice porta con sé le mod stesse — livrea, casco e maschera, completo, guanti, stivali, gomme. Importazione completa mette ogni file dove il gioco lo legge, così anche chi ha la cartella mod vuota finisce per indossare esattamente quello che hai creato.",
   "showcase.v090.purchases":
     "I miei acquisti accede al tuo account mxbikes-shop.com e installa ciò che hai già pagato, con lo stesso riepilogo usato dal trascinamento.",
   "showcase.v090.ridingStyles":

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1071,6 +1071,8 @@ export const ptBR: Translation = {
     "Uma nova aba Pinturas monta pinturas a partir de arquivos de imagem comuns — TGA, PNG, JPG — e instala onde o jogo procura: a pintura de uma moto, de um capacete ou de um óculos, o kit ou as luvas do seu piloto. Descompacte uma pintura que você já tem para conseguir um molde que serve de verdade no modelo, edite em qualquer editor e devolva do mesmo jeito. O estúdio confere os nomes dos seus arquivos contra os que a malha usa antes de salvar, e depois mostra o resultado no modelo de verdade.",
   "showcase.v090.reshade":
     "Procure, instale e troque presets do ReShade pelo app — com uma opção Desligado para comparar com o visual original, e um aviso quando falta algum efeito que o preset precisa.",
+  "showcase.v090.bundles":
+    "Compartilhe um preset como pacote completo — o código leva as próprias mods: pintura, capacete e óculos, roupa, luvas, botas e pneus. Importação completa coloca cada arquivo onde o jogo lê, então quem está com a pasta de mods vazia acaba vestindo exatamente o que você montou.",
   "showcase.v090.purchases":
     "Minhas compras entra na sua conta do mxbikes-shop.com e instala o que você já pagou, pela mesma tela de conferência que o arrastar e soltar usa.",
   "showcase.v090.ridingStyles":


### PR DESCRIPTION
Release prep for **v0.9.0 GA**. The CHANGELOG section is what both the release page and the Discord announcement are built from, so this PR is the release's wording.

## Restores the section heading

#125 replaced the `## 2026-08-09 — v0.9.0 — …` heading line when it inserted its own dated section. That left the release scripts with nothing to find — `changelog-section.sh v0.9.0` returned empty, so tagging would have published a release with download guidance and **no notes at all**. My mistake in #125; caught while rendering the notes.

## Servers and paint sync are held back

Both ship in the binary, but need an account on the invite-only control plane — announcing them would advertise something almost nobody can use. They move to an `## Unannounced` section that the release scripts skip, and fold into the notes of whichever release opens them up.

**Nothing was deleted.** Bullet count is identical before and after (109 → 109); the only two that differ are the pair deliberately reworded. The announced section greps clean for `server`, `paint sync`, `control plane`, `EC2`, `invite`, `enroll`.

## Framing

Full-bundle sharing is presented as a feature of this release. For the record: it was first announced in v0.1.6 and has been dead since pixeldrain closed anonymous uploads; #125 revived it.

## In-app What's new

`releases.ts` had **no** bundle-sharing line — added, with its string in all six locales. `tsc` is what catches a missing locale; nothing catches a missing entry.

## Verification

- `changelog-section.sh v0.9.0 --heading` resolves; body renders at 393 lines.
- `tsc --noEmit` and `eslint` clean.
- Discord will exceed its 3500-char cap and fall back to headlines + a link, as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)