### PR TITLE
feat(macos): launch the game through CrossOver, Whisky or Wine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 2026-08-10 — v0.9.1 — Play works on a Mac
+
+A patch on top of v0.9.0 — everything that release added is still the news, and its notes
+are repeated below.
+
+Worth knowing for this beta: the Mac launch has been tested against a stand-in for Wine, not
+against a real bottle, so if Play does something odd on your machine the app log names the
+exact command it ran — please send it.
+
+### Added
+- **Play and Join Server work on macOS.** MX Bikes is a Windows game, so on a Mac it runs
+  inside a CrossOver, Whisky or Wine bottle — and the app, which had a launcher for Windows
+  and one for Linux, simply refused: *"Launching MX Bikes is supported on Windows and Linux
+  only."* It launches now, through whichever wrapper owns the bottle the game sits in. That
+  bottle is worked out from the install folder itself: every wrapper keeps its fake `C:` drive
+  at `drive_c`, so whatever is above it is the prefix, and no wrapper's private layout has to
+  be guessed at. CrossOver bottles are started by name, the way CodeWeavers documents, so the
+  bottle's own graphics settings apply instead of being skipped; everything else is pointed
+  straight at the prefix. Joining a server goes the same way, connect flag and all.
+- **The app finds a bottled install by itself.** Setup and Settings only ever looked where a
+  *native* Mac game would be — Steam under `~/Library`, mods under `~/Documents` — neither of
+  which a Windows game inside a bottle ever touches. A Mac player had to type a path like
+  `…/Bottles/MXB/drive_c/…` by hand before anything worked at all. Both detectors now search
+  the CrossOver and Whisky bottles on the machine, including a Windows Steam installed inside
+  one, and the setup screen's folder hint points at the bottle rather than at `Documents`.
+- **The sidebar knows when the game is up on a Mac.** Under Wine the game is an ordinary
+  process, so Play now shows "MX Bikes running" instead of quietly starting a second copy.
+- **A Wine runner picker in Settings**, for when the automatic choice is wrong or the wrapper
+  lives somewhere unusual. It also shows which runner was found and how many bottles the app
+  can see — so a bottle it *can't* see shows up as missing before you press Play, not after.
+
 ## 2026-08-09 — v0.9.0 — Servers you can create, paints everyone can see, and a paint studio
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "frost"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frost"
-version = "0.9.0"
+version = "0.9.1"
 description = "Frost — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -47,6 +47,10 @@ pub struct AppConfig {
     /// resolved from `mods_path` — see [`AppConfig::profiles_dir`]. Set it when the
     /// resolver can't find the folder, e.g. profiles on a drive we don't probe.
     pub profiles_path: String,
+    /// macOS: the Wine binary that starts the game. Empty (the normal case) means it's
+    /// auto-detected — see [`crate::winehost::resolve`]. Machine-wide rather than
+    /// per-game: one Mac has one set of wrappers installed. Ignored on Windows and Linux.
+    pub wine_runner: String,
     /// Hide to the tray on window close and keep running.
     pub run_in_background: bool,
     /// Start MXB App automatically on login.
@@ -166,6 +170,7 @@ impl Default for AppConfig {
             mods_path: String::new(),
             game_path: String::new(),
             profiles_path: String::new(),
+            wine_runner: String::new(),
             run_in_background: true,
             launch_at_startup: true,
             auto_run_frostmod: true,
@@ -323,10 +328,11 @@ fn resolve_profiles_dir(primary: PathBuf, fallback: impl FnOnce() -> Option<Path
     }
 }
 
-/// The game's user folder where it puts it when nothing has been moved: the Proton
-/// prefix on Linux, `Documents\PiBoSo\<game>` elsewhere.
+/// The game's user folder where it puts it when nothing has been moved: inside the Wine
+/// prefix wherever the game runs as a Windows process (Proton on Linux, a bottle on
+/// macOS), `Documents\PiBoSo\<game>` on Windows.
 fn default_user_dir(game: &GameProfile) -> Option<PathBuf> {
-    if let Some(p) = detect_proton_mods_path(game) {
+    if let Some(p) = detect_prefix_mods_path(game) {
         return Some(PathBuf::from(p));
     }
     Some(dirs_next::document_dir()?.join("PiBoSo").join(game.user_dir))
@@ -669,32 +675,56 @@ fn parse_ini_mods_folder(bytes: &[u8]) -> Option<String> {
     fallback
 }
 
-/// The game's user folder inside a Proton prefix.
+/// The game's user folder inside a Wine prefix.
 ///
-/// Under Proton the game is a Windows process, so `Documents` is the prefix's fake
-/// `C:` drive — `compatdata/<appid>/pfx/drive_c/users/steamuser/Documents/PiBoSo/<game>`
-/// — and nothing is ever written to the user's real `~/Documents`. Without this a Linux
-/// player lands on the setup screen with no working default to accept.
+/// Wherever the game runs as a Windows process — Proton on Linux, CrossOver/Whisky on
+/// macOS — `Documents` is the prefix's fake `C:` drive, and nothing is ever written to the
+/// user's real `~/Documents`. Without this a player lands on the setup screen with no
+/// working default to accept.
 ///
 /// Returns the first prefix that actually looks like a mods dir, so a stale prefix from an
 /// uninstalled copy can't win over a real one.
-fn detect_proton_mods_path(game: &GameProfile) -> Option<String> {
-    if cfg!(not(target_os = "linux")) {
-        return None;
-    }
-    for lib in steam_libraries() {
-        let candidate = lib
-            .join("steamapps")
-            .join("compatdata")
-            .join(game.steam_appid)
-            .join("pfx/drive_c/users/steamuser/Documents/PiBoSo")
-            .join(game.user_dir);
-        let as_str = candidate.to_string_lossy().into_owned();
-        if looks_like_mods_dir(&as_str) {
-            return Some(as_str);
+fn detect_prefix_mods_path(game: &GameProfile) -> Option<String> {
+    wine_prefixes(game)
+        .iter()
+        .find_map(|prefix| mods_dir_in_prefix(prefix, game))
+}
+
+/// Wine prefixes that could hold the game's user folder: Proton's per-game `compatdata`
+/// on Linux, every CrossOver/Whisky/Wine bottle on macOS. Empty on Windows, where the
+/// game is native and writes to the real `Documents`.
+fn wine_prefixes(game: &GameProfile) -> Vec<PathBuf> {
+    let mut prefixes: Vec<PathBuf> = Vec::new();
+    if cfg!(target_os = "linux") {
+        for lib in steam_libraries() {
+            prefixes.push(
+                lib.join("steamapps")
+                    .join("compatdata")
+                    .join(game.steam_appid)
+                    .join("pfx"),
+            );
         }
     }
-    None
+    prefixes.extend(crate::winehost::bottles());
+    prefixes
+}
+
+/// `<prefix>/drive_c/users/<user>/Documents/PiBoSo/<game>`, if it's really there.
+///
+/// The Windows user varies by wrapper — `steamuser` under Proton, `crossover` under
+/// CrossOver, the login name under plain Wine — so every user in the prefix is tried
+/// rather than guessing which one built it.
+fn mods_dir_in_prefix(prefix: &Path, game: &GameProfile) -> Option<String> {
+    let users = std::fs::read_dir(prefix.join("drive_c").join("users")).ok()?;
+    users.flatten().find_map(|user| {
+        let candidate = user
+            .path()
+            .join("Documents")
+            .join("PiBoSo")
+            .join(game.user_dir);
+        let as_str = candidate.to_string_lossy().into_owned();
+        looks_like_mods_dir(&as_str).then_some(as_str)
+    })
 }
 
 /// Locate the game's install folder (the one holding its `install_marker`) by scanning
@@ -750,6 +780,13 @@ fn steam_libraries() -> Vec<PathBuf> {
                 home.join(".var/app/com.valvesoftware.Steam/data/Steam"),
             );
             push(&mut roots, home.join("snap/steam/common/.local/share/Steam"));
+        }
+        // macOS: the game is a Windows title, so a Steam that owns it is a *Windows* Steam
+        // installed inside a Wine bottle. The native paths above can never hold it.
+        for bottle in crate::winehost::bottles() {
+            let c = bottle.join("drive_c");
+            push(&mut roots, c.join("Program Files (x86)/Steam"));
+            push(&mut roots, c.join("Program Files/Steam"));
         }
     }
 
@@ -1322,7 +1359,7 @@ mod tests {
 }
 
 #[cfg(test)]
-mod linux_paths_tests {
+mod prefix_paths_tests {
     use super::*;
 
     /// A Proton prefix laid out the way Steam actually makes one, checked through the
@@ -1354,11 +1391,36 @@ mod linux_paths_tests {
     }
 
     #[test]
-    fn proton_detection_is_linux_only() {
-        // On Windows/macOS the game is native and writes to the real Documents folder,
-        // so the prefix probe must never hijack detection there.
-        if cfg!(not(target_os = "linux")) {
-            assert!(detect_proton_mods_path(&crate::game::MXB).is_none());
+    fn prefix_detection_never_runs_on_windows() {
+        // On Windows the game is native and writes to the real Documents folder, so the
+        // prefix probe must never hijack detection there.
+        if cfg!(windows) {
+            assert!(detect_prefix_mods_path(&crate::game::MXB).is_none());
         }
+    }
+
+    /// A CrossOver bottle's user folder, found without being told which Windows user
+    /// built it — `crossover` here, `steamuser` under Proton, a login name under Wine.
+    #[test]
+    fn finds_the_user_folder_in_a_bottle_whatever_the_windows_user_is_called() {
+        let root = std::env::temp_dir().join(format!("frost-bottle-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let users = root.join("drive_c/users");
+        // A user with nothing in it must not be mistaken for the one that has the game.
+        std::fs::create_dir_all(users.join("Public")).unwrap();
+        let mods = users.join("crossover/Documents/PiBoSo/MX Bikes");
+        std::fs::create_dir_all(mods.join("mods").join("bikes")).unwrap();
+        std::fs::create_dir_all(mods.join("profiles")).unwrap();
+
+        assert_eq!(
+            mods_dir_in_prefix(&root, &crate::game::MXB).map(PathBuf::from),
+            Some(mods)
+        );
+        // Wrong title: GP Bikes isn't in this bottle.
+        assert!(mods_dir_in_prefix(&root, &crate::game::GPB).is_none());
+        // Not a prefix at all.
+        assert!(mods_dir_in_prefix(&root.join("nope"), &crate::game::MXB).is_none());
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/src-tauri/src/gameproc.rs
+++ b/src-tauri/src/gameproc.rs
@@ -379,7 +379,21 @@ pub fn refresh_look() -> LiveRefresh {
     }
 }
 
-#[cfg(not(windows))]
+/// Under Wine the game is an ordinary macOS process whose argv still names the exe, so
+/// `ps` finds it. Without this Play would cheerfully start a second copy.
+#[cfg(target_os = "macos")]
+pub fn is_game_running() -> bool {
+    let Ok(out) = std::process::Command::new("ps").args(["-Ao", "pid=,args="]).output() else {
+        return false;
+    };
+    crate::winehost::running_exe(
+        &String::from_utf8_lossy(&out.stdout),
+        crate::game::active().exe,
+        std::process::id(),
+    )
+}
+
+#[cfg(not(any(windows, target_os = "macos")))]
 pub fn is_game_running() -> bool {
     false
 }
@@ -415,7 +429,7 @@ pub fn game_window_rect() -> Option<(i32, i32, i32, i32)> {
 }
 
 /// What happened when the user pressed Play.
-// macOS dev builds only ever construct `AlreadyRunning` (the launch bails first).
+// Platforms with no launch arm of their own only ever construct `AlreadyRunning`.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -460,7 +474,8 @@ fn resolve_exe(cfg: &AppConfig) -> anyhow::Result<(std::path::PathBuf, std::path
 /// Windows runs the exe directly rather than going through `steam://`: that works for
 /// standalone (non-Steam) copies too, and doesn't need Steam to be up. Under Proton the
 /// exe isn't ours to spawn — Steam has to set up the prefix — so Linux hands the Steam
-/// URL to the desktop instead.
+/// URL to the desktop instead. macOS runs the exe too, but through the Wine wrapper that
+/// owns the prefix it lives in (see [`crate::winehost`]).
 pub fn launch(cfg: &AppConfig) -> anyhow::Result<LaunchOutcome> {
     launch_with(cfg, None)
 }
@@ -573,10 +588,48 @@ fn launch_with(cfg: &AppConfig, address: Option<&str>) -> anyhow::Result<LaunchO
         Ok(LaunchOutcome::Launched)
     }
 
-    #[cfg(not(any(windows, target_os = "linux")))]
+    #[cfg(target_os = "macos")]
+    {
+        // The game is a Windows binary here, so it runs inside a Wine prefix. The prefix
+        // is whatever sits above `drive_c` in the exe's own path — see `winehost`.
+        let (prefix, _) = crate::winehost::split_prefix(&exe).ok_or_else(|| {
+            anyhow::anyhow!(
+                "{game} is a Windows game — on macOS the install folder has to be the copy \
+                 inside your CrossOver, Whisky or Wine bottle (a path with drive_c in it). \
+                 Set it in Settings, under {game} install folder."
+            )
+        })?;
+        let runner = crate::winehost::resolve(&cfg.wine_runner, Some(&prefix)).ok_or_else(|| {
+            anyhow::anyhow!(
+                "No Wine runner found — install CrossOver, Whisky or Wine to run {game} on \
+                 macOS, or point Settings at one you already have."
+            )
+        })?;
+
+        let extra: Vec<String> = address.map(|a| connect_args(a).to_vec()).unwrap_or_default();
+        let plan = crate::winehost::plan(&runner, &prefix, &exe, &extra);
+        log::info!(
+            "via {}: {} {:?}",
+            runner.via(),
+            plan.program.display(),
+            plan.args
+        );
+
+        let mut cmd = std::process::Command::new(&plan.program);
+        cmd.current_dir(&dir).args(&plan.args);
+        for (key, value) in &plan.env {
+            cmd.env(key, value);
+        }
+        cmd.spawn().map_err(|e| {
+            anyhow::anyhow!("Couldn't start {} through {}: {e}", exe.display(), runner.via())
+        })?;
+        Ok(LaunchOutcome::Launched)
+    }
+
+    #[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
     {
         let _ = (dir, address);
-        anyhow::bail!("Launching MX Bikes is supported on Windows and Linux only")
+        anyhow::bail!("Launching MX Bikes is supported on Windows, macOS and Linux only")
     }
 }
 
@@ -681,6 +734,118 @@ mod tests {
         let msg = format!("{err:#}");
         assert!(msg.contains(crate::game::MXB.exe), "names what's missing: {msg}");
         assert!(msg.contains("Settings"), "points at the fix: {msg}");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The whole macOS launch, end to end, against a stub standing in for Wine.
+    ///
+    /// Everything up to the wrapper is ours and is exercised here: the prefix comes out of
+    /// the exe's path, the runner override is honoured, the game folder becomes the working
+    /// directory, and the connect flag reaches argv as two entries. Only whether Wine then
+    /// runs a Windows binary is out of our hands.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn launches_through_the_runner_with_the_prefix_and_the_connect_args() {
+        let root = temp_dir("mac-launch");
+        let game_dir = root.join("Bottles/MXB/drive_c/Program Files/MX Bikes");
+        std::fs::create_dir_all(&game_dir).unwrap();
+        std::fs::write(game_dir.join(crate::game::MXB.exe), b"stub").unwrap();
+
+        // A stub "Wine" that records how it was called, so the assertion is on the real
+        // spawn rather than on the plan we handed to it.
+        let record = root.join("argv.txt");
+        let runner = root.join("fake-wine");
+        std::fs::write(
+            &runner,
+            format!(
+                "#!/bin/sh\n{{ echo \"$WINEPREFIX\"; pwd; for a in \"$@\"; do echo \"$a\"; done; }} > {}\n",
+                record.display()
+            ),
+        )
+        .unwrap();
+        std::process::Command::new("chmod").arg("+x").arg(&runner).status().unwrap();
+
+        let mut cfg = AppConfig::default();
+        cfg.game_path = game_dir.to_string_lossy().into_owned();
+        cfg.wine_runner = runner.to_string_lossy().into_owned();
+
+        let outcome = join(&cfg, "203.0.113.10").expect("a stub runner is enough to launch");
+        assert!(matches!(outcome, LaunchOutcome::Launched));
+
+        // The child is spawned, not waited on — give it a moment to write.
+        let mut written = String::new();
+        for _ in 0..100 {
+            if let Ok(text) = std::fs::read_to_string(&record) {
+                if !text.is_empty() {
+                    written = text;
+                    break;
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+
+        let lines: Vec<&str> = written.lines().collect();
+        assert_eq!(
+            lines.first().copied(),
+            Some(root.join("Bottles/MXB").to_string_lossy().as_ref()),
+            "WINEPREFIX is the folder above drive_c, not the game folder: {written:?}"
+        );
+        // `pwd` resolves symlinks, and macOS puts the temp dir behind `/private`.
+        assert!(
+            lines.get(1).is_some_and(|cwd| cwd.ends_with("drive_c/Program Files/MX Bikes")),
+            "the game folder is the working directory: {written:?}"
+        );
+        assert_eq!(
+            &lines[2..],
+            [
+                game_dir.join(crate::game::MXB.exe).to_string_lossy().as_ref(),
+                "-directconnect",
+                "203.0.113.10:54210",
+            ],
+            "the exe and the connect flag arrive as separate argv entries: {written:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// With no wrapper installed and none configured, Play has to say what to install —
+    /// "supported on Windows and Linux only" was the old answer and is no longer true.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn without_a_runner_the_error_names_the_wrappers_to_install() {
+        let root = temp_dir("mac-no-runner");
+        let game_dir = root.join("Bottles/MXB/drive_c/MX Bikes");
+        std::fs::create_dir_all(&game_dir).unwrap();
+        std::fs::write(game_dir.join(crate::game::MXB.exe), b"stub").unwrap();
+
+        let mut cfg = AppConfig::default();
+        cfg.game_path = game_dir.to_string_lossy().into_owned();
+        // Point at a runner that isn't there: auto-detection then decides, and this test
+        // only holds on a machine with no wrapper installed — which is the case it covers.
+        cfg.wine_runner = root.join("not-here").to_string_lossy().into_owned();
+
+        if crate::winehost::resolve("", Some(&root.join("Bottles/MXB"))).is_none() {
+            let msg = format!("{:#}", launch(&cfg).expect_err("no runner means no launch"));
+            assert!(msg.contains("CrossOver"), "names a wrapper to install: {msg}");
+            assert!(msg.contains("Wine"), "names a wrapper to install: {msg}");
+        }
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A native folder pick on a Mac isn't inside any prefix — say so, rather than
+    /// failing later inside a wrapper that was never going to be involved.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn an_install_outside_a_bottle_is_named_as_the_problem() {
+        let dir = temp_dir("mac-no-prefix");
+        std::fs::write(dir.join(crate::game::MXB.exe), b"stub").unwrap();
+
+        let mut cfg = AppConfig::default();
+        cfg.game_path = dir.to_string_lossy().into_owned();
+        let msg = format!("{:#}", launch(&cfg).expect_err("no prefix means no launch"));
+        assert!(msg.contains("drive_c"), "names what's missing from the path: {msg}");
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -45,6 +45,7 @@ mod soundmods;
 mod texstore;
 mod upload;
 mod vcruntime;
+mod winehost;
 
 use config::AppConfig;
 use frostmod::ReloadOutcome;
@@ -3318,6 +3319,25 @@ fn set_game_path(app: tauri::AppHandle, path: String) -> Result<(), String> {
     config::save(&app, &cfg).map_err(|e| format!("{e:#}"))
 }
 
+/// macOS: pick the Wine binary that starts the game. Blank hands it back to auto-detection.
+#[tauri::command]
+fn set_wine_runner(app: tauri::AppHandle, path: String) -> Result<winehost::HostInfo, String> {
+    let mut cfg = config::load(&app).unwrap_or_default();
+    cfg.wine_runner = path;
+    config::save(&app, &cfg).map_err(|e| format!("{e:#}"))?;
+    Ok(winehost::describe(&cfg.wine_runner))
+}
+
+/// macOS: what the app found to launch the game with, and which bottles it can see.
+///
+/// Reported rather than assumed — a player whose bottle we can't see needs to know that
+/// before they press Play, not after.
+#[tauri::command]
+fn wine_host_info(app: tauri::AppHandle) -> winehost::HostInfo {
+    let cfg = config::load(&app).unwrap_or_default();
+    winehost::describe(&cfg.wine_runner)
+}
+
 /// The titles this build can drive, with their per-game capabilities. Static data —
 /// the switcher and the feature gating both read it.
 #[tauri::command]
@@ -5567,6 +5587,8 @@ fn main() {
             uninstall_mod,
             reveal_in_explorer,
             set_game_path,
+            set_wine_runner,
+            wine_host_info,
             set_mods_path,
             set_intro_seen,
             set_seen_version,

--- a/src-tauri/src/winehost.rs
+++ b/src-tauri/src/winehost.rs
@@ -1,0 +1,503 @@
+//! Running the game on macOS, where a Windows title lives inside a Wine prefix.
+//!
+//! CrossOver, Whisky, Kegworks and plain Wine all put their fake `C:` drive at
+//! `<prefix>/drive_c`, and that is the only layout fact this module needs: the prefix is
+//! whatever sits above `drive_c` in the game's path. Everything else — which wrapper owns
+//! that prefix, which binary launches it — falls out of where the prefix is.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+/// The fake `C:` drive every Wine prefix carries.
+const DRIVE_C: &str = "drive_c";
+
+/// Which wrapper a prefix belongs to. Decides who gets to launch it: a bottle is best
+/// driven by the wrapper that built it, whose Wine build matches the prefix's version.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Wrapper {
+    CrossOver,
+    Whisky,
+    /// A bare prefix (`$WINEPREFIX`, `~/.wine`) — nobody owns it.
+    Plain,
+}
+
+/// A Wine binary we can launch through, and how it wants to be called.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Runner {
+    pub program: PathBuf,
+    pub kind: RunnerKind,
+}
+
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunnerKind {
+    /// CrossOver, addressed by bottle *name*. Its own `--bottle` form is what applies the
+    /// bottle's graphics environment (D3DMetal/DXVK); a bare `WINEPREFIX` launch skips it.
+    CrossOver { root: PathBuf, bottle: String },
+    /// Any other Wine build, pointed at the prefix with `WINEPREFIX`.
+    Wine { via: &'static str },
+}
+
+impl Runner {
+    /// What to call this in logs and in the UI.
+    pub fn via(&self) -> &str {
+        match &self.kind {
+            RunnerKind::CrossOver { .. } => "CrossOver",
+            RunnerKind::Wine { via } => via,
+        }
+    }
+}
+
+/// The command that starts `exe` under `runner`, ready to spawn.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Launch {
+    pub program: PathBuf,
+    pub args: Vec<String>,
+    pub env: Vec<(String, String)>,
+}
+
+/// Split a path inside a Wine prefix into the prefix and the part below `drive_c`.
+///
+/// The one rule the whole module rests on, and pure, so every wrapper's layout is covered
+/// by tests on a machine with no Wine installed at all.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub fn split_prefix(path: &Path) -> Option<(PathBuf, PathBuf)> {
+    let mut prefix = PathBuf::new();
+    let mut parts = path.components();
+    for part in parts.by_ref() {
+        if part.as_os_str().to_string_lossy().eq_ignore_ascii_case(DRIVE_C) {
+            // A path that *starts* at `drive_c` names no prefix to launch in.
+            if prefix.as_os_str().is_empty() {
+                return None;
+            }
+            return Some((prefix, parts.collect()));
+        }
+        prefix.push(part);
+    }
+    None
+}
+
+/// The exe as the bottle sees it — `C:\Program Files\...` — for wrappers that take a
+/// Windows path rather than a host one.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn windows_path(prefix: &Path, exe: &Path) -> Option<String> {
+    let (found, rel) = split_prefix(exe)?;
+    if found != prefix {
+        return None;
+    }
+    let joined = rel
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join("\\");
+    Some(format!("C:\\{joined}"))
+}
+
+/// Every Wine prefix on this Mac, for the install detectors to search.
+pub fn bottles() -> Vec<PathBuf> {
+    bottles_in(bottle_roots().into_iter().map(|(root, _)| root))
+}
+
+/// A prefix either *is* the root (`~/.wine`) or sits one level under it (a bottles folder).
+fn bottles_in(roots: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
+    let mut found: Vec<PathBuf> = Vec::new();
+    for root in roots {
+        let here = if is_prefix(&root) {
+            vec![root]
+        } else {
+            std::fs::read_dir(&root)
+                .into_iter()
+                .flatten()
+                .flatten()
+                .map(|entry| entry.path())
+                .filter(|path| is_prefix(path))
+                .collect()
+        };
+        // The same prefix can sit under two roots (a per-user CrossOver beside a
+        // system one), and a duplicate would make every detector search it twice.
+        for path in here {
+            if !found.contains(&path) {
+                found.push(path);
+            }
+        }
+    }
+    found
+}
+
+fn is_prefix(dir: &Path) -> bool {
+    dir.join(DRIVE_C).is_dir()
+}
+
+/// Where each wrapper keeps its bottles.
+#[cfg(target_os = "macos")]
+fn bottle_roots() -> Vec<(PathBuf, Wrapper)> {
+    let mut roots: Vec<(PathBuf, Wrapper)> = Vec::new();
+    if let Ok(custom) = std::env::var("CX_BOTTLE_PATH") {
+        roots.push((PathBuf::from(custom), Wrapper::CrossOver));
+    }
+    roots.push((
+        PathBuf::from("/Library/Application Support/CrossOver/Bottles"),
+        Wrapper::CrossOver,
+    ));
+    if let Ok(prefix) = std::env::var("WINEPREFIX") {
+        roots.push((PathBuf::from(prefix), Wrapper::Plain));
+    }
+    if let Some(home) = dirs_next::home_dir() {
+        roots.push((
+            home.join("Library/Application Support/CrossOver/Bottles"),
+            Wrapper::CrossOver,
+        ));
+        // Whisky moved its container id at one point; both layouts are still out there.
+        roots.push((
+            home.join("Library/Containers/com.isaacmarovitz.Whisky/Bottles"),
+            Wrapper::Whisky,
+        ));
+        roots.push((home.join("Library/Containers/Whisky/Bottles"), Wrapper::Whisky));
+        roots.push((home.join(".wine"), Wrapper::Plain));
+    }
+    roots
+}
+
+/// Off macOS there are no bottles — the game is launched natively (Windows) or through
+/// Steam (Linux).
+#[cfg(not(target_os = "macos"))]
+fn bottle_roots() -> Vec<(PathBuf, Wrapper)> {
+    Vec::new()
+}
+
+/// Wine binaries to fall back on, best first. Only the ones that exist are ever used.
+#[cfg(target_os = "macos")]
+fn wine_candidates() -> Vec<(PathBuf, &'static str)> {
+    let mut out: Vec<(PathBuf, &'static str)> = Vec::new();
+    for root in crossover_roots() {
+        out.push((root.join("bin/wine"), "CrossOver"));
+    }
+    if let Some(home) = dirs_next::home_dir() {
+        let whisky = home.join("Library/Application Support/com.isaacmarovitz.Whisky/Libraries/Wine/bin");
+        out.push((whisky.join("wine64"), "Whisky"));
+        out.push((whisky.join("wine"), "Whisky"));
+    }
+    for dir in [
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "/opt/homebrew/opt/game-porting-toolkit/bin",
+        "/usr/local/opt/game-porting-toolkit/bin",
+    ] {
+        out.push((PathBuf::from(dir).join("wine64"), "Wine"));
+        out.push((PathBuf::from(dir).join("wine"), "Wine"));
+    }
+    out
+}
+
+#[cfg(not(target_os = "macos"))]
+fn wine_candidates() -> Vec<(PathBuf, &'static str)> {
+    Vec::new()
+}
+
+/// CrossOver installs into `/Applications` normally, but a per-user copy is legal.
+#[cfg(target_os = "macos")]
+fn crossover_roots() -> Vec<PathBuf> {
+    let suffix = "CrossOver.app/Contents/SharedSupport/CrossOver";
+    let mut roots = vec![PathBuf::from("/Applications").join(suffix)];
+    if let Some(home) = dirs_next::home_dir() {
+        roots.push(home.join("Applications").join(suffix));
+    }
+    roots
+}
+
+/// The wrapper that built `prefix`, if we recognise where it sits.
+fn owner_of(prefix: &Path) -> Option<Wrapper> {
+    let parent = prefix.parent()?;
+    bottle_roots()
+        .into_iter()
+        .find(|(root, _)| root == parent || root == prefix)
+        .map(|(_, wrapper)| wrapper)
+}
+
+/// Pick the binary that will launch `prefix`.
+///
+/// `override_path` is the Settings escape hatch: an explicit Wine binary always wins, and
+/// is always driven the plain `WINEPREFIX` way, because that is the one form every Wine
+/// build understands.
+pub fn resolve(override_path: &str, prefix: Option<&Path>) -> Option<Runner> {
+    let chosen = override_path.trim();
+    if !chosen.is_empty() {
+        let program = PathBuf::from(chosen);
+        return program.is_file().then_some(Runner {
+            program,
+            kind: RunnerKind::Wine { via: "your Wine runner" },
+        });
+    }
+
+    // The wrapper that owns the bottle drives it: its Wine build is the one the prefix was
+    // created with, and running a different build against a prefix can upgrade it in place.
+    if let Some(prefix) = prefix {
+        match owner_of(prefix) {
+            Some(Wrapper::CrossOver) => {
+                if let Some(runner) = crossover_runner(prefix) {
+                    return Some(runner);
+                }
+            }
+            Some(Wrapper::Whisky) => {
+                if let Some(runner) = first_existing("Whisky") {
+                    return Some(runner);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    wine_candidates()
+        .into_iter()
+        .find(|(program, _)| program.is_file())
+        .map(|(program, via)| Runner { program, kind: RunnerKind::Wine { via } })
+}
+
+/// The first candidate belonging to `via` that is actually installed.
+fn first_existing(via: &'static str) -> Option<Runner> {
+    wine_candidates()
+        .into_iter()
+        .find(|(program, owner)| *owner == via && program.is_file())
+        .map(|(program, via)| Runner { program, kind: RunnerKind::Wine { via } })
+}
+
+/// CrossOver driving one of its own bottles, by name.
+fn crossover_runner(prefix: &Path) -> Option<Runner> {
+    let bottle = prefix.file_name()?.to_string_lossy().into_owned();
+    #[cfg(target_os = "macos")]
+    for root in crossover_roots() {
+        let wine = root.join("bin/wine");
+        if wine.is_file() {
+            return Some(Runner {
+                program: wine,
+                kind: RunnerKind::CrossOver { root, bottle },
+            });
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    let _ = bottle;
+    None
+}
+
+/// The exact command that starts `exe` under `runner`.
+///
+/// `extra` is appended last in both forms, as separate argv entries — the game's parser
+/// reads the connect address as the argument *after* the flag, so they must not be joined.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub fn plan(runner: &Runner, prefix: &Path, exe: &Path, extra: &[String]) -> Launch {
+    let mut args: Vec<String> = Vec::new();
+    let mut env: Vec<(String, String)> = Vec::new();
+    match &runner.kind {
+        RunnerKind::CrossOver { root, bottle } => {
+            args.push("--bottle".into());
+            args.push(bottle.clone());
+            args.push("--cx-app".into());
+            // A host path works too, but the bottle-relative Windows path is the form
+            // CodeWeavers documents, and the one `--cx-app` is built to resolve.
+            args.push(
+                windows_path(prefix, exe).unwrap_or_else(|| exe.to_string_lossy().into_owned()),
+            );
+            env.push(("CX_ROOT".into(), root.to_string_lossy().into_owned()));
+        }
+        RunnerKind::Wine { .. } => {
+            args.push(exe.to_string_lossy().into_owned());
+            env.push(("WINEPREFIX".into(), prefix.to_string_lossy().into_owned()));
+        }
+    }
+    args.extend(extra.iter().cloned());
+    Launch { program: runner.program.clone(), args, env }
+}
+
+/// Is a process running `exe`? Reads `ps -Ao pid=,args=` output.
+///
+/// Under Wine the game is a real process whose argv still names `mxbikes.exe`, so the
+/// command line is what identifies it — the executable is Wine's. Our own pid is skipped:
+/// this app's argv can carry the path it is about to launch.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub fn running_exe(ps_output: &str, exe: &str, own_pid: u32) -> bool {
+    let needle = exe.to_ascii_lowercase();
+    ps_output.lines().any(|line| {
+        let Some((pid, args)) = line.trim_start().split_once(char::is_whitespace) else {
+            return false;
+        };
+        pid.parse::<u32>().is_ok_and(|p| p != own_pid) && args.to_ascii_lowercase().contains(&needle)
+    })
+}
+
+/// What the app found to launch with, for Settings to show. Reported rather than assumed:
+/// a player whose bottle we can't see needs to know that before they press Play.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostInfo {
+    /// The binary we'd launch through, or empty when nothing was found.
+    pub runner: String,
+    /// Which wrapper that binary belongs to.
+    pub via: String,
+    /// Prefixes we can see, so a missing bottle is visible as missing.
+    pub bottles: Vec<String>,
+}
+
+/// Describe the launch environment without needing a game to launch.
+pub fn describe(override_path: &str) -> HostInfo {
+    let found = resolve(override_path, None);
+    HostInfo {
+        runner: found
+            .as_ref()
+            .map(|r| r.program.to_string_lossy().into_owned())
+            .unwrap_or_default(),
+        via: found.as_ref().map(|r| r.via().to_string()).unwrap_or_default(),
+        bottles: bottles()
+            .into_iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("frost-winehost-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn finds_the_prefix_above_drive_c() {
+        let exe = PathBuf::from(
+            "/Users/x/Library/Application Support/CrossOver/Bottles/MXB/drive_c/Program Files/MX Bikes/mxbikes.exe",
+        );
+        let (prefix, rel) = split_prefix(&exe).expect("a bottled exe names its prefix");
+        assert_eq!(
+            prefix,
+            PathBuf::from("/Users/x/Library/Application Support/CrossOver/Bottles/MXB")
+        );
+        assert_eq!(rel, PathBuf::from("Program Files/MX Bikes/mxbikes.exe"));
+    }
+
+    /// A native install has no prefix to launch in, and neither does a bare `drive_c`.
+    #[test]
+    fn a_path_outside_a_prefix_names_none() {
+        assert!(split_prefix(Path::new("/Applications/MX Bikes/mxbikes.exe")).is_none());
+        assert!(split_prefix(Path::new("drive_c/Program Files/MX Bikes/mxbikes.exe")).is_none());
+    }
+
+    #[test]
+    fn rewrites_the_exe_as_the_bottle_sees_it() {
+        let prefix = Path::new("/b/MXB");
+        let exe = Path::new("/b/MXB/drive_c/Program Files/MX Bikes/mxbikes.exe");
+        assert_eq!(
+            windows_path(prefix, exe).unwrap(),
+            "C:\\Program Files\\MX Bikes\\mxbikes.exe"
+        );
+    }
+
+    #[test]
+    fn crossover_is_driven_by_bottle_name_and_keeps_the_connect_args_apart() {
+        let runner = Runner {
+            program: PathBuf::from("/Applications/CrossOver.app/Contents/SharedSupport/CrossOver/bin/wine"),
+            kind: RunnerKind::CrossOver {
+                root: PathBuf::from("/Applications/CrossOver.app/Contents/SharedSupport/CrossOver"),
+                bottle: "MXB".into(),
+            },
+        };
+        let launch = plan(
+            &runner,
+            Path::new("/b/MXB"),
+            Path::new("/b/MXB/drive_c/MX Bikes/mxbikes.exe"),
+            &["-directconnect".to_string(), "203.0.113.10:54210".to_string()],
+        );
+        assert_eq!(
+            launch.args,
+            [
+                "--bottle",
+                "MXB",
+                "--cx-app",
+                "C:\\MX Bikes\\mxbikes.exe",
+                "-directconnect",
+                "203.0.113.10:54210",
+            ]
+        );
+        assert!(launch.env.iter().any(|(k, _)| k == "CX_ROOT"));
+    }
+
+    #[test]
+    fn plain_wine_is_pointed_at_the_prefix_and_given_the_host_path() {
+        let runner = Runner {
+            program: PathBuf::from("/opt/homebrew/bin/wine64"),
+            kind: RunnerKind::Wine { via: "Wine" },
+        };
+        let launch = plan(
+            &runner,
+            Path::new("/b/MXB"),
+            Path::new("/b/MXB/drive_c/MX Bikes/mxbikes.exe"),
+            &["-directconnect".to_string(), "203.0.113.10:54210".to_string()],
+        );
+        assert_eq!(
+            launch.args,
+            [
+                "/b/MXB/drive_c/MX Bikes/mxbikes.exe",
+                "-directconnect",
+                "203.0.113.10:54210",
+            ]
+        );
+        assert_eq!(
+            launch.env,
+            [("WINEPREFIX".to_string(), "/b/MXB".to_string())]
+        );
+    }
+
+    #[test]
+    fn collects_bottles_one_level_down_and_roots_that_are_prefixes_themselves() {
+        let root = temp_dir("bottles");
+        let bottles = root.join("Bottles");
+        for name in ["MXB", "Other"] {
+            std::fs::create_dir_all(bottles.join(name).join(DRIVE_C)).unwrap();
+        }
+        // A folder that isn't a prefix must not be offered as one.
+        std::fs::create_dir_all(bottles.join("NotABottle")).unwrap();
+        let bare = root.join("dotwine");
+        std::fs::create_dir_all(bare.join(DRIVE_C)).unwrap();
+
+        let mut found = bottles_in([bottles.clone(), bare.clone(), root.join("missing")]);
+        found.sort();
+        let mut want = vec![bottles.join("MXB"), bottles.join("Other"), bare];
+        want.sort();
+        assert_eq!(found, want);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn spots_the_game_in_a_process_list_but_never_ourselves() {
+        let ps = "\
+  501 /sbin/launchd
+ 8123 /Applications/CrossOver.app/Contents/SharedSupport/CrossOver/bin/wine C:\\MX Bikes\\MXBikes.exe
+ 9000 /Applications/MXB App.app/Contents/MacOS/mxb-app";
+        assert!(running_exe(ps, "mxbikes.exe", 9000));
+        // Our own process is the one that carries the path it just launched.
+        assert!(!running_exe(ps, "mxbikes.exe", 8123));
+        assert!(!running_exe(ps, "gpbikes.exe", 9000));
+        assert!(!running_exe("", "mxbikes.exe", 9000));
+    }
+
+    #[test]
+    fn an_explicit_runner_wins_and_a_missing_one_is_not_used() {
+        let dir = temp_dir("override");
+        let bin = dir.join("wine64");
+        std::fs::write(&bin, b"#!/bin/sh\n").unwrap();
+
+        let runner = resolve(&bin.to_string_lossy(), None).expect("an existing binary is used");
+        assert_eq!(runner.program, bin);
+        assert!(matches!(runner.kind, RunnerKind::Wine { .. }));
+
+        assert!(resolve(&dir.join("gone").to_string_lossy(), None).is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -32,6 +32,9 @@ import {
   setProfilesPath,
   setRunInBackground,
   setWatchModsReload,
+  setWineRunner,
+  wineHostInfo,
+  type WineHostInfo,
   type OverlayState,
   experimentalState as experimentalStateApi,
   setExperimental,
@@ -460,6 +463,46 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
     }
   };
 
+  // macOS: MX Bikes is a Windows binary, so Play has to go through a Wine wrapper. What
+  // we found is shown rather than assumed — "no runner" is the difference between Play
+  // working and Play failing, and the player should see it before they press it.
+  const [wineHost, setWineHost] = useState<WineHostInfo | null>(null);
+  useEffect(() => {
+    if (!isMac) return;
+    wineHostInfo()
+      .then(setWineHost)
+      .catch(() => setWineHost(null));
+  }, [isMac]);
+
+  const changeWineRunner = async () => {
+    const picked = await pickFolder({
+      multiple: false,
+      title: t("settings.pickWineRunner"),
+    });
+    if (typeof picked !== "string") return;
+    setBusy(true);
+    try {
+      setWineHost(await setWineRunner(picked));
+      await reloadConfig();
+    } catch (e) {
+      toast.error(t("settings.wineRunnerFailed"), { description: String(e) });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const resetWineRunner = async () => {
+    setBusy(true);
+    try {
+      setWineHost(await setWineRunner(""));
+      await reloadConfig();
+    } catch (e) {
+      toast.error(t("settings.wineRunnerFailed"), { description: String(e) });
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const changeProfilesFolder = async () => {
     const picked = await pickFolder({
       directory: true,
@@ -694,6 +737,45 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
             >
               Detect automatically
             </button>
+
+            {/* macOS only: the Wine wrapper Play launches through. */}
+            {isMac && (
+              <>
+                <div className="mt-1 h-px bg-border" />
+                <p className="text-[12px] text-muted-foreground">
+                  {t("settings.wineRunnerDesc", { game: game.display })}
+                </p>
+                <div className="flex gap-2">
+                  <div className="flex flex-1 items-center gap-2 rounded-lg border border-input bg-background px-3 py-2.5 font-mono text-[12px] text-muted-foreground">
+                    <span className="flex-1 truncate" title={wineHost?.runner}>
+                      {wineHost?.runner || t("settings.wineRunnerNone")}
+                    </span>
+                    {wineHost?.runner && (
+                      <span className="flex flex-none items-center gap-1 font-sans text-[11px] font-semibold text-success">
+                        <Check className="size-3" strokeWidth={3} /> {wineHost.via}
+                      </span>
+                    )}
+                  </div>
+                  <Button variant="outline" size="sm" onClick={changeWineRunner} disabled={busy}>
+                    {config.wineRunner ? t("settings.change") : t("settings.set")}
+                  </Button>
+                </div>
+                <p className="text-[11.5px] text-muted-foreground">
+                  {wineHost?.bottles.length
+                    ? t("settings.wineBottlesFound", { count: wineHost.bottles.length })
+                    : t("settings.wineBottlesNone", { game: game.display })}
+                </p>
+                {config.wineRunner && (
+                  <button
+                    onClick={resetWineRunner}
+                    disabled={busy}
+                    className="cursor-default self-start text-[11.5px] font-semibold text-primary hover:brightness-110 disabled:opacity-50"
+                  >
+                    {t("settings.resetToDefault")}
+                  </button>
+                )}
+              </>
+            )}
           </Section>
 
           {/* general / background */}

--- a/src/Components/Setup/Setup.tsx
+++ b/src/Components/Setup/Setup.tsx
@@ -29,15 +29,17 @@ interface SetupProps {
 }
 
 /**
- * Where the game keeps its user folder, per OS. On Linux it runs under Proton and writes
- * inside the Wine prefix, so pointing someone at `~/Documents` would send them looking in
- * a folder the game has never touched.
+ * Where the game keeps its user folder, per OS. Anywhere it runs as a Windows process —
+ * Proton on Linux, a CrossOver/Whisky bottle on macOS — it writes inside the Wine prefix,
+ * so pointing someone at `~/Documents` would send them looking in a folder the game has
+ * never touched.
  */
 function hintFor(platform: string | null, game: GameInfo): string {
   const appid = game.id === "gpb" ? "848050" : "655500";
   if (platform === "linux")
     return `steamapps/compatdata/${appid}/.../Documents/PiBoSo/${game.display}`;
-  if (platform === "macos") return `Documents/PiBoSo/${game.display}`;
+  if (platform === "macos")
+    return `Bottles/.../drive_c/users/crossover/Documents/PiBoSo/${game.display}`;
   return `Documents\\PiBoSo\\${game.display}`;
 }
 

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -654,6 +654,30 @@ export function setGamePath(path: string): Promise<void> {
   return invoke<void>("set_game_path", { path });
 }
 
+/**
+ * macOS only: what the app found to run the game with.
+ *
+ * MX Bikes is a Windows binary, so on a Mac it runs inside a CrossOver, Whisky or Wine
+ * bottle. `runner` is the binary we'd launch through — empty means none was found and
+ * Play can't work until one is installed or picked.
+ */
+export interface WineHostInfo {
+  runner: string;
+  /** Which wrapper the runner belongs to ("CrossOver", "Whisky", "Wine"). */
+  via: string;
+  /** Wine prefixes we can see, so a bottle we're missing shows up as missing. */
+  bottles: string[];
+}
+
+export function wineHostInfo(): Promise<WineHostInfo> {
+  return invoke<WineHostInfo>("wine_host_info");
+}
+
+/** Pick the Wine binary that starts the game. Pass an empty string to auto-detect again. */
+export function setWineRunner(path: string): Promise<WineHostInfo> {
+  return invoke<WineHostInfo>("set_wine_runner", { path });
+}
+
 /** Auto-detect the Steam MX Bikes install (holds `rider.pkz`); null if not found. */
 /** Scan Steam for a game's install folder. Omit `game` for the active one; setup passes
  *  it explicitly, since on a first run the pick isn't saved yet. */

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -627,6 +627,17 @@ export const de: Translation = {
   "settings.installFound": "Deine {{game}}-Installation wurde gefunden",
   "settings.detectInstallFailed":
     "Installationsordner konnte nicht erkannt werden",
+  "settings.wineRunnerDesc":
+    "{{game}} ist ein Windows-Spiel — auf einem Mac läuft es in einer CrossOver-, Whisky- oder Wine-Bottle. Darüber startet Spielen es.",
+  "settings.wineRunnerNone": "Kein Wine-Runner gefunden",
+  "settings.pickWineRunner": "Wähle eine Wine-Binärdatei (z. B. das wine von CrossOver)",
+  "settings.wineRunnerFailed": "Wine-Runner konnte nicht gesetzt werden",
+  "settings.wineBottlesFound_one":
+    "{{count}} Bottle gefunden, in der nach deiner Installation gesucht wird.",
+  "settings.wineBottlesFound_other":
+    "{{count}} Bottles gefunden, in denen nach deiner Installation gesucht wird.",
+  "settings.wineBottlesNone":
+    "Keine Bottles gefunden — installiere {{game}} zuerst in CrossOver, Whisky oder Wine.",
   "settings.pickProfilesFolder": "Wähle deinen {{game}}-Profilordner",
   "settings.profilesSet": "Profilordner festgelegt",
   "settings.profilesFound_one": "{{count}} Profil gefunden.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -605,6 +605,15 @@ export const en = {
     "No Steam install detected — set the folder manually.",
   "settings.installFound": "Found your {{game}} install",
   "settings.detectInstallFailed": "Couldn't detect install folder",
+  "settings.wineRunnerDesc":
+    "{{game}} is a Windows game, so on a Mac it runs inside a CrossOver, Whisky or Wine bottle. This is what Play launches it through.",
+  "settings.wineRunnerNone": "No Wine runner found",
+  "settings.pickWineRunner": "Select a Wine binary (e.g. CrossOver's wine)",
+  "settings.wineRunnerFailed": "Couldn't set the Wine runner",
+  "settings.wineBottlesFound_one": "Found {{count}} bottle to search for your install.",
+  "settings.wineBottlesFound_other": "Found {{count}} bottles to search for your install.",
+  "settings.wineBottlesNone":
+    "No bottles found — install {{game}} in CrossOver, Whisky or Wine first.",
   "settings.pickProfilesFolder": "Select your {{game}} profiles folder",
   "settings.profilesSet": "Profiles folder set",
   "settings.profilesFound_one": "Found {{count}} profile.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -619,6 +619,17 @@ export const es: Translation = {
   "settings.installFound": "Instalación de {{game}} encontrada",
   "settings.detectInstallFailed":
     "No se pudo detectar la carpeta de instalación",
+  "settings.wineRunnerDesc":
+    "{{game}} es un juego de Windows, así que en un Mac se ejecuta dentro de una bottle de CrossOver, Whisky o Wine. Es lo que usa Jugar para arrancarlo.",
+  "settings.wineRunnerNone": "No se encontró ningún runner de Wine",
+  "settings.pickWineRunner": "Selecciona un binario de Wine (p. ej. el wine de CrossOver)",
+  "settings.wineRunnerFailed": "No se pudo definir el runner de Wine",
+  "settings.wineBottlesFound_one":
+    "Se encontró {{count}} bottle donde buscar tu instalación.",
+  "settings.wineBottlesFound_other":
+    "Se encontraron {{count}} bottles donde buscar tu instalación.",
+  "settings.wineBottlesNone":
+    "No se encontraron bottles — instala primero {{game}} en CrossOver, Whisky o Wine.",
   "settings.pickProfilesFolder":
     "Selecciona tu carpeta de perfiles de {{game}}",
   "settings.profilesSet": "Carpeta de perfiles definida",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -624,6 +624,18 @@ export const fr: Translation = {
   "settings.installFound": "Installation de {{game}} trouvée",
   "settings.detectInstallFailed":
     "Impossible de détecter le dossier d'installation",
+  "settings.wineRunnerDesc":
+    "{{game}} est un jeu Windows : sur un Mac, il tourne dans une bottle CrossOver, Whisky ou Wine. C'est par là que Jouer le lance.",
+  "settings.wineRunnerNone": "Aucun runner Wine trouvé",
+  "settings.pickWineRunner":
+    "Sélectionnez un binaire Wine (par ex. le wine de CrossOver)",
+  "settings.wineRunnerFailed": "Impossible de définir le runner Wine",
+  "settings.wineBottlesFound_one":
+    "{{count}} bottle trouvée où chercher votre installation.",
+  "settings.wineBottlesFound_other":
+    "{{count}} bottles trouvées où chercher votre installation.",
+  "settings.wineBottlesNone":
+    "Aucune bottle trouvée — installez d'abord {{game}} dans CrossOver, Whisky ou Wine.",
   "settings.pickProfilesFolder":
     "Sélectionnez votre dossier de profils {{game}}",
   "settings.profilesSet": "Dossier de profils défini",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -614,6 +614,17 @@ export const it: Translation = {
   "settings.installFound": "Installazione di {{game}} trovata",
   "settings.detectInstallFailed":
     "Impossibile rilevare la cartella d'installazione",
+  "settings.wineRunnerDesc":
+    "{{game}} è un gioco Windows, quindi su Mac gira dentro una bottle di CrossOver, Whisky o Wine. È da qui che Gioca lo avvia.",
+  "settings.wineRunnerNone": "Nessun runner Wine trovato",
+  "settings.pickWineRunner": "Seleziona un binario Wine (es. il wine di CrossOver)",
+  "settings.wineRunnerFailed": "Impossibile impostare il runner Wine",
+  "settings.wineBottlesFound_one":
+    "Trovata {{count}} bottle in cui cercare la tua installazione.",
+  "settings.wineBottlesFound_other":
+    "Trovate {{count}} bottle in cui cercare la tua installazione.",
+  "settings.wineBottlesNone":
+    "Nessuna bottle trovata — installa prima {{game}} in CrossOver, Whisky o Wine.",
   "settings.pickProfilesFolder":
     "Seleziona la cartella dei profili di {{game}}",
   "settings.profilesSet": "Cartella dei profili impostata",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -619,6 +619,17 @@ export const ptBR: Translation = {
   "settings.installFound": "Instalação do {{game}} encontrada",
   "settings.detectInstallFailed":
     "Não foi possível detectar a pasta de instalação",
+  "settings.wineRunnerDesc":
+    "{{game}} é um jogo de Windows, então em um Mac ele roda dentro de uma bottle do CrossOver, Whisky ou Wine. É por aí que o Jogar o inicia.",
+  "settings.wineRunnerNone": "Nenhum runner do Wine encontrado",
+  "settings.pickWineRunner": "Selecione um binário do Wine (ex.: o wine do CrossOver)",
+  "settings.wineRunnerFailed": "Não foi possível definir o runner do Wine",
+  "settings.wineBottlesFound_one":
+    "{{count}} bottle encontrada para procurar sua instalação.",
+  "settings.wineBottlesFound_other":
+    "{{count}} bottles encontradas para procurar sua instalação.",
+  "settings.wineBottlesNone":
+    "Nenhuma bottle encontrada — instale o {{game}} no CrossOver, Whisky ou Wine primeiro.",
   "settings.pickProfilesFolder":
     "Selecione sua pasta de perfis do {{game}}",
   "settings.profilesSet": "Pasta de perfis definida",

--- a/src/lib/useGameRunning.ts
+++ b/src/lib/useGameRunning.ts
@@ -11,9 +11,9 @@ const POLL_MS = 5000;
  * and the game is a separate thing to watch. `refresh` is exposed so a launch can check
  * straight away instead of waiting out the interval.
  *
- * Note the probe is Win32-only, so off Windows this is permanently `false` — a Linux
- * player sees Play rather than "MX Bikes running", which is harmless: the backend still
- * routes through Steam, which focuses the running game instead of starting a second one.
+ * Windows and macOS both really probe (Win32 on one, `ps` on the other — under Wine the
+ * game is a normal process). Linux is permanently `false`, which is harmless: the backend
+ * routes through Steam, and Steam focuses the running game rather than starting a second.
  */
 export function useGameRunning(): { running: boolean; refresh: () => void } {
   const [running, setRunning] = useState(false);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,6 +76,11 @@ export interface Config {
    * `<modsPath>/profiles`; set only when profiles sit outside the game folder.
    */
   profilesPath?: string;
+  /**
+   * macOS: the Wine binary that starts the game. Empty (normal) means auto-detected.
+   * Ignored on Windows and Linux.
+   */
+  wineRunner?: string;
   /** Hide to the tray on close and keep running (default true). */
   runInBackground?: boolean;
   /** Launch on login (default true). */


### PR DESCRIPTION
## What

Play and Join Server work on macOS. Previously the macOS arm didn't exist — pressing Play returned *"Launching MX Bikes is supported on Windows and Linux only."*

MX Bikes is a Windows binary, so on a Mac it runs inside a Wine prefix. **Every wrapper — CrossOver, Whisky, Kegworks, plain Wine — puts its fake `C:` drive at `drive_c`**, and that single fact is what the design rests on: the prefix is whatever sits above `drive_c` in the exe's own path. No wrapper's private layout has to be encoded, and the rule is a pure function, so it's unit-tested on any host.

## How

- **New `src-tauri/src/winehost.rs`** — prefix splitting, bottle enumeration, runner resolution, and a pure `plan()` that builds the exact command.
- **The wrapper that owns the bottle drives it.** CrossOver bottles go through `--bottle <name> --cx-app <C:\path>` (the form CodeWeavers documents) so the bottle's own D3DMetal/DXVK environment applies — a bare `WINEPREFIX` launch skips it. Everything else is `WINEPREFIX=<prefix> <wine> <exe>`. Chosen over Whisky's `whisky run` CLI, which takes a bottle *name* and doesn't clearly forward program arguments — and Join needs arguments to survive.
- **`is_game_running` on macOS** reads `ps -Ao pid=,args=`; under Wine the game is an ordinary process whose argv still names the exe. Without it Play would start a second copy and the sidebar could never show "MX Bikes running".
- **Detection is bottle-aware.** `steam_libraries()` also looks for a *Windows* Steam installed inside a bottle, and the Proton-only mods-path probe is generalised to any Wine prefix — trying every Windows user in it (`crossover`, `steamuser`, a login name) rather than assuming one.
- **Escape hatch:** a `wineRunner` config field and a macOS-only Settings row showing which runner was detected and how many bottles are visible — so a bottle the app *can't* see reads as missing before Play is pressed, not after.

## Verification

- `cargo test` — 580 pass. Includes a **full end-to-end launch test** against a stub standing in for Wine: `WINEPREFIX`, working directory and argv (exe + `-directconnect` + address as separate entries) are asserted against a real spawn, plus both error paths (no runner installed; install folder outside any bottle).
- `cargo check --target x86_64-pc-windows-gnu` — the Windows half still compiles; no new warnings on either target.
- `tsc --noEmit` and `eslint` clean (the 2 remaining warnings are pre-existing, in `Presets.tsx` and `ViewerDialog.tsx`).
- `tauri dev` on macOS — app boots clean, window renders.

## Not verified

**Whether Wine actually runs the game.** No CrossOver, Whisky or Wine is installed on the dev machine and there's no bottled MX Bikes to point at. Everything up to the wrapper is ours and is tested; the handoff to the wrapper isn't. The launch logs the exact command it runs, and `wineRunner` means a wrong auto-detection is a settings change rather than a new build.

## DB / schema

None. Config gains `wineRunner` with a serde default, so existing configs load unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)