### PR TITLE
Linux: stop the AppImage blanking its own window, and run FrostMod under Proton

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,8 @@ jobs:
       # Tauri links against the GTK/WebKit stack on Linux; `patchelf` is what the
       # AppImage bundler uses to rewrite the runtime paths. Mirrors ci.yml —
       # including `libasound2-dev`, which cpal's alsa-sys needs to build at all.
+      # `squashfs-tools` is ours: scripts/appimage-drop-bundled-wayland.sh rebuilds the
+      # AppImage's filesystem after taking the bundled libwayland out of it.
       - name: Install Linux system dependencies
         if: startsWith(matrix.platform, 'ubuntu')
         run: |
@@ -70,7 +72,8 @@ jobs:
             librsvg2-dev \
             libsoup-3.0-dev \
             libasound2-dev \
-            patchelf
+            patchelf \
+            squashfs-tools
 
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2
@@ -133,6 +136,12 @@ jobs:
           # tags: a workflow_dispatch build's ref_name is a branch, not a version.
           MXB_RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
         with:
+          # Linux builds through our own wrapper: it runs the same `tauri build`, then takes
+          # the bundled libwayland out of the AppImage and signs it again before this step
+          # collects the bundles — so the image that gets uploaded is the one `latest.json`
+          # carries the signature for. Empty on Windows and macOS, which leaves the action
+          # to detect the package manager as it always has.
+          tauriScript: ${{ startsWith(matrix.platform, 'ubuntu') && 'bash scripts/tauri-build.sh' || '' }}
           tagName: ${{ github.ref_type == 'tag' && github.ref_name || format('v{0}', github.run_number) }}
           releaseName: "MXB App ${{ github.ref_type == 'tag' && github.ref_name || format('build-{0}', github.run_number) }}"
           # What shipped, then which file to download — worded in scripts/release-notes.sh.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased — the Linux app stops carrying the library that blanked its window
+
+### Fixed
+- **The AppImage no longer ships its own libwayland.** linuxdeploy pulls libwayland-client,
+  -cursor, -egl and -server in as dependencies of GTK and WebKit, so our AppImage carried
+  Ubuntu 22.04's copies and put them ahead of the host's on the library path — where the
+  *host's* Mesa loaded them, and then couldn't create an EGL display. That is the window that
+  comes up and never paints. The AppImage excludelist names libwayland-client for exactly this
+  reason; the linuxdeploy build Tauri downloads carries an older copy of that list and bundles
+  it regardless. Release builds now take those four libraries back out of the image before it
+  is published, and sign it again over the bytes that ship, so the app uses the same libwayland
+  as every other program on the machine.
+- **The XWayland workaround from v0.9.1 turned out never to run, and has been dropped.** An
+  AppImage sets `GDK_BACKEND=x11` in its own startup hook, before a line of our code executes
+  — so the default the app set for the same thing could never apply, every AppImage was
+  already going through XWayland, and the white screen that release was meant to cure survived
+  it untouched. Nothing about how an AppImage runs changes here: the hook still says x11. The
+  app now only asks for a backend when `MXB_SAFE_GRAPHICS=1` does, which is the one case where
+  it's a knob somebody is deliberately turning.
+
 ## Unreleased — the sheet says which panel, which side, and which face
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## Unreleased — FrostMod runs on Linux, and the app can see the game there
+
+### Added
+- **FrostMod installs and runs on Linux.** It used to refuse with *FrostMod runs on Windows
+  only*, which was true of the binary and beside the point: on Linux the game is a Windows
+  process too — Steam runs it under Proton — so FrostMod belongs in that same Proton prefix,
+  where the process it injects into lives. The app now finds the prefix
+  (`steamapps/compatdata/655500`), finds the Proton build that made it (from the prefix's own
+  `config_info`, so it uses the build Steam used rather than the newest one installed), and
+  starts `frostmod.exe` in it. `--mods` is handed over as the prefix sees the folder —
+  `C:\users\steamuser\…` rather than `/home/…`, which is the same path and not a name FrostMod
+  could have made sense of.
+- **The Reload button works from outside the prefix.** The app is a native Linux process and
+  FrostMod's reload event is a Wine kernel object: nothing this side of the wall can pulse it.
+  So a reload goes as a file instead — FrostMod v0.13.0 reads its command file on a poll — and
+  the status pill reads the process table rather than asking for an event it can't open.
+  Anything older than v0.13.0 is refused with a version to update to, rather than started into
+  a state where the in-game `F8` works and every button here quietly doesn't.
+- **The FrostMod section of Settings, and its log row, appear on Linux** on the same terms as
+  Windows. macOS still hides them: the app launches a CrossOver/Whisky bottle there but does
+  not inject into it.
+
+### Fixed
+- **The app knows when the game is running on Linux.** It answered *no* unconditionally —
+  macOS got a process-table check when Play landed there and Linux was never given one. So Play
+  never greyed out mid-session, and every question that turns on it ("will this paint show now
+  or at the next launch?", "is it safe to move this file?") was answered for a machine where the
+  game supposedly never runs. Under Proton the game is an ordinary Linux process whose command
+  line still names `mxbikes.exe`, so `/proc` finds it — no `ps` needed, which the AppImage
+  doesn't carry.
+
 ## Unreleased — the Linux app stops carrying the library that blanked its window
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ hours), then downloads and installs them on restart.
   `.pkz` / `.pnt` files are placed as-is.
 - **Live reload**: a debounced watcher on `<modsPath>/mods` signals FrostMod to
   reload the game when mods are added — including ones installed outside the app.
+  On Linux that means the game's own Proton prefix: FrostMod is a Windows program
+  and so is the game it injects into, so the app starts it inside
+  `steamapps/compatdata/<appid>` rather than beside itself, and reaches it with a
+  command file instead of a Windows event (nothing outside a Wine prefix can pulse
+  one). Needs FrostMod v0.13.0 or newer, which is what reads that file.
 - **Paint studio**: builds a `.pnt` from `.tga`/`.png` sheets, and unpacks an
   existing paint back into editable sheets that keep the texture names the model
   binds — so a livery made anywhere can be packed, installed and previewed here.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,17 @@ The workflow **publishes** the release with the installers attached
 (`releaseDraft: false`), renames the bundles to `MXB-App-<ver>-<arch>.<ext>` and
 patches `latest.json` so self-update keeps verifying.
 
+The Linux build takes one detour on the way: it goes through
+[`scripts/tauri-build.sh`](scripts/tauri-build.sh), which runs the same `tauri build` the
+other platforms do and then takes the bundled libwayland back out of the AppImage and signs
+it again — [`scripts/appimage-drop-bundled-wayland.sh`](scripts/appimage-drop-bundled-wayland.sh)
+says why, and needs only `squashfs-tools`. It works on an AppImage that has already been
+downloaded too, which is how to hand a Linux tester a fixed build without cutting a tag:
+
+```sh
+scripts/appimage-drop-bundled-wayland.sh MXB-App-0.9.2-amd64.AppImage
+```
+
 A tag can also be created from the GitHub web UI — **Releases → Draft a new
 release → Create new tag on publish** — which is the way to cut one without a
 terminal. **Actions → Release → Run workflow** is *not*: a `workflow_dispatch`

--- a/scripts/appimage-drop-bundled-wayland.sh
+++ b/scripts/appimage-drop-bundled-wayland.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Take the bundled libwayland back out of a built AppImage.
+#
+#   scripts/appimage-drop-bundled-wayland.sh <path/to/App.AppImage>
+#
+# linuxdeploy pulls libwayland-client, -cursor, -egl and -server in as dependencies of GTK
+# and WebKit, so our AppImage carries Ubuntu 22.04's copies and puts them ahead of the
+# host's on the library path. The host's Mesa loads libwayland itself, gets ours instead,
+# and can't create an EGL display — which is the window that comes up and never paints.
+# The AppImage excludelist names libwayland-client for exactly this reason (mesa#11316);
+# the linuxdeploy build Tauri downloads carries an older copy of that list and bundles it
+# anyway.
+#
+# Nothing the app sets can get around it. The loader has resolved these libraries before
+# `main` runs, and the AppImage's own AppRun hook already exports `GDK_BACKEND=x11` — which
+# is why running under XWayland never cured it. Deleting them is the fix: the app then uses
+# the same libwayland every other GTK program on the machine uses.
+#
+# Rebuilt rather than repacked with appimagetool: `--appimage-offset` hands us the exact
+# runtime the bundler shipped and the squashfs superblock its compression, so what comes out
+# is the same AppImage with four fewer libraries in it, and a release build needs no tool it
+# didn't already have — only squashfs-tools.
+#
+# The `.sig` beside the image is over the old bytes, so whatever signs for the updater has
+# to sign again afterwards. scripts/tauri-build.sh, where this runs from, does.
+
+set -euo pipefail
+
+IMAGE="${1:-}"
+if [ -z "$IMAGE" ]; then
+  echo "usage: $0 <path/to/App.AppImage>" >&2
+  exit 2
+fi
+if [ ! -f "$IMAGE" ]; then
+  echo "$0: no such file: $IMAGE" >&2
+  exit 1
+fi
+
+# The host has to own these, because the host's Mesa is what loads them. Everything else
+# linuxdeploy bundled is the app's own business and stays.
+PATTERN='libwayland-*.so*'
+
+for tool in mksquashfs unsquashfs; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "$0: $tool not found — install squashfs-tools" >&2
+    exit 1
+  fi
+done
+
+IMAGE="$(cd "$(dirname "$IMAGE")" && pwd)/$(basename "$IMAGE")"
+name="$(basename "$IMAGE")"
+chmod +x "$IMAGE"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# The runtime unpacks into ./squashfs-root of wherever it's called from, so call it from
+# somewhere disposable. `--appimage-extract` needs no FUSE, which CI hasn't got.
+( cd "$work" && "$IMAGE" --appimage-extract >/dev/null )
+root="$work/squashfs-root"
+
+mapfile -t bundled < <(find "$root" -name "$PATTERN" | sort)
+if [ "${#bundled[@]}" -eq 0 ]; then
+  echo "$name: no bundled libwayland — nothing to drop"
+  exit 0
+fi
+for lib in "${bundled[@]}"; do
+  echo "$name: dropping ${lib#"$root"/}"
+  rm -f "$lib"
+done
+
+# Keep the runtime and the compression the bundler chose rather than deciding either here:
+# an AppImage whose runtime can't read its own filesystem is a worse bug than the one this
+# is fixing.
+offset="$("$IMAGE" --appimage-offset)"
+head -c "$offset" "$IMAGE" >"$work/runtime"
+superblock="$(unsquashfs -o "$offset" -s "$IMAGE")"
+comp="$(awk '/^Compression/ { print $2 }' <<<"$superblock")"
+block="$(awk '/^Block size/ { print $3 }' <<<"$superblock")"
+mksquashfs "$root" "$work/filesystem" \
+  -root-owned -noappend -no-progress \
+  -comp "${comp:-zstd}" -b "${block:-131072}" >/dev/null
+cat "$work/runtime" "$work/filesystem" >"$work/rebuilt"
+chmod +x "$work/rebuilt"
+
+# Prove the rebuilt image before it replaces anything: the runtime has to be able to read
+# the filesystem back, and what we deleted has to be gone from it.
+rm -rf "$root"
+( cd "$work" && ./rebuilt --appimage-extract >/dev/null )
+if [ -n "$(find "$root" -name "$PATTERN" -print -quit)" ]; then
+  echo "$0: libwayland survived the rebuild of $name" >&2
+  exit 1
+fi
+if [ ! -x "$root/AppRun" ]; then
+  echo "$0: the rebuild of $name came out without a runnable AppRun" >&2
+  exit 1
+fi
+
+mv "$work/rebuilt" "$IMAGE"
+chmod +x "$IMAGE"
+echo "$name: rebuilt without the bundled libwayland ($(stat -c %s "$IMAGE") bytes)"

--- a/scripts/tauri-build.sh
+++ b/scripts/tauri-build.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# The build tauri-action runs on Linux — `tauriScript` in .github/workflows/release.yml.
+#
+#   scripts/tauri-build.sh build [args...]
+#
+# The same `tauri build` every other platform gets, plus the one thing that has to happen
+# in between the bundler writing the AppImage and the action collecting it: the bundled
+# libwayland comes out (scripts/appimage-drop-bundled-wayland.sh, which says why), and the
+# updater signature is taken again over the bytes that will actually ship. Doing it here
+# rather than after the release is published means the action uploads the stripped image
+# and writes `latest.json` from the matching signature, so nothing downstream can drift.
+#
+# Windows and macOS don't go through this — the workflow leaves `tauriScript` empty there
+# and the action detects the package manager as before.
+
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(dirname "$here")"
+cd "$root"
+
+# `npx tauri` is the `tauri` script in package.json without npm's round trip through a
+# shell — which matters below, where the bundle's path has a space in it.
+npx tauri "$@"
+
+# `tauri dev` and the rest produce no bundles to fix up.
+if [ "${1:-}" != "build" ]; then
+  exit 0
+fi
+
+shopt -s nullglob
+# Second pattern for a `--target`ed build, which bundles under the triple instead.
+images=(
+  src-tauri/target/release/bundle/appimage/*.AppImage
+  src-tauri/target/*/release/bundle/appimage/*.AppImage
+)
+if [ "${#images[@]}" -eq 0 ]; then
+  echo "$0: no AppImage in this build — nothing to fix up"
+  exit 0
+fi
+
+for image in "${images[@]}"; do
+  bash "$here/appimage-drop-bundled-wayland.sh" "$image"
+
+  # The bundler signed the file the updater is about to be told to trust, and those bytes
+  # have changed. Without this every Linux self-update fails signature verification.
+  if [ -f "$image.sig" ]; then
+    echo "$(basename "$image"): signing again over the rebuilt image"
+    npx tauri signer sign "$image"
+  fi
+done

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -810,7 +810,10 @@ pub fn detect_game_path(game: &GameProfile) -> Option<String> {
 
 /// Candidate Steam library roots: the default install locations plus any extra
 /// libraries registered in `steamapps/libraryfolders.vdf`.
-fn steam_libraries() -> Vec<PathBuf> {
+///
+/// Also used by [`crate::proton`] on Linux, where a game's Proton prefix sits under the
+/// same `steamapps` as the game itself — including on a second drive.
+pub(crate) fn steam_libraries() -> Vec<PathBuf> {
     let mut roots: Vec<PathBuf> = Vec::new();
     let mut push = |roots: &mut Vec<PathBuf>, p: PathBuf| {
         if !roots.contains(&p) {

--- a/src-tauri/src/frostmod.rs
+++ b/src-tauri/src/frostmod.rs
@@ -72,12 +72,37 @@ pub fn is_running() -> bool {
     true
 }
 
-#[cfg(not(windows))]
+/// Linux: FrostMod runs under Proton and its reload event is a Wine kernel object we have
+/// no way to open from out here — this app is a native Linux process outside the prefix.
+/// The command file is the way in instead (see `send_command`), and `reload_mods` is the
+/// verb FrostMod v0.13.0 added for exactly this. A FrostMod too old to read that file is
+/// refused a start at all ([`reads_command_files`]), so anything running here can hear us.
+#[cfg(target_os = "linux")]
+pub fn signal_reload() -> ReloadOutcome {
+    match send_command(command_json("reload_mods", "")) {
+        CommandOutcome::Signaled => ReloadOutcome::Signaled,
+        CommandOutcome::NotRunning => ReloadOutcome::NotRunning,
+        // A command we couldn't write is a reload that won't happen, and saying "not
+        // running" about a FrostMod that is running would send the player looking in the
+        // wrong place — but there is no truer answer in this enum, and the write failure
+        // is logged where it happens.
+        _ => ReloadOutcome::NotRunning,
+    }
+}
+
+/// Linux: the launcher is a Windows process inside the prefix, so the process table is
+/// where we can see it — its reload event isn't reachable from this side.
+#[cfg(target_os = "linux")]
+pub fn is_running() -> bool {
+    crate::proton::running_exe("frostmod.exe")
+}
+
+#[cfg(not(any(windows, target_os = "linux")))]
 pub fn signal_reload() -> ReloadOutcome {
     ReloadOutcome::Unsupported
 }
 
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_os = "linux")))]
 pub fn is_running() -> bool {
     false
 }
@@ -107,17 +132,64 @@ pub fn is_running() -> bool {
 #[cfg(windows)]
 const COMMAND_EVENT_NAME: &[u8] = b"Local\\FrostModCommand\0";
 
+/// Where a Linux build leaves commands: FrostMod's own folder, which this app owns and
+/// which FrostMod (v0.13.0+) reads as well as `%TEMP%`.
+///
+/// Set once at startup rather than passed in, because the senders below are called from
+/// folder watchers and install jobs that hold no Tauri handle to resolve a data dir with,
+/// and threading one through every caller would buy nothing: there is only ever one
+/// FrostMod folder per run.
+#[cfg(target_os = "linux")]
+static COMMAND_DIR: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+
+/// Tell the sender where FrostMod is installed. Called once, from setup.
+#[cfg(target_os = "linux")]
+pub fn set_command_dir(dir: std::path::PathBuf) {
+    let _ = COMMAND_DIR.set(dir);
+}
+
 /// Command file FrostMod reads when the command event fires. Same temp dir the
 /// DLL uses — `std::env::temp_dir()` resolves to the `%TEMP%` that FrostMod's
 /// `GetTempPathA` returns.
+#[cfg(not(target_os = "linux"))]
 fn command_file_path() -> std::path::PathBuf {
     std::env::temp_dir().join("frostmod_cmd.json")
 }
 
+/// Linux: FrostMod's folder, not `/tmp`. Our `/tmp` is not the `%TEMP%` a program inside
+/// the Wine prefix resolves, and FrostMod's folder is one directory both sides can name.
+#[cfg(target_os = "linux")]
+fn command_file_path() -> std::path::PathBuf {
+    COMMAND_DIR
+        .get()
+        .cloned()
+        .unwrap_or_else(std::env::temp_dir)
+        .join("frostmod_cmd.json")
+}
+
 /// Serialize a command. Kept pure (no I/O) so it can be unit-tested and so the
 /// on-disk contract with frostmod.cpp is exercised without a game.
+///
+/// `at` is what makes two identical commands two different documents. It costs nothing on
+/// Windows, where an event says "read this now" — but on Linux the file *is* the signal,
+/// and FrostMod decides a command is new by comparing what it last acted on with what is
+/// on disk now. Without a stamp, pressing Reload twice would write the same bytes twice
+/// and the second press would be indistinguishable from no press at all.
+fn command_json_at(verb: &str, bike_id: &str, at: u128) -> String {
+    serde_json::json!({ "verb": verb, "bikeId": bike_id, "at": at.to_string() }).to_string()
+}
+
 fn command_json(verb: &str, bike_id: &str) -> String {
-    serde_json::json!({ "verb": verb, "bikeId": bike_id }).to_string()
+    command_json_at(verb, bike_id, now_millis())
+}
+
+/// Milliseconds since the epoch, or 0 from a clock we can't read — a stamp that never
+/// moves is no worse than the no-stamp behaviour it replaced.
+fn now_millis() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
 }
 
 #[allow(dead_code)]
@@ -164,7 +236,27 @@ fn send_command(json: String) -> CommandOutcome {
     }
 }
 
-#[cfg(not(windows))]
+/// Linux: the file is the whole signal. There is no event to pulse — `Local\FrostModCommand`
+/// belongs to the Wine prefix FrostMod runs in, and this process is outside it — so the
+/// write lands in FrostMod's folder and its poll picks it up within about a fifth of a
+/// second. Whether it's running is asked of the process table first, so a command isn't
+/// left on disk for a FrostMod that will read it at some unrelated future start-up.
+#[cfg(target_os = "linux")]
+fn send_command(json: String) -> CommandOutcome {
+    if !is_running() {
+        return CommandOutcome::NotRunning;
+    }
+    let path = command_file_path();
+    match std::fs::write(&path, json) {
+        Ok(()) => CommandOutcome::Signaled,
+        Err(e) => {
+            log::warn!("couldn't write the FrostMod command file {}: {e}", path.display());
+            CommandOutcome::WriteFailed
+        }
+    }
+}
+
+#[cfg(not(any(windows, target_os = "linux")))]
 fn send_command(json: String) -> CommandOutcome {
     // Still write the command file on dev builds so the contract can be inspected.
     let _ = std::fs::write(command_file_path(), json);
@@ -232,6 +324,27 @@ pub fn model_refresh_is_safe(tag: Option<&str>) -> bool {
     }
 }
 
+/// The oldest FrostMod that can be driven from Linux.
+///
+/// Not a safety floor like the two around it — a capability one. Every FrostMod before
+/// v0.13.0 reads its command file only when the command *event* fires, and that event is a
+/// Wine kernel object: a native Linux app can't pulse it, so an older build under Proton
+/// would take every write and never look. It would inject fine and reload on `F8`, and
+/// every button in this app would quietly do nothing. v0.13.0 is the release that polls
+/// the file, so on Linux it is the floor for starting FrostMod at all.
+pub const FILE_CHANNEL_MIN_VERSION: &str = "v0.13.0";
+
+/// Does the installed FrostMod, tagged `tag`, read commands from a file?
+///
+/// An unreadable tag counts as no — same reasoning as the floors around it, with a milder
+/// cost: the player is told to update rather than left with buttons that do nothing.
+pub fn reads_command_files(tag: Option<&str>) -> bool {
+    match (tag.and_then(version_parts), version_parts(FILE_CHANNEL_MIN_VERSION)) {
+        (Some(have), Some(min)) => have >= min,
+        _ => false,
+    }
+}
+
 /// The oldest FrostMod that is safe to run against GP Bikes.
 ///
 /// Same shape as [`MODEL_REFRESH_MIN_VERSION`], and the same kind of reason. FrostMod
@@ -267,15 +380,40 @@ mod tests {
     #[test]
     fn swap_command_json_shape_and_escaping() {
         assert_eq!(
-            command_json("swap_bike", "MX2OEM_2023_KTM_250_SX-F"),
-            r#"{"bikeId":"MX2OEM_2023_KTM_250_SX-F","verb":"swap_bike"}"#
+            command_json_at("swap_bike", "MX2OEM_2023_KTM_250_SX-F", 1_723_600_000_000),
+            r#"{"at":"1723600000000","bikeId":"MX2OEM_2023_KTM_250_SX-F","verb":"swap_bike"}"#
         );
         // Ids are arbitrary folder names — ensure quotes/backslashes are escaped.
         // frostmod.cpp's JsonStringField unescapes \" and \\ to match.
         assert_eq!(
-            command_json("swap_bike", r#"a"b\c"#),
-            r#"{"bikeId":"a\"b\\c","verb":"swap_bike"}"#
+            command_json_at("swap_bike", r#"a"b\c"#, 1),
+            r#"{"at":"1","bikeId":"a\"b\\c","verb":"swap_bike"}"#
         );
+    }
+
+    /// What the stamp is for: on Linux the file is the signal, and FrostMod tells a new
+    /// command from an old one by comparing bytes. Two presses of the same button have to
+    /// come out as two different documents or the second one never happens.
+    #[test]
+    fn the_same_command_twice_is_two_different_documents() {
+        assert_ne!(
+            command_json_at("reload_mods", "", 1_723_600_000_000),
+            command_json_at("reload_mods", "", 1_723_600_000_001),
+        );
+    }
+
+    /// The floor exists because an older FrostMod fails *silently* on Linux: it takes the
+    /// write, never polls, and every button in the app looks like it worked.
+    #[test]
+    fn only_a_frostmod_that_polls_is_driven_from_linux() {
+        assert!(reads_command_files(Some("v0.13.0")));
+        assert!(reads_command_files(Some("v0.13.1")));
+        assert!(reads_command_files(Some("v1.0.0")));
+        assert!(!reads_command_files(Some("v0.12.1")));
+        // The numeric-not-lexical trap again: "v0.9.11" sorts above "v0.13.0" as a string.
+        assert!(!reads_command_files(Some("v0.9.11")));
+        assert!(!reads_command_files(None));
+        assert!(!reads_command_files(Some("nightly")));
     }
 
     #[test]
@@ -375,8 +513,18 @@ mod tests {
     fn refresh_command_json_uses_the_verb_frostmod_dispatches_on() {
         // The verb string is the contract with HandleFrostModCommand in frostmod.cpp.
         assert_eq!(
-            command_json("refresh_bike_model", "MX1OEM_1996_Honda_CR250"),
-            r#"{"bikeId":"MX1OEM_1996_Honda_CR250","verb":"refresh_bike_model"}"#
+            command_json_at("refresh_bike_model", "MX1OEM_1996_Honda_CR250", 7),
+            r#"{"at":"7","bikeId":"MX1OEM_1996_Honda_CR250","verb":"refresh_bike_model"}"#
+        );
+    }
+
+    /// The Reload button's verb on Linux, where there is no event to send instead. Same
+    /// contract file, same dispatcher — `reload_mods` in frostmod.cpp.
+    #[test]
+    fn reload_has_a_verb_of_its_own_for_a_platform_with_no_event() {
+        assert_eq!(
+            command_json_at("reload_mods", "", 7),
+            r#"{"at":"7","bikeId":"","verb":"reload_mods"}"#
         );
     }
 }

--- a/src-tauri/src/frostmod_manage.rs
+++ b/src-tauri/src/frostmod_manage.rs
@@ -407,11 +407,15 @@ fn release_binaries(rel: &Release) -> anyhow::Result<Vec<(&'static str, &Asset)>
 /// Download `frostmod.exe` + `frostmod.dll` from the latest release and put them in
 /// place as one unit.
 ///
-/// Refused off Windows: FrostMod is a Win32 DLL injected into the game, so downloading it
-/// elsewhere just parks two unusable binaries in the app's data dir before `start()` bails.
+/// Windows and Linux. FrostMod is a Win32 DLL injected into the game, and on Linux the
+/// game is a Win32 process too — Steam runs it under Proton — so the same two binaries go
+/// into the same prefix and do the same job (see [`crate::proton`]). macOS is refused
+/// because nothing there starts them: the game lives in a CrossOver/Whisky bottle the app
+/// launches but doesn't inject into, and downloading anyway would park two unusable
+/// binaries in the data dir before `start()` bailed.
 pub async fn install(app: &AppHandle) -> anyhow::Result<InstallReport> {
-    if cfg!(not(windows)) {
-        anyhow::bail!("FrostMod runs on Windows only");
+    if cfg!(not(any(windows, target_os = "linux"))) {
+        anyhow::bail!("FrostMod runs on Windows and Linux (under Proton)");
     }
     let rel = latest_release().await?;
     let assets = release_binaries(&rel)?;
@@ -462,15 +466,25 @@ pub async fn install(app: &AppHandle) -> anyhow::Result<InstallReport> {
     })
 }
 
-/// Launch `frostmod.exe` hidden as a managed child. Windows-only.
-#[cfg(windows)]
-pub fn start(app: &AppHandle, state: &FrostmodProcess) -> anyhow::Result<bool> {
-    use std::os::windows::process::CommandExt;
-    /// Don't pop a console window for the headless reloader.
-    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+/// What both platforms need settled before FrostMod can be started, and nothing about how
+/// it is started — that is where Windows and Linux part company.
+#[cfg(any(windows, target_os = "linux"))]
+struct StartPlan {
+    exe: PathBuf,
+    /// `mxb` / `gpb`, for `--game`.
+    game: &'static str,
+    /// The mods *tree*, when the player has a folder set. Still a host path: Linux has to
+    /// rewrite it as the prefix sees it before handing it over.
+    mods_root: Option<PathBuf>,
+}
 
+/// Check what has to be true before starting, and work out what to tell FrostMod.
+///
+/// `None` means FrostMod is already running and there is nothing to do.
+#[cfg(any(windows, target_os = "linux"))]
+fn plan_start(app: &AppHandle) -> anyhow::Result<Option<StartPlan>> {
     if crate::frostmod::is_running() {
-        return Ok(false);
+        return Ok(None);
     }
     let exe = exe_path(app);
     if !exe.exists() {
@@ -510,13 +524,24 @@ pub fn start(app: &AppHandle, state: &FrostmodProcess) -> anyhow::Result<bool> {
     // to whatever `--mods` gives it (its own default is `…\MX Bikes\mods`), so sending
     // `cfg.mods_path` pointed its track manager and model swap at folders that don't
     // exist — silently, since neither reports an empty root as an error.
-    let mods_root = crate::library::mods_root(&cfg.mods_path);
-    let mods_root = mods_root.to_string_lossy();
-    let mut args: Vec<&str> = vec!["--game", cfg.active_game.id()];
-    if !cfg.mods_path.trim().is_empty() {
-        args.extend(["--mods", mods_root.as_ref()]);
+    let mods_root = (!cfg.mods_path.trim().is_empty())
+        .then(|| crate::library::mods_root(&cfg.mods_path));
+    Ok(Some(StartPlan { exe, game: cfg.active_game.id(), mods_root }))
+}
+
+/// Launch `frostmod.exe` hidden as a managed child.
+#[cfg(windows)]
+pub fn start(app: &AppHandle, state: &FrostmodProcess) -> anyhow::Result<bool> {
+    use std::os::windows::process::CommandExt;
+    /// Don't pop a console window for the headless reloader.
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+    let Some(plan) = plan_start(app)? else { return Ok(false) };
+    let mut args: Vec<String> = vec!["--game".into(), plan.game.into()];
+    if let Some(mods) = &plan.mods_root {
+        args.extend(["--mods".into(), mods.to_string_lossy().into_owned()]);
     }
-    let child = std::process::Command::new(&exe)
+    let child = std::process::Command::new(&plan.exe)
         .current_dir(frostmod_dir(app))
         .args(&args)
         .creation_flags(CREATE_NO_WINDOW)
@@ -525,9 +550,88 @@ pub fn start(app: &AppHandle, state: &FrostmodProcess) -> anyhow::Result<bool> {
     Ok(true)
 }
 
-#[cfg(not(windows))]
+/// Where Proton's own output goes on Linux, appended to across a session so a start that
+/// worked and a later one that didn't are both in it. Falls back to discarding the output
+/// rather than failing a start over a log file.
+#[cfg(target_os = "linux")]
+fn proton_log(app: &AppHandle) -> std::process::Stdio {
+    /// Past this, the interesting part is the end anyway — and a log the player is asked
+    /// to attach to a report has to stay attachable.
+    const MAX_BYTES: u64 = 1024 * 1024;
+
+    let path = frostmod_dir(app).join("proton.log");
+    let overgrown = std::fs::metadata(&path).is_ok_and(|m| m.len() > MAX_BYTES);
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(!overgrown)
+        .write(overgrown)
+        .truncate(overgrown)
+        .open(&path)
+        .map(std::process::Stdio::from)
+        .unwrap_or_else(|_| std::process::Stdio::null())
+}
+
+/// Launch `frostmod.exe` inside the Proton prefix the game runs in.
+///
+/// Not "run the Windows binary somehow": FrostMod injects a DLL into `mxbikes.exe`, which
+/// only works from inside the same prefix — the same Wine session, sharing the same
+/// process namespace. [`crate::proton`] is what finds that prefix and the Proton build
+/// that owns it.
+#[cfg(target_os = "linux")]
+pub fn start(app: &AppHandle, state: &FrostmodProcess) -> anyhow::Result<bool> {
+    let Some(plan) = plan_start(app)? else { return Ok(false) };
+
+    // A FrostMod that doesn't poll its command file can't be driven from here at all: it
+    // would inject and reload on F8, while every button in this app wrote a file nothing
+    // ever read. Better to say so than to hand over a half-working install.
+    if !crate::frostmod::reads_command_files(installed_version(app).as_deref()) {
+        anyhow::bail!(
+            "This FrostMod build can't be driven from Linux — update FrostMod to {} or \
+             newer. (Under Proton the app can only reach FrostMod through a file, which \
+             older builds don't read.)",
+            crate::frostmod::FILE_CHANNEL_MIN_VERSION,
+        );
+    }
+
+    let cfg = crate::config::load(app).unwrap_or_default();
+    let runner = crate::proton::find(cfg.game(), &cfg.wine_runner)?;
+
+    let mut args: Vec<String> = vec!["--game".into(), plan.game.into()];
+    if let Some(mods) = &plan.mods_root {
+        // FrostMod is a Windows program: it takes `C:\users\…`, not the `/home/…` this
+        // side of the wall calls the same folder.
+        args.extend(["--mods".into(), crate::proton::windows_path(&runner.prefix(), mods)]);
+    }
+
+    log::info!(
+        "starting FrostMod via {}: {} run {} {:?} (prefix {})",
+        runner.via(),
+        runner.program.display(),
+        plan.exe.display(),
+        args,
+        runner.prefix().display(),
+    );
+    let child = runner
+        .command(&plan.exe, &args)
+        .current_dir(frostmod_dir(app))
+        // FrostMod is a console program and Proton says a great deal on its way to
+        // starting one — none of which would otherwise be anywhere, since the app's own
+        // stdout goes nowhere a player can reach. It lands in FrostMod's folder, where
+        // the log collector already picks up everything that isn't one of our binaries:
+        // if injection under Proton ever fails, this is the file that says why.
+        .stdout(proton_log(app))
+        .stderr(proton_log(app))
+        .spawn()
+        .map_err(|e| {
+            anyhow::anyhow!("Couldn't start FrostMod through {}: {e}", runner.via())
+        })?;
+    *state.0.lock().unwrap() = Some(child);
+    Ok(true)
+}
+
+#[cfg(not(any(windows, target_os = "linux")))]
 pub fn start(_app: &AppHandle, _state: &FrostmodProcess) -> anyhow::Result<bool> {
-    anyhow::bail!("FrostMod runs on Windows only")
+    anyhow::bail!("FrostMod runs on Windows and Linux (under Proton)")
 }
 
 /// Kill the managed FrostMod child, if we started one.
@@ -549,7 +653,16 @@ pub fn force_stop_exe() {
         .output();
 }
 
-#[cfg(not(windows))]
+/// Linux: killing the managed child only reaches the Proton script we spawned, and the
+/// launcher it started inside the prefix outlives it — the status pill would keep saying
+/// "running" because, correctly, it still is. So the process table is asked for everything
+/// running `frostmod.exe`, which is that wrapper *and* the Wine process under it.
+#[cfg(target_os = "linux")]
+pub fn force_stop_exe() {
+    crate::proton::kill_exe("frostmod.exe");
+}
+
+#[cfg(not(any(windows, target_os = "linux")))]
 pub fn force_stop_exe() {}
 
 /// How long to wait for a stopped FrostMod to actually go before calling it a failure.

--- a/src-tauri/src/gameproc.rs
+++ b/src-tauri/src/gameproc.rs
@@ -460,7 +460,17 @@ pub fn is_game_running() -> bool {
     )
 }
 
-#[cfg(not(any(windows, target_os = "macos")))]
+/// Under Proton the game is an ordinary Linux process whose command line still names
+/// `mxbikes.exe`, wrappers and all, so `/proc` finds it. Without this the app believes the
+/// game is never running: Play never greys out, and everything that asks "is it up?" —
+/// whether a paint will show now or next launch, whether it's safe to move files — has
+/// been answering for a machine where the game can't run at all.
+#[cfg(target_os = "linux")]
+pub fn is_game_running() -> bool {
+    crate::proton::running_exe(crate::game::active().exe)
+}
+
+#[cfg(not(any(windows, target_os = "macos", target_os = "linux")))]
 pub fn is_game_running() -> bool {
     false
 }

--- a/src-tauri/src/logs.rs
+++ b/src-tauri/src/logs.rs
@@ -111,6 +111,10 @@ fn is_frostmod_log(name: &str) -> bool {
         || lower.ends_with(".dll")
         || lower == "version.txt"
         || lower.ends_with(".yaml")
+        // The last command we left for FrostMod (Linux, where a file is the only way to
+        // reach it). Ours by the same rule as the binaries — and what FrostMod *did* with
+        // it is in its log, which is the half worth collecting.
+        || lower == "frostmod_cmd.json"
         // A binary moved aside mid-update because the game still had it mapped —
         // `frostmod.dll.in-use-1723…`, swept on the next start.
         || lower.contains(".in-use-");
@@ -353,6 +357,9 @@ mod tests {
         assert!(!is_frostmod_log("version.txt"));
         assert!(!is_frostmod_log("frostmod_serverfilter.yaml"));
         assert!(!is_frostmod_log("frostmod.dll.in-use-1723500000"));
+        // The command we last left for it. Ours, not a log — FrostMod's own log says what
+        // it made of it.
+        assert!(!is_frostmod_log("frostmod_cmd.json"));
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5897,9 +5897,6 @@ fn log_level() -> log::LevelFilter {
 /// the only way to test any of this from a machine that isn't the one it's for.
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
 struct GraphicsEnv {
-    /// Exported by the AppImage runtime. A `.deb`/`.rpm` install links the host's own
-    /// libraries, so the mismatch below can't reach it.
-    appimage: bool,
     /// The compositor's socket — set on any Wayland session, gamescope included.
     wayland: bool,
     /// An X server is reachable, real or XWayland.
@@ -5912,7 +5909,6 @@ impl GraphicsEnv {
     fn read() -> Self {
         let set = |key: &str| std::env::var_os(key).is_some_and(|v| !v.is_empty());
         Self {
-            appimage: set("APPIMAGE"),
             wayland: set("WAYLAND_DISPLAY"),
             x_server: set("DISPLAY"),
             safe_mode: std::env::var("MXB_SAFE_GRAPHICS").unwrap_or_default() == "1",
@@ -5920,8 +5916,8 @@ impl GraphicsEnv {
     }
 }
 
-/// The environment WebKitGTK should start under. Two separate faults both end as a white
-/// window, and each has its own knob here.
+/// The environment WebKitGTK should start under: the renderer every session falls back to,
+/// and the knobs `MXB_SAFE_GRAPHICS` turns when a window still won't paint.
 fn webview_env_defaults(env: GraphicsEnv) -> Vec<(&'static str, &'static str)> {
     // DMA-BUF asks the WebKit our AppImage carries from Ubuntu 22.04 to negotiate buffers
     // with whatever Mesa the host ships; where that fails it fails silently, painting
@@ -5929,12 +5925,17 @@ fn webview_env_defaults(env: GraphicsEnv) -> Vec<(&'static str, &'static str)> {
     // of mostly static lists — and paints everywhere.
     let mut vars = vec![("WEBKIT_DISABLE_DMABUF_RENDERER", "1")];
 
-    // WebKitGTK 2.46+ aborts outright when it can't create an EGL display, and our AppImage
-    // bundles Ubuntu 22.04's libwayland next to the host's Mesa — the pairing the AppImage
-    // excludelist warns about. XWayland never goes down that path. Guarded on there being
-    // an X server to land on: forcing the backend without one trades a white screen for no
-    // window at all.
-    if env.wayland && env.x_server && (env.appimage || env.safe_mode) {
+    // The other fault — WebKitGTK 2.46+ aborting because it can't create an EGL display —
+    // was the bundled libwayland, and it is fixed where it was made: the AppImage no longer
+    // carries those libraries at all (scripts/appimage-drop-bundled-wayland.sh). Nothing
+    // here could have fixed it, and the version that tried never even ran: an AppImage's
+    // AppRun hook exports `GDK_BACKEND=x11` itself, before this process starts, so the
+    // default below was already set by the time we looked.
+    //
+    // What's left is the hand-operated fallback: an X server is a second graphics stack to
+    // land on when a machine still won't paint. Guarded on there being one — forcing the
+    // backend without it trades a white screen for no window at all.
+    if env.safe_mode && env.wayland && env.x_server {
         vars.push(("GDK_BACKEND", "x11"));
     }
 
@@ -6491,7 +6492,6 @@ mod webview_env_tests {
     /// SteamOS, both modes: Desktop is Plasma Wayland and gamescope is a compositor of its
     /// own, and each runs an XWayland the app can land on instead.
     const STEAMOS: GraphicsEnv = GraphicsEnv {
-        appimage: true,
         wayland: true,
         x_server: true,
         safe_mode: false,
@@ -6504,7 +6504,7 @@ mod webview_env_tests {
         for env in [
             GraphicsEnv::default(),
             STEAMOS,
-            GraphicsEnv { appimage: false, ..STEAMOS },
+            GraphicsEnv { wayland: false, ..STEAMOS },
             GraphicsEnv { safe_mode: true, ..STEAMOS },
         ] {
             assert_eq!(
@@ -6515,19 +6515,13 @@ mod webview_env_tests {
         }
     }
 
-    /// The bug this exists for: WebKitGTK aborts on EGL_BAD_PARAMETER and the window never
-    /// paints. XWayland sidesteps the EGL path the bundled libwayland breaks.
+    /// Nothing here forces a backend of its own accord any more. The EGL abort this used to
+    /// answer for was the AppImage's bundled libwayland, taken out of the bundle itself; an
+    /// AppImage is on XWayland regardless, because its AppRun hook says so before this
+    /// process starts.
     #[test]
-    fn an_appimage_on_wayland_goes_through_xwayland() {
-        assert_eq!(defaults(STEAMOS).get("GDK_BACKEND"), Some(&"x11"));
-    }
-
-    /// A `.deb`/`.rpm` links the host's libwayland, so it never hits the mismatch — and
-    /// XWayland would cost it sharpness under fractional scaling for nothing.
-    #[test]
-    fn an_installed_build_keeps_native_wayland() {
-        let installed = GraphicsEnv { appimage: false, ..STEAMOS };
-        assert_eq!(defaults(installed).get("GDK_BACKEND"), None);
+    fn a_wayland_session_is_left_on_its_own_backend() {
+        assert_eq!(defaults(STEAMOS).get("GDK_BACKEND"), None);
     }
 
     /// Without an X server to fall back to, forcing the backend trades a white screen for
@@ -6541,11 +6535,15 @@ mod webview_env_tests {
         assert_eq!(defaults(safe).get("GDK_BACKEND"), None);
     }
 
-    /// GTK already picks X11 there; saying so again would only be noise in the log.
+    /// GTK already picks X11 there; saying so again would only be noise in the log — and
+    /// safe mode has nothing to move the session *to*.
     #[test]
     fn a_plain_x11_session_needs_no_override() {
         let x11_only = GraphicsEnv { wayland: false, ..STEAMOS };
         assert_eq!(defaults(x11_only).get("GDK_BACKEND"), None);
+
+        let safe = GraphicsEnv { safe_mode: true, ..x11_only };
+        assert_eq!(defaults(safe).get("GDK_BACKEND"), None);
     }
 
     /// The escape hatch to hand someone whose screen is still white: every knob at once.
@@ -6555,14 +6553,6 @@ mod webview_env_tests {
         assert_eq!(vars.get("GDK_BACKEND"), Some(&"x11"));
         assert_eq!(vars.get("WEBKIT_DISABLE_COMPOSITING_MODE"), Some(&"1"));
         assert_eq!(vars.get("LIBGL_ALWAYS_SOFTWARE"), Some(&"1"));
-    }
-
-    /// Asking for it by hand reaches an installed build too — the fault it cures needn't be
-    /// the bundled-library one.
-    #[test]
-    fn safe_mode_reaches_an_installed_build() {
-        let installed = GraphicsEnv { appimage: false, safe_mode: true, ..STEAMOS };
-        assert_eq!(defaults(installed).get("GDK_BACKEND"), Some(&"x11"));
     }
 
     /// Nothing is imposed on a desktop that was never broken.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -35,6 +35,9 @@ mod paint;
 mod paintstudio;
 mod paintwatch;
 mod pkz;
+/// Linux only: the Proton prefix the game runs in, and how to put a Windows program in it.
+#[cfg(target_os = "linux")]
+mod proton;
 #[cfg(sidecar)]
 mod sidecar;
 mod presets;
@@ -6138,6 +6141,11 @@ fn main() {
             if let Ok(dir) = app.path().app_local_data_dir() {
                 log::info!("data dir (config/session/frostmod): {}", dir.display());
             }
+            // Linux drives FrostMod by leaving a file in its folder — the one thing this
+            // side of the Wine prefix can reach. Told once here, because the senders are
+            // called from watchers that hold no handle to resolve a data dir with.
+            #[cfg(target_os = "linux")]
+            frostmod::set_command_dir(frostmod_manage::frostmod_dir(app.handle()));
             if let Ok(dir) = app.path().app_log_dir() {
                 log::info!("log dir: {}", dir.display());
             }

--- a/src-tauri/src/proton.rs
+++ b/src-tauri/src/proton.rs
@@ -1,0 +1,441 @@
+//! Running a Windows program inside the Proton prefix the game already uses (Linux).
+//!
+//! MX Bikes has no Linux build. On Linux it is the same `mxbikes.exe`, run by Steam
+//! through Proton inside a Wine prefix at `steamapps/compatdata/<appid>`. FrostMod is a
+//! Win32 launcher that injects a Win32 DLL into that process, so the only place it can
+//! possibly run is *that* prefix — a copy started any other way is a stranger to the game
+//! it is meant to attach to.
+//!
+//! So this module answers three questions, and nothing else:
+//!   - which prefix does this game use, and has it ever been made? ([`find`])
+//!   - which Proton owns it? (`config_info`, then whatever is installed)
+//!   - how does a path we know as `/home/…` read from inside it? ([`windows_path`])
+//!
+//! The macOS equivalent is [`crate::winehost`], which answers the same questions for
+//! CrossOver/Whisky bottles. They stay apart because nothing about the answers is shared:
+//! there the player chose the bottle, here Steam made it.
+
+use std::path::{Path, PathBuf};
+
+/// The fake `C:` drive inside a prefix. Same fact [`crate::winehost`] is built on.
+const DRIVE_C: &str = "drive_c";
+
+/// Everything needed to start a Windows program in the game's prefix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Runner {
+    /// `<library>/steamapps/compatdata/<appid>` — what Proton calls the compat data path.
+    /// The prefix itself is `pfx` inside it.
+    pub compat_data: PathBuf,
+    /// The `proton` script that owns the prefix, or the runner the player named in
+    /// Settings.
+    pub program: PathBuf,
+    /// Steam's own root. Proton refuses to run without being told where it is.
+    pub client: PathBuf,
+    /// Whether `program` is Proton (which takes a `run` verb) or something the player
+    /// pointed us at, which is handed the exe directly.
+    pub kind: RunnerKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunnerKind {
+    /// Valve's `proton` script: `proton run <exe>`, with the compat paths in the
+    /// environment.
+    Proton,
+    /// A binary from Settings — umu-run, a wrapper script, a plain `wine`. Given the exe
+    /// as its first argument and pointed at the prefix with `WINEPREFIX`, which is the one
+    /// form every Wine-ish runner understands.
+    Custom,
+}
+
+impl Runner {
+    pub fn prefix(&self) -> PathBuf {
+        self.compat_data.join("pfx")
+    }
+
+    /// What to call this in a log line.
+    pub fn via(&self) -> &str {
+        match self.kind {
+            RunnerKind::Proton => "Proton",
+            RunnerKind::Custom => "your runner",
+        }
+    }
+
+    /// The command that starts `exe` with `args` inside the prefix.
+    ///
+    /// `STEAM_COMPAT_DATA_PATH` is the whole point: it is what makes this the *game's*
+    /// prefix rather than a fresh one, and so what puts the launcher in the same Windows
+    /// session as the process it wants to inject into.
+    pub fn command(&self, exe: &Path, args: &[String]) -> std::process::Command {
+        let mut cmd = std::process::Command::new(&self.program);
+        match self.kind {
+            RunnerKind::Proton => {
+                cmd.arg("run").arg(exe);
+            }
+            RunnerKind::Custom => {
+                cmd.arg(exe);
+                cmd.env("WINEPREFIX", self.prefix());
+            }
+        }
+        cmd.args(args);
+        cmd.env("STEAM_COMPAT_DATA_PATH", &self.compat_data);
+        cmd.env("STEAM_COMPAT_CLIENT_INSTALL_PATH", &self.client);
+        cmd
+    }
+}
+
+/// The runner for `game`, or an error saying which half is missing.
+///
+/// `override_path` is the Settings escape hatch (the same field macOS uses to name a Wine
+/// binary): an explicit runner always wins, because a machine running Proton from
+/// somewhere we don't look is a machine we can't guess about.
+pub fn find(game: &crate::game::GameProfile, override_path: &str) -> anyhow::Result<Runner> {
+    let (client, compat_data) = compat_data(game).ok_or_else(|| {
+        anyhow::anyhow!(
+            "No Proton prefix for {} yet — start the game through Steam once so Proton \
+             creates it, then start FrostMod.",
+            game.display
+        )
+    })?;
+
+    let chosen = override_path.trim();
+    if !chosen.is_empty() {
+        let program = PathBuf::from(chosen);
+        if !program.is_file() {
+            anyhow::bail!("The Wine/Proton runner set in Settings isn't there: {chosen}");
+        }
+        return Ok(Runner { compat_data, program, client, kind: RunnerKind::Custom });
+    }
+
+    let program = proton_for(&compat_data).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Couldn't find the Proton that runs {} — its prefix is at {}, but no Proton \
+             install named by it (or installed beside it) is there. Reinstalling Proton \
+             for the game in Steam is the fix; a `wineRunner` path in the app's \
+             config.json overrides this if you run Proton from somewhere of your own.",
+            game.display,
+            compat_data.display(),
+        )
+    })?;
+    Ok(Runner { compat_data, program, client, kind: RunnerKind::Proton })
+}
+
+/// The prefix folder inside a compat data dir.
+const PREFIX_DIR: &str = "pfx";
+
+/// The Steam client root, and the game's compat data folder.
+///
+/// Two different things, and a machine with a second drive is where that shows: the
+/// prefix lives beside the game, in whichever *library* holds it, while the client path
+/// Proton wants is where Steam itself is installed. Handing it a library root works
+/// until someone's games are on the other disk.
+///
+/// Only a folder that really holds a `pfx` counts. Steam creates `compatdata/<appid>` for
+/// anything it has *considered* running under Proton, and an empty one names no prefix to
+/// join.
+fn compat_data(game: &crate::game::GameProfile) -> Option<(PathBuf, PathBuf)> {
+    let (library, compat) = crate::config::steam_libraries().into_iter().find_map(|lib| {
+        let dir = lib.join("steamapps").join("compatdata").join(game.steam_appid);
+        dir.join(PREFIX_DIR).is_dir().then_some((lib, dir))
+    })?;
+    // Falling back to the library that holds the prefix costs nothing on the common
+    // single-drive install, where they are the same folder — and is a better guess than
+    // refusing to start over a Steam installed somewhere we don't know to look.
+    Some((steam_client_root().unwrap_or(library), compat))
+}
+
+/// Where Steam itself is installed. The Flatpak and snap builds keep their own home, so
+/// they are looked for too — a Flatpak player is exactly the sort who has never seen
+/// `~/.steam` in their life.
+fn steam_client_root() -> Option<PathBuf> {
+    let home = dirs_next::home_dir()?;
+    [
+        ".steam/steam",
+        ".local/share/Steam",
+        ".steam/root",
+        ".var/app/com.valvesoftware.Steam/data/Steam",
+        "snap/steam/common/.local/share/Steam",
+    ]
+    .into_iter()
+    .map(|rel| home.join(rel))
+    .find(|dir| dir.join("steamapps").is_dir())
+}
+
+/// The Proton that owns `compat_data`, preferring the one Steam recorded for it.
+fn proton_for(compat_data: &Path) -> Option<PathBuf> {
+    if let Ok(text) = std::fs::read_to_string(compat_data.join("config_info")) {
+        if let Some(root) = proton_root_in_config_info(&text) {
+            if let Some(script) = proton_script(&root) {
+                return Some(script);
+            }
+        }
+    }
+    installed_protons().into_iter().find_map(|dir| proton_script(&dir))
+}
+
+/// Pull the Proton install out of a prefix's `config_info`.
+///
+/// Proton writes that file when it builds the prefix, and every path in it points back
+/// into its own install — `…/Proton 9.0/files/share/fonts/`, `…/dist/share/default_pfx/`,
+/// depending on the Proton version's layout. So rather than depend on the file's shape,
+/// take the first line that names one of those two directories and keep what comes before
+/// it. That is the install root whatever the rest of the file says.
+fn proton_root_in_config_info(text: &str) -> Option<PathBuf> {
+    for line in text.lines() {
+        let line = line.trim();
+        for marker in ["/files/", "/dist/"] {
+            if let Some(cut) = line.find(marker) {
+                return Some(PathBuf::from(&line[..cut]));
+            }
+        }
+    }
+    None
+}
+
+/// The runnable `proton` script inside an install, if it's there.
+fn proton_script(root: &Path) -> Option<PathBuf> {
+    let script = root.join("proton");
+    script.is_file().then_some(script)
+}
+
+/// Every Proton install we can see, best first.
+///
+/// Only reached when `config_info` didn't answer — a prefix from a Proton that has since
+/// been uninstalled, say. Ranked by [`proton_rank`].
+fn installed_protons() -> Vec<PathBuf> {
+    let mut found: Vec<PathBuf> = Vec::new();
+    for root in crate::config::steam_libraries() {
+        // Valve's own builds, and anything dropped into compatibilitytools.d (GE-Proton
+        // and friends, which is where a lot of players actually run from).
+        for dir in [
+            root.join("steamapps").join("common"),
+            root.join("compatibilitytools.d"),
+        ] {
+            let Ok(entries) = std::fs::read_dir(&dir) else { continue };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let name = entry.file_name().to_string_lossy().to_lowercase();
+                if name.contains("proton") && !found.contains(&path) {
+                    found.push(path);
+                }
+            }
+        }
+    }
+    found.sort_by_key(|p| {
+        std::cmp::Reverse(proton_rank(&p.file_name().unwrap_or_default().to_string_lossy()))
+    });
+    found
+}
+
+/// How much we'd like to use a Proton, by its folder name. Higher wins.
+///
+/// A guess, and only ever used when Steam's own record of which Proton built the prefix
+/// has already failed us — so it aims at "the one a player most likely runs games with"
+/// rather than at precision. Experimental first (it is what Steam defaults to and is
+/// always current), then the highest version number, with a name that carries no number
+/// at the bottom rather than treated as version zero.
+fn proton_rank(name: &str) -> (u32, u32, u32) {
+    let lower = name.to_lowercase();
+    if lower.contains("experimental") {
+        return (u32::MAX, 0, 0);
+    }
+    // First number in the name is the major version: `Proton 9.0`, `GE-Proton9-20`.
+    let mut nums = name
+        .split(|c: char| !c.is_ascii_digit())
+        .filter(|s| !s.is_empty())
+        .filter_map(|s| s.parse::<u32>().ok());
+    (0, nums.next().unwrap_or(0), nums.next().unwrap_or(0))
+}
+
+/// A host path as the prefix sees it.
+///
+/// Two shapes, and which one applies is a fact about the path rather than a preference:
+/// anything under the prefix's own `drive_c` is on `C:`, and everything else on the
+/// machine is reachable as `Z:`, the drive Wine maps to `/`. FrostMod is handed Windows
+/// paths (`--mods`) because it is a Windows program; it has no idea either of these
+/// started life with forward slashes.
+pub fn windows_path(prefix: &Path, path: &Path) -> String {
+    let drive_c = prefix.join(DRIVE_C);
+    let (drive, rest) = match path.strip_prefix(&drive_c) {
+        Ok(rest) => ("C:", rest),
+        Err(_) => ("Z:", path.strip_prefix("/").unwrap_or(path)),
+    };
+    let joined = rest
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join("\\");
+    format!("{drive}\\{joined}")
+}
+
+/// Is a process on this machine running `exe`?
+///
+/// `/proc` rather than `ps`: the AppImage carries no `ps`, and reading the process table
+/// directly is both cheaper and one less thing to be missing on a slim install. Under
+/// Proton the game is an ordinary Linux process whose command line still names
+/// `mxbikes.exe`, and so is FrostMod's launcher — which is the only handle we have on it
+/// from out here, since its reload event lives inside the prefix where we can't reach.
+pub fn running_exe(exe: &str) -> bool {
+    !exe_pids(exe).is_empty()
+}
+
+/// Every process whose command line names `exe`, ours excluded.
+///
+/// More than one is normal and correct: Proton leaves its own wrapper around the program
+/// it started, so `frostmod.exe` is named by both the wrapper and the Wine process doing
+/// the work, and stopping FrostMod means stopping both.
+pub fn exe_pids(exe: &str) -> Vec<u32> {
+    let own = std::process::id();
+    let mut pids = Vec::new();
+    let Ok(entries) = std::fs::read_dir("/proc") else { return pids };
+    for entry in entries.flatten() {
+        let Ok(pid) = entry.file_name().to_string_lossy().parse::<u32>() else { continue };
+        if pid == own {
+            continue;
+        }
+        // Unreadable is normal — another user's process, or one that exited between the
+        // listing and the read.
+        let Ok(cmdline) = std::fs::read(entry.path().join("cmdline")) else { continue };
+        if cmdline_names_exe(&String::from_utf8_lossy(&cmdline), exe) {
+            pids.push(pid);
+        }
+    }
+    pids
+}
+
+/// Stop everything running `exe`. Best-effort, and TERM rather than KILL: FrostMod's
+/// launcher tidies up after itself when asked politely, and a Wine process killed outright
+/// can leave the prefix's server holding its handles.
+///
+/// Shells out because the app links no libc of its own for a single `kill(2)`. `kill` is
+/// part of a base install everywhere this could plausibly run.
+pub fn kill_exe(exe: &str) {
+    let pids = exe_pids(exe);
+    if pids.is_empty() {
+        return;
+    }
+    let mut cmd = std::process::Command::new("kill");
+    cmd.arg("-TERM");
+    for pid in &pids {
+        cmd.arg(pid.to_string());
+    }
+    match cmd.output() {
+        Ok(out) if !out.status.success() => log::warn!(
+            "asking {exe} ({pids:?}) to stop failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ),
+        Err(e) => log::warn!("couldn't run kill to stop {exe}: {e}"),
+        _ => {}
+    }
+}
+
+/// Does one `/proc/<pid>/cmdline` name `exe`?
+///
+/// The arguments are NUL-separated and the exe may appear as any of them, in either slash
+/// form and any case — `Z:\home\…\frostmod.exe`, `/…/common/MX Bikes/mxbikes.exe`. So the
+/// test is a case-insensitive substring, which is what makes it work through however many
+/// wrappers Steam and Proton put in front of the process.
+fn cmdline_names_exe(cmdline: &str, exe: &str) -> bool {
+    cmdline.to_ascii_lowercase().contains(&exe.to_ascii_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_path_inside_the_prefix_is_on_c_drive() {
+        let prefix = Path::new("/home/rider/.steam/steam/steamapps/compatdata/655500/pfx");
+        let mods = prefix.join("drive_c/users/steamuser/Documents/PiBoSo/MX Bikes/mods");
+        assert_eq!(
+            windows_path(prefix, &mods),
+            "C:\\users\\steamuser\\Documents\\PiBoSo\\MX Bikes\\mods"
+        );
+    }
+
+    /// Everything else on the machine is still reachable — Wine maps `/` to `Z:` — which
+    /// is how the app's own folder (where it leaves commands for FrostMod) is nameable
+    /// from inside the prefix at all.
+    #[test]
+    fn a_path_outside_the_prefix_is_on_z_drive() {
+        let prefix = Path::new("/home/rider/.steam/steam/steamapps/compatdata/655500/pfx");
+        assert_eq!(
+            windows_path(prefix, Path::new("/home/rider/.local/share/com.frost.mxbikes/frostmod")),
+            "Z:\\home\\rider\\.local\\share\\com.frost.mxbikes\\frostmod"
+        );
+    }
+
+    /// Both layouts Proton has used. The point of reading this file at all is to run the
+    /// build that *made* the prefix rather than the newest one installed: a different Wine
+    /// build against the same prefix can upgrade it in place.
+    #[test]
+    fn config_info_names_the_proton_that_built_the_prefix() {
+        let modern = "9.0-303\n/home/rider/.steam/steam/steamapps/common/Proton 9.0/files/share/fonts/\n";
+        assert_eq!(
+            proton_root_in_config_info(modern).unwrap(),
+            PathBuf::from("/home/rider/.steam/steam/steamapps/common/Proton 9.0")
+        );
+
+        let older = "5.13-6\n/home/rider/.steam/steam/steamapps/common/Proton 5.13/dist/share/default_pfx/\n";
+        assert_eq!(
+            proton_root_in_config_info(older).unwrap(),
+            PathBuf::from("/home/rider/.steam/steam/steamapps/common/Proton 5.13")
+        );
+
+        // A file that names neither is one we learn nothing from — the fallback scan is
+        // the answer there, not a half-parsed path.
+        assert!(proton_root_in_config_info("9.0-303\n").is_none());
+        assert!(proton_root_in_config_info("").is_none());
+    }
+
+    /// The fallback ordering, for when `config_info` is gone. Experimental is what Steam
+    /// itself defaults to; after that a bigger version number is the better guess.
+    #[test]
+    fn experimental_outranks_a_numbered_proton_and_numbers_sort_numerically() {
+        assert!(proton_rank("Proton - Experimental") > proton_rank("Proton 9.0"));
+        assert!(proton_rank("Proton 10.0") > proton_rank("Proton 9.0"));
+        assert!(proton_rank("GE-Proton9-20") > proton_rank("GE-Proton8-32"));
+        // The trap a string sort falls into.
+        assert!(proton_rank("Proton 10.0") > proton_rank("Proton 5.13"));
+    }
+
+    #[test]
+    fn a_command_line_names_the_exe_whatever_wraps_it() {
+        // Proton's own argv for the game, wrappers and all.
+        let game = "/home/rider/.steam/steam/steamapps/common/Proton - Experimental/proton\0waitforexitandrun\0/home/rider/.steam/steam/steamapps/common/MX Bikes/mxbikes.exe\0";
+        assert!(cmdline_names_exe(game, "mxbikes.exe"));
+        assert!(!cmdline_names_exe(game, "gpbikes.exe"));
+        // FrostMod as we start it: a Windows path, backslashes and all.
+        let frostmod = "…/proton\0run\0Z:\\home\\rider\\.local\\share\\com.frost.mxbikes\\frostmod\\FrostMod.exe\0--game\0mxb\0";
+        assert!(cmdline_names_exe(frostmod, "frostmod.exe"));
+        assert!(!cmdline_names_exe("", "frostmod.exe"));
+    }
+
+    #[test]
+    fn proton_takes_the_run_verb_and_a_custom_runner_takes_the_exe() {
+        let runner = Runner {
+            compat_data: PathBuf::from("/steam/steamapps/compatdata/655500"),
+            program: PathBuf::from("/steam/steamapps/common/Proton 9.0/proton"),
+            client: PathBuf::from("/steam"),
+            kind: RunnerKind::Proton,
+        };
+        let cmd = runner.command(Path::new("/data/frostmod/frostmod.exe"), &["--game".into(), "mxb".into()]);
+        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().into_owned()).collect();
+        assert_eq!(args, ["run", "/data/frostmod/frostmod.exe", "--game", "mxb"]);
+        let env: Vec<_> = cmd.get_envs().map(|(k, v)| (k.to_string_lossy().into_owned(), v.map(|v| v.to_string_lossy().into_owned()))).collect();
+        assert!(env.contains(&(
+            "STEAM_COMPAT_DATA_PATH".to_string(),
+            Some("/steam/steamapps/compatdata/655500".to_string())
+        )));
+        assert!(!env.iter().any(|(k, _)| k == "WINEPREFIX"), "Proton is told the compat path, not the prefix");
+
+        let custom = Runner { kind: RunnerKind::Custom, ..runner };
+        let cmd = custom.command(Path::new("/data/frostmod/frostmod.exe"), &[]);
+        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().into_owned()).collect();
+        assert_eq!(args, ["/data/frostmod/frostmod.exe"]);
+        let env: Vec<_> = cmd.get_envs().map(|(k, v)| (k.to_string_lossy().into_owned(), v.map(|v| v.to_string_lossy().into_owned()))).collect();
+        assert!(env.contains(&(
+            "WINEPREFIX".to_string(),
+            Some("/steam/steamapps/compatdata/655500/pfx".to_string())
+        )));
+    }
+}

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -267,6 +267,11 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
   const platform = usePlatform();
   const isWindows = platform === "windows";
   const isMac = platform === "macos";
+  // FrostMod is a Win32 DLL injected into the game — which is exactly what the game is on
+  // Linux too, where Steam runs it under Proton and the app puts FrostMod in the same
+  // prefix. macOS is the odd one out: the app launches the bottle but doesn't inject
+  // into it.
+  const hasFrostmod = isWindows || platform === "linux";
   const { theme, setTheme } = useTheme();
   const { running, reload, status, installing, checking, statusError, install, start, stop, refreshStatus, missingRuntime, installRuntime, installingRuntime } =
     useFrostmod();
@@ -286,7 +291,7 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
     ...g,
     sections: g.sections.filter(
       (s) =>
-        (s.id !== "frostmod" || (isWindows && caps.frostmod)) &&
+        (s.id !== "frostmod" || (hasFrostmod && caps.frostmod)) &&
         (s.id !== "game" || multiGame),
     ),
   })).filter((g) => g.sections.length > 0);
@@ -1408,11 +1413,12 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
           </Section>
           )}
 
-          {/* frostmod — a Win32 DLL injected into the game, so it has nothing to do
-              anywhere else. Hidden rather than shown-and-disabled: every control in it
-              would fail, including one that downloads two Windows binaries. The nav drops
-              its entry on the same condition. */}
-          {isWindows && caps.frostmod && active === "frostmod" && (
+          {/* frostmod — a Win32 DLL injected into the game, so it has nothing to do where
+              the game isn't a Windows process. That means Windows and Linux (Proton), and
+              not macOS. Hidden rather than shown-and-disabled: every control in it would
+              fail, including one that downloads two Windows binaries. The nav drops its
+              entry on the same condition. */}
+          {hasFrostmod && caps.frostmod && active === "frostmod" && (
           <Section
             title={t("settings.frostmod")}
             titleRight={
@@ -1641,7 +1647,7 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
                 FrostMod section above: a Win32 DLL injected into the game has no folder
                 to open anywhere else, and a permanently empty row would be the only
                 mention of it on the page. */}
-            {isWindows && caps.frostmod && (
+            {hasFrostmod && caps.frostmod && (
               <LogRow
                 label="FrostMod"
                 hint={t("logs.frostmodLogsDesc")}

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -582,7 +582,7 @@ export const de: Translation = {
   "settings.instantRefreshDesc":
     "Wenn du ein Preset anwendest, während {{game}} läuft, wird der Look sofort im Spiel aktualisiert — ohne Neustart und ohne das Profil neu auszuwählen. Falls das nicht klappt, wirst du gebeten, dein Profil neu auszuwählen.",
   "settings.instantRefreshWindowsOnly":
-    "Den Look ohne Neustart im Spiel zu aktualisieren erfordert FrostMod, und das gibt es nur für Windows — du wirst stattdessen gebeten, dein Profil neu auszuwählen.",
+    "Den Look ohne Neustart im Spiel zu aktualisieren heißt, in das laufende Spiel hineinzugreifen, und das kann nur die Windows-Version — du wirst stattdessen gebeten, dein Profil neu auszuwählen.",
   "settings.autoRunFrostmod": "FrostMod automatisch starten",
   "settings.autoRunFrostmodDesc":
     "FrostMod im Hintergrund starten, sobald MXB App geöffnet wird.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -564,7 +564,7 @@ export const en = {
   "settings.instantRefreshDesc":
     "When you apply a preset while {{game}} is running, refresh the look in-game instantly — no restart or profile reselect. If it can't, you'll be told to reselect your profile.",
   "settings.instantRefreshWindowsOnly":
-    "Refreshing the look in-game without a restart needs FrostMod, which is Windows-only — you'll be told to reselect your profile instead.",
+    "Refreshing the look in-game without a restart means reaching into the running game, which only the Windows build can do — you'll be told to reselect your profile instead.",
   "settings.autoRunFrostmod": "Run FrostMod automatically",
   "settings.autoRunFrostmodDesc":
     "Start FrostMod in the background whenever MXB App opens.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -574,7 +574,7 @@ export const es: Translation = {
   "settings.instantRefreshDesc":
     "Cuando aplicas un preset con {{game}} en marcha, actualiza el look en el juego al instante — sin reiniciar ni volver a seleccionar el perfil. Si no puede, se te pedirá que vuelvas a seleccionar tu perfil.",
   "settings.instantRefreshWindowsOnly":
-    "Actualizar el look en el juego sin reiniciar necesita FrostMod, que es solo para Windows — en su lugar se te pedirá que vuelvas a seleccionar tu perfil.",
+    "Actualizar el look en el juego sin reiniciar implica entrar en el juego en marcha, y eso solo puede hacerlo la versión de Windows — en su lugar se te pedirá que vuelvas a seleccionar tu perfil.",
   "settings.autoRunFrostmod": "Ejecutar FrostMod automáticamente",
   "settings.autoRunFrostmodDesc":
     "Inicia FrostMod en segundo plano cada vez que abres MXB App.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -578,7 +578,7 @@ export const fr: Translation = {
   "settings.instantRefreshDesc":
     "Quand vous appliquez un preset pendant que {{game}} tourne, actualise le look en jeu instantanément — sans redémarrage ni resélection de profil. Si ce n'est pas possible, il vous sera demandé de resélectionner votre profil.",
   "settings.instantRefreshWindowsOnly":
-    "Actualiser le look en jeu sans redémarrer nécessite FrostMod, qui est réservé à Windows — il vous sera demandé de resélectionner votre profil à la place.",
+    "Actualiser le look en jeu sans redémarrer suppose d'intervenir dans le jeu en cours, ce que seule la version Windows peut faire — il vous sera demandé de resélectionner votre profil à la place.",
   "settings.autoRunFrostmod": "Lancer FrostMod automatiquement",
   "settings.autoRunFrostmodDesc":
     "Démarrer FrostMod en arrière-plan à chaque ouverture de MXB App.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -570,7 +570,7 @@ export const it: Translation = {
   "settings.instantRefreshDesc":
     "Quando applichi un preset mentre {{game}} è in esecuzione, aggiorna il look in gioco all'istante — senza riavvio né riselezione del profilo. Se non ci riesce, ti verrà chiesto di riselezionare il profilo.",
   "settings.instantRefreshWindowsOnly":
-    "Aggiornare il look in gioco senza riavviare richiede FrostMod, che è solo per Windows — ti verrà invece chiesto di riselezionare il profilo.",
+    "Aggiornare il look in gioco senza riavviare significa intervenire nel gioco in esecuzione, e può farlo solo la versione Windows — ti verrà invece chiesto di riselezionare il profilo.",
   "settings.autoRunFrostmod": "Avvia FrostMod automaticamente",
   "settings.autoRunFrostmodDesc":
     "Avvia FrostMod in background ogni volta che apri MXB App.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -575,7 +575,7 @@ export const ptBR: Translation = {
   "settings.instantRefreshDesc":
     "Quando você aplica um preset com o {{game}} aberto, atualiza o visual no jogo na hora — sem reiniciar nem reselecionar o perfil. Se não der, você será avisado para selecionar o perfil de novo.",
   "settings.instantRefreshWindowsOnly":
-    "Atualizar o visual no jogo sem reiniciar precisa do FrostMod, que só existe no Windows — em vez disso você será avisado para selecionar o perfil de novo.",
+    "Atualizar o visual no jogo sem reiniciar significa mexer no jogo em execução, e só a versão de Windows consegue fazer isso — em vez disso você será avisado para selecionar o perfil de novo.",
   "settings.autoRunFrostmod": "Iniciar o FrostMod automaticamente",
   "settings.autoRunFrostmodDesc":
     "Iniciar o FrostMod em segundo plano sempre que o MXB App abrir.",


### PR DESCRIPTION
Two commits, both Linux, from chasing the white screen a tester hit on v0.9.2-beta.4.

## 1. The AppImage was carrying the library that blanked its window

linuxdeploy pulls `libwayland-client`, `-cursor`, `-egl` and `-server` in as dependencies of GTK and WebKit, so the AppImage shipped Ubuntu 22.04's copies **ahead of the host's** on the library path — where the *host's* Mesa loaded them and then couldn't create an EGL display. Confirmed on the published beta: all four sit in `usr/lib`, and `libgdk-3` and `libwebkit2gtk` name them as `NEEDED`. The AppImage excludelist names `libwayland-client` for exactly this reason ([mesa#11316](https://gitlab.freedesktop.org/mesa/mesa/-/issues/11316)); the linuxdeploy build Tauri downloads carries an older copy of that list.

Release builds now go through `scripts/tauri-build.sh` (tauri-action's `tauriScript`, Linux only): the same `tauri build`, then the four libraries come out and the updater signature is taken again over the bytes that ship — before the action collects the bundles, so the uploaded image is the one `latest.json` holds a signature for. The image is rebuilt from **its own runtime** (`--appimage-offset`) and its own squashfs compression, so nothing but `squashfs-tools` is needed. Tested against the real beta.4 AppImage: byte-identical content minus those four files, permissions and symlinks intact, idempotent.

**The XWayland default from v0.9.1 never ran.** An AppImage's own AppRun hook exports `GDK_BACKEND=x11` before a line of our code executes, so every AppImage was already on XWayland and that release couldn't have cured anything — which matches the tester's results (unsetting `WAYLAND_DISPLAY` and `MXB_SAFE_GRAPHICS=1` both failed; removing the libraries worked first time). Forcing a backend is now left to `MXB_SAFE_GRAPHICS=1`.

## 2. FrostMod on Linux

It refused with *FrostMod runs on Windows only* — true of the binary and beside the point. On Linux the game is a Windows process too, so FrostMod belongs in the same Proton prefix, where the process it injects into lives.

`src-tauri/src/proton.rs` finds `steamapps/compatdata/655500`, finds the Proton that **built** it (from the prefix's own `config_info`, so it uses Steam's build rather than the newest installed; ranked scan as fallback), and starts `frostmod.exe` through it. `--mods` goes over as the prefix sees the folder — `C:\users\steamuser\…`, not `/home/…`.

Talking to it afterwards needs a different channel: this app is a native Linux process and `Local\FrostModReload` is a Wine kernel object. So reload goes as a file ([frostmod#14](https://github.com/Frostn1/frostmod/pull/14) is what reads it), every command carries an `at` stamp so two presses are two documents, status reads the process table, and stopping asks it for every pid — killing the Proton wrapper leaves the launcher under it running. **A FrostMod older than v0.13.0 is refused a start** with the version to update to, rather than started into a state where `F8` works in game and every button here quietly doesn't.

Proton's own output lands in `frostmod/proton.log`, which the log collector already picks up.

**Also fixed: `is_game_running()` was hardcoded `false` on Linux.** macOS got a process check when Play landed there and Linux was never given one, so Play never greyed out mid-session and everything gated on "is the game up?" — whether a paint shows now or next launch, whether a file is safe to move — was answering for a machine where the game supposedly never runs. `/proc` rather than `ps`, which the AppImage doesn't carry.

## Verification

- `cargo check --all-targets` clean, no new warnings; `cargo test` **723 passed**. One pre-existing failure, `gearrepair::a_move_that_fails_part_way_puts_everything_back`, fails only because this container runs as root and `chmod 0o500` doesn't stop root — it passes on CI.
- `tsc --noEmit` and eslint clean.
- New tests: prefix/`Z:` path conversion, `config_info` parsing for both Proton layouts, Proton version ranking (numeric, not lexical), `/proc` cmdline matching through Proton's wrappers, the v0.13.0 floor, and the `at` stamp making a repeat distinguishable.

## Not verified from here

Whether `CreateRemoteThread` injection survives a `proton run` started outside Steam's pressure-vessel container. If the container has a private `/tmp`, our launcher joins a different wineserver and waits for a game it can never see — the pill would read "running" with no overlay in game. `protontricks-launch --appid 655500 frostmod.exe` while the game is up answers it in five minutes. If it does fail that way, a wrapper around `steam-runtime-launch-client` pointed at the existing `wineRunner` config field is the fix, no code change needed to try it.

---
_Generated by [Claude Code](https://claude.ai/code/session_017fAHvvxa2DJQrntcft7rUh)_