### PR TITLE
fix(release): start on macOS, and credit supporters in "What's new"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,7 +219,7 @@ them up.
 On top of v0.9.0 — everything that release added is still the news, and its notes are
 repeated below.
 
-Worth knowing for this beta: the Mac launch has been tested against a stand-in for Wine, not
+Worth knowing: the Mac launch has been tested against a stand-in for Wine, not
 against a real bottle, so if Play does something odd on your machine the app log names the
 exact command it ran — please send it.
 
@@ -307,6 +307,14 @@ isn't the panel you're over, that's the thing to report, and it explains the res
 - **A Wine runner picker in Settings**, for when the automatic choice is wrong or the wrapper
   lives somewhere unusual. It also shows which runner was found and how many bottles the app
   can see — so a bottle it *can't* see shows up as missing before you press Play, not after.
+- **"What's new" credits the people who paid for it.** The update notice now names the
+  supporters underneath the release it's announcing, and opens the full thank-you list in
+  Settings when you click it. The names are read live rather than baked into the build, so
+  somebody who started supporting after this version was cut is still thanked by it — and the
+  credit is part of the modal itself, not of any one release's entry, so every future update
+  carries it without having to remember to. It credits and links; the button that asks for
+  anything stays on the Settings page, because an update notice is the wrong place to hold
+  out a hat.
 
 ### Changed
 - **A roster means one grid, not the whole platform.** `GET /v1/roster` took a server and
@@ -315,6 +323,16 @@ isn't the panel you're over, that's the thing to report, and it explains the res
   returns the riders actually on it. A rider whose app goes quiet for ten minutes drops out.
 
 ### Fixed
+- **The Mac build starts at all.** It aborted on launch before drawing anything — which would
+  have made the Mac work above impossible to reach in the very release that added it. The
+  drag-drop fix earlier in this cycle moved the main window out of Tauri's startup and into
+  the app's own, so the handler can be switched off under Wine; that needs `"create": false`
+  in the window config, and it was set in the base config only. macOS keeps its own overrides
+  — the rounded title bar — and that file *replaces* the window config rather than merging
+  into it, so the flag was dropped on macOS alone: Tauri opened the window itself, the app
+  opened a second one under the same name, and the process aborted on the duplicate. Windows
+  never had an override, and Linux's doesn't name the window, which is why only the Mac was
+  hit and no beta caught it.
 - **The Linux app opens to its interface on SteamOS instead of a white screen.** Our AppImage
   carries Ubuntu 22.04's libwayland next to whatever Mesa the host ships — the pairing the
   AppImage excludelist warns about — and WebKitGTK 2.46 and later abort outright when that

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5534,7 +5534,9 @@ fn main() {
             // rather than by Tauri's own startup loop, which is the only way to decide the
             // drag-drop handler per run: it can only be turned off while the window is
             // being built. Everything else about the window still comes from the config,
-            // the macOS overrides in `tauri.macos.conf.json` included.
+            // the macOS overrides in `tauri.macos.conf.json` included — and that file
+            // replaces this array wholesale, so it has to repeat `"create": false` or
+            // Tauri opens `main` itself and the build below aborts on the duplicate.
             let drag_drop = drag_drop_enabled();
             log::info!("wine={} drag-drop-handler={}", under_wine(), drag_drop);
             for window_config in app

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -10,7 +10,8 @@
         "minHeight": 700,
         "decorations": true,
         "titleBarStyle": "Overlay",
-        "hiddenTitle": true
+        "hiddenTitle": true,
+        "create": false
       }
     ]
   }

--- a/src/Components/Settings/SupportersCard.tsx
+++ b/src/Components/Settings/SupportersCard.tsx
@@ -1,18 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from "react";
 import { Coffee, ExternalLink, RefreshCw } from "lucide-react";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
 import { useI18n } from "../../i18n/context";
 import { getLocale } from "../../i18n/core";
 import { Button } from "@/Components/ui/button";
 import { cn } from "@/lib/utils";
-import {
-  BUNDLED_SUPPORTERS,
-  SUPPORT_URL,
-  fetchSupporters,
-  groupByTier,
-  readCachedManifest,
-  type SupportersManifest,
-} from "./supporters";
+import { SUPPORT_URL, groupByTier } from "./supporters";
+import { useSupporters } from "./useSupporters";
 
 /** "since Jul 2026". Month and year only — the day somebody pledged is noise, and the
  *  year on its own reads as though they might have stopped in January. */
@@ -20,51 +13,6 @@ function sinceLabel(iso: string): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return "";
   return d.toLocaleDateString(getLocale(), { month: "short", year: "numeric" });
-}
-
-/**
- * The live supporters list.
- *
- * Starts from whatever is already on disk so the section paints filled in, then goes to
- * the network. A failed fetch keeps what's showing and flips `stale` — the alternative,
- * emptying the page because GitHub was unreachable for a second, would tell the player
- * the app has no supporters.
- */
-function useSupporters() {
-  const [manifest, setManifest] = useState<SupportersManifest>(
-    () => readCachedManifest() ?? BUNDLED_SUPPORTERS,
-  );
-  const [loading, setLoading] = useState(true);
-  const [stale, setStale] = useState(false);
-  const alive = useRef(true);
-
-  useEffect(() => {
-    alive.current = true;
-    return () => {
-      alive.current = false;
-    };
-  }, []);
-
-  const refresh = useCallback(async () => {
-    setLoading(true);
-    try {
-      const fresh = await fetchSupporters();
-      if (!alive.current) return;
-      setManifest(fresh);
-      setStale(false);
-    } catch {
-      if (!alive.current) return;
-      setStale(true);
-    } finally {
-      if (alive.current) setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    void refresh();
-  }, [refresh]);
-
-  return { manifest, loading, stale, refresh };
 }
 
 /**

--- a/src/Components/Settings/useSupporters.ts
+++ b/src/Components/Settings/useSupporters.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  BUNDLED_SUPPORTERS,
+  fetchSupporters,
+  readCachedManifest,
+  type SupportersManifest,
+} from "./supporters";
+
+/**
+ * The live supporters list.
+ *
+ * Starts from whatever is already on disk so the section paints filled in, then goes to
+ * the network. A failed fetch keeps what's showing and flips `stale` — the alternative,
+ * emptying the page because GitHub was unreachable for a second, would tell the player
+ * the app has no supporters.
+ *
+ * Lives here rather than inside `SupportersCard` because the release showcase credits
+ * the same people, and two copies would drift.
+ */
+export function useSupporters() {
+  const [manifest, setManifest] = useState<SupportersManifest>(
+    () => readCachedManifest() ?? BUNDLED_SUPPORTERS,
+  );
+  const [loading, setLoading] = useState(true);
+  const [stale, setStale] = useState(false);
+  const alive = useRef(true);
+
+  useEffect(() => {
+    alive.current = true;
+    return () => {
+      alive.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const fresh = await fetchSupporters();
+      if (!alive.current) return;
+      setManifest(fresh);
+      setStale(false);
+    } catch {
+      if (!alive.current) return;
+      setStale(true);
+    } finally {
+      if (alive.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return { manifest, loading, stale, refresh };
+}

--- a/src/Components/Showcase/ReleaseShowcase.tsx
+++ b/src/Components/Showcase/ReleaseShowcase.tsx
@@ -11,6 +11,8 @@ import { useConfig } from "../../Context/Config";
 import { useI18n } from "../../i18n/context";
 import { prettyHotkey } from "../../lib/hotkey";
 import { usePlatform } from "../../lib/usePlatform";
+import type { SectionId } from "../Settings/Settings";
+import ShowcaseSupporters from "./ShowcaseSupporters";
 import type { Release } from "./releases";
 
 const RELEASE_NOTES_URL = "https://github.com/Frostn1/mxb-app/releases/tag/v";
@@ -19,8 +21,9 @@ interface ReleaseShowcaseProps {
   release: Release;
   /** Close it and remember this version has been seen. */
   onDone: () => void;
-  /** Jump to a Settings section — used by the hero's call to action. */
-  onOpenSettings: (section: "overlay") => void;
+  /** Jump to a Settings section — used by the hero's call to action and the supporters
+   *  credit, which lands on the full thank-you list. */
+  onOpenSettings: (section: SectionId) => void;
 }
 
 /**
@@ -51,7 +54,9 @@ export default function ReleaseShowcase({
   return (
     <Dialog open onOpenChange={(open) => !open && onDone()}>
       <DialogContent
-        className="max-w-[520px] gap-5"
+        // The window can be as short as 700px, and a release with a full set of
+        // highlights plus the supporters credit is taller than that leaves room for.
+        className="max-h-[85vh] max-w-[520px] gap-5 overflow-y-auto"
         // Closing by clicking away would leave someone unsure whether it counted;
         // Esc and the corner X both land on `onDone`, which does record it.
         onPointerDownOutside={(e) => e.preventDefault()}
@@ -121,6 +126,14 @@ export default function ReleaseShowcase({
             );
           })}
         </ul>
+
+        {/* Shown with every release, not just this one — see ShowcaseSupporters. */}
+        <ShowcaseSupporters
+          onOpen={() => {
+            onDone();
+            onOpenSettings("supporters");
+          }}
+        />
 
         <div className="flex items-center justify-between gap-3 border-t border-border pt-3">
           <button

--- a/src/Components/Showcase/ShowcaseSupporters.tsx
+++ b/src/Components/Showcase/ShowcaseSupporters.tsx
@@ -1,0 +1,71 @@
+import { ChevronRight, Coffee } from "lucide-react";
+import { useI18n } from "../../i18n/context";
+import { groupByTier } from "../Settings/supporters";
+import { useSupporters } from "../Settings/useSupporters";
+
+/** Enough to feel like a crowd, few enough to stay on two lines at 520px. */
+const SHOWN = 5;
+
+interface ShowcaseSupportersProps {
+  /** Close the modal and land on Settings → Supporters. */
+  onOpen: () => void;
+}
+
+/**
+ * Credits the people paying for the app, inside the "what's new" modal.
+ *
+ * Deliberately not part of any release's entry in `releases.ts`: this is shown with
+ * *every* release, so it can't be something the next version has to remember to add.
+ * The names come from the same live manifest Settings reads, so a supporter who joined
+ * after the build shipped is still thanked by it.
+ *
+ * It credits rather than asks — the block routes to the thank-you page in Settings, and
+ * the "buy a coffee" button lives there. An update notice is a bad place to hold out a
+ * hat, and a nag is what gets this dismissed unread.
+ */
+export default function ShowcaseSupporters({ onOpen }: ShowcaseSupportersProps) {
+  const { t } = useI18n();
+  const { manifest } = useSupporters();
+
+  // Best tier first, longest-standing first within it — `groupByTier` already orders
+  // both, so flattening it keeps Settings and this strip naming the same people.
+  const people = groupByTier(manifest).flatMap((g) => g.people);
+  const count = people.length;
+  // A fetch that legitimately returns nobody shouldn't leave "made possible by 0
+  // supporters" sitting under the release notes.
+  if (count === 0) return null;
+
+  const shown = people.slice(0, SHOWN);
+  const rest = count - shown.length;
+
+  return (
+    <button
+      onClick={onOpen}
+      className="group flex cursor-default flex-col gap-2 rounded-xl border border-amber-400/20 bg-amber-400/[0.06] p-3 text-left transition-colors hover:border-amber-400/35 hover:bg-amber-400/[0.09]"
+    >
+      <div className="flex items-center gap-2">
+        <Coffee className="size-3.5 flex-none text-amber-400/90" />
+        <span className="text-[11.5px] font-semibold text-foreground/85">
+          {t("showcase.supporters.title", { count })}
+        </span>
+        <ChevronRight className="ml-auto size-3.5 flex-none text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1.5">
+        {shown.map((person) => (
+          <span
+            key={person.name}
+            className="max-w-[190px] truncate rounded-full border border-amber-400/20 bg-background/50 px-2 py-0.5 text-[11.5px] text-foreground/80"
+          >
+            {person.name}
+          </span>
+        ))}
+        {rest > 0 && (
+          <span className="text-[11.5px] text-muted-foreground">
+            {t("showcase.supporters.more", { count: rest })}
+          </span>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1097,6 +1097,9 @@ export const de: Translation = {
   "showcase.whileGameRunning": "während MX Bikes läuft",
   "showcase.releaseNotes": "Release Notes lesen",
   "showcase.gotIt": "Alles klar",
+  "showcase.supporters.title_one": "Ermöglicht durch {{count}} Unterstützer",
+  "showcase.supporters.title_other": "Ermöglicht durch {{count}} Unterstützer",
+  "showcase.supporters.more": "+{{count}} weitere",
   "showcase.v091.hero.title": "Male direkt auf die Vorlage",
   "showcase.v091.hero.body":
     "Der Designer konnte Bilder und Text auf den Bahnen eines Designs platzieren, aber keinen einzigen Pixel von Hand setzen — ein Verlauf über eine Spoiler-Flanke hieß: raus in einen Bildeditor und wieder zurück. Jetzt gibt es einen Werkzeugkasten: weicher Pinsel mit Größe, Kante und Stärke, Radierer, Verlauf, Füllung sowie Rechteck, Ellipse und Linie. Alles landet gleichzeitig auf der Bahn und am 3D-Modell, während du ziehst.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1054,6 +1054,9 @@ export const en = {
   "showcase.whileGameRunning": "while MX Bikes is running",
   "showcase.releaseNotes": "Read the release notes",
   "showcase.gotIt": "Got it",
+  "showcase.supporters.title_one": "Made possible by {{count}} supporter",
+  "showcase.supporters.title_other": "Made possible by {{count}} supporters",
+  "showcase.supporters.more": "+{{count}} more",
   "showcase.v091.hero.title": "Paint straight onto the template",
   "showcase.v091.hero.body":
     "The Designer could place images and text on a paint's sheets, but you couldn't put down a single pixel by hand — a fade across a shroud meant leaving for an image editor and coming back. It has a tool kit now: a soft brush with size, edge and strength, an eraser, a gradient, a fill, and rectangle, ellipse and line. Everything lands on the sheet and on the 3D model at the same time, while you drag.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1085,6 +1085,9 @@ export const es: Translation = {
   "showcase.whileGameRunning": "mientras MX Bikes está abierto",
   "showcase.releaseNotes": "Leer las notas de la versión",
   "showcase.gotIt": "Entendido",
+  "showcase.supporters.title_one": "Posible gracias a {{count}} mecenas",
+  "showcase.supporters.title_other": "Posible gracias a {{count}} mecenas",
+  "showcase.supporters.more": "+{{count}} más",
   "showcase.v091.hero.title": "Pinta directamente sobre la plantilla",
   "showcase.v091.hero.body":
     "El Designer sabía colocar imágenes y texto sobre las hojas de una pintura, pero no dejaba poner ni un píxel a mano — un degradado en un lateral obligaba a salir a un editor de imágenes y volver. Ahora tiene su caja de herramientas: pincel suave con tamaño, borde e intensidad, borrador, degradado, relleno, y rectángulo, elipse y línea. Todo aparece en la hoja y en el modelo 3D a la vez, mientras arrastras.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1088,6 +1088,9 @@ export const fr: Translation = {
   "showcase.whileGameRunning": "pendant que MX Bikes tourne",
   "showcase.releaseNotes": "Lire les notes de version",
   "showcase.gotIt": "Compris",
+  "showcase.supporters.title_one": "Rendu possible par {{count}} soutien",
+  "showcase.supporters.title_other": "Rendu possible par {{count}} soutiens",
+  "showcase.supporters.more": "+{{count}} autres",
   "showcase.v091.hero.title": "Peins directement sur le gabarit",
   "showcase.v091.hero.body":
     "Le Designer savait placer images et textes sur les planches d'une déco, mais il ne laissait poser aucun pixel à la main — un dégradé sur un ouïe voulait dire partir dans un éditeur d'images et revenir. Il a maintenant sa boîte à outils : pinceau doux avec taille, bord et intensité, gomme, dégradé, remplissage, rectangle, ellipse et ligne. Tout arrive sur la planche et sur le modèle 3D en même temps, pendant que tu fais glisser.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1077,6 +1077,9 @@ export const it: Translation = {
   "showcase.whileGameRunning": "mentre MX Bikes è in esecuzione",
   "showcase.releaseNotes": "Leggi le note di rilascio",
   "showcase.gotIt": "Ho capito",
+  "showcase.supporters.title_one": "Reso possibile da {{count}} sostenitore",
+  "showcase.supporters.title_other": "Reso possibile da {{count}} sostenitori",
+  "showcase.supporters.more": "+{{count}} altri",
   "showcase.v091.hero.title": "Dipingi direttamente sul template",
   "showcase.v091.hero.body":
     "Il Designer sapeva posizionare immagini e testo sui fogli di una livrea, ma non ti lasciava mettere giù un solo pixel a mano — una sfumatura su una fiancata voleva dire uscire, aprire un editor di immagini e tornare indietro. Ora ha una cassetta degli attrezzi: pennello morbido con dimensione, bordo e intensità, gomma, sfumatura, riempimento, rettangolo, ellisse e linea. Tutto arriva sul foglio e sul modello 3D nello stesso momento, mentre trascini.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1077,6 +1077,9 @@ export const ptBR: Translation = {
   "showcase.whileGameRunning": "enquanto o MX Bikes está aberto",
   "showcase.releaseNotes": "Ler as notas da versão",
   "showcase.gotIt": "Entendi",
+  "showcase.supporters.title_one": "Possível graças a {{count}} apoiador",
+  "showcase.supporters.title_other": "Possível graças a {{count}} apoiadores",
+  "showcase.supporters.more": "+{{count}} outros",
   "showcase.v091.hero.title": "Pinte direto no template",
   "showcase.v091.hero.body":
     "O Designer sabia posicionar imagens e texto nas folhas de uma pintura, mas não deixava colocar um único pixel à mão — um degradê numa carenagem significava sair para um editor de imagens e voltar. Agora ele tem um kit de ferramentas: pincel suave com tamanho, borda e intensidade, borracha, gradiente, preenchimento, retângulo, elipse e linha. Tudo aparece na folha e no modelo 3D ao mesmo tempo, enquanto você arrasta.",


### PR DESCRIPTION
Cuts the plain **v0.9.1** tag off `v0.9.1-beta.4`, and carries the two fixes that had to go in with it.

### macOS was crashing on launch
`tauri.macos.conf.json` **replaces** the base `windows` array rather than merging into it, so the `"create": false` added with the Wine drag-drop fix (2ff71cd, after v0.9.0) was dropped on macOS alone. Tauri opened `main` itself, the setup hook built a second window under the same label, and the process aborted before drawing anything.

That made the Mac work this release advertises impossible to reach. Windows has no override file and Linux's doesn't name the window, which is why only macOS was hit and no beta caught it.

Reproduced and fixed locally: same build panics at `app.rs:1425` with *"a webview with label `main` already exists"* before the change, starts clean after it.

### "What's new" credits the supporters
The update modal now names the supporters under the release it announces and opens the full thank-you list in Settings when clicked. It lives in the modal rather than in any one release's entry, so every future update carries it without having to remember. Names come from the live manifest, so somebody who started supporting after the build shipped is still thanked by it — Qwest already shows up this way on a build cut before that commit.

It credits and links; the button that asks for anything stays on the Settings page.

### Also
- `useSupporters` moved out of `SupportersCard` so Settings and the showcase read one source.
- The showcase dialog scrolls past `85vh` — the window floor is 700px and a full set of highlights plus the credit is taller than that.
- CHANGELOG: dropped "for this beta" from the v0.9.1 caveat, which would otherwise have gone out verbatim in the GitHub release body and the Discord post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)