### PR TITLE
fix(servers): bound each bike download, and say how far through they are

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased — a stalled download no longer hangs a server build
+
+### Fixed
+- **One stuck file could hang a build indefinitely.** Each bike is fetched with a time limit
+  and a stall detector now, so a transfer that stops sending costs that one bike rather than
+  the whole machine; `--retry` never helped, because a connection that stays open and goes
+  quiet is not a failure it can see.
+- **A build says how far through the bikes it is.** The step was announced once and then went
+  silent for the length of a four gigabyte download, which is indistinguishable from having
+  hung — and for three quarters of an hour, it was.
+
 ## 2026-08-20
 
 ### Added

--- a/control-plane/src/bootstrap.ts
+++ b/control-plane/src/bootstrap.ts
@@ -286,15 +286,29 @@ try {
     Write-Output "linked $gameMods -> $userMods"
   }
   $listing = Invoke-RestMethod -Uri "${input.controlPlaneUrl}/v1/content/bikes" -TimeoutSec 60
+  $total = $listing.bikes.Count
   $count = 0
+  $i = 0
   foreach ($bike in $listing.bikes) {
+    $i = $i + 1
     $dest = Join-Path $bikesDir $bike.name
+    # A stalled transfer used to hang here for as long as the instance lived: --retry does
+    # nothing for a connection that stays open and stops sending. --max-time bounds each file
+    # so one bad download costs that bike rather than the whole build, and --speed-limit gives
+    # up on a transfer that has effectively died.
     & $curl -L --fail --silent --show-error --retry 3 --retry-delay 5 \`
+      --max-time 300 --speed-limit 10240 --speed-time 60 \`
       -o $dest "${input.controlPlaneUrl}/v1/content/bikes/$($bike.name)"
     if ($LASTEXITCODE -eq 0) { $count = $count + 1 }
     else { Write-Output "couldn't fetch $($bike.name) (curl $LASTEXITCODE)" }
+    # Say where we are. Reporting the step once and then going quiet for the length of a four
+    # gigabyte download is indistinguishable from having hung -- which is exactly how the
+    # first image build looked for three quarters of an hour.
+    if (($i % 5) -eq 0 -or $i -eq $total) {
+      Send-Stage -Stage "installing bikes $i of $total"
+    }
   }
-  Write-Output "installed $count of $($listing.bikes.Count) bikes"
+  Write-Output "installed $count of $total bikes"
 } catch {
   Write-Output "couldn't install the bike pack: $_"
 }


### PR DESCRIPTION
An image build sat on `installing bikes` for **forty-six minutes**. The pack is 3.78 GB and the control plane serves it at ~11 MB/s — measured — so the step should take about six.

## Two faults

**No time limit per file.** Each bike was fetched with `--retry` and nothing else. Retry does nothing for a connection that stays open and stops sending: curl waits, and the instance waits with it, until the four-hour lifetime backstop eventually kills the machine. Each download now has `--max-time` and a stall detector, so a dead transfer costs one bike rather than the whole build.

**No progress.** The step reported itself once, before a loop over fifty-three files. From outside, a build part way through the pack and a build that had hung looked identical — the same mistake the bootstrap made originally, reintroduced one layer down. It now reports every fifth file, so the next stall names which one.

## Honest note

This does not explain *why* the transfer stalled — only that it can no longer hang forever, and that next time we will see where. Throughput from outside AWS is fine, so the cause is still open: it could be the instance's network, the Worker under sustained load, or one bad object.

Control plane only. No migration. Needs a deploy, then a fresh build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)