### PR TITLE
chore(install): drop the mirrors hint from the download dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased — a quieter download dialog
+
+### Removed
+- The "All mirrors contain the same file. If one fails, try the next." line under the mirror
+  list. The list already reads as a list of the same thing, and a sentence explaining it was
+  taking a row of the dialog to say nothing. The per-bike note, which really does change what
+  you pick, stays.
+
 ## Unreleased — the sheet says where it lands on the bike
 
 ### Added

--- a/src/Components/ModDetail/InstallDialog.tsx
+++ b/src/Components/ModDetail/InstallDialog.tsx
@@ -473,11 +473,9 @@ export default function InstallDialog({
                 </div>
               )}
 
-              {mirrors.length > 1 && (
+              {mirrors.length > 1 && sound && (
                 <span className="text-[11px] text-faint">
-                  {sound
-                    ? t("installDialog.perBikeHint")
-                    : t("installDialog.mirrorsHint")}
+                  {t("installDialog.perBikeHint")}
                 </span>
               )}
             </section>

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -513,8 +513,6 @@ export const de: Translation = {
   "installDialog.moreMirrors_other": "{{count}} weitere Spiegelserver",
   "installDialog.perBikeHint":
     "Jeder Download ist ein anderes Motorrad — automatisch passend zu deiner Auswahl. Wähle das Paket „all bikes“, um alle auf einmal zu bekommen.",
-  "installDialog.mirrorsHint":
-    "Alle Spiegelserver enthalten dieselbe Datei. Wenn einer fehlschlägt, probiere den nächsten.",
 
   // ── Bibliotheksdetails ─────────────────────────────────────────────────────
   "libraryDetail.author": "Autor",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -499,8 +499,6 @@ export const en = {
   "installDialog.moreMirrors_other": "{{count}} more mirrors",
   "installDialog.perBikeHint":
     "Each download is a different bike — auto-selected to match your pick. Choose the “all bikes” pack for every bike at once.",
-  "installDialog.mirrorsHint":
-    "All mirrors contain the same file. If one fails, try the next.",
 
   // ── Library detail panel ───────────────────────────────────────────────────
   "libraryDetail.author": "Author",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -505,8 +505,6 @@ export const es: Translation = {
   "installDialog.moreMirrors_other": "{{count}} espejos más",
   "installDialog.perBikeHint":
     "Cada descarga es una moto distinta — se selecciona automáticamente según tu elección. Elige el pack «all bikes» para todas las motos de una vez.",
-  "installDialog.mirrorsHint":
-    "Todos los espejos contienen el mismo archivo. Si uno falla, prueba el siguiente.",
 
   // ── Detalles de biblioteca ─────────────────────────────────────────────────
   "libraryDetail.author": "Autor",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -509,8 +509,6 @@ export const fr: Translation = {
   "installDialog.moreMirrors_other": "{{count}} autres miroirs",
   "installDialog.perBikeHint":
     "Chaque téléchargement correspond à une moto différente — sélectionné automatiquement selon votre choix. Choisissez le pack « all bikes » pour toutes les motos d'un coup.",
-  "installDialog.mirrorsHint":
-    "Tous les miroirs contiennent le même fichier. Si l'un échoue, essayez le suivant.",
 
   // ── Détails de bibliothèque ────────────────────────────────────────────────
   "libraryDetail.author": "Auteur",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -504,8 +504,6 @@ export const it: Translation = {
   "installDialog.moreMirrors_other": "Altri {{count}} mirror",
   "installDialog.perBikeHint":
     "Ogni download è una moto diversa — selezionato automaticamente in base alla tua scelta. Scegli il pacchetto “all bikes” per averle tutte in una volta.",
-  "installDialog.mirrorsHint":
-    "Tutti i mirror contengono lo stesso file. Se uno non funziona, prova il successivo.",
 
   // ── Dettagli libreria ──────────────────────────────────────────────────────
   "libraryDetail.author": "Autore",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -507,8 +507,6 @@ export const ptBR: Translation = {
   "installDialog.moreMirrors_other": "mais {{count}} espelhos",
   "installDialog.perBikeHint":
     "Cada download é uma moto diferente — selecionado automaticamente conforme a sua escolha. Escolha o pacote “all bikes” para todas de uma vez.",
-  "installDialog.mirrorsHint":
-    "Todos os espelhos têm o mesmo arquivo. Se um falhar, tente o próximo.",
 
   // ── Detalhes da biblioteca ─────────────────────────────────────────────────
   "libraryDetail.author": "Autor",


### PR DESCRIPTION
Removes **"All mirrors contain the same file. If one fails, try the next."** from under the mirror list in the download dialog.

A list of mirrors already reads as a list of the same thing — the sentence was taking a row of the dialog to say nothing.

The per-bike note is kept, since that one actually changes which download you pick. The string is gone from all six locales, and the hint now renders only for that case.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)