### PR TITLE
feat(control-plane): announce Buy Me a Coffee supporters in Discord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Unreleased — a coffee shows up in Discord
+
+### Added
+- **Buy Me a Coffee donations are announced in the Discord channel.** BMAC posts to a new
+  `POST /v1/bmac/webhook` on the control plane, which turns the event into an embed. Nothing
+  told you a coffee had been bought until you went and looked at the dashboard, which is also
+  why somebody could sit unthanked in `supporters.json` for a week — the post is the prompt to
+  add them.
+- Announced for money-in events only — a coffee, a membership started, a recurring donation, an
+  extra, a commission, a wishlist payment. Refunds, cancellations and pauses are accepted and
+  dropped: a public channel is the wrong place to narrate a withdrawal, and answering with an
+  error would only make BMAC retry an event we mean to ignore.
+- **The embed carries a name and their note, and nothing else** — no amount, no coffee count,
+  and the supporter's email is never read out of the payload. Notes are escaped, clipped and
+  posted with mentions disabled, so somebody else's words can't restyle the embed or ping the
+  server.
+- The route holds no bearer token, because BMAC has no account here; its credential is an
+  HMAC-SHA256 signature over the raw body, checked before the body is parsed. A `bmac_events`
+  table records what has already gone out — BMAC retries a delivery up to four more times, and
+  a reply it never received is indistinguishable from a failure, so without it one coffee
+  arrives five times.
+
 ## Unreleased — the sheet says where it lands on the bike
 
 ### Added

--- a/control-plane/README.md
+++ b/control-plane/README.md
@@ -39,6 +39,7 @@ consequences fall out of that, and they're baked into the schema:
 | GET | `/v1/fleet` | bearer | What is running. The count is everyone's (it is what the cap measures); the instance list is only yours. |
 | POST | `/v1/provision` | bearer | Launch a server. Capped, and reaped when idle. |
 | PUT/GET | `/v1/paints/:sha256` | bearer | Content-addressed paint blobs |
+| POST | `/v1/bmac/webhook` | HMAC signature | Buy Me a Coffee announcing a supporter. Posted on to Discord. |
 
 Enrollment by invite code stands in for Steam sign-in until there's an API key. `accounts`
 already carries a nullable `steam_id`, so adding Steam is a backfill rather than a rewrite
@@ -61,6 +62,36 @@ box says so itself: the bootstrap reads its own address from IMDSv2, waits for t
 `agent_url` and flips `published`, which is what puts the server in everyone's join picker.
 Its owner then gets the agent token from `/v1/servers/mine`, which is what makes Start, Stop
 and Set track work on a machine nobody has a console for.
+
+### Donations in Discord
+
+`supporters.json` credits the people who bought a coffee, but nothing said when somebody had.
+Buy Me a Coffee posts an event to `/v1/bmac/webhook`, which turns it into an embed in the
+announcements channel — which is also the prompt to add them to `supporters.json`.
+
+The route takes no bearer token, because BMAC has no account here. Its credential is the
+`x-signature-sha256` header: HMAC-SHA256 over the **raw** body, so nothing may parse the body
+before it is verified. Two secrets, neither in the repository:
+
+```sh
+npx wrangler secret put BMAC_WEBHOOK_SECRET          # shown by BMAC when the webhook is made
+npx wrangler secret put DISCORD_DONATION_WEBHOOK_URL # the channel webhook — a credential itself
+```
+
+Without them the route answers 503, the same way provisioning does without its AWS key.
+
+Only money-in events are announced (`donation.created`, `membership.started`,
+`recurring_donation.started`, `extra_purchase.created`, `commission_order.created`,
+`wishlist_payment.created`). Refunds, cancellations, pauses and anything unrecognised get a
+200 and no post — a public channel is the wrong place to narrate a withdrawal, and a non-2xx
+would only make BMAC retry an event we mean to drop.
+
+The embed carries the supporter's name and their note, and nothing else. No amount, no coffee
+count, and `supporter_email` is never read out of the payload at all. The note is escaped,
+clipped to 400 characters and posted with `allowed_mentions: {parse: []}`, so somebody else's
+words can't restyle the embed or ping the server. `bmac_events` records what has been
+announced: BMAC retries a delivery up to four more times, and a reply it never received looks
+exactly like a failure, so without that table one coffee arrives five times.
 
 ## Security notes
 

--- a/control-plane/migrations/0011_bmac_events.sql
+++ b/control-plane/migrations/0011_bmac_events.sql
@@ -1,0 +1,16 @@
+-- Buy Me a Coffee events already announced in Discord.
+--
+-- BMAC retries a delivery up to four more times, and a response we sent but it never received
+-- is indistinguishable from one that failed. Without a record of what has been announced, a
+-- single coffee can arrive in the channel five times.
+--
+-- The id is BMAC's own `event_id`, stored as text: it comes over as a number today, but the
+-- only thing this column is ever used for is equality against the last one, and text can hold
+-- whatever they send without a migration.
+CREATE TABLE bmac_events (
+  event_id TEXT PRIMARY KEY,
+  -- Which event it was. Not read by the code — it is here so a row means something to a human
+  -- looking at why a donation did or didn't get announced.
+  type     TEXT NOT NULL,
+  seen_at  INTEGER NOT NULL
+);

--- a/control-plane/src/bmac.ts
+++ b/control-plane/src/bmac.ts
@@ -1,0 +1,210 @@
+/**
+ * Buy Me a Coffee → Discord.
+ *
+ * BMAC posts an event here when somebody supports the project; we turn it into an embed in
+ * the announcements channel. The route is unauthenticated because BMAC holds no account —
+ * the HMAC signature over the raw body is the whole of its credential.
+ */
+
+import { tokenMatches } from "./auth";
+
+/** Bigger than any real event, small enough that a junk body can't be used to burn CPU. */
+const MAX_BODY_BYTES = 64 * 1024;
+
+/** How much of a supporter's note is forwarded. The rest is on the BMAC dashboard. */
+const MAX_NOTE_CHARS = 400;
+
+/** BMAC's yellow, so the embed reads as coming from them. */
+const EMBED_COLOUR = 0xffdd00;
+
+/**
+ * The events worth announcing, and what each one says.
+ *
+ * Money-in only. Refunds, cancellations and pauses are accepted and dropped — a public
+ * channel is the wrong place to narrate somebody's withdrawal — and anything not listed
+ * here is dropped too, so a new BMAC event type can never surprise the channel.
+ */
+const ANNOUNCED: Record<string, string> = {
+  "donation.created": "bought you a coffee",
+  "membership.started": "started a membership",
+  "recurring_donation.started": "started a recurring donation",
+  "extra_purchase.created": "bought an extra",
+  "commission_order.created": "ordered a commission",
+  "wishlist_payment.created": "granted a wishlist item",
+};
+
+// BMAC's per-event payloads aren't fully published, and the fields differ between a coffee
+// and a membership. Every read is a list of candidates with a fallback: a missing field must
+// degrade to a vaguer sentence, never to a 500 — that would only earn four retries of the
+// same failure.
+const NAME_KEYS = ["supporter_name", "payer_name", "buyer_name", "name"];
+const NOTE_KEYS = ["support_note", "supporter_message", "message", "note"];
+const TIER_KEYS = ["membership_level_name", "tier_name", "level_name", "plan_name"];
+
+interface BmacEvent {
+  event_id?: unknown;
+  type?: unknown;
+  live_mode?: unknown;
+  created?: unknown;
+  data?: unknown;
+}
+
+export async function bmacWebhook(request: Request, env: Env): Promise<Response> {
+  const secret = env.BMAC_WEBHOOK_SECRET;
+  const channel = env.DISCORD_DONATION_WEBHOOK_URL;
+  // 503 rather than 404, matching how provisioning answers without its AWS key: the route
+  // exists, this deployment just isn't wired for it.
+  if (!secret || !channel) {
+    return json(503, { error: "donation announcements aren't configured on this deployment" });
+  }
+
+  // The signature covers the raw bytes, so nothing may parse the body before it is checked.
+  const raw = await request.text();
+  if (raw.length > MAX_BODY_BYTES) return json(413, { error: "that body is too large" });
+  if (!(await signatureMatches(raw, secret, request.headers.get("x-signature-sha256")))) {
+    return json(401, { error: "bad signature" });
+  }
+
+  let event: BmacEvent;
+  try {
+    event = JSON.parse(raw) as BmacEvent;
+  } catch {
+    return json(400, { error: "expected a JSON body" });
+  }
+
+  const payload = announcement(event);
+  if (!payload) return json(200, { ok: true, announced: false });
+
+  // BMAC retries a delivery up to four more times, and a response we sent but it never
+  // received looks exactly like a failure from its side. Claiming the id first is what keeps
+  // one coffee from being announced five times.
+  const id = eventKey(event);
+  if (id && !(await claim(env, id, String(event.type)))) {
+    return json(200, { ok: true, announced: false, duplicate: true });
+  }
+
+  const posted = await fetch(channel, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!posted.ok) {
+    // Hand the id back so the retry can have another go, rather than swallowing the
+    // announcement because of a blip at Discord's end.
+    if (id) await release(env, id);
+    console.error(JSON.stringify({ msg: "bmac announce failed", status: posted.status }));
+    return json(502, { error: "the announcement was not accepted" });
+  }
+  return json(200, { ok: true, announced: true });
+}
+
+/** HMAC-SHA256 of the raw body, hex, against `x-signature-sha256`. */
+export async function signatureMatches(
+  raw: string,
+  secret: string,
+  header: string | null,
+): Promise<boolean> {
+  if (!header) return false;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const mac = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(raw));
+  const expected = [...new Uint8Array(mac)].map((b) => b.toString(16).padStart(2, "0")).join("");
+  // Some senders prefix the algorithm; the digest is the part that matters.
+  const presented = header.trim().toLowerCase().replace(/^sha256=/, "");
+  return tokenMatches(expected, presented);
+}
+
+/**
+ * The Discord payload for an event, or null if it isn't one we announce.
+ *
+ * Name and note only. No amount, no coffee count, and `supporter_email` is never so much as
+ * read — this goes to a public channel, and what somebody paid is between them and BMAC.
+ */
+export function announcement(event: BmacEvent): unknown | null {
+  const type = typeof event.type === "string" ? event.type : "";
+  const verb = ANNOUNCED[type];
+  if (!verb) return null;
+
+  const data = (event.data && typeof event.data === "object" ? event.data : {}) as Record<
+    string,
+    unknown
+  >;
+  const name = escapeMarkdown(pick(data, NAME_KEYS) ?? "Someone");
+  const tier = type.startsWith("membership.") ? pick(data, TIER_KEYS) : undefined;
+  const note = pick(data, NOTE_KEYS);
+
+  const lines = [`**${name}** ${verb}${tier ? ` — *${escapeMarkdown(tier)}*` : ""}.`];
+  // A test delivery from the BMAC dashboard must never be mistaken for a real supporter.
+  if (event.live_mode === false) lines.unshift("*(test event)*");
+
+  const created = typeof event.created === "number" ? event.created : null;
+  return {
+    // Belt to the escaping's braces: a note is somebody else's text, and it is not going to
+    // ping the server.
+    allowed_mentions: { parse: [] },
+    embeds: [
+      {
+        title: "☕ New supporter",
+        description: lines.join("\n"),
+        color: EMBED_COLOUR,
+        fields: note ? [{ name: "Their message", value: escapeMarkdown(clip(note)) }] : undefined,
+        timestamp: created ? new Date(created * 1000).toISOString() : undefined,
+      },
+    ],
+  };
+}
+
+/** First non-empty string among `keys`. */
+function pick(data: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = data[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+function clip(text: string): string {
+  return text.length > MAX_NOTE_CHARS ? `${text.slice(0, MAX_NOTE_CHARS - 1)}…` : text;
+}
+
+/** Someone else's words shouldn't be able to restyle the embed. */
+function escapeMarkdown(text: string): string {
+  return text.replace(/([\\*_~`|>#-])/g, "\\$1");
+}
+
+/** The event's own id, as a string. Absent or unusable means no dedupe rather than no post. */
+function eventKey(event: BmacEvent): string | null {
+  const id = event.event_id;
+  if (typeof id === "number" && Number.isFinite(id)) return String(id);
+  if (typeof id === "string" && id.trim()) return id.trim().slice(0, 64);
+  return null;
+}
+
+/** True if this id is ours to announce; false if it has already been seen. */
+async function claim(env: Env, id: string, type: string): Promise<boolean> {
+  const row = await env.DB.prepare(
+    "INSERT INTO bmac_events (event_id, type, seen_at) VALUES (?, ?, ?)" +
+      " ON CONFLICT(event_id) DO NOTHING RETURNING event_id",
+  )
+    .bind(id, type, Date.now())
+    .first<{ event_id: string }>();
+  return row !== null;
+}
+
+async function release(env: Env, id: string): Promise<void> {
+  await env.DB.prepare("DELETE FROM bmac_events WHERE event_id = ?").bind(id).run();
+}
+
+// index.ts has its own copy; duplicating four lines beats importing the entry point back
+// into a module it imports.
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/control-plane/src/env.d.ts
+++ b/control-plane/src/env.d.ts
@@ -15,6 +15,11 @@ declare global {
     /** IAM key scoped to launching and managing `mxb:managed` instances in one region. */
     AWS_ACCESS_KEY_ID?: string;
     AWS_SECRET_ACCESS_KEY?: string;
+    /** Buy Me a Coffee's webhook signing secret. Without it `/v1/bmac/webhook` answers 503. */
+    BMAC_WEBHOOK_SECRET?: string;
+    /** Discord webhook the supporter announcements are posted to. A credential in itself:
+     *  anyone holding the URL can post to that channel. */
+    DISCORD_DONATION_WEBHOOK_URL?: string;
   }
 }
 

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -18,6 +18,7 @@ import {
   runInstance,
   terminateInstance,
 } from "./aws";
+import { bmacWebhook } from "./bmac";
 import { bootstrapScript, imageBootstrapScript } from "./bootstrap";
 import { bearer, hashToken, newToken, tokenMatches } from "./auth";
 import {
@@ -127,6 +128,11 @@ async function route(request: Request, env: Env): Promise<Response> {
 
   const boot = /^\/v1\/servers\/([A-Za-z0-9._-]{1,64})\/bootstrap$/.exec(path);
   if (boot && method === "POST") return serverBootstrap(request, boot[1], env);
+
+  // Buy Me a Coffee announcing a supporter, for the Discord channel. Unauthenticated in the
+  // same sense as the two above: the caller is not a player and holds no bearer token. Its
+  // credential is the HMAC signature over the body, checked before the body is parsed.
+  if (method === "POST" && path === "/v1/bmac/webhook") return bmacWebhook(request, env);
 
   const account = await authenticate(request, env);
   if (!account) return json(401, { error: "unauthorized" });

--- a/control-plane/test/bmac.test.ts
+++ b/control-plane/test/bmac.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { announcement, bmacWebhook, signatureMatches } from "../src/bmac";
+
+const SECRET = "whsec_test";
+const CHANNEL = "https://discord.test/webhook";
+
+/** The signature BMAC would send for this body. */
+async function sign(raw: string, secret = SECRET): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const mac = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(raw));
+  return [...new Uint8Array(mac)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** A D1 stand-in that remembers which event ids have been claimed. */
+function stubDb(seen = new Set<string>()) {
+  return {
+    seen,
+    prepare(sql: string) {
+      return {
+        bind(...args: unknown[]) {
+          const id = String(args[0]);
+          return {
+            async first() {
+              if (!sql.startsWith("INSERT")) return null;
+              if (seen.has(id)) return null; // ON CONFLICT DO NOTHING returns no row
+              seen.add(id);
+              return { event_id: id };
+            },
+            async run() {
+              if (sql.startsWith("DELETE")) seen.delete(id);
+              return { success: true };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+function stubEnv(overrides: Record<string, unknown> = {}): Env {
+  return {
+    BMAC_WEBHOOK_SECRET: SECRET,
+    DISCORD_DONATION_WEBHOOK_URL: CHANNEL,
+    DB: stubDb(),
+    ...overrides,
+  } as unknown as Env;
+}
+
+async function deliver(body: unknown, env: Env, signature?: string): Promise<Response> {
+  const raw = JSON.stringify(body);
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  const sig = signature ?? (await sign(raw));
+  if (sig) headers["x-signature-sha256"] = sig;
+  return bmacWebhook(new Request("https://cp.test/v1/bmac/webhook", { method: "POST", body: raw, headers }), env);
+}
+
+const COFFEE = {
+  event_id: 4242,
+  type: "donation.created",
+  live_mode: true,
+  created: 1_770_000_000,
+  data: {
+    supporter_name: "Mouk",
+    support_note: "love the app",
+    supporter_email: "mouk@example.com",
+    amount: 15,
+    currency: "USD",
+    coffee_count: 3,
+  },
+};
+
+let posts: { url: string; body: any }[] = [];
+let discordStatus = 204;
+
+beforeEach(() => {
+  posts = [];
+  discordStatus = 204;
+  vi.stubGlobal("fetch", async (url: unknown, init: RequestInit) => {
+    posts.push({ url: String(url), body: JSON.parse(String(init.body)) });
+    return new Response(null, { status: discordStatus });
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("signature", () => {
+  it("accepts the signature BMAC would send", async () => {
+    const raw = JSON.stringify(COFFEE);
+    expect(await signatureMatches(raw, SECRET, await sign(raw))).toBe(true);
+    // Sent uppercase, or with the algorithm prefixed, is still the same digest.
+    expect(await signatureMatches(raw, SECRET, (await sign(raw)).toUpperCase())).toBe(true);
+    expect(await signatureMatches(raw, SECRET, `sha256=${await sign(raw)}`)).toBe(true);
+  });
+
+  it("rejects a body that was changed after signing", async () => {
+    const signature = await sign(JSON.stringify(COFFEE));
+    const res = await deliver({ ...COFFEE, data: { supporter_name: "Impostor" } }, stubEnv(), signature);
+    expect(res.status).toBe(401);
+    expect(posts).toHaveLength(0);
+  });
+
+  it("rejects a body signed with the wrong secret, and one with no signature at all", async () => {
+    const raw = JSON.stringify(COFFEE);
+    expect(await signatureMatches(raw, SECRET, await sign(raw, "not-the-secret"))).toBe(false);
+    expect(await signatureMatches(raw, SECRET, null)).toBe(false);
+    expect((await deliver(COFFEE, stubEnv(), "")).status).toBe(401);
+  });
+
+  it("answers 503 where the deployment holds no secret, and never posts", async () => {
+    const res = await deliver(COFFEE, stubEnv({ BMAC_WEBHOOK_SECRET: undefined }));
+    expect(res.status).toBe(503);
+    expect((await deliver(COFFEE, stubEnv({ DISCORD_DONATION_WEBHOOK_URL: undefined }))).status).toBe(503);
+    expect(posts).toHaveLength(0);
+  });
+});
+
+describe("what reaches the channel", () => {
+  it("announces a coffee by name, with the note", async () => {
+    const res = await deliver(COFFEE, stubEnv());
+    expect(res.status).toBe(200);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].url).toBe(CHANNEL);
+    const embed = posts[0].body.embeds[0];
+    expect(embed.description).toContain("Mouk");
+    expect(embed.description).toContain("bought you a coffee");
+    expect(embed.fields[0].value).toContain("love the app");
+  });
+
+  it("never carries the supporter's email or what they paid", async () => {
+    await deliver(COFFEE, stubEnv());
+    const sent = JSON.stringify(posts[0].body);
+    expect(sent).not.toContain("mouk@example.com");
+    expect(sent).not.toContain("example.com");
+    expect(sent).not.toMatch(/\$|USD|\b15\b/);
+    // The coffee count is money in disguise — three coffees is a price.
+    expect(sent).not.toContain("coffee_count");
+    expect(sent).not.toMatch(/\b3 coffees\b/);
+  });
+
+  it("names the tier on a membership, since that is what decides their group", async () => {
+    const payload: any = announcement({
+      event_id: 1,
+      type: "membership.started",
+      live_mode: true,
+      data: { supporter_name: "Kelso", membership_level_name: "Pit Crew" },
+    });
+    expect(payload.embeds[0].description).toContain("Kelso");
+    expect(payload.embeds[0].description).toContain("Pit Crew");
+  });
+
+  it("marks a test delivery as one", async () => {
+    const payload: any = announcement({ ...COFFEE, live_mode: false });
+    expect(payload.embeds[0].description).toContain("test event");
+  });
+
+  it("still announces an event whose fields it doesn't recognise", async () => {
+    const payload: any = announcement({ event_id: 9, type: "donation.created", data: {} });
+    expect(payload.embeds[0].description).toContain("Someone");
+    expect(payload.embeds[0].fields).toBeUndefined();
+  });
+
+  it("won't let a note ping the server or restyle the embed", async () => {
+    const payload: any = announcement({
+      event_id: 2,
+      type: "donation.created",
+      data: { supporter_name: "@everyone", support_note: "@everyone **hi** `x`" },
+    });
+    // `@everyone` survives as text — it is what they wrote — but allowed_mentions means it
+    // pings nobody, and every markdown character comes through escaped.
+    expect(payload.allowed_mentions).toEqual({ parse: [] });
+    expect(payload.embeds[0].fields[0].value).toBe("@everyone \\*\\*hi\\*\\* \\`x\\`");
+  });
+
+  it("clips a very long note", async () => {
+    const payload: any = announcement({
+      event_id: 3,
+      type: "donation.created",
+      data: { supporter_name: "Long", support_note: "a".repeat(2000) },
+    });
+    expect(payload.embeds[0].fields[0].value.length).toBeLessThanOrEqual(400);
+  });
+});
+
+describe("what doesn't", () => {
+  it("accepts a refund, a cancellation and an unknown type without posting", async () => {
+    const env = stubEnv();
+    for (const type of [
+      "donation.refunded",
+      "membership.cancelled",
+      "membership.paused",
+      "recurring_donation.updated",
+      "something.new",
+    ]) {
+      const res = await deliver({ ...COFFEE, event_id: `${type}-1`, type }, env);
+      // 200, not an error: a non-2xx would only make BMAC retry an event we mean to drop.
+      expect(res.status).toBe(200);
+      expect(announcement({ type })).toBeNull();
+    }
+    expect(posts).toHaveLength(0);
+  });
+
+  it("announces a redelivered event exactly once", async () => {
+    const env = stubEnv();
+    expect((await deliver(COFFEE, env)).status).toBe(200);
+    expect((await deliver(COFFEE, env)).status).toBe(200);
+    expect((await deliver(COFFEE, env)).status).toBe(200);
+    expect(posts).toHaveLength(1);
+  });
+
+  it("lets the retry through when Discord refused the post", async () => {
+    const env = stubEnv();
+    discordStatus = 500;
+    expect((await deliver(COFFEE, env)).status).toBe(502);
+    discordStatus = 204;
+    expect((await deliver(COFFEE, env)).status).toBe(200);
+    expect(posts).toHaveLength(2); // the failed attempt, then the one that landed
+  });
+});


### PR DESCRIPTION
## Why

`supporters.json` credits the people who bought a coffee, but nothing told us when somebody
had — you found out by going and looking at the BMAC dashboard, which is also how a supporter
could sit unthanked for a week. Buy Me a Coffee has no native Discord announcement (its Discord
integration assigns membership *roles*, and doesn't cover one-off coffees at all), and the
no-code alternatives — Zapier, IFTTT, Pipedream — mean handing every supporter's name, note,
email and amount to a third party to relay. This does the same job in the Worker we already run.

## What

`POST /v1/bmac/webhook` on the control plane. BMAC posts a support event, we post an embed.

- **Money-in events only**: `donation.created`, `membership.started`, `recurring_donation.started`,
  `extra_purchase.created`, `commission_order.created`, `wishlist_payment.created`. Refunds,
  cancellations, pauses and anything unrecognised get a 200 and no post — a public channel is the
  wrong place to narrate a withdrawal, and a non-2xx would only make BMAC retry an event we mean
  to drop.
- **Name and note, nothing else.** No amount, no coffee count, and `supporter_email` is never read
  out of the payload. Notes are escaped, clipped to 400 characters and posted with
  `allowed_mentions: {parse: []}`, so somebody else's words can't restyle the embed or ping the
  server.
- **Unauthenticated by necessity** — BMAC holds no account here — so its credential is an
  HMAC-SHA256 signature over the raw body, verified before the body is parsed, reusing the
  constant-time `tokenMatches` from `auth.ts`.
- **DB:** new `bmac_events` table (`migrations/0011_bmac_events.sql`). BMAC retries a delivery up
  to four more times and a reply it never received is indistinguishable from a failure, so without
  it one coffee arrives five times. The id is claimed before the post and released again if
  Discord refuses, so a blip there doesn't swallow the announcement.
- **Two secrets**, neither in the repo: `BMAC_WEBHOOK_SECRET` and `DISCORD_DONATION_WEBHOOK_URL`.
  Without them the route answers 503, the same way provisioning does without its AWS key.

## Verification

- 14 new tests (55 total pass): signature accepted/tampered/wrong-secret/absent, 503 unconfigured,
  redelivery announced once, refunds and unknown types dropped, no email or amount in the payload,
  mentions defanged, long notes clipped.
- `wrangler types` + `tsc --noEmit` clean — everything CI's control-plane job runs.
- `wrangler dev` against a local stand-in for Discord, fed signed events.
- **Deployed and tested live**: a signed test event reached the real channel, a redelivery was
  suppressed as a duplicate, a wrong-secret delivery got 401.

## Follow-ups

- `BMAC_WEBHOOK_SECRET` currently holds a placeholder used for the live test; it needs replacing
  with the secret BMAC issues when the webhook is created in its dashboard.
- Unrelated, found on the way: production D1 has no `integrity` table (migration `0010` was never
  applied there, and `d1_migrations` is empty), so `PUT /v1/integrity` is failing live. `0011` was
  applied by hand. Worth its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
