### PR TITLE
feat(settings): a Logs section — open any log folder, or save them all as one zip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,15 @@ looking nothing like the track you ride, name it in the report — that's the th
 - **Push-to-talk**, bound through the same global-shortcut path as the overlay hotkey, so
   it works while the game holds focus. It acts on both edges — mic opens on press, closes
   on release — and is bound even when the overlay is switched off.
+- **Your logs, in Settings → Logs.** "Send me your logs" was the first thing every bug
+  report asked for and the one thing there was no way to do: MXB App writes its own log
+  into a folder buried in AppData, and the game writes `log.txt` beside its executable —
+  and when the game's folder has been moved, somewhere only the app knows. Both are now
+  named on one page, with how many files are there and how old the newest one is, so a log
+  that predates the run you're reporting can be seen for what it is. **Open folder** takes
+  you to either with the newest file selected, and **Save logs…** writes the pair into a
+  single zip to attach. The zip holds the logs and a summary of the folders they came from
+  — never the settings file, which carries session cookies.
 - **Qwest and Kelso** credited on Settings → Supporters.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,14 +50,15 @@ looking nothing like the track you ride, name it in the report — that's the th
   it works while the game holds focus. It acts on both edges — mic opens on press, closes
   on release — and is bound even when the overlay is switched off.
 - **Your logs, in Settings → Logs.** "Send me your logs" was the first thing every bug
-  report asked for and the one thing there was no way to do: MXB App writes its own log
-  into a folder buried in AppData, and the game writes `log.txt` beside its executable —
-  and when the game's folder has been moved, somewhere only the app knows. Both are now
-  named on one page, with how many files are there and how old the newest one is, so a log
-  that predates the run you're reporting can be seen for what it is. **Open folder** takes
-  you to either with the newest file selected, and **Save logs…** writes the pair into a
-  single zip to attach. The zip holds the logs and a summary of the folders they came from
-  — never the settings file, which carries session cookies.
+  report asked for and the one thing there was no way to do. There are three sets and they
+  sit in three places: MXB App writes its own into a folder buried in AppData, FrostMod
+  writes into the folder we install and run it from, and the game writes `log.txt` beside
+  its executable — or, when the game's folder has been moved, somewhere only the app knows.
+  All three are now named on one page, with how many files are there and how old the newest
+  one is, so a log that predates the run you're reporting can be seen for what it is.
+  **Open folder** takes you to any of them with the newest file selected, and **Save logs…**
+  writes the lot into a single zip to attach. The zip holds the logs and a summary of the
+  folders they came from — never the settings file, which carries session cookies.
 - **Qwest and Kelso** credited on Settings → Supporters.
 
 ### Fixed

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -14,6 +14,7 @@
     "core:window:allow-close",
     "dialog:default",
     "dialog:allow-open",
+    "dialog:allow-save",
     "shell:allow-open",
     "deep-link:default",
     "updater:default",

--- a/src-tauri/src/frostmod_manage.rs
+++ b/src-tauri/src/frostmod_manage.rs
@@ -49,7 +49,10 @@ pub struct FrostmodStatus {
     pub missing_runtimes: Vec<crate::vcruntime::Runtime>,
 }
 
-fn frostmod_dir(app: &AppHandle) -> PathBuf {
+/// The folder we install FrostMod into and run it from — so also where anything it
+/// writes relative to its working directory lands (see `start`, which sets `current_dir`
+/// to it). Public for `logs`, which offers that folder up when a report needs it.
+pub fn frostmod_dir(app: &AppHandle) -> PathBuf {
     // Local app-data dir (Windows: `%LOCALAPPDATA%\com.frost.mxbikes\frostmod`).
     app.path()
         .app_local_data_dir()

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -208,6 +208,32 @@ pub fn reveal_in_explorer(path: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Open a folder in the OS file manager.
+///
+/// The sibling of [`reveal_in_explorer`] for when there is no file to select — an empty
+/// log folder, say. Explorer's `/select,` on a folder highlights it in its *parent*, which
+/// is not what "open this folder" means, so Windows gets the plain form here.
+pub fn open_folder(path: &str) -> anyhow::Result<()> {
+    let p = PathBuf::from(path);
+    if !p.is_dir() {
+        anyhow::bail!("folder not found: {path}");
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        std::process::Command::new("explorer").arg(&p).spawn()?;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open").arg(&p).spawn()?;
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        std::process::Command::new("xdg-open").arg(&p).spawn()?;
+    }
+    Ok(())
+}
+
 pub fn scan_mods(mods_path: &str, subpath: &str) -> anyhow::Result<Vec<InstalledMod>> {
     let dir = mods_subdir(mods_path, subpath);
     if !dir.exists() {

--- a/src-tauri/src/logs.rs
+++ b/src-tauri/src/logs.rs
@@ -1,14 +1,17 @@
 //! Where the logs are, and how to get them off the machine they're on.
 //!
-//! Two sets matter when something has gone wrong, and they live in different places:
+//! Three sets matter when something has gone wrong, and they live in different places:
 //! MXB App's own file log — written by `tauri_plugin_log` into the OS log dir
-//! (`%LOCALAPPDATA%\com.frost.mxbikes\logs` on Windows) — and the game's `log.txt`,
-//! which PiBoSo titles write beside the executable or into the user folder depending on
-//! how the game was started.
+//! (`%LOCALAPPDATA%\com.frost.mxbikes\logs` on Windows) — the game's `log.txt`, which
+//! PiBoSo titles write beside the executable or into the user folder depending on how the
+//! game was started, and whatever FrostMod leaves in the folder we install and run it
+//! from. Which of the three matters depends entirely on what broke, and the player
+//! reporting it is the last person who can tell.
 //!
-//! Neither is somewhere a player finds on their own, and "send me your logs" is the first
-//! thing every bug report asks for. So this module answers three questions for Settings:
-//! where they are, what's actually in there, and how to hand the lot over as one file.
+//! None of them is somewhere a player finds on their own, and "send me your logs" is the
+//! first thing every bug report asks for. So this module answers three questions for
+//! Settings: where they are, what's actually in there, and how to hand the lot over as
+//! one file.
 
 use serde::Serialize;
 use std::path::{Path, PathBuf};
@@ -62,6 +65,8 @@ impl LogGroup {
 pub struct LogsInfo {
     /// MXB App's own log dir.
     pub app: LogGroup,
+    /// The managed FrostMod folder — where we install it and where it runs from.
+    pub frostmod: LogGroup,
     /// The active game's logs.
     pub game: LogGroup,
 }
@@ -87,6 +92,29 @@ fn is_game_log(name: &str) -> bool {
     lower.ends_with(".log")
         || (lower.starts_with("log") && lower.ends_with(".txt"))
         || (lower.starts_with("crash") && (lower.ends_with(".txt") || lower.ends_with(".log")))
+}
+
+/// Whether a file in the *FrostMod* folder is a log.
+///
+/// Inverted against [`is_game_log`], and deliberately: this folder is the app's own —
+/// we create it, install into it, and run FrostMod with it as the working directory — so
+/// its non-log contents are a known, short list, while what FrostMod names its log is
+/// decided in another repo and could change with any release. Excluding what we put there
+/// therefore catches a log we've never seen the name of; matching on `log*.txt` would
+/// quietly miss it.
+///
+/// The server filter is excluded with the binaries: it's a settings file, and this button
+/// promises not to collect those.
+fn is_frostmod_log(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    let ours = lower.ends_with(".exe")
+        || lower.ends_with(".dll")
+        || lower == "version.txt"
+        || lower.ends_with(".yaml")
+        // A binary moved aside mid-update because the game still had it mapped —
+        // `frostmod.dll.in-use-1723…`, swept on the next start.
+        || lower.contains(".in-use-");
+    !ours
 }
 
 fn describe(path: &Path) -> Option<LogFile> {
@@ -177,8 +205,12 @@ fn game_group(cfg: &AppConfig) -> LogGroup {
     fallback.unwrap_or_else(|| LogGroup::missing(first))
 }
 
-pub fn info(app_log_dir: &Path, cfg: &AppConfig) -> LogsInfo {
-    LogsInfo { app: scan_all(app_log_dir), game: game_group(cfg) }
+pub fn info(app_log_dir: &Path, frostmod_dir: &Path, cfg: &AppConfig) -> LogsInfo {
+    LogsInfo {
+        app: scan_all(app_log_dir),
+        frostmod: scan(frostmod_dir, is_frostmod_log),
+        game: game_group(cfg),
+    }
 }
 
 /// Open the folder a group lives in, with its newest file selected where the platform can
@@ -191,7 +223,7 @@ pub fn open_location(group: &LogGroup) -> anyhow::Result<()> {
     }
 }
 
-/// Write both groups into one zip at `dest`.
+/// Write every group into one zip at `dest`, a folder each.
 ///
 /// Deliberately just the logs and a summary of where they came from — not the config
 /// file, which holds session cookies and shop credentials. The whole point of this button
@@ -212,7 +244,7 @@ pub fn export(dest: &Path, info: &LogsInfo, summary: &str) -> anyhow::Result<Exp
 
     let mut written = 0usize;
     let mut bytes = 0u64;
-    for (folder, group) in [("app", &info.app), ("game", &info.game)] {
+    for (folder, group) in groups(info) {
         for log in &group.files {
             if log.bytes > MAX_EXPORT_FILE {
                 continue;
@@ -231,6 +263,13 @@ pub fn export(dest: &Path, info: &LogsInfo, summary: &str) -> anyhow::Result<Exp
     Ok(ExportResult { path: dest.to_string_lossy().into_owned(), files: written, bytes })
 }
 
+/// The three groups in the order they're written, paired with the folder each takes
+/// inside an exported zip. Named once so the archive's layout and the summary listing it
+/// can't drift apart.
+fn groups(info: &LogsInfo) -> [(&'static str, &LogGroup); 3] {
+    [("app", &info.app), ("frostmod", &info.frostmod), ("game", &info.game)]
+}
+
 /// The plain-text header that goes in beside the logs: what was included, and the handful
 /// of facts every report starts by asking for.
 pub fn summary(version: &str, cfg: &AppConfig, info: &LogsInfo) -> String {
@@ -241,7 +280,7 @@ pub fn summary(version: &str, cfg: &AppConfig, info: &LogsInfo) -> String {
     out.push_str(&format!("mods folder: {}\n", show(&cfg.mods_path)));
     out.push_str(&format!("install folder: {}\n", show(&cfg.install_dir())));
     out.push_str(&format!("profiles folder: {}\n", cfg.profiles_dir().display()));
-    for (label, group) in [("app", &info.app), ("game", &info.game)] {
+    for (label, group) in groups(info) {
         out.push_str(&format!(
             "\n{label} logs: {}{}\n",
             if group.dir.is_empty() { "(unknown)" } else { &group.dir },
@@ -301,6 +340,22 @@ mod tests {
     }
 
     #[test]
+    fn keeps_frostmods_log_and_drops_what_we_put_beside_it() {
+        // Whatever FrostMod writes, under any name — the filter can't be told the name in
+        // advance, so it works by knowing what *isn't* a log.
+        assert!(is_frostmod_log("frostmod.log"));
+        assert!(is_frostmod_log("log.txt"));
+        assert!(is_frostmod_log("frostmod-2026-08-11.txt"));
+        // The install: our binaries, our version marker, our server filter, and a binary
+        // parked mid-update because the game still had it mapped.
+        assert!(!is_frostmod_log("frostmod.exe"));
+        assert!(!is_frostmod_log("frostmod.dll"));
+        assert!(!is_frostmod_log("version.txt"));
+        assert!(!is_frostmod_log("frostmod_serverfilter.yaml"));
+        assert!(!is_frostmod_log("frostmod.dll.in-use-1723500000"));
+    }
+
+    #[test]
     fn scans_newest_first() {
         let dir = tmpdir("order");
         write(&dir, "old.log", "one");
@@ -357,13 +412,17 @@ mod tests {
     }
 
     #[test]
-    fn export_holds_both_sides_and_a_summary() {
+    fn export_holds_every_group_and_a_summary() {
         let root = tmpdir("export");
         let app_dir = root.join("applogs");
+        let frostmod_dir = root.join("frostmod");
         let game_dir = root.join("game");
-        std::fs::create_dir_all(&app_dir).unwrap();
-        std::fs::create_dir_all(&game_dir).unwrap();
+        for d in [&app_dir, &frostmod_dir, &game_dir] {
+            std::fs::create_dir_all(d).unwrap();
+        }
         write(&app_dir, "frost.log", "app side");
+        write(&frostmod_dir, "frostmod.log", "loader side");
+        write(&frostmod_dir, "frostmod.exe", "not a log");
         write(&game_dir, "log.txt", "game side");
         write(&game_dir, "mxbikes.ini", "not a log");
 
@@ -371,20 +430,24 @@ mod tests {
             game_path: game_dir.to_string_lossy().into_owned(),
             ..Default::default()
         };
-        let info = info(&app_dir, &cfg);
+        let info = info(&app_dir, &frostmod_dir, &cfg);
         assert_eq!(info.app.files.len(), 1);
+        assert_eq!(info.frostmod.files.len(), 1);
         assert_eq!(info.game.files.len(), 1);
 
         let dest = root.join("out").join("logs.zip");
         let result = export(&dest, &info, &summary("9.9.9", &cfg, &info)).unwrap();
-        assert_eq!(result.files, 2);
+        assert_eq!(result.files, 3);
 
         let mut zip = zip::ZipArchive::new(std::fs::File::open(&dest).unwrap()).unwrap();
         let names: Vec<String> = zip.file_names().map(str::to_string).collect();
         assert!(names.contains(&"summary.txt".to_string()));
         assert!(names.contains(&"app/frost.log".to_string()));
+        assert!(names.contains(&"frostmod/frostmod.log".to_string()));
         assert!(names.contains(&"game/log.txt".to_string()));
+        // Neither folder's non-log contents came along.
         assert!(!names.iter().any(|n| n.ends_with("mxbikes.ini")));
+        assert!(!names.iter().any(|n| n.ends_with("frostmod.exe")));
 
         let mut body = String::new();
         std::io::Read::read_to_string(&mut zip.by_name("game/log.txt").unwrap(), &mut body).unwrap();

--- a/src-tauri/src/logs.rs
+++ b/src-tauri/src/logs.rs
@@ -1,0 +1,393 @@
+//! Where the logs are, and how to get them off the machine they're on.
+//!
+//! Two sets matter when something has gone wrong, and they live in different places:
+//! MXB App's own file log — written by `tauri_plugin_log` into the OS log dir
+//! (`%LOCALAPPDATA%\com.frost.mxbikes\logs` on Windows) — and the game's `log.txt`,
+//! which PiBoSo titles write beside the executable or into the user folder depending on
+//! how the game was started.
+//!
+//! Neither is somewhere a player finds on their own, and "send me your logs" is the first
+//! thing every bug report asks for. So this module answers three questions for Settings:
+//! where they are, what's actually in there, and how to hand the lot over as one file.
+
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use crate::config::AppConfig;
+
+/// Skip anything absurd rather than build a 400 MB attachment nobody can upload. Log
+/// files are text and rotate; one this big is a runaway, and the tail of it would be no
+/// more diagnostic than the tail of a smaller one.
+const MAX_EXPORT_FILE: u64 = 64 * 1024 * 1024;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogFile {
+    pub name: String,
+    pub path: String,
+    pub bytes: u64,
+    /// Last-modified in Unix ms, or `None` when the platform wouldn't say. The UI leads
+    /// with this — "how old is the newest one" is what says whether a log covers the run
+    /// the player is complaining about.
+    pub modified: Option<u64>,
+}
+
+/// One place logs come from, whether or not it currently holds any.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogGroup {
+    /// The folder the files below came from — or, when there are none, the folder they'd
+    /// be in. Always populated: a path the player can go and look at beats "not found".
+    pub dir: String,
+    /// Whether `dir` is actually there. A missing folder and an empty one are different
+    /// problems (nothing has run yet vs. nothing was written), and only one is worrying.
+    pub exists: bool,
+    /// Newest first.
+    pub files: Vec<LogFile>,
+}
+
+impl LogGroup {
+    fn missing(dir: PathBuf) -> Self {
+        LogGroup { dir: dir.to_string_lossy().into_owned(), exists: false, files: Vec::new() }
+    }
+
+    pub fn total_bytes(&self) -> u64 {
+        self.files.iter().map(|f| f.bytes).sum()
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogsInfo {
+    /// MXB App's own log dir.
+    pub app: LogGroup,
+    /// The active game's logs.
+    pub game: LogGroup,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportResult {
+    pub path: String,
+    /// How many log files made it in. Zero is possible and still worth writing — the
+    /// summary alone says which folders were looked in and found empty.
+    pub files: usize,
+    pub bytes: u64,
+}
+
+/// Whether a file in a *game* folder is a log.
+///
+/// The game folder is the player's, full of things that are none of our business, so this
+/// matches by name rather than sweeping the folder up. `log.txt` is what PiBoSo titles
+/// write; the rest of the patterns cost nothing and cover a rotated or crash-time sibling
+/// without needing to know its exact name in advance.
+fn is_game_log(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower.ends_with(".log")
+        || (lower.starts_with("log") && lower.ends_with(".txt"))
+        || (lower.starts_with("crash") && (lower.ends_with(".txt") || lower.ends_with(".log")))
+}
+
+fn describe(path: &Path) -> Option<LogFile> {
+    let meta = std::fs::metadata(path).ok()?;
+    if !meta.is_file() {
+        return None;
+    }
+    let modified = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as u64);
+    Some(LogFile {
+        name: path.file_name()?.to_string_lossy().into_owned(),
+        path: path.to_string_lossy().into_owned(),
+        bytes: meta.len(),
+        modified,
+    })
+}
+
+/// Everything in `dir`, newest first. For folders that are ours alone — the app log dir,
+/// where every file is a log whatever it's called or however the plugin rotated it.
+fn scan_all(dir: &Path) -> LogGroup {
+    scan(dir, |_| true)
+}
+
+fn scan(dir: &Path, keep: impl Fn(&str) -> bool) -> LogGroup {
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return LogGroup::missing(dir.to_path_buf());
+    };
+    let mut files: Vec<LogFile> = rd
+        .flatten()
+        .filter(|e| keep(&e.file_name().to_string_lossy()))
+        .filter_map(|e| describe(&e.path()))
+        .collect();
+    // Newest first: the run that just went wrong is the one anyone opens.
+    files.sort_by(|a, b| b.modified.cmp(&a.modified).then_with(|| a.name.cmp(&b.name)));
+    LogGroup { dir: dir.to_string_lossy().into_owned(), exists: true, files }
+}
+
+/// The folders the active game could be logging into, best guess first.
+///
+/// The install dir leads because that is where the executable writes: `log.txt` lands
+/// beside `mxbikes.exe`. The user folder follows because a Steam install can be
+/// read-only-ish in practice (and a relocated mods tree moves what we know about), and
+/// looking in both costs one `read_dir`.
+pub fn game_dirs(cfg: &AppConfig) -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    let install = cfg.install_dir();
+    if !install.trim().is_empty() {
+        dirs.push(PathBuf::from(install.trim()));
+    }
+    let mods_path = cfg.mods_path.trim();
+    if !mods_path.is_empty() {
+        let base = Path::new(mods_path);
+        dirs.push(base.to_path_buf());
+        // `mods_path` may be the mods tree itself rather than the folder above it, in
+        // which case the user folder — where the game writes — is its parent.
+        if crate::library::mods_root(mods_path) == base {
+            if let Some(parent) = base.parent().filter(|p| p.parent().is_some()) {
+                dirs.push(parent.to_path_buf());
+            }
+        }
+    }
+    dirs.dedup();
+    dirs
+}
+
+/// Pick the game folder to report on: the first candidate that actually holds logs,
+/// falling back to the first that exists and finally to the first guess, so the UI always
+/// has a path to show and a folder to open.
+fn game_group(cfg: &AppConfig) -> LogGroup {
+    let dirs = game_dirs(cfg);
+    let Some(first) = dirs.first().cloned() else {
+        // No folders configured at all — first run, or a game that was never set up.
+        return LogGroup::missing(PathBuf::new());
+    };
+    let mut fallback: Option<LogGroup> = None;
+    for dir in dirs {
+        let group = scan(&dir, is_game_log);
+        if !group.files.is_empty() {
+            return group;
+        }
+        if group.exists && fallback.is_none() {
+            fallback = Some(group);
+        }
+    }
+    fallback.unwrap_or_else(|| LogGroup::missing(first))
+}
+
+pub fn info(app_log_dir: &Path, cfg: &AppConfig) -> LogsInfo {
+    LogsInfo { app: scan_all(app_log_dir), game: game_group(cfg) }
+}
+
+/// Open the folder a group lives in, with its newest file selected where the platform can
+/// do that. Selecting matters: an app log dir holds several files and the one worth
+/// opening is not the one sorted first alphabetically.
+pub fn open_location(group: &LogGroup) -> anyhow::Result<()> {
+    match group.files.first() {
+        Some(newest) => crate::library::reveal_in_explorer(&newest.path),
+        None => crate::library::open_folder(&group.dir),
+    }
+}
+
+/// Write both groups into one zip at `dest`.
+///
+/// Deliberately just the logs and a summary of where they came from — not the config
+/// file, which holds session cookies and shop credentials. The whole point of this button
+/// is that the archive is safe to drop into a public Discord thread.
+pub fn export(dest: &Path, info: &LogsInfo, summary: &str) -> anyhow::Result<ExportResult> {
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let file = std::fs::File::create(dest)?;
+    let mut zip = zip::ZipWriter::new(file);
+    // Deflate rather than the `Stored` a mod bundle uses: this payload is plain text,
+    // which is the one thing compression is dramatic on.
+    let opts: zip::write::SimpleFileOptions =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+    zip.start_file("summary.txt", opts)?;
+    std::io::Write::write_all(&mut zip, summary.as_bytes())?;
+
+    let mut written = 0usize;
+    let mut bytes = 0u64;
+    for (folder, group) in [("app", &info.app), ("game", &info.game)] {
+        for log in &group.files {
+            if log.bytes > MAX_EXPORT_FILE {
+                continue;
+            }
+            // A file that vanished or turned unreadable between the scan and now is not a
+            // reason to fail the export — the rest of the logs are still worth having.
+            let Ok(data) = std::fs::read(&log.path) else { continue };
+            zip.start_file(format!("{folder}/{}", log.name), opts)?;
+            std::io::Write::write_all(&mut zip, &data)?;
+            written += 1;
+            bytes += data.len() as u64;
+        }
+    }
+    zip.finish()?;
+
+    Ok(ExportResult { path: dest.to_string_lossy().into_owned(), files: written, bytes })
+}
+
+/// The plain-text header that goes in beside the logs: what was included, and the handful
+/// of facts every report starts by asking for.
+pub fn summary(version: &str, cfg: &AppConfig, info: &LogsInfo) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("MXB App {version}\n"));
+    out.push_str(&format!("os: {} ({})\n", std::env::consts::OS, std::env::consts::ARCH));
+    out.push_str(&format!("game: {}\n", cfg.game().display));
+    out.push_str(&format!("mods folder: {}\n", show(&cfg.mods_path)));
+    out.push_str(&format!("install folder: {}\n", show(&cfg.install_dir())));
+    out.push_str(&format!("profiles folder: {}\n", cfg.profiles_dir().display()));
+    for (label, group) in [("app", &info.app), ("game", &info.game)] {
+        out.push_str(&format!(
+            "\n{label} logs: {}{}\n",
+            if group.dir.is_empty() { "(unknown)" } else { &group.dir },
+            if group.exists { "" } else { " (folder not found)" },
+        ));
+        if group.files.is_empty() {
+            out.push_str("  (none)\n");
+        } else {
+            out.push_str(&format!(
+                "  {} file(s), {} bytes\n",
+                group.files.len(),
+                group.total_bytes()
+            ));
+        }
+        for f in &group.files {
+            out.push_str(&format!("  {} ({} bytes)\n", f.name, f.bytes));
+        }
+    }
+    out
+}
+
+fn show(path: &str) -> &str {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        "(not set)"
+    } else {
+        trimmed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmpdir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("frost-logs-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write(dir: &Path, name: &str, body: &str) {
+        std::fs::write(dir.join(name), body).unwrap();
+    }
+
+    #[test]
+    fn matches_the_game_log_and_leaves_the_rest_alone() {
+        assert!(is_game_log("log.txt"));
+        assert!(is_game_log("LOG.TXT"));
+        assert!(is_game_log("log_2026-08-11.txt"));
+        assert!(is_game_log("mxbikes.log"));
+        assert!(is_game_log("crash.txt"));
+        // The game folder is the player's; nothing else in it is ours to collect.
+        assert!(!is_game_log("mxbikes.ini"));
+        assert!(!is_game_log("readme.txt"));
+        assert!(!is_game_log("rider.pkz"));
+    }
+
+    #[test]
+    fn scans_newest_first() {
+        let dir = tmpdir("order");
+        write(&dir, "old.log", "one");
+        write(&dir, "new.log", "two");
+        // mtime granularity is coarse enough that two writes in a row can tie, so set the
+        // order explicitly rather than racing the filesystem clock.
+        let old = std::time::SystemTime::now() - std::time::Duration::from_secs(600);
+        std::fs::File::options().write(true).open(dir.join("old.log")).unwrap().set_modified(old).unwrap();
+
+        let group = scan_all(&dir);
+        assert!(group.exists);
+        let names: Vec<&str> = group.files.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, ["new.log", "old.log"]);
+        assert_eq!(group.total_bytes(), 6);
+    }
+
+    #[test]
+    fn a_missing_folder_still_reports_where_it_looked() {
+        let group = scan_all(Path::new("/definitely/not/here/logs"));
+        assert!(!group.exists);
+        assert!(group.files.is_empty());
+        assert!(group.dir.ends_with("logs"));
+    }
+
+    #[test]
+    fn game_folders_are_tried_install_first_then_the_user_folder() {
+        let root = tmpdir("dirs");
+        let install = root.join("steamapps");
+        let user = root.join("user");
+        std::fs::create_dir_all(&install).unwrap();
+        std::fs::create_dir_all(&user).unwrap();
+
+        let cfg = AppConfig {
+            game_path: install.to_string_lossy().into_owned(),
+            mods_path: user.to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+
+        // Nothing anywhere: we still name the install folder rather than going blank.
+        let group = game_group(&cfg);
+        assert_eq!(group.dir, install.to_string_lossy());
+        assert!(group.files.is_empty());
+
+        // A log in the user folder wins over an install folder that has none.
+        write(&user, "log.txt", "hello");
+        let group = game_group(&cfg);
+        assert_eq!(group.dir, user.to_string_lossy());
+        assert_eq!(group.files.len(), 1);
+
+        // …and the install folder wins as soon as it has one of its own.
+        write(&install, "log.txt", "beside the exe");
+        let group = game_group(&cfg);
+        assert_eq!(group.dir, install.to_string_lossy());
+    }
+
+    #[test]
+    fn export_holds_both_sides_and_a_summary() {
+        let root = tmpdir("export");
+        let app_dir = root.join("applogs");
+        let game_dir = root.join("game");
+        std::fs::create_dir_all(&app_dir).unwrap();
+        std::fs::create_dir_all(&game_dir).unwrap();
+        write(&app_dir, "frost.log", "app side");
+        write(&game_dir, "log.txt", "game side");
+        write(&game_dir, "mxbikes.ini", "not a log");
+
+        let cfg = AppConfig {
+            game_path: game_dir.to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+        let info = info(&app_dir, &cfg);
+        assert_eq!(info.app.files.len(), 1);
+        assert_eq!(info.game.files.len(), 1);
+
+        let dest = root.join("out").join("logs.zip");
+        let result = export(&dest, &info, &summary("9.9.9", &cfg, &info)).unwrap();
+        assert_eq!(result.files, 2);
+
+        let mut zip = zip::ZipArchive::new(std::fs::File::open(&dest).unwrap()).unwrap();
+        let names: Vec<String> = zip.file_names().map(str::to_string).collect();
+        assert!(names.contains(&"summary.txt".to_string()));
+        assert!(names.contains(&"app/frost.log".to_string()));
+        assert!(names.contains(&"game/log.txt".to_string()));
+        assert!(!names.iter().any(|n| n.ends_with("mxbikes.ini")));
+
+        let mut body = String::new();
+        std::io::Read::read_to_string(&mut zip.by_name("game/log.txt").unwrap(), &mut body).unwrap();
+        assert_eq!(body, "game side");
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -20,6 +20,7 @@ mod imgcache;
 mod install;
 mod library;
 mod linkwalk;
+mod logs;
 mod lru;
 mod modelswap;
 mod mods;
@@ -3380,6 +3381,51 @@ fn reveal_in_explorer(path: String) -> Result<(), String> {
     library::reveal_in_explorer(&path).map_err(|e| format!("{e:#}"))
 }
 
+/// Where MXB App's own logs are, where the game's are, and what's currently in each.
+///
+/// Read fresh on every call rather than cached: the whole reason someone opens this is
+/// that something just went wrong, and a stale "no logs found" would send them looking in
+/// the wrong place.
+#[tauri::command]
+fn logs_info(app: tauri::AppHandle) -> logs::LogsInfo {
+    let cfg = config::load(&app).unwrap_or_default();
+    logs::info(&app_log_dir(&app), &cfg)
+}
+
+/// Open the folder one of the two log sets lives in, newest file selected where the OS
+/// can do that. `which` is `"app"` or `"game"`.
+#[tauri::command]
+fn open_logs_folder(app: tauri::AppHandle, which: String) -> Result<(), String> {
+    let info = logs_info(app);
+    let group = if which == "game" { &info.game } else { &info.app };
+    logs::open_location(group).map_err(|e| format!("{e:#}"))
+}
+
+/// Zip both sets of logs to `dest` — a path the user just picked in a save dialog.
+///
+/// Blocking work (reads the whole of every log), so it goes off the UI thread: an app log
+/// that has been growing for a month would otherwise freeze Settings while it's read.
+#[tauri::command]
+async fn export_logs(app: tauri::AppHandle, dest: String) -> Result<logs::ExportResult, String> {
+    let version = app.package_info().version.to_string();
+    let log_dir = app_log_dir(&app);
+    tauri::async_runtime::spawn_blocking(move || {
+        let cfg = config::load(&app).unwrap_or_default();
+        let info = logs::info(&log_dir, &cfg);
+        let summary = logs::summary(&version, &cfg, &info);
+        logs::export(std::path::Path::new(&dest), &info, &summary).map_err(|e| format!("{e:#}"))
+    })
+    .await
+    .map_err(|e| format!("export_logs task failed: {e}"))?
+}
+
+/// Where `tauri_plugin_log`'s `LogDir` target writes. Empty when the path can't be
+/// resolved at all, which [`logs::info`] reports as a folder that isn't there — the same
+/// as any other missing folder, rather than a special failure mode of its own.
+fn app_log_dir(app: &tauri::AppHandle) -> std::path::PathBuf {
+    app.path().app_log_dir().unwrap_or_default()
+}
+
 #[tauri::command]
 fn set_game_path(app: tauri::AppHandle, path: String) -> Result<(), String> {
     let mut cfg = config::load(&app).unwrap_or_default();
@@ -5954,6 +6000,9 @@ fn main() {
             move_mod,
             uninstall_mod,
             reveal_in_explorer,
+            logs_info,
+            open_logs_folder,
+            export_logs,
             set_game_path,
             set_wine_runner,
             wine_host_info,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3389,19 +3389,23 @@ fn reveal_in_explorer(path: String) -> Result<(), String> {
 #[tauri::command]
 fn logs_info(app: tauri::AppHandle) -> logs::LogsInfo {
     let cfg = config::load(&app).unwrap_or_default();
-    logs::info(&app_log_dir(&app), &cfg)
+    logs::info(&app_log_dir(&app), &frostmod_manage::frostmod_dir(&app), &cfg)
 }
 
-/// Open the folder one of the two log sets lives in, newest file selected where the OS
-/// can do that. `which` is `"app"` or `"game"`.
+/// Open the folder one of the log sets lives in, newest file selected where the OS can do
+/// that. `which` is `"app"`, `"frostmod"` or `"game"`.
 #[tauri::command]
 fn open_logs_folder(app: tauri::AppHandle, which: String) -> Result<(), String> {
     let info = logs_info(app);
-    let group = if which == "game" { &info.game } else { &info.app };
+    let group = match which.as_str() {
+        "game" => &info.game,
+        "frostmod" => &info.frostmod,
+        _ => &info.app,
+    };
     logs::open_location(group).map_err(|e| format!("{e:#}"))
 }
 
-/// Zip both sets of logs to `dest` — a path the user just picked in a save dialog.
+/// Zip every set of logs to `dest` — a path the user just picked in a save dialog.
 ///
 /// Blocking work (reads the whole of every log), so it goes off the UI thread: an app log
 /// that has been growing for a month would otherwise freeze Settings while it's read.
@@ -3409,9 +3413,10 @@ fn open_logs_folder(app: tauri::AppHandle, which: String) -> Result<(), String> 
 async fn export_logs(app: tauri::AppHandle, dest: String) -> Result<logs::ExportResult, String> {
     let version = app.package_info().version.to_string();
     let log_dir = app_log_dir(&app);
+    let frostmod_dir = frostmod_manage::frostmod_dir(&app);
     tauri::async_runtime::spawn_blocking(move || {
         let cfg = config::load(&app).unwrap_or_default();
-        let info = logs::info(&log_dir, &cfg);
+        let info = logs::info(&log_dir, &frostmod_dir, &cfg);
         let summary = logs::summary(&version, &cfg, &info);
         logs::export(std::path::Path::new(&dest), &info, &summary).map_err(|e| format!("{e:#}"))
     })

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -10,16 +10,24 @@ import {
   Monitor,
   TriangleAlert,
   Sparkles,
+  FolderOpen,
+  Download,
 } from "lucide-react";
-import { open as pickFolder } from "@tauri-apps/plugin-dialog";
+import { open as pickFolder, save as pickSavePath } from "@tauri-apps/plugin-dialog";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
 import { getVersion } from "@tauri-apps/api/app";
 import { toast } from "sonner";
 import {
   countProfilesIn,
   detectGamePath,
+  exportLogs,
   getModsRoot,
   getOverlayState,
+  logsInfo,
+  openLogsFolder,
+  type LogGroup,
+  type LogsInfo,
+  type LogsKind,
   overlayToggle,
   presetsListProfiles,
   setAutoRunFrostmod,
@@ -60,9 +68,10 @@ import SupportersCard from "./SupportersCard";
 import { useTheme, type ThemeMode } from "../../Context/Theme";
 import { Trans } from "../../i18n";
 import { useI18n, type LocalePref, type TKey } from "../../i18n/context";
-import { LOCALE_OPTIONS } from "../../i18n/core";
+import { getLocale, LOCALE_OPTIONS } from "../../i18n/core";
 import { useFrostmod } from "../../Context/FrostmodContext";
 import { prettyHotkey } from "../../lib/hotkey";
+import { formatBytes, formatDateShort } from "../../lib/mods";
 import { useTour } from "../Tour/Tour";
 import { Button } from "@/Components/ui/button";
 import HelpHint from "@/Components/ui/help-hint";
@@ -91,6 +100,7 @@ export type SectionId =
   | "appearance"
   | "frostmod"
   | "reshade"
+  | "logs"
   | "supporters"
   | "about";
 const SECTIONS: { id: SectionId; label: TKey }[] = [
@@ -102,6 +112,7 @@ const SECTIONS: { id: SectionId; label: TKey }[] = [
   { id: "appearance", label: "settings.appearance" },
   { id: "frostmod", label: "settings.frostmod" },
   { id: "reshade", label: "settings.reshade" },
+  { id: "logs", label: "settings.logs" },
   { id: "supporters", label: "settings.supporters" },
   { id: "about", label: "settings.about" },
 ];
@@ -246,6 +257,7 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
     appearance: null,
     frostmod: null,
     reshade: null,
+    logs: null,
     supporters: null,
     about: null,
   });
@@ -279,6 +291,51 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
       .then(setModsRoot)
       .catch(() => setModsRoot(null));
   }, [config.modsPath]);
+
+  // Where the logs are and what's in them. Re-read whenever the Logs section is opened
+  // (and after an export) rather than once on mount: the reason anyone comes here is that
+  // something just went wrong, and a count from ten minutes ago answers the wrong question.
+  const [logs, setLogs] = useState<LogsInfo | null>(null);
+  const [exportingLogs, setExportingLogs] = useState(false);
+  const refreshLogs = useCallback(() => {
+    logsInfo()
+      .then(setLogs)
+      .catch(() => setLogs(null));
+  }, []);
+  const logsOpen = active === "logs";
+  useEffect(() => {
+    refreshLogs();
+  }, [refreshLogs, config.modsPath, config.gamePath, logsOpen]);
+
+  const openLogs = (which: LogsKind) => {
+    openLogsFolder(which).catch((e) => toast.error(String(e)));
+  };
+
+  const saveLogs = async () => {
+    // A date rather than a clock time: the file is named for the day it was collected,
+    // which is what a support thread refers back to.
+    const stamp = new Date().toISOString().slice(0, 10);
+    const dest = await pickSavePath({
+      defaultPath: `mxb-app-logs-${stamp}.zip`,
+      filters: [{ name: "Zip", extensions: ["zip"] }],
+    }).catch(() => null);
+    if (!dest) return;
+    setExportingLogs(true);
+    try {
+      const written = await exportLogs(dest);
+      toast.success(t("logs.saved"), {
+        description: t("logs.savedDesc", {
+          count: written.files,
+          size: formatBytes(written.bytes),
+        }),
+      });
+      refreshLogs();
+    } catch (e) {
+      toast.error(t("logs.saveFailed"), { description: String(e) });
+    } finally {
+      setExportingLogs(false);
+    }
+  };
 
   const profilesSep = config.modsPath.includes("\\") ? "\\" : "/";
   const defaultProfilesPath =
@@ -1486,6 +1543,41 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
             />
           </Section>
 
+          {/* logs — the first thing any bug report asks for, and the one thing a player
+              has no way to find on their own: MXB App's log dir is buried in AppData, and
+              the game writes its own beside the executable. Both are named here, either
+              can be opened, and the pair zips into one file to attach. */}
+          <Section
+            title={t("settings.logs")}
+            desc={t("logs.desc")}
+            innerRef={(el) => (refs.current.logs = el)}
+          >
+            <LogRow
+              label={t("logs.appLogs")}
+              hint={t("logs.appLogsDesc")}
+              group={logs?.app}
+              onOpen={() => openLogs("app")}
+            />
+            <LogRow
+              label={game.display}
+              hint={t("logs.gameLogsDesc")}
+              group={logs?.game}
+              onOpen={() => openLogs("game")}
+            />
+            <div className="flex gap-2">
+              <Button variant="outline" size="sm" onClick={saveLogs} disabled={exportingLogs}>
+                <Download className="size-3.5" />
+                {exportingLogs ? t("logs.saving") : t("logs.save")}
+              </Button>
+              <Button variant="outline" size="sm" onClick={refreshLogs} disabled={exportingLogs}>
+                <RefreshCw className="size-3.5" /> {t("logs.refresh")}
+              </Button>
+            </div>
+            <p className="text-[11.5px] leading-relaxed text-faint">
+              {t("logs.privacy")}
+            </p>
+          </Section>
+
           {/* supporters — who's buying the coffees that pay for the app. Above About
               rather than inside it: a thank-you buried under the version number and the
               update button is one nobody reads. */}
@@ -1619,6 +1711,83 @@ function LevelSlider({
       </span>
     </div>
   );
+}
+
+/** One log location: where it is, what's in it, and a way into the folder.
+ *
+ * The line under the path is the point of the row. "3 files, newest 12 minutes ago" is
+ * what tells someone the log covers the run that just went wrong — a path on its own
+ * can't say whether there's anything there worth sending. */
+function LogRow({
+  label,
+  hint,
+  group,
+  onOpen,
+}: {
+  label: string;
+  hint: string;
+  /** Undefined until the backend answers. */
+  group?: LogGroup;
+  onOpen: () => void;
+}) {
+  const { t } = useI18n();
+  const newest = group?.files[0];
+  const status = !group
+    ? t("logs.loading")
+    : !group.exists
+      ? t("logs.folderMissing")
+      : group.files.length === 0
+        ? t("logs.empty")
+        : t("logs.summary", {
+            count: group.files.length,
+            size: formatBytes(group.files.reduce((sum, f) => sum + f.bytes, 0)),
+            when: formatWhen(newest?.modified ?? null),
+          });
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <span className="text-[12.5px] font-semibold text-foreground/85">{label}</span>
+        <span className="text-[11.5px] text-muted-foreground">{hint}</span>
+      </div>
+      <div className="flex gap-2">
+        <div className="flex min-w-0 flex-1 items-center rounded-lg border border-input bg-background px-3 py-2 font-mono text-[12px] text-muted-foreground">
+          <span className="flex-1 truncate" title={group?.dir || undefined}>
+            {group?.dir || t("settings.notSet")}
+          </span>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onOpen}
+          // Nothing to open until we know the folder is there. The button going quiet is
+          // itself the answer: the game hasn't written anything here yet.
+          disabled={!group?.exists}
+        >
+          <FolderOpen className="size-3.5" /> {t("logs.open")}
+        </Button>
+      </div>
+      <span
+        className={cn(
+          "text-[11.5px]",
+          group && !group.exists ? "text-warning" : "text-muted-foreground",
+        )}
+      >
+        {status}
+      </span>
+    </div>
+  );
+}
+
+/** "today at 14:32" / "Aug 11 at 14:32" for a log's mtime — the age is what matters,
+ *  so the time of day is always shown and the year never is. */
+function formatWhen(ms: number | null): string {
+  if (!ms) return "";
+  const d = new Date(ms);
+  if (Number.isNaN(d.getTime())) return "";
+  const time = d.toLocaleTimeString(getLocale(), { hour: "2-digit", minute: "2-digit" });
+  const sameDay = new Date().toDateString() === d.toDateString();
+  return sameDay ? time : `${formatDateShort(d.toISOString())} ${time}`;
 }
 
 function ToggleRow({

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -1558,6 +1558,19 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
               group={logs?.app}
               onOpen={() => openLogs("app")}
             />
+            {/* FrostMod's folder is ours — we install it and run it from there — so it
+                is offered on the same terms as the rest, on the same condition as the
+                FrostMod section above: a Win32 DLL injected into the game has no folder
+                to open anywhere else, and a permanently empty row would be the only
+                mention of it on the page. */}
+            {isWindows && caps.frostmod && (
+              <LogRow
+                label="FrostMod"
+                hint={t("logs.frostmodLogsDesc")}
+                group={logs?.frostmod}
+                onOpen={() => openLogs("frostmod")}
+              />
+            )}
             <LogRow
               label={game.display}
               hint={t("logs.gameLogsDesc")}

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -663,13 +663,14 @@ export interface LogGroup {
   files: LogFile[];
 }
 
-/** Both log sets: MXB App's own, and the game's `log.txt`. */
+/** Every log set: MXB App's own, FrostMod's managed folder, and the game's `log.txt`. */
 export interface LogsInfo {
   app: LogGroup;
+  frostmod: LogGroup;
   game: LogGroup;
 }
 
-export type LogsKind = "app" | "game";
+export type LogsKind = "app" | "frostmod" | "game";
 
 export function logsInfo(): Promise<LogsInfo> {
   return invoke<LogsInfo>("logs_info");
@@ -686,7 +687,7 @@ export interface LogsExport {
   bytes: number;
 }
 
-/** Zip both log sets to `dest` — a path the user picked in a save dialog. */
+/** Zip every log set to `dest` — a path the user picked in a save dialog. */
 export function exportLogs(dest: string): Promise<LogsExport> {
   return invoke<LogsExport>("export_logs", { dest });
 }

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -645,6 +645,52 @@ export function revealInExplorer(path: string): Promise<void> {
   return invoke<void>("reveal_in_explorer", { path });
 }
 
+export interface LogFile {
+  name: string;
+  path: string;
+  bytes: number;
+  /** Last modified, Unix ms — null when the OS wouldn't say. */
+  modified: number | null;
+}
+
+/** One place logs come from. `dir` is always set: when nothing was found it's the folder
+ *  we looked in, which is still what someone needs to be told. */
+export interface LogGroup {
+  dir: string;
+  /** Whether the folder itself is there — a different problem from it being empty. */
+  exists: boolean;
+  /** Newest first. */
+  files: LogFile[];
+}
+
+/** Both log sets: MXB App's own, and the game's `log.txt`. */
+export interface LogsInfo {
+  app: LogGroup;
+  game: LogGroup;
+}
+
+export type LogsKind = "app" | "game";
+
+export function logsInfo(): Promise<LogsInfo> {
+  return invoke<LogsInfo>("logs_info");
+}
+
+/** Open the folder a log set lives in, newest file selected where the OS can. */
+export function openLogsFolder(which: LogsKind): Promise<void> {
+  return invoke<void>("open_logs_folder", { which });
+}
+
+export interface LogsExport {
+  path: string;
+  files: number;
+  bytes: number;
+}
+
+/** Zip both log sets to `dest` — a path the user picked in a save dialog. */
+export function exportLogs(dest: string): Promise<LogsExport> {
+  return invoke<LogsExport>("export_logs", { dest });
+}
+
 /** Hide-to-tray + keep-running toggle. */
 export function setRunInBackground(enabled: boolean): Promise<void> {
   return invoke<void>("set_run_in_background", { enabled });

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1354,9 +1354,10 @@ export const de: Translation = {
   // ── Logs ───────────────────────────────────────────────────────────────────
   "settings.logs": "Logs",
   "logs.desc":
-    "Die Dateien, die du schickst, wenn etwas schiefgeht. MXB App und {{game}} führen jeweils eigene — öffne einen der beiden Ordner, oder speichere beide als ein Zip für einen Fehlerbericht.",
+    "Die Dateien, die du schickst, wenn etwas schiefgeht. MXB App, FrostMod und {{game}} führen jeweils eigene — öffne den Ordner, den du brauchst, oder speichere alle als ein Zip für einen Fehlerbericht.",
   "logs.appLogs": "MXB App",
   "logs.appLogsDesc": "Was die App selbst aufgezeichnet hat",
+  "logs.frostmodLogsDesc": "Was der Loader in seinen eigenen Ordner geschrieben hat",
   "logs.gameLogsDesc": "Das Log des Spiels, neben seinen Dateien",
   "logs.open": "Ordner öffnen",
   "logs.save": "Logs speichern…",

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1351,6 +1351,30 @@ export const de: Translation = {
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Postprocessing-Presets — wie {{game}} auf dem Bildschirm aussieht.",
 
+  // ── Logs ───────────────────────────────────────────────────────────────────
+  "settings.logs": "Logs",
+  "logs.desc":
+    "Die Dateien, die du schickst, wenn etwas schiefgeht. MXB App und {{game}} führen jeweils eigene — öffne einen der beiden Ordner, oder speichere beide als ein Zip für einen Fehlerbericht.",
+  "logs.appLogs": "MXB App",
+  "logs.appLogsDesc": "Was die App selbst aufgezeichnet hat",
+  "logs.gameLogsDesc": "Das Log des Spiels, neben seinen Dateien",
+  "logs.open": "Ordner öffnen",
+  "logs.save": "Logs speichern…",
+  "logs.saving": "Wird gespeichert…",
+  "logs.refresh": "Aktualisieren",
+  "logs.loading": "Wird gesucht…",
+  "logs.empty": "Hier gibt es noch keine Log-Dateien.",
+  "logs.folderMissing":
+    "Diesen Ordner gibt es nicht — es hat noch nichts ein Log hineingeschrieben.",
+  "logs.summary_one": "{{count}} Datei · {{size}} · neueste {{when}}",
+  "logs.summary_other": "{{count}} Dateien · {{size}} · neueste {{when}}",
+  "logs.saved": "Logs gespeichert",
+  "logs.savedDesc_one": "{{count}} Log-Datei, {{size}}",
+  "logs.savedDesc_other": "{{count}} Log-Dateien, {{size}}",
+  "logs.saveFailed": "Logs konnten nicht gespeichert werden",
+  "logs.privacy":
+    "Logs enthalten Ordnerpfade und was die App gerade getan hat — nie deine Passwörter oder Session-Cookies, und keine Einstellungsdatei ist dabei.",
+
   // ── Unterstützer (Buy Me a Coffee) ─────────────────────────────────────────
   "settings.supporters": "Unterstützer",
   "settings.supportersDesc":

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1312,9 +1312,10 @@ export const en = {
   // ── Logs ───────────────────────────────────────────────────────────────────
   "settings.logs": "Logs",
   "logs.desc":
-    "The files to send when something goes wrong. MXB App and {{game}} each keep their own — open either folder, or save both as one zip to attach to a bug report.",
+    "The files to send when something goes wrong. MXB App, FrostMod and {{game}} each keep their own — open any of them, or save the lot as one zip to attach to a bug report.",
   "logs.appLogs": "MXB App",
   "logs.appLogsDesc": "What the app itself recorded",
+  "logs.frostmodLogsDesc": "Whatever the loader wrote in its own folder",
   "logs.gameLogsDesc": "The game's own log, beside its files",
   "logs.open": "Open folder",
   "logs.save": "Save logs…",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1309,6 +1309,30 @@ export const en = {
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Post-processing presets — how {{game}} looks on screen.",
 
+  // ── Logs ───────────────────────────────────────────────────────────────────
+  "settings.logs": "Logs",
+  "logs.desc":
+    "The files to send when something goes wrong. MXB App and {{game}} each keep their own — open either folder, or save both as one zip to attach to a bug report.",
+  "logs.appLogs": "MXB App",
+  "logs.appLogsDesc": "What the app itself recorded",
+  "logs.gameLogsDesc": "The game's own log, beside its files",
+  "logs.open": "Open folder",
+  "logs.save": "Save logs…",
+  "logs.saving": "Saving…",
+  "logs.refresh": "Refresh",
+  "logs.loading": "Looking…",
+  "logs.empty": "No log files here yet.",
+  "logs.folderMissing":
+    "That folder isn't there — nothing has written a log to it yet.",
+  "logs.summary_one": "{{count}} file · {{size}} · newest {{when}}",
+  "logs.summary_other": "{{count}} files · {{size}} · newest {{when}}",
+  "logs.saved": "Logs saved",
+  "logs.savedDesc_one": "{{count}} log file, {{size}}",
+  "logs.savedDesc_other": "{{count}} log files, {{size}}",
+  "logs.saveFailed": "Couldn't save the logs",
+  "logs.privacy":
+    "Logs hold folder paths and what the app was doing — never your passwords or session cookies, and no settings file is included.",
+
   // ── Supporters (Buy Me a Coffee) ───────────────────────────────────────────
   "settings.supporters": "Supporters",
   "settings.supportersDesc": "The people keeping MXB App going on Buy Me a Coffee.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1339,6 +1339,30 @@ export const es: Translation = {
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Ajustes de posprocesado — cómo se ve {{game}} en pantalla.",
 
+  // ── Registros ──────────────────────────────────────────────────────────────
+  "settings.logs": "Registros",
+  "logs.desc":
+    "Los archivos que hay que enviar cuando algo falla. MXB App y {{game}} guardan los suyos por separado — abre cualquiera de las dos carpetas o guarda ambos en un zip para adjuntarlo a un informe.",
+  "logs.appLogs": "MXB App",
+  "logs.appLogsDesc": "Lo que registró la propia app",
+  "logs.gameLogsDesc": "El registro del juego, junto a sus archivos",
+  "logs.open": "Abrir carpeta",
+  "logs.save": "Guardar registros…",
+  "logs.saving": "Guardando…",
+  "logs.refresh": "Actualizar",
+  "logs.loading": "Buscando…",
+  "logs.empty": "Aquí todavía no hay archivos de registro.",
+  "logs.folderMissing":
+    "Esa carpeta no está ahí — nada ha escrito aún un registro en ella.",
+  "logs.summary_one": "{{count}} archivo · {{size}} · el más reciente {{when}}",
+  "logs.summary_other": "{{count}} archivos · {{size}} · el más reciente {{when}}",
+  "logs.saved": "Registros guardados",
+  "logs.savedDesc_one": "{{count}} archivo de registro, {{size}}",
+  "logs.savedDesc_other": "{{count}} archivos de registro, {{size}}",
+  "logs.saveFailed": "No se pudieron guardar los registros",
+  "logs.privacy":
+    "Los registros contienen rutas de carpetas y lo que estaba haciendo la app — nunca tus contraseñas ni las cookies de sesión, y no se incluye ningún archivo de ajustes.",
+
   // ── Mecenas (Buy Me a Coffee) ──────────────────────────────────────────────
   "settings.supporters": "Mecenas",
   "settings.supportersDesc": "Quienes mantienen MXB App en Buy Me a Coffee.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1342,9 +1342,10 @@ export const es: Translation = {
   // ── Registros ──────────────────────────────────────────────────────────────
   "settings.logs": "Registros",
   "logs.desc":
-    "Los archivos que hay que enviar cuando algo falla. MXB App y {{game}} guardan los suyos por separado — abre cualquiera de las dos carpetas o guarda ambos en un zip para adjuntarlo a un informe.",
+    "Los archivos que hay que enviar cuando algo falla. MXB App, FrostMod y {{game}} guardan los suyos por separado — abre la carpeta que necesites o guárdalos todos en un zip para adjuntarlo a un informe.",
   "logs.appLogs": "MXB App",
   "logs.appLogsDesc": "Lo que registró la propia app",
+  "logs.frostmodLogsDesc": "Lo que el cargador escribió en su propia carpeta",
   "logs.gameLogsDesc": "El registro del juego, junto a sus archivos",
   "logs.open": "Abrir carpeta",
   "logs.save": "Guardar registros…",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1345,9 +1345,10 @@ export const fr: Translation = {
   // ── Journaux ───────────────────────────────────────────────────────────────
   "settings.logs": "Journaux",
   "logs.desc":
-    "Les fichiers à envoyer quand quelque chose ne va pas. MXB App et {{game}} ont chacun les leurs — ouvre l'un des deux dossiers, ou enregistre les deux dans un zip à joindre à un rapport.",
+    "Les fichiers à envoyer quand quelque chose ne va pas. MXB App, FrostMod et {{game}} ont chacun les leurs — ouvre le dossier qu'il te faut, ou enregistre le tout dans un zip à joindre à un rapport.",
   "logs.appLogs": "MXB App",
   "logs.appLogsDesc": "Ce que l'app elle-même a enregistré",
+  "logs.frostmodLogsDesc": "Ce que le loader a écrit dans son propre dossier",
   "logs.gameLogsDesc": "Le journal du jeu, à côté de ses fichiers",
   "logs.open": "Ouvrir le dossier",
   "logs.save": "Enregistrer les journaux…",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1342,6 +1342,30 @@ export const fr: Translation = {
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Préréglages de post-traitement — le rendu de {{game}} à l'écran.",
 
+  // ── Journaux ───────────────────────────────────────────────────────────────
+  "settings.logs": "Journaux",
+  "logs.desc":
+    "Les fichiers à envoyer quand quelque chose ne va pas. MXB App et {{game}} ont chacun les leurs — ouvre l'un des deux dossiers, ou enregistre les deux dans un zip à joindre à un rapport.",
+  "logs.appLogs": "MXB App",
+  "logs.appLogsDesc": "Ce que l'app elle-même a enregistré",
+  "logs.gameLogsDesc": "Le journal du jeu, à côté de ses fichiers",
+  "logs.open": "Ouvrir le dossier",
+  "logs.save": "Enregistrer les journaux…",
+  "logs.saving": "Enregistrement…",
+  "logs.refresh": "Actualiser",
+  "logs.loading": "Recherche…",
+  "logs.empty": "Aucun fichier de journal ici pour l'instant.",
+  "logs.folderMissing":
+    "Ce dossier n'existe pas — rien n'y a encore écrit de journal.",
+  "logs.summary_one": "{{count}} fichier · {{size}} · le plus récent {{when}}",
+  "logs.summary_other": "{{count}} fichiers · {{size}} · le plus récent {{when}}",
+  "logs.saved": "Journaux enregistrés",
+  "logs.savedDesc_one": "{{count}} fichier de journal, {{size}}",
+  "logs.savedDesc_other": "{{count}} fichiers de journal, {{size}}",
+  "logs.saveFailed": "Impossible d'enregistrer les journaux",
+  "logs.privacy":
+    "Les journaux contiennent des chemins de dossiers et ce que faisait l'app — jamais tes mots de passe ni tes cookies de session, et aucun fichier de réglages n'est inclus.",
+
   // ── Soutiens (Buy Me a Coffee) ─────────────────────────────────────────────
   "settings.supporters": "Soutiens",
   "settings.supportersDesc": "Les personnes qui font vivre MXB App sur Buy Me a Coffee.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1331,6 +1331,30 @@ export const it: Translation = {
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Preset di post-processing — l'aspetto di {{game}} a schermo.",
 
+  // ── Log ────────────────────────────────────────────────────────────────────
+  "settings.logs": "Log",
+  "logs.desc":
+    "I file da inviare quando qualcosa non va. MXB App e {{game}} tengono ciascuno i propri — apri una delle due cartelle, oppure salva entrambi in un unico zip da allegare a una segnalazione.",
+  "logs.appLogs": "MXB App",
+  "logs.appLogsDesc": "Quello che ha registrato l'app stessa",
+  "logs.gameLogsDesc": "Il log del gioco, accanto ai suoi file",
+  "logs.open": "Apri cartella",
+  "logs.save": "Salva i log…",
+  "logs.saving": "Salvataggio…",
+  "logs.refresh": "Aggiorna",
+  "logs.loading": "Ricerca…",
+  "logs.empty": "Ancora nessun file di log qui.",
+  "logs.folderMissing":
+    "Quella cartella non c'è — nessuno ci ha ancora scritto un log.",
+  "logs.summary_one": "{{count}} file · {{size}} · più recente {{when}}",
+  "logs.summary_other": "{{count}} file · {{size}} · più recente {{when}}",
+  "logs.saved": "Log salvati",
+  "logs.savedDesc_one": "{{count}} file di log, {{size}}",
+  "logs.savedDesc_other": "{{count}} file di log, {{size}}",
+  "logs.saveFailed": "Impossibile salvare i log",
+  "logs.privacy":
+    "I log contengono percorsi di cartelle e cosa stava facendo l'app — mai le tue password o i cookie di sessione, e nessun file di impostazioni è incluso.",
+
   // ── Sostenitori (Buy Me a Coffee) ──────────────────────────────────────────
   "settings.supporters": "Sostenitori",
   "settings.supportersDesc": "Chi tiene in piedi MXB App su Buy Me a Coffee.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1334,9 +1334,10 @@ export const it: Translation = {
   // ── Log ────────────────────────────────────────────────────────────────────
   "settings.logs": "Log",
   "logs.desc":
-    "I file da inviare quando qualcosa non va. MXB App e {{game}} tengono ciascuno i propri — apri una delle due cartelle, oppure salva entrambi in un unico zip da allegare a una segnalazione.",
+    "I file da inviare quando qualcosa non va. MXB App, FrostMod e {{game}} tengono ciascuno i propri — apri la cartella che ti serve, oppure salvali tutti in un unico zip da allegare a una segnalazione.",
   "logs.appLogs": "MXB App",
   "logs.appLogsDesc": "Quello che ha registrato l'app stessa",
+  "logs.frostmodLogsDesc": "Quello che il loader ha scritto nella sua cartella",
   "logs.gameLogsDesc": "Il log del gioco, accanto ai suoi file",
   "logs.open": "Apri cartella",
   "logs.save": "Salva i log…",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1334,9 +1334,10 @@ export const ptBR: Translation = {
   // ── Logs ───────────────────────────────────────────────────────────────────
   "settings.logs": "Logs",
   "logs.desc":
-    "Os arquivos para enviar quando algo dá errado. MXB App e {{game}} guardam os seus separadamente — abra qualquer uma das pastas, ou salve os dois num zip para anexar a um relato de bug.",
+    "Os arquivos para enviar quando algo dá errado. MXB App, FrostMod e {{game}} guardam os seus separadamente — abra a pasta que precisar, ou salve todos num zip para anexar a um relato de bug.",
   "logs.appLogs": "MXB App",
   "logs.appLogsDesc": "O que o próprio app registrou",
+  "logs.frostmodLogsDesc": "O que o loader escreveu na pasta dele",
   "logs.gameLogsDesc": "O log do jogo, junto dos arquivos dele",
   "logs.open": "Abrir pasta",
   "logs.save": "Salvar logs…",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1331,6 +1331,30 @@ export const ptBR: Translation = {
   "settings.reshade": "ReShade",
   "settings.reshadeDesc": "Presets de pós-processamento — como {{game}} aparece na tela.",
 
+  // ── Logs ───────────────────────────────────────────────────────────────────
+  "settings.logs": "Logs",
+  "logs.desc":
+    "Os arquivos para enviar quando algo dá errado. MXB App e {{game}} guardam os seus separadamente — abra qualquer uma das pastas, ou salve os dois num zip para anexar a um relato de bug.",
+  "logs.appLogs": "MXB App",
+  "logs.appLogsDesc": "O que o próprio app registrou",
+  "logs.gameLogsDesc": "O log do jogo, junto dos arquivos dele",
+  "logs.open": "Abrir pasta",
+  "logs.save": "Salvar logs…",
+  "logs.saving": "Salvando…",
+  "logs.refresh": "Atualizar",
+  "logs.loading": "Procurando…",
+  "logs.empty": "Ainda não há arquivos de log aqui.",
+  "logs.folderMissing":
+    "Essa pasta não existe — nada escreveu um log nela ainda.",
+  "logs.summary_one": "{{count}} arquivo · {{size}} · mais recente {{when}}",
+  "logs.summary_other": "{{count}} arquivos · {{size}} · mais recente {{when}}",
+  "logs.saved": "Logs salvos",
+  "logs.savedDesc_one": "{{count}} arquivo de log, {{size}}",
+  "logs.savedDesc_other": "{{count}} arquivos de log, {{size}}",
+  "logs.saveFailed": "Não foi possível salvar os logs",
+  "logs.privacy":
+    "Os logs contêm caminhos de pastas e o que o app estava fazendo — nunca suas senhas ou cookies de sessão, e nenhum arquivo de configurações é incluído.",
+
   // ── Apoiadores (Buy Me a Coffee) ───────────────────────────────────────────
   "settings.supporters": "Apoiadores",
   "settings.supportersDesc": "Quem mantém o MXB App de pé no Buy Me a Coffee.",


### PR DESCRIPTION
"Send me your logs" is the first thing every bug report asks for, and until now there was no way for a player to answer it. There are three sets and they sit in three places:

| | Where |
|---|---|
| **MXB App** | the OS log dir `tauri_plugin_log` writes to — `%LOCALAPPDATA%\com.frost.mxbikes\logs` on Windows |
| **FrostMod** | the managed folder we install it into and run it from (`start` sets it as `current_dir`) |
| **MX Bikes / GP Bikes** | `log.txt` beside the executable — or, when the mods tree has been relocated, somewhere only the app knows |

Settings → Logs names all three, says what's in each, and hands them over.

## What it looks like

Each row shows the folder plus a live line underneath: file count, total size, and how old the newest file is. That age line is the point — a path alone can't tell you whether the log predates the run being reported. A folder that isn't there says so in warning colour rather than reading as empty.

- **Open folder** opens any of the three with the newest file selected.
- **Save logs…** zips the lot to a path picked in a save dialog, one folder per group plus a `summary.txt` (app version, OS, active game, resolved folders, what was included).

## Two things worth a reviewer's attention

**The two file filters are deliberately inverted.** A game folder is the player's — full of files that are none of our business — so there we match names we expect (`log.txt`, `*.log`, `crash*`) and leave `mxbikes.ini` and `rider.pkz` alone. The FrostMod folder is ours: we create it, install into it and run from it, so its non-log contents are a known short list (the two binaries, `version.txt`, the server filter, and a binary parked mid-update as `*.in-use-*`), while what FrostMod calls its log is decided in another repo and can change with any release. Excluding what we put there catches a log we've never seen the name of; guessing `log*.txt` would quietly miss it.

**The zip holds logs only, never `config.json`.** It carries session cookies and shop credentials, and the button is only worth having if its output is safe to drop into a public Discord thread. The UI says so under the buttons. The server filter is excluded on the same grounds — it's a settings file.

## Notes

- The game side searches install dir → user folder, first one holding logs wins; when none do, the first that exists is still named, so there's always somewhere to go and look.
- Needed a plain `library::open_folder` alongside `reveal_in_explorer`: Explorer's `/select,` on a folder highlights it in its *parent*, which isn't what "Open folder" says.
- `dialog:allow-save` added to the main window's capability file for the save dialog.
- The FrostMod row is gated on Windows + `caps.frostmod`, the same condition as the FrostMod section itself.
- Export runs off the UI thread — a month-old app log would otherwise freeze Settings while it's read — and skips any single file over 64 MB rather than building an attachment nobody can upload.

## Testing

- 6 new Rust tests in `logs.rs`: both name filters, newest-first ordering, the install-then-user fallback, and an export that lands all three groups while leaving the non-logs out. `cargo test logs::` and `cargo test library::` pass.
- `cargo check`, `npm run typecheck`, `npm run lint` and `npm run build` clean. Strings added to all six locales, so the type-checked dictionaries stay complete.
- **Not run in the app itself** — this was developed in a headless Linux container and it's a Windows-first Tauri app, so the section is verified by types and build rather than by eye. Worth a click-through on Windows before merge, particularly the save dialog and that FrostMod's log actually turns up in its folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H7Lcqb4fxdgtSs56Cns5QC

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7Lcqb4fxdgtSs56Cns5QC)_