### PR TITLE
feat(viewer): reload a paint in 3D when it changes on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased — the paint changes on disk, the model changes with it
+
+### Added
+- **The 3D viewer reloads a paint that changes on disk.** Leave the bike open in the viewer,
+  re-save the paint, and the model re-dresses itself — the draw, look, fix, look loop no
+  longer needs the dialog closed and re-opened between passes. Only the textures are
+  replaced, so nothing rebuilds the bike's geometry for a livery, and a brief **Paint
+  reloaded** chip says when one landed (an edit that turned out to change nothing visible
+  otherwise looks identical to one the viewer missed).
+- The watched paint is whichever one is showing — a bike's installed livery, a model-swap
+  preview's, or a loose gear paint. The paint's *folder* is watched rather than the file,
+  because saving one usually means writing a temp file and renaming it over the target, and
+  a watch on the file itself would go silent after exactly the first save.
+
 ## Unreleased — the bike's own plastics, under the UV map
 
 ### Added

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -33,6 +33,7 @@ mod mxb_session;
 mod overlay;
 mod paint;
 mod paintstudio;
+mod paintwatch;
 mod pkz;
 #[cfg(sidecar)]
 mod sidecar;
@@ -58,6 +59,7 @@ use frostmod::ReloadOutcome;
 use frostmod_manage::{FrostmodProcess, FrostmodStatus, InstallReport};
 use library::InstalledMod;
 use modwatch::ModWatcher;
+use paintwatch::PaintWatcher;
 // Decoding a paint's textures is per-texture CPU work over no shared state, and every path
 // that does it wants the same treatment — so this sits here rather than in one function.
 use rayon::prelude::*;
@@ -1205,6 +1207,16 @@ async fn texture_bytes(token: String) -> tauri::ipc::Response {
     tauri::ipc::Response::new(texstore::bytes_or_missing(&token))
 }
 
+/// Watch the paint files the 3D viewer is currently showing, replacing whatever it was
+/// watching before. An empty list stops.
+///
+/// There is one viewer showing one paint, so this is a set-the-whole-thing call rather than
+/// an add/remove pair: nothing can then leak a watch by forgetting to take one back.
+#[tauri::command]
+fn watch_paint_files(app: tauri::AppHandle, watcher: State<PaintWatcher>, paths: Vec<String>) {
+    paintwatch::start(&app, &watcher, &paths);
+}
+
 #[tauri::command]
 async fn unpack_pkz(path: String, out_dir: String) -> Result<Vec<String>, String> {
     tauri::async_runtime::spawn_blocking(move || unpack_pkz_blocking(path, out_dir))
@@ -1221,6 +1233,10 @@ fn unpack_pkz_blocking(path: String, out_dir: String) -> Result<Vec<String>, Str
 #[serde(rename_all = "camelCase")]
 struct BikePaint {
     name: String,
+    /// Where the `.pnt` sits on disk, for a paint installed loose in the bike's `paints`
+    /// folder — the file the viewer watches so an edit re-dresses the model. `None` for a
+    /// paint packed inside the archive: nothing rewrites one of those in place.
+    path: Option<String>,
     textures: Vec<paint::PaintTexture>,
     changes_preview: bool,
 }
@@ -1273,8 +1289,18 @@ fn mtime_nanos(path: &std::path::Path) -> u128 {
         .unwrap_or(0)
 }
 
+/// Cache key for whatever lives at `source`: its path, when it was last written, and how
+/// big it is.
+///
+/// Size is in there for the viewer's live reload. A paint being re-saved every few seconds
+/// is the one caller that rewrites a file under the cache, and mtime alone would serve it
+/// stale pixels on any filesystem whose timestamps are coarser than the gap between two
+/// saves — FAT32 rounds to two seconds. A recompressed `.pnt` almost never comes back the
+/// same length.
 fn bike_cache_key(source: &str) -> String {
-    format!("{source}:{}", mtime_nanos(std::path::Path::new(source)))
+    let path = std::path::Path::new(source);
+    let size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    format!("{source}:{}:{size}", mtime_nanos(path))
 }
 
 /// A swap preview is keyed by both folders it's built from — the same bike renders
@@ -1351,7 +1377,8 @@ fn build_bike_model(
     label: &str,
     key: String,
     files: Vec<(String, Vec<u8>)>,
-    installed: Vec<(String, Vec<u8>)>,
+    // The loose paints beside the bike, as `installed_paints` answers them.
+    installed: Vec<(String, String, Vec<u8>)>,
     t0: std::time::Instant,
 ) -> Result<BikeModel, String> {
     let t_read = t0.elapsed();
@@ -1364,7 +1391,8 @@ fn build_bike_model(
     let mut gfx_bytes: Option<&Vec<u8>> = None;
     let mut hrcs: std::collections::HashMap<String, &Vec<u8>> = std::collections::HashMap::new();
     let mut tga_jobs: Vec<(String, &[u8])> = Vec::new();
-    let mut pnt_jobs: Vec<(String, &[u8], bool)> = Vec::new();
+    // (display name, bytes, shipped-in-the-archive, path on disk if it has one)
+    let mut pnt_jobs: Vec<(String, &[u8], bool, Option<&str>)> = Vec::new();
     for (name, data) in &files {
         let bn = name.rsplit('/').next().unwrap_or(name).to_ascii_lowercase();
         if bn.ends_with(".edf") {
@@ -1380,7 +1408,7 @@ fn build_bike_model(
             // Lowercased stem — the frontend matches textures case-insensitively.
             tga_jobs.push((stem.to_string(), data.as_slice()));
         } else if bn.ends_with(".pnt") {
-            pnt_jobs.push((paint_display_name(&bn), data.as_slice(), true));
+            pnt_jobs.push((paint_display_name(&bn), data.as_slice(), true, None));
         }
     }
 
@@ -1434,8 +1462,8 @@ fn build_bike_model(
             used.push(data);
         }
     }
-    for (fname, data) in &installed {
-        pnt_jobs.push((paint_display_name(fname), data.as_slice(), false));
+    for (fname, path, data) in &installed {
+        pnt_jobs.push((paint_display_name(fname), data.as_slice(), false, Some(path)));
     }
     if let Some(g) = geom {
         if !edf::assemble_bike(&mut nodes, g) {
@@ -1464,11 +1492,12 @@ fn build_bike_model(
     }
     let mut paints: Vec<(BikePaint, bool)> = pnt_jobs
         .par_iter()
-        .filter_map(|(name, data, shipped)| {
+        .filter_map(|(name, data, shipped, path)| {
             paint::decode_any(data).ok().map(|pnt| {
                 (
                     BikePaint {
                         name: name.clone(),
+                        path: path.map(str::to_string),
                         textures: pnt.into_par_iter().map(paint::into_texture).collect(),
                         changes_preview: false, // resolved below, once bindings are known
                     },
@@ -1522,6 +1551,8 @@ fn build_bike_model(
     if paints.is_empty() {
         paints.push(BikePaint {
             name: "Stock".into(),
+            // The mesh's own textures, which live inside it rather than in a `.pnt`.
+            path: None,
             textures: base,
             changes_preview: true, // the model's own textures, by definition
         });
@@ -1632,7 +1663,11 @@ fn paint_display_name(file_name: &str) -> String {
     }
 }
 
-fn installed_paints(source: &std::path::Path) -> Vec<(String, Vec<u8>)> {
+/// The loose `.pnt`s installed beside a bike, as (file name, full path, bytes).
+///
+/// The path rides along because these are the only paints that can change under the viewer:
+/// they are ordinary files a painter re-saves, where the ones inside the archive are not.
+fn installed_paints(source: &std::path::Path) -> Vec<(String, String, Vec<u8>)> {
     let folder = if source.is_dir() {
         source.to_path_buf()
     } else {
@@ -1644,10 +1679,12 @@ fn installed_paints(source: &std::path::Path) -> Vec<(String, Vec<u8>)> {
         for e in entries.flatten() {
             let p = e.path();
             if p.extension().is_some_and(|x| x.eq_ignore_ascii_case("pnt")) {
-                if let (Some(name), Ok(bytes)) =
-                    (p.file_name().and_then(|n| n.to_str()), std::fs::read(&p))
-                {
-                    out.push((name.to_string(), bytes));
+                if let (Some(name), Some(full), Ok(bytes)) = (
+                    p.file_name().and_then(|n| n.to_str()),
+                    p.to_str(),
+                    std::fs::read(&p),
+                ) {
+                    out.push((name.to_string(), full.to_string(), bytes));
                 }
             }
         }
@@ -6022,6 +6059,7 @@ fn main() {
         .manage(FrostmodProcess::default())
         .manage(ModWatcher::default())
         .manage(ProfileWatcher::default())
+        .manage(PaintWatcher::default())
         .manage(CloudServers::default())
         .manage(shop_session::ShopSession::default())
         .manage(voice::Monitor::default())
@@ -6247,6 +6285,7 @@ fn main() {
             diagnose_track,
             unpack_paint,
             texture_bytes,
+            watch_paint_files,
             unpack_pkz,
             load_bike_model,
             preview_model_swap,
@@ -7262,6 +7301,7 @@ mod viewer_tests {
             nodes: Vec::new(),
             paints: vec![super::BikePaint {
                 name: "Red".into(),
+                path: None,
                 // Its own `plastics`, so the model's never reaches it.
                 textures: vec![tex("plastics", "t-paint"), tex("wheel", "t-shared")],
                 changes_preview: true,
@@ -7274,6 +7314,74 @@ mod viewer_tests {
         // Named twice over — the paints borrowed it — and that's fine: `release` removes by
         // key, so the second pass over a token is a no-op rather than a double free.
         assert_eq!(tokens.iter().filter(|t| *t == "t-shared").count(), 2);
+    }
+
+    /// A paint installed loose beside a bike has to come back with the file it lives in —
+    /// that path is the only thing the viewer can watch, and without it a re-saved livery
+    /// goes unnoticed until the dialog is closed and re-opened.
+    #[test]
+    fn an_installed_paint_names_the_file_it_came_from() {
+        let root = std::env::temp_dir().join(format!("frost-installed-paints-{}", std::process::id()));
+        let paints = root.join("KTM 450").join("paints");
+        std::fs::create_dir_all(&paints).expect("make the bike's paints folder");
+        std::fs::write(paints.join("Frost.pnt"), b"not really a paint").expect("write a paint");
+        // Whatever else is parked in there is not a paint and must not be offered as one.
+        std::fs::write(paints.join("notes.txt"), b"x").expect("write the noise");
+
+        let found = super::installed_paints(&root.join("KTM 450"));
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert_eq!(found.len(), 1, "only the .pnt counts");
+        let (name, path, bytes) = &found[0];
+        assert_eq!(name, "Frost.pnt");
+        assert_eq!(std::path::Path::new(path), paints.join("Frost.pnt"));
+        assert_eq!(bytes, b"not really a paint");
+    }
+
+    /// A paint re-saved inside one timestamp tick still misses the cache.
+    ///
+    /// The viewer's live reload re-decodes a file the moment it changes, which can be twice
+    /// in the same second — and a filesystem with coarse timestamps (FAT32 rounds to two)
+    /// would hand back the previous decode, i.e. the painter's *last* attempt. The mtime is
+    /// pinned here so the size is the only thing left to tell the two apart.
+    #[test]
+    fn a_paint_resaved_within_a_timestamp_tick_is_not_served_stale() {
+        let dir = std::env::temp_dir().join(format!("frost-cache-key-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("make the folder");
+        let paint = dir.join("Frost.pnt");
+        let pinned = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+        let stamp = |bytes: &[u8]| {
+            std::fs::write(&paint, bytes).expect("save the paint");
+            let f = std::fs::File::options().write(true).open(&paint).expect("reopen");
+            f.set_times(std::fs::FileTimes::new().set_modified(pinned))
+                .expect("pin the mtime");
+            super::bike_cache_key(&paint.to_string_lossy())
+        };
+
+        let first = stamp(b"the first attempt");
+        let second = stamp(b"the second attempt, recompressed");
+        let identical = stamp(b"the second attempt, recompressed");
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert_ne!(first, second, "a re-saved paint must miss its cached decode");
+        assert_eq!(identical, second, "and an unchanged one must still hit it");
+    }
+
+    /// The same, reached through the `.pkz` beside the folder — how a packaged bike is
+    /// installed, and the path a painter's own liveries actually sit next to.
+    #[test]
+    fn paints_are_found_beside_a_packaged_bike_too() {
+        let root = std::env::temp_dir().join(format!("frost-packaged-paints-{}", std::process::id()));
+        let paints = root.join("KTM 450").join("paints");
+        std::fs::create_dir_all(&paints).expect("make the bike's paints folder");
+        std::fs::write(paints.join("Frost.pnt"), b"paint").expect("write a paint");
+
+        // The source the viewer is given is the archive, not the folder next to it.
+        let found = super::installed_paints(&root.join("KTM 450.pkz"));
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert_eq!(found.len(), 1);
+        assert_eq!(std::path::Path::new(&found[0].1), paints.join("Frost.pnt"));
     }
 
     #[test]

--- a/src-tauri/src/paintwatch.rs
+++ b/src-tauri/src/paintwatch.rs
@@ -1,0 +1,310 @@
+//! Notice when a paint the 3D viewer is showing gets rewritten on disk.
+//!
+//! A painter's loop is draw, look at it on the model, fix, look again. The "look" step used
+//! to mean closing the viewer and opening it again, because the app read the `.pnt` once and
+//! never asked after it. This watches the file the viewer is currently dressed in and says
+//! when it changes; the frontend re-decodes it and re-dresses the model.
+//!
+//! Two decisions worth keeping:
+//!
+//! * **The folder is watched, not the file.** Saving a paint usually means writing a temp
+//!   file and renaming it over the target, which replaces the inode. A watch registered on
+//!   the file itself follows the old one and goes silent after the very first save — the
+//!   exact save this exists to catch. A non-recursive watch on the parent folder survives
+//!   that, and also catches a paint that doesn't exist yet.
+//! * **Events are matched by file name alone.** Only the folders holding watched files are
+//!   watched, so anything arriving here is already from a folder we asked about, and the
+//!   name is enough. Comparing whole paths would mean out-guessing whatever the OS
+//!   canonicalises them to (`/private/var` on macOS, 8.3 names on Windows) for nothing.
+//!
+//! Scope is deliberately narrow — [`start`] replaces the whole watch set each time, because
+//! there is one viewer and it shows one paint. Unlike `modwatch` there is no settling: a
+//! paint is a single file, the debounce below outlasts writing one, and the caller re-tries
+//! a decode that lands mid-write anyway.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use notify::{RecommendedWatcher, RecursiveMode};
+use notify_debouncer_mini::{new_debouncer, DebounceEventResult, Debouncer};
+use tauri::{AppHandle, Emitter, Runtime};
+
+/// Debounce window. Short, because this is the whole latency a painter feels between
+/// hitting save and seeing the bike change — and long enough to collapse the burst of write
+/// events a multi-megabyte `.pnt` produces into one answer.
+const DEBOUNCE: Duration = Duration::from_millis(400);
+
+/// Emitted with the caller's own spelling of the path that changed, so the frontend can
+/// compare it against the one it asked to watch.
+pub const EVENT: &str = "paint-changed";
+
+/// Upper bound on watched files. The viewer shows one paint; this only exists so a caller
+/// that goes wrong can't turn into a fistful of OS watch handles.
+const MAX_WATCHED: usize = 16;
+
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Changed {
+    path: String,
+}
+
+pub struct Running {
+    /// Dropping the debouncer stops its background thread.
+    _debouncer: Debouncer<RecommendedWatcher>,
+    /// Cleared on stop, so a callback already in flight doesn't announce a change for a
+    /// watcher that has been retired.
+    live: Arc<AtomicBool>,
+}
+
+/// Tauri-managed handle. `None` when nothing is being previewed.
+#[derive(Default)]
+pub struct PaintWatcher(pub Mutex<Option<Running>>);
+
+/// The file name a path ends in, lowercased — what an event is matched on.
+fn file_key(path: &Path) -> Option<String> {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n.to_ascii_lowercase())
+}
+
+/// Group the requested paths by the folder that has to be watched to see them.
+///
+/// A `BTreeMap` rather than a list: two paints in one folder cost one watch, and the order
+/// is fixed so the log reads the same twice running.
+fn by_folder(paths: &[String]) -> BTreeMap<PathBuf, Vec<String>> {
+    let mut out: BTreeMap<PathBuf, Vec<String>> = BTreeMap::new();
+    for p in paths.iter().take(MAX_WATCHED) {
+        let path = Path::new(p);
+        // A bare file name has no folder to watch, and neither has a path that is one.
+        let Some(dir) = path.parent().filter(|d| !d.as_os_str().is_empty()) else {
+            continue;
+        };
+        if file_key(path).is_none() {
+            continue;
+        }
+        out.entry(dir.to_path_buf()).or_default().push(p.clone());
+    }
+    out
+}
+
+/// Which of the watched paths a changed path names, if any — answered as the caller's own
+/// spelling, never the event's.
+fn matches<'a>(watched: &'a [String], changed: &Path) -> Option<&'a str> {
+    let key = file_key(changed)?;
+    watched
+        .iter()
+        .find(|w| file_key(Path::new(w)).as_deref() == Some(key.as_str()))
+        .map(String::as_str)
+}
+
+/// Every watched path a batch of changed paths names, each at most once.
+fn changed_paints(watched: &[String], events: &[PathBuf]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for path in events {
+        if let Some(hit) = matches(watched, path) {
+            if !out.iter().any(|p| p == hit) {
+                out.push(hit.to_string());
+            }
+        }
+    }
+    out
+}
+
+/// Watch `paths`, replacing whatever was being watched before. An empty list just stops.
+///
+/// Best-effort throughout, as the other watchers are: a folder that isn't there or refuses
+/// a watch costs the live reload for that paint, not the viewer.
+/// Generic over the runtime so the tests below can drive it with Tauri's mock one — the
+/// thing worth proving here is that a real save on a real folder comes back out as an
+/// event, and that needs a genuine watcher and a handle to emit through.
+pub fn start<R: Runtime>(app: &AppHandle<R>, state: &PaintWatcher, paths: &[String]) {
+    stop(state);
+    let folders = by_folder(paths);
+    if folders.is_empty() {
+        return;
+    }
+
+    // Flattened once here so the callback matches against a plain list rather than walking
+    // the map — which folder an event came from tells us nothing the name doesn't.
+    let watched: Vec<String> = folders.values().flatten().cloned().collect();
+    let live = Arc::new(AtomicBool::new(true));
+    let alive = live.clone();
+    let handle = app.clone();
+
+    let mut debouncer = match new_debouncer(DEBOUNCE, move |res: DebounceEventResult| {
+        if !alive.load(Ordering::SeqCst) {
+            return;
+        }
+        let Ok(events) = res else { return };
+        let seen: Vec<PathBuf> = events.into_iter().map(|e| e.path).collect();
+        for path in changed_paints(&watched, &seen) {
+            log::info!("paint watcher: {path} changed on disk");
+            let _ = handle.emit(EVENT, Changed { path });
+        }
+    }) {
+        Ok(d) => d,
+        Err(e) => {
+            log::warn!("paint watcher: couldn't start: {e}");
+            return;
+        }
+    };
+
+    let mut any = false;
+    for dir in folders.keys() {
+        // Non-recursive: a paints folder holds paints, and descending into whatever else
+        // someone has parked beside them buys nothing.
+        match debouncer.watcher().watch(dir, RecursiveMode::NonRecursive) {
+            Ok(()) => {
+                any = true;
+                log::info!("paint watcher: watching {}", dir.display());
+            }
+            Err(e) => log::warn!("paint watcher: couldn't watch {}: {e}", dir.display()),
+        }
+    }
+    if !any {
+        return;
+    }
+    *state.0.lock().unwrap_or_else(|e| e.into_inner()) = Some(Running {
+        _debouncer: debouncer,
+        live,
+    });
+}
+
+pub fn stop(state: &PaintWatcher) {
+    if let Some(running) = state.0.lock().unwrap_or_else(|e| e.into_inner()).take() {
+        running.live.store(false, Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn owned(paths: &[&str]) -> Vec<String> {
+        paths.iter().map(|p| p.to_string()).collect()
+    }
+
+    #[test]
+    fn paints_sharing_a_folder_cost_one_watch() {
+        let folders = by_folder(&owned(&[
+            "/mx/mods/bikes/KTM 450/paints/Frost.pnt",
+            "/mx/mods/bikes/KTM 450/paints/Frost Blue.pnt",
+            "/mx/mods/rider/helmets/Fox/paints/Frost.pnt",
+        ]));
+        assert_eq!(folders.len(), 2, "one watch per distinct folder");
+        assert_eq!(
+            folders[Path::new("/mx/mods/bikes/KTM 450/paints")].len(),
+            2,
+            "both bike paints ride the same watch",
+        );
+    }
+
+    #[test]
+    fn a_path_with_no_folder_is_not_watched() {
+        // Nothing to register a watch on — and watching the process's cwd instead would be
+        // a watch on somewhere the caller never named.
+        assert!(by_folder(&owned(&["Frost.pnt"])).is_empty());
+        assert!(by_folder(&owned(&["/"])).is_empty());
+        assert!(by_folder(&[]).is_empty());
+    }
+
+    #[test]
+    fn a_rewritten_paint_is_reported_under_the_name_the_caller_asked_about() {
+        // The event carries the OS's spelling of the path — canonicalised, and on Windows
+        // in whatever case the filesystem kept. The caller compares against the string it
+        // handed over, so that is the string that must come back.
+        let watched = owned(&["/mx/mods/bikes/KTM 450/paints/Frost.pnt"]);
+        assert_eq!(
+            changed_paints(
+                &watched,
+                &[PathBuf::from("/private/mx/mods/bikes/KTM 450/paints/FROST.PNT")],
+            ),
+            owned(&["/mx/mods/bikes/KTM 450/paints/Frost.pnt"]),
+        );
+    }
+
+    #[test]
+    fn the_folders_own_churn_is_ignored() {
+        let watched = owned(&["/mx/paints/Frost.pnt"]);
+        // A packer's scratch file, the folder itself, and a paint nobody asked about.
+        let noise = [
+            PathBuf::from("/mx/paints/Frost.pnt.tmp"),
+            PathBuf::from("/mx/paints"),
+            PathBuf::from("/mx/paints/Someone Else.pnt"),
+        ];
+        assert!(changed_paints(&watched, &noise).is_empty());
+    }
+
+    #[test]
+    fn a_burst_of_writes_names_the_paint_once() {
+        // Writing a multi-megabyte `.pnt` lands as many events inside one debounce window;
+        // re-decoding it once per event would be several seconds of work for one save.
+        let watched = owned(&["/mx/paints/Frost.pnt"]);
+        let burst = vec![PathBuf::from("/mx/paints/Frost.pnt"); 5];
+        assert_eq!(changed_paints(&watched, &burst), owned(&["/mx/paints/Frost.pnt"]));
+    }
+
+    fn mock_app() -> tauri::App<tauri::test::MockRuntime> {
+        tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("mock app")
+    }
+
+    /// The claim the unit tests above can't make: a paint saved the way a packer saves one
+    /// — write a temp file, rename it over the target — comes back out as an event.
+    ///
+    /// That rename is the whole reason the *folder* is watched. A watch on the file itself
+    /// passes a naive "overwrite in place" test and then goes silent in the field, because
+    /// the rename leaves it holding an inode nothing writes to again.
+    #[test]
+    fn a_paint_saved_by_rename_still_reaches_the_viewer() {
+        use tauri::Listener;
+
+        let dir = std::env::temp_dir().join(format!("frost-paintwatch-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("make the paints folder");
+        let paint = dir.join("Frost.pnt");
+        std::fs::write(&paint, b"first").expect("install a paint");
+        let watched = paint.to_string_lossy().to_string();
+
+        let app = mock_app();
+        let seen: Arc<Mutex<Vec<String>>> = Arc::default();
+        let heard = Arc::clone(&seen);
+        app.handle().listen(EVENT, move |e| {
+            heard.lock().unwrap().push(e.payload().to_string());
+        });
+
+        let state = PaintWatcher::default();
+        start(app.handle(), &state, std::slice::from_ref(&watched));
+
+        // Let the watch register before touching the folder — a save that lands in the gap
+        // is one FSEvents never had a reason to report.
+        std::thread::sleep(Duration::from_millis(300));
+        let staged = dir.join("Frost.pnt.tmp");
+        std::fs::write(&staged, b"second").expect("stage the new paint");
+        std::fs::rename(&staged, &paint).expect("rename it over the old one");
+
+        // Generously past DEBOUNCE — this is a real filesystem, not a clock we control.
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        let hit = loop {
+            if seen.lock().unwrap().iter().any(|p| p.contains("Frost.pnt")) {
+                break true;
+            }
+            if std::time::Instant::now() >= deadline {
+                break false;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        };
+        stop(&state);
+        let payloads = seen.lock().unwrap().clone();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(hit, "a renamed-over paint must be reported; saw {payloads:?}");
+        assert!(
+            payloads.iter().all(|p| !p.contains(".tmp")),
+            "the packer's scratch file is not a paint: {payloads:?}",
+        );
+    }
+}

--- a/src/Components/Viewer/ViewerDialog.tsx
+++ b/src/Components/Viewer/ViewerDialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Box, Loader2, X } from "lucide-react";
+import { Box, Loader2, RefreshCw, X } from "lucide-react";
 import { Dialog, DialogClose, DialogContent } from "../ui/dialog";
 import { ModelViewer, type ViewerMode } from "./ModelViewer";
 import {
@@ -10,6 +10,8 @@ import {
   loadGearModel,
   loadStockGearModel,
   listGearPaints,
+  onPaintChanged,
+  watchPaintFiles,
 } from "../../api/mods";
 import type { PaintTexture, BikeModel, EdfNode, RiderPart, GearPaints } from "../../types";
 import { useT } from "../../i18n/context";
@@ -44,6 +46,18 @@ function paintLabel(path: string): string {
   const base = path.replace(/\\/g, "/").split("/").pop() ?? path;
   return base.replace(/\.pnt$/i, "");
 }
+
+/**
+ * How long to wait before a second try at a paint that wouldn't decode.
+ *
+ * The watcher's debounce normally outlasts writing the file, but a save it catches
+ * mid-flight decodes to an error — and a hot reload that silently does nothing is worse
+ * than a late one.
+ */
+const RETRY_MS = 700;
+
+/** How long the "reloaded" chip stays up. */
+const FLASH_MS = 2200;
 
 /** The model's own look leads the picker, ahead of the paints it packs. */
 function withStock(names: string[], hasStock: boolean): string[] {
@@ -93,6 +107,12 @@ export function ViewerDialog({
   // Why the bike itself wouldn't load — a swap preview can be refused (an incomplete set,
   // a bike with nothing behind it), and that reason is worth showing.
   const [modelErr, setModelErr] = useState<string | null>(null);
+  // A bike paint re-decoded after its file changed, and the file it came from — so a pick
+  // that moves on drops it rather than dressing the new paint in the old one's sheets.
+  const [hot, setHot] = useState<{ path: string; textures: PaintTexture[] } | null>(null);
+  // Ticks on each reload, to raise the chip below. A counter and not a boolean: two saves
+  // in a row have to raise it twice, and the second would find it already up.
+  const [reloads, setReloads] = useState(0);
 
   const nodes = model?.nodes ?? null;
   const paints = model?.paints ?? [];
@@ -199,11 +219,82 @@ export function ViewerDialog({
     };
   }, [open, isBike, riderProfile, gearSource, stockGearPart]);
 
+  // A loose gear paint previews the file itself. Installed gear doesn't: its paints come
+  // from inside its own archive, and `gearPath` there indexes loose siblings the picker
+  // isn't showing.
+  const loosePaintPath = gearSource ? undefined : gearPath;
+  // The `.pnt` behind what's on screen, when it's a file that can change. A paint packed
+  // inside an archive has no path, and nothing rewrites one of those in place anyway.
+  const livePath = isBike ? paints[paintIdx]?.path ?? undefined : loosePaintPath;
+
+  // Re-dress the model when that file is re-saved, so the draw/look/fix loop doesn't need
+  // the viewer closed and re-opened between passes. Only the *textures* are replaced —
+  // the geometry is untouched, so nothing re-uploads a bike's vertex buffers for a livery.
+  useEffect(() => {
+    // Whatever was reloaded belongs to the paint that was on screen, not this one.
+    setHot(null);
+    if (!open || !livePath) {
+      // Stop watching: the set is replaced wholesale, and these calls are serialised
+      // against the one below so the order they land in can't be the other way round.
+      void watchPaintFiles([]);
+      return;
+    }
+    let alive = true;
+
+    const reload = async () => {
+      for (const wait of [0, RETRY_MS]) {
+        if (wait) await new Promise((r) => setTimeout(r, wait));
+        if (!alive) return;
+        try {
+          const textures = await unpackPaint(livePath);
+          if (!alive) return;
+          // A gear paint's list *is* this file's textures, so it's replaced outright — a
+          // sheet dropped from the paint has to leave the model too. A bike's carries the
+          // model's own base textures as well, which is why that one is merged below.
+          if (isBike) setHot({ path: livePath, textures });
+          else setGearTextures(textures);
+          setErr(null);
+          setReloads((n) => n + 1);
+          return;
+        } catch (e) {
+          if (wait) console.warn(`[viewer] '${livePath}' changed but wouldn't decode:`, e);
+        }
+      }
+    };
+
+    void watchPaintFiles([livePath]);
+    const pending = onPaintChanged((p) => {
+      if (p === livePath) void reload();
+    });
+    return () => {
+      alive = false;
+      void pending.then((un) => un());
+      // Ordered against the next run's start by `watchPaintFiles` itself, so switching
+      // between two paints can never settle on watching neither.
+      void watchPaintFiles([]);
+    };
+  }, [open, isBike, livePath]);
+
   // The textures the mesh should wear: the selected bike paint, or the gear paint.
-  const activeTextures = useMemo<PaintTexture[]>(
-    () => (isBike ? paints[paintIdx]?.textures ?? [] : gearTextures ?? []),
-    [isBike, paints, paintIdx, gearTextures],
-  );
+  const activeTextures = useMemo<PaintTexture[]>(() => {
+    const base = isBike ? paints[paintIdx]?.textures ?? [] : gearTextures ?? [];
+    if (!hot || hot.path !== livePath) return base;
+    // Re-decoded sheets win by name; the model's own base textures, which the loader
+    // appends to every paint and the `.pnt` never carries, stay behind them.
+    const fresh = new Set(hot.textures.map((t) => t.name.toLowerCase()));
+    return [...hot.textures, ...base.filter((t) => !fresh.has(t.name.toLowerCase()))];
+  }, [isBike, paints, paintIdx, gearTextures, hot, livePath]);
+
+  // Say when a reload landed. Without it the model changing on its own reads as a glitch,
+  // and — worse — an edit that turned out to change nothing visible is indistinguishable
+  // from one the viewer never picked up.
+  const [flash, setFlash] = useState(false);
+  useEffect(() => {
+    if (!reloads) return;
+    setFlash(true);
+    const timer = setTimeout(() => setFlash(false), FLASH_MS);
+    return () => clearTimeout(timer);
+  }, [reloads]);
 
   // Gear ships paints inside the archive — read them out for the picker.
   useEffect(() => {
@@ -417,6 +508,12 @@ export function ViewerDialog({
           {!loading && err && (
             <div className="pointer-events-none absolute left-3 top-3 rounded-md bg-black/55 px-2 py-1 text-xs text-white/85">
               {t("viewer.noPaintPreview", { err })}
+            </div>
+          )}
+          {flash && (
+            <div className="pointer-events-none absolute right-3 top-3 flex items-center gap-1.5 rounded-md bg-black/60 px-2 py-1 text-xs text-white/90">
+              <RefreshCw className="h-3.5 w-3.5" />
+              {t("viewer.paintReloaded")}
             </div>
           )}
         </div>

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -530,6 +530,35 @@ export function unpackPaint(path: string): Promise<PaintTexture[]> {
   return invoke<PaintTexture[]>("unpack_paint", { path });
 }
 
+/**
+ * Serialises the calls below, because they overwrite each other.
+ *
+ * `watch_paint_files` replaces the whole watch set, so two of them racing decides what is
+ * watched by whichever lands second — and a switch between paints issues exactly that pair
+ * (the old effect's stop, then the new effect's start) with nothing ordering them. A viewer
+ * that quietly stopped watching is the one failure this feature can't announce.
+ */
+let watchTurn: Promise<unknown> = Promise.resolve();
+
+/**
+ * Watch these paint files for edits, replacing whatever was being watched. `[]` stops.
+ *
+ * Changes arrive through {@link onPaintChanged}, carrying back the same path strings passed
+ * in here — never the OS's own spelling of them.
+ */
+export function watchPaintFiles(paths: string[]): Promise<void> {
+  // `.catch` first: one refused watch must not wedge every later call behind a rejection.
+  watchTurn = watchTurn
+    .catch(() => {})
+    .then(() => invoke<void>("watch_paint_files", { paths }));
+  return watchTurn as Promise<void>;
+}
+
+/** Fires when a watched paint is rewritten on disk — a repack, or a save from the studio. */
+export function onPaintChanged(cb: (path: string) => void): Promise<UnlistenFn> {
+  return listen<{ path: string }>("paint-changed", (e) => cb(e.payload.path));
+}
+
 /* ── Paint studio ──────────────────────────────────────────────────────────────────── */
 
 /** Read image files as textures — non-power-of-two sizes come back resized, flagged. */

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -313,6 +313,7 @@ export const de: Translation = {
   "viewer.dragToRotate": "Ziehen zum Drehen",
   "viewer.scrollToZoom": "Scrollen zum Zoomen",
   "viewer.rightDragToPan": "Rechts ziehen zum Verschieben",
+  "viewer.paintReloaded": "Lackierung neu geladen",
 
   // ── Combobox ───────────────────────────────────────────────────────────────
   "combobox.search": "Suchen…",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -300,6 +300,7 @@ export const en = {
   "viewer.dragToRotate": "Drag to rotate",
   "viewer.scrollToZoom": "Scroll to zoom",
   "viewer.rightDragToPan": "Right-drag to pan",
+  "viewer.paintReloaded": "Paint reloaded",
 
   // ── Combobox ───────────────────────────────────────────────────────────────
   "combobox.search": "Search…",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -307,6 +307,7 @@ export const es: Translation = {
   "viewer.dragToRotate": "Arrastra para rotar",
   "viewer.scrollToZoom": "Desplaza para hacer zoom",
   "viewer.rightDragToPan": "Arrastra con el botón derecho para mover",
+  "viewer.paintReloaded": "Pintura recargada",
 
   // ── Combobox ───────────────────────────────────────────────────────────────
   "combobox.search": "Buscar…",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -310,6 +310,7 @@ export const fr: Translation = {
   "viewer.dragToRotate": "Glisser pour pivoter",
   "viewer.scrollToZoom": "Molette pour zoomer",
   "viewer.rightDragToPan": "Clic droit glissé pour déplacer",
+  "viewer.paintReloaded": "Déco rechargée",
 
   // ── Combobox ───────────────────────────────────────────────────────────────
   "combobox.search": "Rechercher…",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -306,6 +306,7 @@ export const it: Translation = {
   "viewer.dragToRotate": "Trascina per ruotare",
   "viewer.scrollToZoom": "Scorri per zoomare",
   "viewer.rightDragToPan": "Trascina col destro per spostare",
+  "viewer.paintReloaded": "Livrea ricaricata",
 
   // ── Combobox ───────────────────────────────────────────────────────────────
   "combobox.search": "Cerca…",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -309,6 +309,7 @@ export const ptBR: Translation = {
   "viewer.dragToRotate": "Arraste para girar",
   "viewer.scrollToZoom": "Role para dar zoom",
   "viewer.rightDragToPan": "Arraste com o botão direito para mover",
+  "viewer.paintReloaded": "Pintura recarregada",
 
   // ── Combobox ───────────────────────────────────────────────────────────────
   "combobox.search": "Pesquisar…",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -366,6 +366,12 @@ export interface PaintTexture {
 /** One selectable paint (livery) for a bike: a name + its textures. */
 export interface BikePaint {
   name: string;
+  /**
+   * The `.pnt` on disk, for a paint installed loose in the bike's `paints` folder — the
+   * file the viewer watches so re-saving it re-dresses the model. `null` for a paint packed
+   * inside the archive, which nothing rewrites in place.
+   */
+  path: string | null;
   textures: PaintTexture[];
   changesPreview: boolean;
 }


### PR DESCRIPTION
## What

Open a paint in the 3D viewer, re-save it on disk, and the model re-dresses itself. The draw, look, fix, look loop a painter works in no longer needs the "look" step re-opened by hand — the viewer read the `.pnt` once and never asked after it again.

Only the *textures* are replaced. The geometry is untouched, so a livery never rebuilds the bike's vertex buffers.

## How

**`paintwatch` (new module).** Watches the paint files the viewer is showing and emits `paint-changed`. Two decisions worth the review:

- **The folder is watched, not the file.** Saving a paint usually means writing a temp file and renaming it over the target, which replaces the inode. A watch registered on the file itself follows the old one and goes silent after exactly the first save — the save this exists to catch. There's an end-to-end test that saves by rename against a real filesystem and asserts the event still comes out.
- **Events are matched by file name alone.** Only the folders holding watched files are watched, so anything arriving is already from a folder we asked about. Comparing whole paths would mean out-guessing whatever the OS canonicalises them to (`/private/var` on macOS, 8.3 names on Windows) for nothing.

**Everything else:**

- `BikePaint` carries `path` — the `.pnt` on disk for a livery installed loose beside the bike, `None` for one packed inside the archive (nothing rewrites those in place). Model-swap previews get it too, since their paints come through the same `installed_paints`.
- The viewer re-decodes through the existing `unpack_paint` and layers the fresh sheets over the model's base textures by name. One retry covers a paint caught mid-write; a brief **Paint reloaded** chip says when a reload landed — an edit that turned out to change nothing visible otherwise looks identical to one the viewer missed.
- `bike_cache_key` gained the file size. A paint re-saved twice inside one timestamp tick would otherwise be served its previous decode on any filesystem coarser than the gap between saves (FAT32 rounds to two seconds).
- `watchPaintFiles` calls are serialised frontend-side: the set is replaced wholesale, and switching paints issues stop-then-start with nothing else ordering them.

No DB or schema changes.

## Scope

Photoshop writes images, not `.pnt`, so the loop closes through whatever repacks the sheets — an external packer, or the app's own Paint Studio → Save. The viewer end is live now; auto-reloading the Paint Studio's *source sheets* on a Photoshop save is the next link in the same chain and is deliberately not in this PR.

## Testing

725 Rust tests pass, including 6 new ones (`paintwatch` folder grouping, name matching, burst collapsing, the rename-survival end-to-end, `installed_paints` carrying the path, and the cache key with the mtime pinned so only size can tell two saves apart). Frontend `tsc`, `npm run lint` and `npm run build` clean.

Not verified here: the watcher firing against a real Photoshop save on Windows — macOS has no MX Bikes install to drive the loop end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)