### PR TITLE
docs: bring the README up to date, and credit OHTEA - MXB HUB

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ single flow:
 MXB App downloads the mod, extracts it, and drops the files into the matching MX
 Bikes `mods` folder automatically.
 
-Tracks, bikes and rider gear are supported today; more mod types are planned.
+Tracks, bikes, rider gear, paints, sounds, model swaps and riding-style
+animations are all recognised — and anything can be installed by dropping it on
+the window, sorted by what the archive holds rather than by what its title says.
 
 ## Download
 
@@ -184,7 +186,8 @@ skips the announcement. It's for testing that a build compiles, not for shipping
 
 Features coming next:
 
-- More mod types (assets, wheels, …) — the `ModSource` trait and category ids
-  already generalize beyond tracks, bikes and rider gear.
 - Reading your in-game track list through FrostMod (which already handles the
   live reload) to one-click-install the tracks you're missing.
+- A 3D preview for GP Bikes. Building a `.pnt` is title-agnostic and already
+  works there; only the preview needs part bindings GP Bikes hasn't got yet, so
+  the Studio says so plainly rather than showing an empty stage.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Release date](https://img.shields.io/github/release-date/Frostn1/mxb-app?label=released)](https://github.com/Frostn1/mxb-app/releases)
 [![Downloads](https://img.shields.io/github/downloads/Frostn1/mxb-app/total?label=downloads)](https://github.com/Frostn1/mxb-app/releases)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
-[![Platform](https://img.shields.io/badge/platform-Windows%20x64-0078D6)](#development)
+[![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-0078D6)](#development)
 
 **MXB App** is a desktop mod manager for [MX Bikes](https://mx-bikes.com/). It
 replaces the tedious manual install dance — open mxb-mods.com, follow the link,
@@ -25,7 +25,10 @@ Grab the latest installer from the
 [**Releases**](https://github.com/Frostn1/mxb-app/releases) page:
 
 - **Windows** — `.exe` NSIS installer (recommended; MX Bikes runs on Windows).
-- **macOS** (Apple Silicon) — `.dmg`, for working on the download/extract UI.
+- **macOS** (Apple Silicon) — `.dmg`; Play launches the game through a CrossOver,
+  Whisky or Wine bottle.
+- **Linux** — `.AppImage`, `.deb` and `.rpm`, for playing under Proton (SteamOS
+  included).
 
 Builds are unsigned, so Windows SmartScreen / macOS Gatekeeper will warn on
 first launch — choose _Run anyway_ / right-click _Open_.
@@ -45,10 +48,17 @@ hours), then downloads and installs them on restart.
   `.pkz` / `.pnt` files are placed as-is.
 - **Live reload**: a debounced watcher on `<modsPath>/mods` signals FrostMod to
   reload the game when mods are added — including ones installed outside the app.
-- **Paint studio**: builds a `.pnt` from `.tga`/`.png` sheets drawn in GIMP or
-  Photoshop, and unpacks an existing paint back into editable sheets that keep the
-  texture names the model binds — so a livery can be made, installed and previewed
-  on the model without leaving the app.
+- **Paint studio**: builds a `.pnt` from `.tga`/`.png` sheets, and unpacks an
+  existing paint back into editable sheets that keep the texture names the model
+  binds — so a livery made anywhere can be packed, installed and previewed here.
+- **Designer**: draws the livery itself. Image and text layers, a brush, gradient,
+  fill and shapes, every stroke landing on the 2D sheet and on the 3D model at the
+  same time. Because the model is right there, the editor knows the geometry it is
+  painting for: a reference underlay shows the paint you started from and the
+  model's own UV islands beneath your work, hovering the sheet names the piece of
+  bodywork under the cursor, and a layer can be fitted to a part and clipped to its
+  outline — so an image covers the shroud and stops at the seam. Save writes the
+  packed `.pnt` the game reads.
 - **Self-update**: `tauri-plugin-updater` against the `latest.json` published with
   each release; signature-verified, installs on restart.
 - **Supporters**: Settings → Supporters credits the people who bought a coffee on
@@ -98,9 +108,9 @@ cargo check          # typecheck the Rust
 cargo test           # unit tests (REST/HTML parsing, download resolution)
 ```
 
-> MX Bikes is Windows-only, so downloading into a real game install is a
-> Windows workflow. The cross-platform download/extract logic can be built and
-> tested on any OS.
+> MX Bikes is a Windows game, so a real install is a Windows one — but the app
+> launches it on macOS through a CrossOver, Whisky or Wine bottle, and on Linux
+> under Proton. The cross-platform logic builds and tests on any OS.
 
 ### Building with the shop catalog
 
@@ -136,20 +146,39 @@ uses, so it lands by what the archive contains rather than by what its title sug
 
 Releases are built in CI by
 [`.github/workflows/release.yml`](.github/workflows/release.yml) — it compiles
-Windows and macOS bundles and attaches them to a GitHub Release.
+Windows, macOS and Linux bundles and attaches them to a GitHub Release.
 
-To cut a release, bump the version in `package.json`, `src-tauri/tauri.conf.json`
-and `src-tauri/Cargo.toml`, then push a matching tag:
+Write the version's `CHANGELOG.md` section **before** tagging. The release body
+and the Discord announcement are both composed from it by
+[`scripts/changelog-section.sh`](scripts/changelog-section.sh), which finds a
+section by the `v<version>` in its heading — so work still sitting under an
+"Unreleased" heading ships notes that never mention it.
+
+Then make sure `package.json`, `src-tauri/tauri.conf.json` and
+`src-tauri/Cargo.toml` all carry the version, and push a matching tag:
 
 ```sh
-git tag v0.2.0
-git push origin v0.2.0
+git tag -a v0.9.1 -m "v0.9.1 — what it's called"
+git push origin v0.9.1
 ```
+
+A **suffixed** tag — `v0.9.1-beta.3`, `v0.9.1-rc.2` — builds the same three
+platforms but publishes as a **pre-release**: GitHub keeps it off
+`releases/latest`, which is the endpoint the in-app updater reads, so existing
+installs are never offered it, and it's announced in the beta Discord channel
+rather than the release one. Tagging the plain `v0.9.1` afterwards is what ships
+it to everyone. The workflow decides both of those purely from the `-` in the tag,
+so neither is set by hand.
 
 The workflow **publishes** the release with the installers attached
 (`releaseDraft: false`), renames the bundles to `MXB-App-<ver>-<arch>.<ext>` and
-patches `latest.json` so self-update keeps verifying. You can also trigger a
-build without tagging via **Actions → Release → Run workflow**.
+patches `latest.json` so self-update keeps verifying.
+
+A tag can also be created from the GitHub web UI — **Releases → Draft a new
+release → Create new tag on publish** — which is the way to cut one without a
+terminal. **Actions → Release → Run workflow** is *not*: a `workflow_dispatch`
+build tags itself `v<run number>`, leaves the running app without its version, and
+skips the announcement. It's for testing that a build compiles, not for shipping.
 
 ## Roadmap
 

--- a/src/Components/Settings/supporters.ts
+++ b/src/Components/Settings/supporters.ts
@@ -59,6 +59,7 @@ export interface SupportersManifest {
 export const BUNDLED_SUPPORTERS: SupportersManifest = {
   tiers: [],
   supporters: [
+    { name: "OHTEA - MXB HUB" },
     { name: "HottPie" },
     { name: "Mouk" },
     { name: "SoggySwisher" },

--- a/supporters.json
+++ b/supporters.json
@@ -3,6 +3,7 @@
   "supportUrl": "https://buymeacoffee.com/22ypnh5yfme",
   "tiers": [],
   "supporters": [
+    "OHTEA - MXB HUB",
     "HottPie",
     "Mouk",
     "SoggySwisher",


### PR DESCRIPTION
Docs and the supporters list. No code changes to the app itself beyond the bundled supporters fallback.

## Supporters

Adds **OHTEA - MXB HUB**, in both places: [`supporters.json`](supporters.json), which every installed copy reads live off `main`, and `BUNDLED_SUPPORTERS`, which is what a build shows when it has never once reached the network. Missing the second means an offline launch silently drops the newest name.

This one only takes effect once it's on `main` — that's where the app fetches the manifest from.

## README

**The Designer.** The old text described making a livery as drawing sheets in GIMP or Photoshop and bringing them back, which stopped being true three releases ago. Now split in two: Paint studio packs and unpacks sheets, and the Designer draws the livery — with the point being *why* it can do what an image editor can't, since the model sits beside the canvas.

**Platforms.** The badge said Windows x64 only and the download list omitted Linux, despite `.AppImage`/`.deb`/`.rpm` shipping since v0.9.0. Both now cover all three, with what each is for — a CrossOver/Whisky/Wine bottle on macOS, Proton on Linux. The dev note calling MX Bikes "Windows-only" is corrected the same way.

**Releases.** Documents the two things that are easy to get wrong, both learned the hard way cutting beta.3:

- Write the `CHANGELOG.md` section **before** tagging — the release body and the Discord post are both composed from it by heading, so work left under "Unreleased" ships notes that never mention it.
- A **suffixed** tag is what makes a build a pre-release, off `releases/latest` and announced in the beta channel. The workflow decides both from the `-` alone.
- The web UI (**Releases → Draft a new release → Create new tag on publish**) is the way to tag without a terminal. **Actions → Release → Run workflow** is *not*: a `workflow_dispatch` build tags itself `v<run number>`, leaves the running app without its version, and skips the announcement.

Also mentions Linux as the third platform built, and the tag example is no longer `v0.2.0`.

**Roadmap.** "More mod types (assets, wheels, …)" was listed as coming next, but the library classifies seventeen categories today and the dropzone installs anything by what the archive holds. The intro undersold it the same way. Retired both.

The remaining item is real and stays — nothing reads the in-game track list yet. I added the GP Bikes 3D preview beside it based on evidence in the code (building a `.pnt` already works for that title; only the preview lacks part bindings, which the Studio says out loud), but that's my inference about intent rather than something you told me — drop it if it isn't actually planned.

## Testing

`typecheck` and `lint` clean. Docs and a data file otherwise.

---
_Generated by [Claude Code](https://claude.ai/code/session_015LfU6nut8QAsoFjCogZUL6)_