### PR TITLE
fix(overlay): show the overlay where it can be seen, and say when FrostMod isn't in the game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 2026-08-19
+
+### Fixed
+- **The in-game overlay opens where you can see it.** Once MX Bikes was minimized — which
+  exclusive fullscreen does the moment the overlay takes focus — the hotkey placed the
+  overlay ~32,000px off the left of the desktop: shown, focused, and invisible, so it read
+  as a hotkey that did nothing, and it took focus off the game on its way. A minimized game
+  no longer contributes a position, and the overlay is kept inside the bounds of whichever
+  monitor the game is on.
+- **FrostMod is re-armed when the game restarts.** It was only ever started automatically at
+  app launch, so a second race in one sitting ran without it — no live reloads, no model
+  swaps, no indication anything was different. The app now notices the game starting,
+  whether that came from the Play button, Steam or the desktop.
+- **The FrostMod pill says when FrostMod isn't reaching the game.** "Running" only ever meant
+  the launcher was up. When the game runs as administrator and MXB App doesn't, FrostMod
+  can't get into it at all — no in-game pill — and the app reported it as running the whole
+  time. That case is now named, with both ways out of it (run the game without administrator,
+  or run MXB App with it).
+
+### Changed
+- Starting FrostMod is logged on Windows, on success and on failure, as it already was on
+  Linux and macOS — the platform nearly every report comes from was the one saying nothing.
+
 ## 2026-08-18 — v0.10.0 — A Designer that sets itself up, a Downloads page, and tracks in 3D
 
 The first full release since v0.9.1. It folds in everything the v0.9.2 betas carried, so

--- a/src-tauri/src/frostmod.rs
+++ b/src-tauri/src/frostmod.rs
@@ -387,6 +387,174 @@ pub fn supported_for_game(game: crate::game::Game, tag: Option<&str>) -> bool {
     }
 }
 
+// ===========================================================================
+// Did it actually get in?
+//
+// `is_running` answers "is FrostMod up?", which everything so far has treated as "is
+// FrostMod working?". They come apart in one important case: the game running at a higher
+// integrity level than the app. FrostMod is launched by us, so it inherits our level, and
+// an injector cannot open a process above it — the DLL never goes in, the pill in the game
+// never appears, and the app cheerfully reports FrostMod as running the whole time.
+//
+// So ask the game instead. A DLL that is in the process is in its module list however it
+// got there, and the walk that reads that list is refused by exactly the same barrier that
+// refuses the injection — which makes "we can't look" not a gap in the answer but the
+// answer itself.
+// ===========================================================================
+
+/// The DLL FrostMod injects. Matched by file name: wherever it was loaded from, its being
+/// in the game's module list is what "attached" means.
+const INJECTED_DLL: &str = "frostmod.dll";
+
+/// How long to give an injection before calling it a failure.
+///
+/// FrostMod polls for the game and injects when it sees it, so there is always a window
+/// where the game is up and the DLL legitimately isn't in yet. Complaining inside that
+/// window would fire a warning on every single launch.
+const ATTACH_GRACE: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// When we first saw a game with no FrostMod in it, for [`ATTACH_GRACE`]. Cleared whenever
+/// the answer is anything else, so each game session gets its own grace period.
+static WAITING_SINCE: std::sync::Mutex<Option<std::time::Instant>> = std::sync::Mutex::new(None);
+
+/// Whether FrostMod's DLL is inside the running game.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttachState {
+    /// No game running, so nothing to be attached to.
+    GameNotRunning,
+    /// `frostmod.dll` is in the game.
+    Attached,
+    /// The game is up, the DLL isn't in yet, and it hasn't been long enough to worry.
+    Attaching,
+    /// The game is up, FrostMod's DLL is not in it, and it has had time to be.
+    NotAttached,
+    /// Windows won't let us see inside the game — and won't let FrostMod in either.
+    Blocked,
+    /// This platform can't answer the question.
+    Unknown,
+}
+
+/// The attach answer, plus what to do about it when it's bad news.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Attachment {
+    pub state: AttachState,
+    /// What is wrong and how to fix it. Empty unless the state calls for it — the good
+    /// states are their own explanation.
+    pub reason: String,
+}
+
+impl Attachment {
+    fn plain(state: AttachState) -> Self {
+        Self { state, reason: String::new() }
+    }
+}
+
+/// Is this module path FrostMod's injected DLL?
+fn is_injected_dll(path: &str) -> bool {
+    path.rsplit(['\\', '/'])
+        .next()
+        .is_some_and(|name| name.eq_ignore_ascii_case(INJECTED_DLL))
+}
+
+/// Decide how long a game has been sitting there without FrostMod in it.
+///
+/// Split from [`attachment`] so the grace period is testable without a game: `now` is the
+/// clock, and the `Option` is the stored "first seen like this" the caller keeps.
+fn waiting_verdict(
+    first_seen: &mut Option<std::time::Instant>,
+    now: std::time::Instant,
+) -> AttachState {
+    let since = *first_seen.get_or_insert(now);
+    if now.duration_since(since) >= ATTACH_GRACE {
+        AttachState::NotAttached
+    } else {
+        AttachState::Attaching
+    }
+}
+
+/// Is FrostMod actually in the game — and if not, why not?
+pub fn attachment() -> Attachment {
+    use crate::gameproc::GameModules;
+
+    // Every answer but "the game is up and FrostMod isn't in it yet" ends the wait, so a
+    // later session that comes back around to that state gets a fresh grace period rather
+    // than inheriting the last one's — which would have it warn instantly.
+    let forget_the_wait = || {
+        if let Ok(mut slot) = WAITING_SINCE.lock() {
+            *slot = None;
+        }
+    };
+
+    match crate::gameproc::game_modules() {
+        GameModules::NotRunning => {
+            forget_the_wait();
+            Attachment::plain(AttachState::GameNotRunning)
+        }
+        GameModules::Unavailable => {
+            forget_the_wait();
+            Attachment::plain(AttachState::Unknown)
+        }
+        GameModules::Denied => {
+            forget_the_wait();
+            Attachment { state: AttachState::Blocked, reason: blocked_reason() }
+        }
+        GameModules::Loaded(paths) if paths.iter().any(|p| is_injected_dll(p)) => {
+            forget_the_wait();
+            Attachment::plain(AttachState::Attached)
+        }
+        GameModules::Loaded(_) => {
+            let now = std::time::Instant::now();
+            let state = match WAITING_SINCE.lock() {
+                Ok(mut slot) => waiting_verdict(&mut slot, now),
+                // A poisoned lock must not be what turns into a false alarm.
+                Err(_) => AttachState::Attaching,
+            };
+            let reason = match state {
+                AttachState::NotAttached => not_attached_reason(),
+                _ => String::new(),
+            };
+            Attachment { state, reason }
+        }
+    }
+}
+
+/// What to tell someone whose game we aren't allowed to look inside.
+///
+/// Both ways out are offered because either genuinely works, and which one is right isn't
+/// ours to decide — running the game unelevated is the better habit, running the app
+/// elevated is the quicker fix.
+fn blocked_reason() -> String {
+    let game = crate::game::active().display;
+    match crate::gameproc::we_are_elevated() {
+        // The ordinary case, and the one worth naming outright.
+        Some(false) => format!(
+            "{game} is running as administrator and MXB App isn't, so FrostMod can't get \
+             into it — no in-game pill, no live reloads, no model swaps. Close {game} and \
+             start it without administrator, or run MXB App as administrator too, then \
+             launch the game again."
+        ),
+        // We are the elevated one, or Windows wouldn't say. Either way "run as admin" is
+        // no longer advice we can give straight-faced, so describe the shape of the fix.
+        _ => format!(
+            "Windows won't let MXB App see inside {game}, so FrostMod can't get into it \
+             either — no in-game pill, no live reloads, no model swaps. {game} and MXB App \
+             have to run at the same level: either both as administrator, or neither."
+        ),
+    }
+}
+
+/// The game is readable, FrostMod is not in it, and the grace period is up.
+fn not_attached_reason() -> String {
+    let game = crate::game::active().display;
+    format!(
+        "FrostMod is running but hasn't got into {game} — no in-game pill, no live reloads, \
+         no model swaps. Stop FrostMod and start it again; if it keeps happening, close \
+         {game} first so FrostMod is up before the game is."
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -540,5 +708,74 @@ mod tests {
             command_json_at("reload_mods", "", 7),
             r#"{"at":"7","bikeId":"","verb":"reload_mods"}"#
         );
+    }
+
+    /// Module lists come back as full paths, in whatever case the loader recorded — and on
+    /// Linux the same DLL is reached through a `/proc` mapping with forward slashes.
+    #[test]
+    fn the_injected_dll_is_recognised_wherever_it_was_loaded_from() {
+        for path in [
+            r"C:\Users\me\AppData\Local\com.frost.mxbikes\frostmod\frostmod.dll",
+            r"C:\Users\me\AppData\Local\com.frost.mxbikes\frostmod\FrostMod.DLL",
+            "/home/me/.steam/steamapps/compatdata/pfx/drive_c/frostmod/frostmod.dll",
+            "frostmod.dll",
+        ] {
+            assert!(is_injected_dll(path), "should be FrostMod's DLL: {path}");
+        }
+    }
+
+    /// The near-misses that must not read as an attached FrostMod — the launcher is a
+    /// sibling of the DLL in the same folder, and it is the thing that is always running.
+    #[test]
+    fn nothing_else_counts_as_attached() {
+        for path in [
+            r"C:\frostmod\frostmod.exe",
+            r"C:\Program Files\MX Bikes\mxbikes.exe",
+            r"C:\frostmod\frostmod.dll.bak",
+            r"C:\frostmod\notfrostmod.dll",
+            "",
+        ] {
+            assert!(!is_injected_dll(path), "should not be FrostMod's DLL: {path}");
+        }
+    }
+
+    /// FrostMod injects a moment *after* the game process appears, so the first look is
+    /// always a miss. Warning then would fire on every launch the app ever saw.
+    #[test]
+    fn a_game_that_just_started_is_given_time_to_be_injected() {
+        let start = std::time::Instant::now();
+        let mut first_seen = None;
+        assert_eq!(waiting_verdict(&mut first_seen, start), AttachState::Attaching);
+        assert_eq!(
+            waiting_verdict(&mut first_seen, start + ATTACH_GRACE - std::time::Duration::from_secs(1)),
+            AttachState::Attaching,
+            "still inside the grace period",
+        );
+    }
+
+    /// Past the grace period it is no longer "any moment now", and saying so is the whole
+    /// point — this is the state the player is currently left to work out for themselves.
+    #[test]
+    fn a_game_that_never_got_injected_is_reported() {
+        let start = std::time::Instant::now();
+        let mut first_seen = None;
+        waiting_verdict(&mut first_seen, start);
+        assert_eq!(
+            waiting_verdict(&mut first_seen, start + ATTACH_GRACE),
+            AttachState::NotAttached,
+        );
+    }
+
+    /// The clock starts when we first see the game without FrostMod, not when we're asked.
+    /// Without this a slow poll could hand out a fresh grace period every time.
+    #[test]
+    fn the_grace_period_runs_from_the_first_sighting() {
+        let start = std::time::Instant::now();
+        let mut first_seen = Some(start);
+        assert_eq!(
+            waiting_verdict(&mut first_seen, start + ATTACH_GRACE),
+            AttachState::NotAttached,
+        );
+        assert_eq!(first_seen, Some(start), "the first sighting is not moved by a later look");
     }
 }

--- a/src-tauri/src/frostmod_manage.rs
+++ b/src-tauri/src/frostmod_manage.rs
@@ -539,13 +539,44 @@ pub fn start(app: &AppHandle, state: &FrostmodProcess) -> anyhow::Result<bool> {
     if let Some(mods) = &plan.mods_root {
         args.extend(["--mods".into(), mods.to_string_lossy().into_owned()]);
     }
+    // Logged on both sides, as Linux and macOS already are. FrostMod not working is the
+    // single most reported thing about this app, and until now the Windows path — the one
+    // nearly every report comes from — said nothing at all in the log, whether it worked
+    // or not.
+    log::info!("starting FrostMod: {} {:?}", plan.exe.display(), args);
     let child = std::process::Command::new(&plan.exe)
         .current_dir(frostmod_dir(app))
         .args(&args)
         .creation_flags(CREATE_NO_WINDOW)
-        .spawn()?;
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("Couldn't start {}: {e}", plan.exe.display()))?;
+    log::info!("FrostMod started (pid {})", child.id());
     *state.0.lock().unwrap() = Some(child);
     Ok(true)
+}
+
+/// Re-arm FrostMod for a game session that has just begun.
+///
+/// FrostMod injects into one game process. When that process goes, so does the injection —
+/// and nothing used to bring it back, because the only automatic start was at app launch.
+/// So the second race of a session ran without it: no live reloads, no model swaps, and no
+/// indication that anything was different from the first.
+///
+/// Called from [`crate::integritywatch`], which already polls for the game starting, and so
+/// covers a launch from Steam or the desktop exactly as well as one from the Play button.
+pub fn on_game_started(app: &AppHandle, cfg: &crate::config::AppConfig) {
+    if !cfg.auto_run_frostmod || !is_installed(app) {
+        return;
+    }
+    let state = app.state::<FrostmodProcess>();
+    match start(app, &state) {
+        Ok(true) => log::info!("FrostMod re-armed for the new game session"),
+        // Already up and holding its reload event, which is the ordinary case when the
+        // launcher outlives a game. Whether it got *into* this game is a separate
+        // question, and `frostmod::attachment` is what answers it.
+        Ok(false) => log::debug!("FrostMod was already running when the game started"),
+        Err(e) => log::warn!("couldn't start FrostMod for the new game session: {e:#}"),
+    }
 }
 
 /// Where the wrapper's own output goes — Proton's on Linux, Wine's on macOS — appended to

--- a/src-tauri/src/gameproc.rs
+++ b/src-tauri/src/gameproc.rs
@@ -315,27 +315,78 @@ fn ansi_field(field: &[std::os::raw::c_char]) -> String {
 /// never report a clean bill of health for a machine it failed to read.
 #[cfg(windows)]
 pub fn game_module_paths() -> Option<Vec<String>> {
-    let pid = find_game_pid()?;
-    // A snapshot taken while the game is loading its own modules fails with
-    // ERROR_BAD_LENGTH; the documented remedy is simply to ask again.
-    for _ in 0..8 {
-        if let Some(paths) = module_paths(pid) {
-            return Some(paths);
-        }
+    match game_modules() {
+        GameModules::Loaded(paths) => Some(paths),
+        _ => None,
     }
-    None
 }
 
-/// One Toolhelp module walk over `pid`. `None` if the snapshot itself failed.
+/// What a module walk over the game produced.
+///
+/// The reason `game_module_paths`' `None` was split apart: "Windows refused to let us look"
+/// is a different fact from "the walk came up empty", and it is the one worth acting on.
+/// A refusal means the game is running at a higher integrity level than we are — and that
+/// is the same wall an injector hits, so it is also the answer to "why isn't FrostMod in
+/// the game?" (see [`crate::frostmod::attachment`]).
+// Only the Windows walk can be refused; elsewhere the variant is unreachable by design.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub enum GameModules {
+    /// Everything mapped into the game right now.
+    Loaded(Vec<String>),
+    /// Windows refused the snapshot. Retrying will not help.
+    Denied,
+    /// No game to look at.
+    NotRunning,
+    /// The walk produced nothing usable, and not because we were refused.
+    Unavailable,
+}
+
+/// Walk the game's loaded modules, saying *why* when it doesn't work.
 #[cfg(windows)]
-fn module_paths(pid: u32) -> Option<Vec<String>> {
+pub fn game_modules() -> GameModules {
+    let Some(pid) = find_game_pid() else {
+        return GameModules::NotRunning;
+    };
+    // A snapshot taken while the game is loading its own modules fails with
+    // ERROR_BAD_LENGTH; the documented remedy is simply to ask again. A refusal is not
+    // that, so it breaks out rather than burning the retries on an answer that won't change.
+    for _ in 0..8 {
+        match module_paths(pid) {
+            Ok(paths) => return GameModules::Loaded(paths),
+            Err(WalkFailure::Denied) => return GameModules::Denied,
+            Err(WalkFailure::Transient) => continue,
+        }
+    }
+    GameModules::Unavailable
+}
+
+/// Why one module walk didn't produce a list.
+#[cfg(windows)]
+enum WalkFailure {
+    /// `ERROR_ACCESS_DENIED` — the process is above us.
+    Denied,
+    /// Anything else, including the `ERROR_BAD_LENGTH` that just wants asking again.
+    Transient,
+}
+
+/// One Toolhelp module walk over `pid`.
+#[cfg(windows)]
+fn module_paths(pid: u32) -> Result<Vec<String>, WalkFailure> {
     // SAFETY: module snapshot for a known pid; the handle is closed on every path out,
     // and we only read fields the API filled in.
     unsafe {
         let snap =
             ffi::CreateToolhelp32Snapshot(ffi::TH32CS_SNAPMODULE | ffi::TH32CS_SNAPMODULE32, pid);
         if snap == ffi::INVALID_HANDLE_VALUE {
-            return None;
+            // Reading another process's module list needs rights UIPI withholds across an
+            // integrity boundary, so this is what an elevated game looks like from an
+            // unelevated app — the one failure here that retrying cannot fix.
+            return Err(if ffi::GetLastError() == ffi::ERROR_ACCESS_DENIED {
+                WalkFailure::Denied
+            } else {
+                WalkFailure::Transient
+            });
         }
         let mut me: ffi::ModuleEntry32 = std::mem::zeroed();
         me.dw_size = std::mem::size_of::<ffi::ModuleEntry32>() as u32;
@@ -356,9 +407,9 @@ fn module_paths(pid: u32) -> Option<Vec<String>> {
         // has no modules — every process has at least its own exe. Treat it as a failure so
         // the caller retries rather than reporting an empty machine.
         if paths.is_empty() {
-            None
+            Err(WalkFailure::Transient)
         } else {
-            Some(paths)
+            Ok(paths)
         }
     }
 }
@@ -480,14 +531,29 @@ pub fn foreground_is_another_app() -> bool {
 ///
 /// Used to put the overlay over the game rather than wherever the primary monitor is —
 /// a triple-screen sim rig would otherwise get it on the wrong display.
+///
+/// `None` for a minimized game, which is the case that made this worth a comment:
+/// minimizing does not clear `WS_VISIBLE`, so [`collect_game_window`] hands one back like
+/// any other window, and `GetWindowRect` then reports the iconic position — around
+/// (-32000, -32000), off every monitor there is. Anything centred on that rect goes with
+/// it. The caller wants "no answer" there, not an answer from another world.
+///
+/// Deliberately filtered here rather than in the walk: [`focus_game`] wants the minimized
+/// window precisely so it can restore it.
 #[cfg(windows)]
 pub fn game_window_rect() -> Option<(i32, i32, i32, i32)> {
     let hwnd = game_hwnd()?;
-    let mut rect = ffi::Rect::default();
-    // SAFETY: `hwnd` is a live handle from the walk above; `GetWindowRect` only writes
-    // the four ints of the `RECT` we own.
-    let ok = unsafe { ffi::GetWindowRect(hwnd, &mut rect) != 0 };
-    ok.then_some((rect.left, rect.top, rect.right, rect.bottom))
+    // SAFETY: `hwnd` is a live handle from the walk above; both calls are reads, and both
+    // are safe on a stale handle (they simply fail).
+    unsafe {
+        if ffi::IsIconic(hwnd) != 0 {
+            return None;
+        }
+        let mut rect = ffi::Rect::default();
+        // `GetWindowRect` only writes the four ints of the `RECT` we own.
+        let ok = ffi::GetWindowRect(hwnd, &mut rect) != 0;
+        ok.then_some((rect.left, rect.top, rect.right, rect.bottom))
+    }
 }
 
 /// Is a DirectX app holding the screen in *exclusive* fullscreen right now?
@@ -622,6 +688,22 @@ pub fn game_module_paths() -> Option<Vec<String>> {
 #[cfg(not(any(windows, target_os = "linux")))]
 pub fn running_process_names() -> Option<Vec<String>> {
     None
+}
+
+/// The same answer off Windows, from whatever each platform can see.
+///
+/// No `Denied` arm: the integrity levels that produce one are a Windows idea, and the game
+/// here is a Wine process we either can read the mappings of (Linux, via `/proc`) or cannot
+/// look inside at all (macOS). Both are `Unavailable` rather than a refusal to explain.
+#[cfg(not(windows))]
+pub fn game_modules() -> GameModules {
+    if !is_game_running() {
+        return GameModules::NotRunning;
+    }
+    match game_module_paths() {
+        Some(paths) => GameModules::Loaded(paths),
+        None => GameModules::Unavailable,
+    }
 }
 
 #[cfg(not(windows))]
@@ -831,6 +913,20 @@ unsafe fn token_elevated(process: ffi::Handle) -> Option<bool> {
     ok.then(|| elevation.token_is_elevated != 0)
 }
 
+/// Is *this* process elevated? `None` when Windows won't say.
+#[cfg(windows)]
+pub fn we_are_elevated() -> Option<bool> {
+    // SAFETY: `GetCurrentProcess` hands back a pseudo-handle to ourselves, which is a
+    // constant rather than a handle to close.
+    unsafe { token_elevated(ffi::GetCurrentProcess()) }
+}
+
+/// Off Windows there is no elevation to be on the wrong side of.
+#[cfg(not(windows))]
+pub fn we_are_elevated() -> Option<bool> {
+    Some(false)
+}
+
 /// Why Steam is about to refuse us, when it is.
 ///
 /// Steam will not start a game for a program running at a different Windows integrity
@@ -853,29 +949,33 @@ fn steam_elevation_conflict() -> Option<&'static str> {
         then press Play again.";
 
     let pid = find_pid(STEAM_EXE)?;
-    // SAFETY: `GetCurrentProcess` hands back a pseudo-handle to ourselves, which is a
-    // constant rather than a handle to close.
-    let ours = unsafe { token_elevated(ffi::GetCurrentProcess()) }?;
+    let ours = we_are_elevated()?;
+    let theirs = process_elevated(pid, ours)?;
 
+    (ours != theirs).then_some(if ours { WE_ARE_ELEVATED } else { STEAM_IS_ELEVATED })
+}
+
+/// Is `pid` elevated, as seen from here? `None` when Windows won't say.
+///
+/// `ours` is our own elevation, which the refusal case needs: a process of our own user
+/// that we may not even look at is one sitting above us — which only leaves elevation, and
+/// only when we're the unelevated one. Any other failure (it exited between the walk and
+/// here) says nothing, and a guess would be worse than silence.
+#[cfg(windows)]
+fn process_elevated(pid: u32, ours: bool) -> Option<bool> {
     // SAFETY: the handle is opened for a query-only right and closed on every path out.
-    let theirs = unsafe {
+    unsafe {
         let proc = ffi::OpenProcess(ffi::PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
         if proc.is_null() {
-            // A process of our own user that we may not even look at is one sitting above
-            // us — which only leaves elevation, and only when we're the unelevated one.
-            // Any other failure (Steam exited between the walk and here) says nothing.
             if ours || ffi::GetLastError() != ffi::ERROR_ACCESS_DENIED {
                 return None;
             }
-            Some(true)
-        } else {
-            let elevated = token_elevated(proc);
-            ffi::CloseHandle(proc);
-            elevated
+            return Some(true);
         }
-    }?;
-
-    (ours != theirs).then_some(if ours { WE_ARE_ELEVATED } else { STEAM_IS_ELEVATED })
+        let elevated = token_elevated(proc);
+        ffi::CloseHandle(proc);
+        elevated
+    }
 }
 
 /// Turn a refused `CreateProcess` into something the player can act on.

--- a/src-tauri/src/integritywatch.rs
+++ b/src-tauri/src/integritywatch.rs
@@ -11,6 +11,13 @@
 //! is a standing watcher started at app launch, not something hung off the Play button — it
 //! sits on a cheap "is the game up?" poll and only does real work while it is.
 //!
+//! Because it is already the one place that notices the game starting, it is also where
+//! FrostMod is re-armed for a new session ([`crate::frostmod_manage::on_game_started`]).
+//! That is a second job for one poll rather than a second poll, and it inherits the reason
+//! this watcher is standing rather than hung off the Play button: the game is just as often
+//! started from Steam. The re-arm sits *above* the `integrityWatch` gate — turning the
+//! scanner off is not a request to stop FrostMod working.
+//!
 //! Two settings, deliberately separate, because they are two different decisions:
 //!
 //!   * `integrityWatch` — scan at all. On by default; it reads the game's own module list and
@@ -203,34 +210,48 @@ pub fn start(app: &AppHandle) {
         }
         refresh_rules(&app).await;
 
+        // The game process, tracked regardless of any setting — `scanned` below is the
+        // scanner's own view, which the `integrityWatch` switch is allowed to reset.
         let mut was_running = false;
+        let mut scanned = false;
         loop {
             let cfg = crate::config::load_or_detect(&app).unwrap_or_default();
+
+            let running = crate::gameproc::is_game_running();
+            let started = running && !was_running;
+            was_running = running;
+
+            // Above the `integrityWatch` gate deliberately: re-arming FrostMod has nothing
+            // to do with cheat scanning, and someone who turned the scanner off has not
+            // asked for FrostMod to stop working.
+            if started {
+                crate::frostmod_manage::on_game_started(&app, &cfg);
+            }
+
             if !cfg.integrity_watch {
                 // Turned off mid-session: forget the last answer so the UI shows "not
                 // watching" rather than a stale verdict from an hour ago.
                 if let Ok(mut slot) = last().lock() {
                     *slot = Report::default();
                 }
-                was_running = false;
+                scanned = false;
                 tokio::time::sleep(IDLE_POLL).await;
                 continue;
             }
 
-            let running = crate::gameproc::is_game_running();
-            if running && !was_running {
+            if running && !scanned {
                 // A new session is the natural moment to pick up rules published since the
                 // app started — someone may have been playing for eight hours.
                 refresh_rules(&app).await;
             }
-            if !running && was_running {
+            if !running && scanned {
                 // The session is over, so the verdict is about a game that no longer exists.
                 if let Ok(mut slot) = last().lock() {
                     *slot = Report::default();
                 }
                 let _ = app.emit(EVENT, Report::default());
             }
-            was_running = running;
+            scanned = running;
 
             if running {
                 scan_once(&app);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4059,6 +4059,16 @@ fn frostmod_running() -> bool {
     frostmod::is_running()
 }
 
+/// Whether FrostMod actually got into the running game — and what to do when it didn't.
+///
+/// `frostmod_running` only says the launcher is up, which is what made an elevated game so
+/// confusing to be on the wrong side of: the app said FrostMod was running, and the game
+/// had no pill in it. See [`frostmod::attachment`].
+#[tauri::command]
+fn frostmod_attachment() -> frostmod::Attachment {
+    frostmod::attachment()
+}
+
 /// Start MX Bikes from the Play button in the sidebar.
 #[tauri::command]
 fn launch_game(app: tauri::AppHandle) -> Result<gameproc::LaunchOutcome, String> {
@@ -6461,7 +6471,12 @@ fn main() {
                 }
                 if cfg.auto_run_frostmod && frostmod_manage::is_installed(handle) {
                     let state = handle.state::<FrostmodProcess>();
-                    let _ = frostmod_manage::start(handle, &state);
+                    // Not `let _ =`: a FrostMod that refused to start at launch is the
+                    // reason half the "FrostMod isn't working" reports exist, and it used
+                    // to leave nothing behind in the log to say so.
+                    if let Err(e) = frostmod_manage::start(handle, &state) {
+                        log::warn!("FrostMod didn't start at launch: {e:#}");
+                    }
                 }
                 if cfg.watch_mods_reload {
                     let watcher = handle.state::<ModWatcher>();
@@ -6649,6 +6664,7 @@ fn main() {
             integrity_server_reports,
             frostmod_reload,
             frostmod_running,
+            frostmod_attachment,
             garage_scan_bikes,
             garage_swap_bike,
             frostmod_status,

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -211,15 +211,56 @@ pub fn on_focus_lost<R: Runtime>(app: &AppHandle<R>) {
 /// the multi-monitor rigs this crowd runs. Best-effort: with no game up (or off Windows)
 /// the centred position stands.
 fn center_over_game<R: Runtime>(window: &WebviewWindow<R>) {
-    let Some((left, top, right, bottom)) = gameproc::game_window_rect() else {
+    let Some(rect) = gameproc::game_window_rect() else {
         return;
     };
     let Ok(size) = window.outer_size() else {
         return;
     };
-    let x = left + (right - left - size.width as i32) / 2;
-    let y = top + (bottom - top - size.height as i32) / 2;
+    let bounds = monitor_holding(window, rect);
+    let (x, y) = centered_on(rect, (size.width, size.height), bounds);
     let _ = window.set_position(tauri::PhysicalPosition::new(x, y));
+}
+
+/// A screen rectangle in physical pixels: `left, top, right, bottom`.
+type Rect = (i32, i32, i32, i32);
+
+/// Centre a `(width, height)` window on `rect`, kept inside `bounds` when there are any.
+///
+/// The clamp is the belt to [`gameproc::game_window_rect`]'s braces. That function is what
+/// stops a minimized game handing us its (-32000, -32000) iconic rect, and this is what
+/// makes sure no rect from anywhere can put the overlay somewhere the player can't see it
+/// — an overlay off the edge of the desktop is indistinguishable from a hotkey that did
+/// nothing, except that it also holds focus and takes it off the game.
+fn centered_on(rect: Rect, size: (u32, u32), bounds: Option<Rect>) -> (i32, i32) {
+    let (left, top, right, bottom) = rect;
+    let (w, h) = (size.0 as i32, size.1 as i32);
+    let x = left + (right - left - w) / 2;
+    let y = top + (bottom - top - h) / 2;
+
+    let Some((bl, bt, br, bb)) = bounds else {
+        return (x, y);
+    };
+    // `.max(bl)` for a window larger than the screen it's on: there is no position that
+    // fits, so pin it to the top-left and let it overhang the far edge rather than have
+    // the clamp push its title bar off the near one.
+    (x.clamp(bl, (br - w).max(bl)), y.clamp(bt, (bb - h).max(bt)))
+}
+
+/// The monitor `rect` sits on, as `left, top, right, bottom`.
+///
+/// Found by the rect's centre rather than by the window's own monitor: the whole point of
+/// this path is to move the overlay to the screen the *game* is on, which on a sim rig is
+/// routinely not the one Tauri built it over.
+fn monitor_holding<R: Runtime>(window: &WebviewWindow<R>, rect: Rect) -> Option<Rect> {
+    let (left, top, right, bottom) = rect;
+    let (cx, cy) = ((left + right) / 2, (top + bottom) / 2);
+    window.available_monitors().ok()?.into_iter().find_map(|m| {
+        let (p, s) = (m.position(), m.size());
+        let (l, t) = (p.x, p.y);
+        let (r, b) = (l + s.width as i32, t + s.height as i32);
+        (cx >= l && cx < r && cy >= t && cy < b).then_some((l, t, r, b))
+    })
 }
 
 /// Take the overlay off the screen, leaving the foreground where it lands.
@@ -363,6 +404,63 @@ mod tests {
     fn an_unparseable_hotkey_says_what_was_wrong() {
         let err = parse_hotkey("Ctrl+++").expect_err("nonsense doesn't parse");
         assert!(err.contains("Ctrl+++"), "names the bad combo: {err}");
+    }
+
+    /// A 1920x1080 primary monitor at the origin.
+    const PRIMARY: Rect = (0, 0, 1920, 1080);
+    /// What the overlay is sized to.
+    const OVERLAY: (u32, u32) = (WIDTH as u32, HEIGHT as u32);
+
+    #[test]
+    fn the_overlay_lands_in_the_middle_of_the_game_window() {
+        // A 1600x900 game window centred on the primary monitor.
+        let game = (160, 90, 1760, 990);
+        assert_eq!(
+            centered_on(game, OVERLAY, Some(PRIMARY)),
+            (410, 180),
+            "centred on the game, not on the monitor",
+        );
+    }
+
+    /// The bug this whole path had: a minimized game reports the iconic rect, and an
+    /// overlay centred on it is placed ~32,000px off the left of the desktop — shown,
+    /// focused, and invisible, which is indistinguishable from a hotkey that did nothing.
+    ///
+    /// `game_window_rect` now refuses to return that rect at all. This is the second line
+    /// of defence, and it is the one that holds for *any* rect we haven't thought of.
+    #[test]
+    fn an_iconic_rect_cannot_put_the_overlay_off_the_desktop() {
+        let iconic = (-32000, -32000, -31840, -31970);
+        let (x, y) = centered_on(iconic, OVERLAY, Some(PRIMARY));
+        assert_eq!((x, y), (0, 0), "pulled back onto the monitor");
+
+        let unclamped = centered_on(iconic, OVERLAY, None);
+        assert!(
+            unclamped.0 < -32000,
+            "and without bounds it really would go off-screen: {unclamped:?}",
+        );
+    }
+
+    /// The reason this positions by the game's monitor rather than the primary one. A
+    /// screen to the left of primary has negative coordinates, and a clamp that assumed
+    /// otherwise would drag the overlay back onto the wrong display — breaking exactly
+    /// the multi-monitor case the feature exists for.
+    #[test]
+    fn a_monitor_left_of_primary_keeps_its_negative_coordinates() {
+        let left_screen = (-1920, 0, 0, 1080);
+        let game = (-1920, 0, 0, 1080); // fullscreen on that monitor
+        let (x, y) = centered_on(game, OVERLAY, Some(left_screen));
+        assert_eq!((x, y), (-1510, 180));
+        assert!(x < 0, "stayed on the left-hand screen");
+    }
+
+    /// A window taller than the screen has no position that fits. Pin it to the top-left
+    /// so its controls are reachable, rather than letting the clamp push them off.
+    #[test]
+    fn an_overlay_bigger_than_the_screen_is_pinned_not_pushed() {
+        let small_screen = (0, 0, 800, 600);
+        let game = (0, 0, 800, 600);
+        assert_eq!(centered_on(game, OVERLAY, Some(small_screen)), (0, 0));
     }
 
     /// Tauri's mock runtime — real window bookkeeping, no display, no webview.

--- a/src/Components/Shell/Sidebar.tsx
+++ b/src/Components/Shell/Sidebar.tsx
@@ -35,6 +35,7 @@ import {
 import { useGameRunning } from "../../lib/useGameRunning";
 import { useConfig } from "../../Context/Config";
 import type { GameCaps } from "../../types";
+import { ATTACH_PROBLEM } from "../../types";
 import JoinServerDialog from "./JoinServerDialog";
 import DownloadQueue from "./DownloadQueue";
 
@@ -216,7 +217,11 @@ function NavRow({
 
 export default function Sidebar({ view, onNavigate }: SidebarProps) {
   const t = useT();
-  const { running, reload, status, start, stop } = useFrostmod();
+  const { running, attachment, reload, status, start, stop } = useFrostmod();
+  // FrostMod is up but isn't reaching the game — see `frostmod::attachment`. The good
+  // states (and the grace period after a launch) deliberately look like plain "Running".
+  const attachProblem =
+    attachment !== null && ATTACH_PROBLEM.includes(attachment.state);
   const { unseenFailures } = useDownloads();
   const { running: gameRunning, refresh: refreshGame } = useGameRunning();
   const { game } = useConfig();
@@ -508,14 +513,20 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
         {caps.frostmod && (
         <div
           data-tour="frostmod"
+          // A running FrostMod that never got into the game is the state this pill used
+          // to report as plain "Running", which is exactly as far as the player could get
+          // in working out why nothing was happening in game. The reason goes in the
+          // tooltip whether or not the sidebar is collapsed.
           title={
-            collapsed
-              ? running === null
-                ? t("frostmod.checking")
-                : running
-                  ? t("frostmod.running")
-                  : t("frostmod.notRunning")
-              : undefined
+            attachProblem
+              ? attachment?.reason
+              : collapsed
+                ? running === null
+                  ? t("frostmod.checking")
+                  : running
+                    ? t("frostmod.running")
+                    : t("frostmod.notRunning")
+                : undefined
           }
           className={cn(
             "flex items-center rounded-[10px] border border-white/[0.07] py-2",
@@ -525,16 +536,27 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
           <span
             className={cn(
               "size-[7px] flex-none rounded-full",
-              running ? "bg-success" : "bg-muted-foreground/50",
+              attachProblem
+                ? "bg-warning"
+                : running
+                  ? "bg-success"
+                  : "bg-muted-foreground/50",
             )}
           />
           {!collapsed && (
-            <span className="flex-1 text-[11.5px] text-muted-foreground">
-              {running === null
-                ? t("frostmod.checking")
-                : running
-                  ? t("frostmod.running")
-                  : t("frostmod.notRunning")}
+            <span
+              className={cn(
+                "flex-1 text-[11.5px]",
+                attachProblem ? "text-warning" : "text-muted-foreground",
+              )}
+            >
+              {attachProblem
+                ? t("frostmod.notInGame")
+                : running === null
+                  ? t("frostmod.checking")
+                  : running
+                    ? t("frostmod.running")
+                    : t("frostmod.notRunning")}
             </span>
           )}
           {running ? (

--- a/src/Context/Frostmod.tsx
+++ b/src/Context/Frostmod.tsx
@@ -12,6 +12,7 @@ import {
   frostmodInstall,
   frostmodInstallRuntime,
   frostmodRepairRuntimes,
+  frostmodAttachment,
   frostmodStart,
   frostmodStatus,
   frostmodStop,
@@ -23,7 +24,8 @@ import {
   RUNTIME_DOWNLOADS_PAGE,
   RUNTIME_NAME_KEY,
 } from "../api/mods";
-import type { FrostmodStatus, VcRuntime } from "../types";
+import type { Attachment, FrostmodStatus, VcRuntime } from "../types";
+import { ATTACH_PROBLEM } from "../types";
 import { displayName } from "../lib/mods";
 import { useT, type TFunc } from "../i18n/context";
 import { FrostmodContext } from "./FrostmodContext";
@@ -51,6 +53,11 @@ function watchDescription(mods: string[], t: TFunc): string {
 export function FrostmodProvider({ children }: { children: ReactNode }) {
   const t = useT();
   const [running, setRunning] = useState<boolean | null>(null);
+  const [attachment, setAttachment] = useState<Attachment | null>(null);
+  // What we last warned about, so a problem that persists across the 5s poll is reported
+  // once rather than every tick. Cleared when the state stops being a problem, which is
+  // what lets the *next* game session warn again.
+  const warnedFor = useRef<string | null>(null);
   const [status, setStatus] = useState<FrostmodStatus | null>(null);
   const [installing, setInstalling] = useState(false);
   const [checking, setChecking] = useState(false);
@@ -67,7 +74,30 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
     } catch {
       if (mounted.current) setRunning(false);
     }
-  }, []);
+    // Folded into the same tick rather than given a poll of its own: it answers the
+    // follow-up to the question above, and asking them apart would let the pill show a
+    // running FrostMod and a stale attach state at the same time.
+    try {
+      const a = await frostmodAttachment();
+      if (!mounted.current) return;
+      setAttachment(a);
+      if (!ATTACH_PROBLEM.includes(a.state)) {
+        warnedFor.current = null;
+        return;
+      }
+      // The reason carries the game name, so a state that stays the same while the
+      // player switches title still gets said once for each.
+      const key = `${a.state}:${a.reason}`;
+      if (warnedFor.current === key) return;
+      warnedFor.current = key;
+      toast.warning(t("frostmod.notInGame"), {
+        description: a.reason,
+        duration: 12000,
+      });
+    } catch {
+      /* older backend or non-Tauri — leave the pill on `running` alone */
+    }
+  }, [t]);
 
   const refreshStatus = useCallback(async () => {
     if (mounted.current) setChecking(true);
@@ -326,6 +356,7 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
   const value = useMemo(
     () => ({
       running,
+      attachment,
       status,
       installing,
       checking,
@@ -344,7 +375,7 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
       runtimeWarning,
       missingRuntime,
     }),
-    [running, status, installing, checking, statusError, reload, probe, refreshStatus, install, start, stop, installingRuntime, installRuntime, repairingRuntimes, repairRuntimes, dismissRuntimeWarning, runtimeWarning, missingRuntime],
+    [running, attachment, status, installing, checking, statusError, reload, probe, refreshStatus, install, start, stop, installingRuntime, installRuntime, repairingRuntimes, repairRuntimes, dismissRuntimeWarning, runtimeWarning, missingRuntime],
   );
 
   return (

--- a/src/Context/FrostmodContext.ts
+++ b/src/Context/FrostmodContext.ts
@@ -1,9 +1,22 @@
 import { createContext, useContext } from "react";
-import type { FrostmodStatus, ReloadOutcome, VcRuntime } from "../types";
+import type {
+  Attachment,
+  FrostmodStatus,
+  ReloadOutcome,
+  VcRuntime,
+} from "../types";
 
 export interface FrostmodContextValue {
   /** Whether FrostMod is currently running (polled). `null` until first probe. */
   running: boolean | null;
+  /**
+   * Whether FrostMod's DLL actually made it into the running game (polled alongside
+   * {@link running}). `null` until the first probe.
+   *
+   * Worth having next to `running`, not instead of it: `running` is what the Start/Stop
+   * buttons act on, while this is what says whether any of it is reaching the game.
+   */
+  attachment: Attachment | null;
   /** Install/version snapshot (`null` until first fetched). */
   status: FrostmodStatus | null;
   /** True while an install/update download is in flight. */

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type {
+  Attachment,
   BikeModels,
   BikeSounds,
   DropCommitItem,
@@ -1677,6 +1678,13 @@ export function reloadFrostmod(): Promise<ReloadOutcome> {
 /** Is FrostMod currently running on this PC? */
 export function isFrostmodRunning(): Promise<boolean> {
   return invoke<boolean>("frostmod_running");
+}
+
+/** Did FrostMod actually get into the running game, and if not, why not?
+ *
+ *  Distinct from {@link isFrostmodRunning}, which only reports that the launcher is up. */
+export function frostmodAttachment(): Promise<Attachment> {
+  return invoke<Attachment>("frostmod_attachment");
 }
 
 /** Start MX Bikes. Resolves to `already_running` when the game is already up. */

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -73,6 +73,7 @@ export const de: Translation = {
   "frostmod.checking": "FrostMod wird geprüft…",
   "frostmod.running": "FrostMod läuft",
   "frostmod.notRunning": "FrostMod läuft nicht",
+  "frostmod.notInGame": "FrostMod nicht im Spiel",
   "frostmod.reloadGame": "Spiel neu laden",
   "frostmod.start": "FrostMod starten",
   "frostmod.reloadedGame": "FrostMod hat das Spiel neu geladen.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -67,6 +67,7 @@ export const en = {
   "frostmod.checking": "Checking FrostMod…",
   "frostmod.running": "FrostMod running",
   "frostmod.notRunning": "FrostMod not running",
+  "frostmod.notInGame": "FrostMod not in game",
   "frostmod.reloadGame": "Reload game",
   "frostmod.start": "Start FrostMod",
   "frostmod.reloadedGame": "FrostMod reloaded the game.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -68,6 +68,7 @@ export const es: Translation = {
   "frostmod.checking": "Comprobando FrostMod…",
   "frostmod.running": "FrostMod activo",
   "frostmod.notRunning": "FrostMod inactivo",
+  "frostmod.notInGame": "FrostMod no está en el juego",
   "frostmod.reloadGame": "Recargar el juego",
   "frostmod.start": "Iniciar FrostMod",
   "frostmod.reloadedGame": "FrostMod recargó el juego.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -70,6 +70,7 @@ export const fr: Translation = {
   "frostmod.checking": "Vérification de FrostMod…",
   "frostmod.running": "FrostMod actif",
   "frostmod.notRunning": "FrostMod inactif",
+  "frostmod.notInGame": "FrostMod absent du jeu",
   "frostmod.reloadGame": "Recharger le jeu",
   "frostmod.start": "Démarrer FrostMod",
   "frostmod.reloadedGame": "FrostMod a rechargé le jeu.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -68,6 +68,7 @@ export const it: Translation = {
   "frostmod.checking": "Controllo di FrostMod…",
   "frostmod.running": "FrostMod attivo",
   "frostmod.notRunning": "FrostMod non attivo",
+  "frostmod.notInGame": "FrostMod non è nel gioco",
   "frostmod.reloadGame": "Ricarica il gioco",
   "frostmod.start": "Avvia FrostMod",
   "frostmod.reloadedGame": "FrostMod ha ricaricato il gioco.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -71,6 +71,7 @@ export const ptBR: Translation = {
   "frostmod.checking": "Verificando o FrostMod…",
   "frostmod.running": "FrostMod ativo",
   "frostmod.notRunning": "FrostMod inativo",
+  "frostmod.notInGame": "FrostMod não está no jogo",
   "frostmod.reloadGame": "Recarregar o jogo",
   "frostmod.start": "Iniciar o FrostMod",
   "frostmod.reloadedGame": "O FrostMod recarregou o jogo.",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -794,6 +794,33 @@ export interface FrostmodReload {
   mods?: string[];
 }
 
+/** Whether FrostMod's DLL is actually inside the running game. Mirrors
+ *  `frostmod::AttachState`.
+ *
+ *  `running` (the pill's usual source) only says the launcher process is up. These two
+ *  answers come apart when the game runs at a higher integrity level than the app: the
+ *  injector can't open a process above it, so FrostMod is running and simply never gets
+ *  in — which used to look like the app lying about it. */
+export type AttachState =
+  | "game_not_running"
+  | "attached"
+  /** Up, not in yet, and still inside the grace period. Not a problem. */
+  | "attaching"
+  | "not_attached"
+  /** Windows won't let us look inside the game — and won't let FrostMod in either. */
+  | "blocked"
+  | "unknown";
+
+/** Mirrors `frostmod::Attachment`. */
+export interface Attachment {
+  state: AttachState;
+  /** What is wrong and how to fix it. Empty unless the state calls for it. */
+  reason: string;
+}
+
+/** The attach states worth putting in front of the user. */
+export const ATTACH_PROBLEM: readonly AttachState[] = ["blocked", "not_attached"];
+
 /** Result of pressing Play. `already_running` means we deliberately did nothing. */
 export type LaunchOutcome = "launched" | "already_running";
 


### PR DESCRIPTION
From a v0.10.0 report: the overlay hotkey did nothing in game, and after stopping and reopening the game FrostMod stopped working. Two separate faults, both reproducible from the code.

## The overlay was opening off the desktop

`game_window_rect` filtered its window walk on `IsWindowVisible`, which stays true for a minimized window — `IsIconic` is the separate test, and `focus_game` was already using it. So a minimized game passed the filter, `GetWindowRect` returned the iconic position (~-32000,-32000), and the overlay was centred on that: shown, focused, and nowhere on any monitor. Indistinguishable from a hotkey that did nothing, except it also took focus off the game.

Self-reinforcing, which is why it looked permanently dead — exclusive fullscreen minimizes on focus loss, so the first press created the state that broke every press after it. A second press couldn't recover either: `is_visible()` was true, so it just toggled the invisible window shut.

A minimized game now yields no rect, and the centring is clamped to the bounds of whichever monitor the game is on — the clamp being the general guard, since positioning by the game's monitor is what the multi-monitor case needs and a naive clamp to primary would break it.

## FrostMod was never re-armed for a second session

`frostmod_manage::start` was only reached from app launch and the manual buttons; `launch_game` deliberately doesn't touch it. So the second race in a sitting ran without FrostMod, with nothing to say so.

`integritywatch` already polls for the game starting, for the same reason this needs to — plenty of people press Play in Steam. That transition now re-arms FrostMod. It sits **above** the `integrityWatch` gate: turning the cheat scanner off is not a request to stop FrostMod working.

## "Running" didn't mean "working"

`is_running` only tests that the launcher holds its reload event. With the game elevated and the app not, the injector cannot open the process at all — FrostMod runs, never gets in, no in-game pill, and the app reports it as running throughout. That is the case in the report.

`frostmod::attachment` asks the game instead. `frostmod.dll` in its module list means attached; a **refused** module walk is the same barrier the injection hits, so it isn't a gap in the answer, it is the answer. The pill goes amber with "FrostMod not in game" and carries both ways out — run the game without administrator, or run MXB App with it — once per session rather than every poll. A 15s grace period after the game appears keeps it from crying wolf while injection is still in flight.

`module_paths` now distinguishes `ERROR_ACCESS_DENIED` from the transient `ERROR_BAD_LENGTH` it was really retrying for, and the elevation reasoning `steam_elevation_conflict` already encoded is now one shared helper rather than a second copy.

## Also

Starting FrostMod is logged on Windows, on success and on failure, as it already was on Linux and macOS. The platform nearly every report comes from was the one that said nothing — which is why the log attached to this report has nothing to say about FrostMod at all. The startup call no longer discards its error either.

## Testing

- 794 Rust tests pass, 8 new: the centring math against the iconic rect, a monitor left of primary keeping negative coordinates, an overlay larger than its screen, DLL matching across separators and case, and the grace period's three edges.
- `cargo check --target x86_64-pc-windows-gnu` clean — type-checks the `cfg(windows)` half a macOS build skips, which is all of the new Win32 code.
- `tsc`, `eslint`, `npm run build` clean.

**Needs a pass on Windows.** The two Win32 facts the overlay fix rests on — minimizing leaving `WS_VISIBLE` set, and `GetWindowRect` then reporting ~(-32000,-32000) — are long-standing documented behaviour and the arithmetic is pinned by a test, but the end-to-end behaviour wants a real keypress:

1. Exclusive fullscreen, press the overlay hotkey — should appear centred on the game's monitor every time, including after the game has been minimized once.
2. Play, quit, relaunch from Steam — log should show `FrostMod re-armed for the new game session`.
3. Game as admin, app not — pill amber within ~15s, naming both fixes.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)