### PR TITLE
feat: detect cheats attached to the running game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 ## Unreleased — FrostMod runs on Linux, and the app can see the game there
 
 ### Added
+- **Cheat detection.** MX Bikes ships no anti-cheat, so a hooked client is
+  indistinguishable from an honest one — to the server, to the grid, and to the game. The
+  cheats going round are injected DLLs and external trainers, and an injected DLL has one
+  property worth building on: to hook the game it has to be *inside* the game, which puts it
+  in the process's module list. The app now reads that list while you ride (every 45s for as
+  long as the game is up, whether the app launched it or Steam did) and reports one of four
+  verdicts. Three of them are not accusations: **nothing unaccounted for**, **something
+  unrecognised is loaded** — an overlay or capture tool nobody has listed yet lands here —
+  and **not checked**, which is what a machine we could not read gets and is never a synonym
+  for clean. Only a match against the signature list is called a cheat. Findings name the
+  file, where it loaded from, and why it was reported; Settings → Cheat detection shows the
+  live answer and re-runs it on demand.
+- **Signatures update without a release.** They live in
+  [`integrity-rules.json`](integrity-rules.json) on `main`, fetched and cached at runtime
+  like `supporters.json` — a cheat that appears on a Tuesday cannot wait for a build. What
+  ships in the binary is the *allowlist* and no signatures at all, so an install that never
+  reaches the network is cautious rather than wrong; the allowlist is what stops an ordinary
+  gaming PC (Steam overlay, GPU driver, Discord, OBS, RivaTuner, ReShade) from lighting up
+  on first launch. A remote list can only add to that allowlist, and can never un-flag a
+  signature.
+- **Servers can see their grid's client checks.** With sharing turned on — its own switch,
+  off by default — a client publishes its verdict to the control plane, and the admin of the
+  server it is on sees it in the Servers tab, worst first, with a rider who was flagged
+  earlier in the session still shown as flagged rather than being cleared by unloading the
+  cheat for a lap. What is sent is the verdict and the names of *rule-matched* detections
+  only: an unrecognised-but-unnamed module is counted and never named, because on somebody's
+  machine that could be anything. Readable by the server's owner and by riders currently on
+  it, so you can see the grid you're riding with and can't go fishing for anyone else.
+  The list is honest about what it is: a rider appears only if their app is running,
+  watching and sharing, so somebody missing from it hasn't been cleared — and a cheater who
+  closes MXB App is never scanned at all. This proves an honest client is honest, which is
+  something a server currently has no way to ask for; it does not make cheating impossible.
 - **FrostMod installs and runs on Linux.** It used to refuse with *FrostMod runs on Windows
   only*, which was true of the binary and beside the point: on Linux the game is a Windows
   process too — Steam runs it under Proton — so FrostMod belongs in that same Proton prefix,

--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ hours), then downloads and installs them on restart.
   bodywork under the cursor, and a layer can be fitted to a part and clipped to its
   outline — so an image covers the shroud and stops at the seam. Save writes the
   packed `.pnt` the game reads.
+- **Cheat detection**: MX Bikes has no anti-cheat, so a hooked client looks exactly
+  like an honest one. The app reads what is loaded *into* the running game — the one
+  place an injected DLL has to be in order to hook it — and reports whether anything
+  is unaccounted for. Signatures live in
+  [`integrity-rules.json`](integrity-rules.json) on `main` and are fetched at runtime,
+  so a new cheat is detectable without a release; the binary itself ships only the
+  allowlist that keeps an ordinary machine's overlays and drivers from being reported.
+  A verdict can be shared with the server you're on, which is the only way a server
+  currently has of asking a client anything about itself. It proves an honest client
+  is honest — it can't prove anyone else's is, since a cheater who doesn't run MXB App
+  is never scanned.
 - **Self-update**: `tauri-plugin-updater` against the `latest.json` published with
   each release; signature-verified, installs on restart.
 - **Supporters**: Settings → Supporters credits the people who bought a coffee on

--- a/control-plane/migrations/0010_integrity.sql
+++ b/control-plane/migrations/0010_integrity.sql
@@ -1,0 +1,44 @@
+-- What each client's own cheat scan found, so a server admin can see it.
+--
+-- MX Bikes has no anti-cheat, so a server has no way to ask a joining client anything about
+-- itself. This is the smallest thing that changes that: the player's app scans the running
+-- game (see `src-tauri/src/integrity.rs`) and publishes the verdict here, and the admin of
+-- the server they are on can read it back.
+--
+-- It is attestation, not enforcement, and the table is shaped to keep that honest. A cheater
+-- who does not run MXB App has no row. One who turns reporting off has no row. So the read
+-- answers "who has attested and what did they say" — never "who is clean" — and a missing
+-- row is the most common state, not a suspicious one.
+--
+-- One row per account, rewritten on every heartbeat, exactly like `presence`: this is live
+-- state, not a history. Deliberately not a column on `accounts` for the same reason presence
+-- isn't — a verdict is short-lived and rewritten constantly, an identity is neither.
+CREATE TABLE integrity (
+  account_id    TEXT PRIMARY KEY REFERENCES accounts (id) ON DELETE CASCADE,
+  -- 'unknown' | 'clean' | 'suspect' | 'flagged'. Text rather than an integer so a row read
+  -- straight out of the database says what it means.
+  verdict       TEXT NOT NULL,
+  -- Which rule list produced it. A 'clean' checked against an empty list means much less
+  -- than one checked against the current one, and an admin can only tell them apart if the
+  -- version travels with the verdict.
+  rules_version INTEGER NOT NULL,
+  -- How many loaded modules were unrecognised but matched no rule. A count and never a
+  -- list: "software we don't recognise" is not evidence, and on somebody's machine it could
+  -- be anything. The client never sends their names.
+  suspect_count INTEGER NOT NULL,
+  -- JSON array of {name,label,sha256} for rule-matched detections only. Those are named,
+  -- because a known cheat is the thing worth naming.
+  flagged       TEXT NOT NULL,
+  -- The worst verdict this account has reported recently, and when.
+  --
+  -- Without it the feature is trivially defeated: load the cheat for one lap, unload it, and
+  -- the next 45-second heartbeat overwrites 'flagged' with 'clean' as if nothing happened.
+  -- The read only surfaces this while `worst_at` is inside the same freshness window the
+  -- roster uses, so it describes the current session and then lets go — a verdict about
+  -- somebody should not outlive the race it was about.
+  worst_verdict TEXT NOT NULL,
+  worst_at      INTEGER NOT NULL,
+  -- Refreshed on every publish. A row older than the cutoff is treated as gone, so an admin
+  -- can tell "reported clean a moment ago" from "stopped reporting when the race started".
+  updated_at    INTEGER NOT NULL
+);

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -31,11 +31,16 @@ import {
   isPublicGameAddress,
   isRegion,
   isRelDest,
+  isReportCount,
   isServerKey,
   isRiderName,
   isServerName,
   isSha256,
   isSlot,
+  isVerdict,
+  parseFlagged,
+  verdictRank,
+  type Verdict,
   MAX_BOOTSTRAP_LOG,
   MAX_PAINT_BYTES,
 } from "./validate";
@@ -132,6 +137,8 @@ async function route(request: Request, env: Env): Promise<Response> {
   if (method === "PUT" && path === "/v1/loadouts") return putLoadouts(request, account, env);
   if (method === "GET" && path === "/v1/roster") return roster(url, env);
   if (method === "PUT" && path === "/v1/presence") return putPresence(request, account, env);
+  if (method === "PUT" && path === "/v1/integrity") return putIntegrity(request, account, env);
+  if (method === "GET" && path === "/v1/integrity") return serverIntegrity(url, account, env);
   if (method === "POST" && path === "/v1/servers") return registerServer(request, account, env);
   if (method === "GET" && path === "/v1/servers/mine") return myServers(account, env);
   if (method === "GET" && path === "/v1/fleet") return fleetState(account, env);
@@ -1372,6 +1379,138 @@ async function roster(url: URL, env: Env): Promise<Response> {
     });
   }
   return json(200, { server: serverId, riders: [...riders.values()] });
+}
+
+/**
+ * A client publishing what its own cheat scan found.
+ *
+ * The client decides what to send and could send anything, which is the honest limit of the
+ * whole feature — see `migrations/0010_integrity.sql`. Nothing here tries to work around
+ * that; it validates the shape, keeps the worst verdict of the recent past alongside the
+ * current one, and stores it.
+ */
+async function putIntegrity(request: Request, account: Account, env: Env): Promise<Response> {
+  const body = await readJson(request);
+  if (!body) return json(400, { error: "expected a JSON body" });
+  const { verdict, rulesVersion, suspectCount, flagged } = body as Record<string, unknown>;
+  if (!isVerdict(verdict)) return json(400, { error: "that isn't a verdict" });
+  if (!isReportCount(rulesVersion)) return json(400, { error: "that isn't a rules version" });
+  if (!isReportCount(suspectCount)) return json(400, { error: "that isn't a suspect count" });
+
+  const now = Date.now();
+  // The worst verdict only carries forward while it is still about this session. Past the
+  // freshness window it is history, and history is not what this table is for.
+  const prev = await env.DB.prepare(
+    "SELECT worst_verdict, worst_at FROM integrity WHERE account_id = ?",
+  )
+    .bind(account.id)
+    .first<{ worst_verdict: string; worst_at: number }>();
+  const stillCurrent = prev && prev.worst_at > now - PRESENCE_TTL_MS && isVerdict(prev.worst_verdict);
+  const keepWorst = stillCurrent && verdictRank(prev.worst_verdict as Verdict) > verdictRank(verdict);
+
+  await env.DB.prepare(
+    "INSERT INTO integrity (account_id, verdict, rules_version, suspect_count, flagged," +
+      " worst_verdict, worst_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)" +
+      " ON CONFLICT(account_id) DO UPDATE SET verdict = excluded.verdict," +
+      " rules_version = excluded.rules_version, suspect_count = excluded.suspect_count," +
+      " flagged = excluded.flagged, worst_verdict = excluded.worst_verdict," +
+      " worst_at = excluded.worst_at, updated_at = excluded.updated_at",
+  )
+    .bind(
+      account.id,
+      verdict,
+      rulesVersion,
+      suspectCount,
+      JSON.stringify(parseFlagged(flagged)),
+      keepWorst ? prev!.worst_verdict : verdict,
+      keepWorst ? prev!.worst_at : now,
+      now,
+    )
+    .run();
+  return json(200, { ok: true });
+}
+
+/**
+ * What the riders on one server have attested.
+ *
+ * Readable by the server's owner, and by anyone currently on it — you can see the grid you
+ * are actually riding with, and you cannot go fishing for somebody who isn't near you. A
+ * verdict is about a person, so it is not public the way the server list is.
+ *
+ * The response deliberately reads as "who has attested", not "who is clean". A rider whose
+ * app isn't running, isn't scanning, or isn't reporting simply isn't here, and that is the
+ * ordinary case rather than a suspicious one — the client that matters most is exactly the
+ * one that will never appear.
+ */
+async function serverIntegrity(url: URL, account: Account, env: Env): Promise<Response> {
+  const serverId = url.searchParams.get("server");
+  if (!isServerKey(serverId)) return json(400, { error: "a server id is required" });
+
+  const fresh = Date.now() - PRESENCE_TTL_MS;
+  const owns = await env.DB.prepare(
+    "SELECT 1 FROM servers WHERE id = ? AND owner_account_id = ?",
+  )
+    .bind(serverId, account.id)
+    .first();
+  if (!owns) {
+    const present = await env.DB.prepare(
+      "SELECT 1 FROM presence WHERE account_id = ? AND server_id = ? AND updated_at > ?",
+    )
+      .bind(account.id, serverId, fresh)
+      .first();
+    if (!present) return json(403, { error: "that isn't your server, and you aren't on it" });
+  }
+
+  const rows = await env.DB.prepare(
+    "SELECT a.rider_name, a.guid, i.verdict, i.rules_version, i.suspect_count, i.flagged," +
+      " i.worst_verdict, i.worst_at, i.updated_at" +
+      " FROM accounts a" +
+      " JOIN presence pr ON pr.account_id = a.id" +
+      " JOIN integrity i ON i.account_id = a.id" +
+      " WHERE pr.server_id = ? AND pr.updated_at > ? AND i.updated_at > ?",
+  )
+    .bind(serverId, fresh, fresh)
+    .all<{
+      rider_name: string;
+      guid: string | null;
+      verdict: string;
+      rules_version: number;
+      suspect_count: number;
+      flagged: string;
+      worst_verdict: string;
+      worst_at: number;
+      updated_at: number;
+    }>();
+
+  const riders = rows.results.map((r) => ({
+    riderName: r.rider_name,
+    guid: r.guid ?? "",
+    verdict: isVerdict(r.verdict) ? r.verdict : "unknown",
+    rulesVersion: r.rules_version,
+    suspectCount: r.suspect_count,
+    flagged: parseFlagged(safeParse(r.flagged)),
+    // Only while it still describes this session — see the migration.
+    worstVerdict:
+      r.worst_at > fresh && isVerdict(r.worst_verdict) ? r.worst_verdict : undefined,
+    reportedAt: r.updated_at,
+  }));
+  // Worst first: an admin opening this is looking for the one row that isn't clean.
+  riders.sort(
+    (a, b) =>
+      verdictRank(b.worstVerdict ?? b.verdict) - verdictRank(a.worstVerdict ?? a.verdict) ||
+      a.riderName.localeCompare(b.riderName),
+  );
+  return json(200, { server: serverId, riders });
+}
+
+/** Read a column we wrote as JSON. A row that somehow isn't parseable is an empty list, not
+ *  a 500 — one bad row must not take out an admin's whole view. */
+function safeParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return [];
+  }
 }
 
 async function readJson(request: Request): Promise<unknown | null> {

--- a/control-plane/src/validate.ts
+++ b/control-plane/src/validate.ts
@@ -299,3 +299,76 @@ export function isServerKey(value: unknown): value is string {
   return !/[\u0000-\u001f\u007f]/.test(key);
 }
 
+
+/**
+ * Verdicts a client may report, worst last.
+ *
+ * `unknown` is a real answer and not an error: it is what a client says when it could not
+ * read the game's module list at all. Storing it matters — an admin needs to tell "scanned,
+ * found nothing" from "could not scan", and collapsing the two into a missing row would lose
+ * exactly that distinction.
+ */
+export const VERDICTS = ["unknown", "clean", "suspect", "flagged"] as const;
+export type Verdict = (typeof VERDICTS)[number];
+
+export function isVerdict(value: unknown): value is Verdict {
+  return typeof value === "string" && (VERDICTS as readonly string[]).includes(value);
+}
+
+/** Rank a verdict for comparison, so "worst so far" is a `max` rather than a lookup table. */
+export function verdictRank(value: Verdict): number {
+  return VERDICTS.indexOf(value);
+}
+
+/** One named detection, as the client reports it. */
+export interface FlaggedItem {
+  name: string;
+  label: string;
+  sha256: string;
+}
+
+/** How many detections one report may carry. A client with more than this is malfunctioning,
+ *  not unusually infected, and the array is stored as JSON in a single column. */
+export const MAX_FLAGGED = 32;
+const MAX_FLAGGED_CHARS = 120;
+
+/**
+ * Clean one client's list of named detections into something storable.
+ *
+ * Every field here is attacker-controlled in the one sense that matters: a client reports on
+ * *itself*, so anything in here is whatever that machine chose to send. It is echoed back to
+ * an admin's UI, so it is bounded and stripped of control characters rather than trusted —
+ * and anything unparseable is dropped rather than rejecting the whole report, since the
+ * verdict is the part worth keeping.
+ */
+export function parseFlagged(value: unknown): FlaggedItem[] {
+  if (!Array.isArray(value)) return [];
+  const out: FlaggedItem[] = [];
+  for (const entry of value.slice(0, MAX_FLAGGED)) {
+    if (!entry || typeof entry !== "object") continue;
+    const raw = entry as Record<string, unknown>;
+    const name = text(raw.name);
+    if (!name) continue;
+    out.push({
+      name,
+      label: text(raw.label) ?? "",
+      // Anything that isn't a real digest is dropped rather than stored as junk: its only
+      // use is being pasted into the rule list, and a malformed one there is a dead rule.
+      sha256: isSha256(raw.sha256) ? raw.sha256 : "",
+    });
+  }
+  return out;
+}
+
+function text(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  // eslint-disable-next-line no-control-regex
+  const s = value.trim().replace(/[\x00-\x1f\x7f]/g, "").slice(0, MAX_FLAGGED_CHARS);
+  return s.length ? s : null;
+}
+
+/** A count a client reports about itself. Bounded so a malformed or hostile client can't
+ *  store a number the UI then has to render. */
+export function isReportCount(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 10_000;
+}

--- a/control-plane/test/validate.test.ts
+++ b/control-plane/test/validate.test.ts
@@ -16,7 +16,12 @@ import {
   isServerName,
   isSha256,
   isSlot,
+  isReportCount,
+  isVerdict,
+  MAX_FLAGGED,
   MAX_PAINT_BYTES,
+  parseFlagged,
+  verdictRank,
 } from "../src/validate";
 
 describe("paint filenames", () => {
@@ -342,5 +347,68 @@ describe("server keys", () => {
     for (const bad of ["", "   ", "a".repeat(129), withNewline, 5, null]) {
       expect(isServerKey(bad), JSON.stringify(bad)).toBe(false);
     }
+  });
+});
+
+describe("integrity reports", () => {
+  it("accepts the four verdicts and nothing else", () => {
+    for (const v of ["unknown", "clean", "suspect", "flagged"]) expect(isVerdict(v)).toBe(true);
+    expect(isVerdict("CLEAN")).toBe(false);
+    expect(isVerdict("cheating")).toBe(false);
+    expect(isVerdict(2)).toBe(false);
+    expect(isVerdict(undefined)).toBe(false);
+  });
+
+  // The ordering the "worst so far" logic rests on: a client that loads a cheat for one lap
+  // and unloads it must not be able to overwrite `flagged` with `clean`.
+  it("ranks verdicts worst-last", () => {
+    expect(verdictRank("flagged")).toBeGreaterThan(verdictRank("suspect"));
+    expect(verdictRank("suspect")).toBeGreaterThan(verdictRank("clean"));
+    // Unknown is the *lowest*, not a middle ground: it means nobody looked, so it can never
+    // be the worst thing seen and can never displace a real finding.
+    expect(verdictRank("clean")).toBeGreaterThan(verdictRank("unknown"));
+  });
+
+  it("keeps a well-formed detection", () => {
+    expect(
+      parseFlagged([{ name: "kaizo.dll", label: "Kaizo trainer", sha256: "a".repeat(64) }]),
+    ).toEqual([{ name: "kaizo.dll", label: "Kaizo trainer", sha256: "a".repeat(64) }]);
+  });
+
+  // Everything in a report is chosen by the machine being reported on, and all of it is
+  // echoed back into an admin's UI.
+  it("bounds and strips whatever a client sends", () => {
+    const escape = String.fromCharCode(27);
+    const [item] = parseFlagged([
+      { name: `  kaizo${escape}[31m.dll  `, label: "x".repeat(500), sha256: "nonsense" },
+    ]);
+    expect(item.name).toBe("kaizo[31m.dll");
+    expect(item.label.length).toBeLessThanOrEqual(120);
+    // A digest that isn't one is dropped, not stored: its only use is being pasted into the
+    // rule list, where a malformed entry is a dead rule.
+    expect(item.sha256).toBe("");
+  });
+
+  it("drops entries it cannot use rather than failing the whole report", () => {
+    expect(parseFlagged([null, 7, {}, { label: "no name" }, { name: "real.dll" }])).toEqual([
+      { name: "real.dll", label: "", sha256: "" },
+    ]);
+    expect(parseFlagged("not an array")).toEqual([]);
+    expect(parseFlagged(undefined)).toEqual([]);
+  });
+
+  it("caps how many detections one report may carry", () => {
+    const many = Array.from({ length: MAX_FLAGGED + 20 }, (_, i) => ({ name: `c${i}.dll` }));
+    expect(parseFlagged(many)).toHaveLength(MAX_FLAGGED);
+  });
+
+  it("only accepts counts it can render", () => {
+    expect(isReportCount(0)).toBe(true);
+    expect(isReportCount(12)).toBe(true);
+    expect(isReportCount(-1)).toBe(false);
+    expect(isReportCount(1.5)).toBe(false);
+    expect(isReportCount(10_001)).toBe(false);
+    expect(isReportCount("3")).toBe(false);
+    expect(isReportCount(Number.NaN)).toBe(false);
   });
 });

--- a/integrity-rules.json
+++ b/integrity-rules.json
@@ -1,0 +1,23 @@
+{
+  "_comment": [
+    "Cheat signatures for the in-app scanner. Read from `main` at runtime by every install",
+    "(src-tauri/src/integrity.rs), so adding a signature here reaches everyone within the",
+    "hour — no release needed. Bump `version` on every edit; it is what an admin sees",
+    "beside a verdict.",
+    "",
+    "`cheats` entries match a module or process by `contains` (a lowercase substring of the",
+    "file name) or by `sha256` (the whole file). One or the other, not both — an entry",
+    "needing each is two entries sharing a label. `label` is shown to the user verbatim.",
+    "",
+    "`allow` and `allowPaths` silence a false positive: the scanner reports any DLL loaded",
+    "into the game from outside the game, Windows, or the folders we installed, so a new",
+    "overlay or capture tool will land there until it is listed. These ADD to the allowlist",
+    "compiled into the app; they cannot remove from it, and they cannot un-flag a signature.",
+    "",
+    "Adding a name here accuses whoever is running that file of cheating. Be sure."
+  ],
+  "version": 1,
+  "cheats": [],
+  "allow": [],
+  "allowPaths": []
+}

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -136,6 +136,21 @@ pub struct AppConfig {
     /// What paint sync last did, so the UI can say so instead of the player having to guess
     /// from an empty grid. Written by the background tasks; never edited by hand.
     pub sync: SyncState,
+    /// Watch for cheats attached to the running game — see [`crate::integrity`].
+    ///
+    /// On by default, unlike the other things that talk to a server, because the local half
+    /// costs nothing and talks to nobody: it reads the game's own module list and shows the
+    /// answer here. The half that leaves the machine is gated separately on
+    /// [`AppConfig::integrity_report`], which is off until it's chosen.
+    pub integrity_watch: bool,
+    /// Publish this client's verdict to the control plane, so a server admin can see it.
+    ///
+    /// Off by default and deliberately its own switch. Scanning your own game is one thing;
+    /// telling a server operator what a scan found is another, and a player should choose it
+    /// rather than discover it. What gets sent is spelled out in
+    /// [`crate::integritywatch::publish`] — the verdict and the names of *rule-matched*
+    /// detections, never the list of everything loaded on the machine.
+    pub integrity_report: bool,
 }
 
 /// The record of the last publish and the last pull.
@@ -236,6 +251,8 @@ impl Default for AppConfig {
             cp_rider_name: String::new(),
             cp_guid: String::new(),
             sync: SyncState::default(),
+            integrity_watch: true,
+            integrity_report: false,
         }
     }
 }

--- a/src-tauri/src/gameproc.rs
+++ b/src-tauri/src/gameproc.rs
@@ -295,6 +295,110 @@ pub fn is_game_running() -> bool {
     find_game_pid().is_some()
 }
 
+/// Read a fixed-size NUL-padded ANSI field as a `String`, stopping at the terminator.
+#[cfg(windows)]
+fn ansi_field(field: &[std::os::raw::c_char]) -> String {
+    let bytes: Vec<u8> = field.iter().take_while(|&&c| c != 0).map(|&c| c as u8).collect();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+/// Every DLL currently mapped into the running game, by full path.
+///
+/// This is the question [`crate::integrity`] is really asking. A cheat that hooks MX Bikes
+/// has to get its code into the game's address space, and a module that is *in* there is in
+/// this list no matter how it arrived — `LoadLibrary` from an injector, a proxy DLL the
+/// loader pulled in for the exe, or a manual map that bothered to register itself. (One that
+/// doesn't register is invisible here; see the module docs on what that costs.)
+///
+/// `None` means we could not look — the game isn't up, or the snapshot failed — which is
+/// deliberately different from `Some(vec![])`, "we looked and it is clean". The scanner must
+/// never report a clean bill of health for a machine it failed to read.
+#[cfg(windows)]
+pub fn game_module_paths() -> Option<Vec<String>> {
+    let pid = find_game_pid()?;
+    // A snapshot taken while the game is loading its own modules fails with
+    // ERROR_BAD_LENGTH; the documented remedy is simply to ask again.
+    for _ in 0..8 {
+        if let Some(paths) = module_paths(pid) {
+            return Some(paths);
+        }
+    }
+    None
+}
+
+/// One Toolhelp module walk over `pid`. `None` if the snapshot itself failed.
+#[cfg(windows)]
+fn module_paths(pid: u32) -> Option<Vec<String>> {
+    // SAFETY: module snapshot for a known pid; the handle is closed on every path out,
+    // and we only read fields the API filled in.
+    unsafe {
+        let snap =
+            ffi::CreateToolhelp32Snapshot(ffi::TH32CS_SNAPMODULE | ffi::TH32CS_SNAPMODULE32, pid);
+        if snap == ffi::INVALID_HANDLE_VALUE {
+            return None;
+        }
+        let mut me: ffi::ModuleEntry32 = std::mem::zeroed();
+        me.dw_size = std::mem::size_of::<ffi::ModuleEntry32>() as u32;
+        let mut paths = Vec::new();
+        if ffi::Module32First(snap, &mut me) != 0 {
+            loop {
+                let path = ansi_field(&me.sz_exe_path);
+                if !path.is_empty() {
+                    paths.push(path);
+                }
+                if ffi::Module32Next(snap, &mut me) == 0 {
+                    break;
+                }
+            }
+        }
+        ffi::CloseHandle(snap);
+        // An empty walk means the snapshot gave us nothing usable, not that a live process
+        // has no modules — every process has at least its own exe. Treat it as a failure so
+        // the caller retries rather than reporting an empty machine.
+        if paths.is_empty() {
+            None
+        } else {
+            Some(paths)
+        }
+    }
+}
+
+/// Every process on the machine, by executable name.
+///
+/// Names only: `Process32Next` carries `szExeFile` and nothing else, and asking each pid for
+/// its full path means opening it, which fails on anything running as another user or at a
+/// higher integrity level. A name is what the rule list matches on anyway.
+#[cfg(windows)]
+pub fn running_process_names() -> Option<Vec<String>> {
+    // SAFETY: standard Toolhelp process walk; the snapshot handle is closed before return.
+    unsafe {
+        let snap = ffi::CreateToolhelp32Snapshot(ffi::TH32CS_SNAPPROCESS, 0);
+        if snap == ffi::INVALID_HANDLE_VALUE {
+            return None;
+        }
+        let mut entry: ffi::ProcessEntry32 = std::mem::zeroed();
+        entry.dw_size = std::mem::size_of::<ffi::ProcessEntry32>() as u32;
+        let mut names = Vec::new();
+        if ffi::Process32First(snap, &mut entry) != 0 {
+            loop {
+                let name = ansi_field(&entry.sz_exe_file);
+                if !name.is_empty() {
+                    names.push(name);
+                }
+                if ffi::Process32Next(snap, &mut entry) == 0 {
+                    break;
+                }
+            }
+        }
+        ffi::CloseHandle(snap);
+        if names.is_empty() {
+            None
+        } else {
+            Some(names)
+        }
+    }
+}
+
 /// State threaded through the `EnumWindows` walk: the pid we want, the handle we found.
 #[cfg(windows)]
 struct WindowSearch {
@@ -473,6 +577,54 @@ pub fn is_game_running() -> bool {
 #[cfg(not(any(windows, target_os = "macos", target_os = "linux")))]
 pub fn is_game_running() -> bool {
     false
+}
+
+/// The game's mapped DLLs, read out of Proton's view of the process.
+///
+/// Wine maps a PE the same way the loader would, file-backed, so `/proc/<pid>/maps` names
+/// every DLL the game has loaded — including one an injector pushed in. More than one pid
+/// can name the exe (Proton leaves its wrapper around it), so the union across all of them
+/// is what we want rather than a guess at which is the real one.
+#[cfg(target_os = "linux")]
+pub fn game_module_paths() -> Option<Vec<String>> {
+    let pids = crate::proton::exe_pids(crate::game::active().exe);
+    if pids.is_empty() {
+        return None;
+    }
+    let mut paths: Vec<String> = Vec::new();
+    for pid in pids {
+        paths.extend(crate::proton::mapped_pe_files(pid));
+    }
+    if paths.is_empty() {
+        None
+    } else {
+        paths.sort();
+        paths.dedup();
+        Some(paths)
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn running_process_names() -> Option<Vec<String>> {
+    let names = crate::proton::process_names();
+    if names.is_empty() {
+        None
+    } else {
+        Some(names)
+    }
+}
+
+/// macOS runs the game through a Wine bottle we don't own the process tree of, and there is
+/// no `/proc` to read a mapping list out of. Rather than half-answer, say we couldn't look —
+/// the scanner reports "not supported here" instead of a clean bill of health.
+#[cfg(not(any(windows, target_os = "linux")))]
+pub fn game_module_paths() -> Option<Vec<String>> {
+    None
+}
+
+#[cfg(not(any(windows, target_os = "linux")))]
+pub fn running_process_names() -> Option<Vec<String>> {
+    None
 }
 
 #[cfg(not(windows))]

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -1,0 +1,1031 @@
+//! Is anything foreign attached to the running game?
+//!
+//! MX Bikes ships no anti-cheat of its own, so a client that has been hooked looks exactly
+//! like one that hasn't — to the server, to the other riders, and to the game itself. The
+//! cheats going round the Kaizo servers are injected DLLs and external trainers, and an
+//! injected DLL has one property worth building on: to hook the game it has to be *inside*
+//! the game, which means it is in the process's module list. That list is readable from out
+//! here, and this module reads it.
+//!
+//! The shape of an answer is deliberately three-valued, not two:
+//!
+//!   * **Clean** — we read the module list and everything in it is accounted for.
+//!   * **Suspect** — something is loaded that we can't account for. Not an accusation: a
+//!     capture tool, an overlay nobody has told us about, or a driver shim all land here.
+//!   * **Flagged** — it matched the rule list by name or by hash. This one is an accusation.
+//!
+//! and the fourth state, **Unknown**, is the one that matters most for honesty: the game
+//! isn't up, or the platform can't be read, or the snapshot failed. Every path that cannot
+//! see must say so rather than fall through to "clean" — a scanner that reports a healthy
+//! machine when it simply didn't look is worse than no scanner, because people believe it.
+//!
+//! ## What this can and cannot do
+//!
+//! This is client-side attestation, and it is worth being blunt about the limit: a cheater
+//! who does not run MXB App is not scanned, and one who patches this check out reports
+//! whatever they like. It cannot make cheating impossible. What it does is make an honest
+//! client able to *prove* it is honest — which is the thing a server admin currently has no
+//! way to ask for — and raise the cost of the cheats actually in circulation, which are
+//! downloaded DLLs run by people who are not going to rebuild the mod manager to hide them.
+//! A manually-mapped module that never registers with the loader is likewise invisible here.
+//! Treating a Clean report as proof of innocence is a mistake; treating a Flagged one as
+//! worth a look is not.
+//!
+//! ## Rules
+//!
+//! Signatures live in [`RuleSet`], fetched from `integrity-rules.json` on `main` and cached
+//! on disk — the same arrangement `supporters.json` uses, and for the same reason: a cheat
+//! that appears on a Tuesday cannot wait for a release to be detectable. What ships in the
+//! binary is [`RuleSet::bundled`], which carries the allowlist (the part that prevents false
+//! accusations) and no signatures at all, so a build that never reaches the network is
+//! cautious rather than wrong.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Where the live rule list lives. Read from `main` rather than from a tag, so a new cheat
+/// is one commit away from being detected on every install.
+pub const RULES_URL: &str =
+    "https://raw.githubusercontent.com/Frostn1/mxb-app/main/integrity-rules.json";
+
+/// Cache file name, under the app's local data dir.
+const RULES_CACHE: &str = "integrity-rules.json";
+
+/// Long enough for a cold CDN, short enough that a scan isn't held up by a dead network.
+const FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(8);
+
+/// Refuse to hash anything larger than this. A cheat DLL is a few megabytes; a hundred-
+/// megabyte one would only be a way to make every scan stall on disk I/O.
+const MAX_HASH_BYTES: u64 = 96 * 1024 * 1024;
+
+/// Caps on what the remote list may contain. Nothing hostile is expected from our own repo,
+/// but a rule file with a million entries shouldn't be able to make every scan quadratic.
+const MAX_RULES: usize = 2000;
+const MAX_ALLOW: usize = 2000;
+const MAX_PATTERN_CHARS: usize = 120;
+
+/// How bad a finding is.
+///
+/// Ordered worst-last so a report's verdict is `max()` over its findings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Severity {
+    /// Loaded, unrecognised, and not matched by any rule.
+    Suspect,
+    /// Matched the rule list.
+    Flagged,
+}
+
+/// The overall answer for one scan. Ordered so the worst finding decides the report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Verdict {
+    /// We could not look. Never means "clean".
+    Unknown,
+    Clean,
+    Suspect,
+    Flagged,
+}
+
+/// Where a finding was found.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Kind {
+    /// A DLL mapped into the game's own address space.
+    Module,
+    /// A separate process on the machine.
+    Process,
+}
+
+/// Why we are reporting it, as a stable key the UI translates.
+///
+/// An enum rather than a prose string, for the reason [`crate::dropzone::DetectReason`] is:
+/// the line shown to the user has to survive translation into six languages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Reason {
+    /// Its name matched a rule.
+    RuleName,
+    /// Its contents matched a rule's hash — the strong one; renaming the file doesn't help.
+    RuleHash,
+    /// Loaded into the game from somewhere that isn't the game, the system, or anything we
+    /// installed ourselves.
+    ForeignModule,
+    /// A DLL in the game's own folder, under one of the names the Windows loader will pull
+    /// in for the executable beside it. The classic way to get code into a process without
+    /// injecting anything — and, once ReShade is ruled out, not a shape anything innocent
+    /// has.
+    LoaderHijack,
+}
+
+/// One thing worth reporting.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Finding {
+    pub kind: Kind,
+    /// File name, lowercased — what the user recognises and what rules match on.
+    pub name: String,
+    /// Full path when we have one. Empty for a process: the Windows process walk carries
+    /// names only.
+    pub path: String,
+    pub reason: Reason,
+    pub severity: Severity,
+    /// SHA-256 of the file, lowercase hex, when we could read it. This is what turns "some
+    /// unknown DLL" into a signature somebody can add to the rule list, so it is computed
+    /// for findings and never for the hundreds of files that check out fine.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub sha256: String,
+    /// The rule's own label, when a rule matched.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub label: String,
+}
+
+/// One scan's result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Report {
+    pub verdict: Verdict,
+    pub findings: Vec<Finding>,
+    /// Unix ms. Zero before the first scan.
+    pub scanned_at: u64,
+    /// Which rule list produced it, so a stale answer is recognisable as one.
+    pub rules_version: u32,
+    /// How many modules we looked at — the difference between a thorough Clean and an empty
+    /// one, and the number that makes a report auditable.
+    pub modules_scanned: usize,
+    /// The game was running when we looked. A scan with no game is always [`Verdict::Unknown`].
+    pub game_running: bool,
+}
+
+impl Default for Report {
+    fn default() -> Self {
+        Self {
+            verdict: Verdict::Unknown,
+            findings: Vec::new(),
+            scanned_at: 0,
+            rules_version: 0,
+            modules_scanned: 0,
+            game_running: false,
+        }
+    }
+}
+
+impl Report {
+    /// The verdict implied by a set of findings: the worst of them, or clean if there are
+    /// none. Only ever called on a scan that actually read a module list.
+    fn from_findings(findings: Vec<Finding>, modules_scanned: usize, rules_version: u32) -> Self {
+        let verdict = findings
+            .iter()
+            .map(|f| match f.severity {
+                Severity::Suspect => Verdict::Suspect,
+                Severity::Flagged => Verdict::Flagged,
+            })
+            .max()
+            .unwrap_or(Verdict::Clean);
+        Self {
+            verdict,
+            findings,
+            scanned_at: now_ms(),
+            rules_version,
+            modules_scanned,
+            game_running: true,
+        }
+    }
+
+    /// The answer for a machine we could not read. Distinct from clean, on purpose.
+    pub fn unknown(game_running: bool, rules_version: u32) -> Self {
+        Self {
+            verdict: Verdict::Unknown,
+            findings: Vec::new(),
+            scanned_at: now_ms(),
+            rules_version,
+            modules_scanned: 0,
+            game_running,
+        }
+    }
+}
+
+/// One signature. A rule matches on a name substring **or** a hash, never both — an entry
+/// carrying each is two rules that happen to share a label.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct Rule {
+    /// Lowercase substring, matched against a file name. Substring rather than equality
+    /// because these things ship as `kaizo_v3.dll`, `kaizo (1).dll`, `KaizoLoader.dll`.
+    pub contains: String,
+    /// Lowercase hex SHA-256 of the whole file.
+    pub sha256: String,
+    /// What to call it in the report. Free text — the one string here that isn't translated,
+    /// because a cheat's name is its name.
+    pub label: String,
+}
+
+/// What the scanner matches against.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct RuleSet {
+    /// Bumped by whoever edits the list. Reported alongside every verdict so an admin
+    /// looking at a flag knows which list produced it.
+    pub version: u32,
+    /// Things that are cheats. Empty in the bundled set — see the module docs.
+    pub cheats: Vec<Rule>,
+    /// File names that are known-good wherever they load from. The escape hatch for a false
+    /// positive: a new overlay or capture tool can be silenced within the hour.
+    pub allow: Vec<String>,
+    /// Lowercase path substrings whose contents are known-good. For whole toolchains that
+    /// load a dozen DLLs each — a Wine build, a GPU driver stack.
+    pub allow_paths: Vec<String>,
+}
+
+impl RuleSet {
+    /// What the binary ships with: the allowlist, and no signatures.
+    ///
+    /// Signatures deliberately start empty. A shipped list would be out of date by the time
+    /// anyone installed it, and a wrong entry accuses a real person of cheating — so the
+    /// build errs toward saying "something unrecognised is loaded" and leaves naming it to
+    /// the list that can be corrected in minutes.
+    ///
+    /// The allowlist is the opposite: it has to ship, because it is what stops an ordinary
+    /// machine — Steam overlay, GPU driver, Discord, a capture tool — from lighting up on
+    /// first launch, before anything has been fetched.
+    pub fn bundled() -> Self {
+        Self {
+            version: 0,
+            cheats: Vec::new(),
+            allow: BUNDLED_ALLOW.iter().map(|s| s.to_string()).collect(),
+            allow_paths: BUNDLED_ALLOW_PATHS.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    /// Fold a fetched list into the bundled one.
+    ///
+    /// The remote list *adds* to the bundled allowlist rather than replacing it. A remote
+    /// file that arrived truncated, or an editing mistake that drops a line, must not be
+    /// able to turn every machine's Steam overlay into a finding.
+    pub fn merged_with_bundled(mut self) -> Self {
+        let bundled = Self::bundled();
+        self.allow.extend(bundled.allow);
+        self.allow_paths.extend(bundled.allow_paths);
+        self.normalize()
+    }
+
+    /// Lowercase everything, drop empties, and apply the caps. Run on anything from the
+    /// network before it is matched against.
+    pub fn normalize(mut self) -> Self {
+        let clean = |v: Vec<String>, cap: usize| -> Vec<String> {
+            let mut out: Vec<String> = v
+                .into_iter()
+                .map(|s| s.trim().to_ascii_lowercase())
+                .filter(|s| !s.is_empty() && s.chars().count() <= MAX_PATTERN_CHARS)
+                .collect();
+            out.sort();
+            out.dedup();
+            out.truncate(cap);
+            out
+        };
+        self.allow = clean(self.allow, MAX_ALLOW);
+        // Written with either slash in the file; matched against paths we normalize the
+        // same way.
+        self.allow_paths =
+            clean(self.allow_paths, MAX_ALLOW).into_iter().map(|p| p.replace('\\', "/")).collect();
+        self.cheats.truncate(MAX_RULES);
+        self.cheats.retain_mut(|r| {
+            r.contains = r.contains.trim().to_ascii_lowercase();
+            r.sha256 = r.sha256.trim().to_ascii_lowercase();
+            r.label = r.label.trim().chars().take(MAX_PATTERN_CHARS).collect();
+            // A rule with neither pattern matches everything or nothing depending on how it
+            // is read. Neither is a thing anyone meant, so it is dropped.
+            !r.contains.is_empty() || is_sha256(&r.sha256)
+        });
+        self
+    }
+
+    /// Does any rule name this file? Returns the matching rule.
+    fn name_rule(&self, name: &str) -> Option<&Rule> {
+        self.cheats.iter().find(|r| !r.contains.is_empty() && name.contains(&r.contains))
+    }
+
+    /// Does any rule carry this hash?
+    fn hash_rule(&self, sha256: &str) -> Option<&Rule> {
+        self.cheats.iter().find(|r| !r.sha256.is_empty() && r.sha256 == sha256)
+    }
+
+    /// Is this file name explicitly known-good?
+    fn allows_name(&self, name: &str) -> bool {
+        self.allow.iter().any(|a| a == name)
+    }
+
+    /// Is this path inside something explicitly known-good?
+    fn allows_path(&self, path: &str) -> bool {
+        self.allow_paths.iter().any(|a| path.contains(a.as_str()))
+    }
+
+    /// Do we hold any signatures at all?
+    ///
+    /// A list with none can still find things — the heuristics don't need it — but it can
+    /// never say *what* it found, and the UI says so rather than implying an all-clear was
+    /// checked against something.
+    pub fn has_signatures(&self) -> bool {
+        !self.cheats.is_empty()
+    }
+}
+
+/// True for a well-formed lowercase hex SHA-256.
+fn is_sha256(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Names that legitimately live inside a game process.
+///
+/// Not an exhaustive list of good software — it can't be — but the things that would
+/// otherwise make the first scan on an ordinary gaming PC produce a page of findings.
+/// Everything here loads from somewhere the path rules don't already cover: an overlay
+/// injects from its own install, which is exactly the shape a cheat has.
+const BUNDLED_ALLOW: [&str; 25] = [
+    // Steam: the overlay is injected into every game Steam starts.
+    "gameoverlayrenderer64.dll",
+    "gameoverlayrenderer.dll",
+    "steamclient64.dll",
+    "steamclient.dll",
+    "steam_api64.dll",
+    "steam_api.dll",
+    "steamoverlayvulkanlayer64.dll",
+    // Discord's in-game overlay.
+    "discordhook64.dll",
+    "discordhook.dll",
+    // RivaTuner Statistics Server — ships with MSI Afterburner, so it is on a large share
+    // of the machines this will ever run on.
+    "rtsshooks64.dll",
+    "rtsshooks.dll",
+    // OBS and the game-capture path Streamlabs shares with it.
+    "graphics-hook64.dll",
+    "graphics-hook32.dll",
+    // NVIDIA: GeForce Experience / ShadowPlay overlay and the Reflex + upscaling runtime.
+    "nvspcap64.dll",
+    "nvspcap.dll",
+    "nvngx.dll",
+    "nvngx_dlss.dll",
+    "nvcamera64.dll",
+    // AMD's equivalent.
+    "amfrt64.dll",
+    "amf-mft-decvce-avc64.dll",
+    // ReShade, when it is installed under its own name rather than as a proxy DLL. The
+    // proxy case is handled by asking the file — see [`is_loader_hijack`].
+    "reshade64.dll",
+    "reshade32.dll",
+    // FrostMod, which is the whole point of this app being able to talk to the game.
+    "frostmod.dll",
+    "frostmod64.dll",
+    // Wine's own loader stubs, which appear under the game's folder inside a prefix.
+    "winemenubuilder.exe",
+];
+
+/// Path fragments whose contents are known-good, lowercased, forward slashes.
+///
+/// Where [`BUNDLED_ALLOW`] names individual files, these cover whole toolchains that map a
+/// dozen libraries each and would be tedious and fragile to enumerate.
+const BUNDLED_ALLOW_PATHS: [&str; 8] = [
+    // Wine and Proton builtins on Linux. Under Proton the game's `kernel32.dll` genuinely
+    // does come from `/…/Proton - Experimental/files/lib/wine/…`, which is neither the
+    // system folder nor the game folder.
+    "/wine/",
+    "/proton",
+    "/dist/lib/",
+    "/files/lib/",
+    // Steam's own runtime and overlay libraries, on both platforms.
+    "/steamworks shared/",
+    "/linux64/",
+    // GPU drivers, which map into every 3D process.
+    "/nvidia/",
+    "/amd/",
+];
+
+/// DLL names the Windows loader will pull in from the executable's own folder before it
+/// looks anywhere else.
+///
+/// A file with one of these names sitting next to `mxbikes.exe` is loaded into the game
+/// without anything having to inject it — which makes it the cheapest way to hook a game
+/// that has no anti-cheat, and the one shape worth calling out even though the file is
+/// technically "in the game folder" and would otherwise be trusted.
+///
+/// `opengl32.dll` is on the list and is also how ReShade legitimately installs here (MX
+/// Bikes is an OpenGL title — see [`crate::reshade`]), which is why the check reads the
+/// file rather than trusting the name.
+const LOADER_NAMES: [&str; 12] = [
+    "opengl32.dll",
+    "dxgi.dll",
+    "d3d9.dll",
+    "d3d10.dll",
+    "d3d11.dll",
+    "d3d12.dll",
+    "dinput8.dll",
+    "dsound.dll",
+    "winmm.dll",
+    "version.dll",
+    "wininet.dll",
+    "xinput1_3.dll",
+];
+
+/// Everything one scan needs to know about this machine.
+///
+/// Built once per scan and passed to the pure classifier, which is what lets the whole
+/// decision be tested with made-up paths on a machine with no game installed.
+#[derive(Debug, Clone, Default)]
+pub struct ScanContext {
+    /// Folders whose contents are the player's own install: the game, FrostMod, ReShade.
+    /// Lowercased with forward slashes.
+    pub trusted_roots: Vec<String>,
+    /// The game's install folder specifically — the one place a loader hijack can happen.
+    pub game_dir: String,
+}
+
+impl ScanContext {
+    pub fn new(game_dir: &Path, extra_roots: &[PathBuf]) -> Self {
+        let mut trusted_roots: Vec<String> = extra_roots.iter().map(|p| norm(p)).collect();
+        let game_dir = norm(game_dir);
+        if !game_dir.is_empty() {
+            trusted_roots.push(game_dir.clone());
+        }
+        trusted_roots.retain(|r| !r.is_empty());
+        Self { trusted_roots, game_dir }
+    }
+
+    fn is_trusted_root(&self, path: &str) -> bool {
+        self.trusted_roots.iter().any(|root| is_inside(path, root))
+    }
+
+    fn is_in_game_dir(&self, path: &str) -> bool {
+        !self.game_dir.is_empty() && is_inside(path, &self.game_dir)
+    }
+}
+
+/// A path lowercased with forward slashes, so Windows and Wine spellings of the same folder
+/// compare equal.
+fn norm(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/").trim_end_matches('/').to_ascii_lowercase()
+}
+
+/// Is `path` inside `root`? Compared on path *boundaries*, so `C:/games/mx` does not swallow
+/// `C:/games/mxcheat`.
+fn is_inside(path: &str, root: &str) -> bool {
+    path.strip_prefix(root).is_some_and(|rest| rest.starts_with('/'))
+}
+
+/// Is this one of Windows' own DLLs, by where it lives?
+///
+/// Matched on the shape of the path rather than on a substring, because a substring test
+/// would hand a free pass to anything that put itself in `C:\kaizo\windows\system32\`. The
+/// two legitimate spellings are a drive root (`C:\Windows\System32\…`) and the same folder
+/// inside a Wine prefix (`…/pfx/drive_c/windows/system32/…`).
+fn is_system_path(path: &str) -> bool {
+    const SYSTEM_DIRS: [&str; 4] = ["system32/", "syswow64/", "winsxs/", "globalization/"];
+    let Some((root, rest)) = path.split_once("/windows/") else { return false };
+    let rooted = root.len() == 2 && root.ends_with(':') || root.ends_with("/drive_c");
+    rooted && SYSTEM_DIRS.iter().any(|d| rest.starts_with(d))
+}
+
+/// The file name from a path, lowercased.
+fn file_name_of(path: &str) -> String {
+    path.rsplit('/').next().unwrap_or(path).to_ascii_lowercase()
+}
+
+/// Whether a module in the game's own folder is there to hijack the loader.
+///
+/// Only asks the question for the names the loader actually preloads, and only answers yes
+/// once the file has been read and is not ReShade. `probe` is the ReShade test, passed in so
+/// the classifier stays pure and testable.
+fn is_loader_hijack(name: &str, path: &str, ctx: &ScanContext, probe: &dyn Fn(&Path) -> bool) -> bool {
+    LOADER_NAMES.contains(&name) && ctx.is_in_game_dir(path) && !probe(Path::new(path))
+}
+
+/// Turn one module path into a finding, or `None` if it checks out.
+///
+/// The order here is the whole policy, and it is deliberate:
+///
+///   1. **Rules first.** A name or hash on the list is a cheat wherever it loaded from — a
+///      cheat that copies itself into the game folder must not be trusted for being there.
+///   2. **Allowlist next**, so a false positive can be silenced without a release.
+///   3. **Loader hijack**, which is the one case where being in the game folder is itself
+///      the evidence rather than a defence.
+///   4. **Trusted roots and the system folder**, which is where the overwhelming majority of
+///      an ordinary module list ends up.
+///   5. Anything left is loaded into the game from somewhere unaccounted for: Suspect.
+fn classify_module(
+    path: &str,
+    ctx: &ScanContext,
+    rules: &RuleSet,
+    hash: &dyn Fn(&Path) -> String,
+    is_reshade: &dyn Fn(&Path) -> bool,
+) -> Option<Finding> {
+    let path = path.replace('\\', "/");
+    let lower = path.to_ascii_lowercase();
+    let name = file_name_of(&lower);
+
+    let finding = |reason: Reason, severity: Severity, label: String, sha256: String| {
+        Some(Finding {
+            kind: Kind::Module,
+            name: name.clone(),
+            path: path.clone(),
+            reason,
+            severity,
+            sha256,
+            label,
+        })
+    };
+
+    if let Some(rule) = rules.name_rule(&name) {
+        // Hash it anyway: a name match is the weak half of a signature, and the digest is
+        // what confirms it later.
+        return finding(Reason::RuleName, Severity::Flagged, rule.label.clone(), hash(Path::new(&path)));
+    }
+    // Hashing is the expensive step, so it happens once, here, and only when there are
+    // hash rules to check against — never for the hundreds of modules that will pass.
+    let digest = if rules.cheats.iter().any(|r| !r.sha256.is_empty()) {
+        hash(Path::new(&path))
+    } else {
+        String::new()
+    };
+    if !digest.is_empty() {
+        if let Some(rule) = rules.hash_rule(&digest) {
+            return finding(Reason::RuleHash, Severity::Flagged, rule.label.clone(), digest);
+        }
+    }
+
+    if rules.allows_name(&name) || rules.allows_path(&lower) {
+        return None;
+    }
+    if is_loader_hijack(&name, &lower, ctx, is_reshade) {
+        return finding(
+            Reason::LoaderHijack,
+            Severity::Suspect,
+            String::new(),
+            hash(Path::new(&path)),
+        );
+    }
+    if ctx.is_trusted_root(&lower) || is_system_path(&lower) {
+        return None;
+    }
+    finding(Reason::ForeignModule, Severity::Suspect, String::new(), hash(Path::new(&path)))
+}
+
+/// Turn one running process name into a finding, or `None`.
+///
+/// Processes are matched by rule only. There is no heuristic worth having here: a machine
+/// runs two hundred processes and none of them being recognised is normal, so "unrecognised
+/// process" would flag everybody. This exists so the rule list can name an external trainer
+/// that never injects anything.
+fn classify_process(name: &str, rules: &RuleSet) -> Option<Finding> {
+    let name = name.to_ascii_lowercase();
+    if rules.allows_name(&name) {
+        return None;
+    }
+    let rule = rules.name_rule(&name)?;
+    Some(Finding {
+        kind: Kind::Process,
+        name,
+        path: String::new(),
+        reason: Reason::RuleName,
+        severity: Severity::Flagged,
+        sha256: String::new(),
+        label: rule.label.clone(),
+    })
+}
+
+/// Classify a whole machine. Pure — every fact it needs is an argument.
+pub fn classify(
+    modules: &[String],
+    processes: &[String],
+    ctx: &ScanContext,
+    rules: &RuleSet,
+    hash: &dyn Fn(&Path) -> String,
+    is_reshade: &dyn Fn(&Path) -> bool,
+) -> Report {
+    let mut findings: Vec<Finding> = modules
+        .iter()
+        .filter_map(|m| classify_module(m, ctx, rules, hash, is_reshade))
+        .collect();
+    findings.extend(processes.iter().filter_map(|p| classify_process(p, rules)));
+
+    // One entry per file. A DLL is mapped many times over — once per section on Linux — and
+    // the module list can spell the same path either way, so the identity is the *lowercased*
+    // path rather than the one we display. Two genuinely distinct files on a case-sensitive
+    // filesystem differing only in case would merge; that is a trade worth making against
+    // every Linux player seeing each finding six times.
+    let mut seen = std::collections::HashSet::new();
+    findings.retain(|f| seen.insert((f.name.clone(), f.path.to_ascii_lowercase())));
+    // Worst first, so the UI's first line is the one that matters.
+    findings.sort_by(|a, b| {
+        b.severity.cmp(&a.severity).then_with(|| a.name.cmp(&b.name)).then_with(|| a.path.cmp(&b.path))
+    });
+    Report::from_findings(findings, modules.len(), rules.version)
+}
+
+/// SHA-256 of a file, lowercase hex. Empty when it can't be read or is implausibly large —
+/// a missing digest costs a weaker report, never a wrong one.
+pub fn hash_file(path: &Path) -> String {
+    use sha2::{Digest, Sha256};
+    let Ok(meta) = std::fs::metadata(path) else { return String::new() };
+    if !meta.is_file() || meta.len() > MAX_HASH_BYTES {
+        return String::new();
+    }
+    let Ok(mut file) = std::fs::File::open(path) else { return String::new() };
+    let mut hasher = Sha256::new();
+    if std::io::copy(&mut file, &mut hasher).is_err() {
+        return String::new();
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+/// Scan this machine now.
+///
+/// `None` from either enumeration is what makes the difference between a report and an
+/// [`Verdict::Unknown`]: the game not being up, or a platform with nothing to read, must
+/// never produce a clean bill of health.
+pub fn scan(ctx: &ScanContext, rules: &RuleSet) -> Report {
+    let game_running = crate::gameproc::is_game_running();
+    let Some(modules) = crate::gameproc::game_module_paths() else {
+        return Report::unknown(game_running, rules.version);
+    };
+    // Processes are a bonus: the module list is the real answer, and a failed process walk
+    // shouldn't throw it away.
+    let processes = crate::gameproc::running_process_names().unwrap_or_default();
+    classify(&modules, &processes, ctx, rules, &hash_file, &crate::reshade::is_reshade_dll)
+}
+
+// ---------------------------------------------------------------------------
+// The rule list
+// ---------------------------------------------------------------------------
+
+fn cache_path(app: &tauri::AppHandle) -> Option<PathBuf> {
+    use tauri::Manager;
+    app.path().app_local_data_dir().ok().map(|dir| dir.join(RULES_CACHE))
+}
+
+/// The best rule list available without touching the network: the cache if we have one,
+/// otherwise what the binary shipped with.
+pub fn cached_rules(app: &tauri::AppHandle) -> RuleSet {
+    cache_path(app)
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|text| serde_json::from_str::<RuleSet>(&text).ok())
+        .map(RuleSet::merged_with_bundled)
+        .unwrap_or_else(RuleSet::bundled)
+}
+
+/// Fetch the live rule list and cache it.
+///
+/// Best-effort by design, and the failure mode is the point: an unreachable network leaves
+/// the last good list in place, and a machine that has never reached it still scans with the
+/// bundled allowlist. Nothing about a scan waits on this succeeding.
+pub async fn refresh_rules(app: &tauri::AppHandle) -> anyhow::Result<RuleSet> {
+    let text = reqwest::Client::builder()
+        .timeout(FETCH_TIMEOUT)
+        .build()?
+        .get(RULES_URL)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    // Parse before writing: a cache holding something we can't read would keep failing on
+    // every launch until someone cleared it by hand.
+    let rules: RuleSet = serde_json::from_str(&text)?;
+    if let Some(path) = cache_path(app) {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if let Err(e) = std::fs::write(&path, &text) {
+            log::warn!("[integrity] couldn't cache the rule list: {e}");
+        }
+    }
+    log::info!("[integrity] rule list v{} ({} signatures)", rules.version, rules.cheats.len());
+    Ok(rules.merged_with_bundled())
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A machine with the game installed on Windows and nothing unusual on it.
+    fn ctx() -> ScanContext {
+        ScanContext::new(
+            Path::new("C:\\Games\\MX Bikes"),
+            &[PathBuf::from("C:\\Users\\rider\\AppData\\Local\\com.frost.mxbikes\\frostmod")],
+        )
+    }
+
+    fn no_hash(_: &Path) -> String {
+        String::new()
+    }
+    fn not_reshade(_: &Path) -> bool {
+        false
+    }
+    fn is_reshade(_: &Path) -> bool {
+        true
+    }
+
+    fn scan_with(modules: &[&str], rules: &RuleSet) -> Report {
+        let modules: Vec<String> = modules.iter().map(|s| s.to_string()).collect();
+        classify(&modules, &[], &ctx(), rules, &no_hash, &not_reshade)
+    }
+
+    /// The baseline that decides whether anyone keeps the feature turned on. An ordinary
+    /// module list — the game, Windows, the Steam overlay, a GPU driver, FrostMod — has to
+    /// come back clean, or the first scan buries the real signal in noise.
+    #[test]
+    fn an_ordinary_machine_is_clean() {
+        let report = scan_with(
+            &[
+                "C:\\Games\\MX Bikes\\mxbikes.exe",
+                "C:\\Games\\MX Bikes\\core.dll",
+                "C:\\WINDOWS\\System32\\kernel32.dll",
+                "C:\\Windows\\SysWOW64\\user32.dll",
+                "C:\\Windows\\WinSxS\\x86_amd64_something\\comctl32.dll",
+                "C:\\Program Files (x86)\\Steam\\GameOverlayRenderer64.dll",
+                "C:\\Users\\rider\\AppData\\Local\\com.frost.mxbikes\\frostmod\\FrostMod.dll",
+                "C:\\Program Files\\NVIDIA Corporation\\nvspcap64.dll",
+            ],
+            &RuleSet::bundled(),
+        );
+        assert_eq!(report.verdict, Verdict::Clean, "findings: {:?}", report.findings);
+        assert_eq!(report.modules_scanned, 8);
+    }
+
+    /// The case the whole feature exists for: a DLL loaded into the game from a download
+    /// folder. No rule names it and none has to — being in there at all is the finding.
+    #[test]
+    fn a_dll_injected_from_somewhere_else_is_suspect() {
+        let report =
+            scan_with(&["C:\\Users\\rider\\Downloads\\kaizo_v3.dll"], &RuleSet::bundled());
+        assert_eq!(report.verdict, Verdict::Suspect);
+        assert_eq!(report.findings[0].reason, Reason::ForeignModule);
+        assert_eq!(report.findings[0].name, "kaizo_v3.dll");
+    }
+
+    /// With a signature it stops being "something unrecognised" and gets a name.
+    #[test]
+    fn a_rule_turns_a_suspect_module_into_a_flagged_one() {
+        let rules = RuleSet {
+            version: 7,
+            cheats: vec![Rule {
+                contains: "kaizo".into(),
+                label: "Kaizo trainer".into(),
+                ..Default::default()
+            }],
+            ..RuleSet::bundled()
+        }
+        .normalize();
+        let report = scan_with(&["C:\\Users\\rider\\Downloads\\Kaizo_v3.dll"], &rules);
+        assert_eq!(report.verdict, Verdict::Flagged);
+        assert_eq!(report.findings[0].reason, Reason::RuleName);
+        assert_eq!(report.findings[0].label, "Kaizo trainer");
+        assert_eq!(report.rules_version, 7);
+    }
+
+    /// Rules outrank location. A cheat that copies itself in beside the game is still a
+    /// cheat — this is the ordering the classifier is built around.
+    #[test]
+    fn a_named_cheat_inside_the_game_folder_is_still_flagged() {
+        let rules = RuleSet {
+            cheats: vec![Rule { contains: "kaizo".into(), label: "Kaizo".into(), ..Default::default() }],
+            ..RuleSet::bundled()
+        }
+        .normalize();
+        let report = scan_with(&["C:\\Games\\MX Bikes\\kaizo.dll"], &rules);
+        assert_eq!(report.verdict, Verdict::Flagged);
+    }
+
+    /// A hash rule catches the same file renamed, which is the first thing anyone tries.
+    #[test]
+    fn a_hash_rule_catches_a_renamed_cheat() {
+        let digest = "a".repeat(64);
+        let rules = RuleSet {
+            cheats: vec![Rule {
+                sha256: digest.clone(),
+                label: "Kaizo v3".into(),
+                ..Default::default()
+            }],
+            ..RuleSet::bundled()
+        }
+        .normalize();
+        let hash = |_: &Path| digest.clone();
+        let modules = vec!["C:\\Games\\MX Bikes\\perfectly_innocent.dll".to_string()];
+        let report = classify(&modules, &[], &ctx(), &rules, &hash, &not_reshade);
+        assert_eq!(report.verdict, Verdict::Flagged);
+        assert_eq!(report.findings[0].reason, Reason::RuleHash);
+        assert_eq!(report.findings[0].sha256, digest);
+    }
+
+    /// The allowlist is the release valve for a false positive, and it has to beat the
+    /// heuristics — that is the entire reason it exists.
+    #[test]
+    fn the_allowlist_silences_a_heuristic_finding() {
+        let rules = RuleSet { allow: vec!["newoverlay.dll".into()], ..RuleSet::bundled() }.normalize();
+        let report = scan_with(&["C:\\Program Files\\NewOverlay\\NewOverlay.dll"], &rules);
+        assert_eq!(report.verdict, Verdict::Clean);
+    }
+
+    /// …but it must not be able to un-flag a known cheat. Otherwise one bad line in a file
+    /// anyone can open a PR against turns the whole thing off.
+    #[test]
+    fn the_allowlist_cannot_override_a_signature() {
+        let rules = RuleSet {
+            cheats: vec![Rule { contains: "kaizo".into(), label: "Kaizo".into(), ..Default::default() }],
+            allow: vec!["kaizo.dll".into()],
+            ..RuleSet::bundled()
+        }
+        .normalize();
+        assert_eq!(scan_with(&["C:\\anywhere\\kaizo.dll"], &rules).verdict, Verdict::Flagged);
+    }
+
+    /// A DLL under one of the loader's preload names, in the game folder, that isn't
+    /// ReShade — code in the process with nothing injected.
+    #[test]
+    fn a_proxy_dll_in_the_game_folder_is_suspect() {
+        let report = scan_with(&["C:\\Games\\MX Bikes\\dinput8.dll"], &RuleSet::bundled());
+        assert_eq!(report.verdict, Verdict::Suspect);
+        assert_eq!(report.findings[0].reason, Reason::LoaderHijack);
+    }
+
+    /// ReShade installs as exactly that shape and is not a cheat, so the check reads the
+    /// file instead of trusting the name.
+    #[test]
+    fn a_reshade_opengl32_in_the_game_folder_is_clean() {
+        let modules = vec!["C:\\Games\\MX Bikes\\opengl32.dll".to_string()];
+        let report = classify(&modules, &[], &ctx(), &RuleSet::bundled(), &no_hash, &is_reshade);
+        assert_eq!(report.verdict, Verdict::Clean);
+        // The same file, not ReShade, is the hijack it looks like.
+        let report = classify(&modules, &[], &ctx(), &RuleSet::bundled(), &no_hash, &not_reshade);
+        assert_eq!(report.verdict, Verdict::Suspect);
+    }
+
+    /// Windows' own folders are trusted by shape, not by substring — or anything could put
+    /// itself in a folder called `windows\system32` and be waved through.
+    #[test]
+    fn only_a_real_system_folder_is_a_system_folder() {
+        assert!(is_system_path("c:/windows/system32/kernel32.dll"));
+        assert!(is_system_path("c:/windows/syswow64/user32.dll"));
+        assert!(is_system_path(
+            "/home/rider/.steam/steamapps/compatdata/655500/pfx/drive_c/windows/system32/kernel32.dll"
+        ));
+        assert!(!is_system_path("c:/kaizo/windows/system32/evil.dll"));
+        assert!(!is_system_path("c:/windows/temp/evil.dll"));
+    }
+
+    /// Path containment is on boundaries. A folder that merely starts with the game's path
+    /// is not inside it.
+    #[test]
+    fn a_sibling_folder_is_not_inside_the_game_folder() {
+        let report = scan_with(&["C:\\Games\\MX Bikes Cheats\\loader.dll"], &RuleSet::bundled());
+        assert_eq!(report.verdict, Verdict::Suspect);
+    }
+
+    /// Under Proton the game's own runtime comes out of the Proton build, which is neither
+    /// the system folder nor the game folder. Without the path allowlist every Linux player
+    /// would see a hundred findings.
+    #[test]
+    fn proton_builtins_are_clean() {
+        let ctx = ScanContext::new(
+            Path::new("/home/rider/.steam/steam/steamapps/common/MX Bikes"),
+            &[],
+        );
+        let modules: Vec<String> = [
+            "/home/rider/.steam/steam/steamapps/common/MX Bikes/mxbikes.exe",
+            "/home/rider/.steam/steam/steamapps/common/Proton - Experimental/files/lib/wine/x86_64-windows/kernel32.dll",
+            "/home/rider/.steam/steam/steamapps/compatdata/655500/pfx/drive_c/windows/system32/ntdll.dll",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        let report =
+            classify(&modules, &[], &ctx, &RuleSet::bundled(), &no_hash, &not_reshade);
+        assert_eq!(report.verdict, Verdict::Clean, "findings: {:?}", report.findings);
+    }
+
+    /// A process is only ever reported by name, and only when a rule names it.
+    #[test]
+    fn processes_are_matched_by_rule_only() {
+        let rules = RuleSet {
+            cheats: vec![Rule {
+                contains: "kaizotrainer".into(),
+                label: "Kaizo trainer".into(),
+                ..Default::default()
+            }],
+            ..RuleSet::bundled()
+        }
+        .normalize();
+        let processes: Vec<String> =
+            ["explorer.exe", "steam.exe", "KaizoTrainer.exe"].iter().map(|s| s.to_string()).collect();
+        let report = classify(&[], &processes, &ctx(), &rules, &no_hash, &not_reshade);
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].kind, Kind::Process);
+        assert_eq!(report.findings[0].name, "kaizotrainer.exe");
+    }
+
+    /// Worst finding decides, and the list leads with it.
+    #[test]
+    fn the_worst_finding_decides_the_verdict_and_sorts_first() {
+        let rules = RuleSet {
+            cheats: vec![Rule { contains: "kaizo".into(), label: "Kaizo".into(), ..Default::default() }],
+            ..RuleSet::bundled()
+        }
+        .normalize();
+        let report = scan_with(
+            &["C:\\Users\\rider\\Downloads\\unknown.dll", "C:\\Users\\rider\\Downloads\\kaizo.dll"],
+            &rules,
+        );
+        assert_eq!(report.verdict, Verdict::Flagged);
+        assert_eq!(report.findings[0].name, "kaizo.dll");
+        assert_eq!(report.findings.len(), 2);
+    }
+
+    /// A module mapped more than once is one finding. On Linux every DLL appears in the
+    /// mapping list several times over.
+    #[test]
+    fn the_same_module_twice_is_one_finding() {
+        let report = scan_with(
+            &["C:\\Downloads\\x.dll", "C:\\Downloads\\x.dll", "C:\\Downloads\\X.DLL"],
+            &RuleSet::bundled(),
+        );
+        assert_eq!(report.findings.len(), 1);
+    }
+
+    /// The honesty property. Everything that could not look reports Unknown, and Unknown is
+    /// not Clean — including the ordering, which the UI relies on to rank a grid.
+    #[test]
+    fn a_machine_we_could_not_read_is_unknown_not_clean() {
+        let report = Report::unknown(false, 3);
+        assert_eq!(report.verdict, Verdict::Unknown);
+        assert!(report.findings.is_empty());
+        assert_eq!(report.rules_version, 3);
+        assert!(Verdict::Unknown < Verdict::Clean);
+        assert!(Verdict::Clean < Verdict::Suspect);
+        assert!(Verdict::Suspect < Verdict::Flagged);
+    }
+
+    /// What the binary ships with: an allowlist and no accusations.
+    #[test]
+    fn the_bundled_set_carries_no_signatures() {
+        let bundled = RuleSet::bundled();
+        assert!(!bundled.has_signatures());
+        assert!(!bundled.allow.is_empty());
+    }
+
+    /// A remote list adds to the bundled allowlist rather than replacing it, so a truncated
+    /// fetch can't make every machine's Steam overlay a finding.
+    #[test]
+    fn a_remote_list_cannot_drop_the_bundled_allowlist() {
+        let remote = RuleSet { version: 4, ..Default::default() }.merged_with_bundled();
+        assert!(remote.allows_name("gameoverlayrenderer64.dll"));
+        assert_eq!(remote.version, 4);
+    }
+
+    /// Whatever the file's spelling, matching is lowercase — and a rule with no pattern at
+    /// all is dropped rather than being read as "match everything".
+    #[test]
+    fn normalizing_lowercases_patterns_and_drops_empty_rules() {
+        let rules = RuleSet {
+            cheats: vec![
+                Rule { contains: "  KAIZO  ".into(), ..Default::default() },
+                Rule { label: "nothing to match on".into(), ..Default::default() },
+                Rule { sha256: "NOTAHASH".into(), ..Default::default() },
+            ],
+            allow: vec!["  Overlay.DLL ".into(), "   ".into()],
+            allow_paths: vec!["C:\\Vendor\\Tool".into()],
+            ..Default::default()
+        }
+        .normalize();
+        assert_eq!(rules.cheats.len(), 1);
+        assert_eq!(rules.cheats[0].contains, "kaizo");
+        assert_eq!(rules.allow, ["overlay.dll"]);
+        assert_eq!(rules.allow_paths, ["c:/vendor/tool"]);
+    }
+
+    /// The rule file is JSON with camelCase keys — the shape anyone editing it will write.
+    #[test]
+    fn the_rule_file_parses_as_written() {
+        let text = r#"{
+          "version": 12,
+          "cheats": [
+            { "contains": "kaizo", "label": "Kaizo trainer" },
+            { "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+              "label": "Kaizo v3 loader" }
+          ],
+          "allow": ["someoverlay.dll"],
+          "allowPaths": ["/vendor/tool/"]
+        }"#;
+        let rules: RuleSet = serde_json::from_str(text).unwrap();
+        let rules = rules.merged_with_bundled();
+        assert_eq!(rules.version, 12);
+        assert_eq!(rules.cheats.len(), 2);
+        assert!(rules.has_signatures());
+        assert!(rules.allows_name("someoverlay.dll"));
+        assert!(rules.allows_path("/vendor/tool/x.dll"));
+    }
+}

--- a/src-tauri/src/integritywatch.rs
+++ b/src-tauri/src/integritywatch.rs
@@ -1,0 +1,405 @@
+//! Keep watching while the session is live.
+//!
+//! [`crate::integrity`] can answer "is anything attached to the game?" once. That is not the
+//! question a race asks. A cheat is loaded *during* a session — the player joins clean, gets
+//! beaten, alt-tabs, and attaches something — and a check that ran at launch would have said
+//! everything was fine ten minutes before it stopped being fine. So the scan repeats for as
+//! long as the game is up.
+//!
+//! It also has to cover a game the app never launched. The mods folder is watched that way
+//! for the same reason ([`crate::modwatch`]): plenty of people press Play in Steam. So this
+//! is a standing watcher started at app launch, not something hung off the Play button — it
+//! sits on a cheap "is the game up?" poll and only does real work while it is.
+//!
+//! Two settings, deliberately separate, because they are two different decisions:
+//!
+//!   * `integrityWatch` — scan at all. On by default; it reads the game's own module list and
+//!     the answer goes no further than this window.
+//!   * `integrityReport` — publish the verdict so a server admin can see it. Off until it is
+//!     chosen. See [`publish`] for exactly what leaves the machine, which is much less than
+//!     what a scan sees.
+
+use crate::config::AppConfig;
+use crate::integrity::{self, Report, RuleSet, ScanContext, Severity, Verdict};
+use serde::Serialize;
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+use tauri::{AppHandle, Emitter, Manager};
+
+/// How often to look while the game is running.
+///
+/// A cheat that attaches mid-session is caught within this window, so it wants to be short;
+/// each pass walks a module list and — only when something is unaccounted for — hashes a
+/// file, so it can't be free. Forty-five seconds matches the live paint sync, which is the
+/// other thing running through a race.
+const SCAN_EVERY: std::time::Duration = std::time::Duration::from_secs(45);
+
+/// How often to ask whether the game has started. A process-table walk, and nothing else.
+const IDLE_POLL: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Event name the UI listens on. Emitted only when the answer *changes*, so a settled
+/// session is silent rather than pushing an identical report every 45 seconds.
+pub const EVENT: &str = "integrity-report";
+
+/// The last report, for anything that needs the current answer without waiting for a scan.
+fn last() -> &'static Mutex<Report> {
+    static LAST: OnceLock<Mutex<Report>> = OnceLock::new();
+    LAST.get_or_init(|| Mutex::new(Report::default()))
+}
+
+/// The rule list in force. Loaded from cache at startup and replaced by each refresh.
+fn rules() -> &'static Mutex<RuleSet> {
+    static RULES: OnceLock<Mutex<RuleSet>> = OnceLock::new();
+    RULES.get_or_init(|| Mutex::new(RuleSet::bundled()))
+}
+
+pub fn current() -> Report {
+    last().lock().map(|r| r.clone()).unwrap_or_default()
+}
+
+fn current_rules() -> RuleSet {
+    rules().lock().map(|r| r.clone()).unwrap_or_else(|_| RuleSet::bundled())
+}
+
+/// What the app knows about this machine that the classifier needs.
+///
+/// The trusted roots are the folders whose contents are the player's own install: the game,
+/// the FrostMod we put there, and ReShade if they use it. Everything else that ends up inside
+/// the game process has to explain itself.
+fn context(app: &AppHandle, cfg: &AppConfig) -> ScanContext {
+    let mut roots = vec![crate::frostmod_manage::frostmod_dir(app)];
+    let reshade = cfg.reshade_dir();
+    if !reshade.trim().is_empty() {
+        roots.push(PathBuf::from(reshade));
+    }
+    ScanContext::new(&PathBuf::from(cfg.install_dir()), &roots)
+}
+
+/// Scan once, remember the answer, and tell anyone who is listening.
+///
+/// Returns the report either way — including the [`Verdict::Unknown`] that means we could not
+/// look, which is a real answer and not a failure to be swallowed.
+pub fn scan_once(app: &AppHandle) -> Report {
+    let cfg = crate::config::load_or_detect(app).unwrap_or_default();
+    if !cfg.integrity_watch {
+        return Report::default();
+    }
+    let report = integrity::scan(&context(app, &cfg), &current_rules());
+    remember(app, &cfg, report.clone());
+    report
+}
+
+/// Store a report, emit it if it says something new, and publish it if that's turned on.
+///
+/// "Something new" is the verdict plus the findings — not the timestamp, which changes on
+/// every pass. Without that test a quiet session would emit an identical report every 45
+/// seconds and the UI would flash a banner each time.
+fn remember(app: &AppHandle, cfg: &AppConfig, report: Report) {
+    let changed = match last().lock() {
+        Ok(mut slot) => {
+            let changed = slot.verdict != report.verdict || slot.findings != report.findings;
+            *slot = report.clone();
+            changed
+        }
+        // A poisoned lock means a previous scan panicked. Emit rather than go quiet: the one
+        // thing this must not do is stop reporting without saying so.
+        Err(_) => true,
+    };
+    if !changed {
+        return;
+    }
+    if report.verdict >= Verdict::Suspect {
+        log::warn!(
+            "[integrity] {:?}: {}",
+            report.verdict,
+            report.findings.iter().map(|f| f.name.as_str()).collect::<Vec<_>>().join(", ")
+        );
+    }
+    let _ = app.emit(EVENT, &report);
+    if cfg.integrity_report {
+        publish_soon(app, cfg, &report);
+    }
+}
+
+/// What the control plane is told.
+///
+/// Deliberately not the report: a scan sees every DLL loaded on the machine, and that is
+/// nobody else's business. A [`Severity::Suspect`] finding is by definition "software we do
+/// not recognise", which on somebody's work laptop could be anything — so its *name* never
+/// leaves, only the fact that the count is non-zero. Rule-matched detections do carry their
+/// name and label, because at that point it is a known cheat and naming it is the point.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Attestation {
+    verdict: Verdict,
+    /// Which rule list produced the verdict. An admin looking at a Clean report needs to
+    /// know it was checked against something current.
+    rules_version: u32,
+    /// How many unrecognised-but-unnamed things were loaded.
+    suspect_count: usize,
+    /// The named detections, worst first.
+    flagged: Vec<FlaggedItem>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FlaggedItem {
+    name: String,
+    label: String,
+    sha256: String,
+}
+
+/// Send an attestation to the control plane. Best-effort and fire-and-forget: a failed
+/// publish costs one missing row in an admin's list for a minute.
+fn publish_soon(app: &AppHandle, cfg: &AppConfig, report: &Report) {
+    let token = cfg.cp_token.trim().to_string();
+    if token.is_empty() {
+        return;
+    }
+    let body = Attestation {
+        verdict: report.verdict,
+        rules_version: report.rules_version,
+        suspect_count: report.findings.iter().filter(|f| f.severity == Severity::Suspect).count(),
+        flagged: report
+            .findings
+            .iter()
+            .filter(|f| f.severity == Severity::Flagged)
+            .map(|f| FlaggedItem {
+                name: f.name.clone(),
+                label: f.label.clone(),
+                sha256: f.sha256.clone(),
+            })
+            .collect(),
+    };
+    let _ = app;
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = publish(&token, &body).await {
+            log::debug!("[integrity] couldn't publish the verdict: {e:#}");
+        }
+    });
+}
+
+async fn publish(token: &str, body: &Attestation) -> anyhow::Result<()> {
+    let res = reqwest::Client::new()
+        .put(format!("{}/v1/integrity", crate::paintsync::control_plane()))
+        .bearer_auth(token)
+        .json(body)
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await?;
+    if !res.status().is_success() {
+        anyhow::bail!("control plane said {}", res.status());
+    }
+    Ok(())
+}
+
+/// Start the standing watcher. Call once, from `setup`.
+pub fn start(app: &AppHandle) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        // Load whatever list is cached before the first scan, so a machine that starts
+        // offline still matches against the last one it saw rather than an empty set.
+        if let Ok(mut slot) = rules().lock() {
+            *slot = integrity::cached_rules(&app);
+        }
+        refresh_rules(&app).await;
+
+        let mut was_running = false;
+        loop {
+            let cfg = crate::config::load_or_detect(&app).unwrap_or_default();
+            if !cfg.integrity_watch {
+                // Turned off mid-session: forget the last answer so the UI shows "not
+                // watching" rather than a stale verdict from an hour ago.
+                if let Ok(mut slot) = last().lock() {
+                    *slot = Report::default();
+                }
+                was_running = false;
+                tokio::time::sleep(IDLE_POLL).await;
+                continue;
+            }
+
+            let running = crate::gameproc::is_game_running();
+            if running && !was_running {
+                // A new session is the natural moment to pick up rules published since the
+                // app started — someone may have been playing for eight hours.
+                refresh_rules(&app).await;
+            }
+            if !running && was_running {
+                // The session is over, so the verdict is about a game that no longer exists.
+                if let Ok(mut slot) = last().lock() {
+                    *slot = Report::default();
+                }
+                let _ = app.emit(EVENT, Report::default());
+            }
+            was_running = running;
+
+            if running {
+                scan_once(&app);
+                tokio::time::sleep(SCAN_EVERY).await;
+            } else {
+                tokio::time::sleep(IDLE_POLL).await;
+            }
+        }
+    });
+}
+
+/// Pull the live rule list, keeping the current one if the fetch fails.
+pub async fn refresh_rules(app: &AppHandle) {
+    match integrity::refresh_rules(app).await {
+        Ok(fresh) => {
+            if let Ok(mut slot) = rules().lock() {
+                *slot = fresh;
+            }
+        }
+        Err(e) => log::debug!("[integrity] couldn't refresh the rule list: {e:#}"),
+    }
+}
+
+/// One rider's verdict, as an admin sees it.
+#[derive(Debug, Clone, serde::Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RiderIntegrity {
+    pub rider_name: String,
+    #[serde(default)]
+    pub guid: String,
+    pub verdict: Verdict,
+    #[serde(default)]
+    pub rules_version: u32,
+    #[serde(default)]
+    pub suspect_count: usize,
+    #[serde(default)]
+    pub flagged: Vec<FlaggedSeen>,
+    /// Unix ms of the client's last attestation. What tells an admin the difference between
+    /// "reported clean" and "hasn't reported since they joined".
+    #[serde(default)]
+    pub reported_at: u64,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FlaggedSeen {
+    pub name: String,
+    #[serde(default)]
+    pub label: String,
+    #[serde(default)]
+    pub sha256: String,
+}
+
+/// Everyone on `server_id` who has published a verdict.
+///
+/// An admin's read, and it is worth being clear about what it is not: an absence here is not
+/// innocence and not guilt. A rider shows up only if their app is running, watching, and set
+/// to report — so the list answers "who has attested", and the people missing from it are
+/// exactly the ones this can say nothing about.
+pub async fn server_reports(token: &str, server_id: &str) -> anyhow::Result<Vec<RiderIntegrity>> {
+    #[derive(serde::Deserialize)]
+    struct Body {
+        riders: Vec<RiderIntegrity>,
+    }
+    let body: Body = reqwest::Client::new()
+        .get(format!("{}/v1/integrity", crate::paintsync::control_plane()))
+        .query(&[("server", server_id)])
+        .bearer_auth(token)
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    Ok(body.riders)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::integrity::{Finding, Kind, Reason};
+
+    fn finding(name: &str, severity: Severity) -> Finding {
+        Finding {
+            kind: Kind::Module,
+            name: name.into(),
+            path: format!("C:\\Users\\rider\\Secret Work Tools\\{name}"),
+            reason: if severity == Severity::Flagged {
+                Reason::RuleName
+            } else {
+                Reason::ForeignModule
+            },
+            severity,
+            sha256: "d34d".into(),
+            label: if severity == Severity::Flagged { "Kaizo trainer".into() } else { String::new() },
+        }
+    }
+
+    fn attestation(findings: Vec<Finding>) -> Attestation {
+        let report = Report {
+            verdict: Verdict::Flagged,
+            findings,
+            scanned_at: 1,
+            rules_version: 9,
+            modules_scanned: 120,
+            game_running: true,
+        };
+        Attestation {
+            verdict: report.verdict,
+            rules_version: report.rules_version,
+            suspect_count: report
+                .findings
+                .iter()
+                .filter(|f| f.severity == Severity::Suspect)
+                .count(),
+            flagged: report
+                .findings
+                .iter()
+                .filter(|f| f.severity == Severity::Flagged)
+                .map(|f| FlaggedItem {
+                    name: f.name.clone(),
+                    label: f.label.clone(),
+                    sha256: f.sha256.clone(),
+                })
+                .collect(),
+        }
+    }
+
+    /// The privacy line this feature stands on. A Suspect finding is "software we don't
+    /// recognise", which is not evidence of anything and is nobody else's business — it is
+    /// counted, never named. Anything that changes this test is changing what the app tells
+    /// a stranger about its user's machine.
+    #[test]
+    fn an_attestation_counts_suspects_without_naming_them() {
+        let sent = attestation(vec![
+            finding("kaizo.dll", Severity::Flagged),
+            finding("employer_vpn_hook.dll", Severity::Suspect),
+            finding("some_other_overlay.dll", Severity::Suspect),
+        ]);
+        let json = serde_json::to_string(&sent).unwrap();
+
+        assert_eq!(sent.suspect_count, 2);
+        assert!(!json.contains("employer_vpn_hook"), "a suspect module was named: {json}");
+        assert!(!json.contains("some_other_overlay"), "a suspect module was named: {json}");
+        assert!(!json.contains("Secret Work Tools"), "a path leaked: {json}");
+        // The known cheat is named, which is the whole point of reporting.
+        assert!(json.contains("kaizo.dll"));
+        assert!(json.contains("Kaizo trainer"));
+    }
+
+    /// A clean machine sends a clean attestation and nothing else — no empty finding
+    /// objects, no module list.
+    #[test]
+    fn a_clean_attestation_carries_nothing_about_the_machine() {
+        let sent = attestation(vec![]);
+        assert_eq!(sent.suspect_count, 0);
+        assert!(sent.flagged.is_empty());
+        let json = serde_json::to_string(&sent).unwrap();
+        assert!(!json.contains(".dll"), "{json}");
+    }
+
+    /// The wire shape the control plane parses, in camelCase like every other endpoint.
+    #[test]
+    fn an_attestation_serializes_in_camel_case() {
+        let json = serde_json::to_string(&attestation(vec![finding("k.dll", Severity::Flagged)]))
+            .unwrap();
+        assert!(json.contains("\"rulesVersion\":9"), "{json}");
+        assert!(json.contains("\"suspectCount\":0"), "{json}");
+        assert!(json.contains("\"verdict\":\"flagged\""), "{json}");
+    }
+}

--- a/src-tauri/src/integritywatch.rs
+++ b/src-tauri/src/integritywatch.rs
@@ -117,7 +117,7 @@ fn remember(app: &AppHandle, cfg: &AppConfig, report: Report) {
     }
     let _ = app.emit(EVENT, &report);
     if cfg.integrity_report {
-        publish_soon(app, cfg, &report);
+        publish_soon(cfg, &report);
     }
 }
 
@@ -151,7 +151,7 @@ struct FlaggedItem {
 
 /// Send an attestation to the control plane. Best-effort and fire-and-forget: a failed
 /// publish costs one missing row in an admin's list for a minute.
-fn publish_soon(app: &AppHandle, cfg: &AppConfig, report: &Report) {
+fn publish_soon(cfg: &AppConfig, report: &Report) {
     let token = cfg.cp_token.trim().to_string();
     if token.is_empty() {
         return;
@@ -171,7 +171,6 @@ fn publish_soon(app: &AppHandle, cfg: &AppConfig, report: &Report) {
             })
             .collect(),
     };
-    let _ = app;
     tauri::async_runtime::spawn(async move {
         if let Err(e) = publish(&token, &body).await {
             log::debug!("[integrity] couldn't publish the verdict: {e:#}");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -19,6 +19,8 @@ mod gearrepair;
 mod heightfield;
 mod imgcache;
 mod install;
+mod integrity;
+mod integritywatch;
 mod library;
 mod linkwalk;
 mod logs;
@@ -5277,6 +5279,74 @@ fn set_watch_mods_reload(
     Ok(())
 }
 
+/// The current cheat-scan verdict, without waiting for the next pass.
+///
+/// What the UI reads on open. Returns the standing [`integrity::Verdict::Unknown`] before the
+/// first scan of a session, which is the honest answer: nothing has been looked at yet.
+#[tauri::command]
+fn integrity_status() -> integrity::Report {
+    integritywatch::current()
+}
+
+/// Scan now, rather than at the next pass. The "check again" button.
+///
+/// Refreshes the rule list first: someone pressing this has usually just heard about a cheat,
+/// and matching it against a list fetched at app start would be the one moment it matters that
+/// the list is an hour old.
+#[tauri::command]
+async fn integrity_scan_now(app: tauri::AppHandle) -> integrity::Report {
+    integritywatch::refresh_rules(&app).await;
+    // A blocking scan: a module walk plus, at worst, a hash of the handful of files that
+    // didn't check out. Off the async worker so a slow disk can't stall the runtime.
+    let handle = app.clone();
+    tauri::async_runtime::spawn_blocking(move || integritywatch::scan_once(&handle))
+        .await
+        .unwrap_or_default()
+}
+
+/// Turn the watcher on or off.
+///
+/// No live start/stop needed — unlike the mods watcher, this one is a poll that re-reads the
+/// setting every pass, so it stands down on its own within [`IDLE_POLL`](integritywatch).
+#[tauri::command]
+fn set_integrity_watch(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
+    let mut cfg = config::load(&app).unwrap_or_default();
+    cfg.integrity_watch = enabled;
+    // Reporting a verdict this app is no longer producing would leave an admin looking at
+    // whatever the last scan said, indefinitely. Turning the scan off turns the sharing off.
+    if !enabled {
+        cfg.integrity_report = false;
+    }
+    config::save(&app, &cfg).map_err(|e| format!("{e:#}"))
+}
+
+/// Share this client's verdict with the servers it joins.
+#[tauri::command]
+fn set_integrity_report(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
+    let mut cfg = config::load(&app).unwrap_or_default();
+    cfg.integrity_report = enabled;
+    // Sharing implies scanning; there is nothing to share otherwise.
+    if enabled {
+        cfg.integrity_watch = true;
+    }
+    config::save(&app, &cfg).map_err(|e| format!("{e:#}"))
+}
+
+/// What the riders on one server have attested, for the admin of that server.
+#[tauri::command]
+async fn integrity_server_reports(
+    app: tauri::AppHandle,
+    server_id: String,
+) -> Result<Vec<integritywatch::RiderIntegrity>, String> {
+    let cfg = config::load_or_detect(&app).unwrap_or_default();
+    if cfg.cp_token.trim().is_empty() {
+        return Err("Enroll with an invite code first.".into());
+    }
+    integritywatch::server_reports(&cfg.cp_token, &server_id)
+        .await
+        .map_err(|e| format!("{e:#}"))
+}
+
 #[tauri::command]
 async fn shop_login(app: tauri::AppHandle) -> Result<(), String> {
     if let Some(w) = app.get_webview_window(SHOP_LOGIN_WINDOW) {
@@ -6249,6 +6319,12 @@ fn main() {
             } else {
                 log::info!("no MX Bikes folder found — showing first-run setup");
             }
+            // Watch for a cheat attached to the game. Started unconditionally rather than
+            // from the Play button, and outside the `load_or_detect` arm above: the game is
+            // just as often launched from Steam, and a machine with no config yet still has
+            // a process list worth reading. The watcher re-reads the setting every pass, so
+            // it costs an idle poll and nothing else when it is turned off.
+            integritywatch::start(handle);
             shop_session::load_session(handle);
             shop_catalog_session::load(handle);
             mxb_session::load(handle);
@@ -6398,6 +6474,11 @@ fn main() {
             voice_meter_stop,
             voice_test_output,
             set_watch_mods_reload,
+            integrity_status,
+            integrity_scan_now,
+            set_integrity_watch,
+            set_integrity_report,
+            integrity_server_reports,
             frostmod_reload,
             frostmod_running,
             garage_scan_bikes,

--- a/src-tauri/src/proton.rs
+++ b/src-tauri/src/proton.rs
@@ -328,6 +328,71 @@ pub fn kill_exe(exe: &str) {
     }
 }
 
+/// Every PE file mapped into `pid`, by path.
+///
+/// Wine loads a DLL by mapping the file itself, so the kernel's own mapping list is a
+/// faithful account of what is inside the game — which is what makes cheat detection
+/// possible at all on a platform with no `CreateToolhelp32Snapshot`.
+pub fn mapped_pe_files(pid: u32) -> Vec<String> {
+    std::fs::read_to_string(format!("/proc/{pid}/maps"))
+        .map(|maps| pe_files_in_maps(&maps))
+        .unwrap_or_default()
+}
+
+/// Every process on the machine, by executable name — the Linux half of
+/// [`crate::gameproc::running_process_names`].
+///
+/// `comm` rather than `cmdline`: it is the short name, which is what the rule list matches,
+/// and it is there for kernel threads and short-lived processes whose `cmdline` is empty.
+pub fn process_names() -> Vec<String> {
+    let mut names = Vec::new();
+    let Ok(entries) = std::fs::read_dir("/proc") else { return names };
+    for entry in entries.flatten() {
+        if entry.file_name().to_string_lossy().parse::<u32>().is_err() {
+            continue;
+        }
+        // Unreadable is normal — another user's process, or one that exited mid-walk.
+        if let Ok(comm) = std::fs::read_to_string(entry.path().join("comm")) {
+            let name = comm.trim();
+            if !name.is_empty() {
+                names.push(name.to_string());
+            }
+        }
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// Pull the distinct `.dll`/`.exe` paths out of a `/proc/<pid>/maps` body.
+///
+/// Split out from the read so it can be tested on any OS. Three things the format makes us
+/// careful about:
+///
+///   - a mapping is six fields and the sixth is the path, which **may contain spaces** —
+///     `steamapps/common/MX Bikes/mxbikes.exe` is the ordinary case here, so the path is
+///     everything after the fifth field rather than the sixth token;
+///   - anonymous mappings (heap, stack, `[vvar]`) have no path at all, and every file is
+///     mapped several times over as the loader lays out its sections, so the answer is a
+///     de-duplicated set;
+///   - a file replaced while mapped keeps its old mapping with a ` (deleted)` marker glued
+///     to the path. Stripping it matters: a cheat that unlinks itself after loading is
+///     exactly the case we want to still name.
+fn pe_files_in_maps(maps: &str) -> Vec<String> {
+    let mut files: Vec<String> = maps
+        .lines()
+        .filter_map(|line| {
+            let path = line.splitn(6, char::is_whitespace).nth(5)?.trim();
+            let path = path.strip_suffix(" (deleted)").unwrap_or(path);
+            let lower = path.to_ascii_lowercase();
+            (lower.ends_with(".dll") || lower.ends_with(".exe")).then(|| path.to_string())
+        })
+        .collect();
+    files.sort();
+    files.dedup();
+    files
+}
+
 /// Does one `/proc/<pid>/cmdline` name `exe`?
 ///
 /// The arguments are NUL-separated and the exe may appear as any of them, in either slash
@@ -408,6 +473,38 @@ mod tests {
         let frostmod = "…/proton\0run\0Z:\\home\\rider\\.local\\share\\com.frost.mxbikes\\frostmod\\FrostMod.exe\0--game\0mxb\0";
         assert!(cmdline_names_exe(frostmod, "frostmod.exe"));
         assert!(!cmdline_names_exe("", "frostmod.exe"));
+    }
+
+    /// The mapping list is how Linux answers "what is loaded into the game". Spaces in the
+    /// path, repeated section mappings and anonymous regions all have to come out right, or
+    /// the scanner either misses a DLL or invents one.
+    #[test]
+    fn a_mapping_list_yields_each_mapped_pe_once() {
+        let maps = "\
+00400000-00452000 r-xp 00000000 08:02 173521     /home/rider/.steam/steamapps/common/MX Bikes/mxbikes.exe
+00452000-00453000 r--p 00052000 08:02 173521     /home/rider/.steam/steamapps/common/MX Bikes/mxbikes.exe
+7f0000000000-7f0000021000 rw-p 00000000 00:00 0
+7f1111111000-7f1111120000 r-xp 00000000 08:02 99 /usr/lib/wine/x86_64-windows/kernel32.dll
+7f2222222000-7f2222230000 r-xp 00000000 08:02 42 /home/rider/Downloads/kaizo hack.dll (deleted)
+7f3333333000-7f3333340000 r-xp 00000000 08:02 43 /usr/lib/x86_64-linux-gnu/libc.so.6
+00e2f000-00e50000 rw-p 00000000 00:00 0          [heap]
+";
+        assert_eq!(
+            pe_files_in_maps(maps),
+            [
+                "/home/rider/.steam/steamapps/common/MX Bikes/mxbikes.exe",
+                "/home/rider/Downloads/kaizo hack.dll",
+                "/usr/lib/wine/x86_64-windows/kernel32.dll",
+            ]
+        );
+    }
+
+    /// Nothing readable is an empty answer, never a panic — an unreadable `/proc` entry is
+    /// the ordinary outcome for a process that exited mid-walk.
+    #[test]
+    fn an_empty_or_pathless_mapping_list_yields_nothing() {
+        assert!(pe_files_in_maps("").is_empty());
+        assert!(pe_files_in_maps("7f00-7f01 rw-p 0 00:00 0 \n").is_empty());
     }
 
     #[test]

--- a/src-tauri/src/reshade.rs
+++ b/src-tauri/src/reshade.rs
@@ -197,7 +197,15 @@ fn probe_dll(path: &Path) -> Option<Option<String>> {
     contains(&narrowed, RESHADE_MARKER).then(|| version_near_marker(&narrowed))
 }
 
-fn is_reshade_dll(path: &Path) -> bool {
+/// Is the file at `path` ReShade's own DLL?
+///
+/// Public because [`crate::integrity`] needs it too, and for the opposite reason: there, a
+/// DLL sitting in the game folder under a name the loader preloads is the shape of an
+/// injected cheat, and ReShade is the one legitimate thing that looks exactly like that.
+/// Asking the file rather than trusting its name is what keeps a working ReShade install
+/// from being reported as a cheat — and what stops a cheat from getting a free pass by
+/// being called `opengl32.dll`.
+pub fn is_reshade_dll(path: &Path) -> bool {
     probe_dll(path).is_some()
 }
 

--- a/src/Components/Servers/ServerIntegrity.tsx
+++ b/src/Components/Servers/ServerIntegrity.tsx
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useState } from "react";
+import { RefreshCw, ShieldAlert, ShieldCheck, ShieldQuestion, ShieldX } from "lucide-react";
+import { useI18n } from "../../i18n/context";
+import { Button } from "@/Components/ui/button";
+import { cn } from "@/lib/utils";
+import { integrityServerReports } from "@/api/mods";
+import type { IntegrityVerdict, RiderIntegrity } from "@/types";
+
+/** How often to re-read the grid. Clients publish every 45 seconds, so anything faster is
+ *  asking the same question twice. */
+const POLL_MS = 60_000;
+
+/**
+ * What the riders on this server have said about their own clients.
+ *
+ * The heading and the empty state carry most of the weight here, because the thing an admin
+ * will do with this is accuse somebody, and the list does not support that on its own. A
+ * rider appears only if their app is running, watching, and set to report — so this answers
+ * "who has attested", and the people missing from it are exactly the ones it can say nothing
+ * about. A cheater who closed MXB App is not in this list, and that is not a bug.
+ */
+export default function ServerIntegrity({ serverId }: { serverId: string }) {
+  const { t } = useI18n();
+  const [riders, setRiders] = useState<RiderIntegrity[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setBusy(true);
+    try {
+      setRiders(await integrityServerReports(serverId));
+      setError(null);
+    } catch (e) {
+      setError(String(e));
+    }
+    setBusy(false);
+  }, [serverId]);
+
+  useEffect(() => {
+    void refresh();
+    const id = setInterval(() => void refresh(), POLL_MS);
+    return () => clearInterval(id);
+  }, [refresh]);
+
+  return (
+    <div className="mt-3 border-t border-white/[0.05] pt-3">
+      <div className="flex items-center gap-2">
+        <ShieldCheck className="size-3.5 flex-none text-muted-foreground" />
+        <span className="text-[12px] text-muted-foreground">{t("integrity.gridTitle")}</span>
+        <Button
+          className="ml-auto"
+          size="sm"
+          variant="ghost"
+          onClick={() => void refresh()}
+          disabled={busy}
+        >
+          <RefreshCw className={cn("size-3.5", busy && "animate-spin")} />
+        </Button>
+      </div>
+
+      {error ? (
+        <p className="mt-2 text-[11.5px] text-muted-foreground">{error}</p>
+      ) : riders === null ? (
+        <p className="mt-2 text-[11.5px] text-muted-foreground">{t("integrity.gridLoading")}</p>
+      ) : riders.length === 0 ? (
+        <p className="mt-2 text-[11.5px] leading-relaxed text-muted-foreground">
+          {t("integrity.gridEmpty")}
+        </p>
+      ) : (
+        <ul className="mt-2 flex flex-col gap-1">
+          {riders.map((r) => (
+            <RiderRow key={r.guid || r.riderName} rider={r} />
+          ))}
+        </ul>
+      )}
+
+      <p className="mt-2 text-[11px] leading-relaxed text-faint">{t("integrity.gridNote")}</p>
+    </div>
+  );
+}
+
+function RiderRow({ rider }: { rider: RiderIntegrity }) {
+  const { t } = useI18n();
+  // The worst of the recent past outranks the current answer on the row itself: a client
+  // that loaded a cheat for one lap and unloaded it reports clean now, and "clean" is not
+  // what an admin should see for it.
+  const shown = worse(rider.worstVerdict, rider.verdict);
+  const recovered = shown !== rider.verdict;
+  return (
+    <li className="flex items-center gap-2 rounded-lg border border-white/[0.07] bg-white/[0.02] px-3 py-1.5 text-[12px]">
+      <VerdictDot verdict={shown} />
+      <span className="min-w-0 flex-1 truncate">{rider.riderName}</span>
+      <span
+        className={cn(
+          "flex-none text-[11.5px]",
+          shown === "flagged"
+            ? "text-destructive"
+            : shown === "suspect"
+              ? "text-warning"
+              : "text-muted-foreground",
+        )}
+      >
+        {rider.flagged.length > 0
+          ? // The rule's own label, verbatim and untranslated.
+            rider.flagged.map((f) => f.label || f.name).join(", ")
+          : shown === "suspect"
+            ? t("integrity.gridSuspect", { count: rider.suspectCount })
+            : t(shown === "clean" ? "integrity.clean" : "integrity.unknown")}
+        {recovered && ` ${t("integrity.gridRecovered")}`}
+      </span>
+    </li>
+  );
+}
+
+function worse(a: IntegrityVerdict | undefined, b: IntegrityVerdict): IntegrityVerdict {
+  const order: IntegrityVerdict[] = ["unknown", "clean", "suspect", "flagged"];
+  if (!a) return b;
+  return order.indexOf(a) > order.indexOf(b) ? a : b;
+}
+
+function VerdictDot({ verdict }: { verdict: IntegrityVerdict }) {
+  const cls = "size-3.5 flex-none";
+  if (verdict === "clean") return <ShieldCheck className={cn(cls, "text-success")} />;
+  if (verdict === "suspect") return <ShieldAlert className={cn(cls, "text-warning")} />;
+  if (verdict === "flagged") return <ShieldX className={cn(cls, "text-destructive")} />;
+  return <ShieldQuestion className={cn(cls, "text-muted-foreground")} />;
+}

--- a/src/Components/Servers/Servers.tsx
+++ b/src/Components/Servers/Servers.tsx
@@ -23,6 +23,7 @@ import HelpHint from "@/Components/ui/help-hint";
 import { Button } from "@/Components/ui/button";
 import { Input } from "@/Components/ui/input";
 import { cn } from "@/lib/utils";
+import ServerIntegrity from "./ServerIntegrity";
 import {
   cloudServers,
   destroyCloudServer,
@@ -358,6 +359,11 @@ const ServerRow = ({ server, onRemove, onChanged }: RowProps) => {
           </>
         )}
       </div>
+
+      {/* What the grid's own clients report about themselves. Only for a listed server:
+          the control plane keys these on the registry id, so an unpublished server has no
+          key to ask about — and nobody joining it is reporting one either. */}
+      {listed && <ServerIntegrity serverId={server.registryId!} />}
     </div>
   );
 };

--- a/src/Components/Settings/IntegrityCard.tsx
+++ b/src/Components/Settings/IntegrityCard.tsx
@@ -1,0 +1,168 @@
+import { useCallback, useEffect, useState } from "react";
+import { RefreshCw, ShieldAlert, ShieldCheck, ShieldQuestion, ShieldX } from "lucide-react";
+import { toast } from "sonner";
+import { useI18n } from "../../i18n/context";
+import type { TKey } from "../../i18n";
+import { Button } from "@/Components/ui/button";
+import { cn } from "@/lib/utils";
+import { integrityScanNow, integrityStatus, onIntegrityReport } from "@/api/mods";
+import type { IntegrityFinding, IntegrityReport, IntegrityVerdict } from "@/types";
+
+/**
+ * What the cheat scan currently sees, and the button that re-runs it.
+ *
+ * The hardest thing to get right here isn't the layout, it's the wording. Three of the four
+ * verdicts must not read as an accusation:
+ *
+ *   * `unknown` — we couldn't look. Shown as plainly as possible, because a user who reads
+ *     it as "fine" has been misled by the app.
+ *   * `clean` — nothing unaccounted for. Says what was scanned, so it doesn't read as a
+ *     guarantee.
+ *   * `suspect` — something is loaded that we don't recognise. This is the one that will be
+ *     seen most by people running nothing worse than an overlay we haven't listed, so it is
+ *     phrased as a question and paired with what to do about it.
+ *   * `flagged` — it matched the rule list. Only this one is allowed to sound like an
+ *     accusation.
+ */
+export default function IntegrityCard({ watching }: { watching: boolean }) {
+  const { t } = useI18n();
+  const [report, setReport] = useState<IntegrityReport | null>(null);
+  const [scanning, setScanning] = useState(false);
+
+  useEffect(() => {
+    let live = true;
+    void integrityStatus().then((r) => live && setReport(r));
+    // The watcher pushes on change, so an open Settings page follows a session rather than
+    // showing whatever was true when it was opened.
+    const un = onIntegrityReport((r) => live && setReport(r));
+    return () => {
+      live = false;
+      void un.then((f) => f());
+    };
+  }, []);
+
+  const rescan = useCallback(async () => {
+    setScanning(true);
+    try {
+      setReport(await integrityScanNow());
+    } catch (e) {
+      toast.error(t("integrity.scanFailed"), { description: String(e) });
+    }
+    setScanning(false);
+  }, [t]);
+
+  if (!watching) {
+    return (
+      <p className="text-[12px] leading-relaxed text-muted-foreground">
+        {t("integrity.offNote")}
+      </p>
+    );
+  }
+
+  const verdict = report?.verdict ?? "unknown";
+  const findings = report?.findings ?? [];
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-start gap-3 rounded-lg border border-white/[0.07] px-3 py-2.5">
+        <VerdictIcon verdict={verdict} />
+        <div className="min-w-0 flex-1">
+          <div className="text-[12.5px] text-foreground/90">{t(headline(verdict))}</div>
+          <div className="mt-0.5 text-[11.5px] leading-relaxed text-muted-foreground">
+            {verdict === "clean"
+              ? t("integrity.cleanDetail", { count: report?.modulesScanned ?? 0 })
+              : verdict === "unknown"
+                ? t(report?.gameRunning ? "integrity.unknownRunning" : "integrity.unknownIdle")
+                : t("integrity.foundDetail", { count: findings.length })}
+          </div>
+        </div>
+        <Button size="sm" variant="ghost" onClick={() => void rescan()} disabled={scanning}>
+          <RefreshCw className={cn("size-3.5", scanning && "animate-spin")} />
+          {t("integrity.scanNow")}
+        </Button>
+      </div>
+
+      {findings.length > 0 && (
+        <ul className="flex flex-col gap-1.5">
+          {findings.map((f) => (
+            <FindingRow key={`${f.name}:${f.path}`} finding={f} />
+          ))}
+        </ul>
+      )}
+
+      {/* The limit, stated where somebody about to trust this will read it. Leaving it to
+          the docs would let the card imply something it cannot deliver. */}
+      <p className="text-[11.5px] leading-relaxed text-faint">
+        {t("integrity.limitNote")}
+        {report && report.rulesVersion > 0 && (
+          <> {t("integrity.rulesVersion", { version: report.rulesVersion })}</>
+        )}
+      </p>
+    </div>
+  );
+}
+
+function VerdictIcon({ verdict }: { verdict: IntegrityVerdict }) {
+  const cls = "mt-0.5 size-4 flex-none";
+  if (verdict === "clean") return <ShieldCheck className={cn(cls, "text-success")} />;
+  if (verdict === "suspect") return <ShieldAlert className={cn(cls, "text-warning")} />;
+  if (verdict === "flagged") return <ShieldX className={cn(cls, "text-destructive")} />;
+  return <ShieldQuestion className={cn(cls, "text-muted-foreground")} />;
+}
+
+function headline(verdict: IntegrityVerdict): TKey {
+  switch (verdict) {
+    case "clean":
+      return "integrity.clean";
+    case "suspect":
+      return "integrity.suspect";
+    case "flagged":
+      return "integrity.flagged";
+    default:
+      return "integrity.unknown";
+  }
+}
+
+/** Why one thing was reported. A key rather than prose, so it survives six languages. */
+function reasonKey(finding: IntegrityFinding): TKey {
+  switch (finding.reason) {
+    case "ruleName":
+    case "ruleHash":
+      return "integrity.reasonRule";
+    case "loaderHijack":
+      return "integrity.reasonLoader";
+    default:
+      return finding.kind === "process"
+        ? "integrity.reasonProcess"
+        : "integrity.reasonForeign";
+  }
+}
+
+function FindingRow({ finding }: { finding: IntegrityFinding }) {
+  const { t } = useI18n();
+  const flagged = finding.severity === "flagged";
+  return (
+    <li
+      className={cn(
+        "rounded-lg border px-3 py-2 text-[12px]",
+        flagged
+          ? "border-destructive/30 bg-destructive/[0.07]"
+          : "border-white/[0.07] bg-white/[0.02]",
+      )}
+    >
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="truncate font-medium">{finding.name}</span>
+        {/* The rule's own label, never translated — a cheat's name is its name. */}
+        {finding.label && (
+          <span className="flex-none text-[11.5px] text-destructive">{finding.label}</span>
+        )}
+      </div>
+      <div className="mt-0.5 text-[11.5px] text-muted-foreground">{t(reasonKey(finding))}</div>
+      {finding.path && (
+        <div className="mt-0.5 truncate text-[11px] text-faint" title={finding.path}>
+          {finding.path}
+        </div>
+      )}
+    </li>
+  );
+}

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -39,6 +39,8 @@ import {
   setOverlayHotkey,
   setProfilesPath,
   setRunInBackground,
+  setIntegrityReport,
+  setIntegrityWatch,
   setWatchModsReload,
   setWineRunner,
   wineHostInfo,
@@ -67,6 +69,7 @@ import { useConfig } from "../../Context/Config";
 import GameSwitcher from "../Shell/GameSwitcher";
 import ReshadeCard from "./ReshadeCard";
 import SupportersCard from "./SupportersCard";
+import IntegrityCard from "./IntegrityCard";
 import { useTheme, type ThemeMode } from "../../Context/Theme";
 import { Trans } from "../../i18n";
 import { useI18n, type LocalePref, type TKey } from "../../i18n/context";
@@ -103,6 +106,7 @@ export type SectionId =
   | "frostmod"
   | "reshade"
   | "logs"
+  | "integrity"
   | "experimental"
   | "supporters"
   | "about";
@@ -141,6 +145,7 @@ const GROUPS: { label: TKey; sections: { id: SectionId; label: TKey }[] }[] = [
     label: "settings.groupAdvanced",
     sections: [
       { id: "logs", label: "settings.logs" },
+      { id: "integrity", label: "settings.integrity" },
       // Had no nav entry at all before this, and rendered in the middle of the scroll
       // with nothing pointing at it.
       { id: "experimental", label: "settings.experimental" },
@@ -391,6 +396,9 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
   const autoRunFrostmod = config.autoRunFrostmod ?? true;
   const instantRefresh = config.instantRefresh ?? true;
   const watchModsReload = config.watchModsReload ?? true;
+  // Defaults mirror the backend's: scanning is on, sharing the result is not.
+  const integrityWatch = config.integrityWatch ?? true;
+  const integrityReport = config.integrityReport ?? false;
 
   const overlayEnabled = config.overlayEnabled ?? true;
   const overlayHotkey = config.overlayHotkey || FALLBACK_HOTKEY;
@@ -610,6 +618,24 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
   const toggleWatchModsReload = async (v: boolean) => {
     try {
       await setWatchModsReload(v);
+      await reloadConfig();
+    } catch (e) {
+      toast.error(t("settings.updateFailed"), { description: String(e) });
+    }
+  };
+
+  const toggleIntegrityWatch = async (v: boolean) => {
+    try {
+      await setIntegrityWatch(v);
+      await reloadConfig();
+    } catch (e) {
+      toast.error(t("settings.updateFailed"), { description: String(e) });
+    }
+  };
+
+  const toggleIntegrityReport = async (v: boolean) => {
+    try {
+      await setIntegrityReport(v);
       await reloadConfig();
     } catch (e) {
       toast.error(t("settings.updateFailed"), { description: String(e) });
@@ -1604,6 +1630,27 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
           )}
 
           {/* experimental */}
+          {/* integrity — the cheat scan. Under Advanced rather than beside FrostMod: it is
+              about the game being honest, not about the app driving it, and the two toggles
+              here are the only ones on the page that decide what leaves the machine. */}
+          {active === "integrity" && (
+          <Section title={t("settings.integrity")} desc={t("settings.integrityDesc")}>
+            <ToggleRow
+              label={t("settings.integrityWatch")}
+              desc={t("settings.integrityWatchDesc")}
+              checked={integrityWatch}
+              onChange={toggleIntegrityWatch}
+            />
+            <ToggleRow
+              label={t("settings.integrityReport")}
+              desc={t("settings.integrityReportDesc")}
+              checked={integrityReport}
+              onChange={toggleIntegrityReport}
+            />
+            <IntegrityCard watching={integrityWatch} />
+          </Section>
+          )}
+
           {active === "experimental" && (
           <Section title={t("settings.experimental")}>
             <ToggleRow

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -15,6 +15,8 @@ import type {
   FrostmodInstallReport,
   FrostmodReload,
   FrostmodStatus,
+  IntegrityReport,
+  RiderIntegrity,
   RuntimeInstallOutcome,
   VcRuntime,
   InstalledMod,
@@ -1798,6 +1800,44 @@ export function onVoicePtt(cb: (down: boolean) => void): Promise<UnlistenFn> {
 /** Toggle watching the mods folder to reload the game on external changes. */
 export function setWatchModsReload(enabled: boolean): Promise<void> {
   return invoke<void>("set_watch_mods_reload", { enabled });
+}
+
+/**
+ * The current cheat-scan verdict, without waiting for the next pass.
+ *
+ * Returns `unknown` before the first scan of a session — which is the honest answer, not an
+ * error to hide.
+ */
+export function integrityStatus(): Promise<IntegrityReport> {
+  return invoke<IntegrityReport>("integrity_status");
+}
+
+/** Scan now rather than at the next pass, refreshing the rule list first. */
+export function integrityScanNow(): Promise<IntegrityReport> {
+  return invoke<IntegrityReport>("integrity_scan_now");
+}
+
+/** Toggle watching the running game for an attached cheat. */
+export function setIntegrityWatch(enabled: boolean): Promise<void> {
+  return invoke<void>("set_integrity_watch", { enabled });
+}
+
+/** Toggle publishing this client's verdict to the servers it joins. */
+export function setIntegrityReport(enabled: boolean): Promise<void> {
+  return invoke<void>("set_integrity_report", { enabled });
+}
+
+/** What the riders on one server have attested. Server owners and riders on it only. */
+export function integrityServerReports(serverId: string): Promise<RiderIntegrity[]> {
+  return invoke<RiderIntegrity[]>("integrity_server_reports", { serverId });
+}
+
+/** Fires when the verdict *changes* — a settled session is silent rather than pushing an
+ *  identical report every 45 seconds. */
+export function onIntegrityReport(
+  cb: (report: IntegrityReport) => void,
+): Promise<UnlistenFn> {
+  return listen<IntegrityReport>("integrity-report", (e) => cb(e.payload));
 }
 
 /** Sentinel slug the backend tags folder-watch reloads with (vs in-app installs). */

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1683,4 +1683,44 @@ export const de: Translation = {
   "trackViewer.whyDetails": "Warum?",
   "trackViewer.copyDetails": "Details kopieren",
   "trackViewer.copied": "Kopiert",
+  "settings.integrity": "Cheat-Erkennung",
+  "settings.integrityDesc":
+    "MX Bikes hat keinen Anti-Cheat, ein manipulierter Client sieht also genauso aus wie ein ehrlicher. Dies prüft, ob etwas an deinem laufenden Spiel hängt.",
+  "settings.integrityWatch": "Laufendes Spiel überwachen",
+  "settings.integrityWatchDesc":
+    "Prüft, was während des Spielens in MX Bikes geladen ist. Nichts verlässt deinen Rechner.",
+  "settings.integrityReport": "Ergebnis mit Servern teilen",
+  "settings.integrityReportDesc":
+    "Lässt den Admin des Servers, auf dem du bist, dein Ergebnis sehen. Bekannte Cheats werden benannt; nur Unbekanntes wird gezählt, nie benannt.",
+  "integrity.clean": "Nichts Unerklärliches",
+  "integrity.suspect": "Etwas Unbekanntes ist geladen",
+  "integrity.flagged": "Ein bekannter Cheat hängt am Spiel",
+  "integrity.unknown": "Nicht geprüft",
+  "integrity.cleanDetail_one": "{{count}} geladene Datei geprüft.",
+  "integrity.cleanDetail_other": "{{count}} geladene Dateien geprüft.",
+  "integrity.foundDetail_one": "{{count}} Sache, die einen Blick wert ist.",
+  "integrity.foundDetail_other": "{{count}} Sachen, die einen Blick wert sind.",
+  "integrity.unknownRunning":
+    "Das Spiel läuft, aber die geladenen Dateien konnten nicht gelesen werden — das ist also keine Entwarnung.",
+  "integrity.unknownIdle": "Starte MX Bikes, dann wird beim Fahren geprüft.",
+  "integrity.scanNow": "Jetzt prüfen",
+  "integrity.scanFailed": "Prüfung konnte nicht ausgeführt werden",
+  "integrity.offNote": "Aktiviere die Überwachung oben, um zu sehen, was an deinem Spiel hängt.",
+  "integrity.limitNote":
+    "Das kann beweisen, dass dein eigener Client ehrlich ist — nicht der von anderen. Wer betrügt und MXB App nicht nutzt, wird nie geprüft.",
+  "integrity.rulesVersion": "Signaturliste v{{version}}.",
+  "integrity.reasonRule": "Passt zu einem bekannten Cheat.",
+  "integrity.reasonLoader":
+    "Liegt im Spielordner unter einem Namen, den das Spiel automatisch lädt.",
+  "integrity.reasonForeign":
+    "Von außerhalb ins Spiel geladen — weder vom Spiel, noch von Windows, noch von MXB App installiert.",
+  "integrity.reasonProcess": "Ein Programm auf diesem PC, das zu einem bekannten Cheat passt.",
+  "integrity.gridTitle": "Client-Prüfungen",
+  "integrity.gridLoading": "Wird gelesen…",
+  "integrity.gridEmpty": "Auf diesem Server meldet gerade niemand eine Prüfung.",
+  "integrity.gridSuspect_one": "{{count}} unbekannte Datei",
+  "integrity.gridSuspect_other": "{{count}} unbekannte Dateien",
+  "integrity.gridRecovered": "(früher in dieser Sitzung)",
+  "integrity.gridNote":
+    "Hier erscheinen nur Fahrer, die MXB App mit aktiviertem Teilen nutzen. Wer hier fehlt, ist nicht entlastet — er hat schlicht nichts gemeldet.",
 };

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1636,4 +1636,47 @@ export const en = {
   "trackViewer.whyDetails": "Why?",
   "trackViewer.copyDetails": "Copy details",
   "trackViewer.copied": "Copied",
+  // Cheat detection — see `src-tauri/src/integrity.rs`. Wording matters more than usual
+  // here: three of the four verdicts must not read as an accusation, and the one that does
+  // is only ever shown for a rule match.
+  "settings.integrity": "Cheat detection",
+  "settings.integrityDesc":
+    "MX Bikes has no anti-cheat, so a hooked client looks exactly like an honest one. This checks whether anything is attached to your running game.",
+  "settings.integrityWatch": "Watch the running game",
+  "settings.integrityWatchDesc":
+    "Check what's loaded into MX Bikes while you play. Nothing leaves your machine.",
+  "settings.integrityReport": "Share the result with servers",
+  "settings.integrityReportDesc":
+    "Let the admin of a server you're on see your verdict. Known cheats are named; anything merely unrecognised is counted, never named.",
+  "integrity.clean": "Nothing unaccounted for",
+  "integrity.suspect": "Something unrecognised is loaded",
+  "integrity.flagged": "A known cheat is attached",
+  "integrity.unknown": "Not checked",
+  "integrity.cleanDetail_one": "{{count}} loaded file checked.",
+  "integrity.cleanDetail_other": "{{count}} loaded files checked.",
+  "integrity.foundDetail_one": "{{count}} thing worth a look.",
+  "integrity.foundDetail_other": "{{count}} things worth a look.",
+  "integrity.unknownRunning":
+    "The game is running but its loaded files couldn't be read — so this is not an all-clear.",
+  "integrity.unknownIdle": "Start MX Bikes and this will check it while you ride.",
+  "integrity.scanNow": "Check now",
+  "integrity.scanFailed": "Couldn't run the check",
+  "integrity.offNote": "Turn on watching above to see what's attached to your game.",
+  "integrity.limitNote":
+    "This can prove your own client is honest; it can't prove anyone else's is. A cheater who doesn't run MXB App is never scanned.",
+  "integrity.rulesVersion": "Signature list v{{version}}.",
+  "integrity.reasonRule": "Matches a known cheat.",
+  "integrity.reasonLoader":
+    "Sitting in the game's folder under a name the game loads automatically.",
+  "integrity.reasonForeign":
+    "Loaded into the game from outside the game, Windows, or anything MXB App installed.",
+  "integrity.reasonProcess": "A program on this PC that matches a known cheat.",
+  "integrity.gridTitle": "Client checks",
+  "integrity.gridLoading": "Reading…",
+  "integrity.gridEmpty": "Nobody on this server is reporting a check right now.",
+  "integrity.gridSuspect_one": "{{count}} unrecognised file",
+  "integrity.gridSuspect_other": "{{count}} unrecognised files",
+  "integrity.gridRecovered": "(earlier this session)",
+  "integrity.gridNote":
+    "Only riders running MXB App with sharing turned on appear here. Somebody missing from this list hasn't been cleared — they simply haven't reported.",
 } as const;

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1670,4 +1670,44 @@ export const es: Translation = {
   "trackViewer.whyDetails": "¿Por qué?",
   "trackViewer.copyDetails": "Copiar detalles",
   "trackViewer.copied": "Copiado",
+  "settings.integrity": "Detección de trucos",
+  "settings.integrityDesc":
+    "MX Bikes no tiene anti-cheat, así que un cliente manipulado es idéntico a uno honesto. Esto comprueba si hay algo enganchado a tu juego en ejecución.",
+  "settings.integrityWatch": "Vigilar el juego en ejecución",
+  "settings.integrityWatchDesc":
+    "Comprueba qué se carga en MX Bikes mientras juegas. Nada sale de tu equipo.",
+  "settings.integrityReport": "Compartir el resultado con los servidores",
+  "settings.integrityReportDesc":
+    "Deja que el administrador del servidor en el que estás vea tu veredicto. Los trucos conocidos se nombran; lo que solo es desconocido se cuenta, nunca se nombra.",
+  "integrity.clean": "Nada sin explicar",
+  "integrity.suspect": "Hay algo desconocido cargado",
+  "integrity.flagged": "Hay un truco conocido enganchado",
+  "integrity.unknown": "Sin comprobar",
+  "integrity.cleanDetail_one": "{{count}} archivo cargado comprobado.",
+  "integrity.cleanDetail_other": "{{count}} archivos cargados comprobados.",
+  "integrity.foundDetail_one": "{{count}} cosa que merece un vistazo.",
+  "integrity.foundDetail_other": "{{count}} cosas que merecen un vistazo.",
+  "integrity.unknownRunning":
+    "El juego está en marcha pero no se pudieron leer sus archivos cargados, así que esto no es un visto bueno.",
+  "integrity.unknownIdle": "Inicia MX Bikes y esto lo comprobará mientras ruedas.",
+  "integrity.scanNow": "Comprobar ahora",
+  "integrity.scanFailed": "No se pudo ejecutar la comprobación",
+  "integrity.offNote": "Activa la vigilancia arriba para ver qué hay enganchado a tu juego.",
+  "integrity.limitNote":
+    "Puede demostrar que tu cliente es honesto, no el de los demás. Quien hace trampas sin usar MXB App nunca se comprueba.",
+  "integrity.rulesVersion": "Lista de firmas v{{version}}.",
+  "integrity.reasonRule": "Coincide con un truco conocido.",
+  "integrity.reasonLoader":
+    "Está en la carpeta del juego con un nombre que el juego carga automáticamente.",
+  "integrity.reasonForeign":
+    "Cargado en el juego desde fuera: no es del juego, ni de Windows, ni instalado por MXB App.",
+  "integrity.reasonProcess": "Un programa de este PC que coincide con un truco conocido.",
+  "integrity.gridTitle": "Comprobaciones de clientes",
+  "integrity.gridLoading": "Leyendo…",
+  "integrity.gridEmpty": "Nadie en este servidor está informando de una comprobación ahora mismo.",
+  "integrity.gridSuspect_one": "{{count}} archivo desconocido",
+  "integrity.gridSuspect_other": "{{count}} archivos desconocidos",
+  "integrity.gridRecovered": "(antes en esta sesión)",
+  "integrity.gridNote":
+    "Aquí solo aparecen los pilotos que usan MXB App con el envío activado. Quien no esté en la lista no ha sido descartado: simplemente no ha informado.",
 };

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1674,4 +1674,44 @@ export const fr: Translation = {
   "trackViewer.whyDetails": "Pourquoi ?",
   "trackViewer.copyDetails": "Copier les détails",
   "trackViewer.copied": "Copié",
+  "settings.integrity": "Détection de triche",
+  "settings.integrityDesc":
+    "MX Bikes n'a pas d'anti-triche, donc un client modifié ressemble exactement à un client honnête. Ceci vérifie si quelque chose est accroché à votre jeu en cours.",
+  "settings.integrityWatch": "Surveiller le jeu en cours",
+  "settings.integrityWatchDesc":
+    "Vérifie ce qui est chargé dans MX Bikes pendant que vous jouez. Rien ne quitte votre machine.",
+  "settings.integrityReport": "Partager le résultat avec les serveurs",
+  "settings.integrityReportDesc":
+    "Permet à l'admin du serveur où vous êtes de voir votre verdict. Les triches connues sont nommées ; ce qui est simplement non reconnu est compté, jamais nommé.",
+  "integrity.clean": "Rien d'inexpliqué",
+  "integrity.suspect": "Quelque chose de non reconnu est chargé",
+  "integrity.flagged": "Une triche connue est accrochée",
+  "integrity.unknown": "Non vérifié",
+  "integrity.cleanDetail_one": "{{count}} fichier chargé vérifié.",
+  "integrity.cleanDetail_other": "{{count}} fichiers chargés vérifiés.",
+  "integrity.foundDetail_one": "{{count}} chose à regarder.",
+  "integrity.foundDetail_other": "{{count}} choses à regarder.",
+  "integrity.unknownRunning":
+    "Le jeu tourne mais ses fichiers chargés n'ont pas pu être lus — ce n'est donc pas un feu vert.",
+  "integrity.unknownIdle": "Lancez MX Bikes et la vérification se fera pendant que vous roulez.",
+  "integrity.scanNow": "Vérifier",
+  "integrity.scanFailed": "Impossible de lancer la vérification",
+  "integrity.offNote": "Activez la surveillance ci-dessus pour voir ce qui est accroché au jeu.",
+  "integrity.limitNote":
+    "Ceci peut prouver que votre propre client est honnête, pas celui des autres. Un tricheur qui n'utilise pas MXB App n'est jamais analysé.",
+  "integrity.rulesVersion": "Liste de signatures v{{version}}.",
+  "integrity.reasonRule": "Correspond à une triche connue.",
+  "integrity.reasonLoader":
+    "Placé dans le dossier du jeu sous un nom que le jeu charge automatiquement.",
+  "integrity.reasonForeign":
+    "Chargé dans le jeu depuis l'extérieur : ni le jeu, ni Windows, ni rien installé par MXB App.",
+  "integrity.reasonProcess": "Un programme de ce PC qui correspond à une triche connue.",
+  "integrity.gridTitle": "Vérifications des clients",
+  "integrity.gridLoading": "Lecture…",
+  "integrity.gridEmpty": "Personne sur ce serveur ne signale de vérification pour le moment.",
+  "integrity.gridSuspect_one": "{{count}} fichier non reconnu",
+  "integrity.gridSuspect_other": "{{count}} fichiers non reconnus",
+  "integrity.gridRecovered": "(plus tôt dans la session)",
+  "integrity.gridNote":
+    "Seuls les pilotes utilisant MXB App avec le partage activé apparaissent ici. Quelqu'un absent de cette liste n'est pas innocenté : il n'a simplement rien signalé.",
 };

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1660,4 +1660,44 @@ export const it: Translation = {
   "trackViewer.whyDetails": "Perché?",
   "trackViewer.copyDetails": "Copia i dettagli",
   "trackViewer.copied": "Copiato",
+  "settings.integrity": "Rilevamento cheat",
+  "settings.integrityDesc":
+    "MX Bikes non ha un anti-cheat, quindi un client manomesso è indistinguibile da uno onesto. Questo controlla se qualcosa è agganciato al gioco in esecuzione.",
+  "settings.integrityWatch": "Controlla il gioco in esecuzione",
+  "settings.integrityWatchDesc":
+    "Verifica cosa viene caricato in MX Bikes mentre giochi. Nulla lascia il tuo PC.",
+  "settings.integrityReport": "Condividi il risultato con i server",
+  "settings.integrityReportDesc":
+    "Permetti all'admin del server su cui sei di vedere il tuo esito. I cheat noti vengono nominati; ciò che è solo non riconosciuto viene contato, mai nominato.",
+  "integrity.clean": "Nulla di inspiegato",
+  "integrity.suspect": "È caricato qualcosa di non riconosciuto",
+  "integrity.flagged": "È agganciato un cheat noto",
+  "integrity.unknown": "Non controllato",
+  "integrity.cleanDetail_one": "{{count}} file caricato controllato.",
+  "integrity.cleanDetail_other": "{{count}} file caricati controllati.",
+  "integrity.foundDetail_one": "{{count}} cosa da guardare.",
+  "integrity.foundDetail_other": "{{count}} cose da guardare.",
+  "integrity.unknownRunning":
+    "Il gioco è in esecuzione ma non è stato possibile leggere i file caricati — quindi questo non è un via libera.",
+  "integrity.unknownIdle": "Avvia MX Bikes e il controllo partirà mentre guidi.",
+  "integrity.scanNow": "Controlla ora",
+  "integrity.scanFailed": "Impossibile eseguire il controllo",
+  "integrity.offNote": "Attiva il controllo qui sopra per vedere cosa è agganciato al gioco.",
+  "integrity.limitNote":
+    "Può dimostrare che il tuo client è onesto, non quello degli altri. Chi bara senza usare MXB App non viene mai controllato.",
+  "integrity.rulesVersion": "Elenco firme v{{version}}.",
+  "integrity.reasonRule": "Corrisponde a un cheat noto.",
+  "integrity.reasonLoader":
+    "Si trova nella cartella del gioco con un nome che il gioco carica automaticamente.",
+  "integrity.reasonForeign":
+    "Caricato nel gioco da fuori: non è del gioco, di Windows, né installato da MXB App.",
+  "integrity.reasonProcess": "Un programma su questo PC che corrisponde a un cheat noto.",
+  "integrity.gridTitle": "Controlli dei client",
+  "integrity.gridLoading": "Lettura…",
+  "integrity.gridEmpty": "Nessuno su questo server sta segnalando un controllo in questo momento.",
+  "integrity.gridSuspect_one": "{{count}} file non riconosciuto",
+  "integrity.gridSuspect_other": "{{count}} file non riconosciuti",
+  "integrity.gridRecovered": "(prima, in questa sessione)",
+  "integrity.gridNote":
+    "Qui compaiono solo i piloti che usano MXB App con la condivisione attiva. Chi manca da questa lista non è stato scagionato: semplicemente non ha segnalato nulla.",
 };

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1659,4 +1659,44 @@ export const ptBR: Translation = {
   "trackViewer.whyDetails": "Por quê?",
   "trackViewer.copyDetails": "Copiar detalhes",
   "trackViewer.copied": "Copiado",
+  "settings.integrity": "Detecção de cheats",
+  "settings.integrityDesc":
+    "MX Bikes não tem anti-cheat, então um cliente adulterado é idêntico a um honesto. Isto verifica se há algo acoplado ao seu jogo em execução.",
+  "settings.integrityWatch": "Monitorar o jogo em execução",
+  "settings.integrityWatchDesc":
+    "Verifica o que é carregado no MX Bikes enquanto você joga. Nada sai da sua máquina.",
+  "settings.integrityReport": "Compartilhar o resultado com os servidores",
+  "settings.integrityReportDesc":
+    "Deixa o admin do servidor em que você está ver seu veredito. Cheats conhecidos são nomeados; o que é apenas não reconhecido é contado, nunca nomeado.",
+  "integrity.clean": "Nada sem explicação",
+  "integrity.suspect": "Há algo não reconhecido carregado",
+  "integrity.flagged": "Há um cheat conhecido acoplado",
+  "integrity.unknown": "Não verificado",
+  "integrity.cleanDetail_one": "{{count}} arquivo carregado verificado.",
+  "integrity.cleanDetail_other": "{{count}} arquivos carregados verificados.",
+  "integrity.foundDetail_one": "{{count}} coisa que merece atenção.",
+  "integrity.foundDetail_other": "{{count}} coisas que merecem atenção.",
+  "integrity.unknownRunning":
+    "O jogo está rodando, mas os arquivos carregados não puderam ser lidos — então isto não é um sinal verde.",
+  "integrity.unknownIdle": "Abra o MX Bikes e a verificação acontecerá enquanto você pilota.",
+  "integrity.scanNow": "Verificar agora",
+  "integrity.scanFailed": "Não foi possível executar a verificação",
+  "integrity.offNote": "Ative o monitoramento acima para ver o que está acoplado ao seu jogo.",
+  "integrity.limitNote":
+    "Isto prova que o seu cliente é honesto, não o dos outros. Quem trapaceia sem usar o MXB App nunca é verificado.",
+  "integrity.rulesVersion": "Lista de assinaturas v{{version}}.",
+  "integrity.reasonRule": "Corresponde a um cheat conhecido.",
+  "integrity.reasonLoader":
+    "Está na pasta do jogo com um nome que o jogo carrega automaticamente.",
+  "integrity.reasonForeign":
+    "Carregado no jogo de fora — não é do jogo, nem do Windows, nem instalado pelo MXB App.",
+  "integrity.reasonProcess": "Um programa neste PC que corresponde a um cheat conhecido.",
+  "integrity.gridTitle": "Verificações dos clientes",
+  "integrity.gridLoading": "Lendo…",
+  "integrity.gridEmpty": "Ninguém neste servidor está reportando uma verificação agora.",
+  "integrity.gridSuspect_one": "{{count}} arquivo não reconhecido",
+  "integrity.gridSuspect_other": "{{count}} arquivos não reconhecidos",
+  "integrity.gridRecovered": "(antes, nesta sessão)",
+  "integrity.gridNote":
+    "Só aparecem aqui pilotos usando o MXB App com o compartilhamento ligado. Quem falta nesta lista não foi inocentado — apenas não reportou nada.",
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -129,6 +129,78 @@ export interface Config {
   /** App version whose release showcase has been seen. Blank on an install that
    *  predates the showcase, which is what marks it as an upgrade worth telling. */
   seenVersion?: string;
+  /** Watch for cheats attached to the running game. Default true — the scan reads the
+   *  game's own module list and the answer goes no further than this window. */
+  integrityWatch?: boolean;
+  /** Publish the verdict so a server admin can see it. Default false: scanning your own
+   *  game and telling a server operator what it found are two different decisions. */
+  integrityReport?: boolean;
+}
+
+/**
+ * What a cheat scan concluded, worst last.
+ *
+ * `unknown` is a real answer and the important one: the game isn't running, or the platform
+ * can't be read, or the scan failed. It is never a synonym for clean — a scanner that
+ * reports a healthy machine when it simply didn't look is worse than none.
+ */
+export type IntegrityVerdict = "unknown" | "clean" | "suspect" | "flagged";
+
+/** `suspect` is "loaded and unrecognised"; `flagged` is "matched the rule list". */
+export type IntegritySeverity = "suspect" | "flagged";
+
+export type IntegrityKind = "module" | "process";
+
+/** Why something was reported — a key, so the line survives translation. */
+export type IntegrityReason =
+  | "ruleName"
+  | "ruleHash"
+  | "foreignModule"
+  | "loaderHijack";
+
+export interface IntegrityFinding {
+  kind: IntegrityKind;
+  /** File name, lowercased. */
+  name: string;
+  /** Full path, when there is one. Empty for a process. */
+  path: string;
+  reason: IntegrityReason;
+  severity: IntegritySeverity;
+  /** SHA-256, when the file could be read. What turns "some unknown DLL" into something
+   *  that can be added to the rule list. */
+  sha256?: string;
+  /** The rule's own label, when a rule matched. Never translated — a cheat's name is its
+   *  name. */
+  label?: string;
+}
+
+export interface IntegrityReport {
+  verdict: IntegrityVerdict;
+  findings: IntegrityFinding[];
+  /** Unix ms. Zero before the first scan of a session. */
+  scannedAt: number;
+  /** Which rule list produced it. */
+  rulesVersion: number;
+  /** How many modules were looked at — the difference between a thorough clean answer and
+   *  an empty one. */
+  modulesScanned: number;
+  gameRunning: boolean;
+}
+
+/** One rider's published verdict, as the admin of their server sees it. */
+export interface RiderIntegrity {
+  riderName: string;
+  guid: string;
+  verdict: IntegrityVerdict;
+  rulesVersion: number;
+  /** Unrecognised modules are counted, never named — see the control plane's migration. */
+  suspectCount: number;
+  flagged: { name: string; label: string; sha256: string }[];
+  /** The worst verdict seen recently, when it is worse than the current one. A cheat loaded
+   *  for one lap and then unloaded is the case this exists for. */
+  worstVerdict?: IntegrityVerdict;
+  /** Unix ms of their last report. */
+  reportedAt: number;
 }
 
 /** A track-mod as it appears in search results / browse grid. */


### PR DESCRIPTION
MX Bikes ships no anti-cheat, so a hooked client is indistinguishable from an honest one — to the server, to the grid, and to the game. The cheats going round are injected DLLs and external trainers, and an injected DLL has one property worth building on: to hook the game it has to be **inside** the game, which puts it in the process's module list. That list is readable from out here.

## What it does

`integrity` walks the module list of the running `mxbikes.exe` and classifies each entry. The order is the whole policy:

1. **Rules first** — a name or hash on the list is a cheat wherever it loaded from, so one that copies itself in beside the game doesn't get trusted for being there.
2. **Allowlist** — the release valve for a false positive, silenceable without a release.
3. **Loader hijack** — a DLL in the game folder under a name Windows preloads (`opengl32.dll`, `dinput8.dll`, …). ReShade installs as exactly that shape, so the check reads the file rather than trusting the name.
4. **Trusted roots and the system folder** — matched on path *shape*, not substring, so `C:\kaizo\windows\system32\evil.dll` gets no free pass.
5. Anything left is loaded into the game from somewhere unaccounted for → reported as **Suspect** rather than named as a cheat.

Verdicts are four-valued, and the fourth is the point: a machine we could not read reports **Unknown**, never Clean. A scanner that says "healthy" when it simply did not look is worse than none, because people believe it.

`integritywatch` keeps it running for the length of a session — a cheat is attached mid-race, and a launch-time check would have called that session clean ten minutes before it stopped being. It is a standing watcher rather than something hung off Play: plenty of people start the game from Steam.

## Signatures

They live in `integrity-rules.json` on `main` and are fetched and cached at runtime — the arrangement `supporters.json` already uses. A cheat that appears on a Tuesday cannot wait for a release to be detectable.

What ships in the binary is the **allowlist and no signatures at all**, so a build that never reaches the network is cautious rather than wrong. The allowlist is the half that has to ship: it is what stops an ordinary gaming PC (Steam overlay, GPU driver, Discord, OBS, RivaTuner, ReShade, Proton/Wine builtins) from lighting up on first launch. A remote list can only *add* to it, and can never un-flag a signature.

## Server admins

With sharing on — its own switch, off by default — a client publishes its verdict to the control plane, and the admin of the server it is on reads it back in the Servers tab, worst first.

The table keeps a worst-verdict-so-far beside the current one, because without it the feature is defeated by loading the cheat for one lap and unloading it: the next 45-second heartbeat would overwrite `flagged` with `clean` as if nothing had happened. It is surfaced only while it is still inside the roster's freshness window — a verdict about somebody should not outlive the race it was about.

The read is not public the way the server list is. It is limited to the server's owner and to riders currently on it: you can see the grid you are actually riding with, and you cannot go fishing for someone who isn't near you.

## Two things worth reviewing carefully

**This is attestation, not enforcement.** A cheater who does not run MXB App is never scanned; one who patches the check out reports whatever they like. What it does is let an honest client *prove* it is honest — something a server has no way to ask for today — and raise the cost of the cheats actually in circulation, which are downloaded DLLs run by people who are not going to rebuild the mod manager. That limit is stated in the README, the changelog, the Settings card and the admin list's footnote rather than left to be discovered.

**The privacy line.** A Suspect finding is "software we don't recognise", which on somebody's work laptop could be anything. Those are **counted, never named** in what leaves the machine; only rule-matched detections carry a name. `an_attestation_counts_suspects_without_naming_them` pins that, and will fail loudly if anyone widens it.

## Supporting changes

- `gameproc` gained process enumeration with paths, which it didn't have: Toolhelp on Windows, `/proc/<pid>/maps` on Linux (Wine maps a PE file-backed, so the kernel's own list is a faithful account of what is inside the game). macOS says it cannot look rather than half-answering.
- `reshade::is_reshade_dll` is now public, used for the opposite purpose it was written for — telling a legitimate ReShade proxy DLL from a cheat-shaped one.
- Two config fields, `integrityWatch` (default on, local only) and `integrityReport` (default off). Container-level `serde(default)` means existing configs pick up the struct defaults.

## Verification

- **Rust**: 748 pass, 23 of them new. One pre-existing failure, `gearrepair::a_move_that_fails_part_way_puts_everything_back`, which also fails on a clean `b13c955` in this environment — the tests run as root, and root ignores the read-only directory the test relies on.
- **Control plane**: 41 vitest pass (7 new), typecheck clean.
- **Frontend**: typecheck, lint (2 pre-existing warnings) and build all clean.

Not exercised here: the Windows Toolhelp and Linux `/proc/maps` walks need a real machine with the game running. The parsers are unit-tested; the FFI is not.

---
_Generated by [Claude Code](https://claude.ai/code/session_013gRg8tpASdnK8YYjKKjGfK)_