### PR TITLE
fix(windows): keep the drag-drop handler off only under Wine

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5337,6 +5337,48 @@ fn prepare_webview_env() {
     }
 }
 
+/// Whether this process is running under Wine — CrossOver, Whisky, Kegworks or plain Wine.
+///
+/// `ntdll` exports `wine_get_version` under Wine and never on real Windows, which is the
+/// check Wine documents for programs that need to tell. It matters here because Wine's
+/// `ole32` faults inside `RegisterDragDrop`: the app came up as a transparent window and
+/// died in `ole32` from its own window procedure, with WebView2 already running.
+#[cfg(windows)]
+fn under_wine() -> bool {
+    use std::os::raw::{c_char, c_void};
+
+    extern "system" {
+        fn GetModuleHandleA(name: *const c_char) -> *mut c_void;
+        fn GetProcAddress(module: *mut c_void, name: *const c_char) -> *mut c_void;
+    }
+
+    // SAFETY: both take a NUL-terminated name and return null rather than failing. `ntdll`
+    // is always already loaded, so this never brings a library in.
+    unsafe {
+        let ntdll = GetModuleHandleA(b"ntdll.dll\0".as_ptr() as *const c_char);
+        !ntdll.is_null()
+            && !GetProcAddress(ntdll, b"wine_get_version\0".as_ptr() as *const c_char).is_null()
+    }
+}
+
+#[cfg(not(windows))]
+fn under_wine() -> bool {
+    false
+}
+
+/// Whether to register the OS drag-drop handler on the main window.
+///
+/// Under Wine it is what crashes the app, so it comes off there and stays on everywhere
+/// else — a Windows player keeps the dropzone. `MXB_DRAG_DROP` forces the answer either way
+/// (`0` off, `1` on) so one build can be tried both ways.
+fn drag_drop_enabled() -> bool {
+    match std::env::var("MXB_DRAG_DROP").ok().as_deref() {
+        Some("0") => false,
+        Some("1") => true,
+        _ => !under_wine(),
+    }
+}
+
 fn main() {
     prepare_webview_env();
 
@@ -5413,6 +5455,28 @@ fn main() {
         .manage(shop_session::ShopSession::default())
         .setup(|app| {
             log::info!("MXB App {} starting", env!("CARGO_PKG_VERSION"));
+
+            // The main window is `"create": false` in tauri.conf.json so it is built here
+            // rather than by Tauri's own startup loop, which is the only way to decide the
+            // drag-drop handler per run: it can only be turned off while the window is
+            // being built. Everything else about the window still comes from the config,
+            // the macOS overrides in `tauri.macos.conf.json` included.
+            let drag_drop = drag_drop_enabled();
+            log::info!("wine={} drag-drop-handler={}", under_wine(), drag_drop);
+            for window_config in app
+                .config()
+                .app
+                .windows
+                .iter()
+                .filter(|w| w.label == MAIN_WINDOW)
+            {
+                let mut builder =
+                    tauri::WebviewWindowBuilder::from_config(app.handle(), window_config)?;
+                if !drag_drop {
+                    builder = builder.disable_drag_drop_handler();
+                }
+                builder.build()?;
+            }
             // Cloudflare scores the User-Agent alongside the IP, and a cf_clearance is bound
             // to the UA that earned it — a log about a block should say which one was used.
             log::info!("{} user-agent: {}", mxb_session::site().domain, mxb_session::UA);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
         "minWidth": 1000,
         "minHeight": 700,
         "decorations": false,
-        "dragDropEnabled": false
+        "create": false
       }
     ],
     "security": {


### PR DESCRIPTION
## What this does

Replaces #131's blanket `dragDropEnabled: false` with a runtime decision, so a Windows player keeps the dropzone and only Wine loses it.

#131 was a diagnostic: it turned the OS drag-drop handler off everywhere to test whether `RegisterDragDrop` is what kills the app under CrossOver. That cost every Windows user the whole-window drop target. This keeps the fix and gives that back.

## How

`RegisterDragDrop` is only skippable while the window is being built, and a window declared in `tauri.conf.json` is built by Tauri before anything can influence it — `app.rs:2524` is `for window_config in app.config().app.windows.iter().filter(|w| w.create)`.

So the main window gains `"create": false` and is built in `setup` instead. The config stays the single source of truth for everything else about it, the macOS `titleBarStyle`/`decorations` overrides included, because `WebviewWindowBuilder::from_config` is what consumes it — the same call Tauri's own startup loop makes:

```rust
let mut builder = tauri::WebviewWindowBuilder::from_config(app.handle(), window_config)?;
if !drag_drop { builder = builder.disable_drag_drop_handler(); }
builder.build()?;
```

Wine detection is the documented one — `ntdll` exports `wine_get_version` under Wine and never on real Windows — which covers CrossOver, Whisky, Kegworks and plain Wine without keying on any wrapper's layout. `MXB_DRAG_DROP=0|1` overrides either way, so one build can be tried both paths: default (handler auto-off under Wine) against `MXB_DRAG_DROP=1` (forced on, expected to reproduce the crash).

## Ordering

Building the window in `setup` moves it later than Tauri's own loop. Three things that could have cared, checked:

- `prepare_webview_env()` runs at the top of `main()`, before the builder — unaffected.
- `on_window_event` is registered builder-level, so it still covers a window created later (this is what parks the app in the tray on close).
- The only runtime references to the main window — `show_main` and the shop-login path — are both `if let Some(...)` on user-triggered flows, not startup.

It also lands *after* the single-instance guard rather than before, so a second launch is killed that much earlier.

## Verification

- `cargo check` on Linux (the same build CI's ubuntu job does): **exit 0**, `Compiling frost v0.9.1`, 0 errors. The 9 warnings are pre-existing dead-code ones in other files; none in `main.rs`.
- The `#[cfg(windows)]` FFI can't be reached from a Linux check, so those helpers were compiled standalone against `x86_64-pc-windows-gnu`: **exit 0**, no errors or warnings.
- A full cross-compile of the app for Windows isn't possible in the authoring environment — MSVC wants `lib.exe` and mingw can't build `unrar_sys`' vendored C++. CI's windows-latest job is what covers that.

**Not verified:** whether skipping the registration actually fixes the CrossOver crash. That's still the open question this whole line of work rests on, and it needs a bottle to answer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX4sBgbxNddaNzjBAt1JVt)_