### PR TITLE
feat(designer): show the bike's own plastics under the UV map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## Unreleased — the Designer sets up its own sheets
 
 ### Added
+- **The bike's own plastics, under the UV map.** The reference underlay could show the paint you
+  started from — and on an OEM bike there isn't one: its stock `.pnt` replaces the wheels and the
+  chain, and the plastics are embedded in the model itself. So the one sheet anybody opens the
+  Designer for was the one sheet with nothing to trace, just bare islands. Reference now has a
+  **Stock texture** toggle that draws the model's own artwork beneath them, so you can see where
+  the vents and shut lines fall before drawing over them. Fetched only for the sheet you're
+  looking at, and no more part of what you save than the UV map is.
 - **Create the sheets a model asks for, in one click.** The Designer already listed the texture
   names a bike's paints use — and the name is the whole binding, so a sheet called anything else
   paints nothing — but getting them onto the list meant reading them off and typing each one

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1230,14 +1230,27 @@ struct BikePaint {
 struct BikeModel {
     nodes: Vec<edf::EdfNode>,
     paints: Vec<BikePaint>,
+    /// The model's own textures — the look it ships with, before any paint replaces one.
+    ///
+    /// The same pixels the paints below already carry as fillers, said once on their own.
+    /// Folded into a paint they're indistinguishable from that paint's own sheets, and the
+    /// Designer's reference underlay needs the distinction: an OEM bike's stock `.pnt`
+    /// replaces the wheels and the chain, so `plastics` is only ever in here.
+    base: Vec<paint::PaintTexture>,
 }
 
 impl BikeModel {
     /// Every texture token the model holds, so evicting it can free the pixels too.
+    ///
+    /// `base` as well as the paints, and not only because it is a field now: a base texture
+    /// that *every* paint overrides is folded into none of them, and before this was dropped
+    /// without ever being released. Duplicates are free — `texstore::release` removes by key.
     fn tokens(&self) -> Vec<String> {
         self.paints
             .iter()
-            .flat_map(|p| p.textures.iter().map(|t| t.token.clone()))
+            .flat_map(|p| p.textures.iter())
+            .chain(self.base.iter())
+            .map(|t| t.token.clone())
             .collect()
     }
 }
@@ -1430,6 +1443,10 @@ fn load_bike_model_blocking(source: String) -> Result<BikeModel, String> {
     }
     let mut paints: Vec<BikePaint> = paints.into_iter().map(|(p, _)| p).collect();
 
+    // Kept before the folding below, which is where the model's own look stops being
+    // telling apart from a paint's. Names and tokens only — no pixels are copied.
+    let model_base = base.clone();
+
     for p in &mut paints {
         let own: std::collections::HashSet<String> =
             p.textures.iter().map(|t| t.name.to_ascii_lowercase()).collect();
@@ -1484,7 +1501,7 @@ fn load_bike_model_blocking(source: String) -> Result<BikeModel, String> {
         log::info!("  node '{}' placed={} {}", n.name, n.placed, subs.join(", "));
     }
 
-    let model = BikeModel { nodes, paints };
+    let model = BikeModel { nodes, paints, base: model_base };
     if let Ok(mut c) = bike_cache().lock() {
         // The evicted bike's pixels go with it — nothing else references them.
         if let Some(dropped) = c.insert(key, model.clone()) {
@@ -6939,6 +6956,41 @@ mod deep_link_tests {
 
 #[cfg(test)]
 mod viewer_tests {
+    fn tex(name: &str, token: &str) -> crate::paint::PaintTexture {
+        crate::paint::PaintTexture {
+            name: name.into(),
+            width: 4,
+            height: 4,
+            token: token.into(),
+        }
+    }
+
+    /// Evicting a bike has to free every blob it put in the store.
+    ///
+    /// The one that gets away is a model texture every paint overrides: it is folded into
+    /// none of them, so walking the paints alone never names it and its pixels outlive the
+    /// bike by the whole session. Cheap to leak, since it's the biggest sheets — `plastics`
+    /// on a bike whose paints all replace it — that leak.
+    #[test]
+    fn eviction_frees_the_models_own_textures_too() {
+        let model = super::BikeModel {
+            nodes: Vec::new(),
+            paints: vec![super::BikePaint {
+                name: "Red".into(),
+                // Its own `plastics`, so the model's never reaches it.
+                textures: vec![tex("plastics", "t-paint"), tex("wheel", "t-shared")],
+                changes_preview: true,
+            }],
+            base: vec![tex("plastics", "t-own"), tex("wheel", "t-shared")],
+        };
+        let tokens = model.tokens();
+        assert!(tokens.contains(&"t-own".to_string()), "the overridden one is still released");
+        assert!(tokens.contains(&"t-paint".to_string()));
+        // Named twice over — the paints borrowed it — and that's fine: `release` removes by
+        // key, so the second pass over a token is a no-op rather than a double free.
+        assert_eq!(tokens.iter().filter(|t| *t == "t-shared").count(), 2);
+    }
+
     #[test]
     #[ignore]
     fn bike_model_from_pkz() {
@@ -6981,6 +7033,9 @@ mod viewer_tests {
                 names.join(", ")
             );
         }
+        let mut own: Vec<&str> = m.base.iter().map(|t| t.name.as_str()).collect();
+        own.sort_unstable();
+        eprintln!("the model's own textures: {}", own.join(", "));
         assert!(!m.nodes.is_empty(), "decoded the mesh");
         let have: std::collections::HashSet<String> = m.paints[0]
             .textures
@@ -6994,6 +7049,13 @@ mod viewer_tests {
                 }
             }
         }
+        // The Designer's stock underlay reads exactly this list, and it is wanted most where no
+        // `.pnt` can answer: an OEM bike's stock paint replaces the wheels and the chain, so its
+        // `plastics` is only ever embedded in the mesh. Not asserted by that name — a mod bike
+        // calls its sheets whatever it likes, and a bike whose paints supply everything has a
+        // shorter list than this one — only that the list survived being folded into the paints
+        // above, which is the way it would be lost.
+        assert!(!m.base.is_empty(), "the model's own textures outlive the fold into the paints");
     }
 
 

--- a/src/Components/Studio/Designer/CanvasStage.tsx
+++ b/src/Components/Studio/Designer/CanvasStage.tsx
@@ -284,8 +284,13 @@ export function CanvasStage({
     if (ghost && ghost.opacity > 0) {
       ctx.save();
       ctx.globalAlpha = ghost.opacity;
-      // Template first, islands over it: the outlines have to stay readable against the paint
-      // being traced, and they are the thinner of the two marks.
+      // Artwork first, islands over it: the outlines have to stay readable against whatever
+      // is being traced, and they are the thinnest of the marks. The model's own texture goes
+      // under the template rather than over it — someone who lifted a paint out to trace it
+      // asked for *that* paint, and the stock plastics are the fallback beneath it.
+      if (ghost.showStock && ghost.stock) {
+        ctx.drawImage(ghost.stock, left, top, w, h);
+      }
       if (ghost.showTemplate && ghost.template) {
         ctx.drawImage(ghost.template, left, top, w, h);
       }

--- a/src/Components/Studio/Designer/Designer.tsx
+++ b/src/Components/Studio/Designer/Designer.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
+  Bike,
   Eye,
   EyeOff,
   FilePlus2,
@@ -60,7 +61,7 @@ import {
   type PaintTool,
   type Point,
 } from "./paint";
-import type { EdfNode } from "../../../types";
+import type { EdfNode, PaintTexture } from "../../../types";
 
 /**
  * The paint designer: layers on a sheet, the sheet on the model, and a `.pnt` at the end.
@@ -130,6 +131,9 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   // The mesh the preview is showing, reported back by it. Null until one loads, and null again
   // if it fails — a UV map drawn from a model that isn't on screen would be a confident lie.
   const [geometry, setGeometry] = useState<EdfNode[] | null>(null);
+  // That same model's own textures — the look it ships with. Empty for anything that can't
+  // say which of its textures are its own, which is every model but a bike.
+  const [stockTextures, setStockTextures] = useState<PaintTexture[]>([]);
 
   const destState = usePaintDest();
   const { dest, hints } = destState;
@@ -823,6 +827,17 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     );
   }, []);
 
+  /** The same, for the model's own textures: a new bike, a new set of stock sheets. */
+  const stockRef = useRef<PaintTexture[]>([]);
+  const onStock = useCallback((textures: PaintTexture[]) => {
+    if (stockRef.current === textures) return;
+    stockRef.current = textures;
+    setStockTextures(textures);
+    setGhosts((gs) =>
+      gs.size ? new Map([...gs].map(([id, g]) => [id, { ...g, stock: null, stockFor: null }])) : gs,
+    );
+  }, []);
+
   /**
    * Move the template between the sheet and the ghost.
    *
@@ -874,6 +889,43 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     const wire = uvWireframe(parts, activeWidth, activeHeight);
     patchGhost(activeId, (g) => ({ ...g, wire, wireFor: activeName }));
   }, [activeId, activeName, activeWidth, activeHeight, geometry, ghosts, parts, patchGhost]);
+
+  /**
+   * Fetch the model's own texture for the active sheet, the same way and for the same reasons.
+   *
+   * Lazy and keyed on the name again — the name is what picks the texture out of the model,
+   * exactly as it picks the triangles — but this one crosses to the backend for pixels, so a
+   * 2048² sheet is a few megabytes over IPC. Only the sheet on screen pays for it, and only
+   * once: a paint with twenty sheets fetches the one being looked at.
+   */
+  const stockFetch = useRef<string | null>(null);
+  useEffect(() => {
+    if (!activeId || !activeName.trim() || !stockTextures.length) return;
+    const ghost = ghosts.get(activeId) ?? EMPTY_GHOST;
+    if (!ghost.showStock || ghost.stockFor === activeName) return;
+    // One request in the air per sheet-and-name. This effect re-runs on every change to any
+    // ghost — the opacity slider alone is dozens — and without this each of those would put
+    // another copy of the same megabyte read on the wire while the first was still coming.
+    const key = `${activeId}:${activeName}`;
+    if (stockFetch.current === key) return;
+    stockFetch.current = key;
+    const want = activeName.trim().toLowerCase();
+    const tex = stockTextures.find((t) => t.name.trim().toLowerCase() === want);
+    void (async () => {
+      // Null covers both "the model carries no such texture" and "the pixels are gone" — the
+      // store evicts, and a rejected read is the same nothing to draw as a name that missed.
+      const stock = tex
+        ? await textureBytes(tex.token)
+            .then((buf) => bitmapFromRgba(buf, tex.width, tex.height))
+            .catch(() => null)
+        : null;
+      // Written against the sheet it was asked *for*, not whichever is active now, and both
+      // halves land together. So the worst a slow answer can do is describe a name the sheet
+      // no longer has — which the guard above then notices, and asks again.
+      patchGhost(activeId, (g) => ({ ...g, stock, stockFor: activeName }));
+      if (stockFetch.current === key) stockFetch.current = null;
+    })();
+  }, [activeId, activeName, ghosts, patchGhost, stockTextures]);
 
   // Ghosts of sheets that are gone. Each holds a decoded bitmap and a raster the size of the
   // sheet, so leaving them behind would keep a closed paint's pixels alive for the session.
@@ -1109,6 +1161,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
               sheetName={active.name}
               hasBase={!!active.base}
               hasGeometry={!!geometry}
+              hasStock={!!stockTextures.length}
               onTrace={() => toggleTrace(active.id)}
               onChange={(fn) => patchGhost(active.id, fn)}
             />
@@ -1202,6 +1255,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
           overrides={overrides}
           frameToken={version}
           onGeometry={onGeometry}
+          onStock={onStock}
           className="flex-1"
         />
       </section>
@@ -1372,6 +1426,7 @@ function GhostPanel({
   sheetName,
   hasBase,
   hasGeometry,
+  hasStock,
   onTrace,
   onChange,
 }: {
@@ -1380,6 +1435,8 @@ function GhostPanel({
   /** Whether the sheet still holds a template that tracing could lift out of it. */
   hasBase: boolean;
   hasGeometry: boolean;
+  /** Whether the model on screen can say which of its textures are its own — bikes can. */
+  hasStock: boolean;
   onTrace: () => void;
   onChange: (fn: (g: Ghost) => Ghost) => void;
 }) {
@@ -1388,6 +1445,8 @@ function GhostPanel({
   // A map was built for this name and came back with nothing on it. Distinct from "not built
   // yet" (`wireFor` still null), which is why both halves are checked.
   const noMatch = ghost.showWire && ghost.wireFor === sheetName && !ghost.wire;
+  // The same pair, asked of the model's textures rather than of its triangles.
+  const noStock = hasStock && ghost.showStock && ghost.stockFor === sheetName && !ghost.stock;
   // Nothing to trace: a blank sheet never had a template, and one that did has already had it
   // lifted. The UV map is the guide that still applies, so the button says so rather than
   // sitting there dead with no explanation.
@@ -1404,7 +1463,7 @@ function GhostPanel({
         <button
           type="button"
           className="ml-auto text-muted-foreground transition-colors hover:text-foreground disabled:opacity-30"
-          disabled={!ghost.template && !ghost.wire}
+          disabled={!ghost.template && !ghost.stock && !ghost.wire}
           onClick={() =>
             onChange((g) => {
               // One eye over both, and it turns them off together rather than remembering
@@ -1414,6 +1473,10 @@ function GhostPanel({
               return {
                 ...g,
                 showTemplate: !off,
+                // Not gated on already having one, unlike the wire below: the stock texture is
+                // fetched *because* this is on, so requiring it first would be a switch that
+                // could never be turned back on.
+                showStock: !off,
                 showWire: !off && !!g.wire,
                 // Faded all the way out counts as hidden, so switching back on has to undo
                 // that too. Otherwise the eye says "showing" over a reference at zero.
@@ -1440,6 +1503,14 @@ function GhostPanel({
             if (!tracing || ghost.showTemplate) onTrace();
             else onChange((g) => ({ ...g, showTemplate: true }));
           }}
+        />
+        <GhostToggle
+          icon={<Bike className="size-3.5" />}
+          label={t("designer.stockTexture")}
+          title={t(hasStock ? "designer.stockHint" : "designer.noStock")}
+          on={ghost.showStock}
+          disabled={!hasStock}
+          onClick={() => onChange((g) => ({ ...g, showStock: !g.showStock }))}
         />
         <GhostToggle
           icon={<Grid3x3 className="size-3.5" />}
@@ -1476,6 +1547,16 @@ function GhostPanel({
       {noMatch && (
         <p className="mt-1.5 text-[11px] leading-snug text-destructive">
           {t("designer.uvNoMatch", { name: sheetName.trim() })}
+        </p>
+      )}
+
+      {/* Not the same miss as the one above, and worth saying separately: a model can draw a
+          texture without shipping one of its own, so a sheet every paint replaces has islands
+          to show and no stock artwork behind them. Said without claiming which of the two it
+          is — with the UV map off there is nothing here that knows. */}
+      {noStock && !noMatch && (
+        <p className="mt-1.5 text-[11px] leading-snug text-faint">
+          {t("designer.stockNoMatch", { name: sheetName.trim() })}
         </p>
       )}
     </div>

--- a/src/Components/Studio/Designer/PreviewPanel.tsx
+++ b/src/Components/Studio/Designer/PreviewPanel.tsx
@@ -30,6 +30,9 @@ import { gearPartOf, isBikeKind, type PaintDestState } from "../paintDest";
  * hides the collar. Boots and gloves cover nothing else, so hiding them would be a control with
  * nothing behind it.
  */
+/** "This model can't name its own textures" — one array, so reporting it twice is one value. */
+const NO_STOCK: PaintTexture[] = [];
+
 const HIDEABLE: { part: RiderPart["part"]; label: TKey }[] = [
   { part: "protection", label: "paints.kind.protection" },
   { part: "helmet", label: "paints.kind.helmet" },
@@ -40,6 +43,7 @@ export function PreviewPanel({
   overrides,
   frameToken,
   onGeometry,
+  onStock,
   className,
 }: {
   state: PaintDestState;
@@ -54,6 +58,16 @@ export function PreviewPanel({
    * that question — one that could quietly disagree about which bike is on screen.
    */
   onGeometry?: (nodes: EdfNode[] | null) => void;
+  /**
+   * The model's own textures, handed back with the mesh so the editor can show what the
+   * bike already looks like under a sheet being drawn from blank.
+   *
+   * Bikes only, and empty for anything else. A rider part's textures are whatever dressed
+   * it — often the mesh's own, but a helmet that ships paints and embeds no shell wears a
+   * `.pnt` here, and offering that as "stock" would be a confident lie about somebody
+   * else's paint.
+   */
+  onStock?: (textures: PaintTexture[]) => void;
   className?: string;
 }) {
   const t = useT();
@@ -61,6 +75,8 @@ export function PreviewPanel({
   const { kind, model, bikePreview } = state;
   const [nodes, setNodes] = useState<EdfNode[] | null>(null);
   const [textures, setTextures] = useState<PaintTexture[]>([]);
+  // The model's own textures, kept apart from the ones it is currently wearing.
+  const [stock, setStock] = useState<PaintTexture[]>([]);
   const [riderParts, setRiderParts] = useState<RiderPart[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -103,6 +119,7 @@ export function PreviewPanel({
     if (!isBike || !model || !bikePreview) {
       setNodes(null);
       setTextures([]);
+      setStock([]);
       return;
     }
     let alive = true;
@@ -130,11 +147,15 @@ export function PreviewPanel({
         // The model's own look, under the drawing — so parts this paint doesn't cover still
         // read as the bike rather than as untextured grey.
         setTextures(m.paints[0]?.textures ?? []);
+        // Not `paints[0]`: that's whichever livery happened to sort first, and on a bike
+        // with an installed paint it is somebody's artwork rather than the bike's own.
+        setStock(m.base ?? []);
       })
       .catch((e) => {
         if (!alive) return;
         setNodes(null);
         setTextures([]);
+        setStock([]);
         setErr(String(e).replace(/^Error:\s*/, ""));
       })
       .finally(() => alive && setLoading(false));
@@ -175,9 +196,11 @@ export function PreviewPanel({
    * came from would be a distinction the sheet itself doesn't make.
    */
   useEffect(() => {
-    if (!onGeometry) return;
-    onGeometry(nodes ?? (riderParts ? riderParts.flatMap((p) => p.nodes) : null));
-  }, [nodes, riderParts, onGeometry]);
+    onGeometry?.(nodes ?? (riderParts ? riderParts.flatMap((p) => p.nodes) : null));
+    // Through the same effect, so the mesh and the textures said to be its own can never
+    // describe two different models. Gated on `nodes` because that is the bike branch.
+    onStock?.(nodes ? stock : NO_STOCK);
+  }, [nodes, riderParts, stock, onGeometry, onStock]);
 
   // Toggled-off gear is dropped before it reaches the viewer, which is what makes hiding it
   // reveal what's underneath rather than just dimming it.

--- a/src/Components/Studio/Designer/ghost.ts
+++ b/src/Components/Studio/Designer/ghost.ts
@@ -2,8 +2,9 @@
  * The reference underlay: what a sheet is being drawn *against*, as opposed to what it holds.
  *
  * A livery is drawn flat and worn curved, and the flat version gives away almost nothing about
- * which rectangle of it ends up on a shroud. There are two ways to answer that, and this holds
- * both: the paint you started from, and the model's own UV islands.
+ * which rectangle of it ends up on a shroud. There are three ways to answer that, and this
+ * holds all of them: the paint you started from, the texture the model ships with, and the
+ * model's own UV islands.
  *
  * None of it is part of the sheet. It is never composited, never staged and never saved —
  * `Sheet` is what the `.pnt` will contain, and mixing a guide into it is how a guide ends up
@@ -19,6 +20,16 @@ export interface Ghost {
    * to do when you asked for a tracing guide.
    */
   template: ImageBitmap | null;
+  /**
+   * The model's own texture for this sheet — the plastics as the bike ships them.
+   *
+   * The answer where a template can't be one. An OEM bike's stock paint replaces the wheels
+   * and the chain and nothing else, so on the sheet anybody actually opens the Designer for
+   * there is no `.pnt` to trace: the artwork is embedded in `model.edf`, and this is it.
+   */
+  stock: ImageBitmap | null;
+  /** The sheet name `stock` was fetched for, or null if never — as `wireFor` is for `wire`. */
+  stockFor: string | null;
   /** The UV islands for this sheet's texture name, rasterised once by {@link uvWireframe}. */
   wire: HTMLCanvasElement | null;
   /**
@@ -29,13 +40,16 @@ export interface Ghost {
    */
   wireFor: string | null;
   showTemplate: boolean;
+  showStock: boolean;
   showWire: boolean;
-  /** 0–1, applied to both. */
+  /** 0–1, applied to all of them. */
   opacity: number;
 }
 
 export const EMPTY_GHOST: Ghost = {
   template: null,
+  stock: null,
+  stockFor: null,
   wire: null,
   wireFor: null,
   // Both on. The template shows the moment it is lifted, and the UV map is the answer to the
@@ -46,6 +60,10 @@ export const EMPTY_GHOST: Ghost = {
   // keyed on the *active* sheet's name, so opening a paint with twenty sheets rasterises the
   // one on screen, not twenty.
   showTemplate: true,
+  // Same reasoning again, and it lands hardest here: someone starting a livery from blank
+  // has no template, and the bike's own plastics are the only picture of where the vents
+  // and shut lines fall. Fetched for the sheet on screen and no other — see `Designer`.
+  showStock: true,
   showWire: true,
   opacity: 0.35,
 };
@@ -53,5 +71,9 @@ export const EMPTY_GHOST: Ghost = {
 /** True when there is anything to draw — the stage skips the whole pass otherwise. */
 export function ghostShows(ghost: Ghost | null | undefined): boolean {
   if (!ghost || ghost.opacity <= 0) return false;
-  return (ghost.showTemplate && !!ghost.template) || (ghost.showWire && !!ghost.wire);
+  return (
+    (ghost.showTemplate && !!ghost.template) ||
+    (ghost.showStock && !!ghost.stock) ||
+    (ghost.showWire && !!ghost.wire)
+  );
 }

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1595,6 +1595,13 @@ export const de: Translation = {
   "designer.traceHint":
     "Hebt die Lackierung, mit der du angefangen hast, aus dem Blatt heraus und zeigt sie schwach darunter zum Abpausen. Sie ist dann nicht mehr Teil dessen, was du speicherst.",
   "designer.noTemplate": "Dieses Blatt hat keine Vorlage zum Abpausen — es war von Anfang an leer.",
+  "designer.stockTexture": "Originaltextur",
+  "designer.stockHint":
+    "Zeigt unter deinem Blatt die Textur, mit der das Modell ausgeliefert wird — das eigene Plastik des Bikes, bevor eine Lackierung es ersetzt hat. Nichts davon wird gespeichert.",
+  "designer.noStock":
+    "Nur Bikes können sagen, welche Texturen ihre eigenen sind. Ein Helm trägt die Lackierung, mit der er kam, und die ist kein Originallook zum Abpausen.",
+  "designer.stockNoMatch":
+    "Dieses Modell bringt keine eigene Textur namens „{{name}}“ mit, also gibt es vom Bike nichts unter diesem Blatt zu zeigen.",
   "designer.uvMap": "UV-Karte",
   "designer.uvHint":
     "Zeigt, wo die Verkleidungsteile des Modells auf diesem Blatt landen, jedes in eigener Farbe.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1548,6 +1548,13 @@ export const en = {
   "designer.traceHint":
     "Lift the paint you started from out of the sheet and show it faintly underneath, to trace over. It stops being part of what you save.",
   "designer.noTemplate": "This sheet has no template to trace â it started blank.",
+  "designer.stockTexture": "Stock texture",
+  "designer.stockHint":
+    "Show the texture the model ships with under your sheet — the bike's own plastics, before any paint replaced them. Nothing of it is saved.",
+  "designer.noStock":
+    "Only bikes can say which textures are their own. A helmet wears whichever paint it shipped with, and that isn't a stock look to trace.",
+  "designer.stockNoMatch":
+    "This model carries no texture of its own called “{{name}}”, so there's nothing of the bike's to show under this sheet.",
   "designer.uvMap": "UV map",
   "designer.uvHint":
     "Show where the model's bodywork lands on this sheet, each piece in its own colour.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1582,6 +1582,13 @@ export const es: Translation = {
   "designer.traceHint":
     "Saca de la hoja la pintura de la que partiste y muéstrala tenue por debajo, para calcarla. Deja de formar parte de lo que guardas.",
   "designer.noTemplate": "Esta hoja no tiene plantilla que calcar: nació en blanco.",
+  "designer.stockTexture": "Textura de fábrica",
+  "designer.stockHint":
+    "Muestra bajo tu hoja la textura con la que viene el modelo: los plásticos propios de la moto, antes de que ninguna pintura los reemplazara. Nada de ella se guarda.",
+  "designer.noStock":
+    "Solo las motos pueden decir qué texturas son suyas. Un casco lleva la pintura con la que vino, y eso no es un aspecto de fábrica que calcar.",
+  "designer.stockNoMatch":
+    "Este modelo no trae ninguna textura propia llamada “{{name}}”, así que no hay nada de la moto que mostrar bajo esta hoja.",
   "designer.uvMap": "Mapa UV",
   "designer.uvHint":
     "Muestra dónde cae en esta hoja cada pieza del carenado del modelo, cada una con su color.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1586,6 +1586,13 @@ export const fr: Translation = {
   "designer.traceHint":
     "Sors de la planche la peinture dont tu es parti et affiche-la en transparence dessous, pour la décalquer. Elle cesse de faire partie de ce que tu enregistres.",
   "designer.noTemplate": "Cette planche n'a aucun modèle à décalquer : elle est partie vierge.",
+  "designer.stockTexture": "Texture d'origine",
+  "designer.stockHint":
+    "Affiche sous ta planche la texture livrée avec le modèle : les plastiques de la moto elle-même, avant qu'une peinture ne les remplace. Rien n'en est enregistré.",
+  "designer.noStock":
+    "Seules les motos savent dire quelles textures leur appartiennent. Un casque porte la peinture avec laquelle il est arrivé, et ce n'est pas un aspect d'origine à décalquer.",
+  "designer.stockNoMatch":
+    "Ce modèle n'embarque aucune texture à lui nommée « {{name}} », il n'y a donc rien de la moto à montrer sous cette planche.",
   "designer.uvMap": "Carte UV",
   "designer.uvHint":
     "Montre où tombent sur cette planche les carrosseries du modèle, chacune dans sa couleur.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1572,6 +1572,13 @@ export const it: Translation = {
   "designer.traceHint":
     "Togli dalla planche la vernice di partenza e mostrala in trasparenza sotto, per ricalcarla. Smette di far parte di ciò che salvi.",
   "designer.noTemplate": "Questa planche non ha un modello da ricalcare: è nata vuota.",
+  "designer.stockTexture": "Texture originale",
+  "designer.stockHint":
+    "Mostra sotto la tua planche la texture con cui esce il modello: le plastiche della moto stessa, prima che una vernice le sostituisse. Non ne viene salvato nulla.",
+  "designer.noStock":
+    "Solo le moto sanno dire quali texture sono le loro. Un casco indossa la vernice con cui è arrivato, e quella non è un aspetto originale da ricalcare.",
+  "designer.stockNoMatch":
+    "Questo modello non porta una texture sua chiamata “{{name}}”, quindi non c'è nulla della moto da mostrare sotto questa planche.",
   "designer.uvMap": "Mappa UV",
   "designer.uvHint":
     "Mostra dove finiscono su questa planche le carene del modello, ognuna con il suo colore.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1571,6 +1571,13 @@ export const ptBR: Translation = {
   "designer.traceHint":
     "Tira da folha a pintura da qual você partiu e a mostra apagada por baixo, para decalcar. Ela deixa de fazer parte do que você salva.",
   "designer.noTemplate": "Esta folha não tem modelo para decalcar — ela nasceu em branco.",
+  "designer.stockTexture": "Textura de fábrica",
+  "designer.stockHint":
+    "Mostra sob a sua folha a textura com que o modelo vem — os plásticos da própria moto, antes de qualquer pintura substituí-los. Nada disso é salvo.",
+  "designer.noStock":
+    "Só motos conseguem dizer quais texturas são delas. Um capacete usa a pintura com que veio, e isso não é um visual de fábrica para decalcar.",
+  "designer.stockNoMatch":
+    "Este modelo não traz nenhuma textura própria chamada “{{name}}”, então não há nada da moto para mostrar sob esta folha.",
   "designer.uvMap": "Mapa UV",
   "designer.uvHint":
     "Mostra onde as carenagens do modelo caem nesta folha, cada peça com sua cor.",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -373,6 +373,15 @@ export interface BikePaint {
 export interface BikeModel {
   nodes: EdfNode[];
   paints: BikePaint[];
+  /**
+   * The model's own textures — the look it ships with, before any paint replaces one.
+   *
+   * The same pixels the paints already carry where they don't supply their own, listed
+   * once on their own so "the model's look" can be asked for by name. A paint's `livery`
+   * and the mesh's `livery` are the same field once they're folded together, and the
+   * Designer's reference underlay is the one place that difference matters.
+   */
+  base: PaintTexture[];
 }
 
 export interface RiderPart {


### PR DESCRIPTION
## Why

The reference underlay could offer the paint you started from — and on an OEM bike there isn't one. Its stock `.pnt` replaces the wheels and the chain; the plastics are embedded in `model.edf`. So the one sheet anybody opens the Designer for was the one with nothing to trace: bare islands, no idea where the vents and shut lines fall.

The pixels were already there. `load_bike_model` decodes the model's own textures so unpainted parts read as the bike rather than as grey — then folds them into every paint, where they become indistinguishable from that paint's own sheets.

## What

Reference gets a third toggle, **Stock texture**, on by default. Draw order is stock → template → islands → your sheet: the outlines are the thinnest mark and have to stay readable, and someone who lifted a paint out to trace asked for *that* paint, so the model's own goes beneath it.

- `BikeModel` gains `base`, cloned off before the fold. Not `paints[0]` — on a bike with an installed livery that's somebody's artwork, not the bike's.
- `tokens()` chains `base`, which also closes a latent leak: a model texture that *every* paint overrides reached no paint and was dropped without `texstore::release`.
- `Ghost` gains `stock`/`stockFor`/`showStock`, fetched lazily per sheet name the way the wireframe is rasterised — only the sheet on screen pays the IPC, and only once. Drawn by `CanvasStage` and never composited, so it can't reach a `.pnt`.
- Disabled for gear: a helmet that ships paints and embeds no shell wears a `.pnt`, and calling that stock would be a lie about somebody else's paint.
- Strings in all six locales. No DB or schema changes.

## Verified

`cargo test` 711 pass — including a new unit test for the token fix — clippy clean on the touched ranges, `typecheck` / `lint` / `build` clean. Ran the ignored `bike_model_from_pkz` against three real models; `base` comes back populated and distinct from the paints in each.

Two things worth a look in review:

1. **The headline case is unproven in CI.** A locked OEM `.pkz` needs the `#[cfg(sidecar)]` module, which a worktree doesn't have — `load_bike_model` fails outright on one there. Wants a look from a full build: stock OEM bike, blank `plastics` sheet.
2. **A model-swapped bike may show nothing for `plastics`.** On the installed `MX1OEM_2023_KTM_450_SX-F` the mesh embeds 22 textures and `plastics` isn't among them — the installed paint supplies it. The toggle correctly shows the "no texture of its own" note there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)