### PR TITLE
feat(designer): name the panel, the side and the face a sheet region paints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## Unreleased — the sheet says which panel, which side, and which face
+
+### Fixed
+- **A sheet region no longer names the wrong flank.** The hover asked whichever part won the
+  pick which side of the bike it was, and the winner is the *smallest* part covering the point —
+  so a bracket sharing the shroud's island answered for the shroud, and a region on the right of
+  the bike came up as the left. The side and the facing are now asked of every part covering the
+  point, and where two of them overlap the label names both (`plastics on metal.027`) instead of
+  quietly picking one.
+- **A bike that loaded without its `.geom` no longer gets sides invented for it.** Its parts are
+  never placed into one frame, so a vertex's position says nothing about where it sits on the
+  bike — the flanks were read off those numbers anyway. The model now reports whether it was
+  assembled, and the Designer says nothing about sides when it wasn't. The warning also goes to
+  the app log rather than only to a terminal.
+- **A bike archive with no mesh in it now fails instead of loading empty.** The viewer took the
+  empty result for a successful load and put its stand-in bike on screen, which reads as *this
+  is your bike* rather than *none of this bike arrived*. Cloud-synced archives that haven't been
+  downloaded yet land here, and now say so.
+
+### Added
+- **The sheet says when you're about to paint a panel's underside.** A rear fender's outer skin
+  and its underside are one part with one name and regularly share one island, so artwork could
+  land where nobody will ever see it. The hover now reads `underside` or `top + underside`
+  alongside the part and the flank.
+- **Double-click a part to fill the view with it.** A shroud is a tenth of a 2048² sheet, and
+  reaching it by wheel-and-drag meant aiming at the shape you were trying to see.
+
 ## Unreleased — an empty canvas stops asking for a sheet
 
 ### Changed

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1253,6 +1253,12 @@ struct BikeModel {
     /// Designer's reference underlay needs the distinction: an OEM bike's stock `.pnt`
     /// replaces the wheels and the chain, so `plastics` is only ever in here.
     base: Vec<paint::PaintTexture>,
+    /// Whether the parts were placed into one frame by the bike's `.geom`.
+    ///
+    /// False means every node still sits in its own local frame, so a vertex's position says
+    /// nothing about where it is on the bike. The Designer names the flank a sheet region
+    /// paints from the sign of x, and that answer is only worth giving once this is true.
+    assembled: bool,
 }
 
 impl BikeModel {
@@ -1465,14 +1471,34 @@ fn build_bike_model(
     for (fname, path, data) in &installed {
         pnt_jobs.push((paint_display_name(fname), data.as_slice(), false, Some(path)));
     }
-    if let Some(g) = geom {
-        if !edf::assemble_bike(&mut nodes, g) {
-            eprintln!("[viewer] .geom present but missing mount points — parts unassembled");
+    // Whether the parts ended up in one frame. Logged rather than printed: it decides what the
+    // Designer may say about a sheet's flanks, so "was this bike assembled?" has to be
+    // answerable from the log file after the fact, not only from a terminal nobody kept.
+    let assembled = match geom {
+        Some(g) => {
+            let ok = edf::assemble_bike(&mut nodes, g);
+            if !ok {
+                log::warn!("[viewer] {label}: .geom present but missing mount points — parts unassembled");
+            }
+            ok
         }
-    } else if !nodes.is_empty() {
-        eprintln!("[viewer] no .geom alongside the mesh — parts unassembled");
-    }
+        None => {
+            if !nodes.is_empty() {
+                log::warn!("[viewer] {label}: no .geom alongside the mesh — parts unassembled");
+            }
+            false
+        }
+    };
     edf::to_right_handed(&mut nodes);
+    // Nothing to draw. Returning a model with no nodes is worse than failing: the viewer reads
+    // it as a successful load and puts its stand-in bike on screen, which reads as "this is your
+    // bike" rather than "none of this bike arrived". A cloud-synced archive that hasn't been
+    // downloaded lands here — every entry reads short, so the `.edf` never appears.
+    if nodes.is_empty() {
+        return Err(format!(
+            "{label} holds no readable mesh — if the file is cloud-synced, it may not be fully downloaded yet"
+        ));
+    }
     let t_parse = t0.elapsed();
 
     let mut base: Vec<paint::PaintTexture> = tga_jobs
@@ -1595,7 +1621,7 @@ fn build_bike_model(
         log::info!("  node '{}' placed={} {}", n.name, n.placed, subs.join(", "));
     }
 
-    let model = BikeModel { nodes, paints, base: model_base };
+    let model = BikeModel { nodes, paints, base: model_base, assembled };
     if let Ok(mut c) = bike_cache().lock() {
         // The evicted bike's pixels go with it — nothing else references them.
         if let Some(dropped) = c.insert(key, model.clone()) {
@@ -7307,6 +7333,7 @@ mod viewer_tests {
                 changes_preview: true,
             }],
             base: vec![tex("plastics", "t-own"), tex("wheel", "t-shared")],
+            assembled: true,
         };
         let tokens = model.tokens();
         assert!(tokens.contains(&"t-own".to_string()), "the overridden one is still released");

--- a/src/Components/Studio/Designer/CanvasStage.tsx
+++ b/src/Components/Studio/Designer/CanvasStage.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 import { useT } from "../../../i18n/context";
 import { layerCorners } from "./composite";
 import type { Ghost } from "./ghost";
-import { flankAt, partAt, partPath, type Side, type UvPart } from "./uv";
+import { faceAt, partAt, partPath, partsAt, sideAt, type Face, type Side, type UvPart } from "./uv";
 import { hitTest, type Layer, type Sheet } from "./layers";
 import { constrained, hasTip, isDragTool, type PaintTool, type Point } from "./paint";
 
@@ -130,9 +130,16 @@ export function CanvasStage({
   // being able to answer "what am I painting on" — an outline you have to interpret answers it
   // less well than a name does.
   const [overPart, setOverPart] = useState<UvPart | null>(null);
+  // The largest part sharing that point, when something else does. Two parts over one texel is
+  // ordinary — and it is also the whole reason a small bracket used to answer for the panel it
+  // sits on, so the overlap is named rather than resolved out of sight.
+  const [overAlso, setOverAlso] = useState<string | null>(null);
   // And which flank of the bike that piece is, at the point being pointed at rather than over
   // the part as a whole — the two are different answers wherever the flanks share an island.
   const [overSide, setOverSide] = useState<Side | null>(null);
+  // Which way the surface there faces. The answer that says a rear fender's island has its
+  // underside in it, which is otherwise only discoverable by painting and looking.
+  const [overFace, setOverFace] = useState<Face | null>(null);
   // The press and current point of a gradient or shape drag, so it can be shown while it's
   // being aimed. Only ever set between press and release.
   const [guide, setGuide] = useState<{ from: Point; to: Point } | null>(null);
@@ -499,9 +506,14 @@ export function CanvasStage({
           const at = toSheet(e.clientX, e.clientY);
           const u = at ? at.x / sheet.width : 0;
           const v = at ? at.y / sheet.height : 0;
-          const part = at ? partAt(parts, u, v) : null;
-          setOverPart(part);
-          setOverSide(part ? flankAt(part, u, v) : null);
+          // Everything under the pointer, not just the winner: the side and the facing are
+          // asked of all of it, so a bracket sharing the panel's island can't answer for the
+          // panel. `hits[0]` stays the most specific part, which is what gets outlined.
+          const hits = at ? partsAt(parts, u, v) : [];
+          setOverPart(hits[0] ?? null);
+          setOverAlso(hits.length > 1 ? hits[hits.length - 1].label : null);
+          setOverSide(hits.length ? sideAt(parts, u, v) : null);
+          setOverFace(hits.length ? faceAt(parts, u, v) : null);
         }
         return;
       }
@@ -555,6 +567,33 @@ export function CanvasStage({
     setPan({ x: 0, y: 0 });
   }, []);
 
+  /**
+   * Fill the view with one piece of bodywork.
+   *
+   * A shroud is a tenth of a 2048² sheet, and reaching it by wheel-and-drag means aiming at a
+   * shape whose edges are the thing you were trying to see. Double-click is the gesture because
+   * it costs no mode and no modifier: a paint tool still paints where you clicked, and the view
+   * arrives at the part you were already pointing at.
+   */
+  const focusPart = useCallback(
+    (part: UvPart) => {
+      if (!fit || !box.w || !box.h) return;
+      // A degenerate island — one point, or a sliver — would divide the view to infinity.
+      const pw = Math.max(1, (part.maxU - part.minU) * sheet.width);
+      const ph = Math.max(1, (part.maxV - part.minV) * sheet.height);
+      // 0.8 leaves the part's surroundings in frame. A panel cut exactly to the edges gives
+      // nothing to judge where a decal sits relative to the seam beside it.
+      const z = Math.min(8, Math.max(0.25, (Math.min(box.w / pw, box.h / ph) * 0.8) / fit));
+      const s = fit * z;
+      const cx = ((part.minU + part.maxU) / 2) * sheet.width;
+      const cy = ((part.minV + part.maxV) / 2) * sheet.height;
+      setZoom(z);
+      // Pan is measured from the sheet's centre, which is where the blit is anchored.
+      setPan({ x: -(cx - sheet.width / 2) * s, y: -(cy - sheet.height / 2) * s });
+    },
+    [box.w, box.h, fit, sheet.width, sheet.height],
+  );
+
   const ringed = paints && hasTip(tool);
   // Corners come out of `layerCorners` clockwise from the top left, so 0/2 are one diagonal
   // and 1/3 the other. A rotated layer makes this an approximation — the arrow can end up a
@@ -590,6 +629,16 @@ export function CanvasStage({
           if (cursorRef.current) cursorRef.current.style.opacity = "1";
         }}
         onWheel={onWheel}
+        // The part under the pointer, not the one the hover last recorded: a double-click can
+        // land before a hover has been reported on a touchpad, and framing the previous part
+        // would move the view away from what was just clicked.
+        onDoubleClick={(e) => {
+          if (!parts.length) return;
+          const at = toSheet(e.clientX, e.clientY);
+          if (!at) return;
+          const part = partAt(parts, at.x / sheet.width, at.y / sheet.height);
+          if (part) focusPart(part);
+        }}
         onContextMenu={(e) => e.preventDefault()}
       />
       <div
@@ -611,7 +660,9 @@ export function CanvasStage({
         {overPart && (
           <>
             <span>·</span>
-            <span className="max-w-[160px] truncate text-white/70">{overPart.label}</span>
+            <span className="max-w-[160px] truncate text-white/70" title={t("designer.focusHint")}>
+              {overAlso ? t("designer.partOver", { part: overPart.label, over: overAlso }) : overPart.label}
+            </span>
             {/* Which flank, when the model can say. `both` is the one that saves an
                 afternoon: it means this island is worn by each side of the bike. */}
             {overSide && overSide !== "centre" && (
@@ -620,6 +671,16 @@ export function CanvasStage({
                 title={overSide === "both" ? t("designer.flankSharedHint") : undefined}
               >
                 {t(`designer.flank.${overSide}` as "designer.flank.left")}
+              </span>
+            )}
+            {/* Only the answers worth acting on. "Top" is where a livery goes anyway, so
+                saying it every time would bury the one that means "nobody will see this". */}
+            {(overFace === "under" || overFace === "both") && (
+              <span
+                className="text-amber-300/70"
+                title={t(`designer.faceHint.${overFace}` as "designer.faceHint.under")}
+              >
+                {t(`designer.face.${overFace}` as "designer.face.under")}
               </span>
             )}
           </>

--- a/src/Components/Studio/Designer/Designer.tsx
+++ b/src/Components/Studio/Designer/Designer.tsx
@@ -131,6 +131,9 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   // The mesh the preview is showing, reported back by it. Null until one loads, and null again
   // if it fails — a UV map drawn from a model that isn't on screen would be a confident lie.
   const [geometry, setGeometry] = useState<EdfNode[] | null>(null);
+  // Whether that mesh was assembled about the bike's mirror plane. Without it a position is a
+  // number in some part's own frame, and the sides and facings read off it would be invented.
+  const [assembled, setAssembled] = useState(false);
   // That same model's own textures — the look it ships with. Empty for anything that can't
   // say which of its textures are its own, which is every model but a bike.
   const [stockTextures, setStockTextures] = useState<PaintTexture[]>([]);
@@ -746,10 +749,12 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   const activeHeight = active?.height ?? 0;
   // Left and right are asked for on bikes only: a bike arrives assembled about its mirror
   // plane, where gear is a single piece whose up-axis the viewer has to work out per mod.
+  // And only when it *did* arrive that way — a bike that loaded without its `.geom` is a heap
+  // of parts in their own frames, and a side named from that is worse than no side at all.
   const bike = isBikeKind(destState.kind);
   const parts = useMemo<UvPart[]>(
-    () => (geometry ? uvParts(geometry, activeName, { flanks: bike }) : []),
-    [geometry, activeName, bike],
+    () => (geometry ? uvParts(geometry, activeName, { assembled: bike && assembled }) : []),
+    [geometry, activeName, bike, assembled],
   );
 
   /** Pin the selected layer to a piece of bodywork, or let it cover the sheet again. */
@@ -819,12 +824,13 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
    * isn't there — the worst kind of wrong for a guide.
    */
   const geometryRef = useRef<EdfNode[] | null>(null);
-  const onGeometry = useCallback((nodes: EdfNode[] | null) => {
+  const onGeometry = useCallback((nodes: EdfNode[] | null, assembled: boolean) => {
     // Compared against a ref rather than inside a `setState` updater: an updater has to be
     // pure, and this has to invalidate the wires as well as record the mesh.
     if (geometryRef.current === nodes) return;
     geometryRef.current = nodes;
     setGeometry(nodes);
+    setAssembled(assembled);
     setGhosts((gs) =>
       gs.size ? new Map([...gs].map(([id, g]) => [id, { ...g, wire: null, wireFor: null }])) : gs,
     );

--- a/src/Components/Studio/Designer/PreviewPanel.tsx
+++ b/src/Components/Studio/Designer/PreviewPanel.tsx
@@ -57,7 +57,14 @@ export function PreviewPanel({
    * which destination" through the library, and a second loader would be a second answer to
    * that question — one that could quietly disagree about which bike is on screen.
    */
-  onGeometry?: (nodes: EdfNode[] | null) => void;
+  /**
+   * The mesh on screen, with whether its parts were assembled into one frame.
+   *
+   * The two travel together because the second qualifies the first: `assembled` is what makes a
+   * position mean "left of the bike" rather than "left of whatever this part's frame is", and
+   * handing over geometry without it invites reading the numbers as more than they say.
+   */
+  onGeometry?: (nodes: EdfNode[] | null, assembled: boolean) => void;
   /**
    * The model's own textures, handed back with the mesh so the editor can show what the
    * bike already looks like under a sheet being drawn from blank.
@@ -74,6 +81,8 @@ export function PreviewPanel({
   const { game } = useConfig();
   const { kind, model, bikePreview } = state;
   const [nodes, setNodes] = useState<EdfNode[] | null>(null);
+  // Reported by the backend with the mesh, never inferred here — see `BikeModel.assembled`.
+  const [assembled, setAssembled] = useState(false);
   const [textures, setTextures] = useState<PaintTexture[]>([]);
   // The model's own textures, kept apart from the ones it is currently wearing.
   const [stock, setStock] = useState<PaintTexture[]>([]);
@@ -124,6 +133,7 @@ export function PreviewPanel({
   useEffect(() => {
     if (!isBike || !model || !bikePreview) {
       setNodes(null);
+      setAssembled(false);
       setTextures([]);
       setStock([]);
       return;
@@ -150,6 +160,7 @@ export function PreviewPanel({
       .then((m) => {
         if (!alive) return;
         setNodes(m.nodes);
+        setAssembled(m.assembled);
         // The model's own look, under the drawing — so parts this paint doesn't cover still
         // read as the bike rather than as untextured grey.
         setTextures(m.paints[0]?.textures ?? []);
@@ -160,6 +171,7 @@ export function PreviewPanel({
       .catch((e) => {
         if (!alive) return;
         setNodes(null);
+        setAssembled(false);
         setTextures([]);
         setStock([]);
         setErr(String(e).replace(/^Error:\s*/, ""));
@@ -202,11 +214,16 @@ export function PreviewPanel({
    * came from would be a distinction the sheet itself doesn't make.
    */
   useEffect(() => {
-    onGeometry?.(nodes ?? (riderParts ? riderParts.flatMap((p) => p.nodes) : null));
+    // `assembled` only ever describes the bike branch: a rider's parts are posed by the rig
+    // rather than by a `.geom`, and sides are never asked of them.
+    onGeometry?.(
+      nodes ?? (riderParts ? riderParts.flatMap((p) => p.nodes) : null),
+      nodes ? assembled : false,
+    );
     // Through the same effect, so the mesh and the textures said to be its own can never
     // describe two different models. Gated on `nodes` because that is the bike branch.
     onStock?.(nodes ? stock : NO_STOCK);
-  }, [nodes, riderParts, stock, onGeometry, onStock]);
+  }, [nodes, assembled, riderParts, stock, onGeometry, onStock]);
 
   // Toggled-off gear is dropped before it reaches the viewer, which is what makes hiding it
   // reveal what's underneath rather than just dimming it.

--- a/src/Components/Studio/Designer/uv.ts
+++ b/src/Components/Studio/Designer/uv.ts
@@ -21,10 +21,36 @@ export type Flank = "left" | "right" | "centre";
 /** A flank a region covers, where `both` means the two flanks share it. */
 export type Side = Flank | "both";
 
+/**
+ * Which way a triangle faces — the other half of "where does this land on the bike".
+ *
+ * A rear fender's outer skin and its underside are one panel with one name, and they routinely
+ * unwrap onto one island. Knowing the part is `plastics` doesn't tell you which of the two you
+ * are about to paint, and painting the wrong one puts artwork where nobody will ever see it.
+ */
+export type Facing = "top" | "under" | "edge";
+
+/** A facing a region covers, where `both` means the outer skin and the underside share it. */
+export type Face = Facing | "both";
+
 /** Per-triangle flank codes, packed one byte each. */
 const CENTRE = 0;
 const LEFT = 1;
 const RIGHT = 2;
+
+/** Per-triangle facing codes, in their own numbering — see `EDGE`/`TOP`/`UNDER`. */
+const EDGE = 0;
+const TOP = 1;
+const UNDER = 2;
+
+/**
+ * How steeply a triangle has to lie before it counts as facing up or down.
+ *
+ * A normal's y of ±0.3 is about 17° off vertical. Below that the triangle is effectively a
+ * wall — the side of a shroud, the flank of a tank — and calling it a top or an underside
+ * would put a word on screen that changes as the pointer slides along a curve.
+ */
+const FACE_TOLERANCE = 0.3;
 
 /** One piece of bodywork: a mesh-group name, and where its triangles land on the sheet. */
 export interface UvPart {
@@ -42,6 +68,10 @@ export interface UvPart {
   flanks: Uint8Array | null;
   /** The flanks the part covers as a whole, for a one-word summary. Null when unknown. */
   side: Side | null;
+  /** Per-triangle facing codes, alongside `flanks` and null on the same terms. */
+  faces: Uint8Array | null;
+  /** The facings the part covers as a whole. Null when unknown. */
+  face: Face | null;
   /** uv-space bounds, for fitting an image to the part and for cheap hit rejection. */
   minU: number;
   minV: number;
@@ -81,31 +111,58 @@ function summarise(sides: number[]): Side {
   return left ? "left" : right ? "right" : "centre";
 }
 
+/** The same, for facing codes. */
+function summariseFaces(faces: number[]): Face {
+  let top = false;
+  let under = false;
+  for (const f of faces) {
+    if (f === TOP) top = true;
+    else if (f === UNDER) under = true;
+    if (top && under) return "both";
+  }
+  return top ? "top" : under ? "under" : "edge";
+}
+
 /**
- * The flank of `part` under a uv point — `both` when the two sides land on the same island.
+ * The per-triangle codes at a uv point, gathered across **every** part that covers it.
+ *
+ * Across every part, not the one that happened to win the pick, because a texel is worn by
+ * whatever binds it. A bracket and the panel it bolts to regularly overlap on the sheet, and
+ * answering from the bracket alone is how the editor came to name the far flank of a shroud:
+ * the small part wins the pick by area, and its side is not the side of the panel under the
+ * pointer. Painting there paints both, so both have to be in the answer.
+ */
+function codesAt(parts: UvPart[], u: number, v: number, field: "flanks" | "faces"): number[] {
+  const out: number[] = [];
+  for (const part of parts) {
+    const codes = part[field];
+    if (!codes) continue;
+    if (u < part.minU || u > part.maxU || v < part.minV || v > part.maxV) continue;
+    const { tris } = part;
+    for (let i = 0; i < tris.length; i += 6) {
+      if (inTriangle(u, v, tris[i], tris[i + 1], tris[i + 2], tris[i + 3], tris[i + 4], tris[i + 5]))
+        out.push(codes[i / 6]);
+    }
+  }
+  return out;
+}
+
+/**
+ * The flank worn at a uv point — `both` when the two sides land on the same spot.
  *
  * That last case is the one worth having: a bike's flanks routinely share one region of the
  * sheet, so a decal placed off-centre there comes out at the mirrored spot on the far side.
  * The editor can't change that, and it can say so.
  */
-export function flankAt(part: UvPart, u: number, v: number): Side | null {
-  const { tris, flanks } = part;
-  if (!flanks) return null;
-  let left = false;
-  let right = false;
-  let centre = false;
-  for (let i = 0; i < tris.length; i += 6) {
-    if (!inTriangle(u, v, tris[i], tris[i + 1], tris[i + 2], tris[i + 3], tris[i + 4], tris[i + 5]))
-      continue;
-    const s = flanks[i / 6];
-    if (s === LEFT) left = true;
-    else if (s === RIGHT) right = true;
-    else centre = true;
-    if (left && right) return "both";
-  }
-  if (left) return "left";
-  if (right) return "right";
-  return centre ? "centre" : null;
+export function sideAt(parts: UvPart[], u: number, v: number): Side | null {
+  const codes = codesAt(parts, u, v, "flanks");
+  return codes.length ? summarise(codes) : null;
+}
+
+/** Which way the surface at a uv point faces — `both` when a panel's two skins share it. */
+export function faceAt(parts: UvPart[], u: number, v: number): Face | null {
+  const codes = codesAt(parts, u, v, "faces");
+  return codes.length ? summariseFaces(codes) : null;
 }
 
 /** A stable hue per mesh-group name. */
@@ -131,24 +188,28 @@ function hueOf(label: string): number {
  * same way as a canvas row and no flip belongs here — the same reasoning that keeps the editor
  * from having an opinion about which way up a sheet is.
  *
- * `flanks` asks for the left/right answer as well, and is for bikes only: their positions arrive
- * assembled and centred on the mirror plane, which is what makes the sign of x mean a side.
+ * `assembled` asks for the left/right and top/underside answers as well. Both read a vertex's
+ * position or normal as a statement about where it sits on the bike, which is only true once
+ * the `.geom` has placed the parts into one frame about the mirror plane — an unassembled bike
+ * is a pile of parts each in its own, and the sign of x there is noise. The backend reports
+ * whether that happened; nothing here tries to guess it from the numbers.
  */
 export function uvParts(
   nodes: EdfNode[],
   sheetName: string,
-  opts?: { flanks?: boolean },
+  opts?: { assembled?: boolean },
 ): UvPart[] {
   const want = sheetName.trim().toLowerCase();
   if (!want) return [];
 
   // A fraction of the model's width, so the dead band around the mirror plane scales with the
   // bike rather than being a number of metres — a 65 and a 450 are one shape at two sizes.
-  const sided = !!opts?.flanks;
+  const sided = !!opts?.assembled;
   const tol = sided ? lateralTolerance(nodes) : 0;
 
   const byLabel = new Map<string, number[]>();
   const flanksByLabel = new Map<string, number[]>();
+  const facesByLabel = new Map<string, number[]>();
   for (const node of nodes) {
     if (!node.uvs.length || !node.indices.length) continue;
     const triCount = Math.floor(node.indices.length / 3);
@@ -171,17 +232,32 @@ export function uvParts(
         sides = [];
         flanksByLabel.set(label, sides);
       }
+      let faces = facesByLabel.get(label);
+      if (!faces && sided) {
+        faces = [];
+        facesByLabel.set(label, faces);
+      }
+      // Normals are what say which way a surface looks, and a mesh is free to ship without
+      // them. Without them the facing question goes unanswered rather than being answered from
+      // the winding order, which flips with the exporter.
+      const hasNormals = node.normals.length >= node.positions.length;
       const end = Math.min(start + count, triCount);
       for (let t = Math.max(0, start); t < end; t += 1) {
         let x = 0;
+        let ny = 0;
         for (let c = 0; c < 3; c += 1) {
           const v = node.indices[t * 3 + c];
           flat.push(node.uvs[v * 2], node.uvs[v * 2 + 1]);
           if (sides) x += node.positions[v * 3];
+          if (faces && hasNormals) ny += node.normals[v * 3 + 1];
         }
         // The centroid, not every corner: a triangle with one vertex over the line is still on
         // the side the rest of it is, and a panel's inner edge is full of them.
         if (sides) sides.push(x / 3 > tol ? LEFT : x / 3 < -tol ? RIGHT : CENTRE);
+        if (faces) {
+          const up = hasNormals ? ny / 3 : 0;
+          faces.push(up > FACE_TOLERANCE ? TOP : up < -FACE_TOLERANCE ? UNDER : EDGE);
+        }
       }
     }
   }
@@ -200,11 +276,14 @@ export function uvParts(
       if (flat[i + 1] > maxV) maxV = flat[i + 1];
     }
     const sides = flanksByLabel.get(label);
+    const faces = facesByLabel.get(label);
     parts.push({
       label,
       tris: new Float32Array(flat),
       flanks: sides ? new Uint8Array(sides) : null,
       side: sides ? summarise(sides) : null,
+      faces: faces ? new Uint8Array(faces) : null,
+      face: faces ? summariseFaces(faces) : null,
       minU,
       minV,
       maxU,
@@ -273,22 +352,33 @@ function inTriangle(
  * order so it cannot be silently undone by sorting the parts differently.
  */
 export function partAt(parts: UvPart[], u: number, v: number): UvPart | null {
-  let best: UvPart | null = null;
-  let bestArea = Infinity;
+  return partsAt(parts, u, v)[0] ?? null;
+}
+
+/**
+ * Every part covering a uv point, most specific first.
+ *
+ * Parts genuinely share regions of a sheet — a bracket bolted through a shroud, a badge on a
+ * tank — and one of them winning the pick silently is what makes the editor look like it is
+ * describing the wrong panel. The list keeps `partAt`'s order, so the smallest is still the
+ * one pointed at, while everything else it overlaps stays sayable.
+ */
+export function partsAt(parts: UvPart[], u: number, v: number): UvPart[] {
+  const hits: UvPart[] = [];
   for (const part of parts) {
     if (u < part.minU || u > part.maxU || v < part.minV || v > part.maxV) continue;
-    const area = (part.maxU - part.minU) * (part.maxV - part.minV);
-    if (area >= bestArea) continue;
     const { tris } = part;
     for (let i = 0; i < tris.length; i += 6) {
       if (inTriangle(u, v, tris[i], tris[i + 1], tris[i + 2], tris[i + 3], tris[i + 4], tris[i + 5])) {
-        best = part;
-        bestArea = area;
+        hits.push(part);
         break;
       }
     }
   }
-  return best;
+  return hits.sort(
+    (a, b) =>
+      (a.maxU - a.minU) * (a.maxV - a.minV) - (b.maxU - b.minU) * (b.maxV - b.minV),
+  );
 }
 
 /**

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1577,6 +1577,14 @@ export const de: Translation = {
   "designer.flank.both": "beide Seiten",
   "designer.flankSharedHint":
     "Beide Flanken liegen auf derselben Fläche, deshalb erscheint alles hier Gezeichnete auf jeder Seite des Motorrads — gespiegelt, und nicht dort, wo man es auf der anderen Seite erwarten würde.",
+  "designer.focusHint": "Doppelklick auf ein Teil füllt die Ansicht damit.",
+  "designer.partOver": "{{part}} auf {{over}}",
+  "designer.face.under": "Unterseite",
+  "designer.face.both": "Ober- + Unterseite",
+  "designer.faceHint.under":
+    "Diese Fläche ist die Unterseite des Teils — hier Gemaltes zeigt zum Boden und ist von außen nie zu sehen.",
+  "designer.faceHint.both":
+    "Ober- und Unterseite des Teils liegen auf derselben Fläche, deshalb landet alles hier Gezeichnete auf beiden.",
   "designer.opacity": "Deckkraft",
   "designer.blend": "Modus",
   "designer.blend.normal": "Normal",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1531,6 +1531,14 @@ export const en = {
   "designer.flank.both": "both sides",
   "designer.flankSharedHint":
     "Both flanks are unwrapped onto this same area, so anything drawn here appears on each side of the bike — mirrored, and not where you would expect it on the far one.",
+  "designer.focusHint": "Double-click a part to fill the view with it.",
+  "designer.partOver": "{{part}} on {{over}}",
+  "designer.face.under": "underside",
+  "designer.face.both": "top + underside",
+  "designer.faceHint.under":
+    "This area is the underside of the panel — painted here, it faces the ground and is never seen from outside.",
+  "designer.faceHint.both":
+    "A panel's outer skin and its underside share this area, so anything drawn here lands on both.",
   "designer.opacity": "Opacity",
   "designer.blend": "Blend",
   "designer.blend.normal": "Normal",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1564,6 +1564,14 @@ export const es: Translation = {
   "designer.flank.both": "ambos lados",
   "designer.flankSharedHint":
     "Los dos flancos se despliegan sobre esta misma zona, así que lo que dibujes aquí aparece en ambos lados de la moto: reflejado, y no donde lo esperarías en el otro.",
+  "designer.focusHint": "Haz doble clic en una pieza para llenar la vista con ella.",
+  "designer.partOver": "{{part}} sobre {{over}}",
+  "designer.face.under": "cara interior",
+  "designer.face.both": "exterior + interior",
+  "designer.faceHint.under":
+    "Esta zona es la cara interior de la pieza: lo que pintes aquí mira al suelo y nunca se ve desde fuera.",
+  "designer.faceHint.both":
+    "La cara exterior de la pieza y su cara interior comparten esta zona, así que lo que dibujes aquí cae en las dos.",
   "designer.opacity": "Opacidad",
   "designer.blend": "Fusión",
   "designer.blend.normal": "Normal",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1568,6 +1568,14 @@ export const fr: Translation = {
   "designer.flank.both": "les deux côtés",
   "designer.flankSharedHint":
     "Les deux flancs sont dépliés sur cette même zone : ce que vous dessinez ici apparaît de chaque côté de la moto, en miroir, et pas là où vous l'attendriez de l'autre côté.",
+  "designer.focusHint": "Double-cliquez sur une pièce pour remplir la vue avec elle.",
+  "designer.partOver": "{{part}} sur {{over}}",
+  "designer.face.under": "face intérieure",
+  "designer.face.both": "extérieur + intérieur",
+  "designer.faceHint.under":
+    "Cette zone est la face intérieure de la pièce : ce que vous y peignez regarde le sol et ne se voit jamais de l'extérieur.",
+  "designer.faceHint.both":
+    "La face extérieure de la pièce et sa face intérieure partagent cette zone : ce que vous dessinez ici se retrouve sur les deux.",
   "designer.opacity": "Opacité",
   "designer.blend": "Fusion",
   "designer.blend.normal": "Normal",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1555,6 +1555,14 @@ export const it: Translation = {
   "designer.flank.both": "entrambi i lati",
   "designer.flankSharedHint":
     "I due fianchi sono mappati sulla stessa area, quindi ciò che disegni qui compare su entrambi i lati della moto: speculare, e non dove te lo aspetteresti sull'altro.",
+  "designer.focusHint": "Fai doppio clic su un pezzo per riempire la vista con esso.",
+  "designer.partOver": "{{part}} su {{over}}",
+  "designer.face.under": "lato interno",
+  "designer.face.both": "esterno + interno",
+  "designer.faceHint.under":
+    "Quest'area è il lato interno del pezzo: ciò che dipingi qui guarda a terra e non si vede mai da fuori.",
+  "designer.faceHint.both":
+    "Il lato esterno del pezzo e quello interno condividono quest'area, quindi ciò che disegni qui finisce su entrambi.",
   "designer.opacity": "Opacità",
   "designer.blend": "Fusione",
   "designer.blend.normal": "Normale",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1555,6 +1555,14 @@ export const ptBR: Translation = {
   "designer.flank.both": "ambos os lados",
   "designer.flankSharedHint":
     "Os dois flancos são abertos sobre a mesma área, então o que você desenha aqui aparece nos dois lados da moto: espelhado, e não onde você esperaria no outro.",
+  "designer.focusHint": "Dê um duplo clique numa peça para preencher a vista com ela.",
+  "designer.partOver": "{{part}} sobre {{over}}",
+  "designer.face.under": "lado de baixo",
+  "designer.face.both": "de cima + de baixo",
+  "designer.faceHint.under":
+    "Esta área é o lado de baixo da peça: o que você pintar aqui fica virado para o chão e nunca é visto por fora.",
+  "designer.faceHint.both":
+    "O lado de cima da peça e o de baixo dividem esta área, então o que você desenha aqui cai nos dois.",
   "designer.opacity": "Opacidade",
   "designer.blend": "Mesclagem",
   "designer.blend.normal": "Normal",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -388,6 +388,14 @@ export interface BikeModel {
    * Designer's reference underlay is the one place that difference matters.
    */
   base: PaintTexture[];
+  /**
+   * Whether the bike's `.geom` placed the parts into one frame.
+   *
+   * False means each node is still in its own local frame, so a vertex's position and normal
+   * say nothing about where it sits on the bike. The Designer names a sheet region's flank and
+   * facing from exactly those, and stays quiet rather than guessing when this is false.
+   */
+  assembled: boolean;
 }
 
 export interface RiderPart {


### PR DESCRIPTION
The hover asked whichever part won the pick which flank of the bike it was, and `partAt` deliberately lets the **smallest** part win — so a bracket sharing a shroud's island answered for the shroud, and a region on the right of the bike came up as the left. Reported on a TM bike: hovering the plastics named `metal 27`, called it the left shroud, and the paint landed on the left.

## What changed

- **The side and the facing are asked of every part covering the point**, via the new `partsAt`. Where two overlap the label names both (`plastics on metal.027`) rather than resolving one out of sight — a texel is worn by whatever binds it, and painting there paints all of them.
- **`BikeModel` reports `assembled`.** Flanks are read off a vertex's x, which only means "left of the bike" once the `.geom` has placed the parts into one frame; an unassembled bike was having sides invented for it. The Designer now says nothing about sides when the bike didn't assemble, and that warning is `log::warn!` rather than an `eprintln!` into a terminal nobody kept.
- **A facing pass**, off the vertex normals and gated on the same fact: the chip reads `underside` or `top + underside`. A rear fender's outer skin and its underside are one part with one name on one island, so artwork could land where nobody would ever see it.
- **Double-click a part to fill the view with it.** A shroud is a tenth of a 2048² sheet. No mode and no modifier, so a paint tool still paints where you clicked.
- **`build_bike_model` fails when the mesh is empty** instead of returning a model with no nodes. The viewer read that as a successful load and drew its stand-in bike, which says *this is your bike* rather than *none of it arrived* — which is what a cloud-synced `.pkz` that hasn't been downloaded yet actually produces.

## Verified

- `tsc --noEmit` and `eslint` clean; 725 Rust tests pass.
- On the reported TM bike: the shroud names the plastics alongside the bracket, the rear fender region reads `underside`, double-click frames a part, and a dataless archive now shows the error instead of the box bike.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)