### PR TITLE
fix(servers): install bikes where the game reads them, not beside the exe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@
 - Sharing reuses the preset bundle's upload, so the same 2 GB ceiling and the same slicing
   past one part apply, and a share whose parts have gone missing says which one.
 
+## Unreleased — a created server can see the bikes it installed
+
+### Fixed
+- **A provisioned server rejected riders on bikes it had been given.** The pack was downloaded
+  into the game folder, and MX Bikes reads mods from PiBoSo's user folder instead — the same
+  place the client uses, which under the service account lives elsewhere entirely. The files
+  were on disk the whole time and the game was never looking there. They now install where the
+  game reads, with the game folder linked to the same content so nothing is copied twice.
+
+## Unreleased — a full share isn't capped at 200 MB any more
+
+### Changed
+- **Full-share bundles are no longer capped at 200 MB.** That ceiling was the upload host's,
+  not ours, and a preset carrying a big track or a few detailed bikes ran straight into it. A
+  bundle past 190 MB is now sliced across several uploads and stitched back together on
+  import, taking the limit to 2 GB. Codes for smaller bundles are unchanged, and a share whose
+  parts have gone missing says so — with the size it expected — instead of failing at the
+  unzip.
+
 ## 2026-08-11 — v0.9.2 — A track's terrain in 3D, and voice chat picks its microphone
 
 On top of v0.9.1 — the Designer's painting tools, Play on macOS and the SteamOS white screen

--- a/control-plane/src/bootstrap.ts
+++ b/control-plane/src/bootstrap.ts
@@ -154,10 +154,28 @@ if (-not (Test-Path "${ROOT}\\game\\mxbikes.exe")) {
 #
 # Best-effort: a server with no mod bikes is still a working server for stock ones, and is a
 # far better outcome than destroying the instance over content that can be added later.
-Send-Stage -Stage "installing bikes"
 try {
-  $bikesDir = "${ROOT}\\game\\mods\\bikes"
+  # Where MX Bikes actually reads mods from.
+  #
+  # The client reads them from PiBoSo's user folder -- Documents\\PiBoSo\\MX Bikes\\mods -- not
+  # from beside the executable. The dedicated server is the same program, and running as
+  # SYSTEM its Documents folder is under systemprofile. Installing only into the game folder
+  # is why a server rejected riders on bikes it had supposedly been given: the files were on
+  # disk and the game was never looking there.
+  #
+  # Installed once into the user folder, with the game folder junctioned to it, so the
+  # agent's own track scan sees the same content without a second copy of two gigabytes.
+  $userMods = Join-Path ([Environment]::GetFolderPath("MyDocuments")) "PiBoSo\\MX Bikes\\mods"
+  $bikesDir = Join-Path $userMods "bikes"
   New-Item -ItemType Directory -Force -Path $bikesDir | Out-Null
+  Send-Stage -Stage "installing bikes"
+  Write-Output "mods folder: $userMods"
+  $gameMods = "${ROOT}\\game\\mods"
+  if (-not (Test-Path $gameMods)) {
+    # A junction rather than a copy: same bytes, both paths, no second 2 GB.
+    cmd /c mklink /J "$gameMods" "$userMods" | Out-Null
+    Write-Output "linked $gameMods -> $userMods"
+  }
   $listing = Invoke-RestMethod -Uri "${input.controlPlaneUrl}/v1/content/bikes" -TimeoutSec 60
   $count = 0
   foreach ($bike in $listing.bikes) {


### PR DESCRIPTION
A provisioned server still answered **"bike unknown to server"** for a rider on an MX1OEM bike — one of the twenty-six the bootstrap had just installed.

## Cause

The pack went into `<game>\mods\bikes`. MX Bikes reads mods from **PiBoSo's user folder**, `Documents\PiBoSo\MX Bikes\mods` — which is what the client does and what this app has always assumed for a player's own install. The dedicated server is the same program, and running as SYSTEM its Documents folder is under `systemprofile`.

So the files were on disk, correctly named, and the game was never looking at them.

## Worth being explicit

`<game>\mods` was **never verified**. The agent's track scan assumes it too, and returned an empty list on a server with no mods — which looks identical whether the path is right or wrong. It took a real rider being refused to expose it.

I am hedging deliberately here rather than claiming certainty: bikes install into the user folder, and the game folder is junctioned to that same content where it does not already exist. One copy of two gigabytes, visible at both paths, so the agent's scan keeps working without knowing anything changed — and if the game does read `<game>\mods` after all, that path still resolves.

The next launch is the test. The transcript now prints the resolved mods folder, so if it is still wrong we will see where it went.

Control plane only — no app change, no migration. Needs a deploy, then a fresh server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)