### PR TITLE
feat(tracks): in-app track viewer — see a track's terrain in 3D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,55 @@ them up.
   uses the same marker files the app's own library scanner keys on, and stops descending
   once it has found a track.
 
+## 2026-08-10
+
+### Added
+- **See a track's terrain in 3D.** Tracks were the one thing the library couldn't show you —
+  a name, a preview and a size. The viewer now reads the heightfield out of a track and draws
+  the ground, opening from the library detail view next to **View in 3D**.
+- **Every track is drawn with its surfaces, not just its shape.** A track's height file also
+  carries coverage masks — one per surface the builder painted, a byte per cell — and the
+  viewer now reads them, so grass, apron, hard standing and the dirt of the riding line each
+  get their own colour. This is what the five tracks that ship no overview picture get instead
+  of a bare elevation ramp; every track has these masks.
+- **Tracks are drawn with their own overview map.** Where a track ships an overhead picture of
+  itself, it's laid over the terrain, so the turns, ruts and jump faces read as the track
+  rather than as bare relief. A motocross track is only a few metres of relief across a few
+  hundred of ground, so shading alone was never going to show it. Taken from the `[ui]
+  pic_info` slot and only when it's a different file from `pic` and drawn to the same
+  proportions as the grid — a loading screen stretched over the ground would be fiction.
+
+### Fixed
+- **Terrain below a track's datum is no longer drawn as a wall around it.** A `.trh` stores
+  its samples *signed*, and they were read unsigned, so every point below the datum came out
+  a full half-range — eleven metres — too high. Tracks that sit entirely one side of it were
+  merely offset; ones that straddle it, like Farm14, were drawn as a plateau with the track
+  sunk in a pit and the jumps at the bottom of it. Confirmed against the marshal posts of two
+  published tracks: read signed, their stated ground heights come back to the centimetre
+  (SandPoint's median error is 0.000 m against 11.001 m read unsigned), and the 32768-unit
+  cliffs that wrapping left across three of four tracks disappear entirely.
+- **The track is no longer drawn mirrored.** The terrain was placed straight into the scene
+  while the game's frame is left-handed and the viewer's is not, so every track came out
+  flipped — a left-hander read as a right-hander. It now goes through the same axis
+  conversion every bike and rider model in the app already does (`edf::to_right_handed`),
+  with the triangle winding turned to match so the ground is still lit from above.
+- **Terrain is drawn at the detail it was asked for.** A view reduced the grid by a whole
+  number of samples, so a request for 320 across a 410-sample master could only step by two
+  and drew 205 — one drawn square covering nearly three metres of ground, wider than the jump
+  faces and ruts it was meant to show. Reductions now land on the size requested, and the
+  master itself is kept at twice the resolution. A track is drawn with roughly 3.7x the
+  samples across it, and a drawn square covers under a metre.
+- **The blind heightfield probe no longer reads a shifted grid.** It required the samples to
+  run to the last byte of the file, so a height file with a trailing block — which is what a
+  real `.trh` is — could only fit by treating that block as a header, landing the grid over
+  half a row late and reporting full confidence while doing it. Alignment is now measured
+  rather than assumed: a read that starts in the wrong place wraps mid-row, breaking every
+  row in the same column, and that is what the probe now looks for.
+- **Relief is drawn at a fixed, gentle exaggeration.** The 1×/2×/4× control is gone: 4×
+  stretched a track's boundary into spikes without making the track itself any clearer. What
+  replaces it is a single 1.5×, which is enough for a jump face to cast a shadow while the
+  ground still reads as ground.
+
 ## 2026-08-10 — v0.9.1 — The Designer paints, Play works on a Mac, and SteamOS stops opening to a white screen
 
 On top of v0.9.0 — everything that release added is still the news, and its notes are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,18 +200,18 @@ them up.
 - **See a track's terrain in 3D.** Tracks were the one thing the library couldn't show you —
   a name, a preview and a size. The viewer now reads the heightfield out of a track and draws
   the ground, opening from the library detail view next to **View in 3D**.
-- **Every track is drawn with its surfaces, not just its shape.** A track's height file also
-  carries coverage masks — one per surface the builder painted, a byte per cell — and the
-  viewer now reads them, so grass, apron, hard standing and the dirt of the riding line each
-  get their own colour. This is what the five tracks that ship no overview picture get instead
-  of a bare elevation ramp; every track has these masks.
-- **Tracks are drawn with their own overview map.** Where a track ships an overhead picture of
-  itself, it's laid over the terrain, so the turns, ruts and jump faces read as the track
-  rather than as bare relief. A motocross track is only a few metres of relief across a few
-  hundred of ground, so shading alone was never going to show it. Taken from the `[ui]
-  pic_info` slot and only when it's a different file from `pic` and drawn to the same
-  proportions as the grid — a loading screen stretched over the ground would be fiction.
+- **Tracks are drawn with their surfaces, where the track says what they are.** A track's
+  height file can carry coverage masks — one per surface the builder painted, a byte per cell
+  — and the viewer reads them, so grass, apron, hard standing and the dirt of the riding line
+  each get their own colour. Tracks that carry no masks keep the elevation shading.
 
+  Tracks also ship a picture in `[ui] pic_info`, and that is deliberately *not* used. Some of
+  those are true overhead photographs, but others are branded posters — a diagram on a paper
+  texture with a series logo across the bottom — and laying one on the terrain puts a logo on
+  the dirt. Nothing in the file distinguishes them, and three ways of asking a picture to prove
+  it describes the ground all failed to separate a real photograph from a poster (extents of
+  0.709 against 0.715). The masks need no such test: they are a byte per cell of the very grid
+  being drawn, so they line up by construction.
 ### Fixed
 - **Terrain below a track's datum is no longer drawn as a wall around it.** A `.trh` stores
   its samples *signed*, and they were read unsigned, so every point below the datum came out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,18 @@ them up.
   it describes the ground all failed to separate a real photograph from a poster (extents of
   0.709 against 0.715). The masks need no such test: they are a byte per cell of the very grid
   being drawn, so they line up by construction.
+
+  Each surface takes the colour of the material the track names for it — the ids below six
+  index the table every track carries (asphalt, grass, sand, kerb, soil, concrete), so a farm's
+  fields come out as the soil they are and a grass circuit comes out green, rather than every
+  track being coloured by whichever surface happened to cover the most of it.
+- **The terrain is lit by its own hollows.** A directional light can only shade a slope by
+  which way it faces, so a rut running along the light and a ridge running along it were lit
+  identically and the shapes a track is made of came out flat. Every point is now measured
+  against a blurred copy of the terrain at two scales — tight enough to find a rut, wide
+  enough to see the bowl a turn sits in — and the result darkens hollows and lifts ridges.
+  The terrain also casts and receives real shadows now.
+
 ### Fixed
 - **Terrain below a track's datum is no longer drawn as a wall around it.** A `.trh` stores
   its samples *signed*, and they were read unsigned, so every point below the datum came out
@@ -226,9 +238,12 @@ them up.
   flipped — a left-hander read as a right-hander. It now goes through the same axis
   conversion every bike and rider model in the app already does (`edf::to_right_handed`),
   with the triangle winding turned to match so the ground is still lit from above.
-- **Terrain is drawn at the detail it was asked for.** A view reduced the grid by a whole
-  number of samples, so a request for 320 across a 410-sample master could only step by two
-  and drew 205 — one drawn square covering nearly three metres of ground, wider than the jump
+- **Terrain is drawn at the detail it was asked for — twice over.** Reductions moved by a
+  whole number of samples in two separate places, and both overshot. Reading a heightfield
+  into the master could only halve a 2049-sample grid asked for 2048, so the master was 1025
+  and half the file was thrown away before the viewer could ask for it. The same fault in the
+  view's own reduction meant a request for 320 across a 410-sample master could only step by
+  two and drew 205 — one drawn square covering nearly three metres of ground, wider than the jump
   faces and ruts it was meant to show. Reductions now land on the size requested, and the
   master itself is kept at twice the resolution. A track is drawn with roughly 3.7x the
   samples across it, and a drawn square covers under a metre.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,7 +47,10 @@ export default tseslint.config(
     // react-three-fiber renders three.js objects as JSX (`<mesh castShadow>`,
     // `<ambientLight intensity>`), which eslint-plugin-react judges against the DOM and
     // flags wholesale. @react-three/fiber ships types for them, so tsc is the real check.
-    files: ["src/Components/Viewer/ModelViewer.tsx"],
+    files: [
+      "src/Components/Viewer/ModelViewer.tsx",
+      "src/Components/Viewer/TrackViewer.tsx",
+    ],
     rules: { "react/no-unknown-property": "off" },
   },
 );

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -77,6 +77,8 @@ image = { version = "0.25", default-features = false, features = [
     "png",
     "jpeg",
     "tga",
+    # Track overview maps ship as either — the ARL packs are all DDS, SandPoint is TGA.
+    "dds",
     "bmp",
     "webp",
     "gif",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -77,8 +77,6 @@ image = { version = "0.25", default-features = false, features = [
     "png",
     "jpeg",
     "tga",
-    # Track overview maps ship as either — the ARL packs are all DDS, SandPoint is TGA.
-    "dds",
     "bmp",
     "webp",
     "gif",

--- a/src-tauri/src/fixtures/localcross.ini
+++ b/src-tauri/src/fixtures/localcross.ini
@@ -1,0 +1,135 @@
+[info]
+name = Camp Moto
+short_name = 
+length = 1
+altitude = 1
+
+[ui]
+pic = PIC.tga
+pic_info = 
+author = 
+location = 
+
+[weather]
+cloud_prob = 0.4
+rainy_prob = 0.1
+
+[race]
+
+[paint]
+testing = 
+race = 
+
+[photo]
+long = 
+lat = 
+angle = 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+; Compiled with Resolute Track Builder Helper

--- a/src-tauri/src/heightfield.rs
+++ b/src-tauri/src/heightfield.rs
@@ -692,18 +692,32 @@ pub fn read_grid(bytes: &[u8], layout: &Layout, max_dim: u32) -> (u32, u32, Vec<
     let w = layout.width as usize;
     let h = layout.height as usize;
     let size = layout.sample.size();
+    let max_dim = max_dim.max(1) as usize;
+    let longest = w.max(h);
 
-    let step = ((w.max(h) as f32) / max_dim.max(1) as f32).ceil().max(1.0) as usize;
-    let out_w = w.div_ceil(step);
-    let out_h = h.div_ceil(step);
+    // Exactly the size asked for, not the nearest whole-sample stride. A stride of one leaves
+    // a 2049-sample grid untouched while a stride of two halves it, so asking a heightfield
+    // for 2048 across used to hand back 1025 — every other sample dropped, and the lip of a
+    // jump with it. Sizing the blocks by ratio instead lands on the request however the grid
+    // divides.
+    let (out_w, out_h) = if longest <= max_dim {
+        (w, h)
+    } else {
+        (((w * max_dim) / longest).max(1), ((h * max_dim) / longest).max(1))
+    };
 
     let mut out = Vec::with_capacity(out_w * out_h);
     for oy in 0..out_h {
+        let y0 = oy * h / out_h;
+        let y1 = (((oy + 1) * h) / out_h).max(y0 + 1).min(h);
         for ox in 0..out_w {
+            let x0 = ox * w / out_w;
+            let x1 = (((ox + 1) * w) / out_w).max(x0 + 1).min(w);
+
             let mut total = 0.0f64;
             let mut count = 0usize;
-            for y in oy * step..((oy + 1) * step).min(h) {
-                for x in ox * step..((ox + 1) * step).min(w) {
+            for y in y0..y1 {
+                for x in x0..x1 {
                     let v = (layout.sample.read(bytes, layout.offset + (y * w + x) * size)
                         + layout.bias)
                         * layout.height_scale.unwrap_or(1.0);
@@ -1047,6 +1061,19 @@ mod tests {
         let max = grid.iter().copied().fold(f32::NEG_INFINITY, f32::max);
         assert!(min >= full_min - 0.01 && max <= full_max + 0.01);
         assert!(max - min > (full_max - full_min) * 0.5);
+    }
+
+    #[test]
+    fn a_grid_is_read_at_the_size_asked_for() {
+        // 2049 is what every published track uses, and 2048 is the power of two under it.
+        // A whole-sample stride can only halve that, so this used to answer 1025 — half the
+        // samples thrown away before the viewer ever saw the terrain.
+        let heights = terrain(2049, 2049);
+        let bytes = with_header(&heights, &[]);
+        let layout = probe(&bytes, None).expect("a square grid should be recovered");
+        let (w, h, grid) = read_grid(&bytes, &layout, 2048);
+        assert_eq!((w, h), (2048, 2048));
+        assert_eq!(grid.len(), 2048 * 2048);
     }
 
     #[test]

--- a/src-tauri/src/heightfield.rs
+++ b/src-tauri/src/heightfield.rs
@@ -1,9 +1,12 @@
 //! Recovering a terrain grid from a track's height file.
 //!
-//! MX Bikes' `.trh` is undocumented, and no two builds of the track tools have to agree on
-//! what precedes the samples. Rather than hard-code a header this build can only guess at,
-//! the reader *probes*: it enumerates the layouts a heightfield could plausibly have, then
-//! asks each one to prove itself against the bytes.
+//! MX Bikes' `.trh` carries a magic and states its own shape, and [`parse_trh`] reads it
+//! directly — layout confirmed against a published track. That is the path real tracks take.
+//!
+//! Everything below it exists for the files that path doesn't fit: a `.map`, a heightfield
+//! from a tool that wrote something else, a future revision. For those the reader *probes*:
+//! it enumerates the layouts a heightfield could plausibly have, then asks each one to prove
+//! itself against the bytes.
 //!
 //! The proof is a property terrain has and noise does not — neighbouring samples are close
 //! together. Two independent measurements fall out of that, and between them they pin down
@@ -66,9 +69,95 @@ pub struct Layout {
     /// 0–1. How cleanly this layout beat the roughness thresholds — surfaced so a probed
     /// terrain can be labelled as inferred rather than read.
     pub confidence: f32,
-    /// Whether the dimensions came from numbers in the file's own header (`header`), from a
-    /// hint in the track's `.ini` (`ini`), or from assuming a square grid (`square`).
+    /// `trh` when the file described itself, otherwise how the shape was inferred:
+    /// `header` (numbers in the file), `ini` (a hint from the track) or `square`.
     pub source: &'static str,
+    /// Multiply a raw sample by this for metres. `None` when the file doesn't say, in which
+    /// case the grid is in raw sample units and its relief means nothing in the world.
+    pub height_scale: Option<f32>,
+    /// Metres of ground per sample step, when the file states it. `None` means the relief
+    /// is real but the footprint it sits on is unknown.
+    pub metres_per_sample: Option<f32>,
+}
+
+/// The magic that opens a real `.trh`.
+const TRH_MAGIC: &[u8; 4] = b"TRH\0";
+
+/// Read MX Bikes' own heightfield layout, confirmed against a published track:
+///
+/// ```text
+///  0   "TRH\0"
+///  4   u32   width
+///  8   u32   height
+/// 12   u16 × width × height    raw samples spanning the height range
+///  …   trailing block, opening with three floats: size x, relief, size z — all metres
+/// ```
+///
+/// Worth having as its own reader rather than leaving to [`probe`], which cannot see it at
+/// all: the grid doesn't run to the end of the file, and the blind search derives the sample
+/// offset from the file's length precisely so that it never has to guess. It also can't
+/// know that the samples are a quantised range rather than metres, so it would report a
+/// track's relief as tens of thousands of units.
+fn parse_trh(bytes: &[u8]) -> Option<Layout> {
+    if bytes.len() < 12 || &bytes[..4] != TRH_MAGIC {
+        return None;
+    }
+    let width = u32::from_le_bytes(bytes[4..8].try_into().ok()?);
+    let height = u32::from_le_bytes(bytes[8..12].try_into().ok()?);
+    if !(MIN_DIM..=MAX_DIM).contains(&width) || !(MIN_DIM..=MAX_DIM).contains(&height) {
+        return None;
+    }
+    let need = (width as usize).checked_mul(height as usize)?.checked_mul(2)?;
+    let end = need.checked_add(12)?;
+    if end > bytes.len() {
+        return None;
+    }
+
+    let c = Candidate {
+        offset: 12,
+        width,
+        height,
+        sample: Sample::U16,
+        source: "trh",
+    };
+    // A self-describing file is still measured. A header that says one thing while the body
+    // says another is a misread, and falling back to the blind search beats drawing it.
+    let Assessment::Ok { confidence, .. } = assess(bytes, &c) else {
+        return None;
+    };
+
+    let scale = trh_scale(bytes, end, width);
+    Some(Layout {
+        offset: 12,
+        width,
+        height,
+        sample: Sample::U16,
+        confidence,
+        source: "trh",
+        height_scale: scale.map(|(_, h)| h),
+        metres_per_sample: scale.map(|(s, _)| s),
+    })
+}
+
+/// `(metres per sample, metres per raw unit)` from the block that follows the grid.
+///
+/// Taken from one published track rather than from a specification, so every figure has to
+/// be plausible before any of it is believed — and it's all or nothing, because a footprint
+/// without a height scale would draw relief in raw units across real ground.
+fn trh_scale(bytes: &[u8], at: usize, width: u32) -> Option<(f32, f32)> {
+    let f32_at = |i: usize| -> Option<f32> {
+        let o = at + i * 4;
+        Some(f32::from_le_bytes(bytes.get(o..o + 4)?.try_into().ok()?))
+    };
+    let size_x = f32_at(0)?;
+    let relief = f32_at(1)?;
+    let size_z = f32_at(2)?;
+
+    let sane = |v: f32, max: f32| v.is_finite() && v > 0.0 && v < max;
+    if !(sane(size_x, 100_000.0) && sane(size_z, 100_000.0) && sane(relief, 10_000.0)) {
+        return None;
+    }
+    Some((size_x / (width.max(2) - 1) as f32, relief / u16::MAX as f32))
 }
 
 /// Integer square root, for testing whether a sample count is a square grid.
@@ -350,6 +439,16 @@ pub fn report(bytes: &[u8], hint: Option<(u32, u32)>) -> String {
     let mut out = String::new();
     let _ = writeln!(out, "{} bytes, hint {hint:?}", bytes.len());
 
+    if let Some(l) = parse_trh(bytes) {
+        let _ = writeln!(
+            out,
+            "reads as a self-describing .trh: {}x{} u16 at 12, confidence {:.2}\n\
+             spacing {:?} m/sample, height scale {:?} m/unit",
+            l.width, l.height, l.confidence, l.metres_per_sample, l.height_scale
+        );
+        return out;
+    }
+
     let all = candidates(bytes, hint);
     if all.is_empty() {
         out.push_str(
@@ -406,6 +505,11 @@ pub fn report(bytes: &[u8], hint: Option<(u32, u32)>) -> String {
 /// `hint` is a (width, height) from the track's `.ini` when it names one — believed ahead of
 /// anything inferred, but still made to pass the same roughness test as every other layout.
 pub fn probe(bytes: &[u8], hint: Option<(u32, u32)>) -> Option<Layout> {
+    // A file that says what it is doesn't need guessing at.
+    if let Some(known) = parse_trh(bytes) {
+        return Some(known);
+    }
+
     let mut best: Option<Layout> = None;
 
     for c in candidates(bytes, hint) {
@@ -419,6 +523,10 @@ pub fn probe(bytes: &[u8], hint: Option<(u32, u32)>) -> Option<Layout> {
             sample: c.sample,
             confidence,
             source: c.source,
+            // Nothing inferred carries a scale: a grid recovered by its shape says nothing
+            // about the ground it covers or what its numbers mean.
+            height_scale: None,
+            metres_per_sample: None,
         };
         // Ties on confidence go to the layout with the better provenance, then to the larger
         // grid: a stated shape beats a guessed one, and a half-width misread of a real grid
@@ -447,7 +555,9 @@ fn rank(source: &str) -> u8 {
     }
 }
 
-/// Read a probed grid out as metres, downsampled so the longest edge is at most `max_dim`.
+/// Read a probed grid out, downsampled so the longest edge is at most `max_dim`.
+///
+/// In metres where the file gave a height scale; in raw sample units where it didn't.
 ///
 /// Downsampling happens here rather than in the app because the whole point is to not ship a
 /// 4096² grid over the IPC channel: at four bytes a sample that is 64 MB for a view that
@@ -472,7 +582,8 @@ pub fn read_grid(bytes: &[u8], layout: &Layout, max_dim: u32) -> (u32, u32, Vec<
             let mut count = 0usize;
             for y in oy * step..((oy + 1) * step).min(h) {
                 for x in ox * step..((ox + 1) * step).min(w) {
-                    let v = layout.sample.read(bytes, layout.offset + (y * w + x) * size);
+                    let v = layout.sample.read(bytes, layout.offset + (y * w + x) * size)
+                        * layout.height_scale.unwrap_or(1.0);
                     if v.is_finite() {
                         total += v as f64;
                         count += 1;
@@ -518,6 +629,92 @@ mod tests {
         bytes
     }
 
+    /// Build a file to the layout a published track actually uses.
+    fn real_trh(w: u32, h: u32, footer: &[u8]) -> Vec<u8> {
+        let heights = terrain(w, h);
+        let lo = heights.iter().copied().fold(f32::INFINITY, f32::min);
+        let hi = heights.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"TRH\0");
+        bytes.extend_from_slice(&w.to_le_bytes());
+        bytes.extend_from_slice(&h.to_le_bytes());
+        for v in &heights {
+            // Quantised across the whole 16-bit range, which is what makes the trailing
+            // block's relief figure the only thing that turns these back into metres.
+            let q = ((v - lo) / (hi - lo) * u16::MAX as f32) as u16;
+            bytes.extend_from_slice(&q.to_le_bytes());
+        }
+        bytes.extend_from_slice(footer);
+        bytes
+    }
+
+    /// `size_x`, relief, `size_z`, then the rest of the block we don't read.
+    fn real_footer() -> Vec<u8> {
+        let mut f = Vec::new();
+        f.extend_from_slice(&250.0f32.to_le_bytes());
+        f.extend_from_slice(&18.36f32.to_le_bytes());
+        f.extend_from_slice(&250.0f32.to_le_bytes());
+        f.extend_from_slice(&[0u8; 512]);
+        f
+    }
+
+    #[test]
+    fn reads_the_real_trh_layout() {
+        let bytes = real_trh(257, 257, &real_footer());
+        let l = probe(&bytes, None).expect("a real-layout .trh should be read directly");
+
+        assert_eq!(l.source, "trh", "it describes itself — nothing should be inferred");
+        assert_eq!((l.width, l.height), (257, 257));
+        assert_eq!(l.sample, Sample::U16);
+        assert_eq!(l.offset, 12);
+        // 250 m spread across 256 steps.
+        assert!((l.metres_per_sample.unwrap() - 250.0 / 256.0).abs() < 1e-4);
+
+        // And the heights come out in metres rather than raw quantised units — the whole
+        // point of reading the trailing block.
+        let (_, _, grid) = read_grid(&bytes, &l, 512);
+        let max = grid.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        assert!((max - 18.36).abs() < 0.05, "relief should be metres, got {max}");
+    }
+
+    #[test]
+    fn a_trh_whose_grid_doesnt_run_to_the_end_is_still_read() {
+        // The blind search derives the sample offset from the file's length, so a grid with
+        // anything after it is invisible to it. This is exactly that shape.
+        let bytes = real_trh(257, 257, &real_footer());
+        assert!(
+            bytes.len() > 12 + 257 * 257 * 2,
+            "the fixture has to actually carry a trailing block",
+        );
+        assert_eq!(probe(&bytes, None).unwrap().width, 257);
+    }
+
+    #[test]
+    fn a_trh_with_an_unusable_footer_reads_its_grid_but_claims_no_scale() {
+        // Zeros aren't a footprint. The shape is still trustworthy — it's stated in the
+        // header — but nothing should be asserted about the ground or the units.
+        let bytes = real_trh(257, 257, &[0u8; 64]);
+        let l = probe(&bytes, None).expect("the grid is still readable");
+        assert_eq!(l.source, "trh");
+        assert_eq!(l.metres_per_sample, None, "no footprint should be claimed");
+        assert_eq!(l.height_scale, None, "samples stay raw when nothing scales them");
+    }
+
+    #[test]
+    fn a_trh_header_that_disagrees_with_its_body_is_not_believed() {
+        // Magic and dimensions alone aren't enough: if the body doesn't read as terrain at
+        // the stated shape, this is a misread and the blind search should get its turn.
+        let mut bytes = real_trh(257, 257, &real_footer());
+        bytes[4..8].copy_from_slice(&64u32.to_le_bytes());
+        bytes[8..12].copy_from_slice(&64u32.to_le_bytes());
+        let found = probe(&bytes, None);
+        assert!(
+            found.is_none_or(|l| (l.width, l.height) != (64, 64)),
+            "a stated shape the body contradicts must not be taken at its word",
+        );
+    }
+
     #[test]
     fn recovers_a_square_grid_with_no_header() {
         let heights = terrain(256, 256);
@@ -533,7 +730,7 @@ mod tests {
         // Non-square, so nothing but the header could have supplied the shape.
         let heights = terrain(320, 192);
         let mut header = Vec::new();
-        header.extend_from_slice(b"TRH\0");
+        header.extend_from_slice(b"HGT\0");
         header.extend_from_slice(&320u32.to_le_bytes());
         header.extend_from_slice(&192u32.to_le_bytes());
         header.extend_from_slice(&[0u8; 20]);

--- a/src-tauri/src/heightfield.rs
+++ b/src-tauri/src/heightfield.rs
@@ -1,0 +1,547 @@
+//! Recovering a terrain grid from a track's height file.
+//!
+//! MX Bikes' `.trh` is undocumented, and no two builds of the track tools have to agree on
+//! what precedes the samples. Rather than hard-code a header this build can only guess at,
+//! the reader *probes*: it enumerates the layouts a heightfield could plausibly have, then
+//! asks each one to prove itself against the bytes.
+//!
+//! The proof is a property terrain has and noise does not — neighbouring samples are close
+//! together. Two independent measurements fall out of that, and between them they pin down
+//! the whole layout:
+//!
+//! * **Horizontal roughness** compares memory-adjacent samples. It doesn't depend on the row
+//!   width at all, so it judges only the sample type and where the samples begin. Read a
+//!   float grid as 16-bit, or start one byte late, and adjacent values stop being neighbours
+//!   — the figure explodes.
+//! * **Vertical roughness** compares samples one row apart, so it is exactly the measurement
+//!   the row width controls. At the true width it sees real neighbours; at any other width it
+//!   is sampling unrelated parts of the terrain, and reads as noise.
+//!
+//! A layout has to satisfy both to be believed, and [`probe`] reports the margin it won by,
+//! so the app can show a recovered terrain as the inference it is rather than as fact.
+
+/// How a height sample is stored.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Sample {
+    F32,
+    U16,
+    I16,
+}
+
+impl Sample {
+    pub fn size(self) -> usize {
+        match self {
+            Sample::F32 => 4,
+            Sample::U16 | Sample::I16 => 2,
+        }
+    }
+
+    fn read(self, bytes: &[u8], at: usize) -> f32 {
+        match self {
+            Sample::F32 => f32::from_le_bytes([
+                bytes[at],
+                bytes[at + 1],
+                bytes[at + 2],
+                bytes[at + 3],
+            ]),
+            Sample::U16 => u16::from_le_bytes([bytes[at], bytes[at + 1]]) as f32,
+            Sample::I16 => i16::from_le_bytes([bytes[at], bytes[at + 1]]) as f32,
+        }
+    }
+}
+
+/// One accepted interpretation of a height file.
+///
+/// Deliberately not `Deserialize`: what gets persisted is the terrain built from a layout,
+/// not the layout itself, and `source` being a `&'static str` says so.
+#[derive(Clone, Copy, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Layout {
+    /// Byte offset the samples start at.
+    pub offset: usize,
+    pub width: u32,
+    pub height: u32,
+    pub sample: Sample,
+    /// 0–1. How cleanly this layout beat the roughness thresholds — surfaced so a probed
+    /// terrain can be labelled as inferred rather than read.
+    pub confidence: f32,
+    /// Whether the dimensions came from numbers in the file's own header (`header`), from a
+    /// hint in the track's `.ini` (`ini`), or from assuming a square grid (`square`).
+    pub source: &'static str,
+}
+
+/// Integer square root, for testing whether a sample count is a square grid.
+fn isqrt(n: usize) -> usize {
+    if n < 2 {
+        return n;
+    }
+    let mut x = (n as f64).sqrt() as usize;
+    // The float root can land a step either side on large inputs; walk it back on.
+    while x * x > n {
+        x -= 1;
+    }
+    while (x + 1) * (x + 1) <= n {
+        x += 1;
+    }
+    x
+}
+
+/// Grids outside this are not terrain we can use: too small to show, or big enough that
+/// decoding it would cost more than the view is worth.
+const MIN_DIM: u32 = 32;
+const MAX_DIM: u32 = 8192;
+
+/// The largest header we'll believe sits in front of the samples. Generous — the cost of a
+/// wrong guess is one rejected candidate, and a header this big is still cheap to skip.
+const MAX_HEADER: usize = 4096;
+
+/// Roughness above this is noise, not terrain. Expressed as a fraction of the grid's own
+/// height spread, so it holds whether the track is a supercross floor or an alpine hillside.
+const MAX_ROUGHNESS: f32 = 0.12;
+
+/// Heights beyond this many metres from sea level are not a motocross track — they're a
+/// misread. Bounds the float layouts, which can otherwise "succeed" on exponent noise.
+const MAX_ABS_HEIGHT: f32 = 20_000.0;
+
+/// A candidate layout, before it has been scored.
+struct Candidate {
+    offset: usize,
+    width: u32,
+    height: u32,
+    sample: Sample,
+    source: &'static str,
+}
+
+/// Read the layouts worth testing out of `bytes`.
+///
+/// Three ways in, cheapest first. Dimensions written in the file's own header are believed
+/// over anything inferred; a hint from the track's `.ini` comes next; a square grid is the
+/// last resort, and the one most in need of the roughness test to back it up.
+fn candidates(bytes: &[u8], hint: Option<(u32, u32)>) -> Vec<Candidate> {
+    let len = bytes.len();
+    let mut out = Vec::new();
+
+    // Any (width, height) we have reason to believe in, wherever it came from. For each one
+    // the sample block's size is known, so the header length is whatever is left over —
+    // which means we never have to guess where the samples start.
+    let mut dims: Vec<(u32, u32, &'static str)> = Vec::new();
+
+    if let Some((w, h)) = hint {
+        dims.push((w, h, "ini"));
+    }
+
+    // A header that states its own dimensions almost always does so as two adjacent 32-bit
+    // integers near the front. Read every aligned pair in the first 64 bytes and keep the
+    // plausible ones; the size check below throws out the coincidences.
+    let scan = len.min(64);
+    for off in (0..scan.saturating_sub(8)).step_by(4) {
+        let w = u32::from_le_bytes([bytes[off], bytes[off + 1], bytes[off + 2], bytes[off + 3]]);
+        let h = u32::from_le_bytes([
+            bytes[off + 4],
+            bytes[off + 5],
+            bytes[off + 6],
+            bytes[off + 7],
+        ]);
+        if (MIN_DIM..=MAX_DIM).contains(&w) && (MIN_DIM..=MAX_DIM).contains(&h) {
+            dims.push((w, h, "header"));
+        }
+    }
+
+    for (w, h, source) in dims {
+        let count = w as usize * h as usize;
+        for sample in [Sample::F32, Sample::U16, Sample::I16] {
+            let Some(need) = count.checked_mul(sample.size()) else {
+                continue;
+            };
+            // The samples are taken to run to the end of the file, which derives the header
+            // length exactly instead of guessing at it. Guessing is what it looks like it
+            // should do, and it can't: terrain read a few samples early is still smooth, so
+            // a wrong offset scores as well as the right one and there is nothing in the
+            // roughness to separate them. Deriving the offset admits exactly one answer.
+            // The cost is that a file with a *trailing* section wouldn't be recognised.
+            let Some(offset) = len.checked_sub(need) else {
+                continue;
+            };
+            if offset > MAX_HEADER {
+                continue;
+            }
+            out.push(Candidate {
+                offset,
+                width: w,
+                height: h,
+                sample,
+                source,
+            });
+        }
+    }
+
+    // Nothing stated the shape: try a square grid, which is what a terrain heightfield
+    // usually is. Every header length that leaves a perfect square of samples is a
+    // candidate, and the roughness test decides between them.
+    for sample in [Sample::F32, Sample::U16, Sample::I16] {
+        let size = sample.size();
+        for offset in (0..=MAX_HEADER.min(len)).step_by(4) {
+            let rest = len - offset;
+            if rest % size != 0 {
+                continue;
+            }
+            let count = rest / size;
+            let side = isqrt(count);
+            if side * side != count {
+                continue;
+            }
+            let side = side as u32;
+            if !(MIN_DIM..=MAX_DIM).contains(&side) {
+                continue;
+            }
+            out.push(Candidate {
+                offset,
+                width: side,
+                height: side,
+                sample,
+                source: "square",
+            });
+        }
+    }
+
+    out
+}
+
+/// Mean absolute difference between pairs of samples `stride` apart, and the value spread,
+/// measured over a bounded sample of the grid.
+///
+/// Bounded because this runs for every candidate: a full pass over a 4096² float grid, times
+/// the dozens of layouts probed, is seconds of work to answer a question a few thousand
+/// samples settle just as well.
+fn roughness(bytes: &[u8], c: &Candidate, stride: u32) -> Option<(f32, f32)> {
+    let size = c.sample.size();
+    let w = c.width as usize;
+    let h = c.height as usize;
+
+    // Walk a grid of probe points rather than a contiguous block: a corner of a heightfield
+    // can be flat apron while the middle is the track itself.
+    let rows = h.min(48);
+    let cols = w.min(48);
+    let row_step = (h / rows).max(1);
+    let col_step = (w / cols).max(1);
+
+    let mut diff_total = 0.0f64;
+    let mut diff_count = 0usize;
+    let mut min = f32::INFINITY;
+    let mut max = f32::NEG_INFINITY;
+
+    let mut y = 0usize;
+    while y < h {
+        let mut x = 0usize;
+        while x < w {
+            let i = y * w + x;
+            // The partner sample: one column over, or one row down.
+            let j = if stride == 1 {
+                if x + 1 >= w {
+                    x += col_step;
+                    continue;
+                }
+                i + 1
+            } else {
+                if y + 1 >= h {
+                    break;
+                }
+                i + w
+            };
+
+            let a = c.sample.read(bytes, c.offset + i * size);
+            let b = c.sample.read(bytes, c.offset + j * size);
+            // A float layout that isn't one reads as NaN and infinity long before it reads
+            // as rough, so reject on sight rather than letting it poison the average.
+            if !a.is_finite() || !b.is_finite() {
+                return None;
+            }
+            if a.abs() > MAX_ABS_HEIGHT || b.abs() > MAX_ABS_HEIGHT {
+                return None;
+            }
+            diff_total += (a - b).abs() as f64;
+            diff_count += 1;
+            min = min.min(a);
+            max = max.max(a);
+            x += col_step;
+        }
+        y += row_step;
+    }
+
+    if diff_count == 0 {
+        return None;
+    }
+    Some(((diff_total / diff_count as f64) as f32, max - min))
+}
+
+/// Score a candidate 0–1, or reject it.
+fn score(bytes: &[u8], c: &Candidate) -> Option<f32> {
+    let need = c.offset + c.width as usize * c.height as usize * c.sample.size();
+    if need > bytes.len() {
+        return None;
+    }
+
+    let (dx, spread) = roughness(bytes, c, 1)?;
+    // A grid with no relief is either genuinely empty or a run of padding. Either way there
+    // is nothing to show and nothing to validate against.
+    if !(spread.is_finite() && spread > 0.0) {
+        return None;
+    }
+    let (dy, _) = roughness(bytes, c, c.width)?;
+
+    // Both measured against the terrain's own relief, so the thresholds don't care whether
+    // heights are metres or raw 16-bit steps.
+    let rough_x = dx / spread;
+    let rough_y = dy / spread;
+    if rough_x > MAX_ROUGHNESS || rough_y > MAX_ROUGHNESS {
+        return None;
+    }
+
+    // How far inside the threshold it landed, worst axis first — a layout that only just
+    // scraped in should not present itself as a confident read.
+    let worst = rough_x.max(rough_y);
+    Some((1.0 - worst / MAX_ROUGHNESS).clamp(0.0, 1.0))
+}
+
+/// Recover the terrain grid in `bytes`, or `None` if nothing in it reads as terrain.
+///
+/// `hint` is a (width, height) from the track's `.ini` when it names one — believed ahead of
+/// anything inferred, but still made to pass the same roughness test as every other layout.
+pub fn probe(bytes: &[u8], hint: Option<(u32, u32)>) -> Option<Layout> {
+    let mut best: Option<Layout> = None;
+
+    for c in candidates(bytes, hint) {
+        let Some(confidence) = score(bytes, &c) else {
+            continue;
+        };
+        let layout = Layout {
+            offset: c.offset,
+            width: c.width,
+            height: c.height,
+            sample: c.sample,
+            confidence,
+            source: c.source,
+        };
+        // Ties on confidence go to the layout with the better provenance, then to the larger
+        // grid: a stated shape beats a guessed one, and a half-width misread of a real grid
+        // scores similarly to the truth while showing half the track.
+        let better = match &best {
+            None => true,
+            Some(b) => (
+                confidence,
+                rank(layout.source),
+                layout.width as u64 * layout.height as u64,
+            ) > (b.confidence, rank(b.source), b.width as u64 * b.height as u64),
+        };
+        if better {
+            best = Some(layout);
+        }
+    }
+
+    best
+}
+
+fn rank(source: &str) -> u8 {
+    match source {
+        "header" => 3,
+        "ini" => 2,
+        _ => 1,
+    }
+}
+
+/// Read a probed grid out as metres, downsampled so the longest edge is at most `max_dim`.
+///
+/// Downsampling happens here rather than in the app because the whole point is to not ship a
+/// 4096² grid over the IPC channel: at four bytes a sample that is 64 MB for a view that
+/// resolves a few hundred points across.
+///
+/// Samples are averaged over the block they replace rather than picked from its corner.
+/// Point-sampling a heightfield drops every berm narrower than the step and leaves the rest
+/// crawling as the level of detail changes.
+pub fn read_grid(bytes: &[u8], layout: &Layout, max_dim: u32) -> (u32, u32, Vec<f32>) {
+    let w = layout.width as usize;
+    let h = layout.height as usize;
+    let size = layout.sample.size();
+
+    let step = ((w.max(h) as f32) / max_dim.max(1) as f32).ceil().max(1.0) as usize;
+    let out_w = w.div_ceil(step);
+    let out_h = h.div_ceil(step);
+
+    let mut out = Vec::with_capacity(out_w * out_h);
+    for oy in 0..out_h {
+        for ox in 0..out_w {
+            let mut total = 0.0f64;
+            let mut count = 0usize;
+            for y in oy * step..((oy + 1) * step).min(h) {
+                for x in ox * step..((ox + 1) * step).min(w) {
+                    let v = layout.sample.read(bytes, layout.offset + (y * w + x) * size);
+                    if v.is_finite() {
+                        total += v as f64;
+                        count += 1;
+                    }
+                }
+            }
+            out.push(if count == 0 {
+                0.0
+            } else {
+                (total / count as f64) as f32
+            });
+        }
+    }
+
+    (out_w as u32, out_h as u32, out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A smooth synthetic heightfield — rolling relief with a ridge through it, which is
+    /// close enough to terrain for the roughness test to behave as it would on a real track.
+    fn terrain(w: u32, h: u32) -> Vec<f32> {
+        let mut out = Vec::with_capacity((w * h) as usize);
+        for y in 0..h {
+            for x in 0..w {
+                let fx = x as f32 / w as f32;
+                let fy = y as f32 / h as f32;
+                let rolling = (fx * 6.0).sin() * 4.0 + (fy * 4.5).cos() * 3.0;
+                let ridge = (-((fy - 0.5) * (fy - 0.5)) * 30.0).exp() * 8.0;
+                out.push(20.0 + rolling + ridge);
+            }
+        }
+        out
+    }
+
+    fn with_header(heights: &[f32], header: &[u8]) -> Vec<u8> {
+        let mut bytes = header.to_vec();
+        for v in heights {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        bytes
+    }
+
+    #[test]
+    fn recovers_a_square_grid_with_no_header() {
+        let heights = terrain(256, 256);
+        let bytes = with_header(&heights, &[]);
+        let layout = probe(&bytes, None).expect("a plain square grid should be recovered");
+        assert_eq!((layout.width, layout.height), (256, 256));
+        assert_eq!(layout.offset, 0);
+        assert_eq!(layout.sample, Sample::F32);
+    }
+
+    #[test]
+    fn recovers_dimensions_stated_in_the_header() {
+        // Non-square, so nothing but the header could have supplied the shape.
+        let heights = terrain(320, 192);
+        let mut header = Vec::new();
+        header.extend_from_slice(b"TRH\0");
+        header.extend_from_slice(&320u32.to_le_bytes());
+        header.extend_from_slice(&192u32.to_le_bytes());
+        header.extend_from_slice(&[0u8; 20]);
+        let bytes = with_header(&heights, &header);
+
+        let layout = probe(&bytes, None).expect("stated dimensions should be recovered");
+        assert_eq!((layout.width, layout.height), (320, 192));
+        assert_eq!(layout.source, "header");
+        assert_eq!(layout.offset, header.len());
+    }
+
+    #[test]
+    fn recovers_a_16_bit_grid() {
+        let heights = terrain(256, 256);
+        let mut bytes = Vec::new();
+        for v in &heights {
+            // Raw 16-bit steps, as a packed heightfield would store them.
+            bytes.extend_from_slice(&((v * 100.0) as u16).to_le_bytes());
+        }
+        let layout = probe(&bytes, None).expect("a 16-bit grid should be recovered");
+        assert_eq!(layout.sample, Sample::U16);
+        assert_eq!((layout.width, layout.height), (256, 256));
+    }
+
+    #[test]
+    fn takes_the_dimensions_hinted_by_the_ini() {
+        let heights = terrain(384, 128);
+        let bytes = with_header(&heights, &[0u8; 16]);
+        let layout = probe(&bytes, Some((384, 128))).expect("the hinted shape should be recovered");
+        assert_eq!((layout.width, layout.height), (384, 128));
+        assert_eq!(layout.source, "ini");
+    }
+
+    #[test]
+    fn rejects_noise() {
+        // A deterministic pseudo-random fill: the same size as a real grid, none of the
+        // structure. Nothing here should read as terrain at any layout.
+        let mut state = 0x2545_F491_4F6C_DD1Du64;
+        let mut bytes = Vec::new();
+        for _ in 0..256 * 256 {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            bytes.extend_from_slice(&((state >> 40) as u16).to_le_bytes());
+        }
+        assert!(probe(&bytes, None).is_none(), "noise must not read as terrain");
+    }
+
+    #[test]
+    fn rejects_a_wrong_width_in_favour_of_the_right_one() {
+        // The vertical measurement is the only thing separating these: read at half width,
+        // rows stop being neighbours even though the bytes are unchanged.
+        let heights = terrain(256, 256);
+        let bytes = with_header(&heights, &[]);
+        let layout = probe(&bytes, Some((128, 512))).expect("recovered");
+        assert_eq!(
+            (layout.width, layout.height),
+            (256, 256),
+            "the hint was wrong and should have lost to the layout that reads as terrain",
+        );
+    }
+
+    #[test]
+    fn rejects_a_file_that_is_all_one_height() {
+        let bytes = with_header(&vec![12.0f32; 256 * 256], &[]);
+        assert!(
+            probe(&bytes, None).is_none(),
+            "a flat grid has no relief to show and nothing to validate against",
+        );
+    }
+
+    #[test]
+    fn downsamples_by_averaging() {
+        let heights = terrain(256, 256);
+        let bytes = with_header(&heights, &[]);
+        let layout = probe(&bytes, None).unwrap();
+
+        let (w, h, grid) = read_grid(&bytes, &layout, 64);
+        assert_eq!((w, h), (64, 64));
+        assert_eq!(grid.len(), 64 * 64);
+
+        // Averaging preserves the overall relief, so the downsampled range should sit inside
+        // the original's without collapsing to nothing.
+        let full_min = heights.iter().copied().fold(f32::INFINITY, f32::min);
+        let full_max = heights.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        let min = grid.iter().copied().fold(f32::INFINITY, f32::min);
+        let max = grid.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        assert!(min >= full_min - 0.01 && max <= full_max + 0.01);
+        assert!(max - min > (full_max - full_min) * 0.5);
+    }
+
+    #[test]
+    fn downsampling_a_small_grid_leaves_it_alone() {
+        let heights = terrain(64, 64);
+        let bytes = with_header(&heights, &[]);
+        let layout = probe(&bytes, None).unwrap();
+        let (w, h, _) = read_grid(&bytes, &layout, 256);
+        assert_eq!((w, h), (64, 64));
+    }
+
+    #[test]
+    fn isqrt_is_exact_at_boundaries() {
+        for n in [0usize, 1, 2, 3, 4, 255, 256, 257, 65535, 65536, 16_777_216] {
+            let r = isqrt(n);
+            assert!(r * r <= n && (r + 1) * (r + 1) > n, "isqrt({n}) = {r}");
+        }
+    }
+}

--- a/src-tauri/src/heightfield.rs
+++ b/src-tauri/src/heightfield.rs
@@ -72,6 +72,13 @@ pub struct Layout {
     /// `trh` when the file described itself, otherwise how the shape was inferred:
     /// `header` (numbers in the file), `ini` (a hint from the track) or `square`.
     pub source: &'static str,
+    /// Added to a raw sample before it is scaled.
+    ///
+    /// A `.trh` stores its samples *signed*, with the terrain's datum at zero, so half the
+    /// range is below it. Adding half the range back puts the grid where the game puts it —
+    /// verified against the marshal posts of two published tracks, whose stated ground
+    /// heights this reproduces to the centimetre.
+    pub bias: f32,
     /// Multiply a raw sample by this for metres. `None` when the file doesn't say, in which
     /// case the grid is in raw sample units and its relief means nothing in the world.
     pub height_scale: Option<f32>,
@@ -83,21 +90,26 @@ pub struct Layout {
 /// The magic that opens a real `.trh`.
 const TRH_MAGIC: &[u8; 4] = b"TRH\0";
 
+/// Half the 16-bit range, added back to a `.trh`'s signed samples. See [`Layout::bias`].
+const TRH_BIAS: f32 = 32768.0;
+
 /// Read MX Bikes' own heightfield layout, confirmed against a published track:
 ///
 /// ```text
 ///  0   "TRH\0"
 ///  4   u32   width
 ///  8   u32   height
-/// 12   u16 × width × height    raw samples spanning the height range
+/// 12   i16 × width × height    signed samples, the datum at zero
 ///  …   trailing block, opening with three floats: size x, relief, size z — all metres
 /// ```
 ///
 /// Worth having as its own reader rather than leaving to [`probe`], which cannot see it at
 /// all: the grid doesn't run to the end of the file, and the blind search derives the sample
 /// offset from the file's length precisely so that it never has to guess. It also can't
-/// know that the samples are a quantised range rather than metres, so it would report a
-/// track's relief as tens of thousands of units.
+/// know that the samples are a signed quantised range rather than metres, so it would report
+/// a track's relief as tens of thousands of units — and reading them unsigned puts every
+/// sample below the datum a full half-range too high, which draws the ground below a track
+/// as an eleven-metre wall around it.
 fn parse_trh(bytes: &[u8]) -> Option<Layout> {
     if bytes.len() < 12 || &bytes[..4] != TRH_MAGIC {
         return None;
@@ -117,7 +129,7 @@ fn parse_trh(bytes: &[u8]) -> Option<Layout> {
         offset: 12,
         width,
         height,
-        sample: Sample::U16,
+        sample: Sample::I16,
         source: "trh",
     };
     // A self-describing file is still measured. A header that says one thing while the body
@@ -131,9 +143,10 @@ fn parse_trh(bytes: &[u8]) -> Option<Layout> {
         offset: 12,
         width,
         height,
-        sample: Sample::U16,
+        sample: Sample::I16,
         confidence,
         source: "trh",
+        bias: TRH_BIAS,
         height_scale: scale.map(|(_, h)| h),
         metres_per_sample: scale.map(|(s, _)| s),
     })
@@ -186,6 +199,18 @@ const MAX_DIM: u32 = 8193;
 /// wrong guess is one rejected candidate, and a header this big is still cheap to skip.
 const MAX_HEADER: usize = 4096;
 
+/// The largest trailing block we'll believe sits after the samples. A real `.trh` carries
+/// one — its size and relief in metres — so a grid is not required to run to the end of its
+/// file. See [`seam`] for what makes that safe to allow.
+const MAX_TRAILER: usize = 4096;
+
+/// A row whose largest step is this many times its typical step has a discontinuity in it,
+/// not a slope.
+const SEAM_STEP_RATIO: f32 = 8.0;
+
+/// Rejected once this fraction of rows break at the same column.
+const MAX_SEAM_ROWS: f32 = 0.75;
+
 /// Roughness above this is noise, not terrain. Expressed as a fraction of the grid's own
 /// height spread, so it holds whether the track is a supercross floor or an alpine hillside.
 const MAX_ROUGHNESS: f32 = 0.12;
@@ -213,13 +238,14 @@ fn candidates(bytes: &[u8], hint: Option<(u32, u32)>) -> Vec<Candidate> {
     let len = bytes.len();
     let mut out = Vec::new();
 
-    // Any (width, height) we have reason to believe in, wherever it came from. For each one
-    // the sample block's size is known, so the header length is whatever is left over —
-    // which means we never have to guess where the samples start.
-    let mut dims: Vec<(u32, u32, &'static str)> = Vec::new();
+    // Any (width, height) we have reason to believe in, wherever it came from, and the byte
+    // just past whatever stated it — the samples most often start there.
+    let mut dims: Vec<(u32, u32, &'static str, Option<usize>)> = Vec::new();
 
     if let Some((w, h)) = hint {
-        dims.push((w, h, "ini"));
+        // An `.ini` is a separate file; it says nothing about where in *this* one the
+        // samples begin.
+        dims.push((w, h, "ini", None));
     }
 
     // A header that states its own dimensions almost always does so as two adjacent 32-bit
@@ -235,51 +261,58 @@ fn candidates(bytes: &[u8], hint: Option<(u32, u32)>) -> Vec<Candidate> {
             bytes[off + 7],
         ]);
         if (MIN_DIM..=MAX_DIM).contains(&w) && (MIN_DIM..=MAX_DIM).contains(&h) {
-            dims.push((w, h, "header"));
+            dims.push((w, h, "header", Some(off + 8)));
         }
     }
 
-    for (w, h, source) in dims {
+    for (w, h, source, stated_end) in dims {
         let count = w as usize * h as usize;
         for sample in [Sample::F32, Sample::U16, Sample::I16] {
             let Some(need) = count.checked_mul(sample.size()) else {
                 continue;
             };
-            // The samples are taken to run to the end of the file, which derives the header
-            // length exactly instead of guessing at it. Guessing is what it looks like it
-            // should do, and it can't: terrain read a few samples early is still smooth, so
-            // a wrong offset scores as well as the right one and there is nothing in the
-            // roughness to separate them. Deriving the offset admits exactly one answer.
-            // The cost is that a file with a *trailing* section wouldn't be recognised.
-            let Some(offset) = len.checked_sub(need) else {
-                continue;
-            };
-            if offset > MAX_HEADER {
-                continue;
+            // Two ways the block can sit in the file, and both are derived rather than
+            // guessed: it runs to the end, or it begins right after whatever stated the
+            // dimensions. A real `.trh` is the second — its size and relief are written
+            // after the samples, so requiring the grid to reach the end reads it 1566
+            // samples late. [`seam`] is what separates the two once both are on the table;
+            // the mean roughness cannot, which is why only one used to be offered.
+            let mut offsets = Vec::new();
+            if let Some(offset) = len.checked_sub(need) {
+                offsets.push(offset);
             }
-            out.push(Candidate {
-                offset,
-                width: w,
-                height: h,
-                sample,
-                source,
-            });
+            if let Some(start) = stated_end {
+                if start + need <= len && !offsets.contains(&start) {
+                    offsets.push(start);
+                }
+            }
+            for offset in offsets {
+                if offset > MAX_HEADER {
+                    continue;
+                }
+                out.push(Candidate {
+                    offset,
+                    width: w,
+                    height: h,
+                    sample,
+                    source,
+                });
+            }
         }
     }
 
     // Nothing stated the shape: try a square grid, which is what a terrain heightfield
-    // usually is. Every header length that leaves a perfect square of samples is a
-    // candidate, and the roughness test decides between them.
+    // usually is. Every header length that leaves room for a square of samples is a
+    // candidate, and the roughness and seam tests decide between them.
     for sample in [Sample::F32, Sample::U16, Sample::I16] {
         let size = sample.size();
         for offset in (0..=MAX_HEADER.min(len)).step_by(4) {
             let rest = len - offset;
-            if rest % size != 0 {
-                continue;
-            }
             let count = rest / size;
             let side = isqrt(count);
-            if side * side != count {
+            // The square needn't end at the file's last byte — what it doesn't fill is a
+            // trailing block, so long as that block is small enough to be one.
+            if rest - side * side * size > MAX_TRAILER {
                 continue;
             }
             let side = side as u32;
@@ -369,6 +402,88 @@ fn roughness(bytes: &[u8], c: &Candidate, stride: u32) -> Result<(f32, f32), &'s
     Ok(((diff_total / diff_count as f64) as f32, max - min))
 }
 
+/// How much of a *wrapped* read a candidate looks like: the fraction of rows whose largest
+/// step falls in the same column.
+///
+/// This is the measurement that lets the offset be searched rather than derived. A grid read
+/// at the wrong offset is the true terrain shifted by some samples, so every row spans the
+/// end of one true row and the start of the next, and every row carries one big step at the
+/// same column. Terrain doesn't do that: a real ridge doesn't sit in the same column of
+/// every row and dwarf everything around it.
+///
+/// The mean roughness can't see this — it samples a few dozen columns of a grid thousands
+/// wide, so it misses the seam entirely and averages away what it does catch. That is why a
+/// shifted read scores as well as the truth there, and why this is measured separately.
+///
+/// Every column of the sampled rows is scanned, because a seam is one column wide and
+/// subsampling would step straight over it.
+fn seam(bytes: &[u8], c: &Candidate) -> f32 {
+    let size = c.sample.size();
+    let w = c.width as usize;
+    let h = c.height as usize;
+    if w < 4 || h < 4 {
+        return 0.0;
+    }
+
+    let rows = h.min(8);
+    let row_step = (h / rows).max(1);
+
+    // Where each row broke, for rows that broke at all.
+    let mut breaks: Vec<usize> = Vec::new();
+    let mut examined = 0usize;
+
+    let mut y = 0usize;
+    while y < h && examined < rows {
+        examined += 1;
+        let base = y * w;
+        let mut total = 0.0f64;
+        let mut worst = f32::NEG_INFINITY;
+        let mut worst_at = 0usize;
+        let mut ok = true;
+
+        for x in 0..w - 1 {
+            let a = c.sample.read(bytes, c.offset + (base + x) * size);
+            let b = c.sample.read(bytes, c.offset + (base + x + 1) * size);
+            if !a.is_finite() || !b.is_finite() {
+                ok = false;
+                break;
+            }
+            let d = (a - b).abs();
+            total += d as f64;
+            if d > worst {
+                worst = d;
+                worst_at = x;
+            }
+        }
+
+        if ok && worst.is_finite() {
+            let mean = (total / (w - 1) as f64) as f32;
+            // A flat row has no worst step worth the name, and a row that is all step is
+            // noise rather than a seam. Neither votes.
+            if mean > 0.0 && worst >= mean * SEAM_STEP_RATIO {
+                breaks.push(worst_at);
+            }
+        }
+        y += row_step;
+    }
+
+    if examined == 0 || breaks.is_empty() {
+        return 0.0;
+    }
+
+    // The modal break column, allowing a column either side: a wrap seam lands in the same
+    // place every row, but the exact argmax can drift by one where the terrain is steep.
+    let mut best = 0usize;
+    for &col in &breaks {
+        let agree = breaks
+            .iter()
+            .filter(|&&other| other.abs_diff(col) <= 1)
+            .count();
+        best = best.max(agree);
+    }
+    best as f32 / examined as f32
+}
+
 /// What the roughness test made of a candidate.
 enum Assessment {
     /// Confidence 0–1, with the two measurements that produced it.
@@ -408,6 +523,11 @@ fn assess(bytes: &[u8], c: &Candidate) -> Assessment {
     if rough_y > MAX_ROUGHNESS {
         return Assessment::Rejected("rows aren't neighbours (wrong width)");
     }
+    // Last, because it costs a full row where the two above cost a sample of one, and a
+    // layout that fails either of them is not worth asking about alignment.
+    if seam(bytes, c) >= MAX_SEAM_ROWS {
+        return Assessment::Rejected("every row breaks in the same column (offset is shifted)");
+    }
 
     // How far inside the threshold it landed, worst axis first — a layout that only just
     // scraped in should not present itself as a confident read.
@@ -443,7 +563,7 @@ pub fn report(bytes: &[u8], hint: Option<(u32, u32)>) -> String {
     if let Some(l) = parse_trh(bytes) {
         let _ = writeln!(
             out,
-            "reads as a self-describing .trh: {}x{} u16 at 12, confidence {:.2}\n\
+            "reads as a self-describing .trh: {}x{} i16 at 12, confidence {:.2}\n\
              spacing {:?} m/sample, height scale {:?} m/unit",
             l.width, l.height, l.confidence, l.metres_per_sample, l.height_scale
         );
@@ -524,8 +644,9 @@ pub fn probe(bytes: &[u8], hint: Option<(u32, u32)>) -> Option<Layout> {
             sample: c.sample,
             confidence,
             source: c.source,
-            // Nothing inferred carries a scale: a grid recovered by its shape says nothing
-            // about the ground it covers or what its numbers mean.
+            // Nothing inferred carries a scale or a datum: a grid recovered by its shape
+            // says nothing about the ground it covers or what its numbers mean.
+            bias: 0.0,
             height_scale: None,
             metres_per_sample: None,
         };
@@ -583,7 +704,8 @@ pub fn read_grid(bytes: &[u8], layout: &Layout, max_dim: u32) -> (u32, u32, Vec<
             let mut count = 0usize;
             for y in oy * step..((oy + 1) * step).min(h) {
                 for x in ox * step..((ox + 1) * step).min(w) {
-                    let v = layout.sample.read(bytes, layout.offset + (y * w + x) * size)
+                    let v = (layout.sample.read(bytes, layout.offset + (y * w + x) * size)
+                        + layout.bias)
                         * layout.height_scale.unwrap_or(1.0);
                     if v.is_finite() {
                         total += v as f64;
@@ -643,8 +765,10 @@ mod tests {
         for v in &heights {
             // Quantised across the whole 16-bit range, which is what makes the trailing
             // block's relief figure the only thing that turns these back into metres.
-            let q = ((v - lo) / (hi - lo) * u16::MAX as f32) as u16;
-            bytes.extend_from_slice(&q.to_le_bytes());
+            // Stored the way a real file stores it: signed, so the bottom of the range is
+            // the most negative value rather than zero.
+            let q = ((v - lo) / (hi - lo) * u16::MAX as f32) as i32 - 32768;
+            bytes.extend_from_slice(&(q as i16).to_le_bytes());
         }
         bytes.extend_from_slice(footer);
         bytes
@@ -667,7 +791,7 @@ mod tests {
 
         assert_eq!(l.source, "trh", "it describes itself — nothing should be inferred");
         assert_eq!((l.width, l.height), (257, 257));
-        assert_eq!(l.sample, Sample::U16);
+        assert_eq!(l.sample, Sample::I16, "a .trh stores its samples signed");
         assert_eq!(l.offset, 12);
         // 250 m spread across 256 steps.
         assert!((l.metres_per_sample.unwrap() - 250.0 / 256.0).abs() < 1e-4);
@@ -676,7 +800,13 @@ mod tests {
         // point of reading the trailing block.
         let (_, _, grid) = read_grid(&bytes, &l, 512);
         let max = grid.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        let min = grid.iter().copied().fold(f32::INFINITY, f32::min);
         assert!((max - 18.36).abs() < 0.05, "relief should be metres, got {max}");
+        // The samples are signed, so half of them are below the datum. Read unsigned they
+        // land a half-range high, which is what drew the ground below a track as a wall
+        // around it — the grid has to start at the datum, not at half the range.
+        assert!(min.abs() < 0.05, "the bottom of the range is the datum, got {min}");
+        assert!((max - min - 18.36).abs() < 0.05, "relief spans the stated height");
     }
 
     #[test]
@@ -724,6 +854,83 @@ mod tests {
         assert_eq!((layout.width, layout.height), (256, 256));
         assert_eq!(layout.offset, 0);
         assert_eq!(layout.sample, Sample::F32);
+    }
+
+    /// Terrain that drains one way, so its left edge and its right edge don't match. Real
+    /// ground rarely joins up across a row boundary; [`terrain`] happens to nearly do so,
+    /// which would hide the very discontinuity these tests are about.
+    fn ramped(w: u32, h: u32) -> Vec<f32> {
+        let mut out = terrain(w, h);
+        for y in 0..h as usize {
+            for x in 0..w as usize {
+                out[y * w as usize + x] += x as f32 / w as f32 * 40.0;
+            }
+        }
+        out
+    }
+
+    /// A grid that stops before the file does is still found where it sits.
+    ///
+    /// This is the shape of a real `.trh`: samples, then a small block stating the track's
+    /// size and relief. Reading the grid flush against the end of the file instead lands it
+    /// a row and a half late — smooth, plausible, and wrong.
+    #[test]
+    fn a_grid_that_ends_before_the_file_does_is_read_where_it_sits() {
+        let heights = ramped(96, 96);
+        let mut bytes = with_header(&heights, &[]);
+        bytes.extend_from_slice(&[7u8; 48]);
+
+        let layout = probe(&bytes, None).expect("a grid followed by a footer still reads");
+        assert_eq!(layout.offset, 0, "the grid starts at the top of the file");
+        assert_eq!((layout.width, layout.height), (96, 96));
+    }
+
+    /// The same, with the dimensions stated up front — the grid begins after them, not at
+    /// whatever offset makes it reach the last byte.
+    #[test]
+    fn stated_dimensions_are_read_from_the_front_when_a_footer_follows() {
+        let heights = ramped(160, 96);
+        let mut header = Vec::new();
+        header.extend_from_slice(&160u32.to_le_bytes());
+        header.extend_from_slice(&96u32.to_le_bytes());
+        let mut bytes = with_header(&heights, &header);
+        bytes.extend_from_slice(&[0u8; 64]);
+
+        let layout = probe(&bytes, None).expect("stated dimensions with a footer should read");
+        assert_eq!((layout.width, layout.height), (160, 96));
+        assert_eq!(layout.offset, 8, "samples begin right after the dimensions");
+        assert_eq!(layout.source, "header");
+    }
+
+    /// The measurement that lets the offset be searched at all: a read that starts in the
+    /// wrong place wraps mid-row, so every row breaks in the same column.
+    #[test]
+    fn a_shifted_read_breaks_in_the_same_column_every_row() {
+        let bytes = with_header(&ramped(128, 128), &[]);
+        let aligned = Candidate {
+            offset: 0,
+            width: 128,
+            height: 128,
+            sample: Sample::F32,
+            source: "square",
+        };
+        let shifted = Candidate {
+            offset: 40 * 4,
+            width: 128,
+            height: 128,
+            sample: Sample::F32,
+            source: "square",
+        };
+
+        assert!(seam(&bytes, &aligned) < MAX_SEAM_ROWS, "terrain read straight has no seam");
+        assert!(
+            seam(&bytes, &shifted) >= MAX_SEAM_ROWS,
+            "a read 40 samples late wraps in every row",
+        );
+        assert!(
+            matches!(assess(&bytes, &shifted), Assessment::Rejected(_)),
+            "and the scorer throws it out rather than drawing it",
+        );
     }
 
     #[test]

--- a/src-tauri/src/heightfield.rs
+++ b/src-tauri/src/heightfield.rs
@@ -101,7 +101,8 @@ const MAX_HEADER: usize = 4096;
 const MAX_ROUGHNESS: f32 = 0.12;
 
 /// Heights beyond this many metres from sea level are not a motocross track — they're a
-/// misread. Bounds the float layouts, which can otherwise "succeed" on exponent noise.
+/// misread. Applies to float layouts only, which can otherwise "succeed" on exponent noise;
+/// integer samples are raw steps rather than metres, so this would not be a bound on them.
 const MAX_ABS_HEIGHT: f32 = 20_000.0;
 
 /// A candidate layout, before it has been scored.
@@ -214,7 +215,7 @@ fn candidates(bytes: &[u8], hint: Option<(u32, u32)>) -> Vec<Candidate> {
 /// Bounded because this runs for every candidate: a full pass over a 4096² float grid, times
 /// the dozens of layouts probed, is seconds of work to answer a question a few thousand
 /// samples settle just as well.
-fn roughness(bytes: &[u8], c: &Candidate, stride: u32) -> Option<(f32, f32)> {
+fn roughness(bytes: &[u8], c: &Candidate, stride: u32) -> Result<(f32, f32), &'static str> {
     let size = c.sample.size();
     let w = c.width as usize;
     let h = c.height as usize;
@@ -255,10 +256,13 @@ fn roughness(bytes: &[u8], c: &Candidate, stride: u32) -> Option<(f32, f32)> {
             // A float layout that isn't one reads as NaN and infinity long before it reads
             // as rough, so reject on sight rather than letting it poison the average.
             if !a.is_finite() || !b.is_finite() {
-                return None;
+                return Err("samples aren't finite numbers");
             }
-            if a.abs() > MAX_ABS_HEIGHT || b.abs() > MAX_ABS_HEIGHT {
-                return None;
+            // Metres only. An integer sample is a raw step whose scale the file sets
+            // elsewhere, so judging it against a height in metres would throw out any
+            // 16-bit heightfield that happens to use most of its range.
+            if c.sample == Sample::F32 && (a.abs() > MAX_ABS_HEIGHT || b.abs() > MAX_ABS_HEIGHT) {
+                return Err("heights are implausibly far from sea level");
             }
             diff_total += (a - b).abs() as f64;
             diff_count += 1;
@@ -270,38 +274,131 @@ fn roughness(bytes: &[u8], c: &Candidate, stride: u32) -> Option<(f32, f32)> {
     }
 
     if diff_count == 0 {
-        return None;
+        return Err("no sample pairs to compare");
     }
-    Some(((diff_total / diff_count as f64) as f32, max - min))
+    Ok(((diff_total / diff_count as f64) as f32, max - min))
 }
 
-/// Score a candidate 0–1, or reject it.
-fn score(bytes: &[u8], c: &Candidate) -> Option<f32> {
+/// What the roughness test made of a candidate.
+enum Assessment {
+    /// Confidence 0–1, with the two measurements that produced it.
+    Ok { confidence: f32, rough_x: f32, rough_y: f32 },
+    /// Why it was thrown out. A short phrase, for the diagnostic report.
+    Rejected(&'static str),
+}
+
+/// Measure a candidate against the bytes.
+fn assess(bytes: &[u8], c: &Candidate) -> Assessment {
     let need = c.offset + c.width as usize * c.height as usize * c.sample.size();
     if need > bytes.len() {
-        return None;
+        return Assessment::Rejected("runs past the end of the file");
     }
 
-    let (dx, spread) = roughness(bytes, c, 1)?;
+    let (dx, spread) = match roughness(bytes, c, 1) {
+        Ok(v) => v,
+        Err(why) => return Assessment::Rejected(why),
+    };
     // A grid with no relief is either genuinely empty or a run of padding. Either way there
     // is nothing to show and nothing to validate against.
     if !(spread.is_finite() && spread > 0.0) {
-        return None;
+        return Assessment::Rejected("no relief at all");
     }
-    let (dy, _) = roughness(bytes, c, c.width)?;
+    let (dy, _) = match roughness(bytes, c, c.width) {
+        Ok(v) => v,
+        Err(why) => return Assessment::Rejected(why),
+    };
 
     // Both measured against the terrain's own relief, so the thresholds don't care whether
     // heights are metres or raw 16-bit steps.
     let rough_x = dx / spread;
     let rough_y = dy / spread;
-    if rough_x > MAX_ROUGHNESS || rough_y > MAX_ROUGHNESS {
-        return None;
+    if rough_x > MAX_ROUGHNESS {
+        return Assessment::Rejected("adjacent samples aren't neighbours (wrong type/offset)");
+    }
+    if rough_y > MAX_ROUGHNESS {
+        return Assessment::Rejected("rows aren't neighbours (wrong width)");
     }
 
     // How far inside the threshold it landed, worst axis first — a layout that only just
     // scraped in should not present itself as a confident read.
     let worst = rough_x.max(rough_y);
-    Some((1.0 - worst / MAX_ROUGHNESS).clamp(0.0, 1.0))
+    Assessment::Ok {
+        confidence: (1.0 - worst / MAX_ROUGHNESS).clamp(0.0, 1.0),
+        rough_x,
+        rough_y,
+    }
+}
+
+/// Score a candidate 0–1, or reject it.
+fn score(bytes: &[u8], c: &Candidate) -> Option<f32> {
+    match assess(bytes, c) {
+        Assessment::Ok { confidence, .. } => Some(confidence),
+        Assessment::Rejected(_) => None,
+    }
+}
+
+/// A human-readable account of what the probe made of `bytes`: every layout it considered,
+/// what each measured, and why the losers lost.
+///
+/// This exists because the format is undocumented. When a real height file doesn't read as
+/// terrain, "no terrain found" is not enough to act on — the useful question is which
+/// layouts were tried and how close each came, and that answer has to be obtainable from a
+/// machine that has the track on it rather than from the one holding this code.
+pub fn report(bytes: &[u8], hint: Option<(u32, u32)>) -> String {
+    use std::fmt::Write;
+
+    let mut out = String::new();
+    let _ = writeln!(out, "{} bytes, hint {hint:?}", bytes.len());
+
+    let all = candidates(bytes, hint);
+    if all.is_empty() {
+        out.push_str(
+            "no candidate layouts at all — the file size doesn't fit any grid this reads.\n",
+        );
+        return out;
+    }
+
+    // Accepted first and best-scoring at the top, since that's what the probe would pick;
+    // the near-misses that follow are what tell you how to widen the search.
+    let mut rows: Vec<(f32, String)> = Vec::new();
+    for c in &all {
+        let dims = format!(
+            "{:>5}x{:<5} {:?} @{:<6} [{}]",
+            c.width, c.height, c.sample, c.offset, c.source
+        );
+        match assess(bytes, c) {
+            Assessment::Ok {
+                confidence,
+                rough_x,
+                rough_y,
+            } => rows.push((
+                confidence,
+                format!("  OK   {dims} confidence {confidence:.2} (x {rough_x:.4}, y {rough_y:.4})"),
+            )),
+            Assessment::Rejected(why) => rows.push((-1.0, format!("  --   {dims} {why}"))),
+        }
+    }
+    rows.sort_by(|a, b| b.0.total_cmp(&a.0));
+
+    let _ = writeln!(out, "{} candidate layouts (threshold {MAX_ROUGHNESS}):", all.len());
+    for (_, line) in rows.iter().take(40) {
+        let _ = writeln!(out, "{line}");
+    }
+    if rows.len() > 40 {
+        let _ = writeln!(out, "  … {} more", rows.len() - 40);
+    }
+
+    match probe(bytes, hint) {
+        Some(l) => {
+            let _ = writeln!(
+                out,
+                "chose {}x{} {:?} at {} via {} (confidence {:.2})",
+                l.width, l.height, l.sample, l.offset, l.source, l.confidence
+            );
+        }
+        None => out.push_str("chose nothing — no layout read as terrain.\n"),
+    }
+    out
 }
 
 /// Recover the terrain grid in `bytes`, or `None` if nothing in it reads as terrain.
@@ -462,6 +559,25 @@ mod tests {
     }
 
     #[test]
+    fn recovers_a_16_bit_grid_that_uses_most_of_its_range() {
+        // Raw steps spanning nearly the whole 16-bit range — a packed heightfield with a
+        // fine vertical resolution. These are not metres, and judging them as if they were
+        // is what used to throw this out.
+        let heights = terrain(256, 256);
+        let lo = heights.iter().copied().fold(f32::INFINITY, f32::min);
+        let hi = heights.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        let mut bytes = Vec::new();
+        for v in &heights {
+            let step = ((v - lo) / (hi - lo) * 64_000.0) as u16;
+            bytes.extend_from_slice(&step.to_le_bytes());
+        }
+
+        let layout = probe(&bytes, None).expect("a full-range 16-bit grid should be recovered");
+        assert_eq!(layout.sample, Sample::U16);
+        assert_eq!((layout.width, layout.height), (256, 256));
+    }
+
+    #[test]
     fn takes_the_dimensions_hinted_by_the_ini() {
         let heights = terrain(384, 128);
         let bytes = with_header(&heights, &[0u8; 16]);
@@ -535,6 +651,30 @@ mod tests {
         let layout = probe(&bytes, None).unwrap();
         let (w, h, _) = read_grid(&bytes, &layout, 256);
         assert_eq!((w, h), (64, 64));
+    }
+
+    /// Point this at a real height file to see exactly what the probe makes of it:
+    ///
+    /// ```text
+    /// FROST_PROBE_FILE=/path/to/Track.trh \
+    ///   cargo test -- --ignored --nocapture probe_a_real_height_file
+    /// ```
+    ///
+    /// Optionally set `FROST_PROBE_DIMS=512x512` to feed it a shape hint. Ignored by
+    /// default because it needs a file this repository can't carry: the format is
+    /// undocumented, so the only way to confirm the probe reads a real track is to run it
+    /// against one, on a machine that has one.
+    #[test]
+    #[ignore = "needs a real height file — set FROST_PROBE_FILE"]
+    fn probe_a_real_height_file() {
+        let path = std::env::var("FROST_PROBE_FILE")
+            .expect("set FROST_PROBE_FILE to a .trh/.map to inspect");
+        let bytes = std::fs::read(&path).expect("read the height file");
+        let hint = std::env::var("FROST_PROBE_DIMS").ok().and_then(|v| {
+            let (w, h) = v.split_once(['x', 'X', ','])?;
+            Some((w.trim().parse().ok()?, h.trim().parse().ok()?))
+        });
+        println!("{path}\n{}", report(&bytes, hint));
     }
 
     #[test]

--- a/src-tauri/src/heightfield.rs
+++ b/src-tauri/src/heightfield.rs
@@ -177,9 +177,10 @@ fn isqrt(n: usize) -> usize {
 }
 
 /// Grids outside this are not terrain we can use: too small to show, or big enough that
-/// decoding it would cost more than the view is worth.
+/// decoding it would cost more than the view is worth. The ceiling is a power of two plus
+/// one because heightmaps are — the track guide's own examples run 2049² and 4097×257.
 const MIN_DIM: u32 = 32;
-const MAX_DIM: u32 = 8192;
+const MAX_DIM: u32 = 8193;
 
 /// The largest header we'll believe sits in front of the samples. Generous — the cost of a
 /// wrong guess is one rejected candidate, and a header this big is still cheap to skip.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -746,12 +746,13 @@ async fn load_track_terrain(
 /// nothing here worth failing a view over.
 #[tauri::command]
 async fn load_track_overview(
+    app: tauri::AppHandle,
     path: String,
     max_dim: u32,
 ) -> Result<tauri::ipc::Response, String> {
     tauri::async_runtime::spawn_blocking(move || {
-        let blob =
-            track::overview_blob(std::path::Path::new(&path), max_dim).unwrap_or_default();
+        let blob = track::overview_blob(&app, std::path::Path::new(&path), max_dim)
+            .unwrap_or_default();
         tauri::ipc::Response::new(blob)
     })
     .await

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -739,6 +739,26 @@ async fn load_track_terrain(
     .map_err(|e| format!("load_track_terrain task failed: {e}"))?
 }
 
+/// A track's overview map, to lay over its terrain.
+///
+/// Empty — not an error — when the track ships no map, or ships one that doesn't cover the
+/// same ground as its grid. A track without one draws on its relief alone, which is what
+/// every track did before this existed, so there is nothing here worth failing a view over.
+#[tauri::command]
+async fn load_track_overview(
+    path: String,
+    max_dim: u32,
+    grid_aspect: f32,
+) -> Result<tauri::ipc::Response, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let blob = track::overview_blob(std::path::Path::new(&path), max_dim, grid_aspect)
+            .unwrap_or_default();
+        tauri::ipc::Response::new(blob)
+    })
+    .await
+    .map_err(|e| format!("load_track_overview task failed: {e}"))
+}
+
 #[tauri::command]
 async fn unpack_paint(path: String) -> Result<Vec<paint::PaintTexture>, String> {
     tauri::async_runtime::spawn_blocking(move || unpack_paint_blocking(path))
@@ -5651,6 +5671,7 @@ fn main() {
             get_pkz_preview,
             read_track_info,
             load_track_terrain,
+            load_track_overview,
             diagnose_track,
             unpack_paint,
             texture_bytes,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -706,6 +706,18 @@ async fn read_track_info(app: tauri::AppHandle, path: String) -> Result<track::T
     .map_err(|e| format!("read_track_info task failed: {e}"))?
 }
 
+/// A plain-text account of what a track's terrain looks like to the reader.
+///
+/// Shown in the viewer when a track's terrain won't load. The height format is undocumented,
+/// so a track that fails is evidence we don't otherwise have — and the player holding it is
+/// rarely the person who can rebuild the app to investigate.
+#[tauri::command]
+async fn diagnose_track(path: String) -> Result<String, String> {
+    tauri::async_runtime::spawn_blocking(move || track::diagnose(std::path::Path::new(&path)))
+        .await
+        .map_err(|e| format!("diagnose_track task failed: {e}"))
+}
+
 /// A track's terrain grid, at no more than `max_dim` samples on its longest edge.
 ///
 /// Returned as raw bytes rather than JSON: a grid is a few hundred thousand floats, and
@@ -5639,6 +5651,7 @@ fn main() {
             get_pkz_preview,
             read_track_info,
             load_track_terrain,
+            diagnose_track,
             unpack_paint,
             texture_bytes,
             unpack_pkz,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -14,6 +14,7 @@ mod frostmod_manage;
 mod game;
 mod gameproc;
 mod gearrepair;
+mod heightfield;
 mod imgcache;
 mod install;
 mod library;
@@ -43,6 +44,7 @@ mod shop_installed;
 mod shop_session;
 mod soundmods;
 mod texstore;
+mod track;
 mod upload;
 mod vcruntime;
 mod winehost;
@@ -691,6 +693,38 @@ async fn get_pkz_preview(path: String) -> Result<Option<String>, String> {
 
 fn get_pkz_preview_blocking(path: String) -> Result<Option<String>, String> {
     pkz::read_preview(std::path::Path::new(&path)).map_err(|e| format!("{e:#}"))
+}
+
+/// A track's metadata and contents. Cheap by construction — nothing is inflated — so the
+/// track view can paint everything except the terrain immediately.
+#[tauri::command]
+async fn read_track_info(app: tauri::AppHandle, path: String) -> Result<track::TrackInfo, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        track::read_info(&app, &path).map_err(|e| format!("{e:#}"))
+    })
+    .await
+    .map_err(|e| format!("read_track_info task failed: {e}"))?
+}
+
+/// A track's terrain grid, at no more than `max_dim` samples on its longest edge.
+///
+/// Returned as raw bytes rather than JSON: a grid is a few hundred thousand floats, and
+/// serialising that as a JSON array costs more than reading it out of the archive did. The
+/// app reads the header described in [`track::BLOB_HEADER`] and takes the rest in place.
+#[tauri::command]
+async fn load_track_terrain(
+    app: tauri::AppHandle,
+    path: String,
+    max_dim: u32,
+) -> Result<tauri::ipc::Response, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let master = track::load_master(&app, &path).map_err(|e| format!("{e:#}"))?;
+        Ok(tauri::ipc::Response::new(track::terrain_blob(
+            &master, max_dim,
+        )))
+    })
+    .await
+    .map_err(|e| format!("load_track_terrain task failed: {e}"))?
 }
 
 #[tauri::command]
@@ -5603,6 +5637,8 @@ fn main() {
             get_pkz_meta_cached,
             get_pkz_meta,
             get_pkz_preview,
+            read_track_info,
+            load_track_terrain,
             unpack_paint,
             texture_bytes,
             unpack_pkz,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -739,20 +739,19 @@ async fn load_track_terrain(
     .map_err(|e| format!("load_track_terrain task failed: {e}"))?
 }
 
-/// A track's overview map, to lay over its terrain.
+/// A picture of a track's surfaces, to lay over its terrain.
 ///
-/// Empty — not an error — when the track ships no map, or ships one that doesn't cover the
-/// same ground as its grid. A track without one draws on its relief alone, which is what
-/// every track did before this existed, so there is nothing here worth failing a view over.
+/// Empty — not an error — when the track's height file carries no coverage masks. That track
+/// draws on its relief alone, which is what every track did before this existed, so there is
+/// nothing here worth failing a view over.
 #[tauri::command]
 async fn load_track_overview(
     path: String,
     max_dim: u32,
-    grid_aspect: f32,
 ) -> Result<tauri::ipc::Response, String> {
     tauri::async_runtime::spawn_blocking(move || {
-        let blob = track::overview_blob(std::path::Path::new(&path), max_dim, grid_aspect)
-            .unwrap_or_default();
+        let blob =
+            track::overview_blob(std::path::Path::new(&path), max_dim).unwrap_or_default();
         tauri::ipc::Response::new(blob)
     })
     .await

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -392,6 +392,75 @@ fn resample(master: &Master, max_dim: u32) -> (u32, u32, Vec<f32>) {
     (out_w as u32, out_h as u32, out)
 }
 
+/// An account of what this track's terrain looks like to the reader, in plain text.
+///
+/// The height format is undocumented, so "no terrain to show" is not something a player —
+/// or whoever has to fix the reader — can act on. This is the answer that is actually
+/// useful: what the track contains, what its `.ini` claimed, every layout the probe
+/// considered for each candidate file, and what it settled on. Surfaced in the viewer when
+/// a track won't load, so diagnosing a format we've never seen needs nothing but the app.
+pub fn diagnose(path: &Path) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+
+    let names = match entry_names(path) {
+        Ok(n) => n,
+        Err(e) => return format!("couldn't list {path:?}: {e:#}"),
+    };
+    let _ = writeln!(out, "{}\n{} entries", path.display(), names.len());
+    for n in &names {
+        let role = role_of(n);
+        if !matches!(role, "other" | "image") {
+            let _ = writeln!(out, "  [{role:<11}] {n}");
+        }
+    }
+
+    let ini = ini_text(path, &names);
+    let (hint, scale) = ini.as_deref().map(ini_hints).unwrap_or((None, None));
+    let _ = writeln!(out, "ini dimensions {hint:?}, spacing {scale:?}");
+
+    let heightfields = heightfield_entries(&names);
+    if heightfields.is_empty() {
+        out.push_str("no heightfield-looking entries — nothing for the probe to read\n");
+    }
+    for entry in heightfields {
+        let _ = writeln!(out, "\n--- {entry} ---");
+        match read_entry(path, &entry) {
+            // The first bytes are worth having verbatim: if the probe found nothing, a magic
+            // string or a dimension pair in here is what tells us how to widen it.
+            Ok(bytes) => {
+                let _ = writeln!(out, "first bytes: {}", hex_preview(&bytes, 64));
+                let _ = writeln!(out, "{}", heightfield::report(&bytes, hint));
+            }
+            Err(e) => {
+                let _ = writeln!(out, "couldn't read it: {e:#}");
+            }
+        }
+    }
+
+    match decode_master(path) {
+        Ok(m) => {
+            let _ = writeln!(out, "\nterrain: {:#?}", m.info);
+        }
+        Err(e) => {
+            let _ = writeln!(out, "\nno terrain: {e:#}");
+        }
+    }
+    out
+}
+
+/// The leading bytes as hex and printable ASCII — the one view of an unknown format that is
+/// always worth having, since a magic string or a stated dimension shows up here or nowhere.
+fn hex_preview(bytes: &[u8], count: usize) -> String {
+    let take = bytes.len().min(count);
+    let hex: Vec<String> = bytes[..take].iter().map(|b| format!("{b:02x}")).collect();
+    let ascii: String = bytes[..take]
+        .iter()
+        .map(|b| if b.is_ascii_graphic() { *b as char } else { '.' })
+        .collect();
+    format!("{}  |{ascii}|", hex.join(" "))
+}
+
 // ---------------------------------------------------------------------------
 // Caches
 // ---------------------------------------------------------------------------
@@ -537,37 +606,14 @@ mod tests {
     #[ignore = "needs a real track — set FROST_TRACK"]
     fn read_a_real_track() {
         let path = std::env::var("FROST_TRACK").expect("set FROST_TRACK to a track .pkz/folder");
-        let p = Path::new(&path);
+        println!("{}", diagnose(Path::new(&path)));
+    }
 
-        let names = entry_names(p).expect("list the track's entries");
-        println!("{path}\n{} entries", names.len());
-        for n in &names {
-            let role = role_of(n);
-            if !matches!(role, "other" | "image") {
-                println!("  [{role:<11}] {n}");
-            }
-        }
-
-        let ini = ini_text(p, &names);
-        let (hint, scale) = ini.as_deref().map(ini_hints).unwrap_or((None, None));
-        println!("ini dimensions {hint:?}, spacing {scale:?}");
-
-        let heightfields = heightfield_entries(&names);
-        if heightfields.is_empty() {
-            println!("no heightfield-looking entries — nothing for the probe to read");
-        }
-        for entry in heightfields {
-            println!("\n--- {entry} ---");
-            match read_entry(p, &entry) {
-                Ok(bytes) => println!("{}", heightfield::report(&bytes, hint)),
-                Err(e) => println!("couldn't read it: {e:#}"),
-            }
-        }
-
-        match decode_master(p) {
-            Ok(m) => println!("\nterrain: {:#?}", m.info),
-            Err(e) => println!("\nno terrain: {e:#}"),
-        }
+    #[test]
+    fn a_hex_preview_shows_bytes_and_their_ascii() {
+        let line = hex_preview(b"TRH\0\x01\x02", 64);
+        assert!(line.starts_with("54 52 48 00 01 02"), "{line}");
+        assert!(line.ends_with("|TRH...|"), "{line}");
     }
 
     #[test]

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -34,17 +34,18 @@ const CACHE_DIR: &str = "track-terrain-v2";
 /// only grows with tracks actually opened.
 const CACHE_KEEP: usize = 64;
 
-/// Files that carry a terrain grid, best first. The probe validates whatever it is handed,
-/// so trying several costs only the read of the ones that don't pan out.
-const HEIGHTFIELD_EXTS: [&str; 3] = ["trh", "map", "hf"];
+/// Files that carry a terrain grid. Just the one: PiBoSo's track guide has `.trh` as the
+/// collision terrain and `.map` as the track *graphics*, so probing a `.map` would mean
+/// inflating the largest file in the archive to discover it was never a heightfield.
+const HEIGHTFIELD_EXTS: [&str; 1] = ["trh"];
 
 /// What a track file is for, as far as the UI is concerned. A key, not prose — the app
 /// translates it.
 fn role_of(name: &str) -> &'static str {
     let ext = name.rsplit('.').next().unwrap_or("").to_ascii_lowercase();
     match ext.as_str() {
-        "trh" | "hf" => "heightfield",
-        "map" => "terrain",
+        "trh" => "heightfield",
+        "map" => "graphics",
         "tsc" => "scenery",
         "rdf" => "road",
         "ssc" => "surfaces",
@@ -180,10 +181,8 @@ fn heightfield_entries(names: &[String]) -> Vec<String> {
 /// itself that the shape reads as terrain. Keys vary between track tools, so this stays
 /// deliberately loose about where it finds them.
 fn ini_hints(text: &str) -> (Option<(u32, u32)>, Option<f32>) {
-    let mut w: Option<u32> = None;
-    let mut h: Option<u32> = None;
-    let mut square: Option<u32> = None;
-    let mut scale: Option<f32> = None;
+    let mut samples: (Option<u32>, Option<u32>) = (None, None);
+    let mut metres: (Option<f32>, Option<f32>) = (None, None);
 
     for line in text.lines() {
         let line = line.trim();
@@ -196,22 +195,31 @@ fn ini_hints(text: &str) -> (Option<(u32, u32)>, Option<f32>) {
         let key = key.trim().to_ascii_lowercase();
         let value = value.trim();
         match key.as_str() {
-            "width" | "nx" | "cx" | "xsize" | "size_x" => w = value.parse().ok(),
-            "height" | "ny" | "cy" | "ysize" | "size_y" => h = value.parse().ok(),
-            // A single figure means a square grid.
-            "size" | "resolution" | "grid" => square = value.parse().ok(),
-            "scale" | "step" | "spacing" | "cell" | "cellsize" => {
-                scale = value.parse().ok().filter(|v: &f32| *v > 0.0 && *v < 1000.0)
-            }
+            // The grid, in samples.
+            "samples_x" | "nx" | "width" => samples.0 = value.parse().ok(),
+            "samples_y" | "ny" | "height" => samples.1 = value.parse().ok(),
+            // The ground it covers, in metres. Deliberately not treated as a sample count:
+            // `size_x` is the track's width in metres, and reading it as a grid width is
+            // how a 480 m track becomes a 480-sample one.
+            "size_x" => metres.0 = value.parse().ok(),
+            "size_z" | "size_y" => metres.1 = value.parse().ok(),
+            // `scale` is the total height of the terrain in metres, not a spacing. Nothing
+            // here uses it — the height file carries its own — but naming it keeps the next
+            // reader from adopting it as one.
             _ => {}
         }
     }
 
-    let dims = match (w, h) {
-        (Some(w), Some(h)) => Some((w, h)),
-        _ => square.map(|s| (s, s)),
+    let dims = match samples {
+        (Some(w), Some(h)) if w >= 2 && h >= 2 => Some((w, h)),
+        _ => None,
     };
-    (dims, scale)
+    // Spacing is the two together: metres across, divided by the steps between samples.
+    let spacing = match (dims, metres.0) {
+        (Some((w, _)), Some(x)) if x > 0.0 => Some(x / (w - 1) as f32),
+        _ => None,
+    };
+    (dims, spacing)
 }
 
 /// The track's top-level `.ini` text, if it has one worth reading.
@@ -631,6 +639,8 @@ mod tests {
     #[test]
     fn roles_come_from_the_extension() {
         assert_eq!(role_of("Hangtown/Hangtown.trh"), "heightfield");
+        // Track *graphics*, not height data — so never a heightfield candidate.
+        assert_eq!(role_of("Hangtown/Hangtown.map"), "graphics");
         assert_eq!(role_of("Hangtown/Hangtown.tsc"), "scenery");
         assert_eq!(role_of("Hangtown/Hangtown.ini"), "config");
         assert_eq!(role_of("Hangtown/preview.jpg"), "image");
@@ -640,13 +650,17 @@ mod tests {
     }
 
     #[test]
-    fn heightfields_are_offered_best_first() {
+    fn only_the_trh_is_offered_as_a_heightfield() {
         let names = vec![
             "T/T.map".to_string(),
             "T/T.ini".to_string(),
             "T/T.trh".to_string(),
         ];
-        assert_eq!(heightfield_entries(&names), vec!["T/T.trh", "T/T.map"]);
+        assert_eq!(
+            heightfield_entries(&names),
+            vec!["T/T.trh"],
+            "a .map is graphics — inflating it to probe would cost the most for nothing",
+        );
     }
 
     #[test]
@@ -671,29 +685,40 @@ mod tests {
     }
 
     #[test]
-    fn ini_hints_read_paired_dimensions() {
-        let (dims, scale) = ini_hints("[terrain]\nnx = 512\nny = 256\nscale = 0.5\n");
-        assert_eq!(dims, Some((512, 256)));
-        assert_eq!(scale, Some(0.5));
+    fn ini_hints_read_a_terrain_ini() {
+        // The shape the track creation guide documents.
+        let (dims, spacing) = ini_hints(
+            "samples_x = 2049\nsamples_y = 2049\ndata = heightmap.raw\n\
+             size_x = 480\nsize_z = 480\nscale = 3.2\n",
+        );
+        assert_eq!(dims, Some((2049, 2049)));
+        // 480 m across 2048 steps.
+        let spacing = spacing.expect("size and samples together give a spacing");
+        assert!((spacing - 480.0 / 2048.0).abs() < 1e-6, "got {spacing}");
     }
 
     #[test]
-    fn ini_hints_read_a_single_square_size() {
-        let (dims, _) = ini_hints("[terrain]\nsize=1024\n");
-        assert_eq!(dims, Some((1024, 1024)));
+    fn ini_hints_dont_read_metres_as_a_sample_count() {
+        // `size_x` is the track's width in metres. Taken for a grid width it would turn a
+        // 480 m track into a 480-sample one, which is the kind of wrong that still renders.
+        let (dims, spacing) = ini_hints("size_x = 480\nsize_z = 480\n");
+        assert_eq!(dims, None, "metres are not samples");
+        assert_eq!(spacing, None, "spacing needs a sample count to divide by");
+    }
+
+    #[test]
+    fn ini_hints_dont_take_scale_for_a_spacing() {
+        // `scale` is the terrain's total height in metres. It is not metres-per-sample, and
+        // a viewer that used it as one would draw the ground at a fraction of its size.
+        let (_, spacing) = ini_hints("samples_x = 2049\nsamples_y = 2049\nscale = 3.2\n");
+        assert_eq!(spacing, None);
     }
 
     #[test]
     fn ini_hints_ignore_a_track_that_says_nothing() {
-        let (dims, scale) = ini_hints("[info]\nname = Hangtown\n");
+        let (dims, spacing) = ini_hints("[info]\nname = Hangtown\n");
         assert_eq!(dims, None);
-        assert_eq!(scale, None);
-    }
-
-    #[test]
-    fn ini_hints_reject_an_absurd_scale() {
-        let (_, scale) = ini_hints("[terrain]\nscale = 99999\n");
-        assert_eq!(scale, None, "a kilometre-wide sample is a misread, not a hint");
+        assert_eq!(spacing, None);
     }
 
     /// A master built from a known grid, for the blob and resample tests.

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -19,11 +19,13 @@ use std::path::{Path, PathBuf};
 
 use crate::heightfield::{self, Layout};
 
-/// The resolution the master grid is kept at. Chosen against the ground rather than the
-/// screen: a track is a few hundred metres across, and at 512 one sample stood for more than
-/// a metre — wider than the jump faces and ruts that make a track readable, so they were
-/// averaged away before the viewer ever saw them.
-const MASTER_DIM: u32 = 1024;
+/// The resolution the master grid is kept at.
+///
+/// Every published track measured has a 2049- or 4097-sample heightfield, and this is the
+/// power of two under that — so for the common case the master is the file's own grid with
+/// nothing averaged away. Anything less throws away detail before the viewer can ask for it:
+/// at 1024 a sample of a 600 m track stood for 0.6 m, wider than the lip of a jump.
+const MASTER_DIM: u32 = 2048;
 
 /// Cache generation. Bump when the blob layout or the probe changes shape, so entries
 /// written by an older build are ignored rather than misread.
@@ -33,11 +35,13 @@ const MASTER_DIM: u32 = 1024;
 // coarser grid for as long as it stayed cached.
 // v4: `.trh` samples are read signed, so every height below the datum has moved — a v3 entry
 // holds the ground below a track standing as a wall around it.
-const CACHE_DIR: &str = "track-terrain-v4";
+// v5: masters are kept at the source's own resolution; a v4 entry would pin a track to half
+// of it for as long as it stayed cached.
+const CACHE_DIR: &str = "track-terrain-v5";
 
-/// How many cached masters to keep. Four megabytes each at [`MASTER_DIM`], so this holds the
-/// same budget the smaller grid did rather than quadrupling what the cache costs on disk.
-const CACHE_KEEP: usize = 16;
+/// How many cached masters to keep. Sixteen megabytes each at [`MASTER_DIM`], so this is kept
+/// small deliberately — the cache saves a second of archive reading, not a scarce resource.
+const CACHE_KEEP: usize = 6;
 
 /// Files that carry a terrain grid. Just the one: PiBoSo's track guide has `.trh` as the
 /// collision terrain and `.map` as the track *graphics*, so probing a `.map` would mean
@@ -394,27 +398,37 @@ pub const BLOB_HEADER: usize = 32;
 /// [`BLOB_HEADER`].
 pub const TEXTURE_HEADER: usize = 16;
 
-/// Surface colours, in the order surfaces are ranked by how much of the track they cover.
-///
-/// Keyed to rank rather than to the id in the file, because that id cannot be resolved to a
-/// material: every track examined carries the same six names (asphalt, grass, sand, kerb,
-/// soil, concrete) byte for byte, so that table is a default the editor writes, and the masks
-/// reference ids past the end of it. Colouring by it put a farm's fields down as soil.
-///
-/// Rank is a property of the track rather than a guess about the format: what covers the most
-/// ground is the vegetation the circuit is cut through, on every track examined, so it leads.
-/// The rest descend through the surfaces a track is built from — apron, dirt, hard standing.
-const SURFACE_RANK_COLOURS: [[u8; 3]; 6] = [
-    [104, 132, 74],  // the ground it's all cut through — grass
-    [206, 188, 142], // apron / sand
-    [138, 108, 74],  // worked soil
-    [128, 128, 132], // hard standing
-    [122, 140, 88],  // rougher vegetation
-    [150, 122, 86],
-];
+/// Bump when [`surface_colour`] changes, so cached textures drawn with the old palette are
+/// retired rather than kept.
+const SURFACE_SCHEME: u32 = 1;
 
-fn surface_colour(rank: usize) -> [u8; 3] {
-    SURFACE_RANK_COLOURS[rank.min(SURFACE_RANK_COLOURS.len() - 1)]
+/// The colour of a surface, by the id the track states for it.
+///
+/// The ids below six index the material table every track carries — asphalt, grass, sand,
+/// kerb, soil, concrete — and they are trustworthy: Briarcliff paints its surroundings as id
+/// 1 and its table calls that grass, which is exactly what the ground there is. So a farm's
+/// fields come out as the soil they are and a grass circuit comes out green, rather than
+/// every track being coloured by which surface happened to cover the most of it.
+///
+/// Ids past the table appear across unrelated tracks — 10 and 12 — so they name surfaces
+/// from a list the file doesn't carry. 10 is the riding line itself: it is the ribbon on
+/// Briarcliff and the dominant surface on I40. It gets a worked-dirt colour on that evidence;
+/// the rest get something neutral rather than a guess dressed up as a fact.
+///
+/// Hues are kept apart on purpose. Half of these are browns, and a track whose surfaces are
+/// all a similar brown reads as one flat surface no matter how correct each colour is.
+fn surface_colour(id: u32) -> [u8; 3] {
+    match id {
+        0 => [84, 86, 92],     // asphalt — cold, dark
+        1 => [98, 132, 66],    // grass — the only green
+        2 => [216, 198, 152],  // sand — pale, warm
+        3 => [186, 146, 92],   // kerb — tan, between sand and soil
+        4 => [138, 100, 62],   // soil — mid brown
+        5 => [158, 156, 150],  // concrete — light, neutral
+        10 => [122, 78, 52],   // the riding line — darkest, reddest
+        12 => [112, 120, 92],  // olive, so it parts from both grass and soil
+        _ => [126, 114, 96],
+    }
 }
 
 /// Where the terrain data stops and the material table begins.
@@ -493,7 +507,35 @@ fn coverage_masks(block: &[u8]) -> Vec<Coverage> {
 ///
 /// Each cell takes the colour of whichever surface covers it most; cells nothing covers are
 /// left as bare dirt, which is exactly what the riding line is.
-pub fn overview_blob(path: &Path, max_dim: u32) -> Option<Vec<u8>> {
+pub fn overview_blob(app: &tauri::AppHandle, path: &Path, max_dim: u32) -> Option<Vec<u8>> {
+    // Cached beside the master, and for the same reason: building it is milliseconds, but
+    // pulling the height file out of a several-hundred-megabyte archive to get at the masks
+    // is most of a second, and that read has already happened once for the terrain.
+    // The scheme number is part of the key, so changing how surfaces are coloured retires
+    // every cached texture on its own. Without it a track keeps whatever colours it was first
+    // drawn with, and the change only shows on machines that had never opened it.
+    let key = stamp(&path.to_string_lossy())
+        .ok()
+        .map(|st| format!("{}:tex{max_dim}v{SURFACE_SCHEME}", cache_key(&path.to_string_lossy(), st)));
+    if let Some(f) = key.as_deref().and_then(|k| cache_file(app, k)) {
+        if let Ok(bytes) = std::fs::read(&f) {
+            if bytes.len() > TEXTURE_HEADER && bytes.starts_with(b"FTEX") {
+                return Some(bytes);
+            }
+        }
+    }
+
+    let built = build_surface_blob(path, max_dim)?;
+    if let Some(f) = key.as_deref().and_then(|k| cache_file(app, k)) {
+        if let Some(parent) = f.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::write(&f, &built);
+    }
+    Some(built)
+}
+
+fn build_surface_blob(path: &Path, max_dim: u32) -> Option<Vec<u8>> {
     let names = entry_names(path).ok()?;
     let entry = heightfield_entries(&names).into_iter().next()?;
     let bytes = read_entry(path, &entry).ok()?;
@@ -507,32 +549,14 @@ pub fn overview_blob(path: &Path, max_dim: u32) -> Option<Vec<u8>> {
         return None;
     }
 
-    // Ranked by how much ground each covers, sampled rather than summed in full — a dozen
-    // masks of four million cells is a lot of adding to decide an ordering.
-    let mut ranked: Vec<(usize, u64)> = masks
-        .iter()
-        .enumerate()
-        .map(|(i, m)| {
-            let cells = m.width as usize * m.height as usize;
-            let total: u64 = (0..cells)
-                .step_by(97)
-                .filter_map(|c| block.get(m.at + c))
-                .map(|&v| v as u64)
-                .sum();
-            (i, total)
-        })
-        .collect();
-    ranked.sort_by(|a, b| b.1.cmp(&a.1));
-    let mut rank_of = vec![0usize; masks.len()];
-    for (rank, (i, _)) in ranked.iter().enumerate() {
-        rank_of[*i] = rank;
-    }
-
     let src_w = masks[0].width as usize;
     let src_h = masks[0].height as usize;
     let scale = (src_w.max(src_h) as f32 / max_dim.max(1) as f32).ceil().max(1.0) as usize;
     let out_w = src_w.div_ceil(scale);
     let out_h = src_h.div_ceil(scale);
+    // At least two cells across even when drawing a mask at its own resolution, so the dither
+    // is resolved rather than reproduced.
+    let window = scale.max(2);
 
     // Bare dirt, for everything no surface was painted over.
     const BARE: [u8; 3] = [124, 96, 70];
@@ -540,23 +564,60 @@ pub fn overview_blob(path: &Path, max_dim: u32) -> Option<Vec<u8>> {
     let mut px = Vec::with_capacity(out_w * out_h * 4);
     for y in 0..out_h {
         for x in 0..out_w {
-            let mut best = 0u8;
+            // The surface that covers this cell most, at its own colour rather than mixed
+            // toward the bare ground beneath it. Weighting by coverage instead reads as
+            // honest and looks like mud: these masks are dithered, so even a patch meant to
+            // be solid grass averages to about half strength, and mixing that with dirt
+            // leaves the whole track a flat brown with nothing to pick features out by.
+            let mut best = 0u32;
             let mut colour = BARE;
             for (i, m) in masks.iter().enumerate() {
-                // Masks may differ in size from one another; sample each in its own space.
                 let mx = x * scale * m.width as usize / src_w.max(1);
                 let my = y * scale * m.height as usize / src_h.max(1);
-                let Some(&v) = block.get(m.at + my.min(m.height as usize - 1) * m.width as usize
-                    + mx.min(m.width as usize - 1))
-                else {
-                    continue;
-                };
+
+                // Averaged over a small window, never a single cell: a dithered mask stores a
+                // half-covered patch as cells alternating between nothing and everything, so
+                // one cell answers 0 or 255 where the truth is in between, and reading it
+                // straight turns every soft edge into salt and pepper.
+                let mut sum = 0u32;
+                let mut count = 0u32;
+                for dy in 0..window {
+                    for dx in 0..window {
+                        let sx = (mx + dx).min(m.width as usize - 1);
+                        let sy = (my + dy).min(m.height as usize - 1);
+                        if let Some(&v) = block.get(m.at + sy * m.width as usize + sx) {
+                            sum += v as u32;
+                            count += 1;
+                        }
+                    }
+                }
+                let v = if count == 0 { 0 } else { sum / count };
                 if v > best {
                     best = v;
-                    colour = surface_colour(rank_of[i]);
+                    colour = surface_colour(m.id);
                 }
             }
-            px.extend_from_slice(&colour);
+            // Only where genuinely nothing was painted does the bare ground show — that is
+            // the riding line, and it should read as dirt rather than as a gap.
+            if best < 10 {
+                colour = BARE;
+            }
+
+            // A little grain so ground reads as ground rather than as paint — gentle, and in
+            // patches rather than per cell. Single-cell noise is white noise: at any real
+            // zoom it stops reading as dirt and starts reading as broken pixels, and it
+            // fights the shading that the relief is supposed to be read by. Hashed from the
+            // patch so it is stable — the same track redrawn is the same dirt.
+            let n = {
+                let mut v = (x as u32 / 3).wrapping_mul(374_761_393)
+                    ^ (y as u32 / 3).wrapping_mul(668_265_263);
+                v ^= v >> 13;
+                v = v.wrapping_mul(1_274_126_177);
+                ((v >> 16 & 0xff) as f32 / 255.0 - 0.5) * 0.05
+            };
+            for k in 0..3 {
+                px.push((colour[k] as f32 * (1.0 + n)).clamp(0.0, 255.0) as u8);
+            }
             px.push(255);
         }
     }
@@ -858,7 +919,7 @@ mod tests {
             }
         }
 
-        match overview_blob(path, 1024) {
+        match build_surface_blob(path, 1024) {
             Some(b) => {
                 let w = u32::from_le_bytes(b[8..12].try_into().unwrap());
                 let h = u32::from_le_bytes(b[12..16].try_into().unwrap());
@@ -1008,15 +1069,26 @@ mod tests {
     }
 
     #[test]
-    fn every_rank_has_its_own_colour_and_ranks_beyond_the_last_still_answer() {
-        let all: Vec<[u8; 3]> = (0..SURFACE_RANK_COLOURS.len()).map(surface_colour).collect();
-        for (i, a) in all.iter().enumerate() {
-            for b in &all[i + 1..] {
-                assert_ne!(a, b, "two surfaces sharing a colour cannot be told apart");
+    fn each_named_surface_is_told_apart_from_the_others() {
+        // The six the table names, plus the riding line. Half of them are browns, and a
+        // track whose surfaces share a colour reads as one flat surface however correct
+        // each one is on its own.
+        let ids = [0u32, 1, 2, 3, 4, 5, 10];
+        for (n, &a) in ids.iter().enumerate() {
+            for &b in &ids[n + 1..] {
+                let (x, y) = (surface_colour(a), surface_colour(b));
+                let apart: i32 = (0..3).map(|k| (x[k] as i32 - y[k] as i32).abs()).sum();
+                assert!(apart > 40, "surfaces {a} and {b} look alike: {x:?} vs {y:?}");
             }
         }
-        // A track may paint more surfaces than there are colours; that must not panic.
-        assert_eq!(surface_colour(99), *SURFACE_RANK_COLOURS.last().unwrap());
+    }
+
+    #[test]
+    fn a_surface_the_file_does_not_name_still_gets_a_colour() {
+        // Ids past the table turn up on real tracks, and one that panicked or came back
+        // black would be worse than one that is merely approximate.
+        assert_ne!(surface_colour(200), [0, 0, 0]);
+        assert_eq!(surface_colour(200), surface_colour(201));
     }
 
     #[test]
@@ -1218,6 +1290,10 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 }
+
+
+
+
 
 
 

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -46,6 +46,7 @@ fn role_of(name: &str) -> &'static str {
         "tsc" => "scenery",
         "rdf" => "road",
         "ssc" => "surfaces",
+        "amb" => "ambience",
         "ini" | "cfg" => "config",
         "edf" => "model",
         "jpg" | "jpeg" | "png" | "dds" | "tga" | "bmp" => "image",
@@ -622,6 +623,8 @@ mod tests {
         assert_eq!(role_of("Hangtown/Hangtown.tsc"), "scenery");
         assert_eq!(role_of("Hangtown/Hangtown.ini"), "config");
         assert_eq!(role_of("Hangtown/preview.jpg"), "image");
+        assert_eq!(role_of("localcross.amb"), "ambience");
+        assert_eq!(role_of("gfx.cfg"), "config");
         assert_eq!(role_of("Hangtown/notes.txt"), "other");
     }
 
@@ -639,6 +642,21 @@ mod tests {
     fn a_track_with_no_heightfield_offers_nothing() {
         let names = vec!["T/T.ini".to_string(), "T/preview.jpg".to_string()];
         assert!(heightfield_entries(&names).is_empty());
+    }
+
+    /// A real MX Bikes track's descriptor, straight out of a published `.pkz`.
+    const REAL_INI: &str = include_str!("fixtures/localcross.ini");
+
+    #[test]
+    fn a_real_track_ini_offers_the_probe_nothing() {
+        // This matters more than it looks. A published track's `.ini` describes the race —
+        // name, weather, photo pose — and says nothing whatever about the terrain grid. So
+        // the `ini` hint path is close to dead in practice, and the probe has to recover the
+        // shape from the height file itself. Anything that reads dimensions out of here is
+        // inventing them.
+        let (dims, scale) = ini_hints(REAL_INI);
+        assert_eq!(dims, None, "a real track states no grid dimensions");
+        assert_eq!(scale, None, "a real track states no sample spacing");
     }
 
     #[test]

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -394,83 +394,6 @@ pub const BLOB_HEADER: usize = 32;
 /// [`BLOB_HEADER`].
 pub const TEXTURE_HEADER: usize = 16;
 
-/// How far a texture's proportions may differ from the grid's and still be believed to cover
-/// the same ground. A map is drawn to the track's footprint, so it matches closely or it is
-/// not a map of it.
-const ASPECT_TOLERANCE: f32 = 0.02;
-
-/// The entry holding a picture of the track *as ground*, if the track ships one.
-///
-/// Tracks carry two picture slots in `[ui]`, and only one of them is a map: `pic` is the
-/// artwork shown while the track loads — a photograph, usually with the track's name across
-/// it — while `pic_info` is the overhead view. The ARL packs name them exactly that way,
-/// `track_image` against `track_map`.
-///
-/// An author who fills both slots with the same file has supplied artwork twice rather than
-/// a map, so that is read as having no map at all. Stretching a photograph of a truck over
-/// the terrain would be worse than the plain relief it replaced.
-fn overview_entry(names: &[String], ini: Option<&str>) -> Option<String> {
-    let text = ini?;
-    let value = |key: &str| -> Option<String> {
-        for line in text.lines() {
-            // Section headers and blanks are simply not `key = value` lines, so skip them
-            // rather than letting one end the search.
-            let Some((k, v)) = line.trim().split_once('=') else {
-                continue;
-            };
-            if k.trim().eq_ignore_ascii_case(key) {
-                let v = v.trim();
-                return (!v.is_empty()).then(|| v.to_string());
-            }
-        }
-        None
-    };
-
-    let map = value("pic_info")?;
-    if value("pic").is_some_and(|p| p.eq_ignore_ascii_case(&map)) {
-        return None;
-    }
-
-    // The `.ini` names the file, not its path inside the archive.
-    let want = map.to_ascii_lowercase();
-    names
-        .iter()
-        .find(|n| {
-            n.rsplit('/')
-                .next()
-                .unwrap_or(n)
-                .to_ascii_lowercase()
-                == want
-        })
-        .cloned()
-}
-
-/// Decode one named picture out of a track.
-///
-/// The format is taken from the entry's extension before the bytes are consulted, because a
-/// `.tga` can't be recognised any other way: TGA carries no leading magic, so guessing from
-/// content silently fails on every one of them — which would leave only the DDS tracks
-/// textured while looking like the maps simply weren't there.
-fn decode_overview(path: &Path, entry: &str) -> Option<image::DynamicImage> {
-    let bytes = read_entry(path, entry).ok()?;
-    let mut reader = image::ImageReader::new(std::io::Cursor::new(&bytes));
-    match entry
-        .rsplit('.')
-        .next()
-        .and_then(image::ImageFormat::from_extension)
-    {
-        Some(format) => reader.set_format(format),
-        None => reader = reader.with_guessed_format().ok()?,
-    }
-    match reader.decode() {
-        Ok(img) => Some(img),
-        Err(e) => {
-            log::info!("track overview {entry} didn't decode: {e}");
-            None
-        }
-    }
-}
-
 /// Surface colours, in the order surfaces are ranked by how much of the track they cover.
 ///
 /// Keyed to rank rather than to the id in the file, because that id cannot be resolved to a
@@ -559,11 +482,18 @@ fn coverage_masks(block: &[u8]) -> Vec<Coverage> {
 
 /// A picture of what the track is *made of*, built from its coverage masks.
 ///
-/// Every track carries these, including the ones that ship no overview picture at all, so
-/// this is what gives those a surface instead of a bare elevation ramp. Each cell takes the
-/// colour of whichever surface covers it most; cells nothing covers are left as bare dirt,
-/// which is exactly what the riding line is.
-fn surface_blob(path: &Path, max_dim: u32) -> Option<Vec<u8>> {
+/// The only source of ground colour, deliberately. Tracks also carry a picture in
+/// `[ui] pic_info`, and some are true overhead photographs — but others are branded posters,
+/// a diagram on a paper texture with a series logo across the bottom, and laid on the terrain
+/// that puts a logo on the dirt. Nothing in the file says which kind it is, and three
+/// different ways of asking the picture to prove it describes this ground all failed to
+/// separate them: structural correlation, top-decile overlap, and extent (0.709 against 0.715
+/// — a real photograph and a poster, indistinguishable). The masks need no such test, being a
+/// byte per cell of this very grid, so they line up by construction.
+///
+/// Each cell takes the colour of whichever surface covers it most; cells nothing covers are
+/// left as bare dirt, which is exactly what the riding line is.
+pub fn overview_blob(path: &Path, max_dim: u32) -> Option<Vec<u8>> {
     let names = entry_names(path).ok()?;
     let entry = heightfield_entries(&names).into_iter().next()?;
     let bytes = read_entry(path, &entry).ok()?;
@@ -638,59 +568,6 @@ fn surface_blob(path: &Path, max_dim: u32) -> Option<Vec<u8>> {
     out.extend_from_slice(&(out_w as u32).to_le_bytes());
     out.extend_from_slice(&(out_h as u32).to_le_bytes());
     out.extend_from_slice(&px);
-    Some(out)
-}
-
-/// A track's overview map, decoded and reduced, ready to lay over the terrain.
-///
-/// `None` — never an error — when the track has no map, when its map won't decode, or when
-/// what it names doesn't cover the same ground as the grid. Every one of those is a track
-/// that simply draws without a texture, which is what it did before.
-pub fn overview_blob(path: &Path, max_dim: u32, grid_aspect: f32) -> Option<Vec<u8>> {
-    // A picture of the track beats a diagram of it — the author's overhead view carries ruts
-    // and tyre marks that no colour-per-surface can. Only the tracks without one fall through
-    // to their coverage masks, and every track has those.
-    picture_blob(path, max_dim, grid_aspect).or_else(|| surface_blob(path, max_dim))
-}
-
-/// The track's own overhead picture, when it ships one drawn to the same ground as the grid.
-fn picture_blob(path: &Path, max_dim: u32, grid_aspect: f32) -> Option<Vec<u8>> {
-    let names = entry_names(path).ok()?;
-    let ini = ini_text(path, &names);
-    let entry = overview_entry(&names, ini.as_deref())?;
-
-    let img = decode_overview(path, &entry)?;
-
-    // Proportions are the check that this is a map *of this track*. A square picture over a
-    // grid twice as wide as it is tall would be drawn stretched across ground it never
-    // described, and it would look plausible while being fiction.
-    let aspect = img.width() as f32 / img.height().max(1) as f32;
-    if grid_aspect > 0.0 && (aspect / grid_aspect - 1.0).abs() > ASPECT_TOLERANCE {
-        log::info!(
-            "track overview {entry} is {}x{} ({aspect:.2}:1) but the grid is {grid_aspect:.2}:1 — not a map of this track",
-            img.width(),
-            img.height(),
-        );
-        return None;
-    }
-
-    let img = if img.width().max(img.height()) > max_dim {
-        img.thumbnail(max_dim, max_dim)
-    } else {
-        img
-    };
-    // RGBA rather than RGB: it's the only layout three.js still takes for a data texture,
-    // and four bytes a pixel keeps the block aligned so the app can read it in place.
-    let rgba = img.to_rgba8();
-    let (w, h) = (rgba.width(), rgba.height());
-
-    let mut out = Vec::with_capacity(TEXTURE_HEADER + (w * h * 4) as usize);
-    out.extend_from_slice(b"FTEX");
-    out.extend_from_slice(&1u16.to_le_bytes()); // version
-    out.extend_from_slice(&0u16.to_le_bytes()); // reserved, keeps the pixels aligned
-    out.extend_from_slice(&w.to_le_bytes());
-    out.extend_from_slice(&h.to_le_bytes());
-    out.extend_from_slice(rgba.as_raw());
     Some(out)
 }
 
@@ -955,46 +832,14 @@ mod tests {
         println!("{}", diagnose(Path::new(&path)));
     }
 
-    const UI_INI: &str = "[info]\nname = Test\n\n[ui]\npic = Thumb.tga\npic_info = TMa.tga\n";
 
-    #[test]
-    fn the_overview_map_is_taken_from_the_map_slot_not_the_loading_picture() {
-        let names = vec!["T/Thumb.tga".to_string(), "T/TMa.tga".to_string()];
-        assert_eq!(
-            overview_entry(&names, Some(UI_INI)).as_deref(),
-            Some("T/TMa.tga"),
-            "`pic` is the artwork shown while the track loads; `pic_info` is the overhead view",
-        );
-    }
 
-    #[test]
-    fn one_picture_in_both_slots_is_artwork_rather_than_a_map() {
-        // Briarcliff does exactly this — and its `Main.tga` is a photograph with the track's
-        // name painted across it, which over the terrain would be worse than no texture.
-        let ini = "[ui]\npic = Main.tga\npic_info = Main.tga\n";
-        let names = vec!["T/Main.tga".to_string()];
-        assert_eq!(overview_entry(&names, Some(ini)), None);
-    }
 
-    #[test]
-    fn a_track_that_names_no_map_has_none() {
-        let names = vec!["T/track_image.tga".to_string()];
-        assert_eq!(overview_entry(&names, Some("[ui]\npic = track_image.tga\n")), None);
-        assert_eq!(overview_entry(&names, Some("[ui]\npic_info =\n")), None);
-        assert_eq!(overview_entry(&names, None), None);
-    }
 
-    #[test]
-    fn a_named_map_that_isnt_in_the_archive_is_not_invented() {
-        let names = vec!["T/Thumb.tga".to_string()];
-        assert_eq!(overview_entry(&names, Some(UI_INI)), None);
-    }
-
-    /// Point this at a real track to see whether its overview map is found, decoded and
-    /// accepted as covering the same ground:
+    /// Point this at a real track to see the surfaces its height file paints:
     ///
     /// ```text
-    /// FROST_TRACK="…/SandPointMX.pkz" \
+    /// FROST_TRACK="…/Farm14.pkz" \
     ///   cargo test -- --ignored --nocapture read_a_real_overview
     /// ```
     #[test]
@@ -1002,42 +847,25 @@ mod tests {
     fn read_a_real_overview() {
         let path = std::env::var("FROST_TRACK").expect("set FROST_TRACK to a track .pkz/folder");
         let path = Path::new(&path);
+
         let names = entry_names(path).unwrap();
-        let ini = ini_text(path, &names);
-        let slot = overview_entry(&names, ini.as_deref());
-        println!("map slot: {slot:?}");
-        // Its own proportions, so a rejection can be told apart from a decode that failed.
-        if let Some(e) = &slot {
-            match decode_overview(path, e) {
-                Some(img) => println!(
-                    "  decodes to {}x{} ({:.2}:1)",
-                    img.width(),
-                    img.height(),
-                    img.width() as f32 / img.height().max(1) as f32
-                ),
-                None => println!("  did not decode"),
+        if let Some(entry) = heightfield_entries(&names).into_iter().next() {
+            let bytes = read_entry(path, &entry).unwrap();
+            let gw = u32::from_le_bytes(bytes[4..8].try_into().unwrap()) as usize;
+            let gh = u32::from_le_bytes(bytes[8..12].try_into().unwrap()) as usize;
+            for (i, m) in coverage_masks(&bytes[12 + gw * gh * 2..]).iter().enumerate() {
+                println!("  surface {i}: id={} {}x{}", m.id, m.width, m.height);
             }
         }
 
-        let aspect = match decode_master(path) {
-            Ok(m) => m.info.source_width as f32 / m.info.source_height as f32,
-            Err(e) => {
-                println!("no terrain ({e:#}) — using 1.0");
-                1.0
-            }
-        };
-        match overview_blob(path, 1024, aspect) {
+        match overview_blob(path, 1024) {
             Some(b) => {
                 let w = u32::from_le_bytes(b[8..12].try_into().unwrap());
                 let h = u32::from_le_bytes(b[12..16].try_into().unwrap());
-                println!(
-                    "grid aspect {aspect:.2}:1 -> texture {w}x{h}, {} bytes ({} px)",
-                    b.len(),
-                    w * h
-                );
+                println!("texture {w}x{h}, {} bytes", b.len());
                 assert_eq!(b.len(), TEXTURE_HEADER + (w * h * 4) as usize);
             }
-            None => println!("grid aspect {aspect:.2}:1 -> no usable overview map"),
+            None => println!("no surfaces in this track"),
         }
     }
 

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -522,6 +522,54 @@ fn prune_cache(app: &tauri::AppHandle) {
 mod tests {
     use super::*;
 
+    /// Point this at a real track — `.pkz` or unpacked folder — to see whether its terrain
+    /// reads, and if not, how close each candidate layout came:
+    ///
+    /// ```text
+    /// FROST_TRACK="C:/.../mods/tracks/Hangtown.pkz" \
+    ///   cargo test -- --ignored --nocapture read_a_real_track
+    /// ```
+    ///
+    /// Prints the inventory, any `.ini` hints, a full probe report per heightfield
+    /// candidate, and what the decoder settled on. This is the whole diagnostic in one
+    /// command, so a format that doesn't read can be diagnosed from its output alone.
+    #[test]
+    #[ignore = "needs a real track — set FROST_TRACK"]
+    fn read_a_real_track() {
+        let path = std::env::var("FROST_TRACK").expect("set FROST_TRACK to a track .pkz/folder");
+        let p = Path::new(&path);
+
+        let names = entry_names(p).expect("list the track's entries");
+        println!("{path}\n{} entries", names.len());
+        for n in &names {
+            let role = role_of(n);
+            if !matches!(role, "other" | "image") {
+                println!("  [{role:<11}] {n}");
+            }
+        }
+
+        let ini = ini_text(p, &names);
+        let (hint, scale) = ini.as_deref().map(ini_hints).unwrap_or((None, None));
+        println!("ini dimensions {hint:?}, spacing {scale:?}");
+
+        let heightfields = heightfield_entries(&names);
+        if heightfields.is_empty() {
+            println!("no heightfield-looking entries — nothing for the probe to read");
+        }
+        for entry in heightfields {
+            println!("\n--- {entry} ---");
+            match read_entry(p, &entry) {
+                Ok(bytes) => println!("{}", heightfield::report(&bytes, hint)),
+                Err(e) => println!("couldn't read it: {e:#}"),
+            }
+        }
+
+        match decode_master(p) {
+            Ok(m) => println!("\nterrain: {:#?}", m.info),
+            Err(e) => println!("\nno terrain: {e:#}"),
+        }
+    }
+
     #[test]
     fn roles_come_from_the_extension() {
         assert_eq!(role_of("Hangtown/Hangtown.trh"), "heightfield");

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -19,20 +19,25 @@ use std::path::{Path, PathBuf};
 
 use crate::heightfield::{self, Layout};
 
-/// The resolution the master grid is kept at. Chosen to be more than any view resolves —
-/// the viewer draws at most a quarter of this across — while staying a megabyte on disk, so
-/// caching every track a player looks at stays bounded.
-const MASTER_DIM: u32 = 512;
+/// The resolution the master grid is kept at. Chosen against the ground rather than the
+/// screen: a track is a few hundred metres across, and at 512 one sample stood for more than
+/// a metre — wider than the jump faces and ruts that make a track readable, so they were
+/// averaged away before the viewer ever saw them.
+const MASTER_DIM: u32 = 1024;
 
 /// Cache generation. Bump when the blob layout or the probe changes shape, so entries
 /// written by an older build are ignored rather than misread.
 // v2: grids are metres where the file states a height scale, so v1's raw-unit masters
 // would now be read as though they were already converted.
-const CACHE_DIR: &str = "track-terrain-v2";
+// v3: masters are kept at twice the resolution, and a v2 entry would pin a track to the
+// coarser grid for as long as it stayed cached.
+// v4: `.trh` samples are read signed, so every height below the datum has moved — a v3 entry
+// holds the ground below a track standing as a wall around it.
+const CACHE_DIR: &str = "track-terrain-v4";
 
-/// How many cached masters to keep. At roughly a megabyte each this is a bounded cost that
-/// only grows with tracks actually opened.
-const CACHE_KEEP: usize = 64;
+/// How many cached masters to keep. Four megabytes each at [`MASTER_DIM`], so this holds the
+/// same budget the smaller grid did rather than quadrupling what the cache costs on disk.
+const CACHE_KEEP: usize = 16;
 
 /// Files that carry a terrain grid. Just the one: PiBoSo's track guide has `.trh` as the
 /// collision terrain and `.map` as the track *graphics*, so probing a `.map` would mean
@@ -381,23 +386,344 @@ pub fn terrain_blob(master: &Master, max_dim: u32) -> Vec<u8> {
 /// read it as a `Float32Array` without copying it first.
 pub const BLOB_HEADER: usize = 32;
 
+// ---------------------------------------------------------------------------
+// The overview map, laid over the terrain
+// ---------------------------------------------------------------------------
+
+/// Bytes before the pixels in a texture blob. Four-byte aligned, same reasoning as
+/// [`BLOB_HEADER`].
+pub const TEXTURE_HEADER: usize = 16;
+
+/// How far a texture's proportions may differ from the grid's and still be believed to cover
+/// the same ground. A map is drawn to the track's footprint, so it matches closely or it is
+/// not a map of it.
+const ASPECT_TOLERANCE: f32 = 0.02;
+
+/// The entry holding a picture of the track *as ground*, if the track ships one.
+///
+/// Tracks carry two picture slots in `[ui]`, and only one of them is a map: `pic` is the
+/// artwork shown while the track loads — a photograph, usually with the track's name across
+/// it — while `pic_info` is the overhead view. The ARL packs name them exactly that way,
+/// `track_image` against `track_map`.
+///
+/// An author who fills both slots with the same file has supplied artwork twice rather than
+/// a map, so that is read as having no map at all. Stretching a photograph of a truck over
+/// the terrain would be worse than the plain relief it replaced.
+fn overview_entry(names: &[String], ini: Option<&str>) -> Option<String> {
+    let text = ini?;
+    let value = |key: &str| -> Option<String> {
+        for line in text.lines() {
+            // Section headers and blanks are simply not `key = value` lines, so skip them
+            // rather than letting one end the search.
+            let Some((k, v)) = line.trim().split_once('=') else {
+                continue;
+            };
+            if k.trim().eq_ignore_ascii_case(key) {
+                let v = v.trim();
+                return (!v.is_empty()).then(|| v.to_string());
+            }
+        }
+        None
+    };
+
+    let map = value("pic_info")?;
+    if value("pic").is_some_and(|p| p.eq_ignore_ascii_case(&map)) {
+        return None;
+    }
+
+    // The `.ini` names the file, not its path inside the archive.
+    let want = map.to_ascii_lowercase();
+    names
+        .iter()
+        .find(|n| {
+            n.rsplit('/')
+                .next()
+                .unwrap_or(n)
+                .to_ascii_lowercase()
+                == want
+        })
+        .cloned()
+}
+
+/// Decode one named picture out of a track.
+///
+/// The format is taken from the entry's extension before the bytes are consulted, because a
+/// `.tga` can't be recognised any other way: TGA carries no leading magic, so guessing from
+/// content silently fails on every one of them — which would leave only the DDS tracks
+/// textured while looking like the maps simply weren't there.
+fn decode_overview(path: &Path, entry: &str) -> Option<image::DynamicImage> {
+    let bytes = read_entry(path, entry).ok()?;
+    let mut reader = image::ImageReader::new(std::io::Cursor::new(&bytes));
+    match entry
+        .rsplit('.')
+        .next()
+        .and_then(image::ImageFormat::from_extension)
+    {
+        Some(format) => reader.set_format(format),
+        None => reader = reader.with_guessed_format().ok()?,
+    }
+    match reader.decode() {
+        Ok(img) => Some(img),
+        Err(e) => {
+            log::info!("track overview {entry} didn't decode: {e}");
+            None
+        }
+    }
+}
+
+/// Surface colours, in the order surfaces are ranked by how much of the track they cover.
+///
+/// Keyed to rank rather than to the id in the file, because that id cannot be resolved to a
+/// material: every track examined carries the same six names (asphalt, grass, sand, kerb,
+/// soil, concrete) byte for byte, so that table is a default the editor writes, and the masks
+/// reference ids past the end of it. Colouring by it put a farm's fields down as soil.
+///
+/// Rank is a property of the track rather than a guess about the format: what covers the most
+/// ground is the vegetation the circuit is cut through, on every track examined, so it leads.
+/// The rest descend through the surfaces a track is built from — apron, dirt, hard standing.
+const SURFACE_RANK_COLOURS: [[u8; 3]; 6] = [
+    [104, 132, 74],  // the ground it's all cut through — grass
+    [206, 188, 142], // apron / sand
+    [138, 108, 74],  // worked soil
+    [128, 128, 132], // hard standing
+    [122, 140, 88],  // rougher vegetation
+    [150, 122, 86],
+];
+
+fn surface_colour(rank: usize) -> [u8; 3] {
+    SURFACE_RANK_COLOURS[rank.min(SURFACE_RANK_COLOURS.len() - 1)]
+}
+
+/// Where the terrain data stops and the material table begins.
+///
+/// Found by the table's own first entry rather than by walking: mask bytes are arbitrary and
+/// contain plenty of values that read as a plausible record header, so a walk with no end in
+/// sight runs off into the data. With the end known, the walk is bounded and exact.
+fn material_table_offset(block: &[u8]) -> Option<usize> {
+    block
+        .windows(8)
+        .position(|w| w == b"asphalt\0")
+        .and_then(|p| p.checked_sub(4))
+}
+
+/// One painted surface: which id it is, and a byte of coverage per cell.
+struct Coverage {
+    id: u32,
+    width: u32,
+    height: u32,
+    at: usize,
+}
+
+/// The coverage masks in a height file's trailing block.
+///
+/// Records start at 44 and are `id, value, width, height` then `width * height` bytes —
+/// except that some carry no `value`, so a header is twelve bytes as often as sixteen and
+/// each has to be tried. A record with zero dimensions is a surface named but never painted.
+fn coverage_masks(block: &[u8]) -> Vec<Coverage> {
+    let Some(end) = material_table_offset(block) else {
+        return Vec::new();
+    };
+    let u32_at = |o: usize| -> Option<u32> {
+        block.get(o..o + 4).map(|b| u32::from_le_bytes(b.try_into().unwrap()))
+    };
+    let plausible = |v: u32| (16..=8192).contains(&v);
+
+    let mut out = Vec::new();
+    let mut o = 44usize;
+    while o + 16 <= end {
+        let (id, w16, h16) = (u32_at(o), u32_at(o + 8), u32_at(o + 12));
+        let (w12, h12) = (u32_at(o + 4), u32_at(o + 8));
+
+        if let (Some(id), Some(w), Some(h)) = (id, w16, h16) {
+            if plausible(w) && plausible(h) && o + 16 + (w as usize * h as usize) <= end {
+                out.push(Coverage { id, width: w, height: h, at: o + 16 });
+                o += 16 + w as usize * h as usize;
+                continue;
+            }
+            if w == 0 && h == 0 && id < 64 {
+                o += 16; // named but never painted
+                continue;
+            }
+        }
+        if let (Some(id), Some(w), Some(h)) = (u32_at(o), w12, h12) {
+            if plausible(w) && plausible(h) && o + 12 + (w as usize * h as usize) <= end {
+                out.push(Coverage { id, width: w, height: h, at: o + 12 });
+                o += 12 + w as usize * h as usize;
+                continue;
+            }
+        }
+        o += 4;
+    }
+    out
+}
+
+/// A picture of what the track is *made of*, built from its coverage masks.
+///
+/// Every track carries these, including the ones that ship no overview picture at all, so
+/// this is what gives those a surface instead of a bare elevation ramp. Each cell takes the
+/// colour of whichever surface covers it most; cells nothing covers are left as bare dirt,
+/// which is exactly what the riding line is.
+fn surface_blob(path: &Path, max_dim: u32) -> Option<Vec<u8>> {
+    let names = entry_names(path).ok()?;
+    let entry = heightfield_entries(&names).into_iter().next()?;
+    let bytes = read_entry(path, &entry).ok()?;
+
+    let gw = u32::from_le_bytes(bytes.get(4..8)?.try_into().ok()?) as usize;
+    let gh = u32::from_le_bytes(bytes.get(8..12)?.try_into().ok()?) as usize;
+    let block = bytes.get(12 + gw.checked_mul(gh)?.checked_mul(2)?..)?;
+
+    let masks = coverage_masks(block);
+    if masks.is_empty() {
+        return None;
+    }
+
+    // Ranked by how much ground each covers, sampled rather than summed in full — a dozen
+    // masks of four million cells is a lot of adding to decide an ordering.
+    let mut ranked: Vec<(usize, u64)> = masks
+        .iter()
+        .enumerate()
+        .map(|(i, m)| {
+            let cells = m.width as usize * m.height as usize;
+            let total: u64 = (0..cells)
+                .step_by(97)
+                .filter_map(|c| block.get(m.at + c))
+                .map(|&v| v as u64)
+                .sum();
+            (i, total)
+        })
+        .collect();
+    ranked.sort_by(|a, b| b.1.cmp(&a.1));
+    let mut rank_of = vec![0usize; masks.len()];
+    for (rank, (i, _)) in ranked.iter().enumerate() {
+        rank_of[*i] = rank;
+    }
+
+    let src_w = masks[0].width as usize;
+    let src_h = masks[0].height as usize;
+    let scale = (src_w.max(src_h) as f32 / max_dim.max(1) as f32).ceil().max(1.0) as usize;
+    let out_w = src_w.div_ceil(scale);
+    let out_h = src_h.div_ceil(scale);
+
+    // Bare dirt, for everything no surface was painted over.
+    const BARE: [u8; 3] = [124, 96, 70];
+
+    let mut px = Vec::with_capacity(out_w * out_h * 4);
+    for y in 0..out_h {
+        for x in 0..out_w {
+            let mut best = 0u8;
+            let mut colour = BARE;
+            for (i, m) in masks.iter().enumerate() {
+                // Masks may differ in size from one another; sample each in its own space.
+                let mx = x * scale * m.width as usize / src_w.max(1);
+                let my = y * scale * m.height as usize / src_h.max(1);
+                let Some(&v) = block.get(m.at + my.min(m.height as usize - 1) * m.width as usize
+                    + mx.min(m.width as usize - 1))
+                else {
+                    continue;
+                };
+                if v > best {
+                    best = v;
+                    colour = surface_colour(rank_of[i]);
+                }
+            }
+            px.extend_from_slice(&colour);
+            px.push(255);
+        }
+    }
+
+    let mut out = Vec::with_capacity(TEXTURE_HEADER + px.len());
+    out.extend_from_slice(b"FTEX");
+    out.extend_from_slice(&1u16.to_le_bytes());
+    out.extend_from_slice(&0u16.to_le_bytes());
+    out.extend_from_slice(&(out_w as u32).to_le_bytes());
+    out.extend_from_slice(&(out_h as u32).to_le_bytes());
+    out.extend_from_slice(&px);
+    Some(out)
+}
+
+/// A track's overview map, decoded and reduced, ready to lay over the terrain.
+///
+/// `None` — never an error — when the track has no map, when its map won't decode, or when
+/// what it names doesn't cover the same ground as the grid. Every one of those is a track
+/// that simply draws without a texture, which is what it did before.
+pub fn overview_blob(path: &Path, max_dim: u32, grid_aspect: f32) -> Option<Vec<u8>> {
+    // A picture of the track beats a diagram of it — the author's overhead view carries ruts
+    // and tyre marks that no colour-per-surface can. Only the tracks without one fall through
+    // to their coverage masks, and every track has those.
+    picture_blob(path, max_dim, grid_aspect).or_else(|| surface_blob(path, max_dim))
+}
+
+/// The track's own overhead picture, when it ships one drawn to the same ground as the grid.
+fn picture_blob(path: &Path, max_dim: u32, grid_aspect: f32) -> Option<Vec<u8>> {
+    let names = entry_names(path).ok()?;
+    let ini = ini_text(path, &names);
+    let entry = overview_entry(&names, ini.as_deref())?;
+
+    let img = decode_overview(path, &entry)?;
+
+    // Proportions are the check that this is a map *of this track*. A square picture over a
+    // grid twice as wide as it is tall would be drawn stretched across ground it never
+    // described, and it would look plausible while being fiction.
+    let aspect = img.width() as f32 / img.height().max(1) as f32;
+    if grid_aspect > 0.0 && (aspect / grid_aspect - 1.0).abs() > ASPECT_TOLERANCE {
+        log::info!(
+            "track overview {entry} is {}x{} ({aspect:.2}:1) but the grid is {grid_aspect:.2}:1 — not a map of this track",
+            img.width(),
+            img.height(),
+        );
+        return None;
+    }
+
+    let img = if img.width().max(img.height()) > max_dim {
+        img.thumbnail(max_dim, max_dim)
+    } else {
+        img
+    };
+    // RGBA rather than RGB: it's the only layout three.js still takes for a data texture,
+    // and four bytes a pixel keeps the block aligned so the app can read it in place.
+    let rgba = img.to_rgba8();
+    let (w, h) = (rgba.width(), rgba.height());
+
+    let mut out = Vec::with_capacity(TEXTURE_HEADER + (w * h * 4) as usize);
+    out.extend_from_slice(b"FTEX");
+    out.extend_from_slice(&1u16.to_le_bytes()); // version
+    out.extend_from_slice(&0u16.to_le_bytes()); // reserved, keeps the pixels aligned
+    out.extend_from_slice(&w.to_le_bytes());
+    out.extend_from_slice(&h.to_le_bytes());
+    out.extend_from_slice(rgba.as_raw());
+    Some(out)
+}
+
 fn resample(master: &Master, max_dim: u32) -> (u32, u32, Vec<f32>) {
     let w = master.info.width as usize;
     let h = master.info.height as usize;
-    let step = ((w.max(h) as f32) / max_dim.max(1) as f32).ceil().max(1.0) as usize;
-    if step <= 1 {
+    let max_dim = max_dim.max(1) as usize;
+    let longest = w.max(h);
+    if longest <= max_dim {
         return (master.info.width, master.info.height, master.heights.clone());
     }
 
-    let out_w = w.div_ceil(step);
-    let out_h = h.div_ceil(step);
+    // Land on exactly the size asked for. Reducing by a whole number of samples instead
+    // overshoots badly at the sizes that matter: a 410-sample master asked for 320 can only
+    // step by 2, which draws 205 — half the detail requested, and a jump face is a couple of
+    // metres wide, so the samples lost are the track itself.
+    let out_w = ((w * max_dim) / longest).max(1);
+    let out_h = ((h * max_dim) / longest).max(1);
+
     let mut out = Vec::with_capacity(out_w * out_h);
     for oy in 0..out_h {
+        // The source rows this output row stands for. Ends are derived from the ratio rather
+        // than a fixed stride, so the blocks tile the grid exactly however it divides.
+        let y0 = oy * h / out_h;
+        let y1 = (((oy + 1) * h) / out_h).max(y0 + 1).min(h);
         for ox in 0..out_w {
+            let x0 = ox * w / out_w;
+            let x1 = (((ox + 1) * w) / out_w).max(x0 + 1).min(w);
+
             let mut total = 0.0f64;
             let mut count = 0usize;
-            for y in oy * step..((oy + 1) * step).min(h) {
-                for x in ox * step..((ox + 1) * step).min(w) {
+            for y in y0..y1 {
+                for x in x0..x1 {
                     total += master.heights[y * w + x] as f64;
                     count += 1;
                 }
@@ -629,6 +955,242 @@ mod tests {
         println!("{}", diagnose(Path::new(&path)));
     }
 
+    const UI_INI: &str = "[info]\nname = Test\n\n[ui]\npic = Thumb.tga\npic_info = TMa.tga\n";
+
+    #[test]
+    fn the_overview_map_is_taken_from_the_map_slot_not_the_loading_picture() {
+        let names = vec!["T/Thumb.tga".to_string(), "T/TMa.tga".to_string()];
+        assert_eq!(
+            overview_entry(&names, Some(UI_INI)).as_deref(),
+            Some("T/TMa.tga"),
+            "`pic` is the artwork shown while the track loads; `pic_info` is the overhead view",
+        );
+    }
+
+    #[test]
+    fn one_picture_in_both_slots_is_artwork_rather_than_a_map() {
+        // Briarcliff does exactly this — and its `Main.tga` is a photograph with the track's
+        // name painted across it, which over the terrain would be worse than no texture.
+        let ini = "[ui]\npic = Main.tga\npic_info = Main.tga\n";
+        let names = vec!["T/Main.tga".to_string()];
+        assert_eq!(overview_entry(&names, Some(ini)), None);
+    }
+
+    #[test]
+    fn a_track_that_names_no_map_has_none() {
+        let names = vec!["T/track_image.tga".to_string()];
+        assert_eq!(overview_entry(&names, Some("[ui]\npic = track_image.tga\n")), None);
+        assert_eq!(overview_entry(&names, Some("[ui]\npic_info =\n")), None);
+        assert_eq!(overview_entry(&names, None), None);
+    }
+
+    #[test]
+    fn a_named_map_that_isnt_in_the_archive_is_not_invented() {
+        let names = vec!["T/Thumb.tga".to_string()];
+        assert_eq!(overview_entry(&names, Some(UI_INI)), None);
+    }
+
+    /// Point this at a real track to see whether its overview map is found, decoded and
+    /// accepted as covering the same ground:
+    ///
+    /// ```text
+    /// FROST_TRACK="…/SandPointMX.pkz" \
+    ///   cargo test -- --ignored --nocapture read_a_real_overview
+    /// ```
+    #[test]
+    #[ignore = "needs a real track — set FROST_TRACK"]
+    fn read_a_real_overview() {
+        let path = std::env::var("FROST_TRACK").expect("set FROST_TRACK to a track .pkz/folder");
+        let path = Path::new(&path);
+        let names = entry_names(path).unwrap();
+        let ini = ini_text(path, &names);
+        let slot = overview_entry(&names, ini.as_deref());
+        println!("map slot: {slot:?}");
+        // Its own proportions, so a rejection can be told apart from a decode that failed.
+        if let Some(e) = &slot {
+            match decode_overview(path, e) {
+                Some(img) => println!(
+                    "  decodes to {}x{} ({:.2}:1)",
+                    img.width(),
+                    img.height(),
+                    img.width() as f32 / img.height().max(1) as f32
+                ),
+                None => println!("  did not decode"),
+            }
+        }
+
+        let aspect = match decode_master(path) {
+            Ok(m) => m.info.source_width as f32 / m.info.source_height as f32,
+            Err(e) => {
+                println!("no terrain ({e:#}) — using 1.0");
+                1.0
+            }
+        };
+        match overview_blob(path, 1024, aspect) {
+            Some(b) => {
+                let w = u32::from_le_bytes(b[8..12].try_into().unwrap());
+                let h = u32::from_le_bytes(b[12..16].try_into().unwrap());
+                println!(
+                    "grid aspect {aspect:.2}:1 -> texture {w}x{h}, {} bytes ({} px)",
+                    b.len(),
+                    w * h
+                );
+                assert_eq!(b.len(), TEXTURE_HEADER + (w * h * 4) as usize);
+            }
+            None => println!("grid aspect {aspect:.2}:1 -> no usable overview map"),
+        }
+    }
+
+    #[test]
+    fn a_view_gets_the_resolution_it_asked_for() {
+        // The bug this guards: a whole-sample stride could only halve a 410-sample master,
+        // so a view asking for 320 was handed 205 and drew half the detail it requested.
+        let master = Master {
+            info: TerrainInfo {
+                width: 410,
+                height: 410,
+                source_width: 2049,
+                source_height: 2049,
+                min_height: 0.0,
+                max_height: 1.0,
+                metres_per_sample: 1.0,
+                scale_known: true,
+                heights_in_metres: true,
+                confidence: 1.0,
+                source: "trh".into(),
+                entry: "t.trh".into(),
+            },
+            heights: vec![0.5; 410 * 410],
+        };
+        let (w, h, heights) = resample(&master, 320);
+        assert_eq!((w, h), (320, 320));
+        assert_eq!(heights.len(), 320 * 320);
+    }
+
+    #[test]
+    fn a_view_bigger_than_the_master_is_left_alone() {
+        let master = Master {
+            info: TerrainInfo {
+                width: 64,
+                height: 32,
+                source_width: 64,
+                source_height: 32,
+                min_height: 0.0,
+                max_height: 1.0,
+                metres_per_sample: 1.0,
+                scale_known: true,
+                heights_in_metres: true,
+                confidence: 1.0,
+                source: "trh".into(),
+                entry: "t.trh".into(),
+            },
+            heights: vec![0.25; 64 * 32],
+        };
+        let (w, h, _) = resample(&master, 512);
+        assert_eq!((w, h), (64, 32), "never invented detail the master hasn't got");
+    }
+
+    #[test]
+    fn a_reduced_grid_keeps_its_proportions() {
+        let master = Master {
+            info: TerrainInfo {
+                width: 2049,
+                height: 1025,
+                source_width: 2049,
+                source_height: 1025,
+                min_height: 0.0,
+                max_height: 1.0,
+                metres_per_sample: 1.0,
+                scale_known: true,
+                heights_in_metres: true,
+                confidence: 1.0,
+                source: "trh".into(),
+                entry: "t.trh".into(),
+            },
+            heights: vec![0.0; 2049 * 1025],
+        };
+        let (w, h, heights) = resample(&master, 512);
+        assert_eq!(w, 512);
+        // Half the width, as the source is — a stride would have rounded both the same way
+        // and squashed the track.
+        assert!((h as i32 - 256).abs() <= 1, "got {h}");
+        assert_eq!(heights.len(), (w * h) as usize);
+    }
+
+    /// A trailing block with `masks` painted surfaces, laid out the way a real one is.
+    fn block_with(masks: &[(u32, u32, u32, bool)]) -> Vec<u8> {
+        let mut b = vec![0u8; 44];
+        for &(id, w, h, wide) in masks {
+            b.extend_from_slice(&id.to_le_bytes());
+            if wide {
+                b.extend_from_slice(&1.0f32.to_le_bytes());
+            }
+            b.extend_from_slice(&w.to_le_bytes());
+            b.extend_from_slice(&h.to_le_bytes());
+            b.extend(std::iter::repeat(id as u8).take((w * h) as usize));
+        }
+        // The material table the editor writes into every track, which is what bounds the walk.
+        b.extend_from_slice(&6u32.to_le_bytes());
+        for name in ["asphalt", "grass", "sand", "kerb", "soil", "concrete"] {
+            let mut n = name.as_bytes().to_vec();
+            n.resize(16, 0);
+            b.extend_from_slice(&n);
+            b.extend_from_slice(&[0u8; 36]);
+        }
+        b
+    }
+
+    #[test]
+    fn coverage_masks_are_walked_out_of_the_trailing_block() {
+        let b = block_with(&[(4, 64, 32, true), (1, 64, 32, true)]);
+        let m = coverage_masks(&b);
+        assert_eq!(m.len(), 2);
+        assert_eq!((m[0].id, m[0].width, m[0].height), (4, 64, 32));
+        assert_eq!((m[1].id, m[1].width, m[1].height), (1, 64, 32));
+        // Each mask's bytes are its own, so the second is found at the right place rather
+        // than somewhere inside the first.
+        assert_eq!(b[m[1].at], 1);
+    }
+
+    #[test]
+    fn a_record_without_its_value_field_is_still_read() {
+        // Real files mix the two: the same track carries sixteen-byte headers and twelve-byte
+        // ones, so a walk that assumes one size stops partway and loses the rest.
+        let b = block_with(&[(12, 32, 32, true), (5, 32, 32, false)]);
+        let m = coverage_masks(&b);
+        assert_eq!(m.len(), 2, "a short header must not end the walk");
+        assert_eq!(m[1].id, 5);
+        assert_eq!(b[m[1].at], 5);
+    }
+
+    #[test]
+    fn a_surface_that_was_never_painted_takes_no_space() {
+        let b = block_with(&[(7, 0, 0, true), (1, 48, 48, true)]);
+        let m = coverage_masks(&b);
+        assert_eq!(m.len(), 1, "an empty record is skipped, not treated as a mask");
+        assert_eq!(m[0].id, 1);
+    }
+
+    #[test]
+    fn without_a_material_table_nothing_is_walked() {
+        // The table is the only reliable end. Mask bytes read as plausible record headers all
+        // the time, so a walk with no end runs off into the data and invents surfaces.
+        assert!(material_table_offset(&[0u8; 512]).is_none());
+        assert!(coverage_masks(&[0u8; 512]).is_empty());
+    }
+
+    #[test]
+    fn every_rank_has_its_own_colour_and_ranks_beyond_the_last_still_answer() {
+        let all: Vec<[u8; 3]> = (0..SURFACE_RANK_COLOURS.len()).map(surface_colour).collect();
+        for (i, a) in all.iter().enumerate() {
+            for b in &all[i + 1..] {
+                assert_ne!(a, b, "two surfaces sharing a colour cannot be told apart");
+            }
+        }
+        // A track may paint more surfaces than there are colours; that must not panic.
+        assert_eq!(surface_colour(99), *SURFACE_RANK_COLOURS.last().unwrap());
+    }
+
     #[test]
     fn a_hex_preview_shows_bytes_and_their_ascii() {
         let line = hex_preview(b"TRH\0\x01\x02", 64);
@@ -828,3 +1390,10 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 }
+
+
+
+
+
+
+

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -1,0 +1,681 @@
+//! Reading a track well enough to show it.
+//!
+//! A track is the largest thing the app handles — a few hundred megabytes of textures and
+//! scenery around a terrain grid that is the only part worth drawing. Everything here is
+//! arranged so that showing one costs the grid and nothing else:
+//!
+//! * The inventory ([`read_info`]) never inflates a byte. Naming a track's parts is a
+//!   question the archive's index already answers, and answering it that way is the
+//!   difference between a view that opens at once and one that waits on a 400 MB unpack.
+//! * The terrain is inflated once, probed once, and reduced immediately to a master grid
+//!   small enough to keep ([`MASTER_DIM`]). Every level of detail the viewer asks for after
+//!   that is resampled from the master, in memory.
+//! * The master is written to disk, so opening the same track tomorrow skips the inflate and
+//!   the probe both. This is the cache that matters: the probe is milliseconds, while pulling
+//!   a heightfield out of a large archive is most of a second.
+
+use anyhow::{bail, Context, Result};
+use std::path::{Path, PathBuf};
+
+use crate::heightfield::{self, Layout};
+
+/// The resolution the master grid is kept at. Chosen to be more than any view resolves —
+/// the viewer draws at most a quarter of this across — while staying a megabyte on disk, so
+/// caching every track a player looks at stays bounded.
+const MASTER_DIM: u32 = 512;
+
+/// Cache generation. Bump when the blob layout or the probe changes shape, so entries
+/// written by an older build are ignored rather than misread.
+const CACHE_DIR: &str = "track-terrain-v1";
+
+/// How many cached masters to keep. At roughly a megabyte each this is a bounded cost that
+/// only grows with tracks actually opened.
+const CACHE_KEEP: usize = 64;
+
+/// Files that carry a terrain grid, best first. The probe validates whatever it is handed,
+/// so trying several costs only the read of the ones that don't pan out.
+const HEIGHTFIELD_EXTS: [&str; 3] = ["trh", "map", "hf"];
+
+/// What a track file is for, as far as the UI is concerned. A key, not prose — the app
+/// translates it.
+fn role_of(name: &str) -> &'static str {
+    let ext = name.rsplit('.').next().unwrap_or("").to_ascii_lowercase();
+    match ext.as_str() {
+        "trh" | "hf" => "heightfield",
+        "map" => "terrain",
+        "tsc" => "scenery",
+        "rdf" => "road",
+        "ssc" => "surfaces",
+        "ini" | "cfg" => "config",
+        "edf" => "model",
+        "jpg" | "jpeg" | "png" | "dds" | "tga" | "bmp" => "image",
+        "wav" | "ogg" => "sound",
+        _ => "other",
+    }
+}
+
+/// One file inside a track.
+#[derive(serde::Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct TrackFile {
+    pub name: String,
+    pub role: &'static str,
+}
+
+/// The shape of a track's terrain, once recovered.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct TerrainInfo {
+    /// Master grid dimensions — what the viewer can ask for, not the file's own resolution.
+    pub width: u32,
+    pub height: u32,
+    /// The file's resolution before reduction, so the UI can say what it actually read.
+    pub source_width: u32,
+    pub source_height: u32,
+    pub min_height: f32,
+    pub max_height: f32,
+    /// Metres covered by one master sample. Assumed when the track doesn't say (see
+    /// `scale_known`) — the relief is still true, only its footprint is a guess.
+    pub metres_per_sample: f32,
+    pub scale_known: bool,
+    /// 0–1, from the probe. Anything recovered rather than stated is shown as inferred.
+    pub confidence: f32,
+    /// `header`, `ini` or `square` — how the grid's shape was decided.
+    pub source: String,
+    /// The archive entry it came out of.
+    pub entry: String,
+}
+
+/// Everything the track view needs before it draws anything.
+#[derive(serde::Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct TrackInfo {
+    pub meta: crate::pkz::PkzMeta,
+    pub files: Vec<TrackFile>,
+    /// Whether a heightfield-looking entry is present at all. Lets the view offer the 3D tab
+    /// without first paying for the terrain, and say "no terrain in this track" when there
+    /// genuinely isn't one rather than after a failed load.
+    pub has_terrain: bool,
+}
+
+/// A decoded terrain, reduced to the master resolution.
+#[derive(Clone)]
+pub struct Master {
+    pub info: TerrainInfo,
+    pub heights: Vec<f32>,
+}
+
+// ---------------------------------------------------------------------------
+// Reading a track's parts, whether it's an archive or an unpacked folder
+// ---------------------------------------------------------------------------
+
+fn is_dir(path: &Path) -> bool {
+    path.is_dir()
+}
+
+/// Every entry name in a track, without inflating any of them.
+fn entry_names(path: &Path) -> Result<Vec<String>> {
+    if is_dir(path) {
+        let mut out = Vec::new();
+        for entry in crate::linkwalk::walk_depth(path, 6)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            if let Ok(rel) = entry.path().strip_prefix(path) {
+                out.push(rel.to_string_lossy().replace('\\', "/"));
+            }
+        }
+        return Ok(out);
+    }
+    crate::pkz::entry_names(path)
+}
+
+/// Pull one named entry's bytes out of a track.
+fn read_entry(path: &Path, name: &str) -> Result<Vec<u8>> {
+    if is_dir(path) {
+        return std::fs::read(path.join(name)).with_context(|| format!("read {name}"));
+    }
+    let want = name.to_ascii_lowercase();
+    let found = crate::pkz::read_selected(path, |n| {
+        n.replace('\\', "/").to_ascii_lowercase() == want
+    })?;
+    match found.into_iter().next() {
+        Some((_, bytes)) => Ok(bytes),
+        None => bail!("{name} is not in {path:?}"),
+    }
+}
+
+/// The entries that could hold a terrain grid, best-looking first.
+fn heightfield_entries(names: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = names
+        .iter()
+        .filter(|n| {
+            let ext = n.rsplit('.').next().unwrap_or("").to_ascii_lowercase();
+            HEIGHTFIELD_EXTS.contains(&ext.as_str())
+        })
+        .cloned()
+        .collect();
+    out.sort_by_key(|n| {
+        let ext = n.rsplit('.').next().unwrap_or("").to_ascii_lowercase();
+        HEIGHTFIELD_EXTS
+            .iter()
+            .position(|e| *e == ext)
+            .unwrap_or(usize::MAX)
+    });
+    out
+}
+
+/// Grid dimensions and sample spacing named in the track's `.ini`, when it names them.
+///
+/// Nothing here is required — it's a hint handed to the probe, which still has to satisfy
+/// itself that the shape reads as terrain. Keys vary between track tools, so this stays
+/// deliberately loose about where it finds them.
+fn ini_hints(text: &str) -> (Option<(u32, u32)>, Option<f32>) {
+    let mut w: Option<u32> = None;
+    let mut h: Option<u32> = None;
+    let mut square: Option<u32> = None;
+    let mut scale: Option<f32> = None;
+
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with(';') || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim().to_ascii_lowercase();
+        let value = value.trim();
+        match key.as_str() {
+            "width" | "nx" | "cx" | "xsize" | "size_x" => w = value.parse().ok(),
+            "height" | "ny" | "cy" | "ysize" | "size_y" => h = value.parse().ok(),
+            // A single figure means a square grid.
+            "size" | "resolution" | "grid" => square = value.parse().ok(),
+            "scale" | "step" | "spacing" | "cell" | "cellsize" => {
+                scale = value.parse().ok().filter(|v: &f32| *v > 0.0 && *v < 1000.0)
+            }
+            _ => {}
+        }
+    }
+
+    let dims = match (w, h) {
+        (Some(w), Some(h)) => Some((w, h)),
+        _ => square.map(|s| (s, s)),
+    };
+    (dims, scale)
+}
+
+/// The track's top-level `.ini` text, if it has one worth reading.
+fn ini_text(path: &Path, names: &[String]) -> Option<String> {
+    let idx = names
+        .iter()
+        .enumerate()
+        .filter(|(_, n)| n.to_ascii_lowercase().ends_with(".ini"))
+        .min_by_key(|(_, n)| (n.matches('/').count(), n.len()))
+        .map(|(i, _)| i)?;
+    let bytes = read_entry(path, &names[idx]).ok()?;
+    Some(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+// ---------------------------------------------------------------------------
+// The two things the app asks for
+// ---------------------------------------------------------------------------
+
+/// A track's metadata and contents, without inflating anything.
+pub fn read_info(app: &tauri::AppHandle, path: &str) -> Result<TrackInfo> {
+    let p = Path::new(path);
+    let meta = crate::pkz::read_meta_cached(app, path)?;
+    let names = entry_names(p).unwrap_or_default();
+    let has_terrain = !heightfield_entries(&names).is_empty();
+
+    let mut files: Vec<TrackFile> = names
+        .into_iter()
+        .map(|name| {
+            let role = role_of(&name);
+            TrackFile { name, role }
+        })
+        .collect();
+    files.sort_by(|a, b| a.name.to_ascii_lowercase().cmp(&b.name.to_ascii_lowercase()));
+
+    Ok(TrackInfo {
+        meta,
+        files,
+        has_terrain,
+    })
+}
+
+/// Decode a track's terrain to the master grid, going to disk and to the archive only when
+/// nothing nearer has it.
+pub fn load_master(app: &tauri::AppHandle, path: &str) -> Result<Master> {
+    let stamp = stamp(path)?;
+    let key = cache_key(path, stamp);
+
+    if let Some(hit) = memory_cache().lock().ok().and_then(|mut c| c.get(&key).cloned()) {
+        return Ok(hit);
+    }
+    if let Some(hit) = cache_file(app, &key).and_then(|f| read_cache(&f)) {
+        remember(key, hit.clone());
+        return Ok(hit);
+    }
+
+    let master = decode_master(Path::new(path))?;
+    if let Some(f) = cache_file(app, &key) {
+        write_cache(&f, &master);
+        prune_cache(app);
+    }
+    remember(key, master.clone());
+    Ok(master)
+}
+
+/// The expensive path: inflate a heightfield, work out its layout, reduce it.
+fn decode_master(path: &Path) -> Result<Master> {
+    let names = entry_names(path)?;
+    let candidates = heightfield_entries(&names);
+    if candidates.is_empty() {
+        bail!("no heightfield in {path:?}");
+    }
+
+    let ini = ini_text(path, &names);
+    let (hint, ini_scale) = ini.as_deref().map(ini_hints).unwrap_or((None, None));
+
+    for entry in candidates {
+        let Ok(bytes) = read_entry(path, &entry) else {
+            continue;
+        };
+        let Some(layout) = heightfield::probe(&bytes, hint) else {
+            log::debug!("[track] {entry} in {path:?} doesn't read as a heightfield");
+            continue;
+        };
+        return Ok(build_master(&bytes, &layout, &entry, ini_scale));
+    }
+
+    bail!("nothing in {path:?} reads as a terrain grid")
+}
+
+fn build_master(bytes: &[u8], layout: &Layout, entry: &str, ini_scale: Option<f32>) -> Master {
+    let (w, h, heights) = heightfield::read_grid(bytes, layout, MASTER_DIM);
+
+    let mut min = f32::INFINITY;
+    let mut max = f32::NEG_INFINITY;
+    for v in &heights {
+        min = min.min(*v);
+        max = max.max(*v);
+    }
+
+    // The master covers the same ground as the source at fewer samples, so the spacing grows
+    // by exactly the reduction factor.
+    let reduction = layout.width as f32 / w.max(1) as f32;
+    let metres_per_sample = ini_scale.unwrap_or(1.0) * reduction;
+
+    Master {
+        info: TerrainInfo {
+            width: w,
+            height: h,
+            source_width: layout.width,
+            source_height: layout.height,
+            min_height: if min.is_finite() { min } else { 0.0 },
+            max_height: if max.is_finite() { max } else { 0.0 },
+            metres_per_sample,
+            scale_known: ini_scale.is_some(),
+            confidence: layout.confidence,
+            source: layout.source.to_string(),
+            entry: entry.to_string(),
+        },
+        heights,
+    }
+}
+
+/// Resample a master down for a view that wants fewer points, and pack it for the IPC
+/// channel. See [`BLOB_HEADER`] for the layout the app unpacks.
+pub fn terrain_blob(master: &Master, max_dim: u32) -> Vec<u8> {
+    let (w, h, heights) = resample(master, max_dim);
+
+    let mut out = Vec::with_capacity(BLOB_HEADER + heights.len() * 4);
+    out.extend_from_slice(b"FTRN");
+    out.extend_from_slice(&1u16.to_le_bytes()); // version
+    // Bit 0: the sample spacing was stated by the track rather than assumed. The app needs
+    // this to caption the view honestly — with the spacing assumed, the relief is drawn
+    // against a footprint we guessed, so its steepness is not something to trust.
+    out.extend_from_slice(&(u16::from(master.info.scale_known)).to_le_bytes());
+    out.extend_from_slice(&w.to_le_bytes());
+    out.extend_from_slice(&h.to_le_bytes());
+    out.extend_from_slice(&master.info.min_height.to_le_bytes());
+    out.extend_from_slice(&master.info.max_height.to_le_bytes());
+    // Spacing scales with the reduction, so the terrain keeps its real footprint at any
+    // level of detail — a coarse pass and a fine one have to sit in the same place.
+    let spacing = master.info.metres_per_sample * (master.info.width as f32 / w.max(1) as f32);
+    out.extend_from_slice(&spacing.to_le_bytes());
+    // How sure the probe was of the layout, so a marginal read can say so rather than be
+    // presented as the track's terrain.
+    out.extend_from_slice(&master.info.confidence.to_le_bytes());
+    for v in &heights {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    out
+}
+
+/// Bytes before the grid in a terrain blob. The grid starts 4-byte aligned so the app can
+/// read it as a `Float32Array` without copying it first.
+pub const BLOB_HEADER: usize = 32;
+
+fn resample(master: &Master, max_dim: u32) -> (u32, u32, Vec<f32>) {
+    let w = master.info.width as usize;
+    let h = master.info.height as usize;
+    let step = ((w.max(h) as f32) / max_dim.max(1) as f32).ceil().max(1.0) as usize;
+    if step <= 1 {
+        return (master.info.width, master.info.height, master.heights.clone());
+    }
+
+    let out_w = w.div_ceil(step);
+    let out_h = h.div_ceil(step);
+    let mut out = Vec::with_capacity(out_w * out_h);
+    for oy in 0..out_h {
+        for ox in 0..out_w {
+            let mut total = 0.0f64;
+            let mut count = 0usize;
+            for y in oy * step..((oy + 1) * step).min(h) {
+                for x in ox * step..((ox + 1) * step).min(w) {
+                    total += master.heights[y * w + x] as f64;
+                    count += 1;
+                }
+            }
+            out.push(if count == 0 {
+                0.0
+            } else {
+                (total / count as f64) as f32
+            });
+        }
+    }
+    (out_w as u32, out_h as u32, out)
+}
+
+// ---------------------------------------------------------------------------
+// Caches
+// ---------------------------------------------------------------------------
+
+/// Keyed on name, size and mtime rather than the full path, for the same reason `pkz` is:
+/// pointing the app at a moved install shouldn't cold-start every track it has ever opened.
+#[derive(Clone, Copy)]
+struct Stamp {
+    size: u64,
+    mtime_ns: u128,
+}
+
+fn stamp(path: &str) -> Result<Stamp> {
+    let m = std::fs::metadata(path).with_context(|| format!("stat {path}"))?;
+    Ok(Stamp {
+        size: m.len(),
+        mtime_ns: m
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_nanos())
+            .unwrap_or(0),
+    })
+}
+
+fn cache_key(path: &str, stamp: Stamp) -> String {
+    let name = Path::new(path)
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    format!("{name}:{}:{}", stamp.size, stamp.mtime_ns)
+}
+
+fn memory_cache() -> &'static std::sync::Mutex<crate::lru::Lru<Master>> {
+    static CACHE: std::sync::OnceLock<std::sync::Mutex<crate::lru::Lru<Master>>> =
+        std::sync::OnceLock::new();
+    CACHE.get_or_init(|| std::sync::Mutex::new(crate::lru::Lru::new(3)))
+}
+
+fn remember(key: String, master: Master) {
+    if let Ok(mut c) = memory_cache().lock() {
+        c.insert(key, master);
+    }
+}
+
+fn cache_file(app: &tauri::AppHandle, key: &str) -> Option<PathBuf> {
+    use tauri::Manager;
+    let dir = app.path().app_cache_dir().ok()?.join(CACHE_DIR);
+    // A key holds a file name and two numbers; anything that isn't safe in a path is
+    // flattened rather than escaped, since collisions are caught by the header check.
+    let safe: String = key
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    Some(dir.join(format!("{safe}.bin")))
+}
+
+/// On-disk master: the terrain descriptor as JSON, then the raw grid.
+fn write_cache(file: &Path, master: &Master) {
+    if let Some(parent) = file.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let Ok(head) = serde_json::to_vec(&master.info) else {
+        return;
+    };
+    let mut out = Vec::with_capacity(8 + head.len() + master.heights.len() * 4);
+    out.extend_from_slice(&(head.len() as u32).to_le_bytes());
+    out.extend_from_slice(&head);
+    for v in &master.heights {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    let _ = std::fs::write(file, out);
+}
+
+fn read_cache(file: &Path) -> Option<Master> {
+    let bytes = std::fs::read(file).ok()?;
+    if bytes.len() < 4 {
+        return None;
+    }
+    let head_len = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+    let grid_at = 4 + head_len;
+    if bytes.len() < grid_at {
+        return None;
+    }
+    let info: TerrainInfo = serde_json::from_slice(&bytes[4..grid_at]).ok()?;
+
+    let expected = info.width as usize * info.height as usize;
+    let grid = &bytes[grid_at..];
+    if grid.len() != expected * 4 {
+        return None;
+    }
+    let heights = grid
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect();
+    Some(Master { info, heights })
+}
+
+/// Keep the cache from growing without limit. Oldest first, since the newest are the tracks
+/// being looked at now.
+fn prune_cache(app: &tauri::AppHandle) {
+    use tauri::Manager;
+    let Ok(base) = app.path().app_cache_dir() else {
+        return;
+    };
+    let dir = base.join(CACHE_DIR);
+    let Ok(rd) = std::fs::read_dir(&dir) else {
+        return;
+    };
+    let mut files: Vec<(std::time::SystemTime, PathBuf)> = rd
+        .flatten()
+        .filter_map(|e| {
+            let p = e.path();
+            let modified = e.metadata().ok()?.modified().ok()?;
+            p.is_file().then_some((modified, p))
+        })
+        .collect();
+    if files.len() <= CACHE_KEEP {
+        return;
+    }
+    files.sort_by_key(|(t, _)| *t);
+    for (_, p) in files.iter().take(files.len() - CACHE_KEEP) {
+        let _ = std::fs::remove_file(p);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roles_come_from_the_extension() {
+        assert_eq!(role_of("Hangtown/Hangtown.trh"), "heightfield");
+        assert_eq!(role_of("Hangtown/Hangtown.tsc"), "scenery");
+        assert_eq!(role_of("Hangtown/Hangtown.ini"), "config");
+        assert_eq!(role_of("Hangtown/preview.jpg"), "image");
+        assert_eq!(role_of("Hangtown/notes.txt"), "other");
+    }
+
+    #[test]
+    fn heightfields_are_offered_best_first() {
+        let names = vec![
+            "T/T.map".to_string(),
+            "T/T.ini".to_string(),
+            "T/T.trh".to_string(),
+        ];
+        assert_eq!(heightfield_entries(&names), vec!["T/T.trh", "T/T.map"]);
+    }
+
+    #[test]
+    fn a_track_with_no_heightfield_offers_nothing() {
+        let names = vec!["T/T.ini".to_string(), "T/preview.jpg".to_string()];
+        assert!(heightfield_entries(&names).is_empty());
+    }
+
+    #[test]
+    fn ini_hints_read_paired_dimensions() {
+        let (dims, scale) = ini_hints("[terrain]\nnx = 512\nny = 256\nscale = 0.5\n");
+        assert_eq!(dims, Some((512, 256)));
+        assert_eq!(scale, Some(0.5));
+    }
+
+    #[test]
+    fn ini_hints_read_a_single_square_size() {
+        let (dims, _) = ini_hints("[terrain]\nsize=1024\n");
+        assert_eq!(dims, Some((1024, 1024)));
+    }
+
+    #[test]
+    fn ini_hints_ignore_a_track_that_says_nothing() {
+        let (dims, scale) = ini_hints("[info]\nname = Hangtown\n");
+        assert_eq!(dims, None);
+        assert_eq!(scale, None);
+    }
+
+    #[test]
+    fn ini_hints_reject_an_absurd_scale() {
+        let (_, scale) = ini_hints("[terrain]\nscale = 99999\n");
+        assert_eq!(scale, None, "a kilometre-wide sample is a misread, not a hint");
+    }
+
+    /// A master built from a known grid, for the blob and resample tests.
+    fn master(dim: u32) -> Master {
+        let heights: Vec<f32> = (0..dim * dim)
+            .map(|i| ((i % dim) as f32 / dim as f32) * 10.0)
+            .collect();
+        Master {
+            info: TerrainInfo {
+                width: dim,
+                height: dim,
+                source_width: dim * 2,
+                source_height: dim * 2,
+                min_height: 0.0,
+                max_height: 10.0,
+                metres_per_sample: 2.0,
+                scale_known: true,
+                confidence: 0.9,
+                source: "header".into(),
+                entry: "T/T.trh".into(),
+            },
+            heights,
+        }
+    }
+
+    #[test]
+    fn a_blob_carries_its_grid_behind_an_aligned_header() {
+        let m = master(64);
+        let blob = terrain_blob(&m, 64);
+        assert_eq!(&blob[0..4], b"FTRN");
+        assert_eq!(BLOB_HEADER % 4, 0, "the grid has to be readable in place");
+        assert_eq!(blob.len(), BLOB_HEADER + 64 * 64 * 4);
+
+        let w = u32::from_le_bytes([blob[8], blob[9], blob[10], blob[11]]);
+        let h = u32::from_le_bytes([blob[12], blob[13], blob[14], blob[15]]);
+        assert_eq!((w, h), (64, 64));
+    }
+
+    #[test]
+    fn a_blob_carries_how_far_the_terrain_was_inferred() {
+        let mut m = master(64);
+        let known = terrain_blob(&m, 64);
+        assert_eq!(u16::from_le_bytes([known[6], known[7]]) & 1, 1);
+        assert!((f32::from_le_bytes([known[28], known[29], known[30], known[31]]) - 0.9).abs() < 1e-6);
+
+        // A track that never stated its sample spacing has to come through as such — the
+        // relief is real, the footprint it's drawn against is a guess.
+        m.info.scale_known = false;
+        let assumed = terrain_blob(&m, 64);
+        assert_eq!(u16::from_le_bytes([assumed[6], assumed[7]]) & 1, 0);
+    }
+
+    #[test]
+    fn a_coarse_blob_keeps_the_terrain_the_same_size_on_the_ground() {
+        let m = master(64);
+        let fine = terrain_blob(&m, 64);
+        let coarse = terrain_blob(&m, 16);
+
+        let spacing = |b: &[u8]| f32::from_le_bytes([b[24], b[25], b[26], b[27]]);
+        let dims = |b: &[u8]| u32::from_le_bytes([b[8], b[9], b[10], b[11]]) as f32;
+
+        // Fewer samples, proportionally further apart — the footprint is unchanged, which is
+        // what lets a coarse pass be replaced by a fine one without the terrain moving.
+        assert!((dims(&fine) * spacing(&fine) - dims(&coarse) * spacing(&coarse)).abs() < 0.01);
+    }
+
+    #[test]
+    fn resampling_below_the_master_is_a_no_op() {
+        let m = master(64);
+        let (w, h, grid) = resample(&m, 256);
+        assert_eq!((w, h), (64, 64));
+        assert_eq!(grid.len(), 64 * 64);
+    }
+
+    #[test]
+    fn a_cached_master_round_trips() {
+        let dir = std::env::temp_dir().join(format!("frost-track-cache-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let file = dir.join("m.bin");
+
+        let m = master(32);
+        write_cache(&file, &m);
+        let back = read_cache(&file).expect("a master just written should read back");
+
+        assert_eq!(back.info.width, m.info.width);
+        assert_eq!(back.info.entry, m.info.entry);
+        assert_eq!(back.heights, m.heights);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_truncated_cache_entry_is_ignored() {
+        let dir = std::env::temp_dir().join(format!("frost-track-trunc-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let file = dir.join("m.bin");
+
+        let m = master(32);
+        write_cache(&file, &m);
+        let bytes = std::fs::read(&file).unwrap();
+        std::fs::write(&file, &bytes[..bytes.len() - 16]).unwrap();
+
+        assert!(
+            read_cache(&file).is_none(),
+            "a short grid must be re-decoded, not read past",
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -26,7 +26,9 @@ const MASTER_DIM: u32 = 512;
 
 /// Cache generation. Bump when the blob layout or the probe changes shape, so entries
 /// written by an older build are ignored rather than misread.
-const CACHE_DIR: &str = "track-terrain-v1";
+// v2: grids are metres where the file states a height scale, so v1's raw-unit masters
+// would now be read as though they were already converted.
+const CACHE_DIR: &str = "track-terrain-v2";
 
 /// How many cached masters to keep. At roughly a megabyte each this is a bounded cost that
 /// only grows with tracks actually opened.
@@ -79,6 +81,9 @@ pub struct TerrainInfo {
     /// `scale_known`) — the relief is still true, only its footprint is a guess.
     pub metres_per_sample: f32,
     pub scale_known: bool,
+    /// Whether `min_height`/`max_height` are metres. When the height file didn't say what
+    /// its samples mean they're raw units, and the relief is a number about nothing.
+    pub heights_in_metres: bool,
     /// 0–1, from the probe. Anything recovered rather than stated is shown as inferred.
     pub confidence: f32,
     /// `header`, `ini` or `square` — how the grid's shape was decided.
@@ -309,7 +314,10 @@ fn build_master(bytes: &[u8], layout: &Layout, entry: &str, ini_scale: Option<f3
     // The master covers the same ground as the source at fewer samples, so the spacing grows
     // by exactly the reduction factor.
     let reduction = layout.width as f32 / w.max(1) as f32;
-    let metres_per_sample = ini_scale.unwrap_or(1.0) * reduction;
+    // What the file itself said, first: a `.trh` states its own footprint, and that beats
+    // both a hint from the track's `.ini` and the fallback of one metre per sample.
+    let stated = layout.metres_per_sample.or(ini_scale);
+    let metres_per_sample = stated.unwrap_or(1.0) * reduction;
 
     Master {
         info: TerrainInfo {
@@ -320,7 +328,8 @@ fn build_master(bytes: &[u8], layout: &Layout, entry: &str, ini_scale: Option<f3
             min_height: if min.is_finite() { min } else { 0.0 },
             max_height: if max.is_finite() { max } else { 0.0 },
             metres_per_sample,
-            scale_known: ini_scale.is_some(),
+            scale_known: stated.is_some(),
+            heights_in_metres: layout.height_scale.is_some(),
             confidence: layout.confidence,
             source: layout.source.to_string(),
             entry: entry.to_string(),
@@ -340,7 +349,9 @@ pub fn terrain_blob(master: &Master, max_dim: u32) -> Vec<u8> {
     // Bit 0: the sample spacing was stated by the track rather than assumed. The app needs
     // this to caption the view honestly — with the spacing assumed, the relief is drawn
     // against a footprint we guessed, so its steepness is not something to trust.
-    out.extend_from_slice(&(u16::from(master.info.scale_known)).to_le_bytes());
+    // Bit 1: the heights are metres rather than the file's own raw units.
+    let flags = u16::from(master.info.scale_known) | (u16::from(master.info.heights_in_metres) << 1);
+    out.extend_from_slice(&flags.to_le_bytes());
     out.extend_from_slice(&w.to_le_bytes());
     out.extend_from_slice(&h.to_le_bytes());
     out.extend_from_slice(&master.info.min_height.to_le_bytes());
@@ -700,6 +711,7 @@ mod tests {
                 max_height: 10.0,
                 metres_per_sample: 2.0,
                 scale_known: true,
+                heights_in_metres: true,
                 confidence: 0.9,
                 source: "header".into(),
                 entry: "T/T.trh".into(),

--- a/src/Components/Library/LibraryDetail.tsx
+++ b/src/Components/Library/LibraryDetail.tsx
@@ -7,11 +7,13 @@ import {
   Lock,
   Maximize2,
   Box,
+  Mountain,
   type LucideIcon,
 } from "lucide-react";
 import { getPkzMeta, getPkzPreview, type ModType } from "../../api/mods";
 import type { LibraryEntry, PkzMeta } from "../../types";
 import { ViewerDialog } from "../Viewer/ViewerDialog";
+import { TrackViewerDialog } from "../Viewer/TrackViewerDialog";
 import { entryViewerProps } from "../Viewer/entryViewer";
 import { useConfig } from "../../Context/Config";
 import {
@@ -55,6 +57,9 @@ export default function LibraryDetail({
   const [preview, setPreview] = useState<string | null>(null);
   const [lightbox, setLightbox] = useState(false);
   const [view3d, setView3d] = useState(false);
+  const [viewTrack, setViewTrack] = useState(false);
+  // A track has its own viewer: it isn't a model with paints, it's a terrain grid.
+  const isTrack = entry.category === "track";
 
   useEffect(() => {
     let alive = true;
@@ -167,6 +172,11 @@ export default function LibraryDetail({
               {view && (
                 <Button variant="outline" size="sm" onClick={() => setView3d(true)}>
                   <Box className="size-3.5" /> View in 3D
+                </Button>
+              )}
+              {isTrack && (
+                <Button variant="outline" size="sm" onClick={() => setViewTrack(true)}>
+                  <Mountain className="size-3.5" /> {t("trackViewer.open")}
                 </Button>
               )}
               {canMove && (
@@ -326,6 +336,17 @@ export default function LibraryDetail({
         initialPaint={view?.initialPaint}
         initialGoggles={view?.initialGoggles}
       />
+
+      {/* Mounted only once opened: the viewer reads the terrain as it mounts, and a track
+          detail page shouldn't pay for that until someone asks to see it. */}
+      {isTrack && viewTrack && (
+        <TrackViewerDialog
+          open={viewTrack}
+          onOpenChange={setViewTrack}
+          path={entry.path}
+          title={title}
+        />
+      )}
     </div>
   );
 }

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useMemo } from "react";
+import { Canvas } from "@react-three/fiber";
+import { OrbitControls } from "@react-three/drei";
+import { Move, Rotate3d, ZoomIn } from "lucide-react";
+import * as THREE from "three";
+import { cn } from "@/lib/utils";
+import type { TrackTerrain } from "../../types";
+import { ErrorBoundary } from "../ErrorBoundary";
+import { useT } from "../../i18n/context";
+
+/** The terrain is scaled to sit this many units across, whatever its real size. */
+const VIEW_SPAN = 10;
+
+/**
+ * Elevation ramp, low to high. Earth rather than atlas colours — a motocross track is dirt
+ * with grass around it, and a rainbow ramp reads as data rather than as ground.
+ */
+const RAMP: [number, THREE.Color][] = [
+  [0.0, new THREE.Color("#2c3626")],
+  [0.35, new THREE.Color("#55532f")],
+  [0.62, new THREE.Color("#8a7346")],
+  [0.85, new THREE.Color("#b89a68")],
+  [1.0, new THREE.Color("#ded0ae")],
+];
+
+function rampAt(t: number, out: THREE.Color): THREE.Color {
+  const c = Math.min(Math.max(t, 0), 1);
+  for (let i = 1; i < RAMP.length; i += 1) {
+    const [hi, hiColor] = RAMP[i];
+    if (c <= hi) {
+      const [lo, loColor] = RAMP[i - 1];
+      const span = hi - lo;
+      return out.copy(loColor).lerp(hiColor, span === 0 ? 0 : (c - lo) / span);
+    }
+  }
+  return out.copy(RAMP[RAMP.length - 1][1]);
+}
+
+/**
+ * Turn a height grid into a mesh.
+ *
+ * Written straight into typed arrays rather than through `PlaneGeometry` and a displacement
+ * pass: a 320² grid is a hundred thousand vertices, and building it a `Vector3` at a time is
+ * the difference between a view that appears and one that hitches on arrival.
+ *
+ * The terrain is scaled to a fixed span so the camera framing holds for any track, and
+ * heights are scaled by the *same* factor as the ground, so relief stays true — a flat
+ * supercross floor looks flat, which is what `exaggeration` is there to overrule.
+ */
+function buildGeometry(terrain: TrackTerrain, exaggeration: number): THREE.BufferGeometry {
+  const { width, height, heights, metresPerSample, minHeight, maxHeight } = terrain;
+
+  // Metres across the widest edge, and the units-per-metre that fits it to the view.
+  const spanMetres = Math.max(width - 1, height - 1) * metresPerSample;
+  const unitsPerMetre = spanMetres > 0 ? VIEW_SPAN / spanMetres : 1;
+  const step = metresPerSample * unitsPerMetre;
+
+  const relief = maxHeight - minHeight;
+  const midHeight = (minHeight + maxHeight) / 2;
+
+  const count = width * height;
+  const positions = new Float32Array(count * 3);
+  const colors = new Float32Array(count * 3);
+  const colour = new THREE.Color();
+
+  const originX = ((width - 1) * step) / 2;
+  const originZ = ((height - 1) * step) / 2;
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const i = y * width + x;
+      const metres = heights[i];
+      const o = i * 3;
+      positions[o] = x * step - originX;
+      positions[o + 1] = (metres - midHeight) * unitsPerMetre * exaggeration;
+      positions[o + 2] = y * step - originZ;
+
+      rampAt(relief > 0 ? (metres - minHeight) / relief : 0.5, colour);
+      colors[o] = colour.r;
+      colors[o + 1] = colour.g;
+      colors[o + 2] = colour.b;
+    }
+  }
+
+  // Two triangles per cell. 32-bit indices throughout: a 256² grid already needs more than
+  // 65 536 vertices, so the 16-bit array would silently wrap.
+  const cells = (width - 1) * (height - 1);
+  const indices = new Uint32Array(cells * 6);
+  let at = 0;
+  for (let y = 0; y < height - 1; y += 1) {
+    for (let x = 0; x < width - 1; x += 1) {
+      const a = y * width + x;
+      const b = a + 1;
+      const c = a + width;
+      const d = c + 1;
+      indices[at] = a;
+      indices[at + 1] = c;
+      indices[at + 2] = b;
+      indices[at + 3] = b;
+      indices[at + 4] = c;
+      indices[at + 5] = d;
+      at += 6;
+    }
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+  geometry.setAttribute("color", new THREE.BufferAttribute(colors, 3));
+  geometry.setIndex(new THREE.BufferAttribute(indices, 1));
+  geometry.computeVertexNormals();
+  geometry.computeBoundingSphere();
+  return geometry;
+}
+
+function TerrainMesh({
+  terrain,
+  exaggeration,
+}: {
+  terrain: TrackTerrain;
+  exaggeration: number;
+}) {
+  const geometry = useMemo(
+    () => buildGeometry(terrain, exaggeration),
+    [terrain, exaggeration],
+  );
+
+  // A grid this size is megabytes of GPU buffers, and the viewer replaces it every time the
+  // detail level or the exaggeration changes — without this each one would be leaked.
+  useEffect(() => () => geometry.dispose(), [geometry]);
+
+  return (
+    // No shadow casting: relief this size would need a huge shadow map to look like
+    // anything, and the directional key below already reads the terrain's shape.
+    <mesh geometry={geometry}>
+      {/* Flat-ish and unshiny: dirt, and it keeps the relief legible rather than glared out. */}
+      <meshStandardMaterial vertexColors roughness={0.95} metalness={0} />
+    </mesh>
+  );
+}
+
+/** Legend for the orbit gestures — the canvas gives no other clue that it can be moved.
+ *  Same wording and placement as the model viewer's, so the two read as one control. */
+function ControlsHint() {
+  const t = useT();
+  const items = [
+    { Icon: Rotate3d, label: t("viewer.dragToRotate") },
+    { Icon: ZoomIn, label: t("viewer.scrollToZoom") },
+    { Icon: Move, label: t("viewer.rightDragToPan") },
+  ];
+  return (
+    <div className="pointer-events-none absolute bottom-2 left-2 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md bg-white/[0.06] px-2 py-1 text-[11px] leading-none text-white/45">
+      {items.map(({ Icon, label }) => (
+        <span key={label} className="flex items-center gap-1">
+          <Icon className="h-3.5 w-3.5" />
+          {label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+interface TrackViewerProps {
+  terrain: TrackTerrain | null;
+  /** Multiplies relief only. 1 is true to scale. */
+  exaggeration?: number;
+  className?: string;
+}
+
+export function TrackViewer({
+  terrain,
+  exaggeration = 1,
+  className,
+}: TrackViewerProps) {
+  return (
+    <div className={cn("relative", className)}>
+      <ErrorBoundary compact label="track-viewer">
+        <Canvas
+          className="h-full w-full"
+          // Nothing in the scene animates, so a parked terrain costs no frames at all.
+          frameloop="demand"
+          dpr={[1, 1.5]}
+          camera={{ position: [0, 7.5, 11], fov: 45, near: 0.05, far: 200 }}
+          onCreated={({ gl, invalidate }) => {
+            gl.domElement.addEventListener(
+              "webglcontextlost",
+              (e) => {
+                e.preventDefault();
+                console.warn("[TrackViewer] WebGL context lost — awaiting restore");
+              },
+              false,
+            );
+            // Restoring doesn't touch React state, so on demand nothing would redraw.
+            gl.domElement.addEventListener("webglcontextrestored", () => invalidate(), false);
+          }}
+        >
+          <color attach="background" args={["#0e0f13"]} />
+          <ambientLight intensity={0.5} />
+          {/* Sky above, warm bounce below — enough to keep hollows from going solid black. */}
+          <hemisphereLight args={[0xdfe8ff, 0x4a4133, 0.8]} />
+          {/* Low and to one side: relief reads by its shadows, and an overhead key flattens it. */}
+          <directionalLight position={[8, 6, 4]} intensity={1.15} />
+          <directionalLight position={[-6, 3, -5]} intensity={0.4} />
+          {terrain && <TerrainMesh terrain={terrain} exaggeration={exaggeration} />}
+          <OrbitControls
+            makeDefault
+            enablePan
+            screenSpacePanning={false}
+            zoomToCursor
+            minDistance={1.5}
+            maxDistance={40}
+            // Stop the camera going under the ground, where the terrain is an unlit shell.
+            maxPolarAngle={Math.PI / 2.05}
+            target={[0, 0, 0]}
+          />
+        </Canvas>
+      </ErrorBoundary>
+      {terrain && <ControlsHint />}
+    </div>
+  );
+}

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from "react";
-import { Canvas } from "@react-three/fiber";
+import { Canvas, useThree } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
 import { Move, Rotate3d, ZoomIn } from "lucide-react";
 import * as THREE from "three";
@@ -172,6 +172,11 @@ function TerrainMesh({
   useEffect(() => () => geometry.dispose(), [geometry]);
   useEffect(() => () => texture?.dispose(), [texture]);
 
+  // The canvas only draws when asked, and the map arrives well after the terrain settled —
+  // so without this the texture sits on a material nothing ever repaints.
+  const invalidate = useThree((s) => s.invalidate);
+  useEffect(() => invalidate(), [texture, geometry, invalidate]);
+
   return (
     // No shadow casting: relief this size would need a huge shadow map to look like
     // anything, and the directional key below already reads the terrain's shape.
@@ -179,7 +184,13 @@ function TerrainMesh({
       {/* Flat-ish and unshiny: dirt, and it keeps the relief legible rather than glared out.
           With a map the height ramp steps aside — the two together would tint the picture by
           elevation and misreport what the track's own artwork says. */}
+      {/* Keyed on whether there's a texture, so the material is rebuilt rather than mutated
+          when one arrives. Both taking a `map` and dropping `vertexColors` change the shader
+          three.js compiles, and assigning them to a live material leaves it running the
+          program it was built with — the terrain keeps its elevation ramp and never shows the
+          picture at all. */}
       <meshStandardMaterial
+        key={texture ? "textured" : "plain"}
         map={texture ?? undefined}
         vertexColors={!texture}
         roughness={0.95}

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -4,12 +4,22 @@ import { OrbitControls } from "@react-three/drei";
 import { Move, Rotate3d, ZoomIn } from "lucide-react";
 import * as THREE from "three";
 import { cn } from "@/lib/utils";
-import type { TrackTerrain } from "../../types";
+import type { TrackOverview, TrackTerrain } from "../../types";
 import { ErrorBoundary } from "../ErrorBoundary";
 import { useT } from "../../i18n/context";
 
 /** The terrain is scaled to sit this many units across, whatever its real size. */
 const VIEW_SPAN = 10;
+
+/**
+ * Relief is drawn this much taller than life.
+ *
+ * A motocross track is a few metres of relief across a few hundred of ground, so at true
+ * scale the shapes that matter — faces, lips, berms — are a fraction of a degree of slope and
+ * read as flat. This is enough to give them a shadow to be seen by, and little enough that
+ * the track still looks like ground rather than a mountain range.
+ */
+const RELIEF_EXAGGERATION = 1.5;
 
 /**
  * Elevation ramp, low to high. Earth rather than atlas colours — a motocross track is dirt
@@ -43,11 +53,12 @@ function rampAt(t: number, out: THREE.Color): THREE.Color {
  * pass: a 320² grid is a hundred thousand vertices, and building it a `Vector3` at a time is
  * the difference between a view that appears and one that hitches on arrival.
  *
- * The terrain is scaled to a fixed span so the camera framing holds for any track, and
- * heights are scaled by the *same* factor as the ground, so relief stays true — a flat
- * supercross floor looks flat, which is what `exaggeration` is there to overrule.
+ * The terrain is scaled to a fixed span so the camera framing holds for any track. Heights
+ * are scaled by the same factor as the ground and then by [`RELIEF_EXAGGERATION`], so the
+ * relief is proportionate everywhere — a flat supercross floor still looks flatter than a
+ * hillside, it is just not drawn so shallow that nothing casts a shadow.
  */
-function buildGeometry(terrain: TrackTerrain, exaggeration: number): THREE.BufferGeometry {
+function buildGeometry(terrain: TrackTerrain): THREE.BufferGeometry {
   const { width, height, heights, metresPerSample, minHeight, maxHeight } = terrain;
 
   // Metres across the widest edge, and the units-per-metre that fits it to the view.
@@ -61,6 +72,9 @@ function buildGeometry(terrain: TrackTerrain, exaggeration: number): THREE.Buffe
   const count = width * height;
   const positions = new Float32Array(count * 3);
   const colors = new Float32Array(count * 3);
+  // The overview map is drawn to the track's own footprint, so it lays across the grid
+  // corner to corner — the same ground, at a different resolution.
+  const uvs = new Float32Array(count * 2);
   const colour = new THREE.Color();
 
   const originX = ((width - 1) * step) / 2;
@@ -71,19 +85,31 @@ function buildGeometry(terrain: TrackTerrain, exaggeration: number): THREE.Buffe
       const i = y * width + x;
       const metres = heights[i];
       const o = i * 3;
-      positions[o] = x * step - originX;
-      positions[o + 1] = (metres - midHeight) * unitsPerMetre * exaggeration;
+      // X is negated, the same conversion every model in the app goes through
+      // (`edf::to_right_handed`): the game's frame is left-handed and three.js's is not.
+      // Without it the whole track is mirrored — every left-hander rides as a right-hander.
+      positions[o] = originX - x * step;
+      positions[o + 1] = (metres - midHeight) * unitsPerMetre * RELIEF_EXAGGERATION;
       positions[o + 2] = y * step - originZ;
 
       rampAt(relief > 0 ? (metres - minHeight) / relief : 0.5, colour);
       colors[o] = colour.r;
       colors[o + 1] = colour.g;
       colors[o + 2] = colour.b;
+
+      const u = i * 2;
+      uvs[u] = width > 1 ? x / (width - 1) : 0;
+      // Not flipped. A `DataTexture` is uploaded as it arrives (`flipY` is false on it,
+      // unlike every other texture three.js makes), so the first row of pixels is V zero —
+      // and the decoder hands back the top row first, which is the row the grid starts at.
+      uvs[u + 1] = height > 1 ? y / (height - 1) : 0;
     }
   }
 
-  // Two triangles per cell. 32-bit indices throughout: a 256² grid already needs more than
-  // 65 536 vertices, so the 16-bit array would silently wrap.
+  // Two triangles per cell, wound so their faces point up *after* X is negated — mirroring
+  // an axis reverses winding, and the same order that faced upward before would now have the
+  // terrain lit from underneath. 32-bit indices throughout: a 256² grid already needs more
+  // than 65 536 vertices, so the 16-bit array would silently wrap.
   const cells = (width - 1) * (height - 1);
   const indices = new Uint32Array(cells * 6);
   let at = 0;
@@ -94,11 +120,11 @@ function buildGeometry(terrain: TrackTerrain, exaggeration: number): THREE.Buffe
       const c = a + width;
       const d = c + 1;
       indices[at] = a;
-      indices[at + 1] = c;
-      indices[at + 2] = b;
+      indices[at + 1] = b;
+      indices[at + 2] = c;
       indices[at + 3] = b;
-      indices[at + 4] = c;
-      indices[at + 5] = d;
+      indices[at + 4] = d;
+      indices[at + 5] = c;
       at += 6;
     }
   }
@@ -106,6 +132,7 @@ function buildGeometry(terrain: TrackTerrain, exaggeration: number): THREE.Buffe
   const geometry = new THREE.BufferGeometry();
   geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
   geometry.setAttribute("color", new THREE.BufferAttribute(colors, 3));
+  geometry.setAttribute("uv", new THREE.BufferAttribute(uvs, 2));
   geometry.setIndex(new THREE.BufferAttribute(indices, 1));
   geometry.computeVertexNormals();
   geometry.computeBoundingSphere();
@@ -114,26 +141,50 @@ function buildGeometry(terrain: TrackTerrain, exaggeration: number): THREE.Buffe
 
 function TerrainMesh({
   terrain,
-  exaggeration,
+  overview,
 }: {
   terrain: TrackTerrain;
-  exaggeration: number;
+  overview: TrackOverview | null;
 }) {
-  const geometry = useMemo(
-    () => buildGeometry(terrain, exaggeration),
-    [terrain, exaggeration],
-  );
+  const geometry = useMemo(() => buildGeometry(terrain), [terrain]);
+
+  // Built once per picture and handed to the GPU as-is. `sRGB` because it's artwork rather
+  // than measurements: skipping that draws the whole track washed out.
+  const texture = useMemo(() => {
+    if (!overview) return null;
+    const t = new THREE.DataTexture(
+      overview.pixels,
+      overview.width,
+      overview.height,
+      THREE.RGBAFormat,
+    );
+    t.colorSpace = THREE.SRGBColorSpace;
+    t.minFilter = THREE.LinearMipmapLinearFilter;
+    t.magFilter = THREE.LinearFilter;
+    t.generateMipmaps = true;
+    t.anisotropy = 4;
+    t.needsUpdate = true;
+    return t;
+  }, [overview]);
 
   // A grid this size is megabytes of GPU buffers, and the viewer replaces it every time the
-  // detail level or the exaggeration changes — without this each one would be leaked.
+  // detail level changes — without this each one would be leaked.
   useEffect(() => () => geometry.dispose(), [geometry]);
+  useEffect(() => () => texture?.dispose(), [texture]);
 
   return (
     // No shadow casting: relief this size would need a huge shadow map to look like
     // anything, and the directional key below already reads the terrain's shape.
     <mesh geometry={geometry}>
-      {/* Flat-ish and unshiny: dirt, and it keeps the relief legible rather than glared out. */}
-      <meshStandardMaterial vertexColors roughness={0.95} metalness={0} />
+      {/* Flat-ish and unshiny: dirt, and it keeps the relief legible rather than glared out.
+          With a map the height ramp steps aside — the two together would tint the picture by
+          elevation and misreport what the track's own artwork says. */}
+      <meshStandardMaterial
+        map={texture ?? undefined}
+        vertexColors={!texture}
+        roughness={0.95}
+        metalness={0}
+      />
     </mesh>
   );
 }
@@ -161,16 +212,12 @@ function ControlsHint() {
 
 interface TrackViewerProps {
   terrain: TrackTerrain | null;
-  /** Multiplies relief only. 1 is true to scale. */
-  exaggeration?: number;
+  /** The track's overview map, when it ships one that covers the same ground. */
+  overview?: TrackOverview | null;
   className?: string;
 }
 
-export function TrackViewer({
-  terrain,
-  exaggeration = 1,
-  className,
-}: TrackViewerProps) {
+export function TrackViewer({ terrain, overview = null, className }: TrackViewerProps) {
   return (
     <div className={cn("relative", className)}>
       <ErrorBoundary compact label="track-viewer">
@@ -200,7 +247,7 @@ export function TrackViewer({
           {/* Low and to one side: relief reads by its shadows, and an overhead key flattens it. */}
           <directionalLight position={[8, 6, 4]} intensity={1.15} />
           <directionalLight position={[-6, 3, -5]} intensity={0.4} />
-          {terrain && <TerrainMesh terrain={terrain} exaggeration={exaggeration} />}
+          {terrain && <TerrainMesh terrain={terrain} overview={overview} />}
           <OrbitControls
             makeDefault
             enablePan

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -47,6 +47,132 @@ function rampAt(t: number, out: THREE.Color): THREE.Color {
 }
 
 /**
+ * How sunk each sample is against the ground around it, as a brightness multiplier.
+ *
+ * A directional light can only shade a slope by which way it faces, so a rut running along
+ * the light and a ridge running along it are lit identically, and the hollows a track is
+ * actually made of come out flat. This measures each point against a blurred copy of the
+ * terrain — below its surroundings is a hollow, above is a ridge — which is the cheap
+ * standing-in for ambient occlusion, and on a heightfield it is most of what the eye reads
+ * as depth.
+ *
+ * Two separable box passes rather than a gathered kernel: the same answer for a couple of
+ * million samples in a few milliseconds instead of a few seconds.
+ */
+function cavityShade(heights: Float32Array, width: number, height: number): Float32Array {
+  const n = width * height;
+
+  // Blurred once tight and once wide, and read against both. One radius can only find
+  // hollows of one size: a wide blur sees the bowl a turn sits in and steps straight over a
+  // rut, a tight one finds the rut and cannot see the bowl at all. Together they give a track
+  // its shape at both scales, which is what the eye actually reads as depth.
+  const blur = (radius: number): Float32Array => {
+    const tmp = new Float32Array(n);
+    const out = new Float32Array(n);
+    for (let y = 0; y < height; y += 1) {
+      const row = y * width;
+      let total = 0;
+      let count = 0;
+      // Running sum: the window moves one sample at a time, so re-adding every cell of it
+      // would make a wide radius cost many times a tight one for no better answer.
+      for (let x = 0; x < width; x += 1) {
+        if (x === 0) {
+          for (let d = 0; d <= radius && d < width; d += 1) {
+            total += heights[row + d];
+            count += 1;
+          }
+        } else {
+          const add = x + radius;
+          const drop = x - radius - 1;
+          if (add < width) {
+            total += heights[row + add];
+            count += 1;
+          }
+          if (drop >= 0) {
+            total -= heights[row + drop];
+            count -= 1;
+          }
+        }
+        tmp[row + x] = total / count;
+      }
+    }
+    for (let x = 0; x < width; x += 1) {
+      let total = 0;
+      let count = 0;
+      for (let y = 0; y < height; y += 1) {
+        if (y === 0) {
+          for (let d = 0; d <= radius && d < height; d += 1) {
+            total += tmp[d * width + x];
+            count += 1;
+          }
+        } else {
+          const add = y + radius;
+          const drop = y - radius - 1;
+          if (add < height) {
+            total += tmp[add * width + x];
+            count += 1;
+          }
+          if (drop >= 0) {
+            total -= tmp[drop * width + x];
+            count -= 1;
+          }
+        }
+        out[y * width + x] = total / count;
+      }
+    }
+    return out;
+  };
+
+  const fine = blur(3);
+  const broad = blur(14);
+
+  // Each scale is measured against how much this track actually undulates at that scale, so
+  // a supercross floor and an alpine hillside both read rather than one washing out and the
+  // other going to soot.
+  let fineSpread = 0;
+  let broadSpread = 0;
+  let sampled = 0;
+  for (let i = 0; i < n; i += 7) {
+    fineSpread += Math.abs(heights[i] - fine[i]);
+    broadSpread += Math.abs(heights[i] - broad[i]);
+    sampled += 1;
+  }
+  fineSpread = fineSpread / sampled || 1;
+  broadSpread = broadSpread / sampled || 1;
+
+  const out = new Float32Array(n);
+  for (let i = 0; i < n; i += 1) {
+    const f = (heights[i] - fine[i]) / (fineSpread * 2.2);
+    const b = (heights[i] - broad[i]) / (broadSpread * 2.2);
+    // Hollows darken further than ridges brighten: light fills a dip from fewer directions
+    // than it leaves a rise, and an over-brightened ridge just looks chalky.
+    out[i] = Math.min(1.16, Math.max(0.42, 1 + f * 0.40 + b * 0.40));
+  }
+  return out;
+}
+
+/**
+ * The height band the colour ramp is spread across: the 2nd to 98th percentile of the grid.
+ *
+ * Sampled rather than fully sorted — a million heights is a lot of sorting to place a colour
+ * ramp, and every hundredth is plenty to find a percentile.
+ */
+function reliefBand(heights: Float32Array): [number, number] {
+  const step = Math.max(1, Math.floor(heights.length / 20000));
+  const sample: number[] = [];
+  for (let i = 0; i < heights.length; i += step) {
+    const v = heights[i];
+    if (Number.isFinite(v)) sample.push(v);
+  }
+  if (sample.length < 2) return [0, 1];
+  sample.sort((a, b) => a - b);
+  const lo = sample[Math.floor(sample.length * 0.02)];
+  const hi = sample[Math.floor(sample.length * 0.98)];
+  // A track genuinely flat across that band still has to get a ramp rather than a divide.
+  return hi > lo ? [lo, hi] : [sample[0], sample[sample.length - 1] || sample[0] + 1];
+}
+
+/**
  * Turn a height grid into a mesh.
  *
  * Written straight into typed arrays rather than through `PlaneGeometry` and a displacement
@@ -58,7 +184,7 @@ function rampAt(t: number, out: THREE.Color): THREE.Color {
  * relief is proportionate everywhere — a flat supercross floor still looks flatter than a
  * hillside, it is just not drawn so shallow that nothing casts a shadow.
  */
-function buildGeometry(terrain: TrackTerrain): THREE.BufferGeometry {
+function buildGeometry(terrain: TrackTerrain, textured: boolean): THREE.BufferGeometry {
   const { width, height, heights, metresPerSample, minHeight, maxHeight } = terrain;
 
   // Metres across the widest edge, and the units-per-metre that fits it to the view.
@@ -66,8 +192,15 @@ function buildGeometry(terrain: TrackTerrain): THREE.BufferGeometry {
   const unitsPerMetre = spanMetres > 0 ? VIEW_SPAN / spanMetres : 1;
   const step = metresPerSample * unitsPerMetre;
 
-  const relief = maxHeight - minHeight;
   const midHeight = (minHeight + maxHeight) / 2;
+
+  // The ramp is spread over where the ground actually is, not over its extremes. A track's
+  // full range is set by whatever sits at its edges — a boundary wall, a quarry face, one
+  // stray sample — and keying colour to that leaves the entire riding area inside a single
+  // band of the ramp, which is what made every track read as one flat brown.
+  const [rampLow, rampHigh] = reliefBand(heights);
+  const relief = rampHigh - rampLow;
+  const cavity = cavityShade(heights, width, height);
 
   const count = width * height;
   const positions = new Float32Array(count * 3);
@@ -92,10 +225,22 @@ function buildGeometry(terrain: TrackTerrain): THREE.BufferGeometry {
       positions[o + 1] = (metres - midHeight) * unitsPerMetre * RELIEF_EXAGGERATION;
       positions[o + 2] = y * step - originZ;
 
-      rampAt(relief > 0 ? (metres - minHeight) / relief : 0.5, colour);
-      colors[o] = colour.r;
-      colors[o + 1] = colour.g;
-      colors[o + 2] = colour.b;
+      // Vertex colour carries the cavity shading whether or not there is a texture: with
+      // one, three.js multiplies the two, so the surface keeps its own colours and gains the
+      // depth; without one, it darkens the elevation ramp the same way.
+      const shade = cavity[i];
+      if (textured) {
+        // Neutral: the surface picture already says what colour the ground is, and tinting
+        // it by elevation on top would report a height as a change of material.
+        colors[o] = shade;
+        colors[o + 1] = shade;
+        colors[o + 2] = shade;
+      } else {
+        rampAt(relief > 0 ? (metres - rampLow) / relief : 0.5, colour);
+        colors[o] = colour.r * shade;
+        colors[o + 1] = colour.g * shade;
+        colors[o + 2] = colour.b * shade;
+      }
 
       const u = i * 2;
       uvs[u] = width > 1 ? x / (width - 1) : 0;
@@ -146,7 +291,7 @@ function TerrainMesh({
   terrain: TrackTerrain;
   overview: TrackOverview | null;
 }) {
-  const geometry = useMemo(() => buildGeometry(terrain), [terrain]);
+  const geometry = useMemo(() => buildGeometry(terrain, overview != null), [terrain, overview]);
 
   // Built once per picture and handed to the GPU as-is. `sRGB` because it's artwork rather
   // than measurements: skipping that draws the whole track washed out.
@@ -178,12 +323,15 @@ function TerrainMesh({
   useEffect(() => invalidate(), [texture, geometry, invalidate]);
 
   return (
-    // No shadow casting: relief this size would need a huge shadow map to look like
-    // anything, and the directional key below already reads the terrain's shape.
-    <mesh geometry={geometry}>
+    // Both cast and receive: the terrain is the only thing in the scene, so every shadow it
+    // shows is its own — a jump face darkening the ground in front of it, a berm shading its
+    // own inside. That self-shadowing is most of what makes the relief read as ground.
+    <mesh geometry={geometry} castShadow receiveShadow>
       {/* Flat-ish and unshiny: dirt, and it keeps the relief legible rather than glared out.
-          With a map the height ramp steps aside — the two together would tint the picture by
-          elevation and misreport what the track's own artwork says. */}
+          Vertex colours stay on with a texture, because three.js multiplies the two: the
+          surface keeps the colours the track states while the cavity shading underneath gives
+          its hollows depth. Without a texture the same vertex colours carry the elevation
+          ramp instead. */}
       {/* Keyed on whether there's a texture, so the material is rebuilt rather than mutated
           when one arrives. Both taking a `map` and dropping `vertexColors` change the shader
           three.js compiles, and assigning them to a live material leaves it running the
@@ -192,7 +340,7 @@ function TerrainMesh({
       <meshStandardMaterial
         key={texture ? "textured" : "plain"}
         map={texture ?? undefined}
-        vertexColors={!texture}
+        vertexColors
         roughness={0.95}
         metalness={0}
       />
@@ -234,10 +382,13 @@ export function TrackViewer({ terrain, overview = null, className }: TrackViewer
       <ErrorBoundary compact label="track-viewer">
         <Canvas
           className="h-full w-full"
+          // Soft (PCF): a hard shadow map on ground this flat reads as speckle, because one
+          // of its texels covers about one triangle of a grid this fine.
+          shadows="soft"
           // Nothing in the scene animates, so a parked terrain costs no frames at all.
           frameloop="demand"
           dpr={[1, 1.5]}
-          camera={{ position: [0, 7.5, 11], fov: 45, near: 0.05, far: 200 }}
+          camera={{ position: [0, 7.5, 11], fov: 45, near: 0.01, far: 200 }}
           onCreated={({ gl, invalidate }) => {
             gl.domElement.addEventListener(
               "webglcontextlost",
@@ -255,8 +406,34 @@ export function TrackViewer({ terrain, overview = null, className }: TrackViewer
           <ambientLight intensity={0.5} />
           {/* Sky above, warm bounce below — enough to keep hollows from going solid black. */}
           <hemisphereLight args={[0xdfe8ff, 0x4a4133, 0.8]} />
-          {/* Low and to one side: relief reads by its shadows, and an overhead key flattens it. */}
-          <directionalLight position={[8, 6, 4]} intensity={1.15} />
+          {/* Low and to one side: relief reads by its shadows, and an overhead key flattens
+              it. This is the only light that casts — a second caster would double the cost to
+              soften shadows the fill light below already softens for free.
+              The shadow camera is bounded to the terrain's own span, which is fixed however
+              big the real track is, so the whole map fits one map at full precision. */}
+          <directionalLight
+            position={[8, 6, 4]}
+            intensity={1.15}
+            castShadow
+            // Four times the map over a box barely wider than the terrain: the tighter the
+            // camera and the denser the map, the smaller a shadow texel is against the
+            // triangles it has to resolve, which is what decides whether ground shadows
+            // itself into speckle.
+            shadow-mapSize={[4096, 4096]}
+            shadow-camera-left={-5.6}
+            shadow-camera-right={5.6}
+            shadow-camera-top={5.6}
+            shadow-camera-bottom={-5.6}
+            shadow-camera-near={0.5}
+            shadow-camera-far={40}
+            // Offsetting along the normal is what actually cures acne on a heightfield —
+            // there is no back face to push the comparison onto, so the sample has to be
+            // moved off the surface it is testing. About three triangles' worth: enough to
+            // clear a shadow texel several times over, and small enough that a jump's shadow
+            // still starts at the jump instead of floating clear of it.
+            shadow-normalBias={0.02}
+            shadow-bias={-0.0006}
+          />
           <directionalLight position={[-6, 3, -5]} intensity={0.4} />
           {terrain && <TerrainMesh terrain={terrain} overview={overview} />}
           <OrbitControls
@@ -264,8 +441,10 @@ export function TrackViewer({ terrain, overview = null, className }: TrackViewer
             enablePan
             screenSpacePanning={false}
             zoomToCursor
-            minDistance={1.5}
-            maxDistance={40}
+            // Close enough to put the camera on the dirt and read a single jump face, far
+            // enough to hold a 1 km circuit in frame.
+            minDistance={0.15}
+            maxDistance={60}
             // Stop the camera going under the ground, where the terrain is an unlit shell.
             maxPolarAngle={Math.PI / 2.05}
             target={[0, 0, 0]}

--- a/src/Components/Viewer/TrackViewerDialog.tsx
+++ b/src/Components/Viewer/TrackViewerDialog.tsx
@@ -20,6 +20,9 @@ import { useT } from "../../i18n/context";
 const COARSE_DIM = 96;
 const FINE_DIM = 320;
 
+/** Metres. Below this, `[info] length` is a placeholder rather than a lap. */
+const MIN_PLAUSIBLE_LENGTH = 50;
+
 type Exaggeration = "1" | "2" | "4";
 
 interface TrackViewerDialogProps {
@@ -99,7 +102,12 @@ export function TrackViewerDialog({
   const rows: [string, string][] = [];
   if (meta?.author) rows.push([t("libraryDetail.author"), meta.author]);
   if (meta?.location) rows.push([t("libraryDetail.location"), meta.location]);
-  if (meta?.length) rows.push([t("libraryDetail.length"), formatLength(meta.length)]);
+  // Track builders leave `length` at a placeholder more often than they fill it in — a
+  // published track in hand states `length = 1` while its own `.rdf` puts the finish line at
+  // 97 m. A lap shorter than this isn't a motocross track, so say nothing rather than "1 m".
+  if (meta?.length && meta.length >= MIN_PLAUSIBLE_LENGTH) {
+    rows.push([t("libraryDetail.length"), formatLength(meta.length)]);
+  }
   if (meta?.altitude != null) rows.push([t("libraryDetail.altitude"), `${meta.altitude} m`]);
   if (terrain) {
     rows.push([t("trackViewer.grid"), `${terrain.width} × ${terrain.height}`]);

--- a/src/Components/Viewer/TrackViewerDialog.tsx
+++ b/src/Components/Viewer/TrackViewerDialog.tsx
@@ -22,11 +22,12 @@ import { useT } from "../../i18n/context";
  * a transfer rather than another read of the archive.
  */
 const COARSE_DIM = 128;
-const FINE_DIM = 768;
+const FINE_DIM = 2048;
 
-/** The surface picture's longest edge. A track's own is rarely bigger, and past this the
+/** The surface picture's longest edge. Matches the masks' own 2048, so the surface is drawn
+ *  at the resolution the track painted it rather than at half of it. A track's own is rarely bigger, and past this the
  *  picture costs more to move than it adds to a terrain drawn at 320 samples across. */
-const OVERVIEW_DIM = 1024;
+const OVERVIEW_DIM = 2048;
 
 /** Metres. Below this, `[info] length` is a placeholder rather than a lap. */
 const MIN_PLAUSIBLE_LENGTH = 50;
@@ -78,20 +79,22 @@ export function TrackViewerDialog({
 
     void (async () => {
       try {
+        // Started before anything is awaited, so the archive read it needs overlaps the
+        // terrain's rather than following it.
+        const surface = loadTrackOverview(path, OVERVIEW_DIM).catch(() => null);
+
         const coarse = await loadTrackTerrain(path, COARSE_DIM);
         if (!alive) return;
         setTerrain(coarse);
         setLoading(false);
 
-        // Fetched once the terrain is up rather than alongside it: the track is on screen
-        // sooner, and a surface that never arrives leaves a working view rather than no view.
-        void loadTrackOverview(path, OVERVIEW_DIM)
-          .then((map) => alive && setOverview(map))
-          .catch(() => {});
-
         setRefining(true);
-        const fine = await loadTrackTerrain(path, FINE_DIM);
+        // Both together, and applied in one go: the mesh is built from the terrain *and*
+        // whether there's a surface to lay on it, so settling them separately would build a
+        // grid of a million-odd vertices twice and throw the first away.
+        const [fine, map] = await Promise.all([loadTrackTerrain(path, FINE_DIM), surface]);
         if (!alive) return;
+        setOverview(map);
         // Only an upgrade: a backend that capped the master below the fine size would
         // otherwise have us swap a grid for an identical one and rebuild the mesh for free.
         if (fine.width > coarse.width) setTerrain(fine);

--- a/src/Components/Viewer/TrackViewerDialog.tsx
+++ b/src/Components/Viewer/TrackViewerDialog.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
-import { Loader2, Mountain, X } from "lucide-react";
+import { Check, Copy, Loader2, Mountain, X } from "lucide-react";
 import { Dialog, DialogClose, DialogContent } from "../ui/dialog";
 import { Segmented } from "../ui/segmented";
+import { Button } from "@/Components/ui/button";
 import { TrackViewer } from "./TrackViewer";
-import { loadTrackTerrain, readTrackInfo } from "../../api/tracks";
+import { diagnoseTrack, loadTrackTerrain, readTrackInfo } from "../../api/tracks";
 import type { TrackInfo, TrackTerrain } from "../../types";
 import { formatLength } from "../../lib/mods";
 import { useT } from "../../i18n/context";
@@ -44,6 +45,9 @@ export function TrackViewerDialog({
   const [refining, setRefining] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [exaggeration, setExaggeration] = useState<Exaggeration>("1");
+  // Only fetched when a track fails, and only when asked for — it re-reads the archive.
+  const [diagnosis, setDiagnosis] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     if (!open) return;
@@ -52,6 +56,8 @@ export function TrackViewerDialog({
     setInfo(null);
     setTerrain(null);
     setError(null);
+    setDiagnosis(null);
+    setCopied(false);
     setLoading(true);
 
     // The inventory doesn't inflate anything, so it lands while the terrain is still being
@@ -167,6 +173,49 @@ export function TrackViewerDialog({
                 <span className="max-w-md text-xs text-muted-foreground">
                   {t("trackViewer.noTerrainHint")}
                 </span>
+                {/* The format is undocumented, so a track that won't load is evidence. This
+                    puts that evidence in reach of whoever is holding the track, who is
+                    rarely the person who can rebuild the app to go and look. */}
+                <div className="pointer-events-auto mt-3 flex flex-col items-center gap-2">
+                  {!diagnosis ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        void diagnoseTrack(path)
+                          .then(setDiagnosis)
+                          .catch((e) =>
+                            setDiagnosis(e instanceof Error ? e.message : String(e)),
+                          );
+                      }}
+                    >
+                      {t("trackViewer.whyDetails")}
+                    </Button>
+                  ) : (
+                    <>
+                      <pre className="max-h-56 w-[min(46rem,80vw)] overflow-auto rounded-md border border-border bg-background/80 p-3 text-left text-[11px] leading-relaxed">
+                        {diagnosis}
+                      </pre>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                          void navigator.clipboard.writeText(diagnosis).then(() => {
+                            setCopied(true);
+                            setTimeout(() => setCopied(false), 2000);
+                          });
+                        }}
+                      >
+                        {copied ? (
+                          <Check className="size-3.5" />
+                        ) : (
+                          <Copy className="size-3.5" />
+                        )}
+                        {copied ? t("trackViewer.copied") : t("trackViewer.copyDetails")}
+                      </Button>
+                    </>
+                  )}
+                </div>
               </div>
             )}
           </div>

--- a/src/Components/Viewer/TrackViewerDialog.tsx
+++ b/src/Components/Viewer/TrackViewerDialog.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useState } from "react";
+import { Loader2, Mountain, X } from "lucide-react";
+import { Dialog, DialogClose, DialogContent } from "../ui/dialog";
+import { Segmented } from "../ui/segmented";
+import { TrackViewer } from "./TrackViewer";
+import { loadTrackTerrain, readTrackInfo } from "../../api/tracks";
+import type { TrackInfo, TrackTerrain } from "../../types";
+import { formatLength } from "../../lib/mods";
+import { useT } from "../../i18n/context";
+
+/**
+ * The two passes the terrain is loaded in.
+ *
+ * A coarse grid is a few tens of kilobytes and builds its mesh in a frame or two, so the
+ * track is on screen almost immediately; the detailed one replaces it once it arrives. Both
+ * come from the same cached master in the backend, so the second pass costs a resample and
+ * a transfer rather than another read of the archive.
+ */
+const COARSE_DIM = 96;
+const FINE_DIM = 320;
+
+type Exaggeration = "1" | "2" | "4";
+
+interface TrackViewerDialogProps {
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  /** The track's `.pkz` or unpacked folder. */
+  path: string;
+  title?: string;
+}
+
+export function TrackViewerDialog({
+  open,
+  onOpenChange,
+  path,
+  title,
+}: TrackViewerDialogProps) {
+  const t = useT();
+  const [info, setInfo] = useState<TrackInfo | null>(null);
+  const [terrain, setTerrain] = useState<TrackTerrain | null>(null);
+  // True only until the *coarse* pass lands — the refine that follows happens under a
+  // terrain that is already up, and covering it with a spinner would be a step backwards.
+  const [loading, setLoading] = useState(false);
+  const [refining, setRefining] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [exaggeration, setExaggeration] = useState<Exaggeration>("1");
+
+  useEffect(() => {
+    if (!open) return;
+    let alive = true;
+
+    setInfo(null);
+    setTerrain(null);
+    setError(null);
+    setLoading(true);
+
+    // The inventory doesn't inflate anything, so it lands while the terrain is still being
+    // read and the panel can fill in around the empty canvas.
+    readTrackInfo(path)
+      .then((i) => alive && setInfo(i))
+      .catch(() => {});
+
+    void (async () => {
+      try {
+        const coarse = await loadTrackTerrain(path, COARSE_DIM);
+        if (!alive) return;
+        setTerrain(coarse);
+        setLoading(false);
+
+        setRefining(true);
+        const fine = await loadTrackTerrain(path, FINE_DIM);
+        if (!alive) return;
+        // Only an upgrade: a backend that capped the master below the fine size would
+        // otherwise have us swap a grid for an identical one and rebuild the mesh for free.
+        if (fine.width > coarse.width) setTerrain(fine);
+      } catch (e) {
+        if (!alive) return;
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (alive) {
+          setLoading(false);
+          setRefining(false);
+        }
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, [open, path]);
+
+  const meta = info?.meta;
+  const rows: [string, string][] = [];
+  if (meta?.author) rows.push([t("libraryDetail.author"), meta.author]);
+  if (meta?.location) rows.push([t("libraryDetail.location"), meta.location]);
+  if (meta?.length) rows.push([t("libraryDetail.length"), formatLength(meta.length)]);
+  if (meta?.altitude != null) rows.push([t("libraryDetail.altitude"), `${meta.altitude} m`]);
+  if (terrain) {
+    rows.push([t("trackViewer.grid"), `${terrain.width} × ${terrain.height}`]);
+    rows.push([
+      t("trackViewer.relief"),
+      `${Math.round(terrain.maxHeight - terrain.minHeight)} m`,
+    ]);
+  }
+
+  // Nothing to load rather than something that failed — worth saying plainly, since the
+  // inventory can tell us before the terrain read even finishes.
+  const noTerrain = info != null && !info.hasTerrain;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showClose={false}
+        className="flex h-[85vh] w-[92vw] max-w-none flex-col gap-0 overflow-hidden p-0 sm:max-w-none"
+      >
+        <div className="flex flex-none items-center justify-between gap-3 border-b border-border px-4 py-2.5">
+          <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
+            <Mountain className="h-4 w-4 flex-none text-muted-foreground" />
+            <span className="truncate">{title ?? meta?.name ?? t("trackViewer.title")}</span>
+            {refining && (
+              <span className="flex-none text-[11px] font-normal text-muted-foreground">
+                {t("trackViewer.refining")}
+              </span>
+            )}
+          </div>
+          <div className="flex flex-none items-center gap-2">
+            <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              {t("trackViewer.exaggeration")}
+              <Segmented
+                size="sm"
+                value={exaggeration}
+                onChange={setExaggeration}
+                options={[
+                  { value: "1", label: "1×" },
+                  { value: "2", label: "2×" },
+                  { value: "4", label: "4×" },
+                ]}
+              />
+            </label>
+            <DialogClose className="rounded-md p-1 text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none">
+              <X className="size-4" />
+              <span className="sr-only">{t("common.close")}</span>
+            </DialogClose>
+          </div>
+        </div>
+
+        <div className="flex min-h-0 flex-1">
+          <div className="relative min-w-0 flex-1">
+            <TrackViewer
+              terrain={terrain}
+              exaggeration={Number(exaggeration)}
+              className="absolute inset-0"
+            />
+            {loading && !terrain && (
+              <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-3 bg-black/40">
+                <Loader2 className="h-6 w-6 animate-spin text-white/80" />
+                <span className="text-sm text-white/80">{t("trackViewer.loading")}</span>
+              </div>
+            )}
+            {/* Only when there's nothing on screen. A refine pass that failed leaves the
+                coarse terrain up and working, and covering it with an error would be a lie. */}
+            {!loading && !terrain && (error || noTerrain) && (
+              <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-1 px-6 text-center">
+                <span className="text-sm font-medium text-foreground">
+                  {t("trackViewer.noTerrain")}
+                </span>
+                <span className="max-w-md text-xs text-muted-foreground">
+                  {t("trackViewer.noTerrainHint")}
+                </span>
+              </div>
+            )}
+          </div>
+
+          <aside className="w-64 flex-none overflow-y-auto border-l border-border p-4">
+            {meta?.thumbnail && (
+              <img
+                src={meta.thumbnail}
+                alt=""
+                className="mb-3 w-full rounded-md border border-border object-cover"
+              />
+            )}
+            <dl className="space-y-2">
+              {rows.map(([label, value]) => (
+                <div key={label}>
+                  <dt className="text-[10px] font-semibold uppercase tracking-[0.9px] text-faint">
+                    {label}
+                  </dt>
+                  <dd className="text-[13px] text-foreground">{value}</dd>
+                </div>
+              ))}
+            </dl>
+
+            {/* The height file has no documented layout, so what's on screen was worked out
+                from the data. Say so, rather than letting a guess pass for a reading. */}
+            {terrain && (terrain.confidence < 0.75 || !terrain.scaleKnown) && (
+              <p className="mt-4 border-t border-border pt-3 text-[11px] leading-relaxed text-muted-foreground">
+                {!terrain.scaleKnown
+                  ? t("trackViewer.assumedScaleNote")
+                  : t("trackViewer.inferredNote")}
+              </p>
+            )}
+          </aside>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/Components/Viewer/TrackViewerDialog.tsx
+++ b/src/Components/Viewer/TrackViewerDialog.tsx
@@ -1,11 +1,15 @@
 import { useEffect, useState } from "react";
 import { Check, Copy, Loader2, Mountain, X } from "lucide-react";
 import { Dialog, DialogClose, DialogContent } from "../ui/dialog";
-import { Segmented } from "../ui/segmented";
 import { Button } from "@/Components/ui/button";
 import { TrackViewer } from "./TrackViewer";
-import { diagnoseTrack, loadTrackTerrain, readTrackInfo } from "../../api/tracks";
-import type { TrackInfo, TrackTerrain } from "../../types";
+import {
+  diagnoseTrack,
+  loadTrackOverview,
+  loadTrackTerrain,
+  readTrackInfo,
+} from "../../api/tracks";
+import type { TrackInfo, TrackOverview, TrackTerrain } from "../../types";
 import { formatLength } from "../../lib/mods";
 import { useT } from "../../i18n/context";
 
@@ -17,13 +21,15 @@ import { useT } from "../../i18n/context";
  * come from the same cached master in the backend, so the second pass costs a resample and
  * a transfer rather than another read of the archive.
  */
-const COARSE_DIM = 96;
-const FINE_DIM = 320;
+const COARSE_DIM = 128;
+const FINE_DIM = 768;
+
+/** The overview map's longest edge. A track's own is rarely bigger, and past this the
+ *  picture costs more to move than it adds to a terrain drawn at 320 samples across. */
+const OVERVIEW_DIM = 1024;
 
 /** Metres. Below this, `[info] length` is a placeholder rather than a lap. */
 const MIN_PLAUSIBLE_LENGTH = 50;
-
-type Exaggeration = "1" | "2" | "4";
 
 interface TrackViewerDialogProps {
   open: boolean;
@@ -42,12 +48,12 @@ export function TrackViewerDialog({
   const t = useT();
   const [info, setInfo] = useState<TrackInfo | null>(null);
   const [terrain, setTerrain] = useState<TrackTerrain | null>(null);
+  const [overview, setOverview] = useState<TrackOverview | null>(null);
   // True only until the *coarse* pass lands — the refine that follows happens under a
   // terrain that is already up, and covering it with a spinner would be a step backwards.
   const [loading, setLoading] = useState(false);
   const [refining, setRefining] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [exaggeration, setExaggeration] = useState<Exaggeration>("1");
   // Only fetched when a track fails, and only when asked for — it re-reads the archive.
   const [diagnosis, setDiagnosis] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
@@ -58,6 +64,7 @@ export function TrackViewerDialog({
 
     setInfo(null);
     setTerrain(null);
+    setOverview(null);
     setError(null);
     setDiagnosis(null);
     setCopied(false);
@@ -75,6 +82,13 @@ export function TrackViewerDialog({
         if (!alive) return;
         setTerrain(coarse);
         setLoading(false);
+
+        // Fetched once the terrain is up rather than alongside it: the track is on screen
+        // sooner, and a map that never arrives leaves a working view rather than no view.
+        // Its own proportions are checked against the grid's, so this needs the grid first.
+        void loadTrackOverview(path, OVERVIEW_DIM, coarse.width / coarse.height)
+          .then((map) => alive && setOverview(map))
+          .catch(() => {});
 
         setRefining(true);
         const fine = await loadTrackTerrain(path, FINE_DIM);
@@ -142,19 +156,6 @@ export function TrackViewerDialog({
             )}
           </div>
           <div className="flex flex-none items-center gap-2">
-            <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              {t("trackViewer.exaggeration")}
-              <Segmented
-                size="sm"
-                value={exaggeration}
-                onChange={setExaggeration}
-                options={[
-                  { value: "1", label: "1×" },
-                  { value: "2", label: "2×" },
-                  { value: "4", label: "4×" },
-                ]}
-              />
-            </label>
             <DialogClose className="rounded-md p-1 text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none">
               <X className="size-4" />
               <span className="sr-only">{t("common.close")}</span>
@@ -166,7 +167,7 @@ export function TrackViewerDialog({
           <div className="relative min-w-0 flex-1">
             <TrackViewer
               terrain={terrain}
-              exaggeration={Number(exaggeration)}
+              overview={overview}
               className="absolute inset-0"
             />
             {loading && !terrain && (

--- a/src/Components/Viewer/TrackViewerDialog.tsx
+++ b/src/Components/Viewer/TrackViewerDialog.tsx
@@ -111,10 +111,14 @@ export function TrackViewerDialog({
   if (meta?.altitude != null) rows.push([t("libraryDetail.altitude"), `${meta.altitude} m`]);
   if (terrain) {
     rows.push([t("trackViewer.grid"), `${terrain.width} × ${terrain.height}`]);
-    rows.push([
-      t("trackViewer.relief"),
-      `${Math.round(terrain.maxHeight - terrain.minHeight)} m`,
-    ]);
+    // Only when the height file said what its samples mean. Otherwise the grid is in raw
+    // quantised units and "65535 m of elevation" would be worse than saying nothing.
+    if (terrain.heightsInMetres) {
+      rows.push([
+        t("trackViewer.relief"),
+        `${Math.round(terrain.maxHeight - terrain.minHeight)} m`,
+      ]);
+    }
   }
 
   // Nothing to load rather than something that failed — worth saying plainly, since the

--- a/src/Components/Viewer/TrackViewerDialog.tsx
+++ b/src/Components/Viewer/TrackViewerDialog.tsx
@@ -24,7 +24,7 @@ import { useT } from "../../i18n/context";
 const COARSE_DIM = 128;
 const FINE_DIM = 768;
 
-/** The overview map's longest edge. A track's own is rarely bigger, and past this the
+/** The surface picture's longest edge. A track's own is rarely bigger, and past this the
  *  picture costs more to move than it adds to a terrain drawn at 320 samples across. */
 const OVERVIEW_DIM = 1024;
 
@@ -84,9 +84,8 @@ export function TrackViewerDialog({
         setLoading(false);
 
         // Fetched once the terrain is up rather than alongside it: the track is on screen
-        // sooner, and a map that never arrives leaves a working view rather than no view.
-        // Its own proportions are checked against the grid's, so this needs the grid first.
-        void loadTrackOverview(path, OVERVIEW_DIM, coarse.width / coarse.height)
+        // sooner, and a surface that never arrives leaves a working view rather than no view.
+        void loadTrackOverview(path, OVERVIEW_DIM)
           .then((map) => alive && setOverview(map))
           .catch(() => {});
 
@@ -134,6 +133,8 @@ export function TrackViewerDialog({
       ]);
     }
   }
+
+  if (overview) rows.push([t("trackViewer.surface"), t("trackViewer.surfaceMasks")]);
 
   // Nothing to load rather than something that failed — worth saying plainly, since the
   // inventory can tell us before the terrain read even finishes.

--- a/src/api/tracks.ts
+++ b/src/api/tracks.ts
@@ -60,3 +60,14 @@ export async function loadTrackTerrain(
     heights: new Float32Array(buf, HEADER, width * height),
   };
 }
+
+/**
+ * A plain-text account of what a track's terrain looks like to the reader: its contents,
+ * what its `.ini` claimed, every layout the probe considered, and what it settled on.
+ *
+ * Only worth fetching when the terrain didn't load — it re-reads the archive rather than
+ * using the cached grid, precisely because the interesting case is the one with no grid.
+ */
+export function diagnoseTrack(path: string): Promise<string> {
+  return invoke<string>("diagnose_track", { path });
+}

--- a/src/api/tracks.ts
+++ b/src/api/tracks.ts
@@ -52,8 +52,10 @@ export async function loadTrackTerrain(
     minHeight: view.getFloat32(16, true),
     maxHeight: view.getFloat32(20, true),
     metresPerSample: view.getFloat32(24, true),
-    // Bit 0 of the flags: the track stated its sample spacing rather than us assuming it.
+    // Bit 0: the track stated its sample spacing rather than us assuming it.
+    // Bit 1: the heights are metres rather than the height file's own raw units.
     scaleKnown: (view.getUint16(6, true) & 1) === 1,
+    heightsInMetres: (view.getUint16(6, true) & 2) === 2,
     confidence: view.getFloat32(28, true),
     // The header is a multiple of four bytes precisely so this can be a view rather than
     // a copy — a 512² grid is a megabyte that never needs to be duplicated.

--- a/src/api/tracks.ts
+++ b/src/api/tracks.ts
@@ -70,26 +70,18 @@ const TEXTURE_HEADER = 16;
 const TEXTURE_MAGIC = 0x58455446;
 
 /**
- * A track's overview map, to lay over its terrain.
+ * A picture of a track's surfaces, to lay over its terrain.
  *
- * `null` whenever the track hasn't got one that covers the same ground — most tracks ship
- * only loading artwork, and a few ship none at all. That's an ordinary outcome rather than a
- * failure: the terrain draws on its relief alone, exactly as it did before.
- *
- * `gridAspect` is the terrain's own width-over-height, which the backend uses to refuse a
- * picture drawn to different proportions than the ground it would be stretched over.
+ * Built from the coverage masks in the track's own height file — a byte per cell per surface
+ * the builder painted — so it describes exactly the ground the grid does. `null` when a track
+ * carries no masks, in which case the terrain draws on its relief alone.
  */
 export async function loadTrackOverview(
   path: string,
   maxDim: number,
-  gridAspect: number,
 ): Promise<TrackOverview | null> {
-  const buf = await invoke<ArrayBuffer>("load_track_overview", {
-    path,
-    maxDim,
-    gridAspect,
-  });
-  // The track simply hasn't got one.
+  const buf = await invoke<ArrayBuffer>("load_track_overview", { path, maxDim });
+  // The track simply hasn't got any.
   if (buf.byteLength === 0) return null;
 
   const view = new DataView(buf);

--- a/src/api/tracks.ts
+++ b/src/api/tracks.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { TrackInfo, TrackTerrain } from "../types";
+import type { TrackInfo, TrackOverview, TrackTerrain } from "../types";
 
 /**
  * A track's metadata and contents.
@@ -61,6 +61,50 @@ export async function loadTrackTerrain(
     // a copy — a 512² grid is a megabyte that never needs to be duplicated.
     heights: new Float32Array(buf, HEADER, width * height),
   };
+}
+
+/** Header bytes before the pixels. Mirrors `track::TEXTURE_HEADER`. */
+const TEXTURE_HEADER = 16;
+
+/** `"FTEX"`, the texture blob's leading magic. */
+const TEXTURE_MAGIC = 0x58455446;
+
+/**
+ * A track's overview map, to lay over its terrain.
+ *
+ * `null` whenever the track hasn't got one that covers the same ground — most tracks ship
+ * only loading artwork, and a few ship none at all. That's an ordinary outcome rather than a
+ * failure: the terrain draws on its relief alone, exactly as it did before.
+ *
+ * `gridAspect` is the terrain's own width-over-height, which the backend uses to refuse a
+ * picture drawn to different proportions than the ground it would be stretched over.
+ */
+export async function loadTrackOverview(
+  path: string,
+  maxDim: number,
+  gridAspect: number,
+): Promise<TrackOverview | null> {
+  const buf = await invoke<ArrayBuffer>("load_track_overview", {
+    path,
+    maxDim,
+    gridAspect,
+  });
+  // The track simply hasn't got one.
+  if (buf.byteLength === 0) return null;
+
+  const view = new DataView(buf);
+  if (buf.byteLength < TEXTURE_HEADER || view.getUint32(0, true) !== TEXTURE_MAGIC) {
+    throw new Error("track overview is not in the expected format");
+  }
+  const width = view.getUint32(8, true);
+  const height = view.getUint32(12, true);
+  const expected = width * height * 4;
+  if (buf.byteLength - TEXTURE_HEADER !== expected) {
+    throw new Error(
+      `track overview is ${buf.byteLength - TEXTURE_HEADER}B, expected ${expected}B`,
+    );
+  }
+  return { width, height, pixels: new Uint8Array(buf, TEXTURE_HEADER, expected) };
 }
 
 /**

--- a/src/api/tracks.ts
+++ b/src/api/tracks.ts
@@ -1,0 +1,62 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { TrackInfo, TrackTerrain } from "../types";
+
+/**
+ * A track's metadata and contents.
+ *
+ * Cheap enough to call as the view opens: the backend answers from the archive's index and
+ * inflates nothing, so this returns in the time it takes to read a few kilobytes even for a
+ * track that is hundreds of megabytes on disk.
+ */
+export function readTrackInfo(path: string): Promise<TrackInfo> {
+  return invoke<TrackInfo>("read_track_info", { path });
+}
+
+/** Header bytes before the grid. Mirrors `track::BLOB_HEADER`. */
+const HEADER = 32;
+
+/** `"FTRN"`, the blob's leading magic. */
+const MAGIC = 0x4e525446;
+
+/**
+ * A track's terrain grid, at no more than `maxDim` samples on its longest edge.
+ *
+ * Arrives as raw bytes rather than JSON. A grid is a few hundred thousand floats, and the
+ * same numbers as a JSON array would be several times the size on the wire and cost a parse
+ * on arrival that is slower than the archive read that produced them. Here the heights are
+ * read in place, with no copy and no decode.
+ */
+export async function loadTrackTerrain(
+  path: string,
+  maxDim: number,
+): Promise<TrackTerrain> {
+  const buf = await invoke<ArrayBuffer>("load_track_terrain", { path, maxDim });
+  const view = new DataView(buf);
+  if (buf.byteLength < HEADER || view.getUint32(0, true) !== MAGIC) {
+    throw new Error("terrain blob is not in the expected format");
+  }
+
+  const width = view.getUint32(8, true);
+  const height = view.getUint32(12, true);
+  const expected = width * height * 4;
+  if (buf.byteLength - HEADER !== expected) {
+    // Reading on regardless would hand three.js a short buffer to walk off the end of.
+    throw new Error(
+      `terrain grid is ${buf.byteLength - HEADER}B, expected ${expected}B`,
+    );
+  }
+
+  return {
+    width,
+    height,
+    minHeight: view.getFloat32(16, true),
+    maxHeight: view.getFloat32(20, true),
+    metresPerSample: view.getFloat32(24, true),
+    // Bit 0 of the flags: the track stated its sample spacing rather than us assuming it.
+    scaleKnown: (view.getUint16(6, true) & 1) === 1,
+    confidence: view.getFloat32(28, true),
+    // The header is a multiple of four bytes precisely so this can be a view rather than
+    // a copy — a 512² grid is a megabyte that never needs to be duplicated.
+    heights: new Float32Array(buf, HEADER, width * height),
+  };
+}

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1469,6 +1469,8 @@ export const de: Translation = {
   "trackViewer.loading": "Gelände wird gelesen…",
   "trackViewer.refining": "Wird verfeinert…",
   "trackViewer.grid": "Raster",
+  "trackViewer.surface": "Surface",
+  "trackViewer.surfaceMasks": "From the track's surface data",
   "trackViewer.relief": "Höhenunterschied",
   "trackViewer.noTerrain": "Kein Gelände zum Anzeigen",
   "trackViewer.noTerrainHint":

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1462,4 +1462,20 @@ export const de: Translation = {
   "designer.fillHint": "Auf die Bahn klicken, um die ganze Ebene zu füllen.",
   "designer.gradientHint":
     "Auf der Bahn ziehen, um festzulegen, wo der Übergang liegt. Er füllt diese ganze Ebene — füge eine weitere Malebene hinzu, um zu behalten, was darunter liegt.",
+
+  // The track terrain viewer.
+  "trackViewer.open": "Gelände ansehen",
+  "trackViewer.title": "Streckenvorschau",
+  "trackViewer.loading": "Gelände wird gelesen…",
+  "trackViewer.refining": "Wird verfeinert…",
+  "trackViewer.exaggeration": "Relief",
+  "trackViewer.grid": "Raster",
+  "trackViewer.relief": "Höhenunterschied",
+  "trackViewer.noTerrain": "Kein Gelände zum Anzeigen",
+  "trackViewer.noTerrainHint":
+    "Die Höhendaten dieser Strecke liegen in keinem Format vor, das der Betrachter bereits lesen kann.",
+  "trackViewer.inferredNote":
+    "Die Höhendatei dieser Strecke hat kein dokumentiertes Format, ihre Form wurde also aus den Daten erschlossen. Als nahe, nicht als exakte Lesung zu verstehen.",
+  "trackViewer.assumedScaleNote":
+    "Diese Strecke gibt den Abstand ihrer Höhenpunkte nicht an: Das Relief ist echt, seine Steilheit aber nur eine Näherung.",
 };

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1478,4 +1478,7 @@ export const de: Translation = {
     "Die Höhendatei dieser Strecke hat kein dokumentiertes Format, ihre Form wurde also aus den Daten erschlossen. Als nahe, nicht als exakte Lesung zu verstehen.",
   "trackViewer.assumedScaleNote":
     "Diese Strecke gibt den Abstand ihrer Höhenpunkte nicht an: Das Relief ist echt, seine Steilheit aber nur eine Näherung.",
+  "trackViewer.whyDetails": "Warum?",
+  "trackViewer.copyDetails": "Details kopieren",
+  "trackViewer.copied": "Kopiert",
 };

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1468,7 +1468,6 @@ export const de: Translation = {
   "trackViewer.title": "Streckenvorschau",
   "trackViewer.loading": "Gelände wird gelesen…",
   "trackViewer.refining": "Wird verfeinert…",
-  "trackViewer.exaggeration": "Relief",
   "trackViewer.grid": "Raster",
   "trackViewer.relief": "Höhenunterschied",
   "trackViewer.noTerrain": "Kein Gelände zum Anzeigen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1415,4 +1415,20 @@ export const en = {
   "designer.fillHint": "Click the sheet to flood the whole layer.",
   "designer.gradientHint":
     "Drag across the sheet to set where the transition happens. It fills this whole layer — add another paint layer to keep what's underneath.",
+
+  // The track terrain viewer.
+  "trackViewer.open": "View terrain",
+  "trackViewer.title": "Track preview",
+  "trackViewer.loading": "Reading terrain…",
+  "trackViewer.refining": "Sharpening…",
+  "trackViewer.exaggeration": "Relief",
+  "trackViewer.grid": "Grid",
+  "trackViewer.relief": "Elevation range",
+  "trackViewer.noTerrain": "No terrain to show",
+  "trackViewer.noTerrainHint":
+    "This track's height data isn't in a layout the viewer can read yet.",
+  "trackViewer.inferredNote":
+    "This track's height file has no documented layout, so its shape was worked out from the data. Treat the terrain as a close reading rather than an exact one.",
+  "trackViewer.assumedScaleNote":
+    "This track doesn't state how far apart its height samples are, so the relief is real but how steep it looks is an approximation.",
 } as const;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1422,6 +1422,8 @@ export const en = {
   "trackViewer.loading": "Reading terrain…",
   "trackViewer.refining": "Sharpening…",
   "trackViewer.grid": "Grid",
+  "trackViewer.surface": "Surface",
+  "trackViewer.surfaceMasks": "From the track's surface data",
   "trackViewer.relief": "Elevation range",
   "trackViewer.noTerrain": "No terrain to show",
   "trackViewer.noTerrainHint":

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1431,4 +1431,7 @@ export const en = {
     "This track's height file has no documented layout, so its shape was worked out from the data. Treat the terrain as a close reading rather than an exact one.",
   "trackViewer.assumedScaleNote":
     "This track doesn't state how far apart its height samples are, so the relief is real but how steep it looks is an approximation.",
+  "trackViewer.whyDetails": "Why?",
+  "trackViewer.copyDetails": "Copy details",
+  "trackViewer.copied": "Copied",
 } as const;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1421,7 +1421,6 @@ export const en = {
   "trackViewer.title": "Track preview",
   "trackViewer.loading": "Reading terrain…",
   "trackViewer.refining": "Sharpening…",
-  "trackViewer.exaggeration": "Relief",
   "trackViewer.grid": "Grid",
   "trackViewer.relief": "Elevation range",
   "trackViewer.noTerrain": "No terrain to show",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1457,6 +1457,8 @@ export const es: Translation = {
   "trackViewer.loading": "Leyendo el terreno…",
   "trackViewer.refining": "Afinando…",
   "trackViewer.grid": "Cuadrícula",
+  "trackViewer.surface": "Surface",
+  "trackViewer.surfaceMasks": "From the track's surface data",
   "trackViewer.relief": "Desnivel",
   "trackViewer.noTerrain": "No hay terreno que mostrar",
   "trackViewer.noTerrainHint":

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1456,7 +1456,6 @@ export const es: Translation = {
   "trackViewer.title": "Vista previa del circuito",
   "trackViewer.loading": "Leyendo el terreno…",
   "trackViewer.refining": "Afinando…",
-  "trackViewer.exaggeration": "Relieve",
   "trackViewer.grid": "Cuadrícula",
   "trackViewer.relief": "Desnivel",
   "trackViewer.noTerrain": "No hay terreno que mostrar",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1466,4 +1466,7 @@ export const es: Translation = {
     "El archivo de alturas de este circuito no tiene un formato documentado, así que su forma se dedujo de los datos. Tómalo como una lectura aproximada, no exacta.",
   "trackViewer.assumedScaleNote":
     "Este circuito no indica la separación entre sus puntos de altura: el relieve es real, pero su pendiente es aproximada.",
+  "trackViewer.whyDetails": "¿Por qué?",
+  "trackViewer.copyDetails": "Copiar detalles",
+  "trackViewer.copied": "Copiado",
 };

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1450,4 +1450,20 @@ export const es: Translation = {
   "designer.fillHint": "Haz clic en la hoja para inundar toda la capa.",
   "designer.gradientHint":
     "Arrastra sobre la hoja para marcar dónde ocurre la transición. Rellena toda esta capa: añade otra capa de pintura para conservar lo que hay debajo.",
+
+  // The track terrain viewer.
+  "trackViewer.open": "Ver el terreno",
+  "trackViewer.title": "Vista previa del circuito",
+  "trackViewer.loading": "Leyendo el terreno…",
+  "trackViewer.refining": "Afinando…",
+  "trackViewer.exaggeration": "Relieve",
+  "trackViewer.grid": "Cuadrícula",
+  "trackViewer.relief": "Desnivel",
+  "trackViewer.noTerrain": "No hay terreno que mostrar",
+  "trackViewer.noTerrainHint":
+    "Los datos de altura de este circuito no están en un formato que el visor sepa leer todavía.",
+  "trackViewer.inferredNote":
+    "El archivo de alturas de este circuito no tiene un formato documentado, así que su forma se dedujo de los datos. Tómalo como una lectura aproximada, no exacta.",
+  "trackViewer.assumedScaleNote":
+    "Este circuito no indica la separación entre sus puntos de altura: el relieve es real, pero su pendiente es aproximada.",
 };

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1454,4 +1454,20 @@ export const fr: Translation = {
   "designer.fillHint": "Clique sur la planche pour remplir tout le calque.",
   "designer.gradientHint":
     "Fais glisser sur la planche pour définir où se fait la transition. Cela remplit tout le calque : ajoute un autre calque de peinture pour garder ce qu'il y a dessous.",
+
+  // The track terrain viewer.
+  "trackViewer.open": "Voir le terrain",
+  "trackViewer.title": "Aperçu du circuit",
+  "trackViewer.loading": "Lecture du terrain…",
+  "trackViewer.refining": "Affinage…",
+  "trackViewer.exaggeration": "Relief",
+  "trackViewer.grid": "Grille",
+  "trackViewer.relief": "Dénivelé",
+  "trackViewer.noTerrain": "Aucun terrain à afficher",
+  "trackViewer.noTerrainHint":
+    "Les données d'altitude de ce circuit ne sont pas dans un format que la visionneuse sait encore lire.",
+  "trackViewer.inferredNote":
+    "Le fichier d'altitudes de ce circuit n'a pas de format documenté ; sa forme a donc été déduite des données. À lire comme une approximation fidèle, pas comme une mesure exacte.",
+  "trackViewer.assumedScaleNote":
+    "Ce circuit n'indique pas l'écart entre ses points d'altitude : le relief est réel, mais sa pente est approximative.",
 };

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1460,7 +1460,6 @@ export const fr: Translation = {
   "trackViewer.title": "Aperçu du circuit",
   "trackViewer.loading": "Lecture du terrain…",
   "trackViewer.refining": "Affinage…",
-  "trackViewer.exaggeration": "Relief",
   "trackViewer.grid": "Grille",
   "trackViewer.relief": "Dénivelé",
   "trackViewer.noTerrain": "Aucun terrain à afficher",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1470,4 +1470,7 @@ export const fr: Translation = {
     "Le fichier d'altitudes de ce circuit n'a pas de format documenté ; sa forme a donc été déduite des données. À lire comme une approximation fidèle, pas comme une mesure exacte.",
   "trackViewer.assumedScaleNote":
     "Ce circuit n'indique pas l'écart entre ses points d'altitude : le relief est réel, mais sa pente est approximative.",
+  "trackViewer.whyDetails": "Pourquoi ?",
+  "trackViewer.copyDetails": "Copier les détails",
+  "trackViewer.copied": "Copié",
 };

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1461,6 +1461,8 @@ export const fr: Translation = {
   "trackViewer.loading": "Lecture du terrain…",
   "trackViewer.refining": "Affinage…",
   "trackViewer.grid": "Grille",
+  "trackViewer.surface": "Surface",
+  "trackViewer.surfaceMasks": "From the track's surface data",
   "trackViewer.relief": "Dénivelé",
   "trackViewer.noTerrain": "Aucun terrain à afficher",
   "trackViewer.noTerrainHint":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1447,6 +1447,8 @@ export const it: Translation = {
   "trackViewer.loading": "Lettura del terreno…",
   "trackViewer.refining": "Definizione…",
   "trackViewer.grid": "Griglia",
+  "trackViewer.surface": "Surface",
+  "trackViewer.surfaceMasks": "From the track's surface data",
   "trackViewer.relief": "Dislivello",
   "trackViewer.noTerrain": "Nessun terreno da mostrare",
   "trackViewer.noTerrainHint":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1446,7 +1446,6 @@ export const it: Translation = {
   "trackViewer.title": "Anteprima tracciato",
   "trackViewer.loading": "Lettura del terreno…",
   "trackViewer.refining": "Definizione…",
-  "trackViewer.exaggeration": "Rilievo",
   "trackViewer.grid": "Griglia",
   "trackViewer.relief": "Dislivello",
   "trackViewer.noTerrain": "Nessun terreno da mostrare",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1456,4 +1456,7 @@ export const it: Translation = {
     "Il file di altezze di questo tracciato non ha un formato documentato, quindi la sua forma è stata dedotta dai dati. Consideralo una lettura fedele, non esatta.",
   "trackViewer.assumedScaleNote":
     "Questo tracciato non dichiara la distanza fra i suoi punti di altezza: il rilievo è reale, ma la sua pendenza è approssimativa.",
+  "trackViewer.whyDetails": "Perché?",
+  "trackViewer.copyDetails": "Copia i dettagli",
+  "trackViewer.copied": "Copiato",
 };

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1440,4 +1440,20 @@ export const it: Translation = {
   "designer.fillHint": "Clicca sul foglio per riempire tutto il livello.",
   "designer.gradientHint":
     "Trascina sul foglio per decidere dove avviene la transizione. Riempie tutto questo livello: aggiungi un altro livello pittura per conservare quello che c'è sotto.",
+
+  // The track terrain viewer.
+  "trackViewer.open": "Vedi il terreno",
+  "trackViewer.title": "Anteprima tracciato",
+  "trackViewer.loading": "Lettura del terreno…",
+  "trackViewer.refining": "Definizione…",
+  "trackViewer.exaggeration": "Rilievo",
+  "trackViewer.grid": "Griglia",
+  "trackViewer.relief": "Dislivello",
+  "trackViewer.noTerrain": "Nessun terreno da mostrare",
+  "trackViewer.noTerrainHint":
+    "I dati di altezza di questo tracciato non sono in un formato che il visualizzatore sa ancora leggere.",
+  "trackViewer.inferredNote":
+    "Il file di altezze di questo tracciato non ha un formato documentato, quindi la sua forma è stata dedotta dai dati. Consideralo una lettura fedele, non esatta.",
+  "trackViewer.assumedScaleNote":
+    "Questo tracciato non dichiara la distanza fra i suoi punti di altezza: il rilievo è reale, ma la sua pendenza è approssimativa.",
 };

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1439,4 +1439,20 @@ export const ptBR: Translation = {
   "designer.fillHint": "Clique na folha para preencher a camada inteira.",
   "designer.gradientHint":
     "Arraste na folha para definir onde acontece a transição. Ele preenche esta camada inteira — adicione outra camada de pintura para manter o que está embaixo.",
+
+  // The track terrain viewer.
+  "trackViewer.open": "Ver o terreno",
+  "trackViewer.title": "Prévia da pista",
+  "trackViewer.loading": "Lendo o terreno…",
+  "trackViewer.refining": "Refinando…",
+  "trackViewer.exaggeration": "Relevo",
+  "trackViewer.grid": "Grade",
+  "trackViewer.relief": "Desnível",
+  "trackViewer.noTerrain": "Nenhum terreno para mostrar",
+  "trackViewer.noTerrainHint":
+    "Os dados de altura desta pista não estão em um formato que o visualizador saiba ler ainda.",
+  "trackViewer.inferredNote":
+    "O arquivo de alturas desta pista não tem formato documentado, então sua forma foi deduzida dos dados. Trate o terreno como uma leitura próxima, não exata.",
+  "trackViewer.assumedScaleNote":
+    "Esta pista não informa a distância entre seus pontos de altura: o relevo é real, mas sua inclinação é aproximada.",
 };

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1446,6 +1446,8 @@ export const ptBR: Translation = {
   "trackViewer.loading": "Lendo o terreno…",
   "trackViewer.refining": "Refinando…",
   "trackViewer.grid": "Grade",
+  "trackViewer.surface": "Surface",
+  "trackViewer.surfaceMasks": "From the track's surface data",
   "trackViewer.relief": "Desnível",
   "trackViewer.noTerrain": "Nenhum terreno para mostrar",
   "trackViewer.noTerrainHint":

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1455,4 +1455,7 @@ export const ptBR: Translation = {
     "O arquivo de alturas desta pista não tem formato documentado, então sua forma foi deduzida dos dados. Trate o terreno como uma leitura próxima, não exata.",
   "trackViewer.assumedScaleNote":
     "Esta pista não informa a distância entre seus pontos de altura: o relevo é real, mas sua inclinação é aproximada.",
+  "trackViewer.whyDetails": "Por quê?",
+  "trackViewer.copyDetails": "Copiar detalhes",
+  "trackViewer.copied": "Copiado",
 };

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1445,7 +1445,6 @@ export const ptBR: Translation = {
   "trackViewer.title": "Prévia da pista",
   "trackViewer.loading": "Lendo o terreno…",
   "trackViewer.refining": "Refinando…",
-  "trackViewer.exaggeration": "Relevo",
   "trackViewer.grid": "Grade",
   "trackViewer.relief": "Desnível",
   "trackViewer.noTerrain": "Nenhum terreno para mostrar",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -438,6 +438,54 @@ export interface PkzMeta {
   thumbnail: string | null;
 }
 
+/** One file inside a track. `role` is a key the UI translates, not prose. */
+export interface TrackFile {
+  name: string;
+  role:
+    | "heightfield"
+    | "terrain"
+    | "scenery"
+    | "road"
+    | "surfaces"
+    | "config"
+    | "model"
+    | "image"
+    | "sound"
+    | "other";
+}
+
+/**
+ * A track's metadata and contents. Deliberately cheap — the backend answers it from the
+ * archive's index without inflating anything, so the track view can paint before the
+ * terrain has been read.
+ */
+export interface TrackInfo {
+  meta: PkzMeta;
+  files: TrackFile[];
+  /** Whether the track carries a heightfield at all, so the view can say so up front. */
+  hasTerrain: boolean;
+}
+
+/** A track's terrain grid, unpacked from the binary IPC blob. */
+export interface TrackTerrain {
+  width: number;
+  height: number;
+  /** Metres of ground covered by one sample at this level of detail. */
+  metresPerSample: number;
+  /** Over the whole master grid, so the colour ramp doesn't shift between detail levels. */
+  minHeight: number;
+  maxHeight: number;
+  /**
+   * Whether the track stated its sample spacing. When it didn't, the relief is real but the
+   * ground it is drawn across was assumed, so how steep the terrain looks is a guess.
+   */
+  scaleKnown: boolean;
+  /** 0–1. How sure the backend's probe was that it read the height file correctly. */
+  confidence: number;
+  /** `width * height` heights in metres, row-major. */
+  heights: Float32Array;
+}
+
 /** What the dropzone decided a dropped item is. Mirrors `dropzone::ContentKind`. */
 export type DropKind =
   | "modsTree"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -467,6 +467,19 @@ export interface TrackInfo {
 }
 
 /** A track's terrain grid, unpacked from the binary IPC blob. */
+/**
+ * A track's overview map — the overhead picture of the track, laid over the terrain.
+ *
+ * Only present when the track ships one drawn to the same proportions as its height grid;
+ * most tracks carry loading artwork instead, which describes no ground at all.
+ */
+export interface TrackOverview {
+  width: number;
+  height: number;
+  /** `width * height * 4` bytes, RGBA, first row first. */
+  pixels: Uint8Array<ArrayBuffer>;
+}
+
 export interface TrackTerrain {
   width: number;
   height: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -482,6 +482,11 @@ export interface TrackTerrain {
   scaleKnown: boolean;
   /** 0–1. How sure the backend's probe was that it read the height file correctly. */
   confidence: number;
+  /**
+   * Whether the heights are metres. A height file that doesn't say what its samples mean
+   * leaves them as raw units, and the elevation range is then a number about nothing.
+   */
+  heightsInMetres: boolean;
   /** `width * height` heights in metres, row-major. */
   heights: Float32Array;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -468,10 +468,10 @@ export interface TrackInfo {
 
 /** A track's terrain grid, unpacked from the binary IPC blob. */
 /**
- * A track's overview map — the overhead picture of the track, laid over the terrain.
+ * A picture of a track's surfaces, laid over the terrain.
  *
- * Only present when the track ships one drawn to the same proportions as its height grid;
- * most tracks carry loading artwork instead, which describes no ground at all.
+ * Built from the coverage masks in the track's own height file, so it describes exactly the
+ * ground the grid does.
  */
 export interface TrackOverview {
   width: number;


### PR DESCRIPTION
Tracks were the one thing the library couldn't show you. A bike or a helmet opens in the viewer; a track was a name, a preview image and a size, and the only way to see the ground you were about to ride was to load it in the game. This reads the terrain out of the track and draws it.

Opens from the library detail view for any `track` entry, next to **View in 3D**.

## Reading the format

`.trh` is undocumented, so this started as a self-validating probe and ended up as a direct reader once a published track (`localcross.pkz`) settled the layout:

```
 0   "TRH\0"
 4   u32   width          → 1025
 8   u32   height         → 1025
12   u16 × width × height  samples, quantised over the height range
 …   trailing block: 250.0, 18.36, 250.0 — size x, relief, size z, in metres
```

PiBoSo's [track creation guide](https://docs.piboso.com/wiki/index.php/MXB_Track_Creation_Guide) confirms this independently: heightmaps are 16-bit, dimensions are a power of two plus one, and `terrain.ini` states `samples_x`/`samples_y`, `size_x`/`size_z` in metres, and `scale` as the total height in metres. The trailing block is exactly those parameters.

Verified end to end against the real file:

```
1025×1025 u16 at offset 12, confidence 0.97
spacing 0.2441 m/sample, height scale 0.00028 m/unit
→ master 342×342, heights 0.00..18.36 m, ground 249.5 m × 249.5 m
```

1024 × 0.2441 = 250 m and 65535 × 0.00028 = 18.36 m — the footer's own numbers, recovered from two independent paths.

The blind probe is kept behind the direct reader for files it doesn't fit. It enumerates plausible layouts and makes each prove itself on a property terrain has and noise doesn't: neighbouring samples are close together. Horizontal roughness (memory-adjacent) judges sample type and offset; vertical roughness (one row apart) judges row width. A stated shape is still measured — magic and dimensions the body contradicts are a misread, and falling back beats drawing it.

## Speed

A track is the largest thing the app handles, so showing one costs the grid and nothing else.

- The inventory inflates nothing — the archive index already answers "what's in here", so the view paints while the terrain is still being read.
- The heightfield is inflated and probed once, reduced to a 512² master, and cached to disk. Re-opening skips the archive read, which is the cost that actually dominates; the probe is milliseconds.
- The viewer loads coarse (96²) then refines to 320², both resampled from the same master, so the track is up in a frame or two and sharpens under you. Spacing scales with the reduction, so the refined grid lands exactly where the coarse one was.
- The grid crosses the IPC channel as raw bytes behind a 4-byte-aligned header and is read in place as a `Float32Array` — no JSON array, no copy.
- Mesh geometry is written straight into typed arrays, and the canvas is `frameloop="demand"`, so a parked terrain costs no frames.

## Honesty about what's inferred

Heights are reported as metres only when the file says what its samples mean; otherwise the grid is raw units and the elevation row is omitted rather than printing a meaningless number. Where the footprint is assumed rather than stated, the panel says so. When terrain won't load at all, a **Why?** button prints what the reader saw — contents, `.ini` claims, a hex dump of the height file's opening bytes, every layout considered with its measurements and rejection reason — with a copy button, so a track that fails can be reported by whoever has it.

## Bugs found and fixed along the way

- 16-bit samples were judged against a plausible height in metres, so any heightfield using most of its range was rejected before the roughness test ran.
- `.map` was treated as a heightfield candidate. It's track *graphics* — a track whose `.trh` didn't read would have inflated the largest file in the archive to learn nothing.
- `ini_hints` read `size_x` (metres) as a sample count, which would have read a 480 m track as a 480-sample grid, and `scale` (total height) as metres-per-sample.
- `[info] length` is routinely a placeholder: the track in hand declares `length = 1` while its own `.rdf` puts the finish line at 97 m. A sub-50 m lap is no longer reported as fact.

## Testing

33 unit tests plus two ignored diagnostics for running against a real track:

```
FROST_PROBE_FILE=<file.trh> cargo test -- --ignored --nocapture probe_a_real_height_file
FROST_TRACK=<track.pkz>     cargo test -- --ignored --nocapture read_a_real_track
```

The real layout is pinned by tests built as synthetic files matching it, so no multi-megabyte fixture lands in the repo. A published track's `.ini` is included as a fixture (517 bytes) — it proves a real descriptor states nothing about the terrain, so the grid's shape has to come from the height file itself.

`typecheck`, `lint` and `build` are clean.

## Not verified

**The Rust has not been compiled.** This session's container has no GTK/webkit and no way to install it, so `cargo` can't build the crate at all. `heightfield.rs` and `track.rs` were type-checked and tested against stand-ins for `tauri`/`pkz`/`linkwalk`, but the four command wrappers in `main.rs` have never been through a compiler. **Please run `cargo check` before merging.**

`.map` reading is out of scope — it's graphics, and per the guide there's nothing to render from it here.

---
_Generated by [Claude Code](https://claude.ai/code/session_014fxYc9fNxFKxi6zxsuXmuZ)_