### PR TITLE
feat(downloads): open the download queue and cancel a download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased — the download queue opens, and a download can be called off
+
+### Added
+- **You can see what you're downloading.** Installs have always queued up one behind the
+  other, but the only sign of it was a "+2 queued" line in the sidebar — you couldn't see
+  what was in there, or in what order. That card is now a button: it opens a panel listing
+  the transfer in progress, with its size and percentage, and every mod waiting behind it.
+  Collapse the sidebar and it becomes a download icon with a count, where before there was
+  nothing to see at all.
+- **A download can be cancelled.** Queue up a 400 MB track by mistake and, until now, the
+  only way to stop it was to quit the app. Every row in the panel has an X. One that hasn't
+  started yet simply leaves the queue; the one in flight is stopped mid-transfer, its
+  half-downloaded file cleaned up, and the next mod in the queue starts straight away. It
+  isn't treated as a failure — no error, no retry prompt, just gone.
+
+### Fixed
+- **An install that fails no longer leaves its download behind.** Every abandoned attempt
+  used to leave the partial archive sitting in the temp folder until the system got around
+  to clearing it, which for a large track meant hundreds of megabytes per failed try.
+
 ## Unreleased — MediaFire links stop needing a manual download
 
 ### Fixed

--- a/src-tauri/src/cancel.rs
+++ b/src-tauri/src/cancel.rs
@@ -1,0 +1,125 @@
+//! Abort flags for in-flight installs, keyed by mod slug.
+//!
+//! Keyed by slug because that is already how an install identifies itself on the wire — the
+//! `install-progress` event carries nothing else ([`crate::install`]) — and because the frontend
+//! drains its queue strictly one at a time, so a slug is never ambiguous.
+//!
+//! The flag is looked up by slug at each check point rather than threaded through as a parameter.
+//! That keeps [`crate::install::download`] signature-compatible with [`crate::shop_fetch::download`],
+//! which is load-bearing: `shop_stage` swaps one for the other.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+fn flags() -> &'static Mutex<HashMap<String, Arc<AtomicBool>>> {
+    static FLAGS: OnceLock<Mutex<HashMap<String, Arc<AtomicBool>>>> = OnceLock::new();
+    FLAGS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// A poisoned lock here would disable cancelling for the rest of the session, which is worse
+/// than reading through the poison — nothing in the map is invariant-bearing.
+fn map() -> std::sync::MutexGuard<'static, HashMap<String, Arc<AtomicBool>>> {
+    flags().lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// The cancel flag for one install. `None` when nothing registered the slug — an install
+/// started outside a [`Guard`] simply can't be cancelled, and says so by never firing.
+#[derive(Clone, Default)]
+pub(crate) struct Token(Option<Arc<AtomicBool>>);
+
+impl Token {
+    pub(crate) fn cancelled(&self) -> bool {
+        self.0.as_ref().is_some_and(|f| f.load(Ordering::Relaxed))
+    }
+
+    /// `Err(`[`cancelled`]`)` once the user has asked to stop.
+    pub(crate) fn check(&self) -> anyhow::Result<()> {
+        if self.cancelled() {
+            return Err(cancelled());
+        }
+        Ok(())
+    }
+}
+
+/// Registers `slug` as cancellable and unregisters it on drop.
+pub(crate) struct Guard(String);
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        map().remove(&self.0);
+    }
+}
+
+/// Make `slug` cancellable for as long as the returned guard lives.
+pub(crate) fn begin(slug: &str) -> Guard {
+    map().insert(slug.to_string(), Arc::new(AtomicBool::new(false)));
+    Guard(slug.to_string())
+}
+
+/// The flag for `slug`, grabbed once so a hot loop can poll an atomic instead of a mutex.
+pub(crate) fn token(slug: &str) -> Token {
+    Token(map().get(slug).cloned())
+}
+
+/// Ask the install for `slug` to stop. `false` when there is nothing running under that slug.
+pub(crate) fn request(slug: &str) -> bool {
+    match map().get(slug) {
+        Some(flag) => {
+            flag.store(true, Ordering::Relaxed);
+            true
+        }
+        None => false,
+    }
+}
+
+/// The error a cancelled transfer fails with. The frontend suppresses the failure toast for a
+/// job it cancelled itself, so this text is a fallback rather than the usual path.
+pub(crate) fn cancelled() -> anyhow::Error {
+    anyhow::anyhow!("Download cancelled.")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The registry is process-global, so every test uses a slug of its own.
+
+    #[test]
+    fn unregistered_slug_never_fires() {
+        assert!(!request("nobody-is-installing-this"));
+        assert!(!token("nobody-is-installing-this").cancelled());
+    }
+
+    #[test]
+    fn request_reaches_a_token_taken_before_it() {
+        let _guard = begin("cancel-mid-transfer");
+        // Taken up front, the way a download loop grabs it once and then polls.
+        let held = token("cancel-mid-transfer");
+        assert!(!held.cancelled());
+        assert!(request("cancel-mid-transfer"));
+        assert!(held.cancelled());
+        assert!(held.check().is_err());
+    }
+
+    #[test]
+    fn dropping_the_guard_unregisters() {
+        {
+            let _guard = begin("finished-install");
+            assert!(request("finished-install"));
+        }
+        // The install is over; a late cancel must not linger and stop the next one.
+        assert!(!request("finished-install"));
+        assert!(!token("finished-install").cancelled());
+    }
+
+    #[test]
+    fn a_fresh_run_starts_uncancelled() {
+        let first = begin("retried-install");
+        assert!(request("retried-install"));
+        drop(first);
+
+        let _second = begin("retried-install");
+        assert!(!token("retried-install").cancelled());
+    }
+}

--- a/src-tauri/src/install.rs
+++ b/src-tauri/src/install.rs
@@ -144,7 +144,15 @@ pub async fn download_and_place(
     let work = staging_dir("dl");
     std::fs::create_dir_all(&work)?;
 
-    let archive = download(app, client, slug, direct_url, &work).await?;
+    // A failed or cancelled download used to leave its staging directory behind — every
+    // abandoned attempt at a 400 MB track sat in the temp dir until the OS got around to it.
+    let archive = match download(app, client, slug, direct_url, &work).await {
+        Ok(path) => path,
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&work);
+            return Err(e);
+        }
+    };
     extract_and_place(app, cfg, slug, &archive, &work, subpath, dest_folder)
 }
 
@@ -208,7 +216,13 @@ async fn download_mega_and_place(
     let work = staging_dir("dl");
     std::fs::create_dir_all(&work)?;
 
-    let archive = download_mega(app, client, slug, url, &work).await?;
+    let archive = match download_mega(app, client, slug, url, &work).await {
+        Ok(path) => path,
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&work);
+            return Err(e);
+        }
+    };
     extract_and_place(app, cfg, slug, &archive, &work, subpath, dest_folder)
 }
 
@@ -242,6 +256,7 @@ pub(crate) async fn download_mega(
     let file = File::create(&path)?;
 
     emit(app, slug, "downloading", Some(0), total);
+    let cancel = crate::cancel::token(slug);
     let writer = MegaProgressWriter {
         file,
         app,
@@ -249,10 +264,15 @@ pub(crate) async fn download_mega(
         total,
         received: 0,
         last_emit: 0,
+        cancel: cancel.clone(),
     };
-    mega.download_node(node, writer)
-        .await
-        .map_err(|e| anyhow::anyhow!("MEGA download failed: {e}"))?;
+    if let Err(e) = mega.download_node(node, writer).await {
+        // The writer refuses the next buffer to stop the transfer, so the crate reports this
+        // as a write failure. Asking the flag first keeps "cancelled" from being dressed up
+        // as "MEGA download failed".
+        cancel.check()?;
+        return Err(anyhow::anyhow!("MEGA download failed: {e}"));
+    }
     emit(app, slug, "downloading", total, total);
 
     Ok(path)
@@ -265,6 +285,7 @@ struct MegaProgressWriter<'a> {
     total: Option<u64>,
     received: u64,
     last_emit: u64,
+    cancel: crate::cancel::Token,
 }
 
 impl futures_util::io::AsyncWrite for MegaProgressWriter<'_> {
@@ -274,6 +295,14 @@ impl futures_util::io::AsyncWrite for MegaProgressWriter<'_> {
         buf: &[u8],
     ) -> std::task::Poll<std::io::Result<usize>> {
         let this = self.get_mut();
+        // The `mega` crate drives the transfer itself; refusing the write is the only way in
+        // to stop it.
+        if this.cancel.cancelled() {
+            return std::task::Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "cancelled",
+            )));
+        }
         let n = this.file.write(buf)?;
         this.received += n as u64;
         if this.received - this.last_emit >= EMIT_EVERY_BYTES {
@@ -841,6 +870,9 @@ pub(crate) async fn download(
     url: &str,
     dir: &Path,
 ) -> anyhow::Result<PathBuf> {
+    // Grabbed once: the chunk loop below polls this per chunk, and that has to be an atomic
+    // load rather than a lock on the registry.
+    let cancel = crate::cancel::token(slug);
     let mut resp = get_with_retry(client, url).await?;
     let is_gdrive = url.contains("google");
 
@@ -900,6 +932,7 @@ pub(crate) async fn download(
     let mut last_err: Option<String>;
 
     loop {
+        cancel.check()?;
         let resp = match next.take() {
             Some(r) => r,
             // Without a `Content-Length` there is nothing to resume *against*: reqwest
@@ -930,8 +963,10 @@ pub(crate) async fn download(
             },
         };
 
-        let end = stream_to_file(app, slug, resp, &mut file, &mut received, &mut last_emit, total)
-            .await?;
+        let end = stream_to_file(
+            app, slug, &cancel, resp, &mut file, &mut received, &mut last_emit, total,
+        )
+        .await?;
         // A body can come up short without erroring — some hosts just close the socket
         // cleanly mid-file. Content-Length is what says whether we actually have it all.
         let short = total.is_some_and(|t| received < t);
@@ -976,9 +1011,11 @@ enum BodyEnd {
 /// waited for, so this is deliberately more patient than [`get_with_retry`].
 const RESUME_ATTEMPTS: u32 = 5;
 
+#[allow(clippy::too_many_arguments)]
 async fn stream_to_file(
     app: &AppHandle,
     slug: &str,
+    cancel: &crate::cancel::Token,
     resp: reqwest::Response,
     file: &mut File,
     received: &mut u64,
@@ -987,6 +1024,9 @@ async fn stream_to_file(
 ) -> anyhow::Result<BodyEnd> {
     let mut stream = resp.bytes_stream();
     while let Some(chunk) = stream.next().await {
+        // Per chunk, so cancelling a stalled 400 MB track stops within a buffer rather than
+        // at the end of the file.
+        cancel.check()?;
         match chunk {
             Ok(chunk) => {
                 file.write_all(&chunk)?;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,6 +5,7 @@ mod antidebug;
 mod bikefiles;
 mod bikeswap;
 mod bundle;
+mod cancel;
 mod cfg;
 mod config;
 mod cookie_session;
@@ -3518,9 +3519,20 @@ async fn add_to_library(
     dest_folder: String,
 ) -> Result<(), String> {
     let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
+    let _cancel = cancel::begin(&slug);
     install::add_to_library(&app, &cfg, &slug, &url, &host, &subpath, &dest_folder)
         .await
         .map_err(|e| format!("{e:#}"))
+}
+
+/// Stop the install running under `slug`. `false` when nothing is running under it — the
+/// frontend drops queued items itself and only reaches for this on the one in flight.
+///
+/// Only the transfer is interruptible: once the bytes are down and extraction has started
+/// there is nothing safe to stop, so the flag is polled by the download loops alone.
+#[tauri::command]
+fn cancel_install(slug: String) -> bool {
+    cancel::request(&slug)
 }
 
 #[tauri::command]
@@ -5517,6 +5529,7 @@ async fn shop_install(
     let work = install::staging_dir("shop");
     std::fs::create_dir_all(&work).map_err(|e| format!("{e:#}"))?;
 
+    let _cancel = cancel::begin(&item.slug);
     let archive = match shop_fetch::download(&app, &item.slug, &item.download_url, &work).await {
         Ok(path) => path,
         Err(e) => {
@@ -6432,6 +6445,7 @@ fn main() {
             detect_orphaned_setup,
             repair_orphaned_setup,
             add_to_library,
+            cancel_install,
             import_file,
             plan_drop,
             repreview_drop,

--- a/src-tauri/src/shop_fetch.rs
+++ b/src-tauri/src/shop_fetch.rs
@@ -238,17 +238,24 @@ pub async fn download(app: &AppHandle, slug: &str, url: &str, dir: &Path) -> any
     crate::install::emit_progress(app, slug, "downloading", Some(0), None);
     window.navigate(url.parse()?)?;
 
-    let path = wait_for_start(app, slug).await?;
-    wait_for_finish(app, slug, &path).await?;
+    let outcome = async {
+        let path = wait_for_start(app, slug).await?;
+        wait_for_finish(app, slug, &path).await?;
+        anyhow::Ok(path)
+    }
+    .await;
 
     // Put the window back where it belongs, so the next read finds the purchases page rather
-    // than whatever the download navigation left behind.
+    // than whatever the download navigation left behind. On the way out of a *cancel* this is
+    // also the only lever we have on the transfer itself: `DownloadEvent` carries no abort
+    // handle, so navigating away is as close to stopping it as the WebView gets — and the
+    // caller's `remove_dir_all` over the staging directory has always been best-effort.
     let back = format!("{SHOP_BASE}{DOWNLOADS_PATH}");
     if let Ok(url) = back.parse() {
         let _ = window.navigate(url);
     }
 
-    Ok(path)
+    outcome
 }
 
 /// Wait for `on_download` to fire.
@@ -257,8 +264,10 @@ pub async fn download(app: &AppHandle, slug: &str, url: &str, dir: &Path) -> any
 /// the file, the window quietly renders an interstitial and no download is ever requested. That
 /// has to become a real error rather than a hang.
 async fn wait_for_start(app: &AppHandle, slug: &str) -> anyhow::Result<PathBuf> {
+    let cancel = crate::cancel::token(slug);
     let deadline = std::time::Instant::now() + DOWNLOAD_START_TIMEOUT;
     while std::time::Instant::now() < deadline {
+        cancel.check()?;
         if let Some(path) = lock(download_state()).path.clone() {
             return Ok(path);
         }
@@ -278,8 +287,10 @@ async fn wait_for_start(app: &AppHandle, slug: &str) -> anyhow::Result<PathBuf> 
 /// count rather than a percentage — worse than the streaming path, and much better than a bar
 /// that sits still for several hundred megabytes.
 async fn wait_for_finish(app: &AppHandle, slug: &str, path: &Path) -> anyhow::Result<()> {
+    let cancel = crate::cancel::token(slug);
     let deadline = std::time::Instant::now() + DOWNLOAD_TIMEOUT;
     while std::time::Instant::now() < deadline {
+        cancel.check()?;
         if let Some(success) = lock(download_state()).outcome {
             if !success {
                 anyhow::bail!("the download failed — the store or the connection ended it early");

--- a/src/Components/Shell/DownloadQueue.tsx
+++ b/src/Components/Shell/DownloadQueue.tsx
@@ -1,0 +1,190 @@
+/**
+ * The download queue: what's transferring now, what's waiting behind it, and an X on each.
+ *
+ * Installs have always been queued one at a time (`Context/Install`), but the only sign of it
+ * was a "+N queued" line — you couldn't see what was in there, let alone take something out.
+ * The sidebar card is now the trigger for a panel that shows the whole queue.
+ */
+import { Download, X } from "lucide-react";
+import {
+  useInstall,
+  type ActiveInstall,
+  type QueuedInstall,
+} from "../../Context/Install";
+import { useT } from "../../i18n/context";
+import type { TKey } from "../../i18n";
+import type { InstallStage } from "../../types";
+import { displayName, formatBytes } from "../../lib/mods";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+import { cn } from "@/lib/utils";
+
+/** Stages that mean an install is still moving — anything else is done, failed, or idle. */
+const IN_PROGRESS = new Set<InstallStage>([
+  "resolving",
+  "downloading",
+  "extracting",
+  "placing",
+]);
+
+/** Only the transfer can be stopped. Once the bytes are down, extraction and placement are
+ *  mid-flight file operations with nothing safe to interrupt — so the X goes away rather than
+ *  becoming a button that quietly does nothing. */
+const CANCELLABLE = new Set<InstallStage>(["resolving", "downloading"]);
+
+/** An import has no transfer to stop — it's a local file being unpacked, and the backend
+ *  registers no cancel flag for it. Offering the X would be offering a button that lies. */
+function cancellable(job: ActiveInstall): boolean {
+  return (
+    job.source.kind !== "import" && CANCELLABLE.has(job.stage) && !job.cancelling
+  );
+}
+
+const STAGE_LABEL: Record<string, TKey> = {
+  resolving: "downloads.stageResolving",
+  downloading: "downloads.stageDownloading",
+  extracting: "downloads.stageExtracting",
+  placing: "downloads.stagePlacing",
+};
+
+export default function DownloadQueue({ collapsed }: { collapsed: boolean }) {
+  const t = useT();
+  const { active, queued, cancel } = useInstall();
+
+  const installing = active && IN_PROGRESS.has(active.stage) ? active : null;
+  const pct =
+    installing?.total && installing.received
+      ? Math.round((installing.received / installing.total) * 100)
+      : undefined;
+
+  // Nothing moving and nothing waiting: no card, exactly as before.
+  if (!installing && queued.length === 0) return null;
+
+  const total = (installing ? 1 : 0) + queued.length;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        {collapsed ? (
+          <button
+            title={t("downloads.title")}
+            aria-label={t("downloads.title")}
+            className="relative flex cursor-default items-center justify-center rounded-lg py-2.5 text-muted-foreground transition-colors hover:bg-foreground/[0.05] hover:text-foreground"
+          >
+            <Download className="size-4" />
+            <span className="absolute right-1.5 top-1 min-w-[14px] rounded-full bg-primary px-1 text-[9px] font-bold leading-[14px] text-primary-foreground">
+              {total}
+            </span>
+          </button>
+        ) : (
+          <button
+            title={t("downloads.open")}
+            className="flex cursor-default flex-col gap-[7px] rounded-[10px] border border-white/[0.07] bg-[color-mix(in_srgb,var(--card)_60%,var(--window))] px-3 py-2.5 text-left transition-colors hover:border-white/[0.12]"
+          >
+            <div className="flex items-baseline justify-between gap-2">
+              <span className="truncate text-[11.5px] font-semibold text-foreground/85">
+                {installing
+                  ? t("sidebar.installing", { name: displayName(installing.title) })
+                  : t("downloads.title")}
+              </span>
+              {pct !== undefined && (
+                <span className="flex-none text-[10.5px] text-muted-foreground">{pct}%</span>
+              )}
+            </div>
+            {queued.length > 0 && (
+              <span className="text-[10.5px] text-muted-foreground">
+                {t("sidebar.queued", { count: queued.length })}
+              </span>
+            )}
+            <div className="h-[3px] overflow-hidden rounded-full bg-foreground/[0.08]">
+              <div
+                className={cn(
+                  "h-full rounded-full bg-primary transition-[width]",
+                  pct === undefined &&
+                    "w-1/3 animate-[frost-indeterminate_1.2s_ease-in-out_infinite]",
+                )}
+                style={pct !== undefined ? { width: `${pct}%` } : undefined}
+              />
+            </div>
+          </button>
+        )}
+      </PopoverTrigger>
+
+      <PopoverContent side="right" align="end" className="w-[300px] p-0">
+        <div className="border-b border-white/[0.07] px-3.5 py-2.5">
+          <span className="text-[12px] font-bold">{t("downloads.title")}</span>
+        </div>
+        <div className="flex max-h-[320px] flex-col overflow-y-auto py-1.5">
+          {installing && (
+            <div className="flex flex-col gap-1.5 px-3.5 py-2">
+              <div className="flex items-start gap-2">
+                <span className="min-w-0 flex-1 truncate text-[12px] font-semibold">
+                  {displayName(installing.title)}
+                </span>
+                {cancellable(installing) && (
+                  <CancelButton
+                    label={t("downloads.cancel")}
+                    onClick={() => cancel(installing.key)}
+                  />
+                )}
+              </div>
+              <div className="flex items-baseline justify-between gap-2 text-[10.5px] text-muted-foreground">
+                <span className="truncate">
+                  {installing.cancelling
+                    ? t("downloads.cancelling")
+                    : t(STAGE_LABEL[installing.stage] ?? "downloads.stageDownloading")}
+                </span>
+                {installing.received !== undefined && (
+                  <span className="flex-none tabular-nums">
+                    {installing.total
+                      ? `${formatBytes(installing.received)} / ${formatBytes(installing.total)}`
+                      : formatBytes(installing.received)}
+                  </span>
+                )}
+              </div>
+              <div className="h-[3px] overflow-hidden rounded-full bg-foreground/[0.08]">
+                <div
+                  className={cn(
+                    "h-full rounded-full bg-primary transition-[width]",
+                    pct === undefined &&
+                      "w-1/3 animate-[frost-indeterminate_1.2s_ease-in-out_infinite]",
+                  )}
+                  style={pct !== undefined ? { width: `${pct}%` } : undefined}
+                />
+              </div>
+            </div>
+          )}
+
+          {queued.map((q) => (
+            <QueuedRow key={q.key} item={q} onCancel={() => cancel(q.key)} />
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function QueuedRow({ item, onCancel }: { item: QueuedInstall; onCancel: () => void }) {
+  const t = useT();
+  return (
+    <div className="group flex items-center gap-2 px-3.5 py-2">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-[12px] font-medium">{displayName(item.title)}</span>
+        <span className="text-[10.5px] text-muted-foreground">{t("downloads.waiting")}</span>
+      </div>
+      <CancelButton label={t("downloads.remove")} onClick={onCancel} />
+    </div>
+  );
+}
+
+function CancelButton({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      title={label}
+      aria-label={label}
+      className="flex-none cursor-default rounded-full p-1 text-muted-foreground transition-colors hover:bg-destructive/15 hover:text-destructive"
+    >
+      <X className="size-3.5" />
+    </button>
+  );
+}

--- a/src/Components/Shell/Sidebar.tsx
+++ b/src/Components/Shell/Sidebar.tsx
@@ -21,8 +21,6 @@ import {
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useFrostmod } from "../../Context/FrostmodContext";
-import { useInstall } from "../../Context/Install";
-import { displayName } from "../../lib/mods";
 import { useT, type TKey } from "../../i18n/context";
 import {
   experimentalState,
@@ -35,6 +33,7 @@ import { useGameRunning } from "../../lib/useGameRunning";
 import { useConfig } from "../../Context/Config";
 import type { GameCaps } from "../../types";
 import JoinServerDialog from "./JoinServerDialog";
+import DownloadQueue from "./DownloadQueue";
 
 export type DashboardView =
   | "browse"
@@ -103,15 +102,12 @@ const EXPERIMENTAL_NAV: NavEntry = {
 /** Remembered across launches: a collapsed sidebar is a preference, not a mode. */
 const COLLAPSED_KEY = "mxb:sidebarCollapsed:v1";
 
-const IN_PROGRESS = new Set(["resolving", "downloading", "extracting", "placing"]);
-
 /** MX Bikes takes a while to show up in the process list; stop saying "Starting…" after this. */
 const STARTING_TIMEOUT_MS = 15000;
 
 export default function Sidebar({ view, onNavigate }: SidebarProps) {
   const t = useT();
   const { running, reload, status, start, stop } = useFrostmod();
-  const { active, queueLength } = useInstall();
   const { running: gameRunning, refresh: refreshGame } = useGameRunning();
   const { game } = useConfig();
   const caps = game.caps;
@@ -196,12 +192,6 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
     refreshGame();
   };
 
-  const installing = active && IN_PROGRESS.has(active.stage);
-  const pct =
-    active?.total && active.received
-      ? Math.round((active.received / active.total) * 100)
-      : undefined;
-
   const onReload = async () => {
     const outcome = await reload();
     if (outcome === "signaled") toast.success(t("frostmod.reloadedGame"));
@@ -271,35 +261,8 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
       </nav>
 
       <div className="mt-auto flex flex-col gap-2">
-        {!collapsed && installing && (
-          <div className="flex flex-col gap-[7px] rounded-[10px] border border-white/[0.07] bg-[color-mix(in_srgb,var(--card)_60%,var(--window))] px-3 py-2.5">
-            <div className="flex items-baseline justify-between gap-2">
-              <span className="truncate text-[11.5px] font-semibold text-foreground/85">
-                {t("sidebar.installing", { name: displayName(active.title) })}
-              </span>
-              {pct !== undefined && (
-                <span className="flex-none text-[10.5px] text-muted-foreground">
-                  {pct}%
-                </span>
-              )}
-            </div>
-            {queueLength > 0 && (
-              <span className="text-[10.5px] text-muted-foreground">
-                {t("sidebar.queued", { count: queueLength })}
-              </span>
-            )}
-            <div className="h-[3px] overflow-hidden rounded-full bg-foreground/[0.08]">
-              <div
-                className={cn(
-                  "h-full rounded-full bg-primary transition-[width]",
-                  pct === undefined &&
-                    "w-1/3 animate-[frost-indeterminate_1.2s_ease-in-out_infinite]",
-                )}
-                style={pct !== undefined ? { width: `${pct}%` } : undefined}
-              />
-            </div>
-          </div>
-        )}
+        {/* The install card is the queue's trigger now — same look, opens the panel. */}
+        <DownloadQueue collapsed={collapsed} />
 
         <button
           data-tour="play"

--- a/src/Context/Install.tsx
+++ b/src/Context/Install.tsx
@@ -12,6 +12,7 @@ import { AlertTriangle, X } from "lucide-react";
 import { toast } from "sonner";
 import {
   addToLibrary,
+  cancelInstall,
   importFile,
   onFrostmodReload,
   onInstallProgress,
@@ -54,18 +55,36 @@ export interface ModTarget {
 }
 
 export interface ActiveInstall extends StartParams {
+  /** Identity in the queue panel — the same key `enqueue` dedupes on. */
+  key: string;
   stage: InstallStage;
   received?: number;
   total?: number;
   message?: string;
   frostmod: ReloadOutcome | null;
+  /** The user asked to stop this one and the backend hasn't unwound yet. Deliberately not an
+   *  `InstallStage`: that union mirrors the stages Rust actually emits. */
+  cancelling?: boolean;
+}
+
+/** One install waiting its turn, as the queue panel needs to show it. */
+export interface QueuedInstall {
+  key: string;
+  slug: string;
+  title: string;
+  kind: InstallSource["kind"];
 }
 
 interface InstallContextValue {
   /** The single in-flight (or just-finished) install, or `null`. */
   active: ActiveInstall | null;
+  /** Everything waiting behind the active one, in the order it will run. */
+  queued: QueuedInstall[];
   /** Number of installs waiting behind the active one (bulk quick-install). */
   queueLength: number;
+  /** Drop an install by `key`: a queued one never starts, the active one is stopped mid-transfer.
+   *  A no-op once the bytes are down — extraction and placement can't be interrupted safely. */
+  cancel: (key: string) => void;
   startInstall: (
     p: Omit<StartParams, "source"> & { url: string; host: string },
   ) => void;
@@ -90,7 +109,9 @@ export function InstallProvider({
   children: ReactNode;
 }) {
   const [active, setActive] = useState<ActiveInstall | null>(null);
-  const [queueLength, setQueueLength] = useState(0);
+  // Mirrors `queueRef` for rendering. The ref stays the source of truth — `pump` shifts off it
+  // synchronously — but a ref is invisible to React, so the panel reads this copy.
+  const [queued, setQueued] = useState<QueuedInstall[]>([]);
   const onInstalledRef = useRef(onInstalled);
   onInstalledRef.current = onInstalled;
   const onOpenModRef = useRef(onOpenMod);
@@ -107,6 +128,11 @@ export function InstallProvider({
   const runningRef = useRef(false);
   // What the queue is draining right now, so `enqueue` can turn a repeat request away.
   const activeKeyRef = useRef<string | null>(null);
+  // The same job in full, so `cancel` has its slug without depending on `active` state.
+  const runningParamsRef = useRef<StartParams | null>(null);
+  // The key the user asked to cancel, so `run` can tell a stop it was asked for from a genuine
+  // failure and skip the red toast.
+  const cancelledKeyRef = useRef<string | null>(null);
   // `run`'s retry buttons enqueue rather than re-run, but `enqueue` is defined further
   // down (it needs `pump`, which needs `run`). A ref breaks the cycle without costing
   // `run` its empty dep list.
@@ -119,10 +145,23 @@ export function InstallProvider({
     [],
   );
 
+  /** Republish the pending queue for rendering. Called wherever `queueRef` moves. */
+  const syncQueue = useCallback(() => {
+    setQueued(
+      queueRef.current.map((p) => ({
+        key: installKey(p),
+        slug: p.slug,
+        title: p.title,
+        kind: p.source.kind,
+      })),
+    );
+  }, []);
+
   const run = useCallback(async (params: StartParams) => {
     const { slug, title, subpath, destFolder, source } = params;
+    const key = installKey(params);
     if (clearTimer.current) window.clearTimeout(clearTimer.current);
-    setActive({ ...params, stage: "resolving", frostmod: null });
+    setActive({ ...params, key, stage: "resolving", frostmod: null });
 
     // FrostMod's reload event can land just before the install call resolves;
     // stash the outcome so the success toast can mention it.
@@ -175,6 +214,15 @@ export function InstallProvider({
         );
       }, 5000);
     } catch (e) {
+      // A stop the user asked for isn't a failure: retire the card quietly rather than leaving
+      // a red error and a Retry button behind. Note this only runs when the backend actually
+      // unwound — an install that finished before the cancel landed took the success path above,
+      // which is the honest outcome, since the mod really is installed.
+      if (cancelledKeyRef.current === key) {
+        setActive((cur) => (cur && cur.key === key ? null : cur));
+        toast.info(tRef.current("install.cancelled", { title }));
+        return;
+      }
       const message = String(e);
       setActive((cur) =>
         cur && cur.slug === slug ? { ...cur, stage: "error", message } : cur,
@@ -201,6 +249,7 @@ export function InstallProvider({
         { duration: Infinity },
       );
     } finally {
+      if (cancelledKeyRef.current === key) cancelledKeyRef.current = null;
       unlisten();
       unlistenFrost();
     }
@@ -214,18 +263,20 @@ export function InstallProvider({
     try {
       while (queueRef.current.length) {
         const next = queueRef.current.shift()!;
-        setQueueLength(queueRef.current.length);
+        syncQueue();
         activeKeyRef.current = installKey(next);
+        runningParamsRef.current = next;
         try {
           await run(next);
         } finally {
           activeKeyRef.current = null;
+          runningParamsRef.current = null;
         }
       }
     } finally {
       runningRef.current = false;
     }
-  }, [run]);
+  }, [run, syncQueue]);
 
   const enqueue = useCallback(
     (params: StartParams) => {
@@ -240,12 +291,34 @@ export function InstallProvider({
       if (activeKeyRef.current === key) return;
       if (queueRef.current.some((q) => installKey(q) === key)) return;
       queueRef.current.push(params);
-      setQueueLength(queueRef.current.length);
+      syncQueue();
       void pump();
     },
-    [pump],
+    [pump, syncQueue],
   );
   enqueueRef.current = enqueue;
+
+  const cancel = useCallback(
+    (key: string) => {
+      // Still waiting its turn: drop it here and the backend never hears about it at all.
+      const at = queueRef.current.findIndex((q) => installKey(q) === key);
+      if (at >= 0) {
+        queueRef.current.splice(at, 1);
+        syncQueue();
+        return;
+      }
+      const running = runningParamsRef.current;
+      if (!running || installKey(running) !== key) return;
+      cancelledKeyRef.current = key;
+      setActive((cur) => (cur && cur.key === key ? { ...cur, cancelling: true } : cur));
+      // The install command rejects once the transfer loop notices, and `run`'s catch takes it
+      // from there. Nothing to await: a failure here just means it stops the ordinary way.
+      // Read off the ref rather than `active` so this callback doesn't churn on every progress
+      // tick — the panel's buttons would rebuild 60 times a download.
+      void cancelInstall(running.slug).catch(() => {});
+    },
+    [syncQueue],
+  );
 
   const startInstall: InstallContextValue["startInstall"] = useCallback(
     ({ url, host, ...rest }) =>
@@ -269,13 +342,15 @@ export function InstallProvider({
   const value = useMemo(
     () => ({
       active,
-      queueLength,
+      queued,
+      queueLength: queued.length,
+      cancel,
       startInstall,
       startImport,
       startShopInstall,
       clear,
     }),
-    [active, queueLength, startInstall, startImport, startShopInstall, clear],
+    [active, queued, cancel, startInstall, startImport, startShopInstall, clear],
   );
 
   return (

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -837,6 +837,12 @@ export function addToLibrary(
   return invoke<void>("add_to_library", { slug, url, host, subpath, destFolder });
 }
 
+/** Stop the install in flight for `slug`. `false` when nothing is running under it — only the
+ *  transfer is interruptible, so this does nothing once extraction has begun. */
+export function cancelInstall(slug: string): Promise<boolean> {
+  return invoke<boolean>("cancel_install", { slug });
+}
+
 /** Import a file the user downloaded manually (extract + place into `subpath`). */
 export function importFile(
   path: string,

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1071,6 +1071,18 @@ export const de: Translation = {
   "install.failed": "Installation fehlgeschlagen — {{title}}",
   "install.openModPage": "Die Mod-Seite öffnen",
   "install.clickToOpen": "Klicken, um die Mod-Seite zu öffnen",
+  "install.cancelled": "{{title}} abgebrochen",
+
+  "downloads.title": "Downloads",
+  "downloads.open": "Download-Warteschlange anzeigen",
+  "downloads.waiting": "Wartet",
+  "downloads.cancel": "Diesen Download abbrechen",
+  "downloads.remove": "Aus der Warteschlange entfernen",
+  "downloads.cancelling": "Wird abgebrochen…",
+  "downloads.stageResolving": "Datei wird gesucht…",
+  "downloads.stageDownloading": "Wird heruntergeladen",
+  "downloads.stageExtracting": "Wird entpackt",
+  "downloads.stagePlacing": "Wird installiert",
 
   // ── Kategorien (Singular) ──────────────────────────────────────────────────
   "category.track": "Strecke",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1029,6 +1029,18 @@ export const en = {
   "install.failed": "Install failed — {{title}}",
   "install.openModPage": "Open the mod's page",
   "install.clickToOpen": "Click to open the mod's page",
+  "install.cancelled": "Cancelled {{title}}",
+
+  "downloads.title": "Downloads",
+  "downloads.open": "Show the download queue",
+  "downloads.waiting": "Waiting",
+  "downloads.cancel": "Cancel this download",
+  "downloads.remove": "Remove from the queue",
+  "downloads.cancelling": "Cancelling…",
+  "downloads.stageResolving": "Finding the file…",
+  "downloads.stageDownloading": "Downloading",
+  "downloads.stageExtracting": "Extracting",
+  "downloads.stagePlacing": "Installing",
 
   // ── Library categories (singular — item "Type" label) ──────────────────────
   "category.track": "Track",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1059,6 +1059,18 @@ export const es: Translation = {
   "install.failed": "Fallo en la instalación — {{title}}",
   "install.openModPage": "Abrir la página del mod",
   "install.clickToOpen": "Haz clic para abrir la página del mod",
+  "install.cancelled": "{{title}} cancelado",
+
+  "downloads.title": "Descargas",
+  "downloads.open": "Mostrar la cola de descargas",
+  "downloads.waiting": "En espera",
+  "downloads.cancel": "Cancelar esta descarga",
+  "downloads.remove": "Quitar de la cola",
+  "downloads.cancelling": "Cancelando…",
+  "downloads.stageResolving": "Buscando el archivo…",
+  "downloads.stageDownloading": "Descargando",
+  "downloads.stageExtracting": "Extrayendo",
+  "downloads.stagePlacing": "Instalando",
 
   // ── Categorías (singular) ──────────────────────────────────────────────────
   "category.track": "Pista",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1062,6 +1062,18 @@ export const fr: Translation = {
   "install.failed": "Échec de l'installation — {{title}}",
   "install.openModPage": "Ouvrir la page du mod",
   "install.clickToOpen": "Cliquez pour ouvrir la page du mod",
+  "install.cancelled": "{{title}} annulé",
+
+  "downloads.title": "Téléchargements",
+  "downloads.open": "Afficher la file de téléchargement",
+  "downloads.waiting": "En attente",
+  "downloads.cancel": "Annuler ce téléchargement",
+  "downloads.remove": "Retirer de la file",
+  "downloads.cancelling": "Annulation…",
+  "downloads.stageResolving": "Recherche du fichier…",
+  "downloads.stageDownloading": "Téléchargement",
+  "downloads.stageExtracting": "Extraction",
+  "downloads.stagePlacing": "Installation",
 
   // ── Catégories (singulier) ─────────────────────────────────────────────────
   "category.track": "Circuit",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1051,6 +1051,18 @@ export const it: Translation = {
   "install.failed": "Installazione fallita — {{title}}",
   "install.openModPage": "Apri la pagina della mod",
   "install.clickToOpen": "Clicca per aprire la pagina della mod",
+  "install.cancelled": "{{title}} annullato",
+
+  "downloads.title": "Download",
+  "downloads.open": "Mostra la coda dei download",
+  "downloads.waiting": "In attesa",
+  "downloads.cancel": "Annulla questo download",
+  "downloads.remove": "Rimuovi dalla coda",
+  "downloads.cancelling": "Annullamento…",
+  "downloads.stageResolving": "Ricerca del file…",
+  "downloads.stageDownloading": "Download in corso",
+  "downloads.stageExtracting": "Estrazione",
+  "downloads.stagePlacing": "Installazione",
 
   // ── Categorie (singolare) ──────────────────────────────────────────────────
   "category.track": "Pista",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1051,6 +1051,18 @@ export const ptBR: Translation = {
   "install.failed": "Falha na instalação — {{title}}",
   "install.openModPage": "Abrir a página do mod",
   "install.clickToOpen": "Clique para abrir a página do mod",
+  "install.cancelled": "{{title}} cancelado",
+
+  "downloads.title": "Downloads",
+  "downloads.open": "Mostrar a fila de downloads",
+  "downloads.waiting": "Aguardando",
+  "downloads.cancel": "Cancelar este download",
+  "downloads.remove": "Remover da fila",
+  "downloads.cancelling": "Cancelando…",
+  "downloads.stageResolving": "Localizando o arquivo…",
+  "downloads.stageDownloading": "Baixando",
+  "downloads.stageExtracting": "Extraindo",
+  "downloads.stagePlacing": "Instalando",
 
   // ── Categorias (singular) ──────────────────────────────────────────────────
   "category.track": "Pista",


### PR DESCRIPTION
## What

The sidebar install card above Play becomes a button. It opens a panel listing the transfer in progress and everything queued behind it, with an X on each row.

Installs have always run through a real FIFO queue (`Context/Install`), but the queue lived in a **ref** — invisible to React — so the only sign of it was a `+N queued` line. And there was no cancellation anywhere in the Rust side: no token, no stored handle, no flag checked in a download loop. Quitting the app was the only way to stop a 400 MB track queued by mistake.

## How

**Cancellation** is a new `src-tauri/src/cancel.rs`: a slug-keyed registry of `Arc<AtomicBool>` flags with a drop guard, registered by `add_to_library` and `shop_install`. Each download loop grabs the `Arc` once and then polls a relaxed atomic per chunk.

It is looked up **by slug** rather than threaded through as a parameter. That is the load-bearing choice here — `install::download` and `shop_fetch::download` are deliberately signature-compatible (`shop_stage` swaps one for the other), and `bundle.rs` calls into the same functions.

Check points cover all three transfer paths:

| Path | Where |
|---|---|
| HTTP | the resume loop + `stream_to_file`'s chunk loop |
| MEGA | `MegaProgressWriter::poll_write` — refusing the write is the only way into the `mega` crate's transfer |
| Shop | `wait_for_start` / `wait_for_finish` poll loops |

**Frontend:** the queue is mirrored into state for rendering (the ref stays the source of truth, since `pump` shifts off it synchronously). Cancelling a queued item never reaches the backend. Cancelling the active one suppresses the failure toast and retires the card quietly.

## Deliberate limits

- **The X disappears at `extracting`.** Once the bytes are down, extraction and placement are mid-flight file operations with nothing safe to interrupt — better than a button that silently does nothing. Imports never show one: local unpack, no transfer, no flag registered.
- **A cancel that loses the race is reported as success.** If the install completed before the cancel landed, the mod really is installed, and saying otherwise would be a lie.
- **The shop path can't truly abort.** Tauri's `DownloadEvent` carries no abort handle, so we stop waiting and navigate the window away. The browser may still finish writing the file; the staging cleanup has always been best-effort.
- **Not fixed here:** the overlay window has its own `InstallProvider`, so the same slug installed from both windows shares one cancel flag. Worst case is a cancel that does nothing — no corruption. A proper fix needs a job id in the progress event, which is a bigger change than this warrants.

## Also fixed

- A failed or cancelled download no longer leaves its staging directory behind. Every abandoned attempt used to leave the partial archive in the temp dir.
- `shop_fetch::download` returns the window to the purchases page on every exit, not only on success.

## Verified

`cargo check` (no new warnings) · 4 new `cancel.rs` unit tests · `tsc --noEmit` · `eslint` · `vite build`.

Needs a hand pass on the three transfer paths against live hosts — a normal mirror, a MEGA link, and a shop purchase each hit a different check point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)