### PR TITLE
feat(paints): push a paint saved on disk into the running game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026-08-20
+
+### Added
+- **A paint saved on disk shows up in the running game.** The game reads your look once,
+  when the profile loads, so painting used to mean save, alt-tab, reselect your profile,
+  look, repeat — and mid-session there was no way to see a change at all. The app now
+  watches the `.pnt` files the rider is actually wearing (the bike's paint and font, and
+  every piece of gear) and, when one is rewritten, re-runs the game's own look loader in
+  place. Same call the Locker and presets already make, gated on the same **Instant
+  refresh** setting, so there is nothing new to switch on.
+- **Paints that arrive mid-session are applied without a rejoin.** Paint sync already
+  installed other riders' liveries while you rode and then left them sitting on disk until
+  the next session. They now go into the running game the moment they land.
+
 ## 2026-08-19
 
 ### Fixed

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -67,7 +67,7 @@ use frostmod::ReloadOutcome;
 use frostmod_manage::{FrostmodProcess, FrostmodStatus, InstallReport};
 use library::InstalledMod;
 use modwatch::ModWatcher;
-use paintwatch::PaintWatcher;
+use paintwatch::{LookWatcher, PaintWatcher};
 // Decoding a paint's textures is per-texture CPU work over no shared state, and every path
 // that does it wants the same treatment — so this sits here rather than in one function.
 use rayon::prelude::*;
@@ -462,6 +462,122 @@ fn live_refresh(enabled: bool) -> gameproc::LiveRefresh {
     }
 }
 
+/// Shortest gap between two unattended look refreshes.
+///
+/// Every refresh is a thread started inside the running game, and the watcher that drives
+/// them fires without anyone asking. A painter saving repeatedly, or a sync pull landing
+/// half a grid's paints, would otherwise queue one call per event; this collapses that
+/// burst into one. Sized to outlast a save the debounce didn't already fold together,
+/// while still being imperceptible to someone waiting to see their paint.
+const LIVE_LOOK_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// When the last unattended refresh went out. Not shared with the apply paths — a refresh
+/// the player asked for by clicking is never worth withholding.
+static LAST_LIVE_LOOK: std::sync::Mutex<Option<std::time::Instant>> =
+    std::sync::Mutex::new(None);
+
+/// Has the cooldown passed? Records the attempt when it has, so two callers racing here
+/// produce one refresh.
+fn live_look_cooldown_passed() -> bool {
+    let now = std::time::Instant::now();
+    let mut last = LAST_LIVE_LOOK.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(at) = *last {
+        if now.duration_since(at) < LIVE_LOOK_COOLDOWN {
+            return false;
+        }
+    }
+    *last = Some(now);
+    true
+}
+
+/// Can a look change reach the running game at all?
+///
+/// Two things have to hold, and both are fixed for the life of the process. The title needs
+/// a loader offset ([`game::Caps::instant_refresh`]), and the call that uses it is Windows'
+/// alone — under Wine or Proton the game is a Windows binary but we are not the one that can
+/// start a thread in it. Asked before watching as well as before firing, so a platform that
+/// could never act on a save doesn't hold OS watch handles waiting for one.
+fn can_refresh_live_look() -> bool {
+    cfg!(windows) && game::active().caps.instant_refresh
+}
+
+/// Push a look that changed on disk into the running game.
+///
+/// The trigger nobody clicked: a `.pnt` rewritten under the player's feet, or paints pulled
+/// from the control plane mid-session. Everything else about it is the apply paths' refresh
+/// — the same loader call, gated on the same Instant refresh setting, because that setting
+/// already means "put look changes into the live game" and this is another way one arrives.
+///
+/// Silent when there is nothing to do: no game, no setting, or a title whose loader we don't
+/// have an offset for. Only a real attempt is logged, so the log answers "did it fire, and
+/// what did the game say" — which is the question a first Windows run has to settle.
+fn refresh_live_look(app: &tauri::AppHandle) {
+    if !can_refresh_live_look() {
+        return;
+    }
+    let cfg = config::load_or_detect(app).unwrap_or_default();
+    if !cfg.instant_refresh || !gameproc::is_game_running() {
+        return;
+    }
+    if !live_look_cooldown_passed() {
+        log::debug!("[look] a refresh went out moments ago; folding this one into it");
+        return;
+    }
+    log::info!("[look] refreshing the live game: {:?}", gameproc::refresh_look());
+}
+
+/// The `.pnt` files the game is wearing right now — the bike's own paint and font, and every
+/// piece of gear on the rider.
+///
+/// Read through the same resolver an upload uses, so a paint packed in a `.pkz`, sitting
+/// loose beside it, or living under the rider profile is found the same way here as
+/// everywhere else. [`bundle::plan_detailed`] rather than `plan`, for the reason Manage
+/// needs it too: `plan` collapses a gear paint into the model folder that contains it, and a
+/// folder is not a file to watch. Only the *active* bike — the others aren't on screen, and
+/// re-running the game's loader for a paint nobody can see is a thread started for nothing.
+///
+/// Empty whenever the look can't be read — no profile, no bike, an unreadable `profile.ini`.
+/// That stops the watcher rather than failing anything; the next `profile.ini` write rebuilds
+/// it.
+fn worn_paints(cfg: &AppConfig) -> Vec<String> {
+    let profiles_dir = cfg.profiles_dir();
+    let Some(profile) = sync_profile(cfg) else {
+        return Vec::new();
+    };
+    let Some(bike) = presets::active_bike(&profiles_dir, &profile) else {
+        return Vec::new();
+    };
+    let Ok(loadout) = presets::read_loadout(&profiles_dir, &profile, &bike) else {
+        return Vec::new();
+    };
+    let Ok(plan) = bundle::plan_detailed(cfg, &loadout) else {
+        return Vec::new();
+    };
+    plan.assets
+        .iter()
+        .filter(|a| !a.is_dir && paintsync::is_paint(std::path::Path::new(&a.abs_path)))
+        .map(|a| a.abs_path.clone())
+        .collect()
+}
+
+/// Point the look watcher at whatever the rider is wearing now, replacing what it watched
+/// before. Called from every path that can change the answer, and cheap enough to be: one
+/// `profile.ini` parse and one library walk.
+fn watch_worn_paints(app: &tauri::AppHandle) {
+    if !can_refresh_live_look() {
+        return;
+    }
+    let cfg = config::load_or_detect(app).unwrap_or_default();
+    let paths = worn_paints(&cfg);
+    let handle = app.clone();
+    paintwatch::start_with(
+        &app.state::<LookWatcher>().0,
+        "look watcher",
+        &paths,
+        move |_changed| refresh_live_look(&handle),
+    );
+}
+
 /// Ask FrostMod to re-apply `bike` so a just-swapped model shows live. `None` when
 /// instant refresh is off — the same switch that gates `live_refresh`, since both
 /// reach into the running game.
@@ -519,6 +635,9 @@ fn apply_model_swap_blocking(
     // inside FrostMod, which is the only side that knows). Gated on the same
     // instant-refresh setting as the look refresh — both poke the live game.
     let model_refresh = model_refresh_cmd(&app, cfg.instant_refresh, &bike);
+    // A different model can resolve a slot to a different file, so the look watcher has to
+    // follow the swap — nothing writes `profile.ini` here for it to notice on its own.
+    watch_worn_paints(&app);
     Ok(SwapApplyOutcome {
         content_reload,
         game_running: gameproc::is_game_running(),
@@ -3917,11 +4036,12 @@ fn set_profiles_path(app: tauri::AppHandle, path: String) -> Result<(), String> 
     let mut cfg = config::load(&app).unwrap_or_default();
     cfg.profiles_path = path;
     config::save(&app, &cfg).map_err(|e| format!("{e:#}"))?;
-    // The watcher is pinned to a folder that just moved; re-point it, and publish in case
-    // the new folder's look differs from what the old one last sent.
-    if cfg.experimental_enabled() {
+    // Both watchers are pinned to a folder that just moved; re-point them, and publish in
+    // case the new folder's look differs from what the old one last sent.
+    if watches_looks(&cfg) {
         let profiles = app.state::<ProfileWatcher>();
         profilewatch::start(&app, &profiles, &cfg.profiles_dir());
+        watch_worn_paints(&app);
         publish_paints_soon(&app, &cfg, None);
     }
     Ok(())
@@ -4157,7 +4277,7 @@ fn set_experimental(app: tauri::AppHandle, enabled: bool) -> Result<(), String> 
     // whole session. That is the session a player has just enrolled in, which makes it the
     // worst one to be quietly missing.
     let watcher = app.state::<ProfileWatcher>();
-    if cfg.experimental_enabled() {
+    if watches_looks(&cfg) {
         profilewatch::start(&app, &watcher, &cfg.profiles_dir());
         // And publish once now, since nothing has been watching until this moment.
         publish_paints_soon(&app, &cfg, None);
@@ -4424,6 +4544,20 @@ pub fn publish_look_now(app: &tauri::AppHandle) {
     publish_paints_soon(app, &cfg, None);
 }
 
+/// Is a look change worth noticing? Paint sync publishes them, and the look watcher rebuilds
+/// on them — either one is reason enough to watch `profile.ini`.
+fn watches_looks(cfg: &AppConfig) -> bool {
+    cfg.experimental_enabled() || can_refresh_live_look()
+}
+
+/// The rider is wearing something different: re-point the look watcher at the new files, and
+/// publish. One entry point rather than two calls at every site, because forgetting the
+/// re-point leaves the watcher holding the paints of a look nobody is in any more.
+pub fn look_changed(app: &tauri::AppHandle) {
+    watch_worn_paints(app);
+    publish_look_now(app);
+}
+
 fn emit_sync(app: &tauri::AppHandle, event: SyncEvent) {
     if let Err(e) = app.emit(SYNC_EVENT, event) {
         log::warn!("[sync] couldn't tell the UI: {e}");
@@ -4579,6 +4713,11 @@ fn live_sync_session(app: &tauri::AppHandle, address: Option<String>) {
                 Ok(o) if o.installed > 0 => {
                     log::info!("[sync] {} new paints mid-session", o.installed);
                     emit_sync(&app, SyncEvent::pulled(&o));
+                    // The files are on disk but the game read its grid when it built it.
+                    // Same loader call a save on disk gets, for the same reason: a rider
+                    // who is already out there shouldn't have to rejoin to stop seeing
+                    // default liveries.
+                    refresh_live_look(&app);
                 }
                 Ok(_) => {}
                 Err(e) => log::debug!("[sync] live pull failed: {e}"),
@@ -6318,6 +6457,7 @@ fn main() {
         .manage(ModWatcher::default())
         .manage(ProfileWatcher::default())
         .manage(PaintWatcher::default())
+        .manage(LookWatcher::default())
         .manage(CloudServers::default())
         .manage(shop_session::ShopSession::default())
         .manage(voice::Monitor::default())
@@ -6486,12 +6626,19 @@ fn main() {
                 //  * publish, because the look may have changed in the game's garage while
                 //    the app was shut, and nothing would ever have noticed;
                 //  * watch, so the same change during this session is noticed as it happens.
-                // Both no-op unless the experimental features are on and an account exists.
+                // The publish no-ops unless the experimental features are on and an account
+                // exists; the watching is also what keeps the look watcher pointed at the
+                // right files, which has nothing to do with sync.
                 if cfg.experimental_enabled() {
                     publish_paints_soon(handle, &cfg, None);
+                }
+                if watches_looks(&cfg) {
                     let profiles = handle.state::<ProfileWatcher>();
                     profilewatch::start(handle, &profiles, &cfg.profiles_dir());
                 }
+                // And watch the paints the rider is wearing, so saving one over the top
+                // while the game runs reaches the game.
+                watch_worn_paints(handle);
                 // A combo another app already owns shouldn't stop the app from starting
                 // — Settings reports the state and lets the player pick another.
                 if let Err(e) = overlay::register(handle, &cfg) {
@@ -8776,4 +8923,104 @@ mod viewer_tests {
     }
 }
 
+#[cfg(test)]
+mod live_look_tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
 
+    fn tmp(name: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("frost-look-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        d
+    }
+
+    fn touch(p: &Path) {
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(p, b"x").unwrap();
+    }
+
+    /// A profile wearing a bike paint and a helmet paint, plus a helmet model and a tyre
+    /// set that are emphatically not paints.
+    fn fixture(root: &Path) -> AppConfig {
+        touch(&root.join("mods/bikes/KTM450/paints/RedBud.pnt"));
+        touch(&root.join("mods/bikes/KTM450/paints/Southwick.pnt")); // owned, not worn
+        touch(&root.join("mods/rider/helmets/AGV/AGV.pkz"));
+        touch(&root.join("mods/rider/helmets/AGV/paints/Blue.pnt"));
+        touch(&root.join("mods/tyres/oem_mx.pkz"));
+        touch(&root.join("profiles/Frost/profile.ini"));
+        std::fs::write(
+            root.join("profiles/Frost/profile.ini"),
+            "[info]\nbikeid = KTM450\n\n\
+             [paint]\nKTM450 = RedBud\n\n\
+             [helmet]\nKTM450 = AGV\n\n\
+             [helmet_paint]\nKTM450 = Blue\n\n\
+             [tyres]\nKTM450 = oem_mx\n",
+        )
+        .unwrap();
+        AppConfig {
+            mods_path: root.to_string_lossy().into_owned(),
+            profiles_path: root.join("profiles").to_string_lossy().into_owned(),
+            ..Default::default()
+        }
+    }
+
+    /// The set the watcher is pointed at: every `.pnt` the active bike is wearing, and
+    /// nothing else. A helmet's mesh and a tyre archive are resolved by the same plan and
+    /// must not become watches — re-running the game's loader can't change a mesh, so a
+    /// watch on one is a thread started for nothing.
+    #[test]
+    fn only_the_paints_the_active_bike_is_wearing_are_watched() {
+        let root = tmp("worn");
+        let cfg = fixture(&root);
+
+        let mut names: Vec<String> = worn_paints(&cfg)
+            .iter()
+            .map(|p| Path::new(p).file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+
+        assert_eq!(names, vec!["Blue.pnt".to_string(), "RedBud.pnt".to_string()]);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A profile that names a paint nobody installed leaves nothing to watch, rather than
+    /// leaving the watcher pointed at the last look the rider was in.
+    #[test]
+    fn a_look_that_resolves_to_nothing_watches_nothing() {
+        let root = tmp("empty");
+        let cfg = fixture(&root);
+        std::fs::write(
+            root.join("profiles/Frost/profile.ini"),
+            "[info]\nbikeid = KTM450\n\n[paint]\nKTM450 = A Paint Nobody Has\n",
+        )
+        .unwrap();
+
+        assert!(worn_paints(&cfg).is_empty());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// No profile, no bike, no `profile.ini` — every one of these is an ordinary state for
+    /// a fresh install to be in, and none of them may panic on the way to an empty answer.
+    #[test]
+    fn an_unreadable_look_is_an_empty_answer_not_a_panic() {
+        let root = tmp("unreadable");
+        std::fs::create_dir_all(root.join("profiles")).unwrap();
+        let cfg = AppConfig {
+            mods_path: root.to_string_lossy().into_owned(),
+            profiles_path: root.join("profiles").to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+        assert!(worn_paints(&cfg).is_empty());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The cooldown is what keeps a burst of saves — or half a grid's paints landing at
+    /// once — from becoming a queue of threads started inside the running game.
+    #[test]
+    fn a_burst_gets_one_refresh() {
+        assert!(live_look_cooldown_passed(), "the first one always goes");
+        for _ in 0..5 {
+            assert!(!live_look_cooldown_passed(), "the rest fold into it");
+        }
+    }
+}

--- a/src-tauri/src/paintsync.rs
+++ b/src-tauri/src/paintsync.rs
@@ -52,6 +52,14 @@ pub fn control_plane() -> String {
 /// non-paint slots carry a file a receiver could use.
 const PAINT_EXT: &str = "pnt";
 
+/// Does this path name a paint? Extension only — the bytes are the decoder's business.
+pub fn is_paint(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case(PAINT_EXT))
+        .unwrap_or(false)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PaintEntry {
@@ -304,12 +312,7 @@ fn paints_of(
             continue;
         }
         let path = Path::new(&asset.abs_path);
-        let is_paint = path
-            .extension()
-            .and_then(|e| e.to_str())
-            .map(|e| e.eq_ignore_ascii_case(PAINT_EXT))
-            .unwrap_or(false);
-        if !is_paint {
+        if !is_paint(path) {
             continue;
         }
         // A slot the control plane does not store is not worth failing a publish over.

--- a/src-tauri/src/paintwatch.rs
+++ b/src-tauri/src/paintwatch.rs
@@ -1,9 +1,18 @@
-//! Notice when a paint the 3D viewer is showing gets rewritten on disk.
+//! Notice when a paint gets rewritten on disk, and tell whoever is wearing it.
 //!
 //! A painter's loop is draw, look at it on the model, fix, look again. The "look" step used
 //! to mean closing the viewer and opening it again, because the app read the `.pnt` once and
-//! never asked after it. This watches the file the viewer is currently dressed in and says
-//! when it changes; the frontend re-decodes it and re-dresses the model.
+//! never asked after it. This watches the files it is pointed at and says when they change.
+//!
+//! There are two things that can be dressed in a paint, so there are two watch sets:
+//!
+//! * [`PaintWatcher`] — the paint the 3D viewer is showing. The frontend re-decodes it and
+//!   re-dresses the model.
+//! * [`LookWatcher`] — the paints the *game* is wearing. `main` pushes those into the
+//!   running game by re-running its own look loader.
+//!
+//! Both are the same machinery over a different question, which is why [`start_with`] takes
+//! what to do rather than doing it.
 //!
 //! Two decisions worth keeping:
 //!
@@ -17,10 +26,10 @@
 //!   name is enough. Comparing whole paths would mean out-guessing whatever the OS
 //!   canonicalises them to (`/private/var` on macOS, 8.3 names on Windows) for nothing.
 //!
-//! Scope is deliberately narrow — [`start`] replaces the whole watch set each time, because
-//! there is one viewer and it shows one paint. Unlike `modwatch` there is no settling: a
-//! paint is a single file, the debounce below outlasts writing one, and the caller re-tries
-//! a decode that lands mid-write anyway.
+//! Each set is replace-the-whole-thing rather than add/remove: a viewer shows one paint and
+//! a rider wears one look, so nothing can leak a watch by forgetting to take one back.
+//! Unlike `modwatch` there is no settling: a paint is a single file, the debounce below
+//! outlasts writing one, and the caller re-tries a decode that lands mid-write anyway.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -41,8 +50,9 @@ const DEBOUNCE: Duration = Duration::from_millis(400);
 /// compare it against the one it asked to watch.
 pub const EVENT: &str = "paint-changed";
 
-/// Upper bound on watched files. The viewer shows one paint; this only exists so a caller
-/// that goes wrong can't turn into a fistful of OS watch handles.
+/// Upper bound on watched files per set. The viewer shows one paint and a look is a bike
+/// paint plus its gear — well inside this. It exists so a caller that goes wrong can't turn
+/// into a fistful of OS watch handles.
 const MAX_WATCHED: usize = 16;
 
 #[derive(Clone, serde::Serialize)]
@@ -59,9 +69,19 @@ pub struct Running {
     live: Arc<AtomicBool>,
 }
 
-/// Tauri-managed handle. `None` when nothing is being previewed.
+/// One replaceable set of folder watches. `None` when the set is empty.
 #[derive(Default)]
-pub struct PaintWatcher(pub Mutex<Option<Running>>);
+pub struct WatchSet(pub Mutex<Option<Running>>);
+
+/// Tauri-managed handle for the viewer's paint. `None` when nothing is being previewed.
+#[derive(Default)]
+pub struct PaintWatcher(pub WatchSet);
+
+/// Tauri-managed handle for the paints the game is wearing. A separate set because the two
+/// answer different questions and change at different times — the viewer's on every preview,
+/// this one only when the loadout does.
+#[derive(Default)]
+pub struct LookWatcher(pub WatchSet);
 
 /// The file name a path ends in, lowercased — what an event is matched on.
 fn file_key(path: &Path) -> Option<String> {
@@ -113,15 +133,20 @@ fn changed_paints(watched: &[String], events: &[PathBuf]) -> Vec<String> {
     out
 }
 
-/// Watch `paths`, replacing whatever was being watched before. An empty list just stops.
+/// Watch `paths`, replacing whatever `set` was watching before. An empty list just stops.
+///
+/// `on_change` is handed every watched path a debounced batch named, at most once each.
+/// Taking it as an argument is what lets one piece of machinery serve both the viewer and
+/// the game — the watching is identical, only the answer differs.
 ///
 /// Best-effort throughout, as the other watchers are: a folder that isn't there or refuses
-/// a watch costs the live reload for that paint, not the viewer.
-/// Generic over the runtime so the tests below can drive it with Tauri's mock one — the
-/// thing worth proving here is that a real save on a real folder comes back out as an
-/// event, and that needs a genuine watcher and a handle to emit through.
-pub fn start<R: Runtime>(app: &AppHandle<R>, state: &PaintWatcher, paths: &[String]) {
-    stop(state);
+/// a watch costs the live reload for that paint, not the caller.
+/// `label` prefixes the log lines, so two sets running at once stay tellable apart.
+pub fn start_with<F>(set: &WatchSet, label: &'static str, paths: &[String], on_change: F)
+where
+    F: Fn(Vec<String>) + Send + 'static,
+{
+    stop(set);
     let folders = by_folder(paths);
     if folders.is_empty() {
         return;
@@ -132,7 +157,6 @@ pub fn start<R: Runtime>(app: &AppHandle<R>, state: &PaintWatcher, paths: &[Stri
     let watched: Vec<String> = folders.values().flatten().cloned().collect();
     let live = Arc::new(AtomicBool::new(true));
     let alive = live.clone();
-    let handle = app.clone();
 
     let mut debouncer = match new_debouncer(DEBOUNCE, move |res: DebounceEventResult| {
         if !alive.load(Ordering::SeqCst) {
@@ -140,14 +164,18 @@ pub fn start<R: Runtime>(app: &AppHandle<R>, state: &PaintWatcher, paths: &[Stri
         }
         let Ok(events) = res else { return };
         let seen: Vec<PathBuf> = events.into_iter().map(|e| e.path).collect();
-        for path in changed_paints(&watched, &seen) {
-            log::info!("paint watcher: {path} changed on disk");
-            let _ = handle.emit(EVENT, Changed { path });
+        let changed = changed_paints(&watched, &seen);
+        if changed.is_empty() {
+            return;
         }
+        for path in &changed {
+            log::info!("{label}: {path} changed on disk");
+        }
+        on_change(changed);
     }) {
         Ok(d) => d,
         Err(e) => {
-            log::warn!("paint watcher: couldn't start: {e}");
+            log::warn!("{label}: couldn't start: {e}");
             return;
         }
     };
@@ -159,22 +187,36 @@ pub fn start<R: Runtime>(app: &AppHandle<R>, state: &PaintWatcher, paths: &[Stri
         match debouncer.watcher().watch(dir, RecursiveMode::NonRecursive) {
             Ok(()) => {
                 any = true;
-                log::info!("paint watcher: watching {}", dir.display());
+                log::info!("{label}: watching {}", dir.display());
             }
-            Err(e) => log::warn!("paint watcher: couldn't watch {}: {e}", dir.display()),
+            Err(e) => log::warn!("{label}: couldn't watch {}: {e}", dir.display()),
         }
     }
     if !any {
         return;
     }
-    *state.0.lock().unwrap_or_else(|e| e.into_inner()) = Some(Running {
+    *set.0.lock().unwrap_or_else(|e| e.into_inner()) = Some(Running {
         _debouncer: debouncer,
         live,
     });
 }
 
-pub fn stop(state: &PaintWatcher) {
-    if let Some(running) = state.0.lock().unwrap_or_else(|e| e.into_inner()).take() {
+/// Watch the paints the 3D viewer is showing, announcing each change to the frontend.
+///
+/// Generic over the runtime so the tests below can drive it with Tauri's mock one — the
+/// thing worth proving here is that a real save on a real folder comes back out as an
+/// event, and that needs a genuine watcher and a handle to emit through.
+pub fn start<R: Runtime>(app: &AppHandle<R>, state: &PaintWatcher, paths: &[String]) {
+    let handle = app.clone();
+    start_with(&state.0, "paint watcher", paths, move |changed| {
+        for path in changed {
+            let _ = handle.emit(EVENT, Changed { path });
+        }
+    });
+}
+
+pub fn stop(set: &WatchSet) {
+    if let Some(running) = set.0.lock().unwrap_or_else(|e| e.into_inner()).take() {
         running.live.store(false, Ordering::SeqCst);
     }
 }
@@ -247,6 +289,47 @@ mod tests {
         assert_eq!(changed_paints(&watched, &burst), owned(&["/mx/paints/Frost.pnt"]));
     }
 
+    /// The two sets are genuinely separate. `start_with` replaces the set it is given and
+    /// nothing else — if it reached the other one, opening the viewer would quietly stop the
+    /// game's paints being watched, and the feature would work until the moment a painter
+    /// looked at what they were painting.
+    #[test]
+    fn one_set_does_not_stop_the_other() {
+        let dir = std::env::temp_dir().join(format!("frost-two-sets-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("make the paints folder");
+        let paint = dir.join("Frost.pnt");
+        std::fs::write(&paint, b"first").expect("install a paint");
+        let watched = paint.to_string_lossy().to_string();
+
+        let viewer = WatchSet::default();
+        let look = WatchSet::default();
+        start_with(&viewer, "viewer", std::slice::from_ref(&watched), |_| {});
+
+        let fired: Arc<Mutex<usize>> = Arc::default();
+        let counter = Arc::clone(&fired);
+        start_with(&look, "look", std::slice::from_ref(&watched), move |changed| {
+            *counter.lock().unwrap() += changed.len();
+        });
+
+        // Both sets hold a live watch on the same folder; neither took the other's away.
+        assert!(viewer.0.lock().unwrap().is_some(), "the viewer's set is still watching");
+        assert!(look.0.lock().unwrap().is_some(), "the look set is watching");
+
+        std::thread::sleep(Duration::from_millis(300));
+        std::fs::write(&paint, b"second").expect("save over it");
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while *fired.lock().unwrap() == 0 && std::time::Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        let hits = *fired.lock().unwrap();
+        stop(&viewer);
+        stop(&look);
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(hits > 0, "a save must reach the callback the caller supplied");
+    }
+
     fn mock_app() -> tauri::App<tauri::test::MockRuntime> {
         tauri::test::mock_builder()
             .build(tauri::test::mock_context(tauri::test::noop_assets()))
@@ -297,7 +380,7 @@ mod tests {
             }
             std::thread::sleep(Duration::from_millis(50));
         };
-        stop(&state);
+        stop(&state.0);
         let payloads = seen.lock().unwrap().clone();
         let _ = std::fs::remove_dir_all(&dir);
 

--- a/src-tauri/src/profilewatch.rs
+++ b/src-tauri/src/profilewatch.rs
@@ -5,6 +5,10 @@
 //! MX Bikes writes the same `profile.ini` the app does, so the file itself is the signal —
 //! there just wasn't anything listening to it.
 //!
+//! It has a second reader now: the look watcher in `main` follows the paints the rider is
+//! wearing, and `profile.ini` is the file that says which those are. A change here re-points
+//! it — see `crate::look_changed`.
+//!
 //! `modwatch` deliberately stays out of `profiles/`, and its reasoning still holds: that
 //! folder churns all through a session with replays, telemetry and settings, and a watcher
 //! reacting to all of it would fire constantly mid-race. This one is not that watcher. It
@@ -80,7 +84,7 @@ pub fn start(app: &AppHandle, state: &ProfileWatcher, profiles_dir: &Path) {
         // Which profile changed is not passed on: a rider has one identity, and
         // `publish_paints_soon` resolves it the same way every other caller does.
         log::info!("profile watcher: a look changed on disk");
-        crate::publish_look_now(&app_handle);
+        crate::look_changed(&app_handle);
     }) {
         Ok(d) => d,
         Err(e) => {


### PR DESCRIPTION
## What

MX Bikes reads your look once, when the profile loads. Overwrite a `.pnt` while the game is up and nothing changes until you reselect your profile — mid-session, nothing at all.

The app already had the hard half: `gameproc::refresh_look()` re-runs the game's own customization loader in the live process, and it reloads bike paints, rider paints and gear. Only two things called it — applying a preset, and swapping in the Locker. Nothing watched the paint files themselves.

This adds the missing trigger.

- Watches the `.pnt` files the rider is **actually wearing** — bike paint and font, helmet, goggles, suit, boots, gloves, protection — resolved through `bundle::plan_detailed` (not `plan`, which collapses a gear paint into the model folder that contains it, and a folder is not a file to watch). Only the active bike.
- On a change, re-runs the look loader. Same call, same **Instant refresh** setting — no new toggle, no new locale strings.
- Also fires after a mid-session paint sync pull, so a teammate's livery lands without a rejoin.
- A 2s cooldown collapses a burst of saves into one loader call, and the whole path is off where it could never work (non-Windows; titles with no loader offset).

`paintwatch` grows a second watch set rather than a second module — `start_with` takes what to do, so the viewer and the game share the folder-watch machinery that already survives save-by-rename. `profilewatch` re-points the set on every `profile.ini` write, which is what the game writes when the rider changes kit in its own garage.

## Verification

- `cargo test --locked` — 804 pass, 5 new: the worn-paint set resolves to exactly the `.pnt`s in play (a helmet mesh and a tyre archive resolve alongside them and must not become watches); an unresolvable look watches nothing rather than keeping the last one; an unreadable look is an empty answer, not a panic; the cooldown folds a burst into one; the two watch sets don't stop each other.
- `cargo check --target x86_64-pc-windows-gnu` — clean, so the `cfg(windows)` half a macOS build skips is type-checked.

## Known open

Whether the loader re-dresses a bike **already spawned on track**, or only at the next spawn. That can't be answered from macOS. Every fire logs its outcome (`[look] refreshing the live game: …`), so the first Windows run settles it. If it turns out to land only at the next spawn, the CHANGELOG wording needs softening before this reaches a release.

Separately: this does **not** touch the bike mesh. A model swap still needs re-selecting the bike — see FrostMod v0.9.11, which removed the descriptor-replay that tried it and crashed the game at the next hand-picked bike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)