### PR TITLE
feat(designer): show on the bike where a sheet region paints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased — the sheet says where it lands on the bike
+
+### Added
+- **Hovering the sheet lights that spot up on the 3D model.** A patch follows the pointer
+  across the bike, so "which panel is this region of the square" is answered by the picture
+  instead of by a word. The editor already named the flank in the corner, and a name is the
+  one thing this question can't be settled with: "left" means the bike's own left, the preview
+  opens looking at that flank from the front, and a livery's two shroud islands are mirror
+  images of each other on the sheet — so a region that paints the left panel can look, read
+  and feel like the right one until you watch it light up.
+- Deliberately a patch rather than the whole island under the pointer. UV islands routinely
+  bridge the mirror plane — a seat and a front fender are each one panel with both flanks in
+  them — so highlighting the island would answer "which side does this paint" by lighting most
+  of the bike. The patch is small enough to sit inside a shroud and moves as the pointer does,
+  which is what makes it read as *here*.
+
 ## Unreleased — a repair button that doesn't wait to be asked
 
 ### Added

--- a/src/Components/Studio/Designer/CanvasStage.tsx
+++ b/src/Components/Studio/Designer/CanvasStage.tsx
@@ -3,9 +3,22 @@ import { cn } from "@/lib/utils";
 import { useT } from "../../../i18n/context";
 import { layerCorners } from "./composite";
 import type { Ghost } from "./ghost";
-import { faceAt, partAt, partPath, partsAt, sideAt, type Face, type Side, type UvPart } from "./uv";
+import {
+  faceAt,
+  partAt,
+  partPath,
+  partsAt,
+  sideAt,
+  spotAt,
+  type Face,
+  type Side,
+  type UvPart,
+} from "./uv";
 import { hitTest, type Layer, type Sheet } from "./layers";
 import { constrained, hasTip, isDragTool, type PaintTool, type Point } from "./paint";
+
+/** How far the pointer must travel across the sheet, in uv, before the 3D spot is redrawn. */
+const SPOT_STEP = 0.004;
 
 /** Half-edge of a drawn corner handle, and how far off one a press still counts, in view px. */
 const HANDLE = 3.5;
@@ -60,6 +73,15 @@ interface CanvasStageProps {
   ghost: Ghost | null;
   /** The model's bodywork for this sheet, for naming what the pointer is over. */
   parts: UvPart[];
+  /**
+   * What the pointer is on, as triangle references into the model — null off the sheet.
+   *
+   * Reported so the 3D view can light the piece up. Which flank a region paints is the one
+   * thing a word has never settled on its own: "left" means the bike's left, the preview
+   * opens looking at that flank from the front, and the two readings of the sentence differ
+   * by exactly the mistake this is here to end.
+   */
+  onHoverSpot?: (tris: Int32Array | null) => void;
   selectedId: string | null;
   onSelect: (id: string | null) => void;
   /** Drag, in sheet pixels. */
@@ -97,6 +119,7 @@ export function CanvasStage({
   version,
   ghost,
   parts,
+  onHoverSpot,
   selectedId,
   onSelect,
   onMove,
@@ -134,6 +157,9 @@ export function CanvasStage({
   // recognised, so a run of fast clicks pairs up rather than firing on every press after the
   // second. See `onPointerDown` for why the DOM's own `dblclick` can't be used here.
   const lastPress = useRef<{ t: number; x: number; y: number } | null>(null);
+  // Where the 3D highlight was last asked for, so it is only asked again once the pointer
+  // has moved far enough for the answer to look different.
+  const spotFrom = useRef<{ u: number; v: number } | null>(null);
   // Which corner the pointer is over, purely so the cursor can say the layer is resizable.
   const [overHandle, setOverHandle] = useState(-1);
   // The piece of bodywork under the pointer. The whole reason the UV map is worth having is
@@ -584,6 +610,17 @@ export function CanvasStage({
           setOverAlso(hits.length > 1 ? hits[hits.length - 1].label : null);
           setOverSide(hits.length ? sideAt(parts, u, v) : null);
           setOverFace(hits.length ? faceAt(parts, u, v) : null);
+          // Every move the pointer has actually travelled on, rather than every event: the
+          // spot is meant to track the pointer, but each one re-renders the 3D view, and a
+          // trackpad emits them far faster than the picture can say anything new.
+          if (onHoverSpot) {
+            const last = spotFrom.current;
+            const far = !last || Math.hypot(u - last.u, v - last.v) > SPOT_STEP;
+            if (far) {
+              spotFrom.current = at ? { u, v } : null;
+              onHoverSpot(at ? spotAt(parts, u, v) : null);
+            }
+          }
         }
         return;
       }
@@ -599,6 +636,7 @@ export function CanvasStage({
     [
       handleAt,
       moveCursor,
+      onHoverSpot,
       onMove,
       onPaintMove,
       onScale,
@@ -668,6 +706,8 @@ export function CanvasStage({
           if (cursorRef.current) cursorRef.current.style.opacity = "0";
           setOverHandle(-1);
           setOverPart(null);
+          spotFrom.current = null;
+          onHoverSpot?.(null);
         }}
         onPointerEnter={() => {
           if (cursorRef.current) cursorRef.current.style.opacity = "1";

--- a/src/Components/Studio/Designer/Designer.tsx
+++ b/src/Components/Studio/Designer/Designer.tsx
@@ -803,6 +803,10 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   // And only when it *did* arrive that way — a bike that loaded without its `.geom` is a heap
   // of parts in their own frames, and a side named from that is worse than no side at all.
   const bike = isBikeKind(destState.kind);
+  // The island the pointer is over, for the 3D view to light up. Held here rather than in the
+  // stage because it crosses from the 2D half of the editor to the 3D one, and this is the
+  // only thing that owns both.
+  const [hoverIsland, setHoverIsland] = useState<Int32Array | null>(null);
   const parts = useMemo<UvPart[]>(
     () => (geometry ? uvParts(geometry, activeName, { assembled: bike && assembled }) : []),
     [geometry, activeName, bike, assembled],
@@ -1318,6 +1322,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
               version={version}
               ghost={ghostOf(active.id)}
               parts={parts}
+              onHoverSpot={setHoverIsland}
               selectedId={selectedId}
               onSelect={setSelectedId}
               onMove={moveLayer}
@@ -1354,6 +1359,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
           frameToken={version}
           onGeometry={onGeometry}
           onStock={onStock}
+          highlight={hoverIsland}
           className="flex-1"
         />
       </section>

--- a/src/Components/Studio/Designer/PreviewPanel.tsx
+++ b/src/Components/Studio/Designer/PreviewPanel.tsx
@@ -44,6 +44,7 @@ export function PreviewPanel({
   frameToken,
   onGeometry,
   onStock,
+  highlight,
   className,
 }: {
   state: PaintDestState;
@@ -65,6 +66,8 @@ export function PreviewPanel({
    * handing over geometry without it invites reading the numbers as more than they say.
    */
   onGeometry?: (nodes: EdfNode[] | null, assembled: boolean) => void;
+  /** Triangles to light up — what the pointer is over in the 2D editor. */
+  highlight?: Int32Array | null;
   /**
    * The model's own textures, handed back with the mesh so the editor can show what the
    * bike already looks like under a sheet being drawn from blank.
@@ -301,6 +304,7 @@ export function PreviewPanel({
             <ModelViewer
               mode={isBike ? "bike" : "rider"}
               nodes={nodes}
+              highlight={highlight}
               textures={textures}
               riderParts={shownParts}
               overrides={overrides}

--- a/src/Components/Studio/Designer/uv.ts
+++ b/src/Components/Studio/Designer/uv.ts
@@ -69,6 +69,15 @@ export interface UvPart {
   /** Triangle corners in uv space, six numbers per triangle: u0,v0,u1,v1,u2,v2. */
   tris: Float32Array;
   /**
+   * Where each triangle came from — two numbers each: the node's index in the array the
+   * part was read from, and the triangle's index within that node.
+   *
+   * Carried so a region of the sheet can be pointed at on the *model*. Everything else here
+   * describes the flat square, and the one question a flat square keeps failing to answer —
+   * "which panel is this, really" — is answered by lighting the panel up on the bike.
+   */
+  src: Int32Array;
+  /**
    * One flank code per triangle, or null when the mesh's axes can't be trusted.
    *
    * Kept per triangle rather than per part because the question is asked about a *point*: the
@@ -218,10 +227,12 @@ export function uvParts(
   const tol = sided ? lateralTolerance(nodes) : 0;
 
   const byLabel = new Map<string, number[]>();
+  const srcByLabel = new Map<string, number[]>();
   const flanksByLabel = new Map<string, number[]>();
   const facesByLabel = new Map<string, number[]>();
   const nodesByLabel = new Map<string, Set<string>>();
-  for (const node of nodes) {
+  for (let nodeIndex = 0; nodeIndex < nodes.length; nodeIndex += 1) {
+    const node = nodes[nodeIndex];
     if (!node.uvs.length || !node.indices.length) continue;
     const triCount = Math.floor(node.indices.length / 3);
     const groups = node.submeshes.length
@@ -237,6 +248,11 @@ export function uvParts(
       if (!flat) {
         flat = [];
         byLabel.set(label, flat);
+      }
+      let src = srcByLabel.get(label);
+      if (!src) {
+        src = [];
+        srcByLabel.set(label, src);
       }
       let owners = nodesByLabel.get(label);
       if (!owners) {
@@ -260,6 +276,7 @@ export function uvParts(
       const hasNormals = node.normals.length >= node.positions.length;
       const end = Math.min(start + count, triCount);
       for (let t = Math.max(0, start); t < end; t += 1) {
+        src.push(nodeIndex, t);
         let x = 0;
         let ny = 0;
         for (let c = 0; c < 3; c += 1) {
@@ -301,6 +318,7 @@ export function uvParts(
       // point at, and naming the first would be picking one arbitrarily.
       owner: owners?.size === 1 ? [...owners][0] : null,
       tris: new Float32Array(flat),
+      src: new Int32Array(srcByLabel.get(label) ?? []),
       flanks: sides ? new Uint8Array(sides) : null,
       side: sides ? summarise(sides) : null,
       faces: faces ? new Uint8Array(faces) : null,
@@ -316,6 +334,51 @@ export function uvParts(
   // is the one that takes up half the sheet, not the bracket bolted behind it.
   parts.sort((a, b) => (b.maxU - b.minU) * (b.maxV - b.minV) - (a.maxU - a.minU) * (a.maxV - a.minV));
   return parts;
+}
+
+/**
+ * How much of the sheet a hover lights up on the model, as a fraction of it.
+ *
+ * Small enough to sit inside a shroud rather than swallow it, big enough to find on the bike
+ * without hunting: about 40px of a 2048² sheet.
+ */
+const SPOT_RADIUS = 0.02;
+
+/**
+ * The triangles a hover lands on, as references into the nodes the parts were read from —
+ * two numbers each, node index then triangle index.
+ *
+ * A patch around the point rather than the island it sits in. An island is the tempting
+ * answer and the wrong one: uv islands routinely bridge the mirror plane — a seat and a front
+ * fender are each one panel with both flanks in them — so lighting the island up would answer
+ * "which side does this paint" with most of the bike. The patch is the honest version of the
+ * question, and it moves as the pointer moves, which is what makes it readable as *here*.
+ */
+export function spotAt(parts: UvPart[], u: number, v: number): Int32Array | null {
+  const out: number[] = [];
+  const r2 = SPOT_RADIUS * SPOT_RADIUS;
+  for (const part of parts) {
+    if (
+      u < part.minU - SPOT_RADIUS ||
+      u > part.maxU + SPOT_RADIUS ||
+      v < part.minV - SPOT_RADIUS ||
+      v > part.maxV + SPOT_RADIUS
+    )
+      continue;
+    const { tris, src } = part;
+    for (let i = 0; i < tris.length; i += 6) {
+      // Any corner inside the disc, or the point inside the triangle — the second case is what
+      // keeps a triangle bigger than the spot from dropping out of its own highlight.
+      let hit = inTriangle(u, v, tris[i], tris[i + 1], tris[i + 2], tris[i + 3], tris[i + 4], tris[i + 5]);
+      for (let c = 0; !hit && c < 3; c += 1) {
+        const du = tris[i + c * 2] - u;
+        const dv = tris[i + c * 2 + 1] - v;
+        hit = du * du + dv * dv <= r2;
+      }
+      if (hit) out.push(src[(i / 6) * 2], src[(i / 6) * 2 + 1]);
+    }
+  }
+  return out.length ? new Int32Array(out) : null;
 }
 
 /**

--- a/src/Components/Viewer/ModelViewer.tsx
+++ b/src/Components/Viewer/ModelViewer.tsx
@@ -887,13 +887,70 @@ function useEdfMeshes(
   return { geoms, materials };
 }
 
+/**
+ * The piece of bodywork the pointer is over in the 2D editor, lit up on the bike.
+ *
+ * Triangles rather than a whole mesh group: a bike's bodywork is regularly one group with
+ * both flanks in it, and highlighting the group would answer "which side is this" with the
+ * whole bike. `tris` names the triangles of one uv island — node index, then triangle index.
+ *
+ * Drawn as its own geometry over the model with the depth test still on, so it is occluded by
+ * the parts in front of it: a panel glowing *through* the bike would read as being on the near
+ * side whichever flank it is actually on, which is the confusion this exists to settle.
+ */
+function HighlightMesh({ nodes, tris }: { nodes: EdfNode[]; tris: Int32Array }) {
+  const geom = useMemo(() => {
+    const pos = new Float32Array((tris.length / 2) * 9);
+    let o = 0;
+    for (let i = 0; i < tris.length; i += 2) {
+      const node = nodes[tris[i]];
+      if (!node) continue;
+      const t = tris[i + 1];
+      for (let c = 0; c < 3; c += 1) {
+        const v = node.indices[t * 3 + c];
+        pos[o] = node.positions[v * 3];
+        pos[o + 1] = node.positions[v * 3 + 1];
+        pos[o + 2] = node.positions[v * 3 + 2];
+        o += 3;
+      }
+    }
+    const g = new THREE.BufferGeometry();
+    g.setAttribute("position", new THREE.Float32BufferAttribute(pos.subarray(0, o), 3));
+    g.computeBoundingSphere();
+    return g;
+  }, [nodes, tris]);
+  useEffect(() => () => geom.dispose(), [geom]);
+
+  const mat = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        color: "#22d3ee",
+        transparent: true,
+        opacity: 0.55,
+        side: THREE.DoubleSide,
+        depthWrite: false,
+        // Pulled towards the camera so it wins against the surface it is sitting on, which
+        // is the same surface — without it the two z-fight and the highlight speckles.
+        polygonOffset: true,
+        polygonOffsetFactor: -4,
+        polygonOffsetUnits: -4,
+      }),
+    [],
+  );
+  useEffect(() => () => mat.dispose(), [mat]);
+
+  return <mesh geometry={geom} material={mat} renderOrder={2} />;
+}
+
 // MX Bikes meshes are authored Y-up, +Z forward (three.js' convention) — no rotation.
 function EdfMesh({
   nodes,
   textures,
+  highlight,
 }: {
   nodes: EdfNode[];
   textures: Map<string, THREE.Texture>;
+  highlight?: Int32Array | null;
 }) {
   const { geoms, materials } = useEdfMeshes(nodes, textures);
   return (
@@ -907,6 +964,7 @@ function EdfMesh({
           receiveShadow
         />
       ))}
+      {!!highlight?.length && <HighlightMesh nodes={nodes} tris={highlight} />}
     </group>
   );
 }
@@ -992,6 +1050,14 @@ export interface ModelViewerProps {
    */
   frameToken?: number;
   nodes?: EdfNode[] | null;
+  /**
+   * Triangles to light up on the model — node index and triangle index, two per triangle.
+   *
+   * The Designer's answer to "which panel is this region of the sheet": it hands over what
+   * the pointer is on and the model shows where that lands, instead of naming a flank and
+   * leaving the reader to work out whose left it meant.
+   */
+  highlight?: Int32Array | null;
   riderParts?: RiderPart[] | null;
   loading?: boolean;
   noStandIn?: boolean;
@@ -1005,6 +1071,7 @@ export function ModelViewer({
   overrides,
   frameToken,
   nodes,
+  highlight,
   riderParts,
   loading = false,
   noStandIn = false,
@@ -1063,7 +1130,7 @@ export function ModelViewer({
           <directionalLight position={[0, 1.5, 5]} intensity={0.5} />
           <Center>
             {hasReal ? (
-              <EdfMesh nodes={nodes!} textures={texMap} />
+              <EdfMesh nodes={nodes!} textures={texMap} highlight={highlight} />
             ) : hasRider ? (
               <RiderComposite parts={riderParts!} overrides={overrides} />
             ) : loading || noStandIn ? null : mode === "bike" ? (


### PR DESCRIPTION
Hovering the sheet now lights that spot up on the 3D model — a patch that follows the pointer across the bike.

### Why

The Designer already named the flank under the pointer, and the name kept reading as wrong. Three things stack up to make it look that way, none of which a word can fix:

- "left" means the **bike's** left, while the preview opens looking at that flank from the front — so the left flank fills the right of the frame, the way a person facing you has their left hand on your right.
- a livery's two shroud islands are **mirror images of each other** on the sheet, so the one whose artwork reads backwards looks like "the other side shown wrong" when it is simply the left panel, whose unwrap is mirrored.
- some mods pair the artwork with the wrong flank outright, which puts backwards decals on the bike and makes the editor look like the liar.

So the fix isn't a better word. It's showing the answer.

### What

- `UvPart` carries a back-reference per triangle — node index and triangle index — so a region of the flat sheet can be pointed at on the mesh it came from.
- `spotAt` gathers what the pointer is on; `ModelViewer` draws it as its own geometry over the model, depth-tested so it is occluded by the parts in front of it (a panel glowing *through* the bike would read as being on the near side whichever flank it is on).
- A patch rather than the island under the pointer: UV islands routinely bridge the mirror plane — a seat and a front fender are each one panel with both flanks in them — so highlighting the island would answer "which side does this paint" by lighting most of the bike.
- Recomputed only once the pointer has actually travelled, since each update re-renders the 3D view.

### Testing

Typecheck and lint clean. Driven in `tauri dev` against `MX1OEM_2023_TM_MX_144` and the KTM 450 SX-F: the patch tracks the cursor and lands on the panel the flank badge names.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)