### PR TITLE
fix: cap what a download and a texture can pull into memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## Unreleased — nothing downloads without a ceiling
+
+### Fixed
+- **A thumbnail can no longer pull an unlimited amount into memory.** Browsing mods fetches the
+  picture on each card, and the whole response was held in memory to be checked and resized —
+  with nothing saying how large it was allowed to be. Being on the allowlist only says where a
+  URL points, never how big what it points at is, and an `<img>` on a mod page can name whatever
+  its author uploaded. One such link cost however large that file happened to be, twice over,
+  and eight can be in flight at once. Downloads are now refused above 32 MB — before they start
+  when the site says how big the file is, and mid-download when it doesn't — which is many times
+  more than any real thumbnail and no longer unbounded.
+- **A model's embedded texture is only decompressed as far as it claims to go.** The pixels past
+  the texture's own size were always discarded, but not before being unpacked, so a payload that
+  expanded to gigabytes did exactly that first. These records are found by scanning for a byte
+  pattern, so this needed no ill intent — an ordinary false match was enough.
+
+### Added
+- **The log now writes down how much memory the app is holding.** Quiet by default — a line every
+  quarter of an hour, and one straight away if the figure climbs sharply — with what the caches
+  and the thumbnail loader are holding beside it. After an evening spent idle at tens of
+  gigabytes, the log for those hours was empty, and there was no way to tell afterwards what had
+  grown.
+
 ## Unreleased — the app runs under its own name
 
 ### Changed

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3078,6 +3078,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "memory-stats"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c73f5c649995a115e1a0220b35e4df0a1294500477f97a91d0660fb5abeb574a"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3185,6 +3195,7 @@ dependencies = [
  "log",
  "md-5",
  "mega",
+ "memory-stats",
  "notify",
  "notify-debouncer-mini",
  "obfstr",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,9 @@ walkdir = "2"
 percent-encoding = "2"
 # The custom URI scheme handler builds its own responses. Same crate Tauri re-exports.
 http = "1"
+# How much memory this process is holding, for `memwatch`. A few lines of platform FFI
+# behind one call; not worth hand-rolling three times over.
+memory-stats = "1"
 # rustls: consistent modern TLS across platforms (native SChannel failed on
 # Windows). MediaFire downloads work directly with this client — its CDN no
 # longer blocks the rustls fingerprint (verified against a live 427 MB .pkz).

--- a/src-tauri/src/edf.rs
+++ b/src-tauri/src/edf.rs
@@ -708,9 +708,17 @@ pub fn inflate_texture(b: &[u8], t: &EmbeddedTexture) -> Option<Vec<u8>> {
     use std::io::Read;
     let expected = (t.width as usize) * (t.height as usize) * 4;
     let mut buf = Vec::with_capacity(expected);
-    flate2::read::DeflateDecoder::new(&b[t.data_off..t.data_off + t.data_len])
-        .read_to_end(&mut buf)
-        .ok()?;
+    // Bounded, because `data_len` is a *compressed* length and nothing in the record says what
+    // it expands to. Reading the stream whole let anything that inflates to gigabytes do
+    // exactly that before the size check below threw it away — and the records these come from
+    // are found by scanning for a byte pattern, so a false positive is not a hostile file, it
+    // is Tuesday. Everything past `expected` was truncated anyway.
+    std::io::Read::take(
+        flate2::read::DeflateDecoder::new(&b[t.data_off..t.data_off + t.data_len]),
+        expected as u64,
+    )
+    .read_to_end(&mut buf)
+    .ok()?;
     (buf.len() >= expected).then(|| {
         buf.truncate(expected);
         buf
@@ -1192,6 +1200,31 @@ fn submesh_transform(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A record that claims to be a small texture but whose payload inflates to far more than
+    /// that. Everything past `width * height * 4` was always thrown away — the bug was that it
+    /// was decoded first, so what the file said it expanded to decided how much memory this
+    /// took. 64 MB here stands in for the gigabytes a real one could ask for.
+    #[test]
+    fn a_payload_that_expands_past_its_texture_is_not_inflated_whole() {
+        use flate2::write::DeflateEncoder;
+        use std::io::Write;
+
+        let mut enc = DeflateEncoder::new(Vec::new(), flate2::Compression::default());
+        enc.write_all(&vec![0u8; 64 * 1024 * 1024]).unwrap();
+        let payload = enc.finish().unwrap();
+        assert!(payload.len() < 1024 * 1024, "the point is that it compresses hard");
+
+        let tex = EmbeddedTexture {
+            name: "bomb".into(),
+            width: 64,
+            height: 64,
+            data_off: 0,
+            data_len: payload.len(),
+        };
+        let out = inflate_texture(&payload, &tex).expect("still decodes");
+        assert_eq!(out.len(), 64 * 64 * 4, "bounded by what the record claims to be");
+    }
 
     // Material indices count the colour textures, so a map counted among them slides every
     // later texture onto the wrong mesh — the Tactical Vest wore its pouch's normal map.

--- a/src-tauri/src/imgcache.rs
+++ b/src-tauri/src/imgcache.rs
@@ -61,6 +61,16 @@ const PRUNE_TO: f64 = 0.8;
 /// sockets — the same reasoning as `mods::mxb`'s rating concurrency.
 const MAX_CONCURRENT_FETCHES: usize = 8;
 
+/// Ceiling on a single download.
+///
+/// The whole body is held in memory to be sniffed and downscaled, and being on the allowlist
+/// says only where a URL points, never how big what it points at is: an `<img>` on a mod page
+/// can name whatever its author uploaded. Uncapped, one such link costs however large that
+/// file happens to be — and [`MAX_CONCURRENT_FETCHES`] of them can be in flight at once, so
+/// the grid decides how many times over. Generous for a card rendered around 300px wide: the
+/// store's own product images, the largest thing normally seen here, are ~0.5 MB.
+const MAX_FETCH_BYTES: usize = 32 * 1024 * 1024;
+
 /// How long a failed URL is remembered, so a dead thumbnail isn't refetched on every pass.
 const NEGATIVE_TTL: Duration = Duration::from_secs(5 * 60);
 
@@ -80,6 +90,17 @@ pub fn handle(
     tauri::async_runtime::spawn(async move {
         responder.respond(serve(&app, request.uri().to_string()).await);
     });
+}
+
+/// Images handed to the webview this session, and how many bytes that came to. Read by
+/// [`crate::memwatch`], which is trying to answer "what was the app doing when it grew?" —
+/// a grid being scrolled looks very different here from an app nobody is touching.
+static SERVED: AtomicU64 = AtomicU64::new(0);
+static SERVED_BYTES: AtomicU64 = AtomicU64::new(0);
+
+/// `(images, bytes)` served since launch.
+pub fn traffic() -> (u64, u64) {
+    (SERVED.load(Ordering::Relaxed), SERVED_BYTES.load(Ordering::Relaxed))
 }
 
 /// Drop superseded cache generations, and bring the current one under its size cap. Spawned
@@ -107,7 +128,11 @@ async fn serve(app: &AppHandle, uri: String) -> http::Response<Vec<u8>> {
     let width = requested_width(&uri);
 
     match load(app, &url, width).await {
-        Some((bytes, mime)) => reply(200, mime, bytes),
+        Some((bytes, mime)) => {
+            SERVED.fetch_add(1, Ordering::Relaxed);
+            SERVED_BYTES.fetch_add(bytes.len() as u64, Ordering::Relaxed);
+            reply(200, mime, bytes)
+        }
         // `ModCard`'s existing `onError` fallback fires on this, exactly as it does for a
         // dead remote URL — so a miss degrades to the placeholder icon, not a broken image.
         None => reply(404, "text/plain", b"not cached".to_vec()),
@@ -383,6 +408,8 @@ fn client_for(url: &str) -> Option<&'static reqwest::Client> {
 }
 
 async fn fetch(url: &str) -> Option<Vec<u8>> {
+    use futures_util::StreamExt;
+
     let resp = client_for(url)?
         .get(url)
         .header("accept", "image/avif,image/webp,image/*,*/*;q=0.8")
@@ -392,7 +419,39 @@ async fn fetch(url: &str) -> Option<Vec<u8>> {
     if !resp.status().is_success() {
         return None;
     }
-    Some(resp.bytes().await.ok()?.to_vec())
+
+    // Refuse an oversized body before a byte of it is read, when the origin says how big it
+    // is...
+    if let Some(len) = resp.content_length() {
+        if len > MAX_FETCH_BYTES as u64 {
+            log::warn!("imgcache: {url} declares {len} bytes, past the cap — not fetching it");
+            return None;
+        }
+    }
+    // ...and again as it arrives, because that header is optional and can be wrong. Streaming
+    // rather than `bytes()` also stops the body being held twice over: once whole, once copied
+    // into a `Vec`.
+    let mut body: Vec<u8> = Vec::new();
+    let mut chunks = resp.bytes_stream();
+    while let Some(chunk) = chunks.next().await {
+        if !push_capped(&mut body, &chunk.ok()?) {
+            log::warn!("imgcache: {url} went past the cap mid-download — dropped");
+            return None;
+        }
+    }
+    Some(body)
+}
+
+/// Append `chunk`, unless doing so would take `body` past [`MAX_FETCH_BYTES`].
+///
+/// Returns whether it was appended. The check is against the total rather than the chunk, so
+/// a body arriving in small pieces can't walk past the ceiling one piece at a time.
+fn push_capped(body: &mut Vec<u8>, chunk: &[u8]) -> bool {
+    if body.len().saturating_add(chunk.len()) > MAX_FETCH_BYTES {
+        return false;
+    }
+    body.extend_from_slice(chunk);
+    true
 }
 
 fn fetch_semaphore() -> &'static tokio::sync::Semaphore {
@@ -537,6 +596,33 @@ mod tests {
             "imgcache://localhost/{}",
             percent_encoding::utf8_percent_encode(url, percent_encoding::NON_ALPHANUMERIC)
         )
+    }
+
+    #[test]
+    fn a_body_within_the_cap_is_kept() {
+        let mut body = Vec::new();
+        assert!(push_capped(&mut body, &[1, 2, 3]));
+        assert!(push_capped(&mut body, &[4, 5]));
+        assert_eq!(body, [1, 2, 3, 4, 5]);
+    }
+
+    /// The bug: the cap has to be on the running total. Checking each chunk on its own lets a
+    /// body of any size through as long as it arrives in small enough pieces — which is how
+    /// bodies arrive.
+    #[test]
+    fn small_chunks_cannot_walk_past_the_cap() {
+        let mut body = vec![0u8; MAX_FETCH_BYTES - 1];
+        assert!(push_capped(&mut body, &[1]), "the last byte that fits");
+        assert_eq!(body.len(), MAX_FETCH_BYTES);
+        assert!(!push_capped(&mut body, &[1]), "one past the cap");
+        assert_eq!(body.len(), MAX_FETCH_BYTES, "a refused chunk leaves nothing behind");
+    }
+
+    #[test]
+    fn a_single_oversized_chunk_is_refused_whole() {
+        let mut body = Vec::new();
+        assert!(!push_capped(&mut body, &vec![0u8; MAX_FETCH_BYTES + 1]));
+        assert!(body.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -27,6 +27,7 @@ mod library;
 mod linkwalk;
 mod logs;
 mod lru;
+mod memwatch;
 mod modelswap;
 mod mods;
 mod modstate;
@@ -6419,6 +6420,7 @@ fn main() {
             shop_catalog_session::load(handle);
             mxb_session::load(handle);
             imgcache::start_maintenance(handle);
+            memwatch::start();
             // Only registers the result listener and stashes the handle — the hidden window
             // isn't built until something is actually refused.
             mxb_fetch::init(handle);

--- a/src-tauri/src/memwatch.rs
+++ b/src-tauri/src/memwatch.rs
@@ -1,0 +1,81 @@
+//! A standing note of how much memory this process is holding.
+//!
+//! This exists because of an evening the app spent idle at tens of gigabytes. The log covered
+//! the whole of it and had nothing to say: startup, four watcher pulses, then four silent
+//! hours. Every cache in here has a ceiling and every loop is cheap, so working out what had
+//! happened meant reading the code and guessing — and a guess is all it stayed.
+//!
+//! One number, written down regularly, turns the next one of those into an answer. Left alone
+//! this is nearly silent: a line every quarter of an hour, and one the moment the figure
+//! climbs. The subsystem totals ride along so a jump can be attributed rather than just
+//! noticed.
+
+use std::time::Duration;
+
+/// How often to look. Cheap enough to be unnoticeable, often enough to catch a climb while it
+/// is still climbing rather than after it has finished.
+const SAMPLE_EVERY: Duration = Duration::from_secs(60);
+
+/// Say something anyway every this many samples, so an ordinary session still leaves a
+/// baseline for the next one to be read against.
+const REPORT_EVERY: u32 = 15;
+
+/// ...and say it straight away when the footprint gains this much between two samples.
+const JUMP: u64 = 128 * 1024 * 1024;
+
+/// Start the watcher. Call once, from `setup`.
+pub fn start() {
+    tauri::async_runtime::spawn(async move {
+        let mut last: u64 = 0;
+        let mut quiet: u32 = 0;
+        loop {
+            tokio::time::sleep(SAMPLE_EVERY).await;
+
+            let Some(stats) = memory_stats::memory_stats() else {
+                log::debug!("[mem] this platform won't say what the process is holding");
+                return;
+            };
+            let now = stats.physical_mem as u64;
+            let climbed = now.saturating_sub(last);
+            quiet += 1;
+
+            if climbed >= JUMP {
+                log::warn!("[mem] {} — up {} in a minute. {}", mb(now), mb(climbed), holdings());
+            } else if quiet >= REPORT_EVERY {
+                log::info!("[mem] {}. {}", mb(now), holdings());
+            }
+            if climbed >= JUMP || quiet >= REPORT_EVERY {
+                quiet = 0;
+            }
+            last = now;
+        }
+    });
+}
+
+/// What the parts of the app that hold memory on purpose are holding, so a figure that has
+/// grown can be put next to the thing that grew it.
+fn holdings() -> String {
+    let (served, bytes) = crate::imgcache::traffic();
+    format!(
+        "Textures {}, thumbnails {} served ({})",
+        mb(crate::texstore::resident_bytes() as u64),
+        served,
+        mb(bytes),
+    )
+}
+
+fn mb(bytes: u64) -> String {
+    format!("{:.0} MB", bytes as f64 / (1024.0 * 1024.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bytes_are_reported_in_megabytes() {
+        assert_eq!(mb(0), "0 MB");
+        assert_eq!(mb(48 * 1024 * 1024), "48 MB");
+        assert_eq!(mb(50 * 1024 * 1024 * 1024), "51200 MB", "the size that started this");
+    }
+}


### PR DESCRIPTION
The app was found idling at tens of gigabytes after a session spent in Browse, and the log for those hours was empty — startup, four watcher pulses, then nothing. Neither fix below is *proven* to be what happened. Both are genuinely unbounded, and one of them sits on exactly that path.

## The thumbnail download

`imgcache::fetch` was:

```rust
Some(resp.bytes().await.ok()?.to_vec())
```

The entire response body, buffered in memory with no ceiling, then copied a second time. Browsing mods fetches the image on every card, so this runs constantly on the screen where the problem was seen — and being on the host allowlist says only *where* a URL points, never how big what it points at is. An `<img>` on a mod page can name whatever its author uploaded, and `MAX_CONCURRENT_FETCHES` is 8, so the grid decides how many of those run at once.

Now refused past 32 MB — before a byte is read when the origin declares a length, and against the running total while streaming, because that header is optional and can be wrong. The cap is on the total rather than per chunk, or a body of any size walks past it in small pieces. Streaming also drops the second copy.

32 MB is many times any real thumbnail: the store's product images, the largest thing normally seen here, are around half a megabyte.

## The embedded texture

`edf::inflate_texture` discarded everything past `width * height * 4` — but only after decompressing the payload whole, so what the record claimed it expanded to decided how much memory it cost. The records are located by scanning for a byte pattern, so this needed no hostile file; an ordinary false match would do. The decoder is now bounded by the size the record itself declares.

## Writing the number down

`memwatch` logs the process footprint every quarter of an hour, and immediately on a sharp climb, with the texture store and thumbnail totals beside it so growth can be attributed rather than just noticed. The reason the original question took code-reading and guesswork is that nothing had ever recorded it. Costs one dependency, `memory-stats` — a few lines of platform FFI behind one call.

## Verification

- full suite: 776 passed, 0 failed, 46 ignored (5 new tests)
- the caps are tested where they can be: chunk accumulation against the running total, an oversized single chunk, and a deflate payload that expands to 64 MB behind a record claiming 64×64
- **Not verified:** no live oversized download was exercised against a real origin — the allowlist and client selection make that awkward to reach from a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)