### PR TITLE
feat(share): slice big preset bundles across several uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased — publishing your paints stops failing outright
 
+### Changed
+- **Full-share bundles are no longer capped at 200 MB.** That ceiling was the upload host's,
+  not ours, and a preset carrying a big track or a few detailed bikes ran straight into it. A
+  bundle past 190 MB is now sliced across several uploads and stitched back together on
+  import, taking the limit to 2 GB. Codes for smaller bundles are unchanged, and a share whose
+  parts have gone missing says so — with the size it expected — instead of failing at the
+  unzip.
+
 ### Fixed
 - **A loadout the control plane refused took your whole look with it.** Two things a real
   install produces would fail the entire publish: a paint filed under a slot the control plane

--- a/src-tauri/src/bundle.rs
+++ b/src-tauri/src/bundle.rs
@@ -367,13 +367,30 @@ pub async fn create(
     let zip_path = work.join(format!("{}.zip", sanitize_file(name)));
     zip_dir(&root, &zip_path)?;
 
-    phase(app, "uploading", Some(format!("Uploading {}…", human_size(file_size(&zip_path)))));
+    let total = human_size(file_size(&zip_path));
+    phase(app, "uploading", Some(format!("Uploading {total}…")));
     let client = install::build_client()?;
-    let up = upload::upload_file(&client, &zip_path).await?;
+    let up = upload::upload_file(&client, &zip_path, |i, n| {
+        let msg = if n > 1 {
+            format!("Uploading part {i} of {n} ({total})…")
+        } else {
+            format!("Uploading {total}…")
+        };
+        phase(app, "uploading", Some(msg));
+    })
+    .await?;
 
     let _ = std::fs::remove_dir_all(&work);
 
-    preset.bundle = Some(BundleRef { url: up.url, host: up.host, size: up.size });
+    let first = up
+        .parts
+        .first()
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("the upload returned no link"))?;
+    // `url` stays the first slice so a one-part bundle reads exactly as it always has;
+    // `parts` is only carried when there's more than one to stitch.
+    let parts = if up.parts.len() > 1 { up.parts } else { Vec::new() };
+    preset.bundle = Some(BundleRef { url: first, host: up.host, size: up.size, parts });
     let code = presets::encode_code_public(&preset);
     phase(app, "done", None);
     Ok(code)
@@ -402,6 +419,8 @@ pub async fn import(
     let u = bundle.url.to_lowercase();
     let archive = if h.contains("mega") || u.contains("mega.nz") || u.contains("mega.co") {
         install::download_mega(app, &client, BUNDLE_SLUG, &bundle.url, &work).await?
+    } else if bundle.parts.len() > 1 {
+        download_parts(app, &client, &bundle, &work).await?
     } else {
         let direct = install::resolve_direct_url(&client, &bundle.url, &bundle.host).await?;
         install::download(app, &client, BUNDLE_SLUG, &direct, &work).await?
@@ -421,6 +440,60 @@ pub async fn import(
     phase(app, "done", None);
 
     Ok(preset)
+}
+
+/// Fetch every slice of a multi-part bundle and stitch them back into one zip. The slices are
+/// raw byte ranges, so concatenating them in order reproduces the original file exactly.
+async fn download_parts(
+    app: &AppHandle,
+    client: &reqwest::Client,
+    bundle: &BundleRef,
+    work: &Path,
+) -> anyhow::Result<PathBuf> {
+    let n = bundle.parts.len();
+    let dir = work.join("parts");
+
+    let mut paths = Vec::with_capacity(n);
+    for (i, url) in bundle.parts.iter().enumerate() {
+        phase(app, "downloading", Some(format!("Downloading part {} of {n}…", i + 1)));
+        // Each part lands in its own folder: the host names the file, and two parts of the
+        // same bundle can easily come back under the same name.
+        let into = dir.join(format!("part{}", i + 1));
+        std::fs::create_dir_all(&into)?;
+        let direct = install::resolve_direct_url(client, url, &bundle.host).await?;
+        paths.push(
+            install::download(app, client, BUNDLE_SLUG, &direct, &into)
+                .await
+                .with_context(|| format!("part {} of {n} couldn't be downloaded", i + 1))?,
+        );
+    }
+
+    phase(app, "downloading", Some(format!("Joining {n} parts…")));
+    let zip_path = work.join("bundle.zip");
+    let written = concat_files(&paths, &zip_path)?;
+    if written != bundle.size {
+        anyhow::bail!(
+            "This bundle came back as {} instead of {} — one of its {n} parts is incomplete or \
+             no longer hosted. Ask whoever shared it for a fresh code.",
+            human_size(written),
+            human_size(bundle.size)
+        );
+    }
+    Ok(zip_path)
+}
+
+/// Concatenate `parts` into `dest` in order, returning the bytes written.
+fn concat_files(parts: &[PathBuf], dest: &Path) -> anyhow::Result<u64> {
+    let mut out = std::fs::File::create(dest)
+        .with_context(|| format!("creating {}", dest.display()))?;
+    let mut total = 0u64;
+    for p in parts {
+        let mut input =
+            std::fs::File::open(p).with_context(|| format!("reading {}", p.display()))?;
+        total += std::io::copy(&mut input, &mut out)?;
+    }
+    std::io::Write::flush(&mut out)?;
+    Ok(total)
 }
 
 fn rel_to_native(rel: &str) -> PathBuf {
@@ -505,6 +578,40 @@ mod tests {
         let _ = std::fs::remove_dir_all(&d);
         std::fs::create_dir_all(&d).unwrap();
         d
+    }
+
+    /// The whole multi-part scheme rests on this: slices are raw byte ranges, so joining
+    /// them back in order has to give the original zip byte for byte.
+    #[test]
+    fn joining_slices_rebuilds_the_zip() {
+        let dir = tmp("concat");
+        let original: Vec<u8> = (0..9000u32).map(|i| (i % 251) as u8).collect();
+
+        let mut paths = Vec::new();
+        for (i, chunk) in original.chunks(2048).enumerate() {
+            let p = dir.join(format!("part{i}"));
+            std::fs::write(&p, chunk).unwrap();
+            paths.push(p);
+        }
+        assert_eq!(paths.len(), 5, "expected a short final slice");
+
+        let dest = dir.join("bundle.zip");
+        let written = concat_files(&paths, &dest).unwrap();
+
+        assert_eq!(written, original.len() as u64);
+        assert_eq!(std::fs::read(&dest).unwrap(), original);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn joining_a_missing_slice_fails_instead_of_truncating() {
+        let dir = tmp("concat-missing");
+        let present = dir.join("part0");
+        std::fs::write(&present, b"abc").unwrap();
+        let paths = vec![present, dir.join("part1-never-downloaded")];
+
+        assert!(concat_files(&paths, &dir.join("bundle.zip")).is_err());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src-tauri/src/presets.rs
+++ b/src-tauri/src/presets.rs
@@ -115,6 +115,11 @@ pub struct BundleRef {
     pub url: String,
     pub host: String,
     pub size: u64,
+    /// Every slice of the bundle, in order, when it was too big for one upload. Empty means
+    /// the whole thing is at `url` — which is also the first slice, so old codes and
+    /// single-part codes stay byte-identical.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parts: Vec<String>,
 }
 
 /// The content a preset needs on disk, beyond the cosmetics in its [`Loadout`].
@@ -921,6 +926,33 @@ BSB23_Ducati_V4R=BS_Racing_Battlax
         // And it round-trips back out without growing a `content` key.
         let out = serde_json::to_string(&back).unwrap();
         assert!(!out.contains("content"), "{out}");
+    }
+
+    /// Codes shared before bundles could be sliced carry no `parts` key, and a one-part
+    /// bundle must not grow one — an old app reading a new single-part code has to see
+    /// exactly what it saw before.
+    #[test]
+    fn a_bundle_without_parts_still_loads() {
+        let json = r#"{"name":"Old","loadout":{},"bundle":{"url":"https://x/a.zip","host":"catbox","size":10}}"#;
+        let back = decode_code(json).unwrap();
+        let bundle = back.bundle.clone().unwrap();
+        assert!(bundle.parts.is_empty());
+
+        let out = serde_json::to_string(&back).unwrap();
+        assert!(!out.contains("parts"), "{out}");
+    }
+
+    #[test]
+    fn a_sliced_bundle_carries_its_parts_in_order() {
+        let json = r#"{"name":"Big","loadout":{},"bundle":{"url":"https://x/1.zip","host":"catbox","size":300,"parts":["https://x/1.zip","https://x/2.zip"]}}"#;
+        let back = decode_code(json).unwrap();
+        let bundle = back.bundle.clone().unwrap();
+        assert_eq!(bundle.parts, vec!["https://x/1.zip", "https://x/2.zip"]);
+        // The first slice is also the plain `url`, so nothing has to look in two places.
+        assert_eq!(bundle.url, bundle.parts[0]);
+
+        let back = decode_code(&encode_code(&back)).unwrap();
+        assert_eq!(back.bundle.unwrap().parts.len(), 2);
     }
 
     fn round_trip_raw_json(preset: &Preset) -> anyhow::Result<()> {

--- a/src-tauri/src/upload.rs
+++ b/src-tauri/src/upload.rs
@@ -2,44 +2,101 @@ use anyhow::Context;
 use obfstr::obfstr;
 use reqwest::multipart::{Form, Part};
 use reqwest::Client;
+use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 
-pub struct UploadRef {
-    pub url: String,
+pub struct Upload {
+    /// Direct download URLs, in order. One entry is the whole bundle; more than one means
+    /// the bytes were sliced and have to be concatenated in this order to rebuild the zip.
+    pub parts: Vec<String>,
     pub host: String,
+    /// Size of the original zip, not of any one part.
     pub size: u64,
 }
 
 const HOST: &str = "catbox";
 
-/// catbox refuses anything past this, so we stop before spending the upload.
-const MAX_BYTES: u64 = 200 * 1024 * 1024;
+/// catbox refuses a file past 200 MB, so anything bigger goes up in slices — with headroom
+/// under the ceiling for the multipart envelope around each one.
+const PART_BYTES: u64 = 190 * 1024 * 1024;
 
-pub async fn upload_file(client: &Client, file: &Path) -> anyhow::Result<UploadRef> {
+/// A ceiling on the bundle as a whole. Past this the upload takes long enough, and depends
+/// on enough separate files staying alive, that sharing the plain code is the better answer.
+const MAX_TOTAL_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
+/// Upload `file`, slicing it if it's over one part. `on_part(index, total)` is called before
+/// each slice goes up, so the caller can say which part is in flight.
+pub async fn upload_file(
+    client: &Client,
+    file: &Path,
+    on_part: impl Fn(usize, usize),
+) -> anyhow::Result<Upload> {
     let size = std::fs::metadata(file).map(|m| m.len()).unwrap_or(0);
-    if size > MAX_BYTES {
+    if size > MAX_TOTAL_BYTES {
         anyhow::bail!(
-            "This bundle is {:.0} MB — too large to share (the limit is {} MB). \
+            "This bundle is {:.1} GB — too large to share (the limit is {} GB). \
              Share the plain code instead.",
-            size as f64 / (1024.0 * 1024.0),
-            MAX_BYTES / (1024 * 1024)
+            size as f64 / (1024.0 * 1024.0 * 1024.0),
+            MAX_TOTAL_BYTES / (1024 * 1024 * 1024)
         );
     }
-    let url = catbox_upload(client, file).await?;
-    Ok(UploadRef { url, host: HOST.to_string(), size })
+
+    let plan = part_plan(size);
+    let mut handle = std::fs::File::open(file)
+        .with_context(|| format!("reading {}", file.display()))?;
+    let stem = file
+        .file_stem()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "preset-bundle".to_string());
+
+    let mut parts = Vec::with_capacity(plan.len());
+    for (i, &(offset, len)) in plan.iter().enumerate() {
+        on_part(i + 1, plan.len());
+        let bytes = read_slice(&mut handle, offset, len)
+            .with_context(|| format!("reading {}", file.display()))?;
+        // Keep the .zip extension on every slice — catbox screens uploads by extension.
+        let name = if plan.len() == 1 {
+            format!("{stem}.zip")
+        } else {
+            format!("{stem}.part{}of{}.zip", i + 1, plan.len())
+        };
+        parts.push(catbox_upload(client, &name, bytes).await?);
+    }
+
+    Ok(Upload { parts, host: HOST.to_string(), size })
+}
+
+/// Slice `size` bytes into `(offset, len)` spans no bigger than one part. A zero-byte file
+/// still gets one span, so an empty upload fails at catbox rather than silently succeeding
+/// with no parts at all.
+fn part_plan(size: u64) -> Vec<(u64, u64)> {
+    let mut spans = Vec::new();
+    let mut offset = 0u64;
+    while offset < size {
+        let len = PART_BYTES.min(size - offset);
+        spans.push((offset, len));
+        offset += len;
+    }
+    if spans.is_empty() {
+        spans.push((0, 0));
+    }
+    spans
+}
+
+fn read_slice(file: &mut std::fs::File, offset: u64, len: u64) -> std::io::Result<Vec<u8>> {
+    file.seek(SeekFrom::Start(offset))?;
+    let mut buf = Vec::with_capacity(len as usize);
+    file.take(len).read_to_end(&mut buf)?;
+    Ok(buf)
 }
 
 /// catbox.moe — anonymous multipart POST whose response body *is* the direct download URL.
-async fn catbox_upload(client: &Client, file: &Path) -> anyhow::Result<String> {
-    let bytes = std::fs::read(file).with_context(|| format!("reading {}", file.display()))?;
-    let name = file
-        .file_name()
-        .map(|n| n.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "preset-bundle.zip".to_string());
-
+async fn catbox_upload(client: &Client, name: &str, bytes: Vec<u8>) -> anyhow::Result<String> {
     let form = Form::new().text("reqtype", "fileupload").part(
         "fileToUpload",
-        Part::bytes(bytes).file_name(name).mime_str("application/zip")?,
+        Part::bytes(bytes)
+            .file_name(name.to_string())
+            .mime_str("application/zip")?,
     );
 
     let resp = client
@@ -63,5 +120,55 @@ async fn catbox_upload(client: &Client, file: &Path) -> anyhow::Result<String> {
         anyhow::bail!("catbox upload failed: HTTP {status}")
     } else {
         anyhow::bail!("catbox upload failed: {body}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one_part_up_to_the_ceiling() {
+        assert_eq!(part_plan(0), vec![(0, 0)]);
+        assert_eq!(part_plan(10), vec![(0, 10)]);
+        assert_eq!(part_plan(PART_BYTES), vec![(0, PART_BYTES)]);
+    }
+
+    #[test]
+    fn spans_are_contiguous_and_cover_the_file() {
+        let size = PART_BYTES * 3 + 7;
+        let plan = part_plan(size);
+        assert_eq!(plan.len(), 4);
+        let mut expected = 0;
+        for &(offset, len) in &plan {
+            assert_eq!(offset, expected, "spans must not skip or overlap");
+            assert!(len <= PART_BYTES);
+            expected += len;
+        }
+        assert_eq!(expected, size, "spans must cover every byte");
+        assert_eq!(plan[3].1, 7);
+    }
+
+    #[test]
+    fn slices_rebuild_the_original() {
+        let dir = std::env::temp_dir().join("mxb-upload-slice-test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("bundle.zip");
+
+        // Split on a small boundary rather than 190 MB: the plan is what scales, and this
+        // exercises the same seek/read/concat path.
+        let original: Vec<u8> = (0..5000u32).map(|i| (i % 251) as u8).collect();
+        std::fs::write(&path, &original).unwrap();
+
+        let mut handle = std::fs::File::open(&path).unwrap();
+        let spans = [(0u64, 1024u64), (1024, 1024), (2048, 1024), (3072, 1928)];
+        let mut rebuilt = Vec::new();
+        for &(offset, len) in &spans {
+            rebuilt.extend_from_slice(&read_slice(&mut handle, offset, len).unwrap());
+        }
+
+        assert_eq!(rebuilt, original);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -811,6 +811,11 @@ export interface BundleRef {
   host: string;
   /** Bundle size in bytes. */
   size: number;
+  /**
+   * Every slice of the bundle, in order, when it was too big for one upload. Absent means
+   * the whole thing is at `url` — which is also the first slice.
+   */
+  parts?: string[];
 }
 
 /**


### PR DESCRIPTION
## Why

Full-share bundles were capped at 200 MB. That number was never ours — it's catbox's per-file ceiling for anonymous uploads, so raising the constant alone would only have moved the failure from an instant local check to a rejection after the user sat through the whole upload. A preset carrying a big track or a few detailed bikes hit the wall with nowhere to go.

## What

A bundle past 190 MB is sliced into parts, each uploaded separately, and stitched back together on import. Slices are raw byte ranges, so concatenating them in order reproduces the zip exactly — which matters, because a single 300 MB `.pkz` inside the bundle can't be split by zip entry. New total cap: **2 GB**.

- `upload.rs` — `PART_BYTES = 190 MB` (headroom under 200 for the multipart envelope), `MAX_TOTAL_BYTES = 2 GB`. `upload_file` returns `Upload { parts, host, size }` and reports which part is in flight. Parts keep a `.zip` extension (`name.part2of3.zip`) because catbox screens uploads by extension. Peak memory is one part.
- `presets.rs` — `BundleRef.parts`, `skip_serializing_if = "Vec::is_empty"`, with `url` staying the first slice. **A one-part code serializes byte-identically to before.**
- `bundle.rs` — export shows "Uploading part 2 of 3 (412.0 MB)…"; import adds `download_parts` (each part into its own folder, since the host names the file) and `concat_files`, then checks the joined size against `bundle.size` and bails with "came back as 190 MB instead of 412 MB — one of its 3 parts is incomplete or no longer hosted" rather than failing later at the unzip.
- `types/index.ts` — optional `parts?: string[]`.

## Known limitation

A >200 MB code opened in an **older** app version downloads part 1 and fails at extract with an unhelpful message. Can't be fixed retroactively; today such shares can't exist at all, so nothing regresses. Single-part behaviour is untouched.

The download progress bar restarts per part, with the phase label naming which one. A single continuous bar would mean threading a byte offset through `install::download`; left out deliberately.

## Testing

- 663 Rust tests pass, including 5 new ones: slice spans are contiguous and cover the file; slices rebuild the original; joining a missing slice errors instead of truncating; old `parts`-less codes still decode and don't grow the key; a sliced code round-trips with its parts in order.
- Clippy clean on the changed files; `tsc --noEmit` clean.
- Not yet exercised against a real >190 MB share on Windows.

No DB/schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)