### PR TITLE
fix(browse): open a mod the way a browser does, so Cloudflare lets it through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2026-08-20
+
+### Fixed
+- **Opening a mod no longer dead-ends on a Cloudflare refusal.** mxb-mods.com guards its
+  rendered pages far more tightly than its JSON API, so the catalog could browse fine while a
+  single mod came back "refused the request (403)". The fallback that exists to rescue that
+  couldn't: it asked the browser to `fetch()` the page, and a `fetch()` of a challenged URL is
+  answered with the check itself — only a navigation clears it. The hidden window now navigates
+  to the page and reads it, and the HTTP client asks for a page the way a browser does rather
+  than as if a script wanted JSON.
+- **The hidden mxb-mods.com window no longer reports itself ready while still on the check.**
+  It only asked whether script could run, which is just as true on Cloudflare's "Just a
+  moment…" page, so requests were sent from the interstitial and refused.
+- **The mod page's error now has the Retry button it tells you to hit**, and says so in your
+  own language instead of English.
+
 ## 2026-08-18 — v0.10.0 — A Designer that sets itself up, a Downloads page, and tracks in 3D
 
 The first full release since v0.9.1. It folds in everything the v0.9.2 betas carried, so

--- a/src-tauri/src/mods/mxb.rs
+++ b/src-tauri/src/mods/mxb.rs
@@ -153,10 +153,64 @@ fn on_webview() -> bool {
 /// `GET` with backoff over the transient blocks above. Transport errors retry too, which
 /// is what `install::get_with_retry` already does for download hosts.
 async fn get_with_retry(url: &str, params: &[(&str, String)]) -> anyhow::Result<Fetched> {
+    get(url, params, Want::Api).await
+}
+
+/// `GET` a rendered page, asked for the way a browser asks for one.
+///
+/// Its own entry point because Cloudflare guards the rendered pages far more tightly than the
+/// JSON API — a user whose catalog browses fine can still be refused the moment they open a
+/// single mod, which is the whole shape of this failure.
+async fn get_page(url: &str) -> anyhow::Result<Fetched> {
+    get(url, &[], Want::Page).await
+}
+
+/// Which shape of request this is, and therefore what it has to look like on the wire.
+#[derive(Clone, Copy)]
+enum Want {
+    /// The WP REST API. Script asks for these in a browser, and [`client`]'s default headers
+    /// already say exactly that.
+    Api,
+    /// A rendered page. A browser *navigates* to these — see [`page_headers`] for the HTTP
+    /// client and [`crate::mxb_fetch::read_page`] for the WebView.
+    Page,
+}
+
+/// The headers a browser sends when it navigates to a page, replacing the JSON-fetch defaults
+/// [`build_client`] sets.
+///
+/// Those defaults describe a same-origin `fetch` for JSON, which is what every REST call is.
+/// Sending them for a rendered page asks Cloudflare to believe a script wanted an HTML
+/// document — a shape no browser produces, on the one path its bot rules actually guard.
+fn page_headers() -> reqwest::header::HeaderMap {
+    use reqwest::header::{HeaderMap, HeaderValue};
+    let mut headers = HeaderMap::new();
+    for (k, v) in [
+        (
+            "accept",
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,\
+             image/apng,*/*;q=0.8",
+        ),
+        ("sec-fetch-mode", "navigate"),
+        ("sec-fetch-dest", "document"),
+        // A page reached by clicking a link on the site, which is what this stands in for.
+        ("sec-fetch-site", "same-origin"),
+        ("sec-fetch-user", "?1"),
+        ("upgrade-insecure-requests", "1"),
+    ] {
+        headers.insert(k, HeaderValue::from_static(v));
+    }
+    headers
+}
+
+async fn get(url: &str, params: &[(&str, String)], want: Want) -> anyhow::Result<Fetched> {
     if on_webview() {
         // No backoff loop here: the bridge is a real browser, so a 429/503 it gets is one
         // the site means, and it has its own timeout.
-        return crate::mxb_fetch::get(url, params).await;
+        return match want {
+            Want::Api => crate::mxb_fetch::get(url, params).await,
+            Want::Page => crate::mxb_fetch::read_page(url).await,
+        };
     }
 
     const ATTEMPTS: u32 = 3;
@@ -164,7 +218,12 @@ async fn get_with_retry(url: &str, params: &[(&str, String)]) -> anyhow::Result<
     let mut last_err: Option<anyhow::Error> = None;
     for attempt in 1..=ATTEMPTS {
         let started = Instant::now();
-        match client.get(url).query(params).send().await {
+        let req = client.get(url).query(params);
+        let req = match want {
+            Want::Api => req,
+            Want::Page => req.headers(page_headers()),
+        };
+        match req.send().await {
             Ok(resp) if !worth_retrying(resp.status()) => {
                 // Debug, not info: search runs on every keystroke, and a line per keystroke
                 // would bury the one failure worth reading. `MXB_LOG=debug` turns it on.
@@ -594,7 +653,7 @@ pub async fn detail(slug: &str) -> anyhow::Result<ModDetail> {
     // swallowed: a 403 is `Ok(resp)`, so its error body went to the parsers and produced
     // zero downloads — the page then said "No download link was found on this page"
     // rather than "we couldn't read the page". Surface it instead.
-    let resp = get_with_retry(&link, &[]).await?;
+    let resp = get_page(&link).await?;
     if !resp.is_success() {
         return Err(refusal("the mod page", &resp));
     }
@@ -982,6 +1041,23 @@ fn dedup(v: &mut Vec<String>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The rendered pages are guarded far more tightly than the JSON API, and asking for one
+    /// with the client's JSON-fetch defaults describes a request no browser makes: a script
+    /// wanting an HTML document. Every default this overrides is one that said so.
+    #[test]
+    fn a_page_is_asked_for_the_way_a_browser_navigates() {
+        let h = page_headers();
+        assert_eq!(h.get("sec-fetch-dest").unwrap(), "document");
+        assert_eq!(h.get("sec-fetch-mode").unwrap(), "navigate");
+        assert!(h.get("accept").unwrap().to_str().unwrap().starts_with("text/html"));
+        // A continued string literal is easy to leave a newline in, and a header value with
+        // one in it is rejected outright — which would fail only on the blocked user's machine.
+        for (_, v) in h.iter() {
+            let v = v.to_str().unwrap();
+            assert!(!v.contains('\n') && !v.contains("  "), "{v:?}");
+        }
+    }
 
     #[test]
     fn reads_every_embedded_term_name() {

--- a/src-tauri/src/mxb_fetch.rs
+++ b/src-tauri/src/mxb_fetch.rs
@@ -83,9 +83,17 @@ struct Reply {
     body: String,
     #[serde(default)]
     url: String,
+    /// The document's `performance.timeOrigin`, minted fresh per document. It is how
+    /// [`probe`] tells the page a navigation asked for from the one it asked to leave.
+    #[serde(default)]
+    origin: f64,
     #[serde(default)]
     error: Option<String>,
 }
+
+/// Ids for requests in flight. Module-wide rather than per entry point: [`run`] and
+/// [`read_page`] share one [`waiting`] map, and two counters would hand out the same id twice.
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 
 /// Route a reply to whoever is waiting for it.
 ///
@@ -117,6 +125,71 @@ pub async fn get(url: &str, params: &[(&str, String)]) -> anyhow::Result<Fetched
 
 pub async fn post(url: &str, form: &[(&str, String)]) -> anyhow::Result<Fetched> {
     run(url, Some(&encode_form(form))).await
+}
+
+/// A rendered page, read from the window after *navigating* to it.
+///
+/// [`get`] cannot serve this, and the difference is the whole reason a mod page could be
+/// refused while the catalog browsed fine. A `fetch()` of a challenged URL is answered with
+/// the interstitial — only a navigation runs the check that clears it — and no `fetch` may
+/// claim `sec-fetch-dest: document`, so it never looks like the page view it stands in for.
+/// mxb-mods.com guards its rendered pages far more tightly than its JSON API.
+///
+/// The status comes from the navigation timing entry, which WebView2 exposes and WKWebView
+/// does not; where it is missing, a document we were handed at all counts as a 200. That is
+/// what keeps a refusal reported as one rather than as a page that parsed to nothing.
+pub async fn read_page(url: &str) -> anyhow::Result<Fetched> {
+    let app = app()?;
+    let window = ensure_window(app).await?;
+
+    // Which document is being replaced. `navigate` returns immediately and the old page stays
+    // loaded — and past its own check — until the new one arrives, so a readiness test that
+    // could not tell them apart would pass at once and read the page we just left.
+    let previous = probe(&window).await.ok();
+    window.navigate(url.parse()?)?;
+    wait_until_ready_replacing(&window, previous).await?;
+
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    lock(waiting()).insert(id, tx);
+
+    let started = std::time::Instant::now();
+    if let Err(e) = window.eval(read_script(id)) {
+        lock(waiting()).remove(&id);
+        return Err(anyhow::anyhow!("could not read the mxb-mods.com page: {e}"));
+    }
+
+    let reply = match tokio::time::timeout(TIMEOUT, rx).await {
+        Ok(Ok(reply)) => reply,
+        Ok(Err(_)) => return Err(anyhow::anyhow!("the WebView read was cancelled")),
+        Err(_) => {
+            lock(waiting()).remove(&id);
+            return Err(anyhow::anyhow!(
+                "the WebView did not hand back {url} within {TIMEOUT:?}"
+            ));
+        }
+    };
+
+    log::debug!(
+        "webview PAGE {} -> {} ({} bytes) in {:?}",
+        url.strip_prefix(mxb_session::base()).unwrap_or(url),
+        reply.status,
+        reply.body.len(),
+        started.elapsed()
+    );
+
+    Ok(Fetched {
+        status: reply.status,
+        // A navigation's response headers are not visible to script, so the refusal log will
+        // say `cf-ray=-` for this transport. The body carries the block reason regardless.
+        headers: reply.headers,
+        body: reply.body,
+        url: if reply.url.is_empty() {
+            url.to_string()
+        } else {
+            reply.url
+        },
+    })
 }
 
 /// `application/x-www-form-urlencoded`, matching what `reqwest`'s `.form()` sends, so the
@@ -161,7 +234,6 @@ async fn run(url: &str, body: Option<&str>) -> anyhow::Result<Fetched> {
     let app = app()?;
     let window = ensure_window(app).await?;
 
-    static NEXT_ID: AtomicU64 = AtomicU64::new(1);
     let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
     let (tx, rx) = tokio::sync::oneshot::channel();
     lock(waiting()).insert(id, tx);
@@ -248,6 +320,23 @@ fn script(id: u64, url: &str, body: Option<&str>) -> String {
     )
 }
 
+/// Read the document the window is sitting on, rather than `fetch`ing it — see [`read_page`].
+fn read_script(id: u64) -> String {
+    format!(
+        r#"(function(){{
+  try {{
+    var nav = performance.getEntriesByType('navigation')[0];
+    window.__TAURI_INTERNALS__.invoke('plugin:event|emit', {{
+      event: {event},
+      payload: {{ id: {id}, status: (nav && nav.responseStatus) || 200,
+                  body: document.documentElement.outerHTML, url: location.href }}
+    }});
+  }} catch (e) {{}}
+}})();"#,
+        event = js_string(RESULT_EVENT),
+    )
+}
+
 /// A JS string literal. The URLs here are ours, but they carry user-typed search terms, and
 /// a quote or backslash reaching `eval` unescaped would break the script — or worse.
 fn js_string(s: &str) -> String {
@@ -321,51 +410,83 @@ async fn ensure_window(app: &AppHandle) -> anyhow::Result<tauri::WebviewWindow> 
     Ok(window)
 }
 
-/// Wait for the page to be able to run our script.
-///
-/// Two things have to be true: the IPC primitive has to be injected, and Cloudflare's
-/// challenge — which the window will be served on first navigation, exactly as the visible
-/// clearance window is — has to have cleared. Polling a one-line `eval` covers both, since
-/// the challenge page is replaced by the real one when it passes.
+/// Wait for the page to be able to run our script, and to be past Cloudflare's check.
 async fn wait_until_ready(window: &tauri::WebviewWindow) -> anyhow::Result<()> {
+    wait_until_ready_replacing(window, None).await
+}
+
+/// [`wait_until_ready`], for a page a navigation has just been asked for.
+///
+/// `replacing` is the document that has to be *gone* before the window counts as ready,
+/// identified by its `performance.timeOrigin`. Without it the check answers about whatever is
+/// still on screen, which straight after a `navigate` is the previous page: complete, past its
+/// own check, and wrong.
+async fn wait_until_ready_replacing(
+    window: &tauri::WebviewWindow,
+    replacing: Option<f64>,
+) -> anyhow::Result<()> {
     let deadline = std::time::Instant::now() + READY_TIMEOUT;
     let mut last: Option<String> = None;
     while std::time::Instant::now() < deadline {
         match probe(window).await {
-            Ok(()) => return Ok(()),
+            Ok(origin) if Some(origin) != replacing => return Ok(()),
+            Ok(_) => last = Some("the page it was told to leave is still loaded".to_string()),
             Err(e) => last = Some(e.to_string()),
         }
         tokio::time::sleep(Duration::from_millis(250)).await;
     }
     Err(anyhow::anyhow!(
-        "the hidden mxb-mods.com window never became ready{}",
+        "the hidden mxb-mods.com window never became ready — Cloudflare's check did not clear{}",
         last.map(|e| format!(" ({e})")).unwrap_or_default()
     ))
 }
 
-/// One round-trip that proves script can run and reach us. Doubles as the check that
-/// `__TAURI_INTERNALS__` still exists — if a Tauri upgrade renames it, this fails here with
-/// a clear message instead of every fetch timing out.
-async fn probe(window: &tauri::WebviewWindow) -> anyhow::Result<()> {
+/// One round-trip that proves script can run and reach us, *and* that we are past the check.
+///
+/// This used to ask only whether `__TAURI_INTERNALS__` existed. Tauri injects that into
+/// Cloudflare's interstitial as readily as into the real page, so the window was declared
+/// ready while still sitting on "Just a moment…" — and every request made from there was
+/// refused, which is precisely the "its check window didn't clear it either" a blocked user
+/// was shown. [`crate::shop_fetch`] has always asked the fuller question; this is that.
+///
+/// "Past the check" is asked as `window._cf_chl_opt`, which the interstitial defines and an
+/// ordinary page does not. The obvious test — looking for `challenge-platform` in the HTML —
+/// is wrong, and quietly so: Cloudflare injects that script into ordinary pages too when JS
+/// detections are on, so the window would never be declared ready at all.
+///
+/// Doubles as the check that `__TAURI_INTERNALS__` still exists — if a Tauri upgrade renames
+/// it, this fails here with a clear message instead of every fetch timing out.
+///
+/// Answers with the document's `performance.timeOrigin`, so a caller that has just navigated
+/// can tell the page it asked for from the one it asked to leave.
+async fn probe(window: &tauri::WebviewWindow) -> anyhow::Result<f64> {
     const PROBE_ID: u64 = 0;
     let (tx, rx) = tokio::sync::oneshot::channel();
     lock(waiting()).insert(PROBE_ID, tx);
-    let js = format!(
-        "if (window.__TAURI_INTERNALS__) {{ window.__TAURI_INTERNALS__.invoke\
-         ('plugin:event|emit', {{ event: {event}, payload: {{id:0,status:204}} }}); }}",
-        event = js_string(RESULT_EVENT)
-    );
-    if let Err(e) = window.eval(&js) {
+    if let Err(e) = window.eval(probe_script()) {
         lock(waiting()).remove(&PROBE_ID);
         return Err(anyhow::anyhow!("{e}"));
     }
     match tokio::time::timeout(Duration::from_millis(400), rx).await {
-        Ok(Ok(_)) => Ok(()),
+        Ok(Ok(reply)) => Ok(reply.origin),
         _ => {
             lock(waiting()).remove(&PROBE_ID);
-            Err(anyhow::anyhow!("no answer from the page yet"))
+            Err(anyhow::anyhow!("still on the check, or not ready yet"))
         }
     }
+}
+
+/// The probe, as its own function so a test can hold it to what it has to say.
+fn probe_script() -> String {
+    format!(
+        "if (window.__TAURI_INTERNALS__ && document.readyState === 'complete' \
+         && typeof window._cf_chl_opt === 'undefined' \
+         && !/^just a moment/i.test(document.title || '')) {{ \
+         window.__TAURI_INTERNALS__.invoke\
+         ('plugin:event|emit', {{ event: {event}, \
+         payload: {{id:0, origin: performance.timeOrigin}} }}); }}",
+        event = js_string(RESULT_EVENT)
+    )
 }
 
 #[cfg(test)]
@@ -398,6 +519,47 @@ mod tests {
             !js.contains("JSON.stringify"),
             "the payload must be the object, not a JSON string of it: {js}"
         );
+    }
+
+    /// The bug this module shipped with: the probe answered on Cloudflare's interstitial,
+    /// because Tauri injects its IPC there too. Every question below has to be asked, or the
+    /// window is declared ready while still on "Just a moment…" and every request is refused.
+    #[test]
+    fn the_probe_refuses_to_answer_on_the_challenge() {
+        let js = probe_script();
+        assert!(js.contains("_cf_chl_opt"), "{js}");
+        assert!(js.contains("just a moment"), "{js}");
+        assert!(js.contains("readyState === 'complete'"), "{js}");
+        // The naive test: Cloudflare injects `challenge-platform` into ordinary pages as
+        // well, so keying on it would mean the window is never ready at all.
+        assert!(!js.contains("challenge-platform"), "{js}");
+        // Without a per-document token a caller that just navigated cannot tell the page it
+        // asked for from the one it asked to leave.
+        assert!(js.contains("performance.timeOrigin"), "{js}");
+    }
+
+    /// A page is read off the document, never fetched — a `fetch()` of a challenged URL is
+    /// answered with the interstitial, and cannot claim `sec-fetch-dest: document` either.
+    #[test]
+    fn a_page_is_read_from_the_document_not_fetched() {
+        let js = read_script(11);
+        assert!(js.contains("document.documentElement.outerHTML"), "{js}");
+        assert!(!js.contains("fetch("), "{js}");
+        assert!(js.contains("id: 11"), "{js}");
+        // Where the engine exposes the navigation's status, a refusal stays a refusal rather
+        // than becoming a page that parsed to nothing.
+        assert!(js.contains("responseStatus"), "{js}");
+    }
+
+    /// `run` and `read_page` share one `waiting()` map, so they must share one counter — two
+    /// would issue the same id twice and let one reply resolve the other's request.
+    #[test]
+    fn request_ids_are_issued_from_one_counter() {
+        let a = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let b = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        assert_ne!(a, b);
+        // Zero is the probe's, and must never be handed to a real request.
+        assert!(a > 0 && b > 0);
     }
 
     #[test]
@@ -443,6 +605,7 @@ mod tests {
             headers: HashMap::new(),
             body: "injected".into(),
             url: String::new(),
+            origin: 0.0,
             error: None,
         });
         assert!(
@@ -456,6 +619,7 @@ mod tests {
             headers: HashMap::new(),
             body: "ours".into(),
             url: String::new(),
+            origin: 0.0,
             error: None,
         });
         assert_eq!(rx.try_recv().unwrap().body, "ours");

--- a/src/Components/ModDetail/ModDetail.tsx
+++ b/src/Components/ModDetail/ModDetail.tsx
@@ -124,6 +124,9 @@ export default function ModDetail({
   } | null>(null);
   const [copied, setCopied] = useState(false);
   const [confirmReinstall, setConfirmReinstall] = useState(false);
+  // Bumped by the Retry button below. The load otherwise only re-runs when the slug changes,
+  // so a user the catalog refused once had no way back short of leaving the page.
+  const [reloadKey, setReloadKey] = useState(0);
 
   const { active, startInstall, startImport } = useInstall();
   const myActive = active && active.slug === slug ? active : null;
@@ -184,7 +187,7 @@ export default function ModDetail({
     return () => {
       cancelled = true;
     };
-  }, [slug, modType, livery, sound, game, rider]);
+  }, [slug, modType, livery, sound, game, rider, reloadKey]);
 
   const folderCounts = useMemo(() => {
     const m = new Map<string, number>();
@@ -276,8 +279,18 @@ export default function ModDetail({
     return (
       <div className="flex h-full flex-col px-7 py-5">
         <Breadcrumb modType={modType} title="—" onBack={onBack} link={null} />
-        <div className="mt-6 rounded-xl border border-destructive/30 bg-destructive/[0.06] p-4 text-[13px] text-destructive">
-          Couldn&apos;t load this mod: {loadError}
+        <div className="mt-6 flex flex-col items-start gap-3 rounded-xl border border-destructive/30 bg-destructive/[0.06] p-4">
+          <p className="text-[13px] font-semibold text-destructive">
+            {t("modDetail.loadFailed")}
+          </p>
+          {/* Selectable: a block explains itself in a sentence, and carries the Cloudflare
+              ray that identifies it — which is the whole of what a bug report needs. */}
+          <p className="select-text text-[12.5px] leading-relaxed text-muted-foreground">
+            {loadError.replace(/^Error:\s*/, "")}
+          </p>
+          <Button variant="outline" size="sm" onClick={() => setReloadKey((n) => n + 1)}>
+            {t("common.retry")}
+          </Button>
         </div>
       </div>
     );

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -541,6 +541,7 @@ export const de: Translation = {
   "modDetail.stagePlace": "Ablegen",
   "modDetail.stageReload": "Neu laden",
   "modDetail.modFiles": "Mod-Dateien",
+  "modDetail.loadFailed": "Diese Mod konnte nicht geladen werden",
   "modDetail.copied": "Kopiert",
   "modDetail.copy": "Kopieren",
   "modDetail.addToLibrary": "Zur Bibliothek hinzufügen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -527,6 +527,7 @@ export const en = {
   "modDetail.stagePlace": "Place",
   "modDetail.stageReload": "Reload",
   "modDetail.modFiles": "Mod files",
+  "modDetail.loadFailed": "Couldn't load this mod",
   "modDetail.copied": "Copied",
   "modDetail.copy": "Copy",
   "modDetail.addToLibrary": "Add to Library",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -533,6 +533,7 @@ export const es: Translation = {
   "modDetail.stagePlace": "Colocar",
   "modDetail.stageReload": "Recargar",
   "modDetail.modFiles": "Archivos de mod",
+  "modDetail.loadFailed": "No se pudo cargar este mod",
   "modDetail.copied": "Copiado",
   "modDetail.copy": "Copiar",
   "modDetail.addToLibrary": "Añadir a la biblioteca",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -537,6 +537,7 @@ export const fr: Translation = {
   "modDetail.stagePlace": "Placement",
   "modDetail.stageReload": "Rechargement",
   "modDetail.modFiles": "Fichiers de mod",
+  "modDetail.loadFailed": "Impossible de charger ce mod",
   "modDetail.copied": "Copié",
   "modDetail.copy": "Copier",
   "modDetail.addToLibrary": "Ajouter à la bibliothèque",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -532,6 +532,7 @@ export const it: Translation = {
   "modDetail.stagePlace": "Posizionamento",
   "modDetail.stageReload": "Ricarica",
   "modDetail.modFiles": "File mod",
+  "modDetail.loadFailed": "Impossibile caricare questa mod",
   "modDetail.copied": "Copiato",
   "modDetail.copy": "Copia",
   "modDetail.addToLibrary": "Aggiungi alla libreria",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -535,6 +535,7 @@ export const ptBR: Translation = {
   "modDetail.stagePlace": "Posicionar",
   "modDetail.stageReload": "Recarregar",
   "modDetail.modFiles": "Arquivos de mod",
+  "modDetail.loadFailed": "Não foi possível carregar este mod",
   "modDetail.copied": "Copiado",
   "modDetail.copy": "Copiar",
   "modDetail.addToLibrary": "Adicionar à biblioteca",


### PR DESCRIPTION
A user in Spain hit `Couldn't load this mod: mxb-mods.com refused the request (403), and its check window didn't clear it either` (ray `a2d9a42a7acc0642-MAD`) on a rider mod, with the catalog listing working fine either side of it.

## Why the catalog worked and one mod didn't

The detail view makes one request the listing never does — the **rendered mod page** — and mxb-mods.com guards that document path far harder than its JSON API. The download blocks aren't reachable any other way; they're theme-rendered, absent from `content.rendered`, and `acf` comes back empty over REST.

## Why the fallback didn't rescue it

Both reasons were already solved on the shop side of this codebase:

1. **The hidden window called itself ready while still on the check.** `probe` only asked whether `__TAURI_INTERNALS__` existed — and Tauri injects that into Cloudflare's "Just a moment…" page as readily as into the real one. So the window was ready while sitting on the interstitial, and every request from there was refused.
2. **It read pages with `fetch()`.** `shop_fetch.rs:155` already spells out why that can't work: *"only a navigation runs the challenge that clears it"*. A `fetch()` also can't claim `sec-fetch-dest: document`, so it never looks like the page view it stands in for.

Which is exactly the sentence the user was shown.

## Changes

- **`mxb_fetch`** — challenge-aware probe (`_cf_chl_opt` + title + `readyState`), answering with `performance.timeOrigin` so a caller that just navigated can tell the new document from the one it left. New `read_page` navigates and reads `outerHTML`, taking status from the navigation timing entry where the engine exposes it. `run` and `read_page` now share one request-id counter — two would have issued the same id twice into one `waiting()` map.
- **`mods::mxb`** — `Want::Api` / `Want::Page` splits the request shapes apart. Pages get navigation headers from the HTTP client instead of defaults describing a script that wanted JSON.
- **`ModDetail`** — the Retry button the message told people to hit, plus `modDetail.loadFailed` across all six locales. The string was hardcoded English in an otherwise-translated UI.

## Testing

`cargo test --locked` 789 pass / 0 fail; `typecheck` and `lint` clean. Four new tests pin the specific regressions: the probe refuses to answer on a challenge (and doesn't key on `challenge-platform`, which Cloudflare injects into ordinary pages), a page is read rather than fetched, ids come from one counter, and page headers never claim to be a JSON fetch.

**Not reproducible locally** — the refusal is edge/IP-specific bot scoring, and this IP gets 200 on both paths. To exercise the fixed path without being blocked, run with `MXB_FORCE_WEBVIEW=1`, which routes everything through the bridge from the first request; look for `webview PAGE /<slug> -> 200 (… bytes)`.

**Known gap:** the navigation status comes from `performance.getEntriesByType('navigation')[0].responseStatus`, which WebView2 exposes and WKWebView does not. On macOS a refused page reads as 200 with a block-page body and falls through to the existing "no downloads parsed" path rather than a clean refusal. Windows — where this bug was reported — gets the real status.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)