### PR TITLE
chore(release): cut v0.9.1-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Added
-
-- **The Designer can show you what you're drawing on.** A livery is drawn flat and worn curved,
-  and the flat version gives away almost nothing about which rectangle of it ends up on a
-  shroud — so a sheet has a **reference underlay** now, and it answers that two ways. **Template**
-  lifts the paint you started from *out* of the sheet and shows it faintly underneath to trace
-  over; it stops being part of what you save, which is the difference between drawing *from* a
-  paint and drawing *over* one. **UV map** reads the model already standing beside the canvas
-  and draws its bodywork where it actually lands on the sheet, each piece in its own colour —
-  the thing an image editor cannot tell you. Neither is ever composited, staged or saved: they
-  live outside the sheet entirely, so a guide cannot end up shipped inside somebody's livery.
-  Both sit **underneath** what you're drawing — a ghost, not an overlay — so they show through
-  wherever the sheet is still transparent, which is exactly where you need to know which piece
-  of bodywork you're about to paint on. The two are meant to be used together: lifting the
-  template out is what leaves the sheet transparent enough to see the islands through it, and
-  the panel says so when a still-opaque template is burying the reference.
-- **Layers resize by their corners.** The selected layer's box has grabbable handles, dragged
-  from the centre the same way the inspector's slider scales from it, so the two controls agree
-  about where a logo grows from. The slider stays for typing an exact number; the corners are
-  for the other 90% of the time. Handles are still drawn on a layer too small to grab one —
-  the box is how you see what's selected — but the grab itself steps aside there rather than
-  leaving a tiny layer resizable and no longer draggable.
-- **A sheet name the model never asks for now says so.** Turning on the UV map for a sheet
-  nothing on the mesh binds reports it in the panel instead of drawing an empty overlay, which
-  had been indistinguishable from one still loading. It's the same mistake that makes a paint
-  load and show nothing, caught before the save rather than after it.
-
 ## Unannounced — a debugger can't ride along
 
 Left out of the release notes on purpose: a hardening measure advertised is a hardening
@@ -252,6 +223,10 @@ Worth knowing for this beta: the Mac launch has been tested against a stand-in f
 against a real bottle, so if Play does something odd on your machine the app log names the
 exact command it ran — please send it.
 
+Also worth knowing: the Designer's new UV map has been checked against synthetic meshes, not
+against a real bike's geometry. If the islands land somewhere that doesn't match the bodywork
+on the model beside them, that's the thing to report.
+
 ### Added
 - **You can paint on a template.** The Designer could stack images and text on the sheets of an
   unpacked paint, but it could not put down a single pixel — a fade across a shroud or a stripe
@@ -272,6 +247,30 @@ exact command it ran — please send it.
   edits are not part of it.
 - **Tools have keys.** V, B, E, G, F, R, O and L. Hold Shift for straight lines, squares and
   circles; right-drag still pans, which matters more with a brush than with a logo.
+- **The Designer can show you what you're drawing on.** A livery is drawn flat and worn curved,
+  and the flat version gives away almost nothing about which rectangle of it ends up on a
+  shroud — so a sheet has a **reference underlay** now, and it answers that two ways. **Template**
+  lifts the paint you started from *out* of the sheet and shows it faintly underneath to trace
+  over; it stops being part of what you save, which is the difference between drawing *from* a
+  paint and drawing *over* one. **UV map** reads the model already standing beside the canvas
+  and draws its bodywork where it actually lands on the sheet, each piece in its own colour —
+  the thing an image editor cannot tell you. Neither is ever composited, staged or saved: they
+  live outside the sheet entirely, so a guide cannot end up shipped inside somebody's livery.
+  Both sit **underneath** what you're drawing — a ghost, not an overlay — so they show through
+  wherever the sheet is still transparent, which is exactly where you need to know which piece
+  of bodywork you're about to paint on. The two are meant to be used together: lifting the
+  template out is what leaves the sheet transparent enough to see the islands through it, and
+  the panel says so when a still-opaque template is burying the reference.
+- **Layers resize by their corners.** The selected layer's box has grabbable handles, dragged
+  from the centre the same way the inspector's slider scales from it, so the two controls agree
+  about where a logo grows from. The slider stays for typing an exact number; the corners are
+  for the other 90% of the time. Handles are still drawn on a layer too small to grab one —
+  the box is how you see what's selected — but the grab itself steps aside there rather than
+  leaving a tiny layer resizable and no longer draggable.
+- **A sheet name the model never asks for now says so.** Turning on the UV map for a sheet
+  nothing on the mesh binds reports it in the panel instead of drawing an empty overlay, which
+  had been indistinguishable from one still loading. It's the same mistake that makes a paint
+  load and show nothing, caught before the save rather than after it.
 - **Play and Join Server work on macOS.** MX Bikes is a Windows game, so on a Mac it runs
   inside a CrossOver, Whisky or Wine bottle — and the app, which had a launcher for Windows
   and one for Linux, simply refused: *"Launching MX Bikes is supported on Windows and Linux

--- a/src/Components/Showcase/releases.ts
+++ b/src/Components/Showcase/releases.ts
@@ -12,7 +12,9 @@ import {
   Apple,
   Blend,
   Brush,
+  Grid3x3,
   Layers,
+  Maximize2,
   Monitor,
   Languages,
   ListOrdered,
@@ -66,6 +68,8 @@ export const RELEASES: Release[] = [
     highlights: [
       { icon: Blend, text: "showcase.v091.gradient" },
       { icon: Layers, text: "showcase.v091.paintLayer" },
+      { icon: Grid3x3, text: "showcase.v091.ghost" },
+      { icon: Maximize2, text: "showcase.v091.resize" },
       { icon: Apple, text: "showcase.v091.macos" },
       { icon: Monitor, text: "showcase.v091.steamos" },
     ],

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1104,6 +1104,10 @@ export const de: Translation = {
     "Ein Verlauf, der eine Farbe in eine andere trägt. Zieh, um zu sagen, wo der Übergang liegt: davor die erste Farbe, dahinter die zweite. Linear oder radial, und er kann ins Nichts ausblenden statt in eine Farbe.",
   "showcase.v091.paintLayer":
     "Gemaltes liegt auf einer eigenen Ebene und hat damit Deckkraft, Mischmodus und Reihenfolge wie alles andere — die Vorlage darunter wird nie angefasst. Blende die Ebene aus und du hast die saubere Vorlage zurück. ⌘Z nimmt Striche zurück.",
+  "showcase.v091.ghost":
+    "Zeichne über einem Geist des Motorrads. Ein Blatt kann die Lackierung, mit der du angefangen hast, schwach darunter zum Abpausen zeigen — aus dem Blatt herausgehoben, also nicht in deine hineingespeichert — und dazu eine UV-Karte der Verkleidung des Modells, jedes Teil in eigener Farbe, damit du siehst, welches Panel du gerade lackierst.",
+  "showcase.v091.resize":
+    "Ebenen lassen sich an ihren Ecken skalieren, nicht nur über den Regler.",
   "showcase.v091.macos":
     "Spielen und Server beitreten funktionieren unter macOS, über die CrossOver-, Whisky- oder Wine-Bottle, in der das Spiel liegt — und die App findet eine Bottle-Installation von selbst, statt nach dem Pfad zu fragen.",
   "showcase.v091.steamos":

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1061,6 +1061,10 @@ export const en = {
     "A gradient that carries one colour into another. Drag to say where the transition happens — everything before it is the first colour, everything past it the second. Linear or radial, and it can fade out to nothing instead of to a colour.",
   "showcase.v091.paintLayer":
     "Painting goes on its own layer, so it gets opacity, blending and stacking like everything else — and the template underneath is never touched. Hide the layer and you have the clean template back. ⌘Z undoes strokes.",
+  "showcase.v091.ghost":
+    "Draw against a ghost of the bike. A sheet can show the paint you started from faintly underneath to trace over — lifted out of the sheet, so it isn't saved into yours — and a UV map of the model's bodywork, each piece in its own colour, so you can see which panel you're painting on.",
+  "showcase.v091.resize":
+    "Layers resize by dragging their corners, not just by the slider.",
   "showcase.v091.macos":
     "Play and Join Server work on macOS, through whichever CrossOver, Whisky or Wine bottle holds the game — and the app finds a bottled install by itself instead of asking you to type the path.",
   "showcase.v091.steamos":

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1092,6 +1092,10 @@ export const es: Translation = {
     "Un degradado que lleva un color hasta otro. Arrastra para decir dónde ocurre la transición: antes está el primer color, después el segundo. Lineal o radial, y puede desvanecerse hasta nada en lugar de hasta un color.",
   "showcase.v091.paintLayer":
     "Lo que pintas va en su propia capa, así que tiene opacidad, fusión y orden como todo lo demás — y la plantilla de debajo no se toca nunca. Oculta la capa y tienes la plantilla limpia otra vez. ⌘Z deshace trazos.",
+  "showcase.v091.ghost":
+    "Dibuja sobre un fantasma de la moto. Una hoja puede mostrar tenue por debajo la pintura de la que partiste para calcarla — sacada de la hoja, así que no se guarda en la tuya — y un mapa UV del carenado del modelo, cada pieza con su color, para ver sobre qué panel estás pintando.",
+  "showcase.v091.resize":
+    "Las capas se redimensionan arrastrando sus esquinas, no solo con el deslizador.",
   "showcase.v091.macos":
     "Jugar y Unirse a un servidor funcionan en macOS, a través de la botella CrossOver, Whisky o Wine que contenga el juego — y la app encuentra sola una instalación embotellada en vez de pedirte la ruta.",
   "showcase.v091.steamos":

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1095,6 +1095,10 @@ export const fr: Translation = {
     "Un dégradé qui emmène une couleur vers une autre. Fais glisser pour dire où se fait la transition : avant c'est la première couleur, après la seconde. Linéaire ou radial, et il peut se fondre vers rien plutôt que vers une couleur.",
   "showcase.v091.paintLayer":
     "La peinture va sur son propre calque, donc elle a opacité, fusion et empilement comme le reste — et le gabarit en dessous n'est jamais touché. Masque le calque et tu retrouves le gabarit intact. ⌘Z annule les tracés.",
+  "showcase.v091.ghost":
+    "Dessine par-dessus un fantôme de la moto. Une planche peut afficher en transparence dessous la peinture dont tu es parti, pour la décalquer — sortie de la planche, donc pas enregistrée dans la tienne — et une carte UV des carrosseries du modèle, chaque pièce dans sa couleur, pour voir sur quel panneau tu peins.",
+  "showcase.v091.resize":
+    "Les calques se redimensionnent en tirant leurs coins, pas seulement au curseur.",
   "showcase.v091.macos":
     "Jouer et Rejoindre un serveur fonctionnent sur macOS, via la bouteille CrossOver, Whisky ou Wine qui contient le jeu — et l'app trouve seule une installation en bouteille au lieu de te demander le chemin.",
   "showcase.v091.steamos":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1084,6 +1084,10 @@ export const it: Translation = {
     "Una sfumatura che porta un colore dentro un altro. Trascina per dire dove avviene la transizione: prima c'è il primo colore, dopo il secondo. Lineare o radiale, e può dissolversi nel nulla invece che in un colore.",
   "showcase.v091.paintLayer":
     "La pittura va su un livello suo, quindi ha opacità, fusione e ordine come tutto il resto — e il template sotto non viene mai toccato. Nascondi il livello e hai di nuovo il template pulito. ⌘Z annulla i tratti.",
+  "showcase.v091.ghost":
+    "Disegna sopra un fantasma della moto. Una planche può mostrare in trasparenza sotto la vernice di partenza da ricalcare — tolta dalla planche, quindi non finisce salvata nella tua — e una mappa UV delle carene del modello, ogni pezzo con il suo colore, per vedere su quale pannello stai dipingendo.",
+  "showcase.v091.resize":
+    "I livelli si ridimensionano trascinando gli angoli, non solo con il cursore.",
   "showcase.v091.macos":
     "Gioca e Entra nel server funzionano su macOS, attraverso la bottiglia CrossOver, Whisky o Wine che contiene il gioco — e l'app trova da sola un'installazione in bottiglia invece di chiederti il percorso.",
   "showcase.v091.steamos":

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1084,6 +1084,10 @@ export const ptBR: Translation = {
     "Um gradiente que leva uma cor até outra. Arraste para dizer onde acontece a transição: antes fica a primeira cor, depois a segunda. Linear ou radial, e pode desaparecer no nada em vez de terminar numa cor.",
   "showcase.v091.paintLayer":
     "O que você pinta vai numa camada própria, então tem opacidade, mesclagem e ordem como todo o resto — e o template embaixo nunca é tocado. Esconda a camada e o template limpo volta. ⌘Z desfaz traços.",
+  "showcase.v091.ghost":
+    "Desenhe sobre um fantasma da moto. Uma folha pode mostrar apagada por baixo a pintura da qual você partiu, para decalcar — tirada da folha, então não é salva na sua — e um mapa UV das carenagens do modelo, cada peça com sua cor, para ver em qual painel você está pintando.",
+  "showcase.v091.resize":
+    "As camadas são redimensionadas arrastando os cantos, não só pelo controle deslizante.",
   "showcase.v091.macos":
     "Jogar e Entrar no servidor funcionam no macOS, pela garrafa CrossOver, Whisky ou Wine que contém o jogo — e o app acha sozinho uma instalação engarrafada em vez de pedir o caminho.",
   "showcase.v091.steamos":


### PR DESCRIPTION
Release prep for **v0.9.1-beta.3**. No version bump — `0.9.1` is already what `package.json`, `tauri.conf.json` and `Cargo.toml` say, and the tag carries the beta suffix. Tagging is what cuts the build.

## Why this is needed before the tag

`scripts/changelog-section.sh` finds a section only by the `v<version>` in its heading, and a pre-release tag falls back to the version it's a candidate for. The ghost underlay, corner resize and UV-name warning from #135 were sitting under their own `## Unreleased` heading — so a `v0.9.1-beta.3` tag would have published release notes and a Discord post with no mention of them at all. Same trap the beta.2 prep fixed for the painting tools.

## Changes

- **Fold the Unreleased section into v0.9.1.** The three bullets go among the Designer items rather than at the top: the release's headline is still painting on the template, and the section heading already leads with it.
- **Add a beta caveat** next to the existing one about the Mac launch — the UV map has only been checked against synthetic meshes, so islands that don't line up with the bodywork on the model are the thing worth reporting.
- **Two new "What's new" highlights** on the 0.9.1 showcase entry (the ghost, the corner resize), hero unchanged. Changing the hero mid-series would churn the release's identity for a feature that belongs to the same story the hero already tells.

## Verification

```
scripts/changelog-section.sh v0.9.1-beta.3 --heading   → the v0.9.1 heading
scripts/changelog-section.sh v0.9.1-beta.3 --summary   → all 15 headlines, new ones included
```

`typecheck`, `lint` and `build` clean — the two remaining lint warnings are pre-existing, in `Presets.tsx` and `ViewerDialog.tsx`.

2 new keys across all six locales. No DB or schema changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_015LfU6nut8QAsoFjCogZUL6)_