### PR TITLE
fix(designer): drop the empty-canvas save hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased — an empty canvas stops asking for a sheet
+
+### Changed
+- **The Designer no longer nags about an empty canvas.** Opening it with nothing drawn yet put
+  *Add a sheet to draw on.* next to a greyed-out Save, which stated the obvious about a canvas
+  you had only just opened. Save is still off until there's a sheet to save — it just stays
+  quiet about it, and the hints worth acting on (a missing name, a duplicate texture name, no
+  target picked) read exactly as before.
+
 ## Unreleased — the paint changes on disk, the model changes with it
 
 ### Added

--- a/src/Components/Studio/Designer/Designer.tsx
+++ b/src/Components/Studio/Designer/Designer.tsx
@@ -991,9 +991,10 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     [bump],
   );
 
-  /** Why saving isn't possible yet, as a translated message — or null when it is. */
+  /** Why saving isn't possible yet, as a translated message — or null when it is, and on an
+   *  empty canvas, where there is nothing to fix yet and Save is simply off. */
   const blocked = useMemo<string | null>(() => {
-    if (!sheets.length) return t("designer.needSheets");
+    if (!sheets.length) return null;
     if (!name.trim()) return t("paints.needName");
     if (sheets.some((s) => !s.name.trim())) return t("paints.needTextureNames");
     const seen = new Set<string>();
@@ -1005,6 +1006,8 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     if (!dest) return t("paints.needTarget");
     return null;
   }, [sheets, name, dest, t]);
+
+  const canSave = sheets.length > 0 && !blocked;
 
   const write = useCallback(
     async (overwrite: boolean) => {
@@ -1057,7 +1060,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   );
 
   const save = useCallback(async () => {
-    if (blocked || !dest) {
+    if (!canSave || !dest) {
       if (blocked) toast.error(blocked);
       return;
     }
@@ -1077,7 +1080,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
       return;
     }
     await write(false);
-  }, [blocked, dest, name, t, write]);
+  }, [blocked, canSave, dest, name, t, write]);
 
   const selected = active?.layers.find((l) => l.id === selectedId) ?? null;
 
@@ -1113,7 +1116,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
         />
         <Button
           size="sm"
-          disabled={busy || !!blocked}
+          disabled={busy || !canSave}
           title={blocked ?? undefined}
           onClick={() => void save()}
         >

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1588,7 +1588,6 @@ export const de: Translation = {
   "designer.size": "Textgröße",
   "designer.colour": "Farbe",
   "designer.outline": "Kontur",
-  "designer.needSheets": "Füge eine Bahn zum Zeichnen hinzu.",
   "designer.noModelFound":
     "„{{model}}“ ist nicht in deiner Bibliothek, also gibt es nichts, worauf es gezeigt werden könnte.",
   "designer.noBikePreview":

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1542,7 +1542,6 @@ export const en = {
   "designer.size": "Text size",
   "designer.colour": "Colour",
   "designer.outline": "Outline",
-  "designer.needSheets": "Add a sheet to draw on.",
   "designer.noModelFound":
     "“{{model}}” isn't in your library, so there's nothing to show it on.",
   "designer.noBikePreview":

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1575,7 +1575,6 @@ export const es: Translation = {
   "designer.size": "Tamaño del texto",
   "designer.colour": "Color",
   "designer.outline": "Contorno",
-  "designer.needSheets": "Añade una hoja sobre la que dibujar.",
   "designer.noModelFound":
     "“{{model}}” no está en tu biblioteca, así que no hay nada donde mostrarla.",
   "designer.noBikePreview":

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1579,7 +1579,6 @@ export const fr: Translation = {
   "designer.size": "Taille du texte",
   "designer.colour": "Couleur",
   "designer.outline": "Contour",
-  "designer.needSheets": "Ajoute une planche sur laquelle dessiner.",
   "designer.noModelFound":
     "« {{model}} » n'est pas dans ta bibliothèque, il n'y a donc rien pour l'afficher.",
   "designer.noBikePreview":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1566,7 +1566,6 @@ export const it: Translation = {
   "designer.size": "Dimensione testo",
   "designer.colour": "Colore",
   "designer.outline": "Contorno",
-  "designer.needSheets": "Aggiungi un foglio su cui disegnare.",
   "designer.noModelFound":
     "“{{model}}” non è nella tua libreria, quindi non c'è niente su cui mostrarla.",
   "designer.noBikePreview":

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1566,7 +1566,6 @@ export const ptBR: Translation = {
   "designer.size": "Tamanho do texto",
   "designer.colour": "Cor",
   "designer.outline": "Contorno",
-  "designer.needSheets": "Adicione uma folha para desenhar.",
   "designer.noModelFound": "“{{model}}” não está na sua biblioteca, então não há onde mostrar.",
   "designer.noBikePreview":
     "Esta build não lê a geometria das motos, então uma pintura não tem modelo onde ficar. Todo o resto salva normalmente.",


### PR DESCRIPTION
Opening the Designer with nothing drawn yet showed *Add a sheet to draw on.* beside a greyed-out Save — a hint that stated the obvious about a canvas the user had just opened.

## What changed

- The no-sheets branch of `blocked` returns `null`, so the toolbar stays quiet on an empty canvas instead of falling through to the "needs a name" hint.
- A new `canSave` (sheets present **and** nothing blocked) drives the Save button’s `disabled` and the early return in `save()`. Saving an empty paint is still refused, just silently — an empty sheet set would otherwise write a `.pnt` that *strips* the bike’s textures by name rather than adding blanks.
- Dropped the now-unused `designer.needSheets` key from all six locale files.

The hints worth acting on — missing name, duplicate texture name, no target picked — are unchanged.

## Verification

- `tsc --noEmit` and `eslint` clean.
- Manual: open Designer with no sheets → Save greyed, no text beside it. Add a sheet and clear the name → the "needs a name" hint returns.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)