### PR TITLE
chore(supporters): credit Qwest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Push-to-talk**, bound through the same global-shortcut path as the overlay hotkey, so
   it works while the game holds focus. It acts on both edges — mic opens on press, closes
   on release — and is bound even when the overlay is switched off.
+- **Qwest** credited on Settings → Supporters.
 
 ### Notes
 - **Nothing transmits yet.** This is the device half only; the codec and the voice room on

--- a/src/Components/Settings/supporters.ts
+++ b/src/Components/Settings/supporters.ts
@@ -64,6 +64,7 @@ export const BUNDLED_SUPPORTERS: SupportersManifest = {
     { name: "Mouk" },
     { name: "SoggySwisher" },
     { name: "LupaHo" },
+    { name: "Qwest" },
   ],
 };
 

--- a/supporters.json
+++ b/supporters.json
@@ -7,6 +7,7 @@
     "HottPie",
     "Mouk",
     "SoggySwisher",
-    "LupaHo"
+    "LupaHo",
+    "Qwest"
   ]
 }


### PR DESCRIPTION
Adds **Qwest** to the supporters list.

Both lists, not just one:

- `supporters.json` is what every installed copy fetches off `main`, so it is what actually thanks somebody — the credit lands as soon as this merges, no release needed.
- `BUNDLED_SUPPORTERS` in `src/Components/Settings/supporters.ts` is what a build shows when it has never once reached the network. Leaving it behind means a fresh offline launch quietly drops the newest name.

Plain name, no `tier` or `since`, matching every other entry — `tiers` is empty, so they render in the ungrouped list, sorted alphabetically.

Nothing to test: no code path or test references the names, and the JSON parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)