### PR TITLE
fix(bundle): a full-bundle import keeps the mods you already have

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Importing a full bundle no longer overwrites the mods you already have.** A bundle carries
+  whole asset folders — share a single helmet paint and the helmet's mesh and every other livery
+  on it travel too — so importing one quietly replaced your copy of a model with the sender's.
+  An import now writes only the files you're missing and leaves anything already on disk alone.
+  Downloading or dropping a mod still overwrites, which is how updating one works.
+
 ## 2026-08-11 — v0.9.2 — A track's terrain in 3D, and voice chat picks its microphone
 
 On top of v0.9.1 — the Designer's painting tools, Play on macOS and the SteamOS white screen

--- a/src-tauri/src/bundle.rs
+++ b/src-tauri/src/bundle.rs
@@ -430,7 +430,16 @@ pub async fn import(
     std::fs::create_dir_all(&extracted)?;
     install::extract_archive(&archive, &extracted)?;
     let mods_dir = library::mods_subdir(&cfg.mods_path, "mods");
-    install::place_mod(&extracted, &mods_dir, "bikes", "", BUNDLE_SLUG)?;
+    // Anything the receiver already has wins: a bundle ships whole asset folders, so
+    // overwriting would swap their helmet mesh and their liveries for the sender's.
+    install::place_mod_with(
+        &extracted,
+        &mods_dir,
+        "bikes",
+        "",
+        BUNDLE_SLUG,
+        install::OnConflict::Keep,
+    )?;
 
     presets::save_preset(presets_dir, preset.clone())?;
 
@@ -759,6 +768,47 @@ mod tests {
 
         assert!(mods.join("bikes/KTM450/paints/RedBud.pnt").exists());
         assert!(mods.join("rider/helmets/AGV/model.edf").exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// An import fills gaps, it doesn't trade. Sharing one helmet paint ships the whole
+    /// helmet — `dedup_assets` collapses the paint into its parent folder — so a receiver
+    /// who already owns that helmet would otherwise have their mesh and their own liveries
+    /// replaced by the sender's copies.
+    #[test]
+    fn importing_keeps_what_the_receiver_already_has() {
+        let root = tmp("keep-existing");
+        let src = root.join("bundle");
+        std::fs::create_dir_all(src.join("mods/rider/helmets/AGV/paints")).unwrap();
+        std::fs::write(src.join("mods/rider/helmets/AGV/model.edf"), b"theirs").unwrap();
+        std::fs::write(src.join("mods/rider/helmets/AGV/paints/Theirs.pnt"), b"theirs").unwrap();
+
+        let zip_path = root.join("b.zip");
+        zip_dir(&src, &zip_path).unwrap();
+        let extracted = root.join("extracted");
+        std::fs::create_dir_all(&extracted).unwrap();
+        install::extract_archive(&zip_path, &extracted).unwrap();
+
+        let mods = root.join("game/mods");
+        std::fs::create_dir_all(mods.join("rider/helmets/AGV/paints")).unwrap();
+        std::fs::write(mods.join("rider/helmets/AGV/model.edf"), b"mine").unwrap();
+        std::fs::write(mods.join("rider/helmets/AGV/paints/Mine.pnt"), b"mine").unwrap();
+
+        let written = install::place_mod_with(
+            &extracted,
+            &mods,
+            "bikes",
+            "",
+            "slug",
+            install::OnConflict::Keep,
+        )
+        .unwrap();
+
+        let read = |p: &str| std::fs::read(mods.join(p)).unwrap();
+        assert_eq!(read("rider/helmets/AGV/model.edf"), b"mine", "their mesh stays");
+        assert_eq!(read("rider/helmets/AGV/paints/Mine.pnt"), b"mine", "their paint stays");
+        assert_eq!(read("rider/helmets/AGV/paints/Theirs.pnt"), b"theirs", "the new paint lands");
+        assert_eq!(written, 1, "only the file they were missing was written");
         let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/src-tauri/src/install.rs
+++ b/src-tauri/src/install.rs
@@ -1305,6 +1305,17 @@ fn gear_model_folder(
     (!name.trim().is_empty()).then_some(name)
 }
 
+/// What a placement does with a file that is already sitting at the destination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OnConflict {
+    /// Overwrite it. Re-installing a mod is how a player updates it.
+    Overwrite,
+    /// Keep what's on disk. A preset bundle carries whole asset folders — the sender's
+    /// helmet mesh rides along with the one paint they meant to share — so an import must
+    /// fill in what's missing and never trade the receiver's copy for the sender's.
+    Keep,
+}
+
 pub(crate) fn place_mod(
     extracted: &Path,
     mods_dir: &Path,
@@ -1312,8 +1323,19 @@ pub(crate) fn place_mod(
     dest_folder: &str,
     slug: &str,
 ) -> anyhow::Result<usize> {
+    place_mod_with(extracted, mods_dir, type_folder, dest_folder, slug, OnConflict::Overwrite)
+}
+
+pub(crate) fn place_mod_with(
+    extracted: &Path,
+    mods_dir: &Path,
+    type_folder: &str,
+    dest_folder: &str,
+    slug: &str,
+    on_conflict: OnConflict,
+) -> anyhow::Result<usize> {
     let route = plan_placement(extracted, mods_dir, type_folder, dest_folder, slug);
-    apply(&route.placement).inspect_err(|e| {
+    apply(&route.placement, on_conflict).inspect_err(|e| {
         // The one place every install — download, import, drop — funnels through, so one
         // log line here covers all three. Without it a failed install left no trace at all
         // beyond a toast the player had already dismissed by the time they reported it.
@@ -1367,20 +1389,33 @@ fn roots_for(placement: &Placement) -> Vec<PathBuf> {
 /// or even whether it was the source or the destination. Every step says what it was doing
 /// to what, and a failure is logged as well as returned — the toast is transient, the log
 /// is what a player can send back.
-fn apply(placement: &Placement) -> anyhow::Result<usize> {
+fn apply(placement: &Placement, on_conflict: OnConflict) -> anyhow::Result<usize> {
     for root in roots_for(placement) {
         std::fs::create_dir_all(&root)
             .with_context(|| format!("creating {}", root.display()))?;
     }
     let writes = writes_for(placement);
+    let mut written = 0;
+    let mut kept = 0;
     for (src, dst) in &writes {
+        // The skip sits here rather than in `writes_for` so the enumeration stays the one
+        // description of what a placement covers — the dropzone's preview still lists every
+        // file, whatever this install then decides to leave alone.
+        if on_conflict == OnConflict::Keep && dst.exists() {
+            kept += 1;
+            continue;
+        }
         if let Some(parent) = dst.parent() {
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("creating {}", parent.display()))?;
         }
         copy_staged(src, dst)?;
+        written += 1;
     }
-    Ok(writes.len())
+    if kept > 0 {
+        log::info!("kept {kept} file(s) already on disk, wrote {written}");
+    }
+    Ok(written)
 }
 
 /// How long [`copy_staged`] keeps waiting out a copy that still looks transient.
@@ -2163,6 +2198,26 @@ mod tests {
         assert!(!mods.join("tracks/readme.txt").exists());
         let _ = std::fs::remove_dir_all(&base);
         Ok(())
+    }
+
+    /// Re-installing a mod is how a player updates it, so the default has to keep clobbering.
+    /// Only [`OnConflict::Keep`] — the preset-bundle import — steps around what's on disk.
+    #[test]
+    fn reinstalling_overwrites_by_default() {
+        let root = place_tmp("overwrite");
+        let ex = root.join("ex");
+        std::fs::create_dir_all(&ex).unwrap();
+        std::fs::write(ex.join("track.pkz"), b"new").unwrap();
+
+        let mods = root.join("mods");
+        std::fs::create_dir_all(mods.join("tracks")).unwrap();
+        std::fs::write(mods.join("tracks/track.pkz"), b"old").unwrap();
+
+        let placed = place_mod(&ex, &mods, "tracks", "", "slug").unwrap();
+
+        assert_eq!(placed, 1);
+        assert_eq!(std::fs::read(mods.join("tracks/track.pkz")).unwrap(), b"new");
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]


### PR DESCRIPTION
## The bug

Importing a full bundle overwrote mods the receiver already had.

`bundle::import` hands the extracted tree to `install::place_mod`, and that copy loop is a bare
`fs::copy` with no look at what is already sitting at the destination. The sender's copy of a
model replaced the receiver's, silently.

Collisions are the normal case here, not the edge case: a model swap lands at a fixed
`bikes/<Bike>/FrostMod Models/<variant>` path, and `dedup_assets` collapses a paint into its
parent folder — so sharing one helmet livery ships the helmet's mesh and every other livery on it.

## The fix

`place_mod` is the single funnel for *every* install — download, dropzone, fileshare and bundle
import — and re-installing a mod is how a player updates it, so this could not change globally.

- New `install::OnConflict { Overwrite, Keep }` and `place_mod_with`. `place_mod` keeps its exact
  signature and passes `Overwrite`; no existing caller or test changes.
- `apply` skips a write whose destination exists under `Keep`, and now returns the files actually
  written rather than the files enumerated.
- Bundle import is the one caller that asks for `Keep`.

The skip lives in the copy loop rather than in `writes_for`, so the enumeration stays the one
description of what a placement covers and the dropzone's preview still lists every file.

Behaviour is per file: a shared helmet still drops new liveries into a folder you already own —
it just won't touch your mesh or your existing paints.

## Verification

- `cargo test` — 687 passed, 0 failed.
- Two new tests, one per direction. `bundle::tests::importing_keeps_what_the_receiver_already_has`
  asserts the receiver's `model.edf` and their own paint come out byte-identical, the sender's new
  paint lands, and exactly one file was written.
  `install::tests::reinstalling_overwrites_by_default` pins that a re-download still clobbers.
- `cargo check --target x86_64-pc-windows-gnu` clean, no new warnings.

## Not in scope

- `fileshare` import goes through the same funnel and still overwrites.
- `presets::save_preset` still replaces a preset of the same name — that's the preset entry, not
  mod files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
