### PR TITLE
feat(downloads): queue mods on click, before their page is fetched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased — the queue shows every mod you asked for
+
+### Fixed
+- **Mods join the download queue the moment you click, not when their page comes back.** A quick
+  install had to fetch the mod's page — its mirrors, and where the file should land — before the
+  queue heard about it at all. Select twenty and hit install and the panel filled one mod at a
+  time over a minute or more, with the rest of the selection nowhere on screen and nothing to say
+  the click had registered. The whole selection now takes its place in the queue straight away,
+  each row marked "Preparing" while its turn comes round, and any of them can be cancelled before
+  it ever starts downloading. Working the destination out late also means it is decided against
+  the library as it stands when the mod is about to install, not as it stood twenty mods ago.
+
+### Changed
+- **A mod with no usable download now says which one it is.** Quick-installing a selection used
+  to end with a count of how many had been skipped; each one is now reported by name as the queue
+  reaches it, so it's clear which mod needs opening by hand.
+
 ## Unreleased — a Downloads page, so you can see what you just grabbed
 
 ### Added

--- a/src/Components/Browse/Browse.tsx
+++ b/src/Components/Browse/Browse.tsx
@@ -79,13 +79,12 @@ export default function Browse({
     selectAll,
     scrollTop,
   } = listing;
-  const [bulkBusy, setBulkBusy] = useState(false);
   // A pending reinstall the user must confirm (they already have these mods).
   const [reinstall, setReinstall] = useState<
     { kind: "single"; mod: ModSummary } | { kind: "bulk"; mods: ModSummary[] } | null
   >(null);
 
-  const { startInstall } = useInstall();
+  const { startPendingInstall } = useInstall();
   const selectionActive = selected.size > 0;
 
   // The grid scroller. Its offset is kept in `listing` rather than here, so opening a mod
@@ -102,97 +101,95 @@ export default function Browse({
     [installed],
   );
 
-  // Silent quick-install: resolve the mirror + folder, then enqueue.
+  /**
+   * Silent quick-install: the mod joins the download queue on the spot, and its mirror and
+   * destination folder are worked out when the queue reaches it.
+   *
+   * The lookup used to come first, which meant a mod existed nowhere on screen until its page
+   * came back — and a bulk selection of twenty appeared in the panel a page-fetch at a time.
+   * Resolving late also asks the library where the mod should go *after* the installs ahead of
+   * it have landed, which is the state the answer depends on.
+   */
+  const queueQuickInstall = useCallback(
+    (mod: ModSummary) =>
+      startPendingInstall({
+        slug: mod.slug,
+        title: mod.title,
+        subpath: modType.installSubpath,
+        resolve: async () => {
+          try {
+            const res = await resolveQuickInstall(mod.slug, modType, game, categoryId);
+            if (res.ok) return { ...res.params, categoryId };
+            if (res.reason === "blocked") {
+              toast.error(t("browse.needsBrowser", { title: res.title }), {
+                description: t("browse.needsBrowserDesc", { host: res.host ?? "" }),
+              });
+            } else if (res.reason === "serverOnly") {
+              // Not installed on the user's behalf: one click can't ask which build was meant,
+              // and a server file installs cleanly while the game shows nothing.
+              toast.error(t("browse.serverOnly", { title: res.title }), {
+                description: t("browse.serverOnlyDesc"),
+              });
+            } else {
+              toast.error(t("browse.noDownload", { title: res.title }));
+            }
+          } catch (e) {
+            toast.error(t("browse.quickInstallFailed", { title: mod.title }), {
+              description: String(e),
+            });
+          }
+          return null;
+        },
+      }),
+    [modType, categoryId, game, startPendingInstall, t],
+  );
+
   const doQuickInstall = useCallback(
-    async (mod: ModSummary) => {
-      try {
-        const res = await resolveQuickInstall(mod.slug, modType, game, categoryId);
-        if (res.ok) {
-          startInstall({ ...res.params, categoryId });
-          toast.success(t("browse.queued", { title: res.params.title }), {
-            description: t("browse.queuedDesc", {
-              folder: res.params.destFolder || t("browse.rootFolder"),
-            }),
-          });
-        } else if (res.reason === "blocked") {
-          toast.error(t("browse.needsBrowser", { title: res.title }), {
-            description: t("browse.needsBrowserDesc", { host: res.host ?? "" }),
-          });
-        } else if (res.reason === "serverOnly") {
-          // Not installed on the user's behalf: one click can't ask which build was meant,
-          // and a server file installs cleanly while the game shows nothing.
-          toast.error(t("browse.serverOnly", { title: res.title }), {
-            description: t("browse.serverOnlyDesc"),
-          });
-        } else {
-          toast.error(t("browse.noDownload", { title: res.title }));
-        }
-      } catch (e) {
-        toast.error(t("browse.quickInstallFailed", { title: mod.title }), {
-          description: String(e),
-        });
-      }
+    (mod: ModSummary) => {
+      queueQuickInstall(mod);
+      toast.success(t("browse.queued", { title: mod.title }), {
+        description: t("browse.queuedDesc"),
+      });
     },
-    [modType, categoryId, game, startInstall, t],
+    [queueQuickInstall, t],
   );
 
   // Guard: if the mod is already installed, confirm before overwriting.
   const quickInstall = useCallback(
     (mod: ModSummary) => {
       if (isInstalled(mod)) setReinstall({ kind: "single", mod });
-      else void doQuickInstall(mod);
+      else doQuickInstall(mod);
     },
     [isInstalled, doQuickInstall],
   );
 
+  // The whole selection is queued at once. Nothing is fetched here, so there's no busy state
+  // to sit through and no count of what got skipped — a mod with no usable download says so
+  // itself, by name, when the queue gets to it.
   const doBulkInstall = useCallback(
-    async (list: ModSummary[]) => {
-      setBulkBusy(true);
-      let queued = 0;
-      const skipped: string[] = [];
-      for (const mod of list) {
-        try {
-          const res = await resolveQuickInstall(mod.slug, modType, game, categoryId);
-          if (res.ok) {
-            startInstall({ ...res.params, categoryId });
-            queued++;
-          } else {
-            skipped.push(res.title);
-          }
-        } catch {
-          skipped.push(mod.title);
-        }
-      }
-      setBulkBusy(false);
+    (list: ModSummary[]) => {
+      list.forEach(queueQuickInstall);
       clearSelection();
-      if (queued > 0) {
-        toast.success(t("browse.queuedBulk", { count: queued }), {
-          description: skipped.length
-            ? t("browse.queuedBulkSkipped", { count: skipped.length })
-            : t("browse.queuedBulkDesc"),
-        });
-      } else if (skipped.length) {
-        toast.error(t("browse.bulkFailed"), {
-          description: t("browse.bulkFailedDesc", { count: skipped.length }),
-        });
-      }
+      toast.success(t("browse.queuedBulk", { count: list.length }), {
+        description: t("browse.queuedBulkDesc"),
+      });
     },
-    [modType, categoryId, game, startInstall, clearSelection, t],
+    [queueQuickInstall, clearSelection, t],
   );
 
   const bulkInstall = useCallback(() => {
     const list = [...selected.values()];
     const already = list.filter(isInstalled);
     if (already.length) setReinstall({ kind: "bulk", mods: list });
-    else void doBulkInstall(list);
+    else doBulkInstall(list);
   }, [selected, isInstalled, doBulkInstall]);
 
   const confirmReinstall = useCallback(() => {
     const pending = reinstall;
     setReinstall(null);
     if (!pending) return;
-    if (pending.kind === "single") void doQuickInstall(pending.mod);
-    else void doBulkInstall(pending.mods);
+    if (pending.kind === "single") doQuickInstall(pending.mod);
+    else doBulkInstall(pending.mods);
   }, [reinstall, doQuickInstall, doBulkInstall]);
 
   const isBike = modType.id === "bikes";
@@ -332,20 +329,17 @@ export default function Browse({
           <span className="text-[12.5px] font-semibold">
             {t("browse.selectedCount", { count: selected.size })}
           </span>
-          <Button size="sm" onClick={bulkInstall} disabled={bulkBusy}>
+          <Button size="sm" onClick={bulkInstall}>
             <Download className="size-3.5" />
-            {bulkBusy
-              ? t("browse.queuing")
-              : t("browse.quickInstallCount", { count: selected.size })}
+            {t("browse.quickInstallCount", { count: selected.size })}
           </Button>
-          <Button size="sm" variant="outline" onClick={selectAll} disabled={bulkBusy}>
+          <Button size="sm" variant="outline" onClick={selectAll}>
             {t("common.selectAll")}
           </Button>
           <Button
             size="sm"
             variant="outline"
             onClick={clearSelection}
-            disabled={bulkBusy}
             className="ml-auto"
           >
             <X className="size-3.5" /> {t("common.clear")}

--- a/src/Components/Shell/DownloadQueue.tsx
+++ b/src/Components/Shell/DownloadQueue.tsx
@@ -169,7 +169,9 @@ function QueuedRow({ item, onCancel }: { item: QueuedInstall; onCancel: () => vo
     <div className="group flex items-center gap-2 px-3.5 py-2">
       <div className="flex min-w-0 flex-1 flex-col">
         <span className="truncate text-[12px] font-medium">{displayName(item.title)}</span>
-        <span className="text-[10.5px] text-muted-foreground">{t("downloads.waiting")}</span>
+        <span className="text-[10.5px] text-muted-foreground">
+          {t(item.preparing ? "downloads.preparing" : "downloads.waiting")}
+        </span>
       </div>
       <CancelButton label={t("downloads.remove")} onClick={onCancel} />
     </div>

--- a/src/Context/Install.tsx
+++ b/src/Context/Install.tsx
@@ -48,6 +48,36 @@ function installKey({ slug, subpath, destFolder }: StartParams): string {
   return JSON.stringify([slug, subpath, destFolder]);
 }
 
+/** The same identity for a job whose destination isn't known yet. Enough to turn away a second
+ *  click on the same card; the real key takes over once it resolves. */
+function pendingKey({ slug, subpath }: PendingInstall): string {
+  return JSON.stringify([slug, subpath, null]);
+}
+
+/** What a pending install comes back with: an ordinary download, worked out late. */
+export type ResolvedInstall = Omit<StartParams, "source"> & {
+  url: string;
+  host: string;
+};
+
+/**
+ * An install the user has asked for whose download link and destination aren't known yet.
+ *
+ * The Browse grid's quick install has to fetch the mod's page to work both out, and that used
+ * to happen before the queue heard about the mod at all — so a bulk selection trickled into the
+ * panel one page-fetch at a time, with the rest of it nowhere on screen. Resolving is a stage of
+ * the queue instead: the row appears on click, and the page is fetched when its turn comes.
+ */
+export interface PendingInstall {
+  slug: string;
+  title: string;
+  /** The mod type's install subpath — known on click, and all `pendingKey` needs. */
+  subpath: string;
+  /** `null` when there is nothing installable. The caller reports that itself: only it knows
+   *  whether the host is blocked, the build is server-only, or the page offers no file. */
+  resolve: () => Promise<ResolvedInstall | null>;
+}
+
 /** How the download history names this source. */
 function historySource(source: InstallSource): DownloadSource {
   if (source.kind === "shop") return "shop";
@@ -80,6 +110,21 @@ export interface QueuedInstall {
   slug: string;
   title: string;
   kind: InstallSource["kind"];
+  /** Its download link and destination are being looked up right now: it's next up, but there
+   *  is nothing to transfer yet. */
+  preparing?: boolean;
+}
+
+/** A slot in the queue — a job ready to run, or one still to be resolved. */
+interface QueueItem {
+  key: string;
+  slug: string;
+  title: string;
+  kind: InstallSource["kind"];
+  /** `null` until `resolve` has answered. */
+  params: StartParams | null;
+  resolve?: PendingInstall["resolve"];
+  preparing?: boolean;
 }
 
 interface InstallContextValue {
@@ -96,6 +141,9 @@ interface InstallContextValue {
     p: Omit<StartParams, "source"> & { url: string; host: string },
   ) => void;
   startImport: (p: Omit<StartParams, "source"> & { path: string }) => void;
+  /** Queue a mod whose download link and destination still have to be looked up — it takes its
+   *  place in the panel straight away and resolves when the queue reaches it. */
+  startPendingInstall: (p: PendingInstall) => void;
   /** A purchase from the shop, queued exactly like any other install. */
   startShopInstall: (p: Omit<StartParams, "source"> & { item: ShopItem }) => void;
   /** Clear a finished (done/error) install card. */
@@ -135,7 +183,7 @@ export function InstallProvider({
   const clearTimer = useRef<number | null>(null);
   // Installs run one at a time (the engine handles a single transfer); extra
   // requests wait in this queue and are drained sequentially.
-  const queueRef = useRef<StartParams[]>([]);
+  const queueRef = useRef<QueueItem[]>([]);
   const runningRef = useRef(false);
   // What the queue is draining right now, so `enqueue` can turn a repeat request away.
   const activeKeyRef = useRef<string | null>(null);
@@ -159,11 +207,12 @@ export function InstallProvider({
   /** Republish the pending queue for rendering. Called wherever `queueRef` moves. */
   const syncQueue = useCallback(() => {
     setQueued(
-      queueRef.current.map((p) => ({
-        key: installKey(p),
-        slug: p.slug,
-        title: p.title,
-        kind: p.source.kind,
+      queueRef.current.map((it) => ({
+        key: it.key,
+        slug: it.slug,
+        title: it.title,
+        kind: it.kind,
+        preparing: it.preparing,
       })),
     );
   }, []);
@@ -295,12 +344,40 @@ export function InstallProvider({
     runningRef.current = true;
     try {
       while (queueRef.current.length) {
-        const next = queueRef.current.shift()!;
+        // The head is read, not shifted: a job still being resolved stays in the queue, so it
+        // keeps its row in the panel — and its X — while its page is fetched.
+        const head = queueRef.current[0];
+        let params = head.params;
+        if (!params) {
+          head.preparing = true;
+          syncQueue();
+          try {
+            const resolved = await head.resolve!();
+            if (resolved) {
+              const { url, host, ...rest } = resolved;
+              params = { ...rest, source: { kind: "download", url, host } };
+            }
+          } catch {
+            // The caller reports its own failures; there's simply nothing to install.
+            params = null;
+          }
+          head.preparing = false;
+        }
+        // Gone from the queue means cancelled while it resolved — drop it on the way back.
+        const at = queueRef.current.indexOf(head);
+        if (at < 0) continue;
+        queueRef.current.splice(at, 1);
         syncQueue();
-        activeKeyRef.current = installKey(next);
-        runningParamsRef.current = next;
+        if (!params) continue;
+        const key = installKey(params);
+        // A pending job only learns its destination here, so this is the first moment its real
+        // key exists — and the first chance to see it's the same job as something already
+        // queued. (Nothing can be *running*: this loop is the only thing that runs installs.)
+        if (key !== head.key && queueRef.current.some((q) => q.key === key)) continue;
+        activeKeyRef.current = key;
+        runningParamsRef.current = params;
         try {
-          await run(next);
+          await run(params);
         } finally {
           activeKeyRef.current = null;
           runningParamsRef.current = null;
@@ -322,8 +399,14 @@ export function InstallProvider({
       // different bikes is two real installs and both belong in the queue.
       const key = installKey(params);
       if (activeKeyRef.current === key) return;
-      if (queueRef.current.some((q) => installKey(q) === key)) return;
-      queueRef.current.push(params);
+      if (queueRef.current.some((q) => q.key === key)) return;
+      queueRef.current.push({
+        key,
+        slug: params.slug,
+        title: params.title,
+        kind: params.source.kind,
+        params,
+      });
       syncQueue();
       void pump();
     },
@@ -331,10 +414,30 @@ export function InstallProvider({
   );
   enqueueRef.current = enqueue;
 
+  const startPendingInstall = useCallback(
+    (p: PendingInstall) => {
+      const key = pendingKey(p);
+      if (queueRef.current.some((q) => q.key === key)) return;
+      // Always a site download: a purchase and a local file both know their source already.
+      queueRef.current.push({
+        key,
+        slug: p.slug,
+        title: p.title,
+        kind: "download",
+        params: null,
+        resolve: p.resolve,
+      });
+      syncQueue();
+      void pump();
+    },
+    [pump, syncQueue],
+  );
+
   const cancel = useCallback(
     (key: string) => {
-      // Still waiting its turn: drop it here and the backend never hears about it at all.
-      const at = queueRef.current.findIndex((q) => installKey(q) === key);
+      // Still waiting its turn: drop it here and the backend never hears about it at all. That
+      // covers a row still being resolved — `pump` finds it missing and skips it.
+      const at = queueRef.current.findIndex((q) => q.key === key);
       if (at >= 0) {
         queueRef.current.splice(at, 1);
         syncQueue();
@@ -380,10 +483,20 @@ export function InstallProvider({
       cancel,
       startInstall,
       startImport,
+      startPendingInstall,
       startShopInstall,
       clear,
     }),
-    [active, queued, cancel, startInstall, startImport, startShopInstall, clear],
+    [
+      active,
+      queued,
+      cancel,
+      startInstall,
+      startImport,
+      startPendingInstall,
+      startShopInstall,
+      clear,
+    ],
   );
 
   return (

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -360,7 +360,6 @@ export const de: Translation = {
   "browse.empty": "Keine {{type}} gefunden.",
   "browse.loadMore": "Mehr laden",
   "browse.selectedCount": "{{count}} ausgewählt",
-  "browse.queuing": "Wird eingereiht…",
   "browse.quickInstallCount": "{{count}} schnell installieren",
   "browse.quickInstall": "Schnellinstallation",
   "browse.quickReinstall": "Schnelle Neuinstallation",
@@ -374,8 +373,7 @@ export const de: Translation = {
   "browse.reinstall": "Neu installieren",
   "browse.reinstallAll": "Alle neu installieren",
   "browse.queued": "„{{title}}“ eingereiht",
-  "browse.queuedDesc": "Wird in {{folder}} installiert.",
-  "browse.rootFolder": "Hauptordner",
+  "browse.queuedDesc": "Wird installiert, sobald sie an der Reihe ist.",
   "browse.byAuthor": "von {{author}}",
   "browse.needsBrowser":
     "„{{title}}“ muss über den Browser heruntergeladen werden",
@@ -390,15 +388,6 @@ export const de: Translation = {
   "browse.queuedBulk_one": "{{count}} Mod eingereiht",
   "browse.queuedBulk_other": "{{count}} Mods eingereiht",
   "browse.queuedBulkDesc": "Sie werden nacheinander installiert.",
-  "browse.queuedBulkSkipped_one":
-    "{{count}} übersprungen — öffne sie und wähle einen Download.",
-  "browse.queuedBulkSkipped_other":
-    "{{count}} übersprungen — öffne sie und wähle einen Download.",
-  "browse.bulkFailed": "Die Auswahl konnte nicht schnell installiert werden",
-  "browse.bulkFailedDesc_one":
-    "Öffne sie und wähle einen Download.",
-  "browse.bulkFailedDesc_other":
-    "Bei allen {{count}} muss der Download von Hand gewählt werden.",
 
   // ── Shop (MX Bikes Shop — gekaufte Downloads) ──────────────────────────────
   "shop.help":
@@ -1078,6 +1067,7 @@ export const de: Translation = {
 
   "downloads.title": "Downloads",
   "downloads.open": "Download-Warteschlange anzeigen",
+  "downloads.preparing": "Wird vorbereitet…",
   "downloads.waiting": "Wartet",
   "downloads.cancel": "Diesen Download abbrechen",
   "downloads.remove": "Aus der Warteschlange entfernen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -348,7 +348,6 @@ export const en = {
   "browse.empty": "No {{type}} found.",
   "browse.loadMore": "Load more",
   "browse.selectedCount": "{{count}} selected",
-  "browse.queuing": "Queuing…",
   "browse.quickInstallCount": "Quick install {{count}}",
   "browse.quickInstall": "Quick install",
   "browse.quickReinstall": "Quick reinstall",
@@ -362,8 +361,7 @@ export const en = {
   "browse.reinstall": "Reinstall",
   "browse.reinstallAll": "Reinstall all",
   "browse.queued": "Queued “{{title}}”",
-  "browse.queuedDesc": "Installing to {{folder}}.",
-  "browse.rootFolder": "root",
+  "browse.queuedDesc": "It'll install as soon as the queue reaches it.",
   "browse.byAuthor": "by {{author}}",
   "browse.needsBrowser": "“{{title}}” needs a browser download",
   "browse.needsBrowserDesc":
@@ -376,11 +374,6 @@ export const en = {
   "browse.queuedBulk_one": "Queued {{count}} mod",
   "browse.queuedBulk_other": "Queued {{count}} mods",
   "browse.queuedBulkDesc": "They'll install one after another.",
-  "browse.queuedBulkSkipped_one": "{{count}} skipped — open it to pick a download.",
-  "browse.queuedBulkSkipped_other": "{{count}} skipped — open them to pick a download.",
-  "browse.bulkFailed": "Couldn't quick-install the selection",
-  "browse.bulkFailedDesc_one": "Open it to pick a download.",
-  "browse.bulkFailedDesc_other": "All {{count}} need a download picked by hand.",
 
   // ── Shop (MX Bikes Shop — purchased downloads) ─────────────────────────────
   "shop.help":
@@ -1036,6 +1029,7 @@ export const en = {
 
   "downloads.title": "Downloads",
   "downloads.open": "Show the download queue",
+  "downloads.preparing": "Preparing…",
   "downloads.waiting": "Waiting",
   "downloads.cancel": "Cancel this download",
   "downloads.remove": "Remove from the queue",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -353,7 +353,6 @@ export const es: Translation = {
   "browse.empty": "No se encontraron {{type}}.",
   "browse.loadMore": "Cargar más",
   "browse.selectedCount": "{{count}} seleccionados",
-  "browse.queuing": "Añadiendo a la cola…",
   "browse.quickInstallCount": "Instalar rápido {{count}}",
   "browse.quickInstall": "Instalación rápida",
   "browse.quickReinstall": "Reinstalación rápida",
@@ -367,8 +366,7 @@ export const es: Translation = {
   "browse.reinstall": "Reinstalar",
   "browse.reinstallAll": "Reinstalar todo",
   "browse.queued": "«{{title}}» en cola",
-  "browse.queuedDesc": "Instalando en {{folder}}.",
-  "browse.rootFolder": "raíz",
+  "browse.queuedDesc": "Se instalará en cuanto le llegue el turno.",
   "browse.byAuthor": "por {{author}}",
   "browse.needsBrowser": "«{{title}}» requiere descarga desde el navegador",
   "browse.needsBrowserDesc":
@@ -382,15 +380,6 @@ export const es: Translation = {
   "browse.queuedBulk_one": "{{count}} mod en cola",
   "browse.queuedBulk_other": "{{count}} mods en cola",
   "browse.queuedBulkDesc": "Se instalarán uno tras otro.",
-  "browse.queuedBulkSkipped_one":
-    "{{count}} omitido — ábrelo para elegir una descarga.",
-  "browse.queuedBulkSkipped_other":
-    "{{count}} omitidos — ábrelos para elegir una descarga.",
-  "browse.bulkFailed": "No se pudo instalar rápido la selección",
-  "browse.bulkFailedDesc_one":
-    "Ábrelo para elegir una descarga.",
-  "browse.bulkFailedDesc_other":
-    "Los {{count}} necesitan que elijas la descarga a mano.",
 
   // ── Tienda (MX Bikes Shop — descargas compradas) ───────────────────────────
   "shop.help":
@@ -1066,6 +1055,7 @@ export const es: Translation = {
 
   "downloads.title": "Descargas",
   "downloads.open": "Mostrar la cola de descargas",
+  "downloads.preparing": "Preparando…",
   "downloads.waiting": "En espera",
   "downloads.cancel": "Cancelar esta descarga",
   "downloads.remove": "Quitar de la cola",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -356,7 +356,6 @@ export const fr: Translation = {
   "browse.empty": "Aucun résultat pour {{type}}.",
   "browse.loadMore": "Charger plus",
   "browse.selectedCount": "{{count}} sélectionné(s)",
-  "browse.queuing": "Mise en file…",
   "browse.quickInstallCount": "Installation rapide de {{count}}",
   "browse.quickInstall": "Installation rapide",
   "browse.quickReinstall": "Réinstallation rapide",
@@ -370,8 +369,7 @@ export const fr: Translation = {
   "browse.reinstall": "Réinstaller",
   "browse.reinstallAll": "Tout réinstaller",
   "browse.queued": "« {{title}} » en file d'attente",
-  "browse.queuedDesc": "Installation dans {{folder}}.",
-  "browse.rootFolder": "racine",
+  "browse.queuedDesc": "Il s'installera dès que son tour arrivera.",
   "browse.byAuthor": "par {{author}}",
   "browse.needsBrowser":
     "« {{title}} » doit être téléchargé depuis le navigateur",
@@ -386,15 +384,6 @@ export const fr: Translation = {
   "browse.queuedBulk_one": "{{count}} mod en file d'attente",
   "browse.queuedBulk_other": "{{count}} mods en file d'attente",
   "browse.queuedBulkDesc": "Ils s'installeront l'un après l'autre.",
-  "browse.queuedBulkSkipped_one":
-    "{{count}} ignoré — ouvrez-le pour choisir un téléchargement.",
-  "browse.queuedBulkSkipped_other":
-    "{{count}} ignorés — ouvrez-les pour choisir un téléchargement.",
-  "browse.bulkFailed": "Impossible d'installer rapidement la sélection",
-  "browse.bulkFailedDesc_one":
-    "Ouvrez-le pour choisir un téléchargement.",
-  "browse.bulkFailedDesc_other":
-    "Pour les {{count}}, le téléchargement doit être choisi à la main.",
 
   // ── Boutique (MX Bikes Shop — téléchargements achetés) ─────────────────────
   "shop.help":
@@ -1069,6 +1058,7 @@ export const fr: Translation = {
 
   "downloads.title": "Téléchargements",
   "downloads.open": "Afficher la file de téléchargement",
+  "downloads.preparing": "Préparation…",
   "downloads.waiting": "En attente",
   "downloads.cancel": "Annuler ce téléchargement",
   "downloads.remove": "Retirer de la file",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -352,7 +352,6 @@ export const it: Translation = {
   "browse.empty": "Nessun risultato per {{type}}.",
   "browse.loadMore": "Carica altre",
   "browse.selectedCount": "{{count}} selezionate",
-  "browse.queuing": "Accodamento…",
   "browse.quickInstallCount": "Installa rapidamente {{count}}",
   "browse.quickInstall": "Installazione rapida",
   "browse.quickReinstall": "Reinstallazione rapida",
@@ -366,8 +365,7 @@ export const it: Translation = {
   "browse.reinstall": "Reinstalla",
   "browse.reinstallAll": "Reinstalla tutto",
   "browse.queued": "“{{title}}” in coda",
-  "browse.queuedDesc": "Installazione in {{folder}}.",
-  "browse.rootFolder": "principale",
+  "browse.queuedDesc": "Verrà installata appena arriva il suo turno.",
   "browse.byAuthor": "di {{author}}",
   "browse.needsBrowser": "“{{title}}” va scaricata dal browser",
   "browse.needsBrowserDesc":
@@ -381,12 +379,6 @@ export const it: Translation = {
   "browse.queuedBulk_one": "{{count}} mod in coda",
   "browse.queuedBulk_other": "{{count}} mod in coda",
   "browse.queuedBulkDesc": "Verranno installate una dopo l'altra.",
-  "browse.queuedBulkSkipped_one": "{{count}} saltata — aprila per scegliere un download.",
-  "browse.queuedBulkSkipped_other": "{{count}} saltate — aprile per scegliere un download.",
-  "browse.bulkFailed": "Impossibile installare rapidamente la selezione",
-  "browse.bulkFailedDesc_one": "Aprila per scegliere un download.",
-  "browse.bulkFailedDesc_other":
-    "Per tutte e {{count}} il download va scelto a mano.",
 
   // ── Negozio (MX Bikes Shop — download acquistati) ──────────────────────────
   "shop.help":
@@ -1058,6 +1050,7 @@ export const it: Translation = {
 
   "downloads.title": "Download",
   "downloads.open": "Mostra la coda dei download",
+  "downloads.preparing": "Preparazione…",
   "downloads.waiting": "In attesa",
   "downloads.cancel": "Annulla questo download",
   "downloads.remove": "Rimuovi dalla coda",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -355,7 +355,6 @@ export const ptBR: Translation = {
   "browse.empty": "Nenhum resultado em {{type}}.",
   "browse.loadMore": "Carregar mais",
   "browse.selectedCount": "{{count}} selecionados",
-  "browse.queuing": "Colocando na fila…",
   "browse.quickInstallCount": "Instalar {{count}} rapidamente",
   "browse.quickInstall": "Instalação rápida",
   "browse.quickReinstall": "Reinstalação rápida",
@@ -369,8 +368,7 @@ export const ptBR: Translation = {
   "browse.reinstall": "Reinstalar",
   "browse.reinstallAll": "Reinstalar tudo",
   "browse.queued": "“{{title}}” na fila",
-  "browse.queuedDesc": "Instalando em {{folder}}.",
-  "browse.rootFolder": "raiz",
+  "browse.queuedDesc": "Será instalado assim que chegar a vez dele.",
   "browse.byAuthor": "por {{author}}",
   "browse.needsBrowser": "“{{title}}” precisa ser baixado pelo navegador",
   "browse.needsBrowserDesc":
@@ -384,14 +382,6 @@ export const ptBR: Translation = {
   "browse.queuedBulk_one": "{{count}} mod na fila",
   "browse.queuedBulk_other": "{{count}} mods na fila",
   "browse.queuedBulkDesc": "Eles serão instalados um depois do outro.",
-  "browse.queuedBulkSkipped_one":
-    "{{count}} ignorado — abra-o para escolher um download.",
-  "browse.queuedBulkSkipped_other":
-    "{{count}} ignorados — abra-os para escolher um download.",
-  "browse.bulkFailed": "Não foi possível instalar a seleção rapidamente",
-  "browse.bulkFailedDesc_one": "Abra-o para escolher um download.",
-  "browse.bulkFailedDesc_other":
-    "Nos {{count}} o download precisa ser escolhido à mão.",
 
   // ── Loja (MX Bikes Shop — downloads comprados) ─────────────────────────────
   "shop.help":
@@ -1058,6 +1048,7 @@ export const ptBR: Translation = {
 
   "downloads.title": "Downloads",
   "downloads.open": "Mostrar a fila de downloads",
+  "downloads.preparing": "Preparando…",
   "downloads.waiting": "Aguardando",
   "downloads.cancel": "Cancelar este download",
   "downloads.remove": "Remover da fila",


### PR DESCRIPTION
## What

The download queue only ever showed mods whose page had already been fetched. A quick install
ran `resolveQuickInstall` — a mod-detail request plus a library scan — *before* the mod reached
the queue, so selecting twenty and hitting install filled the panel one page-fetch at a time,
with the rest of the selection nowhere on screen.

Resolving is now a stage of the queue rather than something the caller finishes first.

- `Context/Install` — the queue holds `QueueItem`s that may not be resolved yet.
  `startPendingInstall` adds the row on click; `pump` reads the head instead of shifting it,
  resolves it in place, then splices and runs. A row cancelled mid-resolve is simply gone when
  the pump comes back; a job that resolves onto something already queued is dropped.
- `Components/Browse` — single and bulk quick-install enqueue immediately. The resolve logic and
  every one of its error toasts moved verbatim into the `resolve` closure. The bulk busy state is
  gone, since the click no longer fetches anything.
- `Components/Shell/DownloadQueue` — a row being resolved reads "Preparing" instead of "Waiting".

Side benefit: the destination folder is now worked out against the library as it stands when the
mod is about to install, not as it stood twenty mods earlier.

## Behaviour changes worth knowing

- Bulk install no longer ends with a "3 skipped" count — nothing is resolved at click time. Each
  mod with no usable download names itself when the queue reaches it instead.
- The single-install toast can no longer name the destination folder, for the same reason.

## Verification

`bun run typecheck`, `bun run lint` (only the two pre-existing warnings, in unrelated files) and
`bun run build` all clean. Not exercised against a live game install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)