### PR TITLE
fix(sync): raise the paint size limit, and skip what still will not fit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased — a big livery no longer stops you publishing anything
+
+### Fixed
+- **Paints larger than 32 MB were refused, and took the whole publish with them.** A 4K livery
+  runs well past that: the largest on a normal install is 121.7 MB. Because a loadout is
+  checked as a whole, owning one such paint meant publishing nothing at all and looking default
+  to everyone. The limit is now 192 MB, and anything still over it is left behind — and said
+  out loud — rather than failing the rest.
+
 ## Unreleased — publishing your paints stops failing outright
 
 ### Fixed

--- a/control-plane/src/validate.ts
+++ b/control-plane/src/validate.ts
@@ -110,7 +110,18 @@ export function isRelDest(value: unknown): value is string {
 }
 
 /** Paints are single-digit megabytes; anything far past that is not a paint. */
-export const MAX_PAINT_BYTES = 32 * 1024 * 1024;
+/**
+ * The largest paint that may be published.
+ *
+ * Was 32 MiB, which real content simply exceeds: a 4K livery runs well past it, and the
+ * biggest on a normal install measured 121.7 MB. Every paint over the limit was refused, and
+ * because a loadout is validated as a whole, one of them meant the rider published nothing.
+ *
+ * 192 MiB clears the largest seen with room to spare while still being a bound. It is not
+ * free — every other rider on the server downloads these — which is the argument for the app
+ * skipping the outliers rather than the limit going away.
+ */
+export const MAX_PAINT_BYTES = 192 * 1024 * 1024;
 
 export function isPaintSize(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value > 0 && value <= MAX_PAINT_BYTES;

--- a/src-tauri/src/paintsync.rs
+++ b/src-tauri/src/paintsync.rs
@@ -72,6 +72,8 @@ pub struct PublishOutcome {
     pub bikes: usize,
     /// Bikes past [`MAX_BIKES`] that were left out.
     pub skipped_bikes: usize,
+    /// Paints too large for the control plane to store, so nobody else will see them.
+    pub oversized_paints: usize,
     /// Digest of what was sent, for the caller to remember — see [`LocalLook::digest`].
     pub digest: String,
     /// The look already matched `known_digest`, so nothing was sent.
@@ -191,6 +193,9 @@ pub struct LocalLook {
     /// Bikes left out by [`MAX_BIKES`]. Reported rather than dropped quietly — a cap that
     /// silently covers less than it claims is indistinguishable from a bug.
     pub skipped: usize,
+    /// Paints too large to publish. Named for the same reason: a rider whose livery never
+    /// reaches anyone deserves to be told, not left wondering why they look default.
+    pub oversized: usize,
 }
 
 impl LocalLook {
@@ -249,9 +254,10 @@ pub fn local_look(cfg: &AppConfig, profile: &str) -> anyhow::Result<LocalLook> {
     let plans = bundle::plan_many(cfg, &loadouts.iter().map(|(_, l)| l.clone()).collect::<Vec<_>>());
 
     let mut sources = std::collections::HashMap::new();
+    let mut oversized = 0usize;
     let mut bikes = Vec::new();
     for ((bike_id, _), plan) in loadouts.into_iter().zip(plans) {
-        let paints = paints_of(&plan, &mut sources);
+        let paints = paints_of(&plan, &mut sources, &mut oversized);
         // A bike with nothing custom on it is not worth a row; the receiver would install
         // nothing and the roster would carry an empty entry for every bike ever ridden.
         if paints.is_empty() {
@@ -259,7 +265,7 @@ pub fn local_look(cfg: &AppConfig, profile: &str) -> anyhow::Result<LocalLook> {
         }
         bikes.push(BikeLoadout { bike_id, paints });
     }
-    Ok(LocalLook { bikes, sources, skipped })
+    Ok(LocalLook { bikes, sources, skipped, oversized })
 }
 
 /// The slots the control plane stores.
@@ -269,6 +275,11 @@ pub fn local_look(cfg: &AppConfig, profile: &str) -> anyhow::Result<LocalLook> {
 /// that are models rather than paints — a helmet, boots, a tyre set — and while those are
 /// usually folders or archives and get filtered out by extension, a `.pnt` sitting in one of
 /// those categories would be sent and refused, taking the whole publish with it.
+/// The largest paint the control plane will store, mirrored here for the same reason as
+/// [`PUBLISHABLE_SLOTS`]: a loadout is validated whole, so one file over the limit is a rider
+/// publishing nothing at all. Skipping it costs that one paint; sending it costs the lot.
+const MAX_PAINT_BYTES: u64 = 192 * 1024 * 1024;
+
 const PUBLISHABLE_SLOTS: [&str; 9] = [
     "paint",
     "bike_font",
@@ -285,6 +296,7 @@ const PUBLISHABLE_SLOTS: [&str; 9] = [
 fn paints_of(
     plan: &bundle::BundlePlan,
     sources: &mut std::collections::HashMap<String, PathBuf>,
+    oversized: &mut usize,
 ) -> Vec<PaintEntry> {
     let mut out = Vec::new();
     for asset in &plan.assets {
@@ -310,6 +322,16 @@ fn paints_of(
         // the rider publishes nothing at all. First match wins, as it does in the game.
         if out.iter().any(|e: &PaintEntry| e.slot == asset.slot) {
             log::debug!("[sync] {} matched twice; keeping the first", asset.slot);
+            continue;
+        }
+        if asset.size > MAX_PAINT_BYTES {
+            log::warn!(
+                "[sync] {} is {} MB, past the {} MB limit — not published",
+                asset.name,
+                asset.size / 1_048_576,
+                MAX_PAINT_BYTES / 1_048_576
+            );
+            *oversized += 1;
             continue;
         }
         let Ok(sha) = sha256_file(path) else { continue };
@@ -354,6 +376,7 @@ pub async fn publish_all(
             uploaded: 0,
             bikes: look.bikes.len(),
             skipped_bikes: look.skipped,
+            oversized_paints: look.oversized,
             digest,
             unchanged: true,
         });
@@ -415,6 +438,7 @@ pub async fn publish_all(
         uploaded,
         bikes: look.bikes.len(),
         skipped_bikes: look.skipped,
+        oversized_paints: look.oversized,
         digest,
         unchanged: false,
     })
@@ -883,7 +907,7 @@ mod tests {
     }
 
     fn look(bikes: Vec<BikeLoadout>) -> LocalLook {
-        LocalLook { bikes, sources: std::collections::HashMap::new(), skipped: 0 }
+        LocalLook { bikes, sources: std::collections::HashMap::new(), skipped: 0, oversized: 0 }
     }
 
     // The digest is what lets every path that might have changed a look publish without
@@ -956,7 +980,8 @@ mod tests {
             total_size: 0,
         };
         let mut sources = std::collections::HashMap::new();
-        assert!(paints_of(&plan, &mut sources).is_empty());
+        let mut big = 0;
+        assert!(paints_of(&plan, &mut sources, &mut big).is_empty());
     }
 
     #[test]
@@ -970,9 +995,27 @@ mod tests {
             total_size: 0,
         };
         let mut sources = std::collections::HashMap::new();
+        let mut big = 0;
         // Hashing a path that does not exist drops the entry, so this asserts the guard
         // rather than the file work: at most one `paint` survives either way.
-        assert!(paints_of(&plan, &mut sources).len() <= 1);
+        assert!(paints_of(&plan, &mut sources, &mut big).len() <= 1);
+    }
+
+    // Four paints on a normal install are past the old 32 MiB limit, the largest 121.7 MB.
+    // A loadout is validated whole, so one of them meant the rider published nothing at all.
+    #[test]
+    fn a_paint_too_large_to_store_is_left_behind_rather_than_failing_the_lot() {
+        let mut huge = asset("paint", "Enormous");
+        huge.size = MAX_PAINT_BYTES + 1;
+        let plan = bundle::BundlePlan {
+            assets: vec![huge, asset("helmet_paint", "Normal")],
+            unresolved: Vec::new(),
+            total_size: 0,
+        };
+        let mut sources = std::collections::HashMap::new();
+        let mut oversized = 0;
+        paints_of(&plan, &mut sources, &mut oversized);
+        assert_eq!(oversized, 1, "the outsized paint must be counted, not silently dropped");
     }
 
     #[test]

--- a/src/Components/Servers/Servers.tsx
+++ b/src/Components/Servers/Servers.tsx
@@ -531,6 +531,10 @@ const PaintSync = () => {
       );
       if (r.skippedBikes > 0)
         toast.warning(t("sync.skippedBikes", { count: r.skippedBikes }));
+      // A livery that never leaves the machine is worth saying out loud; otherwise the rider
+      // looks default to everyone else and nothing ever explains why.
+      if (r.oversizedPaints > 0)
+        toast.warning(t("sync.oversized", { count: r.oversizedPaints }));
       refresh();
     } catch (e) {
       toast.error(t("sync.publishFailed"), { description: String(e) });

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -1939,6 +1939,8 @@ export interface PublishOutcome {
   bikes: number;
   /** Bikes beyond the cap that were left out. */
   skippedBikes: number;
+  /** Paints too large for the control plane to store, so nobody else will see them. */
+  oversizedPaints: number;
   digest: string;
   /** The look already matched what was last sent, so nothing went up. */
   unchanged: boolean;

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -795,6 +795,8 @@ export const de: Translation = {
   "sync.lastPulled": "Zuletzt geprüft {{ago}}. Läuft von selbst wieder, wenn du auf Spielen drückst.",
   "sync.neverPulled": "Du hast noch keine Lackierungen der anderen geholt",
   "sync.neverPulledWhy": "Bis dahin erscheinen andere Fahrer mit Standard-Bikes, auch wenn sie ihre veröffentlicht haben.",
+  "sync.oversized_one": "{{count}} Lackierung ist zu groß zum Teilen, andere Fahrer sehen sie nicht.",
+  "sync.oversized_other": "{{count}} Lackierungen sind zu groß zum Teilen, andere Fahrer sehen sie nicht.",
   "sync.skippedBikes_one": "{{count}} Bike wurde nicht veröffentlicht — du hast mehr, als wir speichern können.",
   "sync.skippedBikes_other": "{{count}} Bikes wurden nicht veröffentlicht — du hast mehr, als wir speichern können.",
   "sync.noMatchingProfile": "Dieser Name passt zu keinem MX-Bikes-Profil auf diesem PC, es gibt also nichts zu veröffentlichen. Prüfe den Profilordner in den Einstellungen.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -768,6 +768,8 @@ export const en = {
   "sync.lastPulled": "Last checked {{ago}}. It runs again by itself when you press Play.",
   "sync.neverPulled": "You haven't fetched anyone else's paints yet",
   "sync.neverPulledWhy": "Until you do, other riders show up on default bikes even if they've published theirs.",
+  "sync.oversized_one": "{{count}} paint is too large to share, so other riders won't see it.",
+  "sync.oversized_other": "{{count}} paints are too large to share, so other riders won't see them.",
   "sync.skippedBikes_one": "{{count}} bike wasn't published — you have more than we can hold.",
   "sync.skippedBikes_other": "{{count}} bikes weren't published — you have more than we can hold.",
   "sync.noMatchingProfile": "This name doesn't match any MX Bikes profile on this PC, so there's nothing to publish. Check the profiles folder in Settings.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -788,6 +788,8 @@ export const es: Translation = {
   "sync.lastPulled": "Última comprobación {{ago}}. Se repite sola cuando pulsas Jugar.",
   "sync.neverPulled": "Aún no has descargado las pinturas de los demás",
   "sync.neverPulledWhy": "Hasta que lo hagas, los otros pilotos aparecen con motos por defecto aunque hayan publicado las suyas.",
+  "sync.oversized_one": "{{count}} pintura es demasiado grande para compartirla, así que los demás pilotos no la verán.",
+  "sync.oversized_other": "{{count}} pinturas son demasiado grandes para compartirlas, así que los demás pilotos no las verán.",
   "sync.skippedBikes_one": "{{count}} moto no se publicó — tienes más de las que podemos guardar.",
   "sync.skippedBikes_other": "{{count}} motos no se publicaron — tienes más de las que podemos guardar.",
   "sync.noMatchingProfile": "Este nombre no coincide con ningún perfil de MX Bikes en este PC, así que no hay nada que publicar. Revisa la carpeta de perfiles en Ajustes.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -793,6 +793,8 @@ export const fr: Translation = {
   "sync.lastPulled": "Dernière vérification {{ago}}. Elle repart seule quand vous appuyez sur Jouer.",
   "sync.neverPulled": "Vous n'avez pas encore récupéré les peintures des autres",
   "sync.neverPulledWhy": "Tant que ce n'est pas fait, les autres pilotes apparaissent avec des motos par défaut même s'ils ont publié les leurs.",
+  "sync.oversized_one": "{{count}} peinture est trop lourde à partager, les autres pilotes ne la verront pas.",
+  "sync.oversized_other": "{{count}} peintures sont trop lourdes à partager, les autres pilotes ne les verront pas.",
   "sync.skippedBikes_one": "{{count}} moto n'a pas été publiée — vous en avez plus que ce que nous pouvons stocker.",
   "sync.skippedBikes_other": "{{count}} motos n'ont pas été publiées — vous en avez plus que ce que nous pouvons stocker.",
   "sync.noMatchingProfile": "Ce nom ne correspond à aucun profil MX Bikes sur ce PC, il n'y a donc rien à publier. Vérifiez le dossier des profils dans les Réglages.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -783,6 +783,8 @@ export const it: Translation = {
   "sync.lastPulled": "Ultimo controllo {{ago}}. Riparte da solo quando premi Gioca.",
   "sync.neverPulled": "Non hai ancora scaricato le grafiche degli altri",
   "sync.neverPulledWhy": "Finché non lo fai, gli altri piloti appaiono con moto predefinite anche se hanno pubblicato le loro.",
+  "sync.oversized_one": "{{count}} grafica è troppo grande da condividere, quindi gli altri piloti non la vedranno.",
+  "sync.oversized_other": "{{count}} grafiche sono troppo grandi da condividere, quindi gli altri piloti non le vedranno.",
   "sync.skippedBikes_one": "{{count}} moto non è stata pubblicata — ne hai più di quante possiamo tenerne.",
   "sync.skippedBikes_other": "{{count}} moto non sono state pubblicate — ne hai più di quante possiamo tenerne.",
   "sync.noMatchingProfile": "Questo nome non corrisponde a nessun profilo MX Bikes su questo PC, quindi non c'è nulla da pubblicare. Controlla la cartella dei profili nelle Impostazioni.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -787,6 +787,8 @@ export const ptBR: Translation = {
   "sync.lastPulled": "Última verificação {{ago}}. Ela roda sozinha quando você aperta Jogar.",
   "sync.neverPulled": "Você ainda não baixou as pinturas dos outros",
   "sync.neverPulledWhy": "Até fazer isso, os outros pilotos aparecem com motos padrão mesmo tendo publicado as deles.",
+  "sync.oversized_one": "{{count}} pintura é grande demais para compartilhar, então os outros pilotos não vão vê-la.",
+  "sync.oversized_other": "{{count}} pinturas são grandes demais para compartilhar, então os outros pilotos não vão vê-las.",
   "sync.skippedBikes_one": "{{count}} moto não foi publicada — você tem mais do que conseguimos guardar.",
   "sync.skippedBikes_other": "{{count}} motos não foram publicadas — você tem mais do que conseguimos guardar.",
   "sync.noMatchingProfile": "Esse nome não corresponde a nenhum perfil do MX Bikes neste PC, então não há nada a publicar. Confira a pasta de perfis nas Configurações.",


### PR DESCRIPTION
Publishing failed on a real profile with `invalid size for paint`.

## The limit was wrong

32 MiB, and real content is simply larger. On a normal install **four paints exceed it, the largest at 121.7 MB** — a 4K livery is that size. Now 192 MiB, which clears the largest seen with room to spare while remaining a bound. It is not free: every other rider on the server downloads these.

## The more important half

**One oversized paint no longer costs a rider everything.** A loadout is validated as a whole, so a single file over the limit meant publishing *nothing at all* — appearing in default gear to everyone, with no explanation anywhere. Anything past the limit is now left behind, counted, and reported in the app, because a livery that never leaves the machine is not something a rider should have to deduce.

## This is the third time

Same shape each time — one entry failing the batch:

1. a slot the control plane does not store
2. the same slot resolving twice
3. a file too large

Each was invisible until a real install produced it. The publish is now built to be valid rather than hoping it is.

Measured on a real install: 208 paints, 4 over the old limit, 0 zero-byte.

Client-side and control-plane; no migration. Needs both a deploy and an app build to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)