### PR TITLE
feat(logs): share the log bundle as a link, not just a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased — logs as a link
+
+### Added
+- **Share logs.** Settings → Logs already named all three log sets and saved them into one
+  zip; the file still had to be got to whoever asked, which is where "send me your logs"
+  usually stalls — a save dialog, then a file to find, then somewhere to upload it. **Share
+  logs** packs the same archive and uploads it through the same host a shared track goes out
+  on, then puts the direct link on the clipboard and leaves it on screen with a Copy button.
+  What goes in is what **Save logs…** already packed: the three log sets and the
+  `summary.txt` header (app version, OS, game, folders, and what was collected) — never the
+  config file, which holds session cookies and shop credentials. The link is public to
+  anyone holding it, and the page says so under the field. A bundle big enough to be sliced
+  comes back as a numbered list of parts rather than a first link that loses the rest.
+- **`summary.txt` now names the installed FrostMod build**, in the saved zip as well as the
+  shared one. The loader's log is in the archive and "which build wrote it" is the first
+  question anyone reading it has; `version.txt` itself stays out, being one of the files we
+  put in that folder ourselves.
+
 ## 2026-08-18 — v0.10.0 — A Designer that sets itself up, a Downloads page, and tracks in 3D
 
 The first full release since v0.9.1. It folds in everything the v0.9.2 betas carried, so

--- a/src-tauri/src/logs.rs
+++ b/src-tauri/src/logs.rs
@@ -9,9 +9,10 @@
 //! reporting it is the last person who can tell.
 //!
 //! None of them is somewhere a player finds on their own, and "send me your logs" is the
-//! first thing every bug report asks for. So this module answers three questions for
-//! Settings: where they are, what's actually in there, and how to hand the lot over as
-//! one file.
+//! first thing every bug report asks for. So this module answers four questions for
+//! Settings: where they are, what's actually in there, how to hand the lot over as one
+//! file, and — since the file still has to get to whoever asked — how to turn that file
+//! into a link, through the same upload a shared track goes out on.
 
 use serde::Serialize;
 use std::path::{Path, PathBuf};
@@ -274,12 +275,100 @@ fn groups(info: &LogsInfo) -> [(&'static str, &LogGroup); 3] {
     [("app", &info.app), ("frostmod", &info.frostmod), ("game", &info.game)]
 }
 
+/// A log bundle that went up to the file host, and the link that came back.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShareResult {
+    /// The direct download link — the whole point of the button, pasteable as it stands.
+    pub url: String,
+    /// Every slice's link, in order, on the rare occasion the zip was too big to go up in
+    /// one piece. Empty for the single-part upload every log bundle should be.
+    pub parts: Vec<String>,
+    /// How many log files made it in, as [`ExportResult`] counts them.
+    pub files: usize,
+    /// Bytes of log collected, before compression.
+    pub bytes: u64,
+    /// Bytes actually uploaded — the zip, which for plain text is a fraction of `bytes`.
+    pub size: u64,
+}
+
+/// Phase updates ride their own event, so the Settings share never hears the Library's
+/// upload progress or the other way round.
+pub const SHARE_EVENT: &str = "logs-share-progress";
+
+/// Pack every log set exactly as [`export`] does, upload the zip, and hand back the link.
+///
+/// The save button asks for a folder and leaves the player to attach the file somewhere.
+/// This is the same archive with the last step done for them: one link to paste into a
+/// bug report, uploaded through the same host and the same slicing as a shared track
+/// ([`crate::upload`]). What goes in is unchanged — logs and the summary, never the
+/// config file — because the link is public to anyone who has it.
+pub async fn share(
+    app: &tauri::AppHandle,
+    info: &LogsInfo,
+    summary: &str,
+) -> anyhow::Result<ShareResult> {
+    let work = std::env::temp_dir().join(format!("mxb-logs-share-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&work);
+    std::fs::create_dir_all(&work)?;
+    let zip_path = work.join("mxb-app-logs.zip");
+
+    crate::bundle::emit(app, SHARE_EVENT, "bundling", None);
+    // Reading every log is blocking work, and an app log that has been growing for a month
+    // is not small — off the UI thread, the same as the save-to-disk export.
+    let written = {
+        let (info, summary, dest) = (info.clone(), summary.to_string(), zip_path.clone());
+        tauri::async_runtime::spawn_blocking(move || export(&dest, &info, &summary))
+            .await
+            .map_err(|e| anyhow::anyhow!("packing the logs failed: {e}"))??
+    };
+
+    let size = crate::bundle::file_size(&zip_path);
+    let total = crate::bundle::human_size(size);
+    crate::bundle::emit(app, SHARE_EVENT, "uploading", Some(format!("Uploading {total}…")));
+    let client = crate::install::build_client()?;
+    let up = crate::upload::upload_file(&client, &zip_path, |i, n| {
+        let msg = if n > 1 {
+            format!("Uploading part {i} of {n} ({total})…")
+        } else {
+            format!("Uploading {total}…")
+        };
+        crate::bundle::emit(app, SHARE_EVENT, "uploading", Some(msg));
+    })
+    .await?;
+
+    // The zip is on the host now; the copy under temp has done its job either way.
+    let _ = std::fs::remove_dir_all(&work);
+
+    let mut parts = up.parts;
+    let Some(url) = parts.first().cloned() else {
+        anyhow::bail!("the upload returned no link")
+    };
+    // As in the file share: the first slice is the link, and the rest are only carried
+    // when there is more than one to stitch back together.
+    if parts.len() == 1 {
+        parts.clear();
+    }
+
+    crate::bundle::emit(app, SHARE_EVENT, "done", None);
+    Ok(ShareResult { url, parts, files: written.files, bytes: written.bytes, size: up.size })
+}
+
 /// The plain-text header that goes in beside the logs: what was included, and the handful
 /// of facts every report starts by asking for.
-pub fn summary(version: &str, cfg: &AppConfig, info: &LogsInfo) -> String {
+pub fn summary(
+    version: &str,
+    frostmod_version: Option<&str>,
+    cfg: &AppConfig,
+    info: &LogsInfo,
+) -> String {
     let mut out = String::new();
     out.push_str(&format!("MXB App {version}\n"));
     out.push_str(&format!("os: {} ({})\n", std::env::consts::OS, std::env::consts::ARCH));
+    // Which FrostMod is installed, if any. The loader's own log is in the zip beside this,
+    // and "which build wrote it" is the first thing anyone reading that log has to ask —
+    // `version.txt` itself stays out of the archive as one of the files we put there.
+    out.push_str(&format!("frostmod: {}\n", frostmod_version.unwrap_or("(not installed)")));
     out.push_str(&format!("game: {}\n", cfg.game().display));
     out.push_str(&format!("mods folder: {}\n", show(&cfg.mods_path)));
     out.push_str(&format!("install folder: {}\n", show(&cfg.install_dir())));
@@ -418,6 +507,32 @@ mod tests {
         assert_eq!(group.dir, install.to_string_lossy());
     }
 
+    /// The header is the first thing anyone reading the archive sees, and the FrostMod
+    /// build it names is the one that wrote the loader log sitting beside it — `version.txt`
+    /// itself is filtered out of the zip, so this line is the only place it appears.
+    #[test]
+    fn the_summary_names_the_loader_build() {
+        let root = tmpdir("summary");
+        let app_dir = root.join("applogs");
+        let frostmod_dir = root.join("frostmod");
+        for d in [&app_dir, &frostmod_dir] {
+            std::fs::create_dir_all(d).unwrap();
+        }
+        write(&frostmod_dir, "frostmod.log", "loader side");
+
+        let cfg = AppConfig::default();
+        let info = info(&app_dir, &frostmod_dir, &cfg);
+
+        let text = summary("9.9.9", Some("v0.13.0"), &cfg, &info);
+        assert!(text.contains("MXB App 9.9.9"), "{text}");
+        assert!(text.contains("frostmod: v0.13.0"), "{text}");
+        assert!(text.contains("frostmod.log"), "{text}");
+
+        // Nothing installed is a fact worth stating, not a line to leave out.
+        assert!(summary("9.9.9", None, &cfg, &info).contains("frostmod: (not installed)"));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     #[test]
     fn export_holds_every_group_and_a_summary() {
         let root = tmpdir("export");
@@ -443,7 +558,7 @@ mod tests {
         assert_eq!(info.game.files.len(), 1);
 
         let dest = root.join("out").join("logs.zip");
-        let result = export(&dest, &info, &summary("9.9.9", &cfg, &info)).unwrap();
+        let result = export(&dest, &info, &summary("9.9.9", Some("v0.13.0"), &cfg, &info)).unwrap();
         assert_eq!(result.files, 3);
 
         let mut zip = zip::ZipArchive::new(std::fs::File::open(&dest).unwrap()).unwrap();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3765,14 +3765,33 @@ async fn export_logs(app: tauri::AppHandle, dest: String) -> Result<logs::Export
     let version = app.package_info().version.to_string();
     let log_dir = app_log_dir(&app);
     let frostmod_dir = frostmod_manage::frostmod_dir(&app);
+    let frostmod_version = frostmod_manage::installed_version(&app);
     tauri::async_runtime::spawn_blocking(move || {
         let cfg = config::load(&app).unwrap_or_default();
         let info = logs::info(&log_dir, &frostmod_dir, &cfg);
-        let summary = logs::summary(&version, &cfg, &info);
+        let summary = logs::summary(&version, frostmod_version.as_deref(), &cfg, &info);
         logs::export(std::path::Path::new(&dest), &info, &summary).map_err(|e| format!("{e:#}"))
     })
     .await
     .map_err(|e| format!("export_logs task failed: {e}"))?
+}
+
+/// Zip every set of logs and upload it, handing back the direct link.
+///
+/// The same archive `export_logs` writes to disk, taken one step further: what a bug
+/// report needs is a link, and asking a player to find a save dialog, then a file, then an
+/// upload box is where "send me your logs" usually stalls. The upload is the one the
+/// Library's file share uses, so the ceiling and the slicing are already understood.
+#[tauri::command]
+async fn share_logs(app: tauri::AppHandle) -> Result<logs::ShareResult, String> {
+    let version = app.package_info().version.to_string();
+    let log_dir = app_log_dir(&app);
+    let frostmod_dir = frostmod_manage::frostmod_dir(&app);
+    let cfg = config::load(&app).unwrap_or_default();
+    let info = logs::info(&log_dir, &frostmod_dir, &cfg);
+    let summary =
+        logs::summary(&version, frostmod_manage::installed_version(&app).as_deref(), &cfg, &info);
+    logs::share(&app, &info, &summary).await.map_err(|e| format!("{e:#}"))
 }
 
 /// Where `tauri_plugin_log`'s `LogDir` target writes. Empty when the path can't be
@@ -6609,6 +6628,7 @@ fn main() {
             uninstall_mod,
             reveal_in_explorer,
             logs_info,
+            share_logs,
             open_logs_folder,
             export_logs,
             set_game_path,

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -12,6 +12,9 @@ import {
   Sparkles,
   FolderOpen,
   Download,
+  Share2,
+  Copy,
+  Loader2,
 } from "lucide-react";
 import { open as pickFolder, save as pickSavePath } from "@tauri-apps/plugin-dialog";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
@@ -24,10 +27,13 @@ import {
   getModsRoot,
   getOverlayState,
   logsInfo,
+  onLogsShareProgress,
   openLogsFolder,
+  shareLogs,
   type LogGroup,
   type LogsInfo,
   type LogsKind,
+  type LogsShare,
   overlayToggle,
   presetsListProfiles,
   setAutoRunFrostmod,
@@ -77,6 +83,7 @@ import { getLocale, LOCALE_OPTIONS } from "../../i18n/core";
 import { useFrostmod } from "../../Context/FrostmodContext";
 import { prettyHotkey } from "../../lib/hotkey";
 import { formatBytes, formatDateShort } from "../../lib/mods";
+import { copyText } from "../../lib/clipboard";
 import { useTour } from "../Tour/Tour";
 import { Button } from "@/Components/ui/button";
 import HelpHint from "@/Components/ui/help-hint";
@@ -343,6 +350,12 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
   // something just went wrong, and a count from ten minutes ago answers the wrong question.
   const [logs, setLogs] = useState<LogsInfo | null>(null);
   const [exportingLogs, setExportingLogs] = useState(false);
+  // The link the last share came back with, kept on screen for the rest of the session:
+  // it lands on the clipboard by itself, and a clipboard that has since been used for
+  // something else is the one way an uploaded bundle is lost for good.
+  const [sharedLogs, setSharedLogs] = useState<LogsShare | null>(null);
+  const [sharingLogs, setSharingLogs] = useState<string | null>(null);
+  const [copiedLogsLink, setCopiedLogsLink] = useState(false);
   const refreshLogs = useCallback(() => {
     logsInfo()
       .then(setLogs)
@@ -380,6 +393,54 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
       toast.error(t("logs.saveFailed"), { description: String(e) });
     } finally {
       setExportingLogs(false);
+    }
+  };
+
+  /** Zip the same logs and put them on the file host, handing back one link.
+   *
+   * Saving to disk is only half of "send me your logs" — the file still has to get to
+   * whoever asked, and that is where a bug report usually stalls. This ends with a link
+   * on the clipboard. It goes to a public host, hence the warning that sits under it. */
+  const shareLogsNow = async () => {
+    setSharingLogs(t("logs.sharePacking"));
+    setSharedLogs(null);
+    setCopiedLogsLink(false);
+    const unlisten = await onLogsShareProgress((p) => {
+      // "done" arrives just before the call returns; letting it through would flash the
+      // button back to "Packing…" for a frame on the way out.
+      if (p.phase === "done") return;
+      setSharingLogs(
+        p.phase === "uploading" ? p.message || t("logs.sharing") : t("logs.sharePacking"),
+      );
+    });
+    try {
+      const share = await shareLogs();
+      setSharedLogs(share);
+      // Straight to the clipboard: the link exists to be pasted somewhere, and someone
+      // who has just waited out an upload shouldn't have to click again to collect it.
+      const copied = await copyText(shareLinkText(share));
+      setCopiedLogsLink(copied);
+      toast.success(t("logs.shared"), {
+        description: copied
+          ? t("logs.sharedCopied", { size: formatBytes(share.size) })
+          : t("logs.sharedDesc", { size: formatBytes(share.size) }),
+      });
+      refreshLogs();
+    } catch (e) {
+      toast.error(t("logs.shareFailed"), {
+        description: String(e).replace(/^Error:\s*/, ""),
+      });
+    } finally {
+      unlisten();
+      setSharingLogs(null);
+    }
+  };
+
+  const copyLogsLink = async () => {
+    if (!sharedLogs) return;
+    if (await copyText(shareLinkText(sharedLogs))) {
+      setCopiedLogsLink(true);
+      toast.success(t("logs.linkCopied"));
     }
   };
 
@@ -1724,15 +1785,80 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
               group={logs?.game}
               onOpen={() => openLogs("game")}
             />
-            <div className="flex gap-2">
-              <Button variant="outline" size="sm" onClick={saveLogs} disabled={exportingLogs}>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={saveLogs}
+                disabled={exportingLogs || !!sharingLogs}
+              >
                 <Download className="size-3.5" />
                 {exportingLogs ? t("logs.saving") : t("logs.save")}
               </Button>
-              <Button variant="outline" size="sm" onClick={refreshLogs} disabled={exportingLogs}>
+              {/* The same zip, uploaded — for the far more common case where the logs are
+                  wanted by someone who isn't sitting at this machine. */}
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={shareLogsNow}
+                disabled={exportingLogs || !!sharingLogs}
+              >
+                {sharingLogs ? (
+                  <Loader2 className="size-3.5 animate-spin" />
+                ) : (
+                  <Share2 className="size-3.5" />
+                )}
+                {sharingLogs || t("logs.share")}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={refreshLogs}
+                disabled={exportingLogs || !!sharingLogs}
+              >
                 <RefreshCw className="size-3.5" /> {t("logs.refresh")}
               </Button>
             </div>
+            {sharedLogs && (
+              <div className="flex flex-col gap-1.5">
+                <div className="flex gap-2">
+                  {/* One link is a field; a sliced bundle is a numbered list, and an
+                      `input` would eat the newlines that keep the parts apart. */}
+                  {sharedLogs.parts.length > 1 ? (
+                    <textarea
+                      readOnly
+                      value={shareLinkText(sharedLogs)}
+                      onFocus={(e) => e.currentTarget.select()}
+                      className="h-20 min-w-0 flex-1 resize-none rounded-lg border border-input bg-background px-3 py-2 font-mono text-[12px] leading-snug text-muted-foreground"
+                    />
+                  ) : (
+                    <input
+                      readOnly
+                      value={sharedLogs.url}
+                      onFocus={(e) => e.currentTarget.select()}
+                      className="min-w-0 flex-1 rounded-lg border border-input bg-background px-3 py-2 font-mono text-[12px] text-muted-foreground"
+                    />
+                  )}
+                  <Button variant="outline" size="sm" onClick={copyLogsLink}>
+                    {copiedLogsLink ? (
+                      <Check className="size-3.5" />
+                    ) : (
+                      <Copy className="size-3.5" />
+                    )}
+                    {copiedLogsLink ? t("logs.linkCopiedShort") : t("logs.copyLink")}
+                  </Button>
+                </div>
+                <span className="text-[11.5px] text-muted-foreground">
+                  {t("logs.sharedSummary", {
+                    count: sharedLogs.files,
+                    size: formatBytes(sharedLogs.size),
+                  })}
+                </span>
+                {/* Anonymous public host, no expiry — the one thing worth saying out loud
+                    before a link goes into a Discord thread. */}
+                <span className="text-[11.5px] text-warning">{t("logs.shareWarning")}</span>
+              </div>
+            )}
             <p className="text-[11.5px] leading-relaxed text-faint">
               {t("logs.privacy")}
             </p>
@@ -1941,6 +2067,16 @@ function LogRow({
       </span>
     </div>
   );
+}
+
+/** The link text a share is copied and shown as.
+ *
+ * One line for the single upload a log bundle almost always is. A bundle big enough to
+ * have been sliced needs every part, in order, or it can't be put back together — so
+ * they go out as a numbered list rather than a first link that quietly loses the rest. */
+function shareLinkText(share: LogsShare): string {
+  if (share.parts.length < 2) return share.url;
+  return share.parts.map((url, i) => `${i + 1}/${share.parts.length} ${url}`).join("\n");
 }
 
 /** "today at 14:32" / "Aug 11 at 14:32" for a log's mtime — the age is what matters,

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -753,6 +753,34 @@ export function exportLogs(dest: string): Promise<LogsExport> {
   return invoke<LogsExport>("export_logs", { dest });
 }
 
+/** A shared log bundle: what went up, and the link that came back. */
+export interface LogsShare {
+  /** Direct download link — what gets pasted into a bug report. */
+  url: string;
+  /** Every slice's link, in order, when the zip was too big to go up in one piece.
+   *  Empty for the single-part upload a log bundle almost always is. */
+  parts: string[];
+  files: number;
+  /** Bytes of log collected, before compression. */
+  bytes: number;
+  /** Bytes uploaded — the zip, a fraction of `bytes` for plain text. */
+  size: number;
+}
+
+/** Zip every log set, upload it, and hand back the direct link. Same archive as
+ *  {@link exportLogs}, and the same upload the Library's file share goes out on. */
+export function shareLogs(): Promise<LogsShare> {
+  return invoke<LogsShare>("share_logs");
+}
+
+/** Subscribe to log-share pack/upload phase updates. Same payload as the file share's,
+ *  on its own event so Settings never hears the Library's upload. */
+export function onLogsShareProgress(
+  cb: (p: BundleProgress) => void,
+): Promise<UnlistenFn> {
+  return listen<BundleProgress>("logs-share-progress", (event) => cb(event.payload));
+}
+
 /** Hide-to-tray + keep-running toggle. */
 export function setRunInBackground(enabled: boolean): Promise<void> {
   return invoke<void>("set_run_in_background", { enabled });

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1479,7 +1479,7 @@ export const de: Translation = {
   // ── Logs ───────────────────────────────────────────────────────────────────
   "settings.logs": "Logs",
   "logs.desc":
-    "Die Dateien, die du schickst, wenn etwas schiefgeht. MXB App, FrostMod und {{game}} führen jeweils eigene — öffne den Ordner, den du brauchst, oder speichere alle als ein Zip für einen Fehlerbericht.",
+    "Die Dateien, die du schickst, wenn etwas schiefgeht. MXB App, FrostMod und {{game}} führen jeweils eigene — öffne den Ordner, den du brauchst, speichere alle als ein Zip, oder teile sie als Link für einen Fehlerbericht.",
   "logs.appLogs": "MXB App",
   "logs.appLogsDesc": "Was die App selbst aufgezeichnet hat",
   "logs.frostmodLogsDesc": "Was der Loader in seinen eigenen Ordner geschrieben hat",
@@ -1498,6 +1498,20 @@ export const de: Translation = {
   "logs.savedDesc_one": "{{count}} Log-Datei, {{size}}",
   "logs.savedDesc_other": "{{count}} Log-Dateien, {{size}}",
   "logs.saveFailed": "Logs konnten nicht gespeichert werden",
+  "logs.share": "Logs teilen",
+  "logs.sharePacking": "Wird gepackt…",
+  "logs.sharing": "Wird hochgeladen…",
+  "logs.shared": "Logs hochgeladen",
+  "logs.sharedCopied": "{{size}} — der Link liegt in deiner Zwischenablage.",
+  "logs.sharedDesc": "{{size}} — der Link steht unten.",
+  "logs.sharedSummary_one": "{{count}} Log-Datei, {{size}} hochgeladen.",
+  "logs.sharedSummary_other": "{{count}} Log-Dateien, {{size}} hochgeladen.",
+  "logs.shareFailed": "Logs konnten nicht geteilt werden",
+  "logs.copyLink": "Link kopieren",
+  "logs.linkCopiedShort": "Kopiert",
+  "logs.linkCopied": "Link kopiert",
+  "logs.shareWarning":
+    "Das Zip liegt auf einem öffentlichen Filehoster — wer den Link hat, kann es herunterladen. Gib ihn also nur dem, der danach gefragt hat.",
   "logs.privacy":
     "Logs enthalten Ordnerpfade und was die App gerade getan hat — nie deine Passwörter oder Session-Cookies, und keine Einstellungsdatei ist dabei.",
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1441,7 +1441,7 @@ export const en = {
   // ── Logs ───────────────────────────────────────────────────────────────────
   "settings.logs": "Logs",
   "logs.desc":
-    "The files to send when something goes wrong. MXB App, FrostMod and {{game}} each keep their own — open any of them, or save the lot as one zip to attach to a bug report.",
+    "The files to send when something goes wrong. MXB App, FrostMod and {{game}} each keep their own — open any of them, save the lot as one zip, or share it as a link to paste into a bug report.",
   "logs.appLogs": "MXB App",
   "logs.appLogsDesc": "What the app itself recorded",
   "logs.frostmodLogsDesc": "Whatever the loader wrote in its own folder",
@@ -1460,6 +1460,20 @@ export const en = {
   "logs.savedDesc_one": "{{count}} log file, {{size}}",
   "logs.savedDesc_other": "{{count}} log files, {{size}}",
   "logs.saveFailed": "Couldn't save the logs",
+  "logs.share": "Share logs",
+  "logs.sharePacking": "Packing…",
+  "logs.sharing": "Uploading…",
+  "logs.shared": "Logs uploaded",
+  "logs.sharedCopied": "{{size}} — the link is on your clipboard.",
+  "logs.sharedDesc": "{{size}} — the link is below.",
+  "logs.sharedSummary_one": "{{count}} log file, {{size}} uploaded.",
+  "logs.sharedSummary_other": "{{count}} log files, {{size}} uploaded.",
+  "logs.shareFailed": "Couldn't share the logs",
+  "logs.copyLink": "Copy link",
+  "logs.linkCopiedShort": "Copied",
+  "logs.linkCopied": "Link copied",
+  "logs.shareWarning":
+    "The zip sits on a public file host — anyone with the link can download it, so only hand it to whoever asked for it.",
   "logs.privacy":
     "Logs hold folder paths and what the app was doing — never your passwords or session cookies, and no settings file is included.",
 

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1466,7 +1466,7 @@ export const es: Translation = {
   // ── Registros ──────────────────────────────────────────────────────────────
   "settings.logs": "Registros",
   "logs.desc":
-    "Los archivos que hay que enviar cuando algo falla. MXB App, FrostMod y {{game}} guardan los suyos por separado — abre la carpeta que necesites o guárdalos todos en un zip para adjuntarlo a un informe.",
+    "Los archivos que hay que enviar cuando algo falla. MXB App, FrostMod y {{game}} guardan los suyos por separado — abre la carpeta que necesites, guárdalos todos en un zip, o compártelos como un enlace para pegar en un informe.",
   "logs.appLogs": "MXB App",
   "logs.appLogsDesc": "Lo que registró la propia app",
   "logs.frostmodLogsDesc": "Lo que el cargador escribió en su propia carpeta",
@@ -1485,6 +1485,20 @@ export const es: Translation = {
   "logs.savedDesc_one": "{{count}} archivo de registro, {{size}}",
   "logs.savedDesc_other": "{{count}} archivos de registro, {{size}}",
   "logs.saveFailed": "No se pudieron guardar los registros",
+  "logs.share": "Compartir registros",
+  "logs.sharePacking": "Empaquetando…",
+  "logs.sharing": "Subiendo…",
+  "logs.shared": "Registros subidos",
+  "logs.sharedCopied": "{{size}} — el enlace está en tu portapapeles.",
+  "logs.sharedDesc": "{{size}} — el enlace está abajo.",
+  "logs.sharedSummary_one": "{{count}} archivo de registro, {{size}} subidos.",
+  "logs.sharedSummary_other": "{{count}} archivos de registro, {{size}} subidos.",
+  "logs.shareFailed": "No se pudieron compartir los registros",
+  "logs.copyLink": "Copiar enlace",
+  "logs.linkCopiedShort": "Copiado",
+  "logs.linkCopied": "Enlace copiado",
+  "logs.shareWarning":
+    "El zip queda en un alojamiento público — cualquiera con el enlace puede descargarlo, así que dáselo solo a quien te lo pidió.",
   "logs.privacy":
     "Los registros contienen rutas de carpetas y lo que estaba haciendo la app — nunca tus contraseñas ni las cookies de sesión, y no se incluye ningún archivo de ajustes.",
 

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1470,7 +1470,7 @@ export const fr: Translation = {
   // ── Journaux ───────────────────────────────────────────────────────────────
   "settings.logs": "Journaux",
   "logs.desc":
-    "Les fichiers à envoyer quand quelque chose ne va pas. MXB App, FrostMod et {{game}} ont chacun les leurs — ouvre le dossier qu'il te faut, ou enregistre le tout dans un zip à joindre à un rapport.",
+    "Les fichiers à envoyer quand quelque chose ne va pas. MXB App, FrostMod et {{game}} ont chacun les leurs — ouvre le dossier qu'il te faut, enregistre le tout dans un zip, ou partage-le sous forme de lien à coller dans un rapport.",
   "logs.appLogs": "MXB App",
   "logs.appLogsDesc": "Ce que l'app elle-même a enregistré",
   "logs.frostmodLogsDesc": "Ce que le loader a écrit dans son propre dossier",
@@ -1489,6 +1489,20 @@ export const fr: Translation = {
   "logs.savedDesc_one": "{{count}} fichier de journal, {{size}}",
   "logs.savedDesc_other": "{{count}} fichiers de journal, {{size}}",
   "logs.saveFailed": "Impossible d'enregistrer les journaux",
+  "logs.share": "Partager les journaux",
+  "logs.sharePacking": "Préparation…",
+  "logs.sharing": "Envoi…",
+  "logs.shared": "Journaux envoyés",
+  "logs.sharedCopied": "{{size}} — le lien est dans ton presse-papiers.",
+  "logs.sharedDesc": "{{size}} — le lien est ci-dessous.",
+  "logs.sharedSummary_one": "{{count}} fichier de journal, {{size}} envoyés.",
+  "logs.sharedSummary_other": "{{count}} fichiers de journal, {{size}} envoyés.",
+  "logs.shareFailed": "Impossible de partager les journaux",
+  "logs.copyLink": "Copier le lien",
+  "logs.linkCopiedShort": "Copié",
+  "logs.linkCopied": "Lien copié",
+  "logs.shareWarning":
+    "Le zip est déposé sur un hébergeur public — n'importe qui avec le lien peut le télécharger, alors ne le donne qu'à la personne qui l'a demandé.",
   "logs.privacy":
     "Les journaux contiennent des chemins de dossiers et ce que faisait l'app — jamais tes mots de passe ni tes cookies de session, et aucun fichier de réglages n'est inclus.",
 

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1461,7 +1461,7 @@ export const it: Translation = {
   // ── Log ────────────────────────────────────────────────────────────────────
   "settings.logs": "Log",
   "logs.desc":
-    "I file da inviare quando qualcosa non va. MXB App, FrostMod e {{game}} tengono ciascuno i propri — apri la cartella che ti serve, oppure salvali tutti in un unico zip da allegare a una segnalazione.",
+    "I file da inviare quando qualcosa non va. MXB App, FrostMod e {{game}} tengono ciascuno i propri — apri la cartella che ti serve, salvali tutti in un unico zip, oppure condividili come link da incollare in una segnalazione.",
   "logs.appLogs": "MXB App",
   "logs.appLogsDesc": "Quello che ha registrato l'app stessa",
   "logs.frostmodLogsDesc": "Quello che il loader ha scritto nella sua cartella",
@@ -1480,6 +1480,20 @@ export const it: Translation = {
   "logs.savedDesc_one": "{{count}} file di log, {{size}}",
   "logs.savedDesc_other": "{{count}} file di log, {{size}}",
   "logs.saveFailed": "Impossibile salvare i log",
+  "logs.share": "Condividi i log",
+  "logs.sharePacking": "Preparazione…",
+  "logs.sharing": "Caricamento…",
+  "logs.shared": "Log caricati",
+  "logs.sharedCopied": "{{size}} — il link è nei tuoi appunti.",
+  "logs.sharedDesc": "{{size}} — il link è qui sotto.",
+  "logs.sharedSummary_one": "{{count}} file di log, {{size}} caricati.",
+  "logs.sharedSummary_other": "{{count}} file di log, {{size}} caricati.",
+  "logs.shareFailed": "Impossibile condividere i log",
+  "logs.copyLink": "Copia link",
+  "logs.linkCopiedShort": "Copiato",
+  "logs.linkCopied": "Link copiato",
+  "logs.shareWarning":
+    "Lo zip sta su un host pubblico — chiunque abbia il link può scaricarlo, quindi dallo solo a chi te l'ha chiesto.",
   "logs.privacy":
     "I log contengono percorsi di cartelle e cosa stava facendo l'app — mai le tue password o i cookie di sessione, e nessun file di impostazioni è incluso.",
 

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1459,7 +1459,7 @@ export const ptBR: Translation = {
   // ── Logs ───────────────────────────────────────────────────────────────────
   "settings.logs": "Logs",
   "logs.desc":
-    "Os arquivos para enviar quando algo dá errado. MXB App, FrostMod e {{game}} guardam os seus separadamente — abra a pasta que precisar, ou salve todos num zip para anexar a um relato de bug.",
+    "Os arquivos para enviar quando algo dá errado. MXB App, FrostMod e {{game}} guardam os seus separadamente — abra a pasta que precisar, salve todos num zip, ou compartilhe como um link para colar num relato de bug.",
   "logs.appLogs": "MXB App",
   "logs.appLogsDesc": "O que o próprio app registrou",
   "logs.frostmodLogsDesc": "O que o loader escreveu na pasta dele",
@@ -1478,6 +1478,20 @@ export const ptBR: Translation = {
   "logs.savedDesc_one": "{{count}} arquivo de log, {{size}}",
   "logs.savedDesc_other": "{{count}} arquivos de log, {{size}}",
   "logs.saveFailed": "Não foi possível salvar os logs",
+  "logs.share": "Compartilhar logs",
+  "logs.sharePacking": "Empacotando…",
+  "logs.sharing": "Enviando…",
+  "logs.shared": "Logs enviados",
+  "logs.sharedCopied": "{{size}} — o link está na sua área de transferência.",
+  "logs.sharedDesc": "{{size}} — o link está abaixo.",
+  "logs.sharedSummary_one": "{{count}} arquivo de log, {{size}} enviados.",
+  "logs.sharedSummary_other": "{{count}} arquivos de log, {{size}} enviados.",
+  "logs.shareFailed": "Não foi possível compartilhar os logs",
+  "logs.copyLink": "Copiar link",
+  "logs.linkCopiedShort": "Copiado",
+  "logs.linkCopied": "Link copiado",
+  "logs.shareWarning":
+    "O zip fica num host público — qualquer pessoa com o link pode baixá-lo, então passe só para quem pediu.",
   "logs.privacy":
     "Os logs contêm caminhos de pastas e o que o app estava fazendo — nunca suas senhas ou cookies de sessão, e nenhum arquivo de configurações é incluído.",
 


### PR DESCRIPTION
Settings → Logs already named all three log sets and packed them into one zip. What it couldn't do is the half that matters: the file still has to reach whoever asked for it, and a save dialog, then a file to find, then somewhere to upload it is where "send me your logs" stalls.

**Share logs** packs the same archive, puts it through the same upload a shared track goes out on, and hands back the direct link — on the clipboard by itself, and left on screen with a Copy button, because a clipboard used once more is the one way an uploaded bundle is lost for good.

## What's in it

**Backend** — `src-tauri/src/logs.rs`, `main.rs`
- `logs::share()` stages the zip under temp, reads every log on a blocking thread (an app log that has been growing for a month is not small), uploads through `upload::upload_file` (the same host and the same 190 MB slicing as the Library's file share), and returns `{ url, parts, files, bytes, size }`.
- Phases go out on `logs-share-progress`, its own event, so Settings never hears the Library's upload progress.
- New `share_logs` command, registered in the invoke handler.
- A bundle big enough to be sliced comes back as every part, numbered and in order — one link that quietly loses the rest can't be put back together.
- `summary.txt` now names the installed FrostMod build, in the saved zip as well as the shared one. Its log is in the archive and "which build wrote it" is the first question anyone reading it has; `version.txt` itself stays out, being one of the files we put in that folder.

**Frontend** — `src/api/mods.ts`, `Settings.tsx`, six locales
- `shareLogs()` / `onLogsShareProgress()` bindings and the `LogsShare` type.
- The button shows the live phase ("Packing…" → "Uploading 4.2 MB…"), then the link, a file-and-size line, and the warning below.

## Privacy

What goes in is unchanged from what **Save logs…** already packed: the three log sets and the `summary.txt` header. Never the config file, which holds session cookies and shop credentials. The link is public to anyone holding it — the page says so under the field, in every locale.

## Verified

`cargo check` and the logs tests (7, including a new one over the summary header), `tsc`, `eslint` and `vite build` all clean. The upload itself was not exercised — it is the same code path the Library's file share uses, unchanged.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pFcnMqVVRMXCdaRGtfR3J

---
_Generated by [Claude Code](https://claude.ai/code/session_012pFcnMqVVRMXCdaRGtfR3J)_