### PR TITLE
Make painting cost a brush stamp rather than a whole sheet

### DIFF
--- a/src/Components/Studio/Designer/CanvasStage.tsx
+++ b/src/Components/Studio/Designer/CanvasStage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { useT } from "../../../i18n/context";
 import { layerCorners } from "./composite";
@@ -10,6 +10,34 @@ import { constrained, hasTip, isDragTool, type PaintTool, type Point } from "./p
 /** Half-edge of a drawn corner handle, and how far off one a press still counts, in view px. */
 const HANDLE = 3.5;
 const GRAB = 9;
+
+/** Side of one checkerboard square, in view pixels. Fixed, so zoom doesn't resize the board. */
+const CELL = 8;
+
+/**
+ * The transparency checkerboard, as a two-square tile the canvas repeats for us.
+ *
+ * Drawn a square at a time this is a few thousand `fillRect` calls to cover the sheet, repeated
+ * on every repaint — which during a stroke is every frame, to redraw a pattern that never
+ * changes. One tile handed to `createPattern` is the same picture in a single fill.
+ */
+let tile: HTMLCanvasElement | null = null;
+function checkerTile(): HTMLCanvasElement {
+  if (!tile) {
+    tile = document.createElement("canvas");
+    tile.width = CELL * 2;
+    tile.height = CELL * 2;
+    const ctx = tile.getContext("2d");
+    if (ctx) {
+      ctx.fillStyle = "#2a2c33";
+      ctx.fillRect(0, 0, CELL * 2, CELL * 2);
+      ctx.fillStyle = "#33363e";
+      ctx.fillRect(0, 0, CELL, CELL);
+      ctx.fillRect(CELL, CELL, CELL, CELL);
+    }
+  }
+  return tile;
+}
 
 /** The range a corner drag can take a layer to. The same as the inspector's slider, so the
  *  two controls can't disagree about how big a logo is allowed to get. */
@@ -81,6 +109,9 @@ export function CanvasStage({
   // The brush cursor, moved by writing to its style rather than through state — a ring that
   // re-rendered the stage on every mouse move would redraw the whole sheet to move a circle.
   const cursorRef = useRef<HTMLDivElement>(null);
+  // The checkerboard pattern, built once. Patterns belong to the context they were made from,
+  // and this canvas keeps the same one for its whole life — resizing it doesn't replace it.
+  const checker = useRef<CanvasPattern | null>(null);
   const [box, setBox] = useState({ w: 0, h: 0 });
   const [zoom, setZoom] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
@@ -104,6 +135,18 @@ export function CanvasStage({
   const [guide, setGuide] = useState<{ from: Point; to: Point } | null>(null);
 
   const paints = tool !== "move" && canPaint;
+
+  /**
+   * The hovered part's outline, built when the hover moves rather than when the view repaints.
+   *
+   * A part is a few thousand triangles and the repaint below runs on every frame of a stroke,
+   * with the pointer parked on whatever it was over when the press happened — so rebuilding the
+   * path there was paying for the same unchanged shape once per sample of the drawing.
+   */
+  const overPath = useMemo(
+    () => (overPart ? partPath(overPart, sheet.width, sheet.height) : null),
+    [overPart, sheet.width, sheet.height],
+  );
 
   useEffect(() => {
     const el = wrapRef.current;
@@ -211,19 +254,19 @@ export function CanvasStage({
 
     // Checkerboard first, so transparent parts of the sheet read as transparent rather than
     // as black — which on a livery is a real colour and would be badly misleading.
-    const cell = 8;
     ctx.save();
     ctx.beginPath();
     ctx.rect(left, top, w, h);
     ctx.clip();
-    ctx.fillStyle = "#2a2c33";
-    ctx.fillRect(left, top, w, h);
-    ctx.fillStyle = "#33363e";
-    for (let y = 0; y < h; y += cell) {
-      for (let x = ((y / cell) % 2) * cell; x < w; x += cell * 2) {
-        ctx.fillRect(left + x, top + y, cell, cell);
-      }
-    }
+    // Translated rather than offset per square, so the tile still starts at the sheet's own
+    // corner: the pattern is laid out in the space the current transform describes.
+    ctx.translate(left, top);
+    const board = checker.current ?? ctx.createPattern(checkerTile(), "repeat");
+    checker.current = board;
+    // Flat where a pattern couldn't be built. It still says "nothing is drawn here", which is
+    // the whole job — a board is only the clearer way of saying it.
+    ctx.fillStyle = board ?? "#2a2c33";
+    ctx.fillRect(0, 0, w, h);
     ctx.restore();
 
     ctx.imageSmoothingEnabled = true;
@@ -284,13 +327,12 @@ export function CanvasStage({
 
     // The piece under the pointer, picked out of the map. Only while the map is on: a highlight
     // that appeared over a livery with no islands showing would be an outline from nowhere.
-    if (overPart && ghost?.showWire && ghost.wire) {
+    if (overPart && overPath && ghost?.showWire && ghost.wire) {
       ctx.save();
       ctx.translate(left, top);
       ctx.scale(w / sheet.width, h / sheet.height);
-      const path = partPath(overPart, sheet.width, sheet.height);
       ctx.fillStyle = `hsla(${overPart.hue}, 85%, 65%, 0.18)`;
-      ctx.fill(path, "nonzero");
+      ctx.fill(overPath, "nonzero");
       ctx.restore();
     }
 
@@ -330,6 +372,7 @@ export function CanvasStage({
     source,
     ghost,
     overPart,
+    overPath,
     version,
     guide,
     tool,

--- a/src/Components/Studio/Designer/Designer.tsx
+++ b/src/Components/Studio/Designer/Designer.tsx
@@ -46,8 +46,10 @@ import {
   newId,
   paintLayer,
   textLayer,
+  unionRegion,
   type Layer,
   type PaintLayer,
+  type Region,
   type Sheet,
 } from "./layers";
 import {
@@ -140,6 +142,19 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   const textures = useRef(new Map<string, THREE.DataTexture>());
   // The sheet object each canvas was last drawn from, so an untouched sheet isn't redrawn.
   const drawn = useRef(new Map<string, Sheet>());
+  /**
+   * What has changed on each stale sheet since its canvas was last drawn.
+   *
+   * An entry of `null` means "somewhere, unspecified" and buys nothing — the recomposite falls
+   * back to the whole sheet, which is what it always did. A region is a promise that nothing
+   * outside it moved, and only a stroke is in a position to make that promise, because only a
+   * stroke knows where its own pixels went. Everything else goes through `patchSheet`, which
+   * says `null` on the way past.
+   *
+   * Cleared by the recomposite that consumes it: a region held over from a redraw that already
+   * happened would describe the wrong sheet by the time the next one came round.
+   */
+  const dirty = useRef(new Map<string, Region | null>());
   // The live map the viewer reads, plus the only thing allowed to change its identity.
   const overridesRef = useRef(new Map<string, THREE.Texture>());
   const [overrideNames, setOverrideNames] = useState("");
@@ -166,24 +181,34 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
    * front of the blit.
    *
    * Sheets are compared by identity: an edit replaces exactly the sheet it touched, so this
-   * redraws one 2048² canvas per pointer move rather than all of them.
+   * redraws one 2048² canvas per pointer move rather than all of them. The texture behind it
+   * follows the same test rather than being rebuilt every pass — reading a canvas back is the
+   * most expensive thing in here, and re-reading the three sheets a stroke did not touch was
+   * paying that price for pixels that were identical to the ones already uploaded.
+   *
+   * What did change is redrawn and read back across the region the stroke reported, which is
+   * the difference between a stamp's worth of work per sample and a sheet's worth.
    */
   useLayoutEffect(() => {
     const next = new Map<string, THREE.Texture>();
     for (const sheet of sheets) {
       const canvas = canvasFor(sheet);
+      let tex = textures.current.get(sheet.id) ?? null;
       if (drawn.current.get(sheet.id) !== sheet) {
-        composite(canvas, sheet);
+        const area = composite(canvas, sheet, dirty.current.get(sheet.id) ?? null);
         drawn.current.set(sheet.id, sheet);
+        // Built the same way the viewer builds an installed paint's texture, so the drawing
+        // lands on the mesh exactly where the `.pnt` would have. `needsUpdate` inside carries
+        // the new pixels without any React work. A sheet that turned out to have no pixels to
+        // redraw has none to upload either.
+        if (area) tex = sheetTexture(canvas, tex, area);
       }
-      // Built the same way the viewer builds an installed paint's texture, so the drawing
-      // lands on the mesh exactly where the `.pnt` would have. `needsUpdate` inside carries
-      // the new pixels without any React work.
-      const tex = sheetTexture(canvas, textures.current.get(sheet.id) ?? null);
+      if (!tex) tex = sheetTexture(canvas, null);
       if (!tex) continue;
       textures.current.set(sheet.id, tex);
       if (sheet.name.trim()) next.set(sheet.name.trim().toLowerCase(), tex);
     }
+    dirty.current.clear();
     // Identity changes only when the *names* do. The viewer memoises one material per submesh
     // on this map, so handing it a fresh one per pointer move rebuilt every material in the
     // model on every frame of a drag — which is exactly as slow as it sounds. The textures
@@ -221,6 +246,10 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   }, []);
 
   const patchSheet = useCallback((id: string, fn: (s: Sheet) => Sheet) => {
+    // Every route into a sheet but a stroke comes through here, and none of them says where it
+    // drew. Marking the sheet wholly dirty on the way past is what lets the recomposite treat a
+    // region as a promise rather than a hint: if one is there, a stroke put it there.
+    dirty.current.set(id, null);
     setSheets((prev) => prev.map((s) => (s.id === id ? fn(s) : s)));
   }, []);
 
@@ -241,17 +270,87 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
      higher `rev` inside a fresh sheet, which is exactly the signal the recomposite above
      watches for. ─────────────────────────────────────────────────────────────────────── */
 
-  const touchPaint = useCallback(
+  /**
+   * Record where a stroke drew, without telling React anything.
+   *
+   * Split from the notification below because the two want different rates. Pixels have to be
+   * accounted for the instant they land — miss one sample's region and that part of the stroke
+   * never reaches the composite — while the render they add up to is worth doing once a frame.
+   */
+  const markPaint = useCallback((sheetId: string, region: Region | null) => {
+    const held = dirty.current.get(sheetId);
+    // Once a sheet is wholly dirty it stays that way until the redraw: a region unioned onto
+    // "everything" would narrow the redraw to less than is actually stale.
+    if (region && held !== null) dirty.current.set(sheetId, unionRegion(held ?? null, region));
+    else dirty.current.set(sheetId, null);
+  }, []);
+
+  /** Make the pixels a stroke has already written exist as far as React is concerned. */
+  const notifyPaint = useCallback(
     (sheetId: string, layerId: string) => {
-      patchSheet(sheetId, (s) => ({
-        ...s,
-        layers: s.layers.map((l) =>
-          l.id === layerId && l.kind === "paint" ? { ...l, rev: l.rev + 1 } : l,
+      setSheets((prev) =>
+        prev.map((s) =>
+          s.id === sheetId
+            ? {
+                ...s,
+                layers: s.layers.map((l) =>
+                  l.id === layerId && l.kind === "paint" ? { ...l, rev: l.rev + 1 } : l,
+                ),
+              }
+            : s,
         ),
-      }));
+      );
       bump();
     },
-    [bump, patchSheet],
+    [bump],
+  );
+
+  const touchPaint = useCallback(
+    (sheetId: string, layerId: string, region?: Region | null) => {
+      markPaint(sheetId, region ?? null);
+      notifyPaint(sheetId, layerId);
+    },
+    [markPaint, notifyPaint],
+  );
+
+  /**
+   * One render per frame, however fast the pointer reports.
+   *
+   * Pointer samples are not paced by the display. A high-rate mouse on a webview that doesn't
+   * align them to the frame delivers a dozen or more between two paints, and each one used to
+   * drive a full React commit, a recomposite, a texture upload and a redraw of both views — a
+   * dozen renders where the screen could show one. The stroke itself still takes every sample
+   * the moment it arrives, because that is what the mark is made of; only the telling-everyone
+   * waits, and it waits at most until the next frame, which is the soonest anyone could see it.
+   */
+  const queued = useRef<{ sheetId: string; layerId: string } | null>(null);
+  const frame = useRef(0);
+
+  const flushPaint = useCallback(() => {
+    if (frame.current) {
+      cancelAnimationFrame(frame.current);
+      frame.current = 0;
+    }
+    const q = queued.current;
+    queued.current = null;
+    if (q) notifyPaint(q.sheetId, q.layerId);
+  }, [notifyPaint]);
+
+  const schedulePaint = useCallback(
+    (sheetId: string, layerId: string) => {
+      queued.current = { sheetId, layerId };
+      if (!frame.current) frame.current = requestAnimationFrame(flushPaint);
+    },
+    [flushPaint],
+  );
+
+  // A stroke abandoned by an unmount has already written its pixels; the frame that would have
+  // announced them has nowhere left to land.
+  useEffect(
+    () => () => {
+      if (frame.current) cancelAnimationFrame(frame.current);
+    },
+    [],
   );
 
   /** The paint layer a stroke would land on: the selected one, when it is one. */
@@ -291,30 +390,39 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   const startPaint = useCallback(
     (at: Point) => {
       if (!target || !activeId) return;
-      stroke.current = new Stroke(target.canvas, paint, at);
-      touchPaint(activeId, target.id);
+      const next = new Stroke(target.canvas, paint, at);
+      stroke.current = next;
+      // Straight through rather than queued: the press is the one sample nobody would forgive a
+      // frame's wait on, and a tool that puts nothing down on the press has nothing to show.
+      if (next.dirty) touchPaint(activeId, target.id, next.dirty);
     },
     [activeId, paint, target, touchPaint],
   );
 
   const movePaint = useCallback(
     (points: Point[], constrain: boolean) => {
-      if (!stroke.current || !target || !activeId) return;
-      stroke.current.move(points, constrain);
-      touchPaint(activeId, target.id);
+      const live = stroke.current;
+      if (!live || !target || !activeId) return;
+      live.move(points, constrain);
+      if (!live.dirty) return;
+      markPaint(activeId, live.dirty);
+      schedulePaint(activeId, target.id);
     },
-    [activeId, target, touchPaint],
+    [activeId, markPaint, schedulePaint, target],
   );
 
   const endPaint = useCallback(() => {
     const done = stroke.current;
     stroke.current = null;
+    // Whatever the last frame didn't get to, now — a stroke that ended between two frames would
+    // otherwise leave its final samples drawn on the layer and missing from the composite.
+    flushPaint();
     // A press that put nothing down isn't a step to undo — clicking to check the tool would
     // otherwise fill the history with states identical to the one before them.
     if (!done?.end() || !target || !activeId) return;
     history.current.push(activeId, target.id, done.before);
     setHistoryRev((v) => v + 1);
-  }, [activeId, target]);
+  }, [activeId, flushPaint, target]);
 
   /** The live canvas behind a layer id, wherever it lives — history spans every sheet. */
   const paintCanvas = useCallback(

--- a/src/Components/Studio/Designer/composite.ts
+++ b/src/Components/Studio/Designer/composite.ts
@@ -1,9 +1,11 @@
 import * as THREE from "three";
 import {
   BLEND_OPS,
+  clampRegion,
   fontSpec,
   layerExtent,
   type Layer,
+  type Region,
   type Sheet,
 } from "./layers";
 
@@ -53,24 +55,53 @@ function drawLayer(ctx: CanvasRenderingContext2D, layer: Layer) {
 }
 
 /**
- * Redraw `sheet` into `canvas`, sizing it if needed.
+ * Redraw `sheet` into `canvas`, sizing it if needed, and say which part of it was rewritten.
  *
  * Cleared to transparent, not to white: a paint's alpha is the part of it the game reads for
  * decals and cutouts, and a sheet flattened onto white would lose that on the way to the file.
+ *
+ * `region` narrows the redraw to the part of the sheet the caller knows has moved — a brush
+ * stamp rather than the 2048² square around it. Every layer is still drawn, under a clip: the
+ * saving is in pixels touched, not in work skipped, and a stack that composited differently
+ * inside the region than outside it would leave a seam along the region's edge. Anything that
+ * cannot be narrowed honestly — a sheet that just changed size, or a change nobody described —
+ * passes null and gets the whole thing.
+ *
+ * The region that comes back is the one actually used, clipped to the canvas: it is what the
+ * texture readback downstream has to be told, and letting the caller assume its own region was
+ * honoured is how a resized sheet would upload one stamp's worth of a new canvas.
  */
-export function composite(canvas: HTMLCanvasElement, sheet: Sheet): void {
-  if (canvas.width !== sheet.width || canvas.height !== sheet.height) {
+export function composite(
+  canvas: HTMLCanvasElement,
+  sheet: Sheet,
+  region?: Region | null,
+): Region | null {
+  const resized = canvas.width !== sheet.width || canvas.height !== sheet.height;
+  if (resized) {
     canvas.width = sheet.width;
     canvas.height = sheet.height;
   }
   const ctx = canvas.getContext("2d");
-  if (!ctx) return;
+  if (!ctx) return null;
+  // A fresh canvas has nothing on it to keep, so a region would be describing pixels that were
+  // never drawn in the first place.
+  const area =
+    resized || !region
+      ? { x: 0, y: 0, w: sheet.width, h: sheet.height }
+      : clampRegion(region, sheet.width, sheet.height);
+  if (!area || !area.w || !area.h) return null;
   ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.save();
   ctx.globalAlpha = 1;
   ctx.globalCompositeOperation = "source-over";
-  ctx.clearRect(0, 0, sheet.width, sheet.height);
+  ctx.beginPath();
+  ctx.rect(area.x, area.y, area.w, area.h);
+  ctx.clip();
+  ctx.clearRect(area.x, area.y, area.w, area.h);
   if (sheet.base) ctx.drawImage(sheet.base, 0, 0, sheet.width, sheet.height);
   for (const layer of sheet.layers) drawLayer(ctx, layer);
+  ctx.restore();
+  return area;
 }
 
 /** The selection box for a layer, as the four corners of its rotated bounds in sheet space. */
@@ -121,26 +152,45 @@ export function toPng(canvas: HTMLCanvasElement): Promise<ArrayBuffer> {
  * `.pnt` it came from. Matching the type is the only way to be sure they agree; reasoning
  * about which `flipY` cancels which got it wrong twice.
  *
- * The cost is a full-size readback per change, which is the same order as the composite that
- * just ran.
+ * `region` is the part of the canvas that changed — the same region the composite just drew.
+ * Reading back only those rows is what keeps this off the critical path of a stroke: a full
+ * 2048² readback is sixteen megabytes pulled off the GPU and copied again, per pointer sample,
+ * to carry a brush stamp that covers a few thousand pixels. The upload is still the whole
+ * texture, but that is the GPU's own copy of a buffer it already has; the readback is the
+ * expensive half and it is the half a region can remove.
  */
 export function sheetTexture(
   canvas: HTMLCanvasElement,
   existing: THREE.DataTexture | null,
+  region?: Region | null,
 ): THREE.DataTexture | null {
   const ctx = canvas.getContext("2d", { willReadFrequently: true });
   if (!ctx || !canvas.width || !canvas.height) return existing;
-  const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
 
   // Same size as last time: write into the buffer that's already there rather than handing
   // three.js a new one, so a drag doesn't allocate a sheet-sized array per frame.
   const held = existing?.image.data as Uint8Array | undefined;
-  if (existing && held && held.length === data.length) {
-    held.set(data);
+  if (existing && held && held.length === canvas.width * canvas.height * 4) {
+    const area = region ? clampRegion(region, canvas.width, canvas.height) : null;
+    if (region && !area) return existing;
+    const { x, y, w, h } = area ?? { x: 0, y: 0, w: canvas.width, h: canvas.height };
+    const { data } = ctx.getImageData(x, y, w, h);
+    if (w === canvas.width) {
+      // Full-width rows are contiguous in both buffers, so they go across in one move.
+      held.set(data, y * canvas.width * 4);
+    } else {
+      const stride = canvas.width * 4;
+      const run = w * 4;
+      for (let row = 0; row < h; row += 1) {
+        held.set(data.subarray(row * run, row * run + run), (y + row) * stride + x * 4);
+      }
+    }
     existing.needsUpdate = true;
     return existing;
   }
 
+  // No buffer to patch — a first texture, or a sheet that changed size. Read the lot.
+  const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
   existing?.dispose();
   const pixels = new Uint8Array(data.buffer.slice(0));
   const tex = new THREE.DataTexture(pixels, canvas.width, canvas.height, THREE.RGBAFormat);

--- a/src/Components/Studio/Designer/layers.ts
+++ b/src/Components/Studio/Designer/layers.ts
@@ -94,6 +94,52 @@ export interface PaintLayer extends LayerCommon {
 
 export type Layer = ImageLayer | TextLayer | PaintLayer;
 
+/**
+ * A rectangle of a sheet, in the sheet's own pixels.
+ *
+ * The unit of "what just changed". A brush stamp touches a few hundred pixels of a 2048² sheet,
+ * and the whole chain behind one pointer sample — restore the layer, recomposite it, read it
+ * back for the 3D preview — costs what it is told changed. Redrawing four million pixels to
+ * move a brush a few of them is the difference between a mark that follows the hand and one
+ * that trails behind it.
+ */
+export interface Region {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** The smallest region containing both, or whichever one exists. */
+export function unionRegion(a: Region | null, b: Region | null): Region | null {
+  if (!a) return b;
+  if (!b) return a;
+  const x = Math.min(a.x, b.x);
+  const y = Math.min(a.y, b.y);
+  return {
+    x,
+    y,
+    w: Math.max(a.x + a.w, b.x + b.w) - x,
+    h: Math.max(a.y + a.h, b.y + b.h) - y,
+  };
+}
+
+/**
+ * A region snapped out to whole pixels and trimmed to `width × height`, or null if none of it
+ * lands on the sheet.
+ *
+ * Outwards on every side: a stamp that covers four tenths of a pixel still tints it, and a
+ * region rounded inwards would leave that tenth showing the pixels from before the stroke.
+ */
+export function clampRegion(r: Region, width: number, height: number): Region | null {
+  const x = Math.max(0, Math.floor(r.x));
+  const y = Math.max(0, Math.floor(r.y));
+  const right = Math.min(width, Math.ceil(r.x + r.w));
+  const bottom = Math.min(height, Math.ceil(r.y + r.h));
+  if (right <= x || bottom <= y) return null;
+  return { x, y, w: right - x, h: bottom - y };
+}
+
 /** One texture of the paint: a name the mesh binds, and what's drawn under that name. */
 export interface Sheet {
   id: string;

--- a/src/Components/Studio/Designer/paint.ts
+++ b/src/Components/Studio/Designer/paint.ts
@@ -11,7 +11,16 @@
  * drag and the result after it are the same pixels by construction, and a soft brush can't
  * bruise into dark blobs where its own stamps overlap — the overlap happens inside the scratch,
  * and the scratch is composited once.
+ *
+ * Render is confined to the region the tool actually marked since the last one, which is what
+ * keeps that "once" affordable at sheet size. Restoring and re-laying is per pixel — the pixels
+ * outside the marked region have the same two inputs they had a sample ago, so recomputing them
+ * cannot change them. What the region is *for* is the rest of the chain: it is handed out
+ * through `dirty` so the composite and the texture readback behind it can be told the same
+ * thing, and a brush stroke stops costing a whole sheet per pointer sample at every stage.
  */
+
+import { clampRegion, unionRegion, type Region } from "./layers";
 
 /**
  * What the pointer does on the sheet.
@@ -266,6 +275,23 @@ function drawShape(
 }
 
 /**
+ * Where a shape drawn between two points lands, with room for the pen that draws it.
+ *
+ * Padded by half the stroke width because a line is centred on its path, and by a couple of
+ * pixels beyond that for the round cap and for the antialiasing at its edge — a region that
+ * stopped at the geometry would leave the outer fringe of a thick outline unrestored.
+ */
+function shapeRegion(from: Point, to: Point, s: PaintSettings): Region {
+  const pad = Math.max(1, s.strokeWidth) / 2 + 2;
+  return {
+    x: Math.min(from.x, to.x) - pad,
+    y: Math.min(from.y, to.y) - pad,
+    w: Math.abs(to.x - from.x) + pad * 2,
+    h: Math.abs(to.y - from.y) + pad * 2,
+  };
+}
+
+/**
  * Hold Shift: squares, circles, and axes that snap to 45°.
  *
  * Exported because the stage draws the guide you aim with and this draws what lands, and the
@@ -304,6 +330,12 @@ export class Stroke {
   private last: Point;
   /** Whether anything has actually been put down, so a stray click isn't an undo step. */
   private painted = false;
+  /** What the scratch has gained since the last render, and so what render has to lay down. */
+  private pending: Region | null = null;
+  /** Where the last drag-tool shape landed, since the next one has to wipe it off again. */
+  private shape: Region | null = null;
+  /** What the last render actually rewrote. Read through `dirty`. */
+  private touched: Region | null = null;
 
   constructor(
     private readonly target: HTMLCanvasElement,
@@ -324,6 +356,7 @@ export class Stroke {
         ctx.fillStyle = withAlpha(this.settings.colorA, 1);
         ctx.fillRect(0, 0, this.scratch.width, this.scratch.height);
       }
+      this.mark(this.whole());
       this.painted = true;
     } else if (!DRAG_TOOLS.has(this.settings.tool)) {
       this.dab(at, at);
@@ -332,13 +365,41 @@ export class Stroke {
     this.render();
   }
 
+  /**
+   * The region the last render rewrote, or null if it had nothing to do.
+   *
+   * The only thing anyone outside needs from the bookkeeping above: it says which part of the
+   * layer the sheet's composite — and the texture read back off it — has to catch up with.
+   */
+  get dirty(): Region | null {
+    return this.touched;
+  }
+
+  private whole(): Region {
+    return { x: 0, y: 0, w: this.target.width, h: this.target.height };
+  }
+
+  private mark(r: Region) {
+    this.pending = unionRegion(this.pending, r);
+  }
+
   private dab(from: Point, to: Point) {
     const ctx = this.scratch.getContext("2d");
     if (!ctx) return;
     const { size, hardness, colorA, tool } = this.settings;
     // The eraser's colour never reaches the sheet — the scratch is punched out of the layer,
     // so only its alpha matters. Black keeps a soft edge from tinting what it half-erases.
-    stampSegment(ctx, brushTip(size, hardness, tool === "eraser" ? "#000000" : colorA), from, to);
+    const tip = brushTip(size, hardness, tool === "eraser" ? "#000000" : colorA);
+    stampSegment(ctx, tip, from, to);
+    // The segment's own box, grown by the tip that was walked along it — the stamps at each
+    // end hang half a diameter past the points themselves.
+    const r = tip.width / 2 + 1;
+    this.mark({
+      x: Math.min(from.x, to.x) - r,
+      y: Math.min(from.y, to.y) - r,
+      w: Math.abs(to.x - from.x) + r * 2,
+      h: Math.abs(to.y - from.y) + r * 2,
+    });
   }
 
   /**
@@ -346,6 +407,9 @@ export class Stroke {
    * path, and only the latest for the ones that just need a current corner.
    */
   move(points: Point[], constrain: boolean) {
+    // Cleared up front so a sample that draws nothing reports nothing, rather than leaving the
+    // previous sample's region standing for a second helping of the work it already caused.
+    this.touched = null;
     if (!points.length) return;
     const { tool } = this.settings;
     if (tool === "fill") return;
@@ -364,6 +428,13 @@ export class Stroke {
       } else {
         drawShape(ctx, tool, this.start, to, this.settings);
       }
+      // Both boxes, because the scratch was wiped: the new shape has to be laid down and the
+      // old one has to be taken back off. A gradient covers the sheet, so for that one they
+      // are the same box and it is the whole thing.
+      const next = tool === "gradient" ? this.whole() : shapeRegion(this.start, to, this.settings);
+      this.mark(next);
+      if (this.shape) this.mark(this.shape);
+      this.shape = next;
       this.painted = true;
     } else {
       for (const p of points) {
@@ -375,21 +446,33 @@ export class Stroke {
     this.render();
   }
 
-  /** Put the layer back to the snapshot and lay the whole stroke over it, once. */
+  /**
+   * Put the layer back to the snapshot and lay the whole stroke over it, once — across the part
+   * of it that has moved since the last time.
+   *
+   * Both steps are per pixel and both read the same two canvases, so a pixel outside the region
+   * would be recomputed from unchanged inputs to the value it already holds. What the region
+   * changes is the bill, not the picture.
+   */
   private render() {
+    const rect = this.pending && clampRegion(this.pending, this.target.width, this.target.height);
+    this.pending = null;
+    this.touched = rect ?? null;
+    if (!rect) return;
     const ctx = this.target.getContext("2d");
     if (!ctx) return;
+    const { x, y, w, h } = rect;
     ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.save();
     ctx.globalAlpha = 1;
     ctx.globalCompositeOperation = "source-over";
-    ctx.clearRect(0, 0, this.target.width, this.target.height);
-    ctx.drawImage(this.before, 0, 0);
+    ctx.clearRect(x, y, w, h);
+    ctx.drawImage(this.before, x, y, w, h, x, y, w, h);
     ctx.globalAlpha = this.settings.opacity;
     ctx.globalCompositeOperation =
       this.settings.tool === "eraser" ? "destination-out" : "source-over";
-    ctx.drawImage(this.scratch, 0, 0);
-    ctx.globalAlpha = 1;
-    ctx.globalCompositeOperation = "source-over";
+    ctx.drawImage(this.scratch, x, y, w, h, x, y, w, h);
+    ctx.restore();
   }
 
   /** True when the stroke left something behind, and so is worth an undo entry. */


### PR DESCRIPTION
Drawing in the Designer lags behind the pointer, and gets worse the bigger the paint is.

## What was wrong

Every stage of a stroke worked at sheet size no matter how little had actually changed. One pointer sample:

1. **Rebuilt the layer end to end** — `Stroke.render` cleared the 2048² canvas, redrew the snapshot, and laid the scratch over it.
2. **Recomposited the whole sheet** — clear, base, every layer.
3. **Read *every* sheet in the paint back off its canvas** — `sheetTexture` ran unconditionally in the loop rather than only for the sheet that moved. On a bike with four sheets that is ~67MB of GPU readback and memcpy per sample, to carry a brush stamp covering a few thousand pixels.
4. Then a React commit, a 3D redraw, and a 2D repaint that drew the checkerboard as a few thousand `fillRect` calls and rebuilt the hovered part's `Path2D` from a few thousand triangles.

## What changed

A stroke now tracks where it drew and hands that region down the chain: the layer is restored across it, the composite is clipped to it, and only those rows are read back. Both steps are per pixel and read the same two canvases, so pixels outside the region would be recomputed from unchanged inputs to the values they already hold — the region changes the bill, not the picture.

Anything that cannot narrow honestly — a resized sheet, a layer moved or pinned, an undo, a change nobody described — passes no region and gets the full redraw exactly as before. `patchSheet` marks its sheet wholly dirty on the way past, so a region is a promise rather than a hint: if one is there, a stroke put it there.

Alongside that:

- **Only re-read a sheet's texture when its composite actually changed.** The sheets a stroke never touched were being pulled off the GPU and uploaded again every sample to carry pixels identical to the ones already there.
- **Coalesce pointer samples into one render per frame.** The stroke still takes every sample the instant it arrives, since that is what the mark is made of; only the telling-React-about-it waits, and never longer than the frame it would be shown in. A high-rate mouse on a webview that doesn't align input to the display was driving a dozen full commits, composites, uploads and redraws between two paints.
- **Draw the transparency checkerboard as a repeated tile** instead of a few thousand `fillRect`s per repaint.
- **Build the hovered part's outline when the hover moves** rather than on every repaint. It is a few thousand triangles, and during a stroke the pointer is parked on the part it pressed over, so the same unchanged path was being rebuilt once per sample.

## Verification

The region-aware path was run against the whole-sheet path in Chromium — **18 cases, all byte-identical**: every tool, soft/hard/tiny brushes, partial opacity, eraser, drag tools dragged around versus jumped straight to the end, regions running off the sheet edge, and regions straddling a pinned layer's clip. Patched texture buffers match a full re-read, including the narrow row-at-a-time branch.

On a 2048² sheet with three layers, one sample measures **~0.5ms against ~94ms**. That was measured under software rendering, so it is a ratio rather than a wall-clock figure for any particular machine — a real GPU-backed webview is faster in absolute terms on both sides, though readback stalls tend to hurt the old path more.

`tsc`, `eslint` and `vite build` are clean. The two remaining lint warnings are pre-existing, in `Presets.tsx` and `ViewerDialog.tsx`.

The checkerboard is the one place pixels move: at fractional view origins the tiled fill differs from the old per-square loop by at most 12/255 between the two checker greys at square boundaries, and the clip edge blends once now instead of twice (base fill plus a square on top). Not visible, but it is a change.

Worth driving on a real paint before relying on it — pixel-equivalence and cost are verified, but nothing here drove the actual app with a mouse.

---
_Generated by [Claude Code](https://claude.ai/code/session_019pQwGeSocN2vudRpwvRCJP)_