### PR TITLE
feat(servers): launch from a prebuilt image instead of installing every time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## Unreleased — a server arrives in two minutes, not fifteen
+
+### Added
+- **Servers launch from a prebuilt image.** Every one of them used to download and install the
+  same 6 GB — the game, then the whole bike pack — which was the entire wait. That work now
+  happens once, into a machine image, and each new server writes its own config and starts.
+  Two minutes instead of fifteen, and it stops getting slower every time the pack grows.
+  Building the image is a one-off `POST /v1/images/build`; until one exists, servers install
+  from scratch exactly as before.
+
+## Unreleased — share any track or paint, not just a preset
+
+### Added
+- **Share installed files with a code.** Sharing was a preset's privilege: a code carried a
+  *look*, and the full bundle packed whatever its slots resolved to. Handing someone the track
+  you just rode, or the paint you just made, still meant uploading it somewhere and pasting a
+  link. Anything the Library lists can now go straight into a code — **Share** on any item, or
+  pick several with **Select** and share them together. It packs them, uploads them, and puts
+  one line on your clipboard.
+- **The other end: Import → Paste a share code…** Files land back in the folders the sender
+  had them in — a track filed under `tracks/EU/` arrives under `tracks/EU/`, a helmet paint
+  goes to the helmet it belongs to — so a share carries where things go, not just what they
+  are. The code is previewed before anything downloads: what it holds, how big it is, and
+  where it's hosted.
+- Sharing reuses the preset bundle's upload, so the same 2 GB ceiling and the same slicing
+  past one part apply, and a share whose parts have gone missing says which one.
+
+## Unreleased — a created server can see the bikes it installed
+
+### Fixed
+- **A provisioned server rejected riders on bikes it had been given.** The pack was downloaded
+  into the game folder, and MX Bikes reads mods from PiBoSo's user folder instead — the same
+  place the client uses, which under the service account lives elsewhere entirely. The files
+  were on disk the whole time and the game was never looking there. They now install where the
+  game reads, with the game folder linked to the same content so nothing is copied twice.
+
+## Unreleased — a full share isn't capped at 200 MB any more
+
+### Changed
+- **Full-share bundles are no longer capped at 200 MB.** That ceiling was the upload host's,
+  not ours, and a preset carrying a big track or a few detailed bikes ran straight into it. A
+  bundle past 190 MB is now sliced across several uploads and stitched back together on
+  import, taking the limit to 2 GB. Codes for smaller bundles are unchanged, and a share whose
+  parts have gone missing says so — with the size it expected — instead of failing at the
+  unzip.
+
 ## 2026-08-11 — v0.9.2 — A track's terrain in 3D, and voice chat picks its microphone
 
 On top of v0.9.1 — the Designer's painting tools, Play on macOS and the SteamOS white screen
@@ -181,7 +227,6 @@ looking nothing like the track you ride, name it in the report — that's the th
 - The `msvcr90.dll` copy beside the executable is written without elevation, so it cannot
   land in a game folder under `Program Files`. A Steam install there still needs the runtime
   repaired by hand until the elevated fallback lands.
-
 
 ## Unannounced — a debugger can't ride along
 

--- a/control-plane/migrations/0009_golden_image.sql
+++ b/control-plane/migrations/0009_golden_image.sql
@@ -1,0 +1,20 @@
+-- Somewhere to remember the machine image servers launch from.
+--
+-- Every provisioned server currently downloads and installs from scratch: 2.4 GB of game and
+-- 3.8 GB of bikes, every time, which is the whole of the fifteen minutes it takes to arrive.
+-- None of that changes between servers, so it only has to be done once — into an image every
+-- later server boots from.
+--
+-- A key/value table rather than a column somewhere: what is stored is a fact about the
+-- deployment, not about any one server, and the build is a small state machine (building,
+-- waiting for the image, ready) that wants somewhere to keep its place across cron runs.
+CREATE TABLE settings (
+  key         TEXT PRIMARY KEY,
+  value       TEXT NOT NULL,
+  updated_at  INTEGER NOT NULL
+);
+
+-- Marks the rows that exist to build an image rather than to be ridden on. They are launched,
+-- reported on and reaped like any other server, so they live in the same table; without this
+-- the idle reaper would treat a builder as an empty server and destroy it mid-install.
+ALTER TABLE servers ADD COLUMN role TEXT;

--- a/control-plane/src/aws.ts
+++ b/control-plane/src/aws.ts
@@ -197,6 +197,41 @@ export async function startInstance(env: AwsEnv, instanceId: string): Promise<vo
 }
 
 /** Destroy it, disk included. The only action that stops every charge for a server. */
+/**
+ * Snapshot a built instance into an image later servers launch from.
+ *
+ * `NoReboot=false` on purpose: letting EC2 stop the machine first means the disk is
+ * consistent, which matters when the thing being captured is a half-gigabyte of freshly
+ * written game files. A crash-consistent image of a Windows box mid-write is not worth the
+ * two minutes it saves.
+ */
+export async function createImage(
+  env: AwsEnv,
+  instanceId: string,
+  name: string,
+): Promise<string> {
+  const xml = await ec2(env, "CreateImage", {
+    InstanceId: instanceId,
+    Name: name,
+    Description: "MXB dedicated server, game and bikes preinstalled",
+    NoReboot: "false",
+  });
+  const id = pluck(xml, "imageId")[0];
+  if (!id) throw new Error("CreateImage returned no image id");
+  return id;
+}
+
+/** `pending` while it bakes, `available` once it can be launched, `failed` if it cannot. */
+export async function imageState(env: AwsEnv, imageId: string): Promise<string | null> {
+  const xml = await ec2(env, "DescribeImages", { "ImageId.1": imageId });
+  return pluck(xml, "imageState")[0] ?? null;
+}
+
+/** Retire a superseded image. Its snapshot bills monthly until it goes. */
+export async function deregisterImage(env: AwsEnv, imageId: string): Promise<void> {
+  await ec2(env, "DeregisterImage", { ImageId: imageId });
+}
+
 export async function terminateInstance(env: AwsEnv, instanceId: string): Promise<void> {
   await ec2(env, "TerminateInstances", { "InstanceId.1": instanceId });
 }

--- a/control-plane/src/bootstrap.ts
+++ b/control-plane/src/bootstrap.ts
@@ -47,15 +47,124 @@ const ROOT = "C:\\mxb";
  * rather than as cmd, and `<persist>false</persist>` keeps it to first boot only — this
  * script is not idempotent and re-running it on every start would rewrite live config.
  */
-export function bootstrapScript(input: BootstrapInputs): string {
-  // Values are interpolated into a PowerShell string, so anything that could close a quote
-  // or start a new statement has to be refused rather than escaped. The callers validate
-  // too; this is the last line before it becomes code on someone's machine.
+/**
+ * What a server launched from a prebuilt image runs.
+ *
+ * Everything expensive — the game, the bikes, the agent binary — is already on the disk, so
+ * this only does the parts that differ per server: the name and track it advertises, and its
+ * own agent token, which cannot be baked into a shared image because every server has a
+ * different one.
+ *
+ * Seconds rather than the quarter of an hour a from-scratch install takes, and it stays that
+ * way as the bike pack grows.
+ */
+export function imageBootstrapScript(input: BootstrapInputs): string {
+  guardInputs(input);
+  return `<powershell>
+$ErrorActionPreference = "Stop"
+Start-Transcript -Path "C:\\mxb-bootstrap.log" -Append
+
+function Send-Stage {
+  param([string] $Stage, [bool] $Ok = $true, [string] $Log = "")
+  try {
+    $payload = @{ stage = $Stage; ok = $Ok; log = $Log } | ConvertTo-Json -Compress
+    Invoke-RestMethod -Method POST -Uri "${input.controlPlaneUrl}/v1/servers/${input.serverId}/bootstrap" -Headers @{ "Authorization" = "Bearer ${input.agentToken}"; "Content-Type" = "application/json" } -Body $payload -TimeoutSec 15 | Out-Null
+  } catch {
+    Write-Output "couldn't report stage '$Stage': $_"
+  }
+}
+
+trap {
+  $reason = "$_"
+  Write-Output "bootstrap failed: $reason"
+  try { Stop-Transcript } catch {}
+  $tail = ""
+  try { $tail = (Get-Content -Path "C:\\mxb-bootstrap.log" -Tail 200 | Out-String) } catch {}
+  Send-Stage -Stage "failed" -Ok $false -Log "$reason\`n$tail"
+  Stop-Computer -Force
+  exit 1
+}
+
+Send-Stage -Stage "starting up"
+
+# The image carries the game and the bikes. If it does not, this is not the image we think it
+# is, and a server that comes up without them refuses every rider on a mod bike.
+if (-not (Test-Path "${ROOT}\\game\\mxbikes.exe")) { throw "this image has no game installed" }
+
+@"
+[connection]
+name = ${input.serverName}
+maxclient = 20
+
+[event]
+track = Victoria
+track_layout =
+"@ | Set-Content -Path "${ROOT}\\game\\dedicated.ini" -Encoding ASCII
+
+$imdsToken = Invoke-RestMethod -Method PUT -Uri "http://169.254.169.254/latest/api/token" -Headers @{ "X-aws-ec2-metadata-token-ttl-seconds" = "300" } -TimeoutSec 10
+$publicIp = Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/public-ipv4" -Headers @{ "X-aws-ec2-metadata-token" = $imdsToken } -TimeoutSec 10
+if (-not $publicIp) { throw "this instance has no public address" }
+
+# The one thing that cannot be baked in: every server has its own token.
+@{
+  token = "${input.agentToken}"
+  listen = "0.0.0.0:${input.agentPort}"
+  public_url = "http://$publicIp:${input.agentPort}"
+  game_dir = "${ROOT}\\game"
+  ini = "dedicated.ini"
+  game_port = ${input.gamePort}
+} | ConvertTo-Json | Set-Content -Path "${ROOT}\\agent.json" -Encoding ASCII
+try { Get-Content -Path "${ROOT}\\agent.json" -Raw | ConvertFrom-Json | Out-Null }
+catch { throw "the agent config we just wrote is not valid JSON: $_" }
+
+Start-ScheduledTask -TaskName "mxb-agent"
+Send-Stage -Stage "waiting for the agent"
+
+$ready = $false
+foreach ($attempt in 1..45) {
+  try {
+    Invoke-RestMethod -Uri "http://127.0.0.1:${input.agentPort}/health" -TimeoutSec 5 | Out-Null
+    $ready = $true
+    break
+  } catch { Start-Sleep -Seconds 2 }
+}
+if (-not $ready) { throw "the agent never answered on ${input.agentPort}" }
+
+$announced = $false
+foreach ($attempt in 1..5) {
+  try {
+    Invoke-RestMethod -Method POST -Uri "${input.controlPlaneUrl}/v1/servers/${input.serverId}/hello" -Headers @{ "Authorization" = "Bearer ${input.agentToken}"; "Content-Type" = "application/json" } -Body '{"agentPort":${input.agentPort},"gamePort":${input.gamePort}}' -TimeoutSec 15 | Out-Null
+    $announced = $true
+    break
+  } catch {
+    Write-Output "announce attempt $attempt failed: $_"
+    Start-Sleep -Seconds 5
+  }
+}
+if (-not $announced) { throw "couldn't tell the control plane this server is up" }
+
+Send-Stage -Stage "ready"
+Write-Output "bootstrap complete"
+Stop-Transcript
+</powershell>
+<persist>false</persist>`;
+}
+
+/**
+ * Values are interpolated into a PowerShell string, so anything that could close a quote or
+ * start a new statement is refused rather than escaped. The callers validate too; this is the
+ * last line before it becomes code on someone's machine.
+ */
+function guardInputs(input: BootstrapInputs): void {
   for (const [field, value] of Object.entries(input)) {
     if (typeof value === "string" && /["'`$\r\n]/.test(value)) {
       throw new Error(`${field} contains a character that can't go in the bootstrap script`);
     }
   }
+}
+
+export function bootstrapScript(input: BootstrapInputs): string {
+  guardInputs(input);
 
   return `<powershell>
 $ErrorActionPreference = "Stop"

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -10,13 +10,15 @@
 
 import {
   awsEnv,
+  createImage,
   fleet,
+  imageState,
   latestWindowsAmi,
   REGION,
   runInstance,
   terminateInstance,
 } from "./aws";
-import { bootstrapScript } from "./bootstrap";
+import { bootstrapScript, imageBootstrapScript } from "./bootstrap";
 import { bearer, hashToken, newToken, tokenMatches } from "./auth";
 import {
   isBikeId,
@@ -68,7 +70,9 @@ export default {
    * charges for an empty grid.
    */
   async scheduled(_event: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
-    ctx.waitUntil(reapIdleServers(env));
+    ctx.waitUntil(
+      Promise.all([reapIdleServers(env), advanceImageBuild(env)]).then(() => undefined),
+    );
   },
 } satisfies ExportedHandler<Env>;
 
@@ -132,6 +136,8 @@ async function route(request: Request, env: Env): Promise<Response> {
   if (method === "GET" && path === "/v1/servers/mine") return myServers(account, env);
   if (method === "GET" && path === "/v1/fleet") return fleetState(account, env);
   if (method === "POST" && path === "/v1/provision") return provision(request, account, env);
+  if (method === "POST" && path === "/v1/images/build") return buildImage(request, account, env);
+  if (method === "GET" && path === "/v1/images") return imageStatus(env);
 
   const owned = /^\/v1\/servers\/([A-Za-z0-9._-]{1,64})$/.exec(path);
   if (owned && method === "DELETE") return deleteServer(owned[1], account, env);
@@ -673,6 +679,161 @@ async function fleetState(account: Account, env: Env): Promise<Response> {
   }
 }
 
+/** Where the built image's id lives, and where a build in progress keeps its place. */
+const SETTING_AMI = "server_ami_id";
+const SETTING_PENDING_AMI = "pending_ami_id";
+
+async function getSetting(env: Env, key: string): Promise<string | null> {
+  const row = await env.DB.prepare("SELECT value FROM settings WHERE key = ?")
+    .bind(key)
+    .first<{ value: string }>();
+  return row?.value ?? null;
+}
+
+async function setSetting(env: Env, key: string, value: string | null): Promise<void> {
+  if (value === null) {
+    await env.DB.prepare("DELETE FROM settings WHERE key = ?").bind(key).run();
+    return;
+  }
+  await env.DB.prepare(
+    "INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)" +
+      " ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+  )
+    .bind(key, value, Date.now())
+    .run();
+}
+
+/**
+ * Build the image every later server launches from.
+ *
+ * Installing the game and the bike pack takes a quarter of an hour and produces the same disk
+ * every time. Doing it once and snapshotting the result is the difference between a server
+ * arriving in fifteen minutes and arriving in two — and it stops getting slower as the pack
+ * grows, which it just did, from 1.9 GB to 3.8.
+ *
+ * The builder is an ordinary provisioned instance running the ordinary bootstrap, so what gets
+ * captured is exactly what a working server looks like. It is marked with a role so the idle
+ * reaper leaves it alone: an instance with nobody connected is precisely what a builder is.
+ */
+async function buildImage(request: Request, account: Account, env: Env): Promise<Response> {
+  void request;
+  const aws = awsEnv(env);
+  if (!aws) return json(503, { error: "provisioning isn't configured on this deployment" });
+  const securityGroupId = env.MXB_SECURITY_GROUP_ID?.trim();
+  const agentDownload = env.MXB_AGENT_DOWNLOAD_URL?.trim();
+  const gameDownload = env.MXB_GAME_DOWNLOAD_URL?.trim();
+  if (!securityGroupId || !agentDownload || !gameDownload) {
+    return json(503, { error: "provisioning isn't finished being set up yet" });
+  }
+  if (await getSetting(env, SETTING_PENDING_AMI)) {
+    return json(409, { error: "an image is already being built" });
+  }
+  const existingBuilder = await env.DB.prepare(
+    "SELECT id FROM servers WHERE role = 'builder'",
+  ).first<{ id: string }>();
+  if (existingBuilder) return json(409, { error: "a builder is already running" });
+
+  const id = crypto.randomUUID();
+  const agentToken = newToken();
+  await env.DB.prepare(
+    "INSERT INTO servers (id, name, region, address, created_at, owner_account_id, published," +
+      " agent_token, role) VALUES (?, ?, ?, '', ?, ?, 0, ?, 'builder')",
+  )
+    .bind(id, "image builder", REGION, Date.now(), account.id, agentToken)
+    .run();
+
+  try {
+    const amiId = await latestWindowsAmi(aws);
+    const instanceId = await runInstance(
+      aws,
+      {
+        name: "mxb image builder",
+        instanceType: env.MXB_INSTANCE_TYPE?.trim() || "t3.small",
+        securityGroupId,
+        userData: bootstrapScript({
+          agentToken,
+          agentUrl: agentDownload,
+          gameUrl: gameDownload,
+          serverName: "image builder",
+          gamePort: GAME_PORT,
+          agentPort: AGENT_PORT,
+          serverId: id,
+          controlPlaneUrl: new URL(request.url).origin,
+        }),
+      },
+      amiId,
+    );
+    await env.DB.prepare("UPDATE servers SET instance_id = ? WHERE id = ?")
+      .bind(instanceId, id)
+      .run();
+    return json(201, { id, instanceId, state: "building" });
+  } catch (err) {
+    await env.DB.prepare("DELETE FROM servers WHERE id = ?").bind(id).run();
+    console.error(JSON.stringify({ msg: "buildImage", error: String(err) }));
+    return json(502, { error: String(err) });
+  }
+}
+
+/** What the image situation is: none, building, baking, or ready. */
+async function imageStatus(env: Env): Promise<Response> {
+  const ami = await getSetting(env, SETTING_AMI);
+  const pending = await getSetting(env, SETTING_PENDING_AMI);
+  const builder = await env.DB.prepare(
+    "SELECT bootstrap_stage FROM servers WHERE role = 'builder'",
+  ).first<{ bootstrap_stage: string | null }>();
+  return json(200, {
+    amiId: ami,
+    pendingAmiId: pending,
+    builderStage: builder?.bootstrap_stage ?? null,
+    state: ami ? "ready" : pending ? "baking" : builder ? "building" : "none",
+  });
+}
+
+/**
+ * Move a finished build along, one cron tick at a time.
+ *
+ * Three states, none of which can be waited on inline: the builder installing (~15 minutes),
+ * EC2 baking the image (~10), and then the swap. Each run does whichever step is due.
+ */
+async function advanceImageBuild(env: Env): Promise<void> {
+  const aws = awsEnv(env);
+  if (!aws) return;
+
+  const pending = await getSetting(env, SETTING_PENDING_AMI);
+  if (pending) {
+    const state = await imageState(aws, pending);
+    if (state === "available") {
+      const previous = await getSetting(env, SETTING_AMI);
+      await setSetting(env, SETTING_AMI, pending);
+      await setSetting(env, SETTING_PENDING_AMI, null);
+      console.log(JSON.stringify({ msg: "image ready", ami: pending, replaced: previous }));
+    } else if (state === "failed" || state === null) {
+      // Nothing to salvage, and leaving it pending would block every future build.
+      await setSetting(env, SETTING_PENDING_AMI, null);
+      console.error(JSON.stringify({ msg: "image failed", ami: pending, state }));
+    }
+    return;
+  }
+
+  const builder = await env.DB.prepare(
+    "SELECT id, instance_id, bootstrap_stage FROM servers WHERE role = 'builder'",
+  ).first<{ id: string; instance_id: string | null; bootstrap_stage: string | null }>();
+  if (!builder?.instance_id) return;
+
+  if (builder.bootstrap_stage === "ready") {
+    const imageId = await createImage(aws, builder.instance_id, `mxb-server-${Date.now()}`);
+    await setSetting(env, SETTING_PENDING_AMI, imageId);
+    // CreateImage stops the instance to take a consistent disk; it is of no further use.
+    await terminateInstance(aws, builder.instance_id);
+    await env.DB.prepare("DELETE FROM servers WHERE id = ?").bind(builder.id).run();
+    console.log(JSON.stringify({ msg: "image baking", ami: imageId }));
+  } else if (builder.bootstrap_stage === "failed") {
+    await terminateInstance(aws, builder.instance_id).catch(() => {});
+    await env.DB.prepare("DELETE FROM servers WHERE id = ?").bind(builder.id).run();
+    console.error(JSON.stringify({ msg: "image build failed", id: builder.id }));
+  }
+}
+
 /**
  * Create a server: launch the machine, and record it.
  *
@@ -718,14 +879,19 @@ async function provision(request: Request, account: Account, env: Env): Promise<
     .run();
 
   try {
-    const amiId = await latestWindowsAmi(aws);
+    // Launch from the prebuilt image when there is one: the game and the bike pack are
+    // already on its disk, so the server only has to write its own config and start. That is
+    // two minutes instead of fifteen, and it does not grow with the pack.
+    const built = await getSetting(env, SETTING_AMI);
+    const amiId = built ?? (await latestWindowsAmi(aws));
+    const script = built ? imageBootstrapScript : bootstrapScript;
     const instanceId = await runInstance(
       aws,
       {
         name: `mxb ${(name as string).trim()}`,
         instanceType: env.MXB_INSTANCE_TYPE?.trim() || "t3.small",
         securityGroupId,
-        userData: bootstrapScript({
+        userData: script({
           agentToken,
           agentUrl: agentDownload,
           gameUrl: gameDownload,
@@ -1000,7 +1166,10 @@ async function reapIdleServers(env: Env): Promise<void> {
   // cannot be trusted to find them.
   const instances = await fleet(aws);
   const rows = await env.DB.prepare(
-    "SELECT id, instance_id, agent_token, idle_since FROM servers WHERE instance_id IS NOT NULL",
+    // Builders are excluded: an instance with nobody connected is exactly what a builder is,
+    // and reaping one destroys a quarter of an hour of install.
+    "SELECT id, instance_id, agent_token, idle_since FROM servers" +
+      " WHERE instance_id IS NOT NULL AND (role IS NULL OR role != 'builder')",
   ).all<{
     id: string;
     instance_id: string;


### PR DESCRIPTION
Every provisioned server downloaded and installed the same thing: **2.4 GB of game and 3.8 GB of bikes**. Six gigabytes, from scratch, per server. That is the whole of the fifteen minutes one takes to arrive — and it got worse the moment the pack grew, which it just did, by two gigabytes.

None of that work differs between servers, so it is done once and captured.

## How it works

- `POST /v1/images/build` launches an ordinary instance running the **ordinary bootstrap**, so what gets snapshotted is exactly what a working server looks like rather than something assembled specially for the purpose.
- The cron moves it along: install (~15 min), EC2 baking the image (~10), then the swap. None of those can be waited on inline, so each tick does whichever step is due and keeps its place in a `settings` table.
- `provision` launches from the image when one exists, with a bootstrap that writes only what differs per server — the name, and the agent token, which **cannot** be baked into a shared image because every server has its own.
- **No image yet means the old path, unchanged.** Nothing breaks while the first one builds, and a failed build leaves the previous image in place.

The builder carries a role so the idle reaper leaves it alone — an instance with nobody connected is precisely what a builder is, and reaping one throws away a quarter of an hour.

## ⚠️ Not yet exercised

**The IAM key has never called `CreateImage`.** Everything it does today is `Describe*`, `RunInstances`, `Start/Stop/TerminateInstances`, and it is deliberately scoped to instances tagged `mxb:managed`. If the policy does not grant `CreateImage` (plus `CreateSnapshot`/`DeleteSnapshot` and `DeregisterImage` for rebuilds), the build fails at the final step after a full install — the log will say so, and it costs one builder instance.

## Order matters

Rebased onto #153 deliberately. Building an image *before* that fix would bake the bikes into the wrong folder permanently — every server launched from it would reject riders, and the snapshot would look fine.

Needs `0009_golden_image.sql` applied before deploy.

An AMI holding ~6 GB carries an ongoing EBS snapshot cost, likely a pound or two a month — unlike R2, which is free to serve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)