### PR TITLE
fix(runtime): stop planting a loose msvcr90.dll that crashes the game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## Unreleased — taking back the DLL we planted
+
+### Fixed
+- **MX Bikes crashed with "R6034 — An application has made an attempt to load the C runtime
+  library incorrectly", and this app was the cause.** Since v0.9.2 the FrostMod status poll
+  copied `msvcr90.dll` out of `WinSxS` into the game folder on every start, meaning to serve
+  the plugins with a plain `MSVCR90.dll` import that the redistributable strands. The
+  reasoning was that a loose DLL is invisible to side-by-side binding and so could only ever
+  help those plugins. Half right, and the wrong half mattered: the VC9 CRT polices this
+  itself. `msvcr90.dll` checks at load time that it was resolved through a
+  `Microsoft.VC90.CRT` activation context, and a loose copy beside the exe is by definition
+  outside one, so it refuses to start and takes the process down with it. The copy was
+  therefore never once useful — a plugin carrying a VC90 manifest resolves out of `WinSxS`
+  and never looks at it, and a plugin without one finds it and dies. We had turned a plugin
+  that quietly failed to load into a modal that killed the game.
+- **The app now removes the copy it made.** Deleting the code that placed it does nothing for
+  the players already carrying one, so the same poll that used to lay the file down now takes
+  it away, and "Repair runtimes" does too. It only ever deletes a `msvcr90.dll` whose bytes
+  match a VC90 assembly on this PC — that's where ours came from, and it's what stops us
+  reaching for a file somebody else put there on purpose. A `Microsoft.VC90.CRT` folder beside
+  the exe is left strictly alone: that arrangement is a real side-by-side identity, it
+  satisfies the CRT's check, and it works. If the game is open and holding the file, the next
+  start tries again.
+- **A loose `msvcr90.dll` no longer counts as "VC90 is present".** It isn't a route to the
+  CRT, and counting it let a file we ourselves planted quietly satisfy the check that should
+  have been reporting the machine had no runtime at all.
+
+### Changed
+- "Repair runtimes" no longer offers to put `msvcr90.dll` where the game looks for it, because
+  there is no such place — nothing app-local short of a full private assembly can satisfy the
+  VC9 CRT. It installs the runtimes this PC is short of, both architectures, and clears out
+  what older versions of this app left behind. Plugins with a plain `MSVCR90.dll` import go
+  back to reporting "MSVCR90.dll was not found"; they were never actually fixed, only given a
+  different error.
+
 ## Unreleased — logs as a link
 
 ### Added

--- a/src-tauri/src/frostmod_manage.rs
+++ b/src-tauri/src/frostmod_manage.rs
@@ -226,20 +226,20 @@ pub async fn status(app: &AppHandle) -> FrostmodStatus {
     let supported_for_game =
         crate::frostmod::supported_for_game(active_game, version.as_deref());
 
-    // The game folder is what makes the VC90 answer mean anything: it's both where a copy
-    // of the CRT may already sit and the only place we can put one. `install_dir` hands
-    // back an empty string for "don't know", which must not become the path `""`.
+    // The game folder is what makes the VC90 answer mean anything: it's where a copy of the
+    // CRT may sit, and where a stray one has to be cleaned out of. `install_dir` hands back
+    // an empty string for "don't know", which must not become the path `""`.
     let game_dir = cfg
         .as_ref()
         .map(|c| c.install_dir())
         .filter(|d| !d.trim().is_empty())
         .map(PathBuf::from);
 
-    // Lay the CRT beside the exe if it isn't there yet. This is the half of the VC90 story
-    // the redistributable cannot do — see `crate::vcruntime` — and doing it here means a
-    // player never has to learn the difference between the two failures to be past them.
+    // Take back the loose `msvcr90.dll` versions 0.9.2–0.10.0 laid beside the exe. It kills
+    // the game with R6034 — see `crate::vcruntime` — and the status poll is the only thing
+    // that reaches a player who never opens Settings, so the cleanup rides along here.
     if let Some(dir) = game_dir.as_deref() {
-        crate::vcruntime::ensure_app_local_msvcr90(dir);
+        crate::vcruntime::remove_stray_msvcr90(dir);
     }
 
     FrostmodStatus {

--- a/src-tauri/src/vcruntime.rs
+++ b/src-tauri/src/vcruntime.rs
@@ -11,28 +11,43 @@
 //! versions `9.0.21022.8` and `9.0.30729.1`). That resolves machine-wide out of `WinSxS`,
 //! or out of a private assembly folder sitting beside the exe.
 //!
-//! The part that matters, and that an earlier version of this module got wrong: **the
-//! redistributable does not put `msvcr90.dll` anywhere on the ordinary DLL search path.**
-//! It registers the side-by-side assembly under `WinSxS`, and reaching that requires the
-//! loading module to *ask for it by manifest*. The game does. A module that doesn't —
+//! The redistributable does not put `msvcr90.dll` anywhere on the ordinary DLL search
+//! path. It registers the side-by-side assembly under `WinSxS`, and reaching that requires
+//! the loading module to *ask for it by manifest*. The game does. A module that doesn't —
 //! anything with a plain `MSVCR90.dll` import and no VC90 manifest, which is most
-//! community plugins built with VS2008 — gets the ordinary search order instead: the
-//! exe's own folder, `System32`, `PATH`. The redistributable touches none of those.
+//! community plugins built with VS2008 — gets the ordinary search order instead: the exe's
+//! own folder, `System32`, `PATH`. The redistributable touches none of those.
 //!
 //! So the two failures read differently, and the wording in the dialog tells them apart:
 //!
 //! * *"the side-by-side configuration is incorrect"* (error 14001) — the **game's**
 //!   manifested dependency is unsatisfiable. Installing the redistributable fixes it.
 //! * *"MSVCR90.dll was not found"* / *"is missing from your computer"* — a **plain
-//!   import** went unresolved. Installing the redistributable cannot fix this, because
-//!   nothing it installs lands on the search path. Only a copy of `msvcr90.dll` in the
-//!   game folder does.
+//!   import** went unresolved.
 //!
-//! Hence [`ensure_app_local_msvcr90`]: the remedy places the DLL beside the exe, where
-//! both kinds of consumer can reach it. It is deliberately a *bare* copy and not a
-//! private assembly folder — a private assembly participates in side-by-side binding and
-//! a version-mismatched one could hijack a binding that currently works, whereas a bare
-//! DLL in the app directory is invisible to SxS and only ever serves plain imports.
+//! **The second one has no app-local cure, and an earlier version of this module shipped
+//! one anyway.** It copied `msvcr90.dll` out of `WinSxS` and laid it beside the exe, on the
+//! reasoning that a loose DLL is invisible to side-by-side binding and so can only ever
+//! serve the plain imports the redistributable strands. The first half is true. The second
+//! does not follow, because the VC9 CRT polices this itself: `msvcr90.dll` checks at load
+//! time that it was resolved through a `Microsoft.VC90.CRT` activation context, and a loose
+//! copy in the exe's own directory is by definition outside one. It refuses to initialise
+//! and takes the process down with
+//!
+//! ```text
+//! R6034 — An application has made an attempt to load the C runtime library incorrectly.
+//! ```
+//!
+//! Which makes the copy never once helpful and frequently fatal. A module carrying a VC90
+//! manifest resolves from `WinSxS` and never looks at it; a module without one finds it and
+//! dies. We turned a plugin that quietly failed to load into a modal that killed the game —
+//! see [`remove_stray_msvcr90`], which now takes back the copies we made.
+//!
+//! What does work app-locally is a *private assembly*: a `Microsoft.VC90.CRT` folder beside
+//! the exe holding the DLL and its manifest, which is a real side-by-side identity and
+//! satisfies the check. PiBoSo installers have historically laid one down, so [`vc90_present`]
+//! counts it. We don't build one — it participates in binding, and a version-mismatched one
+//! could hijack a binding that currently works. The redistributable is the cure we offer.
 //!
 //! **VC140 (Visual C++ 2015–2022).** `frostmod.dll` and `frostmod.exe` are modern MSVC
 //! builds. Their import tables name `VCRUNTIME140.dll`, `VCRUNTIME140_1.dll`,
@@ -189,12 +204,18 @@ fn entry_version(name: &str) -> [u32; 4] {
     out
 }
 
+/// Does this WinSxS entry name the amd64 VC90 CRT assembly?
+///
+/// The one place the matching rule lives, so the directory walk and the version pick can't
+/// drift apart on it.
+fn is_vc90_entry(name: &str) -> bool {
+    name.to_ascii_lowercase().starts_with(VC90_SXS_PREFIX)
+}
+
 /// Pick the highest-versioned amd64 VC90 CRT assembly out of a set of WinSxS entry names.
 ///
 /// Split out from the directory walk so the matching rule — the part with the actual
-/// judgement in it — is testable on any platform. Version order is not cosmetic: the copy
-/// we lay down beside the exe should be the newest servicing build on the machine, not
-/// whichever one `read_dir` happened to hand us first.
+/// judgement in it — is testable on any platform.
 fn newest_vc90_entry<I, S>(names: I) -> Option<String>
 where
     I: IntoIterator<Item = S>,
@@ -202,7 +223,7 @@ where
 {
     names
         .into_iter()
-        .filter(|n| n.as_ref().to_ascii_lowercase().starts_with(VC90_SXS_PREFIX))
+        .filter(|n| is_vc90_entry(n.as_ref()))
         .max_by_key(|n| entry_version(n.as_ref()))
         .map(|n| n.as_ref().to_owned())
 }
@@ -228,55 +249,71 @@ fn windir() -> std::path::PathBuf {
         .unwrap_or_else(|| std::path::PathBuf::from(r"C:\Windows"))
 }
 
-/// The newest amd64 VC90 CRT assembly folder in `WinSxS`, if the machine has one.
+/// Every amd64 VC90 CRT assembly folder in `WinSxS`, newest first.
 ///
-/// `None` covers both "no such assembly" and "couldn't read the directory"; callers that
-/// need to tell those apart check `WinSxS` readability themselves.
+/// All of them, not just the newest, because this is what [`remove_stray_msvcr90`] compares
+/// against: a stray copy was taken from whichever build was newest *on the day it was made*,
+/// and a servicing update since then would leave the newest folder holding different bytes.
+/// Matching against every assembly on the machine is what keeps the cleanup working after
+/// Windows Update has moved on.
+///
+/// Empty covers both "no such assembly" and "couldn't read the directory".
 #[cfg(windows)]
-fn sxs_vc90_dir() -> Option<std::path::PathBuf> {
+fn sxs_vc90_dirs() -> Vec<std::path::PathBuf> {
     let sxs = windir().join("WinSxS");
-    let entries = std::fs::read_dir(&sxs).ok()?;
-    let newest = newest_vc90_entry(
-        entries
-            .filter_map(|e| e.ok())
-            .map(|e| e.file_name().to_string_lossy().into_owned()),
-    )?;
-    Some(sxs.join(newest))
+    let Ok(entries) = std::fs::read_dir(&sxs) else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| is_vc90_entry(n))
+        .collect();
+    names.sort_by_key(|n| std::cmp::Reverse(entry_version(n)));
+    names.into_iter().map(|n| sxs.join(n)).collect()
 }
 
-/// Where a copy of `msvcr90.dll` would sit to serve plain imports inside the game.
+/// Where a loose `msvcr90.dll` sits when something has put one beside the game exe.
 ///
-/// The exe's own directory is the first entry in the ordinary DLL search order, which is
-/// the whole point: it is the one place a module with no VC90 manifest will look.
-#[cfg(windows)]
+/// The exe's own directory is the first entry in the ordinary DLL search order — which is
+/// exactly why a copy here is dangerous rather than useful. See [`remove_stray_msvcr90`].
 fn app_local_msvcr90(game_dir: &std::path::Path) -> std::path::PathBuf {
     game_dir.join(MSVCR90_DLL)
 }
 
+/// Does the game folder itself carry a working route to the CRT?
+///
+/// The private assembly folder PiBoSo installers have historically laid down beside the exe.
+/// A real side-by-side identity, so the CRT's own activation-context check is satisfied by
+/// it — which is exactly what a loose `msvcr90.dll` next to it is not, and why only this
+/// arrangement counts. Split out from [`vc90_present`] so that distinction is testable off
+/// Windows, where the `WinSxS` half of the question can't be asked.
+fn game_dir_has_vc90(game_dir: &std::path::Path) -> bool {
+    game_dir.join("Microsoft.VC90.CRT").join(MSVCR90_DLL).is_file()
+}
+
 /// Can anything in the game resolve `MSVCR90` at all?
 ///
-/// This is the question the banner asks, so it stays broad on purpose: a copy beside the
-/// exe, a private assembly folder, or the machine-wide assembly each count. Any one of
-/// them means there is a working route to the CRT and nothing worth alarming about.
+/// This is the question the banner asks, so it stays broad on purpose: the machine-wide
+/// assembly or a private assembly folder beside the exe each count. Either means there is a
+/// working route to the CRT and nothing worth alarming about.
+///
+/// A bare `msvcr90.dll` in the game folder is deliberately **not** counted. It is not a
+/// route to the CRT — it is the R6034 trap described at the top of this module — and
+/// counting it would let a file we ourselves once planted silence the detector that should
+/// be reporting the machine has no VC90.
 ///
 /// It deliberately does *not* try to answer the narrower "will a plain import resolve"
-/// question. That one is false on the overwhelming majority of perfectly healthy machines
-/// — almost nobody has a bare `msvcr90.dll` beside the exe — so asking it here would put
-/// an amber bar in front of everyone. The plain-import gap is closed by
-/// [`ensure_app_local_msvcr90`] doing the copy, not by nagging about it.
+/// question. That one is false on the overwhelming majority of perfectly healthy machines,
+/// so asking it here would put an amber bar in front of everyone — and, as the module doc
+/// sets out, there is nothing we could safely do about the answer anyway.
 ///
 /// Returns `true` ("present") when `WinSxS` can't be read at all. We'd rather miss a real
 /// problem than raise a false alarm on a machine we simply couldn't inspect.
 #[cfg(windows)]
 fn vc90_present(game_dir: Option<&std::path::Path>) -> bool {
-    if let Some(dir) = game_dir {
-        // A bare copy beside the exe, or the private assembly folder PiBoSo installers
-        // have historically laid down next to it.
-        if app_local_msvcr90(dir).is_file()
-            || dir.join("Microsoft.VC90.CRT").join(MSVCR90_DLL).is_file()
-        {
-            return true;
-        }
+    if game_dir.is_some_and(game_dir_has_vc90) {
+        return true;
     }
     let sxs = windir().join("WinSxS");
     match std::fs::read_dir(&sxs) {
@@ -292,112 +329,95 @@ fn vc90_present(game_dir: Option<&std::path::Path>) -> bool {
     }
 }
 
-/// Put `msvcr90.dll` beside the game exe, so a plugin that imports it plainly can find it.
+/// Take back a loose `msvcr90.dll` we laid beside the game exe.
 ///
-/// This is the half the redistributable can't do. Copied out of `WinSxS` — the assembly
-/// there is the same file, and taking it from the machine avoids shipping Microsoft's
-/// binary ourselves or unpacking an installer to get at it.
+/// Versions 0.9.2 through 0.10.0 copied the CRT out of `WinSxS` into the game folder on
+/// every status poll, believing it served the plain imports the redistributable strands. It
+/// does not — the VC9 CRT aborts with R6034 when it is loaded outside a `Microsoft.VC90.CRT`
+/// activation context, which a loose copy always is. Deleting the code that made the copy
+/// does nothing for the players already carrying one, so the app removes it.
 ///
-/// Best-effort by design, and every failure is a log line rather than an error: the game
-/// folder can sit under `Program Files` where we have no write access, and a player whose
-/// plugins all resolve fine loses nothing by the copy not happening. Returns whether the
-/// file is there when we're done.
+/// **Only ever deletes a file whose bytes match a VC90 assembly on this machine.** That is
+/// where our copy came from, so the compare is what stops us reaching for a `msvcr90.dll`
+/// somebody else put there for a reason we don't know. A byte-identical file is equally
+/// R6034-fatal whoever laid it, so provenance is the right test and a marker file — which
+/// the version that did the damage never wrote — would not have helped.
 ///
-/// Safe to call on a hot path. The settled case costs one `is_file()`, and a folder we
-/// failed on is remembered so a read-only install doesn't retry — and re-log — on every
-/// status poll. [`invalidate`] clears that memory, so an install gets a fresh attempt.
+/// A `Microsoft.VC90.CRT` folder beside the exe is left strictly alone: that one works.
+///
+/// Best-effort, and safe on a hot path. The settled case costs one failed `read`. A locked
+/// file — the game running with the DLL mapped — just means the next poll tries again, and
+/// only the first failure per folder is logged so a stuck one doesn't fill the log.
 #[cfg(windows)]
-pub fn ensure_app_local_msvcr90(game_dir: &std::path::Path) -> bool {
-    let dest = app_local_msvcr90(game_dir);
-    if dest.is_file() {
-        return true;
-    }
-    if let Ok(mut tried) = ATTEMPTED.lock() {
-        if !tried.insert(game_dir.to_path_buf()) {
-            return false;
-        }
-    }
-    let Some(src_dir) = sxs_vc90_dir() else {
-        log::info!("no VC90 assembly in WinSxS to copy to {}", game_dir.display());
+pub fn remove_stray_msvcr90(game_dir: &std::path::Path) -> bool {
+    remove_stray_msvcr90_against(game_dir, &sxs_vc90_dirs())
+}
+
+/// The decision and the deletion, with the `WinSxS` lookup handed in.
+///
+/// Split out the way [`newest_vc90_entry`] is: the judgement — *is this file ours to
+/// delete* — is the part worth testing, and it can't be reached on a machine that has no
+/// `WinSxS` to enumerate.
+fn remove_stray_msvcr90_against(
+    game_dir: &std::path::Path,
+    sxs_dirs: &[std::path::PathBuf],
+) -> bool {
+    let stray = app_local_msvcr90(game_dir);
+    let Ok(found) = std::fs::read(&stray) else {
         return false;
     };
-    let src = src_dir.join(MSVCR90_DLL);
-    match std::fs::copy(&src, &dest) {
-        Ok(_) => {
-            log::info!("placed {} from {}", dest.display(), src_dir.display());
+    let ours = sxs_dirs
+        .iter()
+        .any(|d| std::fs::read(d.join(MSVCR90_DLL)).is_ok_and(|sxs| sxs == found));
+    if !ours {
+        if first_time(&LEFT_ALONE, game_dir) {
+            log::info!(
+                "leaving {} alone — it matches no VC90 assembly on this PC, so it isn't ours",
+                stray.display()
+            );
+        }
+        return false;
+    }
+    match std::fs::remove_file(&stray) {
+        Ok(()) => {
+            log::info!(
+                "removed {} — a loose VC9 CRT there aborts the game with R6034",
+                stray.display()
+            );
             true
         }
         Err(e) => {
-            log::warn!("could not place {} ({e})", dest.display());
+            if first_time(&MOANED, game_dir) {
+                log::warn!(
+                    "could not remove {} ({e}) — will retry (the game holding it open is the usual reason)",
+                    stray.display()
+                );
+            }
             false
         }
     }
 }
 
-/// Game folders we've already tried to lay a copy into, so a failure is attempted — and
-/// logged — once rather than on every poll.
-#[cfg(windows)]
-static ATTEMPTED: std::sync::Mutex<std::collections::BTreeSet<std::path::PathBuf>> =
-    std::sync::Mutex::new(std::collections::BTreeSet::new());
+/// Have we not yet said this about this game folder?
+///
+/// The work is repeated on every call by design — the game closing, or the player swapping
+/// the file, changes the answer — but saying so again doesn't help anyone reading the log.
+/// A poisoned lock reports "first time" so a diagnostic is never swallowed by a bookkeeping
+/// failure.
+type Folders = std::sync::Mutex<std::collections::BTreeSet<std::path::PathBuf>>;
+fn first_time(seen: &Folders, game_dir: &std::path::Path) -> bool {
+    seen.lock().map_or(true, |mut s| s.insert(game_dir.to_path_buf()))
+}
+
+/// Folders holding a `msvcr90.dll` we decided isn't ours to delete.
+static LEFT_ALONE: Folders = std::sync::Mutex::new(std::collections::BTreeSet::new());
+
+/// Folders where the delete failed — a locked file complains once, not on every call.
+static MOANED: Folders = std::sync::Mutex::new(std::collections::BTreeSet::new());
 
 #[cfg(not(windows))]
-pub fn ensure_app_local_msvcr90(_game_dir: &std::path::Path) -> bool {
+pub fn remove_stray_msvcr90(_game_dir: &std::path::Path) -> bool {
     false
-}
-
-/// Place `msvcr90.dll` beside the exe, raising UAC if the folder needs it.
-///
-/// The unelevated copy above is silent and gives up on `Program Files` — which is exactly
-/// where a Steam install lives, so on the machines that reported this it never lands. This
-/// is the same job with the shell's `runas` behind it, and it is deliberately **not** on
-/// the status path: it can put a UAC dialog on screen, so it only ever runs from a repair
-/// the player pressed.
-///
-/// `cmd.exe /c copy` rather than an elevated helper of our own — copying one file is not
-/// worth a second binary in the bundle, and `copy` is present on every Windows that can
-/// run the game.
-#[cfg(windows)]
-pub fn place_msvcr90_elevated(game_dir: &std::path::Path) -> anyhow::Result<bool> {
-    let dest = app_local_msvcr90(game_dir);
-    if dest.is_file() {
-        return Ok(true);
-    }
-    // Clear the "already tried" mark first: the unelevated attempt almost certainly failed
-    // on this folder, and that must not stop the elevated one.
-    if let Ok(mut tried) = ATTEMPTED.lock() {
-        tried.remove(game_dir);
-    }
-    if ensure_app_local_msvcr90(game_dir) {
-        return Ok(true);
-    }
-    let Some(src_dir) = sxs_vc90_dir() else {
-        anyhow::bail!(
-            "There's no Visual C++ 2008 runtime on this PC to copy from. Install {} first.",
-            Runtime::Vc90.label()
-        );
-    };
-    let src = src_dir.join(MSVCR90_DLL);
-    let cmd = windir().join("System32").join("cmd.exe");
-    // Quoted because both paths routinely contain spaces — `Program Files`, `MX Bikes`.
-    let args = format!("/c copy /y \"{}\" \"{}\"", src.display(), dest.display());
-    if !run_elevated(&cmd, &args)? {
-        // Declined UAC. Not an error: the caller offers the manual route instead.
-        return Ok(false);
-    }
-    // `copy`'s exit code doesn't travel back through ShellExecuteExW usefully, so the disk
-    // is what settles it.
-    let placed = dest.is_file();
-    if placed {
-        log::info!("placed {} (elevated) from {}", dest.display(), src_dir.display());
-    } else {
-        log::warn!("elevated copy of {} reported no error but nothing landed", dest.display());
-    }
-    Ok(placed)
-}
-
-#[cfg(not(windows))]
-pub fn place_msvcr90_elevated(_game_dir: &std::path::Path) -> anyhow::Result<bool> {
-    anyhow::bail!("Visual C++ runtimes only apply on Windows")
 }
 
 /// The 2015–2022 runtime installs into `System32` rather than WinSxS. This process is
@@ -431,16 +451,12 @@ fn vc140_x86_present() -> bool {
 static CACHE: std::sync::Mutex<Option<(Option<std::path::PathBuf>, Vec<Runtime>)>> =
     std::sync::Mutex::new(None);
 
-/// Drop the cached probe so the next `missing()` re-reads the disk, and let a game folder
-/// we previously failed to copy into be tried again — after an install there is a source
-/// in `WinSxS` that wasn't there before.
+/// Drop the cached probe so the next `missing()` re-reads the disk. Installing a runtime is
+/// the one thing that changes the answer under us.
 #[cfg(windows)]
 fn invalidate() {
     if let Ok(mut c) = CACHE.lock() {
         *c = None;
-    }
-    if let Ok(mut tried) = ATTEMPTED.lock() {
-        tried.clear();
     }
 }
 
@@ -522,8 +538,9 @@ pub struct RepairReport {
     /// Still absent afterwards — a declined UAC prompt, a failed download, an install that
     /// needs a reboot to finish. Each one is a link the UI hands over.
     pub still_missing: Vec<Runtime>,
-    /// Whether `msvcr90.dll` now sits beside the game exe.
-    pub msvcr90_placed: bool,
+    /// Whether a stray `msvcr90.dll` beside the game exe was cleaned up — see
+    /// [`remove_stray_msvcr90`]. Left by 0.9.2–0.10.0, and fatal to the game.
+    pub msvcr90_removed: bool,
     /// Set when we had nowhere to place it — no game folder configured.
     pub game_dir_known: bool,
 }
@@ -566,25 +583,19 @@ pub async fn repair(
         }
     }
 
-    // The copy beside the exe, elevating if the folder needs it. Runs even when VC90 was
-    // already "present" — present in WinSxS is not the same as reachable by a plain
-    // import, and that gap is the whole reason this function exists.
+    // Sweep up the loose CRT older builds of this app left beside the exe. Worth doing here
+    // as well as on the status poll: a player pressing repair is a player whose game is
+    // already misbehaving, and this is the likeliest reason.
     if let Some(dir) = game_dir {
-        report.msvcr90_placed = match place_msvcr90_elevated(dir) {
-            Ok(placed) => placed,
-            Err(e) => {
-                log::warn!("repair: could not place {MSVCR90_DLL}: {e:#}");
-                false
-            }
-        };
+        report.msvcr90_removed = remove_stray_msvcr90(dir);
     }
 
     invalidate();
     log::info!(
-        "repair: installed {:?}, still missing {:?}, msvcr90 beside exe: {}",
+        "repair: installed {:?}, still missing {:?}, stray msvcr90 removed: {}",
         report.installed,
         report.still_missing,
-        report.msvcr90_placed
+        report.msvcr90_removed
     );
     report
 }
@@ -771,17 +782,9 @@ pub async fn install(
         return Ok(InstallOutcome::Cancelled);
     }
 
-    // Trust the disk, not the installer's exit code. Clearing first also re-arms the copy
-    // below on a folder an earlier attempt gave up on.
+    // Trust the disk, not the installer's exit code.
     invalidate();
 
-    // The assembly is registered now, so this is the first moment the copy beside the exe
-    // can be taken from WinSxS. Before the install there was nothing there to copy.
-    if runtime == Runtime::Vc90 {
-        if let Some(dir) = game_dir {
-            ensure_app_local_msvcr90(dir);
-        }
-    }
     if missing(game_dir).contains(&runtime) {
         anyhow::bail!(
             "The installer ran but Windows still can't find the component. A restart usually finishes it off."
@@ -963,5 +966,115 @@ mod tests {
             serde_json::to_string(&InstallOutcome::Cancelled).unwrap(),
             "\"cancelled\""
         );
+    }
+
+    /// A scratch tree, named per test so a parallel run doesn't collide. The house pattern
+    /// — see `paintsync`'s tests — rather than a dev-dependency for four directories.
+    fn scratch(name: &str) -> std::path::PathBuf {
+        let d = std::env::temp_dir()
+            .join(format!("mxb-vcruntime-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    /// A stand-in `WinSxS` assembly folder holding a `msvcr90.dll` of known bytes.
+    fn fake_sxs(root: &std::path::Path, bytes: &[u8]) -> std::path::PathBuf {
+        let dir = root.join("amd64_microsoft.vc90.crt_1fc8b3b9a1e18e3b_9.0.30729.9635_none_x");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(MSVCR90_DLL), bytes).unwrap();
+        dir
+    }
+
+    /// The whole point of the change: the copy versions 0.9.2–0.10.0 laid beside the exe is
+    /// taken back. It came out of `WinSxS`, so it matches byte for byte.
+    #[test]
+    fn a_copy_taken_from_winsxs_is_removed() {
+        let root = scratch("ours");
+        let game = root.join("game");
+        std::fs::create_dir_all(&game).unwrap();
+        let sxs = fake_sxs(&root, b"the real VC9 CRT");
+        std::fs::write(game.join(MSVCR90_DLL), b"the real VC9 CRT").unwrap();
+
+        assert!(remove_stray_msvcr90_against(&game, &[sxs]));
+        assert!(!game.join(MSVCR90_DLL).exists(), "the stray copy must be gone");
+    }
+
+    /// A `msvcr90.dll` we didn't put there is somebody else's decision. It is still an R6034
+    /// waiting to happen, but deleting a file of unknown provenance out of someone's game
+    /// folder is not ours to do.
+    #[test]
+    fn a_file_we_didnt_place_is_left_alone() {
+        let root = scratch("theirs");
+        let game = root.join("game");
+        std::fs::create_dir_all(&game).unwrap();
+        let sxs = fake_sxs(&root, b"the real VC9 CRT");
+        std::fs::write(game.join(MSVCR90_DLL), b"something else entirely").unwrap();
+
+        assert!(!remove_stray_msvcr90_against(&game, &[sxs]));
+        assert!(game.join(MSVCR90_DLL).exists(), "an unrecognised file must survive");
+    }
+
+    /// Our copy was taken from whichever assembly was newest the day it was made. A
+    /// servicing update since then leaves the newest folder holding different bytes, and the
+    /// cleanup still has to fire — which is why every assembly is compared, not just the top
+    /// one.
+    #[test]
+    fn a_copy_from_a_superseded_assembly_is_still_ours() {
+        let root = scratch("superseded");
+        let game = root.join("game");
+        std::fs::create_dir_all(&game).unwrap();
+        let old_dir = root.join("amd64_microsoft.vc90.crt_1fc8b3b9a1e18e3b_9.0.30729.6161_none_x");
+        std::fs::create_dir_all(&old_dir).unwrap();
+        std::fs::write(old_dir.join(MSVCR90_DLL), b"the older servicing build").unwrap();
+        let newest = fake_sxs(&root, b"the newest servicing build");
+        std::fs::write(game.join(MSVCR90_DLL), b"the older servicing build").unwrap();
+
+        assert!(remove_stray_msvcr90_against(&game, &[newest, old_dir]));
+        assert!(!game.join(MSVCR90_DLL).exists());
+    }
+
+    /// Nothing to do, and no source to compare against, are both quiet no-ops.
+    #[test]
+    fn an_empty_game_folder_is_a_no_op() {
+        let root = scratch("empty");
+        let game = root.join("game");
+        std::fs::create_dir_all(&game).unwrap();
+        assert!(!remove_stray_msvcr90_against(&game, &[fake_sxs(&root, b"crt")]));
+        std::fs::write(game.join(MSVCR90_DLL), b"crt").unwrap();
+        assert!(!remove_stray_msvcr90_against(&game, &[]), "no WinSxS means no verdict");
+        assert!(game.join(MSVCR90_DLL).exists());
+    }
+
+    /// The private assembly folder is the arrangement that actually works, and the cleanup
+    /// reaches only the loose file beside it.
+    #[test]
+    fn the_private_assembly_folder_is_never_touched() {
+        let root = scratch("private");
+        let game = root.join("game");
+        let private = game.join("Microsoft.VC90.CRT");
+        std::fs::create_dir_all(&private).unwrap();
+        std::fs::write(private.join(MSVCR90_DLL), b"the real VC9 CRT").unwrap();
+        let sxs = fake_sxs(&root, b"the real VC9 CRT");
+
+        assert!(!remove_stray_msvcr90_against(&game, &[sxs]));
+        assert!(private.join(MSVCR90_DLL).is_file(), "a working private assembly must survive");
+    }
+
+    /// A private assembly is a route to the CRT; a loose DLL beside the exe is the R6034
+    /// trap. Counting the latter would let a file we planted silence the detector that
+    /// should be reporting this machine has no VC90 at all.
+    #[test]
+    fn only_the_private_assembly_counts_as_a_route_to_the_crt() {
+        let root = scratch("present");
+        let bare = root.join("bare");
+        std::fs::create_dir_all(&bare).unwrap();
+        std::fs::write(bare.join(MSVCR90_DLL), b"loose").unwrap();
+        assert!(!game_dir_has_vc90(&bare), "a loose msvcr90.dll is not a working route");
+
+        let proper = root.join("proper");
+        std::fs::create_dir_all(proper.join("Microsoft.VC90.CRT")).unwrap();
+        std::fs::write(proper.join("Microsoft.VC90.CRT").join(MSVCR90_DLL), b"crt").unwrap();
+        assert!(game_dir_has_vc90(&proper));
     }
 }

--- a/src/Context/Frostmod.tsx
+++ b/src/Context/Frostmod.tsx
@@ -250,12 +250,12 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
   );
 
   /**
-   * Install everything the PC is short of, then put `msvcr90.dll` beside the game exe.
+   * Install everything the PC is short of, and sweep up the stray `msvcr90.dll` older
+   * builds of this app left beside the game exe.
    *
    * The one path that doesn't ask detection for permission first. A PC can report every
-   * runtime present and still stop the game dead — the redistributable registers a
-   * side-by-side assembly and leaves the plain DLL search path alone — so this always does
-   * the work and reports what it found rather than deciding there was nothing to do.
+   * runtime present and still stop the game dead, so this always does the work and reports
+   * what it found rather than deciding there was nothing to do.
    *
    * Never throws: the backend returns a report instead, so a UAC prompt declined on one
    * installer doesn't cost the player the other two.
@@ -266,7 +266,7 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
       const report = await frostmodRepairRuntimes();
       await refreshStatus();
 
-      const fixed = report.installed.length > 0 || report.msvcr90Placed;
+      const fixed = report.installed.length > 0 || report.msvcr90Removed;
       if (report.stillMissing.length > 0) {
         // Partly done at best, and every remaining item has a link. Offer the first —
         // opening three tabs at once would be its own kind of unhelpful.
@@ -286,8 +286,8 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
           description: t("runtime.repairDoneDesc"),
         });
       } else if (!report.gameDirKnown) {
-        // Everything was already installed, but we had nowhere to put the copy that
-        // actually stops the "not found" box. Saying "all good" here would be a lie.
+        // Everything was already installed, but with no game folder we never looked at the
+        // half of the job that lives in it. Saying "all good" here would be a lie.
         toast.info(t("runtime.repairNoGameFolder"), {
           description: t("runtime.repairNoGameFolderDesc"),
         });

--- a/src/Context/FrostmodContext.ts
+++ b/src/Context/FrostmodContext.ts
@@ -43,8 +43,8 @@ export interface FrostmodContextValue {
   /** True while a full runtime repair is in flight. */
   repairingRuntimes: boolean;
   /**
-   * Install every Visual C++ runtime this PC is short of, then place `msvcr90.dll` beside
-   * the game executable.
+   * Install every Visual C++ runtime this PC is short of, and remove a stray `msvcr90.dll`
+   * beside the game executable if an older build of this app left one there.
    *
    * Unlike {@link installRuntime} this isn't gated on anything having been detected as
    * missing, which is the point of it: a PC can report every runtime present and still

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -1758,7 +1758,7 @@ export function frostmodInstallRuntime(
   return invoke<RuntimeInstallOutcome>("frostmod_install_runtime", { runtime });
 }
 
-/** Install everything this PC is short of, and put `msvcr90.dll` beside the game exe.
+/** Install everything this PC is short of, and clear a stray `msvcr90.dll` beside the exe.
  *
  *  The repair the warning bar can't reach: it runs whatever detection said, because a
  *  machine can report every runtime present and still fail to start the game. Raises UAC

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -316,7 +316,7 @@ export const de: Translation = {
     "Nicht abgeschlossen: {{what}}. Windows braucht deine Erlaubnis, oder der Download kam nicht an — du kannst es auch von Hand installieren.",
   "runtime.repairNoGameFolder": "Kein Spielordner festgelegt",
   "runtime.repairNoGameFolderDesc":
-    "Die Laufzeitkomponenten sind installiert, aber ohne Installationsordner gibt es keinen Ort für die Kopie, nach der das Spiel sucht. Lege ihn oben fest und repariere erneut.",
+    "Die Laufzeitkomponenten sind installiert, aber ohne Installationsordner können wir den Spielordner selbst nicht prüfen. Lege ihn oben fest und repariere erneut.",
   "runtime.repairFailed": "Laufzeitkomponenten konnten nicht repariert werden",
   "update.checkFailed": "Updates konnten nicht geprüft werden",
   "update.failed": "Update fehlgeschlagen",
@@ -625,7 +625,7 @@ export const de: Translation = {
     "Windows fehlt eine Visual-C++-Komponente, die FrostMod braucht — installiere sie, um den Fehler „dll was not found“ loszuwerden.",
   "settings.repairRuntimes": "Laufzeit reparieren",
   "settings.repairRuntimesHint":
-    "Installiert alle fehlenden Visual-C++-Laufzeiten dieses PCs (32- und 64-Bit) und legt msvcr90.dll dorthin, wo das Spiel sie sucht. Lohnt sich auch, wenn oben nichts falsch aussieht.",
+    "Installiert alle fehlenden Visual-C++-Laufzeiten dieses PCs, 32- und 64-Bit, und räumt weg, was eine ältere Version dieser App im Spielordner hinterlassen hat. Lohnt sich auch, wenn oben nichts falsch aussieht.",
   "settings.frostmodNeedsRepair":
     "Die installierten Dateien passen nicht zu dieser Version — eine Neuinstallation behebt das.",
   "settings.frostmodRepair": "Installation reparieren",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -303,7 +303,7 @@ export const en = {
     "Couldn't finish: {{what}}. Windows needs your permission, or the download didn't arrive — you can install it by hand.",
   "runtime.repairNoGameFolder": "No game folder set",
   "runtime.repairNoGameFolderDesc":
-    "The runtimes are installed, but without the install folder there's nowhere to put the copy the game looks for. Set it above, then repair again.",
+    "The runtimes are installed, but without the install folder we can't check the game folder itself. Set it above, then repair again.",
   "runtime.repairFailed": "Couldn't repair the runtimes",
   "update.checkFailed": "Couldn't check for updates",
   "update.failed": "Update failed",
@@ -610,7 +610,7 @@ export const en = {
     "Windows is missing a Visual C++ component FrostMod needs — install it to stop the \"dll was not found\" error.",
   "settings.repairRuntimes": "Repair runtimes",
   "settings.repairRuntimesHint":
-    "Installs every Visual C++ runtime this PC is short of (both 32- and 64-bit) and puts msvcr90.dll where the game looks for it. Worth running even if nothing above looks wrong.",
+    "Installs every Visual C++ runtime this PC is short of, both 32- and 64-bit, and clears out anything an older version of this app left in the game folder. Worth running even if nothing above looks wrong.",
   "settings.frostmodNeedsRepair":
     "The installed files don't match this version — reinstalling fixes it.",
   "settings.frostmodRepair": "Repair install",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -310,7 +310,7 @@ export const es: Translation = {
     "No se pudo terminar: {{what}}. Windows necesita tu permiso, o la descarga no llegó — puedes instalarlo a mano.",
   "runtime.repairNoGameFolder": "No hay carpeta del juego",
   "runtime.repairNoGameFolderDesc":
-    "Los componentes están instalados, pero sin la carpeta de instalación no hay dónde dejar la copia que el juego busca. Indícala arriba y repara otra vez.",
+    "Los componentes están instalados, pero sin la carpeta de instalación no podemos revisar la carpeta del juego. Indícala arriba y repara otra vez.",
   "runtime.repairFailed": "No se pudieron reparar los componentes",
   "update.checkFailed": "No se pudieron comprobar las actualizaciones",
   "update.failed": "La actualización falló",
@@ -617,7 +617,7 @@ export const es: Translation = {
     "A Windows le falta un componente de Visual C++ que FrostMod necesita — instálalo para quitar el error «dll was not found».",
   "settings.repairRuntimes": "Reparar componentes",
   "settings.repairRuntimesHint":
-    "Instala todos los componentes de Visual C++ que le falten a este PC (32 y 64 bits) y deja msvcr90.dll donde el juego la busca. Vale la pena aunque arriba no se vea nada mal.",
+    "Instala todos los componentes de Visual C++ que le falten a este PC, 32 y 64 bits, y retira lo que una versión anterior de esta app dejó en la carpeta del juego. Vale la pena aunque arriba no se vea nada mal.",
   "settings.frostmodNeedsRepair":
     "Los archivos instalados no coinciden con esta versión — reinstalar lo arregla.",
   "settings.frostmodRepair": "Reparar instalación",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -313,7 +313,7 @@ export const fr: Translation = {
     "N'a pas pu aboutir : {{what}}. Windows demande votre autorisation, ou le téléchargement n'est pas arrivé — vous pouvez l'installer à la main.",
   "runtime.repairNoGameFolder": "Aucun dossier de jeu défini",
   "runtime.repairNoGameFolderDesc":
-    "Les composants sont installés, mais sans le dossier d'installation il n'y a nulle part où déposer la copie que le jeu cherche. Indiquez-le ci-dessus, puis réparez à nouveau.",
+    "Les composants sont installés, mais sans le dossier d'installation nous ne pouvons pas vérifier le dossier du jeu lui-même. Indiquez-le ci-dessus, puis réparez à nouveau.",
   "runtime.repairFailed": "Impossible de réparer les composants",
   "update.checkFailed": "Impossible de vérifier les mises à jour",
   "update.failed": "Échec de la mise à jour",
@@ -622,7 +622,7 @@ export const fr: Translation = {
     "Il manque à Windows un composant Visual C++ dont FrostMod a besoin — installez-le pour faire disparaître l'erreur « dll was not found ».",
   "settings.repairRuntimes": "Réparer les composants",
   "settings.repairRuntimesHint":
-    "Installe tous les composants Visual C++ qui manquent à ce PC (32 et 64 bits) et place msvcr90.dll là où le jeu la cherche. Utile même si rien ne semble anormal ci-dessus.",
+    "Installe tous les composants Visual C++ qui manquent à ce PC, 32 et 64 bits, et retire ce qu'une ancienne version de cette app a laissé dans le dossier du jeu. Utile même si rien ne semble anormal ci-dessus.",
   "settings.frostmodNeedsRepair":
     "Les fichiers installés ne correspondent pas à cette version — une réinstallation corrige ça.",
   "settings.frostmodRepair": "Réparer l'installation",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -309,7 +309,7 @@ export const it: Translation = {
     "Non è stato possibile completare: {{what}}. Windows chiede il tuo permesso, oppure il download non è arrivato — puoi installarlo a mano.",
   "runtime.repairNoGameFolder": "Nessuna cartella di gioco impostata",
   "runtime.repairNoGameFolderDesc":
-    "I componenti sono installati, ma senza la cartella di installazione non c'è dove mettere la copia che il gioco cerca. Impostala qui sopra, poi ripara di nuovo.",
+    "I componenti sono installati, ma senza la cartella di installazione non possiamo controllare la cartella del gioco. Impostala qui sopra, poi ripara di nuovo.",
   "runtime.repairFailed": "Impossibile riparare i componenti",
   "update.checkFailed": "Impossibile controllare gli aggiornamenti",
   "update.failed": "Aggiornamento non riuscito",
@@ -615,7 +615,7 @@ export const it: Translation = {
     "A Windows manca un componente Visual C++ che serve a FrostMod — installalo per togliere l'errore «dll was not found».",
   "settings.repairRuntimes": "Ripara i componenti",
   "settings.repairRuntimesHint":
-    "Installa tutti i componenti Visual C++ che mancano a questo PC (32 e 64 bit) e mette msvcr90.dll dove il gioco la cerca. Vale la pena anche se qui sopra non sembra esserci nulla di sbagliato.",
+    "Installa tutti i componenti Visual C++ che mancano a questo PC, 32 e 64 bit, e rimuove ciò che una versione precedente di questa app ha lasciato nella cartella del gioco. Vale la pena anche se qui sopra non sembra esserci nulla di sbagliato.",
   "settings.frostmodNeedsRepair":
     "I file installati non corrispondono a questa versione — reinstallando si risolve.",
   "settings.frostmodRepair": "Ripara installazione",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -312,7 +312,7 @@ export const ptBR: Translation = {
     "Não deu para concluir: {{what}}. O Windows precisa da sua permissão, ou o download não chegou — você pode instalar na mão.",
   "runtime.repairNoGameFolder": "Nenhuma pasta do jogo definida",
   "runtime.repairNoGameFolderDesc":
-    "Os componentes estão instalados, mas sem a pasta de instalação não há onde deixar a cópia que o jogo procura. Defina-a acima e repare de novo.",
+    "Os componentes estão instalados, mas sem a pasta de instalação não dá para verificar a pasta do jogo. Defina-a acima e repare de novo.",
   "runtime.repairFailed": "Não foi possível reparar os componentes",
   "update.checkFailed": "Não foi possível verificar as atualizações",
   "update.failed": "A atualização falhou",
@@ -618,7 +618,7 @@ export const ptBR: Translation = {
     "Falta ao Windows um componente do Visual C++ que o FrostMod precisa — instale-o para acabar com o erro \"dll was not found\".",
   "settings.repairRuntimes": "Reparar componentes",
   "settings.repairRuntimesHint":
-    "Instala todos os componentes do Visual C++ que faltam neste PC (32 e 64 bits) e coloca a msvcr90.dll onde o jogo a procura. Vale a pena mesmo que nada acima pareça errado.",
+    "Instala todos os componentes do Visual C++ que faltam neste PC, 32 e 64 bits, e remove o que uma versão anterior deste app deixou na pasta do jogo. Vale a pena mesmo que nada acima pareça errado.",
   "settings.frostmodNeedsRepair":
     "Os arquivos instalados não batem com esta versão — reinstalar resolve.",
   "settings.frostmodRepair": "Reparar instalação",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -959,9 +959,10 @@ export interface RuntimeRepairReport {
   alreadyPresent: VcRuntime[];
   /** Still absent afterwards: a declined UAC prompt, a failed download, a pending reboot. */
   stillMissing: VcRuntime[];
-  /** Whether `msvcr90.dll` now sits beside the game executable. */
-  msvcr90Placed: boolean;
-  /** False when no game folder is configured, so there was nowhere to place it. */
+  /** Whether a stray `msvcr90.dll` beside the game executable was cleaned up. Versions
+   *  0.9.2–0.10.0 put one there, and it aborts the game with R6034. */
+  msvcr90Removed: boolean;
+  /** False when no game folder is configured, so there was nowhere to look. */
   gameDirKnown: boolean;
 }
 


### PR DESCRIPTION
## The bug is ours

Since **v0.9.2** the FrostMod status poll has copied `msvcr90.dll` out of `WinSxS` into the game folder on every app start. A reporter hit the consequence on 0.10.0 — MX Bikes dying with a **Microsoft Visual C++ Runtime Library** box:

> **R6034** — An application has made an attempt to load the C runtime library incorrectly.

Their log names the file we planted, at startup:

```
[2026-08-20][02:16:59][mxb_app::vcruntime][INFO] placed
  C:\Program Files (x86)\Steam\steamapps\common\MX Bikes\msvcr90.dll from
  C:\WINDOWS\WinSxS\amd64_microsoft.vc90.crt_1fc8b3b9a1e18e3b_9.0.30729.9635_none_...
```

The truncated `Program: C:\Prog...` in the dialog is the game, not us — `mxbikes.exe` is under `C:\Program Files (x86)\Steam\...` while the app installs per-user into `%LOCALAPPDATA%`. `strings` on the PiBoSo binary confirms it declares `Microsoft.VC90.CRT` (`1fc8b3b9a1e18e3b`, 9.0.21022.8 / 9.0.30729.1) and imports `MSVCR90.dll`.

## Why the copy could never work

The module reasoned that a bare DLL is invisible to side-by-side binding and so could only ever serve the plain imports the redistributable strands. The first half is true; the second doesn't follow. The VC9 CRT polices this itself — `msvcr90.dll` checks at load time that it was resolved through a `Microsoft.VC90.CRT` activation context, and a loose copy beside the exe is by definition outside one. It refuses to initialise and takes the process down.

So the copy was **never once helpful**: a module carrying a VC90 manifest resolves from `WinSxS` and never looks at it; a module without one finds it and dies. We converted a plugin that quietly failed to load into a modal that killed the game.

## What this does

- Removes `ensure_app_local_msvcr90` and `place_msvcr90_elevated`.
- Adds `remove_stray_msvcr90` **on the same status poll that used to lay the file down** — deleting the code alone would leave every affected player carrying the DLL forever. It only ever deletes a `msvcr90.dll` whose bytes match a VC90 assembly on that PC (where ours came from), and compares against *every* assembly rather than just the newest, so a servicing update since the copy was made doesn't defeat the cleanup. A `Microsoft.VC90.CRT` private assembly folder is left strictly alone — that arrangement is a real side-by-side identity and it works. A locked file just retries next start.
- A loose copy no longer counts as "VC90 present" — it was letting a file we planted silence the detector that should have been reporting no runtime at all.
- Repair button reworded in all six locales; `msvcr90Placed` → `msvcr90Removed`.

Plain-import plugins go back to reporting "MSVCR90.dll was not found". Honest: they were never actually fixed, only given a different error. Scope was deliberately held to *stop breaking it* — no private-assembly builder, since that participates in SxS binding and could hijack a binding that currently works.

## Verification

- `cargo test` — 791 pass, including 6 new ones covering: a WinSxS-matching copy is removed; a file we didn't place survives; a copy from a superseded assembly is still recognised as ours; the private assembly folder is never touched; a loose DLL doesn't count as a route to the CRT.
- `cargo check --target x86_64-pc-windows-gnu` — the `cfg(windows)` half a macOS build skips.
- clippy clean on both changed files; `tsc --noEmit` clean; eslint 0 errors.

**Worth checking on Windows:** drop a `WinSxS` copy of `msvcr90.dll` in the game folder, start the app, confirm the log says it was removed and the file is gone; then drop an unrelated file of the same name and confirm it survives.

## Note on release

This is live in v0.10.0 and affected players are only cleaned up when they next run the app, so it wants a prompt **0.10.1** rather than waiting for the next feature release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)