### PR TITLE
feat(showcase): cut v0.10.0 — showcase, version bump, consolidated notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,824 +1,178 @@
 # Changelog
 
-## Unreleased — a quieter download dialog
+## 2026-08-18 — v0.10.0 — A Designer that sets itself up, a Downloads page, and tracks in 3D
 
-### Removed
-- The "All mirrors contain the same file. If one fails, try the next." line under the mirror
-  list. The list already reads as a list of the same thing, and a sentence explaining it was
-  taking a row of the dialog to say nothing. The per-bike note, which really does change what
-  you pick, stays.
-## Unreleased — the sheet says which side of the bike it paints
+The first full release since v0.9.1. It folds in everything the v0.9.2 betas carried, so
+the terrain viewer, the voice device settings and the rest of that line are all in here.
 
-### Fixed
-- **Left and right were the wrong way round.** The side of the mirror plane a triangle sits on
-  was read with the sign inverted, so every flank the editor named was the far one.
-- **A paint you just saved didn't show up on the bike.** The viewer caches a loaded bike
-  against the path, mtime and size of the bike's own file — and a `.pnt` is written into
-  `<bike>/paints/`, which moves none of the three. So every load after a save was a cache hit
-  on the model read before the paint existed. The key now carries a stamp over the paints
-  folder as well, so a paint added, removed or re-saved in place misses the cache.
-- **A panel with a collapsed UV triangle answered for the whole sheet.** Three corners of a
-  triangle landing on one point or one line is a zero-area triangle, and the point-in-triangle
-  test counted every point on the sheet as inside it. One is enough: the part it belongs to
-  then wins the pick everywhere, so the corner named the wrong panel, the flank read as the
-  wrong side, the 3D highlight lit up somewhere else entirely, and a bucket fill was clipped to
-  a panel on the far side of the bike. Meshes are full of them — the 2007 H85R's chassis
-  carries 327, the TM MX 530's `HJ` node 105 — which is why hovering the right shroud could
-  insist, over and over, that it was the left one.
-- **One junk vertex could switch left/right off for a whole bike.** The dead band around the
-  mirror plane was 4% of the widest vertex in the model, and the TM MX 530 ships a node with
-  six vertices at the largest number a float can hold. That made the band wider than the solar
-  system, so every triangle on the bike read as sitting on the centreline and the editor had
-  nothing to say about any of it. It now measures the widest 99% of the sheet's own triangles,
-  so a handful of garbage coordinates — and any node the sheet doesn't bind at all — can't
-  speak for how wide a motorcycle is.
+Worth knowing: **voice chat still doesn't transmit** — this is the device half (mic, output,
+levels and the key that opens the mic), with test buttons that work. The codec and the voice
+room are still to come, and the Settings section says so. Terrain is read from the game's own
+height file and checked against four published tracks, not every track there is; if one comes
+out looking nothing like the track you ride, name it in the report.
 
 ### Added
-- **The islands overlay is now washed warm for the bike's left and cool for its right.** The
-  one thing a livery can never tell you: a bike's two sides routinely unwrap as two
-  near-identical copies of the same panel, same way up, same graphics — the shroud, side panel
-  and airbox of a 2023 YZ450F come out as a single island whose top half is the left of the
-  bike and whose bottom half is the right, with nothing in the artwork marking where one becomes
-  the other. Picking the wrong copy was a coin flip you lost an hour after the fact. The fill
-  says which side, the outline still says which part, and the flank named in the corner is
-  tinted to match.
-## Unreleased — a coffee shows up in Discord
-
-### Added
-- **Buy Me a Coffee donations are announced in the Discord channel.** BMAC posts to a new
-  `POST /v1/bmac/webhook` on the control plane, which turns the event into an embed. Nothing
-  told you a coffee had been bought until you went and looked at the dashboard, which is also
-  why somebody could sit unthanked in `supporters.json` for a week — the post is the prompt to
-  add them.
-- Announced for money-in events only — a coffee, a membership started, a recurring donation, an
-  extra, a commission, a wishlist payment. Refunds, cancellations and pauses are accepted and
-  dropped: a public channel is the wrong place to narrate a withdrawal, and answering with an
-  error would only make BMAC retry an event we mean to ignore.
-- **The embed carries a name and their note, and nothing else** — no amount, no coffee count,
-  and the supporter's email is never read out of the payload. Notes are escaped, clipped and
-  posted with mentions disabled, so somebody else's words can't restyle the embed or ping the
-  server.
-- The route holds no bearer token, because BMAC has no account here; its credential is an
-  HMAC-SHA256 signature over the raw body, checked before the body is parsed. A `bmac_events`
-  table records what has already gone out — BMAC retries a delivery up to four more times, and
-  a reply it never received is indistinguishable from a failure, so without it one coffee
-  arrives five times.
-
-## Unreleased — the sheet says where it lands on the bike
-
-### Added
-- **Hovering the sheet lights that spot up on the 3D model.** A patch follows the pointer
-  across the bike, so "which panel is this region of the square" is answered by the picture
-  instead of by a word. The editor already named the flank in the corner, and a name is the
-  one thing this question can't be settled with: "left" means the bike's own left, the preview
-  opens looking at that flank from the front, and a livery's two shroud islands are mirror
-  images of each other on the sheet — so a region that paints the left panel can look, read
-  and feel like the right one until you watch it light up.
-- Deliberately a patch rather than the whole island under the pointer. UV islands routinely
-  bridge the mirror plane — a seat and a front fender are each one panel with both flanks in
-  them — so highlighting the island would answer "which side does this paint" by lighting most
-  of the bike. The patch is small enough to sit inside a shroud and moves as the pointer does,
-  which is what makes it read as *here*.
-
-## Unreleased — a repair button that doesn't wait to be asked
-
-### Added
-- **"Repair runtimes" in Settings, next to FrostMod.** It installs every Visual C++ runtime
-  this PC is short of and puts `msvcr90.dll` where the game looks for it. Deliberately not
-  gated on anything having been detected as missing — the machine this was built for reported
-  every runtime present and still couldn't start the game, so a repair reachable only from the
-  warning bar would never have run there. Worth pressing even when nothing looks wrong.
-- **Both 32- and 64-bit 2015–2022 runtimes**, from Microsoft's own *Latest Supported Visual
-  C++ Downloads* page. Installing the x64 package does nothing for a 32-bit consumer — a
-  plugin, a tool, or the dedicated-server build, which really is a 32-bit binary — so offering
-  only one left half the cases unfixable. The x86 package is offered by the repair and never
-  raises a warning of its own: nothing the app ships is 32-bit, so its absence proves nothing
-  is wrong.
-- **Every runtime's download link, always available**, so a declined admin prompt or a PC that
-  can't reach Microsoft still has somewhere to go. The repair hands over links for whatever it
-  couldn't finish rather than reporting a flat failure.
-
-### Fixed
-- **The copy beside the game executable now lands in `Program Files` too.** It was a plain
-  unelevated write, so on a Steam install — where the game folder needs admin rights — it
-  failed silently and the fix never arrived on exactly the machines reporting the problem. The
-  repair now asks for permission and copies with it.
-- **A repair no longer stops at the first thing that goes wrong.** One runtime failing says
-  nothing about the next two, so it works through all of them and reports the rest.
-
-## Unreleased — FrostMod runs on macOS
-
-### Added
-- **FrostMod installs, starts, reloads and stops on macOS.** It used to be hidden there
-  entirely — Settings had no FrostMod section and no FrostMod log row — on the grounds that
-  the app launches a CrossOver/Whisky bottle but doesn't inject into it. The first half of
-  that is true and the second was a decision, not a fact: FrostMod is a Windows program and
-  so is the game it attaches to, so it belongs in the same bottle, started through whichever
-  wrapper owns it. The app now finds that bottle the same way Play already does (whatever
-  sits above `drive_c` in the game's path), starts `frostmod.exe` in it, and hands over
-  `--mods` as the bottle names the folder — `C:\users\crossover\Documents\…`, not the
-  `/Users/…` this side calls the same place.
-- **The Reload button works from outside the bottle**, on the same terms as Linux: the app
-  is a native macOS process and FrostMod's reload event is a Wine kernel object nothing out
-  here can pulse, so a reload travels as a file FrostMod polls for. That needs FrostMod
-  v0.13.0 or newer; anything older is refused with a version to update to, rather than
-  started into a state where the in-game `F8` works and every button here quietly doesn't.
-  Stopping reaches both processes that carry the name — the wrapper and the Wine process
-  under it — so the status pill can't be left insisting FrostMod is running.
-- **A bottle with no `Z:` drive is named as the problem before anything starts.** FrostMod
-  lives beside the app's own data rather than inside the bottle, and `Z:` is what makes that
-  folder reachable from in there. Without it FrostMod would inject, reload on `F8`, and
-  ignore the app forever — the one failure worth catching early, because nothing about it is
-  visible in game.
-
-### Fixed
-- **Whatever the wrapper says on its way to starting FrostMod is now kept**, in `wine.log`
-  beside FrostMod, and collected with the other logs. It is the only account of a failed
-  injection a player can send us — the same reason Proton's output is kept on Linux.
-
-## Unreleased — nothing downloads without a ceiling
-
-### Fixed
-- **A thumbnail can no longer pull an unlimited amount into memory.** Browsing mods fetches the
-  picture on each card, and the whole response was held in memory to be checked and resized —
-  with nothing saying how large it was allowed to be. Being on the allowlist only says where a
-  URL points, never how big what it points at is, and an `<img>` on a mod page can name whatever
-  its author uploaded. One such link cost however large that file happened to be, twice over,
-  and eight can be in flight at once. Downloads are now refused above 32 MB — before they start
-  when the site says how big the file is, and mid-download when it doesn't — which is many times
-  more than any real thumbnail and no longer unbounded.
-- **A model's embedded texture is only decompressed as far as it claims to go.** The pixels past
-  the texture's own size were always discarded, but not before being unpacked, so a payload that
-  expanded to gigabytes did exactly that first. These records are found by scanning for a byte
-  pattern, so this needed no ill intent — an ordinary false match was enough.
-
-### Added
-- **The log now writes down how much memory the app is holding.** Quiet by default — a line every
-  quarter of an hour, and one straight away if the figure climbs sharply — with what the caches
-  and the thumbnail loader are holding beside it. After an evening spent idle at tens of
-  gigabytes, the log for those hours was empty, and there was no way to tell afterwards what had
-  grown.
-
-## Unreleased — the app runs under its own name
-
-### Changed
-- **The process is called "MXB App" rather than "frost".** Activity Monitor and Task Manager
-  listed it under the name of the Rust crate behind it, which matches nothing anyone installed —
-  so working out what a process was doing meant first working out that it was this app at all.
-  Both the shipped build and a dev run carry the product name now. Two things ride along with the
-  rename: the login item is written again on the first launch after updating, because it stores
-  the path of the executable it was created for and would otherwise quietly stop starting the app;
-  and the Windows installer closes and clears away the `frost.exe` it finds from earlier versions
-  instead of leaving it parked in the install folder.
-
-## Unreleased — Downloads moves in under the Library
-
-### Changed
-- **Downloads is now part of the Library rather than a tab beside it.** It answers the question
-  the library can't — which of these arrived today, and what didn't arrive at all — so it belongs
-  inside that place instead of competing with it for a row in the sidebar. Library carries a
-  chevron; the group opens when you go there, stays as you left it between launches, and opens by
-  itself whenever the Downloads page is the one on screen. A failed download still shows its
-  count on the Library row while the group is shut, so closing it can't hide the failure with it.
-  Collapse the sidebar to icons and nothing changes — there is no indent to nest into, so both
-  stay side by side as before.
-
-## Unreleased — the queue shows every mod you asked for
-
-### Fixed
-- **Mods join the download queue the moment you click, not when their page comes back.** A quick
-  install had to fetch the mod's page — its mirrors, and where the file should land — before the
-  queue heard about it at all. Select twenty and hit install and the panel filled one mod at a
-  time over a minute or more, with the rest of the selection nowhere on screen and nothing to say
-  the click had registered. The whole selection now takes its place in the queue straight away,
-  each row marked "Preparing" while its turn comes round, and any of them can be cancelled before
-  it ever starts downloading. Working the destination out late also means it is decided against
-  the library as it stands when the mod is about to install, not as it stood twenty mods ago.
-
-### Changed
-- **A mod with no usable download now says which one it is.** Quick-installing a selection used
-  to end with a count of how many had been skipped; each one is now reported by name as the queue
-  reaches it, so it's clear which mod needs opening by hand.
-
-## Unreleased — a Downloads page, so you can see what you just grabbed
-
-### Added
-- **Downloads — everything you've installed, newest first.** Grab eight tracks in an evening
-  and there was no way to see which eight: the library scans your mods folder, which knows what
-  is there but not when it arrived. The new page groups by day, says where each one landed and
-  which mirror served it, and searches by name, destination or host.
-- **Failed downloads are kept instead of vanishing.** A failure used to live only in a toast —
-  dismiss it and there was no record the download had ever been tried, just a mod that silently
-  wasn't there. Failures now stay on the page with their error, retry in place through the same
-  install queue, and put a count on the sidebar so one is noticeable at all.
-- **"Recently added" sort in the library.** The history only knows about downloads from this
-  version on, so the library sorts by file time too — which covers everything already on disk.
-
-## Unreleased — the download queue opens, and a download can be called off
-
-### Added
-- **You can see what you're downloading.** Installs have always queued up one behind the
-  other, but the only sign of it was a "+2 queued" line in the sidebar — you couldn't see
-  what was in there, or in what order. That card is now a button: it opens a panel listing
-  the transfer in progress, with its size and percentage, and every mod waiting behind it.
-  Collapse the sidebar and it becomes a download icon with a count, where before there was
-  nothing to see at all.
-- **A download can be cancelled.** Queue up a 400 MB track by mistake and, until now, the
-  only way to stop it was to quit the app. Every row in the panel has an X. One that hasn't
-  started yet simply leaves the queue; the one in flight is stopped mid-transfer, its
-  half-downloaded file cleaned up, and the next mod in the queue starts straight away. It
-  isn't treated as a failure — no error, no retry prompt, just gone.
-
-### Fixed
-- **An install that fails no longer leaves its download behind.** Every abandoned attempt
-  used to leave the partial archive sitting in the temp folder until the system got around
-  to clearing it, which for a large track meant hundreds of megabytes per failed try.
-
-## Unreleased — MediaFire links stop needing a manual download
-
-### Fixed
-- **MediaFire downloads no longer depend on the shape of MediaFire's page.** Resolving a
-  share meant fetching the file page and hunting for the download button in it, so every
-  time MediaFire moved that button — and it has moved repeatedly — installs broke the same
-  way: *"couldn't find the MediaFire download link — open the mod page to download it
-  manually"*, on links that worked fine in a browser. The link is now looked up through
-  MediaFire's own API, from the key in the share URL, which doesn't care what this month's
-  page looks like. Scraping is still there behind it, for links whose key can't be read and
-  for the day the API stops answering — and it has learned two more places the button has
-  been hiding.
-- **MediaFire folder links install.** A folder share has no download button on it at all, so
-  the old resolver went looking for one, found nothing, and reported the mod as broken. The
-  folder's contents are read instead and the archive picked out of them, the same way a
-  Google Drive folder already worked.
-- **A MediaFire file that is gone, locked or blocked says so.** All four outcomes used to
-  arrive as the same "download it manually" — advice that is simply wrong when a browser hits
-  the identical wall. A removed file, a password-protected one, one MediaFire has taken down,
-  and one that has burned through its bandwidth are now each named, with what to actually do
-  about it.
-
-## Unreleased — undo covers the whole editor, and the bucket stays on its panel
-
-### Added
-- **Undo covers everything now, not just brush strokes.** Adding, moving, scaling, rotating,
-  clipping and deleting layers, and adding, renaming, reordering and deleting sheets, all go on
-  the same timeline as the painting — so Ctrl+Z takes back whatever you actually did last,
-  rather than the last stroke and nothing else. A drag or a slider scrub is one step, not the
-  two hundred events it was made of.
-- **The bucket fills the panel you clicked, not the whole sheet.** A bike sheet is a dozen
-  panels side by side, and flooding the layer buried the eleven you weren't pointing at. Click
-  outside every island — on the sheet's background — and it still floods the layer, since
-  that's the only thing it could mean there.
-
-## Unreleased — double-click actually focuses, and the label says where on the bike
-
-### Fixed
-- **Double-click to focus a part now works.** The canvas takes pointer capture on every press so
-  a stroke survives leaving the element, and a captured pointer is exactly the case where WebKit
-  stops delivering `dblclick` — so the gesture was never seen. It's recognised from the presses
-  themselves now, which also makes it work under a pen or a touchpad.
-
-### Changed
-- **The hover names the mesh node as well as the group** — `chassis250 Metal.027`. A group's name
-  is whatever its author typed, and authors type anything: the TM pack calls its plastic panels
-  `Metal.NNN` and its metal ones `Plastics.NNN`, so the name alone reads as a contradiction of
-  the panel you're pointing at. The node is the bike's own part, so it still says *where*: a
-  shroud is on the chassis and a rear fender is on the rear suspension, whatever the group
-  is called.
-
-## Unreleased — a browse card says who made it
-
-### Added
-- **Mod cards carry a byline.** The catalog knows who posted each mod and the grid never
-  showed it, so telling two versions of the same track apart meant opening both. The name now
-  sits beside the date, the way a shop card already carries its author. It rides along with
-  the listing request rather than costing one of its own, and a mod the catalog names nobody
-  for simply keeps the date.
-
-## Unreleased — the install picker says which file it's about to fetch
-
-### Fixed
-- **A dedicated-server build is no longer installed as if it were the mod.** Server files were
-  detected by looking for the word "server" anywhere in a download block, which missed the
-  authors who only say it in the file's name (`Ironman_2024_Server.pkz`) — an undetected one
-  carrying the page's "Default" flag was preselected and installed without ever being named.
-  The link itself is read now as well, and the same check no longer mistakes a track called
-  *Observer Hill* for a server build, which used to hide the only download it had.
-- **Quick install stops guessing on a mod that offers nothing but server files.** One click
-  can't ask which build was meant, and the wrong one installs cleanly and then does nothing
-  in-game. Those mods now say so and send you to the page, where every file is listed.
-
-### Changed
-- **Every download is shown, with the recommended one picked.** Server builds used to be
-  dropped from the list, so a mod read as having one file while the flag behind that was a
-  guess. They're listed last instead, badged *Server*, folded under a *dedicated server files*
-  disclosure, and never preselected while anything playable is on offer.
-- **The mirror list opens on more than one row.** A single row read as the only file there
-  was; the first few are listed now, each with the author's own name for the file, so two
-  MediaFire links are told apart before one of them is downloaded.
-
-## Unreleased — FrostMod runs on Linux, and the app can see the game there
-
-### Added
-- **Cheat detection.** MX Bikes ships no anti-cheat, so a hooked client is
-  indistinguishable from an honest one — to the server, to the grid, and to the game. The
-  cheats going round are injected DLLs and external trainers, and an injected DLL has one
-  property worth building on: to hook the game it has to be *inside* the game, which puts it
-  in the process's module list. The app now reads that list while you ride (every 45s for as
-  long as the game is up, whether the app launched it or Steam did) and reports one of four
-  verdicts. Three of them are not accusations: **nothing unaccounted for**, **something
-  unrecognised is loaded** — an overlay or capture tool nobody has listed yet lands here —
-  and **not checked**, which is what a machine we could not read gets and is never a synonym
-  for clean. Only a match against the signature list is called a cheat. Findings name the
-  file, where it loaded from, and why it was reported; Settings → Cheat detection shows the
-  live answer and re-runs it on demand.
-- **Signatures update without a release.** They live in
-  [`integrity-rules.json`](integrity-rules.json) on `main`, fetched and cached at runtime
-  like `supporters.json` — a cheat that appears on a Tuesday cannot wait for a build. What
-  ships in the binary is the *allowlist* and no signatures at all, so an install that never
-  reaches the network is cautious rather than wrong; the allowlist is what stops an ordinary
-  gaming PC (Steam overlay, GPU driver, Discord, OBS, RivaTuner, ReShade) from lighting up
-  on first launch. A remote list can only add to that allowlist, and can never un-flag a
-  signature.
-- **Servers can see their grid's client checks.** With sharing turned on — its own switch,
-  off by default — a client publishes its verdict to the control plane, and the admin of the
-  server it is on sees it in the Servers tab, worst first, with a rider who was flagged
-  earlier in the session still shown as flagged rather than being cleared by unloading the
-  cheat for a lap. What is sent is the verdict and the names of *rule-matched* detections
-  only: an unrecognised-but-unnamed module is counted and never named, because on somebody's
-  machine that could be anything. Readable by the server's owner and by riders currently on
-  it, so you can see the grid you're riding with and can't go fishing for anyone else.
-  The list is honest about what it is: a rider appears only if their app is running,
-  watching and sharing, so somebody missing from it hasn't been cleared — and a cheater who
-  closes MXB App is never scanned at all. This proves an honest client is honest, which is
-  something a server currently has no way to ask for; it does not make cheating impossible.
-- **FrostMod installs and runs on Linux.** It used to refuse with *FrostMod runs on Windows
-  only*, which was true of the binary and beside the point: on Linux the game is a Windows
-  process too — Steam runs it under Proton — so FrostMod belongs in that same Proton prefix,
-  where the process it injects into lives. The app now finds the prefix
-  (`steamapps/compatdata/655500`), finds the Proton build that made it (from the prefix's own
-  `config_info`, so it uses the build Steam used rather than the newest one installed), and
-  starts `frostmod.exe` in it. `--mods` is handed over as the prefix sees the folder —
-  `C:\users\steamuser\…` rather than `/home/…`, which is the same path and not a name FrostMod
-  could have made sense of.
-- **The Reload button works from outside the prefix.** The app is a native Linux process and
-  FrostMod's reload event is a Wine kernel object: nothing this side of the wall can pulse it.
-  So a reload goes as a file instead — FrostMod v0.13.0 reads its command file on a poll — and
-  the status pill reads the process table rather than asking for an event it can't open.
-  Anything older than v0.13.0 is refused with a version to update to, rather than started into
-  a state where the in-game `F8` works and every button here quietly doesn't.
-- **The FrostMod section of Settings, and its log row, appear on Linux** on the same terms as
-  Windows. macOS still hides them: the app launches a CrossOver/Whisky bottle there but does
-  not inject into it.
-
-### Fixed
-- **The app knows when the game is running on Linux.** It answered *no* unconditionally —
-  macOS got a process-table check when Play landed there and Linux was never given one. So Play
-  never greyed out mid-session, and every question that turns on it ("will this paint show now
-  or at the next launch?", "is it safe to move this file?") was answered for a machine where the
-  game supposedly never runs. Under Proton the game is an ordinary Linux process whose command
-  line still names `mxbikes.exe`, so `/proc` finds it — no `ps` needed, which the AppImage
-  doesn't carry.
-
-## Unreleased — the Linux app stops carrying the library that blanked its window
-
-### Fixed
-- **The AppImage no longer ships its own libwayland.** linuxdeploy pulls libwayland-client,
-  -cursor, -egl and -server in as dependencies of GTK and WebKit, so our AppImage carried
-  Ubuntu 22.04's copies and put them ahead of the host's on the library path — where the
-  *host's* Mesa loaded them, and then couldn't create an EGL display. That is the window that
-  comes up and never paints. The AppImage excludelist names libwayland-client for exactly this
-  reason; the linuxdeploy build Tauri downloads carries an older copy of that list and bundles
-  it regardless. Release builds now take those four libraries back out of the image before it
-  is published, and sign it again over the bytes that ship, so the app uses the same libwayland
-  as every other program on the machine.
-- **The XWayland workaround from v0.9.1 turned out never to run, and has been dropped.** An
-  AppImage sets `GDK_BACKEND=x11` in its own startup hook, before a line of our code executes
-  — so the default the app set for the same thing could never apply, every AppImage was
-  already going through XWayland, and the white screen that release was meant to cure survived
-  it untouched. Nothing about how an AppImage runs changes here: the hook still says x11. The
-  app now only asks for a backend when `MXB_SAFE_GRAPHICS=1` does, which is the one case where
-  it's a knob somebody is deliberately turning.
-
-## Unreleased — the sheet says which panel, which side, and which face
-
-### Fixed
-- **A sheet region no longer names the wrong flank.** The hover asked whichever part won the
-  pick which side of the bike it was, and the winner is the *smallest* part covering the point —
-  so a bracket sharing the shroud's island answered for the shroud, and a region on the right of
-  the bike came up as the left. The side and the facing are now asked of every part covering the
-  point, and where two of them overlap the label names both (`plastics on metal.027`) instead of
-  quietly picking one.
-- **A bike that loaded without its `.geom` no longer gets sides invented for it.** Its parts are
-  never placed into one frame, so a vertex's position says nothing about where it sits on the
-  bike — the flanks were read off those numbers anyway. The model now reports whether it was
-  assembled, and the Designer says nothing about sides when it wasn't. The warning also goes to
-  the app log rather than only to a terminal.
-- **A bike archive with no mesh in it now fails instead of loading empty.** The viewer took the
-  empty result for a successful load and put its stand-in bike on screen, which reads as *this
-  is your bike* rather than *none of this bike arrived*. Cloud-synced archives that haven't been
-  downloaded yet land here, and now say so.
-
-### Added
-- **The sheet says when you're about to paint a panel's underside.** A rear fender's outer skin
-  and its underside are one part with one name and regularly share one island, so artwork could
-  land where nobody will ever see it. The hover now reads `underside` or `top + underside`
-  alongside the part and the flank.
-- **Double-click a part to fill the view with it.** A shroud is a tenth of a 2048² sheet, and
-  reaching it by wheel-and-drag meant aiming at the shape you were trying to see.
-
-## Unreleased — an empty canvas stops asking for a sheet
-
-### Changed
-- **The Designer no longer nags about an empty canvas.** Opening it with nothing drawn yet put
-  *Add a sheet to draw on.* next to a greyed-out Save, which stated the obvious about a canvas
-  you had only just opened. Save is still off until there's a sheet to save — it just stays
-  quiet about it, and the hints worth acting on (a missing name, a duplicate texture name, no
-  target picked) read exactly as before.
-
-## Unreleased — the paint changes on disk, the model changes with it
-
-### Added
-- **The 3D viewer reloads a paint that changes on disk.** Leave the bike open in the viewer,
-  re-save the paint, and the model re-dresses itself — the draw, look, fix, look loop no
-  longer needs the dialog closed and re-opened between passes. Only the textures are
-  replaced, so nothing rebuilds the bike's geometry for a livery, and a brief **Paint
-  reloaded** chip says when one landed (an edit that turned out to change nothing visible
-  otherwise looks identical to one the viewer missed).
-- The watched paint is whichever one is showing — a bike's installed livery, a model-swap
-  preview's, or a loose gear paint. The paint's *folder* is watched rather than the file,
-  because saving one usually means writing a temp file and renaming it over the target, and
-  a watch on the file itself would go silent after exactly the first save.
-
-## Unreleased — the bike's own plastics, under the UV map
-
-### Added
-- **The bike's own plastics, under the UV map.** The reference underlay could show the paint you
-  started from — and on an OEM bike there isn't one: its stock `.pnt` replaces the wheels and the
-  chain, and the plastics are embedded in the model itself. So the one sheet anybody opens the
-  Designer for was the one sheet with nothing to trace, just bare islands. Reference now has a
-  **Stock texture** toggle that draws the model's own artwork beneath them, so you can see where
-  the vents and shut lines fall before drawing over them. Fetched only for the sheet you're
-  looking at, and no more part of what you save than the UV map is.
-
-## Unreleased — the UV map says which side of the bike it is
-
-### Added
-- **The sheet now says left or right.** Hovering a piece of bodywork named it; it now says which
-  flank of the bike that piece is, and the clip picker carries the same suffix. The model already
-  knew — the geometry arrives assembled about its mirror plane, so the sign of a triangle's x is
-  the answer — and not passing it on left the one question a flat square can't answer to guesswork.
-- **"Both sides" is said out loud.** Bikes routinely unwrap their two flanks onto *one* island, so
-  a decal placed off-centre there comes out at the mirrored spot on the far side — which reads as
-  the editor having painted the wrong side. Where that is what the model does, the sheet says so
-  and the tooltip says what it means. Rider gear is left unlabelled: a helmet's up-axis is worked
-  out per mod, and a side named from the wrong axis would be worse than no side at all.
-
-## Unreleased — the Designer sets up its own sheets
-
-### Added
-- **Create the sheets a model asks for, in one click.** The Designer already listed the texture
-  names a bike's paints use — and the name is the whole binding, so a sheet called anything else
-  paints nothing — but getting them onto the list meant reading them off and typing each one
-  back in. There's now a button beside that list that makes the missing ones.
-- **A ＋ beside Sheets**, and another beside Layers, add one without hunting for a button.
-- **See a model swap before you switch to it.** Every model set in the Locker now has a 3D
-  button beside it, and "Stock" has one too — that one shows the model packed in the bike's
-  own archive, the one your loose files are covering. The bike is assembled in memory exactly
-  as applying the swap would leave it (the set's mesh over the bike's own `.hrc`s, `.geom` and
-  textures), so nothing moves on disk and you can look with the game open.
-- **See the helmet on its own, not on the rider.** Painting a helmet, boots or protection always
-  previewed the piece worn by the stock rider — a small thing across the canvas with half of it
-  turned away, next to a grey body you weren't painting. A **Gear only** toggle in the preview
-  header takes it off and fills the frame with it, the way the library's 3D view already shows
-  one, and puts it back on the rider in a click when you want to see how it sits.
-
-### Changed
-- **The UV map is on by default.** It answers the question a flat sheet always raises — which
-  rectangle of this ends up on the shroud — and having to know it existed before you could ask
-  for it was one step too many. It still only builds for the sheet you're looking at.
-- **"Start from a paint…" is offered only while there is nothing to draw on.** It *replaces*
-  every sheet, which is what makes it a template step, so sitting it beside work in progress was
-  offering to throw that work away.
-- The sheet list scrolls instead of growing: a bike's paint runs to two dozen sheets, and that
-  pushed the hint line and every button below the fold.
-- **Add image and Add text moved down beside the drawing tools**, which is the panel you are
-  already in while working on a sheet — the top bar is for naming and saving the paint. The
-  separate "Paint layer" button is gone with them; the ＋ beside Layers is that.
-
-### Fixed
-- **A paint no longer ships sheets you never drew on.** A `.pnt` replaces the model's textures
-  by name, so an empty sheet doesn't add a blank — it *removes* whatever the bike had there. A
-  paint saved with twenty untouched sheets wiped the bike's own normal and roughness maps, and
-  came to 350 MB of pixels, which is enough on its own to push the texture store past its
-  ceiling and leave the 3D preview grey. Empty sheets are left out, and the save says how many.
-- Offering to create every missing sheet no longer offers the companion maps (`_n`, `_r`). They
-  aren't drawn like a livery, and a blank one is the exact thing above: it throws away the real
-  one. The hint line still lists them, and one can still be added by hand.
-- **The plastics are on the list.** The sheet names came from the paints already installed for a
-  model, and the OEM bikes ship one paint that replaces the wheels and the chain — so a stock
-  Husqvarna offered `chain`, `wheel`, `wheels`, and not the bodywork anyone opened the Designer
-  for. The model's own mesh is now asked what it draws, which is the half no paint can answer.
-  A helmet's goggles still go on their paints alone: a mesh can't say which of its textures
-  belong to the goggles beside it.
-- **Picking a model no longer takes twenty seconds.** Working out what it expects read every
-  installed paint whole — tens of megabytes each — for the few hundred bytes of header that
-  hold the names. It seeks to them instead: 19s down to 0.6s on a bike with paints installed.
-
-## Unreleased — a helmet you installed is a helmet you can see
-
-### Fixed
-- **A packaged mod bought from the shop landed one folder too deep.** A helmet, boots or any
-  other rider mod that downloads as a finished `.pkz` was filed inside a folder named after the
-  download — `helmets/shop-44/` — and a package only loads from the area itself. Neither the
-  game nor this app could see it, and it showed in the pickers under that name rendering
-  nothing. New installs go straight into the area under the mod's own name.
-- **The Rider tab offers to move the ones already buried.** The same banner that gathers a mod
-  installed loose now spots a package a folder too deep and raises it, so a mod already on disk
-  doesn't have to be reinstalled to be found. It moves the package and nothing else, never
-  overwrites a name already in the area, and leaves any folder with files of its own alone.
-- **A one-piece helmet or boot rendered as nothing at all.** Gear whose mesh comes as a single
-  piece — the game's own stock helmet, and any mod that doesn't split the shell from the
-  goggles — was handed one material per piece for a mesh with no pieces to hand them to, and
-  drew not one triangle. Everything else about it arrived intact, which is why the paints were
-  listed for a helmet that never appeared.
-- **A one-piece helmet rendered on its side.** A mesh in that shape never had its placement
-  applied, so one authored in a rotated frame stayed rotated. Harmless where a model is
-  authored square, which is most of them — the game's own gear is unchanged — and every mod
-  now lands where its own file says the model sits.
-
-## 2026-08-13
-
-### Added
-- **Toggle to talk, as an alternative to holding the key.** Press once to open the mic,
-  press again to close it. Push-to-talk stays the default: it cannot leave a microphone
-  open by accident, and toggle can. Because a latched mic has nothing physical to remind
-  you it is open, the Voice section now shows a live **Mic open** indicator whenever it is.
-- The mic key is rebound whenever the mode changes, and always starts closed — a rebind, or
-  switching voice off and on, must never leave someone transmitting with no key press
-  behind it.
-- Auto-repeat is ignored in toggle mode. The OS repeats a held key, and acting on each
-  repeat would open and close the mic dozens of times a second for as long as someone
-  leant on it.
-
-## Unreleased — the image builder survives long enough to build an image
-
-### Fixed
-- **The idle sweep destroyed the machine building the server image.** Builders were left out of
-  the query that lists known instances, which meant the very next check — the one that
-  terminates anything with no database row — saw them as untracked and killed them within five
-  minutes of launching. They are listed like everything else now and skipped at the idle check
-  instead, which is the only part that should ignore them. A build whose machine disappears
-  also clears itself, rather than blocking every later build as one already in progress.
-
-## Unreleased — back to the game's own model, in one click
-
-### Fixed
-- **A bike with one model swap can go back to the game's own model.** The Locker only ever
-  listed model sets that existed as folders, so a bike carrying a single swap showed one tile
-  and "Only one model — install more to swap", with no way back. Every bike now gets a
-  **Stock** row, the way sounds always have. Choosing it files the loose model away under
-  `FrostMod Models/` — never deletes it — and one click puts it back.
-- **Reverting to Stock clears the setup files a swap brought with it.** A swap dropped
-  straight into a bike folder was never registered, so only its meshes were filed away and
-  its `.hrc`/`.cfg` stayed behind, still overriding the packed bike but naming meshes that
-  were gone. Those now travel with the model they belong to.
-
-## Unreleased — an import fills the gaps, it doesn't trade
-
-### Fixed
-- **Importing a full bundle no longer overwrites the mods you already have.** A bundle carries
-  whole asset folders — share a single helmet paint and the helmet's mesh and every other livery
-  on it travel too — so importing one quietly replaced your copy of a model with the sender's.
-  An import now writes only the files you're missing and leaves anything already on disk alone.
-  Downloading or dropping a mod still overwrites, which is how updating one works.
-
-## Unreleased — a server arrives in two minutes, not fifteen
-
-### Added
-- **Servers launch from a prebuilt image.** Every one of them used to download and install the
-  same 6 GB — the game, then the whole bike pack — which was the entire wait. That work now
-  happens once, into a machine image, and each new server writes its own config and starts.
-  Two minutes instead of fifteen, and it stops getting slower every time the pack grows.
-  Building the image is a one-off `POST /v1/images/build`; until one exists, servers install
-  from scratch exactly as before.
-
-## Unreleased — share any track or paint, not just a preset
-
-### Added
-- **Share installed files with a code.** Sharing was a preset's privilege: a code carried a
-  *look*, and the full bundle packed whatever its slots resolved to. Handing someone the track
-  you just rode, or the paint you just made, still meant uploading it somewhere and pasting a
-  link. Anything the Library lists can now go straight into a code — **Share** on any item, or
-  pick several with **Select** and share them together. It packs them, uploads them, and puts
-  one line on your clipboard.
-- **The other end: Import → Paste a share code…** Files land back in the folders the sender
-  had them in — a track filed under `tracks/EU/` arrives under `tracks/EU/`, a helmet paint
-  goes to the helmet it belongs to — so a share carries where things go, not just what they
-  are. The code is previewed before anything downloads: what it holds, how big it is, and
-  where it's hosted.
-- Sharing reuses the preset bundle's upload, so the same 2 GB ceiling and the same slicing
-  past one part apply, and a share whose parts have gone missing says which one.
-
-## Unreleased — a created server can see the bikes it installed
-
-### Fixed
-- **A provisioned server rejected riders on bikes it had been given.** The pack was downloaded
-  into the game folder, and MX Bikes reads mods from PiBoSo's user folder instead — the same
-  place the client uses, which under the service account lives elsewhere entirely. The files
-  were on disk the whole time and the game was never looking there. They now install where the
-  game reads, with the game folder linked to the same content so nothing is copied twice.
-
-## Unreleased — a full share isn't capped at 200 MB any more
-
-### Changed
-- **Full-share bundles are no longer capped at 200 MB.** That ceiling was the upload host's,
-  not ours, and a preset carrying a big track or a few detailed bikes ran straight into it. A
-  bundle past 190 MB is now sliced across several uploads and stitched back together on
-  import, taking the limit to 2 GB. Codes for smaller bundles are unchanged, and a share whose
-  parts have gone missing says so — with the size it expected — instead of failing at the
-  unzip.
-
-## 2026-08-11 — v0.9.2 — A track's terrain in 3D, and voice chat picks its microphone
-
-On top of v0.9.1 — the Designer's painting tools, Play on macOS and the SteamOS white screen
-are all still in here, and v0.9.0's notes are repeated below.
-
-Worth knowing: **voice chat doesn't transmit yet.** This is the device half — the mic, the
-headset, the levels and the key that opens the mic, with test buttons that do work. The codec
-and the voice room are still to come, and the Settings section says so rather than looking
-finished.
-
-Also worth knowing: the terrain is read from the game's own height file and checked against
-four published tracks' marshal posts, not against every track there is. If one comes out
-looking nothing like the track you ride, name it in the report — that's the thing to send.
-
-### Added
-- **See a track's terrain in 3D.** Tracks were the one thing the library couldn't show you —
-  a name, a preview and a size. The viewer now reads the heightfield out of a track and draws
-  the ground, opening from the library detail view next to **View in 3D**.
-- **Tracks are drawn with their surfaces, where the track says what they are.** A track's
-  height file can carry coverage masks — one per surface the builder painted, a byte per cell
-  — and the viewer reads them, so grass, apron, hard standing and the dirt of the riding line
-  each get their own colour. Tracks that carry no masks keep the elevation shading.
-  - Each surface takes the colour of the material the track names for it — the ids below six
-    index the table every track carries (asphalt, grass, sand, kerb, soil, concrete), so a
-    farm's fields come out as the soil they are and a grass circuit comes out green, rather
-    than every track being coloured by whichever surface happened to cover the most of it.
-  - Tracks also ship a picture in `[ui] pic_info`, and that is deliberately *not* used. Some
-    of those are true overhead photographs, but others are branded posters — a diagram on a
-    paper texture with a series logo across the bottom — and laying one on the terrain puts a
-    logo on the dirt. Nothing in the file distinguishes them, and three ways of asking a
-    picture to prove it describes the ground all failed to separate a real photograph from a
-    poster (extents of 0.709 against 0.715). The masks need no such test: they are a byte per
-    cell of the very grid being drawn, so they line up by construction.
-- **The terrain is lit by its own hollows.** A directional light can only shade a slope by
-  which way it faces, so a rut running along the light and a ridge running along it were lit
-  identically and the shapes a track is made of came out flat. Every point is now measured
-  against a blurred copy of the terrain at two scales — tight enough to find a rut, wide
-  enough to see the bowl a turn sits in — and the result darkens hollows and lifts ridges.
-  The terrain also casts and receives real shadows now.
-- **Voice chat settings — microphone, output, levels and a push-to-talk key.** A new
-  Settings section that picks the mic to listen to and the headset other riders will come
-  out of, with a live input meter and a test tone. Both device settings default to *system
-  default* and mean it: they follow whatever Windows is set to rather than pinning the
-  headset that happened to be plugged in when you chose. A device that has since been
-  unplugged falls back to the default and **says so** — silently going mute is the failure
-  that reads as "voice chat is broken".
-- **Push-to-talk**, bound through the same global-shortcut path as the overlay hotkey, so
-  it works while the game holds focus. It acts on both edges — mic opens on press, closes
-  on release — and is bound even when the overlay is switched off.
-- **Your logs, in Settings → Logs.** "Send me your logs" was the first thing every bug
-  report asked for and the one thing there was no way to do. There are three sets and they
-  sit in three places: MXB App writes its own into a folder buried in AppData, FrostMod
-  writes into the folder we install and run it from, and the game writes `log.txt` beside
-  its executable — or, when the game's folder has been moved, somewhere only the app knows.
-  All three are now named on one page, with how many files are there and how old the newest
-  one is, so a log that predates the run you're reporting can be seen for what it is.
-  **Open folder** takes you to any of them with the newest file selected, and **Save logs…**
-  writes the lot into a single zip to attach. The zip holds the logs and a summary of the
-  folders they came from — never the settings file, which carries session cookies.
+- **The Designer sets up its own sheets.** Create the sheets a model asks for in one click,
+  with ＋ buttons beside Sheets and Layers. The model's own mesh is asked what it draws, so an
+  OEM bike's plastics are on the list instead of only its wheels, and picking a model dropped
+  from 19s to 0.6s.
+- **A Stock texture underlay** draws the bike's own artwork — the plastics embedded in an OEM
+  model — beneath the UV map, so the one sheet with nothing to trace finally has something under
+  it.
+- **The sheet says where you are.** Hovering names the part, its flank (left or right), and
+  whether you're over a face you'll see or an underside you won't; the spot under the pointer
+  lights up on the 3D model. Where a bike unwraps both flanks onto one island it says so, with
+  the left washed warm and the right cool.
+- **Double-click a part to fill the view with it**, rather than aiming at it by wheel and drag.
+- **Undo covers the whole editor** — adding, moving, scaling, rotating and deleting layers and
+  sheets are all on one timeline, not just the last brush stroke — and **the bucket fills the
+  panel you clicked**, not the whole sheet.
+- **The 3D viewer reloads a paint that changes on disk**: re-save, and the model re-dresses
+  itself without closing the dialog. Preview a model swap before you switch to it, and take a
+  helmet off the rider to fill the frame with a **Gear only** toggle.
+- **A Downloads page** — everything you've installed, newest first, grouped by day, with where
+  each one landed and which mirror served it, searchable by name, destination or host.
+- **Failed downloads are kept** with their error and retry in place through the same queue, and
+  a **"Recently added" sort** in the library covers everything already on disk.
+- **The download queue opens** into a panel listing the transfer in progress and everything
+  behind it, and **any download can be cancelled** — one waiting simply leaves, the one in
+  flight is stopped mid-transfer and its partial file cleaned up.
+- **See a track's terrain in 3D.** The viewer reads the heightfield out of a track and draws the
+  ground, coloured by the surfaces the track names and lit by its own hollows, from the library
+  detail view next to View in 3D.
+- **Share any track or paint with a code.** Sharing was a preset's privilege; now anything the
+  Library lists goes into a code with **Share**, or several at once with **Select**. The other
+  end is **Import → Paste a share code…**, and files land back in the folders the sender had them
+  in.
+- **FrostMod installs and runs on Linux and macOS** — in the game's Proton prefix on Linux, in
+  the CrossOver/Whisky bottle on macOS. Reload works from outside the prefix or bottle (a polled
+  command file; needs FrostMod v0.13.0 or newer), and the FrostMod Settings section and log row
+  now appear on both.
+- **"Repair runtimes" in Settings** installs every Visual C++ runtime the PC is short of — both
+  32- and 64-bit — and puts `msvcr90.dll` where the game looks for it, elevating when the game
+  lives under Program Files. It's always available rather than gated on a detected fault, and
+  hands over download links for anything it couldn't finish.
+- **Voice chat settings** — pick the microphone you're heard through and the headset everyone
+  else comes out of, with a live meter and a test tone, plus a **push-to-talk** key that works
+  while the game holds focus and a **toggle-to-talk** mode with a live Mic-open indicator.
+- **Your logs, in Settings → Logs.** All three log sets named on one page, with how many files
+  and how old the newest is; **Open folder** and **Save logs…** into a single zip that never
+  carries the settings file.
+- **Mod cards carry a byline**, so two versions of a track are told apart without opening both.
 - **Qwest and Kelso** credited on Settings → Supporters.
-- **Point ReShade at the folder it's actually in.** The ReShade card only ever looked in the
-  game's install folder, so if that was unset or detection landed somewhere else, it said
-  "not installed" to people with ReShade sitting right there, and offered nothing to do about
-  it. It now names the folder it looked in and takes a pick of your own, kept separately from
-  the game folder — that one also drives the 3D rider, the game log location and Play, none of
-  which a choice made on this card should move. A folder with no ReShade in it is still
-  accepted and simply reported as such, and there's a link back to the game folder.
-- **Share installed files with a code.** Sharing was a preset's privilege: a code carried a
-  *look*, and the full bundle packed whatever its slots resolved to. Handing someone the track
-  you just rode, or the paint you just made, still meant uploading it somewhere and pasting a
-  link. Anything the Library lists can now go straight into a code — **Share** on any item, or
-  pick several with **Select** and share them together. It packs them, uploads them, and puts
-  one line on your clipboard.
-- **The other end: Import → Paste a share code…** Files land back in the folders the sender
-  had them in — a track filed under `tracks/EU/` arrives under `tracks/EU/`, a helmet paint
-  goes to the helmet it belongs to — so a share carries where things go, not just what they
-  are. The code is previewed before anything downloads: what it holds, how big it is, and
-  where it's hosted.
-- Sharing reuses the preset bundle's upload, so the same 2 GB ceiling and the same slicing
-  past one part apply, and a share whose parts have gone missing says which one.
 
 ### Changed
-- **Settings shows one section at a time.** Twelve sections rendered into a single column
-  meant the folder settings and the version number shared a scrollbar, and the nav on the left
-  only scrolled you to an anchor in it. That nav is now grouped — Setup, App, Advanced, About
-  — and opens each section on its own. **Experimental** was in that column with nothing in the
-  nav pointing at it; it has an entry now, under Advanced.
-- **Voice chat settings read shorter.** Five lines of help text under controls whose labels
-  already said the same thing are gone — a device picker labelled "Microphone" didn't need a
-  sentence under it explaining that it picks a microphone. What's left is the things the
-  labels can't say: that nothing transmits yet, and what the test buttons do.
-- **Full-share bundles are no longer capped at 200 MB.** That ceiling was the upload host's,
-  not ours, and a preset carrying a big track or a few detailed bikes ran straight into it. A
-  bundle past 190 MB is now sliced across several uploads and stitched back together on
-  import, taking the limit to 2 GB. Codes for smaller bundles are unchanged, and a share whose
-  parts have gone missing says so — with the size it expected — instead of failing at the
-  unzip.
+- **Downloads is now part of the Library** — an expandable group under it in the sidebar rather
+  than a tab beside it. A failed download still shows its count on the Library row while the
+  group is shut.
+- **The install picker shows every download**, the recommended one preselected, dedicated-server
+  builds badged *Server* and folded under a disclosure rather than dropped. The mirror list opens
+  on more than one row, each with the author's own name for the file.
+- **The mirrors hint line is gone** from the download dialog — the list already reads as a list
+  of the same file.
+- **Settings shows one section at a time**, with the left nav grouped into Setup, App, Advanced
+  and About.
+- **The UV map is on by default**, "Start from a paint…" is offered only while the canvas is
+  empty, the sheet list scrolls, and Add image / Add text moved down beside the drawing tools.
+- **Back to the game's own model in one click** — every bike gets a **Stock** row in the Locker,
+  and choosing it files the loose model away (never deletes) along with the setup files a swap
+  brought with it.
+- **The ReShade card takes a folder of your own** and names where it looked, kept separate from
+  the game folder.
+- **The process is called "MXB App"** in Activity Monitor and Task Manager, not the name of the
+  Rust crate behind it.
 
 ### Fixed
-- **Terrain below a track's datum is no longer drawn as a wall around it.** A `.trh` stores
-  its samples *signed*, and they were read unsigned, so every point below the datum came out
-  a full half-range — eleven metres — too high. Tracks that sit entirely one side of it were
-  merely offset; ones that straddle it, like Farm14, were drawn as a plateau with the track
-  sunk in a pit and the jumps at the bottom of it. Confirmed against the marshal posts of two
-  published tracks: read signed, their stated ground heights come back to the centimetre
-  (SandPoint's median error is 0.000 m against 11.001 m read unsigned), and the 32768-unit
-  cliffs that wrapping left across three of four tracks disappear entirely.
-- **The track is no longer drawn mirrored.** The terrain was placed straight into the scene
-  while the game's frame is left-handed and the viewer's is not, so every track came out
-  flipped — a left-hander read as a right-hander. It now goes through the same axis
-  conversion every bike and rider model in the app already does (`edf::to_right_handed`),
-  with the triangle winding turned to match so the ground is still lit from above.
-- **Terrain is drawn at the detail it was asked for — twice over.** Reductions moved by a
-  whole number of samples in two separate places, and both overshot. Reading a heightfield
-  into the master could only halve a 2049-sample grid asked for 2048, so the master was 1025
-  and half the file was thrown away before the viewer could ask for it. The same fault in the
-  view's own reduction meant a request for 320 across a 410-sample master could only step by
-  two and drew 205 — one drawn square covering nearly three metres of ground, wider than the jump
-  faces and ruts it was meant to show. Reductions now land on the size requested, and the
-  master itself is kept at twice the resolution. A track is drawn with roughly 3.7x the
-  samples across it, and a drawn square covers under a metre.
-- **The blind heightfield probe no longer reads a shifted grid.** It required the samples to
-  run to the last byte of the file, so a height file with a trailing block — which is what a
-  real `.trh` is — could only fit by treating that block as a header, landing the grid over
-  half a row late and reporting full confidence while doing it. Alignment is now measured
-  rather than assumed: a read that starts in the wrong place wraps mid-row, breaking every
-  row in the same column, and that is what the probe now looks for.
-- **Relief is drawn at a fixed, gentle exaggeration.** The 1×/2×/4× control is gone: 4×
-  stretched a track's boundary into spikes without making the track itself any clearer. What
-  replaces it is a single 1.5×, which is enough for a jump face to cast a shadow while the
-  ground still reads as ground.
-- **Paints larger than 32 MB were refused, and took the whole publish with them.** A 4K livery
-  runs well past that: the largest on a normal install is 121.7 MB. Because a loadout is
-  checked as a whole, owning one such paint meant publishing nothing at all and looking default
-  to everyone. The limit is now 192 MB, and anything still over it is left behind — and said
-  out loud — rather than failing the rest.
-- **A loadout the control plane refused took your whole look with it.** Two things a real
-  install produces would fail the entire publish: a paint filed under a slot the control plane
-  does not store, and the same slot resolving twice — a livery installed both loose and inside
-  a pack. Either one meant a rider published nothing at all. Only publishable slots are sent
-  now, one paint per slot, first match winning as it does in the game.
-- **A refused publish says why.** The app reported the status and discarded the explanation, so
-  "400 Bad Request" was the whole story. It now carries the control plane's reason.
-- **A provisioned server rejected riders on bikes it had been given.** The pack was downloaded
-  into the game folder, and MX Bikes reads mods from PiBoSo's user folder instead — the same
-  place the client uses, which under the service account lives elsewhere entirely. The files
-  were on disk the whole time and the game was never looking there. They now install where the
-  game reads, with the game folder linked to the same content so nothing is copied twice.
-- **"MSVCR90.dll was not found" now gets the fix it was always missing.** Installing
-  Microsoft's 2008 redistributable registers a side-by-side assembly under `WinSxS` and puts
-  nothing on the ordinary DLL search path. The game reaches that assembly because its manifest
-  asks for it by name; a module with a plain `MSVCR90.dll` import and no VC90 manifest — most
-  things built with VS2008 — gets the ordinary search order instead, and never sees it. So the
-  install succeeded, the check went green, and the box kept appearing. The app now also places
-  a copy of `msvcr90.dll` beside the game executable, which is the one place that import will
-  look. Taken from the machine's own `WinSxS` (newest servicing build). This corrects the fix
-  described under v0.9.0, which addressed the wrong half of the problem.
-- **A game folder that carries its own copy of the CRT is no longer called broken.** The check
-  only ever looked in `WinSxS`, so an install keeping the runtime beside the executable — the
-  way PiBoSo's own installers have long shipped it — showed a warning bar it could never clear.
-- **The missing-runtime check now looks for `vcruntime140_1.dll`.** FrostMod imports it, but
-  only `vcruntime140.dll` and `msvcp140.dll` were probed. A machine still on the original 2015
-  redistributable has those two and not this one, so it read as perfectly healthy while
-  injection failed naming a file the app never checked for.
+- Quick install queues the whole selection the moment you click — each row marked *Preparing* —
+  and names any mod it skips rather than reporting a bare count.
+- **MediaFire** resolves through its own API instead of the shape of its page; folder links
+  install, and a removed, password-protected, taken-down or bandwidth-exhausted file is each
+  named with what to do about it.
+- **Double-click to focus a part works**, recognised from the presses themselves rather than a
+  `dblclick` WebKit won't deliver under pointer capture.
+- A dedicated-server build is no longer installed as if it were the mod, and quick install stops
+  guessing on a mod that offers nothing but server files.
+- **Designer:** a paint no longer ships blank sheets — which removed the bike's own normal and
+  roughness maps and ran to 350 MB — and blank companion maps aren't offered for creation; a
+  collapsed UV triangle no longer answers for the whole sheet; one junk vertex can't switch
+  left/right off for a bike; the flank named is the right one; a bike loaded without its `.geom`
+  gets no invented sides; a bike archive with no mesh fails instead of loading its stand-in; the
+  empty-canvas nag is gone.
+- **Gear:** a packaged mod bought from the shop no longer lands a folder too deep — and the Rider
+  tab offers to raise ones already buried — and a one-piece helmet or boot renders at all, and
+  upright.
+- **Importing a full bundle fills the gaps** rather than overwriting mods you already have.
+- **Terrain** is read signed (no eleven-metre wall below the datum), drawn the right way round
+  rather than mirrored, at roughly four times the detail, with the blind heightfield probe and
+  the relief exaggeration both corrected.
+- **The AppImage no longer ships its own libwayland** — the cause of the SteamOS white screen —
+  and the XWayland workaround that never ran is dropped.
+- **Missing-runtime checks:** the MSVCR90 side-by-side case gets a `msvcr90.dll` beside the game
+  executable, a game folder carrying its own CRT is no longer called broken, and
+  `vcruntime140_1.dll` is now probed.
+- **Nothing downloads without a ceiling:** a thumbnail is refused above 32 MB and an embedded
+  texture is only decompressed as far as it claims to go, so neither a card image nor a scanned
+  model record can pull unbounded memory.
 
 ### Notes
-- Voice is **off until turned on**. A feature that opens a microphone shouldn't be
-  something a player discovers by accident.
-- Global shortcuts are now all rebound from one place. `unregister_all` clears every
-  binding, so a push-to-talk key registered independently would have been wiped the next
-  time the overlay hotkey changed; the overlay binds first, so a push-to-talk combo another
-  app owns costs you the mic key and not the overlay as well.
-- Audio comes from `cpal`, pinned to 0.15 — 0.18 doesn't build for Windows in this
-  workspace (its WASAPI backend collides with the `windows-core` version Tauri unifies on).
-  The pin carries the reason, since a macOS build gives no hint that it's needed.
-- The Linux build and CI now install `libasound2-dev`. cpal reaches ALSA through
-  `alsa-sys`, whose build script shells out to `pkg-config` and fails the entire build
-  without it — the AppImage would not have built either.
-- The `msvcr90.dll` copy beside the executable is written without elevation, so it cannot
-  land in a game folder under `Program Files`. A Steam install there still needs the runtime
-  repaired by hand until the elevated fallback lands.
+- Voice is **off until turned on** — a feature that opens a microphone shouldn't be discovered by
+  accident — and every global shortcut is now rebound from one place.
+- Buy Me a Coffee donations post to the Discord for money-in events only, carrying a name and
+  their note and nothing else — no amount, no email.
+- Audio comes from `cpal` pinned to 0.15; the Linux build and CI install `libasound2-dev`.
+
+## Unannounced — cheat detection
+
+Left out of the release notes on purpose, for the same reason as the anti-debugger measure
+below: an integrity check that is advertised is one a cheat author knows to defeat first. It
+ships silently and folds into whichever release carries it, unnamed. What is here is the
+consent-based, data-minimised implementation already in the app.
+
+### Added
+- **Cheat detection.** MX Bikes ships no anti-cheat, so a hooked client is indistinguishable
+  from an honest one. The cheats going round are injected DLLs and external trainers, and an
+  injected DLL has to be *inside* the game to hook it, which puts it in the process's module
+  list. The app reads that list while you ride (every 45s for as long as the game is up, whether
+  the app launched it or Steam did) and reports one of four verdicts — **nothing unaccounted
+  for**, **something unrecognised is loaded**, **not checked**, or a signature match — only the
+  last of which is called a cheat. Settings → Cheat detection shows the live answer and re-runs
+  it on demand.
+- **Signatures update without a release.** They live in `integrity-rules.json` on `main`, fetched
+  and cached at runtime like `supporters.json`. What ships in the binary is the *allowlist* and
+  no signatures at all, so an offline install is cautious rather than wrong; the allowlist is
+  what stops an ordinary gaming PC (Steam overlay, GPU driver, Discord, OBS, RivaTuner, ReShade)
+  from lighting up. A remote list can only add to that allowlist, never un-flag a signature.
+- **Servers can see their grid's client checks**, with sharing turned on — its own switch, off by
+  default. A client publishes its verdict to the control plane, and only the verdict and the
+  names of *rule-matched* detections are sent; an unrecognised-but-unnamed module is counted and
+  never named. Readable by the server's owner and by riders currently on it, and honest about
+  what it is: a rider appears only if their app is running, watching and sharing.
+
+## Unannounced — server provisioning and paint publishing
+
+Also kept out of the release notes: both need an account on the invite-only control plane, so
+these fold into the notes of whichever release opens enrollment up. They join the servers and
+paint-sync work described further below.
+
+### Added
+- **Servers launch from a prebuilt image.** Every server used to download and install the same
+  6 GB — the game, then the whole bike pack — which was the entire wait. That happens once now,
+  into a machine image, and each new server writes its own config and starts: two minutes instead
+  of fifteen. Building the image is a one-off `POST /v1/images/build`.
+
+### Fixed
+- **The idle sweep no longer destroys the machine building the server image.** Builders were left
+  out of the query that lists known instances, so the next check terminated them as untracked
+  within five minutes of launch. They are listed and skipped at the idle check now, and a build
+  whose machine disappears clears itself instead of blocking every later build.
+- **A provisioned server can see the bikes it was given.** The pack was downloaded into the game
+  folder, but MX Bikes reads mods from PiBoSo's user folder — the files were on disk the whole
+  time and the game was never looking there. They now install where the game reads, with the game
+  folder linked to the same content.
+- **Paints larger than 32 MB no longer fail a publish.** A loadout is checked as a whole, so one
+  4K livery meant publishing nothing and looking default to everyone; the limit is now 192 MB and
+  anything still over it is left behind and said out loud. Only publishable slots are sent, one
+  paint per slot, and a refused publish now carries the control plane's reason.
 
 ## Unannounced — a debugger can't ride along
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.9.2",
+  "version": "0.10.0",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3181,7 +3181,7 @@ dependencies = [
 
 [[package]]
 name = "mxb-app"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # whatever cargo called it. Cargo target names can't hold a space, so this is as close as
 # it gets. The description is what Windows Task Manager shows in its Processes tab.
 name = "mxb-app"
-version = "0.9.2"
+version = "0.10.0"
 description = "MXB App — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
   "mainBinaryName": "MXB App",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/Components/Showcase/releases.ts
+++ b/src/Components/Showcase/releases.ts
@@ -38,6 +38,8 @@ import {
   Wrench,
   RefreshCw,
   Package,
+  Download,
+  Share2,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { TKey } from "../../i18n/context";
@@ -64,6 +66,21 @@ export interface Release {
 }
 
 export const RELEASES: Release[] = [
+  {
+    version: "0.10.0",
+    hero: {
+      icon: Wand2,
+      title: "showcase.v0100.hero.title",
+      body: "showcase.v0100.hero.body",
+    },
+    highlights: [
+      { icon: Grid3x3, text: "showcase.v0100.location" },
+      { icon: Download, text: "showcase.v0100.downloads" },
+      { icon: Mountain, text: "showcase.v0100.terrain" },
+      { icon: Share2, text: "showcase.v0100.sharing" },
+      { icon: Wrench, text: "showcase.v0100.linux" },
+    ],
+  },
   {
     version: "0.9.2",
     hero: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1240,6 +1240,19 @@ export const de: Translation = {
   "showcase.supporters.title_one": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.title_other": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.more": "+{{count}} weitere",
+  "showcase.v0100.hero.title": "Der Designer richtet seine Blätter selbst ein",
+  "showcase.v0100.hero.body":
+    "Er legt jetzt die Blätter an, die ein Modell braucht, legt die eigenen Plastikteile des Bikes darunter zum Abpausen und öffnet ein Modell in etwa einer Sekunde statt in fast zwanzig.",
+  "showcase.v0100.location":
+    "Fahr mit der Maus über das Blatt, und es sagt dir, was unter dem Cursor liegt: das Teil, die Seite des Bikes, auf der es sitzt, und ob es eine Fläche ist, die du siehst, oder eine Unterseite, die du nicht siehst.",
+  "showcase.v0100.downloads":
+    "Die Downloads-Seite listet auf, was du geholt hast: nach Tag, das Neueste oben, mit dem Ort, an dem jede Datei gelandet ist, und dem Mirror, von dem sie kam.",
+  "showcase.v0100.terrain":
+    "Eine Strecke öffnet sich jetzt direkt aus der Bibliothek in 3D, mit ihren Sprüngen und Rillen, gezeichnet aus dem eigenen Höhenfeld des Spiels.",
+  "showcase.v0100.sharing":
+    "Jetzt kann alles in deiner Bibliothek zu einem Code werden, den du jemandem gibst, und es landet wieder in denselben Ordnern, in denen du es hast.",
+  "showcase.v0100.linux":
+    "Unter Linux läuft FrostMod jetzt in genau dem Proton-Prefix, unter dem auch das Spiel läuft.",
   "showcase.v092.hero.title": "Sieh dir das Gelände einer Strecke in 3D an",
   "showcase.v092.hero.body":
     "Strecken waren das Einzige, was die Bibliothek nicht zeigen konnte — ein Name, ein Bild und eine Größe. Der Viewer liest jetzt das Höhenfeld aus einer Strecke und zeichnet den Boden selbst, sodass Sprünge, Rillen und die Form einer Kurve zu sehen sind, bevor du sie überhaupt lädst. Er öffnet sich bei einer Strecke in der Bibliothek, neben In 3D ansehen.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1201,6 +1201,19 @@ export const en = {
   "showcase.supporters.title_one": "Made possible by {{count}} supporter",
   "showcase.supporters.title_other": "Made possible by {{count}} supporters",
   "showcase.supporters.more": "+{{count}} more",
+  "showcase.v0100.hero.title": "The Designer sets up its own sheets",
+  "showcase.v0100.hero.body":
+    "It now builds the sheets a model needs, lays the bike's own plastics underneath to trace over, and opens a model in about a second instead of nearly twenty.",
+  "showcase.v0100.location":
+    "Hover the sheet and it tells you what's under the cursor: the part, the side of the bike it's on, and whether it's a face you'll see or an underside you won't.",
+  "showcase.v0100.downloads":
+    "The Downloads page lists what you've grabbed: by day, newest first, with where each file landed and which mirror it came from.",
+  "showcase.v0100.terrain":
+    "A track now opens in 3D straight from the library, its jumps and ruts drawn from the game's own heightfield.",
+  "showcase.v0100.sharing":
+    "Now anything in your Library can become a code you hand to someone, and it lands back in the same folders you keep it in.",
+  "showcase.v0100.linux":
+    "On Linux, FrostMod now runs in the same Proton prefix the game already runs under.",
   "showcase.v092.hero.title": "See a track's terrain in 3D",
   "showcase.v092.hero.body":
     "Tracks were the one thing the library couldn't show you — a name, a picture and a size. The viewer now reads the heightfield out of a track and draws the ground itself, so the jumps, the ruts and the shape of a turn are there to look at before you ever load it. It opens from a track in the library, next to View in 3D.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1227,6 +1227,19 @@ export const es: Translation = {
   "showcase.supporters.title_one": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.title_other": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.more": "+{{count}} más",
+  "showcase.v0100.hero.title": "El Designer prepara sus propias hojas",
+  "showcase.v0100.hero.body":
+    "Ahora crea las hojas que pide un modelo, coloca debajo los plásticos de la propia moto para calcar y abre un modelo en cerca de un segundo en vez de casi veinte.",
+  "showcase.v0100.location":
+    "Pasa por encima de la hoja y te dice qué hay bajo el cursor: la pieza, el lado de la moto en el que está, y si es una cara que vas a ver o una parte de abajo que no.",
+  "showcase.v0100.downloads":
+    "La página de Descargas lista lo que te has bajado: por día, lo más nuevo arriba, con dónde acabó cada archivo y de qué mirror vino.",
+  "showcase.v0100.terrain":
+    "Un circuito se abre ahora en 3D directamente desde la biblioteca, con sus saltos y roderas dibujados a partir del propio mapa de alturas del juego.",
+  "showcase.v0100.sharing":
+    "Ahora cualquier cosa de tu Biblioteca puede convertirse en un código que le pasas a alguien, y vuelve a las mismas carpetas en las que lo tienes.",
+  "showcase.v0100.linux":
+    "En Linux, FrostMod ahora corre en el mismo prefix de Proton bajo el que ya corre el juego.",
   "showcase.v092.hero.title": "Mira el terreno de un circuito en 3D",
   "showcase.v092.hero.body":
     "Los circuitos eran lo único que la biblioteca no sabía enseñarte: un nombre, una imagen y un tamaño. El visor ahora lee el mapa de alturas de un circuito y dibuja el propio terreno, así que los saltos, las roderas y la forma de una curva están ahí para mirarlos antes incluso de cargarlo. Se abre desde un circuito en la biblioteca, junto a Ver en 3D.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1231,6 +1231,19 @@ export const fr: Translation = {
   "showcase.supporters.title_one": "Rendu possible par {{count}} soutien",
   "showcase.supporters.title_other": "Rendu possible par {{count}} soutiens",
   "showcase.supporters.more": "+{{count}} autres",
+  "showcase.v0100.hero.title": "Le Designer prépare ses planches tout seul",
+  "showcase.v0100.hero.body":
+    "Il crée maintenant les planches qu'un modèle demande, glisse en dessous les plastiques de la moto elle-même pour décalquer et ouvre un modèle en une seconde environ au lieu de près de vingt.",
+  "showcase.v0100.location":
+    "Survole la planche et elle te dit ce qu'il y a sous le curseur : la pièce, le côté de la moto où elle se trouve, et si c'est une face que tu verras ou un dessous que tu ne verras pas.",
+  "showcase.v0100.downloads":
+    "La page Téléchargements liste ce que tu as récupéré : par jour, le plus récent en haut, avec l'endroit où chaque fichier a atterri et le miroir d'où il vient.",
+  "showcase.v0100.terrain":
+    "Un circuit s'ouvre maintenant en 3D directement depuis la bibliothèque, ses sauts et ses ornières dessinés à partir du propre champ de hauteurs du jeu.",
+  "showcase.v0100.sharing":
+    "Maintenant tout ce qui se trouve dans ta Bibliothèque peut devenir un code que tu donnes à quelqu'un, et il repart dans les mêmes dossiers que chez toi.",
+  "showcase.v0100.linux":
+    "Sur Linux, FrostMod tourne maintenant dans le même prefix Proton que celui sous lequel tourne déjà le jeu.",
   "showcase.v092.hero.title": "Regarde le terrain d'un circuit en 3D",
   "showcase.v092.hero.body":
     "Les circuits étaient la seule chose que la bibliothèque ne savait pas montrer : un nom, une image et une taille. Le visualiseur lit maintenant le champ de hauteurs d'un circuit et dessine le sol lui-même, donc les sauts, les ornières et la forme d'un virage sont là à regarder avant même de le charger. Il s'ouvre depuis un circuit dans la bibliothèque, à côté de Voir en 3D.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1222,6 +1222,19 @@ export const it: Translation = {
   "showcase.supporters.title_one": "Reso possibile da {{count}} sostenitore",
   "showcase.supporters.title_other": "Reso possibile da {{count}} sostenitori",
   "showcase.supporters.more": "+{{count}} altri",
+  "showcase.v0100.hero.title": "Il Designer prepara i fogli da solo",
+  "showcase.v0100.hero.body":
+    "Ora crea i fogli che un modello chiede, mette sotto le plastiche della moto stessa da ricalcare e apre un modello in circa un secondo invece che in quasi venti.",
+  "showcase.v0100.location":
+    "Passa sul foglio e ti dice cosa c'è sotto il cursore: il pezzo, il lato della moto su cui sta, e se è una faccia che vedrai o un rovescio che non vedrai.",
+  "showcase.v0100.downloads":
+    "La pagina Download elenca ciò che hai scaricato: per giorno, il più recente in cima, con dove è finito ogni file e da quale mirror è arrivato.",
+  "showcase.v0100.terrain":
+    "Una pista si apre ora in 3D direttamente dalla libreria, con i suoi salti e solchi disegnati dalla mappa delle altezze del gioco stesso.",
+  "showcase.v0100.sharing":
+    "Ora qualsiasi cosa nella tua Libreria può diventare un codice che passi a qualcuno, e torna nelle stesse cartelle in cui la tieni.",
+  "showcase.v0100.linux":
+    "Su Linux, FrostMod ora gira nello stesso prefix Proton sotto cui gira già il gioco.",
   "showcase.v092.hero.title": "Guarda il terreno di una pista in 3D",
   "showcase.v092.hero.body":
     "Le piste erano l'unica cosa che la libreria non sapeva mostrarti: un nome, un'immagine e una dimensione. Il visualizzatore ora legge la mappa delle altezze di una pista e disegna il terreno vero e proprio, così i salti, i solchi e la forma di una curva ci sono da guardare prima ancora di caricarla. Si apre da una pista nella libreria, accanto a Vedi in 3D.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1220,6 +1220,19 @@ export const ptBR: Translation = {
   "showcase.supporters.title_one": "Possível graças a {{count}} apoiador",
   "showcase.supporters.title_other": "Possível graças a {{count}} apoiadores",
   "showcase.supporters.more": "+{{count}} outros",
+  "showcase.v0100.hero.title": "O Designer prepara as próprias folhas",
+  "showcase.v0100.hero.body":
+    "Agora ele cria as folhas que um modelo pede, coloca embaixo os plásticos da própria moto para decalcar e abre um modelo em cerca de um segundo em vez de quase vinte.",
+  "showcase.v0100.location":
+    "Passe o cursor pela folha e ela te diz o que está embaixo dele: a peça, o lado da moto em que ela fica, e se é uma face que você vai ver ou uma parte de baixo que não.",
+  "showcase.v0100.downloads":
+    "A página de Downloads lista o que você baixou: por dia, o mais novo no topo, com onde cada arquivo foi parar e de qual mirror veio.",
+  "showcase.v0100.terrain":
+    "Uma pista agora abre em 3D direto da biblioteca, com seus saltos e sulcos desenhados a partir do próprio mapa de alturas do jogo.",
+  "showcase.v0100.sharing":
+    "Agora qualquer coisa na sua Biblioteca pode virar um código que você passa para alguém, e volta para as mesmas pastas em que você a guarda.",
+  "showcase.v0100.linux":
+    "No Linux, o FrostMod agora roda no mesmo prefix do Proton sob o qual o jogo já roda.",
   "showcase.v092.hero.title": "Veja o terreno de uma pista em 3D",
   "showcase.v092.hero.body":
     "Pistas eram a única coisa que a biblioteca não conseguia te mostrar: um nome, uma imagem e um tamanho. O visualizador agora lê o mapa de alturas de uma pista e desenha o próprio terreno, então os saltos, os sulcos e o formato de uma curva estão ali para olhar antes mesmo de carregar. Abre a partir de uma pista na biblioteca, ao lado de Ver em 3D.",


### PR DESCRIPTION
## What this is

Release prep for **v0.10.0** — the first full release since v0.9.1 (v0.9.2 only ever went out as betas). No tag yet; this is the branch to review before tagging.

## Changes
- **Showcase** — new `0.10.0` entry in `releases.ts` (hero + 5 highlights: Designer setup, where-you-are, Downloads, track terrain, Sharing, Linux). Copy is one self-contained sentence each, in all six locales.
- **Version bump** 0.9.2 → 0.10.0 across `package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`. This is what arms the showcase (`releaseToShow` only fires once the running version ≥ the entry).
- **CHANGELOG consolidated** into a dated `v0.10.0` section, folding in the v0.9.2 beta content.

## Deliberately kept out of the release notes
- **Cheat detection** → moved to its own `## Unannounced` block.
- **Server provisioning / paint publishing** (invite-gated control plane) → its own `## Unannounced` block.

Neither reaches the generated release notes or the Discord post. Verified no cheat/integrity/signature terms appear in the dated v0.10.0 section.

## Gates
- `tsc --noEmit` → 0
- `eslint` on changed files → 0

## Not done here
- No tag (held for review).
- No anti-cheat behaviour change — the endpoint request is still an open decision.