### PR TITLE
feat(designer): view a helmet on its own, off the rider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
   own archive, the one your loose files are covering. The bike is assembled in memory exactly
   as applying the swap would leave it (the set's mesh over the bike's own `.hrc`s, `.geom` and
   textures), so nothing moves on disk and you can look with the game open.
+- **See the helmet on its own, not on the rider.** Painting a helmet, boots or protection always
+  previewed the piece worn by the stock rider — a small thing across the canvas with half of it
+  turned away, next to a grey body you weren't painting. A **Gear only** toggle in the preview
+  header takes it off and fills the frame with it, the way the library's 3D view already shows
+  one, and puts it back on the rider in a click when you want to see how it sits.
 
 ### Changed
 - **The UV map is on by default.** It answers the question a flat sheet always raises — which

--- a/src/Components/Studio/Designer/PreviewPanel.tsx
+++ b/src/Components/Studio/Designer/PreviewPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { Box, Loader2, TriangleAlert } from "lucide-react";
 import type * as THREE from "three";
 import { cn } from "@/lib/utils";
@@ -65,9 +65,12 @@ export function PreviewPanel({
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [hidden, setHidden] = useState<RiderPart["part"][]>([]);
+  const [soloGear, setSoloGear] = useState(false);
 
   const isBike = isBikeKind(kind);
   const gearPart = gearPartOf(kind);
+  /** Gear-only, and something to actually show that way — no model means no piece. */
+  const solo = soloGear && !!gearPart && !!model;
 
   /**
    * Start with the pieces that cover what you're painting taken off.
@@ -78,6 +81,9 @@ export function PreviewPanel({
    */
   useEffect(() => {
     setHidden(HIDEABLE.filter((h) => h.part !== gearPart).map((h) => h.part));
+    // Back to the rider whenever what's being painted changes: kit and gloves have no piece
+    // to show on its own, so a toggle left on would be a control over nothing.
+    setSoloGear(false);
   }, [gearPart]);
 
   /** The rider slots to fill so the piece being painted is the piece on screen. */
@@ -181,9 +187,18 @@ export function PreviewPanel({
 
   // Toggled-off gear is dropped before it reaches the viewer, which is what makes hiding it
   // reveal what's underneath rather than just dimming it.
-  const shownParts = hidden.length
-    ? riderParts?.filter((p) => !hidden.includes(p.part)) ?? null
-    : riderParts;
+  //
+  // Gear-only drops the body along with it, and that alone is the whole view: the viewer reads
+  // "no body" as a solo piece and reframes to it — see `RiderGearSolo` and `CameraRig`.
+  const shownParts = solo
+    ? riderParts?.filter((p) => p.part === gearPart) ?? null
+    : hidden.length
+      ? riderParts?.filter((p) => !hidden.includes(p.part)) ?? null
+      : riderParts;
+
+  // Gear-only with nothing to show: the model didn't load. Say so rather than leave a black
+  // canvas — on the rider there'd at least have been a body to make the absence read.
+  const soloEmpty = solo && !shownParts?.length;
 
   // Two different ways there is nothing to stand a paint on, and they deserve different
   // sentences: this *title* has no part bindings (GP Bikes), or this *build* can't decode bike
@@ -201,30 +216,37 @@ export function PreviewPanel({
       <div className="flex items-center gap-2 border-b border-border px-3 py-1.5 text-[12.5px] font-medium">
         <Box className="size-3.5 text-muted-foreground" />
         {t("viewer.preview3d")}
-        {/* Which pieces of the rider are in the way. A kit is worn under a chest protector,
-            and judging a jersey you can only see half of is judging the protector. */}
+        {/* What you're looking at, and what's in the way of it. A kit is worn under a chest
+            protector, and judging a jersey you can only see half of is judging the protector. */}
         {!isBike && (
           <div className="ml-auto flex items-center gap-1">
-            {HIDEABLE.map(({ part, label }) => (
-              <button
-                key={part}
-                type="button"
-                onClick={() =>
-                  setHidden((h) =>
-                    h.includes(part) ? h.filter((p) => p !== part) : [...h, part],
-                  )
-                }
-                title={t(label)}
-                className={cn(
-                  "rounded border px-1.5 py-0.5 text-[10.5px] font-medium transition-colors",
-                  hidden.includes(part)
-                    ? "border-border text-faint"
-                    : "border-primary/60 bg-primary/10 text-foreground",
-                )}
+            {/* A helmet on a rider is a small thing across the canvas with half of it turned
+                away. This takes it off and fills the frame with it. The hide toggles go while
+                it's on — they'd be controls over a rider that isn't on screen. */}
+            {!!gearPart && !!model && (
+              <Chip
+                on={solo}
+                onClick={() => setSoloGear((s) => !s)}
+                title={t("designer.gearOnlyHint")}
               >
-                {t(label)}
-              </button>
-            ))}
+                {t("designer.gearOnly")}
+              </Chip>
+            )}
+            {!solo &&
+              HIDEABLE.map(({ part, label }) => (
+                <Chip
+                  key={part}
+                  on={!hidden.includes(part)}
+                  onClick={() =>
+                    setHidden((h) =>
+                      h.includes(part) ? h.filter((p) => p !== part) : [...h, part],
+                    )
+                  }
+                  title={t(label)}
+                >
+                  {t(label)}
+                </Chip>
+              ))}
           </div>
         )}
         {loading && <Loader2 className="ml-1 size-3.5 animate-spin text-muted-foreground" />}
@@ -232,6 +254,8 @@ export function PreviewPanel({
       <div className="relative min-h-[240px] flex-1">
         {unavailable ? (
           <Message text={why} />
+        ) : soloEmpty && !loading ? (
+          <Message text={t("designer.noModelFound", { model })} />
         ) : (
           <>
             <ModelViewer
@@ -242,6 +266,9 @@ export function PreviewPanel({
               overrides={overrides}
               frameToken={frameToken}
               loading={loading}
+              // No stand-in body behind a solo piece: a rider that only appears when the gear
+              // fails to load reads as the gear, badly drawn.
+              noStandIn={solo}
               className="absolute inset-0"
             />
             {/* The model on screen is the last one that loaded, so a failure has to keep
@@ -258,12 +285,40 @@ export function PreviewPanel({
           </>
         )}
       </div>
-      {!!gearPart && (
+      {/* Only true of the rider view. */}
+      {!!gearPart && !solo && (
         <p className="border-t border-border px-3 py-1.5 text-[11px] leading-snug text-faint">
           {t("designer.gearNote")}
         </p>
       )}
     </div>
+  );
+}
+
+/** A header toggle: lit when what it names is on. */
+function Chip({
+  on,
+  onClick,
+  title,
+  children,
+}: {
+  on: boolean;
+  onClick: () => void;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className={cn(
+        "rounded border px-1.5 py-0.5 text-[10.5px] font-medium transition-colors",
+        on ? "border-primary/60 bg-primary/10 text-foreground" : "border-border text-faint",
+      )}
+    >
+      {children}
+    </button>
   );
 }
 

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1591,6 +1591,8 @@ export const de: Translation = {
     "Die 3D-Vorschau gibt es vorerst nur für MX Bikes — die Modelle von {{game}} brauchen eigene Teil-Zuordnungen. Alles andere funktioniert gleich, und das Design wird ganz normal gespeichert.",
   "designer.gearNote":
     "Auf dem Standardfahrer gezeigt — deine eigene Ausrüstung ist hier nicht geladen.",
+  "designer.gearOnly": "Nur Teil",
+  "designer.gearOnlyHint": "Nur das Teil zeigen, das du bemalst — ohne Fahrer",
   "designer.reference": "Referenz",
   "designer.traceTemplate": "Vorlage",
   "designer.traceHint":

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1544,6 +1544,8 @@ export const en = {
   "designer.noPreviewForGame":
     "The 3D preview is MX Bikes only for now — the {{game}} models need their own part bindings. Everything else here works the same, and the paint saves normally.",
   "designer.gearNote": "Shown on the stock rider — your own kit isn't loaded here.",
+  "designer.gearOnly": "Gear only",
+  "designer.gearOnlyHint": "Show just the piece you're painting, off the rider",
   "designer.reference": "Reference",
   "designer.traceTemplate": "Template",
   "designer.traceHint":

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1578,6 +1578,8 @@ export const es: Translation = {
     "La vista 3D es solo para MX Bikes por ahora: los modelos de {{game}} necesitan sus propias asignaciones de piezas. Todo lo demás funciona igual y la pintura se guarda con normalidad.",
   "designer.gearNote":
     "Se muestra sobre el piloto de serie — tu propio equipo no está cargado aquí.",
+  "designer.gearOnly": "Solo la pieza",
+  "designer.gearOnlyHint": "Muestra solo la pieza que estás pintando, sin el piloto",
   "designer.reference": "Referencia",
   "designer.traceTemplate": "Plantilla",
   "designer.traceHint":

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1582,6 +1582,8 @@ export const fr: Translation = {
     "L'aperçu 3D est réservé à MX Bikes pour l'instant : les modèles de {{game}} ont besoin de leurs propres liaisons de pièces. Tout le reste fonctionne pareil et la déco s'enregistre normalement.",
   "designer.gearNote":
     "Affiché sur le pilote d'origine — ta propre tenue n'est pas chargée ici.",
+  "designer.gearOnly": "Pièce seule",
+  "designer.gearOnlyHint": "Afficher seulement la pièce que tu peins, sans le pilote",
   "designer.reference": "Référence",
   "designer.traceTemplate": "Modèle",
   "designer.traceHint":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1568,6 +1568,8 @@ export const it: Translation = {
   "designer.noPreviewForGame":
     "L'anteprima 3D per ora è solo per MX Bikes: i modelli di {{game}} hanno bisogno delle proprie associazioni delle parti. Tutto il resto funziona uguale e la livrea si salva normalmente.",
   "designer.gearNote": "Mostrato sul pilota di serie — la tua tenuta non è caricata qui.",
+  "designer.gearOnly": "Solo il pezzo",
+  "designer.gearOnlyHint": "Mostra solo il pezzo che stai dipingendo, senza il pilota",
   "designer.reference": "Riferimento",
   "designer.traceTemplate": "Modello",
   "designer.traceHint":

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1567,6 +1567,8 @@ export const ptBR: Translation = {
   "designer.noPreviewForGame":
     "A prévia 3D é só do MX Bikes por enquanto — os modelos do {{game}} precisam dos próprios vínculos de peças. Todo o resto funciona igual e a pintura salva normalmente.",
   "designer.gearNote": "Mostrado no piloto padrão — o seu equipamento não está carregado aqui.",
+  "designer.gearOnly": "Só a peça",
+  "designer.gearOnlyHint": "Mostra só a peça que você está pintando, sem o piloto",
   "designer.reference": "Referência",
   "designer.traceTemplate": "Modelo",
   "designer.traceHint":


### PR DESCRIPTION
## Why

Painting a helmet, boots or protection in the Designer always previewed the piece **worn by the stock rider**: `PreviewPanel` builds a one-slot loadout and `load_rider_model` always adds a stock body behind it. So the thing you were actually painting was a small object across the canvas with half of it turned away, next to a grey body you weren't painting.

The library's own 3D view already does the opposite — *"A gear preview shows the piece itself — no rider body behind it"* (`ViewerDialog.tsx:161`) — so the Designer was the odd one out.

## What

A **Gear only** toggle in the preview header, shown when you're painting a helmet, boots or protection and a model is picked. Off by default: the rider view stays what you get, this is the extra look.

No viewer work was needed. `ModelViewer` already decides "solo gear" purely from the parts it is handed — `gearSolo` is true when there's no `body`, and `RiderComposite` then renders `RiderGearSolo` (piece up-righted, boots split left/right with toes straightened) under a level, close-in `CameraRig`. `PreviewPanel` just filters what it passes down, next to the gear-hiding filter it already had.

- While solo is on, the Protection/Helmet hide chips and the "Shown on the stock rider" footnote are dropped — both describe a rider that isn't on screen.
- `noStandIn` is passed so a gear model that fails to load can't fall through to the placeholder rider body; if the filter comes back empty it says so (existing `designer.noModelFound`) rather than leaving a black canvas.
- Resets to the rider view when the paint kind changes. Never offered for kit or gloves — those are worn on the body itself, so there is nothing to take off.
- The header chip is extracted into a local `Chip`, shared with the two hide toggles.

Deliberately unchanged: `onGeometry` still flattens **all** parts, so the editor's UV overlay doesn't shift when you toggle the view; and `loadRiderModel` still loads the full rider either way, so toggling is instant rather than a re-decode.

## Notes

- New keys `designer.gearOnly` / `designer.gearOnlyHint` in all six locales (every locale is typed against `en`, so a miss can't reach a build).
- No DB or schema changes.

## Verification

- `bun run typecheck` clean.
- `bun run lint` clean apart from two pre-existing warnings (`Presets.tsx`, `ViewerDialog.tsx`).
- Manually reviewed in the Designer: Helmet / Boots / Protection each show correctly on their own and back on the rider; drawing on a sheet lands on the solo piece live; Kit and Gloves show no chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)