### PR TITLE
FrostMod runs on macOS, in the bottle the game runs in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## Unreleased — FrostMod runs on macOS
+
+### Added
+- **FrostMod installs, starts, reloads and stops on macOS.** It used to be hidden there
+  entirely — Settings had no FrostMod section and no FrostMod log row — on the grounds that
+  the app launches a CrossOver/Whisky bottle but doesn't inject into it. The first half of
+  that is true and the second was a decision, not a fact: FrostMod is a Windows program and
+  so is the game it attaches to, so it belongs in the same bottle, started through whichever
+  wrapper owns it. The app now finds that bottle the same way Play already does (whatever
+  sits above `drive_c` in the game's path), starts `frostmod.exe` in it, and hands over
+  `--mods` as the bottle names the folder — `C:\users\crossover\Documents\…`, not the
+  `/Users/…` this side calls the same place.
+- **The Reload button works from outside the bottle**, on the same terms as Linux: the app
+  is a native macOS process and FrostMod's reload event is a Wine kernel object nothing out
+  here can pulse, so a reload travels as a file FrostMod polls for. That needs FrostMod
+  v0.13.0 or newer; anything older is refused with a version to update to, rather than
+  started into a state where the in-game `F8` works and every button here quietly doesn't.
+  Stopping reaches both processes that carry the name — the wrapper and the Wine process
+  under it — so the status pill can't be left insisting FrostMod is running.
+- **A bottle with no `Z:` drive is named as the problem before anything starts.** FrostMod
+  lives beside the app's own data rather than inside the bottle, and `Z:` is what makes that
+  folder reachable from in there. Without it FrostMod would inject, reload on `F8`, and
+  ignore the app forever — the one failure worth catching early, because nothing about it is
+  visible in game.
+
+### Fixed
+- **Whatever the wrapper says on its way to starting FrostMod is now kept**, in `wine.log`
+  beside FrostMod, and collected with the other logs. It is the only account of a failed
+  injection a player can send us — the same reason Proton's output is kept on Linux.
+
 ## Unreleased — nothing downloads without a ceiling
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ hours), then downloads and installs them on restart.
   `.pkz` / `.pnt` files are placed as-is.
 - **Live reload**: a debounced watcher on `<modsPath>/mods` signals FrostMod to
   reload the game when mods are added — including ones installed outside the app.
-  On Linux that means the game's own Proton prefix: FrostMod is a Windows program
-  and so is the game it injects into, so the app starts it inside
-  `steamapps/compatdata/<appid>` rather than beside itself, and reaches it with a
-  command file instead of a Windows event (nothing outside a Wine prefix can pulse
-  one). Needs FrostMod v0.13.0 or newer, which is what reads that file.
+  Off Windows that means the game's own Wine prefix — Proton's
+  `steamapps/compatdata/<appid>` on Linux, your CrossOver/Whisky bottle on macOS.
+  FrostMod is a Windows program and so is the game it injects into, so the app
+  starts it in there rather than beside itself, and reaches it with a command file
+  instead of a Windows event (nothing outside a Wine prefix can pulse one). Needs
+  FrostMod v0.13.0 or newer, which is what reads that file.
 - **Paint studio**: builds a `.pnt` from `.tga`/`.png` sheets, and unpacks an
   existing paint back into editable sheets that keep the texture names the model
   binds — so a livery made anywhere can be packed, installed and previewed here.

--- a/src-tauri/src/frostmod.rs
+++ b/src-tauri/src/frostmod.rs
@@ -72,12 +72,13 @@ pub fn is_running() -> bool {
     true
 }
 
-/// Linux: FrostMod runs under Proton and its reload event is a Wine kernel object we have
-/// no way to open from out here — this app is a native Linux process outside the prefix.
+/// Linux and macOS: FrostMod runs inside a Wine prefix — Proton's on Linux, a
+/// CrossOver/Whisky bottle on macOS — and its reload event is a Wine kernel object we have
+/// no way to open from out here, where this app is a native process outside that prefix.
 /// The command file is the way in instead (see `send_command`), and `reload_mods` is the
 /// verb FrostMod v0.13.0 added for exactly this. A FrostMod too old to read that file is
 /// refused a start at all ([`reads_command_files`]), so anything running here can hear us.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 pub fn signal_reload() -> ReloadOutcome {
     match send_command(command_json("reload_mods", "")) {
         CommandOutcome::Signaled => ReloadOutcome::Signaled,
@@ -97,12 +98,23 @@ pub fn is_running() -> bool {
     crate::proton::running_exe("frostmod.exe")
 }
 
-#[cfg(not(any(windows, target_os = "linux")))]
+/// macOS: the same answer from the same place, asked of `ps` rather than `/proc`. Under
+/// Wine the launcher is a real macOS process whose argv still names `frostmod.exe`.
+#[cfg(target_os = "macos")]
+pub fn is_running() -> bool {
+    crate::winehost::running_exe(
+        &crate::winehost::process_table(),
+        "frostmod.exe",
+        std::process::id(),
+    )
+}
+
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
 pub fn signal_reload() -> ReloadOutcome {
     ReloadOutcome::Unsupported
 }
 
-#[cfg(not(any(windows, target_os = "linux")))]
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
 pub fn is_running() -> bool {
     false
 }
@@ -132,18 +144,18 @@ pub fn is_running() -> bool {
 #[cfg(windows)]
 const COMMAND_EVENT_NAME: &[u8] = b"Local\\FrostModCommand\0";
 
-/// Where a Linux build leaves commands: FrostMod's own folder, which this app owns and
-/// which FrostMod (v0.13.0+) reads as well as `%TEMP%`.
+/// Where a build outside the Wine prefix leaves commands: FrostMod's own folder, which
+/// this app owns and which FrostMod (v0.13.0+) reads as well as `%TEMP%`.
 ///
 /// Set once at startup rather than passed in, because the senders below are called from
 /// folder watchers and install jobs that hold no Tauri handle to resolve a data dir with,
 /// and threading one through every caller would buy nothing: there is only ever one
 /// FrostMod folder per run.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 static COMMAND_DIR: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
 
 /// Tell the sender where FrostMod is installed. Called once, from setup.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 pub fn set_command_dir(dir: std::path::PathBuf) {
     let _ = COMMAND_DIR.set(dir);
 }
@@ -151,14 +163,15 @@ pub fn set_command_dir(dir: std::path::PathBuf) {
 /// Command file FrostMod reads when the command event fires. Same temp dir the
 /// DLL uses — `std::env::temp_dir()` resolves to the `%TEMP%` that FrostMod's
 /// `GetTempPathA` returns.
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 fn command_file_path() -> std::path::PathBuf {
     std::env::temp_dir().join("frostmod_cmd.json")
 }
 
-/// Linux: FrostMod's folder, not `/tmp`. Our `/tmp` is not the `%TEMP%` a program inside
-/// the Wine prefix resolves, and FrostMod's folder is one directory both sides can name.
-#[cfg(target_os = "linux")]
+/// Outside the prefix: FrostMod's folder, not our temp dir. `/tmp` here is not the `%TEMP%`
+/// a program inside the Wine prefix resolves, and FrostMod's folder is one directory both
+/// sides can name — it reads the file beside its own module, which is `Z:\…` from in there.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn command_file_path() -> std::path::PathBuf {
     COMMAND_DIR
         .get()
@@ -171,7 +184,7 @@ fn command_file_path() -> std::path::PathBuf {
 /// on-disk contract with frostmod.cpp is exercised without a game.
 ///
 /// `at` is what makes two identical commands two different documents. It costs nothing on
-/// Windows, where an event says "read this now" — but on Linux the file *is* the signal,
+/// Windows, where an event says "read this now" — but off it the file *is* the signal,
 /// and FrostMod decides a command is new by comparing what it last acted on with what is
 /// on disk now. Without a stamp, pressing Reload twice would write the same bytes twice
 /// and the second press would be indistinguishable from no press at all.
@@ -236,12 +249,13 @@ fn send_command(json: String) -> CommandOutcome {
     }
 }
 
-/// Linux: the file is the whole signal. There is no event to pulse — `Local\FrostModCommand`
-/// belongs to the Wine prefix FrostMod runs in, and this process is outside it — so the
-/// write lands in FrostMod's folder and its poll picks it up within about a fifth of a
-/// second. Whether it's running is asked of the process table first, so a command isn't
-/// left on disk for a FrostMod that will read it at some unrelated future start-up.
-#[cfg(target_os = "linux")]
+/// Linux and macOS: the file is the whole signal. There is no event to pulse —
+/// `Local\FrostModCommand` belongs to the Wine prefix FrostMod runs in, and this process is
+/// outside it — so the write lands in FrostMod's folder and its poll picks it up within
+/// about a fifth of a second. Whether it's running is asked of the process table first, so
+/// a command isn't left on disk for a FrostMod that will read it at some unrelated future
+/// start-up.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn send_command(json: String) -> CommandOutcome {
     if !is_running() {
         return CommandOutcome::NotRunning;
@@ -256,7 +270,7 @@ fn send_command(json: String) -> CommandOutcome {
     }
 }
 
-#[cfg(not(any(windows, target_os = "linux")))]
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
 fn send_command(json: String) -> CommandOutcome {
     // Still write the command file on dev builds so the contract can be inspected.
     let _ = std::fs::write(command_file_path(), json);
@@ -324,14 +338,14 @@ pub fn model_refresh_is_safe(tag: Option<&str>) -> bool {
     }
 }
 
-/// The oldest FrostMod that can be driven from Linux.
+/// The oldest FrostMod that can be driven from outside a Wine prefix — Linux and macOS.
 ///
 /// Not a safety floor like the two around it — a capability one. Every FrostMod before
 /// v0.13.0 reads its command file only when the command *event* fires, and that event is a
-/// Wine kernel object: a native Linux app can't pulse it, so an older build under Proton
-/// would take every write and never look. It would inject fine and reload on `F8`, and
-/// every button in this app would quietly do nothing. v0.13.0 is the release that polls
-/// the file, so on Linux it is the floor for starting FrostMod at all.
+/// Wine kernel object: a native app out here can't pulse it, so an older build under Proton
+/// or in a bottle would take every write and never look. It would inject fine and reload on
+/// `F8`, and every button in this app would quietly do nothing. v0.13.0 is the release that
+/// polls the file, so off Windows it is the floor for starting FrostMod at all.
 pub const FILE_CHANNEL_MIN_VERSION: &str = "v0.13.0";
 
 /// Does the installed FrostMod, tagged `tag`, read commands from a file?
@@ -402,10 +416,10 @@ mod tests {
         );
     }
 
-    /// The floor exists because an older FrostMod fails *silently* on Linux: it takes the
-    /// write, never polls, and every button in the app looks like it worked.
+    /// The floor exists because an older FrostMod fails *silently* off Windows: it takes
+    /// the write, never polls, and every button in the app looks like it worked.
     #[test]
-    fn only_a_frostmod_that_polls_is_driven_from_linux() {
+    fn only_a_frostmod_that_polls_is_driven_from_outside_the_prefix() {
         assert!(reads_command_files(Some("v0.13.0")));
         assert!(reads_command_files(Some("v0.13.1")));
         assert!(reads_command_files(Some("v1.0.0")));

--- a/src-tauri/src/frostmod_manage.rs
+++ b/src-tauri/src/frostmod_manage.rs
@@ -407,15 +407,13 @@ fn release_binaries(rel: &Release) -> anyhow::Result<Vec<(&'static str, &Asset)>
 /// Download `frostmod.exe` + `frostmod.dll` from the latest release and put them in
 /// place as one unit.
 ///
-/// Windows and Linux. FrostMod is a Win32 DLL injected into the game, and on Linux the
-/// game is a Win32 process too — Steam runs it under Proton — so the same two binaries go
-/// into the same prefix and do the same job (see [`crate::proton`]). macOS is refused
-/// because nothing there starts them: the game lives in a CrossOver/Whisky bottle the app
-/// launches but doesn't inject into, and downloading anyway would park two unusable
-/// binaries in the data dir before `start()` bailed.
+/// Everywhere the game runs. FrostMod is a Win32 DLL injected into the game, and the game
+/// is a Win32 process on all three platforms — natively on Windows, under Proton on Linux
+/// ([`crate::proton`]), in a CrossOver/Whisky bottle on macOS ([`crate::winehost`]) — so
+/// the same two binaries go into the same prefix as the game and do the same job.
 pub async fn install(app: &AppHandle) -> anyhow::Result<InstallReport> {
-    if cfg!(not(any(windows, target_os = "linux"))) {
-        anyhow::bail!("FrostMod runs on Windows and Linux (under Proton)");
+    if cfg!(not(any(windows, target_os = "linux", target_os = "macos"))) {
+        anyhow::bail!("FrostMod runs on Windows, Linux (Proton) and macOS (Wine)");
     }
     let rel = latest_release().await?;
     let assets = release_binaries(&rel)?;
@@ -466,22 +464,22 @@ pub async fn install(app: &AppHandle) -> anyhow::Result<InstallReport> {
     })
 }
 
-/// What both platforms need settled before FrostMod can be started, and nothing about how
-/// it is started — that is where Windows and Linux part company.
-#[cfg(any(windows, target_os = "linux"))]
+/// What every platform needs settled before FrostMod can be started, and nothing about how
+/// it is started — that is where they part company.
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 struct StartPlan {
     exe: PathBuf,
     /// `mxb` / `gpb`, for `--game`.
     game: &'static str,
-    /// The mods *tree*, when the player has a folder set. Still a host path: Linux has to
-    /// rewrite it as the prefix sees it before handing it over.
+    /// The mods *tree*, when the player has a folder set. Still a host path: anything
+    /// running inside a prefix has to rewrite it as the prefix sees it before handing over.
     mods_root: Option<PathBuf>,
 }
 
 /// Check what has to be true before starting, and work out what to tell FrostMod.
 ///
 /// `None` means FrostMod is already running and there is nothing to do.
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 fn plan_start(app: &AppHandle) -> anyhow::Result<Option<StartPlan>> {
     if crate::frostmod::is_running() {
         return Ok(None);
@@ -550,16 +548,16 @@ pub fn start(app: &AppHandle, state: &FrostmodProcess) -> anyhow::Result<bool> {
     Ok(true)
 }
 
-/// Where Proton's own output goes on Linux, appended to across a session so a start that
-/// worked and a later one that didn't are both in it. Falls back to discarding the output
-/// rather than failing a start over a log file.
-#[cfg(target_os = "linux")]
-fn proton_log(app: &AppHandle) -> std::process::Stdio {
+/// Where the wrapper's own output goes — Proton's on Linux, Wine's on macOS — appended to
+/// across a session so a start that worked and a later one that didn't are both in it.
+/// Falls back to discarding the output rather than failing a start over a log file.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn runner_log(app: &AppHandle, name: &str) -> std::process::Stdio {
     /// Past this, the interesting part is the end anyway — and a log the player is asked
     /// to attach to a report has to stay attachable.
     const MAX_BYTES: u64 = 1024 * 1024;
 
-    let path = frostmod_dir(app).join("proton.log");
+    let path = frostmod_dir(app).join(name);
     let overgrown = std::fs::metadata(&path).is_ok_and(|m| m.len() > MAX_BYTES);
     std::fs::OpenOptions::new()
         .create(true)
@@ -584,14 +582,7 @@ pub fn start(app: &AppHandle, state: &FrostmodProcess) -> anyhow::Result<bool> {
     // A FrostMod that doesn't poll its command file can't be driven from here at all: it
     // would inject and reload on F8, while every button in this app wrote a file nothing
     // ever read. Better to say so than to hand over a half-working install.
-    if !crate::frostmod::reads_command_files(installed_version(app).as_deref()) {
-        anyhow::bail!(
-            "This FrostMod build can't be driven from Linux — update FrostMod to {} or \
-             newer. (Under Proton the app can only reach FrostMod through a file, which \
-             older builds don't read.)",
-            crate::frostmod::FILE_CHANNEL_MIN_VERSION,
-        );
-    }
+    needs_the_file_channel(app, "Linux", "Under Proton")?;
 
     let cfg = crate::config::load(app).unwrap_or_default();
     let runner = crate::proton::find(cfg.game(), &cfg.wine_runner)?;
@@ -619,8 +610,8 @@ pub fn start(app: &AppHandle, state: &FrostmodProcess) -> anyhow::Result<bool> {
         // stdout goes nowhere a player can reach. It lands in FrostMod's folder, where
         // the log collector already picks up everything that isn't one of our binaries:
         // if injection under Proton ever fails, this is the file that says why.
-        .stdout(proton_log(app))
-        .stderr(proton_log(app))
+        .stdout(runner_log(app, "proton.log"))
+        .stderr(runner_log(app, "proton.log"))
         .spawn()
         .map_err(|e| {
             anyhow::anyhow!("Couldn't start FrostMod through {}: {e}", runner.via())
@@ -629,9 +620,105 @@ pub fn start(app: &AppHandle, state: &FrostmodProcess) -> anyhow::Result<bool> {
     Ok(true)
 }
 
-#[cfg(not(any(windows, target_os = "linux")))]
+/// The one thing a FrostMod started from outside a Wine prefix has to be able to do: read
+/// a command from a file. Refusing here is what stops a player being handed an install
+/// where the in-game `F8` works and every button in this app silently doesn't.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn needs_the_file_channel(app: &AppHandle, platform: &str, inside: &str) -> anyhow::Result<()> {
+    if crate::frostmod::reads_command_files(installed_version(app).as_deref()) {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "This FrostMod build can't be driven from {platform} — update FrostMod to {} or \
+         newer. ({inside} the app can only reach FrostMod through a file, which older \
+         builds don't read.)",
+        crate::frostmod::FILE_CHANNEL_MIN_VERSION,
+    )
+}
+
+/// Everything about the macOS start that doesn't need a running app: which wrapper, which
+/// prefix, and the argv FrostMod is handed. Split out so the whole of it can be driven in a
+/// test against a stub standing in for Wine — only whether Wine then runs a Windows binary
+/// is out of our hands.
+///
+/// The wrapper's name comes back with the launch because it is what a failure has to be
+/// reported against: "couldn't start FrostMod through CrossOver" names something the player
+/// can act on, and the runner itself doesn't outlive this call.
+#[cfg(target_os = "macos")]
+fn mac_launch(
+    cfg: &crate::config::AppConfig,
+    exe: &Path,
+    game: &str,
+    mods_root: Option<&Path>,
+) -> anyhow::Result<(crate::winehost::Launch, String)> {
+    let (prefix, runner) = crate::gameproc::game_prefix_and_runner(cfg)?;
+    // Without a Z: drive nothing inside the bottle can see FrostMod's folder — not the
+    // launcher we are about to start, and not the command file every button here writes.
+    if !crate::winehost::has_z_drive(&prefix) {
+        anyhow::bail!(
+            "This bottle has no Z: drive, so FrostMod can't be reached from inside it. Add \
+             one mapped to / in your wrapper's drive settings (CrossOver: Bottle → Control \
+             Panel → Drives), then try again."
+        );
+    }
+
+    let mut args: Vec<String> = vec!["--game".into(), game.into()];
+    if let Some(mods) = mods_root {
+        // FrostMod is a Windows program: it takes the path as the bottle sees it, which for
+        // the mods folder — inside the bottle — is `C:\users\…`.
+        args.extend(["--mods".into(), crate::winehost::windows_path(&prefix, mods)]);
+    }
+    Ok((
+        crate::winehost::plan(&runner, &prefix, exe, &args),
+        runner.via().to_string(),
+    ))
+}
+
+/// Launch `frostmod.exe` inside the Wine bottle the game runs in (macOS).
+///
+/// Same requirement as Proton, a different wrapper: the DLL can only be injected from
+/// inside the prefix that holds `mxbikes.exe`, so FrostMod is started through whichever of
+/// CrossOver, Whisky or Wine owns that bottle — [`crate::winehost`] answers both questions,
+/// and [`crate::gameproc::prefix_and_runner`] is where Play asks them too.
+///
+/// FrostMod itself stays in our data folder rather than being copied into the bottle: it is
+/// reached from in there as `Z:\…`, one directory both sides can name, which is also what
+/// makes the command file work.
+#[cfg(target_os = "macos")]
+pub fn start(app: &AppHandle, state: &FrostmodProcess) -> anyhow::Result<bool> {
+    let Some(plan) = plan_start(app)? else { return Ok(false) };
+
+    needs_the_file_channel(app, "macOS", "Inside a Wine bottle")?;
+
+    let cfg = crate::config::load(app).unwrap_or_default();
+    let (launch, via) = mac_launch(&cfg, &plan.exe, plan.game, plan.mods_root.as_deref())?;
+    log::info!(
+        "starting FrostMod via {via}: {} {:?}",
+        launch.program.display(),
+        launch.args,
+    );
+    let mut cmd = std::process::Command::new(&launch.program);
+    cmd.args(&launch.args)
+        // FrostMod writes its log, its flag files and its command file beside itself, and
+        // resolves them from its own module path — but the working directory is what the
+        // wrapper's own output is relative to, and that output is the only account of a
+        // failed injection a player can send us.
+        .current_dir(frostmod_dir(app))
+        .stdout(runner_log(app, "wine.log"))
+        .stderr(runner_log(app, "wine.log"));
+    for (key, value) in &launch.env {
+        cmd.env(key, value);
+    }
+    let child = cmd
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("Couldn't start FrostMod through {via}: {e}"))?;
+    *state.0.lock().unwrap() = Some(child);
+    Ok(true)
+}
+
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
 pub fn start(_app: &AppHandle, _state: &FrostmodProcess) -> anyhow::Result<bool> {
-    anyhow::bail!("FrostMod runs on Windows and Linux (under Proton)")
+    anyhow::bail!("FrostMod runs on Windows, Linux (Proton) and macOS (Wine)")
 }
 
 /// Kill the managed FrostMod child, if we started one.
@@ -662,7 +749,14 @@ pub fn force_stop_exe() {
     crate::proton::kill_exe("frostmod.exe");
 }
 
-#[cfg(not(any(windows, target_os = "linux")))]
+/// macOS: the same problem as Linux — the wrapper we spawned and the Wine process it
+/// started both carry the name, and killing our child only reaches the first.
+#[cfg(target_os = "macos")]
+pub fn force_stop_exe() {
+    crate::winehost::kill_exe("frostmod.exe");
+}
+
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
 pub fn force_stop_exe() {}
 
 /// How long to wait for a stopped FrostMod to actually go before calling it a failure.
@@ -737,6 +831,112 @@ mod tests {
             size: body.len() as u64,
             digest: Some(format!("sha256:{:x}", Sha256::digest(body))),
         }
+    }
+
+    /// The whole macOS start, end to end, against a stub standing in for Wine.
+    ///
+    /// Everything up to the wrapper is ours and is exercised here: the prefix comes out of
+    /// the game exe's path, the runner override is honoured, FrostMod's own folder is the
+    /// working directory, `--mods` arrives as the bottle sees it, and `frostmod.exe` — which
+    /// lives *outside* the bottle — is reachable at all.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn starts_frostmod_in_the_bottle_with_the_mods_path_the_bottle_understands() {
+        let root = temp_dir("mac-start");
+        let prefix = root.join("Bottles/MXB");
+        let game_dir = prefix.join("drive_c/Program Files/MX Bikes");
+        let mods = prefix.join("drive_c/users/crossover/Documents/PiBoSo/MX Bikes/mods");
+        std::fs::create_dir_all(&game_dir).unwrap();
+        std::fs::create_dir_all(&mods).unwrap();
+        std::fs::create_dir_all(prefix.join("dosdevices")).unwrap();
+        std::os::unix::fs::symlink("/", prefix.join("dosdevices/z:")).unwrap();
+        std::fs::write(game_dir.join(crate::game::MXB.exe), b"stub").unwrap();
+
+        // FrostMod is installed in our data folder, not in the bottle — the case `Z:` exists
+        // for, and the reason the command file works at all.
+        let frostmod = root.join("data/frostmod");
+        std::fs::create_dir_all(&frostmod).unwrap();
+        let exe = frostmod.join("frostmod.exe");
+        std::fs::write(&exe, b"stub").unwrap();
+
+        // A stub "Wine" that records how it was called, so the assertion is on a real spawn
+        // rather than on the plan we handed to it. `printf`, not `echo`: a Windows path is
+        // full of backslashes and `echo` would eat them (`\c` alone ends its output).
+        let record = root.join("argv.txt");
+        let runner = root.join("fake-wine");
+        std::fs::write(
+            &runner,
+            format!(
+                "#!/bin/sh\n{{ printf '%s\\n' \"$WINEPREFIX\"; pwd; for a in \"$@\"; do printf '%s\\n' \"$a\"; done; }} > {}\n",
+                record.display()
+            ),
+        )
+        .unwrap();
+        std::process::Command::new("chmod").arg("+x").arg(&runner).status().unwrap();
+
+        let mut cfg = crate::config::AppConfig::default();
+        cfg.game_path = game_dir.to_string_lossy().into_owned();
+        cfg.wine_runner = runner.to_string_lossy().into_owned();
+
+        let (launch, _) =
+            mac_launch(&cfg, &exe, "mxb", Some(&mods)).expect("a stub runner is enough");
+        let mut cmd = std::process::Command::new(&launch.program);
+        cmd.args(&launch.args).current_dir(&frostmod);
+        for (key, value) in &launch.env {
+            cmd.env(key, value);
+        }
+        cmd.spawn().unwrap().wait().unwrap();
+
+        let written = std::fs::read_to_string(&record).unwrap();
+        let lines: Vec<&str> = written.lines().collect();
+        assert_eq!(
+            lines.first().copied(),
+            Some(prefix.to_string_lossy().as_ref()),
+            "the prefix is the folder above the game's drive_c: {written:?}"
+        );
+        // `pwd` resolves symlinks, and macOS puts the temp dir behind `/private`.
+        assert!(
+            lines.get(1).is_some_and(|cwd| cwd.ends_with("data/frostmod")),
+            "FrostMod's own folder is the working directory: {written:?}"
+        );
+        assert_eq!(
+            &lines[2..],
+            [
+                exe.to_string_lossy().as_ref(),
+                "--game",
+                "mxb",
+                "--mods",
+                "C:\\users\\crossover\\Documents\\PiBoSo\\MX Bikes\\mods",
+            ],
+            "the mods tree arrives as the bottle names it, not as /Users/…: {written:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A bottle with no `Z:` can't see FrostMod's folder, and every button in the app would
+    /// write a command file nothing ever reads. Refused, with the fix named.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn a_bottle_with_no_z_drive_is_refused_before_anything_starts() {
+        let root = temp_dir("mac-no-z");
+        let game_dir = root.join("Bottles/MXB/drive_c/MX Bikes");
+        std::fs::create_dir_all(&game_dir).unwrap();
+        std::fs::write(game_dir.join(crate::game::MXB.exe), b"stub").unwrap();
+        let runner = root.join("fake-wine");
+        std::fs::write(&runner, "#!/bin/sh\n").unwrap();
+        std::process::Command::new("chmod").arg("+x").arg(&runner).status().unwrap();
+
+        let mut cfg = crate::config::AppConfig::default();
+        cfg.game_path = game_dir.to_string_lossy().into_owned();
+        cfg.wine_runner = runner.to_string_lossy().into_owned();
+
+        let err = mac_launch(&cfg, &root.join("frostmod.exe"), "mxb", None)
+            .expect_err("no Z: drive, no way in");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("Z:"), "names what's missing: {msg}");
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/src-tauri/src/gameproc.rs
+++ b/src-tauri/src/gameproc.rs
@@ -554,11 +554,8 @@ pub fn refresh_look() -> LiveRefresh {
 /// `ps` finds it. Without this Play would cheerfully start a second copy.
 #[cfg(target_os = "macos")]
 pub fn is_game_running() -> bool {
-    let Ok(out) = std::process::Command::new("ps").args(["-Ao", "pid=,args="]).output() else {
-        return false;
-    };
     crate::winehost::running_exe(
-        &String::from_utf8_lossy(&out.stdout),
+        &crate::winehost::process_table(),
         crate::game::active().exe,
         std::process::id(),
     )
@@ -696,6 +693,43 @@ fn resolve_exe(cfg: &AppConfig) -> anyhow::Result<(std::path::PathBuf, std::path
         );
     }
     Ok((dir, exe))
+}
+
+/// The Wine prefix `exe` lives in, and the runner that should drive it (macOS).
+///
+/// The game is a Windows binary here, so it runs inside a prefix, and the prefix is
+/// whatever sits above `drive_c` in the exe's own path — see [`crate::winehost`]. Shared
+/// with FrostMod's start, which has to land in that same prefix to inject into the game:
+/// both fail with the same words, because it is the same thing missing.
+#[cfg(target_os = "macos")]
+pub fn prefix_and_runner(
+    cfg: &AppConfig,
+    exe: &std::path::Path,
+) -> anyhow::Result<(std::path::PathBuf, crate::winehost::Runner)> {
+    let game = cfg.game().display;
+    let (prefix, _) = crate::winehost::split_prefix(exe).ok_or_else(|| {
+        anyhow::anyhow!(
+            "{game} is a Windows game — on macOS the install folder has to be the copy \
+             inside your CrossOver, Whisky or Wine bottle (a path with drive_c in it). \
+             Set it in Settings, under {game} install folder."
+        )
+    })?;
+    let runner = crate::winehost::resolve(&cfg.wine_runner, Some(&prefix)).ok_or_else(|| {
+        anyhow::anyhow!(
+            "No Wine runner found — install CrossOver, Whisky or Wine to run {game} on \
+             macOS, or point Settings at one you already have."
+        )
+    })?;
+    Ok((prefix, runner))
+}
+
+/// The same pair for a caller that doesn't already have the exe in hand.
+#[cfg(target_os = "macos")]
+pub fn game_prefix_and_runner(
+    cfg: &AppConfig,
+) -> anyhow::Result<(std::path::PathBuf, crate::winehost::Runner)> {
+    let (_, exe) = resolve_exe(cfg)?;
+    prefix_and_runner(cfg, &exe)
 }
 
 /// The Steam client's own executable.
@@ -1003,21 +1037,7 @@ fn launch_with(cfg: &AppConfig, address: Option<&str>) -> anyhow::Result<LaunchO
 
     #[cfg(target_os = "macos")]
     {
-        // The game is a Windows binary here, so it runs inside a Wine prefix. The prefix
-        // is whatever sits above `drive_c` in the exe's own path — see `winehost`.
-        let (prefix, _) = crate::winehost::split_prefix(&exe).ok_or_else(|| {
-            anyhow::anyhow!(
-                "{game} is a Windows game — on macOS the install folder has to be the copy \
-                 inside your CrossOver, Whisky or Wine bottle (a path with drive_c in it). \
-                 Set it in Settings, under {game} install folder."
-            )
-        })?;
-        let runner = crate::winehost::resolve(&cfg.wine_runner, Some(&prefix)).ok_or_else(|| {
-            anyhow::anyhow!(
-                "No Wine runner found — install CrossOver, Whisky or Wine to run {game} on \
-                 macOS, or point Settings at one you already have."
-            )
-        })?;
+        let (prefix, runner) = prefix_and_runner(cfg, &exe)?;
 
         let extra: Vec<String> = address.map(|a| connect_args(a).to_vec()).unwrap_or_default();
         let plan = crate::winehost::plan(&runner, &prefix, &exe, &extra);

--- a/src-tauri/src/logs.rs
+++ b/src-tauri/src/logs.rs
@@ -111,9 +111,9 @@ fn is_frostmod_log(name: &str) -> bool {
         || lower.ends_with(".dll")
         || lower == "version.txt"
         || lower.ends_with(".yaml")
-        // The last command we left for FrostMod (Linux, where a file is the only way to
-        // reach it). Ours by the same rule as the binaries — and what FrostMod *did* with
-        // it is in its log, which is the half worth collecting.
+        // The last command we left for FrostMod (Linux and macOS, where a file is the only
+        // way to reach it). Ours by the same rule as the binaries — and what FrostMod *did*
+        // with it is in its log, which is the half worth collecting.
         || lower == "frostmod_cmd.json"
         // A binary moved aside mid-update because the game still had it mapped —
         // `frostmod.dll.in-use-1723…`, swept on the next start.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6285,10 +6285,11 @@ fn main() {
             if let Ok(dir) = app.path().app_local_data_dir() {
                 log::info!("data dir (config/session/frostmod): {}", dir.display());
             }
-            // Linux drives FrostMod by leaving a file in its folder — the one thing this
-            // side of the Wine prefix can reach. Told once here, because the senders are
-            // called from watchers that hold no handle to resolve a data dir with.
-            #[cfg(target_os = "linux")]
+            // Linux and macOS drive FrostMod by leaving a file in its folder — the one
+            // thing this side of the Wine prefix can reach. Told once here, because the
+            // senders are called from watchers that hold no handle to resolve a data dir
+            // with.
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             frostmod::set_command_dir(frostmod_manage::frostmod_dir(app.handle()));
             if let Ok(dir) = app.path().app_log_dir() {
                 log::info!("log dir: {}", dir.display());

--- a/src-tauri/src/vcruntime.rs
+++ b/src-tauri/src/vcruntime.rs
@@ -368,7 +368,9 @@ pub fn missing(game_dir: Option<&std::path::Path>) -> Vec<Runtime> {
     out
 }
 
-/// Nothing to detect off Windows — FrostMod only runs there.
+/// Nothing to detect off Windows. FrostMod runs under Proton and in a Wine bottle too, but
+/// what it needs there is the prefix's own runtime, installed by the wrapper (`winetricks`,
+/// CrossOver's own installers) and not by anything we could reach from out here.
 #[cfg(not(windows))]
 pub fn missing(_game_dir: Option<&std::path::Path>) -> Vec<Runtime> {
     Vec::new()

--- a/src-tauri/src/winehost.rs
+++ b/src-tauri/src/winehost.rs
@@ -80,20 +80,36 @@ pub fn split_prefix(path: &Path) -> Option<(PathBuf, PathBuf)> {
     None
 }
 
-/// The exe as the bottle sees it — `C:\Program Files\...` — for wrappers that take a
-/// Windows path rather than a host one.
+/// A host path as the bottle sees it, for the wrappers and the Windows programs that take
+/// a Windows path rather than a host one.
+///
+/// Two shapes, and which applies is a fact about the path: anything under the prefix's own
+/// `drive_c` is on `C:`, everything else on the machine is on `Z:`, the drive Wine maps to
+/// `/`. Both matter here — the game is inside the bottle, FrostMod is installed beside our
+/// own data and reached from in there as `Z:`. Same rule as [`crate::proton::windows_path`].
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-fn windows_path(prefix: &Path, exe: &Path) -> Option<String> {
-    let (found, rel) = split_prefix(exe)?;
-    if found != prefix {
-        return None;
-    }
-    let joined = rel
+pub fn windows_path(prefix: &Path, path: &Path) -> String {
+    let drive_c = prefix.join(DRIVE_C);
+    let (drive, rest) = match path.strip_prefix(&drive_c) {
+        Ok(rest) => ("C:", rest),
+        Err(_) => ("Z:", path.strip_prefix("/").unwrap_or(path)),
+    };
+    let joined = rest
         .components()
         .map(|c| c.as_os_str().to_string_lossy().into_owned())
         .collect::<Vec<_>>()
         .join("\\");
-    Some(format!("C:\\{joined}"))
+    format!("{drive}\\{joined}")
+}
+
+/// Can a program inside `prefix` reach the rest of this Mac?
+///
+/// `Z:` is what makes FrostMod's folder addressable from in there, and a bottle whose drive
+/// mapping has been stripped fails *invisibly*: FrostMod injects, `F8` still reloads, and
+/// every button in this app writes a file nothing can see. Worth a check that names the fix.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub fn has_z_drive(prefix: &Path) -> bool {
+    prefix.join("dosdevices/z:").exists()
 }
 
 /// Every Wine prefix on this Mac, for the install detectors to search.
@@ -295,11 +311,10 @@ pub fn plan(runner: &Runner, prefix: &Path, exe: &Path, extra: &[String]) -> Lau
             args.push("--bottle".into());
             args.push(bottle.clone());
             args.push("--cx-app".into());
-            // A host path works too, but the bottle-relative Windows path is the form
-            // CodeWeavers documents, and the one `--cx-app` is built to resolve.
-            args.push(
-                windows_path(prefix, exe).unwrap_or_else(|| exe.to_string_lossy().into_owned()),
-            );
+            // A host path works too, but the Windows path is the form CodeWeavers
+            // documents, and the one `--cx-app` is built to resolve. `C:` for the game,
+            // which lives in the bottle; `Z:` for FrostMod, which doesn't.
+            args.push(windows_path(prefix, exe));
             env.push(("CX_ROOT".into(), root.to_string_lossy().into_owned()));
         }
         RunnerKind::Wine { .. } => {
@@ -318,13 +333,60 @@ pub fn plan(runner: &Runner, prefix: &Path, exe: &Path, extra: &[String]) -> Lau
 /// this app's argv can carry the path it is about to launch.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub fn running_exe(ps_output: &str, exe: &str, own_pid: u32) -> bool {
+    !pids_running(ps_output, exe, own_pid).is_empty()
+}
+
+/// Every pid in `ps_output` whose argv names `exe`, ours excluded.
+///
+/// More than one is normal and correct: the wrapper we spawned and the Wine process doing
+/// the work both carry the path, and stopping FrostMod means stopping both.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub fn pids_running(ps_output: &str, exe: &str, own_pid: u32) -> Vec<u32> {
     let needle = exe.to_ascii_lowercase();
-    ps_output.lines().any(|line| {
-        let Some((pid, args)) = line.trim_start().split_once(char::is_whitespace) else {
-            return false;
-        };
-        pid.parse::<u32>().is_ok_and(|p| p != own_pid) && args.to_ascii_lowercase().contains(&needle)
-    })
+    ps_output
+        .lines()
+        .filter_map(|line| {
+            let (pid, args) = line.trim_start().split_once(char::is_whitespace)?;
+            let pid = pid.parse::<u32>().ok()?;
+            (pid != own_pid && args.to_ascii_lowercase().contains(&needle)).then_some(pid)
+        })
+        .collect()
+}
+
+/// The process table, as `ps` reports it. Empty when we couldn't ask.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub fn process_table() -> String {
+    std::process::Command::new("ps")
+        .args(["-Ao", "pid=,args="])
+        .output()
+        .map(|out| String::from_utf8_lossy(&out.stdout).into_owned())
+        .unwrap_or_default()
+}
+
+/// Stop everything running `exe`. Best-effort, and TERM rather than KILL: FrostMod's
+/// launcher tidies up after itself when asked politely, and a Wine process killed outright
+/// can leave the prefix's server holding its handles.
+///
+/// Shells out because the app links no libc of its own for a single `kill(2)`.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub fn kill_exe(exe: &str) {
+    let pids = pids_running(&process_table(), exe, std::process::id());
+    if pids.is_empty() {
+        return;
+    }
+    let mut cmd = std::process::Command::new("kill");
+    cmd.arg("-TERM");
+    for pid in &pids {
+        cmd.arg(pid.to_string());
+    }
+    match cmd.output() {
+        Ok(out) if !out.status.success() => log::warn!(
+            "asking {exe} ({pids:?}) to stop failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ),
+        Err(e) => log::warn!("couldn't run kill to stop {exe}: {e}"),
+        _ => {}
+    }
 }
 
 /// What the app found to launch with, for Settings to show. Reported rather than assumed:
@@ -392,9 +454,62 @@ mod tests {
         let prefix = Path::new("/b/MXB");
         let exe = Path::new("/b/MXB/drive_c/Program Files/MX Bikes/mxbikes.exe");
         assert_eq!(
-            windows_path(prefix, exe).unwrap(),
+            windows_path(prefix, exe),
             "C:\\Program Files\\MX Bikes\\mxbikes.exe"
         );
+    }
+
+    /// FrostMod is installed in our own data folder, which is nowhere near the bottle —
+    /// and a program inside the bottle reaches it as `Z:`, the drive Wine maps to `/`.
+    /// Without this the launcher is handed a path it can't open.
+    #[test]
+    fn a_path_outside_the_bottle_is_on_the_z_drive() {
+        let prefix = Path::new("/b/MXB");
+        assert_eq!(
+            windows_path(
+                prefix,
+                Path::new("/Users/x/Library/Application Support/MXB App/frostmod/frostmod.exe")
+            ),
+            "Z:\\Users\\x\\Library\\Application Support\\MXB App\\frostmod\\frostmod.exe"
+        );
+    }
+
+    /// A bottle with its `Z:` mapping stripped can't see FrostMod's folder, and nothing
+    /// about that failure is visible from in-game — so it is checked before starting.
+    ///
+    /// Unix only for the symlink `dosdevices/z:` actually is — and there are no bottles on
+    /// Windows to check anyway.
+    #[cfg(unix)]
+    #[test]
+    fn a_bottle_without_a_z_drive_is_spotted() {
+        let root = temp_dir("z-drive");
+        let with = root.join("with");
+        std::fs::create_dir_all(with.join("dosdevices")).unwrap();
+        std::os::unix::fs::symlink("/", with.join("dosdevices/z:")).unwrap();
+        let without = root.join("without");
+        std::fs::create_dir_all(without.join("dosdevices")).unwrap();
+
+        assert!(has_z_drive(&with));
+        assert!(!has_z_drive(&without));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Stopping FrostMod has to reach both processes that carry its name — the wrapper we
+    /// spawned and the Wine process under it — and never this app.
+    #[test]
+    fn every_process_carrying_the_name_is_listed_except_our_own() {
+        let ps = "\
+  501 /sbin/launchd
+ 8123 /Applications/CrossOver.app/Contents/SharedSupport/CrossOver/bin/wine --bottle MXB --cx-app Z:\\Users\\x\\frostmod.exe
+ 8124 /Applications/CrossOver.app/Contents/SharedSupport/CrossOver/bin/wineserver
+ 8125 C:\\windows\\system32\\explorer.exe /desktop FrostMod.exe --game mxb
+ 9000 /Applications/MXB App.app/Contents/MacOS/mxb-app";
+        let mut pids = pids_running(ps, "frostmod.exe", 9000);
+        pids.sort();
+        assert_eq!(pids, [8123, 8125], "both the wrapper and the Wine process: {pids:?}");
+        assert!(pids_running(ps, "frostmod.exe", 8123).iter().all(|p| *p != 8123));
+        assert!(pids_running(ps, "gpbikes.exe", 9000).is_empty());
     }
 
     #[test]

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -272,11 +272,10 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
   const platform = usePlatform();
   const isWindows = platform === "windows";
   const isMac = platform === "macos";
-  // FrostMod is a Win32 DLL injected into the game — which is exactly what the game is on
-  // Linux too, where Steam runs it under Proton and the app puts FrostMod in the same
-  // prefix. macOS is the odd one out: the app launches the bottle but doesn't inject
-  // into it.
-  const hasFrostmod = isWindows || platform === "linux";
+  // FrostMod is a Win32 DLL injected into the game — which is exactly what the game is
+  // everywhere it runs: natively on Windows, under Proton on Linux, in a CrossOver/Whisky
+  // bottle on macOS. The app starts FrostMod in whichever prefix holds the game.
+  const hasFrostmod = isWindows || platform === "linux" || isMac;
   const { theme, setTheme } = useTheme();
   const { running, reload, status, installing, checking, statusError, install, start, stop, refreshStatus, missingRuntime, installRuntime, installingRuntime } =
     useFrostmod();
@@ -1440,10 +1439,10 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
           )}
 
           {/* frostmod — a Win32 DLL injected into the game, so it has nothing to do where
-              the game isn't a Windows process. That means Windows and Linux (Proton), and
-              not macOS. Hidden rather than shown-and-disabled: every control in it would
-              fail, including one that downloads two Windows binaries. The nav drops its
-              entry on the same condition. */}
+              the game isn't a Windows process. It is one on all three platforms (Proton on
+              Linux, a Wine bottle on macOS), and hidden anywhere else rather than
+              shown-and-disabled: every control would fail, including one that downloads two
+              Windows binaries. The nav drops its entry on the same condition. */}
           {hasFrostmod && caps.frostmod && active === "frostmod" && (
           <Section
             title={t("settings.frostmod")}


### PR DESCRIPTION
FrostMod is a Win32 launcher plus an injected DLL. On macOS the game is a Windows process too — it lives in a CrossOver/Whisky/Wine bottle the app already finds and launches — so FrostMod belongs in that same bottle, exactly as it belongs in the Proton prefix on Linux. It was refused outright there: `install` bailed, `start` bailed, and Settings hid the section and its log row.

The hard part was already built. #176 and FrostMod v0.13.0 solved the real problem — driving a Win32 DLL from a host process *outside* the Wine prefix, which cannot pulse a Wine kernel event — with a command file FrostMod polls for. That answer is platform-agnostic: macOS is outside the prefix for the same reason Linux is. What was missing is the mac half of the launch.

## What this does

- **Installs, starts, reloads and stops FrostMod on macOS.** The bottle is found the way Play already finds it (whatever sits above `drive_c` in the game's path), `frostmod.exe` is started through whichever wrapper owns that bottle, and `--mods` is handed over as the bottle names the folder — `C:\users\crossover\Documents\…`, not the `/Users/…` this side calls the same place.
- **Reload travels as a file**, same as Linux, so v0.13.0 is the floor on macOS as well. Anything older is refused with a version to update to, rather than started into a state where the in-game `F8` works and every button in the app quietly doesn't.
- **A bottle with no `Z:` drive is refused with the fix named.** FrostMod stays in the app's data folder rather than being copied into the bottle, and `Z:` is what makes that folder addressable from in there — for the launcher and for the command file both. Without it FrostMod would inject, reload on `F8`, and ignore the app forever, which is invisible from in game.
- **Stop reaches both processes** that carry the name — the wrapper and the Wine process under it — so the status pill can't be left insisting FrostMod is running.

## Shape of the change

- `winehost`: `windows_path` is public and gains the `Z:` case (same rule as `proton::windows_path`); `pids_running` / `process_table` / `kill_exe`; `has_z_drive`.
- `gameproc`: "which prefix, which runner" extracted into `prefix_and_runner`, so Play and the FrostMod start fail with the same words.
- `frostmod`: the command-file channel is now `linux` **or** `macos`; `is_running` reads `ps`.
- `frostmod_manage`: the install gate, a macOS `start`, `force_stop_exe`, and `proton_log` generalized to `runner_log` — the wrapper's own output lands in `wine.log` beside FrostMod and is collected with the other logs, the only account of a failed injection a player can send us.
- Settings shows the section and the log row on macOS.

No DB changes.

## Verification

- 786 tests pass, including the whole macOS start driven against a stub standing in for Wine (prefix, working directory, and `--mods` in the bottle's own path form), the no-`Z:` refusal, the `Z:` rewrite, and pid extraction from a `ps` listing.
- `cargo check --target x86_64-pc-windows-gnu` clean; typecheck, lint and build clean; no new clippy warnings.
- Not yet exercised against a real bottle — no Wine wrapper on the machine this was written on, and FrostMod v0.13.0 has still to be tagged. Both are the next step, and until that release exists this path correctly refuses to start anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)