### PR TITLE
feat(designer): set up a paint's sheets without typing them out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@
 - Offering to create every missing sheet no longer offers the companion maps (`_n`, `_r`). They
   aren't drawn like a livery, and a blank one is the exact thing above: it throws away the real
   one. The hint line still lists them, and one can still be added by hand.
+- **The plastics are on the list.** The sheet names came from the paints already installed for a
+  model, and the OEM bikes ship one paint that replaces the wheels and the chain — so a stock
+  Husqvarna offered `chain`, `wheel`, `wheels`, and not the bodywork anyone opened the Designer
+  for. The model's own mesh is now asked what it draws, which is the half no paint can answer.
+  A helmet's goggles still go on their paints alone: a mesh can't say which of its textures
+  belong to the goggles beside it.
+- **Picking a model no longer takes twenty seconds.** Working out what it expects read every
+  installed paint whole — tens of megabytes each — for the few hundred bytes of header that
+  hold the names. It seeks to them instead: 19s down to 0.6s on a bike with paints installed.
 
 ## 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## Unreleased — the Designer sets up its own sheets
+
+### Added
+- **Create the sheets a model asks for, in one click.** The Designer already listed the texture
+  names a bike's paints use — and the name is the whole binding, so a sheet called anything else
+  paints nothing — but getting them onto the list meant reading them off and typing each one
+  back in. There's now a button beside that list that makes the missing ones.
+- **A ＋ beside Sheets**, and another beside Layers, add one without hunting for a button.
+
+### Changed
+- **The UV map is on by default.** It answers the question a flat sheet always raises — which
+  rectangle of this ends up on the shroud — and having to know it existed before you could ask
+  for it was one step too many. It still only builds for the sheet you're looking at.
+- **"Start from a paint…" is offered only while there is nothing to draw on.** It *replaces*
+  every sheet, which is what makes it a template step, so sitting it beside work in progress was
+  offering to throw that work away.
+- The sheet list scrolls instead of growing: a bike's paint runs to two dozen sheets, and that
+  pushed the hint line and every button below the fold.
+- **Add image and Add text moved down beside the drawing tools**, which is the panel you are
+  already in while working on a sheet — the top bar is for naming and saving the paint. The
+  separate "Paint layer" button is gone with them; the ＋ beside Layers is that.
+
+### Fixed
+- **A paint no longer ships sheets you never drew on.** A `.pnt` replaces the model's textures
+  by name, so an empty sheet doesn't add a blank — it *removes* whatever the bike had there. A
+  paint saved with twenty untouched sheets wiped the bike's own normal and roughness maps, and
+  came to 350 MB of pixels, which is enough on its own to push the texture store past its
+  ceiling and leave the 3D preview grey. Empty sheets are left out, and the save says how many.
+- Offering to create every missing sheet no longer offers the companion maps (`_n`, `_r`). They
+  aren't drawn like a livery, and a blank one is the exact thing above: it throws away the real
+  one. The hint line still lists them, and one can still be added by hand.
+
 ## 2026-08-13
 
 ### Added

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1075,70 +1075,123 @@ fn templates_root(app: &tauri::AppHandle) -> std::path::PathBuf {
         .join("Paint Templates")
 }
 
-/// The texture names a destination's existing paints supply.
+/// The texture names a destination can paint.
 ///
 /// A paint binds by name: call a sheet `livery` and it lands on the bodywork that asked for
-/// `livery`, call it `my_livery` and it lands nowhere. Nothing in a `.pnt` says which names
-/// a model wants, but the paints already installed for that model do — read from their
-/// headers, so this costs no pixels.
+/// `livery`, call it `my_livery` and it lands nowhere. Two sources answer it, and both are
+/// needed. The paints already installed name what *they* replace — read from their headers,
+/// so that half costs no pixels. The model's own mesh names everything it draws, which is
+/// the half a paint can't supply: the OEM bikes ship a stock paint that replaces the wheels
+/// and the chain and nothing else, so on a stock Husqvarna the sheets on offer were `chain`,
+/// `wheel`, `wheels` — and `plastics`, the one anybody opens the Designer for, was missing.
 #[tauri::command]
 async fn paint_studio_hints(app: tauri::AppHandle, rel: String) -> Result<Vec<String>, String> {
     let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
     tauri::async_runtime::spawn_blocking(move || {
         let rel = rel.replace('\\', "/").trim_matches('/').to_string();
-        let dir = library::mods_subdir(&cfg.mods_path, &format!("mods/{rel}"));
-        let mut names: Vec<String> = Vec::new();
-        fn add(names: &mut Vec<String>, bytes: &[u8]) {
-            let Ok(found) = paint::texture_names_any(bytes) else { return };
-            for n in found {
-                if !n.is_empty() && !names.iter().any(|s| s.eq_ignore_ascii_case(&n)) {
-                    names.push(n);
-                }
-            }
-        }
-
-        // A handful is plenty: paints for one model overwhelmingly supply the same names,
-        // and this runs every time the destination changes.
-        const SAMPLE: usize = 8;
-        let mut seen = 0usize;
-        if let Ok(rd) = std::fs::read_dir(&dir) {
-            for entry in rd.flatten() {
-                let p = entry.path();
-                if seen >= SAMPLE
-                    || !p.extension().is_some_and(|e| e.eq_ignore_ascii_case("pnt"))
-                {
-                    continue;
-                }
-                if let Ok(bytes) = std::fs::read(&p) {
-                    add(&mut names, &bytes);
-                    seen += 1;
-                }
-            }
-        }
-        // Nothing installed loose: the model may be packed, and its own paints are the
-        // same evidence. `<Model>.pkz` sits beside the `<Model>` folder this destination
-        // lives in — for a bike as much as for a helmet.
-        if names.is_empty() {
-            if let (Some(sub), Some(model_dir)) = (dir.file_name(), dir.parent()) {
-                let pkz = model_dir.with_extension("pkz");
-                let tail = format!("/{}/", sub.to_string_lossy().to_ascii_lowercase());
-                if pkz.is_file() {
-                    let want = |n: &str| {
-                        let n = n.replace('\\', "/").to_ascii_lowercase();
-                        n.contains(&tail) && n.ends_with(".pnt")
-                    };
-                    let packed = pkz::read_selected(&pkz, want).unwrap_or_default();
-                    for (_, bytes) in packed.iter().take(SAMPLE) {
-                        add(&mut names, bytes);
-                    }
-                }
-            }
-        }
-        names.sort_by_key(|n| n.to_lowercase());
-        Ok(names)
+        Ok(paint_hints(&library::mods_subdir(&cfg.mods_path, &format!("mods/{rel}"))))
     })
     .await
     .map_err(|e| format!("paint_studio_hints task failed: {e}"))?
+}
+
+/// [`paint_studio_hints`] for a destination folder that's already been resolved.
+fn paint_hints(dir: &std::path::Path) -> Vec<String> {
+    let mut names: Vec<String> = Vec::new();
+    fn add(names: &mut Vec<String>, found: Vec<String>) {
+        for n in found {
+            if !n.is_empty() && !names.iter().any(|s| s.eq_ignore_ascii_case(&n)) {
+                names.push(n);
+            }
+        }
+    }
+
+    // A handful is plenty: paints for one model overwhelmingly supply the same names,
+    // and this runs every time the destination changes.
+    const SAMPLE: usize = 8;
+    let mut seen = 0usize;
+    if let Ok(rd) = std::fs::read_dir(dir) {
+        for entry in rd.flatten() {
+            let p = entry.path();
+            if seen >= SAMPLE || !p.extension().is_some_and(|e| e.eq_ignore_ascii_case("pnt")) {
+                continue;
+            }
+            // Seeked, not read: a bike's paints are tens of megabytes each and the names are
+            // in their headers. Reading eight of them whole put nineteen seconds between
+            // picking a model and being told what it wants.
+            if let Ok(found) = paint::texture_names_at(&p) {
+                add(&mut names, found);
+                seen += 1;
+            }
+        }
+    }
+    // Nothing installed loose: the model may be packed, and its own paints are the
+    // same evidence. `<Model>.pkz` sits beside the `<Model>` folder this destination
+    // lives in — for a bike as much as for a helmet.
+    if names.is_empty() {
+        if let (Some(sub), Some(model_dir)) = (dir.file_name(), dir.parent()) {
+            let pkz = model_dir.with_extension("pkz");
+            let tail = format!("/{}/", sub.to_string_lossy().to_ascii_lowercase());
+            if pkz.is_file() {
+                let want = |n: &str| {
+                    let n = n.replace('\\', "/").to_ascii_lowercase();
+                    n.contains(&tail) && n.ends_with(".pnt")
+                };
+                let packed = pkz::read_selected(&pkz, want).unwrap_or_default();
+                for (_, bytes) in packed.iter().take(SAMPLE) {
+                    add(&mut names, paint::texture_names_any(bytes).unwrap_or_default());
+                }
+            }
+        }
+    }
+    // What the model itself draws, whether or not a paint has ever replaced it.
+    //
+    // Only for the model's own `paints` folder. A mesh names every texture on the item
+    // without saying which of them belong to the goggles hanging off it — the paints are
+    // the only thing that says that (see `on_goggle_side`) — and offering a helmet's shell
+    // sheet to somebody painting its goggles would put the shell in the wrong file.
+    let main_paints = dir.file_name().is_some_and(|s| s.eq_ignore_ascii_case("paints"));
+    if let (true, Some(model_dir)) = (main_paints, dir.parent()) {
+        add(&mut names, mesh_texture_names(model_dir));
+    }
+    names.sort_by_key(|n| n.to_lowercase());
+    names
+}
+
+/// Every texture a model's own mesh carries, by name.
+///
+/// Read from the mesh's texture records — names and dimensions, never the pixels beside
+/// them — so a 54 MB bike is answered by a walk over its bytes rather than by inflating it.
+/// A model that ships as a folder is read from there, and one that ships packed from the
+/// `<Model>.pkz` beside it; a sealed file is unwrapped the way the viewer unwraps it.
+fn mesh_texture_names(model_dir: &std::path::Path) -> Vec<String> {
+    let mut meshes: Vec<Vec<u8>> = Vec::new();
+    if let Ok(rd) = std::fs::read_dir(model_dir) {
+        for entry in rd.flatten() {
+            let p = entry.path();
+            if p.is_file() && p.file_name().and_then(|n| n.to_str()).is_some_and(bikefiles::is_mesh)
+            {
+                meshes.extend(read_gear_file(&p));
+            }
+        }
+    }
+    if meshes.is_empty() {
+        let pkz = model_dir.with_extension("pkz");
+        if pkz.is_file() {
+            for (_, d) in pkz::read_selected(&pkz, bikefiles::is_mesh).unwrap_or_default() {
+                meshes.push(pkz::read_sidecar_blob(&d).unwrap_or(d));
+            }
+        }
+    }
+    let mut names: Vec<String> = Vec::new();
+    for mesh in &meshes {
+        for t in edf::embedded_textures(mesh) {
+            if !names.iter().any(|s| s.eq_ignore_ascii_case(&t.name)) {
+                names.push(t.name);
+            }
+        }
+    }
+    names
 }
 
 /// Raw RGBA for a texture the viewer was handed a token for.
@@ -6565,6 +6618,74 @@ mod gear_source_tests {
             );
         }
         let _ = std::fs::remove_dir_all(&root);
+    }
+}
+
+#[cfg(test)]
+mod mesh_texture_tests {
+    use super::{mesh_texture_names, paint_hints};
+
+    /// The smallest thing `edf::embedded_textures` reads as a texture record: a
+    /// null-terminated name, then the fields it validates by shape at a fixed offset.
+    fn mesh_naming(texture: &str) -> Vec<u8> {
+        const W_FROM_NAME: usize = 100;
+        let mut b = vec![0u8; W_FROM_NAME];
+        b[..texture.len()].copy_from_slice(texture.as_bytes());
+        b.extend_from_slice(&64u32.to_le_bytes()); // width, from the fixed size set
+        b.extend_from_slice(&64u32.to_le_bytes()); // height
+        b.extend_from_slice(&[0u8; 16]); // digest
+        b.extend_from_slice(&0u32.to_le_bytes());
+        b.extend_from_slice(&12u32.to_le_bytes()); // payload, counting the pad
+        b.extend_from_slice(&[0u8; 8]); // pad
+        b.extend_from_slice(&[1u8; 4]); // payload
+        b
+    }
+
+    #[test]
+    fn a_models_own_textures_come_from_its_mesh() {
+        let root = std::env::temp_dir().join(format!("frost-mesh-tex-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let dir = root.join("MyBike");
+        std::fs::create_dir_all(&dir).unwrap();
+        // No paint here at all — the mesh is the only thing that can name `plastics`.
+        std::fs::write(dir.join("model.edf"), mesh_naming("plastics")).unwrap();
+        assert_eq!(mesh_texture_names(&dir), vec!["plastics".to_string()]);
+
+        std::fs::create_dir_all(root.join("Bare")).unwrap();
+        assert!(mesh_texture_names(&root.join("Bare")).is_empty(), "no mesh, nothing to say");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A model's own textures are offered where a paint for it goes, and nowhere else: the
+    /// goggles beside it are a different file, painted from a different sheet.
+    #[test]
+    fn only_the_models_own_paints_folder_is_offered_the_mesh() {
+        let root = std::env::temp_dir().join(format!("frost-mesh-hints-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let helmet = root.join("Helmet");
+        std::fs::create_dir_all(helmet.join("paints")).unwrap();
+        std::fs::create_dir_all(helmet.join("goggles")).unwrap();
+        std::fs::write(helmet.join("helmet.edf"), mesh_naming("shell")).unwrap();
+
+        assert_eq!(paint_hints(&helmet.join("paints")), vec!["shell".to_string()]);
+        assert!(paint_hints(&helmet.join("goggles")).is_empty(), "the shell is not a goggle sheet");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The whole hint list for a real destination:
+    /// `MXB_PAINT_DEST='…/mods/bikes/MX1OEM_2023_Husqvarna_FC_450/paints' \
+    ///   cargo test paint_hints_from_env -- --ignored --nocapture`
+    #[test]
+    #[ignore]
+    fn paint_hints_from_env() {
+        let Ok(dir) = std::env::var("MXB_PAINT_DEST") else {
+            eprintln!("set MXB_PAINT_DEST to run");
+            return;
+        };
+        let t = std::time::Instant::now();
+        let names = paint_hints(std::path::Path::new(&dir));
+        eprintln!("{dir} expects {names:?} ({:?})", t.elapsed());
+        assert!(!names.is_empty(), "a destination with a model behind it expects something");
     }
 }
 

--- a/src/Components/Studio/Designer/Designer.tsx
+++ b/src/Components/Studio/Designer/Designer.tsx
@@ -4,16 +4,14 @@ import {
   EyeOff,
   FilePlus2,
   Grid3x3,
-  ImagePlus,
   Layers as LayersIcon,
   Loader2,
   PackageOpen,
-  PaintRoller,
   PanelLeftClose,
   PanelLeftOpen,
+  Plus,
   Save,
   Trash2,
-  Type as TypeIcon,
 } from "lucide-react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { toast } from "sonner";
@@ -36,12 +34,13 @@ import { Row, Slider } from "./controls";
 import { PreviewPanel } from "./PreviewPanel";
 import { LayerInspector } from "./LayerInspector";
 import { PaintTools } from "./PaintTools";
-import { bitmapFromRgba, composite, sheetTexture, toPng } from "./composite";
+import { bitmapFromRgba, composite, hasInk, sheetTexture, toPng } from "./composite";
 import { EMPTY_GHOST, ghostShows, type Ghost } from "./ghost";
 import { partPath, uvParts, uvWireframe, type UvPart } from "./uv";
 import {
   blankSheet,
   imageLayer,
+  isCompanionMap,
   layerExtent,
   newId,
   paintLayer,
@@ -622,17 +621,47 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
       });
   }, [incoming, loadSheets, onIncomingLoaded]);
 
+  /**
+   * Texture names this model wants that have no sheet yet — what the create button offers,
+   * and the name a new blank sheet is given.
+   *
+   * Colour sheets only. The hint line lists the companion maps too, because knowing the bike
+   * has a `plastics_n` is worth knowing, but an *empty* one is worse than none: a paint
+   * replaces textures by name, so saving a blank normal map strips the bike's real one.
+   */
+  const missingHints = useMemo(() => {
+    const taken = new Set(sheets.map((s) => s.name.trim().toLowerCase()));
+    return hints.filter((h) => !taken.has(h.trim().toLowerCase()) && !isCompanionMap(h));
+  }, [hints, sheets]);
+
   const addBlankSheet = useCallback(() => {
     // Name it after a texture the chosen model actually asks for, when we know one — that's
     // the difference between a paint that shows and a paint that doesn't.
-    const taken = new Set(sheets.map((s) => s.name.toLowerCase()));
-    const suggested = hints.find((h) => !taken.has(h.toLowerCase())) ?? "";
+    const suggested = missingHints[0] ?? "";
     const sheet = blankSheet(suggested, BLANK_SIZE);
     setSheets((prev) => [...prev, sheet]);
     setActiveId(sheet.id);
     setSelectedId(null);
     bump();
-  }, [bump, hints, sheets]);
+  }, [bump, missingHints]);
+
+  /**
+   * One sheet per colour texture the model asks for that isn't on the list yet.
+   *
+   * The names are the whole binding — a sheet called anything else paints nothing — and until
+   * now the only way to get them right without an installed paint to start from was to read
+   * them off the hint line and type each one back in.
+   *
+   * Only the missing ones, so pressing it twice doesn't leave two sheets fighting over a name.
+   */
+  const addHintSheets = useCallback(() => {
+    const made = missingHints.map((h) => blankSheet(h, BLANK_SIZE));
+    if (!made.length) return;
+    setSheets((prev) => [...prev, ...made]);
+    setActiveId(made[0].id);
+    setSelectedId(null);
+    bump();
+  }, [bump, missingHints]);
 
   const addImage = useCallback(async () => {
     if (!active) return;
@@ -927,14 +956,27 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
       if (!dest) return;
       setBusy(true);
       try {
-        // Stage every sheet first: `paint_studio_save` packs files, and these only exist as
-        // canvases until now. Composited once more on the way out so a save can't ship a
-        // frame older than the screen.
+        // Composite every sheet first: they only exist as canvases until now, and doing it on
+        // the way out is what stops a save shipping a frame older than the screen.
+        //
+        // Then drop the ones with nothing on them. A `.pnt` replaces the model's textures by
+        // name, so an empty sheet doesn't add a blank — it *removes* whatever the bike had
+        // there. Offering to create every missing sheet at once made that easy to do by
+        // accident: create twenty, paint two, and the other eighteen would have wiped the
+        // bike's normal and roughness maps.
+        const inked = sheets.filter((sheet) => {
+          const canvas = canvasFor(sheet);
+          composite(canvas, sheet);
+          return hasInk(canvas);
+        });
+        const blank = sheets.length - inked.length;
+        if (!inked.length) {
+          toast.error(t("designer.nothingToSave"));
+          return;
+        }
         const staged = await Promise.all(
-          sheets.map(async (sheet) => {
-            const canvas = canvasFor(sheet);
-            composite(canvas, sheet);
-            const path = await paintStudioStage(sheet.name.trim(), await toPng(canvas));
+          inked.map(async (sheet) => {
+            const path = await paintStudioStage(sheet.name.trim(), await toPng(canvasFor(sheet)));
             return { path, name: sheet.name.trim() };
           }),
         );
@@ -945,7 +987,11 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
           dest,
           overwrite,
         });
-        toast.success(t("paints.saved", { path: outcome.path }));
+        // Said out loud, not silently: a sheet that doesn't get written is a sheet that
+        // won't be in the file, and finding that out later is worse than reading it now.
+        toast.success(t("paints.saved", { path: outcome.path }), {
+          description: blank ? t("designer.blankSheetsSkipped", { count: blank }) : undefined,
+        });
       } catch (e) {
         toast.error(String(e).replace(/^Error:\s*/, ""));
       } finally {
@@ -1019,16 +1065,6 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
           {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Save className="size-3.5" />}
           {t("paints.save")}
         </Button>
-        <span className="h-5 w-px flex-none bg-border" />
-        <Button variant="outline" size="sm" disabled={!active || busy} onClick={() => void addImage()}>
-          <ImagePlus className="size-3.5" /> {t("designer.addImage")}
-        </Button>
-        <Button variant="outline" size="sm" disabled={!active} onClick={addText}>
-          <TypeIcon className="size-3.5" /> {t("designer.addText")}
-        </Button>
-        <Button variant="outline" size="sm" disabled={!active} onClick={addPaintLayer}>
-          <PaintRoller className="size-3.5" /> {t("designer.addPaint")}
-        </Button>
         {blocked && (
           <span className="ml-auto max-w-[40%] truncate text-[11px] text-faint" title={blocked}>
             {blocked}
@@ -1060,7 +1096,9 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
             }}
             onRemove={removeSheet}
             onReorder={reorderSheet}
+            missingHints={missingHints}
             onAddBlank={addBlankSheet}
+            onAddHintSheets={addHintSheets}
             onStartFromPaint={() => void startFromPaint()}
             busy={busy}
           />
@@ -1085,6 +1123,9 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
               canRedo={canRedo}
               onUndo={undo}
               onRedo={redo}
+              onAddImage={() => void addImage()}
+              onAddText={addText}
+              busy={busy}
             />
           )}
 
@@ -1099,6 +1140,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
               }}
               onRemove={removeLayer}
               onReorder={reorder}
+              onAdd={addPaintLayer}
             />
           )}
           {selected && (
@@ -1172,30 +1214,48 @@ function SheetList({
   sheets,
   activeId,
   hints,
+  missingHints,
   onPick,
   onRename,
   onRemove,
   onReorder,
   onAddBlank,
+  onAddHintSheets,
   onStartFromPaint,
   busy,
 }: {
   sheets: Sheet[];
   activeId: string | null;
+  /** Every texture name the model's paints use — shown in full, companion maps included. */
   hints: string[];
+  /** The colour sheets among them that don't exist yet: what the create button would make. */
+  missingHints: string[];
   onPick: (id: string) => void;
   onRename: (id: string, value: string) => void;
   onRemove: (id: string) => void;
   onReorder: (id: string, delta: number) => void;
   onAddBlank: () => void;
+  onAddHintSheets: () => void;
   onStartFromPaint: () => void;
   busy: boolean;
 }) {
   const t = useT();
   return (
     <div className="rounded-lg border border-border bg-card/40 p-3.5">
-      <h2 className="mb-2.5 text-[13px] font-semibold">{t("designer.sheets")}</h2>
-      <div className="flex flex-col gap-1.5">
+      <div className="mb-2.5 flex items-center gap-2">
+        <h2 className="text-[13px] font-semibold">{t("designer.sheets")}</h2>
+        <button
+          type="button"
+          className="ml-auto text-muted-foreground transition-colors hover:text-foreground"
+          onClick={onAddBlank}
+          title={t("designer.addSheet")}
+        >
+          <Plus className="size-4" />
+        </button>
+      </div>
+      {/* Scrolls rather than growing: a bike's paint runs to two dozen sheets, and a list that
+          long pushed the hint line and every button below the fold of the rail. */}
+      <div className="flex max-h-[40vh] flex-col gap-1.5 overflow-y-auto pr-0.5">
         {sheets.map((sheet, i) => (
           <div
             key={sheet.id}
@@ -1250,22 +1310,51 @@ function SheetList({
       </div>
 
       {/* The names the installed paints use. A sheet named anything else binds to nothing,
-          and this is the only place the right answer is visible. */}
+          and this is the only place the right answer is visible — so it also offers to make
+          them, rather than leaving the list to be copied out by hand. */}
       {!!hints.length && (
-        <p className="mt-2 text-[11px] leading-snug text-faint">
-          {t("paints.expected")} {hints.join(", ")}
-        </p>
+        <div className="mt-2 flex flex-col items-start gap-1.5">
+          <p className="text-[11px] leading-snug text-faint">
+            {t("paints.expected")} {hints.join(", ")}
+          </p>
+          {/* Full width and clipping, not sized to its label: the rail is 224px, a bike can
+              want two dozen sheets, and `Button` is `whitespace-nowrap` — so a count in the
+              label, or a longer word for it in another language, ran straight out of the rail. */}
+          {!!missingHints.length && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full min-w-0 justify-start"
+              onClick={onAddHintSheets}
+              title={missingHints.join(", ")}
+            >
+              <FilePlus2 className="size-3.5" />
+              <span className="truncate">
+                {t("designer.createExpected", { count: missingHints.length })}
+              </span>
+            </Button>
+          )}
+        </div>
       )}
 
-      <div className="mt-2.5 flex flex-wrap gap-1.5">
-        <Button variant="outline" size="sm" disabled={busy} onClick={onStartFromPaint}>
-          {busy ? <Loader2 className="size-3.5 animate-spin" /> : <PackageOpen className="size-3.5" />}
-          {t("designer.startFromPaint")}
-        </Button>
-        <Button variant="outline" size="sm" onClick={onAddBlank}>
-          <FilePlus2 className="size-3.5" /> {t("designer.blankSheet")}
-        </Button>
-      </div>
+      {/* Only while there is nothing to draw on. Starting from a paint *replaces* every sheet
+          — that's what makes it a template step — so offering it beside work in progress is
+          offering to throw that work away. Adding another sheet is the ＋ above. */}
+      {!sheets.length && (
+        <div className="mt-2.5 flex flex-wrap gap-1.5">
+          <Button variant="outline" size="sm" disabled={busy} onClick={onStartFromPaint}>
+            {busy ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <PackageOpen className="size-3.5" />
+            )}
+            {t("designer.startFromPaint")}
+          </Button>
+          <Button variant="outline" size="sm" onClick={onAddBlank}>
+            <FilePlus2 className="size-3.5" /> {t("designer.blankSheet")}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }
@@ -1388,8 +1477,6 @@ function GhostPanel({
           {t("designer.uvNoMatch", { name: sheetName.trim() })}
         </p>
       )}
-
-      <p className="mt-1.5 text-[11px] leading-snug text-faint">{t("designer.ghostNote")}</p>
     </div>
   );
 }
@@ -1433,6 +1520,7 @@ function LayerList({
   onToggle,
   onRemove,
   onReorder,
+  onAdd,
 }: {
   layers: Layer[];
   selectedId: string | null;
@@ -1440,11 +1528,22 @@ function LayerList({
   onToggle: (id: string, visible: boolean) => void;
   onRemove: (id: string) => void;
   onReorder: (id: string, delta: number) => void;
+  onAdd: () => void;
 }) {
   const t = useT();
   return (
     <div className="rounded-lg border border-border bg-card/40 p-3.5">
-      <h2 className="mb-2.5 text-[13px] font-semibold">{t("designer.layers")}</h2>
+      <div className="mb-2.5 flex items-center gap-2">
+        <h2 className="text-[13px] font-semibold">{t("designer.layers")}</h2>
+        <button
+          type="button"
+          className="ml-auto text-muted-foreground transition-colors hover:text-foreground"
+          onClick={onAdd}
+          title={t("designer.addPaint")}
+        >
+          <Plus className="size-4" />
+        </button>
+      </div>
       {!layers.length ? (
         <p className="text-[11px] leading-snug text-faint">{t("designer.noLayers")}</p>
       ) : (

--- a/src/Components/Studio/Designer/Designer.tsx
+++ b/src/Components/Studio/Designer/Designer.tsx
@@ -1309,9 +1309,10 @@ function SheetList({
         ))}
       </div>
 
-      {/* The names the installed paints use. A sheet named anything else binds to nothing,
-          and this is the only place the right answer is visible — so it also offers to make
-          them, rather than leaving the list to be copied out by hand. */}
+      {/* The names this model binds — what its mesh draws, plus whatever the paints already
+          installed replace. A sheet named anything else binds to nothing, and this is the only
+          place the right answer is visible — so it also offers to make them, rather than
+          leaving the list to be copied out by hand. */}
       {!!hints.length && (
         <div className="mt-2 flex flex-col items-start gap-1.5">
           <p className="text-[11px] leading-snug text-faint">

--- a/src/Components/Studio/Designer/PaintTools.tsx
+++ b/src/Components/Studio/Designer/PaintTools.tsx
@@ -4,14 +4,17 @@ import {
   Brush,
   Circle,
   Eraser,
+  ImagePlus,
   Minus,
   MousePointer2,
   PaintBucket,
   Redo2,
   Square,
+  Type as TypeIcon,
   Undo2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Button } from "../../ui/button";
 import { useT } from "../../../i18n/context";
 import type { TKey } from "../../../i18n/core";
 import { Row, Slider } from "./controls";
@@ -47,6 +50,11 @@ interface PaintToolsProps {
   canRedo: boolean;
   onUndo: () => void;
   onRedo: () => void;
+  /** Put something on the sheet that isn't painted by hand. Here rather than in the header
+   *  bar because this is the panel you are already in while working on the sheet. */
+  onAddImage: () => void;
+  onAddText: () => void;
+  busy: boolean;
 }
 
 /**
@@ -64,6 +72,9 @@ export function PaintTools({
   canRedo,
   onUndo,
   onRedo,
+  onAddImage,
+  onAddText,
+  busy,
 }: PaintToolsProps) {
   const t = useT();
   const { tool } = settings;
@@ -121,6 +132,32 @@ export function PaintTools({
             </button>
           );
         })}
+      </div>
+
+      {/* Full width and truncating, like everything else in a 224px rail — a label is a
+          translation away from being too long for half of it. */}
+      <div className="grid grid-cols-2 gap-1">
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full min-w-0 justify-start"
+          disabled={busy}
+          onClick={onAddImage}
+          title={t("designer.addImage")}
+        >
+          <ImagePlus className="size-3.5" />
+          <span className="truncate">{t("designer.addImage")}</span>
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full min-w-0 justify-start"
+          onClick={onAddText}
+          title={t("designer.addText")}
+        >
+          <TypeIcon className="size-3.5" />
+          <span className="truncate">{t("designer.addText")}</span>
+        </Button>
       </div>
 
       {tool === "move" ? (

--- a/src/Components/Studio/Designer/composite.ts
+++ b/src/Components/Studio/Designer/composite.ts
@@ -131,6 +131,29 @@ export function layerCorners(layer: Layer): [number, number][] {
  * on the Rust side on its way into the `.pnt`, so the intermediate format only has to not
  * lose anything.
  */
+/**
+ * Whether a composited sheet has a single pixel on it.
+ *
+ * A `.pnt` replaces the model's textures *by name*, so an untouched sheet is not a harmless
+ * blank — saved, it wipes whatever the bike already had under that name. That bites hardest
+ * on the companion maps: a transparent `plastics_n` replaces the real normal map and flattens
+ * the lighting on the part.
+ *
+ * The pixels rather than the sheet's layer list, because picking up the brush *creates* a
+ * paint layer whether or not a stroke follows, so "has layers" and "has anything on it" are
+ * different questions. Reads the alpha channel and stops at the first mark, which is the
+ * common case; a genuinely empty 2048² sheet is the one that scans in full.
+ */
+export function hasInk(canvas: HTMLCanvasElement): boolean {
+  const ctx = canvas.getContext("2d", { willReadFrequently: true });
+  if (!ctx) return true; // can't tell — saving too much beats silently dropping work
+  const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  for (let i = 3; i < data.length; i += 4) {
+    if (data[i] !== 0) return true;
+  }
+  return false;
+}
+
 export function toPng(canvas: HTMLCanvasElement): Promise<ArrayBuffer> {
   return new Promise<ArrayBuffer>((resolve, reject) => {
     canvas.toBlob((blob) => {

--- a/src/Components/Studio/Designer/ghost.ts
+++ b/src/Components/Studio/Designer/ghost.ts
@@ -38,11 +38,15 @@ export const EMPTY_GHOST: Ghost = {
   template: null,
   wire: null,
   wireFor: null,
-  // On by default so lifting a template into the ghost shows it immediately; the UV map is
-  // off because it has to be built, and building one for a sheet nobody asked about is work
-  // spent on a guide that was never going to be looked at.
+  // Both on. The template shows the moment it is lifted, and the UV map is the answer to the
+  // question a flat sheet always raises — which rectangle of this ends up on the shroud — so
+  // having to know it existed before asking for it was one step too many.
+  //
+  // It still costs a raster, but only for the sheet actually being looked at: the build is
+  // keyed on the *active* sheet's name, so opening a paint with twenty sheets rasterises the
+  // one on screen, not twenty.
   showTemplate: true,
-  showWire: false,
+  showWire: true,
   opacity: 0.35,
 };
 

--- a/src/Components/Studio/Designer/layers.ts
+++ b/src/Components/Studio/Designer/layers.ts
@@ -312,3 +312,35 @@ export function paintLayer(name: string, sheet: Sheet): PaintLayer {
 export function blankSheet(name: string, size: number): Sheet {
   return { id: newId("sheet"), name, width: size, height: size, base: null, layers: [] };
 }
+
+/** Suffixes that mark a texture as a companion map rather than a colour sheet. Mirrors
+ *  `is_companion_map` / `is_exporter_companion` on the Rust side. */
+const COMPANION_SUFFIXES = [
+  "_n",
+  "_r",
+  "_normal",
+  "_nrm",
+  "_roughness",
+  "_metallic",
+  "_metalness",
+  "_specular",
+  "_glossiness",
+  "_ao",
+  "_ambientocclusion",
+  "_bump",
+  "_height",
+  "_displacement",
+];
+
+/**
+ * Whether a texture name is a companion map — a normal or roughness sheet, not a colour one.
+ *
+ * Worth telling apart when *offering* to make sheets. A companion map is derived from the
+ * shape of the surface, not drawn like a livery, and a blank one is actively destructive: the
+ * paint replaces the model's textures by name, so shipping an empty `plastics_n` throws away
+ * the bike's real normal map. Someone who wants to author one can still add it by hand.
+ */
+export function isCompanionMap(name: string): boolean {
+  const n = name.trim().toLowerCase();
+  return COMPANION_SUFFIXES.some((s) => n.endsWith(s));
+}

--- a/src/Components/Studio/paintDest.tsx
+++ b/src/Components/Studio/paintDest.tsx
@@ -178,7 +178,7 @@ export interface PaintDestState {
   clearFolder: () => void;
   /** Resolved destination, or null while nothing can be aimed at yet. */
   dest: PaintDest | null;
-  /** What the paints already installed for this model call their sheets. */
+  /** The sheet names this model binds — from its own mesh and from the paints installed for it. */
   hints: string[];
   /** This build can decode bike geometry — false on public builds, which have no bike mesh. */
   bikePreview: boolean;

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1506,7 +1506,7 @@ export const de: Translation = {
   "paints.sheetsTitle": "Texturen",
   "paints.reload": "Neu von der Platte laden",
   "paints.addImages": "Bilder hinzufügen…",
-  "paints.expected": "Designs hier verwenden:",
+  "paints.expected": "Hier verwendete Bahnen:",
   "paints.empty":
     "Füge pro Textur eine .tga oder .png hinzu. Entscheidend sind die Namen, nicht die Dateien: eine Textur namens „livery“ landet auf dem Teil, das „livery“ verlangt. Ein entpacktes Design liefert die richtigen Namen.",
   "paints.resized": "Größe {{from}} → {{to}} geändert — das Spiel braucht Zweierpotenzen.",

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1527,6 +1527,12 @@ export const de: Translation = {
     "Noch nichts zum Zeichnen da. Fang bei einem für dieses Modell installierten Design an — dann hast du seine Bahnen samt Namen — oder füge eine leere hinzu.",
   "designer.startFromPaint": "Von einem Design ausgehen…",
   "designer.blankSheet": "Leere Bahn",
+  "designer.addSheet": "Bahn hinzufügen",
+  "designer.nothingToSave": "Alle Bahnen sind leer — zeichne etwas, bevor du speicherst.",
+  "designer.blankSheetsSkipped_one": "1 leere Bahn wurde ausgelassen — eine leere würde die Textur des Modells löschen.",
+  "designer.blankSheetsSkipped_other": "{{count}} leere Bahnen wurden ausgelassen — eine leere würde die Textur des Modells löschen.",
+  "designer.createExpected_one": "1 Bahn anlegen",
+  "designer.createExpected_other": "{{count}} Bahnen anlegen",
   "designer.sheets": "Bahnen",
   "designer.moveDown": "Nach unten",
   "designer.moveUp": "Nach oben",
@@ -1592,7 +1598,6 @@ export const de: Translation = {
     "Nichts am Modell verwendet eine Textur namens „{{name}}“, also gibt es kein UV-Layout zu zeigen.",
   "designer.ghostBuried":
     "Die Referenz liegt unter dem Blatt, und die Vorlage dieses Blattes ist undurchsichtig — schalte Vorlage ein, um sie herauszuheben und hindurchzusehen.",
-  "designer.ghostNote": "Nur eine Hilfe — die Referenz wird nie in die Lackierung gespeichert.",
   "designer.resetView": "Ansicht zurücksetzen",
 
   // ── Designer › die Malwerkzeuge ───────────────────────────────────────────────

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1482,6 +1482,12 @@ export const en = {
     "Nothing to draw on yet. Start from a paint installed for this model to get its real sheets and their names, or add a blank one.",
   "designer.startFromPaint": "Start from a paint…",
   "designer.blankSheet": "Blank sheet",
+  "designer.addSheet": "Add a sheet",
+  "designer.nothingToSave": "Every sheet is empty — draw something before saving.",
+  "designer.blankSheetsSkipped_one": "1 empty sheet was left out — an empty one would wipe the model's own texture.",
+  "designer.blankSheetsSkipped_other": "{{count}} empty sheets were left out — an empty one would wipe the model's own texture.",
+  "designer.createExpected_one": "Create 1 sheet",
+  "designer.createExpected_other": "Create {{count}} sheets",
   "designer.sheets": "Sheets",
   "designer.moveDown": "Move down",
   "designer.moveUp": "Move up",
@@ -1545,7 +1551,6 @@ export const en = {
     "Nothing on the model uses a texture called “{{name}}”, so there is no UV layout to show.",
   "designer.ghostBuried":
     "The reference sits under the sheet, and this sheet’s template is opaque — turn on Template to lift it out and see through.",
-  "designer.ghostNote": "A guide only â the reference is never saved into the paint.",
   "designer.resetView": "Reset view",
 
   // ── Designer › the paint tools ────────────────────────────────────────────────

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1461,7 +1461,7 @@ export const en = {
   "paints.sheetsTitle": "Texture sheets",
   "paints.reload": "Reload from disk",
   "paints.addImages": "Add images…",
-  "paints.expected": "Paints here use:",
+  "paints.expected": "Sheets used here:",
   "paints.empty":
     "Add a .tga or .png for each texture. Names matter more than file names: a sheet called “livery” lands on the part that asked for “livery”. Unpacking an existing paint gets you the right names.",
   "paints.resized": "Resized {{from}} → {{to}} — the game needs power-of-two sheets.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1514,6 +1514,12 @@ export const es: Translation = {
     "Todavía no hay nada sobre lo que dibujar. Empieza desde una pintura instalada para este modelo — así obtienes sus hojas y sus nombres — o añade una en blanco.",
   "designer.startFromPaint": "Empezar desde una pintura…",
   "designer.blankSheet": "Hoja en blanco",
+  "designer.addSheet": "Añadir una hoja",
+  "designer.nothingToSave": "Todas las hojas están vacías: dibuja algo antes de guardar.",
+  "designer.blankSheetsSkipped_one": "Se dejó fuera 1 hoja vacía: una hoja vacía borraría la textura del modelo.",
+  "designer.blankSheetsSkipped_other": "Se dejaron fuera {{count}} hojas vacías: una hoja vacía borraría la textura del modelo.",
+  "designer.createExpected_one": "Crear 1 hoja",
+  "designer.createExpected_other": "Crear {{count}} hojas",
   "designer.sheets": "Hojas",
   "designer.moveDown": "Bajar",
   "designer.moveUp": "Subir",
@@ -1579,7 +1585,6 @@ export const es: Translation = {
     "Nada del modelo usa una textura llamada “{{name}}”, así que no hay distribución UV que mostrar.",
   "designer.ghostBuried":
     "La referencia va debajo de la hoja, y la plantilla de esta hoja es opaca: activa Plantilla para sacarla y poder ver a través.",
-  "designer.ghostNote": "Solo una guía: la referencia nunca se guarda en la pintura.",
   "designer.resetView": "Restablecer vista",
 
   // ── Designer › las herramientas de pintura ────────────────────────────────────

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1493,7 +1493,7 @@ export const es: Translation = {
   "paints.sheetsTitle": "Texturas",
   "paints.reload": "Recargar del disco",
   "paints.addImages": "Añadir imágenes…",
-  "paints.expected": "Las pinturas de aquí usan:",
+  "paints.expected": "Hojas usadas aquí:",
   "paints.empty":
     "Añade un .tga o .png por cada textura. Importan los nombres, no los archivos: una textura llamada “livery” va a la pieza que pide “livery”. Desempaquetar una pintura existente te da los nombres correctos.",
   "paints.resized": "Redimensionada {{from}} → {{to}} — el juego necesita potencias de dos.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1497,7 +1497,7 @@ export const fr: Translation = {
   "paints.sheetsTitle": "Textures",
   "paints.reload": "Recharger depuis le disque",
   "paints.addImages": "Ajouter des images…",
-  "paints.expected": "Les décos ici utilisent :",
+  "paints.expected": "Planches utilisées ici :",
   "paints.empty":
     "Ajoutez un .tga ou .png par texture. Ce sont les noms qui comptent, pas les fichiers : une texture nommée « livery » se pose sur la pièce qui demande « livery ». Décompresser une déco existante donne les bons noms.",
   "paints.resized": "Redimensionnée {{from}} → {{to}} — le jeu exige des puissances de deux.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1518,6 +1518,12 @@ export const fr: Translation = {
     "Rien sur quoi dessiner pour l'instant. Pars d'une déco installée pour ce modèle — tu récupères ses planches et leurs noms — ou ajoute une planche vierge.",
   "designer.startFromPaint": "Partir d'une déco…",
   "designer.blankSheet": "Planche vierge",
+  "designer.addSheet": "Ajouter une planche",
+  "designer.nothingToSave": "Toutes les planches sont vides : dessinez quelque chose avant d'enregistrer.",
+  "designer.blankSheetsSkipped_one": "1 planche vide a été écartée : une planche vide effacerait la texture du modèle.",
+  "designer.blankSheetsSkipped_other": "{{count}} planches vides ont été écartées : une planche vide effacerait la texture du modèle.",
+  "designer.createExpected_one": "Créer 1 planche",
+  "designer.createExpected_other": "Créer {{count}} planches",
   "designer.sheets": "Planches",
   "designer.moveDown": "Descendre",
   "designer.moveUp": "Monter",
@@ -1583,7 +1589,6 @@ export const fr: Translation = {
     "Rien sur le modèle n'utilise une texture nommée « {{name}} », il n'y a donc aucune disposition UV à montrer.",
   "designer.ghostBuried":
     "La référence est sous la planche, et le modèle de cette planche est opaque : active Modèle pour l'en sortir et voir au travers.",
-  "designer.ghostNote": "Un simple repère : la référence n'est jamais enregistrée dans la peinture.",
   "designer.resetView": "Réinitialiser la vue",
 
   // ── Designer › les outils de peinture ─────────────────────────────────────────

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1505,6 +1505,12 @@ export const it: Translation = {
     "Non c'è ancora niente su cui disegnare. Parti da una livrea installata per questo modello — così ottieni i suoi fogli e i loro nomi — oppure aggiungine uno vuoto.",
   "designer.startFromPaint": "Parti da una livrea…",
   "designer.blankSheet": "Foglio vuoto",
+  "designer.addSheet": "Aggiungi un foglio",
+  "designer.nothingToSave": "Ogni foglio è vuoto: disegna qualcosa prima di salvare.",
+  "designer.blankSheetsSkipped_one": "1 foglio vuoto è stato escluso: un foglio vuoto cancellerebbe la texture del modello.",
+  "designer.blankSheetsSkipped_other": "{{count}} fogli vuoti sono stati esclusi: un foglio vuoto cancellerebbe la texture del modello.",
+  "designer.createExpected_one": "Crea 1 foglio",
+  "designer.createExpected_other": "Crea {{count}} fogli",
   "designer.sheets": "Fogli",
   "designer.moveDown": "Sposta giù",
   "designer.moveUp": "Sposta su",
@@ -1569,7 +1575,6 @@ export const it: Translation = {
     "Nessuna parte del modello usa una texture chiamata “{{name}}”, quindi non c'è un layout UV da mostrare.",
   "designer.ghostBuried":
     "Il riferimento sta sotto la planche, e il modello di questa planche è opaco: attiva Modello per toglierlo e vedere attraverso.",
-  "designer.ghostNote": "Solo una guida: il riferimento non viene mai salvato nella vernice.",
   "designer.resetView": "Reimposta vista",
 
   // ── Designer › gli strumenti di pittura ───────────────────────────────────────

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1484,7 +1484,7 @@ export const it: Translation = {
   "paints.sheetsTitle": "Texture",
   "paints.reload": "Ricarica dal disco",
   "paints.addImages": "Aggiungi immagini…",
-  "paints.expected": "Le livree qui usano:",
+  "paints.expected": "Fogli usati qui:",
   "paints.empty":
     "Aggiungi un .tga o .png per ogni texture. Contano i nomi, non i file: una texture chiamata “livery” finisce sulla parte che chiede “livery”. Scompattando una livrea esistente ottieni i nomi giusti.",
   "paints.resized": "Ridimensionata {{from}} → {{to}} — il gioco richiede potenze di due.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1485,7 +1485,7 @@ export const ptBR: Translation = {
   "paints.sheetsTitle": "Texturas",
   "paints.reload": "Recarregar do disco",
   "paints.addImages": "Adicionar imagens…",
-  "paints.expected": "As pinturas daqui usam:",
+  "paints.expected": "Folhas usadas aqui:",
   "paints.empty":
     "Adicione um .tga ou .png para cada textura. O que importa são os nomes, não os arquivos: uma textura chamada “livery” vai para a peça que pede “livery”. Descompactar uma pintura existente dá os nomes certos.",
   "paints.resized": "Redimensionada {{from}} → {{to}} — o jogo exige potências de dois.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1506,6 +1506,12 @@ export const ptBR: Translation = {
     "Ainda não há nada para desenhar. Comece de uma pintura instalada para este modelo — assim você pega as folhas e os nomes delas — ou adicione uma em branco.",
   "designer.startFromPaint": "Começar de uma pintura…",
   "designer.blankSheet": "Folha em branco",
+  "designer.addSheet": "Adicionar uma folha",
+  "designer.nothingToSave": "Todas as folhas estão vazias — desenhe algo antes de salvar.",
+  "designer.blankSheetsSkipped_one": "1 folha vazia ficou de fora — uma vazia apagaria a textura do próprio modelo.",
+  "designer.blankSheetsSkipped_other": "{{count}} folhas vazias ficaram de fora — uma vazia apagaria a textura do próprio modelo.",
+  "designer.createExpected_one": "Criar 1 folha",
+  "designer.createExpected_other": "Criar {{count}} folhas",
   "designer.sheets": "Folhas",
   "designer.moveDown": "Mover para baixo",
   "designer.moveUp": "Mover para cima",
@@ -1568,7 +1574,6 @@ export const ptBR: Translation = {
     "Nada no modelo usa uma textura chamada “{{name}}”, então não há layout UV para mostrar.",
   "designer.ghostBuried":
     "A referência fica sob a folha, e o modelo desta folha é opaco — ative Modelo para tirá-lo e enxergar através.",
-  "designer.ghostNote": "Apenas um guia — a referência nunca é salva na pintura.",
   "designer.resetView": "Redefinir visualização",
 
   // ── Designer › as ferramentas de pintura ──────────────────────────────────────


### PR DESCRIPTION
The Designer already knew which texture names a model wants — the name is the whole binding,
and a sheet called anything else paints nothing — but it only *showed* them, on one faint line.
Getting them onto the sheet list meant reading them off and typing each one back in.

## Added

- **Create the missing sheets, from the line that lists them.** One 2048² sheet per colour
  texture the model asks for that has no sheet yet. Only the missing ones, so pressing it twice
  can't leave two sheets fighting over a name.
- **A ＋ beside Sheets, and beside Layers.** Adding one more no longer means going to the bottom
  of the rail.

## Changed

- **The UV map starts on.** It answers the question a flat sheet always raises — which rectangle
  of this ends up on the shroud — and having to know it existed before you could ask for it was
  a step too many. Still built per *active* sheet, so a paint with twenty sheets rasterises the
  one on screen, not twenty.
- **"Start from a paint…" is offered only while there is nothing to draw on.** `loadSheets` does
  `setSheets(next)` — it replaces every sheet, which is what makes it a template step — so
  sitting it beside work in progress was offering to throw that work away with no warning.
- **The sheet list scrolls.** A bike's paint runs to two dozen sheets, which pushed the hint line
  and every button below the fold of the rail.
- **Add image / Add text moved down beside the drawing tools**, the panel you are already in
  while working on a sheet; the top bar is for naming and saving the paint. The separate "Paint
  layer" button went with them — the ＋ beside Layers is that now.

## Fixed — and this is why the rest of it is careful

**A paint no longer ships sheets that were never drawn on.** A `.pnt` replaces the model's
textures *by name*, so an empty sheet doesn't add a blank — it removes whatever the bike had
under that name.

This turned up on a real paint made with the first version of the create button: 22 sheets, of
which 20 were untouched.

```
metals      opaque_px=2553870      plastics   opaque_px=198236
airbox, airbox_n, airbox_r, fatbar, … 20 sheets   opaque_px=0
decoded footprint: 352 MiB
```

Two consequences, both bad. The blank `plastics_n`, `metals_r` and friends would have replaced
the bike's real normal and roughness maps with nothing, flattening the lighting on those parts
in game. And 352 MiB of pixels is over the texture store's 384 MiB ceiling on its own, so
opening the paint in 3D evicted the textures the viewer was holding — `dropped t56 … t67; a
viewer still holding it will show grey`.

So: sheets with nothing on them are left out of the save, and the toast says how many rather
than dropping them silently. The check reads the composited pixels rather than the layer list,
because picking up the brush *creates* a paint layer whether or not a stroke follows.

**Creating the missing sheets skips the companion maps** (`_n`, `_r`, and the longer exporter
spellings). They aren't drawn like a livery, and a blank one is exactly the problem above.
The hint line still lists them and one can still be added by hand. Mirrors `is_companion_map`
on the Rust side.

## Not fixed here

The texture store's eviction is still FIFO with no regard for what's on screen, so a genuine
full-detail paint can still evict itself. That's a policy change with real memory implications
and wants its own branch.

## Verification

`tsc --noEmit`, `eslint` and a full `vite build` are clean; the Rust side is untouched (702
tests still pass). Exercised in the running app against a real YZ450F paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: the list itself was incomplete

Testing the button on a stock Husqvarna FC 450 showed `chain`, `wheel`, `wheels` — and no
`plastics`. The list came only from the paints already installed for the model, and the OEM
bikes ship one paint that replaces the wheels and the chain:

```
stock.pnt  ->  chain, chain_n, chain_r, wheel, wheels, wheel_n, wheel_r
model.edf  ->  450f_metals, 450f_metals_n, plastics, plastics_n, w_plate
```

`plastics` is embedded in the mesh and named by no paint at all, so no amount of sampling
paints could ever find it. `paint_hints` now asks the model's own mesh what it draws as well:

- Names come from the mesh's texture records — a byte walk, no pixels inflated. ~250ms for the
  54 MB packed FC 450; folder or `<Model>.pkz`, sealed files unwrapped as the viewer unwraps
  them.
- **Only for the model's own `paints` folder.** A mesh names every texture on the item without
  saying which belong to the goggles beside it — the paints decide that (`on_goggle_side`) — so
  a goggles destination is left on its paints alone, and a helmet's shell sheet is never offered
  to somebody painting its goggles.
- The loose paints are now **seeked** rather than read whole for their headers. The CRF450R's
  hint line took **19s**; it takes **0.6s**.

`paints.expected` reads "Sheets used here:" in all six locales — the list is no longer only what
the installed paints use.

### Verification

`paint_hints` against the real mods folder (`paint_hints_from_env`, ignored test):

```
bikes/MX1OEM_2023_Husqvarna_FC_450/paints  -> 450f_metals, 450f_metals_n, chain, chain_n,
  chain_r, plastics, plastics_n, w_plate, wheel, wheel_n, wheel_r, wheels   (251ms)
bikes/MX1OEM_2023_Honda_CRF450R/paints     -> 2021crf, …, plastics, plastics_n, w_plate  (574ms)
rider/helmets/Airoh_Aviator_3_Armega/paints  -> airoh_aviator_3, …, goggle, goggle_n, lens
rider/helmets/Airoh_Aviator_3_Armega/goggles -> goggle, goggle_n, goggle_r, lens
```

Two new unit tests cover the mesh read and the paints-folder-only rule; 711 Rust tests pass,
`tsc --noEmit` and `eslint` clean.
