### PR TITLE
feat(designer): undo the whole editor, and keep the bucket on its panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## Unreleased — undo covers the whole editor, and the bucket stays on its panel
+
+### Added
+- **Undo covers everything now, not just brush strokes.** Adding, moving, scaling, rotating,
+  clipping and deleting layers, and adding, renaming, reordering and deleting sheets, all go on
+  the same timeline as the painting — so Ctrl+Z takes back whatever you actually did last,
+  rather than the last stroke and nothing else. A drag or a slider scrub is one step, not the
+  two hundred events it was made of.
+- **The bucket fills the panel you clicked, not the whole sheet.** A bike sheet is a dozen
+  panels side by side, and flooding the layer buried the eleven you weren't pointing at. Click
+  outside every island — on the sheet's background — and it still floods the layer, since
+  that's the only thing it could mean there.
+
+## Unreleased — double-click actually focuses, and the label says where on the bike
+
+### Fixed
+- **Double-click to focus a part now works.** The canvas takes pointer capture on every press so
+  a stroke survives leaving the element, and a captured pointer is exactly the case where WebKit
+  stops delivering `dblclick` — so the gesture was never seen. It's recognised from the presses
+  themselves now, which also makes it work under a pen or a touchpad.
+
+### Changed
+- **The hover names the mesh node as well as the group** — `chassis250 Metal.027`. A group's name
+  is whatever its author typed, and authors type anything: the TM pack calls its plastic panels
+  `Metal.NNN` and its metal ones `Plastics.NNN`, so the name alone reads as a contradiction of
+  the panel you're pointing at. The node is the bike's own part, so it still says *where*: a
+  shroud is on the chassis and a rear fender is on the rear suspension, whatever the group
+  is called.
+
 ## Unreleased — the sheet says which panel, which side, and which face
 
 ### Fixed

--- a/src/Components/Studio/Designer/CanvasStage.tsx
+++ b/src/Components/Studio/Designer/CanvasStage.tsx
@@ -44,6 +44,12 @@ function checkerTile(): HTMLCanvasElement {
 const MIN_SCALE = 0.05;
 const MAX_SCALE = 4;
 
+/** How long after a press a second one still counts as a double-click, and how far it may move.
+ *  The platform's own thresholds aren't readable from a webview; these are the usual ones, and
+ *  the slop matters more than the interval on a touchpad, where a "stationary" finger drifts. */
+const DOUBLE_MS = 400;
+const DOUBLE_SLOP = 6;
+
 interface CanvasStageProps {
   sheet: Sheet;
   /** The sheet's composite, already drawn. Blitted here rather than redrawn. */
@@ -124,6 +130,10 @@ export function CanvasStage({
     null,
   );
   const painting = useRef(false);
+  // The last left press, for recognising a double-click ourselves. Null once one has been
+  // recognised, so a run of fast clicks pairs up rather than firing on every press after the
+  // second. See `onPointerDown` for why the DOM's own `dblclick` can't be used here.
+  const lastPress = useRef<{ t: number; x: number; y: number } | null>(null);
   // Which corner the pointer is over, purely so the cursor can say the layer is resizable.
   const [overHandle, setOverHandle] = useState(-1);
   // The piece of bodywork under the pointer. The whole reason the UV map is worth having is
@@ -411,10 +421,57 @@ export function CanvasStage({
     [brushSize, scale],
   );
 
+  /**
+   * Fill the view with one piece of bodywork.
+   *
+   * A shroud is a tenth of a 2048² sheet, and reaching it by wheel-and-drag means aiming at a
+   * shape whose edges are the thing you were trying to see. Double-click is the gesture because
+   * it costs no mode and no modifier: a paint tool lays its first dab where you clicked, and
+   * the view arrives at the part you were already pointing at.
+   */
+  const focusPart = useCallback(
+    (part: UvPart) => {
+      if (!fit || !box.w || !box.h) return;
+      // A degenerate island — one point, or a sliver — would divide the view to infinity.
+      const pw = Math.max(1, (part.maxU - part.minU) * sheet.width);
+      const ph = Math.max(1, (part.maxV - part.minV) * sheet.height);
+      // 0.8 leaves the part's surroundings in frame. A panel cut exactly to the edges gives
+      // nothing to judge where a decal sits relative to the seam beside it.
+      const z = Math.min(8, Math.max(0.25, (Math.min(box.w / pw, box.h / ph) * 0.8) / fit));
+      const s = fit * z;
+      const cx = ((part.minU + part.maxU) / 2) * sheet.width;
+      const cy = ((part.minV + part.maxV) / 2) * sheet.height;
+      setZoom(z);
+      // Pan is measured from the sheet's centre, which is where the blit is anchored.
+      setPan({ x: -(cx - sheet.width / 2) * s, y: -(cy - sheet.height / 2) * s });
+    },
+    [box.w, box.h, fit, sheet.width, sheet.height],
+  );
+
   const onPointerDown = useCallback(
     (e: React.PointerEvent<HTMLCanvasElement>) => {
       const at = toSheet(e.clientX, e.clientY);
       if (!at) return;
+      // The second press of a double-click, timed here rather than taken from the DOM's own
+      // `dblclick`. The canvas captures the pointer on every press so a stroke survives leaving
+      // the element, and a captured pointer is exactly the case where WebKit stops delivering
+      // `dblclick` — so the gesture has to be recognised from the presses we already get.
+      if (e.button === 0) {
+        const prev = lastPress.current;
+        const near = prev && Math.hypot(e.clientX - prev.x, e.clientY - prev.y) < DOUBLE_SLOP;
+        const quick = prev && e.timeStamp - prev.t < DOUBLE_MS;
+        lastPress.current = { t: e.timeStamp, x: e.clientX, y: e.clientY };
+        if (near && quick && parts.length) {
+          const part = partAt(parts, at.x / sheet.width, at.y / sheet.height);
+          if (part) {
+            // Forget the pair, so a third press starts a new one rather than focusing again
+            // on every press of a rapid series.
+            lastPress.current = null;
+            focusPart(part);
+            return;
+          }
+        }
+      }
       e.currentTarget.setPointerCapture(e.pointerId);
       // Middle and right drag pan, whatever the tool — panning while painting matters more
       // than it does while dragging a logo, because a stroke needs the part you can't see.
@@ -454,7 +511,20 @@ export function CanvasStage({
       onSelect(hit?.id ?? null);
       drag.current = { id: hit?.id ?? null, x: e.clientX, y: e.clientY };
     },
-    [handleAt, onPaintStart, onSelect, paints, selectedId, sheet.layers, toSheet, tool],
+    [
+      focusPart,
+      handleAt,
+      onPaintStart,
+      onSelect,
+      paints,
+      parts,
+      selectedId,
+      sheet.layers,
+      sheet.width,
+      sheet.height,
+      toSheet,
+      tool,
+    ],
   );
 
   const onPointerMove = useCallback(
@@ -567,32 +637,6 @@ export function CanvasStage({
     setPan({ x: 0, y: 0 });
   }, []);
 
-  /**
-   * Fill the view with one piece of bodywork.
-   *
-   * A shroud is a tenth of a 2048² sheet, and reaching it by wheel-and-drag means aiming at a
-   * shape whose edges are the thing you were trying to see. Double-click is the gesture because
-   * it costs no mode and no modifier: a paint tool still paints where you clicked, and the view
-   * arrives at the part you were already pointing at.
-   */
-  const focusPart = useCallback(
-    (part: UvPart) => {
-      if (!fit || !box.w || !box.h) return;
-      // A degenerate island — one point, or a sliver — would divide the view to infinity.
-      const pw = Math.max(1, (part.maxU - part.minU) * sheet.width);
-      const ph = Math.max(1, (part.maxV - part.minV) * sheet.height);
-      // 0.8 leaves the part's surroundings in frame. A panel cut exactly to the edges gives
-      // nothing to judge where a decal sits relative to the seam beside it.
-      const z = Math.min(8, Math.max(0.25, (Math.min(box.w / pw, box.h / ph) * 0.8) / fit));
-      const s = fit * z;
-      const cx = ((part.minU + part.maxU) / 2) * sheet.width;
-      const cy = ((part.minV + part.maxV) / 2) * sheet.height;
-      setZoom(z);
-      // Pan is measured from the sheet's centre, which is where the blit is anchored.
-      setPan({ x: -(cx - sheet.width / 2) * s, y: -(cy - sheet.height / 2) * s });
-    },
-    [box.w, box.h, fit, sheet.width, sheet.height],
-  );
 
   const ringed = paints && hasTip(tool);
   // Corners come out of `layerCorners` clockwise from the top left, so 0/2 are one diagonal
@@ -629,16 +673,6 @@ export function CanvasStage({
           if (cursorRef.current) cursorRef.current.style.opacity = "1";
         }}
         onWheel={onWheel}
-        // The part under the pointer, not the one the hover last recorded: a double-click can
-        // land before a hover has been reported on a touchpad, and framing the previous part
-        // would move the view away from what was just clicked.
-        onDoubleClick={(e) => {
-          if (!parts.length) return;
-          const at = toSheet(e.clientX, e.clientY);
-          if (!at) return;
-          const part = partAt(parts, at.x / sheet.width, at.y / sheet.height);
-          if (part) focusPart(part);
-        }}
         onContextMenu={(e) => e.preventDefault()}
       />
       <div
@@ -660,7 +694,11 @@ export function CanvasStage({
         {overPart && (
           <>
             <span>·</span>
-            <span className="max-w-[160px] truncate text-white/70" title={t("designer.focusHint")}>
+            {/* The node first, because a group's name is whatever its author typed and the node
+                is the bike's own part — `chassis` still means the shrouds on a pack that calls
+                them `Metal.027`. */}
+            {overPart.owner && <span className="text-white/70">{overPart.owner}</span>}
+            <span className="max-w-[190px] truncate" title={t("designer.focusHint")}>
               {overAlso ? t("designer.partOver", { part: overPart.label, over: overAlso }) : overPart.label}
             </span>
             {/* Which flank, when the model can say. `both` is the one that saves an

--- a/src/Components/Studio/Designer/Designer.tsx
+++ b/src/Components/Studio/Designer/Designer.tsx
@@ -37,7 +37,7 @@ import { LayerInspector } from "./LayerInspector";
 import { PaintTools } from "./PaintTools";
 import { bitmapFromRgba, composite, hasInk, sheetTexture, toPng } from "./composite";
 import { EMPTY_GHOST, ghostShows, type Ghost } from "./ghost";
-import { partPath, uvParts, uvWireframe, type UvPart } from "./uv";
+import { partAt, partBox, partPath, uvParts, uvWireframe, type UvPart } from "./uv";
 import {
   blankSheet,
   imageLayer,
@@ -110,7 +110,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   const [paint, setPaint] = useState<PaintSettings>(DEFAULT_PAINT);
   // Painting history, and a counter to bring its undo/redo buttons back into a render — the
   // stack itself is a mutable object, so nothing about it would reach React on its own.
-  const history = useRef(new PaintHistory());
+  const history = useRef(new PaintHistory<Sheet[]>());
   const [historyRev, setHistoryRev] = useState(0);
   // The stroke in progress. A ref because it changes on every pointer sample and no render
   // depends on it — the pixels it writes are what reach the screen.
@@ -167,6 +167,12 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   // What was last published as `overrideNames`. Held beside the state so the recomposite below
   // can tell whether it has anything to say *before* saying it — see the note there.
   const publishedNames = useRef("");
+
+  // The sheets as they stand, for the undo stack to snapshot on its way past an edit. A mirror
+  // rather than a read of `sheets`: the callbacks that mutate are memoised on their own
+  // dependencies, and one holding a stale array would remember a state that had already moved on.
+  const sheetsRef = useRef(sheets);
+  sheetsRef.current = sheets;
 
   const active = sheets.find((s) => s.id === activeId) ?? null;
   const bump = useCallback(() => setVersion((v) => v + 1), []);
@@ -272,21 +278,46 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     };
   }, []);
 
-  const patchSheet = useCallback((id: string, fn: (s: Sheet) => Sheet) => {
-    // Every route into a sheet but a stroke comes through here, and none of them says where it
-    // drew. Marking the sheet wholly dirty on the way past is what lets the recomposite treat a
-    // region as a promise rather than a hint: if one is there, a stroke put it there.
-    dirty.current.set(id, null);
-    setSheets((prev) => prev.map((s) => (s.id === id ? fn(s) : s)));
+  /**
+   * Record the document as it stands, so the edit about to happen can be taken back.
+   *
+   * Before the mutation, never after: what undo needs is the state that existed a moment ago,
+   * and once `setSheets` has run there is nothing left holding it. `key` collapses a run of
+   * edits that are one gesture — see `PaintHistory.pushDoc`.
+   */
+  const remember = useCallback((key: string | null = null) => {
+    history.current.pushDoc(sheetsRef.current, key);
+    setHistoryRev((v) => v + 1);
   }, []);
 
+  const patchSheet = useCallback(
+    /**
+     * `undoKey` names the gesture for coalescing, or `false` for an edit the history must not
+     * record — one whose other half lives outside the document, where an undo would restore the
+     * sheet and leave that half where it was.
+     */
+    (id: string, fn: (s: Sheet) => Sheet, undoKey: string | null | false = null) => {
+      // Every route into a sheet but a stroke comes through here, and none of them says where it
+      // drew. Marking the sheet wholly dirty on the way past is what lets the recomposite treat a
+      // region as a promise rather than a hint: if one is there, a stroke put it there.
+      if (undoKey !== false) remember(undoKey);
+      dirty.current.set(id, null);
+      setSheets((prev) => prev.map((s) => (s.id === id ? fn(s) : s)));
+    },
+    [remember],
+  );
+
   const patchLayer = useCallback(
-    (layerId: string, fn: (l: Layer) => Layer) => {
+    (layerId: string, fn: (l: Layer) => Layer, undoKey: string | null | false = null) => {
       if (!activeId) return;
-      patchSheet(activeId, (s) => ({
-        ...s,
-        layers: s.layers.map((l) => (l.id === layerId ? fn(l) : l)),
-      }));
+      patchSheet(
+        activeId,
+        (s) => ({
+          ...s,
+          layers: s.layers.map((l) => (l.id === layerId ? fn(l) : l)),
+        }),
+        undoKey,
+      );
     },
     [activeId, patchSheet],
   );
@@ -414,17 +445,6 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     [active, addPaintLayer, selectedId],
   );
 
-  const startPaint = useCallback(
-    (at: Point) => {
-      if (!target || !activeId) return;
-      const next = new Stroke(target.canvas, paint, at);
-      stroke.current = next;
-      // Straight through rather than queued: the press is the one sample nobody would forgive a
-      // frame's wait on, and a tool that puts nothing down on the press has nothing to show.
-      if (next.dirty) touchPaint(activeId, target.id, next.dirty);
-    },
-    [activeId, paint, target, touchPaint],
-  );
 
   const movePaint = useCallback(
     (points: Point[], constrain: boolean) => {
@@ -471,21 +491,49 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     [historyRev],
   );
 
+  /**
+   * Reading and replacing the document for the history — plus putting the cursor somewhere real
+   * afterwards.
+   *
+   * Undoing the sheet you were looking at leaves `activeId` naming something that no longer
+   * exists, and the editor would come back empty rather than showing what it just restored. The
+   * same for a selected layer. Neither is part of the document, so neither is restored by it.
+   */
+  const docAccess = useMemo(
+    () => ({
+      read: () => sheetsRef.current,
+      write: (next: Sheet[]) => {
+        setSheets(next);
+        setActiveId((cur) => (cur && next.some((s) => s.id === cur) ? cur : next[0]?.id ?? null));
+        setSelectedId((cur) =>
+          cur && next.some((s) => s.layers.some((l) => l.id === cur)) ? cur : null,
+        );
+      },
+    }),
+    [],
+  );
+
   // Not while the pointer is still down: the stroke redraws its layer from its own snapshot on
   // the next sample, so an undo mid-drag would be silently taken back a moment later.
   const undo = useCallback(() => {
     if (stroke.current) return;
-    const entry = history.current.undo(paintCanvas);
+    const entry = history.current.undo(paintCanvas, docAccess);
     setHistoryRev((v) => v + 1);
-    if (entry) touchPaint(entry.sheetId, entry.layerId);
-  }, [paintCanvas, touchPaint]);
+    if (!entry) return;
+    // A document step replaces sheet objects wholesale, and the recomposite already follows
+    // sheet identity — so it needs no region, only to be told the drawing moved.
+    if (entry.kind === "pixels") touchPaint(entry.sheetId, entry.layerId);
+    else bump();
+  }, [bump, docAccess, paintCanvas, touchPaint]);
 
   const redo = useCallback(() => {
     if (stroke.current) return;
-    const entry = history.current.redo(paintCanvas);
+    const entry = history.current.redo(paintCanvas, docAccess);
     setHistoryRev((v) => v + 1);
-    if (entry) touchPaint(entry.sheetId, entry.layerId);
-  }, [paintCanvas, touchPaint]);
+    if (!entry) return;
+    if (entry.kind === "pixels") touchPaint(entry.sheetId, entry.layerId);
+    else bump();
+  }, [bump, docAccess, paintCanvas, touchPaint]);
 
   // Which paint layers exist, as a string. `sheets` changes on every pointer sample of a
   // stroke; this changes only when one is added or deleted, which is the only time the
@@ -581,6 +629,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
         base: bitmap,
         layers: [],
       }));
+      remember();
       setSheets(next);
       setActiveId(next[0]?.id ?? null);
       setSelectedId(null);
@@ -588,7 +637,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
       bump();
       toast.success(t("designer.loadedSheets", { count: String(next.length) }));
     },
-    [bump, readImage, t],
+    [bump, readImage, remember, t],
   );
 
   const startFromPaint = useCallback(async () => {
@@ -646,11 +695,12 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     // the difference between a paint that shows and a paint that doesn't.
     const suggested = missingHints[0] ?? "";
     const sheet = blankSheet(suggested, BLANK_SIZE);
+    remember();
     setSheets((prev) => [...prev, sheet]);
     setActiveId(sheet.id);
     setSelectedId(null);
     bump();
-  }, [bump, missingHints]);
+  }, [bump, missingHints, remember]);
 
   /**
    * One sheet per colour texture the model asks for that isn't on the list yet.
@@ -664,11 +714,12 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   const addHintSheets = useCallback(() => {
     const made = missingHints.map((h) => blankSheet(h, BLANK_SIZE));
     if (!made.length) return;
+    remember();
     setSheets((prev) => [...prev, ...made]);
     setActiveId(made[0].id);
     setSelectedId(null);
     bump();
-  }, [bump, missingHints]);
+  }, [bump, missingHints, remember]);
 
   const addImage = useCallback(async () => {
     if (!active) return;
@@ -714,7 +765,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
 
   const moveLayer = useCallback(
     (id: string, dx: number, dy: number) => {
-      patchLayer(id, (l) => ({ ...l, x: l.x + dx, y: l.y + dy }));
+      patchLayer(id, (l) => ({ ...l, x: l.x + dx, y: l.y + dy }), `layer:${id}`);
       bump();
     },
     [bump, patchLayer],
@@ -723,7 +774,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   /** A corner drag, as an absolute scale. Clamped by the stage to the inspector's range. */
   const scaleLayer = useCallback(
     (id: string, scale: number) => {
-      patchLayer(id, (l) => ({ ...l, scale }));
+      patchLayer(id, (l) => ({ ...l, scale }), `layer:${id}`);
       bump();
     },
     [bump, patchLayer],
@@ -755,6 +806,31 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   const parts = useMemo<UvPart[]>(
     () => (geometry ? uvParts(geometry, activeName, { assembled: bike && assembled }) : []),
     [geometry, activeName, bike, assembled],
+  );
+
+  const startPaint = useCallback(
+    (at: Point) => {
+      if (!target || !activeId) return;
+      // The bucket fills the panel under the press, not the sheet. Worked out here rather than
+      // inside `Stroke`, because the parts are the editor's knowledge of the model and paint.ts
+      // is deliberately ignorant of it — it puts pixels down, wherever it is told to.
+      let fillTo: { path: Path2D; box: Region } | null = null;
+      if (paint.tool === "fill" && active && parts.length) {
+        const under = partAt(parts, at.x / active.width, at.y / active.height);
+        if (under) {
+          fillTo = {
+            path: partPath(under, active.width, active.height),
+            box: partBox(under, active.width, active.height),
+          };
+        }
+      }
+      const next = new Stroke(target.canvas, paint, at, fillTo);
+      stroke.current = next;
+      // Straight through rather than queued: the press is the one sample nobody would forgive a
+      // frame's wait on, and a tool that puts nothing down on the press has nothing to show.
+      if (next.dirty) touchPaint(activeId, target.id, next.dirty);
+    },
+    [active, activeId, paint, parts, target, touchPaint],
   );
 
   /** Pin the selected layer to a piece of bodywork, or let it cover the sheet again. */
@@ -859,13 +935,17 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
       const sheet = sheets.find((s) => s.id === sheetId);
       if (!sheet) return;
       const ghost = ghostOf(sheetId);
+      // Not recorded by the history, either way: the bitmap moves between the sheet and the
+      // ghost, and the ghost isn't part of the document — an undo would put the template back
+      // on the sheet while the ghost still held it, which is the copy this is careful not to
+      // make. Pressing the button again is the way back, as it always was.
       if (sheet.base) {
         const template = sheet.base;
-        patchSheet(sheetId, (s) => ({ ...s, base: null }));
+        patchSheet(sheetId, (s) => ({ ...s, base: null }), false);
         patchGhost(sheetId, (g) => ({ ...g, template, showTemplate: true }));
       } else if (ghost.template) {
         const base = ghost.template;
-        patchSheet(sheetId, (s) => ({ ...s, base }));
+        patchSheet(sheetId, (s) => ({ ...s, base }), false);
         patchGhost(sheetId, (g) => ({ ...g, template: null }));
       }
       bump();
@@ -973,20 +1053,26 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
    * the `.pnt`. The mesh binds by name either way, but a paint whose sheets are ordered the
    * way its author expects is easier to diff and to hand to somebody else.
    */
-  const reorderSheet = useCallback((id: string, delta: number) => {
-    setSheets((prev) => {
-      const at = prev.findIndex((s) => s.id === id);
-      const to = at + delta;
-      if (at < 0 || to < 0 || to >= prev.length) return prev;
-      const next = [...prev];
-      const [moved] = next.splice(at, 1);
-      next.splice(to, 0, moved);
-      return next;
-    });
-  }, []);
+  const reorderSheet = useCallback(
+    (id: string, delta: number) => {
+      // Keyed, so walking a sheet three places up is one step back rather than three.
+      remember(`sheet-order:${id}`);
+      setSheets((prev) => {
+        const at = prev.findIndex((s) => s.id === id);
+        const to = at + delta;
+        if (at < 0 || to < 0 || to >= prev.length) return prev;
+        const next = [...prev];
+        const [moved] = next.splice(at, 1);
+        next.splice(to, 0, moved);
+        return next;
+      });
+    },
+    [remember],
+  );
 
   const removeSheet = useCallback(
     (id: string) => {
+      remember();
       setSheets((prev) => {
         const next = prev.filter((s) => s.id !== id);
         setActiveId((cur) => (cur === id ? next[0]?.id ?? null : cur));
@@ -994,7 +1080,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
       });
       bump();
     },
-    [bump],
+    [bump, remember],
   );
 
   /** Why saving isn't possible yet, as a translated message — or null when it is, and on an
@@ -1215,7 +1301,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
               onClip={clipLayer}
               onFit={fitLayer}
               onChange={(fn) => {
-                patchLayer(selected.id, fn);
+                patchLayer(selected.id, fn, `layer:${selected.id}`);
                 bump();
               }}
             />

--- a/src/Components/Studio/Designer/paint.ts
+++ b/src/Components/Studio/Designer/paint.ts
@@ -341,6 +341,16 @@ export class Stroke {
     private readonly target: HTMLCanvasElement,
     private readonly settings: PaintSettings,
     at: Point,
+    /**
+     * The piece of bodywork the fill is confined to, when there is one under the press.
+     *
+     * A bike sheet is a dozen panels side by side, and a flood of the whole layer is almost
+     * never what "fill" was reached for — it buries the eleven you weren't pointing at, and
+     * every one of them has to be painted back. Confined to the part, the bucket does what it
+     * looks like it does. Only the fill uses it: a brush stroke is already aimed by the hand,
+     * and clipping one would make it stop dead at a seam the hand can't see.
+     */
+    fillTo?: { path: Path2D; box: Region } | null,
   ) {
     this.before = cloneCanvas(target);
     this.scratch = scratchFor(target.width, target.height);
@@ -354,9 +364,12 @@ export class Stroke {
       const ctx = this.scratch.getContext("2d");
       if (ctx) {
         ctx.fillStyle = withAlpha(this.settings.colorA, 1);
-        ctx.fillRect(0, 0, this.scratch.width, this.scratch.height);
+        // Nonzero, so the triangles a part is made of stop being separate shapes and the seams
+        // between them don't come out unfilled.
+        if (fillTo) ctx.fill(fillTo.path, "nonzero");
+        else ctx.fillRect(0, 0, this.scratch.width, this.scratch.height);
       }
-      this.mark(this.whole());
+      this.mark(fillTo ? fillTo.box : this.whole());
       this.painted = true;
     } else if (!DRAG_TOOLS.has(this.settings.tool)) {
       this.dab(at, at);
@@ -484,9 +497,46 @@ export class Stroke {
 /* ── Undo ───────────────────────────────────────────────────────────────────────────────── */
 
 export interface Snapshot {
+  kind: "pixels";
   sheetId: string;
   layerId: string;
   canvas: HTMLCanvasElement;
+}
+
+/**
+ * The document as it was before an edit that wasn't pixels — a layer added, moved, deleted, a
+ * sheet renamed or reordered.
+ *
+ * Generic over the document so this file keeps knowing nothing about sheets and layers. It
+ * stores whatever it was handed and hands the same thing back, which is all a snapshot of
+ * immutable state has to do.
+ */
+export interface DocStep<Doc> {
+  kind: "doc";
+  doc: Doc;
+  /**
+   * What kind of edit it was, or null for one that stands alone.
+   *
+   * Dragging a layer across the sheet is one edit to a person and two hundred to the state that
+   * records it. Consecutive edits sharing a key inside `COALESCE_MS` collapse into the first,
+   * so one undo takes back the whole drag rather than a pixel of it.
+   */
+  key: string | null;
+  at: number;
+}
+
+export type Step<Doc> = Snapshot | DocStep<Doc>;
+
+/** How long a run of same-key edits keeps counting as one gesture. */
+const COALESCE_MS = 700;
+
+/** Steps to keep, so a session of small edits can't grow the timeline without end. */
+const MAX_STEPS = 200;
+
+/** Reading and replacing the document, for the steps that are made of it rather than of pixels. */
+export interface DocAccess<Doc> {
+  read: () => Doc;
+  write: (doc: Doc) => void;
 }
 
 /**
@@ -499,15 +549,20 @@ export interface Snapshot {
 const MAX_PIXELS = 24_000_000;
 
 /**
- * Painting history, for the paint layers only.
+ * The editor's undo, over both of the things an edit can be.
  *
- * Deliberately not the whole editor's undo: adding, moving and deleting layers are React state
- * and would need their own mechanism. Undoing a brush stroke you can see is the thing you reach
- * for while painting, and it's the thing that has no other way back.
+ * A stroke changes pixels inside a canvas; adding, moving or deleting a layer changes the
+ * document those canvases hang off. Two stacks would be two timelines, and Ctrl+Z would take
+ * back whichever of them happened to be asked — so both kinds of step live in this one, in the
+ * order they were made.
+ *
+ * Pixels are remembered by copying them, which is why the budget below is counted in pixels.
+ * Document steps cost a reference each: every mutation replaces the state rather than editing
+ * it, so the previous version is still whole and still there to be pointed at.
  */
-export class PaintHistory {
-  private past: Snapshot[] = [];
-  private future: Snapshot[] = [];
+export class PaintHistory<Doc = unknown> {
+  private past: Step<Doc>[] = [];
+  private future: Step<Doc>[] = [];
 
   get canUndo() {
     return this.past.length > 0;
@@ -518,8 +573,30 @@ export class PaintHistory {
   }
 
   push(sheetId: string, layerId: string, before: HTMLCanvasElement) {
-    this.past.push({ sheetId, layerId, canvas: before });
+    this.past.push({ kind: "pixels", sheetId, layerId, canvas: before });
     // A new stroke is a new branch of the drawing; whatever was undone away is gone.
+    this.future = [];
+    this.trim();
+  }
+
+  /**
+   * Remember the document as it is *before* an edit is applied to it.
+   *
+   * Called by the edit rather than derived from watching the state, because only the edit knows
+   * that it is one: the state changes on every pointer sample of a stroke too, and a timeline
+   * built by watching would be a hundred steps of a single brush line.
+   */
+  pushDoc(doc: Doc, key: string | null = null) {
+    const top = this.past[this.past.length - 1];
+    const now = performance.now();
+    if (top?.kind === "doc" && key !== null && top.key === key && now - top.at < COALESCE_MS) {
+      // Still the same gesture. The state to go back to is the one already held, so this keeps
+      // that and only extends the window — a slow drag stays one step however long it takes.
+      top.at = now;
+      this.future = [];
+      return;
+    }
+    this.past.push({ kind: "doc", doc, key, at: now });
     this.future = [];
     this.trim();
   }
@@ -532,12 +609,21 @@ export class PaintHistory {
    * the visible layers were never in.
    */
   private step(
-    from: Snapshot[],
-    to: Snapshot[],
+    from: Step<Doc>[],
+    to: Step<Doc>[],
     resolve: (layerId: string) => HTMLCanvasElement | null,
-  ): Snapshot | null {
+    doc: DocAccess<Doc>,
+  ): Step<Doc> | null {
     while (from.length) {
       const entry = from[from.length - 1];
+      if (entry.kind === "doc") {
+        from.pop();
+        // What's on screen now becomes the way back, so undo and redo are the same move in
+        // opposite directions and neither has to know which way it is going.
+        to.push({ ...entry, doc: doc.read() });
+        doc.write(entry.doc);
+        return entry;
+      }
       const live = resolve(entry.layerId);
       if (!live) {
         from.pop();
@@ -560,17 +646,29 @@ export class PaintHistory {
   }
 
   /** Restore the previous state onto its layer, and hand back which one moved. */
-  undo(resolve: (layerId: string) => HTMLCanvasElement | null): Snapshot | null {
-    return this.step(this.past, this.future, resolve);
+  undo(
+    resolve: (layerId: string) => HTMLCanvasElement | null,
+    doc: DocAccess<Doc>,
+  ): Step<Doc> | null {
+    return this.step(this.past, this.future, resolve, doc);
   }
 
-  redo(resolve: (layerId: string) => HTMLCanvasElement | null): Snapshot | null {
-    return this.step(this.future, this.past, resolve);
+  redo(
+    resolve: (layerId: string) => HTMLCanvasElement | null,
+    doc: DocAccess<Doc>,
+  ): Step<Doc> | null {
+    return this.step(this.future, this.past, resolve, doc);
   }
 
-  /** Drop everything belonging to layers that are no longer there. True if any were. */
+  /**
+   * Drop the pixel steps belonging to layers that are no longer there. True if any were.
+   *
+   * Document steps are kept whatever happened to a layer — one of them is very likely the step
+   * that would *bring it back*, and dropping it because its subject is currently missing is
+   * exactly backwards.
+   */
   keepOnly(alive: (sheetId: string, layerId: string) => boolean): boolean {
-    const live = (s: Snapshot) => alive(s.sheetId, s.layerId);
+    const live = (s: Step<Doc>) => s.kind === "doc" || alive(s.sheetId, s.layerId);
     const before = this.past.length + this.future.length;
     this.past = this.past.filter(live);
     this.future = this.future.filter(live);
@@ -583,11 +681,16 @@ export class PaintHistory {
   }
 
   private trim() {
-    const cost = (s: Snapshot) => s.canvas.width * s.canvas.height;
+    // A document step holds no pixels, so it costs nothing against the pixel budget and is
+    // counted only against the step count below.
+    const cost = (s: Step<Doc>) => (s.kind === "doc" ? 0 : s.canvas.width * s.canvas.height);
     let total = [...this.past, ...this.future].reduce((n, s) => n + cost(s), 0);
     // Oldest first — the step you're least likely to reach for is the one furthest back.
     while (total > MAX_PIXELS && this.past.length > 1) {
-      total -= cost(this.past.shift() as Snapshot);
+      total -= cost(this.past.shift() as Step<Doc>);
+    }
+    while (this.past.length + this.future.length > MAX_STEPS && this.past.length > 1) {
+      this.past.shift();
     }
   }
 }

--- a/src/Components/Studio/Designer/uv.ts
+++ b/src/Components/Studio/Designer/uv.ts
@@ -56,6 +56,16 @@ const FACE_TOLERANCE = 0.3;
 export interface UvPart {
   /** Mesh-group name from the `.edf` — `shroud`, `frame.005`, `chain`. */
   label: string;
+  /**
+   * The mesh node the group sits on — `chassis`, `steer`, `fsusp`, `rsusp` — or null when the
+   * group is spread over several.
+   *
+   * Worth carrying because a group name is whatever the author typed, and authors type
+   * anything: the TM pack calls its plastic panels `Metal.NNN` and its metal ones
+   * `Plastics.NNN`. The node is the bike's own part, so it still says *where* — a shroud is on
+   * the chassis and a rear fender is on the rear suspension, however the group is named.
+   */
+  owner: string | null;
   /** Triangle corners in uv space, six numbers per triangle: u0,v0,u1,v1,u2,v2. */
   tris: Float32Array;
   /**
@@ -210,6 +220,7 @@ export function uvParts(
   const byLabel = new Map<string, number[]>();
   const flanksByLabel = new Map<string, number[]>();
   const facesByLabel = new Map<string, number[]>();
+  const nodesByLabel = new Map<string, Set<string>>();
   for (const node of nodes) {
     if (!node.uvs.length || !node.indices.length) continue;
     const triCount = Math.floor(node.indices.length / 3);
@@ -227,6 +238,12 @@ export function uvParts(
         flat = [];
         byLabel.set(label, flat);
       }
+      let owners = nodesByLabel.get(label);
+      if (!owners) {
+        owners = new Set();
+        nodesByLabel.set(label, owners);
+      }
+      owners.add(node.name);
       let sides = flanksByLabel.get(label);
       if (!sides && sided) {
         sides = [];
@@ -277,8 +294,12 @@ export function uvParts(
     }
     const sides = flanksByLabel.get(label);
     const faces = facesByLabel.get(label);
+    const owners = nodesByLabel.get(label);
     parts.push({
       label,
+      // Only when it's the one answer. A group spread over three nodes has no single place to
+      // point at, and naming the first would be picking one arbitrarily.
+      owner: owners?.size === 1 ? [...owners][0] : null,
       tris: new Float32Array(flat),
       flanks: sides ? new Uint8Array(sides) : null,
       side: sides ? summarise(sides) : null,
@@ -314,6 +335,27 @@ export function partPath(part: UvPart, width: number, height: number): Path2D {
     path.closePath();
   }
   return path;
+}
+
+/**
+ * A part's bounds in sheet pixels, rounded outwards.
+ *
+ * Outwards because this is what a redraw is told to catch up with: a box rounded inwards leaves
+ * the half-pixel at the edge of a fill on the layer and missing from the composite.
+ */
+export function partBox(
+  part: UvPart,
+  width: number,
+  height: number,
+): { x: number; y: number; w: number; h: number } {
+  const x = Math.max(0, Math.floor(part.minU * width));
+  const y = Math.max(0, Math.floor(part.minV * height));
+  return {
+    x,
+    y,
+    w: Math.min(width, Math.ceil(part.maxU * width)) - x,
+    h: Math.min(height, Math.ceil(part.maxV * height)) - y,
+  };
 }
 
 /** Whether (u,v) is inside a triangle, by the sign of the three edge cross-products. */


### PR DESCRIPTION
## Undo covers the editor, not just strokes

`PaintHistory` was pixels only, by design — its own doc said layer and sheet edits "would need their own mechanism". Two stacks would have been two timelines, and Ctrl+Z would take back whichever of them happened to be asked, so both kinds of step now live in one, in the order they were made.

Layer add / move / scale / rotate / clip / delete, sheet add / rename / reorder / delete, and loading sheets from a paint all record. Document steps cost a reference each — every mutation already replaces the state rather than editing it — and a run of same-key edits inside 700ms collapses into one, so a drag or a slider scrub is one step rather than the two hundred events it is made of.

**The trace toggle is deliberately not recorded.** It *moves* the template between the sheet and the ghost, and the ghost isn't part of the document: an undo would restore the sheet's copy while the ghost kept its own — the duplication that feature exists to avoid. Pressing it again is still the way back.

## The bucket fills the panel under the press

A bike sheet is a dozen panels side by side, and flooding the whole layer buried the eleven you weren't pointing at. `Stroke` now takes a path to fill; working out *which* path stays on the editor's side, since `paint.ts` is deliberately ignorant of the model. A press on the sheet's background still floods the layer, which is the only thing it could mean there.

## Double-click to focus, actually firing

It never fired. The canvas takes pointer capture on every press so a stroke survives leaving the element, and a captured pointer is exactly the case where WebKit stops delivering `dblclick`. It's recognised from the presses themselves now (400ms, 6px), which also makes it work under a pen or a touchpad.

## The hover leads with the mesh node

`chassis250 Metal.027`. A group's name is whatever its author typed, and the TM pack calls its plastic panels `Metal.NNN` and its metal ones `Plastics.NNN` — so the group name alone reads as a contradiction of the panel you're pointing at. The node is the bike's own part, so it still says *where*.

## Verified

`tsc --noEmit` and `eslint` clean (the two remaining warnings are pre-existing, in `ViewerDialog`). Exercised in the running app: draw, move a layer, delete it, add a sheet, then Ctrl+Z back through all of it; bucket-fill on a shroud; double-click an island.

Known trade-offs, both deliberate: the history pins a deleted layer's canvas until its step ages out (capped at 200 steps), and two different tweaks to the same layer inside 700ms collapse into one undo step.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)