### PR TITLE
feat(presets): let a bike be removed from a profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-08-20
+
+### Added
+- **Bikes you no longer ride can be removed from the Presets picker.** The Bike list is what
+  your profile carries, not what's installed — the game adds a column for every bike you have
+  ever sat on and never takes one out, so bikes whose mod is long gone kept filling the list
+  with nothing in the Library to uninstall. Each row now has a trash can that clears that bike
+  and the look saved for it out of `profile.ini`, with the previous file kept beside it as
+  `profile.ini.bak`. Nothing installed is deleted, and riding that bike again adds it back.
+
 ## 2026-08-19
 
 ### Fixed

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5750,6 +5750,23 @@ fn presets_list_bikes(app: tauri::AppHandle, profile: String) -> Result<Vec<Stri
     presets::list_bikes(&cfg.profiles_dir(), &profile).map_err(|e| format!("{e:#}"))
 }
 
+/// Drop a bike from a profile — its saved loadout in every section, and the active-bike
+/// pointer if it was the one.
+///
+/// The bike picker is a view of `profile.ini`, not of the mods folder, so a bike whose mod
+/// was deleted long ago still sits in the list with nothing in the Library to uninstall.
+#[tauri::command]
+fn presets_forget_bike(
+    app: tauri::AppHandle,
+    profile: String,
+    bikeid: String,
+) -> Result<Vec<String>, String> {
+    let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
+    let dir = cfg.profiles_dir();
+    presets::forget_bike(&dir, &profile, &bikeid).map_err(|e| format!("{e:#}"))?;
+    presets::list_bikes(&dir, &profile).map_err(|e| format!("{e:#}"))
+}
+
 /// Which cosmetic slots this profile actually has, in `profile.ini` order.
 ///
 /// The two games don't offer the same ones — GP Bikes has no goggles, boots or
@@ -6717,6 +6734,7 @@ fn main() {
             shop_catalog_refresh,
             presets_list_profiles,
             presets_list_bikes,
+            presets_forget_bike,
             presets_read_loadout,
             presets_slots,
             list_games,

--- a/src-tauri/src/presets.rs
+++ b/src-tauri/src/presets.rs
@@ -245,6 +245,25 @@ impl IniDoc {
         }
     }
 
+    /// Drop `key` from `section`, if it's there. Every other line is left as it was.
+    ///
+    /// Case-insensitive on the key: the game is not consistent about the case of a bike id
+    /// between `[info] bikeid` and the columns keyed by it.
+    pub(crate) fn remove(&mut self, section: &str, key: &str) -> bool {
+        let Some((h, end)) = self.section_span(section) else {
+            return false;
+        };
+        for idx in (h + 1)..end {
+            if let Some(eq) = self.lines[idx].find('=') {
+                if self.lines[idx][..eq].trim().eq_ignore_ascii_case(key) {
+                    self.lines.remove(idx);
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     /// Every section header in the file, in the order they appear.
     ///
     /// This is what lets the app read a `profile.ini` it has no hardcoded knowledge of.
@@ -485,6 +504,45 @@ pub fn apply_loadout(
         if !loadout.race_number.trim().is_empty() {
             doc.set("info", "race_number", &loadout.race_number);
         }
+    }
+
+    fs::write(&path, encode_ini(&doc.render(), was_utf8))
+        .with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
+/// Drop every trace of one bike from a profile.
+///
+/// The bike picker lists what `profile.ini` carries, not what's installed — the game adds a
+/// column for every bike the rider has ever sat on and never removes one, so bikes whose mod
+/// is long gone still fill the list and the Library, which only sees `mods/bikes`, has nothing
+/// to delete. This is the only place they can be removed from.
+///
+/// Sections come from the file rather than [`SLOT_SECTIONS`]: any section keyed by bike id
+/// counts, including ones only GP Bikes or a future patch writes. Miss one and the bike is
+/// still in the list afterwards, since [`bikes_in`] reads whichever section it finds.
+pub fn forget_bike(profiles_dir: &Path, profile: &str, bikeid: &str) -> anyhow::Result<()> {
+    let path = profile_ini_path(profiles_dir, profile);
+    let bytes = fs::read(&path).with_context(|| format!("reading {}", path.display()))?;
+
+    // Same rolling backup as `apply_loadout` — raw bytes, so it stays byte-identical.
+    let bak = PathBuf::from(format!("{}.bak", path.display()));
+    let _ = fs::write(&bak, &bytes);
+
+    let (text, was_utf8) = decode_ini(&bytes);
+    let mut doc = IniDoc::parse(&text);
+    for section in doc.sections() {
+        if is_slot_section(&section) {
+            doc.remove(&section, bikeid);
+        }
+    }
+    // Never leave the game pointed at a column that no longer exists.
+    if doc
+        .get("info", "bikeid")
+        .is_some_and(|b| b.trim().eq_ignore_ascii_case(bikeid))
+    {
+        let next = bikes_in(&doc).first().cloned().unwrap_or_default();
+        doc.set("info", "bikeid", &next);
     }
 
     fs::write(&path, encode_ini(&doc.render(), was_utf8))
@@ -861,6 +919,65 @@ BSB23_Ducati_V4R=BS_Racing_Battlax
         assert_eq!(doc.get("info", "bikeid").as_deref(), Some("KTM250"));
         assert_eq!(doc.get("info", "race_number").as_deref(), Some("7"));
         assert!(root.join("profiles/main/profile.ini.bak").is_file());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn forgetting_a_bike_clears_its_columns_and_leaves_the_others() {
+        let root = tmp("forget");
+        let ini = write_sample(&root, "main");
+        let profiles = root.join("profiles");
+
+        forget_bike(&profiles, "main", "KTM250").unwrap();
+
+        assert_eq!(list_bikes(&profiles, "main").unwrap(), vec!["YZ450F"]);
+        let doc = IniDoc::parse(&fs::read_to_string(&ini).unwrap());
+        for section in ["paint", "helmet", "helmet_paint", "rider", "tyres"] {
+            assert_eq!(doc.get(section, "KTM250"), None, "[{section}] still has the bike");
+        }
+        // The bike that stays keeps every value it had.
+        let other = read_loadout(&profiles, "main", "YZ450F").unwrap();
+        assert_eq!(other.paint, "RedBud");
+        assert_eq!(other.helmet, "Fox");
+        assert_eq!(other.helmet_paint, "CLUTCH");
+        // And the pre-change file is recoverable.
+        assert!(root.join("profiles/main/profile.ini.bak").is_file());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// Sections are read from the file, so one this app has no name for goes too — otherwise
+    /// `bikes_in` finds the bike again and forgetting it looks like it did nothing.
+    #[test]
+    fn forgetting_clears_sections_the_app_has_no_name_for() {
+        let root = tmp("forget-extra");
+        let ini = write_ini(
+            &root,
+            "main",
+            &format!("{GP_SAMPLE}\n[visor_tint]\nBSB23_Ducati_V4R=Smoke\n"),
+        );
+        let profiles = root.join("profiles");
+
+        forget_bike(&profiles, "main", "BSB23_Ducati_V4R").unwrap();
+
+        assert!(list_bikes(&profiles, "main").unwrap().is_empty());
+        let doc = IniDoc::parse(&fs::read_to_string(&ini).unwrap());
+        assert_eq!(doc.get("visor_tint", "BSB23_Ducati_V4R"), None);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn forgetting_the_active_bike_repoints_the_profile() {
+        let root = tmp("forget-active");
+        let profiles = root.join("profiles");
+        write_sample(&root, "main");
+
+        // YZ450F is the active one in the sample.
+        forget_bike(&profiles, "main", "YZ450F").unwrap();
+        assert_eq!(active_bike(&profiles, "main").as_deref(), Some("KTM250"));
+
+        // Forgetting the last bike leaves nothing to point at rather than a dangling id.
+        forget_bike(&profiles, "main", "KTM250").unwrap();
+        assert_eq!(active_bike(&profiles, "main"), None);
         let _ = fs::remove_dir_all(&root);
     }
 

--- a/src/Components/Presets/Presets.tsx
+++ b/src/Components/Presets/Presets.tsx
@@ -41,6 +41,7 @@ import {
   onModsChanged,
   presetsListProfiles,
   presetsListBikes,
+  presetsForgetBike,
   presetsReadLoadout,
   presetsSlots,
   presetsApply,
@@ -143,6 +144,11 @@ export default function Presets({
   const [profile, setProfile] = useState<string>("");
   const [bikes, setBikes] = useState<string[]>([]);
   const [bike, setBike] = useState<string>("");
+  // Controlled so the trash on a row can shut the picker before its dialog opens —
+  // an open Select and an open Dialog fight over focus.
+  const [bikeMenuOpen, setBikeMenuOpen] = useState(false);
+  /** The bike the "forget this bike" dialog is about, if it's up. */
+  const [forgetBike, setForgetBike] = useState<string | null>(null);
   const [scans, setScans] = useState<Scans | null>(null);
   const [loadout, setLoadout] = useState<Loadout>(EMPTY_LOADOUT);
   const [saved, setSaved] = useState<Preset[]>([]);
@@ -215,6 +221,27 @@ export default function Presets({
       cancelled = true;
     };
   }, [profile]);
+
+  /** Drop a bike's column from `profile.ini` and re-point the picker at what's left. */
+  const doForgetBike = useCallback(
+    async (target: string) => {
+      setBusy(true);
+      try {
+        const left = await presetsForgetBike(profile, target);
+        setBikes(left);
+        setBike((b) => (b === target ? left[0] ?? "" : b));
+        setForgetBike(null);
+        toast.success(t("presets.bikeForgotten", { name: target }));
+      } catch (e) {
+        toast.error(t("presets.forgetFailed"), {
+          description: String(e).replace(/^Error:\s*/, ""),
+        });
+      } finally {
+        setBusy(false);
+      }
+    },
+    [profile, t],
+  );
 
   const capture = useCallback(async () => {
     if (!profile || !bike) return;
@@ -469,13 +496,43 @@ export default function Presets({
                 <span className="text-[11px] font-medium text-muted-foreground">
                   {t("slotGroup.bike")}
                 </span>
-                <Select value={bike} onValueChange={setBike}>
+                <Select
+                  value={bike}
+                  onValueChange={setBike}
+                  open={bikeMenuOpen}
+                  onOpenChange={setBikeMenuOpen}
+                >
                   <SelectTrigger>
                     <SelectValue placeholder={t("slotGroup.bike")} />
                   </SelectTrigger>
                   <SelectContent>
                     {bikes.map((b) => (
-                      <SelectItem key={b} value={b}>
+                      <SelectItem
+                        key={b}
+                        value={b}
+                        trailing={
+                          <button
+                            type="button"
+                            title={t("presets.forgetBike")}
+                            aria-label={t("presets.forgetBikeOne", { name: b })}
+                            className="rounded p-1 text-faint opacity-60 transition-colors hover:bg-destructive/15 hover:text-destructive hover:opacity-100"
+                            // Radix selects a row on pointer-up (mouse) or click (keyboard),
+                            // both of which bubble from here — so neither may reach it.
+                            onPointerUp={(e) => e.stopPropagation()}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              e.preventDefault();
+                              setBikeMenuOpen(false);
+                              // A tick later: a closing Select hands focus back to its
+                              // trigger, which would yank it straight out of a dialog
+                              // mounted in the same commit.
+                              setTimeout(() => setForgetBike(b), 0);
+                            }}
+                          >
+                            <Trash2 className="size-3.5" />
+                          </button>
+                        }
+                      >
                         {b}
                       </SelectItem>
                     ))}
@@ -668,6 +725,30 @@ export default function Presets({
         onConfirm={() => void commitSave()}
         onCancel={() => setConfirmOpen(false)}
       />
+      <Dialog open={Boolean(forgetBike)} onOpenChange={(o) => !o && setForgetBike(null)}>
+        <DialogContent className="max-w-[420px]">
+          <DialogHeader>
+            <DialogTitle>{t("presets.forgetBikeQ")}</DialogTitle>
+            <DialogDescription>
+              {t("presets.forgetBikeBody", { name: forgetBike ?? "" })}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" size="sm" onClick={() => setForgetBike(null)}>
+              {t("common.cancel")}
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={busy}
+              onClick={() => forgetBike && void doForgetBike(forgetBike)}
+            >
+              <Trash2 className="size-3.5" />
+              {t("presets.forgetBike")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       <ShareDialog preset={sharePreset} onClose={() => setSharePreset(null)} />
       <ImportDialog
         open={importOpen}

--- a/src/Components/ui/select.tsx
+++ b/src/Components/ui/select.tsx
@@ -57,12 +57,18 @@ SelectContent.displayName = "SelectContent";
 
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item> & {
+    /** A control pinned to the right of the row — a row action, not part of the value.
+     *  Kept outside `ItemText` on purpose: Radix clones that into the closed trigger, so
+     *  anything in there would show up next to the selected value too. */
+    trailing?: React.ReactNode;
+  }
+>(({ className, children, trailing, ...props }, ref) => (
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
       "relative flex w-full cursor-default select-none items-center rounded-md py-1.5 pl-8 pr-2 text-[12.5px] outline-none focus:bg-foreground/[0.06] data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      trailing && "pr-8",
       className,
     )}
     {...props}
@@ -73,6 +79,9 @@ const SelectItem = React.forwardRef<
       </SelectPrimitive.ItemIndicator>
     </span>
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    {trailing && (
+      <span className="absolute right-1.5 flex items-center">{trailing}</span>
+    )}
   </SelectPrimitive.Item>
 ));
 SelectItem.displayName = "SelectItem";

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -1985,6 +1985,16 @@ export function presetsListBikes(profile: string): Promise<string[]> {
   return invoke<string[]>("presets_list_bikes", { profile });
 }
 
+/**
+ * Drop a bike from a profile and return what's left.
+ *
+ * The list above is `profile.ini`, not the mods folder, so bikes whose mod is gone linger
+ * there with nothing in the Library to uninstall. This is how they go.
+ */
+export function presetsForgetBike(profile: string, bikeid: string): Promise<string[]> {
+  return invoke<string[]>("presets_forget_bike", { profile, bikeid });
+}
+
 /** Read a bike's current cosmetic column (for "capture current look"). */
 export function presetsReadLoadout(
   profile: string,

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -137,6 +137,13 @@ export const de: Translation = {
   "presets.help":
     "Speichere einen kompletten Fahrer-Look und lade ihn auf Kommando auf ein Motorrad.",
   "presets.profile": "Profil",
+  "presets.forgetBike": "Bike entfernen",
+  "presets.forgetBikeOne": "{{name}} aus diesem Profil entfernen",
+  "presets.forgetBikeQ": "Dieses Bike entfernen?",
+  "presets.forgetBikeBody":
+    "„{{name}}“ verschwindet aus der Bike-Liste dieses Profils, samt dem dafür gespeicherten Look. Installiertes wird nicht gelöscht — fährst du das Bike wieder, trägt das Spiel es sofort erneut ein.",
+  "presets.bikeForgotten": "„{{name}}“ aus diesem Profil entfernt.",
+  "presets.forgetFailed": "Bike konnte nicht entfernt werden",
   "presets.namePlaceholder": "Preset-Name…",
   "presets.savePreset": "Preset speichern",
   "presets.saveChanges": "Änderungen speichern",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -129,6 +129,13 @@ export const en = {
   "presets.help":
     "Save a full rider look and load it onto a bike on command.",
   "presets.profile": "Profile",
+  "presets.forgetBike": "Remove bike",
+  "presets.forgetBikeOne": "Remove {{name}} from this profile",
+  "presets.forgetBikeQ": "Remove this bike?",
+  "presets.forgetBikeBody":
+    "“{{name}}” leaves this profile’s bike list, along with the look saved for it. Nothing installed is deleted — if you ride that bike again the game adds it straight back.",
+  "presets.bikeForgotten": "Removed “{{name}}” from this profile.",
+  "presets.forgetFailed": "Couldn’t remove that bike",
   "presets.namePlaceholder": "Preset name…",
   "presets.savePreset": "Save preset",
   "presets.saveChanges": "Save changes",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -132,6 +132,13 @@ export const es: Translation = {
   "presets.help":
     "Guarda un look completo de piloto y cárgalo en una moto cuando quieras.",
   "presets.profile": "Perfil",
+  "presets.forgetBike": "Quitar moto",
+  "presets.forgetBikeOne": "Quitar {{name}} de este perfil",
+  "presets.forgetBikeQ": "¿Quitar esta moto?",
+  "presets.forgetBikeBody":
+    "“{{name}}” desaparece de la lista de motos de este perfil, junto con el aspecto guardado para ella. No se borra nada instalado: si vuelves a rodar con esa moto, el juego la añade otra vez.",
+  "presets.bikeForgotten": "“{{name}}” quitada de este perfil.",
+  "presets.forgetFailed": "No se pudo quitar esa moto",
   "presets.namePlaceholder": "Nombre del preset…",
   "presets.savePreset": "Guardar preset",
   "presets.saveChanges": "Guardar cambios",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -134,6 +134,13 @@ export const fr: Translation = {
   "presets.help":
     "Enregistrez un look de pilote complet et chargez-le sur une moto à la demande.",
   "presets.profile": "Profil",
+  "presets.forgetBike": "Retirer la moto",
+  "presets.forgetBikeOne": "Retirer {{name}} de ce profil",
+  "presets.forgetBikeQ": "Retirer cette moto ?",
+  "presets.forgetBikeBody":
+    "« {{name}} » quitte la liste des motos de ce profil, avec le look enregistré pour elle. Rien d’installé n’est supprimé : si vous roulez de nouveau avec cette moto, le jeu la remet aussitôt.",
+  "presets.bikeForgotten": "« {{name}} » retirée de ce profil.",
+  "presets.forgetFailed": "Impossible de retirer cette moto",
   "presets.namePlaceholder": "Nom du preset…",
   "presets.savePreset": "Enregistrer le preset",
   "presets.saveChanges": "Enregistrer les modifications",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -132,6 +132,13 @@ export const it: Translation = {
   "presets.help":
     "Salva un look completo del pilota e caricalo su una moto quando vuoi.",
   "presets.profile": "Profilo",
+  "presets.forgetBike": "Rimuovi moto",
+  "presets.forgetBikeOne": "Rimuovi {{name}} da questo profilo",
+  "presets.forgetBikeQ": "Rimuovere questa moto?",
+  "presets.forgetBikeBody":
+    "“{{name}}” sparisce dall’elenco moto di questo profilo, insieme all’aspetto salvato per lei. Non viene eliminato nulla di installato: se torni a guidarla, il gioco la riaggiunge subito.",
+  "presets.bikeForgotten": "“{{name}}” rimossa da questo profilo.",
+  "presets.forgetFailed": "Impossibile rimuovere la moto",
   "presets.namePlaceholder": "Nome del preset…",
   "presets.savePreset": "Salva preset",
   "presets.saveChanges": "Salva modifiche",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -135,6 +135,13 @@ export const ptBR: Translation = {
   "presets.help":
     "Salve um visual completo do piloto e carregue numa moto quando quiser.",
   "presets.profile": "Perfil",
+  "presets.forgetBike": "Remover moto",
+  "presets.forgetBikeOne": "Remover {{name}} deste perfil",
+  "presets.forgetBikeQ": "Remover esta moto?",
+  "presets.forgetBikeBody":
+    "“{{name}}” sai da lista de motos deste perfil, junto com o visual salvo para ela. Nada instalado é apagado — se você pilotar essa moto de novo, o jogo a adiciona outra vez.",
+  "presets.bikeForgotten": "“{{name}}” removida deste perfil.",
+  "presets.forgetFailed": "Não foi possível remover essa moto",
   "presets.namePlaceholder": "Nome do preset…",
   "presets.savePreset": "Salvar preset",
   "presets.saveChanges": "Salvar alterações",


### PR DESCRIPTION
## Why

The **Bike** picker on the Presets tab isn't a list of installed mods — `presets::list_bikes` reads the bike-id keys out of `profiles/<name>/profile.ini`, and the game writes a column there for every bike the rider has ever sat on and never removes one. The Library only scans `mods/bikes`, so a bike whose mod was deleted long ago sits in the picker forever with nothing to uninstall anywhere in the app.

## What

- `presets::forget_bike` — rolls a `profile.ini.bak` of the raw bytes first (same backup `apply_loadout` keeps), drops the bike from **every** section the file has rather than the fifteen named ones, and repoints `[info] bikeid` when it named the bike being dropped. Latin-1 profiles round-trip byte-for-byte.

  Sections come from the file because `bikes_in` reads whichever bike-keyed section it finds — miss a GP Bikes or future one and the bike is still in the list afterwards.
- `presets_forget_bike` command, returning the bikes that are left.
- A trash can on each row of the Bike picker, behind a confirm dialog. `SelectItem` grows a `trailing` slot for row actions, kept outside `ItemText` so Radix doesn't clone it next to the selected value in the closed trigger. Radix selects a row on the item's own `onClick`/`onPointerUp`, so the button stops both.
- Strings in all six locales.

It's offered on every bike, not only uninstalled ones: OEM bikes live inside the game's locked archive and never appear in `mods/bikes`, so an "is it installed" test would wrongly flag them. The dialog carries the caveat instead — the saved look is cleared, nothing installed is deleted, and riding that bike again adds it back.

## Verified

- Three new tests: columns cleared and siblings untouched, sections the app has no name for cleared, active bike repointed (and the last bike leaving no dangling id).
- `cargo test presets`, `tsc`, `bun run build` clean; clippy adds no new warnings.
- The click itself needs a real window — this Mac blocks both screen capture and accessibility into the webview.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)