### PR TITLE
chore: run the app under its own name instead of "frost"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased — the app runs under its own name
+
+### Changed
+- **The process is called "MXB App" rather than "frost".** Activity Monitor and Task Manager
+  listed it under the name of the Rust crate behind it, which matches nothing anyone installed —
+  so working out what a process was doing meant first working out that it was this app at all.
+  Both the shipped build and a dev run carry the product name now. Two things ride along with the
+  rename: the login item is written again on the first launch after updating, because it stores
+  the path of the executable it was created for and would otherwise quietly stop starting the app;
+  and the Windows installer closes and clears away the `frost.exe` it finds from earlier versions
+  instead of leaving it parked in the install folder.
+
 ## Unreleased — Downloads moves in under the Library
 
 ### Changed

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1669,52 +1669,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "frost"
-version = "0.9.2"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "cpal",
- "dirs-next",
- "flate2",
- "futures-util",
- "html-escape",
- "http",
- "image",
- "log",
- "md-5",
- "mega",
- "notify",
- "notify-debouncer-mini",
- "obfstr",
- "percent-encoding",
- "rayon",
- "regex",
- "reqwest 0.12.28",
- "scraper",
- "serde",
- "serde_json",
- "sevenz-rust",
- "sha2",
- "tauri",
- "tauri-build",
- "tauri-plugin-autostart",
- "tauri-plugin-deep-link",
- "tauri-plugin-dialog",
- "tauri-plugin-global-shortcut",
- "tauri-plugin-log",
- "tauri-plugin-process",
- "tauri-plugin-shell",
- "tauri-plugin-single-instance",
- "tauri-plugin-updater",
- "tokio",
- "trash",
- "unrar",
- "walkdir",
- "zip 2.4.2",
-]
-
-[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3213,6 +3167,52 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mxb-app"
+version = "0.9.2"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "cpal",
+ "dirs-next",
+ "flate2",
+ "futures-util",
+ "html-escape",
+ "http",
+ "image",
+ "log",
+ "md-5",
+ "mega",
+ "notify",
+ "notify-debouncer-mini",
+ "obfstr",
+ "percent-encoding",
+ "rayon",
+ "regex",
+ "reqwest 0.12.28",
+ "scraper",
+ "serde",
+ "serde_json",
+ "sevenz-rust",
+ "sha2",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin-autostart",
+ "tauri-plugin-deep-link",
+ "tauri-plugin-dialog",
+ "tauri-plugin-global-shortcut",
+ "tauri-plugin-log",
+ "tauri-plugin-process",
+ "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
+ "tauri-plugin-updater",
+ "tokio",
+ "trash",
+ "unrar",
+ "walkdir",
+ "zip 2.4.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
-name = "frost"
+# `mainBinaryName` renames the bundled binary, but only for `tauri build` — a dev run is
+# whatever cargo called it. Cargo target names can't hold a space, so this is as close as
+# it gets. The description is what Windows Task Manager shows in its Processes tab.
+name = "mxb-app"
 version = "0.9.2"
-description = "Frost — MX Bikes mod manager"
+description = "MXB App — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"
 

--- a/src-tauri/installer-hooks.nsh
+++ b/src-tauri/installer-hooks.nsh
@@ -2,7 +2,7 @@
 ;
 ; MXB App hides to the tray when its window is closed and launches at login, so an
 ; installer a user started by hand nearly always finds it running; the in-app updater
-; launches the installer from inside the app itself. Either way `$INSTDIR\frost.exe` — the
+; launches the installer from inside the app itself. Either way `$INSTDIR\MXB App.exe` — the
 ; app's own image — can still be held when the copy starts, and NSIS answers that with a
 ; blunt "error opening file for writing", reported against v0.8.1.
 ;
@@ -36,6 +36,20 @@
   ; the app's own image.
   nsExec::Exec 'taskkill /F /IM "${MAINBINARYNAME}.exe"'
   Pop $0 ; 0 = closed it, 128 = wasn't running. Either is the state we want.
+!macroend
+
+; Up to v0.9.2 the app shipped as `frost.exe`. `${MAINBINARYNAME}` no longer names it, so
+; everything above walks straight past the build being replaced: an upgrade a user starts by
+; hand leaves the old app running in the tray, and its image sits in `$INSTDIR` forever
+; because `DropMovedBinaries` only sweeps the current name.
+!macro CloseLegacyApp
+  nsExec::Exec 'taskkill /F /IM "frost.exe"'
+  Pop $0 ; 0 = closed it, 128 = wasn't running. Either is the state we want.
+!macroend
+
+!macro DropLegacyBinaries
+  Delete "$INSTDIR\frost.exe"
+  Delete "$INSTDIR\frost.exe.old*"
 !macroend
 
 ; Drop the images past installs moved aside. Plain `Delete`, not `/REBOOTOK`: a leftover
@@ -90,6 +104,7 @@
 
 !macro NSIS_HOOK_PREINSTALL
   !insertmacro CloseRunningApp
+  !insertmacro CloseLegacyApp
   !insertmacro FreeMainBinary
 !macroend
 
@@ -97,11 +112,14 @@
 ; leaves the install folder with nothing but the build that was just written.
 !macro NSIS_HOOK_POSTINSTALL
   !insertmacro DropMovedBinaries
+  !insertmacro DropLegacyBinaries
 !macroend
 
 ; The uninstaller's own `RMDir "$INSTDIR"` runs before its POSTUNINSTALL hook, so the
 ; leftovers have to go here for the folder to come out with them.
 !macro NSIS_HOOK_PREUNINSTALL
   !insertmacro CloseRunningApp
+  !insertmacro CloseLegacyApp
   !insertmacro FreeMainBinary
+  !insertmacro DropLegacyBinaries
 !macroend

--- a/src-tauri/src/antidebug.rs
+++ b/src-tauri/src/antidebug.rs
@@ -21,7 +21,7 @@
 ///
 /// In release builds this checks for a debugger now and, if none is attached yet, leaves a
 /// low-frequency watcher running so a debugger attached *after* launch — the usual way, by
-/// attaching to `frost.exe` once it is up — is caught too. In debug builds it does nothing.
+/// attaching to `MXB App.exe` once it is up — is caught too. In debug builds it does nothing.
 pub fn guard() {
     #[cfg(not(debug_assertions))]
     {
@@ -29,7 +29,7 @@ pub fn guard() {
             bail();
         }
         // Attaching to a process that is already running is the common case (open x64dbg,
-        // pick `frost.exe`), so a one-shot check at startup would miss the very attack it
+        // pick `MXB App.exe`), so a one-shot check at startup would miss the very attack it
         // is meant to stop. A slow poll costs nothing measurable and closes that window.
         std::thread::spawn(|| loop {
             std::thread::sleep(std::time::Duration::from_secs(2));

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -63,6 +63,8 @@ pub struct AppConfig {
     pub run_in_background: bool,
     /// Start MXB App automatically on login.
     pub launch_at_startup: bool,
+    /// Which [`AUTOSTART_BINDING_REV`] the login item was last written for.
+    pub autostart_binding_rev: u32,
     /// Launch FrostMod automatically when the app opens.
     pub auto_run_frostmod: bool,
     /// Re-run the game's profile loader in place after applying a preset (Windows-only).
@@ -201,6 +203,12 @@ impl AppConfig {
 /// Steam (Shift+Tab) and GeForce Experience (Alt+Z, Alt+F*).
 pub const DEFAULT_OVERLAY_HOTKEY: &str = "CommandOrControl+Shift+X";
 
+/// Bumped whenever the executable's path changes, so a login item written for the old one is
+/// re-registered rather than left pointing at a file that no longer exists.
+///
+/// v1: the binary is `MXB App`, not `frost`.
+pub const AUTOSTART_BINDING_REV: u32 = 1;
+
 /// Push-to-talk combo used until the player picks another one.
 ///
 /// A modifier chord rather than a bare key, and not one MX Bikes binds: the game has
@@ -230,6 +238,9 @@ impl Default for AppConfig {
             wine_runner: String::new(),
             run_in_background: true,
             launch_at_startup: true,
+            // Zero, not the current rev: a config without the field predates the rename and
+            // its login item still names the old binary.
+            autostart_binding_rev: 0,
             auto_run_frostmod: true,
             instant_refresh: true,
             watch_mods_reload: true,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3968,6 +3968,31 @@ fn set_launch_at_startup(app: tauri::AppHandle, enabled: bool) -> Result<(), Str
     .map_err(|e| e.to_string())
 }
 
+/// What to do with the login item at startup.
+#[derive(Debug, PartialEq, Eq)]
+enum Autostart {
+    Leave,
+    Enable,
+    /// It is there, but it was written for a binary this build no longer has.
+    Rebind,
+    Disable,
+}
+
+/// Reconcile the login item with the setting.
+///
+/// `stale` is the case that isn't obvious: the entry holds the executable's absolute path, so
+/// renaming the binary leaves every existing one pointing at a file that is gone — while
+/// `is_enabled` still answers yes, because all it looks for is the entry. Left alone, the app
+/// simply stops starting at login and nothing ever says why.
+fn autostart_action(wanted: bool, enabled: bool, stale: bool) -> Autostart {
+    match (wanted, enabled) {
+        (true, false) => Autostart::Enable,
+        (true, true) if stale => Autostart::Rebind,
+        (false, true) => Autostart::Disable,
+        _ => Autostart::Leave,
+    }
+}
+
 fn show_main(app: &tauri::AppHandle) {
     if let Some(w) = app.get_webview_window("main") {
         let _ = w.show();
@@ -6335,11 +6360,28 @@ fn main() {
                     }
                 }
                 let manager = handle.autolaunch();
-                let enabled = manager.is_enabled().unwrap_or(false);
-                if cfg.launch_at_startup && !enabled {
-                    let _ = manager.enable();
-                } else if !cfg.launch_at_startup && enabled {
-                    let _ = manager.disable();
+                let stale = cfg.autostart_binding_rev < config::AUTOSTART_BINDING_REV;
+                match autostart_action(
+                    cfg.launch_at_startup,
+                    manager.is_enabled().unwrap_or(false),
+                    stale,
+                ) {
+                    Autostart::Enable => {
+                        let _ = manager.enable();
+                    }
+                    Autostart::Rebind => {
+                        log::info!("re-binding the login item to this build's binary");
+                        let _ = manager.disable();
+                        let _ = manager.enable();
+                    }
+                    Autostart::Disable => {
+                        let _ = manager.disable();
+                    }
+                    Autostart::Leave => {}
+                }
+                if stale {
+                    cfg.autostart_binding_rev = config::AUTOSTART_BINDING_REV;
+                    let _ = config::save(handle, &cfg);
                 }
                 if cfg.auto_run_frostmod && frostmod_manage::is_installed(handle) {
                     let state = handle.state::<FrostmodProcess>();
@@ -6745,6 +6787,34 @@ mod release_version_tests {
     fn the_tags_v_prefix_is_optional() {
         assert_eq!(pick_release_version(Some("0.9.0"), "0.8.0".into()), "0.9.0");
         assert_eq!(pick_release_version(Some("v0.9.0"), "0.8.0".into()), "0.9.0");
+    }
+}
+
+#[cfg(test)]
+mod autostart_tests {
+    use super::*;
+
+    #[test]
+    fn the_setting_is_honoured_when_the_binding_is_current() {
+        assert_eq!(autostart_action(true, false, false), Autostart::Enable);
+        assert_eq!(autostart_action(true, true, false), Autostart::Leave);
+        assert_eq!(autostart_action(false, true, false), Autostart::Disable);
+        assert_eq!(autostart_action(false, false, false), Autostart::Leave);
+    }
+
+    /// The rename bug: the entry exists, so nothing looks wrong, but it names a binary that
+    /// is gone. Without this the app quietly stops starting at login for everyone upgrading.
+    #[test]
+    fn an_entry_written_for_the_old_binary_is_rewritten() {
+        assert_eq!(autostart_action(true, true, true), Autostart::Rebind);
+    }
+
+    /// Whoever turned it off gets it off, however old their entry is — a stale binding is a
+    /// reason to rewrite the entry, never to bring one back.
+    #[test]
+    fn a_stale_binding_never_revives_a_disabled_login_item() {
+        assert_eq!(autostart_action(false, true, true), Autostart::Disable);
+        assert_eq!(autostart_action(false, false, true), Autostart::Leave);
     }
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
+  "mainBinaryName": "MXB App",
   "version": "0.9.2",
   "identifier": "com.frost.mxbikes",
   "build": {


### PR DESCRIPTION
Activity Monitor and Task Manager listed this app as `frost` — the name of the Rust crate behind it, which matches nothing anyone installed. Working out what a process was doing meant first working out that it was this app at all.

## What changed

- `mainBinaryName: "MXB App"` in `tauri.conf.json`, and the Cargo package renamed `frost` → `mxb-app`. Both are needed: `mainBinaryName` only applies to `tauri build`, so without the package rename a dev run still shows up as `frost` — which is where this started. Cargo target names cannot hold a space, so `mxb-app` is as close as it gets there.
- The crate description now reads "MXB App — MX Bikes mod manager". That string is what Windows Task Manager prints in its Processes tab, so leaving it would have kept the puzzle alive on Windows.
- The `com.frost.mxbikes` identifier is unchanged. Config, logs, cookies and sessions all hang off it, and moving it would orphan every existing install's data.

## Two things that ride along

**The login item.** It stores the executable's *absolute path*, and `is_enabled()` only checks that the entry exists — so after a rename it keeps answering "enabled" while pointing at a binary that is gone, and launch-at-login dies silently for everyone upgrading. The startup reconciliation now rewrites it once, tracked by `autostart_binding_rev` in the config. The decision is pulled out into `autostart_action` with tests, including the case that matters: a stale binding must never revive a login item someone had turned off.

**The Windows installer.** The hooks are parameterised on `${MAINBINARYNAME}`, so after the rename they walk straight past the `frost.exe` they are replacing — leaving the old app running in the tray and its image parked in the install folder forever, since `DropMovedBinaries` only sweeps the current name. Added a legacy pass that closes and clears it on install and uninstall.

## Verification

- `cargo check` clean (pre-existing warnings only)
- full suite: 771 passed, 0 failed, 46 ignored
- **Not verified:** the NSIS half is not compiled by anything. The legacy sweep needs a real Windows upgrade from a 0.9.2 install to prove out, and that is the path every existing user takes — worth exercising before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)