### PR TITLE
chore(supporters): credit three new supporters, honor the file's order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
 - **Paints that arrive mid-session are applied without a rejoin.** Paint sync already
   installed other riders' liveries while you rode and then left them sitting on disk until
   the next session. They now go into the running game the moment they land.
+- Three new supporters credited in Settings → Supporters: RodaksRevivalYT | Black Rifle,
+  MintyFlow and Thomas.
+
+### Changed
+- The supporters list now renders in the order `supporters.json` is written in, rather than
+  alphabetically within each tier — the file is hand-edited, so its order is a decision.
 
 ## Unreleased — taking back the DLL we planted
 

--- a/src/Components/Settings/supporters.ts
+++ b/src/Components/Settings/supporters.ts
@@ -65,6 +65,9 @@ export const BUNDLED_SUPPORTERS: SupportersManifest = {
     { name: "SoggySwisher" },
     { name: "LupaHo" },
     { name: "Qwest" },
+    { name: "RodaksRevivalYT | Black Rifle" },
+    { name: "MintyFlow" },
+    { name: "Thomas" },
     { name: "Kelso" },
   ],
 };
@@ -173,6 +176,9 @@ export interface TierGroup {
  * renaming one on Buy Me a Coffee degrades to "listed last" rather than "silently
  * dropped". People with no level — a one-off coffee — always come last, under a
  * generic heading.
+ *
+ * Within a level, people keep the order they're written in. The manifest is hand-edited,
+ * so that order is a decision somebody made; re-sorting here would quietly overrule it.
  */
 export function groupByTier(manifest: SupportersManifest): TierGroup[] {
   const buckets = new Map<string, Supporter[]>();
@@ -194,19 +200,8 @@ export function groupByTier(manifest: SupportersManifest): TierGroup[] {
 
   const groups: TierGroup[] = [...named, ...rest].map((tier) => ({
     tier,
-    people: sortPeople(buckets.get(tier) ?? []),
+    people: buckets.get(tier) ?? [],
   }));
-  if (untiered.length) groups.push({ tier: null, people: sortPeople(untiered) });
+  if (untiered.length) groups.push({ tier: null, people: untiered });
   return groups;
-}
-
-/** Longest-standing first, then alphabetical — seniority is the one ordering nobody
- *  can read as playing favourites. */
-function sortPeople(people: Supporter[]): Supporter[] {
-  return [...people].sort((a, b) => {
-    if (a.since && b.since && a.since !== b.since) return a.since < b.since ? -1 : 1;
-    if (a.since && !b.since) return -1;
-    if (!a.since && b.since) return 1;
-    return a.name.localeCompare(b.name);
-  });
 }

--- a/src/Components/Showcase/ShowcaseSupporters.tsx
+++ b/src/Components/Showcase/ShowcaseSupporters.tsx
@@ -27,8 +27,8 @@ export default function ShowcaseSupporters({ onOpen }: ShowcaseSupportersProps) 
   const { t } = useI18n();
   const { manifest } = useSupporters();
 
-  // Best tier first, longest-standing first within it — `groupByTier` already orders
-  // both, so flattening it keeps Settings and this strip naming the same people.
+  // Best tier first, manifest order within it — `groupByTier` already orders both, so
+  // flattening it keeps Settings and this strip naming the same people in the same order.
   const people = groupByTier(manifest).flatMap((g) => g.people);
   const count = people.length;
   // A fetch that legitimately returns nobody shouldn't leave "made possible by 0

--- a/supporters.json
+++ b/supporters.json
@@ -9,6 +9,9 @@
     "SoggySwisher",
     "LupaHo",
     "Qwest",
+    "RodaksRevivalYT | Black Rifle",
+    "MintyFlow",
+    "Thomas",
     "Kelso"
   ]
 }


### PR DESCRIPTION
## What

- Adds **RodaksRevivalYT | Black Rifle**, **MintyFlow** and **Thomas** to `supporters.json` and the bundled fallback list.
- Moves **Kelso** to the end of the list.
- `groupByTier` no longer re-sorts people within a tier.

## Why the code change

`sortPeople` fell back to alphabetical whenever nobody carried a `since` date — which is every entry today. That meant the hand-authored order in `supporters.json` was silently overruled, and Kelso would render second no matter where they sat in the file. The manifest is hand-edited, so its order is a decision; the renderer now respects it.

## Rollout

The JSON is fetched live off `main`, so the three new names appear in every installed copy as soon as this merges — no release needed. The ordering change is app code and only takes effect from the next release; until then existing installs keep sorting alphabetically.

## Notes

- `ShowcaseSupporters` only shows the first 5 names, so the three new entries land in the "+N more" count.
- Display names: Rodaks as the user wrote it, MintyFlow and Thomas from their Discord display names. Worth a sanity check that this is how they want to be credited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)