### PR TITLE
docs(readme): badge CI instead of Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MXB App
 
-[![Release](https://github.com/Frostn1/mxb-app/actions/workflows/release.yml/badge.svg)](https://github.com/Frostn1/mxb-app/actions/workflows/release.yml)
+[![CI](https://github.com/Frostn1/mxb-app/actions/workflows/ci.yml/badge.svg)](https://github.com/Frostn1/mxb-app/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/v/release/Frostn1/mxb-app?sort=semver&label=release)](https://github.com/Frostn1/mxb-app/releases)
 [![Release date](https://img.shields.io/github/release-date/Frostn1/mxb-app?label=released)](https://github.com/Frostn1/mxb-app/releases)
 [![Downloads](https://img.shields.io/github/downloads/Frostn1/mxb-app/total?label=downloads)](https://github.com/Frostn1/mxb-app/releases)


### PR DESCRIPTION
The README's top badge has been showing a failure while every tagged release succeeded.

A workflow badge shows the latest run on the **default branch**. Release runs are triggered by tags, so their `head_branch` is the tag (`v0.9.1-beta.3`) rather than `main` — they never reach the badge. The only `release.yml` runs that land on `main` are manual `workflow_dispatch` ones, and the last of those failed, so the badge was advertising a throwaway test build as a broken release.

`ci.yml` runs on push to `main` and on every PR, which is what a reader takes the top badge to mean. The release side is already covered by the "Latest release" and "Release date" badges next to it.

### On that failed dispatch run

It failed at publish, not at compile — every bundle and signature was produced first:

```
Couldn't find release with tag v43. Creating one.
##[error]Validation Failed: "Cannot create ref due to creations being restricted."
                            "Published releases must have a valid tag"
```

A `workflow_dispatch` build names its tag `v<run number>` and then tries to create that ref, which the repository ruleset restricting creations blocks. Worth deleting that run from the Actions tab so it stops being the newest thing on `main`.

Same rule refuses a tag push from CI, so cutting a release from anywhere but a bypassing account needs a ruleset exemption rather than a token permission change.

---
_Generated by [Claude Code](https://claude.ai/code/session_015LfU6nut8QAsoFjCogZUL6)_