### PR TITLE
fix(servers): budget each bike by its size, and retry the ones that miss

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,57 @@ jobs:
       - name: Test
         run: npx vitest run
 
+  bootstrap-script:
+    # The one part of this repo that runs somewhere nobody can watch.
+    #
+    # Both scripts execute only as EC2 user-data on a Windows box with no console and no key
+    # pair, where every failure path ends in `Stop-Computer` and takes the transcript with it.
+    # They are also assembled by string interpolation -- a dozen escaped backticks and thirty
+    # escaped backslashes -- so a mis-escaped one produces PowerShell that is malformed rather
+    # than merely wrong, and `tsc` sees only a string either way. That is what this catches.
+    #
+    # It would not have caught the failures that actually lost builds so far: `-Tail -Raw` was
+    # an invalid parameter set, the hand-built `agent.json` was valid PowerShell holding invalid
+    # JSON, and `Start-BitsTransfer` failed at runtime. A parser sees none of those.
+    name: Bootstrap script (parse)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: control-plane/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ./control-plane
+
+      - name: Render the bootstrap scripts
+        run: npm run render:bootstrap -- "${{ runner.temp }}"
+        working-directory: ./control-plane
+
+      - name: Parse them with PowerShell
+        shell: pwsh
+        run: |
+          $bad = $false
+          foreach ($name in @("bootstrap.ps1", "image-bootstrap.ps1")) {
+            $path = Join-Path "${{ runner.temp }}" $name
+            $errors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile($path, [ref] $null, [ref] $errors) | Out-Null
+            if ($errors -and $errors.Count -gt 0) {
+              $bad = $true
+              Write-Host "::error file=control-plane/src/bootstrap.ts::$name does not parse"
+              foreach ($e in $errors) { Write-Host "  line $($e.Extent.StartLineNumber): $($e.Message)" }
+            } else {
+              Write-Host "$name parses"
+            }
+          }
+          if ($bad) { exit 1 }
+
   server-agent:
     name: Server agent (test)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,24 @@
 ## Unreleased — a stalled download no longer hangs a server build
 
 ### Fixed
-- **One stuck file could hang a build indefinitely.** Each bike is fetched with a time limit
-  and a stall detector now, so a transfer that stops sending costs that one bike rather than
-  the whole machine; `--retry` never helped, because a connection that stays open and goes
-  quiet is not a failure it can see.
+- **One stuck file could hang a build indefinitely.** Each bike now gets a download budget
+  scaled to its own size — the time 100 KB/s would need, and never less than five minutes —
+  alongside a stall detector, so a transfer that stops sending costs that one bike rather than
+  the whole machine. `--retry` never helped: a connection that stays open and goes quiet is not
+  a failure it can see. The flat five-minute cap this started as would have been its own bug —
+  the pack's two biggest bikes are 184 MB, so the slower the instance, the more certain it was
+  to drop exactly the OEM bikes somebody built the server for.
+- **A bike that misses gets a second pass**, and a build that still comes up short records which
+  ones went missing instead of reporting the same "installed" as a complete build.
 - **A build says how far through the bikes it is.** The step was announced once and then went
   silent for the length of a four gigabyte download, which is indistinguishable from having
   hung — and for three quarters of an hour, it was.
+
+### Changed
+- The two bootstrap scripts are rendered and parsed by PowerShell in CI. They run in exactly one
+  place — as user-data on a Windows instance with no console, where every failure path destroys
+  the evidence — and they are assembled by string interpolation, so a mis-escaped backtick is a
+  broken build nobody can see. A stage the control plane would reject is caught there too.
 
 ## 2026-08-20
 

--- a/control-plane/package-lock.json
+++ b/control-plane/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^5.20260801.1",
+        "tsx": "^4.23.12",
         "typescript": "^5.6.0",
         "vitest": "^2.1.0",
         "wrangler": "^4.120.0"
@@ -2226,6 +2227,509 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/control-plane/package.json
+++ b/control-plane/package.json
@@ -8,10 +8,12 @@
     "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit",
     "types": "wrangler types",
-    "test": "vitest run"
+    "test": "vitest run",
+    "render:bootstrap": "tsx scripts/render-bootstrap.ts"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260801.1",
+    "tsx": "^4.23.12",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0",
     "wrangler": "^4.120.0"

--- a/control-plane/scripts/render-bootstrap.ts
+++ b/control-plane/scripts/render-bootstrap.ts
@@ -1,0 +1,30 @@
+/**
+ * Render both bootstrap scripts to disk, so PowerShell itself can be asked whether they parse.
+ *
+ * These two scripts run in exactly one place -- as EC2 user-data on a Windows instance with no
+ * console and no key pair -- and every failure path ends in `Stop-Computer`, which destroys the
+ * evidence. Three builds have been lost to PowerShell mistakes that a parser would have caught
+ * in a second: `Get-Content -Tail N -Raw` (an invalid combination), and an `agent.json` built by
+ * hand whose `C:\mxb\game` was never valid JSON. Neither is a type error, so `tsc` sees nothing:
+ * to TypeScript this file is a string.
+ */
+import { writeFileSync } from "node:fs";
+import { bootstrapScript, imageBootstrapScript } from "../src/bootstrap.js";
+import type { BootstrapInputs } from "../src/bootstrap.js";
+
+const inputs: BootstrapInputs = {
+  agentToken: "ci-token",
+  agentUrl: "https://control-plane.example.com/v1/agent.exe",
+  gameUrl: "https://www.mxbikes.com/installer.exe",
+  // Deliberately not plain ASCII: the name is the operator's, it is interpolated into the
+  // script, and a non-Latin-1 one has broken a launch before.
+  serverName: "CI 🏁 server",
+  gamePort: 54210,
+  agentPort: 8787,
+  serverId: "srv_ci",
+  controlPlaneUrl: "https://control-plane.example.com",
+};
+
+const out = process.argv[2] ?? ".";
+writeFileSync(`${out}/bootstrap.ps1`, bootstrapScript(inputs));
+writeFileSync(`${out}/image-bootstrap.ps1`, imageBootstrapScript(inputs));

--- a/control-plane/src/bootstrap.ts
+++ b/control-plane/src/bootstrap.ts
@@ -288,27 +288,54 @@ try {
   $listing = Invoke-RestMethod -Uri "${input.controlPlaneUrl}/v1/content/bikes" -TimeoutSec 60
   $total = $listing.bikes.Count
   $count = 0
-  $i = 0
-  foreach ($bike in $listing.bikes) {
-    $i = $i + 1
-    $dest = Join-Path $bikesDir $bike.name
-    # A stalled transfer used to hang here for as long as the instance lived: --retry does
-    # nothing for a connection that stays open and stops sending. --max-time bounds each file
-    # so one bad download costs that bike rather than the whole build, and --speed-limit gives
-    # up on a transfer that has effectively died.
-    & $curl -L --fail --silent --show-error --retry 3 --retry-delay 5 \`
-      --max-time 300 --speed-limit 10240 --speed-time 60 \`
-      -o $dest "${input.controlPlaneUrl}/v1/content/bikes/$($bike.name)"
-    if ($LASTEXITCODE -eq 0) { $count = $count + 1 }
-    else { Write-Output "couldn't fetch $($bike.name) (curl $LASTEXITCODE)" }
-    # Say where we are. Reporting the step once and then going quiet for the length of a four
-    # gigabyte download is indistinguishable from having hung -- which is exactly how the
-    # first image build looked for three quarters of an hour.
-    if (($i % 5) -eq 0 -or $i -eq $total) {
-      Send-Stage -Stage "installing bikes $i of $total"
+  # Two passes over whatever is still missing. The common causes of a lost file here are
+  # transient, and the cost of not trying again is a server that rejects riders on a bike it
+  # was meant to have -- which is how this failure is met: "bike unknown to server".
+  $pending = @($listing.bikes)
+  for ($pass = 1; $pass -le 2 -and $pending.Count -gt 0; $pass++) {
+    $next = @()
+    $i = 0
+    foreach ($bike in $pending) {
+      $i = $i + 1
+      $dest = Join-Path $bikesDir $bike.name
+      # A flat five-minute cap was the wrong budget. The pack's two biggest bikes are 184 MB,
+      # which only fits inside five minutes above 0.6 MB/s -- so the slower the instance, the
+      # more certain it was to drop exactly the OEM bikes somebody provisioned a server for.
+      # Each file gets the time 100 KB/s would need instead, never less than five minutes.
+      #
+      # --speed-limit is what actually catches a dead transfer: a connection that stays open
+      # and stops sending, which --retry cannot see and which hung the first build for three
+      # quarters of an hour.
+      $budget = [int][Math]::Max(300, $bike.size / 102400)
+      & $curl -L --fail --silent --show-error --retry 3 --retry-delay 5 \`
+        --max-time $budget --speed-limit 10240 --speed-time 60 \`
+        -o $dest "${input.controlPlaneUrl}/v1/content/bikes/$($bike.name)"
+      if ($LASTEXITCODE -eq 0) { $count = $count + 1 }
+      else {
+        $next += $bike
+        Write-Output "couldn't fetch $($bike.name) (curl $LASTEXITCODE)"
+      }
+      # Say where we are. Reporting the step once and then going quiet for the length of a four
+      # gigabyte download is indistinguishable from having hung -- which is exactly how the
+      # first image build looked.
+      if (($i % 5) -eq 0 -or $i -eq $pending.Count) {
+        Send-Stage -Stage "installing bikes $count of $total"
+      }
+    }
+    $pending = @($next)
+    if ($pending.Count -gt 0 -and $pass -eq 1) {
+      Send-Stage -Stage "retrying $($pending.Count) bikes"
     }
   }
   Write-Output "installed $count of $total bikes"
+  # A short pack is not worth destroying the instance over, but it must not pass for a clean
+  # build either. The names go in the log, which is kept only for a report that says something
+  # went wrong -- and which has no charset, unlike a stage string, where a bike's dots and
+  # underscores would be rejected outright.
+  if ($pending.Count -gt 0) {
+    $names = ($pending | ForEach-Object { $_.name }) -join ", "
+    Send-Stage -Stage "installed $count of $total bikes" -Ok $false -Log "missing: $names"
+  }
 } catch {
   Write-Output "couldn't install the bike pack: $_"
 }

--- a/control-plane/test/validate.test.ts
+++ b/control-plane/test/validate.test.ts
@@ -316,6 +316,30 @@ describe("bootstrap user data", () => {
     expect(offenders, `non-ASCII in the script: ${JSON.stringify(offenders)}`).toEqual([]);
   });
 
+  it("only reports stages the control plane will accept", () => {
+    // `Send-Stage` posts to an endpoint that validates with `isBootstrapStage`, and a stage it
+    // refuses is a 400 the script discards -- the progress line simply stops moving, which is
+    // the exact symptom a build that has hung produces.
+    //
+    // This sees the literal skeleton only: an illegal character written into the string, or one
+    // long enough to be rejected. It cannot judge what interpolation puts there at runtime, so
+    // it would not catch a bike name reaching a stage by way of `$($missed -join ', ')`. That
+    // one is avoided by design -- names go in the log, which has no charset -- not by this.
+    const script = bootstrapScript({
+      agentToken: "t", agentUrl: "https://cp/v1/agent.exe", gameUrl: "https://g/i.exe",
+      serverName: "Test", gamePort: 54210, agentPort: 8787,
+      serverId: "abc", controlPlaneUrl: "https://cp",
+    });
+    const stages = [...script.matchAll(/-Stage "([^"]*)"/g)].map((m) => m[1]);
+    expect(stages.length).toBeGreaterThan(5);
+    for (const stage of stages) {
+      // Whatever PowerShell would interpolate stands in as a number, which is what every one
+      // of them actually is at runtime: a count, an index or a total.
+      const rendered = stage.replace(/\$\([^)]*\)/g, "9").replace(/\$[A-Za-z_][\w.]*/g, "9");
+      expect(isBootstrapStage(rendered), `${stage} -> ${rendered}`).toBe(true);
+    }
+  });
+
   it("survives a server name outside Latin-1", () => {
     // The name is the operator's, and it is interpolated into the script. `btoa` threw on
     // anything above U+00FF, which failed the launch with nothing to go on.


### PR DESCRIPTION
The per-file time limit merged in #164 was a flat five minutes — a budget that shrinks with file size.

The pack's two biggest bikes are **184 MB**, which only fits inside five minutes above **0.61 MB/s**. So the slower the instance, the more certain it was to drop exactly the OEM bikes a server was provisioned for — and a rider meets that as *"bike unknown to server"*, the symptom this whole thread has been chasing.

### What changed

- **Budget scales with size** — the time 100 KB/s would need, floored at five minutes. `--speed-limit 10240 --speed-time 60` remains the thing that actually catches a dead transfer.
- **A second pass** over whatever missed, then the shortfall is recorded with the names of the bikes. They go in the log, not the stage: `isBootstrapStage` rejects the dots and underscores in a bike name, so a stage carrying them would 400 and the progress line would simply stop moving — indistinguishable from a hang.
- **Removed a helper I nearly shipped that inverted the result.** It called `Write-Output` before returning, so a failed fetch returned `@("couldn't fetch …", $false)` — and a two-element array is truthy in PowerShell. Every failed download would have counted as installed.
- **CI parses both bootstrap scripts with PowerShell.** They execute in exactly one place — user-data on a Windows instance with no console, where every failure path ends in `Stop-Computer` and destroys the transcript — and they are assembled by string interpolation with a dozen escaped backticks.

### Honest limits

The parse job would **not** have caught the three failures that actually lost builds: `-Tail -Raw` was an invalid parameter set, the hand-built `agent.json` was valid PowerShell holding invalid JSON, and `Start-BitsTransfer` failed at runtime. It covers malformed-script errors, which is a different class. The new stage test sees literal illegal characters and overlong stages, not values arriving by interpolation. Both are commented as such.

A shortfall is stored in `bootstrap_log`, but the UI only renders that when the stage is literally `"failed"` — so a short build is diagnosable from D1, not from the app.

Verified: `tsc` clean, 49 control-plane tests, both scripts render, and the failure-counting bug confirmed by reading the rendered PowerShell rather than by running it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)