### PR TITLE
fix(diagnostics): record how the game ends, and warn when mods aren't on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 2026-08-20
+
+### Added
+- **The app records how the game ended, not just that it ended.** Until now the only thing
+  watching MX Bikes was a process-table poll, which can say the game is gone and nothing
+  else — a clean quit and a crash on the loading screen looked identical in the log. A
+  handle is now held on the running game, so its exit code and true session length survive
+  it: a clean quit logs as one, and a crash logs `[session] game CRASHED after 4.1s` with
+  the exception named. `STATUS_IN_PAGE_ERROR` is called out by name, because that is what a
+  file the game had mapped but could not read looks like.
+- **A warning when the mods folder isn't really on disk.** OneDrive, Dropbox and iCloud can
+  leave a file looking completely ordinary while its contents still live on a server. MX
+  Bikes reads the mods tree during the load screen, memory-mapped, so a placeholder whose
+  fetch is slow or refused surfaces there as a crash with nothing in any log to explain it.
+  The app now checks the tree when a session starts and names the count, the provider and a
+  few of the files. It only ever reads attributes — never opens a placeholder, which is what
+  would trigger a download.
+
+### Fixed
+- **Steam's own runtime no longer reports as suspicious.** `tier0_s64.dll` and
+  `vstdlib_s64.dll` are loaded into every Steam game from the Steam install, which is
+  neither the game folder nor the system folder, so every scan on every machine ended with
+  two Suspect findings against a rule list holding no signatures. Two false positives on
+  every single run is how people learn to ignore a verdict.
+- **Log timestamps are local time.** They were UTC while FrostMod's log is local, so reading
+  the two side by side meant holding a timezone offset in your head, and support threads
+  were getting it wrong.
+
 ## 2026-08-19
 
 ### Fixed

--- a/src-tauri/src/cloudfiles.rs
+++ b/src-tauri/src/cloudfiles.rs
@@ -1,0 +1,211 @@
+//! Notice when the mods folder isn't really on disk.
+//!
+//! OneDrive, Dropbox and iCloud all offer the same trick: a file that looks completely
+//! ordinary in Explorer — right name, right size — while its bytes still live on a server.
+//! Windows calls these placeholders, and reading one is supposed to be transparent: the
+//! filter driver fetches the content and the read succeeds, a little late.
+//!
+//! "A little late" is the problem. MX Bikes reads the mods tree during the load screen,
+//! memory-mapped and on the critical path, and a placeholder whose fetch is slow, offline
+//! or refused surfaces there as a failed read of a mapped page — `STATUS_IN_PAGE_ERROR`,
+//! which is a crash, not an error message. From the player's side the game "just crashes on
+//! the loading screen", with nothing in any log to say why, and it recurs for as long as
+//! the file stays evicted.
+//!
+//! The app is already watching this folder ([`crate::modwatch`]) and already knows when a
+//! session starts ([`crate::integritywatch`]), so it is in a position to answer the question
+//! before the crash rather than after: are these files actually here?
+//!
+//! Note what this deliberately does **not** do. It never opens a placeholder, because
+//! opening one is what triggers the download — a scan that hydrated the folder would turn a
+//! diagnostic into a multi-gigabyte surprise. It only ever asks for attributes, which the
+//! filter driver answers from metadata it already has.
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+
+/// Event name the UI listens on.
+pub const EVENT: &str = "mods-dehydrated";
+
+/// Only content files matter. A placeholder `readme.txt` is nobody's crash.
+const CONTENT_EXTENSIONS: [&str; 4] = ["pkz", "pnt", "edf", "sav"];
+
+/// Stop walking after this many files. A mods tree in the thousands is normal and the
+/// answer does not get truer past this point — one placeholder is already the whole story.
+const MAX_FILES: usize = 20_000;
+
+/// How deep to walk. Deep enough for `mods/tracks/<name>/<files>` and a level of slack.
+const MAX_DEPTH: usize = 6;
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Dehydrated {
+    /// How many content files are placeholders rather than real bytes.
+    pub count: usize,
+    /// How many content files were looked at, so `count` has a denominator.
+    pub scanned: usize,
+    /// A few names, to make the warning concrete rather than a number.
+    pub examples: Vec<String>,
+    /// Whether the tree sits under a recognisable sync root, which changes the advice.
+    pub provider: Option<String>,
+}
+
+/// Check the mods tree in the background and warn if any of it isn't really there.
+///
+/// Fire-and-forget by design: this runs as the game is starting, and must not add a step
+/// to the Play button under any circumstance.
+pub fn warn_if_dehydrated(app: &AppHandle, cfg: &crate::config::AppConfig) {
+    let root = crate::library::mods_root(&cfg.mods_path);
+    let app = app.clone();
+    std::thread::spawn(move || {
+        let found = scan(&root);
+        if found.count == 0 {
+            return;
+        }
+        let provider = found.provider.clone().unwrap_or_else(|| "a cloud sync tool".into());
+        log::warn!(
+            "[cloud] {} of {} mod file(s) under {} are placeholders, not real files — {provider} \
+             has evicted them. The game reads these during the load screen and can crash there \
+             (in-page error). Fix: right-click the folder in Explorer and choose \
+             \"Always keep on this device\", or move the folder out of {provider}. Examples: {}",
+            found.count,
+            found.scanned,
+            root.display(),
+            found.examples.join(", ")
+        );
+        let _ = app.emit(EVENT, &found);
+    });
+}
+
+/// Walk `root` and count content files that are placeholders.
+fn scan(root: &std::path::Path) -> Dehydrated {
+    let mut out = Dehydrated { provider: provider_of(root), ..Default::default() };
+    let mut stack = vec![(root.to_path_buf(), 0usize)];
+    while let Some((dir, depth)) = stack.pop() {
+        if depth > MAX_DEPTH || out.scanned >= MAX_FILES {
+            continue;
+        }
+        let Ok(entries) = std::fs::read_dir(&dir) else { continue };
+        for entry in entries.flatten() {
+            if out.scanned >= MAX_FILES {
+                break;
+            }
+            let path = entry.path();
+            // `file_type` reads the directory entry we already have — it does not open
+            // the file, so it cannot trigger a download.
+            let Ok(kind) = entry.file_type() else { continue };
+            if kind.is_dir() {
+                stack.push((path, depth + 1));
+                continue;
+            }
+            if !is_content(&path) {
+                continue;
+            }
+            out.scanned += 1;
+            if !is_placeholder(&path) {
+                continue;
+            }
+            out.count += 1;
+            if out.examples.len() < 5 {
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    out.examples.push(name.to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+fn is_content(path: &std::path::Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .is_some_and(|e| CONTENT_EXTENSIONS.contains(&e.as_str()))
+}
+
+/// Name the sync tool from the path, so the advice can name it too. `None` when the folder
+/// is somewhere unrecognised — a placeholder there is still a placeholder.
+fn provider_of(root: &std::path::Path) -> Option<String> {
+    let lower = root.to_string_lossy().to_ascii_lowercase();
+    for (needle, name) in [
+        ("onedrive", "OneDrive"),
+        ("dropbox", "Dropbox"),
+        ("google drive", "Google Drive"),
+        ("icloud", "iCloud Drive"),
+        ("creative cloud", "Creative Cloud"),
+    ] {
+        if lower.contains(needle) {
+            return Some(name.to_string());
+        }
+    }
+    None
+}
+
+/// Is this file a placeholder rather than real bytes?
+///
+/// Three attributes, because the providers do not agree on one:
+///
+///   * `RECALL_ON_DATA_ACCESS` — the modern per-file placeholder (OneDrive Files On-Demand).
+///   * `RECALL_ON_OPEN` — the older whole-file variant.
+///   * `OFFLINE` — set by classic HSM tools, and still what some providers use.
+#[cfg(windows)]
+fn is_placeholder(path: &std::path::Path) -> bool {
+    use std::os::windows::ffi::OsStrExt;
+
+    const FILE_ATTRIBUTE_OFFLINE: u32 = 0x0000_1000;
+    const FILE_ATTRIBUTE_RECALL_ON_OPEN: u32 = 0x0004_0000;
+    const FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS: u32 = 0x0040_0000;
+    const INVALID_FILE_ATTRIBUTES: u32 = u32::MAX;
+
+    extern "system" {
+        fn GetFileAttributesW(name: *const u16) -> u32;
+    }
+
+    let wide: Vec<u16> = path.as_os_str().encode_wide().chain(std::iter::once(0)).collect();
+    // SAFETY: `wide` is a NUL-terminated UTF-16 path that outlives the call. This reads
+    // metadata only — it never opens the file, so it cannot trigger a hydration.
+    let attrs = unsafe { GetFileAttributesW(wide.as_ptr()) };
+    if attrs == INVALID_FILE_ATTRIBUTES {
+        return false;
+    }
+    attrs
+        & (FILE_ATTRIBUTE_OFFLINE
+            | FILE_ATTRIBUTE_RECALL_ON_OPEN
+            | FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS)
+        != 0
+}
+
+/// The crash this exists to catch is a Windows one. macOS has the same idea (iCloud
+/// dataless files, `SF_DATALESS`) and it is worth reading there eventually, but the
+/// reports driving this are all Windows.
+#[cfg(not(windows))]
+fn is_placeholder(_path: &std::path::Path) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_content_extensions_are_counted() {
+        assert!(is_content(std::path::Path::new("a/b/bike.pkz")));
+        assert!(is_content(std::path::Path::new("a/b/PAINT.PNT")));
+        assert!(!is_content(std::path::Path::new("a/b/readme.txt")));
+        assert!(!is_content(std::path::Path::new("a/b/noext")));
+    }
+
+    #[test]
+    fn the_provider_is_named_from_the_path() {
+        let p = std::path::Path::new("C:/Users/x/OneDrive/Documents/PiBoSo/MX Bikes/mods");
+        assert_eq!(provider_of(p).as_deref(), Some("OneDrive"));
+        assert_eq!(provider_of(std::path::Path::new("D:/Games/mods")), None);
+    }
+
+    #[test]
+    fn a_real_folder_reports_nothing_dehydrated() {
+        // Whatever else is true of the temp dir, nothing in it is a cloud placeholder.
+        let found = scan(&std::env::temp_dir());
+        assert_eq!(found.count, 0);
+    }
+}

--- a/src-tauri/src/gameproc.rs
+++ b/src-tauri/src/gameproc.rs
@@ -66,6 +66,16 @@ mod ffi {
     /// blur the very distinction [`super::steam_elevation_conflict`] reads out of it.
     pub const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
 
+    /// Enough to wait on a process handle. Paired with
+    /// `PROCESS_QUERY_LIMITED_INFORMATION` it is the whole access set
+    /// [`super::GameSession`] needs, and it is granted on a process of our own user
+    /// without elevation.
+    pub const SYNCHRONIZE: u32 = 0x0010_0000;
+
+    /// `WaitForSingleObject` said the handle is signalled — for a process handle, that
+    /// means the process has exited.
+    pub const WAIT_OBJECT_0: u32 = 0x0000_0000;
+
     pub const TOKEN_QUERY: u32 = 0x0008;
     /// `TokenElevation` in `TOKEN_INFORMATION_CLASS`.
     pub const TOKEN_ELEVATION_CLASS: i32 = 20;
@@ -129,6 +139,21 @@ mod ffi {
         pub sz_exe_file: [c_char; 260],
     }
 
+    /// A Windows `FILETIME` — 100-nanosecond ticks since 1601, split across two `u32`s
+    /// because the struct is not guaranteed to be 8-byte aligned.
+    #[repr(C)]
+    #[derive(Default, Clone, Copy)]
+    pub struct FileTime {
+        pub low: u32,
+        pub high: u32,
+    }
+
+    impl FileTime {
+        pub fn ticks(self) -> u64 {
+            ((self.high as u64) << 32) | self.low as u64
+        }
+    }
+
     #[repr(C)]
     pub struct ModuleEntry32 {
         pub dw_size: u32,
@@ -160,6 +185,16 @@ mod ffi {
             thread_id: *mut u32,
         ) -> Handle;
         pub fn WaitForSingleObject(handle: Handle, ms: u32) -> u32;
+        pub fn GetExitCodeProcess(process: Handle, exit_code: *mut u32) -> i32;
+        /// Creation and exit stamps, so a session's length is the kernel's own answer
+        /// rather than the gap between two of our polls.
+        pub fn GetProcessTimes(
+            process: Handle,
+            creation: *mut FileTime,
+            exit: *mut FileTime,
+            kernel: *mut FileTime,
+            user: *mut FileTime,
+        ) -> i32;
         pub fn CloseHandle(handle: Handle) -> i32;
         pub fn GetCurrentProcessId() -> u32;
         /// A pseudo-handle for our own process — a constant, not a handle to close.
@@ -293,6 +328,143 @@ fn module_base(pid: u32) -> Option<*mut u8> {
 #[cfg(windows)]
 pub fn is_game_running() -> bool {
     find_game_pid().is_some()
+}
+
+/// A handle held on the running game so that *how it ended* survives it.
+///
+/// Without this the app watches the game through a process-table poll, which can only ever
+/// report presence: the game is there, and then it isn't. That is the same observation
+/// whether the player quit or the process died on an access violation, and support threads
+/// were being argued from logs that could not tell those apart.
+///
+/// A handle opened while the process is alive keeps the exit code readable after it is
+/// gone, and `GetProcessTimes` keeps the session's true length — so a crash four seconds
+/// into a load reads as one, instead of as "somewhere inside the last poll interval".
+#[cfg(windows)]
+pub struct GameSession {
+    handle: ffi::Handle,
+    pid: u32,
+}
+
+#[cfg(windows)]
+impl GameSession {
+    /// Take a handle to the game if it is up. `None` if it isn't, or if the handle is
+    /// refused — which is not worth surfacing, since the only cost is a session whose
+    /// ending we can't describe.
+    pub fn open() -> Option<Self> {
+        let pid = find_game_pid()?;
+        // SAFETY: `pid` came from a process snapshot; the handle is closed in `Drop`.
+        let handle = unsafe {
+            ffi::OpenProcess(ffi::SYNCHRONIZE | ffi::PROCESS_QUERY_LIMITED_INFORMATION, 0, pid)
+        };
+        if handle.is_null() {
+            log::debug!("[session] couldn't hold a handle on pid {pid}: exit code won't be readable");
+            return None;
+        }
+        Some(Self { handle, pid })
+    }
+
+    /// `Some(code)` once the process is gone, `None` while it is still up.
+    fn exit_code(&self) -> Option<u32> {
+        // SAFETY: `self.handle` is live until `Drop`. A zero timeout polls without blocking.
+        unsafe {
+            if ffi::WaitForSingleObject(self.handle, 0) != ffi::WAIT_OBJECT_0 {
+                return None;
+            }
+            let mut code = 0u32;
+            if ffi::GetExitCodeProcess(self.handle, &mut code) == 0 {
+                return Some(u32::MAX);
+            }
+            Some(code)
+        }
+    }
+
+    /// How long the process lived, straight from the kernel.
+    fn lifetime(&self) -> Option<std::time::Duration> {
+        let (mut created, mut exited) = (ffi::FileTime::default(), ffi::FileTime::default());
+        let (mut kernel, mut user) = (ffi::FileTime::default(), ffi::FileTime::default());
+        // SAFETY: `self.handle` is live and carries `PROCESS_QUERY_LIMITED_INFORMATION`.
+        let ok = unsafe {
+            ffi::GetProcessTimes(self.handle, &mut created, &mut exited, &mut kernel, &mut user)
+        };
+        let (created, exited) = (created.ticks(), exited.ticks());
+        // A still-running process reports a zero exit stamp.
+        if ok == 0 || exited <= created {
+            return None;
+        }
+        // FILETIME counts 100ns ticks.
+        Some(std::time::Duration::from_nanos((exited - created) * 100))
+    }
+
+    /// If the game has ended, say how, and consume the session. `None` means it's still up.
+    ///
+    /// The severity is the point: a clean quit is `info` and a crash is `warn`, so the one
+    /// question a support log has to answer is answerable by grep.
+    pub fn report_if_ended(self) -> Option<Self> {
+        // Deliberately not `?`: that would drop `self` — and with it the handle — every
+        // poll the game is still up, so the exit code would never be readable.
+        let Some(code) = self.exit_code() else { return Some(self) };
+        let lived = self
+            .lifetime()
+            .map(|d| format!("{:.1}s", d.as_secs_f64()))
+            .unwrap_or_else(|| "unknown".into());
+        let pid = self.pid;
+        match describe_exit(code) {
+            None => log::info!("[session] game exited cleanly after {lived} (pid {pid})"),
+            Some(what) => log::warn!(
+                "[session] game CRASHED after {lived} — {what} (exit 0x{code:08X}, pid {pid})"
+            ),
+        }
+        None
+    }
+}
+
+// SAFETY: a Windows `HANDLE` belongs to the process, not to the thread that opened it —
+// it stays valid in any thread and `CloseHandle` may be called from any of them. The
+// handle is owned solely by this struct, so there is no aliasing to race over. Needed
+// because the watcher that holds a session is an async task, which may be resumed on a
+// different worker thread across an `.await`.
+#[cfg(windows)]
+unsafe impl Send for GameSession {}
+
+#[cfg(windows)]
+impl Drop for GameSession {
+    fn drop(&mut self) {
+        // SAFETY: opened in `open`, closed exactly once here.
+        unsafe { ffi::CloseHandle(self.handle) };
+    }
+}
+
+/// Name the NTSTATUS values a game actually dies on. `None` means "not a crash".
+///
+/// Exit code 0 is a clean quit. Anything with the high bit set is an unhandled exception
+/// the loader turned into an exit code, and those names are the difference between a
+/// diagnosable report and "it crashed".
+#[cfg(windows)]
+fn describe_exit(code: u32) -> Option<&'static str> {
+    Some(match code {
+        0 => return None,
+        // The one that matters most here: a memory-mapped read that the filesystem could
+        // not satisfy. A cloud-backed file that is a placeholder rather than real bytes
+        // fails exactly this way, which is why the mods folder gets checked at launch.
+        0xC000_0006 => "in-page error — a file the game had mapped couldn't be read (cloud placeholder, failing disk, or removed media)",
+        0xC000_0005 => "access violation",
+        0xC000_001D => "illegal instruction",
+        0xC000_0025 => "non-continuable exception",
+        0xC000_008C => "array bounds exceeded",
+        0xC000_008E => "float divide by zero",
+        0xC000_0094 => "integer divide by zero",
+        0xC000_00FD => "stack overflow",
+        0xC000_0135 => "a required DLL was not found",
+        0xC000_0142 => "a DLL failed to initialise",
+        0xC000_0374 => "heap corruption",
+        0xC000_0409 => "stack buffer overrun",
+        0xC000_0017 => "out of memory",
+        0x8000_0003 => "breakpoint (a debug build or an attached debugger)",
+        u32::MAX => "exit code unreadable",
+        // Anything else non-zero is still an abnormal exit worth seeing.
+        _ => "abnormal exit",
+    })
 }
 
 /// Read a fixed-size NUL-padded ANSI field as a `String`, stopping at the terminator.
@@ -709,6 +881,23 @@ pub fn game_modules() -> GameModules {
 #[cfg(not(windows))]
 pub fn refresh_look() -> LiveRefresh {
     LiveRefresh::Unsupported
+}
+
+/// Exit codes are a Windows story: the crash reports this exists to answer come from
+/// Windows machines, and neither Wine nor a dev build has the same notion of an NTSTATUS
+/// exit. The session opens as `None` and nothing else changes.
+#[cfg(not(windows))]
+pub struct GameSession;
+
+#[cfg(not(windows))]
+impl GameSession {
+    pub fn open() -> Option<Self> {
+        None
+    }
+
+    pub fn report_if_ended(self) -> Option<Self> {
+        None
+    }
 }
 
 /// No game to focus on a dev machine — the overlay just stays a normal window.

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -341,7 +341,7 @@ fn is_sha256(s: &str) -> bool {
 /// otherwise make the first scan on an ordinary gaming PC produce a page of findings.
 /// Everything here loads from somewhere the path rules don't already cover: an overlay
 /// injects from its own install, which is exactly the shape a cheat has.
-const BUNDLED_ALLOW: [&str; 25] = [
+const BUNDLED_ALLOW: [&str; 29] = [
     // Steam: the overlay is injected into every game Steam starts.
     "gameoverlayrenderer64.dll",
     "gameoverlayrenderer.dll",
@@ -350,6 +350,14 @@ const BUNDLED_ALLOW: [&str; 25] = [
     "steam_api64.dll",
     "steam_api.dll",
     "steamoverlayvulkanlayer64.dll",
+    // Valve's own runtime, which `steamclient` pulls in from the Steam install rather than
+    // from the game folder or the system folder. Missing these made every scan on every
+    // Steam machine report two Suspect findings — the shape of a false positive that
+    // teaches people to ignore the verdict.
+    "tier0_s64.dll",
+    "vstdlib_s64.dll",
+    "tier0.dll",
+    "vstdlib.dll",
     // Discord's in-game overlay.
     "discordhook64.dll",
     "discordhook.dll",

--- a/src-tauri/src/integritywatch.rs
+++ b/src-tauri/src/integritywatch.rs
@@ -214,6 +214,9 @@ pub fn start(app: &AppHandle) {
         // scanner's own view, which the `integrityWatch` switch is allowed to reset.
         let mut was_running = false;
         let mut scanned = false;
+        // A handle on the current session, held so that how it ended is still readable
+        // once the process is gone. See [`crate::gameproc::GameSession`].
+        let mut session: Option<crate::gameproc::GameSession> = None;
         loop {
             let cfg = crate::config::load_or_detect(&app).unwrap_or_default();
 
@@ -221,11 +224,22 @@ pub fn start(app: &AppHandle) {
             let started = running && !was_running;
             was_running = running;
 
+            // Checked every pass, not only when the poll says the game is gone: the handle
+            // is what knows the process ended, and it knows it exactly.
+            if let Some(open) = session.take() {
+                session = open.report_if_ended();
+            }
+
             // Above the `integrityWatch` gate deliberately: re-arming FrostMod has nothing
             // to do with cheat scanning, and someone who turned the scanner off has not
             // asked for FrostMod to stop working.
             if started {
                 crate::frostmod_manage::on_game_started(&app, &cfg);
+                session = crate::gameproc::GameSession::open();
+                // The mods folder is read during the load screen, so a placeholder that
+                // isn't really on disk becomes a crash there. Ask now, while there is
+                // still a log line to attach the answer to.
+                crate::cloudfiles::warn_if_dehydrated(&app, &cfg);
             }
 
             if !cfg.integrity_watch {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,6 +7,7 @@ mod bikeswap;
 mod bundle;
 mod cancel;
 mod cfg;
+mod cloudfiles;
 mod config;
 mod cookie_session;
 mod downloads;
@@ -6293,6 +6294,10 @@ fn main() {
         .plugin(
             tauri_plugin_log::Builder::new()
                 .level(log_level())
+                // Local time, not UTC. FrostMod's log is stamped in local time, and a
+                // support thread that has to hold a timezone offset in its head while
+                // reading the two side by side gets read wrong.
+                .timezone_strategy(tauri_plugin_log::TimezoneStrategy::UseLocal)
                 .targets([
                     tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),
                     tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir {


### PR DESCRIPTION
Came out of a support case: a player's game "keeps crashing and won't load", and neither our app log nor the FrostMod log recorded a single thing about why. Both logs together came to 17.4 MB and could not answer the one question they existed to answer.

## What was missing

The only thing watching MX Bikes was a process-table poll, which can report presence and nothing else — so a clean quit and a crash on the loading screen were the *same observation*. Support threads were being argued from logs that could not tell those apart. The app also logged four `launching MX Bikes` lines in that session and never noticed the process died.

## Changes

**`GameSession`** (`gameproc.rs`) — holds a handle on the running game so its exit code outlives it, and takes the session length from `GetProcessTimes` so "crashed 4.1s in" reads as that rather than "somewhere inside the last poll interval". Clean quit logs `info`, a crash logs `warn` with the exception named. `STATUS_IN_PAGE_ERROR` is called out specifically — that is what a file the game had mapped but could not read looks like.

Wired into the **existing** integritywatch poll rather than adding a second one; that loop already tracks the game starting and stopping.

**`cloudfiles.rs`** (new) — OneDrive/Dropbox/iCloud can leave a file looking completely ordinary while its bytes still live on a server. MX Bikes reads the mods tree during the load screen, memory-mapped and on the critical path, so a placeholder whose fetch is slow or refused surfaces there as a crash with nothing in any log. This checks the tree when a session starts and names the count, the provider and a few files.

It reads attributes only and never opens a placeholder — opening one is what triggers the download, so a scan that hydrated the folder would turn a diagnostic into a multi-gigabyte surprise.

**Two fixes** — `tier0_s64.dll` and `vstdlib_s64.dll` allowlisted (Valve's runtime loads into every Steam game from the Steam install, so every scan on every machine ended with two Suspect findings against a rule list holding *no signatures* — two false positives per run is how people learn to ignore a verdict); and log timestamps moved to local time, which is what FrostMod uses, so the two logs line up.

## Verification

- `cargo check --target x86_64-pc-windows-gnu` clean — this type-checks the `cfg(windows)` half a host build skips entirely.
- 3 new `cloudfiles` tests pass.
- The Windows check caught two real bugs while writing this: the raw `HANDLE` isn't `Send` and was being held across an `.await`, and a `?` that would have dropped the session handle on every poll the game was still up. A bogus NTSTATUS constant was also removed.

**Not runtime-tested** — that needs a Windows machine.

## Note

This does not fix the player who prompted it: he crashes with the app off and FrostMod killed from Task Manager, so nothing here is even running. It makes the next one diagnosable. `cloudfiles` is the piece aimed at his class of problem, and it only fires while the app is up.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)