### PR TITLE
feat(sync): keep a session in step with the grid, and scope a roster to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased -- paint sync keeps up with the grid
+
+### Fixed
+- **A rider who joins after you now shows up properly.** The pull happened once, at launch, so
+  paint sync was lopsided: whoever joined last saw everyone, and whoever was there first never
+  saw anyone who arrived afterwards -- they had pulled before those riders existed. The app now
+  keeps checking for the length of the session and installs what turns up.
+
+### Changed
+- **A roster means one grid, not the whole platform.** `GET /v1/roster` took a server and
+  ignored it, because nothing recorded where anyone was, so every rider downloaded the paints
+  of every other enrolled rider. Each app now reports the server it launched into, and a roster
+  returns the riders actually on it. A rider whose app goes quiet for ten minutes drops out.
+
 ## Unannounced — a debugger can't ride along
 
 Left out of the release notes on purpose: a hardening measure advertised is a hardening

--- a/control-plane/migrations/0008_presence.sql
+++ b/control-plane/migrations/0008_presence.sql
@@ -1,0 +1,25 @@
+-- Who is on which server, so a roster can mean "this grid" rather than "everyone".
+--
+-- `roster` has always taken a `?server=` and ignored it, because nothing knew where anyone
+-- was. That was survivable while the platform was one invite-only group; it is wrong as a
+-- design. Every rider downloads the paints of every other enrolled rider, most of whom they
+-- will never share a session with.
+--
+-- Reported by each player's own app, which already knows the server it launched into — the
+-- dedicated server's log knows too, but the agent has no way to tell us yet, and waiting for
+-- that would leave the scoping unbuilt.
+--
+-- Deliberately not a column on `accounts`: presence is short-lived and rewritten constantly,
+-- identity is neither, and keeping them apart leaves room for the agent to report the same
+-- thing later without touching the account row.
+CREATE TABLE presence (
+  account_id  TEXT PRIMARY KEY REFERENCES accounts (id) ON DELETE CASCADE,
+  -- The registry id, or a normalized host:port for a server we do not run. Matches the key
+  -- the app already computes with `server_key_for`.
+  server_id   TEXT NOT NULL,
+  -- Refreshed on every heartbeat. A row older than the cutoff is treated as gone: an app
+  -- that crashed or a player who quit should not haunt a grid forever.
+  updated_at  INTEGER NOT NULL
+);
+
+CREATE INDEX presence_server ON presence (server_id, updated_at);

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -28,6 +28,7 @@ import {
   isPublicGameAddress,
   isRegion,
   isRelDest,
+  isServerKey,
   isRiderName,
   isServerName,
   isSha256,
@@ -109,6 +110,7 @@ async function route(request: Request, env: Env): Promise<Response> {
   if (method === "PUT" && path === "/v1/loadout") return putLoadout(request, account, env);
   if (method === "PUT" && path === "/v1/loadouts") return putLoadouts(request, account, env);
   if (method === "GET" && path === "/v1/roster") return roster(url, env);
+  if (method === "PUT" && path === "/v1/presence") return putPresence(request, account, env);
   if (method === "POST" && path === "/v1/servers") return registerServer(request, account, env);
   if (method === "GET" && path === "/v1/servers/mine") return myServers(account, env);
   if (method === "GET" && path === "/v1/fleet") return fleetState(account, env);
@@ -1060,47 +1062,80 @@ async function connectedCount(
   }
 }
 
+/** How long a presence heartbeat counts for before the rider is treated as gone. */
+const PRESENCE_TTL_MS = 10 * 60 * 1000;
+
 /**
- * Every rider currently registered against a server, with what they are wearing.
+ * "I am on this server."
  *
- * This is what the app polls to know which paints to fetch. Until the agent reports live
- * rosters it returns the whole enrolled set, which on an invite-only server is close enough
- * to be useful and is a strict superset of who is actually on.
+ * Reported by the player's own app, which knows the server it launched into. That is what
+ * lets a roster mean one grid instead of every enrolled account — see `0008_presence.sql`.
+ *
+ * One row per account: a rider is in one place at a time, and the last thing they said wins.
+ */
+async function putPresence(request: Request, account: Account, env: Env): Promise<Response> {
+  const body = await readJson(request);
+  if (!body) return json(400, { error: "expected a JSON body" });
+  const { serverId } = body as { serverId?: unknown };
+  if (!isServerKey(serverId)) return json(400, { error: "that isn't a server" });
+
+  await env.DB.prepare(
+    "INSERT INTO presence (account_id, server_id, updated_at) VALUES (?, ?, ?)" +
+      " ON CONFLICT(account_id) DO UPDATE SET server_id = excluded.server_id," +
+      " updated_at = excluded.updated_at",
+  )
+    .bind(account.id, (serverId as string).trim(), Date.now())
+    .run();
+  return json(200, { ok: true });
+}
+
+/**
+ * The riders on one server, and what they are wearing.
+ *
+ * This is what the app polls to know which paints to fetch. It is scoped to the riders whose
+ * apps have said they are on this server recently — previously it returned every enrolled
+ * account, because nothing recorded where anyone was, so every rider downloaded the paints of
+ * every other rider on the platform.
+ *
+ * A rider whose app has gone quiet for `PRESENCE_TTL_MS` drops out. Better to miss someone
+ * who is genuinely there — the next heartbeat brings them back within a minute — than to
+ * accumulate a grid of people who left hours ago.
  */
 async function roster(url: URL, env: Env): Promise<Response> {
   const serverId = url.searchParams.get("server");
   if (!serverId) return json(400, { error: "a server id is required" });
 
-  // DISTINCT on the destination: loadouts are per bike now, and gear repeats across every
-  // bike a rider owns, so the raw join returns the same helmet paint a dozen times over. The
-  // receiver installs by destination and de-duplicates anyway — doing it here keeps the
-  // response the size it was before bikes were separated.
+  // DISTINCT on the destination: loadouts are per bike, and gear repeats across every bike a
+  // rider owns, so the raw join returns the same helmet paint many times over. The receiver
+  // installs by destination and de-duplicates anyway.
   //
   // MIN(slot) only picks a stable representative for a destination two slots agree on; the
   // client keys on rel_dest, not on slot.
   const rows = await env.DB.prepare(
     "SELECT a.rider_name, a.guid, MIN(p.slot) AS slot, p.file_name, p.sha256, p.size, p.rel_dest" +
-      " FROM accounts a JOIN loadout_paints p ON p.account_id = a.id" +
+      " FROM accounts a" +
+      " JOIN presence pr ON pr.account_id = a.id" +
+      " JOIN loadout_paints p ON p.account_id = a.id" +
+      " WHERE pr.server_id = ? AND pr.updated_at > ?" +
       " GROUP BY a.id, p.rel_dest, p.sha256",
-  ).all<{
-    rider_name: string;
-    guid: string | null;
-    slot: string;
-    file_name: string;
-    sha256: string;
-    size: number;
-    rel_dest: string;
-  }>();
+  )
+    .bind(serverId, Date.now() - PRESENCE_TTL_MS)
+    .all<{
+      rider_name: string;
+      guid: string | null;
+      slot: string;
+      file_name: string;
+      sha256: string;
+      size: number;
+      rel_dest: string;
+    }>();
 
   const riders = new Map<string, { riderName: string; guid: string | null; paints: unknown[] }>();
   for (const r of rows.results) {
-    // Re-checked on the way out as well as in. A row predating the validation, or one
-    // written by some future path that forgot it, must not reach a client that is about to
-    // turn it into a filesystem path.
+    // Re-checked on the way out as well as in. A row predating the validation, or one written
+    // by some future path that forgot it, must not reach a client that is about to turn it
+    // into a filesystem path.
     if (!isRelDest(r.rel_dest)) continue;
-    // Group by GUID where the account has claimed one — it is stable across name changes
-    // and cannot be taken by someone else. Name is the fallback for accounts that have not
-    // supplied a GUID yet, which is every account until the player has connected once.
     const key = r.guid ?? `name:${r.rider_name.toLowerCase()}`;
     let rider = riders.get(key);
     if (!rider) {

--- a/control-plane/src/validate.ts
+++ b/control-plane/src/validate.ts
@@ -259,3 +259,17 @@ export function isBootstrapStage(value: unknown): value is string {
   return /^[a-z0-9 :\-]+$/i.test(stage);
 }
 
+/**
+ * A server key, as the app computes it: a registry id, or a normalized `host:port` for a
+ * server we do not run.
+ *
+ * Loose on purpose — it is an opaque grouping key, not an address anything dials — but still
+ * bounded and free of control characters, since it is stored and echoed back.
+ */
+export function isServerKey(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const key = value.trim();
+  if (key.length === 0 || key.length > 128) return false;
+  return !/[\u0000-\u001f\u007f]/.test(key);
+}
+

--- a/control-plane/test/validate.test.ts
+++ b/control-plane/test/validate.test.ts
@@ -11,6 +11,7 @@ import {
   isPublicGameAddress,
   isRegion,
   isRelDest,
+  isServerKey,
   isRiderName,
   isServerName,
   isSha256,
@@ -325,5 +326,21 @@ describe("bootstrap user data", () => {
         serverId: "abc", controlPlaneUrl: "https://cp",
       }),
     ).not.toThrow();
+  });
+});
+
+describe("server keys", () => {
+  it("takes both shapes the app computes", () => {
+    // A registry id for a server we run, a normalized host:port for one we do not.
+    for (const ok of ["eu-frankfurt-1", "203.0.113.10:54210", "8e68ebe5-ec6e-42dd"]) {
+      expect(isServerKey(ok), ok).toBe(true);
+    }
+  });
+
+  it("refuses what it should not store", () => {
+    const withNewline = "srv" + String.fromCharCode(10) + "other";
+    for (const bad of ["", "   ", "a".repeat(129), withNewline, 5, null]) {
+      expect(isServerKey(bad), JSON.stringify(bad)).toBe(false);
+    }
   });
 });

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3576,6 +3576,7 @@ fn launch_game(app: tauri::AppHandle) -> Result<gameproc::LaunchOutcome, String>
         // Both directions, because Play is the last moment before either one matters: the
         // grid needs everyone else's paints on disk, and everyone else needs ours.
         publish_paints_soon(&app, &cfg, None);
+        live_sync_session(&app, None);
         // No address to aim at — they'll pick from the in-game browser — so this covers
         // the whole registry.
         sync_paints_soon(&app, None);
@@ -4026,6 +4027,62 @@ fn sync_paints_soon(app: &tauri::AppHandle, address: Option<String>) {
     });
 }
 
+/// How often to re-check the grid while a session is running.
+///
+/// A rider who joins after you did is invisible until the next pull, so this is the gap
+/// between someone arriving and their paint appearing. Short enough not to matter in a race,
+/// long enough that an unchanged roster — the overwhelmingly common answer — costs nothing.
+const LIVE_SYNC_EVERY: std::time::Duration = std::time::Duration::from_secs(45);
+
+/// How long to wait for the game to show up before giving up on a session.
+///
+/// MX Bikes takes a while to appear in the process list, and on a platform where we cannot
+/// see processes at all it never will. Either way, stopping is right: the launch pull has
+/// already run.
+const LIVE_SYNC_STARTUP_GRACE: std::time::Duration = std::time::Duration::from_secs(120);
+
+/// A session's worth of syncing, so a rider who arrives after you do still renders.
+///
+/// The pull used to happen once, at launch. That made the whole thing lopsided: whoever
+/// joined last saw everybody, and whoever was there first never saw anyone who turned up
+/// afterwards — they had pulled before those riders existed.
+///
+/// Runs until the game exits. Each pass also re-reports presence, which is what keeps this
+/// rider in other people's rosters; the control plane forgets anyone who goes quiet.
+fn live_sync_session(app: &tauri::AppHandle, address: Option<String>) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let started = std::time::Instant::now();
+        let mut seen_running = false;
+        loop {
+            tokio::time::sleep(LIVE_SYNC_EVERY).await;
+
+            let cfg = config::load_or_detect(&app).unwrap_or_default();
+            if !cfg.experimental_enabled() || cfg.cp_token.trim().is_empty() {
+                return;
+            }
+            // The game is the session. Once it has been seen and then gone, so are we.
+            if gameproc::is_game_running() {
+                seen_running = true;
+            } else if seen_running || started.elapsed() > LIVE_SYNC_STARTUP_GRACE {
+                log::info!("[sync] session over, stopping the live sync");
+                return;
+            }
+
+            match pull_rosters(&app, address.clone()).await {
+                // Only say so when something actually arrived: an unchanged grid is the
+                // common case and does not need announcing every 45 seconds.
+                Ok(o) if o.installed > 0 => {
+                    log::info!("[sync] {} new paints mid-session", o.installed);
+                    emit_sync(&app, SyncEvent::pulled(&o));
+                }
+                Ok(_) => {}
+                Err(e) => log::debug!("[sync] live pull failed: {e}"),
+            }
+        }
+    });
+}
+
 /// Pull the rosters for wherever the player is, or could be, riding.
 ///
 /// `address` narrows this to a single server when we know where they're headed. Without
@@ -4055,6 +4112,14 @@ async fn pull_rosters(
     };
     if keys.is_empty() {
         return Err("No servers to sync with yet.".into());
+    }
+
+    // Say where we are before asking who else is here: the roster is scoped by presence, so
+    // reporting first is what puts this rider into everyone else's grid too.
+    for key in &keys {
+        if let Err(e) = paintsync::report_presence(&cfg.cp_token, key).await {
+            log::debug!("[sync] couldn't report presence on {key}: {e:#}");
+        }
     }
 
     let outcome = paintsync::pull(&cfg, &cfg.cp_token, &keys)
@@ -4521,6 +4586,7 @@ fn join_server(app: tauri::AppHandle, address: String) -> Result<gameproc::Launc
     let outcome = gameproc::join(&cfg, &address).map_err(|e| format!("{e:#}"))?;
     if matches!(outcome, gameproc::LaunchOutcome::Launched) {
         publish_paints_soon(&app, &cfg, None);
+        live_sync_session(&app, Some(address.clone()));
         // We know exactly where they're going, so this syncs that server alone.
         sync_paints_soon(&app, Some(address));
     }

--- a/src-tauri/src/paintsync.rs
+++ b/src-tauri/src/paintsync.rs
@@ -380,6 +380,25 @@ pub async fn publish_all(
     })
 }
 
+/// Tell the control plane which server this rider is on.
+///
+/// The roster is scoped by this. Without it the control plane has no idea where anyone is, so
+/// a roster can only mean "everyone enrolled" — which is what it used to mean, and why every
+/// rider downloaded the paints of every other rider on the platform.
+///
+/// Best-effort: failing to report presence costs a narrower roster for a minute, and must
+/// never be the thing that stops a sync.
+pub async fn report_presence(token: &str, server_id: &str) -> anyhow::Result<()> {
+    client()?
+        .put(format!("{}/v1/presence", control_plane()))
+        .bearer_auth(token)
+        .json(&serde_json::json!({ "serverId": server_id }))
+        .send()
+        .await?
+        .error_for_status()?;
+    Ok(())
+}
+
 /// A server in the control plane's registry, as `GET /v1/servers` returns it.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
Two faults — one you can see, one structural.

## A rider who joins after you was invisible

The pull happened **once**, at launch. So a session was lopsided: whoever joined last pulled everyone and saw them; whoever was there first had pulled *before the newcomers existed* and never saw any of them. "Paint sync works" was true only if you were the last to arrive.

The app now re-checks for as long as the game is running, installs what is new, and stops when the session does.

## A roster meant every enrolled account

`GET /v1/roster` has always taken a `?server=` and **ignored it**, because nothing recorded where anyone was. Fine for one invite-only group; wrong as a design, and it made every rider download the paints of people they will never ride with.

Presence is reported by each player's own app, which already knows the server it launched into. The dedicated server's log knows too, and the agent reading it would additionally cover people who joined from the in-game browser — but the agent has no outbound HTTP client at all, and waiting for that would leave this unbuilt. The table is kept separate from `accounts` for the same reason: it is short-lived and rewritten constantly, so leaving it apart means the agent can report the same thing later without touching identity.

Presence is reported *before* the roster is read, so a rider puts themselves into everyone else's grid in the same pass they read it. Ten minutes without a heartbeat and they drop out — missing someone genuinely there costs one cycle; keeping people who left hours ago costs everyone the download.

## Verified

Against a local worker with four riders:

- nobody reporting → roster is **empty**, not everyone
- two riders on `srv-1`, one on `srv-2` → each roster returns exactly its own

Plus 596 Rust tests, 34 control-plane tests, typecheck and lint clean.

## Not established

**Whether the game re-skins a rider who has already spawned.** New paints landing mid-session pulses FrostMod's content reload, which is the only lever available, but MX Bikes binds a remote rider's look when they appear on track. Proving this needs two people on one server and has not been done — it decides whether this works live or only from the next session.

Needs `0008_presence.sql` applied before deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)