### PR TITLE
feat(downloads): a page for what you just downloaded, failures included

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased — a Downloads page, so you can see what you just grabbed
+
+### Added
+- **Downloads — everything you've installed, newest first.** Grab eight tracks in an evening
+  and there was no way to see which eight: the library scans your mods folder, which knows what
+  is there but not when it arrived. The new page groups by day, says where each one landed and
+  which mirror served it, and searches by name, destination or host.
+- **Failed downloads are kept instead of vanishing.** A failure used to live only in a toast —
+  dismiss it and there was no record the download had ever been tried, just a mod that silently
+  wasn't there. Failures now stay on the page with their error, retry in place through the same
+  install queue, and put a count on the sidebar so one is noticeable at all.
+- **"Recently added" sort in the library.** The history only knows about downloads from this
+  version on, so the library sorts by file time too — which covers everything already on disk.
+
 ## Unreleased — undo covers the whole editor, and the bucket stays on its panel
 
 ### Added

--- a/src-tauri/src/downloads.rs
+++ b/src-tauri/src/downloads.rs
@@ -1,0 +1,323 @@
+//! What the app has downloaded, kept so it can be looked back at.
+//!
+//! Nothing else remembers. The library is a scan of the mods folder, which says what is there but
+//! not when it arrived or what it was called on the site — and a *failed* download leaves no trace
+//! at all once its toast is gone, so a mod can simply be missing with no record it was ever tried.
+//!
+//! Same shape as [`crate::shop_installed`]: a small JSON file, best-effort, a corrupt one reads as
+//! empty. History is never worth failing an install over.
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Newest first; appending past this drops the oldest. A few hundred covers "what did I grab this
+/// week" without the file growing forever.
+const MAX_RECORDS: usize = 300;
+
+/// One download, as recorded. `status` is `installed` or `failed`; `source` is `site`, `shop` or
+/// `file` (imported or dragged in).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadRecord {
+    pub id: String,
+    /// Unix milliseconds, stamped here rather than by the caller so ordering is one clock's.
+    pub at: u64,
+    pub title: String,
+    /// Empty for a dragged-in file: it has no page to go back to.
+    #[serde(default)]
+    pub slug: String,
+    #[serde(default)]
+    pub subpath: String,
+    #[serde(default)]
+    pub dest_folder: String,
+    #[serde(default)]
+    pub category_id: Option<u32>,
+    pub source: String,
+    /// Which mirror served it — MediaFire, Google Drive, MEGA…
+    #[serde(default)]
+    pub host: Option<String>,
+    /// The link it came from, kept so a failed download can be retried straight from the row
+    /// rather than sending the user back to find the mod again. Absent for shops and files.
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub bytes: Option<u64>,
+    pub status: String,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+/// What a caller supplies. `id` and `at` are ours to assign.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NewDownload {
+    pub title: String,
+    #[serde(default)]
+    pub slug: String,
+    #[serde(default)]
+    pub subpath: String,
+    #[serde(default)]
+    pub dest_folder: String,
+    #[serde(default)]
+    pub category_id: Option<u32>,
+    pub source: String,
+    #[serde(default)]
+    pub host: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub bytes: Option<u64>,
+    pub status: String,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct Store {
+    /// Bumped per record, so two downloads inside the same millisecond still get distinct ids.
+    #[serde(default)]
+    seq: u64,
+    #[serde(default)]
+    records: Vec<DownloadRecord>,
+}
+
+fn store_path(dir: &Path) -> PathBuf {
+    dir.join("download-history.json")
+}
+
+fn load(dir: &Path) -> Store {
+    match fs::read_to_string(store_path(dir)) {
+        Ok(text) => serde_json::from_str(&text).unwrap_or_default(),
+        Err(_) => Store::default(),
+    }
+}
+
+fn save(dir: &Path, store: &Store) -> anyhow::Result<()> {
+    fs::create_dir_all(dir)?;
+    fs::write(store_path(dir), serde_json::to_string_pretty(store)?)?;
+    Ok(())
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Note one download. Returns the stored record so the caller can show it without re-reading.
+///
+/// A record with nothing to name is dropped rather than stored: a row with a blank title tells
+/// the user less than no row at all.
+pub fn record(dir: &Path, new: NewDownload) -> anyhow::Result<Option<DownloadRecord>> {
+    if new.title.trim().is_empty() && new.slug.trim().is_empty() {
+        return Ok(None);
+    }
+    let mut store = load(dir);
+    store.seq = store.seq.wrapping_add(1);
+    let at = now_ms();
+    let entry = DownloadRecord {
+        id: format!("{at:x}-{}", store.seq),
+        at,
+        title: new.title,
+        slug: new.slug,
+        subpath: new.subpath,
+        dest_folder: new.dest_folder,
+        category_id: new.category_id,
+        source: new.source,
+        host: new.host,
+        url: new.url,
+        bytes: new.bytes,
+        status: new.status,
+        error: new.error,
+    };
+    store.records.insert(0, entry.clone());
+    store.records.truncate(MAX_RECORDS);
+    save(dir, &store)?;
+    Ok(Some(entry))
+}
+
+/// Everything recorded, newest first.
+pub fn history(dir: &Path) -> Vec<DownloadRecord> {
+    let mut records = load(dir).records;
+    // Sorted on read as well as written: a store hand-edited or merged from another machine
+    // should still come back in order.
+    records.sort_by(|a, b| b.at.cmp(&a.at));
+    records
+}
+
+/// Drop one row. Unknown ids are not an error — the row is gone either way.
+pub fn forget(dir: &Path, id: &str) -> anyhow::Result<()> {
+    let mut store = load(dir);
+    let before = store.records.len();
+    store.records.retain(|r| r.id != id);
+    if store.records.len() != before {
+        save(dir, &store)?;
+    }
+    Ok(())
+}
+
+/// Drop everything, keeping `seq` so ids stay unique against anything still on screen.
+pub fn clear(dir: &Path) -> anyhow::Result<()> {
+    let mut store = load(dir);
+    store.records.clear();
+    save(dir, &store)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "frost-downloads-test-{}-{name}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn sample(title: &str, status: &str) -> NewDownload {
+        NewDownload {
+            title: title.to_string(),
+            slug: title.to_lowercase().replace(' ', "-"),
+            subpath: "tracks".to_string(),
+            dest_folder: "tracks".to_string(),
+            category_id: Some(7),
+            source: "site".to_string(),
+            host: Some("MediaFire".to_string()),
+            url: Some("https://example.invalid/file.pkz".to_string()),
+            bytes: Some(1024),
+            status: status.to_string(),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn a_record_round_trips() {
+        let dir = tmp("roundtrip");
+        record(&dir, sample("Cedar Ridge", "installed")).unwrap();
+
+        let back = history(&dir);
+        assert_eq!(back.len(), 1);
+        assert_eq!(back[0].title, "Cedar Ridge");
+        assert_eq!(back[0].host.as_deref(), Some("MediaFire"));
+        assert!(back[0].at > 0, "a row with no time can't be sorted by time");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// The whole point of the page: the most recent download is the one at the top.
+    #[test]
+    fn history_comes_back_newest_first() {
+        let dir = tmp("order");
+        for n in 0..3 {
+            record(&dir, sample(&format!("Track {n}"), "installed")).unwrap();
+        }
+
+        let back = history(&dir);
+        assert_eq!(
+            back.iter().map(|r| r.title.as_str()).collect::<Vec<_>>(),
+            ["Track 2", "Track 1", "Track 0"]
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Ids have to survive a burst: a bulk install writes several inside one millisecond, and a
+    /// duplicate id would make dismissing one row dismiss another.
+    #[test]
+    fn ids_are_unique_across_a_burst() {
+        let dir = tmp("ids");
+        for n in 0..25 {
+            record(&dir, sample(&format!("Track {n}"), "installed")).unwrap();
+        }
+
+        let ids: std::collections::HashSet<String> =
+            history(&dir).into_iter().map(|r| r.id).collect();
+        assert_eq!(ids.len(), 25);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn the_oldest_rows_fall_off_the_end() {
+        let dir = tmp("cap");
+        for n in 0..(MAX_RECORDS + 5) {
+            record(&dir, sample(&format!("Track {n}"), "installed")).unwrap();
+        }
+
+        let back = history(&dir);
+        assert_eq!(back.len(), MAX_RECORDS);
+        assert_eq!(back[0].title, format!("Track {}", MAX_RECORDS + 4));
+        assert!(
+            !back.iter().any(|r| r.title == "Track 0"),
+            "the cap drops the oldest, not the newest"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_failure_keeps_its_error() {
+        let dir = tmp("failure");
+        let mut failed = sample("Sandbox Park", "failed");
+        failed.error = Some("Google Drive has hit this file's download limit".to_string());
+        record(&dir, failed).unwrap();
+
+        let back = history(&dir);
+        assert_eq!(back[0].status, "failed");
+        assert!(back[0].error.as_deref().unwrap().contains("download limit"));
+        assert!(
+            back[0].url.is_some(),
+            "without the link the row can't offer a retry"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn forgetting_removes_only_that_row() {
+        let dir = tmp("forget");
+        record(&dir, sample("Keep", "installed")).unwrap();
+        let drop = record(&dir, sample("Drop", "installed")).unwrap().unwrap();
+
+        forget(&dir, &drop.id).unwrap();
+        let back = history(&dir);
+        assert_eq!(back.len(), 1);
+        assert_eq!(back[0].title, "Keep");
+
+        forget(&dir, "not-an-id").unwrap();
+        assert_eq!(history(&dir).len(), 1, "an unknown id is a no-op");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn clearing_leaves_later_ids_unique() {
+        let dir = tmp("clear");
+        let first = record(&dir, sample("Old", "installed")).unwrap().unwrap();
+        clear(&dir).unwrap();
+        assert!(history(&dir).is_empty());
+
+        let next = record(&dir, sample("New", "installed")).unwrap().unwrap();
+        assert_ne!(first.id, next.id, "a cleared store must not reuse ids");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Nothing here is worth failing an install over.
+    #[test]
+    fn missing_corrupt_and_nameless_are_survivable() {
+        let dir = tmp("robust");
+        assert!(history(&dir).is_empty(), "no file yet reads as no history");
+
+        let mut nameless = sample("", "installed");
+        nameless.slug = String::new();
+        assert!(record(&dir, nameless).unwrap().is_none());
+        assert!(history(&dir).is_empty(), "a nameless row is not worth a line");
+
+        fs::write(store_path(&dir), "not json").unwrap();
+        assert!(history(&dir).is_empty(), "a corrupt store reads as empty");
+        // ...and writing over it recovers rather than erroring.
+        record(&dir, sample("After", "installed")).unwrap();
+        assert_eq!(history(&dir).len(), 1);
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -365,6 +365,9 @@ pub struct LibraryEntry {
     pub path: String,
     pub folder: String,
     pub size: u64,
+    /// Unix milliseconds, so the library can be sorted by what arrived most recently — the only
+    /// answer available for mods installed before the download history existed.
+    pub modified: u64,
     pub kind: String,
     pub category: String,
     pub parent: Option<String>,
@@ -394,18 +397,33 @@ fn rel_folder(base: &Path, path: &Path) -> String {
         .unwrap_or_default()
 }
 
-fn dir_size(dir: &Path) -> u64 {
+/// Unix milliseconds, or 0 when the filesystem won't say — a mod with no time sorts last under
+/// "recently added" rather than jumping to the top of it.
+pub(crate) fn mtime_ms(m: &fs::Metadata) -> u64 {
+    m.modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Total bytes and the newest mtime among a folder's immediate files, taking the folder's own
+/// mtime as the floor. The files matter as well as the folder because a copy can carry the
+/// original folder timestamp across while the files it wrote are stamped now.
+fn dir_size_and_mtime(dir: &Path) -> (u64, u64) {
     let mut total = 0;
+    let mut newest = fs::metadata(dir).map(|m| mtime_ms(&m)).unwrap_or(0);
     if let Ok(rd) = fs::read_dir(dir) {
         for e in rd.flatten() {
             if let Ok(m) = e.metadata() {
                 if m.is_file() {
                     total += m.len();
+                    newest = newest.max(mtime_ms(&m));
                 }
             }
         }
     }
-    total
+    (total, newest)
 }
 
 fn immediate_dirs(base: &Path) -> Vec<String> {
@@ -432,10 +450,12 @@ fn make_entry(base: &Path, p: &Path, category: &str, parent: Option<String>) -> 
     } else {
         "loose"
     };
-    let size = if is_dir {
-        dir_size(p)
+    let (size, modified) = if is_dir {
+        dir_size_and_mtime(p)
     } else {
-        fs::metadata(p).map(|m| m.len()).unwrap_or(0)
+        fs::metadata(p)
+            .map(|m| (m.len(), mtime_ms(&m)))
+            .unwrap_or((0, 0))
     };
     LibraryEntry {
         name: p
@@ -445,6 +465,7 @@ fn make_entry(base: &Path, p: &Path, category: &str, parent: Option<String>) -> 
         path: p.to_string_lossy().into_owned(),
         folder: rel_folder(base, p),
         size,
+        modified,
         kind: kind.to_string(),
         category: category.to_string(),
         parent,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,6 +8,7 @@ mod bundle;
 mod cfg;
 mod config;
 mod cookie_session;
+mod downloads;
 mod dropzone;
 mod edf;
 mod fileshare;
@@ -349,6 +350,9 @@ fn scan_library_blocking(
             .presets
             .into_iter()
             .map(|p| library::LibraryEntry {
+                modified: std::fs::metadata(&p.path)
+                    .map(|m| library::mtime_ms(&m))
+                    .unwrap_or(0),
                 name: p.name,
                 path: p.path,
                 folder: String::new(),
@@ -5571,6 +5575,37 @@ fn shop_installed_map(
     Ok(shop_installed::recorded(&dir))
 }
 
+/// Note a finished download — installed or failed. Called from the two places every install
+/// passes through (`Context/Install` and `Context/DropReview`), which is why nothing in the
+/// download paths themselves has to know history exists.
+#[tauri::command]
+fn record_download(
+    app: tauri::AppHandle,
+    entry: downloads::NewDownload,
+) -> Result<Option<downloads::DownloadRecord>, String> {
+    let dir = app.path().app_local_data_dir().map_err(|e| format!("{e:#}"))?;
+    downloads::record(&dir, entry).map_err(|e| format!("{e:#}"))
+}
+
+/// Everything downloaded, newest first.
+#[tauri::command]
+fn download_history(app: tauri::AppHandle) -> Result<Vec<downloads::DownloadRecord>, String> {
+    let dir = app.path().app_local_data_dir().map_err(|e| format!("{e:#}"))?;
+    Ok(downloads::history(&dir))
+}
+
+#[tauri::command]
+fn forget_download(app: tauri::AppHandle, id: String) -> Result<(), String> {
+    let dir = app.path().app_local_data_dir().map_err(|e| format!("{e:#}"))?;
+    downloads::forget(&dir, &id).map_err(|e| format!("{e:#}"))
+}
+
+#[tauri::command]
+fn clear_download_history(app: tauri::AppHandle) -> Result<(), String> {
+    let dir = app.path().app_local_data_dir().map_err(|e| format!("{e:#}"))?;
+    downloads::clear(&dir).map_err(|e| format!("{e:#}"))
+}
+
 fn presets_dir(app: &tauri::AppHandle) -> Result<std::path::PathBuf, String> {
     app.path()
         .app_local_data_dir()
@@ -6519,6 +6554,10 @@ fn main() {
             shop_match_catalog,
             shop_install,
             shop_installed_map,
+            record_download,
+            download_history,
+            forget_download,
+            clear_download_history,
             shop_catalog_available,
             shop_catalog_status,
             shop_catalog_categories,
@@ -6743,6 +6782,8 @@ mod window_tests {
                 "shop_install",
                 "shop_logout",
                 "commit_drop",
+                "record_download",
+                "clear_download_history",
                 "plugin:shell|open",
                 "plugin:dialog|open",
                 "plugin:event|listen",

--- a/src/Components/Dashboard/Dashboard.tsx
+++ b/src/Components/Dashboard/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import Sidebar, { type DashboardView } from "../Shell/Sidebar";
 import Library from "../Library/Library";
+import Downloads from "../Downloads/Downloads";
 import Locker from "../Locker/Locker";
 import Presets from "../Presets/Presets";
 import Manage from "../Manage/Manage";
@@ -15,11 +16,13 @@ import Tour, { TourContext, TOUR_DONE_KEY } from "../Tour/Tour";
 import ReleaseShowcase from "../Showcase/ReleaseShowcase";
 import { useReleaseShowcase } from "../Showcase/useReleaseShowcase";
 import { InstallProvider } from "../../Context/Install";
+import { DownloadsProvider } from "../../Context/Downloads";
 import { DropReviewProvider } from "../../Context/DropReview";
 import { useConfig } from "../../Context/Config";
-import { setIntroSeen } from "../../api/mods";
+import { modTypesFor, setIntroSeen } from "../../api/mods";
 import { useModBrowsing } from "../../lib/useModBrowsing";
-import type { Loadout } from "../../types";
+import { displayName } from "../../lib/mods";
+import type { DownloadRecord, Loadout } from "../../types";
 
 interface DashboardProps {
   /** True while the Welcome slideshow is still up. The tour waits for it to close
@@ -108,6 +111,22 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
     startTour();
   }, [welcomeActive, startTour, config.tourDone]);
 
+  // Jump from a download row to the mod it installed: the right library tab, searched for
+  // by name. A fresh object each time so repeating the same jump still re-applies it.
+  const [libraryFocus, setLibraryFocus] = useState<{ name: string } | null>(null);
+  const showInLibrary = useCallback(
+    (record: DownloadRecord) => {
+      const target = modTypesFor(game.id).find(
+        (mt) => mt.installSubpath === record.subpath,
+      );
+      if (target) changeType(target);
+      setLibraryFocus({ name: displayName(record.title) });
+      navigate("library");
+    },
+    [game.id, changeType, navigate],
+  );
+  const clearLibraryFocus = useCallback(() => setLibraryFocus(null), []);
+
   // Jump from Presets into the Rider tab with a preset loaded, to view it on the model.
   const openInRider = useCallback((lo: Loadout) => {
     setRiderPreset(lo);
@@ -117,6 +136,8 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
 
   return (
     <TourContext.Provider value={{ startTour }}>
+    {/* Outside the installers: both of them write to the history, and the sidebar reads it. */}
+    <DownloadsProvider>
     <InstallProvider onInstalled={onInstalled} onOpenMod={openModTarget}>
       {/* Wraps the views because two of them stage plans: a drop anywhere in the window, and
           the Shop's purchases grid. Both finish in the one review sheet this renders. */}
@@ -153,6 +174,14 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
               onChangeType={changeType}
               refreshKey={libraryVersion}
               onChanged={onInstalled}
+              focus={libraryFocus}
+              onFocusApplied={clearLibraryFocus}
+            />
+          ) : view === "downloads" ? (
+            <Downloads
+              onOpenMod={openModTarget}
+              onShowInLibrary={showInLibrary}
+              onOpenShop={() => navigate("shop")}
             />
           ) : view === "locker" ? (
             <Locker />
@@ -193,6 +222,7 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
       )}
       </DropReviewProvider>
     </InstallProvider>
+    </DownloadsProvider>
     </TourContext.Provider>
   );
 };

--- a/src/Components/Downloads/Downloads.tsx
+++ b/src/Components/Downloads/Downloads.tsx
@@ -1,0 +1,363 @@
+/**
+ * Everything the app has downloaded, newest first.
+ *
+ * The library answers "what do I have" by scanning the mods folder, which can't say *when*
+ * anything arrived — and says nothing at all about a download that failed, since a failure
+ * leaves no files behind and its toast is gone the moment it's dismissed. So this reads the
+ * recorded history instead (see `Context/Downloads`), which is the only place both facts live.
+ *
+ * A failed row keeps its error and retries in place through the same install queue as any
+ * other install; nothing here downloads anything itself.
+ */
+import { useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Download,
+  ExternalLink,
+  FileArchive,
+  Library as LibraryIcon,
+  MoreHorizontal,
+  RotateCw,
+  Search,
+  Store,
+  Trash2,
+  X,
+} from "lucide-react";
+import type { DownloadRecord, DownloadStatus } from "../../types";
+import { useDownloads } from "../../Context/Downloads";
+import { useInstall, type ModTarget } from "../../Context/Install";
+import { useT, type TFunc } from "../../i18n/context";
+import { dayStart, displayName, formatBytes, formatDay, formatTime } from "../../lib/mods";
+import { Segmented } from "@/Components/ui/segmented";
+import { Button } from "@/Components/ui/button";
+import HelpHint from "@/Components/ui/help-hint";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/Components/ui/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from "@/Components/ui/alert-dialog";
+import { cn } from "@/lib/utils";
+
+type Filter = "all" | DownloadStatus;
+
+interface DownloadsProps {
+  /** Open a mod's page on the site — where a site download came from. */
+  onOpenMod: (target: ModTarget) => void;
+  /** Show an installed mod in the library, on the right tab and searched for by name. */
+  onShowInLibrary: (record: DownloadRecord) => void;
+  /** Send a failed shop purchase back to the Shop, which is the only place it can be
+   *  re-downloaded from — a purchase link is signed in, so there's nothing to retry here. */
+  onOpenShop: () => void;
+}
+
+/** Records for one calendar day, newest day first. */
+interface DayGroup {
+  key: number;
+  label: string;
+  items: DownloadRecord[];
+}
+
+function groupByDay(records: DownloadRecord[]): DayGroup[] {
+  const groups: DayGroup[] = [];
+  for (const r of records) {
+    const key = dayStart(r.at);
+    const last = groups[groups.length - 1];
+    if (last && last.key === key) last.items.push(r);
+    else groups.push({ key, label: formatDay(r.at), items: [r] });
+  }
+  return groups;
+}
+
+function sourceLabel(record: DownloadRecord, t: TFunc): string {
+  if (record.source === "site") return record.host || t("downloads.sourceSite");
+  return record.source === "shop" ? t("downloads.sourceShop") : t("downloads.sourceFile");
+}
+
+/** Where it landed, as `tracks/MX2` — the answer to "so where did that one go". */
+function destLabel(record: DownloadRecord): string {
+  return [record.subpath, record.destFolder]
+    .filter((p) => p && p !== ".")
+    .join("/");
+}
+
+export default function Downloads({
+  onOpenMod,
+  onShowInLibrary,
+  onOpenShop,
+}: DownloadsProps) {
+  const t = useT();
+  const { records, loading, forget, clear, markSeen } = useDownloads();
+  const { startInstall } = useInstall();
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<Filter>("all");
+  const [clearOpen, setClearOpen] = useState(false);
+
+  // Being here is what "seen" means — it retires the sidebar's failure badge.
+  useEffect(markSeen, [markSeen, records.length]);
+
+  const counts = useMemo(
+    () => ({
+      all: records.length,
+      installed: records.filter((r) => r.status === "installed").length,
+      failed: records.filter((r) => r.status === "failed").length,
+    }),
+    [records],
+  );
+
+  const shown = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return records.filter((r) => {
+      if (filter !== "all" && r.status !== filter) return false;
+      if (!q) return true;
+      return (
+        r.title.toLowerCase().includes(q) ||
+        destLabel(r).toLowerCase().includes(q) ||
+        (r.host ?? "").toLowerCase().includes(q)
+      );
+    });
+  }, [records, search, filter]);
+
+  const groups = useMemo(() => groupByDay(shown), [shown]);
+
+  /** Straight back through the install queue, with the same destination as last time. */
+  const retry = (r: DownloadRecord) => {
+    if (r.source === "shop") return onOpenShop();
+    if (!r.url) return;
+    startInstall({
+      slug: r.slug,
+      title: r.title,
+      subpath: r.subpath,
+      destFolder: r.destFolder,
+      categoryId: r.categoryId ?? undefined,
+      url: r.url,
+      host: r.host ?? "",
+    });
+  };
+
+  const canRetry = (r: DownloadRecord) =>
+    r.status === "failed" && (r.source === "shop" || !!r.url);
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="flex flex-none items-center gap-3.5 px-7 pb-3.5 pt-5">
+        <div className="flex items-center gap-1.5">
+          <h1 className="text-[21px] font-bold tracking-[-0.2px]">
+            {t("nav.downloads")}
+          </h1>
+          <HelpHint title={t("nav.downloads")} description={t("downloads.help")} />
+        </div>
+        <Segmented
+          value={filter}
+          onChange={(v) => setFilter(v as Filter)}
+          options={(["all", "installed", "failed"] as const).map((v) => ({
+            value: v,
+            label: (
+              <span className="flex items-center gap-1.5">
+                {t(
+                  v === "all"
+                    ? "downloads.filterAll"
+                    : v === "installed"
+                      ? "common.installed"
+                      : "downloads.filterFailed",
+                )}
+                <span
+                  className={cn(
+                    "text-muted-foreground",
+                    v === "failed" && counts.failed > 0 && "text-destructive",
+                  )}
+                >
+                  {counts[v]}
+                </span>
+              </span>
+            ),
+          }))}
+        />
+        <div className="ml-auto flex w-[240px] items-center gap-2 rounded-lg border border-input bg-card px-3 py-2">
+          <Search className="size-3.5 text-faint" />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t("downloads.searchPlaceholder")}
+            className="w-full bg-transparent text-[12.5px] placeholder:text-faint focus:outline-none"
+          />
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setClearOpen(true)}
+          disabled={records.length === 0}
+        >
+          <Trash2 className="size-3.5" /> {t("downloads.clearAction")}
+        </Button>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-7 pb-6">
+        {loading ? (
+          <p className="py-16 text-center text-[13px] text-muted-foreground">
+            {t("common.loading")}
+          </p>
+        ) : groups.length === 0 ? (
+          <p className="py-16 text-center text-[13px] text-muted-foreground">
+            {records.length === 0 ? t("downloads.empty") : t("downloads.noMatches")}
+          </p>
+        ) : (
+          <div className="flex flex-col gap-6">
+            {groups.map((group) => (
+              <section key={group.key} className="flex flex-col gap-2.5">
+                <div className="flex items-baseline gap-2">
+                  <span className="text-[12px] font-bold uppercase tracking-[1.2px] text-faint">
+                    ▸ {group.label}
+                  </span>
+                  <span className="text-[11px] text-faint">{group.items.length}</span>
+                </div>
+                <div className="flex flex-col gap-2">
+                  {group.items.map((r) => (
+                    <DownloadRow
+                      key={r.id}
+                      record={r}
+                      onRetry={canRetry(r) ? () => retry(r) : undefined}
+                      onOpenMod={
+                        r.slug && r.source === "site"
+                          ? () =>
+                              onOpenMod({
+                                slug: r.slug,
+                                subpath: r.subpath,
+                                categoryId: r.categoryId ?? undefined,
+                              })
+                          : undefined
+                      }
+                      onShowInLibrary={
+                        r.status === "installed" ? () => onShowInLibrary(r) : undefined
+                      }
+                      onForget={() => forget(r.id)}
+                    />
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <AlertDialog open={clearOpen} onOpenChange={setClearOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("downloads.clearTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>{t("downloads.clearBody")}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                clear();
+                setClearOpen(false);
+              }}
+            >
+              {t("common.clear")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+function DownloadRow({
+  record,
+  onRetry,
+  onOpenMod,
+  onShowInLibrary,
+  onForget,
+}: {
+  record: DownloadRecord;
+  onRetry?: () => void;
+  onOpenMod?: () => void;
+  onShowInLibrary?: () => void;
+  onForget: () => void;
+}) {
+  const t = useT();
+  const failed = record.status === "failed";
+  const SourceIcon =
+    record.source === "shop" ? Store : record.source === "file" ? FileArchive : Download;
+  const dest = destLabel(record);
+
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-3 rounded-xl border bg-card p-3",
+        failed ? "border-destructive/30" : "border-white/[0.07]",
+      )}
+    >
+      {failed ? (
+        <AlertTriangle className="mt-0.5 size-4 flex-none text-destructive" />
+      ) : (
+        <CheckCircle2 className="mt-0.5 size-4 flex-none text-primary" />
+      )}
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <div className="flex items-baseline gap-2">
+          <span className="truncate text-[13px] font-semibold">
+            {displayName(record.title)}
+          </span>
+          <span className="flex-none text-[11px] text-faint">{formatTime(record.at)}</span>
+        </div>
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11.5px] text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <SourceIcon className="size-3" />
+            {sourceLabel(record, t)}
+          </span>
+          {dest && <span className="text-faint">·</span>}
+          {dest && <span className="truncate">{dest}</span>}
+          {!!record.bytes && <span className="text-faint">·</span>}
+          {!!record.bytes && <span>{formatBytes(record.bytes)}</span>}
+        </div>
+        {failed && record.error && (
+          <p className="select-text text-[11.5px] text-destructive/90">{record.error}</p>
+        )}
+      </div>
+      {onRetry && (
+        <Button variant="outline" size="sm" className="flex-none" onClick={onRetry}>
+          <RotateCw className="size-3.5" /> {t("common.retry")}
+        </Button>
+      )}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            aria-label={t("downloads.rowActions")}
+            className="mt-0.5 flex-none cursor-default rounded-md px-1 text-faint transition-colors hover:text-foreground"
+          >
+            <MoreHorizontal className="size-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {onShowInLibrary && (
+            <DropdownMenuItem onSelect={onShowInLibrary}>
+              <LibraryIcon className="size-4" /> {t("downloads.showInLibrary")}
+            </DropdownMenuItem>
+          )}
+          {onOpenMod && (
+            <DropdownMenuItem onSelect={onOpenMod}>
+              <ExternalLink className="size-4" /> {t("downloads.openModPage")}
+            </DropdownMenuItem>
+          )}
+          {(onShowInLibrary || onOpenMod) && <DropdownMenuSeparator />}
+          <DropdownMenuItem variant="destructive" onSelect={onForget}>
+            <X className="size-4" /> {t("downloads.forget")}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/src/Components/Library/Library.tsx
+++ b/src/Components/Library/Library.tsx
@@ -20,6 +20,8 @@ import {
   Loader2,
   Share2,
   ClipboardPaste,
+  ArrowUpDown,
+  Clock,
   type LucideIcon,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -198,10 +200,15 @@ interface Section {
   items: LibraryEntry[];
 }
 
+/** Folder grouping is the default; "Recently added" answers "which of these did I just get",
+ *  for mods that predate the download history as well as ones that don't. */
+export type LibrarySort = "folder" | "recent";
+
 function buildSections(
   modType: ModType,
   entries: LibraryEntry[],
   search: string,
+  sort: LibrarySort,
   t: TFunc,
 ): Section[] {
   const q = search.trim().toLowerCase();
@@ -213,6 +220,15 @@ function buildSections(
           (e.parent ?? "").toLowerCase().includes(q),
       )
     : entries;
+
+  // One flat list, newest first — grouping by folder would scatter the very thing being
+  // looked for across half a dozen sections.
+  if (sort === "recent") {
+    const recent = [...filtered].sort((a, b) => b.modified - a.modified);
+    return recent.length
+      ? [{ key: "__recent__", label: t("library.sortRecent"), items: recent }]
+      : [];
+  }
 
   if (modType.id === "rider") {
     const byCat = new Map<string, LibraryEntry[]>();
@@ -255,6 +271,11 @@ interface LibraryProps {
   onChangeType: (type: ModType) => void;
   refreshKey: number;
   onChanged: () => void;
+  /** Something sent the user here to look at one mod — seeds the search box with its name.
+   *  A new object per jump, so repeating the same jump re-applies it. */
+  focus?: { name: string } | null;
+  /** Consumed: the jump has been applied, and must not be re-applied on the next visit. */
+  onFocusApplied?: () => void;
 }
 
 export default function Library({
@@ -262,6 +283,8 @@ export default function Library({
   onChangeType,
   refreshKey,
   onChanged,
+  focus,
+  onFocusApplied,
 }: LibraryProps) {
   const t = useT();
   const { pickAndImport, staging } = useImport();
@@ -269,6 +292,7 @@ export default function Library({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<LibrarySort>("folder");
   const [busy, setBusy] = useState(false);
   const [detail, setDetail] = useState<LibraryEntry | null>(null);
   const [view3d, setView3d] = useState<LibraryEntry | null>(null);
@@ -304,6 +328,13 @@ export default function Library({
   }, [load, refreshKey]);
 
   useEffect(() => setDetail(null), [modType]);
+  // Arriving from a download row: search for that mod so the jump lands on it, not just on
+  // the right tab. Consumed on arrival — a later visit is not still about that one mod.
+  useEffect(() => {
+    if (!focus) return;
+    setSearch(focus.name);
+    onFocusApplied?.();
+  }, [focus, onFocusApplied]);
   // Leaving a type (or a rescan removing items) should never carry a stale selection.
   const exitSelect = useCallback(() => {
     setSelectMode(false);
@@ -317,8 +348,8 @@ export default function Library({
   );
 
   const sections = useMemo(
-    () => buildSections(modType, entries, search, t),
-    [modType, entries, search, t],
+    () => buildSections(modType, entries, search, sort, t),
+    [modType, entries, search, sort, t],
   );
 
   const visibleItems = useMemo(() => sections.flatMap((s) => s.items), [sections]);
@@ -529,6 +560,24 @@ export default function Library({
             className="w-full bg-transparent text-[12.5px] placeholder:text-faint focus:outline-none"
           />
         </div>
+        {/* Sorting by arrival is the only way to find a mod whose name you never read —
+            and it works for everything on disk, not just what the history remembers. */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="sm">
+              <ArrowUpDown className="size-3.5" />{" "}
+              {t(sort === "recent" ? "library.sortRecent" : "library.sortFolder")}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={() => setSort("folder")}>
+              <Folder className="size-3.5" /> {t("library.sortFolder")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setSort("recent")}>
+              <Clock className="size-3.5" /> {t("library.sortRecent")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
         <Button
           variant={selectMode ? "default" : "outline"}
           size="sm"

--- a/src/Components/Overlay/Overlay.tsx
+++ b/src/Components/Overlay/Overlay.tsx
@@ -14,6 +14,7 @@ import { setAmbientVars, type TKey } from "../../i18n/core";
 import { FrostmodProvider } from "../../Context/Frostmod";
 import { ConfigContext, MXB_FALLBACK } from "../../Context/Config";
 import { InstallProvider } from "../../Context/Install";
+import { DownloadsProvider } from "../../Context/Downloads";
 import { useModBrowsing } from "../../lib/useModBrowsing";
 import {
   bikePreviewAvailable,
@@ -252,6 +253,9 @@ export default function Overlay() {
                         switchGame: async () => {},
                       }}
                     >
+                      {/* No Downloads page in here, but installs made mid-session still
+                          belong in the history the main window shows. */}
+                      <DownloadsProvider>
                       <InstallProvider onInstalled={onInstalled} onOpenMod={openModTarget}>
                         <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
                           {tab === "presets" ? (
@@ -280,6 +284,7 @@ export default function Overlay() {
                           )}
                         </div>
                       </InstallProvider>
+                      </DownloadsProvider>
                     </ConfigContext.Provider>
                   ) : (
                     // No config means the player never finished first-run setup. That

--- a/src/Components/Shell/Sidebar.tsx
+++ b/src/Components/Shell/Sidebar.tsx
@@ -17,11 +17,13 @@ import {
   PanelLeftOpen,
   Server as ServerIcon,
   Plug,
+  Download as DownloadIcon,
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useFrostmod } from "../../Context/FrostmodContext";
 import { useInstall } from "../../Context/Install";
+import { useDownloads } from "../../Context/Downloads";
 import { displayName } from "../../lib/mods";
 import { useT, type TKey } from "../../i18n/context";
 import {
@@ -40,6 +42,7 @@ export type DashboardView =
   | "browse"
   | "shop"
   | "library"
+  | "downloads"
   | "locker"
   | "presets"
   | "studio"
@@ -67,6 +70,9 @@ type NavEntry = {
 const NAV: NavEntry[] = [
   { id: "browse", label: "nav.browse", icon: Home },
   { id: "library", label: "nav.library", icon: LibraryIcon },
+  // Right after the library, because it answers the question the library can't: which of
+  // these arrived today, and what didn't arrive at all.
+  { id: "downloads", label: "nav.downloads", icon: DownloadIcon },
   // The Locker and Rider views are the 3D preview; GP Bikes' meshes need their own
   // part bindings before they can be shown.
   { id: "locker", label: "nav.locker", icon: Bike, cap: "viewer" },
@@ -112,6 +118,7 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
   const t = useT();
   const { running, reload, status, start, stop } = useFrostmod();
   const { active, queueLength } = useInstall();
+  const { unseenFailures } = useDownloads();
   const { running: gameRunning, refresh: refreshGame } = useGameRunning();
   const { game } = useConfig();
   const caps = game.caps;
@@ -256,7 +263,7 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
               title={collapsed ? t(label) : undefined}
               aria-label={collapsed ? t(label) : undefined}
               className={cn(
-                "flex cursor-default items-center gap-2.5 rounded-lg py-2.5 text-[13.5px] transition-colors",
+                "relative flex cursor-default items-center gap-2.5 rounded-lg py-2.5 text-[13.5px] transition-colors",
                 collapsed ? "justify-center px-0" : "px-3",
                 activeNav
                   ? "bg-accent font-semibold text-accent-foreground"
@@ -265,6 +272,21 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
             >
               <Icon className="size-4 flex-none" />
               {!collapsed && <span>{t(label)}</span>}
+              {/* A failed download used to exist only as a toast, so one dismissed in passing
+                  left no sign anything had gone wrong. This is that sign. */}
+              {id === "downloads" && unseenFailures > 0 && (
+                <span
+                  title={t("downloads.failedBadge", { count: unseenFailures })}
+                  className={cn(
+                    "flex-none rounded-full bg-destructive text-center text-[10px] font-bold leading-[16px] text-destructive-foreground",
+                    collapsed
+                      ? "absolute right-1.5 top-1.5 size-2 p-0"
+                      : "ml-auto min-w-[18px] px-1",
+                  )}
+                >
+                  {!collapsed && unseenFailures}
+                </span>
+              )}
             </button>
           );
         })}

--- a/src/Context/Downloads.tsx
+++ b/src/Context/Downloads.tsx
@@ -1,0 +1,113 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  clearDownloadHistory,
+  downloadHistory,
+  forgetDownload,
+  recordDownload,
+} from "../api/mods";
+import type { DownloadRecord, NewDownload } from "../types";
+
+/** When the Downloads page was last looked at, so the sidebar can badge failures that
+ *  happened since. Local to the machine the downloads happened on, hence localStorage. */
+const SEEN_KEY = "frost-downloads-seen";
+
+function readSeen(): number {
+  const raw = Number(localStorage.getItem(SEEN_KEY));
+  return Number.isFinite(raw) ? raw : 0;
+}
+
+interface DownloadsContextValue {
+  /** Newest first. */
+  records: DownloadRecord[];
+  loading: boolean;
+  refresh: () => void;
+  /** Note a finished download — installed or failed. Fire-and-forget by design: a history
+   *  write must never turn a good install into a failed one. */
+  note: (entry: NewDownload) => void;
+  forget: (id: string) => void;
+  clear: () => void;
+  /** Failed downloads since the page was last opened. Failures used to vanish with their
+   *  toast, so this is what makes one noticeable at all. */
+  unseenFailures: number;
+  markSeen: () => void;
+}
+
+const DownloadsContext = createContext<DownloadsContextValue | null>(null);
+
+/**
+ * The download history, held in one place.
+ *
+ * Two things write to it — [`Install`](./Install.tsx) for anything fetched from the site or
+ * the shop, and [`DropReview`](./DropReview.tsx) for files imported or dragged in — and two
+ * read it: the Downloads page and the sidebar's failure badge. A shared provider keeps that
+ * to one copy of the list instead of each corner fetching its own.
+ */
+export function DownloadsProvider({ children }: { children: ReactNode }) {
+  const [records, setRecords] = useState<DownloadRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [seen, setSeen] = useState(readSeen);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
+    downloadHistory()
+      .then(setRecords)
+      .catch(() => setRecords([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(refresh, [refresh]);
+
+  const note = useCallback((entry: NewDownload) => {
+    void recordDownload(entry)
+      .then((saved) => {
+        // Prepend what the backend actually stored rather than re-reading the file: it owns
+        // the id and the timestamp, and this keeps a bulk install to one write each.
+        if (saved) setRecords((cur) => [saved, ...cur]);
+      })
+      .catch(() => {});
+  }, []);
+
+  const forget = useCallback((id: string) => {
+    setRecords((cur) => cur.filter((r) => r.id !== id));
+    void forgetDownload(id).catch(() => {});
+  }, []);
+
+  const clear = useCallback(() => {
+    setRecords([]);
+    void clearDownloadHistory().catch(() => {});
+  }, []);
+
+  const markSeen = useCallback(() => {
+    const now = Date.now();
+    localStorage.setItem(SEEN_KEY, String(now));
+    setSeen(now);
+  }, []);
+
+  const unseenFailures = useMemo(
+    () => records.filter((r) => r.status === "failed" && r.at > seen).length,
+    [records, seen],
+  );
+
+  const value = useMemo(
+    () => ({ records, loading, refresh, note, forget, clear, unseenFailures, markSeen }),
+    [records, loading, refresh, note, forget, clear, unseenFailures, markSeen],
+  );
+
+  return (
+    <DownloadsContext.Provider value={value}>{children}</DownloadsContext.Provider>
+  );
+}
+
+export function useDownloads() {
+  const ctx = useContext(DownloadsContext);
+  if (!ctx) throw new Error("useDownloads must be used within DownloadsProvider");
+  return ctx;
+}

--- a/src/Context/DropReview.tsx
+++ b/src/Context/DropReview.tsx
@@ -9,7 +9,8 @@ import {
 } from "react";
 import { toast } from "sonner";
 import { cancelDrop, commitDrop, repreviewDrop } from "../api/mods";
-import type { DropCommitItem, DropPlan } from "../types";
+import type { DropCommitItem, DropPlan, NewDownload } from "../types";
+import { useDownloads } from "./Downloads";
 import { useT } from "../i18n/context";
 import DropReview, { type RowState } from "../Components/Dropzone/DropReview";
 
@@ -57,6 +58,7 @@ export function DropReviewProvider({
   onInstalledRef.current = onInstalled;
   const tRef = useRef(t);
   tRef.current = t;
+  const { note } = useDownloads();
   // A plan holds a staging directory; if a second one arrives we must release the first.
   const planRef = useRef<DropPlan | null>(null);
   planRef.current = plan;
@@ -204,6 +206,29 @@ export function DropReviewProvider({
     setInstalling(true);
     try {
       const outcome = await commitDrop(current.id, items);
+
+      // One history row per item, from the committed request rather than the receipt: the
+      // receipt shows a display path, and the page needs the real subpath to route back to
+      // the library. A dropped file has no mod page, hence the empty slug.
+      const asked = new Map(items.map((i) => [i.id, i]));
+      const forHistory = (id: string, name: string): NewDownload => ({
+        title: name,
+        slug: "",
+        subpath: asked.get(id)?.subpath ?? "",
+        destFolder: asked.get(id)?.destFolder ?? "",
+        categoryId: null,
+        source: "file",
+        host: null,
+        url: null,
+        bytes: rows.find((r) => r.item.id === id)?.item.bytes ?? null,
+        status: "installed",
+        error: null,
+      });
+      for (const i of outcome.installed) note(forHistory(i.id, i.name));
+      for (const f of outcome.failed) {
+        note({ ...forHistory(f.id, f.name), status: "failed", error: f.error });
+      }
+
       reset();
       if (outcome.installed.length > 0) {
         toast.success(
@@ -228,7 +253,7 @@ export function DropReviewProvider({
         description: String(e),
       });
     }
-  }, [rows, reset]);
+  }, [rows, reset, note]);
 
   const value = useMemo(
     () => ({ reviewPlan, reviewing: plan !== null }),

--- a/src/Context/Install.tsx
+++ b/src/Context/Install.tsx
@@ -18,7 +18,8 @@ import {
   shopInstall,
   type ShopItem,
 } from "../api/mods";
-import type { InstallStage, ReloadOutcome } from "../types";
+import type { DownloadSource, InstallStage, ReloadOutcome } from "../types";
+import { useDownloads } from "./Downloads";
 import { useT } from "../i18n/context";
 
 /** Where the bytes come from — a resolvable host, a file the user picked, or a shop purchase
@@ -44,6 +45,12 @@ interface StartParams {
  *  the one already running; the same paint sent to a second bike does not. */
 function installKey({ slug, subpath, destFolder }: StartParams): string {
   return JSON.stringify([slug, subpath, destFolder]);
+}
+
+/** How the download history names this source. */
+function historySource(source: InstallSource): DownloadSource {
+  if (source.kind === "shop") return "shop";
+  return source.kind === "download" ? "site" : "file";
 }
 
 /** Where a failed install can send the user back to. */
@@ -100,6 +107,10 @@ export function InstallProvider({
   const t = useT();
   const tRef = useRef(t);
   tRef.current = t;
+  // Same reason: the history is written from inside `run`, which must not be rebuilt.
+  const { note } = useDownloads();
+  const noteRef = useRef(note);
+  noteRef.current = note;
   const clearTimer = useRef<number | null>(null);
   // Installs run one at a time (the engine handles a single transfer); extra
   // requests wait in this queue and are drained sequentially.
@@ -127,9 +138,13 @@ export function InstallProvider({
     // FrostMod's reload event can land just before the install call resolves;
     // stash the outcome so the success toast can mention it.
     let frostOutcome: ReloadOutcome | null = null;
+    // The only place the transfer size is known — nothing on disk afterwards tells you how
+    // big the download was, and a failed one leaves nothing at all.
+    let bytes: number | null = null;
 
     const unlisten = await onInstallProgress((p) => {
       if (p.slug !== slug) return;
+      if (p.total) bytes = p.total;
       setActive((cur) =>
         cur && cur.slug === slug
           ? {
@@ -150,6 +165,22 @@ export function InstallProvider({
       );
     });
 
+    /** One record per finished attempt, whichever way it went. */
+    const remember = (status: "installed" | "failed", error: string | null) =>
+      noteRef.current({
+        title,
+        slug,
+        subpath,
+        destFolder,
+        categoryId: params.categoryId ?? null,
+        source: historySource(source),
+        host: source.kind === "download" ? source.host : null,
+        url: source.kind === "download" ? source.url : null,
+        bytes,
+        status,
+        error,
+      });
+
     try {
       if (source.kind === "download") {
         await addToLibrary(slug, source.url, source.host, subpath, destFolder);
@@ -161,6 +192,7 @@ export function InstallProvider({
       setActive((cur) =>
         cur && cur.slug === slug ? { ...cur, stage: "done" } : cur,
       );
+      remember("installed", null);
       onInstalledRef.current?.();
       toast.success(tRef.current("install.installed", { title }), {
         description:
@@ -179,6 +211,7 @@ export function InstallProvider({
       setActive((cur) =>
         cur && cur.slug === slug ? { ...cur, stage: "error", message } : cur,
       );
+      remember("failed", message);
       // Retry goes through `enqueue`, never straight to `run`: a second impatient click used
       // to start a *parallel* run of the same job.
       const target: ModTarget = { slug, subpath, categoryId: params.categoryId };

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -12,6 +12,8 @@ import type {
   RegisterReport,
   Config,
   DownloadOption,
+  DownloadRecord,
+  NewDownload,
   FrostmodInstallReport,
   FrostmodReload,
   FrostmodStatus,
@@ -1631,6 +1633,29 @@ export function shopInstall(
  */
 export function shopInstalledMap(): Promise<Record<string, string[]>> {
   return invoke<Record<string, string[]>>("shop_installed_map");
+}
+
+/**
+ * The download history — everything the app installed, newest first, failures included.
+ *
+ * Kept in Rust rather than derived from the library scan because a scan can only see what is
+ * on disk: it has no idea when a mod arrived, and a download that failed left nothing to find.
+ */
+export function downloadHistory(): Promise<DownloadRecord[]> {
+  return invoke<DownloadRecord[]>("download_history");
+}
+
+/** Note a finished download. Resolves to `null` if there was nothing worth recording. */
+export function recordDownload(entry: NewDownload): Promise<DownloadRecord | null> {
+  return invoke<DownloadRecord | null>("record_download", { entry });
+}
+
+export function forgetDownload(id: string): Promise<void> {
+  return invoke<void>("forget_download", { id });
+}
+
+export function clearDownloadHistory(): Promise<void> {
+  return invoke<void>("clear_download_history");
 }
 
 /** Fires after a WebView sign-in completes; payload is whether it succeeded. */

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -51,6 +51,7 @@ export const de: Translation = {
   "nav.browse": "Entdecken",
   "nav.shop": "Shop",
   "nav.library": "Bibliothek",
+  "nav.downloads": "Downloads",
   "nav.locker": "Spind",
   "nav.presets": "Presets",
   "nav.rider": "Fahrer",
@@ -877,6 +878,8 @@ export const de: Translation = {
   "library.byAuthor": "von {{author}}",
   "library.locked": "Gesperrt — Inhalt kann nicht gelesen werden",
   "library.searchPlaceholder": "Installierte durchsuchen…",
+  "library.sortFolder": "Nach Ordner",
+  "library.sortRecent": "Zuletzt hinzugefügt",
   "library.scanning": "Deine Bibliothek wird gescannt…",
   "library.empty":
     "Noch keine {{type}} installiert — geh zu Entdecken und füge etwas hinzu.",
@@ -1071,6 +1074,31 @@ export const de: Translation = {
   "install.failed": "Installation fehlgeschlagen — {{title}}",
   "install.openModPage": "Die Mod-Seite öffnen",
   "install.clickToOpen": "Klicken, um die Mod-Seite zu öffnen",
+
+  // ── Downloads (Verlauf) ────────────────────────────────────────────────────
+  "downloads.help":
+    "Alles, was du heruntergeladen hast, das Neueste zuerst — auch die fehlgeschlagenen. Filtere nach Status oder such nach einer Mod, deren Namen du nicht mehr genau weißt.",
+  "downloads.filterAll": "Alle",
+  "downloads.filterFailed": "Fehlgeschlagen",
+  "downloads.searchPlaceholder": "Downloads durchsuchen…",
+  "downloads.clearAction": "Leeren",
+  "downloads.clearTitle": "Download-Verlauf leeren?",
+  "downloads.clearBody":
+    "Das vergisst nur die Liste. Nichts Installiertes wird entfernt.",
+  "downloads.empty":
+    "Noch nichts heruntergeladen — geh zu Entdecken und füge etwas hinzu.",
+  "downloads.noMatches": "Keine Treffer.",
+  "downloads.today": "Heute",
+  "downloads.yesterday": "Gestern",
+  "downloads.sourceSite": "Download",
+  "downloads.sourceShop": "Shop",
+  "downloads.sourceFile": "Importierte Datei",
+  "downloads.showInLibrary": "In der Bibliothek zeigen",
+  "downloads.openModPage": "Mod-Seite öffnen",
+  "downloads.forget": "Aus der Liste entfernen",
+  "downloads.rowActions": "Mehr",
+  "downloads.failedBadge_one": "{{count}} Download fehlgeschlagen",
+  "downloads.failedBadge_other": "{{count}} Downloads fehlgeschlagen",
 
   // ── Kategorien (Singular) ──────────────────────────────────────────────────
   "category.track": "Strecke",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -45,6 +45,7 @@ export const en = {
   "nav.browse": "Browse",
   "nav.shop": "Shop",
   "nav.library": "Library",
+  "nav.downloads": "Downloads",
   "nav.locker": "Locker",
   "nav.presets": "Presets",
   "nav.rider": "Rider",
@@ -850,6 +851,8 @@ export const en = {
   "library.byAuthor": "by {{author}}",
   "library.locked": "Locked — contents can't be read",
   "library.searchPlaceholder": "Search installed…",
+  "library.sortFolder": "By folder",
+  "library.sortRecent": "Recently added",
   "library.scanning": "Scanning your library…",
   "library.empty": "No {{type}} installed yet — head to Browse and add one.",
   "library.noMatches": "No matches.",
@@ -1029,6 +1032,30 @@ export const en = {
   "install.failed": "Install failed — {{title}}",
   "install.openModPage": "Open the mod's page",
   "install.clickToOpen": "Click to open the mod's page",
+
+  // ── Downloads (history) ────────────────────────────────────────────────────
+  "downloads.help":
+    "Everything you've downloaded, newest first — the ones that failed included. Filter by status, or search for a mod whose name you can't quite remember.",
+  "downloads.filterAll": "All",
+  "downloads.filterFailed": "Failed",
+  "downloads.searchPlaceholder": "Search downloads…",
+  "downloads.clearAction": "Clear",
+  "downloads.clearTitle": "Clear download history?",
+  "downloads.clearBody":
+    "This only forgets the list. Nothing you've installed is removed.",
+  "downloads.empty": "Nothing downloaded yet — head to Browse and add something.",
+  "downloads.noMatches": "No matches.",
+  "downloads.today": "Today",
+  "downloads.yesterday": "Yesterday",
+  "downloads.sourceSite": "Download",
+  "downloads.sourceShop": "Shop",
+  "downloads.sourceFile": "Imported file",
+  "downloads.showInLibrary": "Show in library",
+  "downloads.openModPage": "Open the mod's page",
+  "downloads.forget": "Remove from list",
+  "downloads.rowActions": "More",
+  "downloads.failedBadge_one": "{{count}} download failed",
+  "downloads.failedBadge_other": "{{count}} downloads failed",
 
   // ── Library categories (singular — item "Type" label) ──────────────────────
   "category.track": "Track",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -46,6 +46,7 @@ export const es: Translation = {
   "nav.browse": "Explorar",
   "nav.shop": "Tienda",
   "nav.library": "Biblioteca",
+  "nav.downloads": "Descargas",
   "nav.locker": "Taquilla",
   "nav.presets": "Presets",
   "nav.rider": "Piloto",
@@ -870,6 +871,8 @@ export const es: Translation = {
   "library.byAuthor": "de {{author}}",
   "library.locked": "Bloqueado — no se puede leer el contenido",
   "library.searchPlaceholder": "Buscar entre los instalados…",
+  "library.sortFolder": "Por carpeta",
+  "library.sortRecent": "Añadidas recientemente",
   "library.scanning": "Analizando tu biblioteca…",
   "library.empty":
     "Aún no hay {{type}} instaladas — ve a Explorar y añade alguna.",
@@ -1059,6 +1062,30 @@ export const es: Translation = {
   "install.failed": "Fallo en la instalación — {{title}}",
   "install.openModPage": "Abrir la página del mod",
   "install.clickToOpen": "Haz clic para abrir la página del mod",
+
+  // ── Descargas (historial) ──────────────────────────────────────────────────
+  "downloads.help":
+    "Todo lo que has descargado, lo más reciente primero — incluidas las que fallaron. Filtra por estado o busca una mod cuyo nombre no recuerdes del todo.",
+  "downloads.filterAll": "Todas",
+  "downloads.filterFailed": "Fallidas",
+  "downloads.searchPlaceholder": "Buscar descargas…",
+  "downloads.clearAction": "Vaciar",
+  "downloads.clearTitle": "¿Vaciar el historial de descargas?",
+  "downloads.clearBody":
+    "Esto solo olvida la lista. No se elimina nada de lo que has instalado.",
+  "downloads.empty": "Aún no has descargado nada — ve a Explorar y añade algo.",
+  "downloads.noMatches": "Sin resultados.",
+  "downloads.today": "Hoy",
+  "downloads.yesterday": "Ayer",
+  "downloads.sourceSite": "Descarga",
+  "downloads.sourceShop": "Tienda",
+  "downloads.sourceFile": "Archivo importado",
+  "downloads.showInLibrary": "Ver en la biblioteca",
+  "downloads.openModPage": "Abrir la página del mod",
+  "downloads.forget": "Quitar de la lista",
+  "downloads.rowActions": "Más",
+  "downloads.failedBadge_one": "{{count}} descarga fallida",
+  "downloads.failedBadge_other": "{{count}} descargas fallidas",
 
   // ── Categorías (singular) ──────────────────────────────────────────────────
   "category.track": "Pista",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -48,6 +48,7 @@ export const fr: Translation = {
   "nav.browse": "Parcourir",
   "nav.shop": "Boutique",
   "nav.library": "Bibliothèque",
+  "nav.downloads": "Téléchargements",
   "nav.locker": "Casier",
   "nav.presets": "Presets",
   "nav.rider": "Pilote",
@@ -875,6 +876,8 @@ export const fr: Translation = {
   "library.byAuthor": "par {{author}}",
   "library.locked": "Verrouillé — le contenu ne peut pas être lu",
   "library.searchPlaceholder": "Rechercher parmi les installés…",
+  "library.sortFolder": "Par dossier",
+  "library.sortRecent": "Ajoutés récemment",
   "library.scanning": "Analyse de votre bibliothèque…",
   "library.empty":
     "Aucun mod {{type}} installé — allez dans Parcourir pour en ajouter un.",
@@ -1062,6 +1065,31 @@ export const fr: Translation = {
   "install.failed": "Échec de l'installation — {{title}}",
   "install.openModPage": "Ouvrir la page du mod",
   "install.clickToOpen": "Cliquez pour ouvrir la page du mod",
+
+  // ── Téléchargements (historique) ───────────────────────────────────────────
+  "downloads.help":
+    "Tout ce que vous avez téléchargé, du plus récent au plus ancien — échecs compris. Filtrez par statut, ou cherchez un mod dont le nom vous échappe.",
+  "downloads.filterAll": "Tous",
+  "downloads.filterFailed": "Échecs",
+  "downloads.searchPlaceholder": "Rechercher dans les téléchargements…",
+  "downloads.clearAction": "Vider",
+  "downloads.clearTitle": "Vider l'historique des téléchargements ?",
+  "downloads.clearBody":
+    "Cela n'oublie que la liste. Rien de ce que vous avez installé n'est supprimé.",
+  "downloads.empty":
+    "Rien de téléchargé pour l'instant — allez dans Parcourir pour ajouter quelque chose.",
+  "downloads.noMatches": "Aucun résultat.",
+  "downloads.today": "Aujourd'hui",
+  "downloads.yesterday": "Hier",
+  "downloads.sourceSite": "Téléchargement",
+  "downloads.sourceShop": "Boutique",
+  "downloads.sourceFile": "Fichier importé",
+  "downloads.showInLibrary": "Voir dans la bibliothèque",
+  "downloads.openModPage": "Ouvrir la page du mod",
+  "downloads.forget": "Retirer de la liste",
+  "downloads.rowActions": "Plus",
+  "downloads.failedBadge_one": "{{count}} téléchargement échoué",
+  "downloads.failedBadge_other": "{{count}} téléchargements échoués",
 
   // ── Catégories (singulier) ─────────────────────────────────────────────────
   "category.track": "Circuit",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -46,6 +46,7 @@ export const it: Translation = {
   "nav.browse": "Esplora",
   "nav.shop": "Shop",
   "nav.library": "Libreria",
+  "nav.downloads": "Download",
   "nav.locker": "Armadietto",
   "nav.presets": "Preset",
   "nav.rider": "Pilota",
@@ -865,6 +866,8 @@ export const it: Translation = {
   "library.byAuthor": "di {{author}}",
   "library.locked": "Bloccato — il contenuto non è leggibile",
   "library.searchPlaceholder": "Cerca tra le installate…",
+  "library.sortFolder": "Per cartella",
+  "library.sortRecent": "Aggiunte di recente",
   "library.scanning": "Scansione della libreria…",
   "library.empty":
     "Nessuna mod {{type}} installata — vai su Esplora e aggiungine una.",
@@ -1051,6 +1054,30 @@ export const it: Translation = {
   "install.failed": "Installazione fallita — {{title}}",
   "install.openModPage": "Apri la pagina della mod",
   "install.clickToOpen": "Clicca per aprire la pagina della mod",
+
+  // ── Download (cronologia) ──────────────────────────────────────────────────
+  "downloads.help":
+    "Tutto quello che hai scaricato, dal più recente — inclusi quelli non riusciti. Filtra per stato o cerca una mod di cui non ricordi bene il nome.",
+  "downloads.filterAll": "Tutti",
+  "downloads.filterFailed": "Non riusciti",
+  "downloads.searchPlaceholder": "Cerca nei download…",
+  "downloads.clearAction": "Svuota",
+  "downloads.clearTitle": "Svuotare la cronologia dei download?",
+  "downloads.clearBody":
+    "Questo dimentica solo l'elenco. Niente di installato viene rimosso.",
+  "downloads.empty": "Ancora nessun download — vai su Esplora e aggiungi qualcosa.",
+  "downloads.noMatches": "Nessun risultato.",
+  "downloads.today": "Oggi",
+  "downloads.yesterday": "Ieri",
+  "downloads.sourceSite": "Download",
+  "downloads.sourceShop": "Negozio",
+  "downloads.sourceFile": "File importato",
+  "downloads.showInLibrary": "Mostra nella libreria",
+  "downloads.openModPage": "Apri la pagina della mod",
+  "downloads.forget": "Rimuovi dall'elenco",
+  "downloads.rowActions": "Altro",
+  "downloads.failedBadge_one": "{{count}} download non riuscito",
+  "downloads.failedBadge_other": "{{count}} download non riusciti",
 
   // ── Categorie (singolare) ──────────────────────────────────────────────────
   "category.track": "Pista",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -49,6 +49,7 @@ export const ptBR: Translation = {
   "nav.browse": "Explorar",
   "nav.shop": "Loja",
   "nav.library": "Biblioteca",
+  "nav.downloads": "Downloads",
   "nav.locker": "Armário",
   "nav.presets": "Presets",
   "nav.rider": "Piloto",
@@ -869,6 +870,8 @@ export const ptBR: Translation = {
   "library.byAuthor": "de {{author}}",
   "library.locked": "Bloqueado — não dá pra ler o conteúdo",
   "library.searchPlaceholder": "Pesquisar entre os instalados…",
+  "library.sortFolder": "Por pasta",
+  "library.sortRecent": "Adicionados recentemente",
   "library.scanning": "Varrendo sua biblioteca…",
   "library.empty":
     "Nenhuma mod de {{type}} instalada — vá em Explorar e adicione uma.",
@@ -1051,6 +1054,30 @@ export const ptBR: Translation = {
   "install.failed": "Falha na instalação — {{title}}",
   "install.openModPage": "Abrir a página do mod",
   "install.clickToOpen": "Clique para abrir a página do mod",
+
+  // ── Downloads (histórico) ──────────────────────────────────────────────────
+  "downloads.help":
+    "Tudo o que você baixou, do mais recente para o mais antigo — incluindo os que falharam. Filtre por status ou procure uma mod cujo nome você não lembra direito.",
+  "downloads.filterAll": "Todos",
+  "downloads.filterFailed": "Falharam",
+  "downloads.searchPlaceholder": "Pesquisar nos downloads…",
+  "downloads.clearAction": "Limpar",
+  "downloads.clearTitle": "Limpar o histórico de downloads?",
+  "downloads.clearBody":
+    "Isso apenas esquece a lista. Nada do que você instalou é removido.",
+  "downloads.empty": "Nada baixado ainda — vá em Explorar e adicione algo.",
+  "downloads.noMatches": "Nenhum resultado.",
+  "downloads.today": "Hoje",
+  "downloads.yesterday": "Ontem",
+  "downloads.sourceSite": "Download",
+  "downloads.sourceShop": "Loja",
+  "downloads.sourceFile": "Arquivo importado",
+  "downloads.showInLibrary": "Ver na biblioteca",
+  "downloads.openModPage": "Abrir a página do mod",
+  "downloads.forget": "Remover da lista",
+  "downloads.rowActions": "Mais",
+  "downloads.failedBadge_one": "{{count}} download falhou",
+  "downloads.failedBadge_other": "{{count}} downloads falharam",
 
   // ── Categorias (singular) ──────────────────────────────────────────────────
   "category.track": "Pista",

--- a/src/lib/mods.ts
+++ b/src/lib/mods.ts
@@ -31,6 +31,34 @@ export function formatDateShort(iso: string): string {
   return d.toLocaleDateString(getLocale(), { month: "short", day: "numeric" });
 }
 
+/** Midnight of the day a timestamp falls on, in local time — the key downloads group by. */
+export function dayStart(ms: number): number {
+  const d = new Date(ms);
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+}
+
+/** Day heading for a timestamp: "Today", "Yesterday", then "Jul 8, 2026". */
+export function formatDay(ms: number): string {
+  if (!ms) return "";
+  const days = Math.round((dayStart(Date.now()) - dayStart(ms)) / 86_400_000);
+  if (days <= 0) return translate(getLocale(), "downloads.today");
+  if (days === 1) return translate(getLocale(), "downloads.yesterday");
+  return new Date(ms).toLocaleDateString(getLocale(), {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+/** Clock time for a timestamp, e.g. "14:32". */
+export function formatTime(ms: number): string {
+  if (!ms) return "";
+  return new Date(ms).toLocaleTimeString(getLocale(), {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
 /** Best-guess file format (e.g. ".pkz") from a download URL. */
 export function fileFormat(url: string): string | null {
   const m = url.match(/\.(pkz|zip|rar|7z)(?:[?#]|$)/i);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -304,6 +304,9 @@ export interface LibraryEntry {
   path: string;
   folder: string;
   size: number;
+  /** Unix milliseconds the files were last written — what "Recently added" sorts on. 0 when
+   *  the filesystem wouldn't say. */
+  modified: number;
   kind: LibraryKind;
   category: LibraryCategory;
   /** For paints / model-swaps: the owning bike / gear model / rider profile. */
@@ -730,6 +733,36 @@ export interface DropOutcome {
   installed: DropInstalled[];
   failed: DropFailed[];
 }
+
+/** Where a download's bytes came from: the mod site, a shop purchase, or a local file the
+ *  user imported or dragged in. */
+export type DownloadSource = "site" | "shop" | "file";
+
+export type DownloadStatus = "installed" | "failed";
+
+/** One finished download, as kept in `download-history.json`. */
+export interface DownloadRecord {
+  id: string;
+  /** Unix milliseconds, stamped by the backend. */
+  at: number;
+  title: string;
+  /** Empty for a dragged-in file — it has no mod page to go back to. */
+  slug: string;
+  subpath: string;
+  destFolder: string;
+  categoryId: number | null;
+  source: DownloadSource;
+  /** Which mirror served it — MediaFire, Google Drive, MEGA… */
+  host: string | null;
+  /** The link it came from, so a failed row can be retried in place. Null for shop and file. */
+  url: string | null;
+  bytes: number | null;
+  status: DownloadStatus;
+  error: string | null;
+}
+
+/** What a caller supplies; `id` and `at` are the backend's to assign. */
+export type NewDownload = Omit<DownloadRecord, "id" | "at">;
 
 export type InstallStage =
   | "resolving"


### PR DESCRIPTION
## Why

The library scans your mods folder: it knows *what* is installed, never *when* it arrived. Grab eight tracks in an evening and there's no way to see which eight. And a failed download lived only in a sonner toast — dismiss it, or browse away, and there was no record it had ever been tried; just a mod that silently wasn't there.

## What

**Downloads page** (new sidebar entry, after Library). Everything the app installed, newest first, grouped by day. Each row: what it was, where it landed, which mirror served it, how big, when. Search by name/destination/host, filter All / Installed / Failed.

- **Failures are kept**, with their error text, and retry in place through the same install queue as any other install (the link is recorded for exactly that). A failed shop purchase routes back to the Shop, which is the only place a signed-in download can be re-fetched.
- **Sidebar badge** counts failures not yet looked at — the part that makes one noticeable at all.
- Installed rows offer *Show in library* (right tab, searched by name) and *Open the mod's page*.

**Where it comes from.** A capped (300), best-effort JSON store in the app data dir, written from the two points every install already funnels through — `Context/Install` for site and shop downloads, `Context/DropReview` for imported and dragged-in files. Nothing in the download paths themselves changed. A missing or corrupt store reads as empty; a history write never fails an install.

**"Recently added" sort in the library.** The history only knows about downloads from this version on, so `LibraryEntry` gained `modified` (file mtime) and the library can sort by it — which covers everything already on disk.

## Notes

- No schema/DB changes. One new local file, `download-history.json`.
- `record_download` / `clear_download_history` are added to the IPC guard's forbidden list, so script on the two remote-origin fetch windows can't write history.
- The overlay gets the provider too — installs made mid-session belong in the same history.

## Verification

- `cargo test` — 762 pass, including 8 new store tests (ordering, id uniqueness across a burst, cap evicting oldest-first, error retention, forget/clear, corrupt-and-missing).
- `tsc --noEmit` + `eslint` clean (2 pre-existing warnings elsewhere); production build succeeds.
- App boots on macOS with the new provider tree, no errors in the log. The page's rendering and interactions were **not** visually verified — screen capture is unavailable on this machine and the webview's accessibility tree isn't exposed, so the UI is worth a click-through before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)