### PR TITLE
feat(settings): a Supporters page for the people buying the coffees

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,11 @@ hours), then downloads and installs them on restart.
   on the model without leaving the app.
 - **Self-update**: `tauri-plugin-updater` against the `latest.json` published with
   each release; signature-verified, installs on restart.
-- **Supporters**: Settings → Supporters credits the app's Patreon backers. The
-  names come from [`supporters.json`](supporters.json) on `main`, fetched at
-  runtime and cached — adding somebody there reaches installed copies without a
-  release, and an offline launch still shows the last list it saw.
+- **Supporters**: Settings → Supporters credits the people who bought a coffee on
+  [Buy Me a Coffee](https://buymeacoffee.com/). The names come from
+  [`supporters.json`](supporters.json) on `main`, fetched at runtime and cached —
+  adding somebody there reaches installed copies without a release, and an offline
+  launch still shows the last list it saw.
 
 ## Tech stack
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ hours), then downloads and installs them on restart.
   on the model without leaving the app.
 - **Self-update**: `tauri-plugin-updater` against the `latest.json` published with
   each release; signature-verified, installs on restart.
+- **Supporters**: Settings → Supporters credits the app's Patreon backers. The
+  names come from [`supporters.json`](supporters.json) on `main`, fetched at
+  runtime and cached — adding somebody there reaches installed copies without a
+  release, and an offline launch still shows the last list it saw.
 
 ## Tech stack
 

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -1161,9 +1161,9 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
             />
           </Section>
 
-          {/* supporters — who's paying for the app on Patreon. Above About rather than
-              inside it: a thank-you buried under the version number and the update
-              button is one nobody reads. */}
+          {/* supporters — who's buying the coffees that pay for the app. Above About
+              rather than inside it: a thank-you buried under the version number and the
+              update button is one nobody reads. */}
           <Section
             title={t("settings.supporters")}
             desc={t("settings.supportersDesc")}

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -45,6 +45,7 @@ import { usePlatform } from "../../lib/usePlatform";
 import { useConfig } from "../../Context/Config";
 import GameSwitcher from "../Shell/GameSwitcher";
 import ReshadeCard from "./ReshadeCard";
+import SupportersCard from "./SupportersCard";
 import { useTheme, type ThemeMode } from "../../Context/Theme";
 import { Trans } from "../../i18n";
 import { useI18n, type LocalePref, type TKey } from "../../i18n/context";
@@ -78,6 +79,7 @@ export type SectionId =
   | "appearance"
   | "frostmod"
   | "reshade"
+  | "supporters"
   | "about";
 const SECTIONS: { id: SectionId; label: TKey }[] = [
   { id: "game", label: "game.label" },
@@ -87,6 +89,7 @@ const SECTIONS: { id: SectionId; label: TKey }[] = [
   { id: "appearance", label: "settings.appearance" },
   { id: "frostmod", label: "settings.frostmod" },
   { id: "reshade", label: "settings.reshade" },
+  { id: "supporters", label: "settings.supporters" },
   { id: "about", label: "settings.about" },
 ];
 
@@ -217,6 +220,7 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
     appearance: null,
     frostmod: null,
     reshade: null,
+    supporters: null,
     about: null,
   });
 
@@ -1155,6 +1159,17 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
                   .catch((e) => toast.error(String(e)));
               }}
             />
+          </Section>
+
+          {/* supporters — who's paying for the app on Patreon. Above About rather than
+              inside it: a thank-you buried under the version number and the update
+              button is one nobody reads. */}
+          <Section
+            title={t("settings.supporters")}
+            desc={t("settings.supportersDesc")}
+            innerRef={(el) => (refs.current.supporters = el)}
+          >
+            <SupportersCard />
           </Section>
 
           {/* about */}

--- a/src/Components/Settings/SupportersCard.tsx
+++ b/src/Components/Settings/SupportersCard.tsx
@@ -79,6 +79,11 @@ export default function SupportersCard() {
   const { manifest, loading, stale, refresh } = useSupporters();
   const groups = groupByTier(manifest);
   const count = manifest.supporters.length;
+  // One nameless group means no distinction is being drawn, and a "Supporters" heading
+  // sitting directly under the "Supporters" section title — counting names the reader
+  // can already see — labels that non-distinction. Headings come back the moment there
+  // is more than one group, or the only group has a level of its own.
+  const showHeadings = groups.length > 1 || groups[0]?.tier != null;
   // A URL the manifest carries wins, so a bad default can be corrected without a
   // release — see the TODO on `SUPPORT_URL`.
   const supportUrl = manifest.supportUrl || SUPPORT_URL;
@@ -112,12 +117,14 @@ export default function SupportersCard() {
         <div className="flex flex-col gap-3">
           {groups.map((group) => (
             <div key={group.tier ?? "__untiered"} className="flex flex-col gap-1.5">
-              <div className="flex items-baseline gap-1.5">
-                <span className="text-[11.5px] font-semibold text-foreground/80">
-                  {group.tier ?? t("supporters.untiered")}
-                </span>
-                <span className="text-[11px] text-faint">{group.people.length}</span>
-              </div>
+              {showHeadings && (
+                <div className="flex items-baseline gap-1.5">
+                  <span className="text-[11.5px] font-semibold text-foreground/80">
+                    {group.tier ?? t("supporters.untiered")}
+                  </span>
+                  <span className="text-[11px] text-faint">{group.people.length}</span>
+                </div>
+              )}
               <div className="flex flex-wrap gap-1.5">
                 {group.people.map((person) => (
                   <span

--- a/src/Components/Settings/SupportersCard.tsx
+++ b/src/Components/Settings/SupportersCard.tsx
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ExternalLink, Heart, RefreshCw } from "lucide-react";
+import { open as openUrl } from "@tauri-apps/plugin-shell";
+import { useI18n } from "../../i18n/context";
+import { getLocale } from "../../i18n/core";
+import { Button } from "@/Components/ui/button";
+import { cn } from "@/lib/utils";
+import {
+  BUNDLED_SUPPORTERS,
+  PATREON_URL,
+  fetchSupporters,
+  groupByTier,
+  readCachedManifest,
+  type SupportersManifest,
+} from "./supporters";
+
+/** "since Jul 2026". Month and year only — the day somebody pledged is noise, and the
+ *  year on its own reads as though they might have stopped in January. */
+function sinceLabel(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleDateString(getLocale(), { month: "short", year: "numeric" });
+}
+
+/**
+ * The live supporters list.
+ *
+ * Starts from whatever is already on disk so the section paints filled in, then goes to
+ * the network. A failed fetch keeps what's showing and flips `stale` — the alternative,
+ * emptying the page because GitHub was unreachable for a second, would tell the player
+ * the app has no supporters.
+ */
+function useSupporters() {
+  const [manifest, setManifest] = useState<SupportersManifest>(
+    () => readCachedManifest() ?? BUNDLED_SUPPORTERS,
+  );
+  const [loading, setLoading] = useState(true);
+  const [stale, setStale] = useState(false);
+  const alive = useRef(true);
+
+  useEffect(() => {
+    alive.current = true;
+    return () => {
+      alive.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const fresh = await fetchSupporters();
+      if (!alive.current) return;
+      setManifest(fresh);
+      setStale(false);
+    } catch {
+      if (!alive.current) return;
+      setStale(true);
+    } finally {
+      if (alive.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return { manifest, loading, stale, refresh };
+}
+
+/**
+ * Credits the people paying for the app's development, and gives everyone else the one
+ * button that joins them.
+ *
+ * Lives in Settings rather than behind a nag banner on purpose: it's a thank-you page
+ * you can go and read, not something the app pushes at you mid-ride.
+ */
+export default function SupportersCard() {
+  const { t } = useI18n();
+  const { manifest, loading, stale, refresh } = useSupporters();
+  const groups = groupByTier(manifest);
+  const count = manifest.supporters.length;
+  // A URL the manifest carries wins, so a bad default can be corrected without a
+  // release — see the TODO on `PATREON_URL`.
+  const patreonUrl = manifest.patreonUrl || PATREON_URL;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-[12px] leading-relaxed text-muted-foreground">
+        {t("supporters.intro")}
+      </p>
+
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11.5px] text-muted-foreground">
+          {count > 0
+            ? t("supporters.count", { count })
+            : loading
+              ? t("supporters.loading")
+              : ""}
+        </span>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => void refresh()}
+          disabled={loading}
+        >
+          <RefreshCw className={cn("size-3.5", loading && "animate-spin")} />
+          {t("supporters.refresh")}
+        </Button>
+      </div>
+
+      {count > 0 ? (
+        <div className="flex flex-col gap-3">
+          {groups.map((group) => (
+            <div key={group.tier ?? "__untiered"} className="flex flex-col gap-1.5">
+              <div className="flex items-baseline gap-1.5">
+                <span className="text-[11.5px] font-semibold text-foreground/80">
+                  {group.tier ?? t("supporters.untiered")}
+                </span>
+                <span className="text-[11px] text-faint">{group.people.length}</span>
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {group.people.map((person) => (
+                  <span
+                    key={`${group.tier ?? ""}:${person.name}`}
+                    className="flex items-center gap-1.5 rounded-full border border-input bg-foreground/[0.03] px-2.5 py-1 text-[12px] text-foreground/85"
+                  >
+                    <Heart className="size-3 flex-none text-primary" />
+                    {person.name}
+                    {person.since && sinceLabel(person.since) && (
+                      <span className="text-[10.5px] text-faint">
+                        {t("supporters.since", { date: sinceLabel(person.since) })}
+                      </span>
+                    )}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        !loading && (
+          <div className="flex flex-col gap-1 rounded-lg border border-input bg-foreground/[0.03] p-3">
+            <span className="text-[12px] font-semibold text-foreground/85">
+              {t("supporters.empty")}
+            </span>
+            <span className="text-[11.5px] leading-relaxed text-muted-foreground">
+              {t("supporters.emptyDesc")}
+            </span>
+          </div>
+        )
+      )}
+
+      {/* Only after a fetch actually failed. Saying "this list may be out of date" on
+          every render would put a warning under a list that is, in fact, current. */}
+      {stale && (
+        <p className="text-[11px] leading-relaxed text-muted-foreground">
+          {t("supporters.offline")}
+        </p>
+      )}
+
+      <div className="flex gap-2 pt-0.5">
+        <Button size="sm" onClick={() => void openUrl(patreonUrl)}>
+          <Heart className="size-3.5" /> {t("supporters.become")}
+          <ExternalLink className="size-3" />
+        </Button>
+      </div>
+
+      <p className="text-[11px] leading-relaxed text-faint">
+        {t("supporters.optOut")}
+      </p>
+    </div>
+  );
+}

--- a/src/Components/Settings/SupportersCard.tsx
+++ b/src/Components/Settings/SupportersCard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ExternalLink, Heart, RefreshCw } from "lucide-react";
+import { Coffee, ExternalLink, RefreshCw } from "lucide-react";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
 import { useI18n } from "../../i18n/context";
 import { getLocale } from "../../i18n/core";
@@ -7,7 +7,7 @@ import { Button } from "@/Components/ui/button";
 import { cn } from "@/lib/utils";
 import {
   BUNDLED_SUPPORTERS,
-  PATREON_URL,
+  SUPPORT_URL,
   fetchSupporters,
   groupByTier,
   readCachedManifest,
@@ -80,8 +80,8 @@ export default function SupportersCard() {
   const groups = groupByTier(manifest);
   const count = manifest.supporters.length;
   // A URL the manifest carries wins, so a bad default can be corrected without a
-  // release — see the TODO on `PATREON_URL`.
-  const patreonUrl = manifest.patreonUrl || PATREON_URL;
+  // release — see the TODO on `SUPPORT_URL`.
+  const supportUrl = manifest.supportUrl || SUPPORT_URL;
 
   return (
     <div className="flex flex-col gap-3">
@@ -124,7 +124,7 @@ export default function SupportersCard() {
                     key={`${group.tier ?? ""}:${person.name}`}
                     className="flex items-center gap-1.5 rounded-full border border-input bg-foreground/[0.03] px-2.5 py-1 text-[12px] text-foreground/85"
                   >
-                    <Heart className="size-3 flex-none text-primary" />
+                    <Coffee className="size-3 flex-none text-primary" />
                     {person.name}
                     {person.since && sinceLabel(person.since) && (
                       <span className="text-[10.5px] text-faint">
@@ -159,8 +159,8 @@ export default function SupportersCard() {
       )}
 
       <div className="flex gap-2 pt-0.5">
-        <Button size="sm" onClick={() => void openUrl(patreonUrl)}>
-          <Heart className="size-3.5" /> {t("supporters.become")}
+        <Button size="sm" onClick={() => void openUrl(supportUrl)}>
+          <Coffee className="size-3.5" /> {t("supporters.become")}
           <ExternalLink className="size-3" />
         </Button>
       </div>

--- a/src/Components/Settings/supporters.ts
+++ b/src/Components/Settings/supporters.ts
@@ -1,0 +1,197 @@
+/**
+ * Who's funding MXB App on Patreon, and where that list comes from.
+ *
+ * The list changes between releases, and a credits page that only refreshes when
+ * someone ships a build would thank a new supporter weeks late — so the names live in
+ * `supporters.json` on `main` and are fetched at runtime. Adding somebody is a one-line
+ * commit to that file, not a release.
+ *
+ * Three layers, in the order they're preferred:
+ *   1. the remote manifest, fetched every time the section opens;
+ *   2. the last remote answer, cached in webview storage so an offline launch still
+ *      shows the real list rather than an empty one;
+ *   3. `BUNDLED_SUPPORTERS`, which is what a build ships with when it has never once
+ *      reached the network.
+ */
+
+/**
+ * The Patreon page every button here opens.
+ *
+ * TODO(maintainer): confirm the handle before release — a wrong URL is a dead button in
+ * a shipped build. `patreonUrl` in the manifest overrides it without a release, so a
+ * mistake here is fixable, but only for someone who can reach the network.
+ */
+export const PATREON_URL = "https://www.patreon.com/mxbapp";
+
+/** Read from `main`, not from a tag: the list has to move faster than releases do. */
+export const SUPPORTERS_URL =
+  "https://raw.githubusercontent.com/Frostn1/mxb-app/main/supporters.json";
+
+export interface Supporter {
+  /** Display name, as they want it shown — not their Patreon account name. */
+  name: string;
+  /** Patreon tier, verbatim. Tier names are the creator's own words, so they're
+   *  never translated; a tier nobody is in simply doesn't render. */
+  tier?: string;
+  /** ISO date they started supporting, shown as "since Jul 2026" when present. */
+  since?: string;
+}
+
+export interface SupportersManifest {
+  /** Overrides {@link PATREON_URL} when set — see the TODO above. */
+  patreonUrl?: string;
+  /** Tier names, best first. Anything not listed here still renders; it just sorts
+   *  after the named ones. */
+  tiers: string[];
+  supporters: Supporter[];
+}
+
+/**
+ * What a build ships with.
+ *
+ * Deliberately empty: inventing names to fill the page would credit people who never
+ * gave anything. Until the manifest lands, the section shows its "nobody yet" state,
+ * which is the honest version of the same screen.
+ */
+export const BUNDLED_SUPPORTERS: SupportersManifest = { tiers: [], supporters: [] };
+
+const CACHE_KEY = "mxb:supporters:v1";
+/** Long enough for a cold CDN, short enough that Settings isn't held open waiting. */
+const FETCH_TIMEOUT_MS = 6000;
+/** Caps on remote data. Nothing hostile is expected from our own repo, but a file with
+ *  a stray million-character name shouldn't be able to wedge the renderer. */
+const MAX_SUPPORTERS = 500;
+const MAX_NAME_CHARS = 48;
+const MAX_TIER_CHARS = 32;
+
+function trimmed(value: unknown, max: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const s = value.trim().slice(0, max);
+  return s || undefined;
+}
+
+/** Validate whatever the network handed us into something this UI can render. */
+export function parseManifest(raw: unknown): SupportersManifest | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  if (!Array.isArray(obj.supporters)) return null;
+
+  const supporters: Supporter[] = [];
+  for (const entry of obj.supporters.slice(0, MAX_SUPPORTERS)) {
+    // A bare string is allowed in the manifest — most entries are just a name, and
+    // `["Alex", "Sam"]` is a nicer thing to hand-edit than a list of one-key objects.
+    const name =
+      typeof entry === "string"
+        ? trimmed(entry, MAX_NAME_CHARS)
+        : trimmed((entry as Record<string, unknown>)?.name, MAX_NAME_CHARS);
+    if (!name) continue;
+    const fields = (typeof entry === "object" && entry ? entry : {}) as Record<
+      string,
+      unknown
+    >;
+    supporters.push({
+      name,
+      tier: trimmed(fields.tier, MAX_TIER_CHARS),
+      since: trimmed(fields.since, 32),
+    });
+  }
+
+  const tiers = Array.isArray(obj.tiers)
+    ? obj.tiers
+        .map((t) => trimmed(t, MAX_TIER_CHARS))
+        .filter((t): t is string => Boolean(t))
+    : [];
+
+  return {
+    patreonUrl: trimmed(obj.patreonUrl, 200),
+    tiers,
+    supporters,
+  };
+}
+
+export function readCachedManifest(): SupportersManifest | null {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    return raw ? parseManifest(JSON.parse(raw)) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCachedManifest(manifest: SupportersManifest) {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify(manifest));
+  } catch {
+    // Storage full or blocked — the list still renders this session, it just won't
+    // survive a restart offline. Not worth telling anyone about.
+  }
+}
+
+/** Fetch the live list. Throws on anything that isn't a usable manifest. */
+export async function fetchSupporters(): Promise<SupportersManifest> {
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(SUPPORTERS_URL, {
+      signal: abort.signal,
+      cache: "no-cache",
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const manifest = parseManifest(await res.json());
+    if (!manifest) throw new Error("malformed supporters.json");
+    writeCachedManifest(manifest);
+    return manifest;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface TierGroup {
+  /** `null` for supporters with no tier of their own. */
+  tier: string | null;
+  people: Supporter[];
+}
+
+/**
+ * Bucket supporters by tier, in the manifest's order.
+ *
+ * A tier the manifest doesn't name still shows up — sorted after the named ones, so
+ * renaming a tier on Patreon degrades to "listed last" rather than "silently dropped".
+ * Untiered names always come last, under a generic heading.
+ */
+export function groupByTier(manifest: SupportersManifest): TierGroup[] {
+  const buckets = new Map<string, Supporter[]>();
+  const untiered: Supporter[] = [];
+  for (const s of manifest.supporters) {
+    if (!s.tier) {
+      untiered.push(s);
+      continue;
+    }
+    const bucket = buckets.get(s.tier);
+    if (bucket) bucket.push(s);
+    else buckets.set(s.tier, [s]);
+  }
+
+  const named = manifest.tiers.filter((t) => buckets.has(t));
+  const rest = [...buckets.keys()]
+    .filter((t) => !manifest.tiers.includes(t))
+    .sort((a, b) => a.localeCompare(b));
+
+  const groups: TierGroup[] = [...named, ...rest].map((tier) => ({
+    tier,
+    people: sortPeople(buckets.get(tier) ?? []),
+  }));
+  if (untiered.length) groups.push({ tier: null, people: sortPeople(untiered) });
+  return groups;
+}
+
+/** Longest-standing first, then alphabetical — seniority is the one ordering nobody
+ *  can read as playing favourites. */
+function sortPeople(people: Supporter[]): Supporter[] {
+  return [...people].sort((a, b) => {
+    if (a.since && b.since && a.since !== b.since) return a.since < b.since ? -1 : 1;
+    if (a.since && !b.since) return -1;
+    if (!a.since && b.since) return 1;
+    return a.name.localeCompare(b.name);
+  });
+}

--- a/src/Components/Settings/supporters.ts
+++ b/src/Components/Settings/supporters.ts
@@ -40,7 +40,8 @@ export interface Supporter {
 }
 
 export interface SupportersManifest {
-  /** Overrides {@link SUPPORT_URL} when set — see the TODO above. */
+  /** Overrides {@link SUPPORT_URL} when set — how a moved page gets fixed without a
+   *  release. */
   supportUrl?: string;
   /** Membership levels, best first. Anything not listed here still renders; it just
    *  sorts after the named ones. */
@@ -49,13 +50,21 @@ export interface SupportersManifest {
 }
 
 /**
- * What a build ships with.
+ * What a build ships with — the list as it stood when the build was cut.
  *
- * Deliberately empty: inventing names to fill the page would credit people who never
- * gave anything. Until the manifest lands, the section shows its "nobody yet" state,
- * which is the honest version of the same screen.
+ * Only ever seen by an install that has never once reached the network; the manifest
+ * replaces it wholesale on the first successful fetch. It exists so a fresh offline
+ * launch thanks the people who are already there rather than claiming nobody is.
  */
-export const BUNDLED_SUPPORTERS: SupportersManifest = { tiers: [], supporters: [] };
+export const BUNDLED_SUPPORTERS: SupportersManifest = {
+  tiers: [],
+  supporters: [
+    { name: "HottPie" },
+    { name: "Mouk" },
+    { name: "SoggySwisher" },
+    { name: "LupaHo" },
+  ],
+};
 
 const CACHE_KEY = "mxb:supporters:v1";
 /** Long enough for a cold CDN, short enough that Settings isn't held open waiting. */

--- a/src/Components/Settings/supporters.ts
+++ b/src/Components/Settings/supporters.ts
@@ -1,5 +1,5 @@
 /**
- * Who's funding MXB App on Patreon, and where that list comes from.
+ * Who's funding MXB App on Buy Me a Coffee, and where that list comes from.
  *
  * The list changes between releases, and a credits page that only refreshes when
  * someone ships a build would thank a new supporter weeks late — so the names live in
@@ -15,33 +15,34 @@
  */
 
 /**
- * The Patreon page every button here opens.
+ * The Buy Me a Coffee page every button here opens.
  *
  * TODO(maintainer): confirm the handle before release — a wrong URL is a dead button in
- * a shipped build. `patreonUrl` in the manifest overrides it without a release, so a
+ * a shipped build. `supportUrl` in the manifest overrides it without a release, so a
  * mistake here is fixable, but only for someone who can reach the network.
  */
-export const PATREON_URL = "https://www.patreon.com/mxbapp";
+export const SUPPORT_URL = "https://buymeacoffee.com/mxbapp";
 
 /** Read from `main`, not from a tag: the list has to move faster than releases do. */
 export const SUPPORTERS_URL =
   "https://raw.githubusercontent.com/Frostn1/mxb-app/main/supporters.json";
 
 export interface Supporter {
-  /** Display name, as they want it shown — not their Patreon account name. */
+  /** Display name, as they want it shown — not their Buy Me a Coffee account name. */
   name: string;
-  /** Patreon tier, verbatim. Tier names are the creator's own words, so they're
-   *  never translated; a tier nobody is in simply doesn't render. */
+  /** Membership level, verbatim. Level names are the creator's own words, so they're
+   *  never translated; a level nobody is in simply doesn't render. Someone who bought a
+   *  one-off coffee has none, and lands in the ungrouped list at the bottom. */
   tier?: string;
   /** ISO date they started supporting, shown as "since Jul 2026" when present. */
   since?: string;
 }
 
 export interface SupportersManifest {
-  /** Overrides {@link PATREON_URL} when set — see the TODO above. */
-  patreonUrl?: string;
-  /** Tier names, best first. Anything not listed here still renders; it just sorts
-   *  after the named ones. */
+  /** Overrides {@link SUPPORT_URL} when set — see the TODO above. */
+  supportUrl?: string;
+  /** Membership levels, best first. Anything not listed here still renders; it just
+   *  sorts after the named ones. */
   tiers: string[];
   supporters: Supporter[];
 }
@@ -103,7 +104,7 @@ export function parseManifest(raw: unknown): SupportersManifest | null {
     : [];
 
   return {
-    patreonUrl: trimmed(obj.patreonUrl, 200),
+    supportUrl: trimmed(obj.supportUrl, 200),
     tiers,
     supporters,
   };
@@ -153,11 +154,12 @@ export interface TierGroup {
 }
 
 /**
- * Bucket supporters by tier, in the manifest's order.
+ * Bucket supporters by membership level, in the manifest's order.
  *
- * A tier the manifest doesn't name still shows up — sorted after the named ones, so
- * renaming a tier on Patreon degrades to "listed last" rather than "silently dropped".
- * Untiered names always come last, under a generic heading.
+ * A level the manifest doesn't name still shows up — sorted after the named ones, so
+ * renaming one on Buy Me a Coffee degrades to "listed last" rather than "silently
+ * dropped". People with no level — a one-off coffee — always come last, under a
+ * generic heading.
  */
 export function groupByTier(manifest: SupportersManifest): TierGroup[] {
   const buckets = new Map<string, Supporter[]>();

--- a/src/Components/Settings/supporters.ts
+++ b/src/Components/Settings/supporters.ts
@@ -17,11 +17,12 @@
 /**
  * The Buy Me a Coffee page every button here opens.
  *
- * TODO(maintainer): confirm the handle before release — a wrong URL is a dead button in
- * a shipped build. `supportUrl` in the manifest overrides it without a release, so a
- * mistake here is fixable, but only for someone who can reach the network.
+ * The handle is the auto-generated one the account was created with, not a word — it's
+ * meant to be opened, never typed, so don't "tidy" it. `supportUrl` in the manifest
+ * overrides it, which is what to reach for if the page ever moves: a shipped build
+ * can't be told about a new link, but the manifest can.
  */
-export const SUPPORT_URL = "https://buymeacoffee.com/mxbapp";
+export const SUPPORT_URL = "https://buymeacoffee.com/22ypnh5yfme";
 
 /** Read from `main`, not from a tag: the list has to move faster than releases do. */
 export const SUPPORTERS_URL =

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1301,25 +1301,26 @@ export const de: Translation = {
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Postprocessing-Presets — wie {{game}} auf dem Bildschirm aussieht.",
 
-  // ── Unterstützer (Patreon) ─────────────────────────────────────────────────
+  // ── Unterstützer (Buy Me a Coffee) ─────────────────────────────────────────
   "settings.supporters": "Unterstützer",
-  "settings.supportersDesc": "Die Leute, die MXB App auf Patreon finanzieren.",
+  "settings.supportersDesc":
+    "Die Leute, die MXB App auf Buy Me a Coffee am Laufen halten.",
   "supporters.intro":
-    "MXB App ist kostenlos und bleibt es. Patreon bezahlt die Zeit, die darin steckt — die Leute unten sind der Grund, warum es überhaupt eine neue Version zu installieren gibt.",
+    "MXB App ist kostenlos und bleibt es. Die Kaffees unten bezahlen die Zeit, die darin steckt — die Leute dahinter sind der Grund, warum es überhaupt eine neue Version zu installieren gibt.",
   "supporters.count_one": "{{count}} Unterstützer",
   "supporters.count_other": "{{count}} Unterstützer",
   "supporters.untiered": "Unterstützer",
   "supporters.since": "seit {{date}}",
   "supporters.loading": "Liste wird geladen…",
   "supporters.refresh": "Aktualisieren",
-  "supporters.become": "Auf Patreon unterstützen",
+  "supporters.become": "Spendier mir einen Kaffee",
   "supporters.empty": "Hier steht noch niemand",
   "supporters.emptyDesc":
-    "Die Liste aktualisiert sich von selbst — unterstütze die App, und dein Name steht hier, ohne auf eine neue Version zu warten.",
+    "Die Liste aktualisiert sich von selbst — spendier einen Kaffee, und dein Name steht hier, ohne auf eine neue Version zu warten.",
   "supporters.offline":
     "Die Liste war gerade nicht erreichbar — das hier ist die zuletzt bekannte.",
   "supporters.optOut":
-    "Namen erscheinen nur mit Einverständnis. Kurz auf Discord oder Patreon melden, dann ist deiner sofort weg.",
+    "Namen erscheinen nur mit Einverständnis. Kurz auf Discord oder Buy Me a Coffee melden, dann ist deiner sofort weg.",
 
   "modType.reshade": "ReShade",
   "modType.reshadeInline": "ReShade-Presets",

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1300,6 +1300,27 @@ export const de: Translation = {
   // ── ReShade ────────────────────────────────────────────────────────────────
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Postprocessing-Presets — wie {{game}} auf dem Bildschirm aussieht.",
+
+  // ── Unterstützer (Patreon) ─────────────────────────────────────────────────
+  "settings.supporters": "Unterstützer",
+  "settings.supportersDesc": "Die Leute, die MXB App auf Patreon finanzieren.",
+  "supporters.intro":
+    "MXB App ist kostenlos und bleibt es. Patreon bezahlt die Zeit, die darin steckt — die Leute unten sind der Grund, warum es überhaupt eine neue Version zu installieren gibt.",
+  "supporters.count_one": "{{count}} Unterstützer",
+  "supporters.count_other": "{{count}} Unterstützer",
+  "supporters.untiered": "Unterstützer",
+  "supporters.since": "seit {{date}}",
+  "supporters.loading": "Liste wird geladen…",
+  "supporters.refresh": "Aktualisieren",
+  "supporters.become": "Auf Patreon unterstützen",
+  "supporters.empty": "Hier steht noch niemand",
+  "supporters.emptyDesc":
+    "Die Liste aktualisiert sich von selbst — unterstütze die App, und dein Name steht hier, ohne auf eine neue Version zu warten.",
+  "supporters.offline":
+    "Die Liste war gerade nicht erreichbar — das hier ist die zuletzt bekannte.",
+  "supporters.optOut":
+    "Namen erscheinen nur mit Einverständnis. Kurz auf Discord oder Patreon melden, dann ist deiner sofort weg.",
+
   "modType.reshade": "ReShade",
   "modType.reshadeInline": "ReShade-Presets",
   "reshade.needsGameFolder":

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1258,6 +1258,27 @@ export const en = {
   // ReShade is a product name and stays untranslated everywhere, capital S included.
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Post-processing presets — how {{game}} looks on screen.",
+
+  // ── Supporters (Patreon) ───────────────────────────────────────────────────
+  "settings.supporters": "Supporters",
+  "settings.supportersDesc": "The people funding MXB App on Patreon.",
+  "supporters.intro":
+    "MXB App is free, and stays that way. Patreon is what pays for the time behind it — the people below are why there's a new build to install.",
+  "supporters.count_one": "{{count}} supporter",
+  "supporters.count_other": "{{count}} supporters",
+  "supporters.untiered": "Supporters",
+  "supporters.since": "since {{date}}",
+  "supporters.loading": "Fetching the list…",
+  "supporters.refresh": "Refresh",
+  "supporters.become": "Support on Patreon",
+  "supporters.empty": "Nobody's listed here yet",
+  "supporters.emptyDesc":
+    "The list updates on its own — back the app and your name shows up here, no new version needed.",
+  "supporters.offline":
+    "Couldn't reach the list just now — this is the last one we saw.",
+  "supporters.optOut":
+    "Names are shown with permission. Ask on Discord or Patreon and yours comes straight off.",
+
   "modType.reshade": "ReShade",
   "modType.reshadeInline": "ReShade presets",
   "reshade.needsGameFolder":

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1259,25 +1259,25 @@ export const en = {
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Post-processing presets — how {{game}} looks on screen.",
 
-  // ── Supporters (Patreon) ───────────────────────────────────────────────────
+  // ── Supporters (Buy Me a Coffee) ───────────────────────────────────────────
   "settings.supporters": "Supporters",
-  "settings.supportersDesc": "The people funding MXB App on Patreon.",
+  "settings.supportersDesc": "The people keeping MXB App going on Buy Me a Coffee.",
   "supporters.intro":
-    "MXB App is free, and stays that way. Patreon is what pays for the time behind it — the people below are why there's a new build to install.",
+    "MXB App is free, and stays that way. The coffees below are what pay for the time behind it — the people who bought them are why there's a new build to install.",
   "supporters.count_one": "{{count}} supporter",
   "supporters.count_other": "{{count}} supporters",
   "supporters.untiered": "Supporters",
   "supporters.since": "since {{date}}",
   "supporters.loading": "Fetching the list…",
   "supporters.refresh": "Refresh",
-  "supporters.become": "Support on Patreon",
+  "supporters.become": "Buy me a coffee",
   "supporters.empty": "Nobody's listed here yet",
   "supporters.emptyDesc":
-    "The list updates on its own — back the app and your name shows up here, no new version needed.",
+    "The list updates on its own — buy a coffee and your name shows up here, no new version needed.",
   "supporters.offline":
     "Couldn't reach the list just now — this is the last one we saw.",
   "supporters.optOut":
-    "Names are shown with permission. Ask on Discord or Patreon and yours comes straight off.",
+    "Names are shown with permission. Ask on Discord or Buy Me a Coffee and yours comes straight off.",
 
   "modType.reshade": "ReShade",
   "modType.reshadeInline": "ReShade presets",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1288,6 +1288,27 @@ export const es: Translation = {
   // ── ReShade ────────────────────────────────────────────────────────────────
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Ajustes de posprocesado — cómo se ve {{game}} en pantalla.",
+
+  // ── Mecenas (Patreon) ──────────────────────────────────────────────────────
+  "settings.supporters": "Mecenas",
+  "settings.supportersDesc": "Quienes financian MXB App en Patreon.",
+  "supporters.intro":
+    "MXB App es gratis, y así seguirá. Patreon es lo que paga el tiempo que hay detrás: la gente de abajo es la razón de que haya una versión nueva que instalar.",
+  "supporters.count_one": "{{count}} mecenas",
+  "supporters.count_other": "{{count}} mecenas",
+  "supporters.untiered": "Mecenas",
+  "supporters.since": "desde {{date}}",
+  "supporters.loading": "Cargando la lista…",
+  "supporters.refresh": "Actualizar",
+  "supporters.become": "Apoyar en Patreon",
+  "supporters.empty": "Todavía no hay nadie en la lista",
+  "supporters.emptyDesc":
+    "La lista se actualiza sola: apoya la app y tu nombre aparecerá aquí sin esperar a una versión nueva.",
+  "supporters.offline":
+    "No se pudo consultar la lista ahora mismo — esta es la última que vimos.",
+  "supporters.optOut":
+    "Los nombres se muestran con permiso. Escribe por Discord o Patreon y el tuyo se quita al momento.",
+
   "modType.reshade": "ReShade",
   "modType.reshadeInline": "ajustes de ReShade",
   "reshade.needsGameFolder":

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1289,25 +1289,25 @@ export const es: Translation = {
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Ajustes de posprocesado — cómo se ve {{game}} en pantalla.",
 
-  // ── Mecenas (Patreon) ──────────────────────────────────────────────────────
+  // ── Mecenas (Buy Me a Coffee) ──────────────────────────────────────────────
   "settings.supporters": "Mecenas",
-  "settings.supportersDesc": "Quienes financian MXB App en Patreon.",
+  "settings.supportersDesc": "Quienes mantienen MXB App en Buy Me a Coffee.",
   "supporters.intro":
-    "MXB App es gratis, y así seguirá. Patreon es lo que paga el tiempo que hay detrás: la gente de abajo es la razón de que haya una versión nueva que instalar.",
+    "MXB App es gratis, y así seguirá. Los cafés de abajo son los que pagan el tiempo que hay detrás: quienes los invitaron son la razón de que haya una versión nueva que instalar.",
   "supporters.count_one": "{{count}} mecenas",
   "supporters.count_other": "{{count}} mecenas",
   "supporters.untiered": "Mecenas",
   "supporters.since": "desde {{date}}",
   "supporters.loading": "Cargando la lista…",
   "supporters.refresh": "Actualizar",
-  "supporters.become": "Apoyar en Patreon",
+  "supporters.become": "Invítame a un café",
   "supporters.empty": "Todavía no hay nadie en la lista",
   "supporters.emptyDesc":
-    "La lista se actualiza sola: apoya la app y tu nombre aparecerá aquí sin esperar a una versión nueva.",
+    "La lista se actualiza sola: invita a un café y tu nombre aparecerá aquí sin esperar a una versión nueva.",
   "supporters.offline":
     "No se pudo consultar la lista ahora mismo — esta es la última que vimos.",
   "supporters.optOut":
-    "Los nombres se muestran con permiso. Escribe por Discord o Patreon y el tuyo se quita al momento.",
+    "Los nombres se muestran con permiso. Escribe por Discord o por Buy Me a Coffee y el tuyo se quita al momento.",
 
   "modType.reshade": "ReShade",
   "modType.reshadeInline": "ajustes de ReShade",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1292,25 +1292,25 @@ export const fr: Translation = {
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Préréglages de post-traitement — le rendu de {{game}} à l'écran.",
 
-  // ── Soutiens (Patreon) ─────────────────────────────────────────────────────
+  // ── Soutiens (Buy Me a Coffee) ─────────────────────────────────────────────
   "settings.supporters": "Soutiens",
-  "settings.supportersDesc": "Les personnes qui financent MXB App sur Patreon.",
+  "settings.supportersDesc": "Les personnes qui font vivre MXB App sur Buy Me a Coffee.",
   "supporters.intro":
-    "MXB App est gratuite, et le restera. Patreon paie le temps passé dessus : les personnes ci-dessous sont la raison pour laquelle il y a une nouvelle version à installer.",
+    "MXB App est gratuite, et le restera. Les cafés ci-dessous paient le temps passé dessus : celles et ceux qui les ont offerts sont la raison pour laquelle il y a une nouvelle version à installer.",
   "supporters.count_one": "{{count}} soutien",
   "supporters.count_other": "{{count}} soutiens",
   "supporters.untiered": "Soutiens",
   "supporters.since": "depuis {{date}}",
   "supporters.loading": "Chargement de la liste…",
   "supporters.refresh": "Actualiser",
-  "supporters.become": "Soutenir sur Patreon",
+  "supporters.become": "Offrez-moi un café",
   "supporters.empty": "Personne n'est encore listé ici",
   "supporters.emptyDesc":
-    "La liste se met à jour toute seule : soutenez l'app et votre nom apparaîtra ici, sans attendre une nouvelle version.",
+    "La liste se met à jour toute seule : offrez un café et votre nom apparaîtra ici, sans attendre une nouvelle version.",
   "supporters.offline":
     "Impossible de joindre la liste pour l'instant — voici la dernière connue.",
   "supporters.optOut":
-    "Les noms sont affichés avec accord. Un message sur Discord ou Patreon et le vôtre est retiré aussitôt.",
+    "Les noms sont affichés avec accord. Un message sur Discord ou Buy Me a Coffee et le vôtre est retiré aussitôt.",
 
   "modType.reshade": "ReShade",
   "modType.reshadeInline": "préréglages ReShade",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1291,6 +1291,27 @@ export const fr: Translation = {
   // ── ReShade ────────────────────────────────────────────────────────────────
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Préréglages de post-traitement — le rendu de {{game}} à l'écran.",
+
+  // ── Soutiens (Patreon) ─────────────────────────────────────────────────────
+  "settings.supporters": "Soutiens",
+  "settings.supportersDesc": "Les personnes qui financent MXB App sur Patreon.",
+  "supporters.intro":
+    "MXB App est gratuite, et le restera. Patreon paie le temps passé dessus : les personnes ci-dessous sont la raison pour laquelle il y a une nouvelle version à installer.",
+  "supporters.count_one": "{{count}} soutien",
+  "supporters.count_other": "{{count}} soutiens",
+  "supporters.untiered": "Soutiens",
+  "supporters.since": "depuis {{date}}",
+  "supporters.loading": "Chargement de la liste…",
+  "supporters.refresh": "Actualiser",
+  "supporters.become": "Soutenir sur Patreon",
+  "supporters.empty": "Personne n'est encore listé ici",
+  "supporters.emptyDesc":
+    "La liste se met à jour toute seule : soutenez l'app et votre nom apparaîtra ici, sans attendre une nouvelle version.",
+  "supporters.offline":
+    "Impossible de joindre la liste pour l'instant — voici la dernière connue.",
+  "supporters.optOut":
+    "Les noms sont affichés avec accord. Un message sur Discord ou Patreon et le vôtre est retiré aussitôt.",
+
   "modType.reshade": "ReShade",
   "modType.reshadeInline": "préréglages ReShade",
   "reshade.needsGameFolder":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1280,6 +1280,27 @@ export const it: Translation = {
   // ── ReShade ────────────────────────────────────────────────────────────────
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Preset di post-processing — l'aspetto di {{game}} a schermo.",
+
+  // ── Sostenitori (Patreon) ──────────────────────────────────────────────────
+  "settings.supporters": "Sostenitori",
+  "settings.supportersDesc": "Chi finanzia MXB App su Patreon.",
+  "supporters.intro":
+    "MXB App è gratuita, e resta così. Patreon è ciò che paga il tempo che ci sta dietro: le persone qui sotto sono il motivo per cui c'è una nuova build da installare.",
+  "supporters.count_one": "{{count}} sostenitore",
+  "supporters.count_other": "{{count}} sostenitori",
+  "supporters.untiered": "Sostenitori",
+  "supporters.since": "da {{date}}",
+  "supporters.loading": "Carico l'elenco…",
+  "supporters.refresh": "Aggiorna",
+  "supporters.become": "Sostieni su Patreon",
+  "supporters.empty": "Ancora nessuno in elenco",
+  "supporters.emptyDesc":
+    "L'elenco si aggiorna da solo: sostieni l'app e il tuo nome compare qui, senza aspettare una nuova versione.",
+  "supporters.offline":
+    "Non sono riuscito a raggiungere l'elenco — questo è l'ultimo che abbiamo visto.",
+  "supporters.optOut":
+    "I nomi sono mostrati con il consenso di chi li porta. Scrivi su Discord o Patreon e il tuo viene tolto subito.",
+
   "modType.reshade": "ReShade",
   "modType.reshadeInline": "preset ReShade",
   "reshade.needsGameFolder":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1281,25 +1281,25 @@ export const it: Translation = {
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Preset di post-processing — l'aspetto di {{game}} a schermo.",
 
-  // ── Sostenitori (Patreon) ──────────────────────────────────────────────────
+  // ── Sostenitori (Buy Me a Coffee) ──────────────────────────────────────────
   "settings.supporters": "Sostenitori",
-  "settings.supportersDesc": "Chi finanzia MXB App su Patreon.",
+  "settings.supportersDesc": "Chi tiene in piedi MXB App su Buy Me a Coffee.",
   "supporters.intro":
-    "MXB App è gratuita, e resta così. Patreon è ciò che paga il tempo che ci sta dietro: le persone qui sotto sono il motivo per cui c'è una nuova build da installare.",
+    "MXB App è gratuita, e resta così. I caffè qui sotto pagano il tempo che ci sta dietro: chi li ha offerti è il motivo per cui c'è una nuova build da installare.",
   "supporters.count_one": "{{count}} sostenitore",
   "supporters.count_other": "{{count}} sostenitori",
   "supporters.untiered": "Sostenitori",
   "supporters.since": "da {{date}}",
   "supporters.loading": "Carico l'elenco…",
   "supporters.refresh": "Aggiorna",
-  "supporters.become": "Sostieni su Patreon",
+  "supporters.become": "Offrimi un caffè",
   "supporters.empty": "Ancora nessuno in elenco",
   "supporters.emptyDesc":
-    "L'elenco si aggiorna da solo: sostieni l'app e il tuo nome compare qui, senza aspettare una nuova versione.",
+    "L'elenco si aggiorna da solo: offri un caffè e il tuo nome compare qui, senza aspettare una nuova versione.",
   "supporters.offline":
     "Non sono riuscito a raggiungere l'elenco — questo è l'ultimo che abbiamo visto.",
   "supporters.optOut":
-    "I nomi sono mostrati con il consenso di chi li porta. Scrivi su Discord o Patreon e il tuo viene tolto subito.",
+    "I nomi sono mostrati con il consenso di chi li porta. Scrivi su Discord o su Buy Me a Coffee e il tuo viene tolto subito.",
 
   "modType.reshade": "ReShade",
   "modType.reshadeInline": "preset ReShade",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1280,6 +1280,27 @@ export const ptBR: Translation = {
   // ── ReShade ────────────────────────────────────────────────────────────────
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Presets de pós-processamento — como {{game}} aparece na tela.",
+
+  // ── Apoiadores (Patreon) ───────────────────────────────────────────────────
+  "settings.supporters": "Apoiadores",
+  "settings.supportersDesc": "Quem banca o MXB App no Patreon.",
+  "supporters.intro":
+    "O MXB App é gratuito, e continua assim. O Patreon é o que paga o tempo investido nele — as pessoas abaixo são o motivo de existir uma versão nova pra instalar.",
+  "supporters.count_one": "{{count}} apoiador",
+  "supporters.count_other": "{{count}} apoiadores",
+  "supporters.untiered": "Apoiadores",
+  "supporters.since": "desde {{date}}",
+  "supporters.loading": "Carregando a lista…",
+  "supporters.refresh": "Atualizar",
+  "supporters.become": "Apoiar no Patreon",
+  "supporters.empty": "Ainda não há ninguém na lista",
+  "supporters.emptyDesc":
+    "A lista se atualiza sozinha — apoie o app e seu nome aparece aqui, sem esperar uma versão nova.",
+  "supporters.offline":
+    "Não deu pra buscar a lista agora — esta é a última que vimos.",
+  "supporters.optOut":
+    "Os nomes aparecem com permissão. É só falar no Discord ou no Patreon que o seu sai na hora.",
+
   "modType.reshade": "ReShade",
   "modType.reshadeInline": "presets do ReShade",
   "reshade.needsGameFolder":

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1281,25 +1281,25 @@ export const ptBR: Translation = {
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Presets de pós-processamento — como {{game}} aparece na tela.",
 
-  // ── Apoiadores (Patreon) ───────────────────────────────────────────────────
+  // ── Apoiadores (Buy Me a Coffee) ───────────────────────────────────────────
   "settings.supporters": "Apoiadores",
-  "settings.supportersDesc": "Quem banca o MXB App no Patreon.",
+  "settings.supportersDesc": "Quem mantém o MXB App de pé no Buy Me a Coffee.",
   "supporters.intro":
-    "O MXB App é gratuito, e continua assim. O Patreon é o que paga o tempo investido nele — as pessoas abaixo são o motivo de existir uma versão nova pra instalar.",
+    "O MXB App é gratuito, e continua assim. Os cafés abaixo pagam o tempo investido nele — quem pagou é o motivo de existir uma versão nova pra instalar.",
   "supporters.count_one": "{{count}} apoiador",
   "supporters.count_other": "{{count}} apoiadores",
   "supporters.untiered": "Apoiadores",
   "supporters.since": "desde {{date}}",
   "supporters.loading": "Carregando a lista…",
   "supporters.refresh": "Atualizar",
-  "supporters.become": "Apoiar no Patreon",
+  "supporters.become": "Me paga um café",
   "supporters.empty": "Ainda não há ninguém na lista",
   "supporters.emptyDesc":
-    "A lista se atualiza sozinha — apoie o app e seu nome aparece aqui, sem esperar uma versão nova.",
+    "A lista se atualiza sozinha — pague um café e seu nome aparece aqui, sem esperar uma versão nova.",
   "supporters.offline":
     "Não deu pra buscar a lista agora — esta é a última que vimos.",
   "supporters.optOut":
-    "Os nomes aparecem com permissão. É só falar no Discord ou no Patreon que o seu sai na hora.",
+    "Os nomes aparecem com permissão. É só falar no Discord ou no Buy Me a Coffee que o seu sai na hora.",
 
   "modType.reshade": "ReShade",
   "modType.reshadeInline": "presets do ReShade",

--- a/supporters.json
+++ b/supporters.json
@@ -1,6 +1,6 @@
 {
   "_note": "Read live by the app's Settings → Supporters page, straight off main — adding somebody here shows up in every installed copy without a release. 'tiers' orders the groups (best first) and holds Buy Me a Coffee membership level names; a level used below but missing from it still renders, just last. Each supporter is either a plain string or { name, tier?, since? }, where 'since' is an ISO date shown as 'since Jul 2026'. Someone who bought a one-off coffee has no tier and lands in the ungrouped list at the bottom. Only list names with the person's permission.",
-  "supportUrl": "https://buymeacoffee.com/mxbapp",
+  "supportUrl": "https://buymeacoffee.com/22ypnh5yfme",
   "tiers": [],
   "supporters": []
 }

--- a/supporters.json
+++ b/supporters.json
@@ -1,6 +1,6 @@
 {
-  "_note": "Read live by the app's Settings → Supporters page, straight off main — adding somebody here shows up in every installed copy without a release. 'tiers' orders the groups (best first); a tier used below but missing from it still renders, just last. Each supporter is either a plain string or { name, tier?, since? }, where 'since' is an ISO date shown as 'since Jul 2026'. Only list names with the person's permission.",
-  "patreonUrl": "https://www.patreon.com/mxbapp",
+  "_note": "Read live by the app's Settings → Supporters page, straight off main — adding somebody here shows up in every installed copy without a release. 'tiers' orders the groups (best first) and holds Buy Me a Coffee membership level names; a level used below but missing from it still renders, just last. Each supporter is either a plain string or { name, tier?, since? }, where 'since' is an ISO date shown as 'since Jul 2026'. Someone who bought a one-off coffee has no tier and lands in the ungrouped list at the bottom. Only list names with the person's permission.",
+  "supportUrl": "https://buymeacoffee.com/mxbapp",
   "tiers": [],
   "supporters": []
 }

--- a/supporters.json
+++ b/supporters.json
@@ -2,5 +2,10 @@
   "_note": "Read live by the app's Settings → Supporters page, straight off main — adding somebody here shows up in every installed copy without a release. 'tiers' orders the groups (best first) and holds Buy Me a Coffee membership level names; a level used below but missing from it still renders, just last. Each supporter is either a plain string or { name, tier?, since? }, where 'since' is an ISO date shown as 'since Jul 2026'. Someone who bought a one-off coffee has no tier and lands in the ungrouped list at the bottom. Only list names with the person's permission.",
   "supportUrl": "https://buymeacoffee.com/22ypnh5yfme",
   "tiers": [],
-  "supporters": []
+  "supporters": [
+    "HottPie",
+    "Mouk",
+    "SoggySwisher",
+    "LupaHo"
+  ]
 }

--- a/supporters.json
+++ b/supporters.json
@@ -1,0 +1,6 @@
+{
+  "_note": "Read live by the app's Settings → Supporters page, straight off main — adding somebody here shows up in every installed copy without a release. 'tiers' orders the groups (best first); a tier used below but missing from it still renders, just last. Each supporter is either a plain string or { name, tier?, since? }, where 'since' is an ISO date shown as 'since Jul 2026'. Only list names with the person's permission.",
+  "patreonUrl": "https://www.patreon.com/mxbapp",
+  "tiers": [],
+  "supporters": []
+}


### PR DESCRIPTION
Settings gets a **Supporters** section, sitting above About: an intro, the people who've bought a coffee, and the one button that joins them. A thank-you buried under the version number and the update button is one nobody reads, so it gets its own entry in the settings nav.

### The names aren't baked into the build

They're read from [`supporters.json`](https://github.com/Frostn1/mxb-app/blob/main/supporters.json) on `main` at runtime and cached in webview storage. Three layers, in order of preference:

1. the remote manifest, fetched every time the section opens;
2. the last remote answer, cached — so an offline launch still shows the real list;
3. the bundled copy, for an install that has never once reached the network.

That means adding somebody is a one-line commit to that file rather than a release. A failed fetch keeps what's on screen and says so under it — emptying the page because GitHub blinked would read as "this app has no supporters".

`supportUrl` in the manifest overrides the built-in Buy Me a Coffee link too, so a moved page is fixable without shipping a build.

### What's in it

- Supporters grouped by membership level, in the manifest's order. A level the manifest doesn't name still renders, just last — renaming one on Buy Me a Coffee degrades to "listed last" rather than "silently dropped". One-off coffees have no level and land in the ungrouped list at the bottom.
- The group heading only appears once there's an actual distinction to draw. Right now nobody's on a level, so a "Supporters · 4" heading directly under the "Supporters" title, over four visible names, would be labelling nothing.
- Longest-standing first within a level, then alphabetical.
- An honest empty state, a refresh button, and an opt-out note — names are shown with permission.
- Remote JSON is validated before it renders: caps on count and string length, junk entries dropped, bare strings accepted so the file stays pleasant to hand-edit.

Seeded with the four people currently on the page: HottPie, Mouk, SoggySwisher and LupaHo.

### Testing

`npm run typecheck`, `npm run lint` (only the two pre-existing warnings, in files this doesn't touch) and `npm run build` all pass. The parse/group helpers were exercised against malformed input — junk entries drop, unknown levels sort last, ungrouped names land at the bottom.

New UI strings are in all six locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Auro6CCCffm4E3VLLni2gS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Auro6CCCffm4E3VLLni2gS)_