### PR TITLE
Stop preselecting a mod's dedicated-server build, and name the author on browse cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased — a browse card says who made it
+
+### Added
+- **Mod cards carry a byline.** The catalog knows who posted each mod and the grid never
+  showed it, so telling two versions of the same track apart meant opening both. The name now
+  sits beside the date, the way a shop card already carries its author. It rides along with
+  the listing request rather than costing one of its own, and a mod the catalog names nobody
+  for simply keeps the date.
+
 ## Unreleased — the install picker says which file it's about to fetch
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Unreleased — the install picker says which file it's about to fetch
+
+### Fixed
+- **A dedicated-server build is no longer installed as if it were the mod.** Server files were
+  detected by looking for the word "server" anywhere in a download block, which missed the
+  authors who only say it in the file's name (`Ironman_2024_Server.pkz`) — an undetected one
+  carrying the page's "Default" flag was preselected and installed without ever being named.
+  The link itself is read now as well, and the same check no longer mistakes a track called
+  *Observer Hill* for a server build, which used to hide the only download it had.
+- **Quick install stops guessing on a mod that offers nothing but server files.** One click
+  can't ask which build was meant, and the wrong one installs cleanly and then does nothing
+  in-game. Those mods now say so and send you to the page, where every file is listed.
+
+### Changed
+- **Every download is shown, with the recommended one picked.** Server builds used to be
+  dropped from the list, so a mod read as having one file while the flag behind that was a
+  guess. They're listed last instead, badged *Server*, folded under a *dedicated server files*
+  disclosure, and never preselected while anything playable is on offer.
+- **The mirror list opens on more than one row.** A single row read as the only file there
+  was; the first few are listed now, each with the author's own name for the file, so two
+  MediaFire links are told apart before one of them is downloaded.
+
 ## Unreleased — the sheet says which panel, which side, and which face
 
 ### Fixed

--- a/src-tauri/src/mods/mod.rs
+++ b/src-tauri/src/mods/mod.rs
@@ -54,6 +54,9 @@ pub struct ModSummary {
     pub date: String,
     pub image: Option<String>,
     pub category_id: u32,
+    /// Who posted it, as the site's own account name. `None` where the catalog didn't say —
+    /// the display name rides in the embedded author, which a site can withhold.
+    pub author: Option<String>,
 }
 
 /// The order a browse listing comes back in.

--- a/src-tauri/src/mods/mxb.rs
+++ b/src-tauri/src/mods/mxb.rs
@@ -823,6 +823,34 @@ fn strip_images(html: &str) -> String {
     img.replace_all(&s, "").into_owned()
 }
 
+/// The file name a download URL ends in — where an author who didn't label the block
+/// often still says what the file is (`…/Track_Server.zip`).
+///
+/// MediaFire and Google Drive hang a routing segment off the end of the path
+/// (`…/track.zip/file`, `…/view`), so those are stepped over to reach the real name.
+fn url_file_name(url: &str) -> &str {
+    let path = url.split(['?', '#']).next().unwrap_or(url);
+    let mut segs = path.trim_end_matches('/').rsplit('/').filter(|s| !s.is_empty());
+    let last = segs.next().unwrap_or("");
+    if ["file", "view", "download"].iter().any(|s| last.eq_ignore_ascii_case(s)) {
+        segs.next().unwrap_or(last)
+    } else {
+        last
+    }
+}
+
+/// Does this text call something a server build?
+///
+/// The word has to stand on its own: a track named "Observer Hill" contains the letters
+/// but isn't a server file, and mistaking one for the other hides the only download a mod
+/// has. Letters are what separate them rather than `\b`, because `_` is a word character
+/// to a regex and `Ironman_2024_Server.pkz` is how these files are actually named.
+fn mentions_server(text: &str) -> bool {
+    Regex::new(r"(?i)(?:^|[^a-z])servers?(?:[^a-z]|$)")
+        .unwrap()
+        .is_match(text)
+}
+
 /// Parse the theme's `div.download-container` blocks into download options.
 fn parse_downloads(html: &str) -> Vec<DownloadOption> {
     let doc = Html::parse_document(html);
@@ -836,10 +864,14 @@ fn parse_downloads(html: &str) -> Vec<DownloadOption> {
             .value()
             .classes()
             .any(|c| c.eq_ignore_ascii_case("container-default"));
-        // Dedicated-server builds are labelled "server" somewhere in the block.
-        let is_server = el.text().collect::<String>().to_lowercase().contains("server");
         let href = el.select(&a_sel).next().and_then(|a| a.value().attr("href"));
         let Some(url) = href else { continue };
+
+        // Dedicated-server builds are labelled "server" in the block — or, when the author
+        // only said it in the file's name, nowhere but the link. Both are read, because a
+        // server build that reaches the app unflagged is one the picker can preselect.
+        let is_server =
+            mentions_server(&el.text().collect::<String>()) || mentions_server(url_file_name(url));
 
         // The shown origin must reflect the ACTUAL link — authors often type a
         // mirror nickname (e.g. "GoWithTheFlow") in `div.filename`, which is not
@@ -862,8 +894,10 @@ fn parse_downloads(html: &str) -> Vec<DownloadOption> {
         });
     }
 
-    // Show the author's default file first.
-    out.sort_by_key(|d| !d.is_default);
+    // The author's default file first, and dedicated-server builds after everything else —
+    // whatever the page's own order was, a server build is never the file someone browsing
+    // for something to ride is after.
+    out.sort_by_key(|d| (d.is_server, !d.is_default));
     out
 }
 
@@ -993,6 +1027,65 @@ mod tests {
         assert_eq!(downloads.len(), 1);
         assert_eq!(downloads[0].host, "MediaFire");
         assert_eq!(downloads[0].label, "GoWithTheFlow");
+    }
+
+    #[test]
+    fn flags_server_builds_and_sorts_them_last() {
+        // The author marked the server build in the block's text, and made it the page's
+        // default — which is exactly how a server file used to end up preselected.
+        let html = r#"
+            <div class="download-container container-default">
+              <div class="filename">Dedicated Server files</div>
+              <a href="https://www.mediafire.com/file/abc/track_srv.zip/file">Download</a>
+            </div>
+            <div class="download-container container-mirror">
+              <div class="filename">mediafire.com</div>
+              <a href="https://www.mediafire.com/file/xyz/track.zip/file">Download</a>
+            </div>
+        "#;
+        let downloads = parse_downloads(html);
+        assert_eq!(downloads.len(), 2);
+        // Playable first, despite the server build carrying the page's "default" flag.
+        assert!(!downloads[0].is_server);
+        assert!(downloads[1].is_server);
+        assert!(downloads[1].is_default);
+    }
+
+    #[test]
+    fn reads_the_server_label_out_of_the_link() {
+        // Nothing in the block says "server"; only the file it points at does.
+        let html = r#"
+            <div class="download-container container-default">
+              <div class="filename">MediaFire</div>
+              <a href="https://www.mediafire.com/file/abc/Ironman_2024_Server.pkz/file">Download</a>
+            </div>
+        "#;
+        assert!(parse_downloads(html)[0].is_server);
+    }
+
+    #[test]
+    fn a_track_named_observer_is_not_a_server_build() {
+        // Substring matching flagged this one, which left the mod looking undownloadable.
+        let html = r#"
+            <div class="download-container container-default">
+              <div class="filename">Observer Hill</div>
+              <a href="https://www.mediafire.com/file/abc/ObserverHill.zip/file">Download</a>
+            </div>
+        "#;
+        assert!(!parse_downloads(html)[0].is_server);
+    }
+
+    #[test]
+    fn file_name_skips_the_hosts_routing_segment() {
+        assert_eq!(
+            url_file_name("https://www.mediafire.com/file/abc/track_server.zip/file"),
+            "track_server.zip",
+        );
+        assert_eq!(
+            url_file_name("https://drive.google.com/file/d/ABC123/view?usp=sharing"),
+            "ABC123",
+        );
+        assert_eq!(url_file_name("https://x.com/downloads/pack.7z"), "pack.7z");
     }
 
     #[test]

--- a/src-tauri/src/mods/mxb.rs
+++ b/src-tauri/src/mods/mxb.rs
@@ -442,7 +442,8 @@ async fn listing_response(
     let url = format!("{}{}", mxb_session::base(), obfstr!("/wp-json/wp/v2/posts"));
     let mut params: Vec<(&str, String)> = vec![
         ("categories", category_id.to_string()),
-        ("_embed", "wp:featuredmedia".to_string()),
+        // `author` rides along so a card can carry a byline; it costs no extra request.
+        ("_embed", "author,wp:featuredmedia".to_string()),
     ];
     match page {
         Page::Number(n) => {
@@ -533,7 +534,7 @@ async fn popular(category_id: u32, page: u32, range: &str) -> anyhow::Result<Vec
         ("order_by", "views".to_string()),
         ("limit", per_page.to_string()),
         ("offset", ((page - 1) * per_page).to_string()),
-        ("_embed", "wp:featuredmedia".to_string()),
+        ("_embed", "author,wp:featuredmedia".to_string()),
     ];
 
     let resp = get_with_retry(&url, &params).await?;
@@ -736,7 +737,25 @@ fn summary_from_post(p: &Value, category_id: u32) -> Option<ModSummary> {
         date: p.get("date").and_then(Value::as_str).unwrap_or("").to_string(),
         image: featured_image(p),
         category_id,
+        author: embedded_author(p),
     })
+}
+
+/// The post author's display name, from `_embed=author`.
+///
+/// Optional on purpose. WordPress answers the embed with an error object rather than a user
+/// when the site keeps its author list private, and a catalog that stops naming anyone is no
+/// reason for a listing to fail — the card simply doesn't show a byline.
+fn embedded_author(p: &Value) -> Option<String> {
+    let name = p
+        .get("_embedded")?
+        .get("author")?
+        .as_array()?
+        .first()?
+        .get("name")?
+        .as_str()?;
+    let name = decode_entities(name).trim().to_string();
+    (!name.is_empty()).then_some(name)
 }
 
 /// `post[field]["rendered"]` as a &str.
@@ -1027,6 +1046,37 @@ mod tests {
         assert_eq!(downloads.len(), 1);
         assert_eq!(downloads[0].host, "MediaFire");
         assert_eq!(downloads[0].label, "GoWithTheFlow");
+    }
+
+    #[test]
+    fn reads_the_posts_author() {
+        let post: Value = serde_json::from_str(
+            r#"{"id":1,"slug":"a-track","title":{"rendered":"A Track"},
+                "_embedded":{"author":[{"name":"Ren&#038;s Bikes"}]}}"#,
+        )
+        .unwrap();
+        let summary = summary_from_post(&post, 22).unwrap();
+        // Entities decoded, same as the title.
+        assert_eq!(summary.author.as_deref(), Some("Ren&s Bikes"));
+
+        // A site that keeps its author list private answers the embed with an error object
+        // instead of a user. That's a card without a byline, not a failed listing.
+        let hidden: Value = serde_json::from_str(
+            r#"{"id":2,"slug":"b-track","title":{"rendered":"B Track"},
+                "_embedded":{"author":[{"code":"rest_user_cannot_view"}]}}"#,
+        )
+        .unwrap();
+        assert_eq!(summary_from_post(&hidden, 22).unwrap().author, None);
+
+        // No `_embed` at all, and a blank name, are the same non-answer.
+        let bare: Value =
+            serde_json::from_str(r#"{"id":3,"slug":"c","title":{"rendered":"C"}}"#).unwrap();
+        assert_eq!(summary_from_post(&bare, 22).unwrap().author, None);
+        let blank: Value = serde_json::from_str(
+            r#"{"id":4,"slug":"d","title":{"rendered":"D"},"_embedded":{"author":[{"name":"  "}]}}"#,
+        )
+        .unwrap();
+        assert_eq!(summary_from_post(&blank, 22).unwrap().author, None);
     }
 
     #[test]

--- a/src/Components/Browse/Browse.tsx
+++ b/src/Components/Browse/Browse.tsx
@@ -118,6 +118,12 @@ export default function Browse({
           toast.error(t("browse.needsBrowser", { title: res.title }), {
             description: t("browse.needsBrowserDesc", { host: res.host ?? "" }),
           });
+        } else if (res.reason === "serverOnly") {
+          // Not installed on the user's behalf: one click can't ask which build was meant,
+          // and a server file installs cleanly while the game shows nothing.
+          toast.error(t("browse.serverOnly", { title: res.title }), {
+            description: t("browse.serverOnlyDesc"),
+          });
         } else {
           toast.error(t("browse.noDownload", { title: res.title }));
         }

--- a/src/Components/Browse/ModCard.tsx
+++ b/src/Components/Browse/ModCard.tsx
@@ -123,9 +123,16 @@ export default function ModCard({
                 </Badge>
               )}
             </div>
-            <span className="text-[11.5px] text-muted-foreground">
-              {formatDateShort(mod.date)}
-            </span>
+            {/* Date and byline share the line, the way a shop card carries its author. A
+                mod the catalog named nobody for just keeps the date. */}
+            <div className="flex items-baseline justify-between gap-2 text-[11.5px] text-muted-foreground">
+              <span className="flex-none">{formatDateShort(mod.date)}</span>
+              {mod.author && (
+                <span className="truncate" title={mod.author}>
+                  {t("browse.byAuthor", { author: mod.author })}
+                </span>
+              )}
+            </div>
           </div>
         </button>
       </ContextMenuTrigger>

--- a/src/Components/ModDetail/InstallDialog.tsx
+++ b/src/Components/ModDetail/InstallDialog.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useMemo, useState } from "react";
-import { ChevronDown, ChevronRight, Plus, Check, X, Search } from "lucide-react";
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  Plus,
+  Check,
+  X,
+  Search,
+} from "lucide-react";
 import { Dialog, DialogContent } from "@/Components/ui/dialog";
 import { Button } from "@/Components/ui/button";
 import { useT } from "../../i18n/context";
@@ -7,9 +15,12 @@ import { labelOf } from "../../i18n/core";
 import { Badge } from "@/Components/ui/badge";
 import { cn } from "@/lib/utils";
 import {
+  defaultMirrorIndex,
   installsOutsideMods,
   isBlockedDownload,
+  isServerOnly,
   pickDownloadForBike,
+  playableMirrors,
   sortMirrors,
   type DestOption,
   type ModType,
@@ -48,10 +59,19 @@ interface InstallDialogProps {
  *  game's install folder rather than the mods tree. */
 const RESHADE_DEST = "FrostMod ReShade";
 
-/** Ordered, de-duped playable mirrors with the "official" default first. */
+/** Every download the page offers, playable ones first and server builds last. */
 function useMirrors(detail: Detail | undefined): DownloadOption[] {
   return useMemo(() => (detail ? sortMirrors(detail) : []), [detail]);
 }
+
+/**
+ * How many mirrors are listed before the rest collapse behind "N more".
+ *
+ * More than one, deliberately: a single row reads as the only file there is, which is how
+ * someone ends up installing a mirror that turned out to be a server build without ever
+ * seeing there was a choice.
+ */
+const MIRRORS_SHOWN = 3;
 
 export default function InstallDialog({
   open,
@@ -77,6 +97,7 @@ export default function InstallDialog({
   const [newFolder, setNewFolder] = useState("");
   const [mirrorIdx, setMirrorIdx] = useState(0);
   const [mirrorsOpen, setMirrorsOpen] = useState(false);
+  const [serverOpen, setServerOpen] = useState(false);
 
   // Reset transient state each time the dialog opens.
   useEffect(() => {
@@ -86,10 +107,19 @@ export default function InstallDialog({
       setFolderSearch("");
       setCreating(false);
       setNewFolder("");
-      setMirrorIdx(0);
-      setMirrorsOpen(false);
     }
   }, [open, initialFolder]);
+
+  // The picked download resets with the dialog, and again if the page's downloads land
+  // after it opened. Never onto a server build while a playable file is on offer — that
+  // preselection is what quietly installed the wrong build.
+  useEffect(() => {
+    if (open) {
+      setMirrorIdx(defaultMirrorIndex(mirrors));
+      setMirrorsOpen(false);
+      setServerOpen(false);
+    }
+  }, [open, mirrors]);
 
   // Sound mods: the chosen bike (the folder value, minus any `/paints`) decides
   // which *download* to grab — the links are per-bike, not mirrors of one file.
@@ -182,9 +212,76 @@ export default function InstallDialog({
     onConfirm({ destFolder, mirror: selectedMirror });
   };
 
+  const serverBuilds = useMemo(() => mirrors.filter((m) => m.isServer), [mirrors]);
+  const playable = useMemo(() => playableMirrors(mirrors), [mirrors]);
+  // Nothing playable on the page means there is no "other" list to fold the server builds
+  // away behind: they are the downloads, shown as such and clearly marked.
+  const serverOnly = isServerOnly(mirrors);
+  const mainList = serverOnly ? mirrors : playable;
+
   // Show every option for sound mods (each is a different bike, not a mirror);
-  // otherwise collapse to the primary until expanded.
-  const shownMirrors = mirrorsOpen || sound ? mirrors : mirrors.slice(0, 1);
+  // otherwise list the first few and fold the rest away.
+  const shownMirrors = mirrorsOpen || sound ? mainList : mainList.slice(0, MIRRORS_SHOWN);
+  const hiddenCount = mainList.length - shownMirrors.length;
+
+  const renderMirror = (m: DownloadOption) => {
+    const idx = mirrors.indexOf(m);
+    const on = idx === mirrorIdx;
+    const blocked = isBlockedDownload(m);
+    // The author's own name for the file, where it says more than the host does. Two
+    // MediaFire rows are otherwise indistinguishable — and one of them may be the server
+    // build the parser had to guess at.
+    const fileLabel =
+      m.label && m.label.toLowerCase() !== m.host.toLowerCase() ? m.label : "";
+    const note = blocked
+      ? t("installDialog.opensInBrowser")
+      : m.isServer
+        ? t("installDialog.serverBuildNote")
+        : sound
+          ? on
+            ? t("installDialog.matchedBike")
+            : t("installDialog.differentBike")
+          : m.isDefault
+            ? t("installDialog.directFastest")
+            : t("installDialog.direct");
+    return (
+      <button
+        key={`${m.url}-${idx}`}
+        onClick={() => setMirrorIdx(idx)}
+        className={cn(
+          "flex cursor-default items-center gap-[11px] rounded-[9px] border bg-background px-3 py-2.5 text-left transition-colors",
+          on ? "border-primary/50" : "border-input hover:border-white/20",
+        )}
+      >
+        <span
+          className={cn(
+            "size-[15px] flex-none rounded-full",
+            on ? "border-4 border-primary" : "border-[1.5px] border-foreground/25",
+          )}
+        />
+        <span className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate text-[12.5px] font-semibold">{m.host}</span>
+          <span className="text-[11px] text-muted-foreground">{note}</span>
+          {fileLabel && (
+            <span className="truncate font-mono text-[10.5px] text-faint">{fileLabel}</span>
+          )}
+        </span>
+        {m.isServer ? (
+          <Badge variant="warning" className="flex-none">
+            {t("installDialog.serverBadge")}
+          </Badge>
+        ) : blocked ? (
+          <Badge variant="warning" className="flex-none">
+            {t("installDialog.browserBadge")}
+          </Badge>
+        ) : m.isDefault ? (
+          <Badge variant="success" className="flex-none border-primary/35 text-primary">
+            {t("installDialog.recommendedBadge")}
+          </Badge>
+        ) : null}
+      </button>
+    );
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -336,64 +433,46 @@ export default function InstallDialog({
                   ? t("installDialog.downloadPerBike")
                   : t("installDialog.downloadFrom")}
               </span>
+              {/* A mod with nothing but server files is worth saying outright: it installs
+                  fine and then does nothing in-game, which reads as a broken install. */}
+              {serverOnly && (
+                <div className="flex items-start gap-2.5 rounded-[10px] border border-warning/30 bg-warning/[0.07] px-3 py-2.5">
+                  <AlertTriangle className="mt-px size-3.5 flex-none text-warning" />
+                  <span className="text-[11.5px] text-warning/90">
+                    {t("installDialog.serverOnlyNotice")}
+                  </span>
+                </div>
+              )}
               <div className="flex flex-col gap-1.5">
-                {shownMirrors.map((m) => {
-                  const idx = mirrors.indexOf(m);
-                  const on = idx === mirrorIdx;
-                  const blocked = isBlockedDownload(m);
-                  return (
-                    <button
-                      key={`${m.url}-${idx}`}
-                      onClick={() => setMirrorIdx(idx)}
-                      className={cn(
-                        "flex cursor-default items-center gap-[11px] rounded-[9px] border bg-background px-3 py-2.5 text-left transition-colors",
-                        on ? "border-primary/50" : "border-input hover:border-white/20",
-                      )}
-                    >
-                      <span
-                        className={cn(
-                          "size-[15px] flex-none rounded-full",
-                          on
-                            ? "border-4 border-primary"
-                            : "border-[1.5px] border-foreground/25",
-                        )}
-                      />
-                      <span className="flex flex-1 flex-col">
-                        <span className="text-[12.5px] font-semibold">{m.host}</span>
-                        <span className="text-[11px] text-muted-foreground">
-                          {blocked
-                            ? t("installDialog.opensInBrowser")
-                            : sound
-                              ? on
-                                ? t("installDialog.matchedBike")
-                                : t("installDialog.differentBike")
-                              : m.isDefault
-                                ? t("installDialog.directFastest")
-                                : t("installDialog.direct")}
-                        </span>
-                      </span>
-                      {blocked ? (
-                        <Badge variant="warning" className="flex-none">
-                          Browser
-                        </Badge>
-                      ) : m.isDefault ? (
-                        <Badge variant="success" className="flex-none border-primary/35 text-primary">
-                          Default
-                        </Badge>
-                      ) : null}
-                    </button>
-                  );
-                })}
-                {!sound && !mirrorsOpen && mirrors.length > 1 && (
+                {shownMirrors.map(renderMirror)}
+                {!sound && hiddenCount > 0 && (
                   <button
                     onClick={() => setMirrorsOpen(true)}
                     className="flex cursor-default items-center gap-1 self-start px-1 text-[11px] text-muted-foreground hover:text-foreground"
                   >
-                    {mirrors.length - 1} more mirror{mirrors.length - 1 > 1 ? "s" : ""}
+                    {t("installDialog.moreMirrors", { count: hiddenCount })}
                     <ChevronDown className="size-3" />
                   </button>
                 )}
               </div>
+
+              {/* Server builds are listed, not hidden — folded away by default, because
+                  they're rarely what's wanted, but reachable for whoever runs a server. */}
+              {!serverOnly && serverBuilds.length > 0 && (
+                <div className="flex flex-col gap-1.5">
+                  <button
+                    onClick={() => setServerOpen((v) => !v)}
+                    className="flex cursor-default items-center gap-1 self-start px-1 text-[11px] text-muted-foreground hover:text-foreground"
+                  >
+                    {t("installDialog.serverFiles", { count: serverBuilds.length })}
+                    <ChevronDown
+                      className={cn("size-3 transition-transform", serverOpen && "rotate-180")}
+                    />
+                  </button>
+                  {serverOpen && serverBuilds.map(renderMirror)}
+                </div>
+              )}
+
               {mirrors.length > 1 && (
                 <span className="text-[11px] text-faint">
                   {sound

--- a/src/Components/ModDetail/ModDetail.tsx
+++ b/src/Components/ModDetail/ModDetail.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import {
+  AlertTriangle,
   ArrowLeft,
   ExternalLink,
   Check,
@@ -13,11 +14,13 @@ import { useT, type TKey } from "../../i18n/context";
 import {
   buildDestinations,
   buildRiderDestinations,
+  defaultMirrorIndex,
   destStorageKey,
   getInstalledMods,
   getModDetail,
   isBlockedDownload,
   isLiveryContext,
+  isServerOnly,
   isSoundContext,
   riderTarget,
   resolveInitialFolder,
@@ -192,9 +195,15 @@ export default function ModDetail({
   // "Official" mirror + metadata for the collapsed install panel.
   const mirrors = useMemo(() => (detail ? sortMirrors(detail) : []), [detail]);
 
-  const primary = mirrors[0] ?? null;
+  // What the dialog would start on — the best playable file, so the panel below the button
+  // describes the download that's actually about to run.
+  const primary = mirrors[defaultMirrorIndex(mirrors)] ?? null;
   const format = primary ? fileFormat(primary.url) : null;
-  const mirrorNames = [...new Set(mirrors.map((m) => m.host))].join(" · ");
+  // Server builds aren't mirrors of the playable file, so they don't belong in this count.
+  const mirrorNames = [
+    ...new Set(mirrors.filter((m) => !m.isServer).map((m) => m.host)),
+  ].join(" · ");
+  const serverOnly = isServerOnly(mirrors);
 
   const destKey = destStorageKey(game, modType);
   const initialFolder = useMemo(
@@ -383,6 +392,17 @@ export default function ModDetail({
               />
             ) : primary ? (
               <>
+                {/* Every file this page offers is a dedicated-server build. Said before the
+                    button, not after the install: it lands in the library either way and
+                    then does nothing in-game, which reads as a broken mod. */}
+                {serverOnly && (
+                  <div className="flex items-start gap-2.5 rounded-[10px] border border-warning/30 bg-warning/[0.07] px-3 py-2.5">
+                    <AlertTriangle className="mt-px size-3.5 flex-none text-warning" />
+                    <span className="text-[12px] text-warning/90">
+                      {t("modDetail.serverOnlyNotice")}
+                    </span>
+                  </div>
+                )}
                 <Button className="h-11 w-full text-[14px]" onClick={openInstall}>
                   {isInstalled ? t("browse.reinstall") : t("modDetail.addToLibrary")}
                 </Button>

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -1341,11 +1341,17 @@ export function isBlockedDownload(opt: { url: string; host: string }): boolean {
   return BLOCKED_HOST_PATTERNS.some((p) => s.includes(p));
 }
 
+/**
+ * Every download a mod offers, best first.
+ *
+ * Dedicated-server builds are sorted last rather than dropped. Hiding them read as "this
+ * mod has one file" while the flag was a guess — a mislabelled block took the only download
+ * off the page, and a server build the parser missed was silently preselected instead.
+ * Ranked below even a browser-only mirror, since that at least installs something playable.
+ */
 export function sortMirrors(detail: ModDetail): DownloadOption[] {
-  const all = detail.downloads ?? [];
-  const playable = all.filter((d) => !d.isServer);
-  const pool = playable.length ? playable : all;
-  return [...pool].sort((a, b) => {
+  return [...(detail.downloads ?? [])].sort((a, b) => {
+    if (a.isServer !== b.isServer) return Number(a.isServer) - Number(b.isServer);
     const ab = isBlockedDownload(a) ? 1 : 0;
     const bb = isBlockedDownload(b) ? 1 : 0;
     if (ab !== bb) return ab - bb;
@@ -1353,17 +1359,40 @@ export function sortMirrors(detail: ModDetail): DownloadOption[] {
   });
 }
 
+/** The downloads that install something playable — everything but the server builds. */
+export function playableMirrors(mirrors: DownloadOption[]): DownloadOption[] {
+  return mirrors.filter((m) => !m.isServer);
+}
+
+/**
+ * Which of `mirrors` (in {@link sortMirrors} order) a picker should start on: the best
+ * playable file, never a server build while anything else is on offer.
+ */
+export function defaultMirrorIndex(mirrors: DownloadOption[]): number {
+  const i = mirrors.findIndex((m) => !m.isServer);
+  return i >= 0 ? i : 0;
+}
+
+/** A mod whose every download is a dedicated-server build — nothing here is playable. */
+export function isServerOnly(mirrors: DownloadOption[]): boolean {
+  return mirrors.length > 0 && mirrors.every((m) => m.isServer);
+}
+
 export function pickDownloadForBike(
   mirrors: DownloadOption[],
   bikeName: string,
 ): DownloadOption | null {
   if (mirrors.length === 0) return null;
-  const fallback = () => mirrors.find((m) => m.isDefault) ?? mirrors[0];
+  // A sound pack's server build is named after the same bike as the file to play with, so
+  // it matches just as well — pick among the playable ones while there are any.
+  const playable = playableMirrors(mirrors);
+  const pool = playable.length ? playable : mirrors;
+  const fallback = () => pool.find((m) => m.isDefault) ?? pool[0];
   const want = tokens(bikeName);
   if (want.size === 0) return fallback();
 
   let best: { m: DownloadOption; score: number } | null = null;
-  for (const m of mirrors) {
+  for (const m of pool) {
     const fname = m.url.split(/[/\\]/).pop() ?? "";
     const hay = tokens(`${m.label} ${m.host} ${fname}`);
     let score = 0;
@@ -1436,7 +1465,13 @@ export interface QuickInstallParams {
 
 export type QuickInstallResult =
   | { ok: true; params: QuickInstallParams }
-  | { ok: false; reason: "blocked" | "none"; title: string; host?: string };
+  | {
+      ok: false;
+      /** `serverOnly` — every file the page offers is a dedicated-server build. */
+      reason: "blocked" | "none" | "serverOnly";
+      title: string;
+      host?: string;
+    };
 
 /**
  * The folder a one-click install from the Browse grid uses — the same answer the install
@@ -1454,8 +1489,12 @@ export async function resolveQuickInstall(
 ): Promise<QuickInstallResult> {
   const detail = await getModDetail(slug);
   const mirrors = sortMirrors(detail);
-  const primary = mirrors[0];
+  const primary = mirrors[defaultMirrorIndex(mirrors)];
   if (!primary) return { ok: false, reason: "none", title: detail.title };
+  // One click can't ask which build was meant, and a dedicated-server file installed by
+  // mistake looks installed while the game shows nothing. Send them to the mod's page,
+  // where every download is spelled out.
+  if (primary.isServer) return { ok: false, reason: "serverOnly", title: detail.title };
   if (isBlockedDownload(primary))
     return { ok: false, reason: "blocked", title: detail.title, host: primary.host };
 

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -375,6 +375,7 @@ export const de: Translation = {
   "browse.queued": "„{{title}}“ eingereiht",
   "browse.queuedDesc": "Wird in {{folder}} installiert.",
   "browse.rootFolder": "Hauptordner",
+  "browse.byAuthor": "von {{author}}",
   "browse.needsBrowser":
     "„{{title}}“ muss über den Browser heruntergeladen werden",
   "browse.needsBrowserDesc":

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -380,20 +380,23 @@ export const de: Translation = {
   "browse.needsBrowserDesc":
     "{{host}} blockiert Downloads in der App — öffne die Seite, um fertigzustellen.",
   "browse.noDownload": "Kein Download für „{{title}}“ gefunden",
+  "browse.serverOnly": "„{{title}}“ bietet nur Server-Dateien",
+  "browse.serverOnlyDesc":
+    "Öffne die Mod, um ihre Downloads zu sehen — ein Build für dedizierte Server wird nicht für dich installiert.",
   "browse.quickInstallFailed":
     "„{{title}}“ konnte nicht schnell installiert werden",
   "browse.queuedBulk_one": "{{count}} Mod eingereiht",
   "browse.queuedBulk_other": "{{count}} Mods eingereiht",
   "browse.queuedBulkDesc": "Sie werden nacheinander installiert.",
   "browse.queuedBulkSkipped_one":
-    "{{count}} übersprungen — nur über den Browser verfügbar.",
+    "{{count}} übersprungen — öffne sie und wähle einen Download.",
   "browse.queuedBulkSkipped_other":
-    "{{count}} übersprungen — nur über den Browser verfügbar.",
+    "{{count}} übersprungen — öffne sie und wähle einen Download.",
   "browse.bulkFailed": "Die Auswahl konnte nicht schnell installiert werden",
   "browse.bulkFailedDesc_one":
-    "Er muss über den Browser heruntergeladen werden.",
+    "Öffne sie und wähle einen Download.",
   "browse.bulkFailedDesc_other":
-    "Alle {{count}} müssen über den Browser heruntergeladen werden.",
+    "Bei allen {{count}} muss der Download von Hand gewählt werden.",
 
   // ── Shop (MX Bikes Shop — gekaufte Downloads) ──────────────────────────────
   "shop.help":
@@ -490,6 +493,16 @@ export const de: Translation = {
   "installDialog.differentBike": "Anderes Motorrad / Paket",
   "installDialog.directFastest": "Direkt · am schnellsten",
   "installDialog.direct": "Direkt",
+  "installDialog.recommendedBadge": "Empfohlen",
+  "installDialog.browserBadge": "Browser",
+  "installDialog.serverBadge": "Server",
+  "installDialog.serverBuildNote": "Build für dedizierte Server — nicht zum Spielen",
+  "installDialog.serverFiles_one": "1 Datei für dedizierte Server",
+  "installDialog.serverFiles_other": "{{count}} Dateien für dedizierte Server",
+  "installDialog.serverOnlyNotice":
+    "Jeder Download hier ist ein Build für dedizierte Server. Installiere ihn nur, wenn du einen Server betreibst — zum Fahren kommt nichts dazu.",
+  "installDialog.moreMirrors_one": "1 weiterer Spiegelserver",
+  "installDialog.moreMirrors_other": "{{count}} weitere Spiegelserver",
   "installDialog.perBikeHint":
     "Jeder Download ist ein anderes Motorrad — automatisch passend zu deiner Auswahl. Wähle das Paket „all bikes“, um alle auf einmal zu bekommen.",
   "installDialog.mirrorsHint":
@@ -528,6 +541,8 @@ export const de: Translation = {
   "modDetail.host": "Host",
   "modDetail.installsTo": "Installiert nach",
   "modDetail.noDownloadLink": "Auf dieser Seite wurde kein Download-Link gefunden — öffne sie auf {{site}}.",
+  "modDetail.serverOnlyNotice":
+    "Diese Seite bietet nur Dateien für dedizierte Server. Sie lassen sich installieren, aber im Spiel gibt es nichts zu fahren.",
   "modDetail.frostmodHint":
     "FrostMod lädt die Liste ({{kind}}) neu, sobald das fertig ist.",
   "modDetail.kindRider": "Fahrer",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -363,6 +363,7 @@ export const en = {
   "browse.queued": "Queued “{{title}}”",
   "browse.queuedDesc": "Installing to {{folder}}.",
   "browse.rootFolder": "root",
+  "browse.byAuthor": "by {{author}}",
   "browse.needsBrowser": "“{{title}}” needs a browser download",
   "browse.needsBrowserDesc":
     "{{host}} blocks in-app downloads — open its page to finish.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -367,15 +367,18 @@ export const en = {
   "browse.needsBrowserDesc":
     "{{host}} blocks in-app downloads — open its page to finish.",
   "browse.noDownload": "No download found for “{{title}}”",
+  "browse.serverOnly": "“{{title}}” only offers server files",
+  "browse.serverOnlyDesc":
+    "Open the mod to see its downloads — a dedicated-server build isn't installed for you.",
   "browse.quickInstallFailed": "Couldn't quick-install “{{title}}”",
   "browse.queuedBulk_one": "Queued {{count}} mod",
   "browse.queuedBulk_other": "Queued {{count}} mods",
   "browse.queuedBulkDesc": "They'll install one after another.",
-  "browse.queuedBulkSkipped_one": "{{count}} skipped — browser-only host.",
-  "browse.queuedBulkSkipped_other": "{{count}} skipped — browser-only host.",
+  "browse.queuedBulkSkipped_one": "{{count}} skipped — open it to pick a download.",
+  "browse.queuedBulkSkipped_other": "{{count}} skipped — open them to pick a download.",
   "browse.bulkFailed": "Couldn't quick-install the selection",
-  "browse.bulkFailedDesc_one": "It needs a browser download.",
-  "browse.bulkFailedDesc_other": "All {{count}} need a browser download.",
+  "browse.bulkFailedDesc_one": "Open it to pick a download.",
+  "browse.bulkFailedDesc_other": "All {{count}} need a download picked by hand.",
 
   // ── Shop (MX Bikes Shop — purchased downloads) ─────────────────────────────
   "shop.help":
@@ -472,6 +475,16 @@ export const en = {
   "installDialog.differentBike": "Different bike / pack",
   "installDialog.directFastest": "Direct · fastest",
   "installDialog.direct": "Direct",
+  "installDialog.recommendedBadge": "Recommended",
+  "installDialog.browserBadge": "Browser",
+  "installDialog.serverBadge": "Server",
+  "installDialog.serverBuildNote": "Dedicated server build — not for playing",
+  "installDialog.serverFiles_one": "1 dedicated server file",
+  "installDialog.serverFiles_other": "{{count}} dedicated server files",
+  "installDialog.serverOnlyNotice":
+    "Every download here is a dedicated-server build. Install one only if you're running a server — it adds nothing to ride.",
+  "installDialog.moreMirrors_one": "1 more mirror",
+  "installDialog.moreMirrors_other": "{{count}} more mirrors",
   "installDialog.perBikeHint":
     "Each download is a different bike — auto-selected to match your pick. Choose the “all bikes” pack for every bike at once.",
   "installDialog.mirrorsHint":
@@ -510,6 +523,8 @@ export const en = {
   "modDetail.host": "Host",
   "modDetail.installsTo": "Installs to",
   "modDetail.noDownloadLink": "No download link was found on this page — open it on {{site}}.",
+  "modDetail.serverOnlyNotice":
+    "This page only offers dedicated-server files. They install fine, but there's nothing to ride in-game.",
   "modDetail.frostmodHint":
     "FrostMod will hot-reload the {{kind}} list when this finishes.",
   "modDetail.kindRider": "rider",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -372,20 +372,23 @@ export const es: Translation = {
   "browse.needsBrowserDesc":
     "{{host}} bloquea las descargas dentro de la app — abre su página para terminar.",
   "browse.noDownload": "No se encontró descarga para «{{title}}»",
+  "browse.serverOnly": "«{{title}}» solo ofrece archivos de servidor",
+  "browse.serverOnlyDesc":
+    "Abre el mod para ver sus descargas: una compilación para servidor dedicado no se instala por ti.",
   "browse.quickInstallFailed":
     "No se pudo instalar rápido «{{title}}»",
   "browse.queuedBulk_one": "{{count}} mod en cola",
   "browse.queuedBulk_other": "{{count}} mods en cola",
   "browse.queuedBulkDesc": "Se instalarán uno tras otro.",
   "browse.queuedBulkSkipped_one":
-    "{{count}} omitido — host solo de navegador.",
+    "{{count}} omitido — ábrelo para elegir una descarga.",
   "browse.queuedBulkSkipped_other":
-    "{{count}} omitidos — host solo de navegador.",
+    "{{count}} omitidos — ábrelos para elegir una descarga.",
   "browse.bulkFailed": "No se pudo instalar rápido la selección",
   "browse.bulkFailedDesc_one":
-    "Requiere descarga desde el navegador.",
+    "Ábrelo para elegir una descarga.",
   "browse.bulkFailedDesc_other":
-    "Los {{count}} requieren descarga desde el navegador.",
+    "Los {{count}} necesitan que elijas la descarga a mano.",
 
   // ── Tienda (MX Bikes Shop — descargas compradas) ───────────────────────────
   "shop.help":
@@ -482,6 +485,16 @@ export const es: Translation = {
   "installDialog.differentBike": "Moto / pack distinto",
   "installDialog.directFastest": "Directo · el más rápido",
   "installDialog.direct": "Directo",
+  "installDialog.recommendedBadge": "Recomendado",
+  "installDialog.browserBadge": "Navegador",
+  "installDialog.serverBadge": "Servidor",
+  "installDialog.serverBuildNote": "Compilación para servidor dedicado — no sirve para jugar",
+  "installDialog.serverFiles_one": "1 archivo para servidor dedicado",
+  "installDialog.serverFiles_other": "{{count}} archivos para servidor dedicado",
+  "installDialog.serverOnlyNotice":
+    "Todas las descargas de aquí son compilaciones para servidor dedicado. Instala una solo si gestionas un servidor: no añade nada para rodar.",
+  "installDialog.moreMirrors_one": "1 espejo más",
+  "installDialog.moreMirrors_other": "{{count}} espejos más",
   "installDialog.perBikeHint":
     "Cada descarga es una moto distinta — se selecciona automáticamente según tu elección. Elige el pack «all bikes» para todas las motos de una vez.",
   "installDialog.mirrorsHint":
@@ -520,6 +533,8 @@ export const es: Translation = {
   "modDetail.host": "Host",
   "modDetail.installsTo": "Se instala en",
   "modDetail.noDownloadLink": "No se encontró ningún enlace de descarga en esta página — ábrela en {{site}}.",
+  "modDetail.serverOnlyNotice":
+    "Esta página solo ofrece archivos para servidor dedicado. Se instalan bien, pero en el juego no hay nada que rodar.",
   "modDetail.frostmodHint":
     "FrostMod recargará la lista de {{kind}} cuando esto termine.",
   "modDetail.kindRider": "piloto",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -368,6 +368,7 @@ export const es: Translation = {
   "browse.queued": "«{{title}}» en cola",
   "browse.queuedDesc": "Instalando en {{folder}}.",
   "browse.rootFolder": "raíz",
+  "browse.byAuthor": "por {{author}}",
   "browse.needsBrowser": "«{{title}}» requiere descarga desde el navegador",
   "browse.needsBrowserDesc":
     "{{host}} bloquea las descargas dentro de la app — abre su página para terminar.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -376,20 +376,23 @@ export const fr: Translation = {
   "browse.needsBrowserDesc":
     "{{host}} bloque les téléchargements dans l'application — ouvrez sa page pour terminer.",
   "browse.noDownload": "Aucun téléchargement trouvé pour « {{title}} »",
+  "browse.serverOnly": "« {{title}} » ne propose que des fichiers serveur",
+  "browse.serverOnlyDesc":
+    "Ouvrez le mod pour voir ses téléchargements — une version pour serveur dédié n'est pas installée à votre place.",
   "browse.quickInstallFailed":
     "Impossible d'installer rapidement « {{title}} »",
   "browse.queuedBulk_one": "{{count}} mod en file d'attente",
   "browse.queuedBulk_other": "{{count}} mods en file d'attente",
   "browse.queuedBulkDesc": "Ils s'installeront l'un après l'autre.",
   "browse.queuedBulkSkipped_one":
-    "{{count}} ignoré — hébergeur navigateur uniquement.",
+    "{{count}} ignoré — ouvrez-le pour choisir un téléchargement.",
   "browse.queuedBulkSkipped_other":
-    "{{count}} ignorés — hébergeur navigateur uniquement.",
+    "{{count}} ignorés — ouvrez-les pour choisir un téléchargement.",
   "browse.bulkFailed": "Impossible d'installer rapidement la sélection",
   "browse.bulkFailedDesc_one":
-    "Il doit être téléchargé depuis le navigateur.",
+    "Ouvrez-le pour choisir un téléchargement.",
   "browse.bulkFailedDesc_other":
-    "Les {{count}} doivent être téléchargés depuis le navigateur.",
+    "Pour les {{count}}, le téléchargement doit être choisi à la main.",
 
   // ── Boutique (MX Bikes Shop — téléchargements achetés) ─────────────────────
   "shop.help":
@@ -486,6 +489,16 @@ export const fr: Translation = {
   "installDialog.differentBike": "Moto / pack différent",
   "installDialog.directFastest": "Direct · le plus rapide",
   "installDialog.direct": "Direct",
+  "installDialog.recommendedBadge": "Recommandé",
+  "installDialog.browserBadge": "Navigateur",
+  "installDialog.serverBadge": "Serveur",
+  "installDialog.serverBuildNote": "Version serveur dédié — pas pour jouer",
+  "installDialog.serverFiles_one": "1 fichier pour serveur dédié",
+  "installDialog.serverFiles_other": "{{count}} fichiers pour serveur dédié",
+  "installDialog.serverOnlyNotice":
+    "Ici, chaque téléchargement est une version pour serveur dédié. N'en installez une que si vous hébergez un serveur — elle n'ajoute rien à piloter.",
+  "installDialog.moreMirrors_one": "1 autre miroir",
+  "installDialog.moreMirrors_other": "{{count}} autres miroirs",
   "installDialog.perBikeHint":
     "Chaque téléchargement correspond à une moto différente — sélectionné automatiquement selon votre choix. Choisissez le pack « all bikes » pour toutes les motos d'un coup.",
   "installDialog.mirrorsHint":
@@ -524,6 +537,8 @@ export const fr: Translation = {
   "modDetail.host": "Hébergeur",
   "modDetail.installsTo": "Installe dans",
   "modDetail.noDownloadLink": "Aucun lien de téléchargement trouvé sur cette page — ouvrez-la sur {{site}}.",
+  "modDetail.serverOnlyNotice":
+    "Cette page ne propose que des fichiers pour serveur dédié. Ils s'installent, mais il n'y a rien à piloter en jeu.",
   "modDetail.frostmodHint":
     "FrostMod rechargera la liste des {{kind}} une fois terminé.",
   "modDetail.kindRider": "pilotes",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -371,6 +371,7 @@ export const fr: Translation = {
   "browse.queued": "« {{title}} » en file d'attente",
   "browse.queuedDesc": "Installation dans {{folder}}.",
   "browse.rootFolder": "racine",
+  "browse.byAuthor": "par {{author}}",
   "browse.needsBrowser":
     "« {{title}} » doit être téléchargé depuis le navigateur",
   "browse.needsBrowserDesc":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -371,17 +371,20 @@ export const it: Translation = {
   "browse.needsBrowserDesc":
     "{{host}} blocca i download nell'app — apri la sua pagina per completare.",
   "browse.noDownload": "Nessun download trovato per “{{title}}”",
+  "browse.serverOnly": "“{{title}}” offre solo file per server",
+  "browse.serverOnlyDesc":
+    "Apri la mod per vedere i suoi download — una build per server dedicato non viene installata al posto tuo.",
   "browse.quickInstallFailed":
     "Impossibile installare rapidamente “{{title}}”",
   "browse.queuedBulk_one": "{{count}} mod in coda",
   "browse.queuedBulk_other": "{{count}} mod in coda",
   "browse.queuedBulkDesc": "Verranno installate una dopo l'altra.",
-  "browse.queuedBulkSkipped_one": "{{count}} saltata — host solo browser.",
-  "browse.queuedBulkSkipped_other": "{{count}} saltate — host solo browser.",
+  "browse.queuedBulkSkipped_one": "{{count}} saltata — aprila per scegliere un download.",
+  "browse.queuedBulkSkipped_other": "{{count}} saltate — aprile per scegliere un download.",
   "browse.bulkFailed": "Impossibile installare rapidamente la selezione",
-  "browse.bulkFailedDesc_one": "Va scaricata dal browser.",
+  "browse.bulkFailedDesc_one": "Aprila per scegliere un download.",
   "browse.bulkFailedDesc_other":
-    "Tutte e {{count}} vanno scaricate dal browser.",
+    "Per tutte e {{count}} il download va scelto a mano.",
 
   // ── Negozio (MX Bikes Shop — download acquistati) ──────────────────────────
   "shop.help":
@@ -478,6 +481,16 @@ export const it: Translation = {
   "installDialog.differentBike": "Moto / pacchetto diverso",
   "installDialog.directFastest": "Diretto · il più veloce",
   "installDialog.direct": "Diretto",
+  "installDialog.recommendedBadge": "Consigliato",
+  "installDialog.browserBadge": "Browser",
+  "installDialog.serverBadge": "Server",
+  "installDialog.serverBuildNote": "Build per server dedicato — non per giocare",
+  "installDialog.serverFiles_one": "1 file per server dedicato",
+  "installDialog.serverFiles_other": "{{count}} file per server dedicato",
+  "installDialog.serverOnlyNotice":
+    "Qui ogni download è una build per server dedicato. Installane una solo se gestisci un server — non aggiunge nulla da guidare.",
+  "installDialog.moreMirrors_one": "1 altro mirror",
+  "installDialog.moreMirrors_other": "Altri {{count}} mirror",
   "installDialog.perBikeHint":
     "Ogni download è una moto diversa — selezionato automaticamente in base alla tua scelta. Scegli il pacchetto “all bikes” per averle tutte in una volta.",
   "installDialog.mirrorsHint":
@@ -516,6 +529,8 @@ export const it: Translation = {
   "modDetail.host": "Host",
   "modDetail.installsTo": "Installa in",
   "modDetail.noDownloadLink": "Nessun link di download trovato in questa pagina — aprila su {{site}}.",
+  "modDetail.serverOnlyNotice":
+    "Questa pagina offre solo file per server dedicato. Si installano senza problemi, ma in gioco non c’è nulla da guidare.",
   "modDetail.frostmodHint":
     "FrostMod ricaricherà l'elenco {{kind}} al termine.",
   "modDetail.kindRider": "pilota",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -367,6 +367,7 @@ export const it: Translation = {
   "browse.queued": "“{{title}}” in coda",
   "browse.queuedDesc": "Installazione in {{folder}}.",
   "browse.rootFolder": "principale",
+  "browse.byAuthor": "di {{author}}",
   "browse.needsBrowser": "“{{title}}” va scaricata dal browser",
   "browse.needsBrowserDesc":
     "{{host}} blocca i download nell'app — apri la sua pagina per completare.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -374,19 +374,22 @@ export const ptBR: Translation = {
   "browse.needsBrowserDesc":
     "O {{host}} bloqueia downloads dentro do app — abra a página dele para concluir.",
   "browse.noDownload": "Nenhum download encontrado para “{{title}}”",
+  "browse.serverOnly": "“{{title}}” só oferece arquivos de servidor",
+  "browse.serverOnlyDesc":
+    "Abra o mod para ver os downloads — uma versão para servidor dedicado não é instalada por você.",
   "browse.quickInstallFailed":
     "Não foi possível instalar “{{title}}” rapidamente",
   "browse.queuedBulk_one": "{{count}} mod na fila",
   "browse.queuedBulk_other": "{{count}} mods na fila",
   "browse.queuedBulkDesc": "Eles serão instalados um depois do outro.",
   "browse.queuedBulkSkipped_one":
-    "{{count}} ignorado — host só pelo navegador.",
+    "{{count}} ignorado — abra-o para escolher um download.",
   "browse.queuedBulkSkipped_other":
-    "{{count}} ignorados — host só pelo navegador.",
+    "{{count}} ignorados — abra-os para escolher um download.",
   "browse.bulkFailed": "Não foi possível instalar a seleção rapidamente",
-  "browse.bulkFailedDesc_one": "Ele precisa ser baixado pelo navegador.",
+  "browse.bulkFailedDesc_one": "Abra-o para escolher um download.",
   "browse.bulkFailedDesc_other":
-    "Todos os {{count}} precisam ser baixados pelo navegador.",
+    "Nos {{count}} o download precisa ser escolhido à mão.",
 
   // ── Loja (MX Bikes Shop — downloads comprados) ─────────────────────────────
   "shop.help":
@@ -483,6 +486,16 @@ export const ptBR: Translation = {
   "installDialog.differentBike": "Moto / pacote diferente",
   "installDialog.directFastest": "Direto · o mais rápido",
   "installDialog.direct": "Direto",
+  "installDialog.recommendedBadge": "Recomendado",
+  "installDialog.browserBadge": "Navegador",
+  "installDialog.serverBadge": "Servidor",
+  "installDialog.serverBuildNote": "Versão para servidor dedicado — não serve para jogar",
+  "installDialog.serverFiles_one": "1 arquivo para servidor dedicado",
+  "installDialog.serverFiles_other": "{{count}} arquivos para servidor dedicado",
+  "installDialog.serverOnlyNotice":
+    "Todos os downloads aqui são versões para servidor dedicado. Instale uma só se você mantém um servidor — não acrescenta nada para pilotar.",
+  "installDialog.moreMirrors_one": "mais 1 espelho",
+  "installDialog.moreMirrors_other": "mais {{count}} espelhos",
   "installDialog.perBikeHint":
     "Cada download é uma moto diferente — selecionado automaticamente conforme a sua escolha. Escolha o pacote “all bikes” para todas de uma vez.",
   "installDialog.mirrorsHint":
@@ -521,6 +534,8 @@ export const ptBR: Translation = {
   "modDetail.host": "Host",
   "modDetail.installsTo": "Instala em",
   "modDetail.noDownloadLink": "Nenhum link de download foi encontrado nesta página — abra-a em {{site}}.",
+  "modDetail.serverOnlyNotice":
+    "Esta página só oferece arquivos para servidor dedicado. Eles instalam normalmente, mas não há nada para pilotar no jogo.",
   "modDetail.frostmodHint":
     "O FrostMod vai recarregar a lista de {{kind}} quando isso terminar.",
   "modDetail.kindRider": "piloto",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -370,6 +370,7 @@ export const ptBR: Translation = {
   "browse.queued": "“{{title}}” na fila",
   "browse.queuedDesc": "Instalando em {{folder}}.",
   "browse.rootFolder": "raiz",
+  "browse.byAuthor": "por {{author}}",
   "browse.needsBrowser": "“{{title}}” precisa ser baixado pelo navegador",
   "browse.needsBrowserDesc":
     "O {{host}} bloqueia downloads dentro do app — abra a página dele para concluir.",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -143,6 +143,14 @@ export interface ModSummary {
   /** Featured image URL, if any. */
   image: string | null;
   categoryId: number;
+  /**
+   * Who posted the mod, as the catalog names them. Null where the site didn't say.
+   *
+   * Optional rather than required because `ShopItem` extends this shape and a purchased
+   * download has no byline to carry — the store's "All My Downloads" page lists files, not
+   * authors.
+   */
+  author?: string | null;
 }
 
 /** A mod's community score on mxb-mods.com, as shown under the site's own thumbnails. */


### PR DESCRIPTION
Two unrelated changes, one branch.

## 1. The install picker says which file it's about to fetch

Installing from mxb-mods sometimes landed on the **dedicated-server build**. Two things caused it together:

- **Detection** flagged a server build by looking for `"server"` as a *substring* of the download block's text. That misses an author who only says it in the file name (`Ironman_2024_Server.pkz`), and false-positives on a track called *Observer Hill*.
- **Presentation** then *dropped* whatever was flagged. So a mislabelled block took a mod's only download off the page, while a server build that went undetected and carried the page's `container-default` flag sorted first, got preselected, and was installed with nothing on screen naming it.

**Parser** (`src-tauri/src/mods/mxb.rs`) now reads the link's file name as well as the block text, matches the word only where it stands on its own — letters as boundaries rather than `\b`, since `_` is a word character and `track_server.zip` is how these are named — and sorts server builds last regardless of the page's default flag.

**Install dialog** lists every download instead of filtering:

- Recommended/default preselected, never a server build while anything playable exists.
- First 3 mirrors visible (was 1, which read as "this is the only file"), with a "N more mirrors" toggle.
- Each row shows the author's own name for the file, so two MediaFire links are distinguishable.
- Server builds sit under a *dedicated server files (N)* disclosure, badged **Server**, still selectable for whoever runs one.
- **Recommended** / **Browser** / **Server** badges are translated now; they were hardcoded English.

**Quick install** from the grid refuses a mod that offers nothing but server files and points at the mod page, rather than silently installing one. That page shows a warning above Add to Library.

The now-inaccurate bulk-skip strings ("browser-only host") were reworded, since server-only mods land in that same bucket.

## 2. A browse card says who made it

The catalog knows who posted each mod and the grid never showed it. The listing request already asks WordPress to embed the featured image, so the post's author rides along in the same request — no extra round trip — and lands beside the date, mirroring the shop card that has carried a byline all along.

Optional at every layer: a WordPress site can keep its author list private and answers the embed with an error object when it does. A card without a byline keeps its date; the listing doesn't fail. `author` is optional on the TS `ModSummary` too, because `ShopItem` extends that shape and a purchased download has no author to carry.

## Verification

- 5 new Rust tests covering the parser and the author embed (real name, private-author error object, no `_embed`, blank name). The dev container has no GTK/gdk system libs, so `cargo test` can't build the Tauri crate there — these were run against the extracted functions in an isolated crate, and CI here is their first run in the real build. That harness is what caught the `\b`-vs-underscore bug in the first regex.
- `tsc --noEmit`, `eslint` and `vite build` clean.
- 12 behavioral checks over the mirror helpers (ordering, server-only, per-bike sound matching, empty pages), bundled and run under node. Scratch-run, not added to the repo — there's no JS test runner here.

## Worth checking against live data

The dev container's network policy blocks mxb-mods.com, so the author embed was implemented against the standard WordPress REST shape without seeing a live response. Two things to eyeball: whether the site exposes authors at all (if not, every card silently keeps just the date), and whether the WP post author is the *modder* or a site upload account. If it's the latter, every card shows the same name and the real creator is likely still only in the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfSM265CxPFw2shKEcVQSF

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfSM265CxPFw2shKEcVQSF)_