### PR TITLE
feat(share): share any installed track or paint, not just a preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased — share any track or paint, not just a preset
+
+### Added
+- **Share installed files with a code.** Sharing was a preset's privilege: a code carried a
+  *look*, and the full bundle packed whatever its slots resolved to. Handing someone the track
+  you just rode, or the paint you just made, still meant uploading it somewhere and pasting a
+  link. Anything the Library lists can now go straight into a code — **Share** on any item, or
+  pick several with **Select** and share them together. It packs them, uploads them, and puts
+  one line on your clipboard.
+- **The other end: Import → Paste a share code…** Files land back in the folders the sender
+  had them in — a track filed under `tracks/EU/` arrives under `tracks/EU/`, a helmet paint
+  goes to the helmet it belongs to — so a share carries where things go, not just what they
+  are. The code is previewed before anything downloads: what it holds, how big it is, and
+  where it's hosted.
+- Sharing reuses the preset bundle's upload, so the same 2 GB ceiling and the same slicing
+  past one part apply, and a share whose parts have gone missing says which one.
+
 ## 2026-08-11 — v0.9.2 — A track's terrain in 3D, and voice chat picks its microphone
 
 On top of v0.9.1 — the Designer's painting tools, Play on macOS and the SteamOS white screen

--- a/src-tauri/src/bundle.rs
+++ b/src-tauri/src/bundle.rs
@@ -300,7 +300,9 @@ fn dedup_assets(assets: &mut Vec<AssetRef>) {
     });
 }
 
-fn dir_size_deep(dir: &Path) -> u64 {
+/// Total bytes under `dir`, following the links a mods tree is full of. Shared with
+/// [`crate::fileshare`], which sizes a picked folder the same way this sizes a model variant.
+pub(crate) fn dir_size_deep(dir: &Path) -> u64 {
     let mut total = 0;
     for e in crate::linkwalk::walk(dir).into_iter().flatten() {
         if e.file_type().is_file() {
@@ -320,8 +322,17 @@ struct BundleProgress {
 
 pub const BUNDLE_SLUG: &str = "__preset_bundle__";
 
+pub const BUNDLE_EVENT: &str = "preset-bundle-progress";
+
+/// Emit one phase update on `event`. The event name is a parameter because the same
+/// create/download machinery serves two flows — the preset bundle here and the file share
+/// in [`crate::fileshare`] — and each has its own dialog listening.
+pub(crate) fn emit(app: &AppHandle, event: &str, phase: &'static str, message: Option<String>) {
+    let _ = app.emit(event, BundleProgress { phase, message });
+}
+
 fn phase(app: &AppHandle, phase: &'static str, message: Option<String>) {
-    let _ = app.emit("preset-bundle-progress", BundleProgress { phase, message });
+    emit(app, BUNDLE_EVENT, phase, message);
 }
 
 pub async fn create(
@@ -412,19 +423,7 @@ pub async fn import(
     let _ = std::fs::remove_dir_all(&work);
     std::fs::create_dir_all(&work)?;
 
-    // MEGA links decrypt in-app; everything else streams via the shared downloader.
-    phase(app, "downloading", None);
-    let client = install::build_client()?;
-    let h = bundle.host.to_lowercase();
-    let u = bundle.url.to_lowercase();
-    let archive = if h.contains("mega") || u.contains("mega.nz") || u.contains("mega.co") {
-        install::download_mega(app, &client, BUNDLE_SLUG, &bundle.url, &work).await?
-    } else if bundle.parts.len() > 1 {
-        download_parts(app, &client, &bundle, &work).await?
-    } else {
-        let direct = install::resolve_direct_url(&client, &bundle.url, &bundle.host).await?;
-        install::download(app, &client, BUNDLE_SLUG, &direct, &work).await?
-    };
+    let archive = fetch(app, BUNDLE_EVENT, BUNDLE_SLUG, &bundle, &work).await?;
 
     phase(app, "installing", None);
     let extracted = work.join("extracted");
@@ -442,10 +441,36 @@ pub async fn import(
     Ok(preset)
 }
 
+/// Bring a hosted bundle down to `work` as one archive file, whatever shape it was uploaded
+/// in: a MEGA link that decrypts in-app, a sliced upload that has to be stitched, or a plain
+/// single file. Shared with [`crate::fileshare`], which hosts its payload the same way.
+pub(crate) async fn fetch(
+    app: &AppHandle,
+    event: &str,
+    slug: &str,
+    bundle: &BundleRef,
+    work: &Path,
+) -> anyhow::Result<PathBuf> {
+    emit(app, event, "downloading", None);
+    let client = install::build_client()?;
+    let h = bundle.host.to_lowercase();
+    let u = bundle.url.to_lowercase();
+    if h.contains("mega") || u.contains("mega.nz") || u.contains("mega.co") {
+        install::download_mega(app, &client, slug, &bundle.url, work).await
+    } else if bundle.parts.len() > 1 {
+        download_parts(app, event, slug, &client, bundle, work).await
+    } else {
+        let direct = install::resolve_direct_url(&client, &bundle.url, &bundle.host).await?;
+        install::download(app, &client, slug, &direct, work).await
+    }
+}
+
 /// Fetch every slice of a multi-part bundle and stitch them back into one zip. The slices are
 /// raw byte ranges, so concatenating them in order reproduces the original file exactly.
 async fn download_parts(
     app: &AppHandle,
+    event: &str,
+    slug: &str,
     client: &reqwest::Client,
     bundle: &BundleRef,
     work: &Path,
@@ -455,20 +480,20 @@ async fn download_parts(
 
     let mut paths = Vec::with_capacity(n);
     for (i, url) in bundle.parts.iter().enumerate() {
-        phase(app, "downloading", Some(format!("Downloading part {} of {n}…", i + 1)));
+        emit(app, event, "downloading", Some(format!("Downloading part {} of {n}…", i + 1)));
         // Each part lands in its own folder: the host names the file, and two parts of the
         // same bundle can easily come back under the same name.
         let into = dir.join(format!("part{}", i + 1));
         std::fs::create_dir_all(&into)?;
         let direct = install::resolve_direct_url(client, url, &bundle.host).await?;
         paths.push(
-            install::download(app, client, BUNDLE_SLUG, &direct, &into)
+            install::download(app, client, slug, &direct, &into)
                 .await
                 .with_context(|| format!("part {} of {n} couldn't be downloaded", i + 1))?,
         );
     }
 
-    phase(app, "downloading", Some(format!("Joining {n} parts…")));
+    emit(app, event, "downloading", Some(format!("Joining {n} parts…")));
     let zip_path = work.join("bundle.zip");
     let written = concat_files(&paths, &zip_path)?;
     if written != bundle.size {
@@ -496,7 +521,7 @@ fn concat_files(parts: &[PathBuf], dest: &Path) -> anyhow::Result<u64> {
     Ok(total)
 }
 
-fn rel_to_native(rel: &str) -> PathBuf {
+pub(crate) fn rel_to_native(rel: &str) -> PathBuf {
     let mut p = PathBuf::new();
     for seg in rel.split('/').filter(|s| !s.is_empty()) {
         p.push(seg);
@@ -507,11 +532,11 @@ fn rel_to_native(rel: &str) -> PathBuf {
 /// Copy an asset folder into the bundle, resolving any links inside it — a bundle is for
 /// someone else's machine, where the far end of the sender's junction doesn't exist. See
 /// [`crate::linkwalk::copy_tree`].
-fn copy_tree(src: &Path, dst: &Path) -> anyhow::Result<()> {
+pub(crate) fn copy_tree(src: &Path, dst: &Path) -> anyhow::Result<()> {
     Ok(crate::linkwalk::copy_tree(src, dst)?)
 }
 
-fn zip_dir(root: &Path, zip_path: &Path) -> anyhow::Result<()> {
+pub(crate) fn zip_dir(root: &Path, zip_path: &Path) -> anyhow::Result<()> {
     let file = std::fs::File::create(zip_path)?;
     let mut zip = zip::ZipWriter::new(file);
     // Stored (no re-compression): payload is mostly already-compressed `.pkz`/`.pnt`.
@@ -536,7 +561,7 @@ fn zip_dir(root: &Path, zip_path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn file_size(p: &Path) -> u64 {
+pub(crate) fn file_size(p: &Path) -> u64 {
     std::fs::metadata(p).map(|m| m.len()).unwrap_or(0)
 }
 
@@ -552,7 +577,7 @@ pub(crate) fn human_size(bytes: u64) -> String {
     }
 }
 
-fn sanitize_file(name: &str) -> String {
+pub(crate) fn sanitize_file(name: &str) -> String {
     let s: String = name
         .chars()
         .map(|c| match c {

--- a/src-tauri/src/fileshare.rs
+++ b/src-tauri/src/fileshare.rs
@@ -1,0 +1,464 @@
+//! Sharing installed content directly — a track, a paint, a handful of both.
+//!
+//! [`crate::bundle`] shares a *look*: a preset code names slots, and the full bundle packs
+//! whatever those slots resolved to. That covers the rider and never the rest, so handing
+//! someone the track you just rode still meant a Discord upload and a link in chat.
+//!
+//! This shares the files themselves. Anything the Library lists can go in a code — the same
+//! catbox upload, the same slicing for anything past one part, the same `mods/`-shaped zip
+//! that [`crate::install::place_mod`] already knows how to lay back down. What a code
+//! carries is a list of `mods/`-relative paths, so a track picked out of `tracks/EU/` lands
+//! in `tracks/EU/` on the other machine.
+
+use crate::bundle;
+use crate::config::AppConfig;
+use crate::install;
+use crate::library;
+use crate::presets::BundleRef;
+use crate::upload;
+use anyhow::Context;
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use tauri::AppHandle;
+
+/// Phase updates ride their own event, so the Library's dialog and the Presets one never
+/// hear each other's progress.
+pub const EVENT: &str = "file-share-progress";
+
+const SLUG: &str = "__file_share__";
+
+const CODE_PREFIX: &str = "MXBS1-";
+
+/// The preset code prefix, recognised only to say where it belongs.
+const PRESET_PREFIX: &str = "MXBP1-";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ShareItem {
+    pub name: String,
+    /// Where it sits under the mods root, forward-slashed (`tracks/EU/RedBud.pkz`). This is
+    /// the whole portability story: it survives the sender's mods folder living on another
+    /// drive, and it puts a rider paint back under `rider/`, not wherever the importer's
+    /// Library tab happened to be pointing.
+    pub rel: String,
+    pub size: u64,
+    pub is_dir: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Skipped {
+    pub path: String,
+    pub reason: String,
+}
+
+/// What a share would carry, before anything is packed or uploaded.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SharePlan {
+    pub items: Vec<ShareItem>,
+    pub skipped: Vec<Skipped>,
+    pub total_size: u64,
+}
+
+/// The payload a `MXBS1-` code decodes to.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileShare {
+    pub items: Vec<ShareItem>,
+    /// Size of the packed zip — what the importer is about to download, which is not the
+    /// sum of `items` once the zip's own bookkeeping is counted.
+    pub total_size: u64,
+    pub bundle: BundleRef,
+}
+
+/// Resolve picked absolute paths into `mods/`-relative items, saying what was left out.
+///
+/// Everything shared has to live under the mods root: the rel path is what the code carries,
+/// and a file from anywhere else has no rel path to give. That check doubles as the guard on
+/// paths arriving from the frontend — nothing outside the mods tree can be packed up and
+/// uploaded, whatever the caller asks for.
+pub fn plan(cfg: &AppConfig, paths: &[String]) -> SharePlan {
+    let root = library::mods_root(&cfg.mods_path);
+    let mut items: Vec<ShareItem> = Vec::new();
+    let mut skipped: Vec<Skipped> = Vec::new();
+
+    for raw in paths {
+        let p = PathBuf::from(raw.trim());
+        let reason = if !p.exists() {
+            Some("no longer on disk")
+        } else if !p.starts_with(&root) {
+            Some("outside the mods folder")
+        } else {
+            None
+        };
+        if let Some(reason) = reason {
+            skipped.push(Skipped { path: raw.clone(), reason: reason.to_string() });
+            continue;
+        }
+
+        let rel = p
+            .strip_prefix(&root)
+            .map(|r| r.to_string_lossy().replace('\\', "/"))
+            .unwrap_or_default();
+        let rel = rel.trim_matches('/').to_string();
+        if rel.is_empty() {
+            skipped.push(Skipped {
+                path: raw.clone(),
+                reason: "that's the mods folder itself".to_string(),
+            });
+            continue;
+        }
+
+        let is_dir = p.is_dir();
+        items.push(ShareItem {
+            name: p.file_name().map(|n| n.to_string_lossy().into_owned()).unwrap_or_default(),
+            rel,
+            size: if is_dir { bundle::dir_size_deep(&p) } else { bundle::file_size(&p) },
+            is_dir,
+        });
+    }
+
+    dedup(&mut items);
+    items.sort_by(|a, b| a.rel.to_lowercase().cmp(&b.rel.to_lowercase()));
+    let total_size = items.iter().map(|i| i.size).sum();
+    SharePlan { items, skipped, total_size }
+}
+
+/// Drop repeats, and anything already carried by a folder that's also in the list — picking
+/// a track folder *and* a file inside it must not pack that file twice.
+fn dedup(items: &mut Vec<ShareItem>) {
+    let dirs: Vec<String> = items
+        .iter()
+        .filter(|i| i.is_dir)
+        .map(|i| i.rel.trim_end_matches('/').to_lowercase())
+        .collect();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    items.retain(|i| {
+        let key = i.rel.to_lowercase();
+        if !seen.insert(key.clone()) {
+            return false;
+        }
+        !dirs.iter().any(|d| key != *d && key.starts_with(&format!("{d}/")))
+    });
+}
+
+/// Zip name for a share: the single item's name, or how many items there are.
+fn archive_stem(items: &[ShareItem]) -> String {
+    match items {
+        [only] => bundle::sanitize_file(&strip_ext(&only.name)),
+        _ => format!("mxb-share-{}-items", items.len()),
+    }
+}
+
+fn strip_ext(name: &str) -> String {
+    let lower = name.to_ascii_lowercase();
+    for ext in [".pkz", ".pnt", ".zip"] {
+        if lower.ends_with(ext) {
+            return name[..name.len() - ext.len()].to_string();
+        }
+    }
+    name.to_string()
+}
+
+pub async fn create(
+    app: &AppHandle,
+    cfg: &AppConfig,
+    paths: &[String],
+) -> anyhow::Result<String> {
+    let plan = plan(cfg, paths);
+    if plan.items.is_empty() {
+        anyhow::bail!(
+            "Nothing here can be shared — pick installed files from your mods folder."
+        );
+    }
+
+    bundle::emit(app, EVENT, "bundling", None);
+    let root_dir = library::mods_root(&cfg.mods_path);
+    let work = std::env::temp_dir().join(format!("mxb-share-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&work);
+    let root = work.join("share");
+    std::fs::create_dir_all(&root)?;
+
+    for item in &plan.items {
+        let src = root_dir.join(bundle::rel_to_native(&item.rel));
+        let dest = root.join("mods").join(bundle::rel_to_native(&item.rel));
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        if item.is_dir {
+            // Resolved, not linked: a junction into the sender's tree means nothing on the
+            // machine this is headed for. Same reason the preset bundle resolves its folders.
+            bundle::copy_tree(&src, &dest)?;
+        } else {
+            std::fs::copy(&src, &dest)
+                .with_context(|| format!("copying {}", src.display()))?;
+        }
+    }
+
+    // A manifest for anyone who unzips the archive by hand rather than pasting the code.
+    // `place_mod` routes on the `mods/` child alone, so this sits beside it harmlessly.
+    std::fs::write(root.join("share.json"), serde_json::to_vec_pretty(&plan.items)?)?;
+
+    let zip_path = work.join(format!("{}.zip", archive_stem(&plan.items)));
+    bundle::zip_dir(&root, &zip_path)?;
+
+    let size = bundle::file_size(&zip_path);
+    let total = bundle::human_size(size);
+    bundle::emit(app, EVENT, "uploading", Some(format!("Uploading {total}…")));
+    let client = install::build_client()?;
+    let up = upload::upload_file(&client, &zip_path, |i, n| {
+        let msg = if n > 1 {
+            format!("Uploading part {i} of {n} ({total})…")
+        } else {
+            format!("Uploading {total}…")
+        };
+        bundle::emit(app, EVENT, "uploading", Some(msg));
+    })
+    .await?;
+
+    let _ = std::fs::remove_dir_all(&work);
+
+    let first = up
+        .parts
+        .first()
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("the upload returned no link"))?;
+    // As in the preset bundle: `url` is the first slice, and `parts` is only carried when
+    // there's more than one to stitch back together.
+    let parts = if up.parts.len() > 1 { up.parts } else { Vec::new() };
+    let share = FileShare {
+        items: plan.items,
+        total_size: up.size,
+        bundle: BundleRef { url: first, host: up.host, size: up.size, parts },
+    };
+    bundle::emit(app, EVENT, "done", None);
+    Ok(encode(&share))
+}
+
+pub fn encode(share: &FileShare) -> String {
+    let json = serde_json::to_vec(share).unwrap_or_default();
+    format!("{CODE_PREFIX}{}", STANDARD.encode(json))
+}
+
+/// Read a share code. A preset code is recognised on purpose, so pasting one here says
+/// where it belongs instead of "bad code".
+pub fn decode(text: &str) -> anyhow::Result<FileShare> {
+    let t = text.trim();
+    if t.starts_with(PRESET_PREFIX) {
+        anyhow::bail!("That's a preset code — import it from the Presets tab.");
+    }
+    let body = t.strip_prefix(CODE_PREFIX).unwrap_or(t).trim();
+    if body.starts_with('{') {
+        return serde_json::from_str(body).context("that JSON isn't a valid share");
+    }
+    let bytes = STANDARD
+        .decode(body)
+        .context("that doesn't look like a share code")?;
+    let share: FileShare =
+        serde_json::from_slice(&bytes).context("share code isn't a valid file share")?;
+    if share.items.is_empty() {
+        anyhow::bail!("this share code carries no files");
+    }
+    Ok(share)
+}
+
+pub async fn import(
+    app: &AppHandle,
+    cfg: &AppConfig,
+    text: &str,
+) -> anyhow::Result<FileShare> {
+    let share = decode(text)?;
+
+    let work = std::env::temp_dir().join(format!("mxb-share-import-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&work);
+    std::fs::create_dir_all(&work)?;
+
+    let archive = bundle::fetch(app, EVENT, SLUG, &share.bundle, &work).await?;
+
+    bundle::emit(app, EVENT, "installing", None);
+    let extracted = work.join("extracted");
+    std::fs::create_dir_all(&extracted)?;
+    install::extract_archive(&archive, &extracted)?;
+    let mods_dir = library::mods_subdir(&cfg.mods_path, "mods");
+    // The archive is a `mods/` tree, which routes as a merge — the type folder is only a
+    // fallback for shapes this never produces, but naming the real one keeps the log honest.
+    install::place_mod(&extracted, &mods_dir, &type_folder(&share.items), "", SLUG)?;
+
+    let _ = std::fs::remove_dir_all(&work);
+    install::notify_frostmod(app, SLUG);
+    bundle::emit(app, EVENT, "done", None);
+
+    Ok(share)
+}
+
+/// The `mods/` child the first item lives under (`tracks`, `bikes`, `rider`, …).
+fn type_folder(items: &[ShareItem]) -> String {
+    items
+        .first()
+        .and_then(|i| i.rel.split('/').next())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("bikes")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn touch(p: &Path) {
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(p, b"x").unwrap();
+    }
+
+    fn tmp(name: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("mxb-share-test-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn cfg_at(root: &Path) -> AppConfig {
+        AppConfig { mods_path: root.to_string_lossy().into_owned(), ..Default::default() }
+    }
+
+    /// The point of the whole feature: a track and a rider paint, picked from two different
+    /// corners of the tree, keep the folders they were found in.
+    #[test]
+    fn planning_keeps_each_pick_where_it_lives() {
+        let root = tmp("plan");
+        touch(&root.join("mods/tracks/EU/RedBud.pkz"));
+        touch(&root.join("mods/rider/helmets/AGV/paints/Blue.pnt"));
+
+        let p = plan(
+            &cfg_at(&root),
+            &[
+                root.join("mods/tracks/EU/RedBud.pkz").to_string_lossy().into_owned(),
+                root.join("mods/rider/helmets/AGV/paints/Blue.pnt").to_string_lossy().into_owned(),
+            ],
+        );
+
+        let rels: Vec<&str> = p.items.iter().map(|i| i.rel.as_str()).collect();
+        assert_eq!(rels, ["rider/helmets/AGV/paints/Blue.pnt", "tracks/EU/RedBud.pkz"]);
+        assert!(p.skipped.is_empty(), "{:?}", p.skipped);
+        assert_eq!(p.total_size, 2);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Paths come in from the frontend, so "is it under the mods root" is a guard, not a
+    /// convenience: nothing else may be packed up and uploaded to a public host.
+    #[test]
+    fn planning_refuses_anything_outside_the_mods_folder() {
+        let root = tmp("outside");
+        touch(&root.join("mods/tracks/RedBud.pkz"));
+        let elsewhere = root.join("secrets.txt");
+        touch(&elsewhere);
+
+        let p = plan(
+            &cfg_at(&root),
+            &[
+                elsewhere.to_string_lossy().into_owned(),
+                root.join("mods/tracks/Gone.pkz").to_string_lossy().into_owned(),
+            ],
+        );
+
+        assert!(p.items.is_empty(), "{:?}", p.items);
+        assert_eq!(p.skipped.len(), 2);
+        assert!(p.skipped[0].reason.contains("outside"));
+        assert!(p.skipped[1].reason.contains("no longer on disk"));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn planning_drops_a_file_its_own_folder_already_carries() {
+        let root = tmp("nested");
+        touch(&root.join("mods/tracks/Loose Track/track.trh"));
+
+        let p = plan(
+            &cfg_at(&root),
+            &[
+                root.join("mods/tracks/Loose Track").to_string_lossy().into_owned(),
+                root.join("mods/tracks/Loose Track/track.trh").to_string_lossy().into_owned(),
+                root.join("mods/tracks/Loose Track").to_string_lossy().into_owned(),
+            ],
+        );
+
+        assert_eq!(p.items.len(), 1);
+        assert_eq!(p.items[0].rel, "tracks/Loose Track");
+        assert!(p.items[0].is_dir);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn code_round_trips() {
+        let share = FileShare {
+            items: vec![ShareItem {
+                name: "RedBud.pkz".into(),
+                rel: "tracks/EU/RedBud.pkz".into(),
+                size: 12,
+                is_dir: false,
+            }],
+            total_size: 40,
+            bundle: BundleRef {
+                url: "https://files.catbox.moe/abc.zip".into(),
+                host: "catbox".into(),
+                size: 40,
+                parts: Vec::new(),
+            },
+        };
+
+        let code = encode(&share);
+        assert!(code.starts_with(CODE_PREFIX));
+        let back = decode(&code).unwrap();
+        assert_eq!(back.items, share.items);
+        assert_eq!(back.bundle.url, share.bundle.url);
+        // Pasted without its prefix — chat clients love to eat the start of a line.
+        assert_eq!(decode(code.trim_start_matches(CODE_PREFIX)).unwrap().items, share.items);
+    }
+
+    /// The two codes look alike and land in different dialogs. Saying which is which beats
+    /// "share code isn't valid".
+    #[test]
+    fn a_preset_code_says_where_it_belongs() {
+        let err = decode("MXBP1-eyJuYW1lIjoiUmVkQnVkIn0=").unwrap_err().to_string();
+        assert!(err.contains("Presets tab"), "{err}");
+    }
+
+    /// End to end minus the network: what `create` stages has to be what `import` lays down,
+    /// in the same folders, on a machine that has none of it.
+    #[test]
+    fn a_staged_share_lands_back_in_the_same_folders() {
+        let root = tmp("roundtrip");
+        let staged = root.join("share");
+        touch(&staged.join("mods/tracks/EU/RedBud.pkz"));
+        touch(&staged.join("mods/rider/helmets/AGV/paints/Blue.pnt"));
+        touch(&staged.join("share.json"));
+
+        let zip_path = root.join("share.zip");
+        bundle::zip_dir(&staged, &zip_path).unwrap();
+
+        let extracted = root.join("extracted");
+        std::fs::create_dir_all(&extracted).unwrap();
+        install::extract_archive(&zip_path, &extracted).unwrap();
+        let mods = root.join("game/mods");
+        install::place_mod(&extracted, &mods, "tracks", "", SLUG).unwrap();
+
+        assert!(mods.join("tracks/EU/RedBud.pkz").exists());
+        assert!(mods.join("rider/helmets/AGV/paints/Blue.pnt").exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn the_archive_is_named_after_what_it_carries() {
+        let item = |name: &str| ShareItem {
+            name: name.into(),
+            rel: format!("tracks/{name}"),
+            size: 1,
+            is_dir: false,
+        };
+        assert_eq!(archive_stem(&[item("RedBud.pkz")]), "RedBud");
+        assert_eq!(archive_stem(&[item("A.pkz"), item("B.pkz")]), "mxb-share-2-items");
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,6 +10,7 @@ mod config;
 mod cookie_session;
 mod dropzone;
 mod edf;
+mod fileshare;
 mod frostmod;
 mod frostmod_manage;
 mod game;
@@ -5384,6 +5385,53 @@ async fn preset_bundle_import(
         .map_err(|e| format!("{e:#}"))
 }
 
+/// What sharing these picked files would carry, and what it would leave out. Nothing is
+/// packed or uploaded — this is the dialog's preview.
+#[tauri::command]
+async fn file_share_plan(
+    app: tauri::AppHandle,
+    paths: Vec<String>,
+) -> Result<fileshare::SharePlan, String> {
+    // Off the UI thread: sizing a picked folder walks it, and a track folder is thousands
+    // of files.
+    tauri::async_runtime::spawn_blocking(move || {
+        let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
+        Ok(fileshare::plan(&cfg, &paths))
+    })
+    .await
+    .map_err(|e| format!("file_share_plan task failed: {e}"))?
+}
+
+/// Pack the picked files, upload them, and hand back the `MXBS1-` code.
+#[tauri::command]
+async fn file_share_create(
+    app: tauri::AppHandle,
+    paths: Vec<String>,
+) -> Result<String, String> {
+    let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
+    fileshare::create(&app, &cfg, &paths)
+        .await
+        .map_err(|e| format!("{e:#}"))
+}
+
+/// Read a share code without downloading anything — the import dialog's preview.
+#[tauri::command]
+fn file_share_preview(text: String) -> Result<fileshare::FileShare, String> {
+    fileshare::decode(&text).map_err(|e| format!("{e:#}"))
+}
+
+/// Download a share code's files and install them where they came from.
+#[tauri::command]
+async fn file_share_import(
+    app: tauri::AppHandle,
+    text: String,
+) -> Result<fileshare::FileShare, String> {
+    let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
+    fileshare::import(&app, &cfg, &text)
+        .await
+        .map_err(|e| format!("{e:#}"))
+}
+
 /// Every mod Manage can act on, enabled and disabled alike.
 #[tauri::command]
 async fn mods_state_scan(app: tauri::AppHandle) -> Result<Vec<modstate::ModEntry>, String> {
@@ -6120,6 +6168,10 @@ fn main() {
             preset_bundle_stats,
             preset_bundle_create,
             preset_bundle_import,
+            file_share_plan,
+            file_share_create,
+            file_share_preview,
+            file_share_import,
             mods_state_scan,
             mods_state_plan,
             mods_state_set,

--- a/src/Components/Library/Library.tsx
+++ b/src/Components/Library/Library.tsx
@@ -18,6 +18,8 @@ import {
   FileArchive,
   Folder,
   Loader2,
+  Share2,
+  ClipboardPaste,
   type LucideIcon,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -42,6 +44,7 @@ import {
 } from "./categories";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import LibraryDetail from "./LibraryDetail";
+import { ShareDialog, ImportShareDialog } from "./ShareDialogs";
 import { ViewerDialog } from "../Viewer/ViewerDialog";
 import { entryViewerProps } from "../Viewer/entryViewer";
 import { useConfig } from "../../Context/Config";
@@ -276,6 +279,9 @@ export default function Library({
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [bulkMoveOpen, setBulkMoveOpen] = useState(false);
   const [bulkUninstallOpen, setBulkUninstallOpen] = useState(false);
+  // Non-null while the share dialog is up: the absolute paths it's about to pack.
+  const [sharePaths, setSharePaths] = useState<string[] | null>(null);
+  const [importShareOpen, setImportShareOpen] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -452,6 +458,12 @@ export default function Library({
         ]
       : []),
     {
+      key: "share",
+      icon: Share2,
+      label: t("share.action"),
+      onSelect: () => setSharePaths([item.path]),
+    },
+    {
       key: "reveal",
       icon: FolderOpen,
       label: t("library.showInExplorer"),
@@ -478,6 +490,7 @@ export default function Library({
           onReveal={reveal}
           onUninstall={setUninstallTarget}
           onMove={setMoveTarget}
+          onShare={(e) => setSharePaths([e.path])}
           onOpenEntry={setDetail}
         />
       ) : (
@@ -546,6 +559,12 @@ export default function Library({
             <DropdownMenuItem onSelect={() => void pickAndImport("folder")}>
               <Folder className="size-3.5" />
               {t("import.pickFolder")}
+            </DropdownMenuItem>
+            {/* The other end of the Share action below — someone pasted you a code. */}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => setImportShareOpen(true)}>
+              <ClipboardPaste className="size-3.5" />
+              {t("share.importAction")}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
@@ -696,6 +715,14 @@ export default function Library({
             <Button
               variant="outline"
               size="sm"
+              disabled={selected.size === 0 || busy}
+              onClick={() => setSharePaths(selectedEntries.map((e) => e.path))}
+            >
+              <Share2 className="size-3.5" /> {t("share.share")}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
               disabled={selectedMovable.length === 0 || busy}
               onClick={() => setBulkMoveOpen(true)}
             >
@@ -728,6 +755,18 @@ export default function Library({
         stockGearPart={view3dProps?.stockGearPart}
         initialPaint={view3dProps?.initialPaint}
         initialGoggles={view3dProps?.initialGoggles}
+      />
+
+      <ShareDialog paths={sharePaths} onClose={() => setSharePaths(null)} />
+
+      <ImportShareDialog
+        open={importShareOpen}
+        onClose={() => setImportShareOpen(false)}
+        onImported={() => {
+          setImportShareOpen(false);
+          void load();
+          onChanged();
+        }}
       />
 
       <MoveDialog

--- a/src/Components/Library/LibraryDetail.tsx
+++ b/src/Components/Library/LibraryDetail.tsx
@@ -8,6 +8,7 @@ import {
   Maximize2,
   Box,
   Mountain,
+  Share2,
   type LucideIcon,
 } from "lucide-react";
 import { getPkzMeta, getPkzPreview, type ModType } from "../../api/mods";
@@ -35,6 +36,7 @@ interface LibraryDetailProps {
   onReveal: (e: LibraryEntry) => void;
   onUninstall: (e: LibraryEntry) => void;
   onMove: (e: LibraryEntry) => void;
+  onShare: (e: LibraryEntry) => void;
   onOpenEntry: (e: LibraryEntry) => void;
 }
 
@@ -50,6 +52,7 @@ export default function LibraryDetail({
   onReveal,
   onUninstall,
   onMove,
+  onShare,
   onOpenEntry,
 }: LibraryDetailProps) {
   const t = useT();
@@ -184,6 +187,9 @@ export default function LibraryDetail({
                   <FolderInput className="size-3.5" /> Move
                 </Button>
               )}
+              <Button variant="outline" size="sm" onClick={() => onShare(entry)}>
+                <Share2 className="size-3.5" /> {t("share.share")}
+              </Button>
               <Button variant="outline" size="sm" onClick={() => onReveal(entry)}>
                 <FolderOpen className="size-3.5" /> Show in Explorer
               </Button>

--- a/src/Components/Library/ShareDialogs.tsx
+++ b/src/Components/Library/ShareDialogs.tsx
@@ -1,0 +1,332 @@
+/**
+ * Sharing installed content, and taking someone else's.
+ *
+ * The preset share in the Presets tab hands over a *look*. This hands over the files —
+ * a track, a paint, a folder of both — as a one-line code that installs them where the
+ * sender had them. Same upload, same slicing past one part; see `src-tauri/src/fileshare.rs`.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { AlertTriangle, Check, Copy, Download, Loader2, Share2, UploadCloud } from "lucide-react";
+import { toast } from "sonner";
+import {
+  fileShareCreate,
+  fileShareImport,
+  fileSharePlan,
+  fileSharePreview,
+  onFileShareProgress,
+} from "../../api/mods";
+import type { BundlePhase, FileShare, SharePlan } from "../../types";
+import { formatBytes } from "../../lib/mods";
+import { copyText } from "../../lib/clipboard";
+import { useT, type TFunc } from "../../i18n/context";
+import { Button } from "@/Components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/Components/ui/dialog";
+
+function phaseLabel(phase: BundlePhase, t: TFunc): string {
+  switch (phase) {
+    case "bundling":
+      return t("share.phasePacking");
+    case "uploading":
+      return t("share.phaseUploading");
+    case "downloading":
+      return t("share.phaseDownloading");
+    case "installing":
+      return t("share.phaseInstalling");
+    case "done":
+      return t("common.done");
+  }
+}
+
+/** The files a share carries, listed with the folder each one goes back into. */
+function ItemList({ items }: { items: { rel: string; name: string; size: number }[] }) {
+  return (
+    <div className="max-h-40 overflow-y-auto rounded-lg border border-white/[0.07] bg-card/40">
+      {items.map((item) => (
+        <div
+          key={item.rel}
+          className="flex items-baseline gap-2 border-b border-white/[0.04] px-2.5 py-1.5 text-[12px] last:border-b-0"
+        >
+          <span className="truncate font-semibold">{item.name}</span>
+          <span className="truncate text-[11px] text-faint">{item.rel}</span>
+          <span className="ml-auto flex-none text-[11px] text-muted-foreground">
+            {formatBytes(item.size)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Share the picked paths. `paths` non-null opens the dialog; the plan is worked out
+ * up front so the size is on screen *before* anything is uploaded.
+ */
+export function ShareDialog({
+  paths,
+  onClose,
+}: {
+  paths: string[] | null;
+  onClose: () => void;
+}) {
+  const t = useT();
+  const [plan, setPlan] = useState<SharePlan | null>(null);
+  const [code, setCode] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [phase, setPhase] = useState<BundlePhase | null>(null);
+
+  useEffect(() => {
+    if (!paths) return;
+    setPlan(null);
+    setCode(null);
+    setCopied(false);
+    setPhase(null);
+    let cancelled = false;
+    fileSharePlan(paths)
+      .then((p) => !cancelled && setPlan(p))
+      .catch((e) => !cancelled && toast.error(String(e).replace(/^Error:\s*/, "")));
+    return () => {
+      cancelled = true;
+    };
+  }, [paths]);
+
+  const create = useCallback(async () => {
+    if (!paths) return;
+    setBusy(true);
+    setPhase("bundling");
+    const unlisten = await onFileShareProgress((p) => setPhase(p.phase));
+    try {
+      const c = await fileShareCreate(paths);
+      setCode(c);
+      setCopied(false);
+      // Straight to the clipboard: the code exists to be pasted somewhere, and a player
+      // who has waited out an upload shouldn't have to click again to collect it.
+      if (await copyText(c)) {
+        setCopied(true);
+        toast.success(t("share.uploadedCopied"));
+      } else {
+        toast.success(t("share.uploaded"));
+      }
+    } catch (e) {
+      toast.error(String(e).replace(/^Error:\s*/, ""));
+    } finally {
+      unlisten();
+      setBusy(false);
+      setPhase(null);
+    }
+  }, [paths, t]);
+
+  const count = plan?.items.length ?? 0;
+
+  return (
+    <Dialog open={!!paths} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("share.title")}</DialogTitle>
+          <DialogDescription>
+            {code ? t("share.hintDone") : t("share.hint")}
+          </DialogDescription>
+        </DialogHeader>
+
+        {plan && count > 0 && <ItemList items={plan.items} />}
+
+        {plan && count === 0 && (
+          <p className="flex items-start gap-1.5 text-[12px] text-muted-foreground">
+            <AlertTriangle className="mt-px size-3.5 flex-none" />
+            {t("share.nothingToShare")}
+          </p>
+        )}
+
+        {plan && plan.skipped.length > 0 && (
+          <p className="flex items-start gap-1.5 text-[11.5px] text-amber-500">
+            <AlertTriangle className="mt-px size-3.5 flex-none" />
+            <span>
+              {t("share.skipped", {
+                count: plan.skipped.length,
+                reason: plan.skipped[0].reason,
+              })}
+            </span>
+          </p>
+        )}
+
+        {code ? (
+          <textarea
+            readOnly
+            value={code}
+            onFocus={(e) => e.currentTarget.select()}
+            className="h-24 w-full resize-none rounded-lg border border-input bg-transparent p-2.5 font-mono text-[11px] leading-snug"
+          />
+        ) : (
+          plan &&
+          count > 0 && (
+            <p className="text-[11px] text-faint">{t("presets.shareWarning")}</p>
+          )
+        )}
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose} disabled={busy}>
+            {t("common.close")}
+          </Button>
+          {code ? (
+            <Button
+              onClick={async () => {
+                if (await copyText(code)) {
+                  setCopied(true);
+                  toast.success(t("share.copied"));
+                } else {
+                  toast.error(t("presets.copyFailed"));
+                }
+              }}
+            >
+              {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+              {copied ? t("modDetail.copied") : t("share.copyCode")}
+            </Button>
+          ) : (
+            <Button disabled={busy || !plan || count === 0} onClick={() => void create()}>
+              {busy ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <UploadCloud className="size-4" />
+              )}
+              {busy && phase
+                ? phaseLabel(phase, t)
+                : t("share.createCode", {
+                    count,
+                    size: formatBytes(plan?.totalSize ?? 0),
+                  })}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** Paste a `MXBS1-` code and install what it carries. */
+export function ImportShareDialog({
+  open,
+  onClose,
+  onImported,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onImported: () => void;
+}) {
+  const t = useT();
+  const [text, setText] = useState("");
+  const [preview, setPreview] = useState<FileShare | null>(null);
+  const [previewErr, setPreviewErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [phase, setPhase] = useState<BundlePhase | null>(null);
+
+  useEffect(() => {
+    if (open) return;
+    setText("");
+    setPreview(null);
+    setPreviewErr(null);
+    setPhase(null);
+  }, [open]);
+
+  useEffect(() => {
+    const code = text.trim();
+    if (!code) {
+      setPreview(null);
+      setPreviewErr(null);
+      return;
+    }
+    let cancelled = false;
+    fileSharePreview(code)
+      .then((s) => {
+        if (cancelled) return;
+        setPreview(s);
+        setPreviewErr(null);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setPreview(null);
+        setPreviewErr(String(e).replace(/^Error:\s*/, ""));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [text]);
+
+  const install = useCallback(async () => {
+    if (!preview) return;
+    setBusy(true);
+    setPhase("downloading");
+    const unlisten = await onFileShareProgress((p) => setPhase(p.phase));
+    try {
+      const done = await fileShareImport(text.trim());
+      toast.success(t("share.installed", { count: done.items.length }));
+      onImported();
+    } catch (e) {
+      toast.error(String(e).replace(/^Error:\s*/, ""));
+    } finally {
+      unlisten();
+      setBusy(false);
+      setPhase(null);
+    }
+  }, [preview, text, onImported, t]);
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("share.importTitle")}</DialogTitle>
+          <DialogDescription>{t("share.importBody")}</DialogDescription>
+        </DialogHeader>
+
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="MXBS1-…"
+          className="h-24 w-full resize-none rounded-lg border border-input bg-transparent p-2.5 font-mono text-[11px] leading-snug placeholder:text-faint focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+        />
+
+        {previewErr && text.trim() && (
+          <p className="flex items-start gap-1.5 text-[12px] text-destructive">
+            <AlertTriangle className="mt-px size-3.5 flex-none" />
+            {previewErr}
+          </p>
+        )}
+
+        {preview && (
+          <>
+            <ItemList items={preview.items} />
+            <p className="flex items-start gap-1.5 text-[11.5px] text-emerald-500">
+              <Share2 className="mt-px size-3.5 flex-none" />
+              <span>
+                {t("share.downloadNotice", {
+                  size: formatBytes(preview.totalSize),
+                  host: preview.bundle.host,
+                })}
+              </span>
+            </p>
+          </>
+        )}
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose} disabled={busy}>
+            {t("common.cancel")}
+          </Button>
+          <Button disabled={!preview || busy} onClick={() => void install()}>
+            {busy ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Download className="size-4" />
+            )}
+            {busy && phase ? phaseLabel(phase, t) : t("share.install")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/Components/Presets/Presets.tsx
+++ b/src/Components/Presets/Presets.tsx
@@ -75,6 +75,7 @@ import {
   type Scans,
 } from "../../lib/presets";
 import { useGearPaints } from "../../lib/useGearPaints";
+import { copyText } from "../../lib/clipboard";
 
 function humanSize(bytes: number): string {
   if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
@@ -94,27 +95,6 @@ function phaseLabel(phase: BundlePhase, t: TFunc): string {
       return t("presets.phaseInstalling");
     case "done":
       return t("common.done");
-  }
-}
-
-async function copyText(text: string): Promise<boolean> {
-  try {
-    await navigator.clipboard.writeText(text);
-    return true;
-  } catch {
-    try {
-      const ta = document.createElement("textarea");
-      ta.value = text;
-      ta.style.position = "fixed";
-      ta.style.opacity = "0";
-      document.body.appendChild(ta);
-      ta.select();
-      const ok = document.execCommand("copy");
-      document.body.removeChild(ta);
-      return ok;
-    } catch {
-      return false;
-    }
   }
 }
 

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -48,6 +48,8 @@ import type {
   ReloadOutcome,
   BundlePlan,
   BundleProgress,
+  SharePlan,
+  FileShare,
   GameId,
   GameInfo,
 } from "../types";
@@ -1897,6 +1899,36 @@ export function onPresetBundleProgress(
   cb: (p: BundleProgress) => void,
 ): Promise<UnlistenFn> {
   return listen<BundleProgress>("preset-bundle-progress", (event) => cb(event.payload));
+}
+
+// ── Sharing installed files (any track, paint or pack — not just presets) ────
+
+/** What sharing these installed paths would carry, and what it would leave out. */
+export function fileSharePlan(paths: string[]): Promise<SharePlan> {
+  return invoke<SharePlan>("file_share_plan", { paths });
+}
+
+/** Pack + upload the picked files, returning a one-line share code (`MXBS1-…`). */
+export function fileShareCreate(paths: string[]): Promise<string> {
+  return invoke<string>("file_share_create", { paths });
+}
+
+/** Read a share code *without* downloading — preview what it carries. */
+export function fileSharePreview(text: string): Promise<FileShare> {
+  return invoke<FileShare>("file_share_preview", { text });
+}
+
+/** Download a share code's files and install them where the sender had them. */
+export function fileShareImport(text: string): Promise<FileShare> {
+  return invoke<FileShare>("file_share_import", { text });
+}
+
+/** Subscribe to file-share create/import phase updates. Same payload as the preset
+ *  bundle's, on its own event so the two dialogs never cross. */
+export function onFileShareProgress(
+  cb: (p: BundleProgress) => void,
+): Promise<UnlistenFn> {
+  return listen<BundleProgress>("file-share-progress", (event) => cb(event.payload));
 }
 
 /** `"windows"` | `"macos"` | `"linux"`. Features gated on the OS ask the backend rather

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -898,6 +898,36 @@ export const de: Translation = {
   "library.bulkMoved_other":
     "{{count}} Elemente nach {{folder}} verschoben",
 
+  // ── Installierte Dateien teilen (jede Strecke, jede Lackierung) ────────────
+  "share.share": "Teilen",
+  "share.action": "Teilen…",
+  "share.title": "Diese Dateien teilen",
+  "share.hint":
+    "Wir packen sie ein, laden sie hoch und geben dir einen einzigen Code zum Einfügen. Wer ihn einfügt, bekommt die Dateien in denselben Ordnern.",
+  "share.hintDone": "Schick diesen Code weiter — er installiert alles von oben.",
+  "share.nothingToShare":
+    "Hier gibt es nichts zu teilen — in einen Code passen nur Dateien aus deinem mods-Ordner.",
+  "share.skipped_one": "1 Auswahl ausgelassen ({{reason}}).",
+  "share.skipped_other": "{{count}} Auswahlen ausgelassen ({{reason}}).",
+  "share.createCode_one": "1 Datei teilen ({{size}})",
+  "share.createCode_other": "{{count}} Dateien teilen ({{size}})",
+  "share.copyCode": "Code kopieren",
+  "share.copied": "Teilen-Code kopiert.",
+  "share.uploaded": "Hochgeladen — kopier den Code unten.",
+  "share.uploadedCopied": "Hochgeladen — der Code liegt in der Zwischenablage.",
+  "share.importAction": "Teilen-Code einfügen…",
+  "share.importTitle": "Geteilte Dateien importieren",
+  "share.importBody":
+    "Füg den Code ein, den du bekommen hast. Die Dateien landen dort, wo der Absender sie hatte.",
+  "share.downloadNotice": "Lädt {{size}} von {{host}}.",
+  "share.install": "Herunterladen & installieren",
+  "share.installed_one": "1 Datei installiert.",
+  "share.installed_other": "{{count}} Dateien installiert.",
+  "share.phasePacking": "Dateien werden gepackt…",
+  "share.phaseUploading": "Wird hochgeladen…",
+  "share.phaseDownloading": "Wird heruntergeladen…",
+  "share.phaseInstalling": "Wird installiert…",
+
   // ── Spind ──────────────────────────────────────────────────────────────────
   "locker.help":
     "Wechsle Modell und Motorsound jedes Motorrads zwischen den Sets, die du installiert hast.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -867,6 +867,36 @@ export const en = {
   "library.bulkMoved_one": "Moved {{count}} item to {{folder}}",
   "library.bulkMoved_other": "Moved {{count}} items to {{folder}}",
 
+  // ── Sharing installed files (any track or paint, not just presets) ─────────
+  "share.share": "Share",
+  "share.action": "Share…",
+  "share.title": "Share these files",
+  "share.hint":
+    "Packs them up, uploads them, and gives you one code to paste anywhere. Whoever pastes it back gets the files in the same folders.",
+  "share.hintDone": "Send this code — it installs everything listed above.",
+  "share.nothingToShare":
+    "Nothing here can be shared — only files inside your mods folder can go in a code.",
+  "share.skipped_one": "1 pick left out ({{reason}}).",
+  "share.skipped_other": "{{count}} picks left out ({{reason}}).",
+  "share.createCode_one": "Share 1 file ({{size}})",
+  "share.createCode_other": "Share {{count}} files ({{size}})",
+  "share.copyCode": "Copy code",
+  "share.copied": "Share code copied.",
+  "share.uploaded": "Uploaded — copy the code below.",
+  "share.uploadedCopied": "Uploaded — the code is on your clipboard.",
+  "share.importAction": "Paste a share code…",
+  "share.importTitle": "Import shared files",
+  "share.importBody":
+    "Paste a share code someone sent you. The files install where they had them.",
+  "share.downloadNotice": "Downloads {{size}} from {{host}}.",
+  "share.install": "Download & install",
+  "share.installed_one": "Installed 1 file.",
+  "share.installed_other": "Installed {{count}} files.",
+  "share.phasePacking": "Packing files…",
+  "share.phaseUploading": "Uploading…",
+  "share.phaseDownloading": "Downloading…",
+  "share.phaseInstalling": "Installing…",
+
   // ── Locker (per-bike model + sound swaps) ──────────────────────────────────
   "locker.help":
     "Swap each bike's model and engine sound between the sets you've installed.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -889,6 +889,36 @@ export const es: Translation = {
   "library.bulkMoved_one": "{{count}} elemento movido a {{folder}}",
   "library.bulkMoved_other": "{{count}} elementos movidos a {{folder}}",
 
+  // ── Compartir archivos instalados (cualquier pista o pintura) ──────────────
+  "share.share": "Compartir",
+  "share.action": "Compartir…",
+  "share.title": "Comparte estos archivos",
+  "share.hint":
+    "Los empaqueta, los sube y te da un único código para pegar donde quieras. Quien lo pegue recibe los archivos en las mismas carpetas.",
+  "share.hintDone": "Envía este código: instala todo lo que aparece arriba.",
+  "share.nothingToShare":
+    "Aquí no hay nada que compartir: en un código solo caben archivos de tu carpeta mods.",
+  "share.skipped_one": "1 elemento excluido ({{reason}}).",
+  "share.skipped_other": "{{count}} elementos excluidos ({{reason}}).",
+  "share.createCode_one": "Compartir 1 archivo ({{size}})",
+  "share.createCode_other": "Compartir {{count}} archivos ({{size}})",
+  "share.copyCode": "Copiar código",
+  "share.copied": "Código de compartir copiado.",
+  "share.uploaded": "Subido: copia el código de abajo.",
+  "share.uploadedCopied": "Subido: el código está en el portapapeles.",
+  "share.importAction": "Pegar un código…",
+  "share.importTitle": "Importar archivos compartidos",
+  "share.importBody":
+    "Pega el código que te han enviado. Los archivos se instalan donde los tenía quien los compartió.",
+  "share.downloadNotice": "Descarga {{size}} desde {{host}}.",
+  "share.install": "Descargar e instalar",
+  "share.installed_one": "1 archivo instalado.",
+  "share.installed_other": "{{count}} archivos instalados.",
+  "share.phasePacking": "Empaquetando archivos…",
+  "share.phaseUploading": "Subiendo…",
+  "share.phaseDownloading": "Descargando…",
+  "share.phaseInstalling": "Instalando…",
+
   // ── Taquilla ───────────────────────────────────────────────────────────────
   "locker.help":
     "Cambia el modelo y el sonido del motor de cada moto entre los sets que tengas instalados.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -892,6 +892,36 @@ export const fr: Translation = {
   "library.bulkMoved_one": "{{count}} élément déplacé vers {{folder}}",
   "library.bulkMoved_other": "{{count}} éléments déplacés vers {{folder}}",
 
+  // ── Partage des fichiers installés (n'importe quel circuit ou peinture) ────
+  "share.share": "Partager",
+  "share.action": "Partager…",
+  "share.title": "Partager ces fichiers",
+  "share.hint":
+    "On les empaquette, on les envoie, et tu récupères un seul code à coller où tu veux. Celui qui le colle retrouve les fichiers dans les mêmes dossiers.",
+  "share.hintDone": "Envoie ce code : il installe tout ce qui est listé au-dessus.",
+  "share.nothingToShare":
+    "Rien à partager ici : seuls les fichiers de ton dossier mods peuvent entrer dans un code.",
+  "share.skipped_one": "1 élément écarté ({{reason}}).",
+  "share.skipped_other": "{{count}} éléments écartés ({{reason}}).",
+  "share.createCode_one": "Partager 1 fichier ({{size}})",
+  "share.createCode_other": "Partager {{count}} fichiers ({{size}})",
+  "share.copyCode": "Copier le code",
+  "share.copied": "Code de partage copié.",
+  "share.uploaded": "Envoyé : copie le code ci-dessous.",
+  "share.uploadedCopied": "Envoyé : le code est dans le presse-papiers.",
+  "share.importAction": "Coller un code…",
+  "share.importTitle": "Importer des fichiers partagés",
+  "share.importBody":
+    "Colle le code qu'on t'a envoyé. Les fichiers s'installent là où l'expéditeur les avait.",
+  "share.downloadNotice": "Télécharge {{size}} depuis {{host}}.",
+  "share.install": "Télécharger et installer",
+  "share.installed_one": "1 fichier installé.",
+  "share.installed_other": "{{count}} fichiers installés.",
+  "share.phasePacking": "Préparation des fichiers…",
+  "share.phaseUploading": "Envoi…",
+  "share.phaseDownloading": "Téléchargement…",
+  "share.phaseInstalling": "Installation…",
+
   // ── Casier ─────────────────────────────────────────────────────────────────
   "locker.help":
     "Changez le modèle et le son moteur de chaque moto parmi les sets que vous avez installés.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -882,6 +882,36 @@ export const it: Translation = {
   "library.bulkMoved_one": "Spostato {{count}} elemento in {{folder}}",
   "library.bulkMoved_other": "Spostati {{count}} elementi in {{folder}}",
 
+  // ── Condivisione dei file installati (qualsiasi pista o vernice) ───────────
+  "share.share": "Condividi",
+  "share.action": "Condividi…",
+  "share.title": "Condividi questi file",
+  "share.hint":
+    "Li impacchetta, li carica e ti dà un unico codice da incollare dove vuoi. Chi lo incolla ottiene i file nelle stesse cartelle.",
+  "share.hintDone": "Invia questo codice: installa tutto quello che vedi sopra.",
+  "share.nothingToShare":
+    "Qui non c'è niente da condividere: in un codice possono finire solo i file dentro la tua cartella mods.",
+  "share.skipped_one": "1 elemento escluso ({{reason}}).",
+  "share.skipped_other": "{{count}} elementi esclusi ({{reason}}).",
+  "share.createCode_one": "Condividi 1 file ({{size}})",
+  "share.createCode_other": "Condividi {{count}} file ({{size}})",
+  "share.copyCode": "Copia codice",
+  "share.copied": "Codice di condivisione copiato.",
+  "share.uploaded": "Caricato: copia il codice qui sotto.",
+  "share.uploadedCopied": "Caricato: il codice è negli appunti.",
+  "share.importAction": "Incolla un codice…",
+  "share.importTitle": "Importa file condivisi",
+  "share.importBody":
+    "Incolla il codice che ti hanno mandato. I file si installano dove li teneva chi li ha condivisi.",
+  "share.downloadNotice": "Scarica {{size}} da {{host}}.",
+  "share.install": "Scarica e installa",
+  "share.installed_one": "Installato 1 file.",
+  "share.installed_other": "Installati {{count}} file.",
+  "share.phasePacking": "Preparazione dei file…",
+  "share.phaseUploading": "Caricamento…",
+  "share.phaseDownloading": "Download…",
+  "share.phaseInstalling": "Installazione…",
+
   // ── Armadietto ─────────────────────────────────────────────────────────────
   "locker.help":
     "Cambia il modello e il suono del motore di ogni moto tra i set che hai installato.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -886,6 +886,36 @@ export const ptBR: Translation = {
   "library.bulkMoved_one": "{{count}} item movido para {{folder}}",
   "library.bulkMoved_other": "{{count}} itens movidos para {{folder}}",
 
+  // ── Compartilhar arquivos instalados (qualquer pista ou pintura) ───────────
+  "share.share": "Compartilhar",
+  "share.action": "Compartilhar…",
+  "share.title": "Compartilhar estes arquivos",
+  "share.hint":
+    "A gente empacota, envia e te devolve um código só para colar onde quiser. Quem colar recebe os arquivos nas mesmas pastas.",
+  "share.hintDone": "Manda esse código — ele instala tudo que está listado acima.",
+  "share.nothingToShare":
+    "Não há nada para compartilhar aqui — só arquivos dentro da sua pasta mods cabem em um código.",
+  "share.skipped_one": "1 item de fora ({{reason}}).",
+  "share.skipped_other": "{{count}} itens de fora ({{reason}}).",
+  "share.createCode_one": "Compartilhar 1 arquivo ({{size}})",
+  "share.createCode_other": "Compartilhar {{count}} arquivos ({{size}})",
+  "share.copyCode": "Copiar código",
+  "share.copied": "Código de compartilhamento copiado.",
+  "share.uploaded": "Enviado — copie o código abaixo.",
+  "share.uploadedCopied": "Enviado — o código está na área de transferência.",
+  "share.importAction": "Colar um código…",
+  "share.importTitle": "Importar arquivos compartilhados",
+  "share.importBody":
+    "Cole o código que te mandaram. Os arquivos são instalados onde quem compartilhou os mantinha.",
+  "share.downloadNotice": "Baixa {{size}} de {{host}}.",
+  "share.install": "Baixar e instalar",
+  "share.installed_one": "1 arquivo instalado.",
+  "share.installed_other": "{{count}} arquivos instalados.",
+  "share.phasePacking": "Empacotando arquivos…",
+  "share.phaseUploading": "Enviando…",
+  "share.phaseDownloading": "Baixando…",
+  "share.phaseInstalling": "Instalando…",
+
   // ── Armário ────────────────────────────────────────────────────────────────
   "locker.help":
     "Troque o modelo e o som do motor de cada moto entre os sets que você instalou.",

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,28 @@
+/**
+ * Copy text to the clipboard, saying whether it worked.
+ *
+ * The async Clipboard API is the right call and fails anyway in a webview that hasn't
+ * focused the document — which is exactly the moment a player clicks "Copy code". The
+ * `execCommand` fallback is deprecated everywhere and still the one that lands there, so
+ * both paths stay until the webviews agree.
+ */
+export async function copyText(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    try {
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      const ok = document.execCommand("copy");
+      document.body.removeChild(ta);
+      return ok;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -917,6 +917,36 @@ export interface BundleProgress {
   message?: string;
 }
 
+/** Where a shared file goes back on the importer's machine. */
+export interface ShareItem {
+  name: string;
+  /** Path under the mods root, forward-slashed (`tracks/EU/RedBud.pkz`). */
+  rel: string;
+  size: number;
+  isDir: boolean;
+}
+
+/** A picked path that can't be shared, and why. */
+export interface ShareSkipped {
+  path: string;
+  reason: string;
+}
+
+/** Preview of what sharing the current picks would carry — nothing is uploaded yet. */
+export interface SharePlan {
+  items: ShareItem[];
+  skipped: ShareSkipped[];
+  totalSize: number;
+}
+
+/** What a `MXBS1-` file-share code decodes to. */
+export interface FileShare {
+  items: ShareItem[];
+  /** Size of the hosted zip — what an import downloads. */
+  totalSize: number;
+  bundle: BundleRef;
+}
+
 export type SlotSource =
   | "bikePaint" // liveries for the selected bike
   | "helmet" // helmet models


### PR DESCRIPTION
Sharing was a preset's privilege: a code named slots, and the full bundle packed whatever those slots resolved to. Handing someone the track you just rode, or a paint you just made, still meant uploading it somewhere and pasting a link in chat. Anything the Library lists can now go straight into a code.

## What's in it

**`src-tauri/src/fileshare.rs`** — plan → pack → upload → `MXBS1-…` code, and the same in reverse on import. A code carries `mods/`-relative paths, so a track picked out of `tracks/EU/` lands in `tracks/EU/` on the other machine and a helmet paint goes back to its helmet, rather than wherever the importer's Library tab happened to be pointing.

`plan` is also the guard on paths arriving from the frontend: anything not under the mods root is skipped with a reason, never packed or uploaded. Repeats, and files a picked folder already carries, are dropped so nothing is packed twice.

**Reuse over a fork.** `bundle::fetch` (MEGA / sliced / plain), `zip_dir`, `copy_tree` and the phase emitter are now shared with the preset bundle, with the event name a parameter so the two dialogs never hear each other's progress. That brings the 2 GB ceiling and multi-part slicing along for free — a big track already works, and a share whose parts have gone missing says which one.

**UI.** Share on any Library row, on the detail view, and on a multi-select (the bulk bar shares everything ticked as one code). The Import menu gains *Paste a share code…*, which previews what a code holds, how big the download is and where it's hosted before anything is fetched. Pasting a preset code there says to use the Presets tab instead of failing as a bad code. Strings are in all six locales; `copyText` moved out of Presets into `lib/clipboard` now that two screens copy a code.

No DB or schema changes. Preset codes are untouched — `BundleRef` is reused as-is and serializes exactly as before.

## Checks

- 7 new Rust tests: rel-path resolution across two corners of the tree, the outside-the-mods-root refusal, nested-pick dedup, code round-trip (with and without the prefix — chat clients eat the start of a line), the preset-code message, archive naming, and a staged share extracting back into the same folders. Existing bundle / install / presets tests still pass.
- `tsc` and `eslint` clean over `src`; `vite build` succeeds.

Two pre-existing issues I ran into and did **not** touch, both reproducible on a clean checkout:

- `gearrepair::tests::a_move_that_fails_part_way_puts_everything_back` fails when the suite runs as root — it needs a permission-denied rename, which root ignores.
- `npm run typecheck` / `npm run build` fail at the `tsc` step on `tsconfig.json`'s deprecated `baseUrl` under the locked TypeScript 5.9.3 (TS5101). I verified types with an override config instead. A one-line `"ignoreDeprecations": "5.0"` would make the build script green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sjntGjfnNzxuxyspKsKUA

---
_Generated by [Claude Code](https://claude.ai/code/session_011sjntGjfnNzxuxyspKsKUA)_