### PR TITLE
feat(servers): worldnet module gate — server-browser groundwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased — groundwork for a public server browser
+
+### Added
+- **A local-only `worldnet` module gate**, built the same way as the existing sidecar: when
+  its source file is present the build turns on `cfg(worldnet)` and compiles it in; the public
+  tree has neither the file nor the feature and builds unchanged. First groundwork toward
+  listing real dedicated servers and joining them from the app — not yet wired to any UI.
+
 ## Unreleased — undo covers the whole editor, and the bucket stays on its panel
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 ## Unreleased — FrostMod runs on Linux, and the app can see the game there
 
 ### Added
+- **Cheat detection.** MX Bikes ships no anti-cheat, so a hooked client is
+  indistinguishable from an honest one — to the server, to the grid, and to the game. The
+  cheats going round are injected DLLs and external trainers, and an injected DLL has one
+  property worth building on: to hook the game it has to be *inside* the game, which puts it
+  in the process's module list. The app now reads that list while you ride (every 45s for as
+  long as the game is up, whether the app launched it or Steam did) and reports one of four
+  verdicts. Three of them are not accusations: **nothing unaccounted for**, **something
+  unrecognised is loaded** — an overlay or capture tool nobody has listed yet lands here —
+  and **not checked**, which is what a machine we could not read gets and is never a synonym
+  for clean. Only a match against the signature list is called a cheat. Findings name the
+  file, where it loaded from, and why it was reported; Settings → Cheat detection shows the
+  live answer and re-runs it on demand.
+- **Signatures update without a release.** They live in
+  [`integrity-rules.json`](integrity-rules.json) on `main`, fetched and cached at runtime
+  like `supporters.json` — a cheat that appears on a Tuesday cannot wait for a build. What
+  ships in the binary is the *allowlist* and no signatures at all, so an install that never
+  reaches the network is cautious rather than wrong; the allowlist is what stops an ordinary
+  gaming PC (Steam overlay, GPU driver, Discord, OBS, RivaTuner, ReShade) from lighting up
+  on first launch. A remote list can only add to that allowlist, and can never un-flag a
+  signature.
+- **Servers can see their grid's client checks.** With sharing turned on — its own switch,
+  off by default — a client publishes its verdict to the control plane, and the admin of the
+  server it is on sees it in the Servers tab, worst first, with a rider who was flagged
+  earlier in the session still shown as flagged rather than being cleared by unloading the
+  cheat for a lap. What is sent is the verdict and the names of *rule-matched* detections
+  only: an unrecognised-but-unnamed module is counted and never named, because on somebody's
+  machine that could be anything. Readable by the server's owner and by riders currently on
+  it, so you can see the grid you're riding with and can't go fishing for anyone else.
+  The list is honest about what it is: a rider appears only if their app is running,
+  watching and sharing, so somebody missing from it hasn't been cleared — and a cheater who
+  closes MXB App is never scanned at all. This proves an honest client is honest, which is
+  something a server currently has no way to ask for; it does not make cheating impossible.
 - **FrostMod installs and runs on Linux.** It used to refuse with *FrostMod runs on Windows
   only*, which was true of the binary and beside the point: on Linux the game is a Windows
   process too — Steam runs it under Proton — so FrostMod belongs in that same Proton prefix,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased — a browse card says who made it
+
+### Added
+- **Mod cards carry a byline.** The catalog knows who posted each mod and the grid never
+  showed it, so telling two versions of the same track apart meant opening both. The name now
+  sits beside the date, the way a shop card already carries its author. It rides along with
+  the listing request rather than costing one of its own, and a mod the catalog names nobody
+  for simply keeps the date.
+
 ## Unreleased — the install picker says which file it's about to fetch
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Unreleased — the install picker says which file it's about to fetch
+
+### Fixed
+- **A dedicated-server build is no longer installed as if it were the mod.** Server files were
+  detected by looking for the word "server" anywhere in a download block, which missed the
+  authors who only say it in the file's name (`Ironman_2024_Server.pkz`) — an undetected one
+  carrying the page's "Default" flag was preselected and installed without ever being named.
+  The link itself is read now as well, and the same check no longer mistakes a track called
+  *Observer Hill* for a server build, which used to hide the only download it had.
+- **Quick install stops guessing on a mod that offers nothing but server files.** One click
+  can't ask which build was meant, and the wrong one installs cleanly and then does nothing
+  in-game. Those mods now say so and send you to the page, where every file is listed.
+
+### Changed
+- **Every download is shown, with the recommended one picked.** Server builds used to be
+  dropped from the list, so a mod read as having one file while the flag behind that was a
+  guess. They're listed last instead, badged *Server*, folded under a *dedicated server files*
+  disclosure, and never preselected while anything playable is on offer.
+- **The mirror list opens on more than one row.** A single row read as the only file there
+  was; the first few are listed now, each with the author's own name for the file, so two
+  MediaFire links are told apart before one of them is downloaded.
+
 ## Unreleased — the sheet says which panel, which side, and which face
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## Unreleased — undo covers the whole editor, and the bucket stays on its panel
+
+### Added
+- **Undo covers everything now, not just brush strokes.** Adding, moving, scaling, rotating,
+  clipping and deleting layers, and adding, renaming, reordering and deleting sheets, all go on
+  the same timeline as the painting — so Ctrl+Z takes back whatever you actually did last,
+  rather than the last stroke and nothing else. A drag or a slider scrub is one step, not the
+  two hundred events it was made of.
+- **The bucket fills the panel you clicked, not the whole sheet.** A bike sheet is a dozen
+  panels side by side, and flooding the layer buried the eleven you weren't pointing at. Click
+  outside every island — on the sheet's background — and it still floods the layer, since
+  that's the only thing it could mean there.
+
+## Unreleased — double-click actually focuses, and the label says where on the bike
+
+### Fixed
+- **Double-click to focus a part now works.** The canvas takes pointer capture on every press so
+  a stroke survives leaving the element, and a captured pointer is exactly the case where WebKit
+  stops delivering `dblclick` — so the gesture was never seen. It's recognised from the presses
+  themselves now, which also makes it work under a pen or a touchpad.
+
+### Changed
+- **The hover names the mesh node as well as the group** — `chassis250 Metal.027`. A group's name
+  is whatever its author typed, and authors type anything: the TM pack calls its plastic panels
+  `Metal.NNN` and its metal ones `Plastics.NNN`, so the name alone reads as a contradiction of
+  the panel you're pointing at. The node is the bike's own part, so it still says *where*: a
+  shroud is on the chassis and a rear fender is on the rear suspension, whatever the group
+  is called.
+
 ## Unreleased — the sheet says which panel, which side, and which face
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ hours), then downloads and installs them on restart.
   bodywork under the cursor, and a layer can be fitted to a part and clipped to its
   outline — so an image covers the shroud and stops at the seam. Save writes the
   packed `.pnt` the game reads.
+- **Cheat detection**: MX Bikes has no anti-cheat, so a hooked client looks exactly
+  like an honest one. The app reads what is loaded *into* the running game — the one
+  place an injected DLL has to be in order to hook it — and reports whether anything
+  is unaccounted for. Signatures live in
+  [`integrity-rules.json`](integrity-rules.json) on `main` and are fetched at runtime,
+  so a new cheat is detectable without a release; the binary itself ships only the
+  allowlist that keeps an ordinary machine's overlays and drivers from being reported.
+  A verdict can be shared with the server you're on, which is the only way a server
+  currently has of asking a client anything about itself. It proves an honest client
+  is honest — it can't prove anyone else's is, since a cheater who doesn't run MXB App
+  is never scanned.
 - **Self-update**: `tauri-plugin-updater` against the `latest.json` published with
   each release; signature-verified, installs on restart.
 - **Supporters**: Settings → Supporters credits the people who bought a coffee on

--- a/control-plane/migrations/0010_integrity.sql
+++ b/control-plane/migrations/0010_integrity.sql
@@ -1,0 +1,44 @@
+-- What each client's own cheat scan found, so a server admin can see it.
+--
+-- MX Bikes has no anti-cheat, so a server has no way to ask a joining client anything about
+-- itself. This is the smallest thing that changes that: the player's app scans the running
+-- game (see `src-tauri/src/integrity.rs`) and publishes the verdict here, and the admin of
+-- the server they are on can read it back.
+--
+-- It is attestation, not enforcement, and the table is shaped to keep that honest. A cheater
+-- who does not run MXB App has no row. One who turns reporting off has no row. So the read
+-- answers "who has attested and what did they say" — never "who is clean" — and a missing
+-- row is the most common state, not a suspicious one.
+--
+-- One row per account, rewritten on every heartbeat, exactly like `presence`: this is live
+-- state, not a history. Deliberately not a column on `accounts` for the same reason presence
+-- isn't — a verdict is short-lived and rewritten constantly, an identity is neither.
+CREATE TABLE integrity (
+  account_id    TEXT PRIMARY KEY REFERENCES accounts (id) ON DELETE CASCADE,
+  -- 'unknown' | 'clean' | 'suspect' | 'flagged'. Text rather than an integer so a row read
+  -- straight out of the database says what it means.
+  verdict       TEXT NOT NULL,
+  -- Which rule list produced it. A 'clean' checked against an empty list means much less
+  -- than one checked against the current one, and an admin can only tell them apart if the
+  -- version travels with the verdict.
+  rules_version INTEGER NOT NULL,
+  -- How many loaded modules were unrecognised but matched no rule. A count and never a
+  -- list: "software we don't recognise" is not evidence, and on somebody's machine it could
+  -- be anything. The client never sends their names.
+  suspect_count INTEGER NOT NULL,
+  -- JSON array of {name,label,sha256} for rule-matched detections only. Those are named,
+  -- because a known cheat is the thing worth naming.
+  flagged       TEXT NOT NULL,
+  -- The worst verdict this account has reported recently, and when.
+  --
+  -- Without it the feature is trivially defeated: load the cheat for one lap, unload it, and
+  -- the next 45-second heartbeat overwrites 'flagged' with 'clean' as if nothing happened.
+  -- The read only surfaces this while `worst_at` is inside the same freshness window the
+  -- roster uses, so it describes the current session and then lets go — a verdict about
+  -- somebody should not outlive the race it was about.
+  worst_verdict TEXT NOT NULL,
+  worst_at      INTEGER NOT NULL,
+  -- Refreshed on every publish. A row older than the cutoff is treated as gone, so an admin
+  -- can tell "reported clean a moment ago" from "stopped reporting when the race started".
+  updated_at    INTEGER NOT NULL
+);

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -31,11 +31,16 @@ import {
   isPublicGameAddress,
   isRegion,
   isRelDest,
+  isReportCount,
   isServerKey,
   isRiderName,
   isServerName,
   isSha256,
   isSlot,
+  isVerdict,
+  parseFlagged,
+  verdictRank,
+  type Verdict,
   MAX_BOOTSTRAP_LOG,
   MAX_PAINT_BYTES,
 } from "./validate";
@@ -132,6 +137,8 @@ async function route(request: Request, env: Env): Promise<Response> {
   if (method === "PUT" && path === "/v1/loadouts") return putLoadouts(request, account, env);
   if (method === "GET" && path === "/v1/roster") return roster(url, env);
   if (method === "PUT" && path === "/v1/presence") return putPresence(request, account, env);
+  if (method === "PUT" && path === "/v1/integrity") return putIntegrity(request, account, env);
+  if (method === "GET" && path === "/v1/integrity") return serverIntegrity(url, account, env);
   if (method === "POST" && path === "/v1/servers") return registerServer(request, account, env);
   if (method === "GET" && path === "/v1/servers/mine") return myServers(account, env);
   if (method === "GET" && path === "/v1/fleet") return fleetState(account, env);
@@ -1372,6 +1379,138 @@ async function roster(url: URL, env: Env): Promise<Response> {
     });
   }
   return json(200, { server: serverId, riders: [...riders.values()] });
+}
+
+/**
+ * A client publishing what its own cheat scan found.
+ *
+ * The client decides what to send and could send anything, which is the honest limit of the
+ * whole feature — see `migrations/0010_integrity.sql`. Nothing here tries to work around
+ * that; it validates the shape, keeps the worst verdict of the recent past alongside the
+ * current one, and stores it.
+ */
+async function putIntegrity(request: Request, account: Account, env: Env): Promise<Response> {
+  const body = await readJson(request);
+  if (!body) return json(400, { error: "expected a JSON body" });
+  const { verdict, rulesVersion, suspectCount, flagged } = body as Record<string, unknown>;
+  if (!isVerdict(verdict)) return json(400, { error: "that isn't a verdict" });
+  if (!isReportCount(rulesVersion)) return json(400, { error: "that isn't a rules version" });
+  if (!isReportCount(suspectCount)) return json(400, { error: "that isn't a suspect count" });
+
+  const now = Date.now();
+  // The worst verdict only carries forward while it is still about this session. Past the
+  // freshness window it is history, and history is not what this table is for.
+  const prev = await env.DB.prepare(
+    "SELECT worst_verdict, worst_at FROM integrity WHERE account_id = ?",
+  )
+    .bind(account.id)
+    .first<{ worst_verdict: string; worst_at: number }>();
+  const stillCurrent = prev && prev.worst_at > now - PRESENCE_TTL_MS && isVerdict(prev.worst_verdict);
+  const keepWorst = stillCurrent && verdictRank(prev.worst_verdict as Verdict) > verdictRank(verdict);
+
+  await env.DB.prepare(
+    "INSERT INTO integrity (account_id, verdict, rules_version, suspect_count, flagged," +
+      " worst_verdict, worst_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)" +
+      " ON CONFLICT(account_id) DO UPDATE SET verdict = excluded.verdict," +
+      " rules_version = excluded.rules_version, suspect_count = excluded.suspect_count," +
+      " flagged = excluded.flagged, worst_verdict = excluded.worst_verdict," +
+      " worst_at = excluded.worst_at, updated_at = excluded.updated_at",
+  )
+    .bind(
+      account.id,
+      verdict,
+      rulesVersion,
+      suspectCount,
+      JSON.stringify(parseFlagged(flagged)),
+      keepWorst ? prev!.worst_verdict : verdict,
+      keepWorst ? prev!.worst_at : now,
+      now,
+    )
+    .run();
+  return json(200, { ok: true });
+}
+
+/**
+ * What the riders on one server have attested.
+ *
+ * Readable by the server's owner, and by anyone currently on it — you can see the grid you
+ * are actually riding with, and you cannot go fishing for somebody who isn't near you. A
+ * verdict is about a person, so it is not public the way the server list is.
+ *
+ * The response deliberately reads as "who has attested", not "who is clean". A rider whose
+ * app isn't running, isn't scanning, or isn't reporting simply isn't here, and that is the
+ * ordinary case rather than a suspicious one — the client that matters most is exactly the
+ * one that will never appear.
+ */
+async function serverIntegrity(url: URL, account: Account, env: Env): Promise<Response> {
+  const serverId = url.searchParams.get("server");
+  if (!isServerKey(serverId)) return json(400, { error: "a server id is required" });
+
+  const fresh = Date.now() - PRESENCE_TTL_MS;
+  const owns = await env.DB.prepare(
+    "SELECT 1 FROM servers WHERE id = ? AND owner_account_id = ?",
+  )
+    .bind(serverId, account.id)
+    .first();
+  if (!owns) {
+    const present = await env.DB.prepare(
+      "SELECT 1 FROM presence WHERE account_id = ? AND server_id = ? AND updated_at > ?",
+    )
+      .bind(account.id, serverId, fresh)
+      .first();
+    if (!present) return json(403, { error: "that isn't your server, and you aren't on it" });
+  }
+
+  const rows = await env.DB.prepare(
+    "SELECT a.rider_name, a.guid, i.verdict, i.rules_version, i.suspect_count, i.flagged," +
+      " i.worst_verdict, i.worst_at, i.updated_at" +
+      " FROM accounts a" +
+      " JOIN presence pr ON pr.account_id = a.id" +
+      " JOIN integrity i ON i.account_id = a.id" +
+      " WHERE pr.server_id = ? AND pr.updated_at > ? AND i.updated_at > ?",
+  )
+    .bind(serverId, fresh, fresh)
+    .all<{
+      rider_name: string;
+      guid: string | null;
+      verdict: string;
+      rules_version: number;
+      suspect_count: number;
+      flagged: string;
+      worst_verdict: string;
+      worst_at: number;
+      updated_at: number;
+    }>();
+
+  const riders = rows.results.map((r) => ({
+    riderName: r.rider_name,
+    guid: r.guid ?? "",
+    verdict: isVerdict(r.verdict) ? r.verdict : "unknown",
+    rulesVersion: r.rules_version,
+    suspectCount: r.suspect_count,
+    flagged: parseFlagged(safeParse(r.flagged)),
+    // Only while it still describes this session — see the migration.
+    worstVerdict:
+      r.worst_at > fresh && isVerdict(r.worst_verdict) ? r.worst_verdict : undefined,
+    reportedAt: r.updated_at,
+  }));
+  // Worst first: an admin opening this is looking for the one row that isn't clean.
+  riders.sort(
+    (a, b) =>
+      verdictRank(b.worstVerdict ?? b.verdict) - verdictRank(a.worstVerdict ?? a.verdict) ||
+      a.riderName.localeCompare(b.riderName),
+  );
+  return json(200, { server: serverId, riders });
+}
+
+/** Read a column we wrote as JSON. A row that somehow isn't parseable is an empty list, not
+ *  a 500 — one bad row must not take out an admin's whole view. */
+function safeParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return [];
+  }
 }
 
 async function readJson(request: Request): Promise<unknown | null> {

--- a/control-plane/src/validate.ts
+++ b/control-plane/src/validate.ts
@@ -299,3 +299,76 @@ export function isServerKey(value: unknown): value is string {
   return !/[\u0000-\u001f\u007f]/.test(key);
 }
 
+
+/**
+ * Verdicts a client may report, worst last.
+ *
+ * `unknown` is a real answer and not an error: it is what a client says when it could not
+ * read the game's module list at all. Storing it matters — an admin needs to tell "scanned,
+ * found nothing" from "could not scan", and collapsing the two into a missing row would lose
+ * exactly that distinction.
+ */
+export const VERDICTS = ["unknown", "clean", "suspect", "flagged"] as const;
+export type Verdict = (typeof VERDICTS)[number];
+
+export function isVerdict(value: unknown): value is Verdict {
+  return typeof value === "string" && (VERDICTS as readonly string[]).includes(value);
+}
+
+/** Rank a verdict for comparison, so "worst so far" is a `max` rather than a lookup table. */
+export function verdictRank(value: Verdict): number {
+  return VERDICTS.indexOf(value);
+}
+
+/** One named detection, as the client reports it. */
+export interface FlaggedItem {
+  name: string;
+  label: string;
+  sha256: string;
+}
+
+/** How many detections one report may carry. A client with more than this is malfunctioning,
+ *  not unusually infected, and the array is stored as JSON in a single column. */
+export const MAX_FLAGGED = 32;
+const MAX_FLAGGED_CHARS = 120;
+
+/**
+ * Clean one client's list of named detections into something storable.
+ *
+ * Every field here is attacker-controlled in the one sense that matters: a client reports on
+ * *itself*, so anything in here is whatever that machine chose to send. It is echoed back to
+ * an admin's UI, so it is bounded and stripped of control characters rather than trusted —
+ * and anything unparseable is dropped rather than rejecting the whole report, since the
+ * verdict is the part worth keeping.
+ */
+export function parseFlagged(value: unknown): FlaggedItem[] {
+  if (!Array.isArray(value)) return [];
+  const out: FlaggedItem[] = [];
+  for (const entry of value.slice(0, MAX_FLAGGED)) {
+    if (!entry || typeof entry !== "object") continue;
+    const raw = entry as Record<string, unknown>;
+    const name = text(raw.name);
+    if (!name) continue;
+    out.push({
+      name,
+      label: text(raw.label) ?? "",
+      // Anything that isn't a real digest is dropped rather than stored as junk: its only
+      // use is being pasted into the rule list, and a malformed one there is a dead rule.
+      sha256: isSha256(raw.sha256) ? raw.sha256 : "",
+    });
+  }
+  return out;
+}
+
+function text(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  // eslint-disable-next-line no-control-regex
+  const s = value.trim().replace(/[\x00-\x1f\x7f]/g, "").slice(0, MAX_FLAGGED_CHARS);
+  return s.length ? s : null;
+}
+
+/** A count a client reports about itself. Bounded so a malformed or hostile client can't
+ *  store a number the UI then has to render. */
+export function isReportCount(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 10_000;
+}

--- a/control-plane/test/validate.test.ts
+++ b/control-plane/test/validate.test.ts
@@ -16,7 +16,12 @@ import {
   isServerName,
   isSha256,
   isSlot,
+  isReportCount,
+  isVerdict,
+  MAX_FLAGGED,
   MAX_PAINT_BYTES,
+  parseFlagged,
+  verdictRank,
 } from "../src/validate";
 
 describe("paint filenames", () => {
@@ -342,5 +347,68 @@ describe("server keys", () => {
     for (const bad of ["", "   ", "a".repeat(129), withNewline, 5, null]) {
       expect(isServerKey(bad), JSON.stringify(bad)).toBe(false);
     }
+  });
+});
+
+describe("integrity reports", () => {
+  it("accepts the four verdicts and nothing else", () => {
+    for (const v of ["unknown", "clean", "suspect", "flagged"]) expect(isVerdict(v)).toBe(true);
+    expect(isVerdict("CLEAN")).toBe(false);
+    expect(isVerdict("cheating")).toBe(false);
+    expect(isVerdict(2)).toBe(false);
+    expect(isVerdict(undefined)).toBe(false);
+  });
+
+  // The ordering the "worst so far" logic rests on: a client that loads a cheat for one lap
+  // and unloads it must not be able to overwrite `flagged` with `clean`.
+  it("ranks verdicts worst-last", () => {
+    expect(verdictRank("flagged")).toBeGreaterThan(verdictRank("suspect"));
+    expect(verdictRank("suspect")).toBeGreaterThan(verdictRank("clean"));
+    // Unknown is the *lowest*, not a middle ground: it means nobody looked, so it can never
+    // be the worst thing seen and can never displace a real finding.
+    expect(verdictRank("clean")).toBeGreaterThan(verdictRank("unknown"));
+  });
+
+  it("keeps a well-formed detection", () => {
+    expect(
+      parseFlagged([{ name: "kaizo.dll", label: "Kaizo trainer", sha256: "a".repeat(64) }]),
+    ).toEqual([{ name: "kaizo.dll", label: "Kaizo trainer", sha256: "a".repeat(64) }]);
+  });
+
+  // Everything in a report is chosen by the machine being reported on, and all of it is
+  // echoed back into an admin's UI.
+  it("bounds and strips whatever a client sends", () => {
+    const escape = String.fromCharCode(27);
+    const [item] = parseFlagged([
+      { name: `  kaizo${escape}[31m.dll  `, label: "x".repeat(500), sha256: "nonsense" },
+    ]);
+    expect(item.name).toBe("kaizo[31m.dll");
+    expect(item.label.length).toBeLessThanOrEqual(120);
+    // A digest that isn't one is dropped, not stored: its only use is being pasted into the
+    // rule list, where a malformed entry is a dead rule.
+    expect(item.sha256).toBe("");
+  });
+
+  it("drops entries it cannot use rather than failing the whole report", () => {
+    expect(parseFlagged([null, 7, {}, { label: "no name" }, { name: "real.dll" }])).toEqual([
+      { name: "real.dll", label: "", sha256: "" },
+    ]);
+    expect(parseFlagged("not an array")).toEqual([]);
+    expect(parseFlagged(undefined)).toEqual([]);
+  });
+
+  it("caps how many detections one report may carry", () => {
+    const many = Array.from({ length: MAX_FLAGGED + 20 }, (_, i) => ({ name: `c${i}.dll` }));
+    expect(parseFlagged(many)).toHaveLength(MAX_FLAGGED);
+  });
+
+  it("only accepts counts it can render", () => {
+    expect(isReportCount(0)).toBe(true);
+    expect(isReportCount(12)).toBe(true);
+    expect(isReportCount(-1)).toBe(false);
+    expect(isReportCount(1.5)).toBe(false);
+    expect(isReportCount(10_001)).toBe(false);
+    expect(isReportCount("3")).toBe(false);
+    expect(isReportCount(Number.NaN)).toBe(false);
   });
 });

--- a/integrity-rules.json
+++ b/integrity-rules.json
@@ -1,0 +1,23 @@
+{
+  "_comment": [
+    "Cheat signatures for the in-app scanner. Read from `main` at runtime by every install",
+    "(src-tauri/src/integrity.rs), so adding a signature here reaches everyone within the",
+    "hour — no release needed. Bump `version` on every edit; it is what an admin sees",
+    "beside a verdict.",
+    "",
+    "`cheats` entries match a module or process by `contains` (a lowercase substring of the",
+    "file name) or by `sha256` (the whole file). One or the other, not both — an entry",
+    "needing each is two entries sharing a label. `label` is shown to the user verbatim.",
+    "",
+    "`allow` and `allowPaths` silence a false positive: the scanner reports any DLL loaded",
+    "into the game from outside the game, Windows, or the folders we installed, so a new",
+    "overlay or capture tool will land there until it is listed. These ADD to the allowlist",
+    "compiled into the app; they cannot remove from it, and they cannot un-flag a signature.",
+    "",
+    "Adding a name here accuses whoever is running that file of cheating. Be sure."
+  ],
+  "version": 1,
+  "cheats": [],
+  "allow": [],
+  "allowPaths": []
+}

--- a/src-tauri/.gitignore
+++ b/src-tauri/.gitignore
@@ -8,4 +8,5 @@
 
 # Local-only module (not part of the public tree)
 /src/sidecar.rs
+/src/worldnet.rs
 /src/fixtures/test_sidecar.pkz

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -6,12 +6,18 @@ use std::path::Path;
 const SHOP_KEYS: [&str; 2] = ["MXB_SHOP_API_HEADER", "MXB_SHOP_API_KEY"];
 
 fn main() {
-    // Optional local-only module: enable cfg when its file is present.
+    // Optional local-only modules: enable each cfg when its file is present.
     println!("cargo::rustc-check-cfg=cfg(sidecar)");
     if Path::new("src/sidecar.rs").exists() {
         println!("cargo::rustc-cfg=sidecar");
     }
     println!("cargo::rerun-if-changed=src/sidecar.rs");
+
+    println!("cargo::rustc-check-cfg=cfg(worldnet)");
+    if Path::new("src/worldnet.rs").exists() {
+        println!("cargo::rustc-cfg=worldnet");
+    }
+    println!("cargo::rerun-if-changed=src/worldnet.rs");
 
     shop_credentials();
     release_tag();

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -136,6 +136,21 @@ pub struct AppConfig {
     /// What paint sync last did, so the UI can say so instead of the player having to guess
     /// from an empty grid. Written by the background tasks; never edited by hand.
     pub sync: SyncState,
+    /// Watch for cheats attached to the running game — see [`crate::integrity`].
+    ///
+    /// On by default, unlike the other things that talk to a server, because the local half
+    /// costs nothing and talks to nobody: it reads the game's own module list and shows the
+    /// answer here. The half that leaves the machine is gated separately on
+    /// [`AppConfig::integrity_report`], which is off until it's chosen.
+    pub integrity_watch: bool,
+    /// Publish this client's verdict to the control plane, so a server admin can see it.
+    ///
+    /// Off by default and deliberately its own switch. Scanning your own game is one thing;
+    /// telling a server operator what a scan found is another, and a player should choose it
+    /// rather than discover it. What gets sent is spelled out in
+    /// [`crate::integritywatch::publish`] — the verdict and the names of *rule-matched*
+    /// detections, never the list of everything loaded on the machine.
+    pub integrity_report: bool,
 }
 
 /// The record of the last publish and the last pull.
@@ -236,6 +251,8 @@ impl Default for AppConfig {
             cp_rider_name: String::new(),
             cp_guid: String::new(),
             sync: SyncState::default(),
+            integrity_watch: true,
+            integrity_report: false,
         }
     }
 }

--- a/src-tauri/src/gameproc.rs
+++ b/src-tauri/src/gameproc.rs
@@ -295,6 +295,110 @@ pub fn is_game_running() -> bool {
     find_game_pid().is_some()
 }
 
+/// Read a fixed-size NUL-padded ANSI field as a `String`, stopping at the terminator.
+#[cfg(windows)]
+fn ansi_field(field: &[std::os::raw::c_char]) -> String {
+    let bytes: Vec<u8> = field.iter().take_while(|&&c| c != 0).map(|&c| c as u8).collect();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+/// Every DLL currently mapped into the running game, by full path.
+///
+/// This is the question [`crate::integrity`] is really asking. A cheat that hooks MX Bikes
+/// has to get its code into the game's address space, and a module that is *in* there is in
+/// this list no matter how it arrived — `LoadLibrary` from an injector, a proxy DLL the
+/// loader pulled in for the exe, or a manual map that bothered to register itself. (One that
+/// doesn't register is invisible here; see the module docs on what that costs.)
+///
+/// `None` means we could not look — the game isn't up, or the snapshot failed — which is
+/// deliberately different from `Some(vec![])`, "we looked and it is clean". The scanner must
+/// never report a clean bill of health for a machine it failed to read.
+#[cfg(windows)]
+pub fn game_module_paths() -> Option<Vec<String>> {
+    let pid = find_game_pid()?;
+    // A snapshot taken while the game is loading its own modules fails with
+    // ERROR_BAD_LENGTH; the documented remedy is simply to ask again.
+    for _ in 0..8 {
+        if let Some(paths) = module_paths(pid) {
+            return Some(paths);
+        }
+    }
+    None
+}
+
+/// One Toolhelp module walk over `pid`. `None` if the snapshot itself failed.
+#[cfg(windows)]
+fn module_paths(pid: u32) -> Option<Vec<String>> {
+    // SAFETY: module snapshot for a known pid; the handle is closed on every path out,
+    // and we only read fields the API filled in.
+    unsafe {
+        let snap =
+            ffi::CreateToolhelp32Snapshot(ffi::TH32CS_SNAPMODULE | ffi::TH32CS_SNAPMODULE32, pid);
+        if snap == ffi::INVALID_HANDLE_VALUE {
+            return None;
+        }
+        let mut me: ffi::ModuleEntry32 = std::mem::zeroed();
+        me.dw_size = std::mem::size_of::<ffi::ModuleEntry32>() as u32;
+        let mut paths = Vec::new();
+        if ffi::Module32First(snap, &mut me) != 0 {
+            loop {
+                let path = ansi_field(&me.sz_exe_path);
+                if !path.is_empty() {
+                    paths.push(path);
+                }
+                if ffi::Module32Next(snap, &mut me) == 0 {
+                    break;
+                }
+            }
+        }
+        ffi::CloseHandle(snap);
+        // An empty walk means the snapshot gave us nothing usable, not that a live process
+        // has no modules — every process has at least its own exe. Treat it as a failure so
+        // the caller retries rather than reporting an empty machine.
+        if paths.is_empty() {
+            None
+        } else {
+            Some(paths)
+        }
+    }
+}
+
+/// Every process on the machine, by executable name.
+///
+/// Names only: `Process32Next` carries `szExeFile` and nothing else, and asking each pid for
+/// its full path means opening it, which fails on anything running as another user or at a
+/// higher integrity level. A name is what the rule list matches on anyway.
+#[cfg(windows)]
+pub fn running_process_names() -> Option<Vec<String>> {
+    // SAFETY: standard Toolhelp process walk; the snapshot handle is closed before return.
+    unsafe {
+        let snap = ffi::CreateToolhelp32Snapshot(ffi::TH32CS_SNAPPROCESS, 0);
+        if snap == ffi::INVALID_HANDLE_VALUE {
+            return None;
+        }
+        let mut entry: ffi::ProcessEntry32 = std::mem::zeroed();
+        entry.dw_size = std::mem::size_of::<ffi::ProcessEntry32>() as u32;
+        let mut names = Vec::new();
+        if ffi::Process32First(snap, &mut entry) != 0 {
+            loop {
+                let name = ansi_field(&entry.sz_exe_file);
+                if !name.is_empty() {
+                    names.push(name);
+                }
+                if ffi::Process32Next(snap, &mut entry) == 0 {
+                    break;
+                }
+            }
+        }
+        ffi::CloseHandle(snap);
+        if names.is_empty() {
+            None
+        } else {
+            Some(names)
+        }
+    }
+}
+
 /// State threaded through the `EnumWindows` walk: the pid we want, the handle we found.
 #[cfg(windows)]
 struct WindowSearch {
@@ -473,6 +577,54 @@ pub fn is_game_running() -> bool {
 #[cfg(not(any(windows, target_os = "macos", target_os = "linux")))]
 pub fn is_game_running() -> bool {
     false
+}
+
+/// The game's mapped DLLs, read out of Proton's view of the process.
+///
+/// Wine maps a PE the same way the loader would, file-backed, so `/proc/<pid>/maps` names
+/// every DLL the game has loaded — including one an injector pushed in. More than one pid
+/// can name the exe (Proton leaves its wrapper around it), so the union across all of them
+/// is what we want rather than a guess at which is the real one.
+#[cfg(target_os = "linux")]
+pub fn game_module_paths() -> Option<Vec<String>> {
+    let pids = crate::proton::exe_pids(crate::game::active().exe);
+    if pids.is_empty() {
+        return None;
+    }
+    let mut paths: Vec<String> = Vec::new();
+    for pid in pids {
+        paths.extend(crate::proton::mapped_pe_files(pid));
+    }
+    if paths.is_empty() {
+        None
+    } else {
+        paths.sort();
+        paths.dedup();
+        Some(paths)
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn running_process_names() -> Option<Vec<String>> {
+    let names = crate::proton::process_names();
+    if names.is_empty() {
+        None
+    } else {
+        Some(names)
+    }
+}
+
+/// macOS runs the game through a Wine bottle we don't own the process tree of, and there is
+/// no `/proc` to read a mapping list out of. Rather than half-answer, say we couldn't look —
+/// the scanner reports "not supported here" instead of a clean bill of health.
+#[cfg(not(any(windows, target_os = "linux")))]
+pub fn game_module_paths() -> Option<Vec<String>> {
+    None
+}
+
+#[cfg(not(any(windows, target_os = "linux")))]
+pub fn running_process_names() -> Option<Vec<String>> {
+    None
 }
 
 #[cfg(not(windows))]

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -1,0 +1,1031 @@
+//! Is anything foreign attached to the running game?
+//!
+//! MX Bikes ships no anti-cheat of its own, so a client that has been hooked looks exactly
+//! like one that hasn't — to the server, to the other riders, and to the game itself. The
+//! cheats going round the Kaizo servers are injected DLLs and external trainers, and an
+//! injected DLL has one property worth building on: to hook the game it has to be *inside*
+//! the game, which means it is in the process's module list. That list is readable from out
+//! here, and this module reads it.
+//!
+//! The shape of an answer is deliberately three-valued, not two:
+//!
+//!   * **Clean** — we read the module list and everything in it is accounted for.
+//!   * **Suspect** — something is loaded that we can't account for. Not an accusation: a
+//!     capture tool, an overlay nobody has told us about, or a driver shim all land here.
+//!   * **Flagged** — it matched the rule list by name or by hash. This one is an accusation.
+//!
+//! and the fourth state, **Unknown**, is the one that matters most for honesty: the game
+//! isn't up, or the platform can't be read, or the snapshot failed. Every path that cannot
+//! see must say so rather than fall through to "clean" — a scanner that reports a healthy
+//! machine when it simply didn't look is worse than no scanner, because people believe it.
+//!
+//! ## What this can and cannot do
+//!
+//! This is client-side attestation, and it is worth being blunt about the limit: a cheater
+//! who does not run MXB App is not scanned, and one who patches this check out reports
+//! whatever they like. It cannot make cheating impossible. What it does is make an honest
+//! client able to *prove* it is honest — which is the thing a server admin currently has no
+//! way to ask for — and raise the cost of the cheats actually in circulation, which are
+//! downloaded DLLs run by people who are not going to rebuild the mod manager to hide them.
+//! A manually-mapped module that never registers with the loader is likewise invisible here.
+//! Treating a Clean report as proof of innocence is a mistake; treating a Flagged one as
+//! worth a look is not.
+//!
+//! ## Rules
+//!
+//! Signatures live in [`RuleSet`], fetched from `integrity-rules.json` on `main` and cached
+//! on disk — the same arrangement `supporters.json` uses, and for the same reason: a cheat
+//! that appears on a Tuesday cannot wait for a release to be detectable. What ships in the
+//! binary is [`RuleSet::bundled`], which carries the allowlist (the part that prevents false
+//! accusations) and no signatures at all, so a build that never reaches the network is
+//! cautious rather than wrong.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Where the live rule list lives. Read from `main` rather than from a tag, so a new cheat
+/// is one commit away from being detected on every install.
+pub const RULES_URL: &str =
+    "https://raw.githubusercontent.com/Frostn1/mxb-app/main/integrity-rules.json";
+
+/// Cache file name, under the app's local data dir.
+const RULES_CACHE: &str = "integrity-rules.json";
+
+/// Long enough for a cold CDN, short enough that a scan isn't held up by a dead network.
+const FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(8);
+
+/// Refuse to hash anything larger than this. A cheat DLL is a few megabytes; a hundred-
+/// megabyte one would only be a way to make every scan stall on disk I/O.
+const MAX_HASH_BYTES: u64 = 96 * 1024 * 1024;
+
+/// Caps on what the remote list may contain. Nothing hostile is expected from our own repo,
+/// but a rule file with a million entries shouldn't be able to make every scan quadratic.
+const MAX_RULES: usize = 2000;
+const MAX_ALLOW: usize = 2000;
+const MAX_PATTERN_CHARS: usize = 120;
+
+/// How bad a finding is.
+///
+/// Ordered worst-last so a report's verdict is `max()` over its findings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Severity {
+    /// Loaded, unrecognised, and not matched by any rule.
+    Suspect,
+    /// Matched the rule list.
+    Flagged,
+}
+
+/// The overall answer for one scan. Ordered so the worst finding decides the report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Verdict {
+    /// We could not look. Never means "clean".
+    Unknown,
+    Clean,
+    Suspect,
+    Flagged,
+}
+
+/// Where a finding was found.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Kind {
+    /// A DLL mapped into the game's own address space.
+    Module,
+    /// A separate process on the machine.
+    Process,
+}
+
+/// Why we are reporting it, as a stable key the UI translates.
+///
+/// An enum rather than a prose string, for the reason [`crate::dropzone::DetectReason`] is:
+/// the line shown to the user has to survive translation into six languages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Reason {
+    /// Its name matched a rule.
+    RuleName,
+    /// Its contents matched a rule's hash — the strong one; renaming the file doesn't help.
+    RuleHash,
+    /// Loaded into the game from somewhere that isn't the game, the system, or anything we
+    /// installed ourselves.
+    ForeignModule,
+    /// A DLL in the game's own folder, under one of the names the Windows loader will pull
+    /// in for the executable beside it. The classic way to get code into a process without
+    /// injecting anything — and, once ReShade is ruled out, not a shape anything innocent
+    /// has.
+    LoaderHijack,
+}
+
+/// One thing worth reporting.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Finding {
+    pub kind: Kind,
+    /// File name, lowercased — what the user recognises and what rules match on.
+    pub name: String,
+    /// Full path when we have one. Empty for a process: the Windows process walk carries
+    /// names only.
+    pub path: String,
+    pub reason: Reason,
+    pub severity: Severity,
+    /// SHA-256 of the file, lowercase hex, when we could read it. This is what turns "some
+    /// unknown DLL" into a signature somebody can add to the rule list, so it is computed
+    /// for findings and never for the hundreds of files that check out fine.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub sha256: String,
+    /// The rule's own label, when a rule matched.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub label: String,
+}
+
+/// One scan's result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Report {
+    pub verdict: Verdict,
+    pub findings: Vec<Finding>,
+    /// Unix ms. Zero before the first scan.
+    pub scanned_at: u64,
+    /// Which rule list produced it, so a stale answer is recognisable as one.
+    pub rules_version: u32,
+    /// How many modules we looked at — the difference between a thorough Clean and an empty
+    /// one, and the number that makes a report auditable.
+    pub modules_scanned: usize,
+    /// The game was running when we looked. A scan with no game is always [`Verdict::Unknown`].
+    pub game_running: bool,
+}
+
+impl Default for Report {
+    fn default() -> Self {
+        Self {
+            verdict: Verdict::Unknown,
+            findings: Vec::new(),
+            scanned_at: 0,
+            rules_version: 0,
+            modules_scanned: 0,
+            game_running: false,
+        }
+    }
+}
+
+impl Report {
+    /// The verdict implied by a set of findings: the worst of them, or clean if there are
+    /// none. Only ever called on a scan that actually read a module list.
+    fn from_findings(findings: Vec<Finding>, modules_scanned: usize, rules_version: u32) -> Self {
+        let verdict = findings
+            .iter()
+            .map(|f| match f.severity {
+                Severity::Suspect => Verdict::Suspect,
+                Severity::Flagged => Verdict::Flagged,
+            })
+            .max()
+            .unwrap_or(Verdict::Clean);
+        Self {
+            verdict,
+            findings,
+            scanned_at: now_ms(),
+            rules_version,
+            modules_scanned,
+            game_running: true,
+        }
+    }
+
+    /// The answer for a machine we could not read. Distinct from clean, on purpose.
+    pub fn unknown(game_running: bool, rules_version: u32) -> Self {
+        Self {
+            verdict: Verdict::Unknown,
+            findings: Vec::new(),
+            scanned_at: now_ms(),
+            rules_version,
+            modules_scanned: 0,
+            game_running,
+        }
+    }
+}
+
+/// One signature. A rule matches on a name substring **or** a hash, never both — an entry
+/// carrying each is two rules that happen to share a label.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct Rule {
+    /// Lowercase substring, matched against a file name. Substring rather than equality
+    /// because these things ship as `kaizo_v3.dll`, `kaizo (1).dll`, `KaizoLoader.dll`.
+    pub contains: String,
+    /// Lowercase hex SHA-256 of the whole file.
+    pub sha256: String,
+    /// What to call it in the report. Free text — the one string here that isn't translated,
+    /// because a cheat's name is its name.
+    pub label: String,
+}
+
+/// What the scanner matches against.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct RuleSet {
+    /// Bumped by whoever edits the list. Reported alongside every verdict so an admin
+    /// looking at a flag knows which list produced it.
+    pub version: u32,
+    /// Things that are cheats. Empty in the bundled set — see the module docs.
+    pub cheats: Vec<Rule>,
+    /// File names that are known-good wherever they load from. The escape hatch for a false
+    /// positive: a new overlay or capture tool can be silenced within the hour.
+    pub allow: Vec<String>,
+    /// Lowercase path substrings whose contents are known-good. For whole toolchains that
+    /// load a dozen DLLs each — a Wine build, a GPU driver stack.
+    pub allow_paths: Vec<String>,
+}
+
+impl RuleSet {
+    /// What the binary ships with: the allowlist, and no signatures.
+    ///
+    /// Signatures deliberately start empty. A shipped list would be out of date by the time
+    /// anyone installed it, and a wrong entry accuses a real person of cheating — so the
+    /// build errs toward saying "something unrecognised is loaded" and leaves naming it to
+    /// the list that can be corrected in minutes.
+    ///
+    /// The allowlist is the opposite: it has to ship, because it is what stops an ordinary
+    /// machine — Steam overlay, GPU driver, Discord, a capture tool — from lighting up on
+    /// first launch, before anything has been fetched.
+    pub fn bundled() -> Self {
+        Self {
+            version: 0,
+            cheats: Vec::new(),
+            allow: BUNDLED_ALLOW.iter().map(|s| s.to_string()).collect(),
+            allow_paths: BUNDLED_ALLOW_PATHS.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    /// Fold a fetched list into the bundled one.
+    ///
+    /// The remote list *adds* to the bundled allowlist rather than replacing it. A remote
+    /// file that arrived truncated, or an editing mistake that drops a line, must not be
+    /// able to turn every machine's Steam overlay into a finding.
+    pub fn merged_with_bundled(mut self) -> Self {
+        let bundled = Self::bundled();
+        self.allow.extend(bundled.allow);
+        self.allow_paths.extend(bundled.allow_paths);
+        self.normalize()
+    }
+
+    /// Lowercase everything, drop empties, and apply the caps. Run on anything from the
+    /// network before it is matched against.
+    pub fn normalize(mut self) -> Self {
+        let clean = |v: Vec<String>, cap: usize| -> Vec<String> {
+            let mut out: Vec<String> = v
+                .into_iter()
+                .map(|s| s.trim().to_ascii_lowercase())
+                .filter(|s| !s.is_empty() && s.chars().count() <= MAX_PATTERN_CHARS)
+                .collect();
+            out.sort();
+            out.dedup();
+            out.truncate(cap);
+            out
+        };
+        self.allow = clean(self.allow, MAX_ALLOW);
+        // Written with either slash in the file; matched against paths we normalize the
+        // same way.
+        self.allow_paths =
+            clean(self.allow_paths, MAX_ALLOW).into_iter().map(|p| p.replace('\\', "/")).collect();
+        self.cheats.truncate(MAX_RULES);
+        self.cheats.retain_mut(|r| {
+            r.contains = r.contains.trim().to_ascii_lowercase();
+            r.sha256 = r.sha256.trim().to_ascii_lowercase();
+            r.label = r.label.trim().chars().take(MAX_PATTERN_CHARS).collect();
+            // A rule with neither pattern matches everything or nothing depending on how it
+            // is read. Neither is a thing anyone meant, so it is dropped.
+            !r.contains.is_empty() || is_sha256(&r.sha256)
+        });
+        self
+    }
+
+    /// Does any rule name this file? Returns the matching rule.
+    fn name_rule(&self, name: &str) -> Option<&Rule> {
+        self.cheats.iter().find(|r| !r.contains.is_empty() && name.contains(&r.contains))
+    }
+
+    /// Does any rule carry this hash?
+    fn hash_rule(&self, sha256: &str) -> Option<&Rule> {
+        self.cheats.iter().find(|r| !r.sha256.is_empty() && r.sha256 == sha256)
+    }
+
+    /// Is this file name explicitly known-good?
+    fn allows_name(&self, name: &str) -> bool {
+        self.allow.iter().any(|a| a == name)
+    }
+
+    /// Is this path inside something explicitly known-good?
+    fn allows_path(&self, path: &str) -> bool {
+        self.allow_paths.iter().any(|a| path.contains(a.as_str()))
+    }
+
+    /// Do we hold any signatures at all?
+    ///
+    /// A list with none can still find things — the heuristics don't need it — but it can
+    /// never say *what* it found, and the UI says so rather than implying an all-clear was
+    /// checked against something.
+    pub fn has_signatures(&self) -> bool {
+        !self.cheats.is_empty()
+    }
+}
+
+/// True for a well-formed lowercase hex SHA-256.
+fn is_sha256(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Names that legitimately live inside a game process.
+///
+/// Not an exhaustive list of good software — it can't be — but the things that would
+/// otherwise make the first scan on an ordinary gaming PC produce a page of findings.
+/// Everything here loads from somewhere the path rules don't already cover: an overlay
+/// injects from its own install, which is exactly the shape a cheat has.
+const BUNDLED_ALLOW: [&str; 25] = [
+    // Steam: the overlay is injected into every game Steam starts.
+    "gameoverlayrenderer64.dll",
+    "gameoverlayrenderer.dll",
+    "steamclient64.dll",
+    "steamclient.dll",
+    "steam_api64.dll",
+    "steam_api.dll",
+    "steamoverlayvulkanlayer64.dll",
+    // Discord's in-game overlay.
+    "discordhook64.dll",
+    "discordhook.dll",
+    // RivaTuner Statistics Server — ships with MSI Afterburner, so it is on a large share
+    // of the machines this will ever run on.
+    "rtsshooks64.dll",
+    "rtsshooks.dll",
+    // OBS and the game-capture path Streamlabs shares with it.
+    "graphics-hook64.dll",
+    "graphics-hook32.dll",
+    // NVIDIA: GeForce Experience / ShadowPlay overlay and the Reflex + upscaling runtime.
+    "nvspcap64.dll",
+    "nvspcap.dll",
+    "nvngx.dll",
+    "nvngx_dlss.dll",
+    "nvcamera64.dll",
+    // AMD's equivalent.
+    "amfrt64.dll",
+    "amf-mft-decvce-avc64.dll",
+    // ReShade, when it is installed under its own name rather than as a proxy DLL. The
+    // proxy case is handled by asking the file — see [`is_loader_hijack`].
+    "reshade64.dll",
+    "reshade32.dll",
+    // FrostMod, which is the whole point of this app being able to talk to the game.
+    "frostmod.dll",
+    "frostmod64.dll",
+    // Wine's own loader stubs, which appear under the game's folder inside a prefix.
+    "winemenubuilder.exe",
+];
+
+/// Path fragments whose contents are known-good, lowercased, forward slashes.
+///
+/// Where [`BUNDLED_ALLOW`] names individual files, these cover whole toolchains that map a
+/// dozen libraries each and would be tedious and fragile to enumerate.
+const BUNDLED_ALLOW_PATHS: [&str; 8] = [
+    // Wine and Proton builtins on Linux. Under Proton the game's `kernel32.dll` genuinely
+    // does come from `/…/Proton - Experimental/files/lib/wine/…`, which is neither the
+    // system folder nor the game folder.
+    "/wine/",
+    "/proton",
+    "/dist/lib/",
+    "/files/lib/",
+    // Steam's own runtime and overlay libraries, on both platforms.
+    "/steamworks shared/",
+    "/linux64/",
+    // GPU drivers, which map into every 3D process.
+    "/nvidia/",
+    "/amd/",
+];
+
+/// DLL names the Windows loader will pull in from the executable's own folder before it
+/// looks anywhere else.
+///
+/// A file with one of these names sitting next to `mxbikes.exe` is loaded into the game
+/// without anything having to inject it — which makes it the cheapest way to hook a game
+/// that has no anti-cheat, and the one shape worth calling out even though the file is
+/// technically "in the game folder" and would otherwise be trusted.
+///
+/// `opengl32.dll` is on the list and is also how ReShade legitimately installs here (MX
+/// Bikes is an OpenGL title — see [`crate::reshade`]), which is why the check reads the
+/// file rather than trusting the name.
+const LOADER_NAMES: [&str; 12] = [
+    "opengl32.dll",
+    "dxgi.dll",
+    "d3d9.dll",
+    "d3d10.dll",
+    "d3d11.dll",
+    "d3d12.dll",
+    "dinput8.dll",
+    "dsound.dll",
+    "winmm.dll",
+    "version.dll",
+    "wininet.dll",
+    "xinput1_3.dll",
+];
+
+/// Everything one scan needs to know about this machine.
+///
+/// Built once per scan and passed to the pure classifier, which is what lets the whole
+/// decision be tested with made-up paths on a machine with no game installed.
+#[derive(Debug, Clone, Default)]
+pub struct ScanContext {
+    /// Folders whose contents are the player's own install: the game, FrostMod, ReShade.
+    /// Lowercased with forward slashes.
+    pub trusted_roots: Vec<String>,
+    /// The game's install folder specifically — the one place a loader hijack can happen.
+    pub game_dir: String,
+}
+
+impl ScanContext {
+    pub fn new(game_dir: &Path, extra_roots: &[PathBuf]) -> Self {
+        let mut trusted_roots: Vec<String> = extra_roots.iter().map(|p| norm(p)).collect();
+        let game_dir = norm(game_dir);
+        if !game_dir.is_empty() {
+            trusted_roots.push(game_dir.clone());
+        }
+        trusted_roots.retain(|r| !r.is_empty());
+        Self { trusted_roots, game_dir }
+    }
+
+    fn is_trusted_root(&self, path: &str) -> bool {
+        self.trusted_roots.iter().any(|root| is_inside(path, root))
+    }
+
+    fn is_in_game_dir(&self, path: &str) -> bool {
+        !self.game_dir.is_empty() && is_inside(path, &self.game_dir)
+    }
+}
+
+/// A path lowercased with forward slashes, so Windows and Wine spellings of the same folder
+/// compare equal.
+fn norm(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/").trim_end_matches('/').to_ascii_lowercase()
+}
+
+/// Is `path` inside `root`? Compared on path *boundaries*, so `C:/games/mx` does not swallow
+/// `C:/games/mxcheat`.
+fn is_inside(path: &str, root: &str) -> bool {
+    path.strip_prefix(root).is_some_and(|rest| rest.starts_with('/'))
+}
+
+/// Is this one of Windows' own DLLs, by where it lives?
+///
+/// Matched on the shape of the path rather than on a substring, because a substring test
+/// would hand a free pass to anything that put itself in `C:\kaizo\windows\system32\`. The
+/// two legitimate spellings are a drive root (`C:\Windows\System32\…`) and the same folder
+/// inside a Wine prefix (`…/pfx/drive_c/windows/system32/…`).
+fn is_system_path(path: &str) -> bool {
+    const SYSTEM_DIRS: [&str; 4] = ["system32/", "syswow64/", "winsxs/", "globalization/"];
+    let Some((root, rest)) = path.split_once("/windows/") else { return false };
+    let rooted = root.len() == 2 && root.ends_with(':') || root.ends_with("/drive_c");
+    rooted && SYSTEM_DIRS.iter().any(|d| rest.starts_with(d))
+}
+
+/// The file name from a path, lowercased.
+fn file_name_of(path: &str) -> String {
+    path.rsplit('/').next().unwrap_or(path).to_ascii_lowercase()
+}
+
+/// Whether a module in the game's own folder is there to hijack the loader.
+///
+/// Only asks the question for the names the loader actually preloads, and only answers yes
+/// once the file has been read and is not ReShade. `probe` is the ReShade test, passed in so
+/// the classifier stays pure and testable.
+fn is_loader_hijack(name: &str, path: &str, ctx: &ScanContext, probe: &dyn Fn(&Path) -> bool) -> bool {
+    LOADER_NAMES.contains(&name) && ctx.is_in_game_dir(path) && !probe(Path::new(path))
+}
+
+/// Turn one module path into a finding, or `None` if it checks out.
+///
+/// The order here is the whole policy, and it is deliberate:
+///
+///   1. **Rules first.** A name or hash on the list is a cheat wherever it loaded from — a
+///      cheat that copies itself into the game folder must not be trusted for being there.
+///   2. **Allowlist next**, so a false positive can be silenced without a release.
+///   3. **Loader hijack**, which is the one case where being in the game folder is itself
+///      the evidence rather than a defence.
+///   4. **Trusted roots and the system folder**, which is where the overwhelming majority of
+///      an ordinary module list ends up.
+///   5. Anything left is loaded into the game from somewhere unaccounted for: Suspect.
+fn classify_module(
+    path: &str,
+    ctx: &ScanContext,
+    rules: &RuleSet,
+    hash: &dyn Fn(&Path) -> String,
+    is_reshade: &dyn Fn(&Path) -> bool,
+) -> Option<Finding> {
+    let path = path.replace('\\', "/");
+    let lower = path.to_ascii_lowercase();
+    let name = file_name_of(&lower);
+
+    let finding = |reason: Reason, severity: Severity, label: String, sha256: String| {
+        Some(Finding {
+            kind: Kind::Module,
+            name: name.clone(),
+            path: path.clone(),
+            reason,
+            severity,
+            sha256,
+            label,
+        })
+    };
+
+    if let Some(rule) = rules.name_rule(&name) {
+        // Hash it anyway: a name match is the weak half of a signature, and the digest is
+        // what confirms it later.
+        return finding(Reason::RuleName, Severity::Flagged, rule.label.clone(), hash(Path::new(&path)));
+    }
+    // Hashing is the expensive step, so it happens once, here, and only when there are
+    // hash rules to check against — never for the hundreds of modules that will pass.
+    let digest = if rules.cheats.iter().any(|r| !r.sha256.is_empty()) {
+        hash(Path::new(&path))
+    } else {
+        String::new()
+    };
+    if !digest.is_empty() {
+        if let Some(rule) = rules.hash_rule(&digest) {
+            return finding(Reason::RuleHash, Severity::Flagged, rule.label.clone(), digest);
+        }
+    }
+
+    if rules.allows_name(&name) || rules.allows_path(&lower) {
+        return None;
+    }
+    if is_loader_hijack(&name, &lower, ctx, is_reshade) {
+        return finding(
+            Reason::LoaderHijack,
+            Severity::Suspect,
+            String::new(),
+            hash(Path::new(&path)),
+        );
+    }
+    if ctx.is_trusted_root(&lower) || is_system_path(&lower) {
+        return None;
+    }
+    finding(Reason::ForeignModule, Severity::Suspect, String::new(), hash(Path::new(&path)))
+}
+
+/// Turn one running process name into a finding, or `None`.
+///
+/// Processes are matched by rule only. There is no heuristic worth having here: a machine
+/// runs two hundred processes and none of them being recognised is normal, so "unrecognised
+/// process" would flag everybody. This exists so the rule list can name an external trainer
+/// that never injects anything.
+fn classify_process(name: &str, rules: &RuleSet) -> Option<Finding> {
+    let name = name.to_ascii_lowercase();
+    if rules.allows_name(&name) {
+        return None;
+    }
+    let rule = rules.name_rule(&name)?;
+    Some(Finding {
+        kind: Kind::Process,
+        name,
+        path: String::new(),
+        reason: Reason::RuleName,
+        severity: Severity::Flagged,
+        sha256: String::new(),
+        label: rule.label.clone(),
+    })
+}
+
+/// Classify a whole machine. Pure — every fact it needs is an argument.
+pub fn classify(
+    modules: &[String],
+    processes: &[String],
+    ctx: &ScanContext,
+    rules: &RuleSet,
+    hash: &dyn Fn(&Path) -> String,
+    is_reshade: &dyn Fn(&Path) -> bool,
+) -> Report {
+    let mut findings: Vec<Finding> = modules
+        .iter()
+        .filter_map(|m| classify_module(m, ctx, rules, hash, is_reshade))
+        .collect();
+    findings.extend(processes.iter().filter_map(|p| classify_process(p, rules)));
+
+    // One entry per file. A DLL is mapped many times over — once per section on Linux — and
+    // the module list can spell the same path either way, so the identity is the *lowercased*
+    // path rather than the one we display. Two genuinely distinct files on a case-sensitive
+    // filesystem differing only in case would merge; that is a trade worth making against
+    // every Linux player seeing each finding six times.
+    let mut seen = std::collections::HashSet::new();
+    findings.retain(|f| seen.insert((f.name.clone(), f.path.to_ascii_lowercase())));
+    // Worst first, so the UI's first line is the one that matters.
+    findings.sort_by(|a, b| {
+        b.severity.cmp(&a.severity).then_with(|| a.name.cmp(&b.name)).then_with(|| a.path.cmp(&b.path))
+    });
+    Report::from_findings(findings, modules.len(), rules.version)
+}
+
+/// SHA-256 of a file, lowercase hex. Empty when it can't be read or is implausibly large —
+/// a missing digest costs a weaker report, never a wrong one.
+pub fn hash_file(path: &Path) -> String {
+    use sha2::{Digest, Sha256};
+    let Ok(meta) = std::fs::metadata(path) else { return String::new() };
+    if !meta.is_file() || meta.len() > MAX_HASH_BYTES {
+        return String::new();
+    }
+    let Ok(mut file) = std::fs::File::open(path) else { return String::new() };
+    let mut hasher = Sha256::new();
+    if std::io::copy(&mut file, &mut hasher).is_err() {
+        return String::new();
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+/// Scan this machine now.
+///
+/// `None` from either enumeration is what makes the difference between a report and an
+/// [`Verdict::Unknown`]: the game not being up, or a platform with nothing to read, must
+/// never produce a clean bill of health.
+pub fn scan(ctx: &ScanContext, rules: &RuleSet) -> Report {
+    let game_running = crate::gameproc::is_game_running();
+    let Some(modules) = crate::gameproc::game_module_paths() else {
+        return Report::unknown(game_running, rules.version);
+    };
+    // Processes are a bonus: the module list is the real answer, and a failed process walk
+    // shouldn't throw it away.
+    let processes = crate::gameproc::running_process_names().unwrap_or_default();
+    classify(&modules, &processes, ctx, rules, &hash_file, &crate::reshade::is_reshade_dll)
+}
+
+// ---------------------------------------------------------------------------
+// The rule list
+// ---------------------------------------------------------------------------
+
+fn cache_path(app: &tauri::AppHandle) -> Option<PathBuf> {
+    use tauri::Manager;
+    app.path().app_local_data_dir().ok().map(|dir| dir.join(RULES_CACHE))
+}
+
+/// The best rule list available without touching the network: the cache if we have one,
+/// otherwise what the binary shipped with.
+pub fn cached_rules(app: &tauri::AppHandle) -> RuleSet {
+    cache_path(app)
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|text| serde_json::from_str::<RuleSet>(&text).ok())
+        .map(RuleSet::merged_with_bundled)
+        .unwrap_or_else(RuleSet::bundled)
+}
+
+/// Fetch the live rule list and cache it.
+///
+/// Best-effort by design, and the failure mode is the point: an unreachable network leaves
+/// the last good list in place, and a machine that has never reached it still scans with the
+/// bundled allowlist. Nothing about a scan waits on this succeeding.
+pub async fn refresh_rules(app: &tauri::AppHandle) -> anyhow::Result<RuleSet> {
+    let text = reqwest::Client::builder()
+        .timeout(FETCH_TIMEOUT)
+        .build()?
+        .get(RULES_URL)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    // Parse before writing: a cache holding something we can't read would keep failing on
+    // every launch until someone cleared it by hand.
+    let rules: RuleSet = serde_json::from_str(&text)?;
+    if let Some(path) = cache_path(app) {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if let Err(e) = std::fs::write(&path, &text) {
+            log::warn!("[integrity] couldn't cache the rule list: {e}");
+        }
+    }
+    log::info!("[integrity] rule list v{} ({} signatures)", rules.version, rules.cheats.len());
+    Ok(rules.merged_with_bundled())
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A machine with the game installed on Windows and nothing unusual on it.
+    fn ctx() -> ScanContext {
+        ScanContext::new(
+            Path::new("C:\\Games\\MX Bikes"),
+            &[PathBuf::from("C:\\Users\\rider\\AppData\\Local\\com.frost.mxbikes\\frostmod")],
+        )
+    }
+
+    fn no_hash(_: &Path) -> String {
+        String::new()
+    }
+    fn not_reshade(_: &Path) -> bool {
+        false
+    }
+    fn is_reshade(_: &Path) -> bool {
+        true
+    }
+
+    fn scan_with(modules: &[&str], rules: &RuleSet) -> Report {
+        let modules: Vec<String> = modules.iter().map(|s| s.to_string()).collect();
+        classify(&modules, &[], &ctx(), rules, &no_hash, &not_reshade)
+    }
+
+    /// The baseline that decides whether anyone keeps the feature turned on. An ordinary
+    /// module list — the game, Windows, the Steam overlay, a GPU driver, FrostMod — has to
+    /// come back clean, or the first scan buries the real signal in noise.
+    #[test]
+    fn an_ordinary_machine_is_clean() {
+        let report = scan_with(
+            &[
+                "C:\\Games\\MX Bikes\\mxbikes.exe",
+                "C:\\Games\\MX Bikes\\core.dll",
+                "C:\\WINDOWS\\System32\\kernel32.dll",
+                "C:\\Windows\\SysWOW64\\user32.dll",
+                "C:\\Windows\\WinSxS\\x86_amd64_something\\comctl32.dll",
+                "C:\\Program Files (x86)\\Steam\\GameOverlayRenderer64.dll",
+                "C:\\Users\\rider\\AppData\\Local\\com.frost.mxbikes\\frostmod\\FrostMod.dll",
+                "C:\\Program Files\\NVIDIA Corporation\\nvspcap64.dll",
+            ],
+            &RuleSet::bundled(),
+        );
+        assert_eq!(report.verdict, Verdict::Clean, "findings: {:?}", report.findings);
+        assert_eq!(report.modules_scanned, 8);
+    }
+
+    /// The case the whole feature exists for: a DLL loaded into the game from a download
+    /// folder. No rule names it and none has to — being in there at all is the finding.
+    #[test]
+    fn a_dll_injected_from_somewhere_else_is_suspect() {
+        let report =
+            scan_with(&["C:\\Users\\rider\\Downloads\\kaizo_v3.dll"], &RuleSet::bundled());
+        assert_eq!(report.verdict, Verdict::Suspect);
+        assert_eq!(report.findings[0].reason, Reason::ForeignModule);
+        assert_eq!(report.findings[0].name, "kaizo_v3.dll");
+    }
+
+    /// With a signature it stops being "something unrecognised" and gets a name.
+    #[test]
+    fn a_rule_turns_a_suspect_module_into_a_flagged_one() {
+        let rules = RuleSet {
+            version: 7,
+            cheats: vec![Rule {
+                contains: "kaizo".into(),
+                label: "Kaizo trainer".into(),
+                ..Default::default()
+            }],
+            ..RuleSet::bundled()
+        }
+        .normalize();
+        let report = scan_with(&["C:\\Users\\rider\\Downloads\\Kaizo_v3.dll"], &rules);
+        assert_eq!(report.verdict, Verdict::Flagged);
+        assert_eq!(report.findings[0].reason, Reason::RuleName);
+        assert_eq!(report.findings[0].label, "Kaizo trainer");
+        assert_eq!(report.rules_version, 7);
+    }
+
+    /// Rules outrank location. A cheat that copies itself in beside the game is still a
+    /// cheat — this is the ordering the classifier is built around.
+    #[test]
+    fn a_named_cheat_inside_the_game_folder_is_still_flagged() {
+        let rules = RuleSet {
+            cheats: vec![Rule { contains: "kaizo".into(), label: "Kaizo".into(), ..Default::default() }],
+            ..RuleSet::bundled()
+        }
+        .normalize();
+        let report = scan_with(&["C:\\Games\\MX Bikes\\kaizo.dll"], &rules);
+        assert_eq!(report.verdict, Verdict::Flagged);
+    }
+
+    /// A hash rule catches the same file renamed, which is the first thing anyone tries.
+    #[test]
+    fn a_hash_rule_catches_a_renamed_cheat() {
+        let digest = "a".repeat(64);
+        let rules = RuleSet {
+            cheats: vec![Rule {
+                sha256: digest.clone(),
+                label: "Kaizo v3".into(),
+                ..Default::default()
+            }],
+            ..RuleSet::bundled()
+        }
+        .normalize();
+        let hash = |_: &Path| digest.clone();
+        let modules = vec!["C:\\Games\\MX Bikes\\perfectly_innocent.dll".to_string()];
+        let report = classify(&modules, &[], &ctx(), &rules, &hash, &not_reshade);
+        assert_eq!(report.verdict, Verdict::Flagged);
+        assert_eq!(report.findings[0].reason, Reason::RuleHash);
+        assert_eq!(report.findings[0].sha256, digest);
+    }
+
+    /// The allowlist is the release valve for a false positive, and it has to beat the
+    /// heuristics — that is the entire reason it exists.
+    #[test]
+    fn the_allowlist_silences_a_heuristic_finding() {
+        let rules = RuleSet { allow: vec!["newoverlay.dll".into()], ..RuleSet::bundled() }.normalize();
+        let report = scan_with(&["C:\\Program Files\\NewOverlay\\NewOverlay.dll"], &rules);
+        assert_eq!(report.verdict, Verdict::Clean);
+    }
+
+    /// …but it must not be able to un-flag a known cheat. Otherwise one bad line in a file
+    /// anyone can open a PR against turns the whole thing off.
+    #[test]
+    fn the_allowlist_cannot_override_a_signature() {
+        let rules = RuleSet {
+            cheats: vec![Rule { contains: "kaizo".into(), label: "Kaizo".into(), ..Default::default() }],
+            allow: vec!["kaizo.dll".into()],
+            ..RuleSet::bundled()
+        }
+        .normalize();
+        assert_eq!(scan_with(&["C:\\anywhere\\kaizo.dll"], &rules).verdict, Verdict::Flagged);
+    }
+
+    /// A DLL under one of the loader's preload names, in the game folder, that isn't
+    /// ReShade — code in the process with nothing injected.
+    #[test]
+    fn a_proxy_dll_in_the_game_folder_is_suspect() {
+        let report = scan_with(&["C:\\Games\\MX Bikes\\dinput8.dll"], &RuleSet::bundled());
+        assert_eq!(report.verdict, Verdict::Suspect);
+        assert_eq!(report.findings[0].reason, Reason::LoaderHijack);
+    }
+
+    /// ReShade installs as exactly that shape and is not a cheat, so the check reads the
+    /// file instead of trusting the name.
+    #[test]
+    fn a_reshade_opengl32_in_the_game_folder_is_clean() {
+        let modules = vec!["C:\\Games\\MX Bikes\\opengl32.dll".to_string()];
+        let report = classify(&modules, &[], &ctx(), &RuleSet::bundled(), &no_hash, &is_reshade);
+        assert_eq!(report.verdict, Verdict::Clean);
+        // The same file, not ReShade, is the hijack it looks like.
+        let report = classify(&modules, &[], &ctx(), &RuleSet::bundled(), &no_hash, &not_reshade);
+        assert_eq!(report.verdict, Verdict::Suspect);
+    }
+
+    /// Windows' own folders are trusted by shape, not by substring — or anything could put
+    /// itself in a folder called `windows\system32` and be waved through.
+    #[test]
+    fn only_a_real_system_folder_is_a_system_folder() {
+        assert!(is_system_path("c:/windows/system32/kernel32.dll"));
+        assert!(is_system_path("c:/windows/syswow64/user32.dll"));
+        assert!(is_system_path(
+            "/home/rider/.steam/steamapps/compatdata/655500/pfx/drive_c/windows/system32/kernel32.dll"
+        ));
+        assert!(!is_system_path("c:/kaizo/windows/system32/evil.dll"));
+        assert!(!is_system_path("c:/windows/temp/evil.dll"));
+    }
+
+    /// Path containment is on boundaries. A folder that merely starts with the game's path
+    /// is not inside it.
+    #[test]
+    fn a_sibling_folder_is_not_inside_the_game_folder() {
+        let report = scan_with(&["C:\\Games\\MX Bikes Cheats\\loader.dll"], &RuleSet::bundled());
+        assert_eq!(report.verdict, Verdict::Suspect);
+    }
+
+    /// Under Proton the game's own runtime comes out of the Proton build, which is neither
+    /// the system folder nor the game folder. Without the path allowlist every Linux player
+    /// would see a hundred findings.
+    #[test]
+    fn proton_builtins_are_clean() {
+        let ctx = ScanContext::new(
+            Path::new("/home/rider/.steam/steam/steamapps/common/MX Bikes"),
+            &[],
+        );
+        let modules: Vec<String> = [
+            "/home/rider/.steam/steam/steamapps/common/MX Bikes/mxbikes.exe",
+            "/home/rider/.steam/steam/steamapps/common/Proton - Experimental/files/lib/wine/x86_64-windows/kernel32.dll",
+            "/home/rider/.steam/steam/steamapps/compatdata/655500/pfx/drive_c/windows/system32/ntdll.dll",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        let report =
+            classify(&modules, &[], &ctx, &RuleSet::bundled(), &no_hash, &not_reshade);
+        assert_eq!(report.verdict, Verdict::Clean, "findings: {:?}", report.findings);
+    }
+
+    /// A process is only ever reported by name, and only when a rule names it.
+    #[test]
+    fn processes_are_matched_by_rule_only() {
+        let rules = RuleSet {
+            cheats: vec![Rule {
+                contains: "kaizotrainer".into(),
+                label: "Kaizo trainer".into(),
+                ..Default::default()
+            }],
+            ..RuleSet::bundled()
+        }
+        .normalize();
+        let processes: Vec<String> =
+            ["explorer.exe", "steam.exe", "KaizoTrainer.exe"].iter().map(|s| s.to_string()).collect();
+        let report = classify(&[], &processes, &ctx(), &rules, &no_hash, &not_reshade);
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].kind, Kind::Process);
+        assert_eq!(report.findings[0].name, "kaizotrainer.exe");
+    }
+
+    /// Worst finding decides, and the list leads with it.
+    #[test]
+    fn the_worst_finding_decides_the_verdict_and_sorts_first() {
+        let rules = RuleSet {
+            cheats: vec![Rule { contains: "kaizo".into(), label: "Kaizo".into(), ..Default::default() }],
+            ..RuleSet::bundled()
+        }
+        .normalize();
+        let report = scan_with(
+            &["C:\\Users\\rider\\Downloads\\unknown.dll", "C:\\Users\\rider\\Downloads\\kaizo.dll"],
+            &rules,
+        );
+        assert_eq!(report.verdict, Verdict::Flagged);
+        assert_eq!(report.findings[0].name, "kaizo.dll");
+        assert_eq!(report.findings.len(), 2);
+    }
+
+    /// A module mapped more than once is one finding. On Linux every DLL appears in the
+    /// mapping list several times over.
+    #[test]
+    fn the_same_module_twice_is_one_finding() {
+        let report = scan_with(
+            &["C:\\Downloads\\x.dll", "C:\\Downloads\\x.dll", "C:\\Downloads\\X.DLL"],
+            &RuleSet::bundled(),
+        );
+        assert_eq!(report.findings.len(), 1);
+    }
+
+    /// The honesty property. Everything that could not look reports Unknown, and Unknown is
+    /// not Clean — including the ordering, which the UI relies on to rank a grid.
+    #[test]
+    fn a_machine_we_could_not_read_is_unknown_not_clean() {
+        let report = Report::unknown(false, 3);
+        assert_eq!(report.verdict, Verdict::Unknown);
+        assert!(report.findings.is_empty());
+        assert_eq!(report.rules_version, 3);
+        assert!(Verdict::Unknown < Verdict::Clean);
+        assert!(Verdict::Clean < Verdict::Suspect);
+        assert!(Verdict::Suspect < Verdict::Flagged);
+    }
+
+    /// What the binary ships with: an allowlist and no accusations.
+    #[test]
+    fn the_bundled_set_carries_no_signatures() {
+        let bundled = RuleSet::bundled();
+        assert!(!bundled.has_signatures());
+        assert!(!bundled.allow.is_empty());
+    }
+
+    /// A remote list adds to the bundled allowlist rather than replacing it, so a truncated
+    /// fetch can't make every machine's Steam overlay a finding.
+    #[test]
+    fn a_remote_list_cannot_drop_the_bundled_allowlist() {
+        let remote = RuleSet { version: 4, ..Default::default() }.merged_with_bundled();
+        assert!(remote.allows_name("gameoverlayrenderer64.dll"));
+        assert_eq!(remote.version, 4);
+    }
+
+    /// Whatever the file's spelling, matching is lowercase — and a rule with no pattern at
+    /// all is dropped rather than being read as "match everything".
+    #[test]
+    fn normalizing_lowercases_patterns_and_drops_empty_rules() {
+        let rules = RuleSet {
+            cheats: vec![
+                Rule { contains: "  KAIZO  ".into(), ..Default::default() },
+                Rule { label: "nothing to match on".into(), ..Default::default() },
+                Rule { sha256: "NOTAHASH".into(), ..Default::default() },
+            ],
+            allow: vec!["  Overlay.DLL ".into(), "   ".into()],
+            allow_paths: vec!["C:\\Vendor\\Tool".into()],
+            ..Default::default()
+        }
+        .normalize();
+        assert_eq!(rules.cheats.len(), 1);
+        assert_eq!(rules.cheats[0].contains, "kaizo");
+        assert_eq!(rules.allow, ["overlay.dll"]);
+        assert_eq!(rules.allow_paths, ["c:/vendor/tool"]);
+    }
+
+    /// The rule file is JSON with camelCase keys — the shape anyone editing it will write.
+    #[test]
+    fn the_rule_file_parses_as_written() {
+        let text = r#"{
+          "version": 12,
+          "cheats": [
+            { "contains": "kaizo", "label": "Kaizo trainer" },
+            { "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+              "label": "Kaizo v3 loader" }
+          ],
+          "allow": ["someoverlay.dll"],
+          "allowPaths": ["/vendor/tool/"]
+        }"#;
+        let rules: RuleSet = serde_json::from_str(text).unwrap();
+        let rules = rules.merged_with_bundled();
+        assert_eq!(rules.version, 12);
+        assert_eq!(rules.cheats.len(), 2);
+        assert!(rules.has_signatures());
+        assert!(rules.allows_name("someoverlay.dll"));
+        assert!(rules.allows_path("/vendor/tool/x.dll"));
+    }
+}

--- a/src-tauri/src/integritywatch.rs
+++ b/src-tauri/src/integritywatch.rs
@@ -1,0 +1,405 @@
+//! Keep watching while the session is live.
+//!
+//! [`crate::integrity`] can answer "is anything attached to the game?" once. That is not the
+//! question a race asks. A cheat is loaded *during* a session — the player joins clean, gets
+//! beaten, alt-tabs, and attaches something — and a check that ran at launch would have said
+//! everything was fine ten minutes before it stopped being fine. So the scan repeats for as
+//! long as the game is up.
+//!
+//! It also has to cover a game the app never launched. The mods folder is watched that way
+//! for the same reason ([`crate::modwatch`]): plenty of people press Play in Steam. So this
+//! is a standing watcher started at app launch, not something hung off the Play button — it
+//! sits on a cheap "is the game up?" poll and only does real work while it is.
+//!
+//! Two settings, deliberately separate, because they are two different decisions:
+//!
+//!   * `integrityWatch` — scan at all. On by default; it reads the game's own module list and
+//!     the answer goes no further than this window.
+//!   * `integrityReport` — publish the verdict so a server admin can see it. Off until it is
+//!     chosen. See [`publish`] for exactly what leaves the machine, which is much less than
+//!     what a scan sees.
+
+use crate::config::AppConfig;
+use crate::integrity::{self, Report, RuleSet, ScanContext, Severity, Verdict};
+use serde::Serialize;
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+use tauri::{AppHandle, Emitter, Manager};
+
+/// How often to look while the game is running.
+///
+/// A cheat that attaches mid-session is caught within this window, so it wants to be short;
+/// each pass walks a module list and — only when something is unaccounted for — hashes a
+/// file, so it can't be free. Forty-five seconds matches the live paint sync, which is the
+/// other thing running through a race.
+const SCAN_EVERY: std::time::Duration = std::time::Duration::from_secs(45);
+
+/// How often to ask whether the game has started. A process-table walk, and nothing else.
+const IDLE_POLL: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Event name the UI listens on. Emitted only when the answer *changes*, so a settled
+/// session is silent rather than pushing an identical report every 45 seconds.
+pub const EVENT: &str = "integrity-report";
+
+/// The last report, for anything that needs the current answer without waiting for a scan.
+fn last() -> &'static Mutex<Report> {
+    static LAST: OnceLock<Mutex<Report>> = OnceLock::new();
+    LAST.get_or_init(|| Mutex::new(Report::default()))
+}
+
+/// The rule list in force. Loaded from cache at startup and replaced by each refresh.
+fn rules() -> &'static Mutex<RuleSet> {
+    static RULES: OnceLock<Mutex<RuleSet>> = OnceLock::new();
+    RULES.get_or_init(|| Mutex::new(RuleSet::bundled()))
+}
+
+pub fn current() -> Report {
+    last().lock().map(|r| r.clone()).unwrap_or_default()
+}
+
+fn current_rules() -> RuleSet {
+    rules().lock().map(|r| r.clone()).unwrap_or_else(|_| RuleSet::bundled())
+}
+
+/// What the app knows about this machine that the classifier needs.
+///
+/// The trusted roots are the folders whose contents are the player's own install: the game,
+/// the FrostMod we put there, and ReShade if they use it. Everything else that ends up inside
+/// the game process has to explain itself.
+fn context(app: &AppHandle, cfg: &AppConfig) -> ScanContext {
+    let mut roots = vec![crate::frostmod_manage::frostmod_dir(app)];
+    let reshade = cfg.reshade_dir();
+    if !reshade.trim().is_empty() {
+        roots.push(PathBuf::from(reshade));
+    }
+    ScanContext::new(&PathBuf::from(cfg.install_dir()), &roots)
+}
+
+/// Scan once, remember the answer, and tell anyone who is listening.
+///
+/// Returns the report either way — including the [`Verdict::Unknown`] that means we could not
+/// look, which is a real answer and not a failure to be swallowed.
+pub fn scan_once(app: &AppHandle) -> Report {
+    let cfg = crate::config::load_or_detect(app).unwrap_or_default();
+    if !cfg.integrity_watch {
+        return Report::default();
+    }
+    let report = integrity::scan(&context(app, &cfg), &current_rules());
+    remember(app, &cfg, report.clone());
+    report
+}
+
+/// Store a report, emit it if it says something new, and publish it if that's turned on.
+///
+/// "Something new" is the verdict plus the findings — not the timestamp, which changes on
+/// every pass. Without that test a quiet session would emit an identical report every 45
+/// seconds and the UI would flash a banner each time.
+fn remember(app: &AppHandle, cfg: &AppConfig, report: Report) {
+    let changed = match last().lock() {
+        Ok(mut slot) => {
+            let changed = slot.verdict != report.verdict || slot.findings != report.findings;
+            *slot = report.clone();
+            changed
+        }
+        // A poisoned lock means a previous scan panicked. Emit rather than go quiet: the one
+        // thing this must not do is stop reporting without saying so.
+        Err(_) => true,
+    };
+    if !changed {
+        return;
+    }
+    if report.verdict >= Verdict::Suspect {
+        log::warn!(
+            "[integrity] {:?}: {}",
+            report.verdict,
+            report.findings.iter().map(|f| f.name.as_str()).collect::<Vec<_>>().join(", ")
+        );
+    }
+    let _ = app.emit(EVENT, &report);
+    if cfg.integrity_report {
+        publish_soon(app, cfg, &report);
+    }
+}
+
+/// What the control plane is told.
+///
+/// Deliberately not the report: a scan sees every DLL loaded on the machine, and that is
+/// nobody else's business. A [`Severity::Suspect`] finding is by definition "software we do
+/// not recognise", which on somebody's work laptop could be anything — so its *name* never
+/// leaves, only the fact that the count is non-zero. Rule-matched detections do carry their
+/// name and label, because at that point it is a known cheat and naming it is the point.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Attestation {
+    verdict: Verdict,
+    /// Which rule list produced the verdict. An admin looking at a Clean report needs to
+    /// know it was checked against something current.
+    rules_version: u32,
+    /// How many unrecognised-but-unnamed things were loaded.
+    suspect_count: usize,
+    /// The named detections, worst first.
+    flagged: Vec<FlaggedItem>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FlaggedItem {
+    name: String,
+    label: String,
+    sha256: String,
+}
+
+/// Send an attestation to the control plane. Best-effort and fire-and-forget: a failed
+/// publish costs one missing row in an admin's list for a minute.
+fn publish_soon(app: &AppHandle, cfg: &AppConfig, report: &Report) {
+    let token = cfg.cp_token.trim().to_string();
+    if token.is_empty() {
+        return;
+    }
+    let body = Attestation {
+        verdict: report.verdict,
+        rules_version: report.rules_version,
+        suspect_count: report.findings.iter().filter(|f| f.severity == Severity::Suspect).count(),
+        flagged: report
+            .findings
+            .iter()
+            .filter(|f| f.severity == Severity::Flagged)
+            .map(|f| FlaggedItem {
+                name: f.name.clone(),
+                label: f.label.clone(),
+                sha256: f.sha256.clone(),
+            })
+            .collect(),
+    };
+    let _ = app;
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = publish(&token, &body).await {
+            log::debug!("[integrity] couldn't publish the verdict: {e:#}");
+        }
+    });
+}
+
+async fn publish(token: &str, body: &Attestation) -> anyhow::Result<()> {
+    let res = reqwest::Client::new()
+        .put(format!("{}/v1/integrity", crate::paintsync::control_plane()))
+        .bearer_auth(token)
+        .json(body)
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await?;
+    if !res.status().is_success() {
+        anyhow::bail!("control plane said {}", res.status());
+    }
+    Ok(())
+}
+
+/// Start the standing watcher. Call once, from `setup`.
+pub fn start(app: &AppHandle) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        // Load whatever list is cached before the first scan, so a machine that starts
+        // offline still matches against the last one it saw rather than an empty set.
+        if let Ok(mut slot) = rules().lock() {
+            *slot = integrity::cached_rules(&app);
+        }
+        refresh_rules(&app).await;
+
+        let mut was_running = false;
+        loop {
+            let cfg = crate::config::load_or_detect(&app).unwrap_or_default();
+            if !cfg.integrity_watch {
+                // Turned off mid-session: forget the last answer so the UI shows "not
+                // watching" rather than a stale verdict from an hour ago.
+                if let Ok(mut slot) = last().lock() {
+                    *slot = Report::default();
+                }
+                was_running = false;
+                tokio::time::sleep(IDLE_POLL).await;
+                continue;
+            }
+
+            let running = crate::gameproc::is_game_running();
+            if running && !was_running {
+                // A new session is the natural moment to pick up rules published since the
+                // app started — someone may have been playing for eight hours.
+                refresh_rules(&app).await;
+            }
+            if !running && was_running {
+                // The session is over, so the verdict is about a game that no longer exists.
+                if let Ok(mut slot) = last().lock() {
+                    *slot = Report::default();
+                }
+                let _ = app.emit(EVENT, Report::default());
+            }
+            was_running = running;
+
+            if running {
+                scan_once(&app);
+                tokio::time::sleep(SCAN_EVERY).await;
+            } else {
+                tokio::time::sleep(IDLE_POLL).await;
+            }
+        }
+    });
+}
+
+/// Pull the live rule list, keeping the current one if the fetch fails.
+pub async fn refresh_rules(app: &AppHandle) {
+    match integrity::refresh_rules(app).await {
+        Ok(fresh) => {
+            if let Ok(mut slot) = rules().lock() {
+                *slot = fresh;
+            }
+        }
+        Err(e) => log::debug!("[integrity] couldn't refresh the rule list: {e:#}"),
+    }
+}
+
+/// One rider's verdict, as an admin sees it.
+#[derive(Debug, Clone, serde::Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RiderIntegrity {
+    pub rider_name: String,
+    #[serde(default)]
+    pub guid: String,
+    pub verdict: Verdict,
+    #[serde(default)]
+    pub rules_version: u32,
+    #[serde(default)]
+    pub suspect_count: usize,
+    #[serde(default)]
+    pub flagged: Vec<FlaggedSeen>,
+    /// Unix ms of the client's last attestation. What tells an admin the difference between
+    /// "reported clean" and "hasn't reported since they joined".
+    #[serde(default)]
+    pub reported_at: u64,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FlaggedSeen {
+    pub name: String,
+    #[serde(default)]
+    pub label: String,
+    #[serde(default)]
+    pub sha256: String,
+}
+
+/// Everyone on `server_id` who has published a verdict.
+///
+/// An admin's read, and it is worth being clear about what it is not: an absence here is not
+/// innocence and not guilt. A rider shows up only if their app is running, watching, and set
+/// to report — so the list answers "who has attested", and the people missing from it are
+/// exactly the ones this can say nothing about.
+pub async fn server_reports(token: &str, server_id: &str) -> anyhow::Result<Vec<RiderIntegrity>> {
+    #[derive(serde::Deserialize)]
+    struct Body {
+        riders: Vec<RiderIntegrity>,
+    }
+    let body: Body = reqwest::Client::new()
+        .get(format!("{}/v1/integrity", crate::paintsync::control_plane()))
+        .query(&[("server", server_id)])
+        .bearer_auth(token)
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    Ok(body.riders)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::integrity::{Finding, Kind, Reason};
+
+    fn finding(name: &str, severity: Severity) -> Finding {
+        Finding {
+            kind: Kind::Module,
+            name: name.into(),
+            path: format!("C:\\Users\\rider\\Secret Work Tools\\{name}"),
+            reason: if severity == Severity::Flagged {
+                Reason::RuleName
+            } else {
+                Reason::ForeignModule
+            },
+            severity,
+            sha256: "d34d".into(),
+            label: if severity == Severity::Flagged { "Kaizo trainer".into() } else { String::new() },
+        }
+    }
+
+    fn attestation(findings: Vec<Finding>) -> Attestation {
+        let report = Report {
+            verdict: Verdict::Flagged,
+            findings,
+            scanned_at: 1,
+            rules_version: 9,
+            modules_scanned: 120,
+            game_running: true,
+        };
+        Attestation {
+            verdict: report.verdict,
+            rules_version: report.rules_version,
+            suspect_count: report
+                .findings
+                .iter()
+                .filter(|f| f.severity == Severity::Suspect)
+                .count(),
+            flagged: report
+                .findings
+                .iter()
+                .filter(|f| f.severity == Severity::Flagged)
+                .map(|f| FlaggedItem {
+                    name: f.name.clone(),
+                    label: f.label.clone(),
+                    sha256: f.sha256.clone(),
+                })
+                .collect(),
+        }
+    }
+
+    /// The privacy line this feature stands on. A Suspect finding is "software we don't
+    /// recognise", which is not evidence of anything and is nobody else's business — it is
+    /// counted, never named. Anything that changes this test is changing what the app tells
+    /// a stranger about its user's machine.
+    #[test]
+    fn an_attestation_counts_suspects_without_naming_them() {
+        let sent = attestation(vec![
+            finding("kaizo.dll", Severity::Flagged),
+            finding("employer_vpn_hook.dll", Severity::Suspect),
+            finding("some_other_overlay.dll", Severity::Suspect),
+        ]);
+        let json = serde_json::to_string(&sent).unwrap();
+
+        assert_eq!(sent.suspect_count, 2);
+        assert!(!json.contains("employer_vpn_hook"), "a suspect module was named: {json}");
+        assert!(!json.contains("some_other_overlay"), "a suspect module was named: {json}");
+        assert!(!json.contains("Secret Work Tools"), "a path leaked: {json}");
+        // The known cheat is named, which is the whole point of reporting.
+        assert!(json.contains("kaizo.dll"));
+        assert!(json.contains("Kaizo trainer"));
+    }
+
+    /// A clean machine sends a clean attestation and nothing else — no empty finding
+    /// objects, no module list.
+    #[test]
+    fn a_clean_attestation_carries_nothing_about_the_machine() {
+        let sent = attestation(vec![]);
+        assert_eq!(sent.suspect_count, 0);
+        assert!(sent.flagged.is_empty());
+        let json = serde_json::to_string(&sent).unwrap();
+        assert!(!json.contains(".dll"), "{json}");
+    }
+
+    /// The wire shape the control plane parses, in camelCase like every other endpoint.
+    #[test]
+    fn an_attestation_serializes_in_camel_case() {
+        let json = serde_json::to_string(&attestation(vec![finding("k.dll", Severity::Flagged)]))
+            .unwrap();
+        assert!(json.contains("\"rulesVersion\":9"), "{json}");
+        assert!(json.contains("\"suspectCount\":0"), "{json}");
+        assert!(json.contains("\"verdict\":\"flagged\""), "{json}");
+    }
+}

--- a/src-tauri/src/integritywatch.rs
+++ b/src-tauri/src/integritywatch.rs
@@ -117,7 +117,7 @@ fn remember(app: &AppHandle, cfg: &AppConfig, report: Report) {
     }
     let _ = app.emit(EVENT, &report);
     if cfg.integrity_report {
-        publish_soon(app, cfg, &report);
+        publish_soon(cfg, &report);
     }
 }
 
@@ -151,7 +151,7 @@ struct FlaggedItem {
 
 /// Send an attestation to the control plane. Best-effort and fire-and-forget: a failed
 /// publish costs one missing row in an admin's list for a minute.
-fn publish_soon(app: &AppHandle, cfg: &AppConfig, report: &Report) {
+fn publish_soon(cfg: &AppConfig, report: &Report) {
     let token = cfg.cp_token.trim().to_string();
     if token.is_empty() {
         return;
@@ -171,7 +171,6 @@ fn publish_soon(app: &AppHandle, cfg: &AppConfig, report: &Report) {
             })
             .collect(),
     };
-    let _ = app;
     tauri::async_runtime::spawn(async move {
         if let Err(e) = publish(&token, &body).await {
             log::debug!("[integrity] couldn't publish the verdict: {e:#}");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -19,6 +19,8 @@ mod gearrepair;
 mod heightfield;
 mod imgcache;
 mod install;
+mod integrity;
+mod integritywatch;
 mod library;
 mod linkwalk;
 mod logs;
@@ -5277,6 +5279,74 @@ fn set_watch_mods_reload(
     Ok(())
 }
 
+/// The current cheat-scan verdict, without waiting for the next pass.
+///
+/// What the UI reads on open. Returns the standing [`integrity::Verdict::Unknown`] before the
+/// first scan of a session, which is the honest answer: nothing has been looked at yet.
+#[tauri::command]
+fn integrity_status() -> integrity::Report {
+    integritywatch::current()
+}
+
+/// Scan now, rather than at the next pass. The "check again" button.
+///
+/// Refreshes the rule list first: someone pressing this has usually just heard about a cheat,
+/// and matching it against a list fetched at app start would be the one moment it matters that
+/// the list is an hour old.
+#[tauri::command]
+async fn integrity_scan_now(app: tauri::AppHandle) -> integrity::Report {
+    integritywatch::refresh_rules(&app).await;
+    // A blocking scan: a module walk plus, at worst, a hash of the handful of files that
+    // didn't check out. Off the async worker so a slow disk can't stall the runtime.
+    let handle = app.clone();
+    tauri::async_runtime::spawn_blocking(move || integritywatch::scan_once(&handle))
+        .await
+        .unwrap_or_default()
+}
+
+/// Turn the watcher on or off.
+///
+/// No live start/stop needed — unlike the mods watcher, this one is a poll that re-reads the
+/// setting every pass, so it stands down on its own within [`IDLE_POLL`](integritywatch).
+#[tauri::command]
+fn set_integrity_watch(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
+    let mut cfg = config::load(&app).unwrap_or_default();
+    cfg.integrity_watch = enabled;
+    // Reporting a verdict this app is no longer producing would leave an admin looking at
+    // whatever the last scan said, indefinitely. Turning the scan off turns the sharing off.
+    if !enabled {
+        cfg.integrity_report = false;
+    }
+    config::save(&app, &cfg).map_err(|e| format!("{e:#}"))
+}
+
+/// Share this client's verdict with the servers it joins.
+#[tauri::command]
+fn set_integrity_report(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
+    let mut cfg = config::load(&app).unwrap_or_default();
+    cfg.integrity_report = enabled;
+    // Sharing implies scanning; there is nothing to share otherwise.
+    if enabled {
+        cfg.integrity_watch = true;
+    }
+    config::save(&app, &cfg).map_err(|e| format!("{e:#}"))
+}
+
+/// What the riders on one server have attested, for the admin of that server.
+#[tauri::command]
+async fn integrity_server_reports(
+    app: tauri::AppHandle,
+    server_id: String,
+) -> Result<Vec<integritywatch::RiderIntegrity>, String> {
+    let cfg = config::load_or_detect(&app).unwrap_or_default();
+    if cfg.cp_token.trim().is_empty() {
+        return Err("Enroll with an invite code first.".into());
+    }
+    integritywatch::server_reports(&cfg.cp_token, &server_id)
+        .await
+        .map_err(|e| format!("{e:#}"))
+}
+
 #[tauri::command]
 async fn shop_login(app: tauri::AppHandle) -> Result<(), String> {
     if let Some(w) = app.get_webview_window(SHOP_LOGIN_WINDOW) {
@@ -6249,6 +6319,12 @@ fn main() {
             } else {
                 log::info!("no MX Bikes folder found — showing first-run setup");
             }
+            // Watch for a cheat attached to the game. Started unconditionally rather than
+            // from the Play button, and outside the `load_or_detect` arm above: the game is
+            // just as often launched from Steam, and a machine with no config yet still has
+            // a process list worth reading. The watcher re-reads the setting every pass, so
+            // it costs an idle poll and nothing else when it is turned off.
+            integritywatch::start(handle);
             shop_session::load_session(handle);
             shop_catalog_session::load(handle);
             mxb_session::load(handle);
@@ -6398,6 +6474,11 @@ fn main() {
             voice_meter_stop,
             voice_test_output,
             set_watch_mods_reload,
+            integrity_status,
+            integrity_scan_now,
+            set_integrity_watch,
+            set_integrity_report,
+            integrity_server_reports,
             frostmod_reload,
             frostmod_running,
             garage_scan_bikes,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -42,6 +42,8 @@ mod pkz;
 mod proton;
 #[cfg(sidecar)]
 mod sidecar;
+#[cfg(worldnet)]
+mod worldnet;
 mod presets;
 mod paintsync;
 mod reshade;

--- a/src-tauri/src/mods/mod.rs
+++ b/src-tauri/src/mods/mod.rs
@@ -54,6 +54,9 @@ pub struct ModSummary {
     pub date: String,
     pub image: Option<String>,
     pub category_id: u32,
+    /// Who posted it, as the site's own account name. `None` where the catalog didn't say —
+    /// the display name rides in the embedded author, which a site can withhold.
+    pub author: Option<String>,
 }
 
 /// The order a browse listing comes back in.

--- a/src-tauri/src/mods/mxb.rs
+++ b/src-tauri/src/mods/mxb.rs
@@ -823,6 +823,34 @@ fn strip_images(html: &str) -> String {
     img.replace_all(&s, "").into_owned()
 }
 
+/// The file name a download URL ends in — where an author who didn't label the block
+/// often still says what the file is (`…/Track_Server.zip`).
+///
+/// MediaFire and Google Drive hang a routing segment off the end of the path
+/// (`…/track.zip/file`, `…/view`), so those are stepped over to reach the real name.
+fn url_file_name(url: &str) -> &str {
+    let path = url.split(['?', '#']).next().unwrap_or(url);
+    let mut segs = path.trim_end_matches('/').rsplit('/').filter(|s| !s.is_empty());
+    let last = segs.next().unwrap_or("");
+    if ["file", "view", "download"].iter().any(|s| last.eq_ignore_ascii_case(s)) {
+        segs.next().unwrap_or(last)
+    } else {
+        last
+    }
+}
+
+/// Does this text call something a server build?
+///
+/// The word has to stand on its own: a track named "Observer Hill" contains the letters
+/// but isn't a server file, and mistaking one for the other hides the only download a mod
+/// has. Letters are what separate them rather than `\b`, because `_` is a word character
+/// to a regex and `Ironman_2024_Server.pkz` is how these files are actually named.
+fn mentions_server(text: &str) -> bool {
+    Regex::new(r"(?i)(?:^|[^a-z])servers?(?:[^a-z]|$)")
+        .unwrap()
+        .is_match(text)
+}
+
 /// Parse the theme's `div.download-container` blocks into download options.
 fn parse_downloads(html: &str) -> Vec<DownloadOption> {
     let doc = Html::parse_document(html);
@@ -836,10 +864,14 @@ fn parse_downloads(html: &str) -> Vec<DownloadOption> {
             .value()
             .classes()
             .any(|c| c.eq_ignore_ascii_case("container-default"));
-        // Dedicated-server builds are labelled "server" somewhere in the block.
-        let is_server = el.text().collect::<String>().to_lowercase().contains("server");
         let href = el.select(&a_sel).next().and_then(|a| a.value().attr("href"));
         let Some(url) = href else { continue };
+
+        // Dedicated-server builds are labelled "server" in the block — or, when the author
+        // only said it in the file's name, nowhere but the link. Both are read, because a
+        // server build that reaches the app unflagged is one the picker can preselect.
+        let is_server =
+            mentions_server(&el.text().collect::<String>()) || mentions_server(url_file_name(url));
 
         // The shown origin must reflect the ACTUAL link — authors often type a
         // mirror nickname (e.g. "GoWithTheFlow") in `div.filename`, which is not
@@ -862,8 +894,10 @@ fn parse_downloads(html: &str) -> Vec<DownloadOption> {
         });
     }
 
-    // Show the author's default file first.
-    out.sort_by_key(|d| !d.is_default);
+    // The author's default file first, and dedicated-server builds after everything else —
+    // whatever the page's own order was, a server build is never the file someone browsing
+    // for something to ride is after.
+    out.sort_by_key(|d| (d.is_server, !d.is_default));
     out
 }
 
@@ -993,6 +1027,65 @@ mod tests {
         assert_eq!(downloads.len(), 1);
         assert_eq!(downloads[0].host, "MediaFire");
         assert_eq!(downloads[0].label, "GoWithTheFlow");
+    }
+
+    #[test]
+    fn flags_server_builds_and_sorts_them_last() {
+        // The author marked the server build in the block's text, and made it the page's
+        // default — which is exactly how a server file used to end up preselected.
+        let html = r#"
+            <div class="download-container container-default">
+              <div class="filename">Dedicated Server files</div>
+              <a href="https://www.mediafire.com/file/abc/track_srv.zip/file">Download</a>
+            </div>
+            <div class="download-container container-mirror">
+              <div class="filename">mediafire.com</div>
+              <a href="https://www.mediafire.com/file/xyz/track.zip/file">Download</a>
+            </div>
+        "#;
+        let downloads = parse_downloads(html);
+        assert_eq!(downloads.len(), 2);
+        // Playable first, despite the server build carrying the page's "default" flag.
+        assert!(!downloads[0].is_server);
+        assert!(downloads[1].is_server);
+        assert!(downloads[1].is_default);
+    }
+
+    #[test]
+    fn reads_the_server_label_out_of_the_link() {
+        // Nothing in the block says "server"; only the file it points at does.
+        let html = r#"
+            <div class="download-container container-default">
+              <div class="filename">MediaFire</div>
+              <a href="https://www.mediafire.com/file/abc/Ironman_2024_Server.pkz/file">Download</a>
+            </div>
+        "#;
+        assert!(parse_downloads(html)[0].is_server);
+    }
+
+    #[test]
+    fn a_track_named_observer_is_not_a_server_build() {
+        // Substring matching flagged this one, which left the mod looking undownloadable.
+        let html = r#"
+            <div class="download-container container-default">
+              <div class="filename">Observer Hill</div>
+              <a href="https://www.mediafire.com/file/abc/ObserverHill.zip/file">Download</a>
+            </div>
+        "#;
+        assert!(!parse_downloads(html)[0].is_server);
+    }
+
+    #[test]
+    fn file_name_skips_the_hosts_routing_segment() {
+        assert_eq!(
+            url_file_name("https://www.mediafire.com/file/abc/track_server.zip/file"),
+            "track_server.zip",
+        );
+        assert_eq!(
+            url_file_name("https://drive.google.com/file/d/ABC123/view?usp=sharing"),
+            "ABC123",
+        );
+        assert_eq!(url_file_name("https://x.com/downloads/pack.7z"), "pack.7z");
     }
 
     #[test]

--- a/src-tauri/src/mods/mxb.rs
+++ b/src-tauri/src/mods/mxb.rs
@@ -442,7 +442,8 @@ async fn listing_response(
     let url = format!("{}{}", mxb_session::base(), obfstr!("/wp-json/wp/v2/posts"));
     let mut params: Vec<(&str, String)> = vec![
         ("categories", category_id.to_string()),
-        ("_embed", "wp:featuredmedia".to_string()),
+        // `author` rides along so a card can carry a byline; it costs no extra request.
+        ("_embed", "author,wp:featuredmedia".to_string()),
     ];
     match page {
         Page::Number(n) => {
@@ -533,7 +534,7 @@ async fn popular(category_id: u32, page: u32, range: &str) -> anyhow::Result<Vec
         ("order_by", "views".to_string()),
         ("limit", per_page.to_string()),
         ("offset", ((page - 1) * per_page).to_string()),
-        ("_embed", "wp:featuredmedia".to_string()),
+        ("_embed", "author,wp:featuredmedia".to_string()),
     ];
 
     let resp = get_with_retry(&url, &params).await?;
@@ -736,7 +737,25 @@ fn summary_from_post(p: &Value, category_id: u32) -> Option<ModSummary> {
         date: p.get("date").and_then(Value::as_str).unwrap_or("").to_string(),
         image: featured_image(p),
         category_id,
+        author: embedded_author(p),
     })
+}
+
+/// The post author's display name, from `_embed=author`.
+///
+/// Optional on purpose. WordPress answers the embed with an error object rather than a user
+/// when the site keeps its author list private, and a catalog that stops naming anyone is no
+/// reason for a listing to fail — the card simply doesn't show a byline.
+fn embedded_author(p: &Value) -> Option<String> {
+    let name = p
+        .get("_embedded")?
+        .get("author")?
+        .as_array()?
+        .first()?
+        .get("name")?
+        .as_str()?;
+    let name = decode_entities(name).trim().to_string();
+    (!name.is_empty()).then_some(name)
 }
 
 /// `post[field]["rendered"]` as a &str.
@@ -1027,6 +1046,37 @@ mod tests {
         assert_eq!(downloads.len(), 1);
         assert_eq!(downloads[0].host, "MediaFire");
         assert_eq!(downloads[0].label, "GoWithTheFlow");
+    }
+
+    #[test]
+    fn reads_the_posts_author() {
+        let post: Value = serde_json::from_str(
+            r#"{"id":1,"slug":"a-track","title":{"rendered":"A Track"},
+                "_embedded":{"author":[{"name":"Ren&#038;s Bikes"}]}}"#,
+        )
+        .unwrap();
+        let summary = summary_from_post(&post, 22).unwrap();
+        // Entities decoded, same as the title.
+        assert_eq!(summary.author.as_deref(), Some("Ren&s Bikes"));
+
+        // A site that keeps its author list private answers the embed with an error object
+        // instead of a user. That's a card without a byline, not a failed listing.
+        let hidden: Value = serde_json::from_str(
+            r#"{"id":2,"slug":"b-track","title":{"rendered":"B Track"},
+                "_embedded":{"author":[{"code":"rest_user_cannot_view"}]}}"#,
+        )
+        .unwrap();
+        assert_eq!(summary_from_post(&hidden, 22).unwrap().author, None);
+
+        // No `_embed` at all, and a blank name, are the same non-answer.
+        let bare: Value =
+            serde_json::from_str(r#"{"id":3,"slug":"c","title":{"rendered":"C"}}"#).unwrap();
+        assert_eq!(summary_from_post(&bare, 22).unwrap().author, None);
+        let blank: Value = serde_json::from_str(
+            r#"{"id":4,"slug":"d","title":{"rendered":"D"},"_embedded":{"author":[{"name":"  "}]}}"#,
+        )
+        .unwrap();
+        assert_eq!(summary_from_post(&blank, 22).unwrap().author, None);
     }
 
     #[test]

--- a/src-tauri/src/proton.rs
+++ b/src-tauri/src/proton.rs
@@ -328,6 +328,71 @@ pub fn kill_exe(exe: &str) {
     }
 }
 
+/// Every PE file mapped into `pid`, by path.
+///
+/// Wine loads a DLL by mapping the file itself, so the kernel's own mapping list is a
+/// faithful account of what is inside the game — which is what makes cheat detection
+/// possible at all on a platform with no `CreateToolhelp32Snapshot`.
+pub fn mapped_pe_files(pid: u32) -> Vec<String> {
+    std::fs::read_to_string(format!("/proc/{pid}/maps"))
+        .map(|maps| pe_files_in_maps(&maps))
+        .unwrap_or_default()
+}
+
+/// Every process on the machine, by executable name — the Linux half of
+/// [`crate::gameproc::running_process_names`].
+///
+/// `comm` rather than `cmdline`: it is the short name, which is what the rule list matches,
+/// and it is there for kernel threads and short-lived processes whose `cmdline` is empty.
+pub fn process_names() -> Vec<String> {
+    let mut names = Vec::new();
+    let Ok(entries) = std::fs::read_dir("/proc") else { return names };
+    for entry in entries.flatten() {
+        if entry.file_name().to_string_lossy().parse::<u32>().is_err() {
+            continue;
+        }
+        // Unreadable is normal — another user's process, or one that exited mid-walk.
+        if let Ok(comm) = std::fs::read_to_string(entry.path().join("comm")) {
+            let name = comm.trim();
+            if !name.is_empty() {
+                names.push(name.to_string());
+            }
+        }
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// Pull the distinct `.dll`/`.exe` paths out of a `/proc/<pid>/maps` body.
+///
+/// Split out from the read so it can be tested on any OS. Three things the format makes us
+/// careful about:
+///
+///   - a mapping is six fields and the sixth is the path, which **may contain spaces** —
+///     `steamapps/common/MX Bikes/mxbikes.exe` is the ordinary case here, so the path is
+///     everything after the fifth field rather than the sixth token;
+///   - anonymous mappings (heap, stack, `[vvar]`) have no path at all, and every file is
+///     mapped several times over as the loader lays out its sections, so the answer is a
+///     de-duplicated set;
+///   - a file replaced while mapped keeps its old mapping with a ` (deleted)` marker glued
+///     to the path. Stripping it matters: a cheat that unlinks itself after loading is
+///     exactly the case we want to still name.
+fn pe_files_in_maps(maps: &str) -> Vec<String> {
+    let mut files: Vec<String> = maps
+        .lines()
+        .filter_map(|line| {
+            let path = line.splitn(6, char::is_whitespace).nth(5)?.trim();
+            let path = path.strip_suffix(" (deleted)").unwrap_or(path);
+            let lower = path.to_ascii_lowercase();
+            (lower.ends_with(".dll") || lower.ends_with(".exe")).then(|| path.to_string())
+        })
+        .collect();
+    files.sort();
+    files.dedup();
+    files
+}
+
 /// Does one `/proc/<pid>/cmdline` name `exe`?
 ///
 /// The arguments are NUL-separated and the exe may appear as any of them, in either slash
@@ -408,6 +473,38 @@ mod tests {
         let frostmod = "…/proton\0run\0Z:\\home\\rider\\.local\\share\\com.frost.mxbikes\\frostmod\\FrostMod.exe\0--game\0mxb\0";
         assert!(cmdline_names_exe(frostmod, "frostmod.exe"));
         assert!(!cmdline_names_exe("", "frostmod.exe"));
+    }
+
+    /// The mapping list is how Linux answers "what is loaded into the game". Spaces in the
+    /// path, repeated section mappings and anonymous regions all have to come out right, or
+    /// the scanner either misses a DLL or invents one.
+    #[test]
+    fn a_mapping_list_yields_each_mapped_pe_once() {
+        let maps = "\
+00400000-00452000 r-xp 00000000 08:02 173521     /home/rider/.steam/steamapps/common/MX Bikes/mxbikes.exe
+00452000-00453000 r--p 00052000 08:02 173521     /home/rider/.steam/steamapps/common/MX Bikes/mxbikes.exe
+7f0000000000-7f0000021000 rw-p 00000000 00:00 0
+7f1111111000-7f1111120000 r-xp 00000000 08:02 99 /usr/lib/wine/x86_64-windows/kernel32.dll
+7f2222222000-7f2222230000 r-xp 00000000 08:02 42 /home/rider/Downloads/kaizo hack.dll (deleted)
+7f3333333000-7f3333340000 r-xp 00000000 08:02 43 /usr/lib/x86_64-linux-gnu/libc.so.6
+00e2f000-00e50000 rw-p 00000000 00:00 0          [heap]
+";
+        assert_eq!(
+            pe_files_in_maps(maps),
+            [
+                "/home/rider/.steam/steamapps/common/MX Bikes/mxbikes.exe",
+                "/home/rider/Downloads/kaizo hack.dll",
+                "/usr/lib/wine/x86_64-windows/kernel32.dll",
+            ]
+        );
+    }
+
+    /// Nothing readable is an empty answer, never a panic — an unreadable `/proc` entry is
+    /// the ordinary outcome for a process that exited mid-walk.
+    #[test]
+    fn an_empty_or_pathless_mapping_list_yields_nothing() {
+        assert!(pe_files_in_maps("").is_empty());
+        assert!(pe_files_in_maps("7f00-7f01 rw-p 0 00:00 0 \n").is_empty());
     }
 
     #[test]

--- a/src-tauri/src/reshade.rs
+++ b/src-tauri/src/reshade.rs
@@ -197,7 +197,15 @@ fn probe_dll(path: &Path) -> Option<Option<String>> {
     contains(&narrowed, RESHADE_MARKER).then(|| version_near_marker(&narrowed))
 }
 
-fn is_reshade_dll(path: &Path) -> bool {
+/// Is the file at `path` ReShade's own DLL?
+///
+/// Public because [`crate::integrity`] needs it too, and for the opposite reason: there, a
+/// DLL sitting in the game folder under a name the loader preloads is the shape of an
+/// injected cheat, and ReShade is the one legitimate thing that looks exactly like that.
+/// Asking the file rather than trusting its name is what keeps a working ReShade install
+/// from being reported as a cheat — and what stops a cheat from getting a free pass by
+/// being called `opengl32.dll`.
+pub fn is_reshade_dll(path: &Path) -> bool {
     probe_dll(path).is_some()
 }
 

--- a/src/Components/Browse/Browse.tsx
+++ b/src/Components/Browse/Browse.tsx
@@ -118,6 +118,12 @@ export default function Browse({
           toast.error(t("browse.needsBrowser", { title: res.title }), {
             description: t("browse.needsBrowserDesc", { host: res.host ?? "" }),
           });
+        } else if (res.reason === "serverOnly") {
+          // Not installed on the user's behalf: one click can't ask which build was meant,
+          // and a server file installs cleanly while the game shows nothing.
+          toast.error(t("browse.serverOnly", { title: res.title }), {
+            description: t("browse.serverOnlyDesc"),
+          });
         } else {
           toast.error(t("browse.noDownload", { title: res.title }));
         }

--- a/src/Components/Browse/ModCard.tsx
+++ b/src/Components/Browse/ModCard.tsx
@@ -123,9 +123,16 @@ export default function ModCard({
                 </Badge>
               )}
             </div>
-            <span className="text-[11.5px] text-muted-foreground">
-              {formatDateShort(mod.date)}
-            </span>
+            {/* Date and byline share the line, the way a shop card carries its author. A
+                mod the catalog named nobody for just keeps the date. */}
+            <div className="flex items-baseline justify-between gap-2 text-[11.5px] text-muted-foreground">
+              <span className="flex-none">{formatDateShort(mod.date)}</span>
+              {mod.author && (
+                <span className="truncate" title={mod.author}>
+                  {t("browse.byAuthor", { author: mod.author })}
+                </span>
+              )}
+            </div>
           </div>
         </button>
       </ContextMenuTrigger>

--- a/src/Components/ModDetail/InstallDialog.tsx
+++ b/src/Components/ModDetail/InstallDialog.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useMemo, useState } from "react";
-import { ChevronDown, ChevronRight, Plus, Check, X, Search } from "lucide-react";
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  Plus,
+  Check,
+  X,
+  Search,
+} from "lucide-react";
 import { Dialog, DialogContent } from "@/Components/ui/dialog";
 import { Button } from "@/Components/ui/button";
 import { useT } from "../../i18n/context";
@@ -7,9 +15,12 @@ import { labelOf } from "../../i18n/core";
 import { Badge } from "@/Components/ui/badge";
 import { cn } from "@/lib/utils";
 import {
+  defaultMirrorIndex,
   installsOutsideMods,
   isBlockedDownload,
+  isServerOnly,
   pickDownloadForBike,
+  playableMirrors,
   sortMirrors,
   type DestOption,
   type ModType,
@@ -48,10 +59,19 @@ interface InstallDialogProps {
  *  game's install folder rather than the mods tree. */
 const RESHADE_DEST = "FrostMod ReShade";
 
-/** Ordered, de-duped playable mirrors with the "official" default first. */
+/** Every download the page offers, playable ones first and server builds last. */
 function useMirrors(detail: Detail | undefined): DownloadOption[] {
   return useMemo(() => (detail ? sortMirrors(detail) : []), [detail]);
 }
+
+/**
+ * How many mirrors are listed before the rest collapse behind "N more".
+ *
+ * More than one, deliberately: a single row reads as the only file there is, which is how
+ * someone ends up installing a mirror that turned out to be a server build without ever
+ * seeing there was a choice.
+ */
+const MIRRORS_SHOWN = 3;
 
 export default function InstallDialog({
   open,
@@ -77,6 +97,7 @@ export default function InstallDialog({
   const [newFolder, setNewFolder] = useState("");
   const [mirrorIdx, setMirrorIdx] = useState(0);
   const [mirrorsOpen, setMirrorsOpen] = useState(false);
+  const [serverOpen, setServerOpen] = useState(false);
 
   // Reset transient state each time the dialog opens.
   useEffect(() => {
@@ -86,10 +107,19 @@ export default function InstallDialog({
       setFolderSearch("");
       setCreating(false);
       setNewFolder("");
-      setMirrorIdx(0);
-      setMirrorsOpen(false);
     }
   }, [open, initialFolder]);
+
+  // The picked download resets with the dialog, and again if the page's downloads land
+  // after it opened. Never onto a server build while a playable file is on offer — that
+  // preselection is what quietly installed the wrong build.
+  useEffect(() => {
+    if (open) {
+      setMirrorIdx(defaultMirrorIndex(mirrors));
+      setMirrorsOpen(false);
+      setServerOpen(false);
+    }
+  }, [open, mirrors]);
 
   // Sound mods: the chosen bike (the folder value, minus any `/paints`) decides
   // which *download* to grab — the links are per-bike, not mirrors of one file.
@@ -182,9 +212,76 @@ export default function InstallDialog({
     onConfirm({ destFolder, mirror: selectedMirror });
   };
 
+  const serverBuilds = useMemo(() => mirrors.filter((m) => m.isServer), [mirrors]);
+  const playable = useMemo(() => playableMirrors(mirrors), [mirrors]);
+  // Nothing playable on the page means there is no "other" list to fold the server builds
+  // away behind: they are the downloads, shown as such and clearly marked.
+  const serverOnly = isServerOnly(mirrors);
+  const mainList = serverOnly ? mirrors : playable;
+
   // Show every option for sound mods (each is a different bike, not a mirror);
-  // otherwise collapse to the primary until expanded.
-  const shownMirrors = mirrorsOpen || sound ? mirrors : mirrors.slice(0, 1);
+  // otherwise list the first few and fold the rest away.
+  const shownMirrors = mirrorsOpen || sound ? mainList : mainList.slice(0, MIRRORS_SHOWN);
+  const hiddenCount = mainList.length - shownMirrors.length;
+
+  const renderMirror = (m: DownloadOption) => {
+    const idx = mirrors.indexOf(m);
+    const on = idx === mirrorIdx;
+    const blocked = isBlockedDownload(m);
+    // The author's own name for the file, where it says more than the host does. Two
+    // MediaFire rows are otherwise indistinguishable — and one of them may be the server
+    // build the parser had to guess at.
+    const fileLabel =
+      m.label && m.label.toLowerCase() !== m.host.toLowerCase() ? m.label : "";
+    const note = blocked
+      ? t("installDialog.opensInBrowser")
+      : m.isServer
+        ? t("installDialog.serverBuildNote")
+        : sound
+          ? on
+            ? t("installDialog.matchedBike")
+            : t("installDialog.differentBike")
+          : m.isDefault
+            ? t("installDialog.directFastest")
+            : t("installDialog.direct");
+    return (
+      <button
+        key={`${m.url}-${idx}`}
+        onClick={() => setMirrorIdx(idx)}
+        className={cn(
+          "flex cursor-default items-center gap-[11px] rounded-[9px] border bg-background px-3 py-2.5 text-left transition-colors",
+          on ? "border-primary/50" : "border-input hover:border-white/20",
+        )}
+      >
+        <span
+          className={cn(
+            "size-[15px] flex-none rounded-full",
+            on ? "border-4 border-primary" : "border-[1.5px] border-foreground/25",
+          )}
+        />
+        <span className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate text-[12.5px] font-semibold">{m.host}</span>
+          <span className="text-[11px] text-muted-foreground">{note}</span>
+          {fileLabel && (
+            <span className="truncate font-mono text-[10.5px] text-faint">{fileLabel}</span>
+          )}
+        </span>
+        {m.isServer ? (
+          <Badge variant="warning" className="flex-none">
+            {t("installDialog.serverBadge")}
+          </Badge>
+        ) : blocked ? (
+          <Badge variant="warning" className="flex-none">
+            {t("installDialog.browserBadge")}
+          </Badge>
+        ) : m.isDefault ? (
+          <Badge variant="success" className="flex-none border-primary/35 text-primary">
+            {t("installDialog.recommendedBadge")}
+          </Badge>
+        ) : null}
+      </button>
+    );
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -336,64 +433,46 @@ export default function InstallDialog({
                   ? t("installDialog.downloadPerBike")
                   : t("installDialog.downloadFrom")}
               </span>
+              {/* A mod with nothing but server files is worth saying outright: it installs
+                  fine and then does nothing in-game, which reads as a broken install. */}
+              {serverOnly && (
+                <div className="flex items-start gap-2.5 rounded-[10px] border border-warning/30 bg-warning/[0.07] px-3 py-2.5">
+                  <AlertTriangle className="mt-px size-3.5 flex-none text-warning" />
+                  <span className="text-[11.5px] text-warning/90">
+                    {t("installDialog.serverOnlyNotice")}
+                  </span>
+                </div>
+              )}
               <div className="flex flex-col gap-1.5">
-                {shownMirrors.map((m) => {
-                  const idx = mirrors.indexOf(m);
-                  const on = idx === mirrorIdx;
-                  const blocked = isBlockedDownload(m);
-                  return (
-                    <button
-                      key={`${m.url}-${idx}`}
-                      onClick={() => setMirrorIdx(idx)}
-                      className={cn(
-                        "flex cursor-default items-center gap-[11px] rounded-[9px] border bg-background px-3 py-2.5 text-left transition-colors",
-                        on ? "border-primary/50" : "border-input hover:border-white/20",
-                      )}
-                    >
-                      <span
-                        className={cn(
-                          "size-[15px] flex-none rounded-full",
-                          on
-                            ? "border-4 border-primary"
-                            : "border-[1.5px] border-foreground/25",
-                        )}
-                      />
-                      <span className="flex flex-1 flex-col">
-                        <span className="text-[12.5px] font-semibold">{m.host}</span>
-                        <span className="text-[11px] text-muted-foreground">
-                          {blocked
-                            ? t("installDialog.opensInBrowser")
-                            : sound
-                              ? on
-                                ? t("installDialog.matchedBike")
-                                : t("installDialog.differentBike")
-                              : m.isDefault
-                                ? t("installDialog.directFastest")
-                                : t("installDialog.direct")}
-                        </span>
-                      </span>
-                      {blocked ? (
-                        <Badge variant="warning" className="flex-none">
-                          Browser
-                        </Badge>
-                      ) : m.isDefault ? (
-                        <Badge variant="success" className="flex-none border-primary/35 text-primary">
-                          Default
-                        </Badge>
-                      ) : null}
-                    </button>
-                  );
-                })}
-                {!sound && !mirrorsOpen && mirrors.length > 1 && (
+                {shownMirrors.map(renderMirror)}
+                {!sound && hiddenCount > 0 && (
                   <button
                     onClick={() => setMirrorsOpen(true)}
                     className="flex cursor-default items-center gap-1 self-start px-1 text-[11px] text-muted-foreground hover:text-foreground"
                   >
-                    {mirrors.length - 1} more mirror{mirrors.length - 1 > 1 ? "s" : ""}
+                    {t("installDialog.moreMirrors", { count: hiddenCount })}
                     <ChevronDown className="size-3" />
                   </button>
                 )}
               </div>
+
+              {/* Server builds are listed, not hidden — folded away by default, because
+                  they're rarely what's wanted, but reachable for whoever runs a server. */}
+              {!serverOnly && serverBuilds.length > 0 && (
+                <div className="flex flex-col gap-1.5">
+                  <button
+                    onClick={() => setServerOpen((v) => !v)}
+                    className="flex cursor-default items-center gap-1 self-start px-1 text-[11px] text-muted-foreground hover:text-foreground"
+                  >
+                    {t("installDialog.serverFiles", { count: serverBuilds.length })}
+                    <ChevronDown
+                      className={cn("size-3 transition-transform", serverOpen && "rotate-180")}
+                    />
+                  </button>
+                  {serverOpen && serverBuilds.map(renderMirror)}
+                </div>
+              )}
+
               {mirrors.length > 1 && (
                 <span className="text-[11px] text-faint">
                   {sound

--- a/src/Components/ModDetail/ModDetail.tsx
+++ b/src/Components/ModDetail/ModDetail.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import {
+  AlertTriangle,
   ArrowLeft,
   ExternalLink,
   Check,
@@ -13,11 +14,13 @@ import { useT, type TKey } from "../../i18n/context";
 import {
   buildDestinations,
   buildRiderDestinations,
+  defaultMirrorIndex,
   destStorageKey,
   getInstalledMods,
   getModDetail,
   isBlockedDownload,
   isLiveryContext,
+  isServerOnly,
   isSoundContext,
   riderTarget,
   resolveInitialFolder,
@@ -192,9 +195,15 @@ export default function ModDetail({
   // "Official" mirror + metadata for the collapsed install panel.
   const mirrors = useMemo(() => (detail ? sortMirrors(detail) : []), [detail]);
 
-  const primary = mirrors[0] ?? null;
+  // What the dialog would start on — the best playable file, so the panel below the button
+  // describes the download that's actually about to run.
+  const primary = mirrors[defaultMirrorIndex(mirrors)] ?? null;
   const format = primary ? fileFormat(primary.url) : null;
-  const mirrorNames = [...new Set(mirrors.map((m) => m.host))].join(" · ");
+  // Server builds aren't mirrors of the playable file, so they don't belong in this count.
+  const mirrorNames = [
+    ...new Set(mirrors.filter((m) => !m.isServer).map((m) => m.host)),
+  ].join(" · ");
+  const serverOnly = isServerOnly(mirrors);
 
   const destKey = destStorageKey(game, modType);
   const initialFolder = useMemo(
@@ -383,6 +392,17 @@ export default function ModDetail({
               />
             ) : primary ? (
               <>
+                {/* Every file this page offers is a dedicated-server build. Said before the
+                    button, not after the install: it lands in the library either way and
+                    then does nothing in-game, which reads as a broken mod. */}
+                {serverOnly && (
+                  <div className="flex items-start gap-2.5 rounded-[10px] border border-warning/30 bg-warning/[0.07] px-3 py-2.5">
+                    <AlertTriangle className="mt-px size-3.5 flex-none text-warning" />
+                    <span className="text-[12px] text-warning/90">
+                      {t("modDetail.serverOnlyNotice")}
+                    </span>
+                  </div>
+                )}
                 <Button className="h-11 w-full text-[14px]" onClick={openInstall}>
                   {isInstalled ? t("browse.reinstall") : t("modDetail.addToLibrary")}
                 </Button>

--- a/src/Components/Servers/ServerIntegrity.tsx
+++ b/src/Components/Servers/ServerIntegrity.tsx
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useState } from "react";
+import { RefreshCw, ShieldAlert, ShieldCheck, ShieldQuestion, ShieldX } from "lucide-react";
+import { useI18n } from "../../i18n/context";
+import { Button } from "@/Components/ui/button";
+import { cn } from "@/lib/utils";
+import { integrityServerReports } from "@/api/mods";
+import type { IntegrityVerdict, RiderIntegrity } from "@/types";
+
+/** How often to re-read the grid. Clients publish every 45 seconds, so anything faster is
+ *  asking the same question twice. */
+const POLL_MS = 60_000;
+
+/**
+ * What the riders on this server have said about their own clients.
+ *
+ * The heading and the empty state carry most of the weight here, because the thing an admin
+ * will do with this is accuse somebody, and the list does not support that on its own. A
+ * rider appears only if their app is running, watching, and set to report — so this answers
+ * "who has attested", and the people missing from it are exactly the ones it can say nothing
+ * about. A cheater who closed MXB App is not in this list, and that is not a bug.
+ */
+export default function ServerIntegrity({ serverId }: { serverId: string }) {
+  const { t } = useI18n();
+  const [riders, setRiders] = useState<RiderIntegrity[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setBusy(true);
+    try {
+      setRiders(await integrityServerReports(serverId));
+      setError(null);
+    } catch (e) {
+      setError(String(e));
+    }
+    setBusy(false);
+  }, [serverId]);
+
+  useEffect(() => {
+    void refresh();
+    const id = setInterval(() => void refresh(), POLL_MS);
+    return () => clearInterval(id);
+  }, [refresh]);
+
+  return (
+    <div className="mt-3 border-t border-white/[0.05] pt-3">
+      <div className="flex items-center gap-2">
+        <ShieldCheck className="size-3.5 flex-none text-muted-foreground" />
+        <span className="text-[12px] text-muted-foreground">{t("integrity.gridTitle")}</span>
+        <Button
+          className="ml-auto"
+          size="sm"
+          variant="ghost"
+          onClick={() => void refresh()}
+          disabled={busy}
+        >
+          <RefreshCw className={cn("size-3.5", busy && "animate-spin")} />
+        </Button>
+      </div>
+
+      {error ? (
+        <p className="mt-2 text-[11.5px] text-muted-foreground">{error}</p>
+      ) : riders === null ? (
+        <p className="mt-2 text-[11.5px] text-muted-foreground">{t("integrity.gridLoading")}</p>
+      ) : riders.length === 0 ? (
+        <p className="mt-2 text-[11.5px] leading-relaxed text-muted-foreground">
+          {t("integrity.gridEmpty")}
+        </p>
+      ) : (
+        <ul className="mt-2 flex flex-col gap-1">
+          {riders.map((r) => (
+            <RiderRow key={r.guid || r.riderName} rider={r} />
+          ))}
+        </ul>
+      )}
+
+      <p className="mt-2 text-[11px] leading-relaxed text-faint">{t("integrity.gridNote")}</p>
+    </div>
+  );
+}
+
+function RiderRow({ rider }: { rider: RiderIntegrity }) {
+  const { t } = useI18n();
+  // The worst of the recent past outranks the current answer on the row itself: a client
+  // that loaded a cheat for one lap and unloaded it reports clean now, and "clean" is not
+  // what an admin should see for it.
+  const shown = worse(rider.worstVerdict, rider.verdict);
+  const recovered = shown !== rider.verdict;
+  return (
+    <li className="flex items-center gap-2 rounded-lg border border-white/[0.07] bg-white/[0.02] px-3 py-1.5 text-[12px]">
+      <VerdictDot verdict={shown} />
+      <span className="min-w-0 flex-1 truncate">{rider.riderName}</span>
+      <span
+        className={cn(
+          "flex-none text-[11.5px]",
+          shown === "flagged"
+            ? "text-destructive"
+            : shown === "suspect"
+              ? "text-warning"
+              : "text-muted-foreground",
+        )}
+      >
+        {rider.flagged.length > 0
+          ? // The rule's own label, verbatim and untranslated.
+            rider.flagged.map((f) => f.label || f.name).join(", ")
+          : shown === "suspect"
+            ? t("integrity.gridSuspect", { count: rider.suspectCount })
+            : t(shown === "clean" ? "integrity.clean" : "integrity.unknown")}
+        {recovered && ` ${t("integrity.gridRecovered")}`}
+      </span>
+    </li>
+  );
+}
+
+function worse(a: IntegrityVerdict | undefined, b: IntegrityVerdict): IntegrityVerdict {
+  const order: IntegrityVerdict[] = ["unknown", "clean", "suspect", "flagged"];
+  if (!a) return b;
+  return order.indexOf(a) > order.indexOf(b) ? a : b;
+}
+
+function VerdictDot({ verdict }: { verdict: IntegrityVerdict }) {
+  const cls = "size-3.5 flex-none";
+  if (verdict === "clean") return <ShieldCheck className={cn(cls, "text-success")} />;
+  if (verdict === "suspect") return <ShieldAlert className={cn(cls, "text-warning")} />;
+  if (verdict === "flagged") return <ShieldX className={cn(cls, "text-destructive")} />;
+  return <ShieldQuestion className={cn(cls, "text-muted-foreground")} />;
+}

--- a/src/Components/Servers/Servers.tsx
+++ b/src/Components/Servers/Servers.tsx
@@ -23,6 +23,7 @@ import HelpHint from "@/Components/ui/help-hint";
 import { Button } from "@/Components/ui/button";
 import { Input } from "@/Components/ui/input";
 import { cn } from "@/lib/utils";
+import ServerIntegrity from "./ServerIntegrity";
 import {
   cloudServers,
   destroyCloudServer,
@@ -358,6 +359,11 @@ const ServerRow = ({ server, onRemove, onChanged }: RowProps) => {
           </>
         )}
       </div>
+
+      {/* What the grid's own clients report about themselves. Only for a listed server:
+          the control plane keys these on the registry id, so an unpublished server has no
+          key to ask about — and nobody joining it is reporting one either. */}
+      {listed && <ServerIntegrity serverId={server.registryId!} />}
     </div>
   );
 };

--- a/src/Components/Settings/IntegrityCard.tsx
+++ b/src/Components/Settings/IntegrityCard.tsx
@@ -1,0 +1,168 @@
+import { useCallback, useEffect, useState } from "react";
+import { RefreshCw, ShieldAlert, ShieldCheck, ShieldQuestion, ShieldX } from "lucide-react";
+import { toast } from "sonner";
+import { useI18n } from "../../i18n/context";
+import type { TKey } from "../../i18n";
+import { Button } from "@/Components/ui/button";
+import { cn } from "@/lib/utils";
+import { integrityScanNow, integrityStatus, onIntegrityReport } from "@/api/mods";
+import type { IntegrityFinding, IntegrityReport, IntegrityVerdict } from "@/types";
+
+/**
+ * What the cheat scan currently sees, and the button that re-runs it.
+ *
+ * The hardest thing to get right here isn't the layout, it's the wording. Three of the four
+ * verdicts must not read as an accusation:
+ *
+ *   * `unknown` — we couldn't look. Shown as plainly as possible, because a user who reads
+ *     it as "fine" has been misled by the app.
+ *   * `clean` — nothing unaccounted for. Says what was scanned, so it doesn't read as a
+ *     guarantee.
+ *   * `suspect` — something is loaded that we don't recognise. This is the one that will be
+ *     seen most by people running nothing worse than an overlay we haven't listed, so it is
+ *     phrased as a question and paired with what to do about it.
+ *   * `flagged` — it matched the rule list. Only this one is allowed to sound like an
+ *     accusation.
+ */
+export default function IntegrityCard({ watching }: { watching: boolean }) {
+  const { t } = useI18n();
+  const [report, setReport] = useState<IntegrityReport | null>(null);
+  const [scanning, setScanning] = useState(false);
+
+  useEffect(() => {
+    let live = true;
+    void integrityStatus().then((r) => live && setReport(r));
+    // The watcher pushes on change, so an open Settings page follows a session rather than
+    // showing whatever was true when it was opened.
+    const un = onIntegrityReport((r) => live && setReport(r));
+    return () => {
+      live = false;
+      void un.then((f) => f());
+    };
+  }, []);
+
+  const rescan = useCallback(async () => {
+    setScanning(true);
+    try {
+      setReport(await integrityScanNow());
+    } catch (e) {
+      toast.error(t("integrity.scanFailed"), { description: String(e) });
+    }
+    setScanning(false);
+  }, [t]);
+
+  if (!watching) {
+    return (
+      <p className="text-[12px] leading-relaxed text-muted-foreground">
+        {t("integrity.offNote")}
+      </p>
+    );
+  }
+
+  const verdict = report?.verdict ?? "unknown";
+  const findings = report?.findings ?? [];
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-start gap-3 rounded-lg border border-white/[0.07] px-3 py-2.5">
+        <VerdictIcon verdict={verdict} />
+        <div className="min-w-0 flex-1">
+          <div className="text-[12.5px] text-foreground/90">{t(headline(verdict))}</div>
+          <div className="mt-0.5 text-[11.5px] leading-relaxed text-muted-foreground">
+            {verdict === "clean"
+              ? t("integrity.cleanDetail", { count: report?.modulesScanned ?? 0 })
+              : verdict === "unknown"
+                ? t(report?.gameRunning ? "integrity.unknownRunning" : "integrity.unknownIdle")
+                : t("integrity.foundDetail", { count: findings.length })}
+          </div>
+        </div>
+        <Button size="sm" variant="ghost" onClick={() => void rescan()} disabled={scanning}>
+          <RefreshCw className={cn("size-3.5", scanning && "animate-spin")} />
+          {t("integrity.scanNow")}
+        </Button>
+      </div>
+
+      {findings.length > 0 && (
+        <ul className="flex flex-col gap-1.5">
+          {findings.map((f) => (
+            <FindingRow key={`${f.name}:${f.path}`} finding={f} />
+          ))}
+        </ul>
+      )}
+
+      {/* The limit, stated where somebody about to trust this will read it. Leaving it to
+          the docs would let the card imply something it cannot deliver. */}
+      <p className="text-[11.5px] leading-relaxed text-faint">
+        {t("integrity.limitNote")}
+        {report && report.rulesVersion > 0 && (
+          <> {t("integrity.rulesVersion", { version: report.rulesVersion })}</>
+        )}
+      </p>
+    </div>
+  );
+}
+
+function VerdictIcon({ verdict }: { verdict: IntegrityVerdict }) {
+  const cls = "mt-0.5 size-4 flex-none";
+  if (verdict === "clean") return <ShieldCheck className={cn(cls, "text-success")} />;
+  if (verdict === "suspect") return <ShieldAlert className={cn(cls, "text-warning")} />;
+  if (verdict === "flagged") return <ShieldX className={cn(cls, "text-destructive")} />;
+  return <ShieldQuestion className={cn(cls, "text-muted-foreground")} />;
+}
+
+function headline(verdict: IntegrityVerdict): TKey {
+  switch (verdict) {
+    case "clean":
+      return "integrity.clean";
+    case "suspect":
+      return "integrity.suspect";
+    case "flagged":
+      return "integrity.flagged";
+    default:
+      return "integrity.unknown";
+  }
+}
+
+/** Why one thing was reported. A key rather than prose, so it survives six languages. */
+function reasonKey(finding: IntegrityFinding): TKey {
+  switch (finding.reason) {
+    case "ruleName":
+    case "ruleHash":
+      return "integrity.reasonRule";
+    case "loaderHijack":
+      return "integrity.reasonLoader";
+    default:
+      return finding.kind === "process"
+        ? "integrity.reasonProcess"
+        : "integrity.reasonForeign";
+  }
+}
+
+function FindingRow({ finding }: { finding: IntegrityFinding }) {
+  const { t } = useI18n();
+  const flagged = finding.severity === "flagged";
+  return (
+    <li
+      className={cn(
+        "rounded-lg border px-3 py-2 text-[12px]",
+        flagged
+          ? "border-destructive/30 bg-destructive/[0.07]"
+          : "border-white/[0.07] bg-white/[0.02]",
+      )}
+    >
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="truncate font-medium">{finding.name}</span>
+        {/* The rule's own label, never translated — a cheat's name is its name. */}
+        {finding.label && (
+          <span className="flex-none text-[11.5px] text-destructive">{finding.label}</span>
+        )}
+      </div>
+      <div className="mt-0.5 text-[11.5px] text-muted-foreground">{t(reasonKey(finding))}</div>
+      {finding.path && (
+        <div className="mt-0.5 truncate text-[11px] text-faint" title={finding.path}>
+          {finding.path}
+        </div>
+      )}
+    </li>
+  );
+}

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -39,6 +39,8 @@ import {
   setOverlayHotkey,
   setProfilesPath,
   setRunInBackground,
+  setIntegrityReport,
+  setIntegrityWatch,
   setWatchModsReload,
   setWineRunner,
   wineHostInfo,
@@ -67,6 +69,7 @@ import { useConfig } from "../../Context/Config";
 import GameSwitcher from "../Shell/GameSwitcher";
 import ReshadeCard from "./ReshadeCard";
 import SupportersCard from "./SupportersCard";
+import IntegrityCard from "./IntegrityCard";
 import { useTheme, type ThemeMode } from "../../Context/Theme";
 import { Trans } from "../../i18n";
 import { useI18n, type LocalePref, type TKey } from "../../i18n/context";
@@ -103,6 +106,7 @@ export type SectionId =
   | "frostmod"
   | "reshade"
   | "logs"
+  | "integrity"
   | "experimental"
   | "supporters"
   | "about";
@@ -141,6 +145,7 @@ const GROUPS: { label: TKey; sections: { id: SectionId; label: TKey }[] }[] = [
     label: "settings.groupAdvanced",
     sections: [
       { id: "logs", label: "settings.logs" },
+      { id: "integrity", label: "settings.integrity" },
       // Had no nav entry at all before this, and rendered in the middle of the scroll
       // with nothing pointing at it.
       { id: "experimental", label: "settings.experimental" },
@@ -391,6 +396,9 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
   const autoRunFrostmod = config.autoRunFrostmod ?? true;
   const instantRefresh = config.instantRefresh ?? true;
   const watchModsReload = config.watchModsReload ?? true;
+  // Defaults mirror the backend's: scanning is on, sharing the result is not.
+  const integrityWatch = config.integrityWatch ?? true;
+  const integrityReport = config.integrityReport ?? false;
 
   const overlayEnabled = config.overlayEnabled ?? true;
   const overlayHotkey = config.overlayHotkey || FALLBACK_HOTKEY;
@@ -610,6 +618,24 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
   const toggleWatchModsReload = async (v: boolean) => {
     try {
       await setWatchModsReload(v);
+      await reloadConfig();
+    } catch (e) {
+      toast.error(t("settings.updateFailed"), { description: String(e) });
+    }
+  };
+
+  const toggleIntegrityWatch = async (v: boolean) => {
+    try {
+      await setIntegrityWatch(v);
+      await reloadConfig();
+    } catch (e) {
+      toast.error(t("settings.updateFailed"), { description: String(e) });
+    }
+  };
+
+  const toggleIntegrityReport = async (v: boolean) => {
+    try {
+      await setIntegrityReport(v);
       await reloadConfig();
     } catch (e) {
       toast.error(t("settings.updateFailed"), { description: String(e) });
@@ -1604,6 +1630,27 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
           )}
 
           {/* experimental */}
+          {/* integrity — the cheat scan. Under Advanced rather than beside FrostMod: it is
+              about the game being honest, not about the app driving it, and the two toggles
+              here are the only ones on the page that decide what leaves the machine. */}
+          {active === "integrity" && (
+          <Section title={t("settings.integrity")} desc={t("settings.integrityDesc")}>
+            <ToggleRow
+              label={t("settings.integrityWatch")}
+              desc={t("settings.integrityWatchDesc")}
+              checked={integrityWatch}
+              onChange={toggleIntegrityWatch}
+            />
+            <ToggleRow
+              label={t("settings.integrityReport")}
+              desc={t("settings.integrityReportDesc")}
+              checked={integrityReport}
+              onChange={toggleIntegrityReport}
+            />
+            <IntegrityCard watching={integrityWatch} />
+          </Section>
+          )}
+
           {active === "experimental" && (
           <Section title={t("settings.experimental")}>
             <ToggleRow

--- a/src/Components/Studio/Designer/CanvasStage.tsx
+++ b/src/Components/Studio/Designer/CanvasStage.tsx
@@ -44,6 +44,12 @@ function checkerTile(): HTMLCanvasElement {
 const MIN_SCALE = 0.05;
 const MAX_SCALE = 4;
 
+/** How long after a press a second one still counts as a double-click, and how far it may move.
+ *  The platform's own thresholds aren't readable from a webview; these are the usual ones, and
+ *  the slop matters more than the interval on a touchpad, where a "stationary" finger drifts. */
+const DOUBLE_MS = 400;
+const DOUBLE_SLOP = 6;
+
 interface CanvasStageProps {
   sheet: Sheet;
   /** The sheet's composite, already drawn. Blitted here rather than redrawn. */
@@ -124,6 +130,10 @@ export function CanvasStage({
     null,
   );
   const painting = useRef(false);
+  // The last left press, for recognising a double-click ourselves. Null once one has been
+  // recognised, so a run of fast clicks pairs up rather than firing on every press after the
+  // second. See `onPointerDown` for why the DOM's own `dblclick` can't be used here.
+  const lastPress = useRef<{ t: number; x: number; y: number } | null>(null);
   // Which corner the pointer is over, purely so the cursor can say the layer is resizable.
   const [overHandle, setOverHandle] = useState(-1);
   // The piece of bodywork under the pointer. The whole reason the UV map is worth having is
@@ -411,10 +421,57 @@ export function CanvasStage({
     [brushSize, scale],
   );
 
+  /**
+   * Fill the view with one piece of bodywork.
+   *
+   * A shroud is a tenth of a 2048² sheet, and reaching it by wheel-and-drag means aiming at a
+   * shape whose edges are the thing you were trying to see. Double-click is the gesture because
+   * it costs no mode and no modifier: a paint tool lays its first dab where you clicked, and
+   * the view arrives at the part you were already pointing at.
+   */
+  const focusPart = useCallback(
+    (part: UvPart) => {
+      if (!fit || !box.w || !box.h) return;
+      // A degenerate island — one point, or a sliver — would divide the view to infinity.
+      const pw = Math.max(1, (part.maxU - part.minU) * sheet.width);
+      const ph = Math.max(1, (part.maxV - part.minV) * sheet.height);
+      // 0.8 leaves the part's surroundings in frame. A panel cut exactly to the edges gives
+      // nothing to judge where a decal sits relative to the seam beside it.
+      const z = Math.min(8, Math.max(0.25, (Math.min(box.w / pw, box.h / ph) * 0.8) / fit));
+      const s = fit * z;
+      const cx = ((part.minU + part.maxU) / 2) * sheet.width;
+      const cy = ((part.minV + part.maxV) / 2) * sheet.height;
+      setZoom(z);
+      // Pan is measured from the sheet's centre, which is where the blit is anchored.
+      setPan({ x: -(cx - sheet.width / 2) * s, y: -(cy - sheet.height / 2) * s });
+    },
+    [box.w, box.h, fit, sheet.width, sheet.height],
+  );
+
   const onPointerDown = useCallback(
     (e: React.PointerEvent<HTMLCanvasElement>) => {
       const at = toSheet(e.clientX, e.clientY);
       if (!at) return;
+      // The second press of a double-click, timed here rather than taken from the DOM's own
+      // `dblclick`. The canvas captures the pointer on every press so a stroke survives leaving
+      // the element, and a captured pointer is exactly the case where WebKit stops delivering
+      // `dblclick` — so the gesture has to be recognised from the presses we already get.
+      if (e.button === 0) {
+        const prev = lastPress.current;
+        const near = prev && Math.hypot(e.clientX - prev.x, e.clientY - prev.y) < DOUBLE_SLOP;
+        const quick = prev && e.timeStamp - prev.t < DOUBLE_MS;
+        lastPress.current = { t: e.timeStamp, x: e.clientX, y: e.clientY };
+        if (near && quick && parts.length) {
+          const part = partAt(parts, at.x / sheet.width, at.y / sheet.height);
+          if (part) {
+            // Forget the pair, so a third press starts a new one rather than focusing again
+            // on every press of a rapid series.
+            lastPress.current = null;
+            focusPart(part);
+            return;
+          }
+        }
+      }
       e.currentTarget.setPointerCapture(e.pointerId);
       // Middle and right drag pan, whatever the tool — panning while painting matters more
       // than it does while dragging a logo, because a stroke needs the part you can't see.
@@ -454,7 +511,20 @@ export function CanvasStage({
       onSelect(hit?.id ?? null);
       drag.current = { id: hit?.id ?? null, x: e.clientX, y: e.clientY };
     },
-    [handleAt, onPaintStart, onSelect, paints, selectedId, sheet.layers, toSheet, tool],
+    [
+      focusPart,
+      handleAt,
+      onPaintStart,
+      onSelect,
+      paints,
+      parts,
+      selectedId,
+      sheet.layers,
+      sheet.width,
+      sheet.height,
+      toSheet,
+      tool,
+    ],
   );
 
   const onPointerMove = useCallback(
@@ -567,32 +637,6 @@ export function CanvasStage({
     setPan({ x: 0, y: 0 });
   }, []);
 
-  /**
-   * Fill the view with one piece of bodywork.
-   *
-   * A shroud is a tenth of a 2048² sheet, and reaching it by wheel-and-drag means aiming at a
-   * shape whose edges are the thing you were trying to see. Double-click is the gesture because
-   * it costs no mode and no modifier: a paint tool still paints where you clicked, and the view
-   * arrives at the part you were already pointing at.
-   */
-  const focusPart = useCallback(
-    (part: UvPart) => {
-      if (!fit || !box.w || !box.h) return;
-      // A degenerate island — one point, or a sliver — would divide the view to infinity.
-      const pw = Math.max(1, (part.maxU - part.minU) * sheet.width);
-      const ph = Math.max(1, (part.maxV - part.minV) * sheet.height);
-      // 0.8 leaves the part's surroundings in frame. A panel cut exactly to the edges gives
-      // nothing to judge where a decal sits relative to the seam beside it.
-      const z = Math.min(8, Math.max(0.25, (Math.min(box.w / pw, box.h / ph) * 0.8) / fit));
-      const s = fit * z;
-      const cx = ((part.minU + part.maxU) / 2) * sheet.width;
-      const cy = ((part.minV + part.maxV) / 2) * sheet.height;
-      setZoom(z);
-      // Pan is measured from the sheet's centre, which is where the blit is anchored.
-      setPan({ x: -(cx - sheet.width / 2) * s, y: -(cy - sheet.height / 2) * s });
-    },
-    [box.w, box.h, fit, sheet.width, sheet.height],
-  );
 
   const ringed = paints && hasTip(tool);
   // Corners come out of `layerCorners` clockwise from the top left, so 0/2 are one diagonal
@@ -629,16 +673,6 @@ export function CanvasStage({
           if (cursorRef.current) cursorRef.current.style.opacity = "1";
         }}
         onWheel={onWheel}
-        // The part under the pointer, not the one the hover last recorded: a double-click can
-        // land before a hover has been reported on a touchpad, and framing the previous part
-        // would move the view away from what was just clicked.
-        onDoubleClick={(e) => {
-          if (!parts.length) return;
-          const at = toSheet(e.clientX, e.clientY);
-          if (!at) return;
-          const part = partAt(parts, at.x / sheet.width, at.y / sheet.height);
-          if (part) focusPart(part);
-        }}
         onContextMenu={(e) => e.preventDefault()}
       />
       <div
@@ -660,7 +694,11 @@ export function CanvasStage({
         {overPart && (
           <>
             <span>·</span>
-            <span className="max-w-[160px] truncate text-white/70" title={t("designer.focusHint")}>
+            {/* The node first, because a group's name is whatever its author typed and the node
+                is the bike's own part — `chassis` still means the shrouds on a pack that calls
+                them `Metal.027`. */}
+            {overPart.owner && <span className="text-white/70">{overPart.owner}</span>}
+            <span className="max-w-[190px] truncate" title={t("designer.focusHint")}>
               {overAlso ? t("designer.partOver", { part: overPart.label, over: overAlso }) : overPart.label}
             </span>
             {/* Which flank, when the model can say. `both` is the one that saves an

--- a/src/Components/Studio/Designer/Designer.tsx
+++ b/src/Components/Studio/Designer/Designer.tsx
@@ -37,7 +37,7 @@ import { LayerInspector } from "./LayerInspector";
 import { PaintTools } from "./PaintTools";
 import { bitmapFromRgba, composite, hasInk, sheetTexture, toPng } from "./composite";
 import { EMPTY_GHOST, ghostShows, type Ghost } from "./ghost";
-import { partPath, uvParts, uvWireframe, type UvPart } from "./uv";
+import { partAt, partBox, partPath, uvParts, uvWireframe, type UvPart } from "./uv";
 import {
   blankSheet,
   imageLayer,
@@ -110,7 +110,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   const [paint, setPaint] = useState<PaintSettings>(DEFAULT_PAINT);
   // Painting history, and a counter to bring its undo/redo buttons back into a render — the
   // stack itself is a mutable object, so nothing about it would reach React on its own.
-  const history = useRef(new PaintHistory());
+  const history = useRef(new PaintHistory<Sheet[]>());
   const [historyRev, setHistoryRev] = useState(0);
   // The stroke in progress. A ref because it changes on every pointer sample and no render
   // depends on it — the pixels it writes are what reach the screen.
@@ -167,6 +167,12 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   // What was last published as `overrideNames`. Held beside the state so the recomposite below
   // can tell whether it has anything to say *before* saying it — see the note there.
   const publishedNames = useRef("");
+
+  // The sheets as they stand, for the undo stack to snapshot on its way past an edit. A mirror
+  // rather than a read of `sheets`: the callbacks that mutate are memoised on their own
+  // dependencies, and one holding a stale array would remember a state that had already moved on.
+  const sheetsRef = useRef(sheets);
+  sheetsRef.current = sheets;
 
   const active = sheets.find((s) => s.id === activeId) ?? null;
   const bump = useCallback(() => setVersion((v) => v + 1), []);
@@ -272,21 +278,46 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     };
   }, []);
 
-  const patchSheet = useCallback((id: string, fn: (s: Sheet) => Sheet) => {
-    // Every route into a sheet but a stroke comes through here, and none of them says where it
-    // drew. Marking the sheet wholly dirty on the way past is what lets the recomposite treat a
-    // region as a promise rather than a hint: if one is there, a stroke put it there.
-    dirty.current.set(id, null);
-    setSheets((prev) => prev.map((s) => (s.id === id ? fn(s) : s)));
+  /**
+   * Record the document as it stands, so the edit about to happen can be taken back.
+   *
+   * Before the mutation, never after: what undo needs is the state that existed a moment ago,
+   * and once `setSheets` has run there is nothing left holding it. `key` collapses a run of
+   * edits that are one gesture — see `PaintHistory.pushDoc`.
+   */
+  const remember = useCallback((key: string | null = null) => {
+    history.current.pushDoc(sheetsRef.current, key);
+    setHistoryRev((v) => v + 1);
   }, []);
 
+  const patchSheet = useCallback(
+    /**
+     * `undoKey` names the gesture for coalescing, or `false` for an edit the history must not
+     * record — one whose other half lives outside the document, where an undo would restore the
+     * sheet and leave that half where it was.
+     */
+    (id: string, fn: (s: Sheet) => Sheet, undoKey: string | null | false = null) => {
+      // Every route into a sheet but a stroke comes through here, and none of them says where it
+      // drew. Marking the sheet wholly dirty on the way past is what lets the recomposite treat a
+      // region as a promise rather than a hint: if one is there, a stroke put it there.
+      if (undoKey !== false) remember(undoKey);
+      dirty.current.set(id, null);
+      setSheets((prev) => prev.map((s) => (s.id === id ? fn(s) : s)));
+    },
+    [remember],
+  );
+
   const patchLayer = useCallback(
-    (layerId: string, fn: (l: Layer) => Layer) => {
+    (layerId: string, fn: (l: Layer) => Layer, undoKey: string | null | false = null) => {
       if (!activeId) return;
-      patchSheet(activeId, (s) => ({
-        ...s,
-        layers: s.layers.map((l) => (l.id === layerId ? fn(l) : l)),
-      }));
+      patchSheet(
+        activeId,
+        (s) => ({
+          ...s,
+          layers: s.layers.map((l) => (l.id === layerId ? fn(l) : l)),
+        }),
+        undoKey,
+      );
     },
     [activeId, patchSheet],
   );
@@ -414,17 +445,6 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     [active, addPaintLayer, selectedId],
   );
 
-  const startPaint = useCallback(
-    (at: Point) => {
-      if (!target || !activeId) return;
-      const next = new Stroke(target.canvas, paint, at);
-      stroke.current = next;
-      // Straight through rather than queued: the press is the one sample nobody would forgive a
-      // frame's wait on, and a tool that puts nothing down on the press has nothing to show.
-      if (next.dirty) touchPaint(activeId, target.id, next.dirty);
-    },
-    [activeId, paint, target, touchPaint],
-  );
 
   const movePaint = useCallback(
     (points: Point[], constrain: boolean) => {
@@ -471,21 +491,49 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     [historyRev],
   );
 
+  /**
+   * Reading and replacing the document for the history — plus putting the cursor somewhere real
+   * afterwards.
+   *
+   * Undoing the sheet you were looking at leaves `activeId` naming something that no longer
+   * exists, and the editor would come back empty rather than showing what it just restored. The
+   * same for a selected layer. Neither is part of the document, so neither is restored by it.
+   */
+  const docAccess = useMemo(
+    () => ({
+      read: () => sheetsRef.current,
+      write: (next: Sheet[]) => {
+        setSheets(next);
+        setActiveId((cur) => (cur && next.some((s) => s.id === cur) ? cur : next[0]?.id ?? null));
+        setSelectedId((cur) =>
+          cur && next.some((s) => s.layers.some((l) => l.id === cur)) ? cur : null,
+        );
+      },
+    }),
+    [],
+  );
+
   // Not while the pointer is still down: the stroke redraws its layer from its own snapshot on
   // the next sample, so an undo mid-drag would be silently taken back a moment later.
   const undo = useCallback(() => {
     if (stroke.current) return;
-    const entry = history.current.undo(paintCanvas);
+    const entry = history.current.undo(paintCanvas, docAccess);
     setHistoryRev((v) => v + 1);
-    if (entry) touchPaint(entry.sheetId, entry.layerId);
-  }, [paintCanvas, touchPaint]);
+    if (!entry) return;
+    // A document step replaces sheet objects wholesale, and the recomposite already follows
+    // sheet identity — so it needs no region, only to be told the drawing moved.
+    if (entry.kind === "pixels") touchPaint(entry.sheetId, entry.layerId);
+    else bump();
+  }, [bump, docAccess, paintCanvas, touchPaint]);
 
   const redo = useCallback(() => {
     if (stroke.current) return;
-    const entry = history.current.redo(paintCanvas);
+    const entry = history.current.redo(paintCanvas, docAccess);
     setHistoryRev((v) => v + 1);
-    if (entry) touchPaint(entry.sheetId, entry.layerId);
-  }, [paintCanvas, touchPaint]);
+    if (!entry) return;
+    if (entry.kind === "pixels") touchPaint(entry.sheetId, entry.layerId);
+    else bump();
+  }, [bump, docAccess, paintCanvas, touchPaint]);
 
   // Which paint layers exist, as a string. `sheets` changes on every pointer sample of a
   // stroke; this changes only when one is added or deleted, which is the only time the
@@ -581,6 +629,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
         base: bitmap,
         layers: [],
       }));
+      remember();
       setSheets(next);
       setActiveId(next[0]?.id ?? null);
       setSelectedId(null);
@@ -588,7 +637,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
       bump();
       toast.success(t("designer.loadedSheets", { count: String(next.length) }));
     },
-    [bump, readImage, t],
+    [bump, readImage, remember, t],
   );
 
   const startFromPaint = useCallback(async () => {
@@ -646,11 +695,12 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     // the difference between a paint that shows and a paint that doesn't.
     const suggested = missingHints[0] ?? "";
     const sheet = blankSheet(suggested, BLANK_SIZE);
+    remember();
     setSheets((prev) => [...prev, sheet]);
     setActiveId(sheet.id);
     setSelectedId(null);
     bump();
-  }, [bump, missingHints]);
+  }, [bump, missingHints, remember]);
 
   /**
    * One sheet per colour texture the model asks for that isn't on the list yet.
@@ -664,11 +714,12 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   const addHintSheets = useCallback(() => {
     const made = missingHints.map((h) => blankSheet(h, BLANK_SIZE));
     if (!made.length) return;
+    remember();
     setSheets((prev) => [...prev, ...made]);
     setActiveId(made[0].id);
     setSelectedId(null);
     bump();
-  }, [bump, missingHints]);
+  }, [bump, missingHints, remember]);
 
   const addImage = useCallback(async () => {
     if (!active) return;
@@ -714,7 +765,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
 
   const moveLayer = useCallback(
     (id: string, dx: number, dy: number) => {
-      patchLayer(id, (l) => ({ ...l, x: l.x + dx, y: l.y + dy }));
+      patchLayer(id, (l) => ({ ...l, x: l.x + dx, y: l.y + dy }), `layer:${id}`);
       bump();
     },
     [bump, patchLayer],
@@ -723,7 +774,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   /** A corner drag, as an absolute scale. Clamped by the stage to the inspector's range. */
   const scaleLayer = useCallback(
     (id: string, scale: number) => {
-      patchLayer(id, (l) => ({ ...l, scale }));
+      patchLayer(id, (l) => ({ ...l, scale }), `layer:${id}`);
       bump();
     },
     [bump, patchLayer],
@@ -755,6 +806,31 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   const parts = useMemo<UvPart[]>(
     () => (geometry ? uvParts(geometry, activeName, { assembled: bike && assembled }) : []),
     [geometry, activeName, bike, assembled],
+  );
+
+  const startPaint = useCallback(
+    (at: Point) => {
+      if (!target || !activeId) return;
+      // The bucket fills the panel under the press, not the sheet. Worked out here rather than
+      // inside `Stroke`, because the parts are the editor's knowledge of the model and paint.ts
+      // is deliberately ignorant of it — it puts pixels down, wherever it is told to.
+      let fillTo: { path: Path2D; box: Region } | null = null;
+      if (paint.tool === "fill" && active && parts.length) {
+        const under = partAt(parts, at.x / active.width, at.y / active.height);
+        if (under) {
+          fillTo = {
+            path: partPath(under, active.width, active.height),
+            box: partBox(under, active.width, active.height),
+          };
+        }
+      }
+      const next = new Stroke(target.canvas, paint, at, fillTo);
+      stroke.current = next;
+      // Straight through rather than queued: the press is the one sample nobody would forgive a
+      // frame's wait on, and a tool that puts nothing down on the press has nothing to show.
+      if (next.dirty) touchPaint(activeId, target.id, next.dirty);
+    },
+    [active, activeId, paint, parts, target, touchPaint],
   );
 
   /** Pin the selected layer to a piece of bodywork, or let it cover the sheet again. */
@@ -859,13 +935,17 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
       const sheet = sheets.find((s) => s.id === sheetId);
       if (!sheet) return;
       const ghost = ghostOf(sheetId);
+      // Not recorded by the history, either way: the bitmap moves between the sheet and the
+      // ghost, and the ghost isn't part of the document — an undo would put the template back
+      // on the sheet while the ghost still held it, which is the copy this is careful not to
+      // make. Pressing the button again is the way back, as it always was.
       if (sheet.base) {
         const template = sheet.base;
-        patchSheet(sheetId, (s) => ({ ...s, base: null }));
+        patchSheet(sheetId, (s) => ({ ...s, base: null }), false);
         patchGhost(sheetId, (g) => ({ ...g, template, showTemplate: true }));
       } else if (ghost.template) {
         const base = ghost.template;
-        patchSheet(sheetId, (s) => ({ ...s, base }));
+        patchSheet(sheetId, (s) => ({ ...s, base }), false);
         patchGhost(sheetId, (g) => ({ ...g, template: null }));
       }
       bump();
@@ -973,20 +1053,26 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
    * the `.pnt`. The mesh binds by name either way, but a paint whose sheets are ordered the
    * way its author expects is easier to diff and to hand to somebody else.
    */
-  const reorderSheet = useCallback((id: string, delta: number) => {
-    setSheets((prev) => {
-      const at = prev.findIndex((s) => s.id === id);
-      const to = at + delta;
-      if (at < 0 || to < 0 || to >= prev.length) return prev;
-      const next = [...prev];
-      const [moved] = next.splice(at, 1);
-      next.splice(to, 0, moved);
-      return next;
-    });
-  }, []);
+  const reorderSheet = useCallback(
+    (id: string, delta: number) => {
+      // Keyed, so walking a sheet three places up is one step back rather than three.
+      remember(`sheet-order:${id}`);
+      setSheets((prev) => {
+        const at = prev.findIndex((s) => s.id === id);
+        const to = at + delta;
+        if (at < 0 || to < 0 || to >= prev.length) return prev;
+        const next = [...prev];
+        const [moved] = next.splice(at, 1);
+        next.splice(to, 0, moved);
+        return next;
+      });
+    },
+    [remember],
+  );
 
   const removeSheet = useCallback(
     (id: string) => {
+      remember();
       setSheets((prev) => {
         const next = prev.filter((s) => s.id !== id);
         setActiveId((cur) => (cur === id ? next[0]?.id ?? null : cur));
@@ -994,7 +1080,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
       });
       bump();
     },
-    [bump],
+    [bump, remember],
   );
 
   /** Why saving isn't possible yet, as a translated message — or null when it is, and on an
@@ -1215,7 +1301,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
               onClip={clipLayer}
               onFit={fitLayer}
               onChange={(fn) => {
-                patchLayer(selected.id, fn);
+                patchLayer(selected.id, fn, `layer:${selected.id}`);
                 bump();
               }}
             />

--- a/src/Components/Studio/Designer/paint.ts
+++ b/src/Components/Studio/Designer/paint.ts
@@ -341,6 +341,16 @@ export class Stroke {
     private readonly target: HTMLCanvasElement,
     private readonly settings: PaintSettings,
     at: Point,
+    /**
+     * The piece of bodywork the fill is confined to, when there is one under the press.
+     *
+     * A bike sheet is a dozen panels side by side, and a flood of the whole layer is almost
+     * never what "fill" was reached for — it buries the eleven you weren't pointing at, and
+     * every one of them has to be painted back. Confined to the part, the bucket does what it
+     * looks like it does. Only the fill uses it: a brush stroke is already aimed by the hand,
+     * and clipping one would make it stop dead at a seam the hand can't see.
+     */
+    fillTo?: { path: Path2D; box: Region } | null,
   ) {
     this.before = cloneCanvas(target);
     this.scratch = scratchFor(target.width, target.height);
@@ -354,9 +364,12 @@ export class Stroke {
       const ctx = this.scratch.getContext("2d");
       if (ctx) {
         ctx.fillStyle = withAlpha(this.settings.colorA, 1);
-        ctx.fillRect(0, 0, this.scratch.width, this.scratch.height);
+        // Nonzero, so the triangles a part is made of stop being separate shapes and the seams
+        // between them don't come out unfilled.
+        if (fillTo) ctx.fill(fillTo.path, "nonzero");
+        else ctx.fillRect(0, 0, this.scratch.width, this.scratch.height);
       }
-      this.mark(this.whole());
+      this.mark(fillTo ? fillTo.box : this.whole());
       this.painted = true;
     } else if (!DRAG_TOOLS.has(this.settings.tool)) {
       this.dab(at, at);
@@ -484,9 +497,46 @@ export class Stroke {
 /* ── Undo ───────────────────────────────────────────────────────────────────────────────── */
 
 export interface Snapshot {
+  kind: "pixels";
   sheetId: string;
   layerId: string;
   canvas: HTMLCanvasElement;
+}
+
+/**
+ * The document as it was before an edit that wasn't pixels — a layer added, moved, deleted, a
+ * sheet renamed or reordered.
+ *
+ * Generic over the document so this file keeps knowing nothing about sheets and layers. It
+ * stores whatever it was handed and hands the same thing back, which is all a snapshot of
+ * immutable state has to do.
+ */
+export interface DocStep<Doc> {
+  kind: "doc";
+  doc: Doc;
+  /**
+   * What kind of edit it was, or null for one that stands alone.
+   *
+   * Dragging a layer across the sheet is one edit to a person and two hundred to the state that
+   * records it. Consecutive edits sharing a key inside `COALESCE_MS` collapse into the first,
+   * so one undo takes back the whole drag rather than a pixel of it.
+   */
+  key: string | null;
+  at: number;
+}
+
+export type Step<Doc> = Snapshot | DocStep<Doc>;
+
+/** How long a run of same-key edits keeps counting as one gesture. */
+const COALESCE_MS = 700;
+
+/** Steps to keep, so a session of small edits can't grow the timeline without end. */
+const MAX_STEPS = 200;
+
+/** Reading and replacing the document, for the steps that are made of it rather than of pixels. */
+export interface DocAccess<Doc> {
+  read: () => Doc;
+  write: (doc: Doc) => void;
 }
 
 /**
@@ -499,15 +549,20 @@ export interface Snapshot {
 const MAX_PIXELS = 24_000_000;
 
 /**
- * Painting history, for the paint layers only.
+ * The editor's undo, over both of the things an edit can be.
  *
- * Deliberately not the whole editor's undo: adding, moving and deleting layers are React state
- * and would need their own mechanism. Undoing a brush stroke you can see is the thing you reach
- * for while painting, and it's the thing that has no other way back.
+ * A stroke changes pixels inside a canvas; adding, moving or deleting a layer changes the
+ * document those canvases hang off. Two stacks would be two timelines, and Ctrl+Z would take
+ * back whichever of them happened to be asked — so both kinds of step live in this one, in the
+ * order they were made.
+ *
+ * Pixels are remembered by copying them, which is why the budget below is counted in pixels.
+ * Document steps cost a reference each: every mutation replaces the state rather than editing
+ * it, so the previous version is still whole and still there to be pointed at.
  */
-export class PaintHistory {
-  private past: Snapshot[] = [];
-  private future: Snapshot[] = [];
+export class PaintHistory<Doc = unknown> {
+  private past: Step<Doc>[] = [];
+  private future: Step<Doc>[] = [];
 
   get canUndo() {
     return this.past.length > 0;
@@ -518,8 +573,30 @@ export class PaintHistory {
   }
 
   push(sheetId: string, layerId: string, before: HTMLCanvasElement) {
-    this.past.push({ sheetId, layerId, canvas: before });
+    this.past.push({ kind: "pixels", sheetId, layerId, canvas: before });
     // A new stroke is a new branch of the drawing; whatever was undone away is gone.
+    this.future = [];
+    this.trim();
+  }
+
+  /**
+   * Remember the document as it is *before* an edit is applied to it.
+   *
+   * Called by the edit rather than derived from watching the state, because only the edit knows
+   * that it is one: the state changes on every pointer sample of a stroke too, and a timeline
+   * built by watching would be a hundred steps of a single brush line.
+   */
+  pushDoc(doc: Doc, key: string | null = null) {
+    const top = this.past[this.past.length - 1];
+    const now = performance.now();
+    if (top?.kind === "doc" && key !== null && top.key === key && now - top.at < COALESCE_MS) {
+      // Still the same gesture. The state to go back to is the one already held, so this keeps
+      // that and only extends the window — a slow drag stays one step however long it takes.
+      top.at = now;
+      this.future = [];
+      return;
+    }
+    this.past.push({ kind: "doc", doc, key, at: now });
     this.future = [];
     this.trim();
   }
@@ -532,12 +609,21 @@ export class PaintHistory {
    * the visible layers were never in.
    */
   private step(
-    from: Snapshot[],
-    to: Snapshot[],
+    from: Step<Doc>[],
+    to: Step<Doc>[],
     resolve: (layerId: string) => HTMLCanvasElement | null,
-  ): Snapshot | null {
+    doc: DocAccess<Doc>,
+  ): Step<Doc> | null {
     while (from.length) {
       const entry = from[from.length - 1];
+      if (entry.kind === "doc") {
+        from.pop();
+        // What's on screen now becomes the way back, so undo and redo are the same move in
+        // opposite directions and neither has to know which way it is going.
+        to.push({ ...entry, doc: doc.read() });
+        doc.write(entry.doc);
+        return entry;
+      }
       const live = resolve(entry.layerId);
       if (!live) {
         from.pop();
@@ -560,17 +646,29 @@ export class PaintHistory {
   }
 
   /** Restore the previous state onto its layer, and hand back which one moved. */
-  undo(resolve: (layerId: string) => HTMLCanvasElement | null): Snapshot | null {
-    return this.step(this.past, this.future, resolve);
+  undo(
+    resolve: (layerId: string) => HTMLCanvasElement | null,
+    doc: DocAccess<Doc>,
+  ): Step<Doc> | null {
+    return this.step(this.past, this.future, resolve, doc);
   }
 
-  redo(resolve: (layerId: string) => HTMLCanvasElement | null): Snapshot | null {
-    return this.step(this.future, this.past, resolve);
+  redo(
+    resolve: (layerId: string) => HTMLCanvasElement | null,
+    doc: DocAccess<Doc>,
+  ): Step<Doc> | null {
+    return this.step(this.future, this.past, resolve, doc);
   }
 
-  /** Drop everything belonging to layers that are no longer there. True if any were. */
+  /**
+   * Drop the pixel steps belonging to layers that are no longer there. True if any were.
+   *
+   * Document steps are kept whatever happened to a layer — one of them is very likely the step
+   * that would *bring it back*, and dropping it because its subject is currently missing is
+   * exactly backwards.
+   */
   keepOnly(alive: (sheetId: string, layerId: string) => boolean): boolean {
-    const live = (s: Snapshot) => alive(s.sheetId, s.layerId);
+    const live = (s: Step<Doc>) => s.kind === "doc" || alive(s.sheetId, s.layerId);
     const before = this.past.length + this.future.length;
     this.past = this.past.filter(live);
     this.future = this.future.filter(live);
@@ -583,11 +681,16 @@ export class PaintHistory {
   }
 
   private trim() {
-    const cost = (s: Snapshot) => s.canvas.width * s.canvas.height;
+    // A document step holds no pixels, so it costs nothing against the pixel budget and is
+    // counted only against the step count below.
+    const cost = (s: Step<Doc>) => (s.kind === "doc" ? 0 : s.canvas.width * s.canvas.height);
     let total = [...this.past, ...this.future].reduce((n, s) => n + cost(s), 0);
     // Oldest first — the step you're least likely to reach for is the one furthest back.
     while (total > MAX_PIXELS && this.past.length > 1) {
-      total -= cost(this.past.shift() as Snapshot);
+      total -= cost(this.past.shift() as Step<Doc>);
+    }
+    while (this.past.length + this.future.length > MAX_STEPS && this.past.length > 1) {
+      this.past.shift();
     }
   }
 }

--- a/src/Components/Studio/Designer/uv.ts
+++ b/src/Components/Studio/Designer/uv.ts
@@ -56,6 +56,16 @@ const FACE_TOLERANCE = 0.3;
 export interface UvPart {
   /** Mesh-group name from the `.edf` — `shroud`, `frame.005`, `chain`. */
   label: string;
+  /**
+   * The mesh node the group sits on — `chassis`, `steer`, `fsusp`, `rsusp` — or null when the
+   * group is spread over several.
+   *
+   * Worth carrying because a group name is whatever the author typed, and authors type
+   * anything: the TM pack calls its plastic panels `Metal.NNN` and its metal ones
+   * `Plastics.NNN`. The node is the bike's own part, so it still says *where* — a shroud is on
+   * the chassis and a rear fender is on the rear suspension, however the group is named.
+   */
+  owner: string | null;
   /** Triangle corners in uv space, six numbers per triangle: u0,v0,u1,v1,u2,v2. */
   tris: Float32Array;
   /**
@@ -210,6 +220,7 @@ export function uvParts(
   const byLabel = new Map<string, number[]>();
   const flanksByLabel = new Map<string, number[]>();
   const facesByLabel = new Map<string, number[]>();
+  const nodesByLabel = new Map<string, Set<string>>();
   for (const node of nodes) {
     if (!node.uvs.length || !node.indices.length) continue;
     const triCount = Math.floor(node.indices.length / 3);
@@ -227,6 +238,12 @@ export function uvParts(
         flat = [];
         byLabel.set(label, flat);
       }
+      let owners = nodesByLabel.get(label);
+      if (!owners) {
+        owners = new Set();
+        nodesByLabel.set(label, owners);
+      }
+      owners.add(node.name);
       let sides = flanksByLabel.get(label);
       if (!sides && sided) {
         sides = [];
@@ -277,8 +294,12 @@ export function uvParts(
     }
     const sides = flanksByLabel.get(label);
     const faces = facesByLabel.get(label);
+    const owners = nodesByLabel.get(label);
     parts.push({
       label,
+      // Only when it's the one answer. A group spread over three nodes has no single place to
+      // point at, and naming the first would be picking one arbitrarily.
+      owner: owners?.size === 1 ? [...owners][0] : null,
       tris: new Float32Array(flat),
       flanks: sides ? new Uint8Array(sides) : null,
       side: sides ? summarise(sides) : null,
@@ -314,6 +335,27 @@ export function partPath(part: UvPart, width: number, height: number): Path2D {
     path.closePath();
   }
   return path;
+}
+
+/**
+ * A part's bounds in sheet pixels, rounded outwards.
+ *
+ * Outwards because this is what a redraw is told to catch up with: a box rounded inwards leaves
+ * the half-pixel at the edge of a fill on the layer and missing from the composite.
+ */
+export function partBox(
+  part: UvPart,
+  width: number,
+  height: number,
+): { x: number; y: number; w: number; h: number } {
+  const x = Math.max(0, Math.floor(part.minU * width));
+  const y = Math.max(0, Math.floor(part.minV * height));
+  return {
+    x,
+    y,
+    w: Math.min(width, Math.ceil(part.maxU * width)) - x,
+    h: Math.min(height, Math.ceil(part.maxV * height)) - y,
+  };
 }
 
 /** Whether (u,v) is inside a triangle, by the sign of the three edge cross-products. */

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -15,6 +15,8 @@ import type {
   FrostmodInstallReport,
   FrostmodReload,
   FrostmodStatus,
+  IntegrityReport,
+  RiderIntegrity,
   RuntimeInstallOutcome,
   VcRuntime,
   InstalledMod,
@@ -1798,6 +1800,44 @@ export function onVoicePtt(cb: (down: boolean) => void): Promise<UnlistenFn> {
 /** Toggle watching the mods folder to reload the game on external changes. */
 export function setWatchModsReload(enabled: boolean): Promise<void> {
   return invoke<void>("set_watch_mods_reload", { enabled });
+}
+
+/**
+ * The current cheat-scan verdict, without waiting for the next pass.
+ *
+ * Returns `unknown` before the first scan of a session — which is the honest answer, not an
+ * error to hide.
+ */
+export function integrityStatus(): Promise<IntegrityReport> {
+  return invoke<IntegrityReport>("integrity_status");
+}
+
+/** Scan now rather than at the next pass, refreshing the rule list first. */
+export function integrityScanNow(): Promise<IntegrityReport> {
+  return invoke<IntegrityReport>("integrity_scan_now");
+}
+
+/** Toggle watching the running game for an attached cheat. */
+export function setIntegrityWatch(enabled: boolean): Promise<void> {
+  return invoke<void>("set_integrity_watch", { enabled });
+}
+
+/** Toggle publishing this client's verdict to the servers it joins. */
+export function setIntegrityReport(enabled: boolean): Promise<void> {
+  return invoke<void>("set_integrity_report", { enabled });
+}
+
+/** What the riders on one server have attested. Server owners and riders on it only. */
+export function integrityServerReports(serverId: string): Promise<RiderIntegrity[]> {
+  return invoke<RiderIntegrity[]>("integrity_server_reports", { serverId });
+}
+
+/** Fires when the verdict *changes* — a settled session is silent rather than pushing an
+ *  identical report every 45 seconds. */
+export function onIntegrityReport(
+  cb: (report: IntegrityReport) => void,
+): Promise<UnlistenFn> {
+  return listen<IntegrityReport>("integrity-report", (e) => cb(e.payload));
 }
 
 /** Sentinel slug the backend tags folder-watch reloads with (vs in-app installs). */

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -1341,11 +1341,17 @@ export function isBlockedDownload(opt: { url: string; host: string }): boolean {
   return BLOCKED_HOST_PATTERNS.some((p) => s.includes(p));
 }
 
+/**
+ * Every download a mod offers, best first.
+ *
+ * Dedicated-server builds are sorted last rather than dropped. Hiding them read as "this
+ * mod has one file" while the flag was a guess — a mislabelled block took the only download
+ * off the page, and a server build the parser missed was silently preselected instead.
+ * Ranked below even a browser-only mirror, since that at least installs something playable.
+ */
 export function sortMirrors(detail: ModDetail): DownloadOption[] {
-  const all = detail.downloads ?? [];
-  const playable = all.filter((d) => !d.isServer);
-  const pool = playable.length ? playable : all;
-  return [...pool].sort((a, b) => {
+  return [...(detail.downloads ?? [])].sort((a, b) => {
+    if (a.isServer !== b.isServer) return Number(a.isServer) - Number(b.isServer);
     const ab = isBlockedDownload(a) ? 1 : 0;
     const bb = isBlockedDownload(b) ? 1 : 0;
     if (ab !== bb) return ab - bb;
@@ -1353,17 +1359,40 @@ export function sortMirrors(detail: ModDetail): DownloadOption[] {
   });
 }
 
+/** The downloads that install something playable — everything but the server builds. */
+export function playableMirrors(mirrors: DownloadOption[]): DownloadOption[] {
+  return mirrors.filter((m) => !m.isServer);
+}
+
+/**
+ * Which of `mirrors` (in {@link sortMirrors} order) a picker should start on: the best
+ * playable file, never a server build while anything else is on offer.
+ */
+export function defaultMirrorIndex(mirrors: DownloadOption[]): number {
+  const i = mirrors.findIndex((m) => !m.isServer);
+  return i >= 0 ? i : 0;
+}
+
+/** A mod whose every download is a dedicated-server build — nothing here is playable. */
+export function isServerOnly(mirrors: DownloadOption[]): boolean {
+  return mirrors.length > 0 && mirrors.every((m) => m.isServer);
+}
+
 export function pickDownloadForBike(
   mirrors: DownloadOption[],
   bikeName: string,
 ): DownloadOption | null {
   if (mirrors.length === 0) return null;
-  const fallback = () => mirrors.find((m) => m.isDefault) ?? mirrors[0];
+  // A sound pack's server build is named after the same bike as the file to play with, so
+  // it matches just as well — pick among the playable ones while there are any.
+  const playable = playableMirrors(mirrors);
+  const pool = playable.length ? playable : mirrors;
+  const fallback = () => pool.find((m) => m.isDefault) ?? pool[0];
   const want = tokens(bikeName);
   if (want.size === 0) return fallback();
 
   let best: { m: DownloadOption; score: number } | null = null;
-  for (const m of mirrors) {
+  for (const m of pool) {
     const fname = m.url.split(/[/\\]/).pop() ?? "";
     const hay = tokens(`${m.label} ${m.host} ${fname}`);
     let score = 0;
@@ -1436,7 +1465,13 @@ export interface QuickInstallParams {
 
 export type QuickInstallResult =
   | { ok: true; params: QuickInstallParams }
-  | { ok: false; reason: "blocked" | "none"; title: string; host?: string };
+  | {
+      ok: false;
+      /** `serverOnly` — every file the page offers is a dedicated-server build. */
+      reason: "blocked" | "none" | "serverOnly";
+      title: string;
+      host?: string;
+    };
 
 /**
  * The folder a one-click install from the Browse grid uses — the same answer the install
@@ -1454,8 +1489,12 @@ export async function resolveQuickInstall(
 ): Promise<QuickInstallResult> {
   const detail = await getModDetail(slug);
   const mirrors = sortMirrors(detail);
-  const primary = mirrors[0];
+  const primary = mirrors[defaultMirrorIndex(mirrors)];
   if (!primary) return { ok: false, reason: "none", title: detail.title };
+  // One click can't ask which build was meant, and a dedicated-server file installed by
+  // mistake looks installed while the game shows nothing. Send them to the mod's page,
+  // where every download is spelled out.
+  if (primary.isServer) return { ok: false, reason: "serverOnly", title: detail.title };
   if (isBlockedDownload(primary))
     return { ok: false, reason: "blocked", title: detail.title, host: primary.host };
 

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1683,4 +1683,44 @@ export const de: Translation = {
   "trackViewer.whyDetails": "Warum?",
   "trackViewer.copyDetails": "Details kopieren",
   "trackViewer.copied": "Kopiert",
+  "settings.integrity": "Cheat-Erkennung",
+  "settings.integrityDesc":
+    "MX Bikes hat keinen Anti-Cheat, ein manipulierter Client sieht also genauso aus wie ein ehrlicher. Dies prüft, ob etwas an deinem laufenden Spiel hängt.",
+  "settings.integrityWatch": "Laufendes Spiel überwachen",
+  "settings.integrityWatchDesc":
+    "Prüft, was während des Spielens in MX Bikes geladen ist. Nichts verlässt deinen Rechner.",
+  "settings.integrityReport": "Ergebnis mit Servern teilen",
+  "settings.integrityReportDesc":
+    "Lässt den Admin des Servers, auf dem du bist, dein Ergebnis sehen. Bekannte Cheats werden benannt; nur Unbekanntes wird gezählt, nie benannt.",
+  "integrity.clean": "Nichts Unerklärliches",
+  "integrity.suspect": "Etwas Unbekanntes ist geladen",
+  "integrity.flagged": "Ein bekannter Cheat hängt am Spiel",
+  "integrity.unknown": "Nicht geprüft",
+  "integrity.cleanDetail_one": "{{count}} geladene Datei geprüft.",
+  "integrity.cleanDetail_other": "{{count}} geladene Dateien geprüft.",
+  "integrity.foundDetail_one": "{{count}} Sache, die einen Blick wert ist.",
+  "integrity.foundDetail_other": "{{count}} Sachen, die einen Blick wert sind.",
+  "integrity.unknownRunning":
+    "Das Spiel läuft, aber die geladenen Dateien konnten nicht gelesen werden — das ist also keine Entwarnung.",
+  "integrity.unknownIdle": "Starte MX Bikes, dann wird beim Fahren geprüft.",
+  "integrity.scanNow": "Jetzt prüfen",
+  "integrity.scanFailed": "Prüfung konnte nicht ausgeführt werden",
+  "integrity.offNote": "Aktiviere die Überwachung oben, um zu sehen, was an deinem Spiel hängt.",
+  "integrity.limitNote":
+    "Das kann beweisen, dass dein eigener Client ehrlich ist — nicht der von anderen. Wer betrügt und MXB App nicht nutzt, wird nie geprüft.",
+  "integrity.rulesVersion": "Signaturliste v{{version}}.",
+  "integrity.reasonRule": "Passt zu einem bekannten Cheat.",
+  "integrity.reasonLoader":
+    "Liegt im Spielordner unter einem Namen, den das Spiel automatisch lädt.",
+  "integrity.reasonForeign":
+    "Von außerhalb ins Spiel geladen — weder vom Spiel, noch von Windows, noch von MXB App installiert.",
+  "integrity.reasonProcess": "Ein Programm auf diesem PC, das zu einem bekannten Cheat passt.",
+  "integrity.gridTitle": "Client-Prüfungen",
+  "integrity.gridLoading": "Wird gelesen…",
+  "integrity.gridEmpty": "Auf diesem Server meldet gerade niemand eine Prüfung.",
+  "integrity.gridSuspect_one": "{{count}} unbekannte Datei",
+  "integrity.gridSuspect_other": "{{count}} unbekannte Dateien",
+  "integrity.gridRecovered": "(früher in dieser Sitzung)",
+  "integrity.gridNote":
+    "Hier erscheinen nur Fahrer, die MXB App mit aktiviertem Teilen nutzen. Wer hier fehlt, ist nicht entlastet — er hat schlicht nichts gemeldet.",
 };

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -375,6 +375,7 @@ export const de: Translation = {
   "browse.queued": "„{{title}}“ eingereiht",
   "browse.queuedDesc": "Wird in {{folder}} installiert.",
   "browse.rootFolder": "Hauptordner",
+  "browse.byAuthor": "von {{author}}",
   "browse.needsBrowser":
     "„{{title}}“ muss über den Browser heruntergeladen werden",
   "browse.needsBrowserDesc":

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -380,20 +380,23 @@ export const de: Translation = {
   "browse.needsBrowserDesc":
     "{{host}} blockiert Downloads in der App — öffne die Seite, um fertigzustellen.",
   "browse.noDownload": "Kein Download für „{{title}}“ gefunden",
+  "browse.serverOnly": "„{{title}}“ bietet nur Server-Dateien",
+  "browse.serverOnlyDesc":
+    "Öffne die Mod, um ihre Downloads zu sehen — ein Build für dedizierte Server wird nicht für dich installiert.",
   "browse.quickInstallFailed":
     "„{{title}}“ konnte nicht schnell installiert werden",
   "browse.queuedBulk_one": "{{count}} Mod eingereiht",
   "browse.queuedBulk_other": "{{count}} Mods eingereiht",
   "browse.queuedBulkDesc": "Sie werden nacheinander installiert.",
   "browse.queuedBulkSkipped_one":
-    "{{count}} übersprungen — nur über den Browser verfügbar.",
+    "{{count}} übersprungen — öffne sie und wähle einen Download.",
   "browse.queuedBulkSkipped_other":
-    "{{count}} übersprungen — nur über den Browser verfügbar.",
+    "{{count}} übersprungen — öffne sie und wähle einen Download.",
   "browse.bulkFailed": "Die Auswahl konnte nicht schnell installiert werden",
   "browse.bulkFailedDesc_one":
-    "Er muss über den Browser heruntergeladen werden.",
+    "Öffne sie und wähle einen Download.",
   "browse.bulkFailedDesc_other":
-    "Alle {{count}} müssen über den Browser heruntergeladen werden.",
+    "Bei allen {{count}} muss der Download von Hand gewählt werden.",
 
   // ── Shop (MX Bikes Shop — gekaufte Downloads) ──────────────────────────────
   "shop.help":
@@ -490,6 +493,16 @@ export const de: Translation = {
   "installDialog.differentBike": "Anderes Motorrad / Paket",
   "installDialog.directFastest": "Direkt · am schnellsten",
   "installDialog.direct": "Direkt",
+  "installDialog.recommendedBadge": "Empfohlen",
+  "installDialog.browserBadge": "Browser",
+  "installDialog.serverBadge": "Server",
+  "installDialog.serverBuildNote": "Build für dedizierte Server — nicht zum Spielen",
+  "installDialog.serverFiles_one": "1 Datei für dedizierte Server",
+  "installDialog.serverFiles_other": "{{count}} Dateien für dedizierte Server",
+  "installDialog.serverOnlyNotice":
+    "Jeder Download hier ist ein Build für dedizierte Server. Installiere ihn nur, wenn du einen Server betreibst — zum Fahren kommt nichts dazu.",
+  "installDialog.moreMirrors_one": "1 weiterer Spiegelserver",
+  "installDialog.moreMirrors_other": "{{count}} weitere Spiegelserver",
   "installDialog.perBikeHint":
     "Jeder Download ist ein anderes Motorrad — automatisch passend zu deiner Auswahl. Wähle das Paket „all bikes“, um alle auf einmal zu bekommen.",
   "installDialog.mirrorsHint":
@@ -528,6 +541,8 @@ export const de: Translation = {
   "modDetail.host": "Host",
   "modDetail.installsTo": "Installiert nach",
   "modDetail.noDownloadLink": "Auf dieser Seite wurde kein Download-Link gefunden — öffne sie auf {{site}}.",
+  "modDetail.serverOnlyNotice":
+    "Diese Seite bietet nur Dateien für dedizierte Server. Sie lassen sich installieren, aber im Spiel gibt es nichts zu fahren.",
   "modDetail.frostmodHint":
     "FrostMod lädt die Liste ({{kind}}) neu, sobald das fertig ist.",
   "modDetail.kindRider": "Fahrer",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -363,6 +363,7 @@ export const en = {
   "browse.queued": "Queued “{{title}}”",
   "browse.queuedDesc": "Installing to {{folder}}.",
   "browse.rootFolder": "root",
+  "browse.byAuthor": "by {{author}}",
   "browse.needsBrowser": "“{{title}}” needs a browser download",
   "browse.needsBrowserDesc":
     "{{host}} blocks in-app downloads — open its page to finish.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -367,15 +367,18 @@ export const en = {
   "browse.needsBrowserDesc":
     "{{host}} blocks in-app downloads — open its page to finish.",
   "browse.noDownload": "No download found for “{{title}}”",
+  "browse.serverOnly": "“{{title}}” only offers server files",
+  "browse.serverOnlyDesc":
+    "Open the mod to see its downloads — a dedicated-server build isn't installed for you.",
   "browse.quickInstallFailed": "Couldn't quick-install “{{title}}”",
   "browse.queuedBulk_one": "Queued {{count}} mod",
   "browse.queuedBulk_other": "Queued {{count}} mods",
   "browse.queuedBulkDesc": "They'll install one after another.",
-  "browse.queuedBulkSkipped_one": "{{count}} skipped — browser-only host.",
-  "browse.queuedBulkSkipped_other": "{{count}} skipped — browser-only host.",
+  "browse.queuedBulkSkipped_one": "{{count}} skipped — open it to pick a download.",
+  "browse.queuedBulkSkipped_other": "{{count}} skipped — open them to pick a download.",
   "browse.bulkFailed": "Couldn't quick-install the selection",
-  "browse.bulkFailedDesc_one": "It needs a browser download.",
-  "browse.bulkFailedDesc_other": "All {{count}} need a browser download.",
+  "browse.bulkFailedDesc_one": "Open it to pick a download.",
+  "browse.bulkFailedDesc_other": "All {{count}} need a download picked by hand.",
 
   // ── Shop (MX Bikes Shop — purchased downloads) ─────────────────────────────
   "shop.help":
@@ -472,6 +475,16 @@ export const en = {
   "installDialog.differentBike": "Different bike / pack",
   "installDialog.directFastest": "Direct · fastest",
   "installDialog.direct": "Direct",
+  "installDialog.recommendedBadge": "Recommended",
+  "installDialog.browserBadge": "Browser",
+  "installDialog.serverBadge": "Server",
+  "installDialog.serverBuildNote": "Dedicated server build — not for playing",
+  "installDialog.serverFiles_one": "1 dedicated server file",
+  "installDialog.serverFiles_other": "{{count}} dedicated server files",
+  "installDialog.serverOnlyNotice":
+    "Every download here is a dedicated-server build. Install one only if you're running a server — it adds nothing to ride.",
+  "installDialog.moreMirrors_one": "1 more mirror",
+  "installDialog.moreMirrors_other": "{{count}} more mirrors",
   "installDialog.perBikeHint":
     "Each download is a different bike — auto-selected to match your pick. Choose the “all bikes” pack for every bike at once.",
   "installDialog.mirrorsHint":
@@ -510,6 +523,8 @@ export const en = {
   "modDetail.host": "Host",
   "modDetail.installsTo": "Installs to",
   "modDetail.noDownloadLink": "No download link was found on this page — open it on {{site}}.",
+  "modDetail.serverOnlyNotice":
+    "This page only offers dedicated-server files. They install fine, but there's nothing to ride in-game.",
   "modDetail.frostmodHint":
     "FrostMod will hot-reload the {{kind}} list when this finishes.",
   "modDetail.kindRider": "rider",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1636,4 +1636,47 @@ export const en = {
   "trackViewer.whyDetails": "Why?",
   "trackViewer.copyDetails": "Copy details",
   "trackViewer.copied": "Copied",
+  // Cheat detection — see `src-tauri/src/integrity.rs`. Wording matters more than usual
+  // here: three of the four verdicts must not read as an accusation, and the one that does
+  // is only ever shown for a rule match.
+  "settings.integrity": "Cheat detection",
+  "settings.integrityDesc":
+    "MX Bikes has no anti-cheat, so a hooked client looks exactly like an honest one. This checks whether anything is attached to your running game.",
+  "settings.integrityWatch": "Watch the running game",
+  "settings.integrityWatchDesc":
+    "Check what's loaded into MX Bikes while you play. Nothing leaves your machine.",
+  "settings.integrityReport": "Share the result with servers",
+  "settings.integrityReportDesc":
+    "Let the admin of a server you're on see your verdict. Known cheats are named; anything merely unrecognised is counted, never named.",
+  "integrity.clean": "Nothing unaccounted for",
+  "integrity.suspect": "Something unrecognised is loaded",
+  "integrity.flagged": "A known cheat is attached",
+  "integrity.unknown": "Not checked",
+  "integrity.cleanDetail_one": "{{count}} loaded file checked.",
+  "integrity.cleanDetail_other": "{{count}} loaded files checked.",
+  "integrity.foundDetail_one": "{{count}} thing worth a look.",
+  "integrity.foundDetail_other": "{{count}} things worth a look.",
+  "integrity.unknownRunning":
+    "The game is running but its loaded files couldn't be read — so this is not an all-clear.",
+  "integrity.unknownIdle": "Start MX Bikes and this will check it while you ride.",
+  "integrity.scanNow": "Check now",
+  "integrity.scanFailed": "Couldn't run the check",
+  "integrity.offNote": "Turn on watching above to see what's attached to your game.",
+  "integrity.limitNote":
+    "This can prove your own client is honest; it can't prove anyone else's is. A cheater who doesn't run MXB App is never scanned.",
+  "integrity.rulesVersion": "Signature list v{{version}}.",
+  "integrity.reasonRule": "Matches a known cheat.",
+  "integrity.reasonLoader":
+    "Sitting in the game's folder under a name the game loads automatically.",
+  "integrity.reasonForeign":
+    "Loaded into the game from outside the game, Windows, or anything MXB App installed.",
+  "integrity.reasonProcess": "A program on this PC that matches a known cheat.",
+  "integrity.gridTitle": "Client checks",
+  "integrity.gridLoading": "Reading…",
+  "integrity.gridEmpty": "Nobody on this server is reporting a check right now.",
+  "integrity.gridSuspect_one": "{{count}} unrecognised file",
+  "integrity.gridSuspect_other": "{{count}} unrecognised files",
+  "integrity.gridRecovered": "(earlier this session)",
+  "integrity.gridNote":
+    "Only riders running MXB App with sharing turned on appear here. Somebody missing from this list hasn't been cleared — they simply haven't reported.",
 } as const;

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1670,4 +1670,44 @@ export const es: Translation = {
   "trackViewer.whyDetails": "¿Por qué?",
   "trackViewer.copyDetails": "Copiar detalles",
   "trackViewer.copied": "Copiado",
+  "settings.integrity": "Detección de trucos",
+  "settings.integrityDesc":
+    "MX Bikes no tiene anti-cheat, así que un cliente manipulado es idéntico a uno honesto. Esto comprueba si hay algo enganchado a tu juego en ejecución.",
+  "settings.integrityWatch": "Vigilar el juego en ejecución",
+  "settings.integrityWatchDesc":
+    "Comprueba qué se carga en MX Bikes mientras juegas. Nada sale de tu equipo.",
+  "settings.integrityReport": "Compartir el resultado con los servidores",
+  "settings.integrityReportDesc":
+    "Deja que el administrador del servidor en el que estás vea tu veredicto. Los trucos conocidos se nombran; lo que solo es desconocido se cuenta, nunca se nombra.",
+  "integrity.clean": "Nada sin explicar",
+  "integrity.suspect": "Hay algo desconocido cargado",
+  "integrity.flagged": "Hay un truco conocido enganchado",
+  "integrity.unknown": "Sin comprobar",
+  "integrity.cleanDetail_one": "{{count}} archivo cargado comprobado.",
+  "integrity.cleanDetail_other": "{{count}} archivos cargados comprobados.",
+  "integrity.foundDetail_one": "{{count}} cosa que merece un vistazo.",
+  "integrity.foundDetail_other": "{{count}} cosas que merecen un vistazo.",
+  "integrity.unknownRunning":
+    "El juego está en marcha pero no se pudieron leer sus archivos cargados, así que esto no es un visto bueno.",
+  "integrity.unknownIdle": "Inicia MX Bikes y esto lo comprobará mientras ruedas.",
+  "integrity.scanNow": "Comprobar ahora",
+  "integrity.scanFailed": "No se pudo ejecutar la comprobación",
+  "integrity.offNote": "Activa la vigilancia arriba para ver qué hay enganchado a tu juego.",
+  "integrity.limitNote":
+    "Puede demostrar que tu cliente es honesto, no el de los demás. Quien hace trampas sin usar MXB App nunca se comprueba.",
+  "integrity.rulesVersion": "Lista de firmas v{{version}}.",
+  "integrity.reasonRule": "Coincide con un truco conocido.",
+  "integrity.reasonLoader":
+    "Está en la carpeta del juego con un nombre que el juego carga automáticamente.",
+  "integrity.reasonForeign":
+    "Cargado en el juego desde fuera: no es del juego, ni de Windows, ni instalado por MXB App.",
+  "integrity.reasonProcess": "Un programa de este PC que coincide con un truco conocido.",
+  "integrity.gridTitle": "Comprobaciones de clientes",
+  "integrity.gridLoading": "Leyendo…",
+  "integrity.gridEmpty": "Nadie en este servidor está informando de una comprobación ahora mismo.",
+  "integrity.gridSuspect_one": "{{count}} archivo desconocido",
+  "integrity.gridSuspect_other": "{{count}} archivos desconocidos",
+  "integrity.gridRecovered": "(antes en esta sesión)",
+  "integrity.gridNote":
+    "Aquí solo aparecen los pilotos que usan MXB App con el envío activado. Quien no esté en la lista no ha sido descartado: simplemente no ha informado.",
 };

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -372,20 +372,23 @@ export const es: Translation = {
   "browse.needsBrowserDesc":
     "{{host}} bloquea las descargas dentro de la app — abre su página para terminar.",
   "browse.noDownload": "No se encontró descarga para «{{title}}»",
+  "browse.serverOnly": "«{{title}}» solo ofrece archivos de servidor",
+  "browse.serverOnlyDesc":
+    "Abre el mod para ver sus descargas: una compilación para servidor dedicado no se instala por ti.",
   "browse.quickInstallFailed":
     "No se pudo instalar rápido «{{title}}»",
   "browse.queuedBulk_one": "{{count}} mod en cola",
   "browse.queuedBulk_other": "{{count}} mods en cola",
   "browse.queuedBulkDesc": "Se instalarán uno tras otro.",
   "browse.queuedBulkSkipped_one":
-    "{{count}} omitido — host solo de navegador.",
+    "{{count}} omitido — ábrelo para elegir una descarga.",
   "browse.queuedBulkSkipped_other":
-    "{{count}} omitidos — host solo de navegador.",
+    "{{count}} omitidos — ábrelos para elegir una descarga.",
   "browse.bulkFailed": "No se pudo instalar rápido la selección",
   "browse.bulkFailedDesc_one":
-    "Requiere descarga desde el navegador.",
+    "Ábrelo para elegir una descarga.",
   "browse.bulkFailedDesc_other":
-    "Los {{count}} requieren descarga desde el navegador.",
+    "Los {{count}} necesitan que elijas la descarga a mano.",
 
   // ── Tienda (MX Bikes Shop — descargas compradas) ───────────────────────────
   "shop.help":
@@ -482,6 +485,16 @@ export const es: Translation = {
   "installDialog.differentBike": "Moto / pack distinto",
   "installDialog.directFastest": "Directo · el más rápido",
   "installDialog.direct": "Directo",
+  "installDialog.recommendedBadge": "Recomendado",
+  "installDialog.browserBadge": "Navegador",
+  "installDialog.serverBadge": "Servidor",
+  "installDialog.serverBuildNote": "Compilación para servidor dedicado — no sirve para jugar",
+  "installDialog.serverFiles_one": "1 archivo para servidor dedicado",
+  "installDialog.serverFiles_other": "{{count}} archivos para servidor dedicado",
+  "installDialog.serverOnlyNotice":
+    "Todas las descargas de aquí son compilaciones para servidor dedicado. Instala una solo si gestionas un servidor: no añade nada para rodar.",
+  "installDialog.moreMirrors_one": "1 espejo más",
+  "installDialog.moreMirrors_other": "{{count}} espejos más",
   "installDialog.perBikeHint":
     "Cada descarga es una moto distinta — se selecciona automáticamente según tu elección. Elige el pack «all bikes» para todas las motos de una vez.",
   "installDialog.mirrorsHint":
@@ -520,6 +533,8 @@ export const es: Translation = {
   "modDetail.host": "Host",
   "modDetail.installsTo": "Se instala en",
   "modDetail.noDownloadLink": "No se encontró ningún enlace de descarga en esta página — ábrela en {{site}}.",
+  "modDetail.serverOnlyNotice":
+    "Esta página solo ofrece archivos para servidor dedicado. Se instalan bien, pero en el juego no hay nada que rodar.",
   "modDetail.frostmodHint":
     "FrostMod recargará la lista de {{kind}} cuando esto termine.",
   "modDetail.kindRider": "piloto",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -368,6 +368,7 @@ export const es: Translation = {
   "browse.queued": "«{{title}}» en cola",
   "browse.queuedDesc": "Instalando en {{folder}}.",
   "browse.rootFolder": "raíz",
+  "browse.byAuthor": "por {{author}}",
   "browse.needsBrowser": "«{{title}}» requiere descarga desde el navegador",
   "browse.needsBrowserDesc":
     "{{host}} bloquea las descargas dentro de la app — abre su página para terminar.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1674,4 +1674,44 @@ export const fr: Translation = {
   "trackViewer.whyDetails": "Pourquoi ?",
   "trackViewer.copyDetails": "Copier les détails",
   "trackViewer.copied": "Copié",
+  "settings.integrity": "Détection de triche",
+  "settings.integrityDesc":
+    "MX Bikes n'a pas d'anti-triche, donc un client modifié ressemble exactement à un client honnête. Ceci vérifie si quelque chose est accroché à votre jeu en cours.",
+  "settings.integrityWatch": "Surveiller le jeu en cours",
+  "settings.integrityWatchDesc":
+    "Vérifie ce qui est chargé dans MX Bikes pendant que vous jouez. Rien ne quitte votre machine.",
+  "settings.integrityReport": "Partager le résultat avec les serveurs",
+  "settings.integrityReportDesc":
+    "Permet à l'admin du serveur où vous êtes de voir votre verdict. Les triches connues sont nommées ; ce qui est simplement non reconnu est compté, jamais nommé.",
+  "integrity.clean": "Rien d'inexpliqué",
+  "integrity.suspect": "Quelque chose de non reconnu est chargé",
+  "integrity.flagged": "Une triche connue est accrochée",
+  "integrity.unknown": "Non vérifié",
+  "integrity.cleanDetail_one": "{{count}} fichier chargé vérifié.",
+  "integrity.cleanDetail_other": "{{count}} fichiers chargés vérifiés.",
+  "integrity.foundDetail_one": "{{count}} chose à regarder.",
+  "integrity.foundDetail_other": "{{count}} choses à regarder.",
+  "integrity.unknownRunning":
+    "Le jeu tourne mais ses fichiers chargés n'ont pas pu être lus — ce n'est donc pas un feu vert.",
+  "integrity.unknownIdle": "Lancez MX Bikes et la vérification se fera pendant que vous roulez.",
+  "integrity.scanNow": "Vérifier",
+  "integrity.scanFailed": "Impossible de lancer la vérification",
+  "integrity.offNote": "Activez la surveillance ci-dessus pour voir ce qui est accroché au jeu.",
+  "integrity.limitNote":
+    "Ceci peut prouver que votre propre client est honnête, pas celui des autres. Un tricheur qui n'utilise pas MXB App n'est jamais analysé.",
+  "integrity.rulesVersion": "Liste de signatures v{{version}}.",
+  "integrity.reasonRule": "Correspond à une triche connue.",
+  "integrity.reasonLoader":
+    "Placé dans le dossier du jeu sous un nom que le jeu charge automatiquement.",
+  "integrity.reasonForeign":
+    "Chargé dans le jeu depuis l'extérieur : ni le jeu, ni Windows, ni rien installé par MXB App.",
+  "integrity.reasonProcess": "Un programme de ce PC qui correspond à une triche connue.",
+  "integrity.gridTitle": "Vérifications des clients",
+  "integrity.gridLoading": "Lecture…",
+  "integrity.gridEmpty": "Personne sur ce serveur ne signale de vérification pour le moment.",
+  "integrity.gridSuspect_one": "{{count}} fichier non reconnu",
+  "integrity.gridSuspect_other": "{{count}} fichiers non reconnus",
+  "integrity.gridRecovered": "(plus tôt dans la session)",
+  "integrity.gridNote":
+    "Seuls les pilotes utilisant MXB App avec le partage activé apparaissent ici. Quelqu'un absent de cette liste n'est pas innocenté : il n'a simplement rien signalé.",
 };

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -376,20 +376,23 @@ export const fr: Translation = {
   "browse.needsBrowserDesc":
     "{{host}} bloque les téléchargements dans l'application — ouvrez sa page pour terminer.",
   "browse.noDownload": "Aucun téléchargement trouvé pour « {{title}} »",
+  "browse.serverOnly": "« {{title}} » ne propose que des fichiers serveur",
+  "browse.serverOnlyDesc":
+    "Ouvrez le mod pour voir ses téléchargements — une version pour serveur dédié n'est pas installée à votre place.",
   "browse.quickInstallFailed":
     "Impossible d'installer rapidement « {{title}} »",
   "browse.queuedBulk_one": "{{count}} mod en file d'attente",
   "browse.queuedBulk_other": "{{count}} mods en file d'attente",
   "browse.queuedBulkDesc": "Ils s'installeront l'un après l'autre.",
   "browse.queuedBulkSkipped_one":
-    "{{count}} ignoré — hébergeur navigateur uniquement.",
+    "{{count}} ignoré — ouvrez-le pour choisir un téléchargement.",
   "browse.queuedBulkSkipped_other":
-    "{{count}} ignorés — hébergeur navigateur uniquement.",
+    "{{count}} ignorés — ouvrez-les pour choisir un téléchargement.",
   "browse.bulkFailed": "Impossible d'installer rapidement la sélection",
   "browse.bulkFailedDesc_one":
-    "Il doit être téléchargé depuis le navigateur.",
+    "Ouvrez-le pour choisir un téléchargement.",
   "browse.bulkFailedDesc_other":
-    "Les {{count}} doivent être téléchargés depuis le navigateur.",
+    "Pour les {{count}}, le téléchargement doit être choisi à la main.",
 
   // ── Boutique (MX Bikes Shop — téléchargements achetés) ─────────────────────
   "shop.help":
@@ -486,6 +489,16 @@ export const fr: Translation = {
   "installDialog.differentBike": "Moto / pack différent",
   "installDialog.directFastest": "Direct · le plus rapide",
   "installDialog.direct": "Direct",
+  "installDialog.recommendedBadge": "Recommandé",
+  "installDialog.browserBadge": "Navigateur",
+  "installDialog.serverBadge": "Serveur",
+  "installDialog.serverBuildNote": "Version serveur dédié — pas pour jouer",
+  "installDialog.serverFiles_one": "1 fichier pour serveur dédié",
+  "installDialog.serverFiles_other": "{{count}} fichiers pour serveur dédié",
+  "installDialog.serverOnlyNotice":
+    "Ici, chaque téléchargement est une version pour serveur dédié. N'en installez une que si vous hébergez un serveur — elle n'ajoute rien à piloter.",
+  "installDialog.moreMirrors_one": "1 autre miroir",
+  "installDialog.moreMirrors_other": "{{count}} autres miroirs",
   "installDialog.perBikeHint":
     "Chaque téléchargement correspond à une moto différente — sélectionné automatiquement selon votre choix. Choisissez le pack « all bikes » pour toutes les motos d'un coup.",
   "installDialog.mirrorsHint":
@@ -524,6 +537,8 @@ export const fr: Translation = {
   "modDetail.host": "Hébergeur",
   "modDetail.installsTo": "Installe dans",
   "modDetail.noDownloadLink": "Aucun lien de téléchargement trouvé sur cette page — ouvrez-la sur {{site}}.",
+  "modDetail.serverOnlyNotice":
+    "Cette page ne propose que des fichiers pour serveur dédié. Ils s'installent, mais il n'y a rien à piloter en jeu.",
   "modDetail.frostmodHint":
     "FrostMod rechargera la liste des {{kind}} une fois terminé.",
   "modDetail.kindRider": "pilotes",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -371,6 +371,7 @@ export const fr: Translation = {
   "browse.queued": "« {{title}} » en file d'attente",
   "browse.queuedDesc": "Installation dans {{folder}}.",
   "browse.rootFolder": "racine",
+  "browse.byAuthor": "par {{author}}",
   "browse.needsBrowser":
     "« {{title}} » doit être téléchargé depuis le navigateur",
   "browse.needsBrowserDesc":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -371,17 +371,20 @@ export const it: Translation = {
   "browse.needsBrowserDesc":
     "{{host}} blocca i download nell'app — apri la sua pagina per completare.",
   "browse.noDownload": "Nessun download trovato per “{{title}}”",
+  "browse.serverOnly": "“{{title}}” offre solo file per server",
+  "browse.serverOnlyDesc":
+    "Apri la mod per vedere i suoi download — una build per server dedicato non viene installata al posto tuo.",
   "browse.quickInstallFailed":
     "Impossibile installare rapidamente “{{title}}”",
   "browse.queuedBulk_one": "{{count}} mod in coda",
   "browse.queuedBulk_other": "{{count}} mod in coda",
   "browse.queuedBulkDesc": "Verranno installate una dopo l'altra.",
-  "browse.queuedBulkSkipped_one": "{{count}} saltata — host solo browser.",
-  "browse.queuedBulkSkipped_other": "{{count}} saltate — host solo browser.",
+  "browse.queuedBulkSkipped_one": "{{count}} saltata — aprila per scegliere un download.",
+  "browse.queuedBulkSkipped_other": "{{count}} saltate — aprile per scegliere un download.",
   "browse.bulkFailed": "Impossibile installare rapidamente la selezione",
-  "browse.bulkFailedDesc_one": "Va scaricata dal browser.",
+  "browse.bulkFailedDesc_one": "Aprila per scegliere un download.",
   "browse.bulkFailedDesc_other":
-    "Tutte e {{count}} vanno scaricate dal browser.",
+    "Per tutte e {{count}} il download va scelto a mano.",
 
   // ── Negozio (MX Bikes Shop — download acquistati) ──────────────────────────
   "shop.help":
@@ -478,6 +481,16 @@ export const it: Translation = {
   "installDialog.differentBike": "Moto / pacchetto diverso",
   "installDialog.directFastest": "Diretto · il più veloce",
   "installDialog.direct": "Diretto",
+  "installDialog.recommendedBadge": "Consigliato",
+  "installDialog.browserBadge": "Browser",
+  "installDialog.serverBadge": "Server",
+  "installDialog.serverBuildNote": "Build per server dedicato — non per giocare",
+  "installDialog.serverFiles_one": "1 file per server dedicato",
+  "installDialog.serverFiles_other": "{{count}} file per server dedicato",
+  "installDialog.serverOnlyNotice":
+    "Qui ogni download è una build per server dedicato. Installane una solo se gestisci un server — non aggiunge nulla da guidare.",
+  "installDialog.moreMirrors_one": "1 altro mirror",
+  "installDialog.moreMirrors_other": "Altri {{count}} mirror",
   "installDialog.perBikeHint":
     "Ogni download è una moto diversa — selezionato automaticamente in base alla tua scelta. Scegli il pacchetto “all bikes” per averle tutte in una volta.",
   "installDialog.mirrorsHint":
@@ -516,6 +529,8 @@ export const it: Translation = {
   "modDetail.host": "Host",
   "modDetail.installsTo": "Installa in",
   "modDetail.noDownloadLink": "Nessun link di download trovato in questa pagina — aprila su {{site}}.",
+  "modDetail.serverOnlyNotice":
+    "Questa pagina offre solo file per server dedicato. Si installano senza problemi, ma in gioco non c’è nulla da guidare.",
   "modDetail.frostmodHint":
     "FrostMod ricaricherà l'elenco {{kind}} al termine.",
   "modDetail.kindRider": "pilota",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -367,6 +367,7 @@ export const it: Translation = {
   "browse.queued": "“{{title}}” in coda",
   "browse.queuedDesc": "Installazione in {{folder}}.",
   "browse.rootFolder": "principale",
+  "browse.byAuthor": "di {{author}}",
   "browse.needsBrowser": "“{{title}}” va scaricata dal browser",
   "browse.needsBrowserDesc":
     "{{host}} blocca i download nell'app — apri la sua pagina per completare.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1660,4 +1660,44 @@ export const it: Translation = {
   "trackViewer.whyDetails": "Perché?",
   "trackViewer.copyDetails": "Copia i dettagli",
   "trackViewer.copied": "Copiato",
+  "settings.integrity": "Rilevamento cheat",
+  "settings.integrityDesc":
+    "MX Bikes non ha un anti-cheat, quindi un client manomesso è indistinguibile da uno onesto. Questo controlla se qualcosa è agganciato al gioco in esecuzione.",
+  "settings.integrityWatch": "Controlla il gioco in esecuzione",
+  "settings.integrityWatchDesc":
+    "Verifica cosa viene caricato in MX Bikes mentre giochi. Nulla lascia il tuo PC.",
+  "settings.integrityReport": "Condividi il risultato con i server",
+  "settings.integrityReportDesc":
+    "Permetti all'admin del server su cui sei di vedere il tuo esito. I cheat noti vengono nominati; ciò che è solo non riconosciuto viene contato, mai nominato.",
+  "integrity.clean": "Nulla di inspiegato",
+  "integrity.suspect": "È caricato qualcosa di non riconosciuto",
+  "integrity.flagged": "È agganciato un cheat noto",
+  "integrity.unknown": "Non controllato",
+  "integrity.cleanDetail_one": "{{count}} file caricato controllato.",
+  "integrity.cleanDetail_other": "{{count}} file caricati controllati.",
+  "integrity.foundDetail_one": "{{count}} cosa da guardare.",
+  "integrity.foundDetail_other": "{{count}} cose da guardare.",
+  "integrity.unknownRunning":
+    "Il gioco è in esecuzione ma non è stato possibile leggere i file caricati — quindi questo non è un via libera.",
+  "integrity.unknownIdle": "Avvia MX Bikes e il controllo partirà mentre guidi.",
+  "integrity.scanNow": "Controlla ora",
+  "integrity.scanFailed": "Impossibile eseguire il controllo",
+  "integrity.offNote": "Attiva il controllo qui sopra per vedere cosa è agganciato al gioco.",
+  "integrity.limitNote":
+    "Può dimostrare che il tuo client è onesto, non quello degli altri. Chi bara senza usare MXB App non viene mai controllato.",
+  "integrity.rulesVersion": "Elenco firme v{{version}}.",
+  "integrity.reasonRule": "Corrisponde a un cheat noto.",
+  "integrity.reasonLoader":
+    "Si trova nella cartella del gioco con un nome che il gioco carica automaticamente.",
+  "integrity.reasonForeign":
+    "Caricato nel gioco da fuori: non è del gioco, di Windows, né installato da MXB App.",
+  "integrity.reasonProcess": "Un programma su questo PC che corrisponde a un cheat noto.",
+  "integrity.gridTitle": "Controlli dei client",
+  "integrity.gridLoading": "Lettura…",
+  "integrity.gridEmpty": "Nessuno su questo server sta segnalando un controllo in questo momento.",
+  "integrity.gridSuspect_one": "{{count}} file non riconosciuto",
+  "integrity.gridSuspect_other": "{{count}} file non riconosciuti",
+  "integrity.gridRecovered": "(prima, in questa sessione)",
+  "integrity.gridNote":
+    "Qui compaiono solo i piloti che usano MXB App con la condivisione attiva. Chi manca da questa lista non è stato scagionato: semplicemente non ha segnalato nulla.",
 };

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1659,4 +1659,44 @@ export const ptBR: Translation = {
   "trackViewer.whyDetails": "Por quê?",
   "trackViewer.copyDetails": "Copiar detalhes",
   "trackViewer.copied": "Copiado",
+  "settings.integrity": "Detecção de cheats",
+  "settings.integrityDesc":
+    "MX Bikes não tem anti-cheat, então um cliente adulterado é idêntico a um honesto. Isto verifica se há algo acoplado ao seu jogo em execução.",
+  "settings.integrityWatch": "Monitorar o jogo em execução",
+  "settings.integrityWatchDesc":
+    "Verifica o que é carregado no MX Bikes enquanto você joga. Nada sai da sua máquina.",
+  "settings.integrityReport": "Compartilhar o resultado com os servidores",
+  "settings.integrityReportDesc":
+    "Deixa o admin do servidor em que você está ver seu veredito. Cheats conhecidos são nomeados; o que é apenas não reconhecido é contado, nunca nomeado.",
+  "integrity.clean": "Nada sem explicação",
+  "integrity.suspect": "Há algo não reconhecido carregado",
+  "integrity.flagged": "Há um cheat conhecido acoplado",
+  "integrity.unknown": "Não verificado",
+  "integrity.cleanDetail_one": "{{count}} arquivo carregado verificado.",
+  "integrity.cleanDetail_other": "{{count}} arquivos carregados verificados.",
+  "integrity.foundDetail_one": "{{count}} coisa que merece atenção.",
+  "integrity.foundDetail_other": "{{count}} coisas que merecem atenção.",
+  "integrity.unknownRunning":
+    "O jogo está rodando, mas os arquivos carregados não puderam ser lidos — então isto não é um sinal verde.",
+  "integrity.unknownIdle": "Abra o MX Bikes e a verificação acontecerá enquanto você pilota.",
+  "integrity.scanNow": "Verificar agora",
+  "integrity.scanFailed": "Não foi possível executar a verificação",
+  "integrity.offNote": "Ative o monitoramento acima para ver o que está acoplado ao seu jogo.",
+  "integrity.limitNote":
+    "Isto prova que o seu cliente é honesto, não o dos outros. Quem trapaceia sem usar o MXB App nunca é verificado.",
+  "integrity.rulesVersion": "Lista de assinaturas v{{version}}.",
+  "integrity.reasonRule": "Corresponde a um cheat conhecido.",
+  "integrity.reasonLoader":
+    "Está na pasta do jogo com um nome que o jogo carrega automaticamente.",
+  "integrity.reasonForeign":
+    "Carregado no jogo de fora — não é do jogo, nem do Windows, nem instalado pelo MXB App.",
+  "integrity.reasonProcess": "Um programa neste PC que corresponde a um cheat conhecido.",
+  "integrity.gridTitle": "Verificações dos clientes",
+  "integrity.gridLoading": "Lendo…",
+  "integrity.gridEmpty": "Ninguém neste servidor está reportando uma verificação agora.",
+  "integrity.gridSuspect_one": "{{count}} arquivo não reconhecido",
+  "integrity.gridSuspect_other": "{{count}} arquivos não reconhecidos",
+  "integrity.gridRecovered": "(antes, nesta sessão)",
+  "integrity.gridNote":
+    "Só aparecem aqui pilotos usando o MXB App com o compartilhamento ligado. Quem falta nesta lista não foi inocentado — apenas não reportou nada.",
 };

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -374,19 +374,22 @@ export const ptBR: Translation = {
   "browse.needsBrowserDesc":
     "O {{host}} bloqueia downloads dentro do app — abra a página dele para concluir.",
   "browse.noDownload": "Nenhum download encontrado para “{{title}}”",
+  "browse.serverOnly": "“{{title}}” só oferece arquivos de servidor",
+  "browse.serverOnlyDesc":
+    "Abra o mod para ver os downloads — uma versão para servidor dedicado não é instalada por você.",
   "browse.quickInstallFailed":
     "Não foi possível instalar “{{title}}” rapidamente",
   "browse.queuedBulk_one": "{{count}} mod na fila",
   "browse.queuedBulk_other": "{{count}} mods na fila",
   "browse.queuedBulkDesc": "Eles serão instalados um depois do outro.",
   "browse.queuedBulkSkipped_one":
-    "{{count}} ignorado — host só pelo navegador.",
+    "{{count}} ignorado — abra-o para escolher um download.",
   "browse.queuedBulkSkipped_other":
-    "{{count}} ignorados — host só pelo navegador.",
+    "{{count}} ignorados — abra-os para escolher um download.",
   "browse.bulkFailed": "Não foi possível instalar a seleção rapidamente",
-  "browse.bulkFailedDesc_one": "Ele precisa ser baixado pelo navegador.",
+  "browse.bulkFailedDesc_one": "Abra-o para escolher um download.",
   "browse.bulkFailedDesc_other":
-    "Todos os {{count}} precisam ser baixados pelo navegador.",
+    "Nos {{count}} o download precisa ser escolhido à mão.",
 
   // ── Loja (MX Bikes Shop — downloads comprados) ─────────────────────────────
   "shop.help":
@@ -483,6 +486,16 @@ export const ptBR: Translation = {
   "installDialog.differentBike": "Moto / pacote diferente",
   "installDialog.directFastest": "Direto · o mais rápido",
   "installDialog.direct": "Direto",
+  "installDialog.recommendedBadge": "Recomendado",
+  "installDialog.browserBadge": "Navegador",
+  "installDialog.serverBadge": "Servidor",
+  "installDialog.serverBuildNote": "Versão para servidor dedicado — não serve para jogar",
+  "installDialog.serverFiles_one": "1 arquivo para servidor dedicado",
+  "installDialog.serverFiles_other": "{{count}} arquivos para servidor dedicado",
+  "installDialog.serverOnlyNotice":
+    "Todos os downloads aqui são versões para servidor dedicado. Instale uma só se você mantém um servidor — não acrescenta nada para pilotar.",
+  "installDialog.moreMirrors_one": "mais 1 espelho",
+  "installDialog.moreMirrors_other": "mais {{count}} espelhos",
   "installDialog.perBikeHint":
     "Cada download é uma moto diferente — selecionado automaticamente conforme a sua escolha. Escolha o pacote “all bikes” para todas de uma vez.",
   "installDialog.mirrorsHint":
@@ -521,6 +534,8 @@ export const ptBR: Translation = {
   "modDetail.host": "Host",
   "modDetail.installsTo": "Instala em",
   "modDetail.noDownloadLink": "Nenhum link de download foi encontrado nesta página — abra-a em {{site}}.",
+  "modDetail.serverOnlyNotice":
+    "Esta página só oferece arquivos para servidor dedicado. Eles instalam normalmente, mas não há nada para pilotar no jogo.",
   "modDetail.frostmodHint":
     "O FrostMod vai recarregar a lista de {{kind}} quando isso terminar.",
   "modDetail.kindRider": "piloto",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -370,6 +370,7 @@ export const ptBR: Translation = {
   "browse.queued": "“{{title}}” na fila",
   "browse.queuedDesc": "Instalando em {{folder}}.",
   "browse.rootFolder": "raiz",
+  "browse.byAuthor": "por {{author}}",
   "browse.needsBrowser": "“{{title}}” precisa ser baixado pelo navegador",
   "browse.needsBrowserDesc":
     "O {{host}} bloqueia downloads dentro do app — abra a página dele para concluir.",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -129,6 +129,78 @@ export interface Config {
   /** App version whose release showcase has been seen. Blank on an install that
    *  predates the showcase, which is what marks it as an upgrade worth telling. */
   seenVersion?: string;
+  /** Watch for cheats attached to the running game. Default true — the scan reads the
+   *  game's own module list and the answer goes no further than this window. */
+  integrityWatch?: boolean;
+  /** Publish the verdict so a server admin can see it. Default false: scanning your own
+   *  game and telling a server operator what it found are two different decisions. */
+  integrityReport?: boolean;
+}
+
+/**
+ * What a cheat scan concluded, worst last.
+ *
+ * `unknown` is a real answer and the important one: the game isn't running, or the platform
+ * can't be read, or the scan failed. It is never a synonym for clean — a scanner that
+ * reports a healthy machine when it simply didn't look is worse than none.
+ */
+export type IntegrityVerdict = "unknown" | "clean" | "suspect" | "flagged";
+
+/** `suspect` is "loaded and unrecognised"; `flagged` is "matched the rule list". */
+export type IntegritySeverity = "suspect" | "flagged";
+
+export type IntegrityKind = "module" | "process";
+
+/** Why something was reported — a key, so the line survives translation. */
+export type IntegrityReason =
+  | "ruleName"
+  | "ruleHash"
+  | "foreignModule"
+  | "loaderHijack";
+
+export interface IntegrityFinding {
+  kind: IntegrityKind;
+  /** File name, lowercased. */
+  name: string;
+  /** Full path, when there is one. Empty for a process. */
+  path: string;
+  reason: IntegrityReason;
+  severity: IntegritySeverity;
+  /** SHA-256, when the file could be read. What turns "some unknown DLL" into something
+   *  that can be added to the rule list. */
+  sha256?: string;
+  /** The rule's own label, when a rule matched. Never translated — a cheat's name is its
+   *  name. */
+  label?: string;
+}
+
+export interface IntegrityReport {
+  verdict: IntegrityVerdict;
+  findings: IntegrityFinding[];
+  /** Unix ms. Zero before the first scan of a session. */
+  scannedAt: number;
+  /** Which rule list produced it. */
+  rulesVersion: number;
+  /** How many modules were looked at — the difference between a thorough clean answer and
+   *  an empty one. */
+  modulesScanned: number;
+  gameRunning: boolean;
+}
+
+/** One rider's published verdict, as the admin of their server sees it. */
+export interface RiderIntegrity {
+  riderName: string;
+  guid: string;
+  verdict: IntegrityVerdict;
+  rulesVersion: number;
+  /** Unrecognised modules are counted, never named — see the control plane's migration. */
+  suspectCount: number;
+  flagged: { name: string; label: string; sha256: string }[];
+  /** The worst verdict seen recently, when it is worse than the current one. A cheat loaded
+   *  for one lap and then unloaded is the case this exists for. */
+  worstVerdict?: IntegrityVerdict;
+  /** Unix ms of their last report. */
+  reportedAt: number;
 }
 
 /** A track-mod as it appears in search results / browse grid. */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -143,6 +143,14 @@ export interface ModSummary {
   /** Featured image URL, if any. */
   image: string | null;
   categoryId: number;
+  /**
+   * Who posted the mod, as the catalog names them. Null where the site didn't say.
+   *
+   * Optional rather than required because `ShopItem` extends this shape and a purchased
+   * download has no byline to carry — the store's "All My Downloads" page lists files, not
+   * authors.
+   */
+  author?: string | null;
 }
 
 /** A mod's community score on mxb-mods.com, as shown under the site's own thumbnails. */


### PR DESCRIPTION
## What

First groundwork toward a **public MX Bikes server browser** — list real dedicated servers, search a player to find their server, inspect track/category/bikes/roster, and join with the app temporarily switching your preset so the join is accepted.

This PR is only the **plumbing**: an optional, local-only `worldnet` module gate, built exactly like the existing `sidecar`.

- `build.rs` — sets `cfg(worldnet)` when `src/worldnet.rs` is present
- `main.rs` — `#[cfg(worldnet)] mod worldnet;`
- `.gitignore` — keeps `worldnet.rs` out of the public tree
- `CHANGELOG.md` — entry

The public tree has neither the file nor the feature and **compiles unchanged** (`cargo check` green). The module isn't wired to any Tauri command yet, so it's dead code behind the cfg until the UI lands.

## Why the code itself isn't in the PR

`worldnet.rs` is the reverse-engineered client for PiBoSo's online protocol (Blowfish codec, packet framing, `GETINFO`/`GETLIST` builders, a provisional `SERVERINFO` parser, 8 passing unit tests). It embeds PiBoSo's Blowfish key, so per the standing IP rule it lives in the gitignored sidecar area and is never referenced from committed code. It sits in the worktree for local review.

## Findings that shaped this (full notes in `tasks/mxb-server-browser.md`)

- The list comes from PiBoSo's master (`master.mx-bikes.com:54200`, from `mxbikes.ini`) — **not** Steam's master, which is retired.
- The protocol is `\n`-token text, `\n`-padded, **Blowfish-ECB**. Codec proven twice: the published `TESTKEY` vector, and the live master decrypting a packet we built (`Auth\nNO\nInvalid Key`).
- The master requires a **licence login**, not an anonymous query. Steam copies auth via a Steam session ticket — deferred (needs a key + a Windows capture).
- The running game can't supply the list: the plugin API exposes only the current event + in-session roster.

## Verification

- `cargo check` — exit 0, no new warnings
- 8 `worldnet` unit tests green (standalone `rustc --test`)
- No DB/schema changes

## Not done yet (next, both need a live sample)

1. Decode the exact `SERVERINFO`/`LIST` reply layouts → make the parser proven, not provisional.
2. Steam-ticket `LOGIN` emulation, if we want the real master list vs direct-query-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)