### PR TITLE
fix(runtime): repair the runtimes without waiting to be asked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## Unreleased — a repair button that doesn't wait to be asked
+
+### Added
+- **"Repair runtimes" in Settings, next to FrostMod.** It installs every Visual C++ runtime
+  this PC is short of and puts `msvcr90.dll` where the game looks for it. Deliberately not
+  gated on anything having been detected as missing — the machine this was built for reported
+  every runtime present and still couldn't start the game, so a repair reachable only from the
+  warning bar would never have run there. Worth pressing even when nothing looks wrong.
+- **Both 32- and 64-bit 2015–2022 runtimes**, from Microsoft's own *Latest Supported Visual
+  C++ Downloads* page. Installing the x64 package does nothing for a 32-bit consumer — a
+  plugin, a tool, or the dedicated-server build, which really is a 32-bit binary — so offering
+  only one left half the cases unfixable. The x86 package is offered by the repair and never
+  raises a warning of its own: nothing the app ships is 32-bit, so its absence proves nothing
+  is wrong.
+- **Every runtime's download link, always available**, so a declined admin prompt or a PC that
+  can't reach Microsoft still has somewhere to go. The repair hands over links for whatever it
+  couldn't finish rather than reporting a flat failure.
+
+### Fixed
+- **The copy beside the game executable now lands in `Program Files` too.** It was a plain
+  unelevated write, so on a Steam install — where the game folder needs admin rights — it
+  failed silently and the fix never arrived on exactly the machines reporting the problem. The
+  repair now asks for permission and copies with it.
+- **A repair no longer stops at the first thing that goes wrong.** One runtime failing says
+  nothing about the next two, so it works through all of them and reports the rest.
+
 ## Unreleased — nothing downloads without a ceiling
 
 ### Fixed

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5095,6 +5095,33 @@ async fn frostmod_install(
 /// Raises a UAC prompt — Microsoft's redistributables require admin, and only the shell
 /// can ask. A declined prompt comes back as `cancelled`, not an error, so the UI can fall
 /// back to handing over the download link instead of reading as broken.
+/// Install every Visual C++ runtime this machine is short of, and finish the VC90 job by
+/// placing `msvcr90.dll` beside the game exe.
+///
+/// Deliberately not gated on `frostmod_status` having reported anything missing. The
+/// machine this exists for reported everything present and still couldn't start the game,
+/// so a repair reachable only from the warning bar would never have run there.
+#[tauri::command]
+async fn frostmod_repair_runtimes(app: tauri::AppHandle) -> vcruntime::RepairReport {
+    let game_dir = config::load(&app)
+        .ok()
+        .map(|c| c.install_dir())
+        .filter(|d| !d.trim().is_empty())
+        .map(std::path::PathBuf::from);
+    vcruntime::repair(&app, game_dir.as_deref()).await
+}
+
+/// Microsoft's download page links for every runtime, so the UI can always offer the
+/// manual route — the backstop for a declined UAC prompt or a PC that can't reach
+/// `aka.ms`.
+#[tauri::command]
+fn runtime_downloads() -> Vec<(vcruntime::Runtime, &'static str, &'static str)> {
+    vcruntime::Runtime::ALL
+        .into_iter()
+        .map(|r| (r, r.label(), r.url()))
+        .collect()
+}
+
 #[tauri::command]
 async fn frostmod_install_runtime(
     app: tauri::AppHandle,
@@ -6579,6 +6606,8 @@ fn main() {
             frostmod_status,
             frostmod_install,
             frostmod_install_runtime,
+            frostmod_repair_runtimes,
+            runtime_downloads,
             frostmod_start,
             frostmod_stop,
             launch_game,

--- a/src-tauri/src/vcruntime.rs
+++ b/src-tauri/src/vcruntime.rs
@@ -60,8 +60,17 @@ use serde::{Deserialize, Serialize};
 pub enum Runtime {
     /// Visual C++ 2008 (`MSVCR90`) — what the *game* imports.
     Vc90,
-    /// Visual C++ 2015–2022 (`vcruntime140` / `msvcp140`) — what `frostmod.dll` imports.
+    /// Visual C++ 2015–2022, x64 (`vcruntime140` / `msvcp140`) — what `frostmod.dll` imports.
     Vc140,
+    /// Visual C++ 2015–2022, x86.
+    ///
+    /// Nothing in our own chain needs this one: the app, FrostMod and the modern game
+    /// builds are all x64. It is here because plenty of what players run alongside the
+    /// game isn't — 32-bit plugins, tools, and the dedicated-server build, which really is
+    /// a 32-bit binary — and because the pair is what Microsoft's own "Latest Supported
+    /// Visual C++ Downloads" page hands out. Offered by the repair, never a banner: see
+    /// [`missing`] for why an unprompted alarm about it would be wrong.
+    Vc140X86,
 }
 
 /// What an install attempt actually did.
@@ -93,11 +102,21 @@ const VC90_SXS_PREFIX: &str = "amd64_microsoft.vc90.crt_1fc8b3b9a1e18e3b_";
 /// injection dies naming a DLL we never looked for.
 const VC140_DLLS: [&str; 3] = ["vcruntime140.dll", "vcruntime140_1.dll", "msvcp140.dll"];
 
+/// The x86 probe, deliberately shorter than [`VC140_DLLS`].
+///
+/// `vcruntime140_1.dll` is left out because we could not confirm the 32-bit package ships
+/// it — the redistributable is a Burn bundle with its payload compressed, so the honest
+/// answer from here is "unknown". Probing for a file that may never exist on x86 would
+/// mark every machine permanently short of a runtime it already has, and a false alarm we
+/// can't clear is worse than a gap we don't report. The two below are certain.
+const VC140_X86_DLLS: [&str; 2] = ["vcruntime140.dll", "msvcp140.dll"];
+
 /// The file every one of these paths is ultimately about.
 const MSVCR90_DLL: &str = "msvcr90.dll";
 
 /// An installer under this is a captive-portal login page or a truncated download, not a
-/// redistributable. The real ones are ~5 MB (VC90) and ~25 MB (VC140).
+/// redistributable. The real ones are ~5 MB (VC90), ~25.6 MB (VC140 x64) and ~14 MB
+/// (VC140 x86), so a megabyte clears all three with room to spare.
 const MIN_INSTALLER_BYTES: usize = 1024 * 1024;
 
 impl Runtime {
@@ -107,8 +126,22 @@ impl Runtime {
         match self {
             // Visual C++ 2008 SP1 redistributable, x64.
             Runtime::Vc90 => "https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x64.exe",
-            // Evergreen "latest supported x64" link — always the current 2015–2022 build.
+            // Evergreen "latest supported" links off Microsoft's own downloads page —
+            // always the current 2015–2022 build, so they don't rot the way a versioned
+            // link does. HEAD-checked when this landed: 25.6 MB x64, 14.0 MB x86.
             Runtime::Vc140 => "https://aka.ms/vs/17/release/vc_redist.x64.exe",
+            Runtime::Vc140X86 => "https://aka.ms/vs/17/release/vc_redist.x86.exe",
+        }
+    }
+
+    /// What to call this in a sentence to the player. The architecture is part of the
+    /// name: someone told to install "Visual C++" who already has the x64 package needs to
+    /// know it's the other one being asked for.
+    pub fn label(self) -> &'static str {
+        match self {
+            Runtime::Vc90 => "Microsoft Visual C++ 2008 (x64)",
+            Runtime::Vc140 => "Microsoft Visual C++ 2015–2022 (x64)",
+            Runtime::Vc140X86 => "Microsoft Visual C++ 2015–2022 (x86)",
         }
     }
 
@@ -119,17 +152,23 @@ impl Runtime {
     pub fn installer_args(self) -> &'static str {
         match self {
             Runtime::Vc90 => "/q /norestart",
-            Runtime::Vc140 => "/install /quiet /norestart",
+            Runtime::Vc140 | Runtime::Vc140X86 => "/install /quiet /norestart",
         }
     }
 
-    /// Filename to stage the download under.
+    /// Filename to stage the download under. Distinct per runtime so two staged installers
+    /// can never overwrite one another mid-repair.
     fn installer_name(self) -> &'static str {
         match self {
             Runtime::Vc90 => "vcredist_x64_2008.exe",
             Runtime::Vc140 => "vc_redist.x64.exe",
+            Runtime::Vc140X86 => "vc_redist.x86.exe",
         }
     }
+
+    /// Every runtime the repair knows how to fetch, in the order it works through them:
+    /// the game's own CRT first, since that is the one whose absence stops the game dead.
+    pub const ALL: [Runtime; 3] = [Runtime::Vc90, Runtime::Vc140, Runtime::Vc140X86];
 }
 
 /// The four-part version embedded in a WinSxS entry name, as a sortable key.
@@ -306,12 +345,79 @@ pub fn ensure_app_local_msvcr90(_game_dir: &std::path::Path) -> bool {
     false
 }
 
+/// Place `msvcr90.dll` beside the exe, raising UAC if the folder needs it.
+///
+/// The unelevated copy above is silent and gives up on `Program Files` — which is exactly
+/// where a Steam install lives, so on the machines that reported this it never lands. This
+/// is the same job with the shell's `runas` behind it, and it is deliberately **not** on
+/// the status path: it can put a UAC dialog on screen, so it only ever runs from a repair
+/// the player pressed.
+///
+/// `cmd.exe /c copy` rather than an elevated helper of our own — copying one file is not
+/// worth a second binary in the bundle, and `copy` is present on every Windows that can
+/// run the game.
+#[cfg(windows)]
+pub fn place_msvcr90_elevated(game_dir: &std::path::Path) -> anyhow::Result<bool> {
+    let dest = app_local_msvcr90(game_dir);
+    if dest.is_file() {
+        return Ok(true);
+    }
+    // Clear the "already tried" mark first: the unelevated attempt almost certainly failed
+    // on this folder, and that must not stop the elevated one.
+    if let Ok(mut tried) = ATTEMPTED.lock() {
+        tried.remove(game_dir);
+    }
+    if ensure_app_local_msvcr90(game_dir) {
+        return Ok(true);
+    }
+    let Some(src_dir) = sxs_vc90_dir() else {
+        anyhow::bail!(
+            "There's no Visual C++ 2008 runtime on this PC to copy from. Install {} first.",
+            Runtime::Vc90.label()
+        );
+    };
+    let src = src_dir.join(MSVCR90_DLL);
+    let cmd = windir().join("System32").join("cmd.exe");
+    // Quoted because both paths routinely contain spaces — `Program Files`, `MX Bikes`.
+    let args = format!("/c copy /y \"{}\" \"{}\"", src.display(), dest.display());
+    if !run_elevated(&cmd, &args)? {
+        // Declined UAC. Not an error: the caller offers the manual route instead.
+        return Ok(false);
+    }
+    // `copy`'s exit code doesn't travel back through ShellExecuteExW usefully, so the disk
+    // is what settles it.
+    let placed = dest.is_file();
+    if placed {
+        log::info!("placed {} (elevated) from {}", dest.display(), src_dir.display());
+    } else {
+        log::warn!("elevated copy of {} reported no error but nothing landed", dest.display());
+    }
+    Ok(placed)
+}
+
+#[cfg(not(windows))]
+pub fn place_msvcr90_elevated(_game_dir: &std::path::Path) -> anyhow::Result<bool> {
+    anyhow::bail!("Visual C++ runtimes only apply on Windows")
+}
+
 /// The 2015–2022 runtime installs into `System32` rather than WinSxS. This process is
 /// x64, so `System32` is the genuine 64-bit directory — no WOW64 redirection to unpick.
 #[cfg(windows)]
 fn vc140_present() -> bool {
     let sys32 = windir().join("System32");
     VC140_DLLS.iter().all(|dll| sys32.join(dll).exists())
+}
+
+/// The 32-bit runtime lands in `SysWOW64` — the 64-bit-Windows home for 32-bit system
+/// DLLs, despite a name that reads the other way round.
+///
+/// Naming the path literally is what makes this correct from here: WOW64 file-system
+/// redirection rewrites `System32` for 32-bit processes, and this process is 64-bit, so
+/// nothing is rewritten in either direction and `SysWOW64` means exactly what it says.
+#[cfg(windows)]
+fn vc140_x86_present() -> bool {
+    let syswow = windir().join("SysWOW64");
+    VC140_X86_DLLS.iter().all(|dll| syswow.join(dll).exists())
 }
 
 /// Cached detection result, together with the game folder it was computed for.
@@ -343,6 +449,11 @@ fn invalidate() {
 /// `game_dir` is where the active title is installed, when the app knows it. Without it
 /// the VC90 probe can only consult `WinSxS` and will call a game folder carrying its own
 /// copy of the CRT "missing" — so pass it wherever it is to hand.
+///
+/// [`Runtime::Vc140X86`] is deliberately absent from this list. It drives a banner, and
+/// nothing we ship is 32-bit, so its absence proves nothing is broken — raising an amber
+/// bar over it would be telling a working player their PC is wrong. The repair installs it
+/// on request; see [`short_of`], which is the same question asked without that restraint.
 #[cfg(windows)]
 pub fn missing(game_dir: Option<&std::path::Path>) -> Vec<Runtime> {
     if let Ok(cache) = CACHE.lock() {
@@ -372,6 +483,116 @@ pub fn missing(game_dir: Option<&std::path::Path>) -> Vec<Runtime> {
 #[cfg(not(windows))]
 pub fn missing(_game_dir: Option<&std::path::Path>) -> Vec<Runtime> {
     Vec::new()
+}
+
+/// Every runtime this machine is short of, including the ones we'd never raise a banner
+/// about. This is what the repair works from: the player asked, so the restraint that
+/// governs [`missing`] doesn't apply.
+///
+/// Uncached on purpose — it runs once per button press, and it must see the disk as it is
+/// now rather than as some earlier poll found it.
+#[cfg(windows)]
+pub fn short_of(game_dir: Option<&std::path::Path>) -> Vec<Runtime> {
+    Runtime::ALL
+        .into_iter()
+        .filter(|r| match r {
+            Runtime::Vc90 => !vc90_present(game_dir),
+            Runtime::Vc140 => !vc140_present(),
+            Runtime::Vc140X86 => !vc140_x86_present(),
+        })
+        .collect()
+}
+
+#[cfg(not(windows))]
+pub fn short_of(_game_dir: Option<&std::path::Path>) -> Vec<Runtime> {
+    Vec::new()
+}
+
+/// What a repair run did, in the terms the player needs to hear it.
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RepairReport {
+    /// Runtimes that went on during this run.
+    pub installed: Vec<Runtime>,
+    /// Runtimes that were already there. Worth saying: "nothing to do" is a real answer
+    /// and reads as a broken button when it's silent.
+    pub already_present: Vec<Runtime>,
+    /// Still absent afterwards — a declined UAC prompt, a failed download, an install that
+    /// needs a reboot to finish. Each one is a link the UI hands over.
+    pub still_missing: Vec<Runtime>,
+    /// Whether `msvcr90.dll` now sits beside the game exe.
+    pub msvcr90_placed: bool,
+    /// Set when we had nowhere to place it — no game folder configured.
+    pub game_dir_known: bool,
+}
+
+/// Install whatever this machine is short of, then finish the VC90 job by hand.
+///
+/// The one entry point that doesn't depend on detection having raised a flag. That matters
+/// more than it sounds: the machine this was written for reported every runtime present
+/// and still couldn't start the game, so anything reachable only through the banner would
+/// never have run there.
+///
+/// Never bails part-way. One runtime failing says nothing about the next, and a repair that
+/// stops at the first problem leaves the player worse off than one that does what it can
+/// and reports the rest — which the UI turns into download links.
+#[cfg(windows)]
+pub async fn repair(
+    app: &tauri::AppHandle,
+    game_dir: Option<&std::path::Path>,
+) -> RepairReport {
+    let mut report = RepairReport {
+        game_dir_known: game_dir.is_some(),
+        ..Default::default()
+    };
+    let short = short_of(game_dir);
+    for runtime in Runtime::ALL {
+        if !short.contains(&runtime) {
+            report.already_present.push(runtime);
+            continue;
+        }
+        match install(app, runtime, game_dir).await {
+            Ok(InstallOutcome::Installed) => report.installed.push(runtime),
+            Ok(InstallOutcome::Cancelled) => {
+                log::info!("repair: {runtime:?} declined at the UAC prompt");
+                report.still_missing.push(runtime);
+            }
+            Err(e) => {
+                log::warn!("repair: {runtime:?} failed: {e:#}");
+                report.still_missing.push(runtime);
+            }
+        }
+    }
+
+    // The copy beside the exe, elevating if the folder needs it. Runs even when VC90 was
+    // already "present" — present in WinSxS is not the same as reachable by a plain
+    // import, and that gap is the whole reason this function exists.
+    if let Some(dir) = game_dir {
+        report.msvcr90_placed = match place_msvcr90_elevated(dir) {
+            Ok(placed) => placed,
+            Err(e) => {
+                log::warn!("repair: could not place {MSVCR90_DLL}: {e:#}");
+                false
+            }
+        };
+    }
+
+    invalidate();
+    log::info!(
+        "repair: installed {:?}, still missing {:?}, msvcr90 beside exe: {}",
+        report.installed,
+        report.still_missing,
+        report.msvcr90_placed
+    );
+    report
+}
+
+#[cfg(not(windows))]
+pub async fn repair(
+    _app: &tauri::AppHandle,
+    _game_dir: Option<&std::path::Path>,
+) -> RepairReport {
+    RepairReport::default()
 }
 
 // ===========================================================================
@@ -660,6 +881,49 @@ mod tests {
             VC140_DLLS.contains(&"vcruntime140_1.dll"),
             "frostmod.dll imports vcruntime140_1.dll, so it has to be probed: {VC140_DLLS:?}"
         );
+    }
+
+    /// Both 2015–2022 builds are offered, off Microsoft's "Latest Supported Visual C++
+    /// Downloads" page. Installing x64 does nothing for a 32-bit consumer and vice versa,
+    /// so a single link would leave half the cases unfixable.
+    #[test]
+    fn offers_both_architectures_of_the_modern_runtime() {
+        assert!(Runtime::ALL.contains(&Runtime::Vc140));
+        assert!(Runtime::ALL.contains(&Runtime::Vc140X86));
+        assert!(Runtime::Vc140.url().ends_with("vc_redist.x64.exe"));
+        assert!(Runtime::Vc140X86.url().ends_with("vc_redist.x86.exe"));
+    }
+
+    /// Every runtime needs its own staging filename and its own URL — two sharing either
+    /// would have one silently overwrite or stand in for the other mid-repair.
+    #[test]
+    fn every_runtime_is_distinct_on_disk_and_on_the_wire() {
+        for (i, a) in Runtime::ALL.iter().enumerate() {
+            for b in &Runtime::ALL[i + 1..] {
+                assert_ne!(a.installer_name(), b.installer_name(), "{a:?} vs {b:?}");
+                assert_ne!(a.url(), b.url(), "{a:?} vs {b:?}");
+                assert_ne!(a.label(), b.label(), "{a:?} vs {b:?}");
+            }
+        }
+    }
+
+    /// The architecture belongs in the name. Someone who already has the x64 package and is
+    /// told to install "Visual C++" will reasonably conclude they already did.
+    #[test]
+    fn labels_name_the_architecture() {
+        assert!(Runtime::Vc140.label().contains("x64"));
+        assert!(Runtime::Vc140X86.label().contains("x86"));
+    }
+
+    /// The x86 probe stays off `vcruntime140_1.dll` on purpose — we could not confirm the
+    /// 32-bit package ships it, and probing for a file that may never exist would mark
+    /// every machine permanently short of a runtime it already has.
+    #[test]
+    fn the_x86_probe_stays_conservative() {
+        assert!(!VC140_X86_DLLS.contains(&"vcruntime140_1.dll"));
+        for dll in VC140_X86_DLLS {
+            assert!(VC140_DLLS.contains(&dll), "{dll} should be in both probes");
+        }
     }
 
     /// The two packages take different switches; swapping them silently does nothing.

--- a/src/Components/RuntimeBanner/RuntimeBanner.tsx
+++ b/src/Components/RuntimeBanner/RuntimeBanner.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, Download, Loader2, X } from "lucide-react";
 import { Button } from "@/Components/ui/button";
+import { RUNTIME_NAME_KEY } from "@/api/mods";
 import { useFrostmod } from "@/Context/FrostmodContext";
 import { Trans } from "@/i18n";
 import { useT } from "@/i18n/context";
@@ -26,9 +27,10 @@ export default function RuntimeBanner() {
   // when one of the two is visibly working.
   const isGameRuntime = runtimeWarning === "vc90";
   const bodyKey = isGameRuntime ? "runtime.bannerGame" : "runtime.bannerFrostmod";
-  const nameKey = isGameRuntime
-    ? "runtime.componentVc90"
-    : "runtime.componentVc140";
+  // `vc140_x86` never reaches here — the backend keeps it out of `missingRuntimes` because
+  // nothing we ship is 32-bit — but the lookup covers it rather than leaving a hole that
+  // would render an empty name if that ever changed.
+  const nameKey = RUNTIME_NAME_KEY[runtimeWarning];
 
   return (
     <div className="flex items-center gap-3 border-b border-amber-500/25 bg-amber-500/10 px-4 py-2 text-sm text-foreground">

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -278,7 +278,7 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
   // into it.
   const hasFrostmod = isWindows || platform === "linux";
   const { theme, setTheme } = useTheme();
-  const { running, reload, status, installing, checking, statusError, install, start, stop, refreshStatus, missingRuntime, installRuntime, installingRuntime } =
+  const { running, reload, status, installing, checking, statusError, install, start, stop, refreshStatus, missingRuntime, installRuntime, installingRuntime, repairRuntimes, repairingRuntimes } =
     useFrostmod();
   const { check: checkForUpdates } = useUpdate();
   const { startTour } = useTour();
@@ -1514,13 +1514,30 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
                   <Button
                     size="sm"
                     onClick={() => void installRuntime(missingRuntime)}
-                    disabled={installingRuntime}
+                    disabled={installingRuntime || repairingRuntimes}
                   >
                     {installingRuntime
                       ? t("runtime.installing")
                       : t("runtime.fixIt")}
                   </Button>
                 )}
+                {/* Always offered, never gated on `missingRuntime`. Detection can say a PC
+                    has everything and be right about that while the game still won't
+                    start: the redistributable registers a side-by-side assembly and leaves
+                    the plain DLL search path alone. A repair reachable only when we'd
+                    already spotted a problem would never run on the machines that need it
+                    most — the ones where we spotted nothing. */}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void repairRuntimes()}
+                  disabled={repairingRuntimes || installingRuntime}
+                  title={t("settings.repairRuntimesHint")}
+                >
+                  {repairingRuntimes
+                    ? t("runtime.repairing")
+                    : t("settings.repairRuntimes")}
+                </Button>
                 {status?.installed && (
                   <Button
                     variant="ghost"

--- a/src/Context/Frostmod.tsx
+++ b/src/Context/Frostmod.tsx
@@ -11,6 +11,7 @@ import { open as openUrl } from "@tauri-apps/plugin-shell";
 import {
   frostmodInstall,
   frostmodInstallRuntime,
+  frostmodRepairRuntimes,
   frostmodStart,
   frostmodStatus,
   frostmodStop,
@@ -19,6 +20,8 @@ import {
   onFrostmodReload,
   reloadFrostmod,
   RUNTIME_DOWNLOAD_URL,
+  RUNTIME_DOWNLOADS_PAGE,
+  RUNTIME_NAME_KEY,
 } from "../api/mods";
 import type { FrostmodStatus, VcRuntime } from "../types";
 import { displayName } from "../lib/mods";
@@ -53,6 +56,7 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
   const [checking, setChecking] = useState(false);
   const [statusError, setStatusError] = useState(false);
   const [installingRuntime, setInstallingRuntime] = useState(false);
+  const [repairingRuntimes, setRepairingRuntimes] = useState(false);
   const [runtimeDismissed, setRuntimeDismissed] = useState(false);
   const mounted = useRef(true);
 
@@ -215,6 +219,66 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
     [refreshStatus, t],
   );
 
+  /**
+   * Install everything the PC is short of, then put `msvcr90.dll` beside the game exe.
+   *
+   * The one path that doesn't ask detection for permission first. A PC can report every
+   * runtime present and still stop the game dead — the redistributable registers a
+   * side-by-side assembly and leaves the plain DLL search path alone — so this always does
+   * the work and reports what it found rather than deciding there was nothing to do.
+   *
+   * Never throws: the backend returns a report instead, so a UAC prompt declined on one
+   * installer doesn't cost the player the other two.
+   */
+  const repairRuntimes = useCallback(async () => {
+    setRepairingRuntimes(true);
+    try {
+      const report = await frostmodRepairRuntimes();
+      await refreshStatus();
+
+      const fixed = report.installed.length > 0 || report.msvcr90Placed;
+      if (report.stillMissing.length > 0) {
+        // Partly done at best, and every remaining item has a link. Offer the first —
+        // opening three tabs at once would be its own kind of unhelpful.
+        const first = report.stillMissing[0];
+        toast.warning(t("runtime.repairPartial"), {
+          description: t("runtime.repairPartialDesc", {
+            what: report.stillMissing.map((r) => t(RUNTIME_NAME_KEY[r])).join(", "),
+          }),
+          action: {
+            label: t("runtime.downloadManually"),
+            onClick: () => void openUrl(RUNTIME_DOWNLOAD_URL[first]),
+          },
+          duration: 12000,
+        });
+      } else if (fixed) {
+        toast.success(t("runtime.repairDone"), {
+          description: t("runtime.repairDoneDesc"),
+        });
+      } else if (!report.gameDirKnown) {
+        // Everything was already installed, but we had nowhere to put the copy that
+        // actually stops the "not found" box. Saying "all good" here would be a lie.
+        toast.info(t("runtime.repairNoGameFolder"), {
+          description: t("runtime.repairNoGameFolderDesc"),
+        });
+      } else {
+        toast.info(t("runtime.repairNothingToDo"), {
+          description: t("runtime.repairNothingToDoDesc"),
+        });
+      }
+    } catch (e) {
+      toast.error(t("runtime.repairFailed"), {
+        description: String(e),
+        action: {
+          label: t("runtime.downloadManually"),
+          onClick: () => void openUrl(RUNTIME_DOWNLOADS_PAGE),
+        },
+      });
+    } finally {
+      setRepairingRuntimes(false);
+    }
+  }, [refreshStatus, t]);
+
   // Only ever surface one at a time: two banners stacked over the app is noise, and the
   // game's own runtime (vc90) is the one that produces the error people actually report,
   // so `missingRuntimes` order (vc90 first) decides.
@@ -274,11 +338,13 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
       stop,
       installingRuntime,
       installRuntime,
+      repairingRuntimes,
+      repairRuntimes,
       dismissRuntimeWarning,
       runtimeWarning,
       missingRuntime,
     }),
-    [running, status, installing, checking, statusError, reload, probe, refreshStatus, install, start, stop, installingRuntime, installRuntime, dismissRuntimeWarning, runtimeWarning, missingRuntime],
+    [running, status, installing, checking, statusError, reload, probe, refreshStatus, install, start, stop, installingRuntime, installRuntime, repairingRuntimes, repairRuntimes, dismissRuntimeWarning, runtimeWarning, missingRuntime],
   );
 
   return (

--- a/src/Context/FrostmodContext.ts
+++ b/src/Context/FrostmodContext.ts
@@ -27,6 +27,20 @@ export interface FrostmodContextValue {
    * way, and opens Microsoft's download page if the prompt was declined.
    */
   installRuntime: (runtime: VcRuntime) => Promise<void>;
+  /** True while a full runtime repair is in flight. */
+  repairingRuntimes: boolean;
+  /**
+   * Install every Visual C++ runtime this PC is short of, then place `msvcr90.dll` beside
+   * the game executable.
+   *
+   * Unlike {@link installRuntime} this isn't gated on anything having been detected as
+   * missing, which is the point of it: a PC can report every runtime present and still
+   * stop the game with "MSVCR90.dll was not found", because the redistributable registers
+   * a side-by-side assembly and never touches the plain DLL search path. Prompts for admin
+   * once per installer and resolves either way, handing over download links for whatever
+   * it couldn't do.
+   */
+  repairRuntimes: () => Promise<void>;
   /** Hide the runtime banner for this session (the Settings panel keeps showing it). */
   dismissRuntimeWarning: () => void;
   /** What the banner should warn about — `null` once dismissed this session. */

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -20,6 +20,7 @@ import type {
   IntegrityReport,
   RiderIntegrity,
   RuntimeInstallOutcome,
+  RuntimeRepairReport,
   VcRuntime,
   InstalledMod,
   InstallProgress,
@@ -1721,13 +1722,41 @@ export function frostmodInstallRuntime(
   return invoke<RuntimeInstallOutcome>("frostmod_install_runtime", { runtime });
 }
 
+/** Install everything this PC is short of, and put `msvcr90.dll` beside the game exe.
+ *
+ *  The repair the warning bar can't reach: it runs whatever detection said, because a
+ *  machine can report every runtime present and still fail to start the game. Raises UAC
+ *  once per installer, and never rejects — what it couldn't do comes back in
+ *  `stillMissing` for the caller to offer links for. */
+export function frostmodRepairRuntimes(): Promise<RuntimeRepairReport> {
+  return invoke<RuntimeRepairReport>("frostmod_repair_runtimes");
+}
+
 /** Where to send someone whose UAC prompt we can't raise (or who declined it).
  *
  *  Microsoft's own direct downloads, the same ones the backend fetches — a download page
- *  would make them pick an architecture, and picking x86 here fixes nothing. */
+ *  would make them pick an architecture, and picking the wrong one fixes nothing. Both
+ *  2015–2022 builds are here because that is what Microsoft's "Latest Supported Visual C++
+ *  Downloads" page hands out, and a 32-bit plugin or the dedicated-server build needs the
+ *  x86 one no matter how many x64 packages are already installed. */
 export const RUNTIME_DOWNLOAD_URL: Record<VcRuntime, string> = {
   vc90: "https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x64.exe",
   vc140: "https://aka.ms/vs/17/release/vc_redist.x64.exe",
+  vc140_x86: "https://aka.ms/vs/17/release/vc_redist.x86.exe",
+};
+
+/** Microsoft's index page for the pair above, for a player who'd rather see the source. */
+export const RUNTIME_DOWNLOADS_PAGE =
+  "https://learn.microsoft.com/cpp/windows/latest-supported-vc-redist";
+
+/** Translation key naming each runtime the way Microsoft's installer does.
+ *
+ *  The architecture is part of the name on purpose: someone told to install "Visual C++"
+ *  who already has the x64 package needs to see that it's the other one being asked for. */
+export const RUNTIME_NAME_KEY: Record<VcRuntime, TKey> = {
+  vc90: "runtime.componentVc90",
+  vc140: "runtime.componentVc140",
+  vc140_x86: "runtime.componentVc140X86",
 };
 
 /** Launch the managed FrostMod process if it isn't already running. */

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -302,6 +302,21 @@ export const de: Translation = {
     "Windows braucht dafür deine Erlaubnis. Der Download von Microsoft wird stattdessen geöffnet.",
   "runtime.installFailed": "Komponente konnte nicht installiert werden",
   "runtime.downloadManually": "Selbst herunterladen",
+  "runtime.componentVc140X86": "Microsoft Visual C++ 2015–2022 (x86)",
+  "runtime.repairing": "Wird repariert…",
+  "runtime.repairDone": "Laufzeitkomponenten repariert",
+  "runtime.repairDoneDesc":
+    "Starte MX Bikes neu, falls es schon läuft, und versuche es dann noch einmal.",
+  "runtime.repairNothingToDo": "Es war bereits alles vorhanden",
+  "runtime.repairNothingToDoDesc":
+    "Alle Visual-C++-Laufzeitkomponenten sind installiert und im Spielordner liegt, was er braucht. Startet das Spiel trotzdem nicht, schick uns dein Protokoll.",
+  "runtime.repairPartial": "Ein Teil braucht noch dich",
+  "runtime.repairPartialDesc":
+    "Nicht abgeschlossen: {{what}}. Windows braucht deine Erlaubnis, oder der Download kam nicht an — du kannst es auch von Hand installieren.",
+  "runtime.repairNoGameFolder": "Kein Spielordner festgelegt",
+  "runtime.repairNoGameFolderDesc":
+    "Die Laufzeitkomponenten sind installiert, aber ohne Installationsordner gibt es keinen Ort für die Kopie, nach der das Spiel sucht. Lege ihn oben fest und repariere erneut.",
+  "runtime.repairFailed": "Laufzeitkomponenten konnten nicht repariert werden",
   "update.checkFailed": "Updates konnten nicht geprüft werden",
   "update.failed": "Update fehlgeschlagen",
 
@@ -609,6 +624,9 @@ export const de: Translation = {
   "settings.latestVersion": "Neueste: {{version}}",
   "settings.frostmodRuntimeMissing":
     "Windows fehlt eine Visual-C++-Komponente, die FrostMod braucht — installiere sie, um den Fehler „dll was not found“ loszuwerden.",
+  "settings.repairRuntimes": "Laufzeit reparieren",
+  "settings.repairRuntimesHint":
+    "Installiert alle fehlenden Visual-C++-Laufzeiten dieses PCs (32- und 64-Bit) und legt msvcr90.dll dorthin, wo das Spiel sie sucht. Lohnt sich auch, wenn oben nichts falsch aussieht.",
   "settings.frostmodNeedsRepair":
     "Die installierten Dateien passen nicht zu dieser Version — eine Neuinstallation behebt das.",
   "settings.frostmodRepair": "Installation reparieren",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -289,6 +289,21 @@ export const en = {
     "Windows needs your permission to install it. Opening Microsoft's download instead.",
   "runtime.installFailed": "Couldn't install the component",
   "runtime.downloadManually": "Download it yourself",
+  "runtime.componentVc140X86": "Microsoft Visual C++ 2015–2022 (x86)",
+  "runtime.repairing": "Repairing…",
+  "runtime.repairDone": "Runtimes repaired",
+  "runtime.repairDoneDesc":
+    "Restart MX Bikes if it's already open, then try again.",
+  "runtime.repairNothingToDo": "Everything was already in place",
+  "runtime.repairNothingToDoDesc":
+    "Every Visual C++ runtime is installed and the game folder has what it needs. If the game still won't start, send us your log.",
+  "runtime.repairPartial": "Some of it still needs you",
+  "runtime.repairPartialDesc":
+    "Couldn't finish: {{what}}. Windows needs your permission, or the download didn't arrive — you can install it by hand.",
+  "runtime.repairNoGameFolder": "No game folder set",
+  "runtime.repairNoGameFolderDesc":
+    "The runtimes are installed, but without the install folder there's nowhere to put the copy the game looks for. Set it above, then repair again.",
+  "runtime.repairFailed": "Couldn't repair the runtimes",
   "update.checkFailed": "Couldn't check for updates",
   "update.failed": "Update failed",
 
@@ -594,6 +609,9 @@ export const en = {
   "settings.latestVersion": "Latest: {{version}}",
   "settings.frostmodRuntimeMissing":
     "Windows is missing a Visual C++ component FrostMod needs — install it to stop the \"dll was not found\" error.",
+  "settings.repairRuntimes": "Repair runtimes",
+  "settings.repairRuntimesHint":
+    "Installs every Visual C++ runtime this PC is short of (both 32- and 64-bit) and puts msvcr90.dll where the game looks for it. Worth running even if nothing above looks wrong.",
   "settings.frostmodNeedsRepair":
     "The installed files don't match this version — reinstalling fixes it.",
   "settings.frostmodRepair": "Repair install",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -296,6 +296,21 @@ export const es: Translation = {
     "Windows necesita tu permiso para instalarlo. Abriendo la descarga de Microsoft.",
   "runtime.installFailed": "No se pudo instalar el componente",
   "runtime.downloadManually": "Descargarlo tú mismo",
+  "runtime.componentVc140X86": "Microsoft Visual C++ 2015–2022 (x86)",
+  "runtime.repairing": "Reparando…",
+  "runtime.repairDone": "Componentes reparados",
+  "runtime.repairDoneDesc":
+    "Reinicia MX Bikes si ya está abierto y vuelve a intentarlo.",
+  "runtime.repairNothingToDo": "Ya estaba todo en su sitio",
+  "runtime.repairNothingToDoDesc":
+    "Todos los componentes de Visual C++ están instalados y la carpeta del juego tiene lo que necesita. Si aun así no arranca, mándanos tu registro.",
+  "runtime.repairPartial": "Una parte todavía te necesita",
+  "runtime.repairPartialDesc":
+    "No se pudo terminar: {{what}}. Windows necesita tu permiso, o la descarga no llegó — puedes instalarlo a mano.",
+  "runtime.repairNoGameFolder": "No hay carpeta del juego",
+  "runtime.repairNoGameFolderDesc":
+    "Los componentes están instalados, pero sin la carpeta de instalación no hay dónde dejar la copia que el juego busca. Indícala arriba y repara otra vez.",
+  "runtime.repairFailed": "No se pudieron reparar los componentes",
   "update.checkFailed": "No se pudieron comprobar las actualizaciones",
   "update.failed": "La actualización falló",
 
@@ -601,6 +616,9 @@ export const es: Translation = {
   "settings.latestVersion": "Última: {{version}}",
   "settings.frostmodRuntimeMissing":
     "A Windows le falta un componente de Visual C++ que FrostMod necesita — instálalo para quitar el error «dll was not found».",
+  "settings.repairRuntimes": "Reparar componentes",
+  "settings.repairRuntimesHint":
+    "Instala todos los componentes de Visual C++ que le falten a este PC (32 y 64 bits) y deja msvcr90.dll donde el juego la busca. Vale la pena aunque arriba no se vea nada mal.",
   "settings.frostmodNeedsRepair":
     "Los archivos instalados no coinciden con esta versión — reinstalar lo arregla.",
   "settings.frostmodRepair": "Reparar instalación",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -299,6 +299,21 @@ export const fr: Translation = {
     "Windows a besoin de votre autorisation. Ouverture du téléchargement Microsoft à la place.",
   "runtime.installFailed": "Impossible d'installer le composant",
   "runtime.downloadManually": "Le télécharger soi-même",
+  "runtime.componentVc140X86": "Microsoft Visual C++ 2015–2022 (x86)",
+  "runtime.repairing": "Réparation…",
+  "runtime.repairDone": "Composants réparés",
+  "runtime.repairDoneDesc":
+    "Redémarrez MX Bikes s'il est déjà ouvert, puis réessayez.",
+  "runtime.repairNothingToDo": "Tout était déjà en place",
+  "runtime.repairNothingToDoDesc":
+    "Tous les composants Visual C++ sont installés et le dossier du jeu a ce qu'il lui faut. Si le jeu ne démarre toujours pas, envoyez-nous votre journal.",
+  "runtime.repairPartial": "Une partie a encore besoin de vous",
+  "runtime.repairPartialDesc":
+    "N'a pas pu aboutir : {{what}}. Windows demande votre autorisation, ou le téléchargement n'est pas arrivé — vous pouvez l'installer à la main.",
+  "runtime.repairNoGameFolder": "Aucun dossier de jeu défini",
+  "runtime.repairNoGameFolderDesc":
+    "Les composants sont installés, mais sans le dossier d'installation il n'y a nulle part où déposer la copie que le jeu cherche. Indiquez-le ci-dessus, puis réparez à nouveau.",
+  "runtime.repairFailed": "Impossible de réparer les composants",
   "update.checkFailed": "Impossible de vérifier les mises à jour",
   "update.failed": "Échec de la mise à jour",
 
@@ -606,6 +621,9 @@ export const fr: Translation = {
   "settings.latestVersion": "Dernière : {{version}}",
   "settings.frostmodRuntimeMissing":
     "Il manque à Windows un composant Visual C++ dont FrostMod a besoin — installez-le pour faire disparaître l'erreur « dll was not found ».",
+  "settings.repairRuntimes": "Réparer les composants",
+  "settings.repairRuntimesHint":
+    "Installe tous les composants Visual C++ qui manquent à ce PC (32 et 64 bits) et place msvcr90.dll là où le jeu la cherche. Utile même si rien ne semble anormal ci-dessus.",
   "settings.frostmodNeedsRepair":
     "Les fichiers installés ne correspondent pas à cette version — une réinstallation corrige ça.",
   "settings.frostmodRepair": "Réparer l'installation",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -295,6 +295,21 @@ export const it: Translation = {
     "Windows ha bisogno del tuo permesso. Apro invece il download di Microsoft.",
   "runtime.installFailed": "Impossibile installare il componente",
   "runtime.downloadManually": "Scaricalo da solo",
+  "runtime.componentVc140X86": "Microsoft Visual C++ 2015–2022 (x86)",
+  "runtime.repairing": "Riparazione…",
+  "runtime.repairDone": "Componenti riparati",
+  "runtime.repairDoneDesc":
+    "Riavvia MX Bikes se è già aperto, poi riprova.",
+  "runtime.repairNothingToDo": "Era già tutto a posto",
+  "runtime.repairNothingToDoDesc":
+    "Tutti i componenti Visual C++ sono installati e la cartella del gioco ha quello che le serve. Se il gioco non parte lo stesso, mandaci il tuo log.",
+  "runtime.repairPartial": "Una parte ha ancora bisogno di te",
+  "runtime.repairPartialDesc":
+    "Non è stato possibile completare: {{what}}. Windows chiede il tuo permesso, oppure il download non è arrivato — puoi installarlo a mano.",
+  "runtime.repairNoGameFolder": "Nessuna cartella di gioco impostata",
+  "runtime.repairNoGameFolderDesc":
+    "I componenti sono installati, ma senza la cartella di installazione non c'è dove mettere la copia che il gioco cerca. Impostala qui sopra, poi ripara di nuovo.",
+  "runtime.repairFailed": "Impossibile riparare i componenti",
   "update.checkFailed": "Impossibile controllare gli aggiornamenti",
   "update.failed": "Aggiornamento non riuscito",
 
@@ -599,6 +614,9 @@ export const it: Translation = {
   "settings.latestVersion": "Ultima: {{version}}",
   "settings.frostmodRuntimeMissing":
     "A Windows manca un componente Visual C++ che serve a FrostMod — installalo per togliere l'errore «dll was not found».",
+  "settings.repairRuntimes": "Ripara i componenti",
+  "settings.repairRuntimesHint":
+    "Installa tutti i componenti Visual C++ che mancano a questo PC (32 e 64 bit) e mette msvcr90.dll dove il gioco la cerca. Vale la pena anche se qui sopra non sembra esserci nulla di sbagliato.",
   "settings.frostmodNeedsRepair":
     "I file installati non corrispondono a questa versione — reinstallando si risolve.",
   "settings.frostmodRepair": "Ripara installazione",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -298,6 +298,21 @@ export const ptBR: Translation = {
     "O Windows precisa da sua permissão. Abrindo o download da Microsoft no lugar.",
   "runtime.installFailed": "Não foi possível instalar o componente",
   "runtime.downloadManually": "Baixar por conta própria",
+  "runtime.componentVc140X86": "Microsoft Visual C++ 2015–2022 (x86)",
+  "runtime.repairing": "Reparando…",
+  "runtime.repairDone": "Componentes reparados",
+  "runtime.repairDoneDesc":
+    "Reinicie o MX Bikes se ele já estiver aberto e tente de novo.",
+  "runtime.repairNothingToDo": "Já estava tudo no lugar",
+  "runtime.repairNothingToDoDesc":
+    "Todos os componentes do Visual C++ estão instalados e a pasta do jogo tem o que precisa. Se mesmo assim o jogo não abrir, mande seu log para a gente.",
+  "runtime.repairPartial": "Uma parte ainda depende de você",
+  "runtime.repairPartialDesc":
+    "Não deu para concluir: {{what}}. O Windows precisa da sua permissão, ou o download não chegou — você pode instalar na mão.",
+  "runtime.repairNoGameFolder": "Nenhuma pasta do jogo definida",
+  "runtime.repairNoGameFolderDesc":
+    "Os componentes estão instalados, mas sem a pasta de instalação não há onde deixar a cópia que o jogo procura. Defina-a acima e repare de novo.",
+  "runtime.repairFailed": "Não foi possível reparar os componentes",
   "update.checkFailed": "Não foi possível verificar as atualizações",
   "update.failed": "A atualização falhou",
 
@@ -602,6 +617,9 @@ export const ptBR: Translation = {
   "settings.latestVersion": "Última: {{version}}",
   "settings.frostmodRuntimeMissing":
     "Falta ao Windows um componente do Visual C++ que o FrostMod precisa — instale-o para acabar com o erro \"dll was not found\".",
+  "settings.repairRuntimes": "Reparar componentes",
+  "settings.repairRuntimesHint":
+    "Instala todos os componentes do Visual C++ que faltam neste PC (32 e 64 bits) e coloca a msvcr90.dll onde o jogo a procura. Vale a pena mesmo que nada acima pareça errado.",
   "settings.frostmodNeedsRepair":
     "Os arquivos instalados não batem com esta versão — reinstalar resolve.",
   "settings.frostmodRepair": "Reparar instalação",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -906,11 +906,37 @@ export interface FrostmodStatus {
   missingRuntimes: VcRuntime[];
 }
 
-/** A Visual C++ runtime the FrostMod chain needs. Matches `vcruntime::Runtime`. */
-export type VcRuntime = "vc90" | "vc140";
+/**
+ * A Visual C++ runtime the FrostMod chain needs. Matches `vcruntime::Runtime`.
+ *
+ * `vc140_x86` never appears in {@link FrostmodStatus.missingRuntimes} — nothing we ship is
+ * 32-bit, so its absence proves nothing is wrong and it would only ever be a false alarm.
+ * It exists for the repair, which installs the pair Microsoft's own downloads page hands
+ * out, and for the manual download links.
+ */
+export type VcRuntime = "vc90" | "vc140" | "vc140_x86";
 
 /** What a runtime install did. `cancelled` is the user dismissing the UAC prompt. */
 export type RuntimeInstallOutcome = "installed" | "cancelled";
+
+/**
+ * What a repair run did. Mirrors `vcruntime::RepairReport`.
+ *
+ * Nothing here is an error: a repair does what it can and reports the rest, so
+ * `stillMissing` is a list to hand download links for rather than a failure.
+ */
+export interface RuntimeRepairReport {
+  /** Runtimes that went on during this run. */
+  installed: VcRuntime[];
+  /** Runtimes that were already there — "nothing to do" is a real answer worth saying. */
+  alreadyPresent: VcRuntime[];
+  /** Still absent afterwards: a declined UAC prompt, a failed download, a pending reboot. */
+  stillMissing: VcRuntime[];
+  /** Whether `msvcr90.dll` now sits beside the game executable. */
+  msvcr90Placed: boolean;
+  /** False when no game folder is configured, so there was nowhere to place it. */
+  gameDirKnown: boolean;
+}
 
 /** What an install landed, beyond succeeding. */
 export interface FrostmodInstallReport {


### PR DESCRIPTION
Follow-up to #158, which fixed the right thing but could not reach the machines that reported the bug.

## Why #158 wasn't enough

The reporting player's app log settled it:

- **No `missing Visual C++ runtimes` line at all.** Detection called the PC healthy, so the warning bar never appeared and nothing was ever offered.
- **Game folder was `C:\Program Files (x86)\Steam\steamapps\common\MX Bikes`.** The copy #158 added was a plain unelevated `fs::copy`, so it would have failed there anyway.

Their two errors were one bug, incidentally: `mxbikes.exe` couldn't resolve `msvcr90`, died in loader init, and Steam's `0x12B` (`ERROR_PARTIAL_COPY`) was Steam writing into a process already collapsing.

## What this adds

- **`frostmod_repair_runtimes`, surfaced as "Repair runtimes" in Settings.** Installs whatever the PC is short of, then places `msvcr90.dll` beside the game exe. **Ungated on detection** — that's the whole point. A PC can report every runtime present and still stop the game dead, because the redistributable registers a side-by-side assembly and never touches the plain DLL search path.
- **`place_msvcr90_elevated`** reuses the existing `ShellExecuteExW`/`runas` machinery. Kept off the status path so UAC only ever appears for a repair the player pressed.
- **Both architectures of the 2015–2022 runtime**, from Microsoft's *Latest Supported Visual C++ Downloads*: x64 does nothing for a 32-bit consumer, and `mxbikes-beta21d.exe` — the dedicated-server build — is genuinely a 32-bit binary.
- **Download links for everything**, so a declined UAC prompt or an unreachable `aka.ms` still has a route.

## Judgement calls worth reviewing

- **`vc140_x86` never raises a banner.** Nothing we ship is 32-bit, so its absence proves nothing is broken; an amber bar over it would be telling a working player their PC is wrong. It's offered by the repair only.
- **The x86 probe omits `vcruntime140_1.dll`.** I could not confirm the 32-bit package ships it — the redistributable is a Burn bundle with its payload compressed, so the honest answer from here is "unknown". Probing for a file that may never exist would mark every machine permanently short of a runtime it already has. The two it does check are certain.
- **A repair never bails part-way.** One runtime failing says nothing about the next; what it couldn't do comes back as links rather than an exception.

## Verification

- `cargo check` clean on host **and** `x86_64-pc-windows-gnu` — the `cfg(windows)` half a macOS build never compiles.
- **785 tests pass**, 0 failures; 4 new covering architecture coverage, per-runtime distinctness (staging name, URL, label), and the deliberate x86 probe shape.
- `tsc`, `eslint` and the production `vite build` all clean.
- Both installer URLs HEAD-checked live: 25,635,768 bytes (x64), 13,953,392 (x86).
- All six locales carry the new strings — they're type-enforced against `en`, so a gap wouldn't compile.

## Still not verified

Whether this fixes *that* player's PC. Their WinSxS holds a VC90 CRT yet the game still can't resolve `msvcr90`, which is consistent with the game having relied on a copy in its own folder that has since gone. The repair addresses that directly, but confirmation has to come from them running it. A `dir /b C:\Windows\WinSxS | findstr /i vc90` would also say whether the publisher policy is missing — the one mechanism I've left alone rather than guess at twice.

No DB or schema changes.
