### PR TITLE
feat(nav): nest Downloads under Library as an expandable group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased — Downloads moves in under the Library
+
+### Changed
+- **Downloads is now part of the Library rather than a tab beside it.** It answers the question
+  the library can't — which of these arrived today, and what didn't arrive at all — so it belongs
+  inside that place instead of competing with it for a row in the sidebar. Library carries a
+  chevron; the group opens when you go there, stays as you left it between launches, and opens by
+  itself whenever the Downloads page is the one on screen. A failed download still shows its
+  count on the Library row while the group is shut, so closing it can't hide the failure with it.
+  Collapse the sidebar to icons and nothing changes — there is no indent to nest into, so both
+  stay side by side as before.
+
 ## Unreleased — the queue shows every mod you asked for
 
 ### Fixed

--- a/src/Components/Shell/Sidebar.tsx
+++ b/src/Components/Shell/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
   Server as ServerIcon,
   Plug,
   Download as DownloadIcon,
+  ChevronDown,
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
@@ -64,14 +65,21 @@ type NavEntry = {
   label: TKey;
   icon: typeof Home;
   cap?: keyof GameCaps;
+  /** Indented under this entry, behind a chevron. */
+  children?: NavEntry[];
 };
 
 const NAV: NavEntry[] = [
   { id: "browse", label: "nav.browse", icon: Home },
-  { id: "library", label: "nav.library", icon: LibraryIcon },
-  // Right after the library, because it answers the question the library can't: which of
-  // these arrived today, and what didn't arrive at all.
-  { id: "downloads", label: "nav.downloads", icon: DownloadIcon },
+  {
+    id: "library",
+    label: "nav.library",
+    icon: LibraryIcon,
+    // Under the library rather than beside it: Downloads answers the question the library
+    // can't — which of these arrived today, and what didn't arrive at all — so it reads as
+    // part of the same place, not a seventh destination competing with it.
+    children: [{ id: "downloads", label: "nav.downloads", icon: DownloadIcon }],
+  },
   // The Locker and Rider views are the 3D preview; GP Bikes' meshes need their own
   // part bindings before they can be shown.
   { id: "locker", label: "nav.locker", icon: Bike, cap: "viewer" },
@@ -108,8 +116,103 @@ const EXPERIMENTAL_NAV: NavEntry = {
 /** Remembered across launches: a collapsed sidebar is a preference, not a mode. */
 const COLLAPSED_KEY = "mxb:sidebarCollapsed:v1";
 
+/** Same idea, for the nav groups the user left open. */
+const OPEN_GROUPS_KEY = "mxb:sidebarOpenGroups:v1";
+
 /** MX Bikes takes a while to show up in the process list; stop saying "Starting…" after this. */
 const STARTING_TIMEOUT_MS = 15000;
+
+/**
+ * One row of the nav.
+ *
+ * A row with children carries a chevron beside its label, and its children are indented under
+ * it — except when the sidebar is collapsed, where there is nothing to indent into and a group
+ * is simply its icons one after another.
+ */
+function NavRow({
+  entry,
+  active,
+  collapsed,
+  child,
+  badge,
+  group,
+  onSelect,
+}: {
+  entry: NavEntry;
+  active: boolean;
+  collapsed: boolean;
+  child: boolean;
+  /** Unseen download failures to flag on this row; 0 for none. */
+  badge: number;
+  /** Only on a row that has children. */
+  group?: { open: boolean; onToggle: () => void };
+  onSelect: () => void;
+}) {
+  const t = useT();
+  const Icon = entry.icon;
+  const indented = child && !collapsed;
+  return (
+    // The pill is the row, not the button inside it, so the active background and the hover
+    // reach under the chevron too.
+    <div
+      data-tour={entry.id}
+      className={cn(
+        "relative flex items-center rounded-lg transition-colors",
+        active
+          ? "bg-accent text-accent-foreground"
+          : "text-muted-foreground hover:bg-foreground/[0.05] hover:text-foreground",
+      )}
+    >
+      <button
+        onClick={onSelect}
+        title={collapsed ? t(entry.label) : undefined}
+        aria-label={collapsed ? t(entry.label) : undefined}
+        className={cn(
+          "flex min-w-0 flex-1 cursor-default items-center gap-2.5",
+          collapsed ? "justify-center px-0 py-2.5" : indented ? "py-2 pl-9 pr-3" : "px-3 py-2.5",
+          indented ? "text-[13px]" : "text-[13.5px]",
+          active ? "font-semibold" : "font-medium",
+        )}
+      >
+        <Icon className={cn("flex-none", indented ? "size-3.5" : "size-4")} />
+        {!collapsed && <span className="truncate">{t(entry.label)}</span>}
+      </button>
+
+      {/* A failed download used to exist only as a toast, so one dismissed in passing left no
+          sign anything had gone wrong. This is that sign — and it sits on the parent while the
+          group is shut, because closing a group must not hide the failure with it. */}
+      {badge > 0 && (
+        <span
+          title={t("downloads.failedBadge", { count: badge })}
+          className={cn(
+            "flex-none rounded-full bg-destructive text-center text-[10px] font-bold leading-[16px] text-destructive-foreground",
+            collapsed ? "absolute right-1.5 top-1.5 size-2 p-0" : "mr-2.5 min-w-[18px] px-1",
+          )}
+        >
+          {!collapsed && badge}
+        </span>
+      )}
+
+      {group && !collapsed && (
+        <button
+          onClick={group.onToggle}
+          title={t(group.open ? "sidebar.hideGroup" : "sidebar.showGroup", {
+            name: t(entry.label),
+          })}
+          aria-label={t(group.open ? "sidebar.hideGroup" : "sidebar.showGroup", {
+            name: t(entry.label),
+          })}
+          aria-expanded={group.open}
+          className="flex flex-none cursor-default items-center py-2.5 pl-1 pr-2.5"
+        >
+          <ChevronDown
+            className={cn("size-3.5 transition-transform", !group.open && "-rotate-90")}
+          />
+        </button>
+      )}
+    </div>
+  );
+}
 
 export default function Sidebar({ view, onNavigate }: SidebarProps) {
   const t = useT();
@@ -130,6 +233,17 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
       }),
     [],
   );
+  const [openGroups, setOpenGroups] = useState<string[]>(() =>
+    (localStorage.getItem(OPEN_GROUPS_KEY) ?? "").split(",").filter(Boolean),
+  );
+  const setGroupOpen = useCallback((id: DashboardView, open: boolean) => {
+    setOpenGroups((cur) => {
+      if (cur.includes(id) === open) return cur;
+      const next = open ? [...cur, id] : cur.filter((g) => g !== id);
+      localStorage.setItem(OPEN_GROUPS_KEY, next.join(","));
+      return next;
+    });
+  }, []);
   const [joinOpen, setJoinOpen] = useState(false);
   // Re-read on navigation rather than subscribing: the toggle lives in Settings, and
   // leaving that page is exactly when the nav needs to reflect a change.
@@ -163,12 +277,37 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
 
   // Two independent gates: servers needs the experimental toggle, and every entry needs the
   // active game to support it. Built here rather than inline so the JSX stays one `.map`.
-  const nav = [
-    NAV[0],
-    SHOP_ENTRY,
-    ...NAV.slice(1),
-    ...(experimental ? [EXPERIMENTAL_NAV] : []),
-  ].filter(({ cap }) => !cap || caps[cap]);
+  const supported = ({ cap }: NavEntry) => !cap || caps[cap];
+  const nav = [NAV[0], SHOP_ENTRY, ...NAV.slice(1), ...(experimental ? [EXPERIMENTAL_NAV] : [])]
+    .filter(supported)
+    .map((e) => (e.children ? { ...e, children: e.children.filter(supported) } : e));
+
+  // Flattened to the rows actually on screen, so the JSX below stays one `.map`: a group
+  // contributes its own row, then its children when it's open — or always when the sidebar is
+  // collapsed, where there is no indent to hide them behind.
+  const rows = nav.flatMap((entry) => {
+    const kids = entry.children ?? [];
+    // Open because the user opened it, or because one of its pages is the one on screen —
+    // arriving at Downloads from a toast shouldn't leave it hidden inside a shut group.
+    const open = kids.some((k) => k.id === view) || openGroups.includes(entry.id);
+    const shown = collapsed || open ? kids : [];
+    const failures = (e: NavEntry) => (e.id === "downloads" ? unseenFailures : 0);
+    return [
+      {
+        entry,
+        child: false,
+        // Whatever the children would have flagged, while they aren't on screen to flag it.
+        badge: shown.length ? failures(entry) : Math.max(...kids.map(failures), failures(entry)),
+        group: kids.length ? { open, onToggle: () => setGroupOpen(entry.id, !open) } : undefined,
+      },
+      ...shown.map((kid) => ({
+        entry: kid,
+        child: true,
+        badge: failures(kid),
+        group: undefined,
+      })),
+    ];
+  });
 
   // Drop out of "Starting…" once the game shows up — or once it's clear it isn't going
   // to, so a launch that failed silently doesn't leave the button stuck.
@@ -243,43 +382,23 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
       </div>
 
       <nav className="flex flex-col gap-0.5">
-        {nav.map(({ id, label, icon: Icon }) => {
-          const activeNav = view === id;
-          return (
-            <button
-              key={id}
-              data-tour={id}
-              onClick={() => onNavigate(id)}
-              title={collapsed ? t(label) : undefined}
-              aria-label={collapsed ? t(label) : undefined}
-              className={cn(
-                "relative flex cursor-default items-center gap-2.5 rounded-lg py-2.5 text-[13.5px] transition-colors",
-                collapsed ? "justify-center px-0" : "px-3",
-                activeNav
-                  ? "bg-accent font-semibold text-accent-foreground"
-                  : "font-medium text-muted-foreground hover:bg-foreground/[0.05] hover:text-foreground",
-              )}
-            >
-              <Icon className="size-4 flex-none" />
-              {!collapsed && <span>{t(label)}</span>}
-              {/* A failed download used to exist only as a toast, so one dismissed in passing
-                  left no sign anything had gone wrong. This is that sign. */}
-              {id === "downloads" && unseenFailures > 0 && (
-                <span
-                  title={t("downloads.failedBadge", { count: unseenFailures })}
-                  className={cn(
-                    "flex-none rounded-full bg-destructive text-center text-[10px] font-bold leading-[16px] text-destructive-foreground",
-                    collapsed
-                      ? "absolute right-1.5 top-1.5 size-2 p-0"
-                      : "ml-auto min-w-[18px] px-1",
-                  )}
-                >
-                  {!collapsed && unseenFailures}
-                </span>
-              )}
-            </button>
-          );
-        })}
+        {rows.map(({ entry, child, badge, group }) => (
+          <NavRow
+            key={entry.id}
+            entry={entry}
+            active={view === entry.id}
+            collapsed={collapsed}
+            child={child}
+            badge={badge}
+            group={group}
+            onSelect={() => {
+              onNavigate(entry.id);
+              // Opening the parent's page shows what's under it. Only ever opens: clicking
+              // Library twice shouldn't make Downloads disappear — that's the chevron's job.
+              if (group) setGroupOpen(entry.id, true);
+            }}
+          />
+        ))}
       </nav>
 
       <div className="mt-auto flex flex-col gap-2">

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -66,6 +66,8 @@ export const de: Translation = {
   "sidebar.queued": "+{{count}} in der Warteschlange",
   "sidebar.expand": "Seitenleiste ausklappen",
   "sidebar.collapse": "Seitenleiste einklappen",
+  "sidebar.showGroup": "Zeigen, was unter {{name}} liegt",
+  "sidebar.hideGroup": "Ausblenden, was unter {{name}} liegt",
 
   // ── FrostMod ───────────────────────────────────────────────────────────────
   "frostmod.checking": "FrostMod wird geprüft…",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -60,6 +60,8 @@ export const en = {
   "sidebar.queued": "+{{count}} queued",
   "sidebar.expand": "Expand the sidebar",
   "sidebar.collapse": "Collapse the sidebar",
+  "sidebar.showGroup": "Show what's under {{name}}",
+  "sidebar.hideGroup": "Hide what's under {{name}}",
 
   // ── FrostMod status + actions ──────────────────────────────────────────────
   "frostmod.checking": "Checking FrostMod…",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -61,6 +61,8 @@ export const es: Translation = {
   "sidebar.queued": "+{{count}} en cola",
   "sidebar.expand": "Expandir la barra lateral",
   "sidebar.collapse": "Contraer la barra lateral",
+  "sidebar.showGroup": "Mostrar lo que hay dentro de {{name}}",
+  "sidebar.hideGroup": "Ocultar lo que hay dentro de {{name}}",
 
   // ── FrostMod ───────────────────────────────────────────────────────────────
   "frostmod.checking": "Comprobando FrostMod…",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -63,6 +63,8 @@ export const fr: Translation = {
   "sidebar.queued": "+{{count}} en attente",
   "sidebar.expand": "Développer la barre latérale",
   "sidebar.collapse": "Réduire la barre latérale",
+  "sidebar.showGroup": "Afficher ce qui se trouve sous {{name}}",
+  "sidebar.hideGroup": "Masquer ce qui se trouve sous {{name}}",
 
   // ── FrostMod ───────────────────────────────────────────────────────────────
   "frostmod.checking": "Vérification de FrostMod…",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -61,6 +61,8 @@ export const it: Translation = {
   "sidebar.queued": "+{{count}} in coda",
   "sidebar.expand": "Espandi la barra laterale",
   "sidebar.collapse": "Riduci la barra laterale",
+  "sidebar.showGroup": "Mostra cosa c'è sotto {{name}}",
+  "sidebar.hideGroup": "Nascondi cosa c'è sotto {{name}}",
 
   // ── FrostMod ───────────────────────────────────────────────────────────────
   "frostmod.checking": "Controllo di FrostMod…",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -64,6 +64,8 @@ export const ptBR: Translation = {
   "sidebar.queued": "+{{count}} na fila",
   "sidebar.expand": "Expandir a barra lateral",
   "sidebar.collapse": "Recolher a barra lateral",
+  "sidebar.showGroup": "Mostrar o que está em {{name}}",
+  "sidebar.hideGroup": "Ocultar o que está em {{name}}",
 
   // ── FrostMod ───────────────────────────────────────────────────────────────
   "frostmod.checking": "Verificando o FrostMod…",


### PR DESCRIPTION
## What

Downloads landed as a seventh top-level tab sitting next to Library. It's really the library's
other half — what arrived and when, against what is on disk — so it now lives *inside* it, behind
a chevron, instead of competing with it for a row.

- `NavEntry` gains `children`, and Downloads moves into Library's. The nav renders from a flat
  row list built off that tree, so the JSX stays a single `.map`.
- New `NavRow`: the pill is the row rather than the button inside it, so the active background
  and the hover reach under the chevron too.

## Behaviour

- Clicking **Library** navigates there *and* opens the group. It never closes it — clicking
  Library twice shouldn't make Downloads vanish. That's the chevron's job.
- The group opens by itself whenever Downloads is the page on screen, so arriving there from a
  toast or the failure badge doesn't leave it hidden inside a shut group.
- Open/closed is remembered in `localStorage`, alongside the sidebar-collapse preference.
- **Collapsed sidebar:** there is no indent to nest into, so the group renders as its icons one
  after another — identical to today.
- **Failure badge:** moves up onto Library while the group is shut. A closed group must not hide
  the one thing that badge exists to make noticeable.
- The tour's `[data-tour="library"]` anchor moved to the row wrapper, so the highlight covers the
  whole pill including the chevron.

## Verification

`bun run typecheck`, `bun run lint` (only the two pre-existing warnings, in unrelated files) and
`bun run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)