### PR TITLE
feat(settings): one section at a time, and a folder picker for ReShade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,24 @@ looking nothing like the track you ride, name it in the report — that's the th
   writes the lot into a single zip to attach. The zip holds the logs and a summary of the
   folders they came from — never the settings file, which carries session cookies.
 - **Qwest and Kelso** credited on Settings → Supporters.
+- **Point ReShade at the folder it's actually in.** The ReShade card only ever looked in the
+  game's install folder, so if that was unset or detection landed somewhere else, it said
+  "not installed" to people with ReShade sitting right there, and offered nothing to do about
+  it. It now names the folder it looked in and takes a pick of your own, kept separately from
+  the game folder — that one also drives the 3D rider, the game log location and Play, none of
+  which a choice made on this card should move. A folder with no ReShade in it is still
+  accepted and simply reported as such, and there's a link back to the game folder.
+
+### Changed
+- **Settings shows one section at a time.** Twelve sections rendered into a single column
+  meant the folder settings and the version number shared a scrollbar, and the nav on the left
+  only scrolled you to an anchor in it. That nav is now grouped — Setup, App, Advanced, About
+  — and opens each section on its own. **Experimental** was in that column with nothing in the
+  nav pointing at it; it has an entry now, under Advanced.
+- **Voice chat settings read shorter.** Five lines of help text under controls whose labels
+  already said the same thing are gone — a device picker labelled "Microphone" didn't need a
+  sentence under it explaining that it picks a microphone. What's left is the things the
+  labels can't say: that nothing transmits yet, and what the test buttons do.
 
 ### Fixed
 - **Terrain below a track's datum is no longer drawn as a wall around it.** A `.trh` stores

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -13,6 +13,7 @@ pub struct GamePaths {
     pub mods_path: String,
     pub game_path: String,
     pub profiles_path: String,
+    pub reshade_path: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -47,6 +48,13 @@ pub struct AppConfig {
     /// resolved from `mods_path` — see [`AppConfig::profiles_dir`]. Set it when the
     /// resolver can't find the folder, e.g. profiles on a drive we don't probe.
     pub profiles_path: String,
+    /// Override for the folder ReShade is installed in. Empty (the normal case) means the
+    /// game's install dir — see [`AppConfig::reshade_dir`]. Set it when detection lands on
+    /// the wrong folder, or when the install dir isn't configured at all and the player
+    /// only wants to point at ReShade. Deliberately not `game_path`: that one also drives
+    /// `rider.pkz` lookup, the game log folder and launching, none of which a pick made
+    /// from the ReShade card should move.
+    pub reshade_path: String,
     /// macOS: the Wine binary that starts the game. Empty (the normal case) means it's
     /// auto-detected — see [`crate::winehost::resolve`]. Machine-wide rather than
     /// per-game: one Mac has one set of wrappers installed. Ignored on Windows and Linux.
@@ -196,6 +204,7 @@ impl Default for AppConfig {
             mods_path: String::new(),
             game_path: String::new(),
             profiles_path: String::new(),
+            reshade_path: String::new(),
             wine_runner: String::new(),
             run_in_background: true,
             launch_at_startup: true,
@@ -258,6 +267,7 @@ impl AppConfig {
                 mods_path: self.mods_path.clone(),
                 game_path: self.game_path.clone(),
                 profiles_path: self.profiles_path.clone(),
+                reshade_path: self.reshade_path.clone(),
             },
         );
     }
@@ -279,6 +289,7 @@ impl AppConfig {
         self.mods_path = next.mods_path;
         self.game_path = next.game_path;
         self.profiles_path = next.profiles_path;
+        self.reshade_path = next.reshade_path;
         true
     }
 
@@ -307,6 +318,22 @@ impl AppConfig {
             return gp.to_string();
         }
         detect_game_path(self.game()).unwrap_or_default()
+    }
+
+    /// The folder ReShade is installed in — everything in [`crate::reshade`] reads this
+    /// rather than [`AppConfig::install_dir`].
+    ///
+    /// Normally they are the same folder: ReShade attaches by sitting next to the
+    /// executable, so it can't be anywhere else and still load. The override exists for
+    /// when the app's idea of the install dir is wrong or missing — Steam detection came up
+    /// empty, or the player runs two copies — and it stays separate from `game_path` so
+    /// pointing this at the wrong place can only ever break ReShade.
+    pub fn reshade_dir(&self) -> String {
+        let custom = self.reshade_path.trim();
+        if !custom.is_empty() {
+            return custom.to_string();
+        }
+        self.install_dir()
     }
 
     pub fn profiles_dir(&self) -> PathBuf {

--- a/src-tauri/src/install.rs
+++ b/src-tauri/src/install.rs
@@ -166,10 +166,10 @@ pub(crate) fn extract_and_place(
 
     emit(app, slug, "placing", None, None);
 
-    // A ReShade preset lands in the game's *install* dir, not the mods tree, and is sorted by
+    // A ReShade preset lands beside ReShade itself, not in the mods tree, and is sorted by
     // file type rather than routed by folder — none of the placement planner below applies.
     if crate::reshade::is_reshade_subpath(subpath) {
-        crate::reshade::install_extracted(&extracted, &cfg.install_dir())?;
+        crate::reshade::install_extracted(&extracted, &cfg.reshade_dir())?;
         let _ = std::fs::remove_dir_all(work);
         emit(app, slug, "done", None, None);
         return Ok(());
@@ -324,7 +324,7 @@ pub fn import_file(
     }
 
     if crate::reshade::is_reshade_subpath(subpath) {
-        crate::reshade::install_extracted(&extracted, &cfg.install_dir())?;
+        crate::reshade::install_extracted(&extracted, &cfg.reshade_dir())?;
         let _ = std::fs::remove_dir_all(&work);
         return Ok(());
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -337,7 +337,7 @@ fn scan_library_blocking(
     // names against catalog titles to draw its "Installed" badge, so it has to be the real
     // list. See `reshade::status`.
     if reshade::is_reshade_subpath(&subpath) {
-        return Ok(reshade::status(&cfg.install_dir())
+        return Ok(reshade::status(&cfg.reshade_dir())
             .presets
             .into_iter()
             .map(|p| library::LibraryEntry {
@@ -544,15 +544,34 @@ async fn apply_sound_swap(
     .map_err(|e| format!("apply_sound_swap task failed: {e}"))?
 }
 
-/// The ReShade card's whole state, read fresh from the game folder — see [`reshade`].
+/// The ReShade card's whole state, read fresh from the folder ReShade lives in — see
+/// [`reshade`].
 #[tauri::command]
 async fn reshade_status(app: tauri::AppHandle) -> Result<reshade::Status, String> {
     tauri::async_runtime::spawn_blocking(move || {
         let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
-        Ok(reshade::status(&cfg.install_dir()))
+        let mut status = reshade::status(&cfg.reshade_dir());
+        // Only this side knows where that folder came from, and the card has to say so
+        // before it offers to hand the folder back to the game's install dir.
+        status.custom = !cfg.reshade_path.trim().is_empty();
+        Ok(status)
     })
     .await
     .map_err(|e| format!("reshade_status task failed: {e}"))?
+}
+
+/// Point the ReShade card at a folder of the player's choosing. An empty string clears the
+/// override, back to the game's install dir.
+///
+/// The pick is taken as given rather than validated: a folder with no ReShade in it is a
+/// perfectly ordinary thing to land on mid-setup, and `reshade_status` says so plainly on
+/// the very next read. Refusing it would leave the player with a dialog and no way to see
+/// what the app thinks is wrong.
+#[tauri::command]
+fn set_reshade_path(app: tauri::AppHandle, path: String) -> Result<(), String> {
+    let mut cfg = config::load(&app).unwrap_or_default();
+    cfg.reshade_path = path;
+    config::save(&app, &cfg).map_err(|e| format!("{e:#}"))
 }
 
 #[tauri::command]
@@ -562,7 +581,7 @@ async fn apply_reshade_preset(
 ) -> Result<ReshadeApplyOutcome, String> {
     tauri::async_runtime::spawn_blocking(move || {
         let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
-        reshade::apply(&cfg.install_dir(), &name).map_err(|e| format!("{e:#}"))?;
+        reshade::apply(&cfg.reshade_dir(), &name).map_err(|e| format!("{e:#}"))?;
         // Unlike a content swap there is nothing to signal: ReShade owns its own config and
         // FrostMod has no part in it. All the UI needs is whether the player will see this
         // now or on the next launch.
@@ -578,7 +597,7 @@ async fn apply_reshade_preset(
 async fn delete_reshade_preset(app: tauri::AppHandle, name: String) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
         let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
-        reshade::delete(&cfg.install_dir(), &name).map_err(|e| format!("{e:#}"))
+        reshade::delete(&cfg.reshade_dir(), &name).map_err(|e| format!("{e:#}"))
     })
     .await
     .map_err(|e| format!("delete_reshade_preset task failed: {e}"))?
@@ -5990,6 +6009,7 @@ fn main() {
             bind_sound,
             unbind_sound,
             reshade_status,
+            set_reshade_path,
             apply_reshade_preset,
             delete_reshade_preset,
             detect_loose_swaps,

--- a/src-tauri/src/reshade.rs
+++ b/src-tauri/src/reshade.rs
@@ -93,9 +93,16 @@ pub struct Preset {
 #[derive(Debug, Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Status {
-    /// The game's install dir. Empty when it isn't configured yet, which is the one state
+    /// The folder we looked in. Empty when none is configured yet, which is the one state
     /// where nothing below can be trusted.
     pub game_dir: String,
+    /// That folder came from the player's `reshade_path` override rather than from the
+    /// game's install dir. Set by the command layer, which is the only side that knows.
+    pub custom: bool,
+    /// A folder *is* configured, and it isn't there. Distinct from the empty `game_dir`
+    /// above: "the folder you picked has moved" and "you haven't picked one" need
+    /// different answers, and both used to come back as the latter.
+    pub folder_missing: bool,
     /// A ReShade `opengl32.dll` is in place — the game will load it.
     pub installed: bool,
     /// ReShade is here, but as this DLL, which these games never load. Set only when the
@@ -420,15 +427,22 @@ fn ini_files(dir: &Path) -> Vec<PathBuf> {
 // Public surface
 // ---------------------------------------------------------------------------
 
-/// Everything the ReShade card renders, in one pass over the game folder.
-pub fn status(game_path: &str) -> Status {
-    let game_path = game_path.trim();
-    if game_path.is_empty() {
+/// Everything the ReShade card renders, in one pass over the folder ReShade lives in —
+/// [`crate::config::AppConfig::reshade_dir`], normally the game's install dir.
+pub fn status(reshade_path: &str) -> Status {
+    let reshade_path = reshade_path.trim();
+    if reshade_path.is_empty() {
         return Status::default();
     }
-    let game_dir = PathBuf::from(game_path);
+    let game_dir = PathBuf::from(reshade_path);
     if !game_dir.is_dir() {
-        return Status::default();
+        // Named rather than blanked. A folder that has been picked and has since moved is
+        // a different problem from one that was never set, and only the path says which.
+        return Status {
+            game_dir: reshade_path.to_string(),
+            folder_missing: true,
+            ..Status::default()
+        };
     }
 
     let gl = probe_dll(&resolve_child(&game_dir, OPENGL_DLL));
@@ -480,6 +494,8 @@ pub fn status(game_path: &str) -> Status {
 
     Status {
         game_dir: game_dir.to_string_lossy().into_owned(),
+        custom: false,
+        folder_missing: false,
         installed,
         wrong_api,
         version: gl.flatten(),
@@ -1177,6 +1193,44 @@ mod tests {
     fn unset_game_folder_is_empty_not_negative() {
         let s = status("   ");
         assert!(s.game_dir.is_empty());
+        assert!(!s.folder_missing);
         assert!(s.presets.is_empty());
+    }
+
+    /// A folder that was picked and has since moved is a different problem from one that was
+    /// never picked — and it used to come back as the latter, with the path thrown away.
+    #[test]
+    fn a_configured_folder_that_is_gone_is_named() {
+        let dir = tmp("folder-gone");
+        let path = dir.join("moved-away");
+        let s = status(&path.to_string_lossy());
+        assert!(s.folder_missing);
+        assert_eq!(s.game_dir, path.to_string_lossy());
+        assert!(!s.installed);
+    }
+
+    /// The whole point of the override: presets are read from wherever the player pointed us,
+    /// not from the game's install dir.
+    #[test]
+    fn presets_come_from_whichever_folder_it_is_given() {
+        let install = fixture("override-install", OPENGL_DLL);
+        let elsewhere = fixture("override-elsewhere", OPENGL_DLL);
+        write(&install.join(PRESET_DIR).join("FromInstall.ini"), PRESET);
+        write(&elsewhere.join(PRESET_DIR).join("FromElsewhere.ini"), PRESET);
+
+        let names = |dir: &Path| {
+            status(&game(dir))
+                .presets
+                .into_iter()
+                .map(|p| p.name)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(names(&install), vec!["FromInstall"]);
+        assert_eq!(names(&elsewhere), vec!["FromElsewhere"]);
+
+        // And applying writes the config next to the ReShade that will read it.
+        apply(&game(&elsewhere), "FromElsewhere").unwrap();
+        assert!(elsewhere.join(CONFIG).is_file());
+        assert!(!install.join(CONFIG).exists());
     }
 }

--- a/src/Components/Settings/ReshadeCard.tsx
+++ b/src/Components/Settings/ReshadeCard.tsx
@@ -1,11 +1,20 @@
 import { useCallback, useEffect, useState } from "react";
-import { Check, ExternalLink, RefreshCw, Trash2, TriangleAlert } from "lucide-react";
+import {
+  Check,
+  ExternalLink,
+  FolderOpen,
+  RefreshCw,
+  Trash2,
+  TriangleAlert,
+} from "lucide-react";
+import { open as pickFolder } from "@tauri-apps/plugin-dialog";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
 import { toast } from "sonner";
 import {
   applyReshadePreset,
   deleteReshadePreset,
   reshadeStatus,
+  setReshadePath,
   RESHADE_OFF,
 } from "../../api/mods";
 import type { ReshadePreset, ReshadeStatus } from "../../types";
@@ -25,10 +34,15 @@ const RESHADE_URL = "https://reshade.me/";
  * Two jobs, in order of what the player needs: say whether ReShade is there at all — and if
  * it's there under the wrong graphics API, say *that*, because these games are OpenGL and a
  * DirectX install simply never loads — then let them switch between the presets they have.
+ *
+ * Every answer comes from one folder, normally the game's install dir. When the app's idea of
+ * that folder is wrong or missing, the player can name it themselves — see `reshadePath` in
+ * the config, and `Choose folder…` below, which is offered in every state where the card has
+ * bad news.
  */
 export default function ReshadeCard() {
   const { t } = useI18n();
-  const { config, game } = useConfig();
+  const { config, reloadConfig, game } = useConfig();
   const { running } = useGameRunning();
   const [status, setStatus] = useState<ReshadeStatus | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
@@ -41,11 +55,62 @@ export default function ReshadeCard() {
     }
   }, []);
 
-  // Re-read on mount and whenever the game folder changes — that folder is where every
-  // answer on this card comes from.
+  // Re-read on mount and whenever either folder changes — the override when it's set, the
+  // game folder when it isn't.
   useEffect(() => {
     void refresh();
-  }, [refresh, config.gamePath]);
+  }, [refresh, config.gamePath, config.reshadePath]);
+
+  /** Name the folder ReShade is in. Kept whether or not ReShade turns out to be there:
+   *  the card re-reads immediately and says which, and a rejected pick would leave the
+   *  player guessing what the app disagreed with. */
+  const chooseFolder = async () => {
+    const picked = await pickFolder({
+      directory: true,
+      multiple: false,
+      title: t("reshade.pickFolder"),
+    });
+    if (typeof picked !== "string") return;
+    try {
+      await setReshadePath(picked);
+      await reloadConfig();
+      const next = await reshadeStatus();
+      setStatus(next);
+      if (next.installed) {
+        toast.success(t("reshade.folderSet"), { description: picked });
+      } else {
+        toast.warning(t("reshade.notThere"), { description: picked });
+      }
+    } catch (e) {
+      toast.error(String(e));
+    }
+  };
+
+  const revertToGameFolder = async () => {
+    try {
+      await setReshadePath("");
+      await reloadConfig();
+      setStatus(await reshadeStatus());
+    } catch (e) {
+      toast.error(String(e));
+    }
+  };
+
+  const chooseButton = (
+    <Button size="sm" variant="outline" onClick={() => void chooseFolder()}>
+      <FolderOpen className="size-3.5" />
+      {t("reshade.browse")}
+    </Button>
+  );
+
+  const gameFolderLink = status?.custom ? (
+    <button
+      onClick={() => void revertToGameFolder()}
+      className="cursor-default self-start text-[11.5px] font-semibold text-primary hover:brightness-110"
+    >
+      {t("reshade.resetFolder")}
+    </button>
+  ) : null;
 
   const activate = async (name: string) => {
     setBusy(name);
@@ -79,13 +144,36 @@ export default function ReshadeCard() {
 
   const openSite = () => void openUrl(RESHADE_URL);
 
-  // The game folder isn't set, so nothing below can be answered. Saying "not installed"
-  // here would send someone off to install what they may well already have.
+  // No folder at all, so nothing below can be answered. Saying "not installed" here would
+  // send someone off to install what they may well already have — but they can name the
+  // folder themselves rather than being sent to the game-folder setting and back.
   if (!status || !status.gameDir) {
     return (
-      <p className="text-[12px] leading-relaxed text-muted-foreground">
-        {t("reshade.needsGameFolder")}
-      </p>
+      <div className="flex flex-col items-start gap-3">
+        <p className="text-[12px] leading-relaxed text-muted-foreground">
+          {t("reshade.needsGameFolder")}
+        </p>
+        {chooseButton}
+      </div>
+    );
+  }
+
+  // A folder was picked and has since moved. Distinct from the case above: the path is the
+  // whole answer, and "set your game folder" would be the wrong thing to say.
+  if (status.folderMissing) {
+    return (
+      <div className="flex flex-col items-start gap-3">
+        <div className="flex gap-2 rounded-lg border border-warning/40 bg-warning/10 p-3">
+          <TriangleAlert className="mt-px size-4 shrink-0 text-warning" />
+          <p className="text-[12px] leading-relaxed text-foreground/85">
+            {t("reshade.folderMissing")}
+            <br />
+            <span className="font-mono text-[11.5px]">{status.gameDir}</span>
+          </p>
+        </div>
+        {chooseButton}
+        {gameFolderLink}
+      </div>
     );
   }
 
@@ -112,16 +200,23 @@ export default function ReshadeCard() {
           <li className="text-foreground/85">{t("reshade.step3")}</li>
         </ol>
 
-        <div className="flex gap-2">
+        {/* Which folder we looked in. Without it "not installed" is unarguable — someone
+            who has ReShade sitting right there has no way to see that we're looking
+            somewhere else, and no reason to think the button below applies to them. */}
+        <FolderLine dir={status.gameDir} custom={status.custom} />
+
+        <div className="flex flex-wrap gap-2">
           <Button size="sm" onClick={openSite}>
             <ExternalLink className="size-3.5" />
             {t("reshade.getIt")}
           </Button>
-          <Button size="sm" variant="outline" onClick={() => void refresh()}>
+          {chooseButton}
+          <Button size="sm" variant="ghost" onClick={() => void refresh()}>
             <RefreshCw className="size-3.5" />
             {t("reshade.recheck")}
           </Button>
         </div>
+        {gameFolderLink}
       </div>
     );
   }
@@ -220,6 +315,27 @@ export default function ReshadeCard() {
             ? t("reshade.nextLaunchHint")
             : t("reshade.browseHint")}
       </p>
+
+      {/* Only worth saying once ReShade is found, and only when it isn't where the app
+          would have looked on its own — otherwise it's the game folder, which the setting
+          above this section already names. */}
+      {status.custom && (
+        <div className="flex flex-col items-start gap-1.5">
+          <FolderLine dir={status.gameDir} custom />
+          {gameFolderLink}
+        </div>
+      )}
     </div>
+  );
+}
+
+/** The folder every answer on this card came from. */
+function FolderLine({ dir, custom }: { dir: string; custom?: boolean }) {
+  const { t } = useI18n();
+  return (
+    <p className="text-[11.5px] leading-relaxed text-muted-foreground">
+      {custom ? t("reshade.customFolder") : t("reshade.folder")}{" "}
+      <span className="break-all font-mono">{dir}</span>
+    </p>
   );
 }

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -101,20 +101,56 @@ export type SectionId =
   | "frostmod"
   | "reshade"
   | "logs"
+  | "experimental"
   | "supporters"
   | "about";
-const SECTIONS: { id: SectionId; label: TKey }[] = [
-  { id: "game", label: "game.label" },
-  { id: "folder", label: "settings.gameFolder" },
-  { id: "general", label: "settings.general" },
-  { id: "overlay", label: "overlay.section" },
-  { id: "voice", label: "voice.section" },
-  { id: "appearance", label: "settings.appearance" },
-  { id: "frostmod", label: "settings.frostmod" },
-  { id: "reshade", label: "settings.reshade" },
-  { id: "logs", label: "settings.logs" },
-  { id: "supporters", label: "settings.supporters" },
-  { id: "about", label: "settings.about" },
+
+/**
+ * The nav, and with it the page: exactly one of these sections is on screen at a time.
+ *
+ * It used to be one column with all twelve rendered into it and a nav that only scrolled
+ * you to an anchor — which meant the folder settings and the version number shared a
+ * scrollbar, and finding anything in the middle meant reading past everything else.
+ *
+ * Grouped because twelve flat entries is its own kind of list. The groups are about where
+ * a setting *lives* — the game, the app, the things you only touch when something's wrong
+ * — not about how often they're used.
+ */
+const GROUPS: { label: TKey; sections: { id: SectionId; label: TKey }[] }[] = [
+  {
+    label: "settings.groupSetup",
+    sections: [
+      { id: "game", label: "game.label" },
+      { id: "folder", label: "settings.gameFolder" },
+      { id: "frostmod", label: "settings.frostmod" },
+      { id: "reshade", label: "settings.reshade" },
+    ],
+  },
+  {
+    label: "settings.groupApp",
+    sections: [
+      { id: "general", label: "settings.general" },
+      { id: "appearance", label: "settings.appearance" },
+      { id: "overlay", label: "overlay.section" },
+      { id: "voice", label: "voice.section" },
+    ],
+  },
+  {
+    label: "settings.groupAdvanced",
+    sections: [
+      { id: "logs", label: "settings.logs" },
+      // Had no nav entry at all before this, and rendered in the middle of the scroll
+      // with nothing pointing at it.
+      { id: "experimental", label: "settings.experimental" },
+    ],
+  },
+  {
+    label: "settings.groupAbout",
+    sections: [
+      { id: "supporters", label: "settings.supporters" },
+      { id: "about", label: "settings.about" },
+    ],
+  },
 ];
 
 /** Default shown before the backend answers, so the field is never blank. */
@@ -240,27 +276,26 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
   // only survives in what the backend reports (see `release_version`), so a beta names
   // itself here. `getVersion()` covers the moment before that call lands.
   const shownVersion = experimental?.version || version;
-  const [active, setActive] = useState<SectionId>(initialSection ?? "folder");
-  // FrostMod has no GP Bikes build, so its section isn't there to jump to either — and
-  // neither is the game picker when there's only one game to pick.
-  const sections = SECTIONS.filter(
-    (s) =>
-      (s.id !== "frostmod" || caps.frostmod) && (s.id !== "game" || multiGame),
-  );
+  const [wanted, setActive] = useState<SectionId>(initialSection ?? "folder");
+  // FrostMod is a Win32 DLL injected into the game and has no GP Bikes build, so its
+  // section isn't there to open either — and neither is the game picker when there's only
+  // one game to pick. A group left with nothing in it drops out of the nav entirely.
+  const groups = GROUPS.map((g) => ({
+    ...g,
+    sections: g.sections.filter(
+      (s) =>
+        (s.id !== "frostmod" || (isWindows && caps.frostmod)) &&
+        (s.id !== "game" || multiGame),
+    ),
+  })).filter((g) => g.sections.length > 0);
+  // Only one section is on screen, so being sent to one this build doesn't have would
+  // leave the page empty rather than merely missing a card the way the old scroll did —
+  // `initialSection="frostmod"` on a Mac, say. Fall back to the first section there is.
+  const shown = groups.flatMap((g) => g.sections).map((s) => s.id);
+  const active = shown.includes(wanted) ? wanted : (shown[0] ?? "folder");
   const [busy, setBusy] = useState(false);
-  const refs = useRef<Record<SectionId, HTMLDivElement | null>>({
-    game: null,
-    folder: null,
-    general: null,
-    overlay: null,
-    voice: null,
-    appearance: null,
-    frostmod: null,
-    reshade: null,
-    logs: null,
-    supporters: null,
-    about: null,
-  });
+  // Each pane starts at the top rather than wherever the last one was left.
+  const pane = useRef<HTMLDivElement | null>(null);
 
   // The folder the backend *actually* reads profiles from when there's no override.
   // Usually `<modsPath>/profiles`, but it falls back to `Documents\PiBoSo\MX Bikes\
@@ -450,6 +485,13 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
     };
   }, []);
 
+  // Navigating to another section closes the meter with it. The state that drives it lives
+  // up here rather than in the section, so without this a mic left testing would keep
+  // recording behind a pane that isn't even on screen.
+  useEffect(() => {
+    if (active !== "voice") setMicTesting(false);
+  }, [active]);
+
   const toggleVoice = async (v: boolean) => {
     try {
       await setVoiceEnabled(v);
@@ -585,15 +627,13 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
 
   const goto = (id: SectionId) => {
     setActive(id);
-    refs.current[id]?.scrollIntoView({ behavior: "smooth", block: "start" });
+    pane.current?.scrollTo({ top: 0 });
   };
 
-  // Sent here for one setting in particular — scroll to it rather than making them
-  // find it. Runs after the first paint, when the section refs exist.
+  // Sent here for one setting in particular — open it rather than making them find it.
   useEffect(() => {
     if (!initialSection) return;
     setActive(initialSection);
-    refs.current[initialSection]?.scrollIntoView({ block: "start" });
   }, [initialSection]);
 
   const changeFolder = async () => {
@@ -768,24 +808,31 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
 
   return (
     <div className="flex h-full">
-      <nav className="flex w-[170px] flex-none flex-col gap-0.5 px-4 pt-[70px]">
-        {sections.map((s) => (
-          <button
-            key={s.id}
-            onClick={() => goto(s.id)}
-            className={cn(
-              "cursor-default rounded-md px-3 py-1.5 text-left text-[12.5px] transition-colors",
-              active === s.id
-                ? "bg-foreground/[0.07] font-semibold text-foreground"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-          >
-            {t(s.label)}
-          </button>
+      <nav className="flex w-[170px] flex-none flex-col gap-4 overflow-y-auto px-4 pb-5 pt-[70px]">
+        {groups.map((g) => (
+          <div key={g.label} className="flex flex-col gap-0.5">
+            <span className="px-3 pb-1 text-[10.5px] font-semibold uppercase tracking-wide text-faint">
+              {t(g.label)}
+            </span>
+            {g.sections.map((s) => (
+              <button
+                key={s.id}
+                onClick={() => goto(s.id)}
+                className={cn(
+                  "cursor-default rounded-md px-3 py-1.5 text-left text-[12.5px] transition-colors",
+                  active === s.id
+                    ? "bg-foreground/[0.07] font-semibold text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {t(s.label)}
+              </button>
+            ))}
+          </div>
         ))}
       </nav>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-5">
+      <div ref={pane} className="min-h-0 flex-1 overflow-y-auto px-2 py-5">
         <div className="flex max-w-[640px] flex-col gap-[18px]">
           <div className="flex items-center gap-1.5">
             <h1 className="text-[21px] font-bold tracking-[-0.2px]">
@@ -800,21 +847,17 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
           {/* game — which title the app is driving. Its own card, above the folders it
               scopes: everything below belongs to whatever is picked here, so it isn't a
               property of the folder setting it used to sit inside. */}
-          {multiGame && (
-            <Section
-              title={t("game.label")}
-              desc={t("settings.gameDesc")}
-              innerRef={(el) => (refs.current.game = el)}
-            >
+          {multiGame && active === "game" && (
+            <Section title={t("game.label")} desc={t("settings.gameDesc")}>
               <GameSwitcher />
             </Section>
           )}
 
           {/* game folder */}
+          {active === "folder" && (
           <Section
             title={t("setup.modsFolder", { game: game.display })}
             desc={t("settings.modsFolderDesc")}
-            innerRef={(el) => (refs.current.folder = el)}
           >
             <div className="flex gap-2">
               <div className="flex flex-1 items-center gap-2 rounded-lg border border-input bg-background px-3 py-2.5 font-mono text-[12px] text-muted-foreground">
@@ -990,9 +1033,11 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
               </>
             )}
           </Section>
+          )}
 
           {/* general / background */}
-          <Section title={t("settings.general")} innerRef={(el) => (refs.current.general = el)}>
+          {active === "general" && (
+          <Section title={t("settings.general")}>
             <ToggleRow
               label={t("settings.runInBackground")}
               desc={t("settings.runInBackgroundDesc")}
@@ -1021,12 +1066,11 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
               onChange={toggleInstantRefresh}
             />
           </Section>
+          )}
 
           {/* in-game overlay */}
-          <Section
-            title={t("overlay.section")}
-            innerRef={(el) => (refs.current.overlay = el)}
-          >
+          {active === "overlay" && (
+          <Section title={t("overlay.section")}>
             <ToggleRow
               label={t("overlay.enable")}
               desc={t("overlay.enableDesc")}
@@ -1105,18 +1149,18 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
               {t("overlay.notWorkingDesc")}
             </p>
           </Section>
+          )}
 
           {/* voice — devices, levels and the mic key. The transport that carries any of
               this to other riders isn't built yet, which the callout says plainly rather
-              than leaving a page that looks finished and does nothing. */}
-          <Section
-            title={t("voice.section")}
-            desc={t("voice.sectionDesc")}
-            innerRef={(el) => (refs.current.voice = el)}
-          >
+              than leaving a page that looks finished and does nothing.
+
+              The labels carry this section on their own: "Microphone" beside a device
+              picker doesn't need a line under it explaining that it picks a microphone. */}
+          {active === "voice" && (
+          <Section title={t("voice.section")}>
             <ToggleRow
               label={t("voice.enable")}
-              desc={t("voice.enableDesc")}
               checked={voiceEnabled}
               onChange={toggleVoice}
             />
@@ -1132,13 +1176,8 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
             {/* Microphone. "" is a real, selectable value — it means "follow whatever
                 Windows is set to", which keeps tracking a default the player changes
                 later. Storing the resolved name would freeze it instead. */}
-            <div className="flex items-start justify-between gap-6">
-              <div className="flex flex-col gap-1">
-                <span className="text-[12.5px] text-foreground/85">{t("voice.microphone")}</span>
-                <span className="text-[11.5px] leading-relaxed text-muted-foreground">
-                  {t("voice.microphoneDesc")}
-                </span>
-              </div>
+            <div className="flex items-center justify-between gap-6">
+              <span className="text-[12.5px] text-foreground/85">{t("voice.microphone")}</span>
               <Select
                 value={voiceInput || DEVICE_DEFAULT}
                 onValueChange={pickInput}
@@ -1197,13 +1236,8 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
 
             {/* Output, deliberately separate from game audio: voice on the headset with
                 the game on speakers is a setup people actually run. */}
-            <div className="flex items-start justify-between gap-6">
-              <div className="flex flex-col gap-1">
-                <span className="text-[12.5px] text-foreground/85">{t("voice.output")}</span>
-                <span className="text-[11.5px] leading-relaxed text-muted-foreground">
-                  {t("voice.outputDesc")}
-                </span>
-              </div>
+            <div className="flex items-center justify-between gap-6">
+              <span className="text-[12.5px] text-foreground/85">{t("voice.output")}</span>
               <Select
                 value={voiceOutput || DEVICE_DEFAULT}
                 onValueChange={pickOutput}
@@ -1258,13 +1292,8 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
 
             <div className="h-px bg-border" />
 
-            <div className="flex items-start justify-between gap-6">
-              <div className="flex flex-col gap-1">
-                <span className="text-[12.5px] text-foreground/85">{t("voice.ptt")}</span>
-                <span className="text-[11.5px] leading-relaxed text-muted-foreground">
-                  {t("voice.pttDesc")}
-                </span>
-              </div>
+            <div className="flex items-center justify-between gap-6">
+              <span className="text-[12.5px] text-foreground/85">{t("voice.ptt")}</span>
               <HotkeyField
                 value={voicePtt}
                 onCapture={rebindPtt}
@@ -1278,12 +1307,11 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
               {t("voice.notConnectedDesc")}
             </Callout>
           </Section>
+          )}
 
           {/* appearance */}
-          <Section
-            title={t("settings.appearance")}
-            innerRef={(el) => (refs.current.appearance = el)}
-          >
+          {active === "appearance" && (
+          <Section title={t("settings.appearance")}>
             <div className="flex items-center justify-between">
               <span className="text-[12.5px] text-foreground/85">
                 {t("settings.theme")}
@@ -1326,14 +1354,15 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
               </Select>
             </div>
           </Section>
+          )}
 
           {/* frostmod — a Win32 DLL injected into the game, so it has nothing to do
               anywhere else. Hidden rather than shown-and-disabled: every control in it
-              would fail, including one that downloads two Windows binaries. */}
-          {isWindows && caps.frostmod && (
+              would fail, including one that downloads two Windows binaries. The nav drops
+              its entry on the same condition. */}
+          {isWindows && caps.frostmod && active === "frostmod" && (
           <Section
             title={t("settings.frostmod")}
-            innerRef={(el) => (refs.current.frostmod = el)}
             titleRight={
               <span
                 className={cn(
@@ -1510,16 +1539,15 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
 
           {/* reshade — post-processing presets. Not gated on a capability: both titles are
               OpenGL, so ReShade attaches to either one the same way. */}
-          <Section
-            title={t("settings.reshade")}
-            desc={t("settings.reshadeDesc")}
-            innerRef={(el) => (refs.current.reshade = el)}
-          >
+          {active === "reshade" && (
+          <Section title={t("settings.reshade")} desc={t("settings.reshadeDesc")}>
             <ReshadeCard />
           </Section>
+          )}
 
           {/* experimental */}
-          <Section title={t("settings.experimental")} innerRef={() => {}}>
+          {active === "experimental" && (
+          <Section title={t("settings.experimental")}>
             <ToggleRow
               label={t("settings.experimentalServers")}
               desc={
@@ -1542,16 +1570,14 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
               }}
             />
           </Section>
+          )}
 
           {/* logs — the first thing any bug report asks for, and the one thing a player
               has no way to find on their own: MXB App's log dir is buried in AppData, and
               the game writes its own beside the executable. Both are named here, either
               can be opened, and the pair zips into one file to attach. */}
-          <Section
-            title={t("settings.logs")}
-            desc={t("logs.desc")}
-            innerRef={(el) => (refs.current.logs = el)}
-          >
+          {active === "logs" && (
+          <Section title={t("settings.logs")} desc={t("logs.desc")}>
             <LogRow
               label={t("logs.appLogs")}
               hint={t("logs.appLogsDesc")}
@@ -1590,20 +1616,23 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
               {t("logs.privacy")}
             </p>
           </Section>
+          )}
 
-          {/* supporters — who's buying the coffees that pay for the app. Above About
-              rather than inside it: a thank-you buried under the version number and the
-              update button is one nobody reads. */}
+          {/* supporters — who's buying the coffees that pay for the app. Its own entry
+              rather than a footnote under About: a thank-you buried under the version
+              number and the update button is one nobody reads. */}
+          {active === "supporters" && (
           <Section
             title={t("settings.supporters")}
             desc={t("settings.supportersDesc")}
-            innerRef={(el) => (refs.current.supporters = el)}
           >
             <SupportersCard />
           </Section>
+          )}
 
           {/* about */}
-          <Section title={t("settings.about")} innerRef={(el) => (refs.current.about = el)}>
+          {active === "about" && (
+          <Section title={t("settings.about")}>
             <div className="flex items-center gap-3 text-[12px] text-muted-foreground">
               <span>{shownVersion ? `mxb-app v${shownVersion}` : "mxb-app"}</span>
               {experimental?.prerelease && (
@@ -1661,6 +1690,7 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
               </div>
             </div>
           </Section>
+          )}
         </div>
       </div>
     </div>
@@ -1813,7 +1843,8 @@ function ToggleRow({
   disabled = false,
 }: {
   label: string;
-  desc: string;
+  /** Optional — a label that already says it doesn't need a line under it repeating it. */
+  desc?: string;
   checked: boolean;
   onChange: (v: boolean) => void;
   disabled?: boolean;
@@ -1822,9 +1853,11 @@ function ToggleRow({
     <div className={cn("flex items-start justify-between gap-4", disabled && "opacity-60")}>
       <div className="flex flex-col gap-0.5">
         <span className="text-[12.5px] text-foreground/85">{label}</span>
-        <span className="text-[11.5px] leading-relaxed text-muted-foreground">
-          {desc}
-        </span>
+        {desc && (
+          <span className="text-[11.5px] leading-relaxed text-muted-foreground">
+            {desc}
+          </span>
+        )}
       </div>
       <div className="pt-0.5">
         <Switch checked={checked} onCheckedChange={onChange} disabled={disabled} />
@@ -1872,20 +1905,15 @@ function Section({
   title,
   desc,
   titleRight,
-  innerRef,
   children,
 }: {
   title: string;
   desc?: string;
   titleRight?: React.ReactNode;
-  innerRef: (el: HTMLDivElement | null) => void;
   children: React.ReactNode;
 }) {
   return (
-    <div
-      ref={innerRef}
-      className="flex scroll-mt-4 flex-col gap-3 rounded-xl border border-input bg-card p-[18px]"
-    >
+    <div className="flex flex-col gap-3 rounded-xl border border-input bg-card p-[18px]">
       <div className="flex items-center gap-2">
         <span className="flex-1 text-[14px] font-bold">{title}</span>
         {titleRight}

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -429,6 +429,17 @@ export function reshadeStatus(): Promise<ReshadeStatus> {
   return invoke<ReshadeStatus>("reshade_status");
 }
 
+/**
+ * Point ReShade support at a folder of the player's choosing. Pass an empty string to clear
+ * it, back to the game's install dir.
+ *
+ * Taken as given, ReShade there or not — {@link reshadeStatus} reports what's actually in the
+ * folder on the very next read, which is a better answer than a rejected pick.
+ */
+export function setReshadePath(path: string): Promise<void> {
+  return invoke<void>("set_reshade_path", { path });
+}
+
 /** Make `name` the active preset. `RESHADE_OFF` is the no-effects preset. */
 export function applyReshadePreset(name: string): Promise<ReshadeApplyOutcome> {
   return invoke<ReshadeApplyOutcome>("apply_reshade_preset", { name });

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -541,6 +541,10 @@ export const de: Translation = {
   // ── Einstellungen ──────────────────────────────────────────────────────────
   "settings.help":
     "Konfiguriere deinen Spielordner, Updates und App-Einstellungen.",
+  "settings.groupSetup": "Einrichtung",
+  "settings.groupApp": "App",
+  "settings.groupAdvanced": "Erweitert",
+  "settings.groupAbout": "Über",
   "settings.gameFolder": "Spielordner",
   "settings.general": "Allgemein",
   "settings.appearance": "Darstellung",
@@ -1078,13 +1082,9 @@ export const de: Translation = {
   "overlay.notWorkingDesc": "Prüfe das Kürzel oben: eine andere App hat diese Kombination womöglich schon, und eine freie zu wählen ist die Lösung.",
   // Voice chat — devices and levels.
   "voice.section": "Voice-Chat",
-  "voice.sectionDesc": "Dein Mikrofon, dein Headset und die Taste, die das Mikro öffnet.",
   "voice.enable": "Voice-Chat aktivieren",
-  "voice.enableDesc": "Standardmäßig aus. Wenn er an ist, öffnet die Push-to-Talk-Taste dein Mikrofon, solange du sie hältst.",
   "voice.microphone": "Mikrofon",
-  "voice.microphoneDesc": "Lass es auf dem Systemstandard, dann folgt es dem, was du in Windows einstellst.",
   "voice.output": "Ausgabe",
-  "voice.outputDesc": "Wo die anderen Fahrer rauskommen. Getrennt vom Spiel-Audio, damit das Spiel auf den Boxen bleiben kann.",
   "voice.systemDefault": "Systemstandard",
   "voice.testMic": "Mikro testen",
   "voice.stopTest": "Stopp",
@@ -1094,7 +1094,6 @@ export const de: Translation = {
   "voice.micGain": "Mikrofonverstärkung",
   "voice.volume": "Lautstärke",
   "voice.ptt": "Push-to-Talk",
-  "voice.pttDesc": "Funktioniert, während das Spiel im Vordergrund ist. Halten zum Sprechen, loslassen zum Beenden.",
   "voice.pttUpdated": "Push-to-Talk-Taste aktualisiert",
   "voice.micFailed": "Mikrofon konnte nicht geöffnet werden",
   "voice.outputFailed": "Testton konnte nicht abgespielt werden",
@@ -1400,7 +1399,15 @@ export const de: Translation = {
   "modType.reshade": "ReShade",
   "modType.reshadeInline": "ReShade-Presets",
   "reshade.needsGameFolder":
-    "Lege oben deinen {{game}}-Ordner fest, dann erscheinen die ReShade-Presets hier.",
+    "ReShade liegt in deinem {{game}}-Ordner — lege den unter Spielordner fest, oder zeige hier direkt darauf.",
+  "reshade.folder": "Gesucht wird in deinem {{game}}-Ordner:",
+  "reshade.customFolder": "Gesucht wird in dem Ordner, den du gewählt hast:",
+  "reshade.browse": "Ordner wählen…",
+  "reshade.pickFolder": "Wähle den Ordner, in dem ReShade installiert ist",
+  "reshade.folderMissing": "Den gewählten Ordner gibt es nicht mehr.",
+  "reshade.resetFolder": "Zurück zum {{game}}-Ordner",
+  "reshade.folderSet": "ReShade gefunden",
+  "reshade.notThere": "Kein ReShade in diesem Ordner",
   "reshade.intro":
     "ReShade fügt {{game}} Postprocessing hinzu. Es ist ein separates, kostenloses Tool — einmal installieren, dann hier ein Preset wählen.",
   "reshade.wrongApi":

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -522,6 +522,11 @@ export const en = {
 
   // ── Settings ───────────────────────────────────────────────────────────────
   "settings.help": "Configure your game folder, updates, and app preferences.",
+  // Nav groups. One section shows at a time; these head the list on the left.
+  "settings.groupSetup": "Setup",
+  "settings.groupApp": "App",
+  "settings.groupAdvanced": "Advanced",
+  "settings.groupAbout": "About",
   "settings.gameFolder": "Game folder",
   "settings.general": "General",
   "settings.appearance": "Appearance",
@@ -1036,13 +1041,9 @@ export const en = {
   // Voice chat — devices and levels. The transport that carries this to other riders
   // isn't built yet; `voice.notConnected*` is what says so on the page.
   "voice.section": "Voice chat",
-  "voice.sectionDesc": "Your microphone, your headset, and the key that opens the mic.",
   "voice.enable": "Enable voice chat",
-  "voice.enableDesc": "Off until you turn it on. While it's on, holding the push-to-talk key opens your microphone.",
   "voice.microphone": "Microphone",
-  "voice.microphoneDesc": "Leave it on the system default and it follows whatever you set in Windows.",
   "voice.output": "Output",
-  "voice.outputDesc": "Where other riders come out. Separate from game audio, so you can keep the game on speakers.",
   "voice.systemDefault": "System default",
   "voice.testMic": "Test mic",
   "voice.stopTest": "Stop",
@@ -1052,7 +1053,6 @@ export const en = {
   "voice.micGain": "Microphone gain",
   "voice.volume": "Volume",
   "voice.ptt": "Push to talk",
-  "voice.pttDesc": "Works while the game has focus. Hold it to talk, release to stop.",
   "voice.pttUpdated": "Push-to-talk key updated",
   "voice.micFailed": "Couldn't open the microphone",
   "voice.outputFailed": "Couldn't play the test tone",
@@ -1357,7 +1357,15 @@ export const en = {
   "modType.reshade": "ReShade",
   "modType.reshadeInline": "ReShade presets",
   "reshade.needsGameFolder":
-    "Set your {{game}} folder above and ReShade presets show up here.",
+    "ReShade sits in your {{game}} folder — set that under Game folder, or point straight at it here.",
+  "reshade.folder": "Looking in your {{game}} folder:",
+  "reshade.customFolder": "Looking in the folder you picked:",
+  "reshade.browse": "Choose folder…",
+  "reshade.pickFolder": "Choose the folder ReShade is installed in",
+  "reshade.folderMissing": "The folder you picked isn't there any more.",
+  "reshade.resetFolder": "Go back to the {{game}} folder",
+  "reshade.folderSet": "ReShade found",
+  "reshade.notThere": "No ReShade in that folder",
   "reshade.intro":
     "ReShade adds post-processing to {{game}}. It's a separate free tool — install it once, then pick a preset here.",
   "reshade.wrongApi":

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -533,6 +533,10 @@ export const es: Translation = {
   // ── Ajustes ────────────────────────────────────────────────────────────────
   "settings.help":
     "Configura tu carpeta de juego, las actualizaciones y las preferencias de la aplicación.",
+  "settings.groupSetup": "Configuración",
+  "settings.groupApp": "App",
+  "settings.groupAdvanced": "Avanzado",
+  "settings.groupAbout": "Acerca de",
   "settings.gameFolder": "Carpeta del juego",
   "settings.general": "General",
   "settings.appearance": "Apariencia",
@@ -1066,13 +1070,9 @@ export const es: Translation = {
   "overlay.notWorkingDesc": "Revisa el atajo de arriba: puede que otra aplicación ya tenga esa combinación, y elegir una libre es lo que lo arregla.",
   // Voice chat — devices and levels.
   "voice.section": "Chat de voz",
-  "voice.sectionDesc": "Tu micrófono, tus auriculares y la tecla que abre el micro.",
   "voice.enable": "Activar el chat de voz",
-  "voice.enableDesc": "Desactivado hasta que lo actives. Mientras esté activo, mantener la tecla de pulsar para hablar abre tu micrófono.",
   "voice.microphone": "Micrófono",
-  "voice.microphoneDesc": "Déjalo en el predeterminado del sistema y seguirá lo que configures en Windows.",
   "voice.output": "Salida",
-  "voice.outputDesc": "Por dónde salen los demás pilotos. Independiente del audio del juego, así puedes dejar el juego en los altavoces.",
   "voice.systemDefault": "Predeterminado del sistema",
   "voice.testMic": "Probar micro",
   "voice.stopTest": "Parar",
@@ -1082,7 +1082,6 @@ export const es: Translation = {
   "voice.micGain": "Ganancia del micrófono",
   "voice.volume": "Volumen",
   "voice.ptt": "Pulsar para hablar",
-  "voice.pttDesc": "Funciona mientras el juego tiene el foco. Mantén para hablar, suelta para parar.",
   "voice.pttUpdated": "Tecla de pulsar para hablar actualizada",
   "voice.micFailed": "No se pudo abrir el micrófono",
   "voice.outputFailed": "No se pudo reproducir el tono de prueba",
@@ -1387,7 +1386,15 @@ export const es: Translation = {
   "modType.reshade": "ReShade",
   "modType.reshadeInline": "ajustes de ReShade",
   "reshade.needsGameFolder":
-    "Configura la carpeta de {{game}} arriba y los ajustes de ReShade aparecerán aquí.",
+    "ReShade está en tu carpeta de {{game}} — configúrala en Carpeta del juego, o apunta directamente aquí.",
+  "reshade.folder": "Buscando en tu carpeta de {{game}}:",
+  "reshade.customFolder": "Buscando en la carpeta que elegiste:",
+  "reshade.browse": "Elegir carpeta…",
+  "reshade.pickFolder": "Elige la carpeta donde está instalado ReShade",
+  "reshade.folderMissing": "La carpeta que elegiste ya no está.",
+  "reshade.resetFolder": "Volver a la carpeta de {{game}}",
+  "reshade.folderSet": "ReShade encontrado",
+  "reshade.notThere": "No hay ReShade en esa carpeta",
   "reshade.intro":
     "ReShade añade posprocesado a {{game}}. Es una herramienta gratuita aparte: instálala una vez y luego elige un ajuste aquí.",
   "reshade.wrongApi":

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -537,6 +537,10 @@ export const fr: Translation = {
   // ── Réglages ───────────────────────────────────────────────────────────────
   "settings.help":
     "Configurez votre dossier de jeu, les mises à jour et les préférences de l'application.",
+  "settings.groupSetup": "Configuration",
+  "settings.groupApp": "App",
+  "settings.groupAdvanced": "Avancé",
+  "settings.groupAbout": "À propos",
   "settings.gameFolder": "Dossier de jeu",
   "settings.general": "Général",
   "settings.appearance": "Apparence",
@@ -1069,13 +1073,9 @@ export const fr: Translation = {
   "overlay.notWorkingDesc": "Vérifie le raccourci ci-dessus : une autre application a peut-être déjà cette combinaison, et en choisir une libre suffit à régler ça.",
   // Voice chat — devices and levels.
   "voice.section": "Chat vocal",
-  "voice.sectionDesc": "Ton micro, ton casque et la touche qui ouvre le micro.",
   "voice.enable": "Activer le chat vocal",
-  "voice.enableDesc": "Désactivé tant que tu ne l'actives pas. Une fois actif, maintenir la touche push-to-talk ouvre ton micro.",
   "voice.microphone": "Microphone",
-  "voice.microphoneDesc": "Laisse-le sur le périphérique par défaut et il suivra ce que tu règles dans Windows.",
   "voice.output": "Sortie",
-  "voice.outputDesc": "Par où sortent les autres pilotes. Séparé du son du jeu, pour garder le jeu sur les enceintes.",
   "voice.systemDefault": "Périphérique par défaut",
   "voice.testMic": "Tester le micro",
   "voice.stopTest": "Arrêter",
@@ -1085,7 +1085,6 @@ export const fr: Translation = {
   "voice.micGain": "Gain du microphone",
   "voice.volume": "Volume",
   "voice.ptt": "Push-to-talk",
-  "voice.pttDesc": "Fonctionne quand le jeu a le focus. Maintiens pour parler, relâche pour arrêter.",
   "voice.pttUpdated": "Touche push-to-talk mise à jour",
   "voice.micFailed": "Impossible d'ouvrir le microphone",
   "voice.outputFailed": "Impossible de jouer le son test",
@@ -1390,7 +1389,15 @@ export const fr: Translation = {
   "modType.reshade": "ReShade",
   "modType.reshadeInline": "préréglages ReShade",
   "reshade.needsGameFolder":
-    "Indique ton dossier {{game}} ci-dessus et les préréglages ReShade apparaîtront ici.",
+    "ReShade se trouve dans ton dossier {{game}} — indique-le dans Dossier de jeu, ou pointe directement dessus ici.",
+  "reshade.folder": "Recherche dans ton dossier {{game}} :",
+  "reshade.customFolder": "Recherche dans le dossier que tu as choisi :",
+  "reshade.browse": "Choisir un dossier…",
+  "reshade.pickFolder": "Choisis le dossier où ReShade est installé",
+  "reshade.folderMissing": "Le dossier que tu as choisi n'existe plus.",
+  "reshade.resetFolder": "Revenir au dossier {{game}}",
+  "reshade.folderSet": "ReShade trouvé",
+  "reshade.notThere": "Pas de ReShade dans ce dossier",
   "reshade.intro":
     "ReShade ajoute du post-traitement à {{game}}. C'est un outil gratuit distinct : installe-le une fois, puis choisis un préréglage ici.",
   "reshade.wrongApi":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -529,6 +529,10 @@ export const it: Translation = {
   // ── Impostazioni ───────────────────────────────────────────────────────────
   "settings.help":
     "Configura la cartella di gioco, gli aggiornamenti e le preferenze dell'app.",
+  "settings.groupSetup": "Configurazione",
+  "settings.groupApp": "App",
+  "settings.groupAdvanced": "Avanzate",
+  "settings.groupAbout": "Info",
   "settings.gameFolder": "Cartella di gioco",
   "settings.general": "Generali",
   "settings.appearance": "Aspetto",
@@ -1058,13 +1062,9 @@ export const it: Translation = {
   "overlay.notWorkingDesc": "Controlla la scorciatoia qui sopra: un'altra app potrebbe già avere quella combinazione, e sceglierne una libera è ciò che risolve.",
   // Voice chat — devices and levels.
   "voice.section": "Chat vocale",
-  "voice.sectionDesc": "Il tuo microfono, le tue cuffie e il tasto che apre il micro.",
   "voice.enable": "Attiva la chat vocale",
-  "voice.enableDesc": "Disattivata finché non la accendi. Quando è attiva, tenere premuto il tasto push-to-talk apre il microfono.",
   "voice.microphone": "Microfono",
-  "voice.microphoneDesc": "Lascialo sul predefinito di sistema e seguirà quello che imposti in Windows.",
   "voice.output": "Uscita",
-  "voice.outputDesc": "Da dove escono gli altri piloti. Separata dall'audio del gioco, così puoi tenere il gioco sulle casse.",
   "voice.systemDefault": "Predefinito di sistema",
   "voice.testMic": "Prova il micro",
   "voice.stopTest": "Ferma",
@@ -1074,7 +1074,6 @@ export const it: Translation = {
   "voice.micGain": "Guadagno del microfono",
   "voice.volume": "Volume",
   "voice.ptt": "Push-to-talk",
-  "voice.pttDesc": "Funziona mentre il gioco ha il focus. Tieni premuto per parlare, rilascia per smettere.",
   "voice.pttUpdated": "Tasto push-to-talk aggiornato",
   "voice.micFailed": "Impossibile aprire il microfono",
   "voice.outputFailed": "Impossibile riprodurre il tono di prova",
@@ -1379,7 +1378,15 @@ export const it: Translation = {
   "modType.reshade": "ReShade",
   "modType.reshadeInline": "preset ReShade",
   "reshade.needsGameFolder":
-    "Imposta la cartella di {{game}} qui sopra e i preset ReShade compariranno qui.",
+    "ReShade sta nella tua cartella di {{game}} — impostala in Cartella di gioco, oppure puntala direttamente qui.",
+  "reshade.folder": "Sto guardando nella tua cartella di {{game}}:",
+  "reshade.customFolder": "Sto guardando nella cartella che hai scelto:",
+  "reshade.browse": "Scegli cartella…",
+  "reshade.pickFolder": "Scegli la cartella in cui è installato ReShade",
+  "reshade.folderMissing": "La cartella che hai scelto non c'è più.",
+  "reshade.resetFolder": "Torna alla cartella di {{game}}",
+  "reshade.folderSet": "ReShade trovato",
+  "reshade.notThere": "Nessun ReShade in quella cartella",
   "reshade.intro":
     "ReShade aggiunge il post-processing a {{game}}. È uno strumento gratuito a parte: installalo una volta, poi scegli un preset qui.",
   "reshade.wrongApi":

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -534,6 +534,10 @@ export const ptBR: Translation = {
   // ── Configurações ──────────────────────────────────────────────────────────
   "settings.help":
     "Configure sua pasta do jogo, as atualizações e as preferências do app.",
+  "settings.groupSetup": "Configuração",
+  "settings.groupApp": "App",
+  "settings.groupAdvanced": "Avançado",
+  "settings.groupAbout": "Sobre",
   "settings.gameFolder": "Pasta do jogo",
   "settings.general": "Geral",
   "settings.appearance": "Aparência",
@@ -1058,13 +1062,9 @@ export const ptBR: Translation = {
   "overlay.notWorkingDesc": "Confira o atalho acima: outro app pode já ter essa combinação, e escolher uma livre é o que resolve.",
   // Voice chat — devices and levels.
   "voice.section": "Chat de voz",
-  "voice.sectionDesc": "Seu microfone, seu fone e a tecla que abre o microfone.",
   "voice.enable": "Ativar o chat de voz",
-  "voice.enableDesc": "Desligado até você ativar. Com ele ligado, segurar a tecla de apertar para falar abre seu microfone.",
   "voice.microphone": "Microfone",
-  "voice.microphoneDesc": "Deixe no padrão do sistema e ele segue o que você configurar no Windows.",
   "voice.output": "Saída",
-  "voice.outputDesc": "Por onde os outros pilotos saem. Separada do áudio do jogo, então dá para deixar o jogo nas caixas.",
   "voice.systemDefault": "Padrão do sistema",
   "voice.testMic": "Testar microfone",
   "voice.stopTest": "Parar",
@@ -1074,7 +1074,6 @@ export const ptBR: Translation = {
   "voice.micGain": "Ganho do microfone",
   "voice.volume": "Volume",
   "voice.ptt": "Apertar para falar",
-  "voice.pttDesc": "Funciona enquanto o jogo está em foco. Segure para falar, solte para parar.",
   "voice.pttUpdated": "Tecla de apertar para falar atualizada",
   "voice.micFailed": "Não foi possível abrir o microfone",
   "voice.outputFailed": "Não foi possível tocar o tom de teste",
@@ -1379,7 +1378,15 @@ export const ptBR: Translation = {
   "modType.reshade": "ReShade",
   "modType.reshadeInline": "presets do ReShade",
   "reshade.needsGameFolder":
-    "Defina a pasta do {{game}} acima e os presets do ReShade aparecem aqui.",
+    "O ReShade fica na sua pasta do {{game}} — defina ela em Pasta do jogo, ou aponte direto para ela aqui.",
+  "reshade.folder": "Procurando na sua pasta do {{game}}:",
+  "reshade.customFolder": "Procurando na pasta que você escolheu:",
+  "reshade.browse": "Escolher pasta…",
+  "reshade.pickFolder": "Escolha a pasta onde o ReShade está instalado",
+  "reshade.folderMissing": "A pasta que você escolheu não está mais lá.",
+  "reshade.resetFolder": "Voltar para a pasta do {{game}}",
+  "reshade.folderSet": "ReShade encontrado",
+  "reshade.notThere": "Nenhum ReShade nessa pasta",
   "reshade.intro":
     "O ReShade adiciona pós-processamento ao {{game}}. É uma ferramenta gratuita à parte: instale uma vez e depois escolha um preset aqui.",
   "reshade.wrongApi":

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,6 +59,7 @@ export interface GamePaths {
   modsPath?: string;
   gamePath?: string;
   profilesPath?: string;
+  reshadePath?: string;
 }
 
 export interface Config {
@@ -76,6 +77,12 @@ export interface Config {
    * `<modsPath>/profiles`; set only when profiles sit outside the game folder.
    */
   profilesPath?: string;
+  /**
+   * Override for the folder ReShade is installed in. Empty (normal) means the game's
+   * install dir. Kept apart from `gamePath` on purpose: that one also drives `rider.pkz`
+   * lookup, the game log folder and launching.
+   */
+  reshadePath?: string;
   /**
    * macOS: the Wine binary that starts the game. Empty (normal) means auto-detected.
    * Ignored on Windows and Linux.
@@ -690,8 +697,12 @@ export interface ReshadePreset {
 
 /** State of the ReShade install and its presets. Mirrors `reshade::Status`. */
 export interface ReshadeStatus {
-  /** The game's install dir. Empty means it isn't configured — "don't know", not "absent". */
+  /** The folder we looked in. Empty means none is configured — "don't know", not "absent". */
   gameDir: string;
+  /** That folder is the player's `reshadePath` override rather than the game's install dir. */
+  custom: boolean;
+  /** A folder is configured and isn't there — distinct from never having picked one. */
+  folderMissing: boolean;
   /** A ReShade `opengl32.dll` is in place. MX Bikes and GP Bikes are OpenGL. */
   installed: boolean;
   /** ReShade is here under a DirectX name these games never load — a fixable mistake. */


### PR DESCRIPTION
Three things, all in Settings.

## Settings shows one section at a time

Twelve sections rendered into a single column meant the game folders and the version number shared a scrollbar, and the nav on the left only scrolled you to an anchor in it. The nav is now grouped and each entry opens its own pane:

| Setup | App | Advanced | About |
| --- | --- | --- | --- |
| Game*, Game folder, FrostMod*, ReShade | General, Appearance, In-game overlay, Voice chat | Logs, Experimental | Supporters, About & updates |

<sub>* shown on the same conditions as before — the game picker only in a multi-game build, FrostMod only on Windows with `caps.frostmod`. A group left with nothing in it drops out of the nav.</sub>

**Experimental** was in that column with nothing in the nav pointing at it. It has an entry now. No section's controls changed.

Two things fell out of the rewrite:

- A mic left testing now stops when you leave the Voice pane. `micTesting` lives on `Settings`, not in the section, so without this it would keep the microphone open behind a pane that isn't on screen.
- A deep link to a section this build doesn't have — `initialSection="frostmod"` on a Mac — falls back to the first section there is. With everything rendered at once that case was a missing card; with one pane on screen it would have been an empty page.

## A folder picker for ReShade

The card read `install_dir()` and nothing else, so an unset or wrongly-detected game folder produced "not installed" for people with ReShade sitting right there, and offered nothing to do about it. It now names the folder it looked in — without that, "not installed" is unarguable — and takes a pick of the player's own.

That pick is a new `reshade_path`, **not** a write to `game_path`. The game folder also drives `rider.pkz` lookup, the game log location and Play; a wrong pick made from this card must only ever be able to break ReShade. It's per-game alongside the other folders in `GamePaths`, and `reshade_dir()` falls back to `install_dir()` when blank — the normal case, since ReShade has to sit beside the executable to load at all. Every ReShade call site moves to it; no other `install_dir()` caller changes.

The pick is taken as given whether or not ReShade is in it, warning rather than refusing — the same rule `changeProfilesFolder` already follows, and the card re-reads immediately and says which. `Status` also grew `folder_missing`, so a folder that has since moved is reported as that instead of collapsing into "set your game folder" and throwing the path away.

## Voice chat settings read shorter

Five help lines under controls whose labels already said the same thing are gone — a picker labelled "Microphone" didn't need a sentence under it explaining that it picks a microphone. Removed as keys from all six locales, not just unwired. What stays is what the labels can't say: that nothing transmits yet, and what the test buttons do.

## Verification

- `bun run typecheck` and `bun run lint` clean. Typecheck is the real gate on the locale work — every locale is `Record<keyof typeof en, string>`, so a key added or removed in one file and not the others fails the build.
- 649 Rust tests pass, including three new ones: presets are read from and written to whichever folder `status`/`apply` are given, a configured-but-missing folder is named rather than blanked, and the never-configured case still reports "don't know".
- `cargo check --target x86_64-pc-windows-gnu` clean.
- App builds and launches with no errors in the dev log.

**Not verified:** no screenshots — screen recording wasn't available on the machine this was built on, so the new layout has not been looked at. Worth a glance at the nav group headings in the 170px column before this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)