### PR TITLE
feat(designer): a ghost underlay of the plastics, and corner resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **The Designer can show you what you're drawing on.** A livery is drawn flat and worn curved,
+  and the flat version gives away almost nothing about which rectangle of it ends up on a
+  shroud — so a sheet has a **reference underlay** now, and it answers that two ways. **Template**
+  lifts the paint you started from *out* of the sheet and shows it faintly underneath to trace
+  over; it stops being part of what you save, which is the difference between drawing *from* a
+  paint and drawing *over* one. **UV map** reads the model already standing beside the canvas
+  and draws its bodywork where it actually lands on the sheet, each piece in its own colour —
+  the thing an image editor cannot tell you. Neither is ever composited, staged or saved: they
+  live outside the sheet entirely, so a guide cannot end up shipped inside somebody's livery.
+  The template sits under your work because that is what tracing is; the UV map sits over it,
+  because a ruler beneath an opaque paint tells you nothing.
+- **Layers resize by their corners.** The selected layer's box has grabbable handles, dragged
+  from the centre the same way the inspector's slider scales from it, so the two controls agree
+  about where a logo grows from. The slider stays for typing an exact number; the corners are
+  for the other 90% of the time. Handles are still drawn on a layer too small to grab one —
+  the box is how you see what's selected — but the grab itself steps aside there rather than
+  leaving a tiny layer resizable and no longer draggable.
+- **A sheet name the model never asks for now says so.** Turning on the UV map for a sheet
+  nothing on the mesh binds reports it in the panel instead of drawing an empty overlay, which
+  had been indistinguishable from one still loading. It's the same mistake that makes a paint
+  load and show nothing, caught before the save rather than after it.
+
 ## Unannounced — a debugger can't ride along
 
 Left out of the release notes on purpose: a hardening measure advertised is a hardening

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@
   and draws its bodywork where it actually lands on the sheet, each piece in its own colour —
   the thing an image editor cannot tell you. Neither is ever composited, staged or saved: they
   live outside the sheet entirely, so a guide cannot end up shipped inside somebody's livery.
-  The template sits under your work because that is what tracing is; the UV map sits over it,
-  because a ruler beneath an opaque paint tells you nothing.
+  Both sit **underneath** what you're drawing — a ghost, not an overlay — so they show through
+  wherever the sheet is still transparent, which is exactly where you need to know which piece
+  of bodywork you're about to paint on. The two are meant to be used together: lifting the
+  template out is what leaves the sheet transparent enough to see the islands through it, and
+  the panel says so when a still-opaque template is burying the reference.
 - **Layers resize by their corners.** The selected layer's box has grabbable handles, dragged
   from the centre the same way the inspector's slider scales from it, so the two controls agree
   about where a logo grows from. The slider stays for typing an exact number; the corners are

--- a/src/Components/Studio/Designer/CanvasStage.tsx
+++ b/src/Components/Studio/Designer/CanvasStage.tsx
@@ -2,8 +2,18 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { useT } from "../../../i18n/context";
 import { layerCorners } from "./composite";
+import type { Ghost } from "./ghost";
 import { hitTest, type Layer, type Sheet } from "./layers";
 import { constrained, hasTip, isDragTool, type PaintTool, type Point } from "./paint";
+
+/** Half-edge of a drawn corner handle, and how far off one a press still counts, in view px. */
+const HANDLE = 3.5;
+const GRAB = 9;
+
+/** The range a corner drag can take a layer to. The same as the inspector's slider, so the
+ *  two controls can't disagree about how big a logo is allowed to get. */
+const MIN_SCALE = 0.05;
+const MAX_SCALE = 4;
 
 interface CanvasStageProps {
   sheet: Sheet;
@@ -11,10 +21,14 @@ interface CanvasStageProps {
   source: HTMLCanvasElement | null;
   /** Bumped by the editor whenever the composite changes, to force a repaint. */
   version: number;
+  /** The reference underlay, if any. Drawn here and nowhere else — see `ghost.ts`. */
+  ghost: Ghost | null;
   selectedId: string | null;
   onSelect: (id: string | null) => void;
   /** Drag, in sheet pixels. */
   onMove: (id: string, dx: number, dy: number) => void;
+  /** Corner drag, as the layer's new absolute scale. */
+  onScale: (id: string, scale: number) => void;
   /** What the pointer does here. `move` is the select-and-drag behaviour. */
   tool: PaintTool;
   /** Brush and eraser diameter in sheet pixels, for the cursor. */
@@ -36,14 +50,19 @@ interface CanvasStageProps {
  * Zoom and pan are view state and live here; nothing in them reaches the sheet. Strokes are the
  * other way round: this turns pointer events into sheet coordinates and hands them up, because
  * the pixels they land on belong to the layer, not to the view they were drawn through.
+ *
+ * The ghost is drawn here for the same reason, read backwards: a guide that never enters the
+ * composite cannot reach the file, whatever anyone later does to the save path.
  */
 export function CanvasStage({
   sheet,
   source,
   version,
+  ghost,
   selectedId,
   onSelect,
   onMove,
+  onScale,
   tool,
   brushSize,
   canPaint,
@@ -63,7 +82,15 @@ export function CanvasStage({
   const [pan, setPan] = useState({ x: 0, y: 0 });
   // Where the pointer went down, and what it was doing — a drag of a layer, or of the view.
   const drag = useRef<{ id: string | null; x: number; y: number } | null>(null);
+  // A corner drag: the layer's centre and the distance the press was from it, both in sheet
+  // pixels, plus the scale it started at. Scale comes out as a ratio of distances, so the
+  // grabbed corner stays under the pointer however the view is zoomed or panned mid-drag.
+  const sizing = useRef<{ id: string; cx: number; cy: number; dist: number; scale: number } | null>(
+    null,
+  );
   const painting = useRef(false);
+  // Which corner the pointer is over, purely so the cursor can say the layer is resizable.
+  const [overHandle, setOverHandle] = useState(-1);
   // The press and current point of a gradient or shape drag, so it can be shown while it's
   // being aimed. Only ever set between press and release.
   const [guide, setGuide] = useState<{ from: Point; to: Point } | null>(null);
@@ -109,6 +136,50 @@ export function CanvasStage({
     [originX, originY, scale, sheet.width, sheet.height],
   );
 
+  /**
+   * The selected layer's corners in view space — what's drawn as handles, and what's grabbed.
+   *
+   * Computed rather than remembered from the last paint, so a handle is always tested against
+   * where the corner is now. A resize moves all four while the pointer is still down, and a
+   * cached set would have the grab point drift away from the square under the cursor.
+   */
+  const handles = useCallback((): [number, number][] => {
+    const selected = sheet.layers.find((l) => l.id === selectedId);
+    // Paint layers are the sheet — see `layers.ts`. There is nothing to resize, and the
+    // corners would sit on the sheet edge where they'd catch every click near the border.
+    if (!selected || selected.kind === "paint") return [];
+    return layerCorners(selected).map((c) => toView({ x: c[0], y: c[1] }));
+  }, [sheet.layers, selectedId, toView]);
+
+  /**
+   * The corner under a client point, or -1.
+   *
+   * Corners are still *drawn* on a layer too small to have grabbable ones — the box is how you
+   * see what's selected, and it has to survive being small. What's dropped here is the grab:
+   * four 18px zones on a box 20px across leave no middle to take hold of, and a layer you can
+   * resize but can no longer drag is a worse trade than one that needs a zoom first.
+   */
+  const handleAt = useCallback(
+    (clientX: number, clientY: number) => {
+      const rect = viewRef.current?.getBoundingClientRect();
+      if (!rect) return -1;
+      const pts = handles();
+      if (!pts.length) return -1;
+      const xs = pts.map((p) => p[0]);
+      const ys = pts.map((p) => p[1]);
+      const room = Math.min(Math.max(...xs) - Math.min(...xs), Math.max(...ys) - Math.min(...ys));
+      if (room < GRAB * 3) return -1;
+
+      const vx = clientX - rect.left;
+      const vy = clientY - rect.top;
+      for (let i = 0; i < pts.length; i += 1) {
+        if (Math.abs(pts[i][0] - vx) <= GRAB && Math.abs(pts[i][1] - vy) <= GRAB) return i;
+      }
+      return -1;
+    },
+    [handles],
+  );
+
   // Repaint whenever anything visible changes. Not a `useEffect` on the layers themselves:
   // `version` is the editor's single "the composite moved" signal, and following it keeps
   // this from having an opinion about what counts as a change.
@@ -149,18 +220,40 @@ export function CanvasStage({
 
     ctx.imageSmoothingEnabled = true;
     ctx.imageSmoothingQuality = "high";
+
+    // The template ghost goes *under* the drawing, because that is what tracing is: the paint
+    // you are copying sits behind the one you are making. It only shows through where the
+    // sheet is still transparent, which is exactly where there is nothing drawn yet.
+    if (ghost?.showTemplate && ghost.template && ghost.opacity > 0) {
+      ctx.save();
+      ctx.globalAlpha = ghost.opacity;
+      ctx.drawImage(ghost.template, left, top, w, h);
+      ctx.restore();
+    }
+
     ctx.drawImage(source, left, top, w, h);
+
+    // The UV map goes *over* it, and that isn't an inconsistency — it answers a different
+    // question. A template is something to copy and belongs behind your work; the islands are
+    // a ruler, and a ruler underneath an opaque livery tells you nothing.
+    if (ghost?.showWire && ghost.wire && ghost.opacity > 0) {
+      ctx.save();
+      ctx.globalAlpha = ghost.opacity;
+      ctx.drawImage(ghost.wire, left, top, w, h);
+      ctx.restore();
+    }
 
     // Sheet edge, so you can see where the texture stops.
     ctx.strokeStyle = "rgba(255,255,255,0.18)";
     ctx.lineWidth = 1;
     ctx.strokeRect(left + 0.5, top + 0.5, w - 1, h - 1);
 
-    const selected = sheet.layers.find((l) => l.id === selectedId);
     // A paint layer's box is the sheet's own edge, which is already drawn — outlining it again
-    // would just put a blue border round everything for as long as a brush is selected.
-    if (selected && selected.kind !== "paint") {
-      const pts = layerCorners(selected).map(([sx, sy]) => toView({ x: sx, y: sy }));
+    // would just put a blue border round everything for as long as a brush is selected. That
+    // exclusion lives in `handles`, which is also what the corner grab tests against, so the
+    // squares you can see and the squares you can grab are one list.
+    const pts = handles();
+    if (pts.length) {
       ctx.beginPath();
       ctx.moveTo(pts[0][0], pts[0][1]);
       for (const [px, py] of pts.slice(1)) ctx.lineTo(px, py);
@@ -168,8 +261,14 @@ export function CanvasStage({
       ctx.strokeStyle = "#3b82f6";
       ctx.lineWidth = 1.5;
       ctx.stroke();
-      ctx.fillStyle = "#3b82f6";
-      for (const [px, py] of pts) ctx.fillRect(px - 2.5, py - 2.5, 5, 5);
+      // Filled white with a blue edge rather than solid blue: a handle has to look like
+      // something you take hold of, or a resizable layer reads as a decorated one.
+      ctx.lineWidth = 1;
+      for (const [px, py] of pts) {
+        ctx.fillStyle = "#ffffff";
+        ctx.fillRect(px - HANDLE, py - HANDLE, HANDLE * 2, HANDLE * 2);
+        ctx.strokeRect(px - HANDLE, py - HANDLE, HANDLE * 2, HANDLE * 2);
+      }
     }
 
     // Where a gradient runs, or what a shape will cover. The stroke itself is already visible
@@ -199,7 +298,7 @@ export function CanvasStage({
       }
       ctx.restore();
     }
-  }, [box, scale, originX, originY, sheet, source, selectedId, version, guide, tool, toView]);
+  }, [box, scale, originX, originY, sheet, source, ghost, version, guide, tool, toView, handles]);
 
   /** Put the brush ring where the pointer is, at the size it will actually paint. */
   const moveCursor = useCallback(
@@ -236,16 +335,48 @@ export function CanvasStage({
         onPaintStart(at);
         return;
       }
+      // Corners before contents. A handle sits on the layer's own edge, so hit-testing first
+      // would answer "you clicked the layer" every time and there would be no way to resize
+      // anything — and the corner of a small layer often overlaps a bigger one behind it.
+      const corner = handleAt(e.clientX, e.clientY);
+      const selected = sheet.layers.find((l) => l.id === selectedId);
+      if (corner >= 0 && selected) {
+        const dist = Math.hypot(at.x - selected.x, at.y - selected.y);
+        // A press exactly on the centre has no distance to take a ratio of. Can only happen
+        // on a layer scaled down to nothing, and dropping the drag beats dividing by zero.
+        if (dist > 0.5) {
+          sizing.current = {
+            id: selected.id,
+            cx: selected.x,
+            cy: selected.y,
+            dist,
+            scale: selected.scale,
+          };
+          return;
+        }
+      }
       const hit = hitTest(sheet.layers, at.x, at.y);
       onSelect(hit?.id ?? null);
       drag.current = { id: hit?.id ?? null, x: e.clientX, y: e.clientY };
     },
-    [onPaintStart, onSelect, paints, sheet.layers, toSheet, tool],
+    [handleAt, onPaintStart, onSelect, paints, selectedId, sheet.layers, toSheet, tool],
   );
 
   const onPointerMove = useCallback(
     (e: React.PointerEvent<HTMLCanvasElement>) => {
       moveCursor(e.clientX, e.clientY);
+
+      const size = sizing.current;
+      if (size) {
+        const p = toSheet(e.clientX, e.clientY);
+        if (!p) return;
+        // Scale as the ratio of distances from the layer's centre, which is where it grows
+        // from — the same fixed point the inspector's slider uses, so dragging a corner and
+        // typing a number move the layer's pixels the same way.
+        const next = (size.scale * Math.hypot(p.x - size.cx, p.y - size.cy)) / size.dist;
+        onScale(size.id, Math.min(MAX_SCALE, Math.max(MIN_SCALE, next)));
+        return;
+      }
 
       if (painting.current) {
         // Every sample the browser had, not just the one it chose to deliver. A fast stroke
@@ -271,7 +402,14 @@ export function CanvasStage({
       }
 
       const d = drag.current;
-      if (!d || !scale) return;
+      if (!d) {
+        // Nothing is being dragged, so this is a hover: say whether a corner is under the
+        // pointer. `setState` with an unchanged value doesn't re-render, so this only costs
+        // anything on the moves that actually cross a handle's edge.
+        setOverHandle(paints ? -1 : handleAt(e.clientX, e.clientY));
+        return;
+      }
+      if (!scale) return;
       const dx = e.clientX - d.x;
       const dy = e.clientY - d.y;
       if (!dx && !dy) return;
@@ -280,7 +418,7 @@ export function CanvasStage({
       if (d.id) onMove(d.id, dx / scale, dy / scale);
       else setPan((p) => ({ x: p.x + dx, y: p.y + dy }));
     },
-    [moveCursor, onMove, onPaintMove, scale, toSheet, tool],
+    [handleAt, moveCursor, onMove, onPaintMove, onScale, paints, scale, toSheet, tool],
   );
 
   const endDrag = useCallback(
@@ -291,6 +429,7 @@ export function CanvasStage({
         onPaintEnd();
       }
       drag.current = null;
+      sizing.current = null;
       if (e.currentTarget.hasPointerCapture(e.pointerId)) {
         e.currentTarget.releasePointerCapture(e.pointerId);
       }
@@ -308,6 +447,11 @@ export function CanvasStage({
   }, []);
 
   const ringed = paints && hasTip(tool);
+  // Corners come out of `layerCorners` clockwise from the top left, so 0/2 are one diagonal
+  // and 1/3 the other. A rotated layer makes this an approximation — the arrow can end up a
+  // notch off the true diagonal — but the thing it has to say is "this corner resizes", and
+  // it says that at every angle.
+  const resizeCursor = overHandle < 0 ? null : overHandle % 2 === 0 ? "nwse-resize" : "nesw-resize";
 
   return (
     <div
@@ -322,7 +466,7 @@ export function CanvasStage({
           height: box.h,
           // The ring is the cursor for a brush, so the arrow would be a second one. Everything
           // else that paints aims at a point, and a crosshair is the thing that says so.
-          cursor: ringed ? "none" : paints ? "crosshair" : "default",
+          cursor: ringed ? "none" : paints ? "crosshair" : (resizeCursor ?? "default"),
         }}
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
@@ -330,6 +474,7 @@ export function CanvasStage({
         onPointerCancel={endDrag}
         onPointerLeave={() => {
           if (cursorRef.current) cursorRef.current.style.opacity = "0";
+          setOverHandle(-1);
         }}
         onPointerEnter={() => {
           if (cursorRef.current) cursorRef.current.style.opacity = "1";

--- a/src/Components/Studio/Designer/CanvasStage.tsx
+++ b/src/Components/Studio/Designer/CanvasStage.tsx
@@ -221,27 +221,30 @@ export function CanvasStage({
     ctx.imageSmoothingEnabled = true;
     ctx.imageSmoothingQuality = "high";
 
-    // The template ghost goes *under* the drawing, because that is what tracing is: the paint
-    // you are copying sits behind the one you are making. It only shows through where the
-    // sheet is still transparent, which is exactly where there is nothing drawn yet.
-    if (ghost?.showTemplate && ghost.template && ghost.opacity > 0) {
+    // The whole reference goes *under* the drawing — that is what makes it a ghost rather than
+    // an overlay. Both halves show through wherever the sheet is still transparent, which is
+    // exactly where there is nothing drawn yet and exactly where you need to know which piece
+    // of bodywork you are about to paint on.
+    //
+    // The consequence is worth being clear about: a sheet that still has its template baked in
+    // is opaque, and an underlay beneath it is invisible. That is what the trace toggle is for
+    // — it lifts the template out and leaves the sheet transparent, and the two features are
+    // meant to be used together.
+    if (ghost && ghost.opacity > 0) {
       ctx.save();
       ctx.globalAlpha = ghost.opacity;
-      ctx.drawImage(ghost.template, left, top, w, h);
+      // Template first, islands over it: the outlines have to stay readable against the paint
+      // being traced, and they are the thinner of the two marks.
+      if (ghost.showTemplate && ghost.template) {
+        ctx.drawImage(ghost.template, left, top, w, h);
+      }
+      if (ghost.showWire && ghost.wire) {
+        ctx.drawImage(ghost.wire, left, top, w, h);
+      }
       ctx.restore();
     }
 
     ctx.drawImage(source, left, top, w, h);
-
-    // The UV map goes *over* it, and that isn't an inconsistency — it answers a different
-    // question. A template is something to copy and belongs behind your work; the islands are
-    // a ruler, and a ruler underneath an opaque livery tells you nothing.
-    if (ghost?.showWire && ghost.wire && ghost.opacity > 0) {
-      ctx.save();
-      ctx.globalAlpha = ghost.opacity;
-      ctx.drawImage(ghost.wire, left, top, w, h);
-      ctx.restore();
-    }
 
     // Sheet edge, so you can see where the texture stops.
     ctx.strokeStyle = "rgba(255,255,255,0.18)";

--- a/src/Components/Studio/Designer/Designer.tsx
+++ b/src/Components/Studio/Designer/Designer.tsx
@@ -3,7 +3,9 @@ import {
   Eye,
   EyeOff,
   FilePlus2,
+  Grid3x3,
   ImagePlus,
+  Layers as LayersIcon,
   Loader2,
   PackageOpen,
   PaintRoller,
@@ -30,10 +32,12 @@ import {
 import { useT } from "../../../i18n/context";
 import { IMAGE_EXTS, PaintDestBar, usePaintDest } from "../paintDest";
 import { CanvasStage } from "./CanvasStage";
+import { Row, Slider } from "./controls";
 import { PreviewPanel } from "./PreviewPanel";
 import { LayerInspector } from "./LayerInspector";
 import { PaintTools } from "./PaintTools";
 import { bitmapFromRgba, composite, sheetTexture, toPng } from "./composite";
+import { EMPTY_GHOST, ghostShows, uvWireframe, type Ghost } from "./ghost";
 import {
   blankSheet,
   imageLayer,
@@ -53,6 +57,7 @@ import {
   type PaintTool,
   type Point,
 } from "./paint";
+import type { EdfNode } from "../../../types";
 
 /**
  * The paint designer: layers on a sheet, the sheet on the model, and a `.pnt` at the end.
@@ -109,6 +114,19 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   // The pane stays mounted while another Studio tab is on screen, so the keyboard shortcuts
   // need a way to tell whether they're the ones being typed at.
   const rootRef = useRef<HTMLDivElement>(null);
+
+  /**
+   * Reference underlays, by sheet id — deliberately *beside* the sheets rather than inside them.
+   *
+   * A ghost is something to look at while drawing, not part of what is drawn, and keeping it
+   * out of `Sheet` means two things at once: the save path has nothing to filter out, and
+   * fading one in and out doesn't count as a change to the sheet, so it never triggers the
+   * recomposite that every real edit does.
+   */
+  const [ghosts, setGhosts] = useState<Map<string, Ghost>>(new Map());
+  // The mesh the preview is showing, reported back by it. Null until one loads, and null again
+  // if it fails — a UV map drawn from a model that isn't on screen would be a confident lie.
+  const [geometry, setGeometry] = useState<EdfNode[] | null>(null);
 
   const destState = usePaintDest();
   const { dest, hints } = destState;
@@ -535,6 +553,111 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     [bump, patchLayer],
   );
 
+  /** A corner drag, as an absolute scale. Clamped by the stage to the inspector's range. */
+  const scaleLayer = useCallback(
+    (id: string, scale: number) => {
+      patchLayer(id, (l) => ({ ...l, scale }));
+      bump();
+    },
+    [bump, patchLayer],
+  );
+
+  /* ── The reference underlay ────────────────────────────────────────────────────────────
+     None of this touches a sheet, with one exception: turning tracing on *moves* the template
+     out of `Sheet.base`, which is a real edit to what would be saved and is meant to be — it
+     is the whole difference between drawing over a paint and drawing from one. ───────── */
+
+  const ghostOf = useCallback(
+    (id: string | null | undefined) => (id && ghosts.get(id)) || EMPTY_GHOST,
+    [ghosts],
+  );
+
+  const patchGhost = useCallback((id: string, fn: (g: Ghost) => Ghost) => {
+    setGhosts((prev) => {
+      const next = new Map(prev);
+      next.set(id, fn(prev.get(id) ?? EMPTY_GHOST));
+      return next;
+    });
+  }, []);
+
+  /**
+   * Take the model the preview loaded, and drop every wireframe built from the last one.
+   *
+   * Switching bikes keeps the sheet names, so without this a `livery` map rasterised from the
+   * previous model would look perfectly valid over the new one while describing bodywork that
+   * isn't there — the worst kind of wrong for a guide.
+   */
+  const geometryRef = useRef<EdfNode[] | null>(null);
+  const onGeometry = useCallback((nodes: EdfNode[] | null) => {
+    // Compared against a ref rather than inside a `setState` updater: an updater has to be
+    // pure, and this has to invalidate the wires as well as record the mesh.
+    if (geometryRef.current === nodes) return;
+    geometryRef.current = nodes;
+    setGeometry(nodes);
+    setGhosts((gs) =>
+      gs.size ? new Map([...gs].map(([id, g]) => [id, { ...g, wire: null, wireFor: null }])) : gs,
+    );
+  }, []);
+
+  /**
+   * Move the template between the sheet and the ghost.
+   *
+   * Moved, never copied. A template that stayed as `base` while also showing as a ghost would
+   * be saved into the paint, which is the thing somebody asking to trace is trying to avoid;
+   * and keeping the bitmap on the other side is what lets this be undone by pressing it again.
+   */
+  const toggleTrace = useCallback(
+    (sheetId: string) => {
+      const sheet = sheets.find((s) => s.id === sheetId);
+      if (!sheet) return;
+      const ghost = ghostOf(sheetId);
+      if (sheet.base) {
+        const template = sheet.base;
+        patchSheet(sheetId, (s) => ({ ...s, base: null }));
+        patchGhost(sheetId, (g) => ({ ...g, template, showTemplate: true }));
+      } else if (ghost.template) {
+        const base = ghost.template;
+        patchSheet(sheetId, (s) => ({ ...s, base }));
+        patchGhost(sheetId, (g) => ({ ...g, template: null }));
+      }
+      bump();
+    },
+    [bump, ghostOf, patchGhost, patchSheet, sheets],
+  );
+
+  /**
+   * Build the active sheet's UV map, once the user has asked for one.
+   *
+   * Lazily, and keyed on the sheet's *name*, because the name is the entire binding — rename a
+   * sheet from `livery` to `plate` and it describes different triangles. Rasterising eagerly
+   * would spend the work on sheets nobody looks at, and rasterising on every render would spend
+   * it again on every brush stroke, since a stroke replaces the sheet object.
+   */
+  useEffect(() => {
+    if (!active || !geometry) return;
+    // A half-typed name is not a name yet. Without this, every keystroke of "livery" would be
+    // asked of the mesh and answered "nothing binds that", which is true and useless.
+    if (!active.name.trim()) return;
+    const ghost = ghosts.get(active.id) ?? EMPTY_GHOST;
+    if (!ghost.showWire || ghost.wireFor === active.name) return;
+    // `wireFor` records the attempt whether or not it found anything, so a name that matches
+    // nothing is asked once rather than on every render. The panel reads the pair to say so —
+    // out loud, because an empty overlay is indistinguishable from one still being built.
+    const wire = uvWireframe(geometry, active.name, active.width, active.height);
+    patchGhost(active.id, (g) => ({ ...g, wire, wireFor: active.name }));
+  }, [active, geometry, ghosts, patchGhost]);
+
+  // Ghosts of sheets that are gone. Each holds a decoded bitmap and a raster the size of the
+  // sheet, so leaving them behind would keep a closed paint's pixels alive for the session.
+  useEffect(() => {
+    setGhosts((prev) => {
+      if (!prev.size) return prev;
+      const live = new Set(sheets.map((s) => s.id));
+      if ([...prev.keys()].every((id) => live.has(id))) return prev;
+      return new Map([...prev].filter(([id]) => live.has(id)));
+    });
+  }, [sheets]);
+
   /** Reorder within the stack. `delta` of -1 is one step down (further back). */
   const reorder = useCallback(
     (id: string, delta: number) => {
@@ -743,6 +866,17 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
           />
 
           {active && (
+            <GhostPanel
+              ghost={ghostOf(active.id)}
+              sheetName={active.name}
+              hasBase={!!active.base}
+              hasGeometry={!!geometry}
+              onTrace={() => toggleTrace(active.id)}
+              onChange={(fn) => patchGhost(active.id, fn)}
+            />
+          )}
+
+          {active && (
             <PaintTools
               settings={paint}
               onTool={pickTool}
@@ -786,9 +920,11 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
               sheet={active}
               source={canvases.current.get(active.id) ?? null}
               version={version}
+              ghost={ghostOf(active.id)}
               selectedId={selectedId}
               onSelect={setSelectedId}
               onMove={moveLayer}
+              onScale={scaleLayer}
               tool={paint.tool}
               brushSize={paint.size}
               canPaint={!!target}
@@ -815,7 +951,13 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
 
       {/* ── The model ────────────────────────────────────────────────────────── */}
       <section className="flex min-h-0 flex-col">
-        <PreviewPanel state={destState} overrides={overrides} frameToken={version} className="flex-1" />
+        <PreviewPanel
+          state={destState}
+          overrides={overrides}
+          frameToken={version}
+          onGeometry={onGeometry}
+          className="flex-1"
+        />
       </section>
       </div>
     </div>
@@ -921,6 +1063,150 @@ function SheetList({
         </Button>
       </div>
     </div>
+  );
+}
+
+/**
+ * The reference underlay's controls.
+ *
+ * Sits under the sheet list rather than in the layer panel, because a ghost belongs to the
+ * sheet and not to the stack — it can't be reordered, selected, painted on or saved, and
+ * putting it among things that can would be four wrong promises at once.
+ */
+function GhostPanel({
+  ghost,
+  sheetName,
+  hasBase,
+  hasGeometry,
+  onTrace,
+  onChange,
+}: {
+  ghost: Ghost;
+  sheetName: string;
+  /** Whether the sheet still holds a template that tracing could lift out of it. */
+  hasBase: boolean;
+  hasGeometry: boolean;
+  onTrace: () => void;
+  onChange: (fn: (g: Ghost) => Ghost) => void;
+}) {
+  const t = useT();
+  const tracing = !!ghost.template;
+  // A map was built for this name and came back with nothing on it. Distinct from "not built
+  // yet" (`wireFor` still null), which is why both halves are checked.
+  const noMatch = ghost.showWire && ghost.wireFor === sheetName && !ghost.wire;
+  // Nothing to trace: a blank sheet never had a template, and one that did has already had it
+  // lifted. The UV map is the guide that still applies, so the button says so rather than
+  // sitting there dead with no explanation.
+  const canTrace = hasBase || tracing;
+  const showing = ghostShows(ghost);
+
+  return (
+    <div className="rounded-lg border border-border bg-card/40 p-3.5">
+      <div className="mb-2.5 flex items-center gap-2">
+        <h2 className="text-[13px] font-semibold">{t("designer.reference")}</h2>
+        <button
+          type="button"
+          className="ml-auto text-muted-foreground transition-colors hover:text-foreground disabled:opacity-30"
+          disabled={!ghost.template && !ghost.wire}
+          onClick={() =>
+            onChange((g) => {
+              // One eye over both, and it turns them off together rather than remembering
+              // which was on — coming back to a "reference" that shows half of what it did
+              // is the kind of state nobody is keeping track of.
+              const off = ghostShows(g);
+              return {
+                ...g,
+                showTemplate: !off,
+                showWire: !off && !!g.wire,
+                // Faded all the way out counts as hidden, so switching back on has to undo
+                // that too. Otherwise the eye says "showing" over a reference at zero.
+                opacity: !off && g.opacity <= 0 ? EMPTY_GHOST.opacity : g.opacity,
+              };
+            })
+          }
+          title={t(showing ? "designer.hide" : "designer.show")}
+        >
+          {showing ? <Eye className="size-3.5" /> : <EyeOff className="size-3.5" />}
+        </button>
+      </div>
+
+      <div className="mb-2 flex flex-wrap gap-1.5">
+        <GhostToggle
+          icon={<LayersIcon className="size-3.5" />}
+          label={t("designer.traceTemplate")}
+          title={t(canTrace ? "designer.traceHint" : "designer.noTemplate")}
+          on={tracing && ghost.showTemplate}
+          disabled={!canTrace}
+          onClick={() => {
+            // Already lifted and visible — this press is asking to see it in the paint again,
+            // so put it back. Otherwise lift it, or just show what has already been lifted.
+            if (!tracing || ghost.showTemplate) onTrace();
+            else onChange((g) => ({ ...g, showTemplate: true }));
+          }}
+        />
+        <GhostToggle
+          icon={<Grid3x3 className="size-3.5" />}
+          label={t("designer.uvMap")}
+          title={t(hasGeometry ? "designer.uvHint" : "designer.noGeometry")}
+          on={ghost.showWire}
+          disabled={!hasGeometry}
+          onClick={() => onChange((g) => ({ ...g, showWire: !g.showWire }))}
+        />
+      </div>
+
+      <Row label={t("designer.opacity")}>
+        <Slider
+          value={ghost.opacity}
+          min={0}
+          max={1}
+          step={0.01}
+          onChange={(v) => onChange((g) => ({ ...g, opacity: v }))}
+          format={(v) => `${Math.round(v * 100)}%`}
+        />
+      </Row>
+
+      {/* The name binds the sheet to the mesh, so a name nothing asks for is worth saying
+          plainly — it is the same mistake that makes a paint load and show nothing. */}
+      {noMatch && (
+        <p className="mt-1.5 text-[11px] leading-snug text-destructive">
+          {t("designer.uvNoMatch", { name: sheetName.trim() })}
+        </p>
+      )}
+
+      <p className="mt-1.5 text-[11px] leading-snug text-faint">{t("designer.ghostNote")}</p>
+    </div>
+  );
+}
+
+function GhostToggle({
+  icon,
+  label,
+  title,
+  on,
+  disabled,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  title: string;
+  on: boolean;
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        "flex items-center gap-1.5 rounded-md border px-2 py-1 text-[11px] font-medium transition-colors disabled:opacity-35",
+        on ? "border-primary/60 bg-primary/10 text-foreground" : "border-border text-faint",
+      )}
+    >
+      {icon}
+      {label}
+    </button>
   );
 }
 

--- a/src/Components/Studio/Designer/Designer.tsx
+++ b/src/Components/Studio/Designer/Designer.tsx
@@ -1099,6 +1099,9 @@ function GhostPanel({
   // sitting there dead with no explanation.
   const canTrace = hasBase || tracing;
   const showing = ghostShows(ghost);
+  // Something to show, and an opaque template still in the sheet sitting on top of it. The
+  // reference draws underneath, so this is showing nothing until the template is lifted out.
+  const buried = showing && hasBase;
 
   return (
     <div className="rounded-lg border border-border bg-card/40 p-3.5">
@@ -1164,6 +1167,15 @@ function GhostPanel({
           format={(v) => `${Math.round(v * 100)}%`}
         />
       </Row>
+
+      {/* The reference is underneath, so an opaque sheet hides it completely. Saying so is
+          the difference between a feature that looks broken and one that tells you the next
+          move — which is the button directly above this line. */}
+      {buried && (
+        <p className="mt-1.5 text-[11px] leading-snug text-amber-500/90">
+          {t("designer.ghostBuried")}
+        </p>
+      )}
 
       {/* The name binds the sheet to the mesh, so a name nothing asks for is worth saying
           plainly — it is the same mistake that makes a paint load and show nothing. */}

--- a/src/Components/Studio/Designer/PreviewPanel.tsx
+++ b/src/Components/Studio/Designer/PreviewPanel.tsx
@@ -39,12 +39,21 @@ export function PreviewPanel({
   state,
   overrides,
   frameToken,
+  onGeometry,
   className,
 }: {
   state: PaintDestState;
   overrides: Map<string, THREE.Texture>;
   /** Bumped whenever the canvas changed, so a frame gets drawn without any prop moving. */
   frameToken?: number;
+  /**
+   * The mesh this is showing, handed back so the editor can draw its UV layout.
+   *
+   * Reported from here rather than loaded twice: this panel already resolves "which model, for
+   * which destination" through the library, and a second loader would be a second answer to
+   * that question — one that could quietly disagree about which bike is on screen.
+   */
+  onGeometry?: (nodes: EdfNode[] | null) => void;
   className?: string;
 }) {
   const t = useT();
@@ -154,6 +163,21 @@ export function PreviewPanel({
       alive = false;
     };
   }, [loadout]);
+
+  /**
+   * Hand the loaded mesh up, whichever of the two shapes it arrived in.
+   *
+   * One effect over both, rather than a call inside each loader: a failure sets its state back
+   * to null and this follows it, so the UV map cannot outlive the model it describes.
+   *
+   * The rider's parts are flattened because a UV layout is per texture name, not per part —
+   * a `suit` sheet is bound by whichever pieces ask for it, and asking which of them a triangle
+   * came from would be a distinction the sheet itself doesn't make.
+   */
+  useEffect(() => {
+    if (!onGeometry) return;
+    onGeometry(nodes ?? (riderParts ? riderParts.flatMap((p) => p.nodes) : null));
+  }, [nodes, riderParts, onGeometry]);
 
   // Toggled-off gear is dropped before it reaches the viewer, which is what makes hiding it
   // reveal what's underneath rather than just dimming it.

--- a/src/Components/Studio/Designer/ghost.ts
+++ b/src/Components/Studio/Designer/ghost.ts
@@ -1,0 +1,195 @@
+import type { EdfNode } from "../../../types";
+
+/**
+ * The reference underlay: what a sheet is being drawn *against*, as opposed to what it holds.
+ *
+ * A livery is drawn flat and worn curved, and the flat version gives away almost nothing about
+ * which rectangle of it ends up on a shroud. There are two ways to answer that, and this holds
+ * both: the paint you started from, and the model's own UV islands.
+ *
+ * None of it is part of the sheet. It is never composited, never staged and never saved —
+ * `Sheet` is what the `.pnt` will contain, and mixing a guide into it is how a guide ends up
+ * shipped inside somebody's livery. The 2D stage draws these separately, which makes that
+ * impossible rather than merely unlikely.
+ */
+export interface Ghost {
+  /**
+   * The donor paint's pixels, lifted out of `Sheet.base`.
+   *
+   * Moving it here rather than copying it is the point: a template that is both the ghost and
+   * the base would be traced over *and* saved, which is exactly the thing you were trying not
+   * to do when you asked for a tracing guide.
+   */
+  template: ImageBitmap | null;
+  /** The UV islands for this sheet's texture name, rasterised once by {@link uvWireframe}. */
+  wire: HTMLCanvasElement | null;
+  /**
+   * The sheet name `wire` was built for, or null if it has never been built.
+   *
+   * The name is the whole binding — rename the sheet and the islands it maps to are different
+   * ones — so this is what says whether the cached raster still describes the sheet.
+   */
+  wireFor: string | null;
+  showTemplate: boolean;
+  showWire: boolean;
+  /** 0–1, applied to both. */
+  opacity: number;
+}
+
+export const EMPTY_GHOST: Ghost = {
+  template: null,
+  wire: null,
+  wireFor: null,
+  // On by default so lifting a template into the ghost shows it immediately; the UV map is
+  // off because it has to be built, and building one for a sheet nobody asked about is work
+  // spent on a guide that was never going to be looked at.
+  showTemplate: true,
+  showWire: false,
+  opacity: 0.35,
+};
+
+/** True when there is anything to draw — the stage skips the whole pass otherwise. */
+export function ghostShows(ghost: Ghost | null | undefined): boolean {
+  if (!ghost || ghost.opacity <= 0) return false;
+  return (ghost.showTemplate && !!ghost.template) || (ghost.showWire && !!ghost.wire);
+}
+
+/**
+ * Biggest edge a wireframe is rasterised at.
+ *
+ * The wire is a guide blitted under the sheet, not something anyone inspects pixel for pixel,
+ * and a 4096² raster per sheet costs 64MB to say the same thing this says in four.
+ */
+const MAX_WIRE = 1024;
+
+/** A group of triangles that share a name — one piece of bodywork, as the mesh files it. */
+interface Island {
+  label: string;
+  /** uv0 for the whole node, indexed by the entries in `tris`. */
+  uvs: number[];
+  /** Flat vertex indices, three per triangle. */
+  tris: number[];
+}
+
+/**
+ * The triangles across `nodes` that are textured by `sheetName`, grouped by mesh-group name.
+ *
+ * Submeshes first and the node's own texture only as a fallback, which is the same order
+ * `ModelViewer` binds materials in — the islands drawn here are then the islands the preview
+ * beside them actually textures, rather than a second opinion about the same mesh.
+ */
+function islandsFor(nodes: EdfNode[], sheetName: string): Island[] {
+  const want = sheetName.trim().toLowerCase();
+  if (!want) return [];
+  const islands: Island[] = [];
+
+  for (const node of nodes) {
+    if (!node.uvs.length || !node.indices.length) continue;
+    const groups = node.submeshes.length
+      ? node.submeshes
+          .filter((sm) => sm.texture?.toLowerCase() === want)
+          .map((sm) => ({ label: sm.name, start: sm.triStart, count: sm.triCount }))
+      : node.texture?.toLowerCase() === want
+        ? [{ label: node.name, start: 0, count: node.indices.length / 3 }]
+        : [];
+
+    for (const { label, start, count } of groups) {
+      const tris: number[] = [];
+      const end = Math.min(start + count, node.indices.length / 3);
+      for (let t = Math.max(0, start); t < end; t += 1) {
+        tris.push(node.indices[t * 3], node.indices[t * 3 + 1], node.indices[t * 3 + 2]);
+      }
+      if (tris.length) islands.push({ label, uvs: node.uvs, tris });
+    }
+  }
+  return islands;
+}
+
+/** A stable hue per mesh-group name, so a shroud and a fender never read as one shape. */
+function hueOf(label: string): number {
+  let h = 0;
+  for (let i = 0; i < label.length; i += 1) h = (h * 31 + label.charCodeAt(i)) % 360;
+  return h;
+}
+
+/**
+ * The model's UV layout for one sheet, drawn as filled, outlined islands.
+ *
+ * This is the part an image editor cannot tell you: which region of a 2048² square is the
+ * airbox and which is the rear fender. Every triangle that samples `sheetName` is projected
+ * into texture space and drawn where it lands.
+ *
+ * Returns null when nothing on the model binds this name — worth saying out loud, because a
+ * sheet named something the mesh never asks for is a paint that loads and shows nothing, and
+ * an empty overlay would look identical to a model that simply hadn't finished loading.
+ *
+ * uv0 is used as-is. The sheet is uploaded with `flipY = false` (see `sheetTexture`), so v runs
+ * the same way as a canvas row and no flip belongs here — the same reasoning that keeps the
+ * editor from having an opinion about which way up a sheet is. Coordinates outside 0–1 are
+ * drawn and clipped rather than wrapped: the tiled case is rare on bodywork, and a guide that
+ * silently folded a decal back over itself would be worse than one that stops at the edge.
+ */
+export function uvWireframe(
+  nodes: EdfNode[],
+  sheetName: string,
+  width: number,
+  height: number,
+): HTMLCanvasElement | null {
+  const islands = islandsFor(nodes, sheetName);
+  if (!islands.length) return null;
+
+  const k = Math.min(1, MAX_WIRE / Math.max(width, height));
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.max(1, Math.round(width * k));
+  canvas.height = Math.max(1, Math.round(height * k));
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+
+  const sx = canvas.width;
+  const sy = canvas.height;
+  ctx.lineJoin = "round";
+  ctx.lineWidth = Math.max(1, Math.round(Math.max(sx, sy) / 512));
+
+  for (const island of islands) {
+    const hue = hueOf(island.label);
+
+    // One path for the whole island, filled with the nonzero rule: triangles that share an
+    // edge stop being separate shapes, so the fill comes out flat instead of banded along
+    // every seam the way a per-triangle fill would.
+    const fill = new Path2D();
+    for (let i = 0; i < island.tris.length; i += 3) {
+      const [a, b, c] = [island.tris[i], island.tris[i + 1], island.tris[i + 2]];
+      fill.moveTo(island.uvs[a * 2] * sx, island.uvs[a * 2 + 1] * sy);
+      fill.lineTo(island.uvs[b * 2] * sx, island.uvs[b * 2 + 1] * sy);
+      fill.lineTo(island.uvs[c * 2] * sx, island.uvs[c * 2 + 1] * sy);
+      fill.closePath();
+    }
+    ctx.fillStyle = `hsla(${hue}, 70%, 60%, 0.13)`;
+    ctx.fill(fill, "nonzero");
+
+    // Edges once each. A closed mesh shares almost every edge between two triangles, and
+    // drawing both makes the interior twice as bright as the outline that matters.
+    const seen = new Set<number>();
+    const edges = new Path2D();
+    for (let i = 0; i < island.tris.length; i += 3) {
+      const tri = [island.tris[i], island.tris[i + 1], island.tris[i + 2]];
+      for (let e = 0; e < 3; e += 1) {
+        const p = tri[e];
+        const q = tri[(e + 1) % 3];
+        // A single number rather than a string: this runs over every edge of every triangle
+        // on the bike, and `${min}-${max}` allocates a string for each one. The shift leaves
+        // room for four million vertices in a node and still lands well inside an exact
+        // integer, so two different edges cannot come out as the same key.
+        const key = Math.min(p, q) * 0x400000 + Math.max(p, q);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        edges.moveTo(island.uvs[p * 2] * sx, island.uvs[p * 2 + 1] * sy);
+        edges.lineTo(island.uvs[q * 2] * sx, island.uvs[q * 2 + 1] * sy);
+      }
+    }
+    ctx.strokeStyle = `hsla(${hue}, 85%, 72%, 0.85)`;
+    ctx.stroke(edges);
+  }
+
+  return canvas;
+}

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1447,6 +1447,18 @@ export const de: Translation = {
     "Die 3D-Vorschau gibt es vorerst nur für MX Bikes — die Modelle von {{game}} brauchen eigene Teil-Zuordnungen. Alles andere funktioniert gleich, und das Design wird ganz normal gespeichert.",
   "designer.gearNote":
     "Auf dem Standardfahrer gezeigt — deine eigene Ausrüstung ist hier nicht geladen.",
+  "designer.reference": "Referenz",
+  "designer.traceTemplate": "Vorlage",
+  "designer.traceHint":
+    "Hebt die Lackierung, mit der du angefangen hast, aus dem Blatt heraus und zeigt sie schwach darunter zum Abpausen. Sie ist dann nicht mehr Teil dessen, was du speicherst.",
+  "designer.noTemplate": "Dieses Blatt hat keine Vorlage zum Abpausen — es war von Anfang an leer.",
+  "designer.uvMap": "UV-Karte",
+  "designer.uvHint":
+    "Zeigt, wo die Verkleidungsteile des Modells auf diesem Blatt landen, jedes in eigener Farbe.",
+  "designer.noGeometry": "Lade in der Vorschau ein Modell, um sein UV-Layout zu sehen.",
+  "designer.uvNoMatch":
+    "Nichts am Modell verwendet eine Textur namens „{{name}}“, also gibt es kein UV-Layout zu zeigen.",
+  "designer.ghostNote": "Nur eine Hilfe — die Referenz wird nie in die Lackierung gespeichert.",
   "designer.resetView": "Ansicht zurücksetzen",
 
   // ── Designer › die Malwerkzeuge ───────────────────────────────────────────────

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1458,6 +1458,8 @@ export const de: Translation = {
   "designer.noGeometry": "Lade in der Vorschau ein Modell, um sein UV-Layout zu sehen.",
   "designer.uvNoMatch":
     "Nichts am Modell verwendet eine Textur namens „{{name}}“, also gibt es kein UV-Layout zu zeigen.",
+  "designer.ghostBuried":
+    "Die Referenz liegt unter dem Blatt, und die Vorlage dieses Blattes ist undurchsichtig — schalte Vorlage ein, um sie herauszuheben und hindurchzusehen.",
   "designer.ghostNote": "Nur eine Hilfe — die Referenz wird nie in die Lackierung gespeichert.",
   "designer.resetView": "Ansicht zurücksetzen",
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1410,6 +1410,8 @@ export const en = {
   "designer.noGeometry": "Load a model in the preview to see its UV layout.",
   "designer.uvNoMatch":
     "Nothing on the model uses a texture called “{{name}}”, so there is no UV layout to show.",
+  "designer.ghostBuried":
+    "The reference sits under the sheet, and this sheet’s template is opaque — turn on Template to lift it out and see through.",
   "designer.ghostNote": "A guide only â the reference is never saved into the paint.",
   "designer.resetView": "Reset view",
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1399,6 +1399,18 @@ export const en = {
   "designer.noPreviewForGame":
     "The 3D preview is MX Bikes only for now — the {{game}} models need their own part bindings. Everything else here works the same, and the paint saves normally.",
   "designer.gearNote": "Shown on the stock rider — your own kit isn't loaded here.",
+  "designer.reference": "Reference",
+  "designer.traceTemplate": "Template",
+  "designer.traceHint":
+    "Lift the paint you started from out of the sheet and show it faintly underneath, to trace over. It stops being part of what you save.",
+  "designer.noTemplate": "This sheet has no template to trace â it started blank.",
+  "designer.uvMap": "UV map",
+  "designer.uvHint":
+    "Show where the model's bodywork lands on this sheet, each piece in its own colour.",
+  "designer.noGeometry": "Load a model in the preview to see its UV layout.",
+  "designer.uvNoMatch":
+    "Nothing on the model uses a texture called “{{name}}”, so there is no UV layout to show.",
+  "designer.ghostNote": "A guide only â the reference is never saved into the paint.",
   "designer.resetView": "Reset view",
 
   // ── Designer › the paint tools ────────────────────────────────────────────────

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1445,6 +1445,8 @@ export const es: Translation = {
   "designer.noGeometry": "Carga un modelo en la vista previa para ver su distribución UV.",
   "designer.uvNoMatch":
     "Nada del modelo usa una textura llamada “{{name}}”, así que no hay distribución UV que mostrar.",
+  "designer.ghostBuried":
+    "La referencia va debajo de la hoja, y la plantilla de esta hoja es opaca: activa Plantilla para sacarla y poder ver a través.",
   "designer.ghostNote": "Solo una guía: la referencia nunca se guarda en la pintura.",
   "designer.resetView": "Restablecer vista",
 

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1434,6 +1434,18 @@ export const es: Translation = {
     "La vista 3D es solo para MX Bikes por ahora: los modelos de {{game}} necesitan sus propias asignaciones de piezas. Todo lo demás funciona igual y la pintura se guarda con normalidad.",
   "designer.gearNote":
     "Se muestra sobre el piloto de serie — tu propio equipo no está cargado aquí.",
+  "designer.reference": "Referencia",
+  "designer.traceTemplate": "Plantilla",
+  "designer.traceHint":
+    "Saca de la hoja la pintura de la que partiste y muéstrala tenue por debajo, para calcarla. Deja de formar parte de lo que guardas.",
+  "designer.noTemplate": "Esta hoja no tiene plantilla que calcar: nació en blanco.",
+  "designer.uvMap": "Mapa UV",
+  "designer.uvHint":
+    "Muestra dónde cae en esta hoja cada pieza del carenado del modelo, cada una con su color.",
+  "designer.noGeometry": "Carga un modelo en la vista previa para ver su distribución UV.",
+  "designer.uvNoMatch":
+    "Nada del modelo usa una textura llamada “{{name}}”, así que no hay distribución UV que mostrar.",
+  "designer.ghostNote": "Solo una guía: la referencia nunca se guarda en la pintura.",
   "designer.resetView": "Restablecer vista",
 
   // ── Designer › las herramientas de pintura ────────────────────────────────────

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1438,6 +1438,18 @@ export const fr: Translation = {
     "L'aperçu 3D est réservé à MX Bikes pour l'instant : les modèles de {{game}} ont besoin de leurs propres liaisons de pièces. Tout le reste fonctionne pareil et la déco s'enregistre normalement.",
   "designer.gearNote":
     "Affiché sur le pilote d'origine — ta propre tenue n'est pas chargée ici.",
+  "designer.reference": "Référence",
+  "designer.traceTemplate": "Modèle",
+  "designer.traceHint":
+    "Sors de la planche la peinture dont tu es parti et affiche-la en transparence dessous, pour la décalquer. Elle cesse de faire partie de ce que tu enregistres.",
+  "designer.noTemplate": "Cette planche n'a aucun modèle à décalquer : elle est partie vierge.",
+  "designer.uvMap": "Carte UV",
+  "designer.uvHint":
+    "Montre où tombent sur cette planche les carrosseries du modèle, chacune dans sa couleur.",
+  "designer.noGeometry": "Charge un modèle dans l'aperçu pour voir sa disposition UV.",
+  "designer.uvNoMatch":
+    "Rien sur le modèle n'utilise une texture nommée « {{name}} », il n'y a donc aucune disposition UV à montrer.",
+  "designer.ghostNote": "Un simple repère : la référence n'est jamais enregistrée dans la peinture.",
   "designer.resetView": "Réinitialiser la vue",
 
   // ── Designer › les outils de peinture ─────────────────────────────────────────

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1449,6 +1449,8 @@ export const fr: Translation = {
   "designer.noGeometry": "Charge un modèle dans l'aperçu pour voir sa disposition UV.",
   "designer.uvNoMatch":
     "Rien sur le modèle n'utilise une texture nommée « {{name}} », il n'y a donc aucune disposition UV à montrer.",
+  "designer.ghostBuried":
+    "La référence est sous la planche, et le modèle de cette planche est opaque : active Modèle pour l'en sortir et voir au travers.",
   "designer.ghostNote": "Un simple repère : la référence n'est jamais enregistrée dans la peinture.",
   "designer.resetView": "Réinitialiser la vue",
 

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1424,6 +1424,18 @@ export const it: Translation = {
   "designer.noPreviewForGame":
     "L'anteprima 3D per ora è solo per MX Bikes: i modelli di {{game}} hanno bisogno delle proprie associazioni delle parti. Tutto il resto funziona uguale e la livrea si salva normalmente.",
   "designer.gearNote": "Mostrato sul pilota di serie — la tua tenuta non è caricata qui.",
+  "designer.reference": "Riferimento",
+  "designer.traceTemplate": "Modello",
+  "designer.traceHint":
+    "Togli dalla planche la vernice di partenza e mostrala in trasparenza sotto, per ricalcarla. Smette di far parte di ciò che salvi.",
+  "designer.noTemplate": "Questa planche non ha un modello da ricalcare: è nata vuota.",
+  "designer.uvMap": "Mappa UV",
+  "designer.uvHint":
+    "Mostra dove finiscono su questa planche le carene del modello, ognuna con il suo colore.",
+  "designer.noGeometry": "Carica un modello nell'anteprima per vederne il layout UV.",
+  "designer.uvNoMatch":
+    "Nessuna parte del modello usa una texture chiamata “{{name}}”, quindi non c'è un layout UV da mostrare.",
+  "designer.ghostNote": "Solo una guida: il riferimento non viene mai salvato nella vernice.",
   "designer.resetView": "Reimposta vista",
 
   // ── Designer › gli strumenti di pittura ───────────────────────────────────────

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1435,6 +1435,8 @@ export const it: Translation = {
   "designer.noGeometry": "Carica un modello nell'anteprima per vederne il layout UV.",
   "designer.uvNoMatch":
     "Nessuna parte del modello usa una texture chiamata “{{name}}”, quindi non c'è un layout UV da mostrare.",
+  "designer.ghostBuried":
+    "Il riferimento sta sotto la planche, e il modello di questa planche è opaco: attiva Modello per toglierlo e vedere attraverso.",
   "designer.ghostNote": "Solo una guida: il riferimento non viene mai salvato nella vernice.",
   "designer.resetView": "Reimposta vista",
 

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1434,6 +1434,8 @@ export const ptBR: Translation = {
   "designer.noGeometry": "Carregue um modelo na prévia para ver o layout UV dele.",
   "designer.uvNoMatch":
     "Nada no modelo usa uma textura chamada “{{name}}”, então não há layout UV para mostrar.",
+  "designer.ghostBuried":
+    "A referência fica sob a folha, e o modelo desta folha é opaco — ative Modelo para tirá-lo e enxergar através.",
   "designer.ghostNote": "Apenas um guia — a referência nunca é salva na pintura.",
   "designer.resetView": "Redefinir visualização",
 

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1423,6 +1423,18 @@ export const ptBR: Translation = {
   "designer.noPreviewForGame":
     "A prévia 3D é só do MX Bikes por enquanto — os modelos do {{game}} precisam dos próprios vínculos de peças. Todo o resto funciona igual e a pintura salva normalmente.",
   "designer.gearNote": "Mostrado no piloto padrão — o seu equipamento não está carregado aqui.",
+  "designer.reference": "Referência",
+  "designer.traceTemplate": "Modelo",
+  "designer.traceHint":
+    "Tira da folha a pintura da qual você partiu e a mostra apagada por baixo, para decalcar. Ela deixa de fazer parte do que você salva.",
+  "designer.noTemplate": "Esta folha não tem modelo para decalcar — ela nasceu em branco.",
+  "designer.uvMap": "Mapa UV",
+  "designer.uvHint":
+    "Mostra onde as carenagens do modelo caem nesta folha, cada peça com sua cor.",
+  "designer.noGeometry": "Carregue um modelo na prévia para ver o layout UV dele.",
+  "designer.uvNoMatch":
+    "Nada no modelo usa uma textura chamada “{{name}}”, então não há layout UV para mostrar.",
+  "designer.ghostNote": "Apenas um guia — a referência nunca é salva na pintura.",
   "designer.resetView": "Redefinir visualização",
 
   // ── Designer › as ferramentas de pintura ──────────────────────────────────────


### PR DESCRIPTION
A livery is drawn flat and worn curved, and the flat sheet gives away almost nothing about which rectangle of it ends up on a shroud.

Starting from an installed paint was the only guide there was, and it came at a price: `base` is composited into the sheet and the save encodes that same composite, so the donor's graphics were inherited permanently — paintable over, never removable. A blank sheet had the opposite problem and no guide at all.

## What this adds

**A reference underlay per sheet**, with two sources:

- **Template** — the trace toggle *moves* the bitmap between `Sheet.base` and the ghost. Moved, not copied: a template that was both would be traced over *and* saved, which is the thing someone asking to trace is trying to avoid. Holding it on the other side is what lets the toggle be pressed again.
- **UV map** — every triangle that samples the sheet's texture name, projected into texture space, grouped by mesh-group name, one hue per piece. This is the part an image editor cannot tell you: which region of a 2048² square is the airbox and which is the rear fender.

Both draw **underneath** the composite — a ghost, not an overlay — so they show through wherever the sheet is still transparent, which is exactly where you're about to paint. The two compose: lifting the template out is what leaves the sheet transparent enough to see the islands through it, and the panel says so when a still-opaque template is burying the reference.

**Corner-drag resize on layers.** Scaled as a ratio of distances from the layer's centre, so the grabbed corner tracks the pointer through a zoom or pan mid-drag, clamped to the inspector slider's range so the two controls agree about where a logo grows from.

## Design notes

- The ghost lives *beside* the sheets, not inside them. It is never composited, staged or saved — a property of where it lives rather than a rule the save path has to keep. It also means fading one in and out isn't a change to the sheet, so it never triggers the recomposite every real edit does.
- `uvWireframe` fills each island with the nonzero rule so shared edges don't band, and strokes each unique edge once. Submeshes first, node texture as fallback — the order `ModelViewer` binds materials in, so the islands drawn are the islands the preview beside them textures.
- uv0 is used as-is: the sheet uploads with `flipY = false`, so v already runs the way a canvas row does. Same reason the editor has no opinion about which way up a sheet is. Rasterised once at 1024 max, aspect kept.
- `PreviewPanel` reports the mesh it loaded rather than the Designer loading a second copy — one answer to "which model, for which destination", not two that can disagree. Wires are dropped when the model changes, since sheet names survive a bike swap and a stale map would look valid while describing absent bodywork.
- The corner grab is suppressed on a box under three grab-widths across: four 18px zones on a 20px box leave no middle, and resizable-but-undraggable is the worse trade. Corners are still *drawn* there — the box is how you see what's selected.
- A sheet name nothing on the mesh binds is reported in the panel, not as a toast: `wireFor` records the attempt so it's asked once, and typing "livery" would otherwise have fired six.

## Testing

`typecheck`, `lint` and `build` are clean — the two remaining lint warnings are pre-existing, in `Presets.tsx` and `ViewerDialog.tsx`.

The UV projection was exercised against synthetic meshes with a stubbed canvas: island selection by texture name (case-insensitive), submesh vs node-level fallback, resolution capping with aspect kept, uv→canvas mapping with no flip, edge dedup (5 unique edges on a quad, not 6), and distinct colours per piece. That was a scratch harness rather than a committed test — the repo has no frontend test runner, and adding one was outside this change.

**Not verified:** how it looks against a real bike. That needs the Tauri app with an installed game, so the geometry path has only been exercised by the stub above.

10 new keys across all six locales. No DB or schema changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_015LfU6nut8QAsoFjCogZUL6)_