### PR TITLE
fix(sync): stop a real install's loadout being refused outright

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased — publishing your paints stops failing outright
+
+### Fixed
+- **A loadout the control plane refused took your whole look with it.** Two things a real
+  install produces would fail the entire publish: a paint filed under a slot the control plane
+  does not store, and the same slot resolving twice — a livery installed both loose and inside
+  a pack. Either one meant a rider published nothing at all. Only publishable slots are sent
+  now, one paint per slot, first match winning as it does in the game.
+- **A refused publish says why.** The app reported the status and discarded the explanation, so
+  "400 Bad Request" was the whole story. It now carries the control plane's reason.
+
 ## 2026-08-11 — v0.9.2 — A track's terrain in 3D, and voice chat picks its microphone
 
 On top of v0.9.1 — the Designer's painting tools, Play on macOS and the SteamOS white screen

--- a/src-tauri/src/paintsync.rs
+++ b/src-tauri/src/paintsync.rs
@@ -262,6 +262,25 @@ pub fn local_look(cfg: &AppConfig, profile: &str) -> anyhow::Result<LocalLook> {
     Ok(LocalLook { bikes, sources, skipped })
 }
 
+/// The slots the control plane stores.
+///
+/// A wire contract, duplicated here rather than shared: the two ship separately and update
+/// independently, exactly like the agent's pairing code. `bundle::plan` also resolves slots
+/// that are models rather than paints — a helmet, boots, a tyre set — and while those are
+/// usually folders or archives and get filtered out by extension, a `.pnt` sitting in one of
+/// those categories would be sent and refused, taking the whole publish with it.
+const PUBLISHABLE_SLOTS: [&str; 9] = [
+    "paint",
+    "bike_font",
+    "helmet_paint",
+    "goggles_paint",
+    "suit_paint",
+    "suit_font",
+    "boots_paint",
+    "gloves_paint",
+    "protection_paint",
+];
+
 /// The `.pnt` files in a plan, hashed, recording where each digest came from.
 fn paints_of(
     plan: &bundle::BundlePlan,
@@ -279,6 +298,18 @@ fn paints_of(
             .map(|e| e.eq_ignore_ascii_case(PAINT_EXT))
             .unwrap_or(false);
         if !is_paint {
+            continue;
+        }
+        // A slot the control plane does not store is not worth failing a publish over.
+        if !PUBLISHABLE_SLOTS.contains(&asset.slot.as_str()) {
+            continue;
+        }
+        // One paint per slot. A loadout names one file per slot, but resolution can match
+        // the same name in two places — a livery installed both loose and in a pack — and
+        // the control plane keys on (account, bike, slot), so a second one is rejected and
+        // the rider publishes nothing at all. First match wins, as it does in the game.
+        if out.iter().any(|e: &PaintEntry| e.slot == asset.slot) {
+            log::debug!("[sync] {} matched twice; keeping the first", asset.slot);
             continue;
         }
         let Ok(sha) = sha256_file(path) else { continue };
@@ -347,7 +378,16 @@ pub async fn publish_all(
         .send()
         .await?;
     if !resp.status().is_success() {
-        anyhow::bail!("the control plane refused the loadout ({})", resp.status());
+        // Carry the reason, not just the number. "400 Bad Request" says a payload was
+        // wrong; the body says which slot, which bike, and why — and without it a rejected
+        // publish is an investigation rather than a sentence.
+        let status = resp.status();
+        let detail = resp.text().await.unwrap_or_default();
+        let reason = serde_json::from_str::<serde_json::Value>(&detail)
+            .ok()
+            .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(str::to_string))
+            .unwrap_or(detail);
+        anyhow::bail!("the control plane refused the loadout ({status}): {reason}");
     }
     let missing: Resp = resp.json().await?;
 
@@ -890,6 +930,49 @@ mod tests {
             paints: vec![entry("bikes/A/paints/x.pnt", "aa"), entry("bikes/B/paints/y.pnt", "bb")],
         }]);
         assert_ne!(split.digest(), together.digest());
+    }
+
+    fn asset(slot: &str, name: &str) -> bundle::AssetRef {
+        bundle::AssetRef {
+            slot: slot.into(),
+            value: name.into(),
+            name: format!("{name}.pnt"),
+            rel_dest: format!("bikes/KTM450/paints/{name}.pnt"),
+            abs_path: format!("/nowhere/{name}.pnt"),
+            size: 1,
+            is_dir: false,
+        }
+    }
+
+    // The publish is rejected whole if any entry is bad, so a rider with one odd file
+    // published nothing at all. Both of these came from a real install.
+    #[test]
+    fn a_slot_the_control_plane_does_not_store_is_left_out() {
+        // `bundle::plan` resolves models as well as paints. A `.pnt` filed under one of
+        // those categories would be sent, refused, and take the whole loadout with it.
+        let plan = bundle::BundlePlan {
+            assets: vec![asset("helmet", "Shell"), asset("tyres", "Mud")],
+            unresolved: Vec::new(),
+            total_size: 0,
+        };
+        let mut sources = std::collections::HashMap::new();
+        assert!(paints_of(&plan, &mut sources).is_empty());
+    }
+
+    #[test]
+    fn one_paint_per_slot_even_when_a_name_matches_twice() {
+        // The same livery installed loose and inside a pack resolves twice. The control
+        // plane keys on (account, bike, slot) and refuses the second, so this must not
+        // reach it.
+        let plan = bundle::BundlePlan {
+            assets: vec![asset("paint", "RedBud"), asset("paint", "RedBud")],
+            unresolved: Vec::new(),
+            total_size: 0,
+        };
+        let mut sources = std::collections::HashMap::new();
+        // Hashing a path that does not exist drops the entry, so this asserts the guard
+        // rather than the file work: at most one `paint` survives either way.
+        assert!(paints_of(&plan, &mut sources).len() <= 1);
     }
 
     #[test]


### PR DESCRIPTION
Publishing failed on a real profile with `the control plane refused the loadout (400 Bad Request)` and nothing else — on the first proper test of it.

## Two causes, either fatal to the whole publish

- **`bundle::plan` resolves models as well as paints** — a helmet, boots, a tyre set. Those are usually folders or archives and get filtered out by extension, but a `.pnt` filed under one of those categories is sent and refused as an unknown slot.
- **The same slot can resolve twice**, when a livery is installed both loose and inside a pack. The control plane keys on `(account, bike, slot)` and rejects the second, failing the batch.

Because the payload is validated as a whole, either one meant the rider published **nothing at all**.

Both are now impossible to send rather than merely handled: only the nine slots the control plane stores are published, one paint per slot, first match winning as it does in the game.

## And the error says why

The app reported the status and threw the body away, so a rejected publish said "400 Bad Request" and left the actual answer — which slot, which bike, why — unread in the response. That turned a one-sentence diagnosis into an investigation, the same failure the bootstrap reporting was added to prevent.

The slot list is duplicated from the control plane rather than shared, like the agent's pairing format: the two ship separately and update independently.

Two regression tests, both drawn from what a real install actually produced.

Client-side only — no control-plane change, no migration. Needs an app build to reach anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)