### PR TITLE
test(windows): build without the OS drag-drop handler to isolate a Wine ole32 crash

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "height": 800,
         "minWidth": 1000,
         "minHeight": 700,
-        "decorations": false
+        "decorations": false,
+        "dragDropEnabled": false
       }
     ],
     "security": {


### PR DESCRIPTION
## What this is

A one-key diagnostic build to test whether drag-drop registration is what crashes MXB App under CrossOver on macOS.

```json
"decorations": false,
"dragDropEnabled": false
```

## Why

A user running the Windows build under CrossOver gets a transparent window and a Wine crash dump. The fault is in `ole32`, on `movq (%rax), %rax` with a junk `rax`, reached from the app's own window procedure via user32's dispatch. `rdi` and `r12` both point into ole32's data segment 0x40 apart, which reads as a global list being walked onto a bad `next` pointer.

WebView2 is **not** the culprit — the first guess, and wrong. The dump shows four live `msedgewebview2.exe` processes with a renderer, a GPU thread and a compositor, so the engine started and was drawing.

What calls into ole32 from a window proc here is drag-drop registration: wry calls `RegisterDragDrop` whenever `dragDropEnabled` is on, which it is by default and which this config never set. `DropZone` depends on that handler precisely because an HTML5 `File` carries no filesystem path. Turning it off skips the registration — so if that call is the trigger, the crash goes with it.

## Risk — please read before merging

**This disables whole-window drag-and-drop on every platform, not just under Wine.** That is a shipped headline feature (`d44fe5f`, "a dropzone that takes anything" in the v0.8.0 notes), so merging this as-is is a user-facing regression on Windows in exchange for an as-yet-unverified Wine fix.

It degrades quietly rather than breaking: `DropZone`'s docstring already notes that where the event never arrives, dropping silently does nothing, and it routes through `useImport`/`stagePaths` — shared with the Library's Import button — so installing still works by picking a file.

If this does boot under CrossOver, the shippable form is a **runtime opt-out** (env var or a `wineRunner`-adjacent flag) so Windows keeps the drop target, not a static config flag.

## Verification

- Key name, type and default checked against `config.schema.json` from `@tauri-apps/cli` 2.11.4: `dragDropEnabled`, boolean, default `true`, described as required-to-disable for HTML5 drag and drop on Windows. (`fileDropEnabled` is the v1 name, absent from the v2 schema.)
- The edited config validates against that schema.
- **Not** verified: no Rust toolchain in the authoring environment and no Mac with a bottle to run it against. This is a hypothesis test, not a confirmed fix.

## Getting an artifact

`ci.yml` builds no installers. A manual `workflow_dispatch` of `release.yml` from this branch tags `v<run_number>` (no collision with the `v0.9.x` line), is flagged pre-release so it stays off `releases/latest` and out of the updater, and posts nothing to Discord (the announce job is gated on `github.ref_type == 'tag'`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX4sBgbxNddaNzjBAt1JVt)_