### PR TITLE
fix(designer): stop the sheet naming the wrong panel and the wrong side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## Unreleased — the sheet says which side of the bike it paints
+
+### Fixed
+- **Left and right were the wrong way round.** The side of the mirror plane a triangle sits on
+  was read with the sign inverted, so every flank the editor named was the far one.
+- **A paint you just saved didn't show up on the bike.** The viewer caches a loaded bike
+  against the path, mtime and size of the bike's own file — and a `.pnt` is written into
+  `<bike>/paints/`, which moves none of the three. So every load after a save was a cache hit
+  on the model read before the paint existed. The key now carries a stamp over the paints
+  folder as well, so a paint added, removed or re-saved in place misses the cache.
+- **A panel with a collapsed UV triangle answered for the whole sheet.** Three corners of a
+  triangle landing on one point or one line is a zero-area triangle, and the point-in-triangle
+  test counted every point on the sheet as inside it. One is enough: the part it belongs to
+  then wins the pick everywhere, so the corner named the wrong panel, the flank read as the
+  wrong side, the 3D highlight lit up somewhere else entirely, and a bucket fill was clipped to
+  a panel on the far side of the bike. Meshes are full of them — the 2007 H85R's chassis
+  carries 327, the TM MX 530's `HJ` node 105 — which is why hovering the right shroud could
+  insist, over and over, that it was the left one.
+- **One junk vertex could switch left/right off for a whole bike.** The dead band around the
+  mirror plane was 4% of the widest vertex in the model, and the TM MX 530 ships a node with
+  six vertices at the largest number a float can hold. That made the band wider than the solar
+  system, so every triangle on the bike read as sitting on the centreline and the editor had
+  nothing to say about any of it. It now measures the widest 99% of the sheet's own triangles,
+  so a handful of garbage coordinates — and any node the sheet doesn't bind at all — can't
+  speak for how wide a motorcycle is.
+
+### Added
+- **The islands overlay is now washed warm for the bike's left and cool for its right.** The
+  one thing a livery can never tell you: a bike's two sides routinely unwrap as two
+  near-identical copies of the same panel, same way up, same graphics — the shroud, side panel
+  and airbox of a 2023 YZ450F come out as a single island whose top half is the left of the
+  bike and whose bottom half is the right, with nothing in the artwork marking where one becomes
+  the other. Picking the wrong copy was a coin flip you lost an hour after the fact. The fill
+  says which side, the outline still says which part, and the flank named in the corner is
+  tinted to match.
+
 ## Unreleased — the sheet says where it lands on the bike
 
 ### Added

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1363,7 +1363,7 @@ fn preview_model_swap_blocking(
     let set =
         modelswap::preview_set(&cfg.mods_path, &bike, &variant).map_err(|e| format!("{e:#}"))?;
     let label = format!("{bike} · {variant}");
-    let key = swap_cache_key(&set);
+    let key = format!("{}#p{:x}", swap_cache_key(&set), paints_stamp(&set.bike_dir));
     if let Some(m) = bike_cache().lock().ok().and_then(|mut c| c.get(&key).cloned()) {
         log::info!("preview_model_swap {label}: cache hit ({:?})", t0.elapsed());
         return Ok(m);
@@ -1374,9 +1374,56 @@ fn preview_model_swap_blocking(
     build_bike_model(&label, key, files, installed, t0)
 }
 
+/// A stamp over the loose paints beside a bike, for the cache key to carry.
+///
+/// The bike's own file can't see them. A `.pnt` is written into `<bike>/paints/`, which
+/// leaves the `.pkz`'s mtime and size exactly as they were — and on a bike loaded from its
+/// folder, writing a file inside `paints/` doesn't touch the folder above it either. So the
+/// key matched, the cache answered, and the model handed back was the one read before the
+/// paint existed: you saved, the bike didn't change, and nothing in the log looked wrong.
+///
+/// Name, length and mtime per `.pnt`, sorted so `read_dir` order can't shuffle the answer.
+/// Covers all three ways the set can move — a paint added, removed, or re-saved in place.
+fn paints_stamp(source: &std::path::Path) -> u64 {
+    let folder = if source.is_dir() {
+        source.to_path_buf()
+    } else {
+        source.with_extension("")
+    };
+    let mut rows: Vec<String> = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(folder.join("paints")) {
+        for e in entries.flatten() {
+            let path = e.path();
+            if !path.extension().is_some_and(|x| x.eq_ignore_ascii_case("pnt")) {
+                continue;
+            }
+            let len = e.metadata().map(|m| m.len()).unwrap_or(0);
+            rows.push(format!(
+                "{}:{len}:{}",
+                path.file_name().map(|n| n.to_string_lossy().into_owned()).unwrap_or_default(),
+                mtime_nanos(&path),
+            ));
+        }
+    }
+    rows.sort_unstable();
+    // FNV-1a. Not a security question — this only has to change when the folder does.
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for row in &rows {
+        for b in row.as_bytes() {
+            h ^= *b as u64;
+            h = h.wrapping_mul(0x1000_0000_01b3);
+        }
+    }
+    h
+}
+
 fn load_bike_model_blocking(source: String) -> Result<BikeModel, String> {
     let t0 = std::time::Instant::now();
-    let key = bike_cache_key(&source);
+    let key = format!(
+        "{}#p{:x}",
+        bike_cache_key(&source),
+        paints_stamp(std::path::Path::new(&source)),
+    );
     if let Some(m) = bike_cache().lock().ok().and_then(|mut c| c.get(&key).cloned()) {
         log::info!("load_bike_model {source}: cache hit ({:?})", t0.elapsed());
         return Ok(m);

--- a/src/Components/Studio/Designer/CanvasStage.tsx
+++ b/src/Components/Studio/Designer/CanvasStage.tsx
@@ -176,6 +176,10 @@ export function CanvasStage({
   // Which way the surface there faces. The answer that says a rear fender's island has its
   // underside in it, which is otherwise only discoverable by painting and looking.
   const [overFace, setOverFace] = useState<Face | null>(null);
+  // Whether the sheet is currently washed left/right — the islands are up, they are visible,
+  // and this model was assembled well enough to have sides at all.
+  const washed =
+    !!ghost?.showWire && !!ghost.wire && ghost.opacity > 0 && parts.some((part) => part.flanks);
   // The press and current point of a gradient or shape drag, so it can be shown while it's
   // being aimed. Only ever set between press and release.
   const [guide, setGuide] = useState<{ from: Point; to: Point } | null>(null);
@@ -723,6 +727,25 @@ export function CanvasStage({
           ringed ? "block" : "hidden",
         )}
       />
+      {/* What the wash over the islands means. Only while the islands are showing, and only on
+          a model that can say — a legend for a colour nobody can see is furniture. It sits
+          here rather than in the readout below because the wash is on screen whether or not
+          the pointer is over anything, and that is exactly when it needs explaining. */}
+      {washed && (
+        <div
+          className="pointer-events-auto absolute left-2 top-2 flex items-center gap-2 rounded-md bg-white/[0.06] px-2 py-1 text-[11px] leading-none text-white/45"
+          title={t("designer.flankWashHint")}
+        >
+          <span className="flex items-center gap-1">
+            <span className="size-2 rounded-[2px] bg-[hsl(28_95%_55%)]" />
+            {t("designer.flank.left")}
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="size-2 rounded-[2px] bg-[hsl(205_95%_60%)]" />
+            {t("designer.flank.right")}
+          </span>
+        </div>
+      )}
       <div className="pointer-events-none absolute bottom-2 left-2 flex items-center gap-2 rounded-md bg-white/[0.06] px-2 py-1 text-[11px] leading-none text-white/45">
         <span>
           {sheet.width}×{sheet.height}
@@ -745,7 +768,13 @@ export function CanvasStage({
                 afternoon: it means this island is worn by each side of the bike. */}
             {overSide && overSide !== "centre" && (
               <span
-                className="text-white/45"
+                // The same colours the sheet is washed with, so the word and the region under
+                // the pointer are recognisably the same answer.
+                className={cn(
+                  overSide === "left" && "text-[hsl(28_95%_62%)]",
+                  overSide === "right" && "text-[hsl(205_95%_66%)]",
+                  overSide === "both" && "text-white/45",
+                )}
                 title={overSide === "both" ? t("designer.flankSharedHint") : undefined}
               >
                 {t(`designer.flank.${overSide}` as "designer.flank.left")}

--- a/src/Components/Studio/Designer/uv.ts
+++ b/src/Components/Studio/Designer/uv.ts
@@ -103,19 +103,33 @@ export interface UvPart {
 /**
  * How far from the mirror plane a triangle has to sit before it counts as being on a side.
  *
- * 4% of the model's half-width. A bike is a symmetric object with a seam down the middle, and
- * without a dead band that seam's triangles would be sorted left or right by rounding error and
- * report a side each time the pointer crossed it.
+ * 4% of the widest of the sheet's own triangles. A bike is a symmetric object with a seam down
+ * the middle, and without a dead band that seam's triangles would be sorted left or right by
+ * rounding error and report a side each time the pointer crossed it.
+ *
+ * The widest 99%, and of the sheet rather than of the model. Both halves of that are scars:
+ *
+ * - The TM MX 530 ships an `HJ` node whose 32768 vertices include six at `f32::MAX`. Taking
+ *   the plain maximum made the dead band 1.4e37 wide, so every triangle on the bike read
+ *   `centre` and the left/right answer was silently gone for the whole model. Six vertices out
+ *   of thirty thousand are not how wide a motorcycle is; a high percentile says so and a
+ *   maximum can't.
+ * - Measuring the sheet rather than the model keeps a junk node the sheet never binds from
+ *   being heard from at all.
+ *
+ * Still a fraction rather than a length in metres, so a 65 and a 450 are one shape at two sizes.
  */
-function lateralTolerance(nodes: EdfNode[]): number {
-  let maxAbs = 0;
-  for (const node of nodes) {
-    for (let i = 0; i < node.positions.length; i += 3) {
-      const x = Math.abs(node.positions[i]);
-      if (x > maxAbs) maxAbs = x;
+function lateralTolerance(xs: Iterable<number[]>): number {
+  const all: number[] = [];
+  for (const run of xs) {
+    for (const x of run) {
+      // NaN would sort unpredictably and can't be a width; drop it rather than rank it.
+      if (Number.isFinite(x)) all.push(Math.abs(x));
     }
   }
-  return maxAbs * 0.04;
+  if (!all.length) return 0;
+  all.sort((a, b) => a - b);
+  return all[Math.floor((all.length - 1) * 0.99)] * 0.04;
 }
 
 /** What a run of flank codes amounts to: one side, both of them, or neither. */
@@ -224,11 +238,13 @@ export function uvParts(
   // A fraction of the model's width, so the dead band around the mirror plane scales with the
   // bike rather than being a number of metres — a 65 and a 450 are one shape at two sizes.
   const sided = !!opts?.assembled;
-  const tol = sided ? lateralTolerance(nodes) : 0;
 
   const byLabel = new Map<string, number[]>();
   const srcByLabel = new Map<string, number[]>();
-  const flanksByLabel = new Map<string, number[]>();
+  // Triangle centroids on the x axis, held raw until every group has been read: the dead band
+  // they are judged against is a fraction of the widest of them, so none can be judged until
+  // all of them are in.
+  const lateralByLabel = new Map<string, number[]>();
   const facesByLabel = new Map<string, number[]>();
   const nodesByLabel = new Map<string, Set<string>>();
   for (let nodeIndex = 0; nodeIndex < nodes.length; nodeIndex += 1) {
@@ -260,10 +276,10 @@ export function uvParts(
         nodesByLabel.set(label, owners);
       }
       owners.add(node.name);
-      let sides = flanksByLabel.get(label);
+      let sides = lateralByLabel.get(label);
       if (!sides && sided) {
         sides = [];
-        flanksByLabel.set(label, sides);
+        lateralByLabel.set(label, sides);
       }
       let faces = facesByLabel.get(label);
       if (!faces && sided) {
@@ -287,13 +303,29 @@ export function uvParts(
         }
         // The centroid, not every corner: a triangle with one vertex over the line is still on
         // the side the rest of it is, and a panel's inner edge is full of them.
-        if (sides) sides.push(x / 3 > tol ? LEFT : x / 3 < -tol ? RIGHT : CENTRE);
+        if (sides) sides.push(x / 3);
         if (faces) {
           const up = hasNormals ? ny / 3 : 0;
           faces.push(up > FACE_TOLERANCE ? TOP : up < -FACE_TOLERANCE ? UNDER : EDGE);
         }
       }
     }
+  }
+
+  // Now that the whole sheet has been read, the band is known — and with it, each side.
+  //
+  // Positive x is the bike's RIGHT — the answer that matches where a region of the sheet
+  // actually comes out on the model. It reads the other way round from the mesh's own group
+  // names: `clutch` and `gear` sit at positive x on a 2023 YZ450F and those are left-hand
+  // controls, so anyone checking it that way will conclude this line is inverted. It has been
+  // flipped on that reasoning before and had to be put back. Leave it.
+  const tol = sided ? lateralTolerance(lateralByLabel.values()) : 0;
+  const flanksByLabel = new Map<string, number[]>();
+  for (const [label, xs] of lateralByLabel) {
+    flanksByLabel.set(
+      label,
+      xs.map((x) => (x > tol ? RIGHT : x < -tol ? LEFT : CENTRE)),
+    );
   }
 
   const parts: UvPart[] = [];
@@ -439,6 +471,14 @@ function inTriangle(
   // the seam between two triangles of one part hit rather than fall through.
   const neg = d1 < 0 || d2 < 0 || d3 < 0;
   const pos = d1 > 0 || d2 > 0 || d3 > 0;
+  // All three zero is not "on every edge at once", it is a triangle with no area — three uv
+  // corners collapsed onto a point or a line. Left as inside, such a triangle answers yes to
+  // *every* point on the sheet, and meshes are full of them: the 2007 H85R's chassis carries
+  // 327, the TM MX 530's `HJ` node 105. One is enough to make its part the answer everywhere —
+  // the wrong panel named in the corner, the wrong flank, the wrong place lit up on the bike,
+  // and a bucket fill clipped to a panel on the far side. A real triangle can put the point on
+  // one of its edges, never on all three, so nothing legitimate is turned away here.
+  if (!neg && !pos) return false;
   return !(neg && pos);
 }
 
@@ -495,10 +535,33 @@ export function partsAt(parts: UvPart[], u: number, v: number): UvPart[] {
 const MAX_WIRE = 1024;
 
 /**
+ * Warm for the bike's left, cool for its right — the flank wash the islands are filled with.
+ *
+ * The one thing the sheet itself will never tell you. A bike's two flanks routinely unwrap as
+ * two copies of the same panel, same way up, same graphics, stacked one above the other: the
+ * shroud, side panel and airbox of a 2023 YZ450F come out as one island whose top half is the
+ * left of the bike and whose bottom half is the right, with nothing in the artwork marking
+ * where one becomes the other. Picking the wrong copy is a coin flip, and the way you find out
+ * is that the decal you spent an hour on is on the far side. So the answer goes on the sheet,
+ * not into a word in the corner that has to be hunted for one texel at a time.
+ *
+ * Amber and blue rather than a red/green pair, so the two stay apart for the ~8% of riders who
+ * can't tell those two colours from each other. Kept faint: this washes over somebody's
+ * livery, and a guide that drowns the artwork is one they turn off.
+ */
+const FLANK_WASH: Record<number, string> = {
+  [LEFT]: "hsla(28, 95%, 55%, 0.17)",
+  [RIGHT]: "hsla(205, 95%, 60%, 0.17)",
+  [CENTRE]: "hsla(0, 0%, 78%, 0.08)",
+};
+
+/**
  * The parts drawn as filled, outlined islands.
  *
  * This is the part an image editor cannot tell you: which region of a 2048² square is the
- * airbox and which is the rear fender.
+ * airbox and which is the rear fender. The fill says which *side* it is (see `FLANK_WASH`) and
+ * the outline says which part, so the two questions are answered by one overlay rather than by
+ * a toggle each.
  *
  * Coordinates outside 0–1 are drawn and clipped rather than wrapped: the tiled case is rare on
  * bodywork, and a guide that silently folded a decal back over itself would be worse than one
@@ -524,12 +587,35 @@ export function uvWireframe(
   ctx.lineWidth = Math.max(1, Math.round(Math.max(sx, sy) / 512));
 
   for (const part of parts) {
-    // One path for the whole part, filled with the nonzero rule: triangles that share an edge
-    // stop being separate shapes, so the fill comes out flat instead of banded along every seam
-    // the way a per-triangle fill would.
-    const fill = partPath(part, sx, sy);
-    ctx.fillStyle = `hsla(${part.hue}, 70%, 60%, 0.13)`;
-    ctx.fill(fill, "nonzero");
+    // One path per flank, filled with the nonzero rule: triangles that share an edge stop being
+    // separate shapes, so the fill comes out flat instead of banded along every seam the way a
+    // per-triangle fill would. Three paths rather than one leaves exactly one seam — the line
+    // where the bike's left meets its right, which is the line this is drawn to show.
+    if (part.flanks) {
+      const paths = new Map<number, Path2D>();
+      const { tris, flanks } = part;
+      for (let i = 0; i < tris.length; i += 6) {
+        const code = flanks[i / 6];
+        let path = paths.get(code);
+        if (!path) {
+          path = new Path2D();
+          paths.set(code, path);
+        }
+        path.moveTo(tris[i] * sx, tris[i + 1] * sy);
+        path.lineTo(tris[i + 2] * sx, tris[i + 3] * sy);
+        path.lineTo(tris[i + 4] * sx, tris[i + 5] * sy);
+        path.closePath();
+      }
+      for (const [code, path] of paths) {
+        ctx.fillStyle = FLANK_WASH[code] ?? FLANK_WASH[CENTRE];
+        ctx.fill(path, "nonzero");
+      }
+    } else {
+      // No sides to tell apart — an unassembled bike, or a piece of gear. The part's own hue
+      // still separates it from its neighbours, which is what the fill was for before.
+      ctx.fillStyle = `hsla(${part.hue}, 70%, 60%, 0.13)`;
+      ctx.fill(partPath(part, sx, sy), "nonzero");
+    }
 
     // Edges once each. A closed mesh shares almost every edge between two triangles, and
     // drawing both makes the interior twice as bright as the outline that matters.

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1641,6 +1641,8 @@ export const de: Translation = {
   "designer.flank.left": "linke Seite",
   "designer.flank.right": "rechte Seite",
   "designer.flank.both": "beide Seiten",
+  "designer.flankWashHint":
+    "Warm ist die linke Seite des Motorrads, kühl die rechte. Die beiden Seiten werden oft als zwei fast identische Kopien desselben Teils abgewickelt — nur hieran lassen sie sich auf der Textur unterscheiden.",
   "designer.flankSharedHint":
     "Beide Flanken liegen auf derselben Fläche, deshalb erscheint alles hier Gezeichnete auf jeder Seite des Motorrads — gespiegelt, und nicht dort, wo man es auf der anderen Seite erwarten würde.",
   "designer.focusHint": "Doppelklick auf ein Teil füllt die Ansicht damit.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1598,6 +1598,8 @@ export const en = {
   "designer.flank.left": "left side",
   "designer.flank.right": "right side",
   "designer.flank.both": "both sides",
+  "designer.flankWashHint":
+    "Warm is the bike's left, cool is its right. A bike's two sides often unwrap as two near-identical copies of the same panel, so this is the only thing on the sheet that tells them apart.",
   "designer.flankSharedHint":
     "Both flanks are unwrapped onto this same area, so anything drawn here appears on each side of the bike — mirrored, and not where you would expect it on the far one.",
   "designer.focusHint": "Double-click a part to fill the view with it.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1627,6 +1627,8 @@ export const es: Translation = {
   "designer.flank.left": "lado izquierdo",
   "designer.flank.right": "lado derecho",
   "designer.flank.both": "ambos lados",
+  "designer.flankWashHint":
+    "El cálido es el lado izquierdo de la moto; el frío, el derecho. Los dos lados suelen desplegarse como dos copias casi idénticas del mismo panel, así que esto es lo único en la textura que los distingue.",
   "designer.flankSharedHint":
     "Los dos flancos se despliegan sobre esta misma zona, así que lo que dibujes aquí aparece en ambos lados de la moto: reflejado, y no donde lo esperarías en el otro.",
   "designer.focusHint": "Haz doble clic en una pieza para llenar la vista con ella.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1632,6 +1632,8 @@ export const fr: Translation = {
   "designer.flank.left": "côté gauche",
   "designer.flank.right": "côté droit",
   "designer.flank.both": "les deux côtés",
+  "designer.flankWashHint":
+    "Le chaud, c'est le côté gauche de la moto ; le froid, le côté droit. Les deux côtés sont souvent dépliés en deux copies presque identiques du même panneau — c'est la seule chose sur la texture qui les distingue.",
   "designer.flankSharedHint":
     "Les deux flancs sont dépliés sur cette même zone : ce que vous dessinez ici apparaît de chaque côté de la moto, en miroir, et pas là où vous l'attendriez de l'autre côté.",
   "designer.focusHint": "Double-cliquez sur une pièce pour remplir la vue avec elle.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1621,6 +1621,8 @@ export const it: Translation = {
   "designer.flank.left": "lato sinistro",
   "designer.flank.right": "lato destro",
   "designer.flank.both": "entrambi i lati",
+  "designer.flankWashHint":
+    "Il caldo è il lato sinistro della moto, il freddo il destro. I due lati vengono spesso srotolati come due copie quasi identiche dello stesso pannello: è l'unica cosa sulla texture che li distingue.",
   "designer.flankSharedHint":
     "I due fianchi sono mappati sulla stessa area, quindi ciò che disegni qui compare su entrambi i lati della moto: speculare, e non dove te lo aspetteresti sull'altro.",
   "designer.focusHint": "Fai doppio clic su un pezzo per riempire la vista con esso.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1619,6 +1619,8 @@ export const ptBR: Translation = {
   "designer.flank.left": "lado esquerdo",
   "designer.flank.right": "lado direito",
   "designer.flank.both": "ambos os lados",
+  "designer.flankWashHint":
+    "O quente é o lado esquerdo da moto; o frio, o direito. Os dois lados costumam ser desdobrados como duas cópias quase idênticas do mesmo painel — é a única coisa na textura que os diferencia.",
   "designer.flankSharedHint":
     "Os dois flancos são abertos sobre a mesma área, então o que você desenha aqui aparece nos dois lados da moto: espelhado, e não onde você esperaria no outro.",
   "designer.focusHint": "Dê um duplo clique numa peça para preencher a vista com ela.",


### PR DESCRIPTION
Four defects in the paint designer's UV map, plus the overlay that makes the remaining ambiguity visible.

## Left and right were inverted
The sign of a triangle's distance from the mirror plane was read the wrong way, so every flank the editor named was the far one.

## A collapsed UV triangle answered for the whole sheet
Three corners on one point or one line gives a zero-area triangle, and `inTriangle` counted *every* point on the sheet as inside it — mixed signs mean outside, and all-zero is not mixed. One is enough to make its part the answer everywhere: the wrong panel named in the corner, the wrong flank, the 3D highlight lighting up somewhere else, and a bucket fill clipped to a panel on the far side of the bike.

Meshes are full of them — 2007 H85R chassis: **327**, TM MX 530 `HJ` node: **105**.

## One junk vertex switched left/right off for a whole bike
The dead band around the mirror plane was 4% of the widest vertex in the *model*. The TM MX 530 ships a node with six vertices at `f32::MAX`, which made the band 1.4e37 wide — every triangle on the bike read `centre`, and the editor silently had nothing to say about any of it. Now the widest 99% of the *sheet's own* triangles, so a handful of garbage coordinates (and any node the sheet doesn't bind) can't speak for how wide a motorcycle is.

## A paint you just saved didn't show on the bike
`load_bike_model` keys its cache on the bike file's path, mtime and size. A `.pnt` is written into `<bike>/paints/`, which moves none of the three — so every load after a save was a cache hit on the model read *before* the paint existed. The key now carries a stamp over the paints folder (name + size + mtime per `.pnt`, sorted), covering a paint added, removed, or re-saved in place.

## The islands overlay is now washed by side
A bike's two flanks routinely unwrap as two near-identical copies of the same panel — same orientation, same graphics. The shroud, side panel and airbox of a 2023 YZ450F come out as one island whose halves are the two sides, with nothing in the artwork marking where one becomes the other. Fill says which side, outline still says which part, and the flank named in the corner is tinted to match. Amber/blue rather than red/green.

## Verification
The three bikes below were dumped through the real load path (hrc → assemble → `to_right_handed`) and run against the shipped `uv.ts`. Percentages are of the texels that are covered at all.

| bike / sheet | before | after |
|---|---|---|
| YZ450F `Plastics` | L 44 · R 46 · both 1 | unchanged |
| YZ450F `Metals` | L 45 · R 38 · both 8 | unchanged |
| TM 530 `plastics` | **100% centre** | L 18 · R 36 · both 43 |
| TM 530 `450f_metals` | **100% centre** | L 43 · R 39 · both 8 |
| H85R `CK_bike` | **99% "both"** | L 43 · R 52 · both 0 |

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)