### PR TITLE
chore(supporters): credit Kelso

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-08-11
+
+### Added
+- **Kelso** credited on Settings → Supporters.
+
 ## 2026-08-10
 
 ### Added

--- a/src/Components/Settings/supporters.ts
+++ b/src/Components/Settings/supporters.ts
@@ -65,6 +65,7 @@ export const BUNDLED_SUPPORTERS: SupportersManifest = {
     { name: "SoggySwisher" },
     { name: "LupaHo" },
     { name: "Qwest" },
+    { name: "Kelso" },
   ],
 };
 

--- a/supporters.json
+++ b/supporters.json
@@ -8,6 +8,7 @@
     "Mouk",
     "SoggySwisher",
     "LupaHo",
-    "Qwest"
+    "Qwest",
+    "Kelso"
   ]
 }


### PR DESCRIPTION
Adds **Kelso** to the supporters list.

- `supporters.json` — the list every installed copy reads live off `main`, so this credits them today rather than at the next release.
- `BUNDLED_SUPPORTERS` in `src/Components/Settings/supporters.ts` — so an install that has never reached the network doesn't quietly drop the newest name.
- Plain name, no tier or `since`, matching every other entry.

Same shape as #144 (Qwest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)