### PR TITLE
chore(release): fold the painting tools into v0.9.1 and show them off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,7 +194,14 @@ them up.
   uses the same marker files the app's own library scanner keys on, and stops descending
   once it has found a track.
 
-## 2026-08-10 — the Designer paints
+## 2026-08-10 — v0.9.1 — The Designer paints, Play works on a Mac, and SteamOS stops opening to a white screen
+
+On top of v0.9.0 — everything that release added is still the news, and its notes are
+repeated below.
+
+Worth knowing for this beta: the Mac launch has been tested against a stand-in for Wine, not
+against a real bottle, so if Play does something odd on your machine the app log names the
+exact command it ran — please send it.
 
 ### Added
 - **You can paint on a template.** The Designer could stack images and text on the sheets of an
@@ -216,17 +223,6 @@ them up.
   edits are not part of it.
 - **Tools have keys.** V, B, E, G, F, R, O and L. Hold Shift for straight lines, squares and
   circles; right-drag still pans, which matters more with a brush than with a logo.
-
-## 2026-08-10 — v0.9.1 — Play works on a Mac, and SteamOS stops opening to a white screen
-
-A patch on top of v0.9.0 — everything that release added is still the news, and its notes
-are repeated below.
-
-Worth knowing for this beta: the Mac launch has been tested against a stand-in for Wine, not
-against a real bottle, so if Play does something odd on your machine the app log names the
-exact command it ran — please send it.
-
-### Added
 - **Play and Join Server work on macOS.** MX Bikes is a Windows game, so on a Mac it runs
   inside a CrossOver, Whisky or Wine bottle — and the app, which had a launcher for Windows
   and one for Linux, simply refused: *"Launching MX Bikes is supported on Windows and Linux

--- a/src/Components/Showcase/releases.ts
+++ b/src/Components/Showcase/releases.ts
@@ -9,6 +9,10 @@
  * else knows about versions.
  */
 import {
+  Apple,
+  Blend,
+  Brush,
+  Layers,
   Monitor,
   Languages,
   ListOrdered,
@@ -52,6 +56,20 @@ export interface Release {
 }
 
 export const RELEASES: Release[] = [
+  {
+    version: "0.9.1",
+    hero: {
+      icon: Brush,
+      title: "showcase.v091.hero.title",
+      body: "showcase.v091.hero.body",
+    },
+    highlights: [
+      { icon: Blend, text: "showcase.v091.gradient" },
+      { icon: Layers, text: "showcase.v091.paintLayer" },
+      { icon: Apple, text: "showcase.v091.macos" },
+      { icon: Monitor, text: "showcase.v091.steamos" },
+    ],
+  },
   {
     version: "0.9.0",
     hero: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1097,6 +1097,17 @@ export const de: Translation = {
   "showcase.whileGameRunning": "während MX Bikes läuft",
   "showcase.releaseNotes": "Release Notes lesen",
   "showcase.gotIt": "Alles klar",
+  "showcase.v091.hero.title": "Male direkt auf die Vorlage",
+  "showcase.v091.hero.body":
+    "Der Designer konnte Bilder und Text auf den Bahnen eines Designs platzieren, aber keinen einzigen Pixel von Hand setzen — ein Verlauf über eine Spoiler-Flanke hieß: raus in einen Bildeditor und wieder zurück. Jetzt gibt es einen Werkzeugkasten: weicher Pinsel mit Größe, Kante und Stärke, Radierer, Verlauf, Füllung sowie Rechteck, Ellipse und Linie. Alles landet gleichzeitig auf der Bahn und am 3D-Modell, während du ziehst.",
+  "showcase.v091.gradient":
+    "Ein Verlauf, der eine Farbe in eine andere trägt. Zieh, um zu sagen, wo der Übergang liegt: davor die erste Farbe, dahinter die zweite. Linear oder radial, und er kann ins Nichts ausblenden statt in eine Farbe.",
+  "showcase.v091.paintLayer":
+    "Gemaltes liegt auf einer eigenen Ebene und hat damit Deckkraft, Mischmodus und Reihenfolge wie alles andere — die Vorlage darunter wird nie angefasst. Blende die Ebene aus und du hast die saubere Vorlage zurück. ⌘Z nimmt Striche zurück.",
+  "showcase.v091.macos":
+    "Spielen und Server beitreten funktionieren unter macOS, über die CrossOver-, Whisky- oder Wine-Bottle, in der das Spiel liegt — und die App findet eine Bottle-Installation von selbst, statt nach dem Pfad zu fragen.",
+  "showcase.v091.steamos":
+    "Unter SteamOS öffnet die Linux-App ihre Oberfläche statt eines weißen Bildschirms.",
   "showcase.v090.hero.title": "Mach aus deinen Grafiken ein Design, das das Spiel lädt",
   "showcase.v090.hero.body":
     "Ein neuer Designs-Tab baut Designs aus ganz normalen Bilddateien — TGA, PNG, JPG — und installiert sie dort, wo das Spiel sucht: eine Bike-Lackierung, ein Helm- oder Brillen-Design, Kit oder Handschuhe deines Fahrers. Entpack ein vorhandenes Design, um eine Vorlage zu bekommen, die wirklich zum Modell passt, bearbeite sie in jedem Editor und leg sie direkt wieder ab. Das Studio prüft deine Dateinamen gegen die, die das Mesh bindet, bevor du speicherst, und zeigt das Ergebnis danach am echten Modell.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1054,6 +1054,17 @@ export const en = {
   "showcase.whileGameRunning": "while MX Bikes is running",
   "showcase.releaseNotes": "Read the release notes",
   "showcase.gotIt": "Got it",
+  "showcase.v091.hero.title": "Paint straight onto the template",
+  "showcase.v091.hero.body":
+    "The Designer could place images and text on a paint's sheets, but you couldn't put down a single pixel by hand — a fade across a shroud meant leaving for an image editor and coming back. It has a tool kit now: a soft brush with size, edge and strength, an eraser, a gradient, a fill, and rectangle, ellipse and line. Everything lands on the sheet and on the 3D model at the same time, while you drag.",
+  "showcase.v091.gradient":
+    "A gradient that carries one colour into another. Drag to say where the transition happens — everything before it is the first colour, everything past it the second. Linear or radial, and it can fade out to nothing instead of to a colour.",
+  "showcase.v091.paintLayer":
+    "Painting goes on its own layer, so it gets opacity, blending and stacking like everything else — and the template underneath is never touched. Hide the layer and you have the clean template back. ⌘Z undoes strokes.",
+  "showcase.v091.macos":
+    "Play and Join Server work on macOS, through whichever CrossOver, Whisky or Wine bottle holds the game — and the app finds a bottled install by itself instead of asking you to type the path.",
+  "showcase.v091.steamos":
+    "The Linux app opens to its interface on SteamOS instead of a white screen.",
   "showcase.v090.hero.title": "Turn your artwork into a paint the game loads",
   "showcase.v090.hero.body":
     "A new Paints tab builds paints out of ordinary image sheets — TGA, PNG, JPG — and installs them where the game looks: a bike livery, a helmet or goggle paint, a rider's kit or gloves. Unpack a paint you already have to get a template that actually fits the model, edit it in any editor, and put it straight back. The studio checks your sheet names against the ones the mesh binds before you save, then previews the result on the real model.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1085,6 +1085,17 @@ export const es: Translation = {
   "showcase.whileGameRunning": "mientras MX Bikes está abierto",
   "showcase.releaseNotes": "Leer las notas de la versión",
   "showcase.gotIt": "Entendido",
+  "showcase.v091.hero.title": "Pinta directamente sobre la plantilla",
+  "showcase.v091.hero.body":
+    "El Designer sabía colocar imágenes y texto sobre las hojas de una pintura, pero no dejaba poner ni un píxel a mano — un degradado en un lateral obligaba a salir a un editor de imágenes y volver. Ahora tiene su caja de herramientas: pincel suave con tamaño, borde e intensidad, borrador, degradado, relleno, y rectángulo, elipse y línea. Todo aparece en la hoja y en el modelo 3D a la vez, mientras arrastras.",
+  "showcase.v091.gradient":
+    "Un degradado que lleva un color hasta otro. Arrastra para decir dónde ocurre la transición: antes está el primer color, después el segundo. Lineal o radial, y puede desvanecerse hasta nada en lugar de hasta un color.",
+  "showcase.v091.paintLayer":
+    "Lo que pintas va en su propia capa, así que tiene opacidad, fusión y orden como todo lo demás — y la plantilla de debajo no se toca nunca. Oculta la capa y tienes la plantilla limpia otra vez. ⌘Z deshace trazos.",
+  "showcase.v091.macos":
+    "Jugar y Unirse a un servidor funcionan en macOS, a través de la botella CrossOver, Whisky o Wine que contenga el juego — y la app encuentra sola una instalación embotellada en vez de pedirte la ruta.",
+  "showcase.v091.steamos":
+    "En SteamOS la app de Linux abre en su interfaz en lugar de una pantalla en blanco.",
   "showcase.v090.hero.title": "Convierte tus imágenes en un diseño que el juego carga",
   "showcase.v090.hero.body":
     "Una nueva pestaña Diseños crea diseños a partir de imágenes corrientes — TGA, PNG, JPG — y los instala donde el juego los busca: una decoración de moto, un diseño de casco o de gafas, el kit o los guantes de tu piloto. Descomprime un diseño que ya tengas para conseguir una plantilla que encaje de verdad con el modelo, edítala en cualquier editor y devuélvela tal cual. El estudio comprueba tus nombres de archivo frente a los que usa la malla antes de guardar, y luego muestra el resultado sobre el modelo real.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1088,6 +1088,17 @@ export const fr: Translation = {
   "showcase.whileGameRunning": "pendant que MX Bikes tourne",
   "showcase.releaseNotes": "Lire les notes de version",
   "showcase.gotIt": "Compris",
+  "showcase.v091.hero.title": "Peins directement sur le gabarit",
+  "showcase.v091.hero.body":
+    "Le Designer savait placer images et textes sur les planches d'une déco, mais il ne laissait poser aucun pixel à la main — un dégradé sur un ouïe voulait dire partir dans un éditeur d'images et revenir. Il a maintenant sa boîte à outils : pinceau doux avec taille, bord et intensité, gomme, dégradé, remplissage, rectangle, ellipse et ligne. Tout arrive sur la planche et sur le modèle 3D en même temps, pendant que tu fais glisser.",
+  "showcase.v091.gradient":
+    "Un dégradé qui emmène une couleur vers une autre. Fais glisser pour dire où se fait la transition : avant c'est la première couleur, après la seconde. Linéaire ou radial, et il peut se fondre vers rien plutôt que vers une couleur.",
+  "showcase.v091.paintLayer":
+    "La peinture va sur son propre calque, donc elle a opacité, fusion et empilement comme le reste — et le gabarit en dessous n'est jamais touché. Masque le calque et tu retrouves le gabarit intact. ⌘Z annule les tracés.",
+  "showcase.v091.macos":
+    "Jouer et Rejoindre un serveur fonctionnent sur macOS, via la bouteille CrossOver, Whisky ou Wine qui contient le jeu — et l'app trouve seule une installation en bouteille au lieu de te demander le chemin.",
+  "showcase.v091.steamos":
+    "Sur SteamOS, l'app Linux s'ouvre sur son interface au lieu d'un écran blanc.",
   "showcase.v090.hero.title": "Transforme tes images en une déco que le jeu charge",
   "showcase.v090.hero.body":
     "Un nouvel onglet Décos fabrique des décos à partir de simples fichiers image — TGA, PNG, JPG — et les installe là où le jeu les cherche : une livrée de moto, une déco de casque ou de masque, la tenue ou les gants de ton pilote. Décompresse une déco existante pour obtenir un gabarit vraiment adapté au modèle, retouche-la dans n'importe quel éditeur et remets-la telle quelle. Le studio vérifie tes noms de fichiers face à ceux que le maillage utilise avant l'enregistrement, puis affiche le résultat sur le vrai modèle.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1077,6 +1077,17 @@ export const it: Translation = {
   "showcase.whileGameRunning": "mentre MX Bikes è in esecuzione",
   "showcase.releaseNotes": "Leggi le note di rilascio",
   "showcase.gotIt": "Ho capito",
+  "showcase.v091.hero.title": "Dipingi direttamente sul template",
+  "showcase.v091.hero.body":
+    "Il Designer sapeva posizionare immagini e testo sui fogli di una livrea, ma non ti lasciava mettere giù un solo pixel a mano — una sfumatura su una fiancata voleva dire uscire, aprire un editor di immagini e tornare indietro. Ora ha una cassetta degli attrezzi: pennello morbido con dimensione, bordo e intensità, gomma, sfumatura, riempimento, rettangolo, ellisse e linea. Tutto arriva sul foglio e sul modello 3D nello stesso momento, mentre trascini.",
+  "showcase.v091.gradient":
+    "Una sfumatura che porta un colore dentro un altro. Trascina per dire dove avviene la transizione: prima c'è il primo colore, dopo il secondo. Lineare o radiale, e può dissolversi nel nulla invece che in un colore.",
+  "showcase.v091.paintLayer":
+    "La pittura va su un livello suo, quindi ha opacità, fusione e ordine come tutto il resto — e il template sotto non viene mai toccato. Nascondi il livello e hai di nuovo il template pulito. ⌘Z annulla i tratti.",
+  "showcase.v091.macos":
+    "Gioca e Entra nel server funzionano su macOS, attraverso la bottiglia CrossOver, Whisky o Wine che contiene il gioco — e l'app trova da sola un'installazione in bottiglia invece di chiederti il percorso.",
+  "showcase.v091.steamos":
+    "Su SteamOS l'app Linux si apre sulla sua interfaccia invece che su una schermata bianca.",
   "showcase.v090.hero.title": "Trasforma le tue immagini in una livrea che il gioco carica",
   "showcase.v090.hero.body":
     "Una nuova scheda Livree costruisce le livree da normali file immagine — TGA, PNG, JPG — e le installa dove il gioco le cerca: la livrea di una moto, la grafica di un casco o di una maschera, il completo o i guanti del tuo pilota. Estrai una livrea che hai già per ottenere un template che calza davvero sul modello, modificalo in qualsiasi editor e rimettilo dentro così com'è. Lo studio controlla i nomi dei tuoi file contro quelli che la mesh usa prima del salvataggio, poi mostra il risultato sul modello vero.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1077,6 +1077,17 @@ export const ptBR: Translation = {
   "showcase.whileGameRunning": "enquanto o MX Bikes está aberto",
   "showcase.releaseNotes": "Ler as notas da versão",
   "showcase.gotIt": "Entendi",
+  "showcase.v091.hero.title": "Pinte direto no template",
+  "showcase.v091.hero.body":
+    "O Designer sabia posicionar imagens e texto nas folhas de uma pintura, mas não deixava colocar um único pixel à mão — um degradê numa carenagem significava sair para um editor de imagens e voltar. Agora ele tem um kit de ferramentas: pincel suave com tamanho, borda e intensidade, borracha, gradiente, preenchimento, retângulo, elipse e linha. Tudo aparece na folha e no modelo 3D ao mesmo tempo, enquanto você arrasta.",
+  "showcase.v091.gradient":
+    "Um gradiente que leva uma cor até outra. Arraste para dizer onde acontece a transição: antes fica a primeira cor, depois a segunda. Linear ou radial, e pode desaparecer no nada em vez de terminar numa cor.",
+  "showcase.v091.paintLayer":
+    "O que você pinta vai numa camada própria, então tem opacidade, mesclagem e ordem como todo o resto — e o template embaixo nunca é tocado. Esconda a camada e o template limpo volta. ⌘Z desfaz traços.",
+  "showcase.v091.macos":
+    "Jogar e Entrar no servidor funcionam no macOS, pela garrafa CrossOver, Whisky ou Wine que contém o jogo — e o app acha sozinho uma instalação engarrafada em vez de pedir o caminho.",
+  "showcase.v091.steamos":
+    "No SteamOS o app Linux abre na interface em vez de uma tela branca.",
   "showcase.v090.hero.title": "Transforme suas imagens numa pintura que o jogo carrega",
   "showcase.v090.hero.body":
     "Uma nova aba Pinturas monta pinturas a partir de arquivos de imagem comuns — TGA, PNG, JPG — e instala onde o jogo procura: a pintura de uma moto, de um capacete ou de um óculos, o kit ou as luvas do seu piloto. Descompacte uma pintura que você já tem para conseguir um molde que serve de verdade no modelo, edite em qualquer editor e devolva do mesmo jeito. O estúdio confere os nomes dos seus arquivos contra os que a malha usa antes de salvar, e depois mostra o resultado no modelo de verdade.",


### PR DESCRIPTION
Release prep for `v0.9.1-beta.2`.

**The changelog needed consolidating.** The painting tools landed as their own dated section with no version marker, and `changelog-section.sh` finds a section only by the `v<version>` in its `## ` heading. A tag cut against the file as it stood would have published release notes — and a Discord post — that never mentioned the feature. Folded into the v0.9.1 section, headline first, with the heading now naming the Designer.

**There was no v0.9.1 "What's new" entry.** `RELEASES` in `releases.ts` stopped at 0.9.0, so v0.9.1-beta.1 shipped announcing nothing in-app, and nothing in CI catches that. Added one: painting on the template as the hero, plus the gradient, the paint layer, the macOS launch and the SteamOS white screen — strings in all six locales.

No version bump: the manifests already say 0.9.1. A suffixed tag publishes as a pre-release, so this stays off `releases/latest` and the in-app updater, and posts to the beta Discord channel.

Checked before opening:

```
$ scripts/changelog-section.sh v0.9.1-beta.2 --heading
## 2026-08-10 — v0.9.1 — The Designer paints, Play works on a Mac, and SteamOS stops opening to a white screen
```

`--summary` lists all ten headlines. `typecheck`, `lint` and `build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)