### PR TITLE
feat(designer): show the sheet the right way up, and keep shapes editable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## Unreleased — the sheet the right way up
+
+### Fixed
+- **The sheet was shown upside down.** A `.pnt` stores its rows in the order the mesh samples
+  them, which is inverted from the template painters work in — the forks land top-left where
+  the template has them bottom-left. Confirmed on the OEM KTM's `plastics` sheet, where the
+  Renthal bar pads read "brembo", "RENTHAL" and "REGINA" inverted as stored and upright once
+  flipped; bar pads carry no mirrored twin, so they answer it where a number plate can't. The
+  flip is the view's alone: the sheet, the composite, the saved file and the 3D preview all
+  stay in the file's own row order, so loading a paint and saving it back is byte-identical.
+- **Decals came out upside down on the bike.** Following from the same thing — a logo or a line
+  of type placed upright in the editor was written into the sheet upright, and the sheet is
+  inverted, so it wore inverted. Both now go in mirrored and land the right way up.
+- **Left and right were the wrong way round.** Again: positive x is the bike's left, which is
+  what the mesh's own group names have said all along — `clutch` and `gear` sit at positive x
+  on a 2023 YZ450F and both are left-hand controls. Read off the sheet with the stage the right
+  way up, the group names are what agrees with it. This inverts the previous release's fix.
+
+### Changed
+- **The bucket fills one UV triangle, not the whole mesh group.** A group like `shroud` is both
+  flanks and often several scattered islands, so confining a fill to it still flooded panels
+  the press never pointed at. Right-click fills the whole island instead, for when a triangle
+  is too fine — which costs the bucket its right-drag pan; the middle button still pans.
+
+### Added
+- **Rectangles, ellipses and lines are layers you can still resize.** They used to rasterise on
+  release, so nudging one meant undoing it and drawing again. Now the drag builds the object
+  itself — it lands selected, with corner handles — and its colour, fill-or-outline and pen
+  width stay editable for as long as the paint is open. The gradient stays a stroke: it is a
+  wash with no edge to take hold of.
+
 ## Unreleased — a quieter download dialog
 
 ### Removed

--- a/src/Components/Studio/Designer/CanvasStage.tsx
+++ b/src/Components/Studio/Designer/CanvasStage.tsx
@@ -94,7 +94,11 @@ interface CanvasStageProps {
   brushSize: number;
   /** True when there is a paint layer for a stroke to land on. */
   canPaint: boolean;
-  onPaintStart: (at: Point) => void;
+  /**
+   * `whole` is a right-click with the bucket: fill the island rather than the one triangle
+   * under the pointer. Meaningless to every other tool, which ignore it.
+   */
+  onPaintStart: (at: Point, whole: boolean) => void;
   onPaintMove: (points: Point[], constrain: boolean) => void;
   onPaintEnd: () => void;
   className?: string;
@@ -112,6 +116,13 @@ interface CanvasStageProps {
  *
  * The ghost is drawn here for the same reason, read backwards: a guide that never enters the
  * composite cannot reach the file, whatever anyone later does to the save path.
+ *
+ * The sheet is shown flipped top-to-bottom. A `.pnt` stores its rows in the order the mesh
+ * samples them, which is upside down from the template painters work in — open one flat and
+ * the forks land top-left where the template has them bottom-left. The flip lives here and
+ * only here: the composite, the saved file and the 3D preview all stay in the sheet's own row
+ * order, so no amount of work on the view can change what a paint contains. Everything
+ * crossing between the two spaces goes through `toSheet`, `toView` or `sheetSpace`.
  */
 export function CanvasStage({
   sheet,
@@ -223,7 +234,7 @@ export function CanvasStage({
       if (!rect || !scale) return null;
       const vx = clientX - rect.left - originX;
       const vy = clientY - rect.top - originY;
-      return { x: vx / scale + sheet.width / 2, y: vy / scale + sheet.height / 2 };
+      return { x: vx / scale + sheet.width / 2, y: sheet.height / 2 - vy / scale };
     },
     [originX, originY, scale, sheet.width, sheet.height],
   );
@@ -232,7 +243,7 @@ export function CanvasStage({
   const toView = useCallback(
     (p: Point): [number, number] => [
       originX + (p.x - sheet.width / 2) * scale,
-      originY + (p.y - sheet.height / 2) * scale,
+      originY - (p.y - sheet.height / 2) * scale,
     ],
     [originX, originY, scale, sheet.width, sheet.height],
   );
@@ -322,6 +333,21 @@ export function CanvasStage({
     ctx.imageSmoothingEnabled = true;
     ctx.imageSmoothingQuality = "high";
 
+    /**
+     * Draw in sheet pixels, flipped: anchored at the bottom edge with y running back up.
+     *
+     * Every picture of the sheet goes through this — the composite and all three ghosts — so
+     * they cannot come out a row apart from each other, which is the one way an underlay is
+     * worse than no underlay. The overlays below are in view pixels already and don't.
+     */
+    const sheetSpace = (draw: () => void) => {
+      ctx.save();
+      ctx.translate(left, top + h);
+      ctx.scale(1, -1);
+      draw();
+      ctx.restore();
+    };
+
     // The whole reference goes *under* the drawing — that is what makes it a ghost rather than
     // an overlay. Both halves show through wherever the sheet is still transparent, which is
     // exactly where there is nothing drawn yet and exactly where you need to know which piece
@@ -338,19 +364,21 @@ export function CanvasStage({
       // is being traced, and they are the thinnest of the marks. The model's own texture goes
       // under the template rather than over it — someone who lifted a paint out to trace it
       // asked for *that* paint, and the stock plastics are the fallback beneath it.
-      if (ghost.showStock && ghost.stock) {
-        ctx.drawImage(ghost.stock, left, top, w, h);
-      }
-      if (ghost.showTemplate && ghost.template) {
-        ctx.drawImage(ghost.template, left, top, w, h);
-      }
-      if (ghost.showWire && ghost.wire) {
-        ctx.drawImage(ghost.wire, left, top, w, h);
-      }
+      sheetSpace(() => {
+        if (ghost.showStock && ghost.stock) {
+          ctx.drawImage(ghost.stock, 0, 0, w, h);
+        }
+        if (ghost.showTemplate && ghost.template) {
+          ctx.drawImage(ghost.template, 0, 0, w, h);
+        }
+        if (ghost.showWire && ghost.wire) {
+          ctx.drawImage(ghost.wire, 0, 0, w, h);
+        }
+      });
       ctx.restore();
     }
 
-    ctx.drawImage(source, left, top, w, h);
+    sheetSpace(() => ctx.drawImage(source, 0, 0, w, h));
 
     // Sheet edge, so you can see where the texture stops.
     ctx.strokeStyle = "rgba(255,255,255,0.18)";
@@ -383,12 +411,11 @@ export function CanvasStage({
     // The piece under the pointer, picked out of the map. Only while the map is on: a highlight
     // that appeared over a livery with no islands showing would be an outline from nowhere.
     if (overPart && overPath && ghost?.showWire && ghost.wire) {
-      ctx.save();
-      ctx.translate(left, top);
-      ctx.scale(w / sheet.width, h / sheet.height);
-      ctx.fillStyle = `hsla(${overPart.hue}, 85%, 65%, 0.18)`;
-      ctx.fill(overPath, "nonzero");
-      ctx.restore();
+      sheetSpace(() => {
+        ctx.scale(w / sheet.width, h / sheet.height);
+        ctx.fillStyle = `hsla(${overPart.hue}, 85%, 65%, 0.18)`;
+        ctx.fill(overPath, "nonzero");
+      });
     }
 
     // Where a gradient runs, or what a shape will cover. The stroke itself is already visible
@@ -472,8 +499,9 @@ export function CanvasStage({
       const cx = ((part.minU + part.maxU) / 2) * sheet.width;
       const cy = ((part.minV + part.maxV) / 2) * sheet.height;
       setZoom(z);
-      // Pan is measured from the sheet's centre, which is where the blit is anchored.
-      setPan({ x: -(cx - sheet.width / 2) * s, y: -(cy - sheet.height / 2) * s });
+      // Pan is measured from the sheet's centre, which is where the blit is anchored. The y
+      // term doesn't take the minus the x one does: the view runs the other way up.
+      setPan({ x: -(cx - sheet.width / 2) * s, y: (cy - sheet.height / 2) * s });
     },
     [box.w, box.h, fit, sheet.width, sheet.height],
   );
@@ -503,6 +531,15 @@ export function CanvasStage({
         }
       }
       e.currentTarget.setPointerCapture(e.pointerId);
+      // Right-click with the bucket fills the whole island. The left button takes the single
+      // triangle under the pointer, which is right for trimming an edge and hopeless for
+      // covering a shroud — so the coarse answer gets the other button rather than a mode.
+      // It costs the bucket its right-drag pan; the middle button still pans for every tool.
+      if (e.button === 2 && paints && tool === "fill") {
+        painting.current = true;
+        onPaintStart(at, true);
+        return;
+      }
       // Middle and right drag pan, whatever the tool — panning while painting matters more
       // than it does while dragging a logo, because a stroke needs the part you can't see.
       // Not mid-stroke, though: the view moving under a brush that is still down would drag
@@ -514,7 +551,7 @@ export function CanvasStage({
       if (paints) {
         painting.current = true;
         if (isDragTool(tool)) setGuide({ from: at, to: at });
-        onPaintStart(at);
+        onPaintStart(at, false);
         return;
       }
       // Corners before contents. A handle sits on the layer's own edge, so hit-testing first
@@ -634,7 +671,7 @@ export function CanvasStage({
       if (!dx && !dy) return;
       d.x = e.clientX;
       d.y = e.clientY;
-      if (d.id) onMove(d.id, dx / scale, dy / scale);
+      if (d.id) onMove(d.id, dx / scale, -dy / scale);
       else setPan((p) => ({ x: p.x + dx, y: p.y + dy }));
     },
     [

--- a/src/Components/Studio/Designer/Designer.tsx
+++ b/src/Components/Studio/Designer/Designer.tsx
@@ -37,7 +37,16 @@ import { LayerInspector } from "./LayerInspector";
 import { PaintTools } from "./PaintTools";
 import { bitmapFromRgba, composite, hasInk, sheetTexture, toPng } from "./composite";
 import { EMPTY_GHOST, ghostShows, type Ghost } from "./ghost";
-import { partAt, partBox, partPath, uvParts, uvWireframe, type UvPart } from "./uv";
+import {
+  islandAt,
+  partAt,
+  partBox,
+  partPath,
+  triangleAt,
+  uvParts,
+  uvWireframe,
+  type UvPart,
+} from "./uv";
 import {
   blankSheet,
   imageLayer,
@@ -45,18 +54,22 @@ import {
   layerExtent,
   newId,
   paintLayer,
+  shapeLayer,
   textLayer,
   unionRegion,
   type Layer,
   type PaintLayer,
+  type ShapeLayer,
   type Region,
   type Sheet,
 } from "./layers";
 import {
   DEFAULT_PAINT,
   PaintHistory,
+  SHAPE_TOOLS,
   Stroke,
   TOOL_KEYS,
+  constrained,
   type PaintSettings,
   type PaintTool,
   type Point,
@@ -381,6 +394,10 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
    * the moment it arrives, because that is what the mark is made of; only the telling-everyone
    * waits, and it waits at most until the next frame, which is the soonest anyone could see it.
    */
+  // The shape layer a drag is currently rewriting, and where the press landed. Null except
+  // between the press and the release of a shape tool — the stroke ref's opposite number.
+  const shaping = useRef<{ id: string; from: Point } | null>(null);
+
   const queued = useRef<{ sheetId: string; layerId: string } | null>(null);
   const frame = useRef(0);
 
@@ -435,7 +452,8 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   const pickTool = useCallback(
     (tool: PaintTool) => {
       setPaint((p) => ({ ...p, tool }));
-      if (tool === "move" || !active) return;
+      // A shape makes its own layer on the press, so it needs nothing selected to land on.
+      if (tool === "move" || SHAPE_TOOLS.has(tool) || !active) return;
       const selected = active.layers.find((l) => l.id === selectedId);
       if (selected?.kind === "paint") return;
       const existing = [...active.layers].reverse().find((l) => l.kind === "paint");
@@ -448,6 +466,31 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
 
   const movePaint = useCallback(
     (points: Point[], constrain: boolean) => {
+      // A shape in progress is a layer, not a stroke: the drag rewrites its box and the
+      // composite redraws it, so what is on screen mid-drag is the shape itself rather than a
+      // preview of one. See `startPaint`.
+      const drawing = shaping.current;
+      if (drawing) {
+        const raw = points[points.length - 1];
+        if (!raw) return;
+        const to = constrain ? constrained(drawing.from, raw, paint.tool) : raw;
+        patchLayer(
+          drawing.id,
+          (l) =>
+            l.kind === "shape"
+              ? {
+                  ...l,
+                  x: (drawing.from.x + to.x) / 2,
+                  y: (drawing.from.y + to.y) / 2,
+                  w: to.x - drawing.from.x,
+                  h: -(to.y - drawing.from.y),
+                }
+              : l,
+          `shape:${drawing.id}`,
+        );
+        bump();
+        return;
+      }
       const live = stroke.current;
       if (!live || !target || !activeId) return;
       live.move(points, constrain);
@@ -455,10 +498,28 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
       markPaint(activeId, live.dirty);
       schedulePaint(activeId, target.id);
     },
-    [activeId, markPaint, schedulePaint, target],
+    [activeId, bump, markPaint, paint.tool, patchLayer, schedulePaint, target],
   );
 
   const endPaint = useCallback(() => {
+    const drawing = shaping.current;
+    if (drawing) {
+      shaping.current = null;
+      // A click with a shape tool selected is not a shape. Left in, it would be an invisible
+      // layer in the list with handles too small to grab and nothing to see.
+      if (active) {
+        const made = active.layers.find((l) => l.id === drawing.id);
+        if (made?.kind === "shape" && Math.abs(made.w) < 2 && Math.abs(made.h) < 2) {
+          patchSheet(active.id, (sh) => ({
+            ...sh,
+            layers: sh.layers.filter((l) => l.id !== drawing.id),
+          }));
+          setSelectedId(null);
+          bump();
+        }
+      }
+      return;
+    }
     const done = stroke.current;
     stroke.current = null;
     // Whatever the last frame didn't get to, now — a stroke that ended between two frames would
@@ -469,7 +530,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     if (!done?.end() || !target || !activeId) return;
     history.current.push(activeId, target.id, done.before);
     setHistoryRev((v) => v + 1);
-  }, [activeId, flushPaint, target]);
+  }, [active, activeId, bump, flushPaint, patchSheet, target]);
 
   /** The live canvas behind a layer id, wherever it lives — history spans every sheet. */
   const paintCanvas = useCallback(
@@ -592,10 +653,11 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   /**
    * Pixels for a file the user picked, at the sheet's own resolution.
    *
-   * No orientation is imposed. A `.pnt` doesn't record which way up its rows are and paints in
-   * the wild are stored both ways, so the editor shows exactly what the file holds — the same
-   * rows the viewer renders and the game reads. A sheet that looks upside down here is upside
-   * down in the file, and guessing otherwise would flip every correctly-made paint.
+   * The rows arrive in the order the file holds them, which is the order the mesh samples
+   * them — and that is upside down from the template a painter works in. Nothing is flipped
+   * here: the sheet, the composite and the save all stay in the file's own row order, and the
+   * 2D stage turns it the right way up for display alone (see `CanvasStage`). Flipping the
+   * pixels instead would put the editor's opinion about orientation inside the saved paint.
    */
   const readImage = useCallback(async (path: string) => {
     const tex = await paintStudioPixels(path);
@@ -813,18 +875,49 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   );
 
   const startPaint = useCallback(
-    (at: Point) => {
+    (at: Point, whole: boolean) => {
+      // A rectangle, ellipse or line becomes a layer, not pixels. Made on the press and
+      // rewritten as the drag goes, so the thing being dragged out *is* the finished object —
+      // there is no separate preview to disagree with the result, and on release it is
+      // already selected with handles on it.
+      if (SHAPE_TOOLS.has(paint.tool) && active) {
+        const shape = paint.tool as ShapeLayer["shape"];
+        const layer = shapeLayer(
+          t(`designer.tool.${shape}`),
+          shape,
+          at,
+          at,
+          paint.shape,
+          paint.colorA,
+          paint.strokeWidth,
+        );
+        remember();
+        patchSheet(active.id, (sh) => ({ ...sh, layers: [...sh.layers, layer] }));
+        setSelectedId(layer.id);
+        shaping.current = { id: layer.id, from: at };
+        bump();
+        return;
+      }
       if (!target || !activeId) return;
-      // The bucket fills the panel under the press, not the sheet. Worked out here rather than
-      // inside `Stroke`, because the parts are the editor's knowledge of the model and paint.ts
-      // is deliberately ignorant of it — it puts pixels down, wherever it is told to.
+      // The bucket fills the uv triangle under the press, not the sheet and not the whole mesh
+      // group. Worked out here rather than inside `Stroke`, because the parts are the editor's
+      // knowledge of the model and paint.ts is deliberately ignorant of it — it puts pixels
+      // down, wherever it is told to.
+      //
+      // The group is only the first cut: `shroud` is both flanks and often several islands, so
+      // stopping there floods panels the press never pointed at. Left button takes the one
+      // triangle under the pointer; right button takes the island it belongs to.
       let fillTo: { path: Path2D; box: Region } | null = null;
       if (paint.tool === "fill" && active && parts.length) {
-        const under = partAt(parts, at.x / active.width, at.y / active.height);
-        if (under) {
+        const u = at.x / active.width;
+        const v = at.y / active.height;
+        const under = partAt(parts, u, v);
+        const pick = whole ? islandAt : triangleAt;
+        const region = under ? (pick(under, u, v) ?? under) : null;
+        if (region) {
           fillTo = {
-            path: partPath(under, active.width, active.height),
-            box: partBox(under, active.width, active.height),
+            path: partPath(region, active.width, active.height),
+            box: partBox(region, active.width, active.height),
           };
         }
       }
@@ -834,7 +927,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
       // frame's wait on, and a tool that puts nothing down on the press has nothing to show.
       if (next.dirty) touchPaint(activeId, target.id, next.dirty);
     },
-    [active, activeId, paint, parts, target, touchPaint],
+    [active, activeId, bump, paint, parts, patchSheet, remember, t, target, touchPaint],
   );
 
   /** Pin the selected layer to a piece of bodywork, or let it cover the sheet again. */
@@ -1329,7 +1422,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
               onScale={scaleLayer}
               tool={paint.tool}
               brushSize={paint.size}
-              canPaint={!!target}
+              canPaint={!!target || SHAPE_TOOLS.has(paint.tool)}
               onPaintStart={startPaint}
               onPaintMove={movePaint}
               onPaintEnd={endPaint}

--- a/src/Components/Studio/Designer/LayerInspector.tsx
+++ b/src/Components/Studio/Designer/LayerInspector.tsx
@@ -137,6 +137,58 @@ export function LayerInspector({
         </select>
       </Row>
 
+      {/* A shape is geometry, so it keeps its colour and its pen editable for as long as the
+          paint is open — which is the whole point of it not being pixels. Size and angle are
+          the shared controls above; only what it is drawn *with* is particular to it. */}
+      {layer.kind === "shape" && (
+        <>
+          <Row label={t("designer.colour")}>
+            <input
+              type="color"
+              value={layer.color}
+              onChange={(e) =>
+                patch((l) => (l.kind === "shape" ? { ...l, color: e.target.value } : l))
+              }
+              className="h-7 w-full cursor-pointer rounded-md border border-input bg-background"
+            />
+          </Row>
+
+          {layer.shape !== "line" && (
+            <Row label={t("designer.shape")}>
+              <select
+                value={layer.style}
+                onChange={(e) =>
+                  patch((l) =>
+                    l.kind === "shape"
+                      ? { ...l, style: e.target.value as "fill" | "outline" }
+                      : l,
+                  )
+                }
+                className="min-w-0 flex-1 rounded-md border border-input bg-background px-2 py-1 text-[11.5px]"
+              >
+                <option value="fill">{t("designer.shape.fill")}</option>
+                <option value="outline">{t("designer.shape.outline")}</option>
+              </select>
+            </Row>
+          )}
+
+          {(layer.style === "outline" || layer.shape === "line") && (
+            <Row label={t("designer.lineWidth")}>
+              <Slider
+                value={layer.strokeWidth}
+                min={1}
+                max={128}
+                step={1}
+                onChange={(v) =>
+                  patch((l) => (l.kind === "shape" ? { ...l, strokeWidth: v } : l))
+                }
+                format={(v) => `${v}px`}
+              />
+            </Row>
+          )}
+        </>
+      )}
+
       {layer.kind === "text" && (
         <>
           <Row label={t("designer.text")}>

--- a/src/Components/Studio/Designer/composite.ts
+++ b/src/Components/Studio/Designer/composite.ts
@@ -4,6 +4,8 @@ import {
   clampRegion,
   fontSpec,
   layerExtent,
+  mirrored,
+  sheetRotation,
   type Layer,
   type Region,
   type Sheet,
@@ -29,14 +31,38 @@ function drawLayer(ctx: CanvasRenderingContext2D, layer: Layer) {
   // translate would carry the part around with the layer, which is the opposite of pinning it.
   if (layer.clip) ctx.clip(layer.clip.path, "nonzero");
   ctx.translate(layer.x, layer.y);
-  ctx.rotate(layer.rotation);
-  ctx.scale(layer.scale, layer.scale);
+  // Mirrored, because the stage is — see `mirrored`. The sheet keeps the file's row order and
+  // the view turns it over, so upright content has to go in upside down to come out upright.
+  ctx.rotate(sheetRotation(layer));
+  ctx.scale(layer.scale, mirrored(layer) ? -layer.scale : layer.scale);
 
   if (layer.kind === "image" || layer.kind === "paint") {
     // A paint layer's raster is sheet-sized and its transform is the identity, so this puts it
     // back exactly where it was painted — the same call, from the same centre, as an image.
     const src = layer.kind === "image" ? layer.image : layer.canvas;
     ctx.drawImage(src, -src.width / 2, -src.height / 2);
+  } else if (layer.kind === "shape") {
+    // Drawn about the centre, because that is the fixed point every other layer scales and
+    // turns around — a shape anchored at a corner would walk across the sheet as it grew.
+    const hw = layer.w / 2;
+    const hh = layer.h / 2;
+    ctx.strokeStyle = layer.color;
+    ctx.fillStyle = layer.color;
+    ctx.lineWidth = Math.max(1, layer.strokeWidth);
+    ctx.lineJoin = "round";
+    ctx.lineCap = "round";
+    ctx.beginPath();
+    if (layer.shape === "line") {
+      // Corner to corner of the signed box, which is what makes `h`'s sign worth carrying.
+      ctx.moveTo(-hw, -hh);
+      ctx.lineTo(hw, hh);
+      ctx.stroke();
+    } else {
+      if (layer.shape === "ellipse") ctx.ellipse(0, 0, Math.abs(hw), Math.abs(hh), 0, 0, Math.PI * 2);
+      else ctx.rect(-Math.abs(hw), -Math.abs(hh), Math.abs(layer.w), Math.abs(layer.h));
+      if (layer.style === "fill") ctx.fill();
+      else ctx.stroke();
+    }
   } else {
     ctx.font = fontSpec(layer);
     ctx.textAlign = "center";
@@ -109,8 +135,8 @@ export function layerCorners(layer: Layer): [number, number][] {
   const { w, h } = layerExtent(layer);
   const hw = (w * layer.scale) / 2;
   const hh = (h * layer.scale) / 2;
-  const cos = Math.cos(layer.rotation);
-  const sin = Math.sin(layer.rotation);
+  const cos = Math.cos(sheetRotation(layer));
+  const sin = Math.sin(sheetRotation(layer));
   return (
     [
       [-hw, -hh],
@@ -124,8 +150,9 @@ export function layerCorners(layer: Layer): [number, number][] {
 /**
  * The sheet as PNG bytes, for staging before a save.
  *
- * The rows leave exactly as they were drawn, which is exactly as they were read — the editor
- * takes no view on which way up a sheet is, because the format doesn't either.
+ * The rows leave exactly as they were drawn, which is exactly as they were read. The stage
+ * shows the sheet the other way up, but that is a view transform and stops at the screen —
+ * nothing on the way to the file knows about it.
  *
  * PNG because it's lossless and what a canvas encodes natively — the sheet is decoded again
  * on the Rust side on its way into the `.pnt`, so the intermediate format only has to not

--- a/src/Components/Studio/Designer/layers.ts
+++ b/src/Components/Studio/Designer/layers.ts
@@ -92,7 +92,32 @@ export interface PaintLayer extends LayerCommon {
   rev: number;
 }
 
-export type Layer = ImageLayer | TextLayer | PaintLayer;
+/**
+ * A rectangle, ellipse or line kept as geometry rather than as pixels.
+ *
+ * The shape tools used to rasterise on release, which made a square something you could only
+ * undo — nudging one a few pixels meant redrawing it, and by then whatever it overlapped had
+ * been painted over. Held as a layer it keeps handles for as long as the paint is open, and is
+ * flattened where every other layer is: at the composite, on the way to the file.
+ *
+ * `w`/`h` are the box the drag described, *signed*, before `scale` — so a line knows which of
+ * the box's two diagonals it runs along, which is the one thing a rectangle can't say. Both
+ * are in the layer's own upright frame, the same frame an image or a line of type is in; see
+ * `mirrored` for why that is not the sheet's frame.
+ */
+export interface ShapeLayer extends LayerCommon {
+  kind: "shape";
+  shape: "rect" | "ellipse" | "line";
+  w: number;
+  h: number;
+  /** Filled, or drawn as an outline. A line is always stroked, whatever this says. */
+  style: "fill" | "outline";
+  color: string;
+  /** Outline and line width in sheet pixels, before `scale`. */
+  strokeWidth: number;
+}
+
+export type Layer = ImageLayer | TextLayer | PaintLayer | ShapeLayer;
 
 /**
  * A rectangle of a sheet, in the sheet's own pixels.
@@ -202,6 +227,12 @@ export function layerExtent(layer: Layer): { w: number; h: number } {
   if (layer.kind === "paint") {
     return { w: layer.canvas.width, h: layer.canvas.height };
   }
+  if (layer.kind === "shape") {
+    // The pen is centred on the path, so half of it hangs outside the box on each side. A
+    // hairline shape would otherwise get a selection box narrower than the mark it describes.
+    const pen = layer.style === "outline" || layer.shape === "line" ? layer.strokeWidth : 0;
+    return { w: Math.abs(layer.w) + pen, h: Math.abs(layer.h) + pen };
+  }
   const ctx = measurer();
   if (!ctx) return { w: layer.text.length * layer.size * 0.6, h: layer.size };
   ctx.font = fontSpec(layer);
@@ -215,6 +246,63 @@ export function layerExtent(layer: Layer): { w: number; h: number } {
 export function layerHalfSize(layer: Layer): { hw: number; hh: number } {
   const { w, h } = layerExtent(layer);
   return { hw: (w * layer.scale) / 2, hh: (h * layer.scale) / 2 };
+}
+
+/**
+ * Whether a layer's content goes into the sheet mirrored.
+ *
+ * The 2D stage shows the sheet flipped top-to-bottom (see `CanvasStage`), so anything authored
+ * the right way up — a logo file, a line of type — has to be laid in upside down to come out
+ * upright on screen. A paint layer is the exception: its pixels were put down through that
+ * same flipped view, so they are in sheet space already and mirroring them would undo them.
+ */
+export function mirrored(layer: Layer): boolean {
+  return layer.kind !== "paint";
+}
+
+/** A layer built from a press-drag-release across the stage — see `shapeLayer`. */
+export function shapeLayer(
+  name: string,
+  shape: ShapeLayer["shape"],
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  style: ShapeLayer["style"],
+  color: string,
+  strokeWidth: number,
+): ShapeLayer {
+  return {
+    id: newId("shape"),
+    kind: "shape",
+    name,
+    visible: true,
+    opacity: 1,
+    blend: "normal",
+    x: (from.x + to.x) / 2,
+    y: (from.y + to.y) / 2,
+    scale: 1,
+    rotation: 0,
+    clip: null,
+    shape,
+    w: to.x - from.x,
+    // Negated on the way in: the drag is in sheet coordinates and the layer's own frame is the
+    // upright one, which runs the other way up. Only a line can tell the difference, and it
+    // would come out along the wrong diagonal.
+    h: -(to.y - from.y),
+    style,
+    color,
+    strokeWidth,
+  };
+}
+
+/**
+ * How far a layer is turned in *sheet* space, which is not what the rotation slider says.
+ *
+ * A mirrored thing turns the other way, so {@link mirrored} layers rotate against the stored
+ * angle. Everything that has to agree about where a layer's corners are — the composite, the
+ * selection box, the hit test — asks here rather than reading `layer.rotation` directly.
+ */
+export function sheetRotation(layer: Layer): number {
+  return mirrored(layer) ? -layer.rotation : layer.rotation;
 }
 
 /**
@@ -233,8 +321,8 @@ export function hitTest(layers: Layer[], px: number, py: number): Layer | null {
     // Into the layer's own frame: translate to its centre, then undo its rotation.
     const dx = px - layer.x;
     const dy = py - layer.y;
-    const cos = Math.cos(-layer.rotation);
-    const sin = Math.sin(-layer.rotation);
+    const cos = Math.cos(-sheetRotation(layer));
+    const sin = Math.sin(-sheetRotation(layer));
     const lx = dx * cos - dy * sin;
     const ly = dx * sin + dy * cos;
     const { hw, hh } = layerHalfSize(layer);

--- a/src/Components/Studio/Designer/paint.ts
+++ b/src/Components/Studio/Designer/paint.ts
@@ -50,8 +50,22 @@ export const PAINT_TOOLS: PaintTool[] = [
   "line",
 ];
 
-/** Tools whose result is defined by a press-drag-release, rather than by the path dragged. */
-const DRAG_TOOLS = new Set<PaintTool>(["gradient", "rect", "ellipse", "line"]);
+/**
+ * Tools whose result is defined by a press-drag-release, rather than by the path dragged.
+ *
+ * Only the gradient, now that the shapes are layers. A gradient is a wash across whatever it
+ * is dragged over, with no edge to take hold of afterwards, so there is nothing a handle could
+ * grab and nothing gained by keeping it as geometry.
+ */
+const DRAG_TOOLS = new Set<PaintTool>(["gradient"]);
+
+/**
+ * The drag tools that produce a *layer* rather than pixels — see `shapeLayer`.
+ *
+ * They never reach `Stroke` at all: the Designer makes the layer on the press and rewrites its
+ * box as the drag goes, so what is being dragged out is the finished object.
+ */
+export const SHAPE_TOOLS = new Set<PaintTool>(["rect", "ellipse", "line"]);
 
 /**
  * One key per tool, the way every editor of this kind does it.
@@ -241,61 +255,12 @@ function gradientFill(
   ctx.fillRect(0, 0, w, h);
 }
 
-function drawShape(
-  ctx: CanvasRenderingContext2D,
-  tool: PaintTool,
-  from: Point,
-  to: Point,
-  s: PaintSettings,
-) {
-  ctx.strokeStyle = withAlpha(s.colorA, 1);
-  ctx.fillStyle = withAlpha(s.colorA, 1);
-  ctx.lineWidth = Math.max(1, s.strokeWidth);
-  ctx.lineJoin = "round";
-  ctx.lineCap = "round";
-
-  if (tool === "line") {
-    ctx.beginPath();
-    ctx.moveTo(from.x, from.y);
-    ctx.lineTo(to.x, to.y);
-    ctx.stroke();
-    return;
-  }
-
-  const x = Math.min(from.x, to.x);
-  const y = Math.min(from.y, to.y);
-  const w = Math.abs(to.x - from.x);
-  const h = Math.abs(to.y - from.y);
-
-  ctx.beginPath();
-  if (tool === "ellipse") ctx.ellipse(x + w / 2, y + h / 2, w / 2, h / 2, 0, 0, Math.PI * 2);
-  else ctx.rect(x, y, w, h);
-  if (s.shape === "fill") ctx.fill();
-  else ctx.stroke();
-}
-
-/**
- * Where a shape drawn between two points lands, with room for the pen that draws it.
- *
- * Padded by half the stroke width because a line is centred on its path, and by a couple of
- * pixels beyond that for the round cap and for the antialiasing at its edge — a region that
- * stopped at the geometry would leave the outer fringe of a thick outline unrestored.
- */
-function shapeRegion(from: Point, to: Point, s: PaintSettings): Region {
-  const pad = Math.max(1, s.strokeWidth) / 2 + 2;
-  return {
-    x: Math.min(from.x, to.x) - pad,
-    y: Math.min(from.y, to.y) - pad,
-    w: Math.abs(to.x - from.x) + pad * 2,
-    h: Math.abs(to.y - from.y) + pad * 2,
-  };
-}
-
 /**
  * Hold Shift: squares, circles, and axes that snap to 45°.
  *
- * Exported because the stage draws the guide you aim with and this draws what lands, and the
- * two have to agree — a dashed box in one place and a square in another is worse than no guide.
+ * Exported because the shape tools no longer land here — the Designer rewrites a shape layer's
+ * box as the drag goes and applies this to the corner first, so the square you are dragging out
+ * and the square you end up with are the same one.
  */
 export function constrained(from: Point, to: Point, tool: PaintTool): Point {
   const dx = to.x - from.x;
@@ -436,15 +401,10 @@ export class Stroke {
       // Redrawn from scratch each time, not added to: dragging a gradient back and forth
       // should show the gradient it would leave, not every one it passed through.
       ctx.clearRect(0, 0, this.scratch.width, this.scratch.height);
-      if (tool === "gradient") {
-        gradientFill(ctx, this.scratch.width, this.scratch.height, this.start, to, this.settings);
-      } else {
-        drawShape(ctx, tool, this.start, to, this.settings);
-      }
-      // Both boxes, because the scratch was wiped: the new shape has to be laid down and the
-      // old one has to be taken back off. A gradient covers the sheet, so for that one they
-      // are the same box and it is the whole thing.
-      const next = tool === "gradient" ? this.whole() : shapeRegion(this.start, to, this.settings);
+      gradientFill(ctx, this.scratch.width, this.scratch.height, this.start, to, this.settings);
+      // The whole sheet, twice over: a gradient covers it, and the scratch was just wiped, so
+      // the new wash has to be laid down and the old one taken back off.
+      const next = this.whole();
       this.mark(next);
       if (this.shape) this.mark(this.shape);
       this.shape = next;

--- a/src/Components/Studio/Designer/uv.ts
+++ b/src/Components/Studio/Designer/uv.ts
@@ -218,8 +218,9 @@ function hueOf(label: string): number {
  * answer would be a worse list than no list.
  *
  * uv0 is taken as-is. The sheet uploads with `flipY = false` (see `sheetTexture`), so v runs the
- * same way as a canvas row and no flip belongs here — the same reasoning that keeps the editor
- * from having an opinion about which way up a sheet is.
+ * same way as a canvas row and no flip belongs here. The 2D stage does show the sheet flipped,
+ * but it flips these islands along with the pixels they describe, so both stay in texture
+ * space and the parts named here are the parts the pointer is actually over.
  *
  * `assembled` asks for the left/right and top/underside answers as well. Both read a vertex's
  * position or normal as a statement about where it sits on the bike, which is only true once
@@ -314,17 +315,23 @@ export function uvParts(
 
   // Now that the whole sheet has been read, the band is known — and with it, each side.
   //
-  // Positive x is the bike's RIGHT — the answer that matches where a region of the sheet
-  // actually comes out on the model. It reads the other way round from the mesh's own group
-  // names: `clutch` and `gear` sit at positive x on a 2023 YZ450F and those are left-hand
-  // controls, so anyone checking it that way will conclude this line is inverted. It has been
-  // flipped on that reasoning before and had to be put back. Leave it.
+  // Positive x is the bike's LEFT.
+  //
+  // This line has now been flipped twice, so the history is worth keeping. It read RIGHT on the
+  // grounds that that was where a region of the sheet came out on the model, and the check
+  // against the mesh's own group names — `clutch` and `gear` sit at positive x on a 2023
+  // YZ450F and both are left-hand controls — was dismissed as the misleading one. Read off the
+  // 2D sheet with the stage the right way up, the group names are what agrees: the side a part
+  // is labelled is the side it is on. Changed on that reading (2026-08-18).
+  //
+  // Whichever way it ends up, it is one line, and the hover label and the flank wash both come
+  // off it — so they can disagree with the bike, but never with each other.
   const tol = sided ? lateralTolerance(lateralByLabel.values()) : 0;
   const flanksByLabel = new Map<string, number[]>();
   for (const [label, xs] of lateralByLabel) {
     flanksByLabel.set(
       label,
-      xs.map((x) => (x > tol ? RIGHT : x < -tol ? LEFT : CENTRE)),
+      xs.map((x) => (x > tol ? LEFT : x < -tol ? RIGHT : CENTRE)),
     );
   }
 
@@ -430,6 +437,146 @@ export function partPath(part: UvPart, width: number, height: number): Path2D {
     path.closePath();
   }
   return path;
+}
+
+/**
+ * The single triangle under a uv point, as a part in its own right.
+ *
+ * What the bucket fills. A mesh group is not one shape on the sheet — `shroud` is both flanks
+ * and often several scattered islands — so a fill confined to the group floods panels the
+ * press never pointed at. One triangle is the finest the model can describe, and it is the
+ * unit the unwrapper actually laid down.
+ *
+ * Null when the point lands on no triangle of the part: between its islands, or in the slack
+ * of its bounding box. The caller falls back to the whole part there, because a bucket that
+ * silently does nothing reads as a broken tool.
+ */
+export function triangleAt(part: UvPart, u: number, v: number): UvPart | null {
+  const { tris } = part;
+  const count = Math.floor(tris.length / 6);
+  for (let t = 0; t < count; t += 1) {
+    const i = t * 6;
+    if (!inTriangle(u, v, tris[i], tris[i + 1], tris[i + 2], tris[i + 3], tris[i + 4], tris[i + 5])) {
+      continue;
+    }
+    const flanks = part.flanks ? Uint8Array.of(part.flanks[t]) : null;
+    const faces = part.faces ? Uint8Array.of(part.faces[t]) : null;
+    return {
+      ...part,
+      tris: tris.slice(i, i + 6),
+      src: part.src.slice(t * 2, t * 2 + 2),
+      flanks,
+      faces,
+      // One triangle sits on one side and faces one way, whatever the group as a whole does.
+      side: flanks ? summarise([flanks[0]]) : part.side,
+      face: faces ? summariseFaces([faces[0]]) : part.face,
+      minU: Math.min(tris[i], tris[i + 2], tris[i + 4]),
+      minV: Math.min(tris[i + 1], tris[i + 3], tris[i + 5]),
+      maxU: Math.max(tris[i], tris[i + 2], tris[i + 4]),
+      maxV: Math.max(tris[i + 1], tris[i + 3], tris[i + 5]),
+    };
+  }
+  return null;
+}
+
+/**
+ * The connected run of triangles containing a uv point, as a part in its own right.
+ *
+ * What a right-click with the bucket fills. An island is what the eye reads as "this panel":
+ * exactly the triangles reachable through shared uv vertices, which is the same cut the
+ * unwrapper made — a seam is a duplicated vertex. Filling one triangle at a time is right for
+ * a decal edge and hopeless for a whole shroud, so both are offered.
+ *
+ * Null on the same terms as {@link triangleAt}, and for the same reason.
+ */
+export function islandAt(part: UvPart, u: number, v: number): UvPart | null {
+  const { tris } = part;
+  const count = Math.floor(tris.length / 6);
+  let seed = -1;
+  for (let t = 0; t < count && seed < 0; t += 1) {
+    const i = t * 6;
+    if (inTriangle(u, v, tris[i], tris[i + 1], tris[i + 2], tris[i + 3], tris[i + 4], tris[i + 5])) {
+      seed = t;
+    }
+  }
+  if (seed < 0) return null;
+
+  // Quantised, because two nodes merged under one label hold their own copies of a shared edge
+  // and those need not be bit-identical. 1e-5 of uv is a fiftieth of a texel on a 2048 sheet —
+  // far below anything an unwrapper would call two places.
+  const key = (i: number) => `${Math.round(tris[i] * 1e5)},${Math.round(tris[i + 1] * 1e5)}`;
+  const byVertex = new Map<string, number[]>();
+  for (let t = 0; t < count; t += 1) {
+    for (let c = 0; c < 3; c += 1) {
+      const k = key(t * 6 + c * 2);
+      const run = byVertex.get(k);
+      if (run) run.push(t);
+      else byVertex.set(k, [t]);
+    }
+  }
+
+  const taken = new Uint8Array(count);
+  const queue = [seed];
+  taken[seed] = 1;
+  const picked: number[] = [];
+  while (queue.length) {
+    const t = queue.pop() as number;
+    picked.push(t);
+    for (let c = 0; c < 3; c += 1) {
+      for (const n of byVertex.get(key(t * 6 + c * 2)) ?? []) {
+        if (!taken[n]) {
+          taken[n] = 1;
+          queue.push(n);
+        }
+      }
+    }
+  }
+  // The whole part is one island: hand it straight back rather than rebuilding a copy of it.
+  if (picked.length === count) return part;
+  picked.sort((a, b) => a - b);
+
+  const out = new Float32Array(picked.length * 6);
+  const src = new Int32Array(picked.length * 2);
+  const flanks = part.flanks ? new Uint8Array(picked.length) : null;
+  const faces = part.faces ? new Uint8Array(picked.length) : null;
+  let minU = Infinity;
+  let minV = Infinity;
+  let maxU = -Infinity;
+  let maxV = -Infinity;
+  for (let n = 0; n < picked.length; n += 1) {
+    const t = picked[n];
+    for (let j = 0; j < 6; j += 1) {
+      const value = tris[t * 6 + j];
+      out[n * 6 + j] = value;
+      if (j % 2 === 0) {
+        if (value < minU) minU = value;
+        if (value > maxU) maxU = value;
+      } else {
+        if (value < minV) minV = value;
+        if (value > maxV) maxV = value;
+      }
+    }
+    src[n * 2] = part.src[t * 2];
+    src[n * 2 + 1] = part.src[t * 2 + 1];
+    if (flanks && part.flanks) flanks[n] = part.flanks[t];
+    if (faces && part.faces) faces[n] = part.faces[t];
+  }
+
+  return {
+    ...part,
+    tris: out,
+    src,
+    flanks,
+    faces,
+    // Summarised over the island, not inherited: half a shroud is one flank where the group
+    // was "both", and what gets said should describe what was filled.
+    side: flanks ? summarise(Array.from(flanks)) : part.side,
+    face: faces ? summariseFaces(Array.from(faces)) : part.face,
+    minU,
+    minV,
+    maxU,
+    maxV,
+  };
 }
 
 /**


### PR DESCRIPTION
Reported by L21: the sheet in the 2D pane is oriented wrongly against the template painters work from — the 3D projects it correctly, but flat it reads upside down, with the forks top-left where the template has them bottom-left.

## Why it's real

A `.pnt` stores its rows in the order the mesh samples them, which is inverted from how a template reads. This has looked settled twice before and been reverted, so it's settled here on evidence rather than on one reading — the **Renthal bar pads** on the OEM KTM's `plastics` sheet:

| as stored | flipped |
|---|---|
| "brembo", "RENTHAL", "REGINA" all inverted | all three upright |

Bar pads carry no mirrored twin on the sheet, so they answer it where a number plate can't. A plate reading correctly is as likely to be the opposite flank's copy — which is exactly what made this look settled before.

## What changed

**The 2D stage flips top-to-bottom — view only.** `toSheet`/`toView` and a single `sheetSpace` helper that every blit goes through. The sheet, the composite, the saved file and the 3D preview all stay in the file's own row order, so nothing here can reach a saved paint. Load a paint and save it back and the bytes are identical.

**Decals land upright on the bike.** Image and text layers now go into the sheet mirrored, which follows from the sheet being inverted — placed upright, they used to wear inverted. Paint layers are exempt, their pixels having been laid down through the same flipped view. `mirrored`/`sheetRotation` own that in one place so the composite, the selection box and the hit test can't disagree.

**Positive x reads the bike's LEFT.** What the mesh's own group names have said all along — `clutch` and `gear` sit at positive x on a 2023 YZ450F and both are left-hand controls. ⚠️ **This inverts the previous release's fix.** The reasoning both ways is recorded above the line, since it has now moved twice.

**The bucket fills one UV triangle.** It was confined to the mesh group, which is why it looked unconfined — `shroud` is both flanks and several scattered islands. Right-click fills the whole island instead. This costs the bucket its right-drag pan; the middle button still pans for every tool.

**Rect, ellipse and line are resizable layers.** They used to rasterise on release, so nudging one meant undoing it and drawing again. The drag now builds the object itself: it lands selected with corner handles, and colour, fill-or-outline and pen width stay editable. The gradient stays a stroke — a wash with no edge to grab. The shape rasteriser in `paint.ts` had no callers left and is gone.

No DB or schema changes.

## Verification

`tsc`, `eslint` and `vite build` clean. The view-transform algebra, the layer transform, the hit-test inverse and both UV picks were checked against the real bundled modules — a line renders exactly between the two points it was dragged between, rectangles span the box whichever way you drag, disjoint islands separate, and a press between islands falls back rather than filling nothing.

The 3D preview was not exercised. It is unchanged by this, but worth a look.

## Known, not addressed here

The 3D/2D sync is slow, and it isn't the UV scans — those measure 0.9 ms per hover pass at 120k triangles. `sheetTexture` ends with `needsUpdate = true`, which re-uploads the whole sheet and rebuilds its mipmap chain every frame; on a 4096² plastics sheet that's 67 MB per frame. The fix is a partial upload via `renderer.copyTextureToTexture`, which needs the r3f renderer and so belongs in `PreviewPanel`. Left for its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)