### PR TITLE
chore(release): v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2026-08-21
+## 2026-08-21 — v0.10.1 — Mods you deleted, remembered — and a crash we caused, undone
 
 ### Added
 - **The Library remembers what you used to have installed.** It only ever showed what was on
@@ -20,43 +20,6 @@
   the remembered name, and a result opens straight on its mod page. Sources live in one list,
   so a new one added later shows up here without another button.
 
-### Fixed
-- **The Library no longer loses the name and picture of a mod that is merely offloaded.**
-  A `.pkz` whose bytes live in iCloud or OneDrive reads as an empty archive, so its details
-  came back blank. They are now recognised and left for a moment when the file is really
-  there. macOS gained the offloaded-file check it previously only had on Windows, which also
-  makes the existing "your mods aren't really on disk" warning work there.
-- **Uninstalling a mod stored in iCloud no longer fails on macOS.** Deleting went through
-  Finder, which refuses a file iCloud has offloaded — *"the item needs to be downloaded"* —
-  so with a mods folder under `Documents` and most of it offloaded, uninstall failed on
-  nearly every mod. It now goes through `NSFileManager` instead, which handles an offloaded
-  file without downloading it first and still puts the mod in the Trash, recoverable.
-
-## Unreleased — a stalled download no longer hangs a server build
-
-### Fixed
-- **One stuck file could hang a build indefinitely.** Each bike now gets a download budget
-  scaled to its own size — the time 100 KB/s would need, and never less than five minutes —
-  alongside a stall detector, so a transfer that stops sending costs that one bike rather than
-  the whole machine. `--retry` never helped: a connection that stays open and goes quiet is not
-  a failure it can see. The flat five-minute cap this started as would have been its own bug —
-  the pack's two biggest bikes are 184 MB, so the slower the instance, the more certain it was
-  to drop exactly the OEM bikes somebody built the server for.
-- **A bike that misses gets a second pass**, and a build that still comes up short records which
-  ones went missing instead of reporting the same "installed" as a complete build.
-- **A build says how far through the bikes it is.** The step was announced once and then went
-  silent for the length of a four gigabyte download, which is indistinguishable from having
-  hung — and for three quarters of an hour, it was.
-
-### Changed
-- The two bootstrap scripts are rendered and parsed by PowerShell in CI. They run in exactly one
-  place — as user-data on a Windows instance with no console, where every failure path destroys
-  the evidence — and they are assembled by string interpolation, so a mis-escaped backtick is a
-  broken build nobody can see. A stage the control plane would reject is caught there too.
-
-## 2026-08-20
-
-### Added
 - **A paint saved on disk shows up in the running game.** The game reads your look once,
   when the profile loads, so painting used to mean save, alt-tab, reselect your profile,
   look, repeat — and mid-session there was no way to see a change at all. The app now
@@ -70,13 +33,86 @@
 - Three new supporters credited in Settings → Supporters: RodaksRevivalYT | Black Rifle,
   MintyFlow and Thomas.
 
+- **Share logs.** Settings → Logs already named all three log sets and saved them into one
+  zip; the file still had to be got to whoever asked, which is where "send me your logs"
+  usually stalls — a save dialog, then a file to find, then somewhere to upload it. **Share
+  logs** packs the same archive and uploads it through the same host a shared track goes out
+  on, then puts the direct link on the clipboard and leaves it on screen with a Copy button.
+  What goes in is what **Save logs…** already packed: the three log sets and the
+  `summary.txt` header (app version, OS, game, folders, and what was collected) — never the
+  config file, which holds session cookies and shop credentials. The link is public to
+  anyone holding it, and the page says so under the field. A bundle big enough to be sliced
+  comes back as a numbered list of parts rather than a first link that loses the rest.
+- **`summary.txt` now names the installed FrostMod build**, in the saved zip as well as the
+  shared one. The loader's log is in the archive and "which build wrote it" is the first
+  question anyone reading it has; `version.txt` itself stays out, being one of the files we
+  put in that folder ourselves.
+
+- **The app records how the game ended, not just that it ended.** Until now the only thing
+  watching MX Bikes was a process-table poll, which can say the game is gone and nothing
+  else — a clean quit and a crash on the loading screen looked identical in the log. A
+  handle is now held on the running game, so its exit code and true session length survive
+  it: a clean quit logs as one, and a crash logs `[session] game CRASHED after 4.1s` with
+  the exception named. `STATUS_IN_PAGE_ERROR` is called out by name, because that is what a
+  file the game had mapped but could not read looks like.
+- **A warning when the mods folder isn't really on disk.** OneDrive, Dropbox and iCloud can
+  leave a file looking completely ordinary while its contents still live on a server. MX
+  Bikes reads the mods tree during the load screen, memory-mapped, so a placeholder whose
+  fetch is slow or refused surfaces there as a crash with nothing in any log to explain it.
+  The app now checks the tree when a session starts and names the count, the provider and a
+  few of the files. It only ever reads attributes — never opens a placeholder, which is what
+  would trigger a download.
+- **Bikes you no longer ride can be removed from the Presets picker.** The Bike list is what
+  your profile carries, not what's installed — the game adds a column for every bike you have
+  ever sat on and never takes one out, so bikes whose mod is long gone kept filling the list
+  with nothing in the Library to uninstall. Each row now has a trash can that clears that bike
+  and the look saved for it out of `profile.ini`, with the previous file kept beside it as
+  `profile.ini.bak`. Nothing installed is deleted, and riding that bike again adds it back.
+
 ### Changed
+- The two bootstrap scripts are rendered and parsed by PowerShell in CI. They run in exactly one
+  place — as user-data on a Windows instance with no console, where every failure path destroys
+  the evidence — and they are assembled by string interpolation, so a mis-escaped backtick is a
+  broken build nobody can see. A stage the control plane would reject is caught there too.
+
 - The supporters list now renders in the order `supporters.json` is written in, rather than
   alphabetically within each tier — the file is hand-edited, so its order is a decision.
 
-## Unreleased — taking back the DLL we planted
+- "Repair runtimes" no longer offers to put `msvcr90.dll` where the game looks for it, because
+  there is no such place — nothing app-local short of a full private assembly can satisfy the
+  VC9 CRT. It installs the runtimes this PC is short of, both architectures, and clears out
+  what older versions of this app left behind. Plugins with a plain `MSVCR90.dll` import go
+  back to reporting "MSVCR90.dll was not found"; they were never actually fixed, only given a
+  different error.
+
+- Starting FrostMod is logged on Windows, on success and on failure, as it already was on
+  Linux and macOS — the platform nearly every report comes from was the one saying nothing.
 
 ### Fixed
+- **The Library no longer loses the name and picture of a mod that is merely offloaded.**
+  A `.pkz` whose bytes live in iCloud or OneDrive reads as an empty archive, so its details
+  came back blank. They are now recognised and left for a moment when the file is really
+  there. macOS gained the offloaded-file check it previously only had on Windows, which also
+  makes the existing "your mods aren't really on disk" warning work there.
+- **Uninstalling a mod stored in iCloud no longer fails on macOS.** Deleting went through
+  Finder, which refuses a file iCloud has offloaded — *"the item needs to be downloaded"* —
+  so with a mods folder under `Documents` and most of it offloaded, uninstall failed on
+  nearly every mod. It now goes through `NSFileManager` instead, which handles an offloaded
+  file without downloading it first and still puts the mod in the Trash, recoverable.
+
+- **One stuck file could hang a build indefinitely.** Each bike now gets a download budget
+  scaled to its own size — the time 100 KB/s would need, and never less than five minutes —
+  alongside a stall detector, so a transfer that stops sending costs that one bike rather than
+  the whole machine. `--retry` never helped: a connection that stays open and goes quiet is not
+  a failure it can see. The flat five-minute cap this started as would have been its own bug —
+  the pack's two biggest bikes are 184 MB, so the slower the instance, the more certain it was
+  to drop exactly the OEM bikes somebody built the server for.
+- **A bike that misses gets a second pass**, and a build that still comes up short records which
+  ones went missing instead of reporting the same "installed" as a complete build.
+- **A build says how far through the bikes it is.** The step was announced once and then went
+  silent for the length of a four gigabyte download, which is indistinguishable from having
+  hung — and for three quarters of an hour, it was.
+
 - **MX Bikes crashed with "R6034 — An application has made an attempt to load the C runtime
   library incorrectly", and this app was the cause.** Since v0.9.2 the FrostMod status poll
   copied `msvcr90.dll` out of `WinSxS` into the game folder on every start, meaning to serve
@@ -101,57 +137,6 @@
   CRT, and counting it let a file we ourselves planted quietly satisfy the check that should
   have been reporting the machine had no runtime at all.
 
-### Changed
-- "Repair runtimes" no longer offers to put `msvcr90.dll` where the game looks for it, because
-  there is no such place — nothing app-local short of a full private assembly can satisfy the
-  VC9 CRT. It installs the runtimes this PC is short of, both architectures, and clears out
-  what older versions of this app left behind. Plugins with a plain `MSVCR90.dll` import go
-  back to reporting "MSVCR90.dll was not found"; they were never actually fixed, only given a
-  different error.
-
-## Unreleased — logs as a link
-
-### Added
-- **Share logs.** Settings → Logs already named all three log sets and saved them into one
-  zip; the file still had to be got to whoever asked, which is where "send me your logs"
-  usually stalls — a save dialog, then a file to find, then somewhere to upload it. **Share
-  logs** packs the same archive and uploads it through the same host a shared track goes out
-  on, then puts the direct link on the clipboard and leaves it on screen with a Copy button.
-  What goes in is what **Save logs…** already packed: the three log sets and the
-  `summary.txt` header (app version, OS, game, folders, and what was collected) — never the
-  config file, which holds session cookies and shop credentials. The link is public to
-  anyone holding it, and the page says so under the field. A bundle big enough to be sliced
-  comes back as a numbered list of parts rather than a first link that loses the rest.
-- **`summary.txt` now names the installed FrostMod build**, in the saved zip as well as the
-  shared one. The loader's log is in the archive and "which build wrote it" is the first
-  question anyone reading it has; `version.txt` itself stays out, being one of the files we
-  put in that folder ourselves.
-
-## 2026-08-20
-
-### Added
-- **The app records how the game ended, not just that it ended.** Until now the only thing
-  watching MX Bikes was a process-table poll, which can say the game is gone and nothing
-  else — a clean quit and a crash on the loading screen looked identical in the log. A
-  handle is now held on the running game, so its exit code and true session length survive
-  it: a clean quit logs as one, and a crash logs `[session] game CRASHED after 4.1s` with
-  the exception named. `STATUS_IN_PAGE_ERROR` is called out by name, because that is what a
-  file the game had mapped but could not read looks like.
-- **A warning when the mods folder isn't really on disk.** OneDrive, Dropbox and iCloud can
-  leave a file looking completely ordinary while its contents still live on a server. MX
-  Bikes reads the mods tree during the load screen, memory-mapped, so a placeholder whose
-  fetch is slow or refused surfaces there as a crash with nothing in any log to explain it.
-  The app now checks the tree when a session starts and names the count, the provider and a
-  few of the files. It only ever reads attributes — never opens a placeholder, which is what
-  would trigger a download.
-- **Bikes you no longer ride can be removed from the Presets picker.** The Bike list is what
-  your profile carries, not what's installed — the game adds a column for every bike you have
-  ever sat on and never takes one out, so bikes whose mod is long gone kept filling the list
-  with nothing in the Library to uninstall. Each row now has a trash can that clears that bike
-  and the look saved for it out of `profile.ini`, with the previous file kept beside it as
-  `profile.ini.bak`. Nothing installed is deleted, and riding that bike again adds it back.
-
-### Fixed
 - **Steam's own runtime no longer reports as suspicious.** `tier0_s64.dll` and
   `vstdlib_s64.dll` are loaded into every Steam game from the Steam install, which is
   neither the game folder nor the system folder, so every scan on every machine ended with
@@ -173,9 +158,6 @@
 - **The mod page's error now has the Retry button it tells you to hit**, and says so in your
   own language instead of English.
 
-## 2026-08-19
-
-### Fixed
 - **The in-game overlay opens where you can see it.** Once MX Bikes was minimized — which
   exclusive fullscreen does the moment the overlay takes focus — the hotkey placed the
   overlay ~32,000px off the left of the desktop: shown, focused, and invisible, so it read
@@ -191,10 +173,6 @@
   can't get into it at all — no in-game pill — and the app reported it as running the whole
   time. That case is now named, with both ways out of it (run the game without administrator,
   or run MXB App with it).
-
-### Changed
-- Starting FrostMod is logged on Windows, on success and on failure, as it already was on
-  Linux and macOS — the platform nearly every report comes from was the one saying nothing.
 
 ## 2026-08-18 — v0.10.0 — A Designer that sets itself up, a Downloads page, and tracks in 3D
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.10.1",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3181,7 +3181,7 @@ dependencies = [
 
 [[package]]
 name = "mxb-app"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # whatever cargo called it. Cargo target names can't hold a space, so this is as close as
 # it gets. The description is what Windows Task Manager shows in its Processes tab.
 name = "mxb-app"
-version = "0.10.0"
+version = "0.10.1"
 description = "MXB App — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
   "mainBinaryName": "MXB App",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/Components/Showcase/releases.ts
+++ b/src/Components/Showcase/releases.ts
@@ -40,6 +40,9 @@ import {
   Package,
   Download,
   Share2,
+  History,
+  Undo2,
+  ShieldAlert,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { TKey } from "../../i18n/context";
@@ -66,6 +69,21 @@ export interface Release {
 }
 
 export const RELEASES: Release[] = [
+  {
+    version: "0.10.1",
+    hero: {
+      icon: History,
+      title: "showcase.v0101.hero.title",
+      body: "showcase.v0101.hero.body",
+    },
+    highlights: [
+      { icon: Undo2, text: "showcase.v0101.restore" },
+      { icon: Palette, text: "showcase.v0101.paints" },
+      { icon: ShieldAlert, text: "showcase.v0101.r6034" },
+      { icon: Share2, text: "showcase.v0101.logs" },
+      { icon: Bike, text: "showcase.v0101.bikes" },
+    ],
+  },
   {
     version: "0.10.0",
     hero: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1272,6 +1272,20 @@ export const de: Translation = {
   "showcase.supporters.title_one": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.title_other": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.more": "+{{count}} weitere",
+  "showcase.v0101.hero.title":
+    "Deine Bibliothek merkt sich, was du gelöscht hast",
+  "showcase.v0101.hero.body":
+    "Eine gelöschte Strecke war früher spurlos weg. Jetzt bleiben Name, Autor, Ort und ein Bild erhalten — damit du die, deren Namen du Monate später nicht mehr weißt, trotzdem wiederfindest.",
+  "showcase.v0101.restore":
+    "Wiederherstellen legt einen von der App gelöschten Mod zurück, und „Wiederfinden“ durchsucht mxb-mods und den Shop mit dem gemerkten Namen.",
+  "showcase.v0101.paints":
+    "Ein gespeichertes Paint erscheint jetzt im laufenden Spiel — kein Alt-Tab, kein erneutes Profilwählen.",
+  "showcase.v0101.r6034":
+    "Ein Absturz, den diese App verursacht hat, ist behoben: die von ihr abgelegte msvcr90.dll ließ MX Bikes mit R6034 sterben. Sie räumt die Kopie jetzt wieder weg.",
+  "showcase.v0101.logs":
+    "„Logs teilen“ packt dasselbe Archiv wie „Logs speichern“ und gibt dir einen Link statt einer Datei zum Hochladen.",
+  "showcase.v0101.bikes":
+    "Bikes, die du nicht mehr fährst, lassen sich aus der Presets-Auswahl entfernen.",
   "showcase.v0100.hero.title": "Der Designer richtet seine Blätter selbst ein",
   "showcase.v0100.hero.body":
     "Er legt jetzt die Blätter an, die ein Modell braucht, legt die eigenen Plastikteile des Bikes darunter zum Abpausen und öffnet ein Modell in etwa einer Sekunde statt in fast zwanzig.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1233,6 +1233,20 @@ export const en = {
   "showcase.supporters.title_one": "Made possible by {{count}} supporter",
   "showcase.supporters.title_other": "Made possible by {{count}} supporters",
   "showcase.supporters.more": "+{{count}} more",
+  "showcase.v0101.hero.title":
+    "Your library remembers what you deleted",
+  "showcase.v0101.hero.body":
+    "Delete a track and the app used to forget it had ever existed. It now keeps the name, the author, where it was and a picture of it — so the one you can't name months later is still there to find.",
+  "showcase.v0101.restore":
+    "Restore puts a mod the app deleted back where it came from, and “Find it again” searches mxb-mods and the Shop using the name it kept.",
+  "showcase.v0101.paints":
+    "A paint saved on disk now shows up in the running game — no alt-tab, no reselecting your profile.",
+  "showcase.v0101.r6034":
+    "A crash this app was causing is fixed: the copy of msvcr90.dll it planted made MX Bikes die with R6034. It now takes that copy back.",
+  "showcase.v0101.logs":
+    "Share logs packs the same archive as Save logs and hands you a link, instead of a file to go and upload.",
+  "showcase.v0101.bikes":
+    "Bikes you no longer ride can be cleared out of the Presets picker.",
   "showcase.v0100.hero.title": "The Designer sets up its own sheets",
   "showcase.v0100.hero.body":
     "It now builds the sheets a model needs, lays the bike's own plastics underneath to trace over, and opens a model in about a second instead of nearly twenty.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1259,6 +1259,20 @@ export const es: Translation = {
   "showcase.supporters.title_one": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.title_other": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.more": "+{{count}} más",
+  "showcase.v0101.hero.title":
+    "Tu biblioteca recuerda lo que borraste",
+  "showcase.v0101.hero.body":
+    "Antes, borrar un circuito lo borraba de la memoria de la app. Ahora guarda el nombre, el autor, dónde estaba y una imagen — así el que no sabes nombrar meses después sigue ahí para encontrarlo.",
+  "showcase.v0101.restore":
+    "Restaurar devuelve a su sitio un mod que borró la app, y “Encontrarlo otra vez” busca en mxb-mods y en la tienda con el nombre guardado.",
+  "showcase.v0101.paints":
+    "Una pintura guardada en disco ya aparece en el juego en marcha: sin alt-tab y sin volver a elegir tu perfil.",
+  "showcase.v0101.r6034":
+    "Arreglado un fallo que causaba esta app: la copia de msvcr90.dll que dejaba mataba MX Bikes con R6034. Ahora la retira.",
+  "showcase.v0101.logs":
+    "Compartir registros empaqueta lo mismo que Guardar registros y te da un enlace, en vez de un archivo que subir.",
+  "showcase.v0101.bikes":
+    "Las motos que ya no usas se pueden quitar del selector de Ajustes rápidos.",
   "showcase.v0100.hero.title": "El Designer prepara sus propias hojas",
   "showcase.v0100.hero.body":
     "Ahora crea las hojas que pide un modelo, coloca debajo los plásticos de la propia moto para calcar y abre un modelo en cerca de un segundo en vez de casi veinte.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1263,6 +1263,20 @@ export const fr: Translation = {
   "showcase.supporters.title_one": "Rendu possible par {{count}} soutien",
   "showcase.supporters.title_other": "Rendu possible par {{count}} soutiens",
   "showcase.supporters.more": "+{{count}} autres",
+  "showcase.v0101.hero.title":
+    "Ta bibliothèque se souvient de ce que tu as supprimé",
+  "showcase.v0101.hero.body":
+    "Supprimer un circuit l'effaçait complètement. L'app garde désormais le nom, l'auteur, le lieu et une image — pour que celui dont tu ne retrouves plus le nom des mois après reste retrouvable.",
+  "showcase.v0101.restore":
+    "Restaurer remet en place un mod supprimé par l'app, et « Le retrouver » cherche sur mxb-mods et la boutique avec le nom conservé.",
+  "showcase.v0101.paints":
+    "Une peinture enregistrée apparaît maintenant dans le jeu en cours — sans alt-tab, sans resélectionner ton profil.",
+  "showcase.v0101.r6034":
+    "Un plantage causé par cette app est corrigé : la copie de msvcr90.dll qu'elle déposait tuait MX Bikes avec R6034. Elle la retire désormais.",
+  "showcase.v0101.logs":
+    "Partager les journaux crée la même archive que Enregistrer et te rend un lien, au lieu d'un fichier à téléverser.",
+  "showcase.v0101.bikes":
+    "Les motos que tu ne pilotes plus peuvent être retirées du sélecteur des préréglages.",
   "showcase.v0100.hero.title": "Le Designer prépare ses planches tout seul",
   "showcase.v0100.hero.body":
     "Il crée maintenant les planches qu'un modèle demande, glisse en dessous les plastiques de la moto elle-même pour décalquer et ouvre un modèle en une seconde environ au lieu de près de vingt.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1254,6 +1254,20 @@ export const it: Translation = {
   "showcase.supporters.title_one": "Reso possibile da {{count}} sostenitore",
   "showcase.supporters.title_other": "Reso possibile da {{count}} sostenitori",
   "showcase.supporters.more": "+{{count}} altri",
+  "showcase.v0101.hero.title":
+    "La libreria si ricorda cosa hai cancellato",
+  "showcase.v0101.hero.body":
+    "Cancellare una pista la faceva sparire del tutto. Ora restano nome, autore, dove si trovava e un'immagine — così quella di cui mesi dopo non ricordi il nome la ritrovi lo stesso.",
+  "showcase.v0101.restore":
+    "Ripristina rimette a posto una mod cancellata dall'app, e “Ritrovala” cerca su mxb-mods e nello shop con il nome che si è tenuto.",
+  "showcase.v0101.paints":
+    "Una livrea salvata su disco ora compare nel gioco già avviato: niente alt-tab, niente riselezionare il profilo.",
+  "showcase.v0101.r6034":
+    "Risolto un crash causato da questa app: la copia di msvcr90.dll che lasciava faceva morire MX Bikes con R6034. Ora se la riprende.",
+  "showcase.v0101.logs":
+    "Condividi i log crea lo stesso archivio di Salva i log e ti restituisce un link, invece di un file da caricare.",
+  "showcase.v0101.bikes":
+    "Le moto che non usi più si possono togliere dall'elenco dei preset.",
   "showcase.v0100.hero.title": "Il Designer prepara i fogli da solo",
   "showcase.v0100.hero.body":
     "Ora crea i fogli che un modello chiede, mette sotto le plastiche della moto stessa da ricalcare e apre un modello in circa un secondo invece che in quasi venti.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1252,6 +1252,20 @@ export const ptBR: Translation = {
   "showcase.supporters.title_one": "Possível graças a {{count}} apoiador",
   "showcase.supporters.title_other": "Possível graças a {{count}} apoiadores",
   "showcase.supporters.more": "+{{count}} outros",
+  "showcase.v0101.hero.title":
+    "Sua biblioteca lembra o que você apagou",
+  "showcase.v0101.hero.body":
+    "Apagar uma pista fazia o app esquecer que ela existiu. Agora ficam o nome, o autor, onde era e uma imagem — pra que aquela que você não consegue nomear meses depois ainda dê pra achar.",
+  "showcase.v0101.restore":
+    "Restaurar devolve ao lugar um mod que o app apagou, e “Achar de novo” procura no mxb-mods e na loja com o nome guardado.",
+  "showcase.v0101.paints":
+    "Uma pintura salva no disco agora aparece no jogo rodando — sem alt-tab, sem reselecionar o perfil.",
+  "showcase.v0101.r6034":
+    "Corrigido um crash que este app causava: a cópia de msvcr90.dll que ele deixava matava o MX Bikes com R6034. Agora ele recolhe essa cópia.",
+  "showcase.v0101.logs":
+    "Compartilhar logs monta o mesmo arquivo que Salvar logs e te devolve um link, em vez de um arquivo pra subir.",
+  "showcase.v0101.bikes":
+    "Motos que você não usa mais podem sair do seletor de presets.",
   "showcase.v0100.hero.title": "O Designer prepara as próprias folhas",
   "showcase.v0100.hero.body":
     "Agora ele cria as folhas que um modelo pede, coloca embaixo os plásticos da própria moto para decalcar e abre um modelo em cerca de um segundo em vez de quase vinte.",


### PR DESCRIPTION
Cuts **v0.10.1**.

## Changelog consolidation

`main` had **seven** stacked unreleased sections — parallel branches each added their own, so the top of the file carried duplicate `## 2026-08-20` headings and repeated `### Added`/`### Fixed` groups. They are folded into one `## 2026-08-21 — v0.10.1 — …` heading, grouped Added / Changed / Fixed.

Verified nothing was lost: **32 top-level bullets and 156 content lines before and after, zero dropped**.

Per the release runbook, the two things that silently break a release are both checked:
- `scripts/changelog-section.sh v0.10.1 --heading` resolves (exit 0) — a section is only found by the `v<version>` marker in its heading.
- `scripts/release-notes.sh v0.10.1` renders the full body (317 lines).

## Version

0.10.0 → 0.10.1 in `package.json`, `tauri.conf.json`, `Cargo.toml`.

## In-app "What's new"

`RELEASES` gains its v0.10.1 entry plus seven strings in all six locales — nothing in CI catches a missing entry, and without it the release announces nothing. Hero is the library ledger; highlights are Restore/Find-it-again, live paint refresh, the R6034 crash fix, Share logs, and clearing bikes from the Presets picker.

## Note

This is tagged as a **patch** as requested, but it carries a fair amount of accumulated feature work from other merged branches (live paint refresh, Share logs, the crash-diagnostics work, forget-bike). Worth a look before tagging if you'd rather it went out as 0.11.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)