### PR TITLE
feat(designer): say which side of the bike a sheet region paints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased — the UV map says which side of the bike it is
+
+### Added
+- **The sheet now says left or right.** Hovering a piece of bodywork named it; it now says which
+  flank of the bike that piece is, and the clip picker carries the same suffix. The model already
+  knew — the geometry arrives assembled about its mirror plane, so the sign of a triangle's x is
+  the answer — and not passing it on left the one question a flat square can't answer to guesswork.
+- **"Both sides" is said out loud.** Bikes routinely unwrap their two flanks onto *one* island, so
+  a decal placed off-centre there comes out at the mirrored spot on the far side — which reads as
+  the editor having painted the wrong side. Where that is what the model does, the sheet says so
+  and the tooltip says what it means. Rider gear is left unlabelled: a helmet's up-axis is worked
+  out per mod, and a side named from the wrong axis would be worse than no side at all.
+
 ## Unreleased — the Designer sets up its own sheets
 
 ### Added

--- a/src/Components/Studio/Designer/CanvasStage.tsx
+++ b/src/Components/Studio/Designer/CanvasStage.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 import { useT } from "../../../i18n/context";
 import { layerCorners } from "./composite";
 import type { Ghost } from "./ghost";
-import { partAt, partPath, type UvPart } from "./uv";
+import { flankAt, partAt, partPath, type Side, type UvPart } from "./uv";
 import { hitTest, type Layer, type Sheet } from "./layers";
 import { constrained, hasTip, isDragTool, type PaintTool, type Point } from "./paint";
 
@@ -130,6 +130,9 @@ export function CanvasStage({
   // being able to answer "what am I painting on" — an outline you have to interpret answers it
   // less well than a name does.
   const [overPart, setOverPart] = useState<UvPart | null>(null);
+  // And which flank of the bike that piece is, at the point being pointed at rather than over
+  // the part as a whole — the two are different answers wherever the flanks share an island.
+  const [overSide, setOverSide] = useState<Side | null>(null);
   // The press and current point of a gradient or shape drag, so it can be shown while it's
   // being aimed. Only ever set between press and release.
   const [guide, setGuide] = useState<{ from: Point; to: Point } | null>(null);
@@ -489,9 +492,11 @@ export function CanvasStage({
         setOverHandle(paints ? -1 : handleAt(e.clientX, e.clientY));
         if (parts.length) {
           const at = toSheet(e.clientX, e.clientY);
-          setOverPart(
-            at ? partAt(parts, at.x / sheet.width, at.y / sheet.height) : null,
-          );
+          const u = at ? at.x / sheet.width : 0;
+          const v = at ? at.y / sheet.height : 0;
+          const part = at ? partAt(parts, u, v) : null;
+          setOverPart(part);
+          setOverSide(part ? flankAt(part, u, v) : null);
         }
         return;
       }
@@ -602,6 +607,16 @@ export function CanvasStage({
           <>
             <span>·</span>
             <span className="max-w-[160px] truncate text-white/70">{overPart.label}</span>
+            {/* Which flank, when the model can say. `both` is the one that saves an
+                afternoon: it means this island is worn by each side of the bike. */}
+            {overSide && overSide !== "centre" && (
+              <span
+                className="text-white/45"
+                title={overSide === "both" ? t("designer.flankSharedHint") : undefined}
+              >
+                {t(`designer.flank.${overSide}` as "designer.flank.left")}
+              </span>
+            )}
           </>
         )}
       </div>

--- a/src/Components/Studio/Designer/Designer.tsx
+++ b/src/Components/Studio/Designer/Designer.tsx
@@ -28,7 +28,7 @@ import {
   textureBytes,
 } from "../../../api/mods";
 import { useT } from "../../../i18n/context";
-import { IMAGE_EXTS, PaintDestBar, usePaintDest } from "../paintDest";
+import { IMAGE_EXTS, PaintDestBar, isBikeKind, usePaintDest } from "../paintDest";
 import { CanvasStage } from "./CanvasStage";
 import { Row, Slider } from "./controls";
 import { PreviewPanel } from "./PreviewPanel";
@@ -740,9 +740,12 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   // replaces the sheet object without changing any of these.
   const activeWidth = active?.width ?? 0;
   const activeHeight = active?.height ?? 0;
+  // Left and right are asked for on bikes only: a bike arrives assembled about its mirror
+  // plane, where gear is a single piece whose up-axis the viewer has to work out per mod.
+  const bike = isBikeKind(destState.kind);
   const parts = useMemo<UvPart[]>(
-    () => (geometry ? uvParts(geometry, activeName) : []),
-    [geometry, activeName],
+    () => (geometry ? uvParts(geometry, activeName, { flanks: bike }) : []),
+    [geometry, activeName, bike],
   );
 
   /** Pin the selected layer to a piece of bodywork, or let it cover the sheet again. */

--- a/src/Components/Studio/Designer/LayerInspector.tsx
+++ b/src/Components/Studio/Designer/LayerInspector.tsx
@@ -78,7 +78,11 @@ export function LayerInspector({
               <option value="">{t("designer.wholeSheet")}</option>
               {parts.map((p) => (
                 <option key={p.label} value={p.label}>
-                  {p.label}
+                  {/* The side is part of the name here rather than a column of its own: a
+                      picker of one-word options is read as a list of names. */}
+                  {p.side && p.side !== "centre"
+                    ? `${p.label} — ${t(`designer.flank.${p.side}` as "designer.flank.left")}`
+                    : p.label}
                 </option>
               ))}
             </select>

--- a/src/Components/Studio/Designer/uv.ts
+++ b/src/Components/Studio/Designer/uv.ts
@@ -12,12 +12,36 @@ import type { EdfNode } from "../../../types";
  * the parts were read for.
  */
 
+/**
+ * Which flank of the bike a triangle sits on. `centre` straddles the mirror plane — a front
+ * fender, the seat's spine — and belongs to neither.
+ */
+export type Flank = "left" | "right" | "centre";
+
+/** A flank a region covers, where `both` means the two flanks share it. */
+export type Side = Flank | "both";
+
+/** Per-triangle flank codes, packed one byte each. */
+const CENTRE = 0;
+const LEFT = 1;
+const RIGHT = 2;
+
 /** One piece of bodywork: a mesh-group name, and where its triangles land on the sheet. */
 export interface UvPart {
   /** Mesh-group name from the `.edf` — `shroud`, `frame.005`, `chain`. */
   label: string;
   /** Triangle corners in uv space, six numbers per triangle: u0,v0,u1,v1,u2,v2. */
   tris: Float32Array;
+  /**
+   * One flank code per triangle, or null when the mesh's axes can't be trusted.
+   *
+   * Kept per triangle rather than per part because the question is asked about a *point*: the
+   * two flanks of a shroud regularly land on one island, and a part-wide answer would have to
+   * say "both" everywhere the precise answer is "here, both".
+   */
+  flanks: Uint8Array | null;
+  /** The flanks the part covers as a whole, for a one-word summary. Null when unknown. */
+  side: Side | null;
   /** uv-space bounds, for fitting an image to the part and for cheap hit rejection. */
   minU: number;
   minV: number;
@@ -25,6 +49,63 @@ export interface UvPart {
   maxV: number;
   /** Stable hue, so a shroud and a fender never read as one shape. */
   hue: number;
+}
+
+/**
+ * How far from the mirror plane a triangle has to sit before it counts as being on a side.
+ *
+ * 4% of the model's half-width. A bike is a symmetric object with a seam down the middle, and
+ * without a dead band that seam's triangles would be sorted left or right by rounding error and
+ * report a side each time the pointer crossed it.
+ */
+function lateralTolerance(nodes: EdfNode[]): number {
+  let maxAbs = 0;
+  for (const node of nodes) {
+    for (let i = 0; i < node.positions.length; i += 3) {
+      const x = Math.abs(node.positions[i]);
+      if (x > maxAbs) maxAbs = x;
+    }
+  }
+  return maxAbs * 0.04;
+}
+
+/** What a run of flank codes amounts to: one side, both of them, or neither. */
+function summarise(sides: number[]): Side {
+  let left = false;
+  let right = false;
+  for (const s of sides) {
+    if (s === LEFT) left = true;
+    else if (s === RIGHT) right = true;
+    if (left && right) return "both";
+  }
+  return left ? "left" : right ? "right" : "centre";
+}
+
+/**
+ * The flank of `part` under a uv point — `both` when the two sides land on the same island.
+ *
+ * That last case is the one worth having: a bike's flanks routinely share one region of the
+ * sheet, so a decal placed off-centre there comes out at the mirrored spot on the far side.
+ * The editor can't change that, and it can say so.
+ */
+export function flankAt(part: UvPart, u: number, v: number): Side | null {
+  const { tris, flanks } = part;
+  if (!flanks) return null;
+  let left = false;
+  let right = false;
+  let centre = false;
+  for (let i = 0; i < tris.length; i += 6) {
+    if (!inTriangle(u, v, tris[i], tris[i + 1], tris[i + 2], tris[i + 3], tris[i + 4], tris[i + 5]))
+      continue;
+    const s = flanks[i / 6];
+    if (s === LEFT) left = true;
+    else if (s === RIGHT) right = true;
+    else centre = true;
+    if (left && right) return "both";
+  }
+  if (left) return "left";
+  if (right) return "right";
+  return centre ? "centre" : null;
 }
 
 /** A stable hue per mesh-group name. */
@@ -49,12 +130,25 @@ function hueOf(label: string): number {
  * uv0 is taken as-is. The sheet uploads with `flipY = false` (see `sheetTexture`), so v runs the
  * same way as a canvas row and no flip belongs here — the same reasoning that keeps the editor
  * from having an opinion about which way up a sheet is.
+ *
+ * `flanks` asks for the left/right answer as well, and is for bikes only: their positions arrive
+ * assembled and centred on the mirror plane, which is what makes the sign of x mean a side.
  */
-export function uvParts(nodes: EdfNode[], sheetName: string): UvPart[] {
+export function uvParts(
+  nodes: EdfNode[],
+  sheetName: string,
+  opts?: { flanks?: boolean },
+): UvPart[] {
   const want = sheetName.trim().toLowerCase();
   if (!want) return [];
 
+  // A fraction of the model's width, so the dead band around the mirror plane scales with the
+  // bike rather than being a number of metres — a 65 and a 450 are one shape at two sizes.
+  const sided = !!opts?.flanks;
+  const tol = sided ? lateralTolerance(nodes) : 0;
+
   const byLabel = new Map<string, number[]>();
+  const flanksByLabel = new Map<string, number[]>();
   for (const node of nodes) {
     if (!node.uvs.length || !node.indices.length) continue;
     const triCount = Math.floor(node.indices.length / 3);
@@ -72,12 +166,22 @@ export function uvParts(nodes: EdfNode[], sheetName: string): UvPart[] {
         flat = [];
         byLabel.set(label, flat);
       }
+      let sides = flanksByLabel.get(label);
+      if (!sides && sided) {
+        sides = [];
+        flanksByLabel.set(label, sides);
+      }
       const end = Math.min(start + count, triCount);
       for (let t = Math.max(0, start); t < end; t += 1) {
+        let x = 0;
         for (let c = 0; c < 3; c += 1) {
           const v = node.indices[t * 3 + c];
           flat.push(node.uvs[v * 2], node.uvs[v * 2 + 1]);
+          if (sides) x += node.positions[v * 3];
         }
+        // The centroid, not every corner: a triangle with one vertex over the line is still on
+        // the side the rest of it is, and a panel's inner edge is full of them.
+        if (sides) sides.push(x / 3 > tol ? LEFT : x / 3 < -tol ? RIGHT : CENTRE);
       }
     }
   }
@@ -95,7 +199,18 @@ export function uvParts(nodes: EdfNode[], sheetName: string): UvPart[] {
       if (flat[i + 1] < minV) minV = flat[i + 1];
       if (flat[i + 1] > maxV) maxV = flat[i + 1];
     }
-    parts.push({ label, tris: new Float32Array(flat), minU, minV, maxU, maxV, hue: hueOf(label) });
+    const sides = flanksByLabel.get(label);
+    parts.push({
+      label,
+      tris: new Float32Array(flat),
+      flanks: sides ? new Uint8Array(sides) : null,
+      side: sides ? summarise(sides) : null,
+      minU,
+      minV,
+      maxU,
+      maxV,
+      hue: hueOf(label),
+    });
   }
   // Biggest first: the list is a menu, and the panel someone means when they say "the shroud"
   // is the one that takes up half the sheet, not the bracket bolted behind it.

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1570,6 +1570,11 @@ export const de: Translation = {
   "designer.fitNotForPaint": "Eine Malebene ist das Blatt selbst — da gibt es nichts zu verschieben oder zu skalieren.",
   "designer.clipped": "Zugeschnitten",
   "designer.clippedHint": "Diese Ebene ist auf das Teil beschnitten — nichts ragt über die Naht hinaus.",
+  "designer.flank.left": "linke Seite",
+  "designer.flank.right": "rechte Seite",
+  "designer.flank.both": "beide Seiten",
+  "designer.flankSharedHint":
+    "Beide Flanken liegen auf derselben Fläche, deshalb erscheint alles hier Gezeichnete auf jeder Seite des Motorrads — gespiegelt, und nicht dort, wo man es auf der anderen Seite erwarten würde.",
   "designer.opacity": "Deckkraft",
   "designer.blend": "Modus",
   "designer.blend.normal": "Normal",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1524,6 +1524,11 @@ export const en = {
   "designer.fitNotForPaint": "A paint layer is the sheet, so there is nothing to move or scale.",
   "designer.clipped": "Clipped",
   "designer.clippedHint": "This layer is trimmed to the part — nothing it holds spills past the seam.",
+  "designer.flank.left": "left side",
+  "designer.flank.right": "right side",
+  "designer.flank.both": "both sides",
+  "designer.flankSharedHint":
+    "Both flanks are unwrapped onto this same area, so anything drawn here appears on each side of the bike — mirrored, and not where you would expect it on the far one.",
   "designer.opacity": "Opacity",
   "designer.blend": "Blend",
   "designer.blend.normal": "Normal",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1557,6 +1557,11 @@ export const es: Translation = {
   "designer.fitNotForPaint": "Una capa de pintura es la hoja, así que no hay nada que mover ni escalar.",
   "designer.clipped": "Recortada",
   "designer.clippedHint": "Esta capa está recortada a la pieza: nada se sale por la junta.",
+  "designer.flank.left": "lado izquierdo",
+  "designer.flank.right": "lado derecho",
+  "designer.flank.both": "ambos lados",
+  "designer.flankSharedHint":
+    "Los dos flancos se despliegan sobre esta misma zona, así que lo que dibujes aquí aparece en ambos lados de la moto: reflejado, y no donde lo esperarías en el otro.",
   "designer.opacity": "Opacidad",
   "designer.blend": "Fusión",
   "designer.blend.normal": "Normal",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1561,6 +1561,11 @@ export const fr: Translation = {
   "designer.fitNotForPaint": "Un calque de peinture est la planche : il n'y a rien à déplacer ni à redimensionner.",
   "designer.clipped": "Découpé",
   "designer.clippedHint": "Ce calque est rogné sur la pièce : rien ne dépasse la jointure.",
+  "designer.flank.left": "côté gauche",
+  "designer.flank.right": "côté droit",
+  "designer.flank.both": "les deux côtés",
+  "designer.flankSharedHint":
+    "Les deux flancs sont dépliés sur cette même zone : ce que vous dessinez ici apparaît de chaque côté de la moto, en miroir, et pas là où vous l'attendriez de l'autre côté.",
   "designer.opacity": "Opacité",
   "designer.blend": "Fusion",
   "designer.blend.normal": "Normal",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1548,6 +1548,11 @@ export const it: Translation = {
   "designer.fitNotForPaint": "Un livello pittura è la planche stessa: non c'è nulla da spostare o ridimensionare.",
   "designer.clipped": "Ritagliato",
   "designer.clippedHint": "Questo livello è tagliato sul pezzo: niente esce oltre la giunzione.",
+  "designer.flank.left": "lato sinistro",
+  "designer.flank.right": "lato destro",
+  "designer.flank.both": "entrambi i lati",
+  "designer.flankSharedHint":
+    "I due fianchi sono mappati sulla stessa area, quindi ciò che disegni qui compare su entrambi i lati della moto: speculare, e non dove te lo aspetteresti sull'altro.",
   "designer.opacity": "Opacità",
   "designer.blend": "Fusione",
   "designer.blend.normal": "Normale",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1548,6 +1548,11 @@ export const ptBR: Translation = {
   "designer.fitNotForPaint": "Uma camada de pintura é a folha, então não há o que mover ou redimensionar.",
   "designer.clipped": "Recortada",
   "designer.clippedHint": "Esta camada está recortada na peça: nada passa da emenda.",
+  "designer.flank.left": "lado esquerdo",
+  "designer.flank.right": "lado direito",
+  "designer.flank.both": "ambos os lados",
+  "designer.flankSharedHint":
+    "Os dois flancos são abertos sobre a mesma área, então o que você desenha aqui aparece nos dois lados da moto: espelhado, e não onde você esperaria no outro.",
   "designer.opacity": "Opacidade",
   "designer.blend": "Mesclagem",
   "designer.blend.normal": "Normal",


### PR DESCRIPTION
Reported as "the Designer paints the bike on the wrong side". The pipeline turned out not to be mirrored — probing a real bike mesh (`MX1OEM_2023_KTM_450_SX-F/model.edf`) through the app's own loader puts the silencer and the rear-brake pedal at −X after `to_right_handed`, and with the front at +Z (the rake convention in `assemble_bike`) that is the bike's right, where they belong. The composite also uploads with the same settings as an installed `.pnt`, so there is no flip between what is drawn and what the game binds.

What was missing is that nothing said which flank a region of the sheet belongs to — and on this KTM both flanks unwrap onto the *same* island (the tank's left triangles cover uv `[0.278,0.357]..[0.998,0.968]`, its right triangles `[0.299,0.353]..[0.998,0.968]`), so a decal placed off-centre comes out at the mirrored spot on the far side. That is the model's own unwrap, and the editor can at least say so.

## Changes
- `uv.ts` — a flank per triangle from the sign of x, with a dead band of 4% of the model's half-width so seam triangles aren't sorted by rounding. New `flankAt(part, u, v)` answers per point; `UvPart.side` summarises the part.
- Hover chip names the flank; "both sides" carries a tooltip explaining the mirroring.
- Clip picker reads `shroud — left side`.
- Bikes only — a helmet's up-axis is worked out per mod, so gear stays unlabelled.
- Six locales, plus a CHANGELOG section.

## Verification
- `tsc` clean; `eslint` clean (two warnings, both pre-existing on `main`).
- No frontend test runner in the repo, so `uv.ts` was bundled and run against a synthetic mirror-symmetric mesh: shared island → "both", split islands → left/right on the correct sign, centreline parts unlabelled, gear given no opinion. 10/10.
- Still to check on Windows: the exhaust side reads "right side" on a bike you know, and a shared livery island says "both sides".

🤖 Generated with [Claude Code](https://claude.com/claude-code)