### PR TITLE
feat(locker): see a model swap in 3D before switching to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   paints nothing — but getting them onto the list meant reading them off and typing each one
   back in. There's now a button beside that list that makes the missing ones.
 - **A ＋ beside Sheets**, and another beside Layers, add one without hunting for a button.
+- **See a model swap before you switch to it.** Every model set in the Locker now has a 3D
+  button beside it, and "Stock" has one too — that one shows the model packed in the bike's
+  own archive, the one your loose files are covering. The bike is assembled in memory exactly
+  as applying the swap would leave it (the set's mesh over the bike's own `.hrc`s, `.geom` and
+  textures), so nothing moves on disk and you can look with the game open.
 
 ### Changed
 - **The UV map is on by default.** It answers the question a flat sheet always raises — which

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1251,14 +1251,29 @@ fn bike_cache() -> &'static std::sync::Mutex<lru::Lru<BikeModel>> {
     CACHE.get_or_init(|| std::sync::Mutex::new(lru::Lru::new(BIKE_CACHE_CAP)))
 }
 
-fn bike_cache_key(source: &str) -> String {
-    let mtime = std::fs::metadata(source)
+fn mtime_nanos(path: &std::path::Path) -> u128 {
+    std::fs::metadata(path)
         .and_then(|m| m.modified())
         .ok()
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
         .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    format!("{source}:{mtime}")
+        .unwrap_or(0)
+}
+
+fn bike_cache_key(source: &str) -> String {
+    format!("{source}:{}", mtime_nanos(std::path::Path::new(source)))
+}
+
+/// A swap preview is keyed by both folders it's built from — the same bike renders
+/// differently per variant, and either side can change under us.
+fn swap_cache_key(set: &modelswap::PreviewSet) -> String {
+    format!(
+        "{}#{}:{}:{}",
+        set.bike_dir.display(),
+        set.variant_dir.display(),
+        mtime_nanos(&set.bike_dir),
+        mtime_nanos(&set.variant_dir),
+    )
 }
 
 #[tauri::command]
@@ -1266,6 +1281,41 @@ async fn load_bike_model(source: String) -> Result<BikeModel, String> {
     tauri::async_runtime::spawn_blocking(move || load_bike_model_blocking(source))
         .await
         .map_err(|e| format!("load_bike_model task failed: {e}"))?
+}
+
+/// Draw `bike` as the model-swap variant `variant` would leave it, without applying the
+/// swap. The file set is assembled in memory (see `gather_preview_files`) — nothing on
+/// disk moves, so this is safe to run with the game open.
+#[tauri::command]
+async fn preview_model_swap(
+    app: tauri::AppHandle,
+    bike: String,
+    variant: String,
+) -> Result<BikeModel, String> {
+    tauri::async_runtime::spawn_blocking(move || preview_model_swap_blocking(app, bike, variant))
+        .await
+        .map_err(|e| format!("preview_model_swap task failed: {e}"))?
+}
+
+fn preview_model_swap_blocking(
+    app: tauri::AppHandle,
+    bike: String,
+    variant: String,
+) -> Result<BikeModel, String> {
+    let t0 = std::time::Instant::now();
+    let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
+    let set =
+        modelswap::preview_set(&cfg.mods_path, &bike, &variant).map_err(|e| format!("{e:#}"))?;
+    let label = format!("{bike} · {variant}");
+    let key = swap_cache_key(&set);
+    if let Some(m) = bike_cache().lock().ok().and_then(|mut c| c.get(&key).cloned()) {
+        log::info!("preview_model_swap {label}: cache hit ({:?})", t0.elapsed());
+        return Ok(m);
+    }
+
+    let files = gather_preview_files(&set).map_err(|e| format!("{e:#}"))?;
+    let installed = installed_paints(&set.bike_dir);
+    build_bike_model(&label, key, files, installed, t0)
 }
 
 fn load_bike_model_blocking(source: String) -> Result<BikeModel, String> {
@@ -1278,6 +1328,19 @@ fn load_bike_model_blocking(source: String) -> Result<BikeModel, String> {
 
     let files = gather_bike_files(std::path::Path::new(&source)).map_err(|e| format!("{e:#}"))?;
     let installed = installed_paints(std::path::Path::new(&source));
+    build_bike_model(&source, key, files, installed, t0)
+}
+
+/// Turn a bike's files into the viewer's model: resolve each part's mesh through the
+/// `.hrc`s, bind its textures, decode the paints. Shared by a bike loaded from disk and a
+/// model-swap preview assembled in memory — `label` only names it in the log.
+fn build_bike_model(
+    label: &str,
+    key: String,
+    files: Vec<(String, Vec<u8>)>,
+    installed: Vec<(String, Vec<u8>)>,
+    t0: std::time::Instant,
+) -> Result<BikeModel, String> {
     let t_read = t0.elapsed();
 
     let mut nodes = Vec::new();
@@ -1452,7 +1515,7 @@ fn load_bike_model_blocking(source: String) -> Result<BikeModel, String> {
         .flat_map(|p| p.textures.iter().map(|t| t.token.as_str()))
         .collect();
     log::info!(
-        "load_bike_model {source}: {} paint(s) + {base_count} base tex | read {t_read:?}, parse {:?}, decode {:?}, total {:?} | {} distinct texture(s), {:.1} MB resident in the texture store",
+        "load_bike_model {label}: {} paint(s) + {base_count} base tex | read {t_read:?}, parse {:?}, decode {:?}, total {:?} | {} distinct texture(s), {:.1} MB resident in the texture store",
         paints.len(),
         t_parse - t_read,
         t_textures - t_parse,
@@ -1627,6 +1690,72 @@ fn gather_bike_files(p: &std::path::Path) -> anyhow::Result<Vec<(String, Vec<u8>
         bail!("no .edf mesh for bike folder {p:?}");
     }
     bail!("can't load a bike model from {p:?}")
+}
+
+/// Add `incoming` to `files`, replacing any entry of the same name — later wins, which is
+/// how the game reads a bike too: loose files layer over the packed archive, and a swap's
+/// files layer over the loose ones.
+fn overlay_files(files: &mut Vec<(String, Vec<u8>)>, incoming: Vec<(String, Vec<u8>)>) {
+    for (name, data) in incoming {
+        let bn = name.rsplit(['/', '\\']).next().unwrap_or(&name).to_ascii_lowercase();
+        match files
+            .iter_mut()
+            .find(|(n, _)| n.rsplit(['/', '\\']).next().unwrap_or(n).eq_ignore_ascii_case(&bn))
+        {
+            Some(slot) => *slot = (name, data),
+            None => files.push((name, data)),
+        }
+    }
+}
+
+/// Read the named files out of `dir`, keeping only what the viewer draws with.
+fn read_named(dir: &std::path::Path, names: &[String]) -> Vec<(String, Vec<u8>)> {
+    names
+        .iter()
+        .filter(|n| wanted_bike_file(n))
+        .filter_map(|n| std::fs::read(dir.join(n)).ok().map(|b| (n.clone(), b)))
+        .collect()
+}
+
+/// The bike's packed model, either inside the folder or as its `<Bike>.pkz` sibling —
+/// both layouts exist, and it's the fallback a Stock preview shows.
+fn packed_bike(bike_dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    if let Ok(rd) = std::fs::read_dir(bike_dir) {
+        for e in rd.flatten() {
+            let p = e.path();
+            if p.is_file() && p.extension().is_some_and(|x| x.eq_ignore_ascii_case("pkz")) {
+                return Some(p);
+            }
+        }
+    }
+    let sibling = bike_dir.with_extension("pkz");
+    sibling.exists().then_some(sibling)
+}
+
+/// The bytes behind a `PreviewSet`: the loose files that stay, with the variant's laid over
+/// them. Reverting to Stock parks every loose mesh, so the packed model goes underneath —
+/// otherwise there'd be nothing to draw, which is precisely what Stock means.
+fn gather_preview_files(
+    set: &modelswap::PreviewSet,
+) -> anyhow::Result<Vec<(String, Vec<u8>)>> {
+    use anyhow::bail;
+    let mut out: Vec<(String, Vec<u8>)> = Vec::new();
+    let loose_mesh = set
+        .root_keep
+        .iter()
+        .chain(set.variant_files.iter())
+        .any(|f| bikefiles::is_mesh(f));
+    if !loose_mesh {
+        if let Some(pkz) = packed_bike(&set.bike_dir) {
+            overlay_files(&mut out, pkz::read_selected(&pkz, wanted_bike_file)?);
+        }
+    }
+    overlay_files(&mut out, read_named(&set.bike_dir, &set.root_keep));
+    overlay_files(&mut out, read_named(&set.variant_dir, &set.variant_files));
+    if !out.iter().any(|(n, _)| bikefiles::is_mesh(n)) {
+        bail!("this model has no mesh to show — the bike would have no model at all");
+    }
+    Ok(out)
 }
 
 #[derive(serde::Serialize)]
@@ -6103,6 +6232,7 @@ fn main() {
             texture_bytes,
             unpack_pkz,
             load_bike_model,
+            preview_model_swap,
             load_rider_model,
             load_rider_body_model,
             load_gear_model,
@@ -6939,6 +7069,161 @@ mod deep_link_tests {
 
 #[cfg(test)]
 mod viewer_tests {
+    use std::path::{Path, PathBuf};
+
+    fn copy_tree(src: &Path, dst: &Path) {
+        std::fs::create_dir_all(dst).unwrap();
+        for e in std::fs::read_dir(src).unwrap().flatten() {
+            let (from, to) = (e.path(), dst.join(e.file_name()));
+            if from.is_dir() {
+                copy_tree(&from, &to);
+            } else {
+                std::fs::copy(&from, &to).unwrap();
+            }
+        }
+    }
+
+    /// How the viewer sees a bike, as a comparable shape: which parts resolved and what
+    /// each submesh is bound to. Node order is fixed by `GFX_PARTS`, so this is stable.
+    fn shape(m: &super::BikeModel) -> Vec<(String, Vec<(String, Option<String>)>)> {
+        m.nodes
+            .iter()
+            .map(|n| {
+                (
+                    n.name.clone(),
+                    n.submeshes.iter().map(|s| (s.name.clone(), s.texture.clone())).collect(),
+                )
+            })
+            .collect()
+    }
+
+    /// The contract behind the Locker's 3D preview: what it shows is what applying the
+    /// swap would give you. Run against a **real** bike, because the in-memory overlay has
+    /// to pick up the `.hrc`s, `.geom` and textures the root keeps while the mesh comes
+    /// from the variant folder — a synthetic bike can't exercise that chain.
+    ///
+    /// MXB_REAL_BIKES=~/Projects/PiBoSo/"MX Bikes" \
+    ///   cargo test preview_matches_the_applied_swap -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn preview_matches_the_applied_swap() {
+        let Ok(src_root) = std::env::var("MXB_REAL_BIKES") else {
+            eprintln!("set MXB_REAL_BIKES to the MX Bikes folder to run");
+            return;
+        };
+        let src_bikes = Path::new(&src_root).join("mods").join("bikes");
+        let Some((bike, src_dir)) = std::fs::read_dir(&src_bikes)
+            .expect("read bikes")
+            .flatten()
+            .map(|e| (e.file_name().to_string_lossy().to_string(), e.path()))
+            .find(|(_, p)| p.is_dir() && crate::bikefiles::dir_has_mesh(p))
+        else {
+            eprintln!("no extracted bike with a mesh found");
+            return;
+        };
+        eprintln!("using real bike: {bike}");
+
+        let root: PathBuf =
+            std::env::temp_dir().join(format!("frost-preview-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let mp = root.to_str().unwrap();
+        let dst = crate::library::mods_subdir(mp, "mods/bikes").join(&bike);
+        copy_tree(&src_dir, &dst);
+
+        // A realistic swap set: the bike's own mesh under a variant name, nothing else.
+        // The preview must find everything else at the root.
+        let mesh = std::fs::read_dir(&dst)
+            .unwrap()
+            .flatten()
+            .filter_map(|e| e.file_name().to_str().map(str::to_string))
+            .find(|f| crate::bikefiles::is_mesh(f))
+            .expect("mesh");
+        let variant = dst.join("FrostMod Models").join("Factory");
+        std::fs::create_dir_all(&variant).unwrap();
+        std::fs::copy(dst.join(&mesh), variant.join(&mesh)).unwrap();
+
+        let set = super::modelswap::preview_set(mp, &bike, "Factory").expect("preview set");
+        eprintln!("keeps {:?} + brings {:?}", set.root_keep, set.variant_files);
+        let files = super::gather_preview_files(&set).expect("preview files");
+        let previewed = super::build_bike_model(
+            "preview",
+            "preview-test".into(),
+            files,
+            super::installed_paints(&set.bike_dir),
+            std::time::Instant::now(),
+        )
+        .expect("preview builds");
+        assert!(!previewed.nodes.is_empty(), "the preview drew nothing");
+
+        super::modelswap::apply_model_swap(mp, &bike, "Factory").expect("swap applies");
+        let applied = super::load_bike_model_blocking(dst.to_string_lossy().to_string())
+            .expect("the swapped bike loads");
+
+        assert_eq!(shape(&previewed), shape(&applied), "preview differs from the real swap");
+        assert_eq!(
+            previewed.paints.iter().map(|p| p.name.clone()).collect::<Vec<_>>(),
+            applied.paints.iter().map(|p| p.name.clone()).collect::<Vec<_>>(),
+            "the preview offers different paints",
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Stock parks every loose override, so there'd be nothing to draw if the packed model
+    /// didn't come through underneath. Needs a real `.pkz` — that's the whole mechanism.
+    ///
+    /// MXB_REAL_BIKES=~/Projects/PiBoSo/"MX Bikes" \
+    ///   cargo test preview_of_stock_shows_the_packed_model -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn preview_of_stock_shows_the_packed_model() {
+        let Ok(src_root) = std::env::var("MXB_REAL_BIKES") else {
+            eprintln!("set MXB_REAL_BIKES to the MX Bikes folder to run");
+            return;
+        };
+        let src_bikes = Path::new(&src_root).join("mods").join("bikes");
+        // A bike that is both extracted *and* packed — the loose files hide a packed model.
+        let Some((bike, src_dir)) = std::fs::read_dir(&src_bikes)
+            .expect("read bikes")
+            .flatten()
+            .map(|e| (e.file_name().to_string_lossy().to_string(), e.path()))
+            .find(|(_, p)| {
+                p.is_dir()
+                    && crate::bikefiles::dir_has_mesh(p)
+                    && p.with_extension("pkz").exists()
+            })
+        else {
+            eprintln!("no bike with both a loose mesh and a .pkz found");
+            return;
+        };
+        eprintln!("using real bike: {bike}");
+
+        let root: PathBuf =
+            std::env::temp_dir().join(format!("frost-preview-stock-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let mp = root.to_str().unwrap();
+        let bikes = crate::library::mods_subdir(mp, "mods/bikes");
+        copy_tree(&src_dir, &bikes.join(&bike));
+        std::fs::copy(src_dir.with_extension("pkz"), bikes.join(format!("{bike}.pkz"))).unwrap();
+
+        let set = super::modelswap::preview_set(mp, &bike, "Stock").expect("preview set");
+        eprintln!("keeps {:?}", set.root_keep);
+        assert!(
+            !set.root_keep.iter().any(|f| crate::bikefiles::is_mesh(f)),
+            "Stock must park every loose mesh",
+        );
+        let files = super::gather_preview_files(&set).expect("preview files");
+        let m = super::build_bike_model(
+            "stock preview",
+            "stock-preview-test".into(),
+            files,
+            super::installed_paints(&set.bike_dir),
+            std::time::Instant::now(),
+        )
+        .expect("stock preview builds");
+        assert!(!m.nodes.is_empty(), "the packed model didn't come through");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     #[test]
     #[ignore]
     fn bike_model_from_pkz() {

--- a/src-tauri/src/modelswap.rs
+++ b/src-tauri/src/modelswap.rs
@@ -433,6 +433,68 @@ pub fn apply_model_swap(mods_path: &str, bike: &str, target: &str) -> anyhow::Re
     Ok(())
 }
 
+/// What the bike's files would look like with `variant` active — filenames only, nothing
+/// read and nothing moved. Lets the viewer show a swap before it's applied.
+#[derive(Debug, Clone)]
+pub struct PreviewSet {
+    pub bike_dir: PathBuf,
+    /// Loose root files that stay put, i.e. the root minus the set the swap would park.
+    pub root_keep: Vec<String>,
+    /// The variant folder and the files it would bring in — empty for Stock, which brings
+    /// in nothing and lets the packed model show through.
+    pub variant_dir: PathBuf,
+    pub variant_files: Vec<String>,
+}
+
+/// The file accounting `apply_model_swap` would do, without doing it. Same rules on
+/// purpose: what the preview shows has to be what applying the swap gives you, so the two
+/// resolve the set through `active_set_files` and the same Stock special-case.
+pub fn preview_set(mods_path: &str, bike: &str, variant: &str) -> anyhow::Result<PreviewSet> {
+    if !is_simple_name(bike) || !is_simple_name(variant) {
+        anyhow::bail!("invalid bike or model name");
+    }
+    let root = bike_dir(mods_path, bike);
+    if !dir_exists(&root) {
+        anyhow::bail!("bike '{bike}' not found");
+    }
+    let active = current_active(mods_path, bike);
+    let target_dir = variant_dir(mods_path, bike, variant);
+
+    // The active set is already loose at the root — show the bike as it stands.
+    if variant.eq_ignore_ascii_case(&active) {
+        return Ok(PreviewSet {
+            root_keep: list_files(&root),
+            bike_dir: root,
+            variant_dir: target_dir,
+            variant_files: Vec::new(),
+        });
+    }
+
+    let is_stock = variant.eq_ignore_ascii_case(STOCK);
+    if !is_stock && !dir_exists(&target_dir) {
+        anyhow::bail!("model '{variant}' not found");
+    }
+    let variant_files = set_files(&target_dir);
+    if !variant_files.is_empty() && !crate::bikefiles::dir_has_mesh(&target_dir) {
+        anyhow::bail!("model '{variant}' has no mesh (.edf) — it looks like an incomplete set");
+    }
+
+    let mut parked = active_set_files(mods_path, bike, &active, &variant_files);
+    if is_stock && read_manifest(&variant_dir(mods_path, bike, &active)).is_none() {
+        for f in root_setup_files(mods_path, bike) {
+            if !contains_ci(&parked, &f) {
+                parked.push(f);
+            }
+        }
+    }
+
+    let root_keep = list_files(&root)
+        .into_iter()
+        .filter(|f| !contains_ci(&parked, f))
+        .collect();
+    Ok(PreviewSet { bike_dir: root, root_keep, variant_dir: target_dir, variant_files })
+}
+
 /// A bike whose setup files (`.hrc`/`.cfg`/`.geom`) were carried off into a swap folder
 /// by a version that treated the whole folder as the model set. The game can't see such
 /// a bike at all until they're back at the root.
@@ -878,6 +940,70 @@ mod tests {
             vec!["_files.txt", "factory.tga", "model.edf"],
             "the swap is parked whole again"
         );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// The whole point of a preview: what it shows must be what applying the swap gives
+    /// you. Asserted against the real thing — predict the root, then apply and compare.
+    #[test]
+    fn preview_predicts_the_root_the_swap_would_leave() {
+        let root = tmp("preview-matches");
+        let mp = root.to_str().unwrap();
+        make_bike(mp, "KTM450", "model.edf");
+        touch(&bike_dir(mp, "KTM450").join("body.tga"));
+        touch(&variant_dir(mp, "KTM450", "Factory").join("model.edf"));
+        touch(&variant_dir(mp, "KTM450", "Factory").join("factory.tga"));
+
+        let set = preview_set(mp, "KTM450", "Factory").unwrap();
+        let mut predicted: Vec<String> =
+            set.root_keep.iter().chain(set.variant_files.iter()).cloned().collect();
+        predicted.sort();
+
+        apply_model_swap(mp, "KTM450", "Factory").unwrap();
+        assert_eq!(predicted, names_at(&bike_dir(mp, "KTM450")));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// Stock brings in nothing, so the preview has to clear the loose overrides — meshes
+    /// *and* the setup naming them — leaving the packed model to show through.
+    #[test]
+    fn preview_of_stock_clears_every_loose_override() {
+        let root = tmp("preview-stock");
+        let mp = root.to_str().unwrap();
+        make_bike(mp, "KTM450", "model.edf");
+        touch(&bike_dir(mp, "KTM450").join("KTM450.pkz"));
+
+        let set = preview_set(mp, "KTM450", STOCK).unwrap();
+        assert_eq!(set.root_keep, vec!["KTM450.pkz"], "only the packed bike is left");
+        assert!(set.variant_files.is_empty(), "Stock is never a folder");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn preview_of_the_active_model_is_the_bike_as_it_stands() {
+        let root = tmp("preview-active");
+        let mp = root.to_str().unwrap();
+        make_bike(mp, "KTM450", "model.edf");
+
+        let set = preview_set(mp, "KTM450", ORIGINAL).unwrap();
+        let mut keep = set.root_keep.clone();
+        keep.sort();
+        assert_eq!(keep, names_at(&bike_dir(mp, "KTM450")));
+        assert!(set.variant_files.is_empty());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn preview_refuses_what_the_swap_would_refuse() {
+        let root = tmp("preview-refuse");
+        let mp = root.to_str().unwrap();
+        make_bike(mp, "KTM450", "model.edf");
+        // Files but no mesh — an incomplete set, rejected on apply and on preview alike.
+        touch(&variant_dir(mp, "KTM450", "Broken").join("body.tga"));
+
+        assert!(preview_set(mp, "KTM450", "Broken").is_err(), "incomplete set");
+        assert!(preview_set(mp, "KTM450", "Nope").is_err(), "no such variant");
+        assert!(preview_set(mp, "Ghost", "Factory").is_err(), "no such bike");
         let _ = fs::remove_dir_all(&root);
     }
 

--- a/src/Components/Locker/Locker.tsx
+++ b/src/Components/Locker/Locker.tsx
@@ -7,6 +7,7 @@ import {
   Loader2,
   AlertTriangle,
   Ban,
+  Box,
   FolderInput,
   Link2,
   Link2Off,
@@ -37,6 +38,8 @@ import type {
   SwapApplyOutcome,
 } from "../../types";
 import RegisterSwapsDialog from "./RegisterSwapsDialog";
+import { ViewerDialog } from "../Viewer/ViewerDialog";
+import { useConfig } from "../../Context/Config";
 import { Trans } from "../../i18n";
 import { useT, type TFunc } from "../../i18n/context";
 
@@ -96,6 +99,11 @@ function swapNote(
   }
 }
 
+/** The row standing for the game's own model/sound, which is never a folder in the library. */
+function isStockRow(v: { name: string }): boolean {
+  return v.name.toLowerCase() === "stock";
+}
+
 /** One bike's row: its models (null for sound-only bikes) and its sounds (always present). */
 interface Row {
   bike: string;
@@ -130,6 +138,10 @@ function mergeRows(models: BikeModels[], sounds: BikeSounds[]): Row[] {
 
 export default function Locker() {
   const t = useT();
+  // Bike geometry needs the optional local module — without it there's nothing to show.
+  const { bikePreview } = useConfig();
+  // The swap being previewed in 3D, if any. Nothing on disk moves to show it.
+  const [preview, setPreview] = useState<{ bike: string; variant: string } | null>(null);
   const [rows, setRows] = useState<Row[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   // Bike name currently being mutated (disables its rows + spins the target).
@@ -362,6 +374,11 @@ export default function Locker() {
                 disabled={busy !== null}
                 onModelSwap={onModelSwap}
                 onSoundSwap={onSoundSwap}
+                onPreview={
+                  bikePreview
+                    ? (bike, variant) => setPreview({ bike, variant })
+                    : undefined
+                }
                 onBind={onBind}
                 onUnbind={onUnbind}
               />
@@ -376,6 +393,14 @@ export default function Locker() {
         bikes={loose}
         onDone={() => void load()}
       />
+
+      <ViewerDialog
+        open={preview !== null}
+        onOpenChange={(o) => !o && setPreview(null)}
+        title={preview ? `${preview.bike} · ${preview.variant}` : undefined}
+        initialMode="bike"
+        modelSwap={preview ?? undefined}
+      />
     </div>
   );
 }
@@ -386,6 +411,7 @@ function BikeCard({
   disabled,
   onModelSwap,
   onSoundSwap,
+  onPreview,
   onBind,
   onUnbind,
 }: {
@@ -394,6 +420,8 @@ function BikeCard({
   disabled: boolean;
   onModelSwap: (bike: string, target: string) => void;
   onSoundSwap: (bike: string, target: string) => void;
+  /** Undefined when this build can't draw bike geometry — then no row offers a preview. */
+  onPreview?: (bike: string, variant: string) => void;
   onBind: (bike: string, model: string, sound: string) => void;
   onUnbind: (bike: string, model: string, sound: string) => void;
 }) {
@@ -435,6 +463,13 @@ function BikeCard({
               busy={busy}
               disabled={disabled}
               onClick={() => onModelSwap(bike, v.name)}
+              // A set with a mesh can be drawn; so can Stock, which shows the packed model
+              // the loose files are covering. A "no model" set has nothing to show.
+              onPreview={
+                onPreview && (v.valid || isStockRow(v))
+                  ? () => onPreview(bike, v.name)
+                  : undefined
+              }
             />
           ))}
         </SwapSection>
@@ -512,6 +547,7 @@ function VariantButton({
   disabled,
   boundModels = [],
   onClick,
+  onPreview,
 }: {
   variant: ModelVariant | SoundVariant;
   kind: "model" | "sound";
@@ -519,12 +555,14 @@ function VariantButton({
   disabled: boolean;
   boundModels?: string[];
   onClick: () => void;
+  /** Show this set in 3D without switching to it. Models only. */
+  onPreview?: () => void;
 }) {
   const t = useT();
   // A model row named "Stock" is the game's own model, packed in the bike's `.pkz` —
   // reached by clearing the loose set, so it's empty like a "no model" row but means the
   // opposite. Only the wording differs.
-  const isStockModel = kind === "model" && v.name.toLowerCase() === "stock";
+  const isStockModel = kind === "model" && isStockRow(v);
   const emptyLabel = isStockModel
     ? t("locker.stockModel")
     : kind === "model"
@@ -540,74 +578,89 @@ function VariantButton({
   const applicable = v.valid || v.empty;
   const selectable = !v.active && applicable && !disabled;
   return (
-    <button
-      disabled={!selectable}
-      onClick={onClick}
-      title={
-        v.active
-          ? kind === "model"
-            ? t("locker.activeModel")
-            : t("locker.activeSound")
-          : v.empty
-            ? emptyTitle
-            : !v.valid
-              ? kind === "model"
-                ? t("locker.missingModelEdf")
-                : t("locker.missingSoundFiles")
-              : t("locker.switchTo", { name: v.name })
-      }
-      className={cn(
-        "flex items-center gap-2 rounded-lg border px-3 py-2.5 text-left transition-colors",
-        v.active
-          ? "border-primary/60 bg-primary/10"
-          : applicable
-            ? "cursor-pointer border-white/[0.07] hover:border-white/20"
-            : "border-white/[0.05] opacity-50",
-        disabled && !v.active && "pointer-events-none opacity-60",
-      )}
-    >
-      <span className="flex size-4 flex-none items-center justify-center">
-        {v.active ? (
-          busy ? (
-            <Loader2 className="size-3.5 animate-spin text-primary" />
-          ) : (
-            <Check className="size-4 text-primary" />
-          )
-        ) : v.empty ? (
-          <Ban className="size-3.5 text-muted-foreground" />
-        ) : !v.valid ? (
-          <AlertTriangle className="size-3.5 text-amber-500/80" />
-        ) : busy ? (
-          <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
-        ) : null}
-      </span>
-      <span className="min-w-0 flex-1">
-        <span
-          className={cn(
-            "block truncate text-[12.5px] font-medium",
-            v.active ? "text-foreground" : "text-foreground/90",
-          )}
-        >
-          {v.name}
-        </span>
-        <span className="flex items-center gap-1 text-[10.5px] text-faint">
-          {v.active
-            ? t("common.active")
+    <div className="relative">
+      <button
+        disabled={!selectable}
+        onClick={onClick}
+        title={
+          v.active
+            ? kind === "model"
+              ? t("locker.activeModel")
+              : t("locker.activeSound")
             : v.empty
-              ? emptyLabel
-              : t("swaps.fileCount", { count: v.fileCount })}
-          {boundModels.length > 0 && (
-            <span
-              className="flex items-center gap-0.5 text-primary/70"
-              title={t("locker.tiedToModel", { models: boundModels.join(", ") })}
-            >
-              <Link2 className="size-3" />
-              {boundModels.join(", ")}
-            </span>
-          )}
+              ? emptyTitle
+              : !v.valid
+                ? kind === "model"
+                  ? t("locker.missingModelEdf")
+                  : t("locker.missingSoundFiles")
+                : t("locker.switchTo", { name: v.name })
+        }
+        className={cn(
+          "flex w-full items-center gap-2 rounded-lg border px-3 py-2.5 text-left transition-colors",
+          onPreview && "pr-10",
+          v.active
+            ? "border-primary/60 bg-primary/10"
+            : applicable
+              ? "cursor-pointer border-white/[0.07] hover:border-white/20"
+              : "border-white/[0.05] opacity-50",
+          disabled && !v.active && "pointer-events-none opacity-60",
+        )}
+      >
+        <span className="flex size-4 flex-none items-center justify-center">
+          {v.active ? (
+            busy ? (
+              <Loader2 className="size-3.5 animate-spin text-primary" />
+            ) : (
+              <Check className="size-4 text-primary" />
+            )
+          ) : v.empty ? (
+            <Ban className="size-3.5 text-muted-foreground" />
+          ) : !v.valid ? (
+            <AlertTriangle className="size-3.5 text-amber-500/80" />
+          ) : busy ? (
+            <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
+          ) : null}
         </span>
-      </span>
-    </button>
+        <span className="min-w-0 flex-1">
+          <span
+            className={cn(
+              "block truncate text-[12.5px] font-medium",
+              v.active ? "text-foreground" : "text-foreground/90",
+            )}
+          >
+            {v.name}
+          </span>
+          <span className="flex items-center gap-1 text-[10.5px] text-faint">
+            {v.active
+              ? t("common.active")
+              : v.empty
+                ? emptyLabel
+                : t("swaps.fileCount", { count: v.fileCount })}
+            {boundModels.length > 0 && (
+              <span
+                className="flex items-center gap-0.5 text-primary/70"
+                title={t("locker.tiedToModel", { models: boundModels.join(", ") })}
+              >
+                <Link2 className="size-3" />
+                {boundModels.join(", ")}
+              </span>
+            )}
+          </span>
+        </span>
+      </button>
+      {/* Outside the swap button, not nested in it: previewing must never switch the
+          model by accident, and a button inside a button isn't valid markup either. */}
+      {onPreview && (
+        <button
+          onClick={onPreview}
+          title={t("locker.preview3d", { name: v.name })}
+          aria-label={t("locker.preview3d", { name: v.name })}
+          className="absolute right-1.5 top-1/2 grid size-7 -translate-y-1/2 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-white/[0.07] hover:text-foreground"
+        >
+          <Box className="size-3.5" />
+        </button>
+      )}
+    </div>
   );
 }
 

--- a/src/Components/Viewer/ViewerDialog.tsx
+++ b/src/Components/Viewer/ViewerDialog.tsx
@@ -5,6 +5,7 @@ import { ModelViewer, type ViewerMode } from "./ModelViewer";
 import {
   unpackPaint,
   loadBikeModel,
+  previewModelSwap,
   loadRiderBodyModel,
   loadGearModel,
   loadStockGearModel,
@@ -20,6 +21,9 @@ interface ViewerDialogProps {
   initialMode?: ViewerMode;
   paintPaths?: string[];
   modelSource?: string;
+  /** A bike shown as one of its model swaps would leave it, rather than as it is on disk.
+   *  Named by bike + variant because the swap is resolved backend-side, not by path. */
+  modelSwap?: { bike: string; variant: string };
   gearSource?: string;
   gearPart?: RiderPart["part"];
   stockGearPart?: RiderPart["part"];
@@ -60,6 +64,7 @@ export function ViewerDialog({
   title,
   paintPaths = [],
   modelSource,
+  modelSwap,
   gearSource,
   gearPart,
   stockGearPart,
@@ -68,7 +73,7 @@ export function ViewerDialog({
 }: ViewerDialogProps) {
   const t = useT();
   // A bike model → bike; gear/rider paint → rider. No user switch.
-  const isBike = !!modelSource;
+  const isBike = !!modelSource || !!modelSwap;
   const mode: ViewerMode = isBike ? "bike" : "rider";
   // Null until the player picks: the selection falls back to `initialPaint`, and the
   // names it matches against only arrive once the model (or its archive) has loaded.
@@ -85,6 +90,9 @@ export function ViewerDialog({
   const [gear, setGear] = useState<RiderPart | null>(null);
   const [gearPaints, setGearPaints] = useState<GearPaints>(EMPTY_GEAR_PAINTS);
   const [err, setErr] = useState<string | null>(null);
+  // Why the bike itself wouldn't load — a swap preview can be refused (an incomplete set,
+  // a bike with nothing behind it), and that reason is worth showing.
+  const [modelErr, setModelErr] = useState<string | null>(null);
 
   const nodes = model?.nodes ?? null;
   const paints = model?.paints ?? [];
@@ -102,22 +110,41 @@ export function ViewerDialog({
   const paintIdx = paintPick ?? indexOfName(paintNames, initialPaint);
   const gogglesIdx = gogglesPick ?? indexOfName(goggleNames, initialGoggles);
 
-  // Load the real bike geometry + its paints once per open (cached backend-side).
+  // Load the real bike geometry + its paints once per open (cached backend-side). A swap
+  // preview takes the same shape — it's the same bike, assembled from a different set.
+  const swapBike = modelSwap?.bike;
+  const swapVariant = modelSwap?.variant;
   useEffect(() => {
-    if (!open || !modelSource) {
+    if (!open) {
+      setModel(null);
+      return;
+    }
+    const load =
+      swapBike && swapVariant
+        ? previewModelSwap(swapBike, swapVariant)
+        : modelSource
+          ? loadBikeModel(modelSource)
+          : null;
+    if (!load) {
       setModel(null);
       return;
     }
     let alive = true;
     setLoadingModel(true);
-    loadBikeModel(modelSource)
+    setModelErr(null);
+    load
       .then((m) => alive && setModel(m))
-      .catch(() => alive && setModel(null))
+      .catch((e) => {
+        if (alive) {
+          setModelErr(String(e).replace(/^Error:\s*/, ""));
+          setModel(null);
+        }
+      })
       .finally(() => alive && setLoadingModel(false));
     return () => {
       alive = false;
     };
-  }, [open, modelSource]);
+  }, [open, modelSource, swapBike, swapVariant]);
 
   // Drop any pick each time it opens, so the next thing shown starts from its own paint
   // rather than the index left behind by the last one.
@@ -277,8 +304,10 @@ export function ViewerDialog({
   const paintNoChange = isBike && paints[paintIdx]?.changesPreview === false;
 
   const loading = loadingModel || loadingPaint;
-  // A bike that loaded but yielded no geometry (older split-`.edf` bikes) — show a message, not a fake.
-  const bikeFailed = isBike && !loadingModel && !!model && !model.nodes.length;
+  // A bike that loaded but yielded no geometry (older split-`.edf` bikes), or one that
+  // wouldn't load at all — show a message, not a fake.
+  const bikeFailed =
+    isBike && !loadingModel && (!!modelErr || (!!model && !model.nodes.length));
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -363,8 +392,9 @@ export function ViewerDialog({
               <span className="text-sm font-medium text-foreground">
                 Can&apos;t load bike model
               </span>
-              <span className="text-xs text-muted-foreground">
-                This bike&apos;s 3D model isn&apos;t in a format the viewer supports yet.
+              <span className="max-w-md px-6 text-xs text-muted-foreground">
+                {modelErr ??
+                  "This bike's 3D model isn't in a format the viewer supports yet."}
               </span>
             </div>
           )}

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -427,6 +427,15 @@ export function applyModelSwap(bike: string, target: string): Promise<SwapApplyO
   return invoke<SwapApplyOutcome>("apply_model_swap", { bike, target });
 }
 
+/**
+ * The bike as a model swap would leave it, without applying it — the swap's file set is
+ * assembled in memory, so nothing moves on disk and the game can stay open. "Stock" shows
+ * the packed model the loose files are hiding.
+ */
+export function previewModelSwap(bike: string, variant: string): Promise<BikeModel> {
+  return invoke<BikeModel>("preview_model_swap", { bike, variant });
+}
+
 export function scanSoundSwaps(): Promise<BikeSounds[]> {
   return invoke<BikeSounds[]>("scan_sound_swaps");
 }

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -979,6 +979,7 @@ export const de: Translation = {
   "locker.missingSoundFiles":
     "Diesem Set fehlt engine.scl oder sfx.cfg",
   "locker.switchTo": "Auf {{name}} wechseln",
+  "locker.preview3d": "{{name}} in 3D ansehen — es wird nichts gewechselt",
   "locker.tiedToModel": "Verknüpft mit Modell {{models}}",
   "locker.boundHint":
     "„{{sound}}“ ist mit Modell „{{model}}“ verknüpft — er wandert mit diesem Modell mit. Zum Lösen klicken.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -943,6 +943,7 @@ export const en = {
   "locker.missingModelEdf": "This set has no model.edf",
   "locker.missingSoundFiles": "This set is missing engine.scl or sfx.cfg",
   "locker.switchTo": "Switch to {{name}}",
+  "locker.preview3d": "See {{name}} in 3D — nothing is switched",
   "locker.tiedToModel": "Tied to model {{models}}",
   "locker.boundHint":
     "“{{sound}}” is tied to model “{{model}}” — it travels with that model. Click to untie.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -969,6 +969,7 @@ export const es: Translation = {
   "locker.missingModelEdf": "Este set no tiene model.edf",
   "locker.missingSoundFiles": "A este set le falta engine.scl o sfx.cfg",
   "locker.switchTo": "Cambiar a {{name}}",
+  "locker.preview3d": "Ver {{name}} en 3D — no se cambia nada",
   "locker.tiedToModel": "Vinculado al modelo {{models}}",
   "locker.boundHint":
     "«{{sound}}» está vinculado al modelo «{{model}}» — viaja con ese modelo. Haz clic para desvincular.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -972,6 +972,7 @@ export const fr: Translation = {
   "locker.missingModelEdf": "Ce set n'a pas de model.edf",
   "locker.missingSoundFiles": "Il manque engine.scl ou sfx.cfg à ce set",
   "locker.switchTo": "Passer à {{name}}",
+  "locker.preview3d": "Voir {{name}} en 3D — rien n’est changé",
   "locker.tiedToModel": "Lié au modèle {{models}}",
   "locker.boundHint":
     "« {{sound}} » est lié au modèle « {{model}} » — il suit ce modèle. Cliquez pour délier.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -961,6 +961,7 @@ export const it: Translation = {
   "locker.missingModelEdf": "Questo set non ha model.edf",
   "locker.missingSoundFiles": "A questo set mancano engine.scl o sfx.cfg",
   "locker.switchTo": "Passa a {{name}}",
+  "locker.preview3d": "Vedi {{name}} in 3D — non cambia nulla",
   "locker.tiedToModel": "Legato al modello {{models}}",
   "locker.boundHint":
     "“{{sound}}” è legato al modello “{{model}}” — segue quel modello. Clicca per slegarlo.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -964,6 +964,7 @@ export const ptBR: Translation = {
   "locker.missingModelEdf": "Este set não tem model.edf",
   "locker.missingSoundFiles": "Falta engine.scl ou sfx.cfg neste set",
   "locker.switchTo": "Mudar para {{name}}",
+  "locker.preview3d": "Ver {{name}} em 3D — nada é trocado",
   "locker.tiedToModel": "Vinculado ao modelo {{models}}",
   "locker.boundHint":
     "“{{sound}}” está vinculado ao modelo “{{model}}” — ele acompanha esse modelo. Clique para desvincular.",


### PR DESCRIPTION
Every model set in the Locker now has a 3D button beside it. It opens the existing viewer showing the bike **as that swap would leave it** — nothing moves on disk, so it's safe to look with the game open. "Stock" previews the model packed in the bike's own archive, the one the loose files are covering.

## How it works

Pointing the viewer at the variant folder doesn't work: `gather_bike_files` reads one flat dir and needs a `.edf`, and a real swap set is often an alternate mesh and nothing else — you'd lose `gfx.cfg`, the `.hrc`s, `.geom`, loose `.tga`s and `paints/`. So the preview is the overlay the swap would perform, done in memory:

- `modelswap::preview_set` repeats `apply_model_swap`'s accounting — `active_set_files`, plus the Stock case that also clears loose setup — but returns filenames instead of moving anything. Same rules on purpose: what the preview shows has to be what applying gives you.
- `gather_preview_files` reads it: kept root files, the variant's laid over them by name, and the packed `.pkz` underneath when nothing loose has a mesh (which is exactly what Stock means).
- `load_bike_model_blocking` splits into gather + `build_bike_model`, now shared by a bike loaded from disk and a preview assembled in memory. New `preview_model_swap` command, cache-keyed on both folders so a preview never collides with the active model.
- `ViewerDialog` takes a `modelSwap={{bike, variant}}` source, and a bike that won't load now says *why* instead of showing an empty viewer. The Locker button is gated on `bikePreview`, like the Library's.

No DB or schema changes.

## Verification

715 unit tests green, plus four new ones. Two run against a real MX Bikes tree (`MXB_REAL_BIKES=…`, `--ignored`) because the in-memory overlay has to pick up the `.hrc`s, `.geom` and textures the root keeps while the mesh comes from the variant folder — a synthetic bike can't exercise that chain:

- `preview_matches_the_applied_swap` — on `MX1OEM_2023_KTM_450_SX-F` the preview keeps `gfx.cfg` + four `.hrc`s and brings in the variant's `model.edf`; the resulting nodes, submeshes and texture bindings are identical to actually applying the swap.
- `preview_of_stock_shows_the_packed_model` — Stock parks every loose file and the packed model still draws.

Plus, on synthetic trees: the preview predicts the exact root the swap leaves, Stock clears every loose override, and an incomplete set is refused the same way `apply_model_swap` refuses it.

Typecheck, eslint, clippy and a production build are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)