### PR TITLE
feat(locker): let a bike's setup-repair warning be dismissed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-08-22
+
+### Added
+- **A Locker repair warning can be dismissed.** The banner for a bike whose setup files an
+  old swap moved away sat at the top of the Locker with no way to put it down, so anyone who
+  had decided to leave that bike alone read the same three lines every visit. Each one now
+  carries a ✕. Hiding is remembered per bike *and* per set of missing files, so the same bike
+  breaking a different way still speaks up, and a bike you repair — then break again later —
+  warns afresh rather than staying quietly hidden.
+
 ## 2026-08-21 — v0.10.1 — Mods you deleted, remembered — and a crash we caused, undone
 
 ### Added

--- a/src/Components/Locker/Locker.tsx
+++ b/src/Components/Locker/Locker.tsx
@@ -12,6 +12,7 @@ import {
   Link2,
   Link2Off,
   Wrench,
+  X,
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
@@ -55,6 +56,35 @@ import { useT, type TFunc } from "../../i18n/context";
  * switching a model preserves the sound (and vice versa). A sound can optionally be
  * **bound** to a model swap, so activating that model pulls its sound along.
  */
+
+/**
+ * Orphan warnings the user has hidden, keyed on the bike *and* the files it's missing —
+ * a different breakage on the same bike is news again. Stored per machine, since which
+ * bikes are broken is a property of the install, not the account.
+ */
+const HIDDEN_ORPHANS_KEY = "mxb:orphanWarningsHidden:v1";
+
+function orphanKey(o: OrphanedSetup): string {
+  return `${o.bike}/${[...o.files].sort().join(",")}`;
+}
+
+function readHiddenOrphans(): Set<string> {
+  return new Set(
+    (localStorage.getItem(HIDDEN_ORPHANS_KEY) ?? "").split("|").filter(Boolean),
+  );
+}
+
+function writeHiddenOrphans(keys: Set<string>): Set<string> {
+  localStorage.setItem(HIDDEN_ORPHANS_KEY, [...keys].join("|"));
+  return keys;
+}
+
+/** Forget hidden warnings whose breakage is gone, so a repaired bike that breaks the
+ *  same way later warns afresh instead of staying silently hidden forever. */
+function pruneHiddenOrphans(live: OrphanedSetup[]): Set<string> {
+  const alive = new Set(live.map(orphanKey));
+  return writeHiddenOrphans(new Set([...readHiddenOrphans()].filter((k) => alive.has(k))));
+}
 
 /**
  * Trailing feedback for a swap toast.
@@ -151,6 +181,8 @@ export default function Locker() {
   const [registerOpen, setRegisterOpen] = useState(false);
   // Bikes gutted by a pre-0.6.3 swap — their setup files are in a swap folder.
   const [orphaned, setOrphaned] = useState<OrphanedSetup[]>([]);
+  // Of those, the ones the user has hidden with the banner's ✕.
+  const [hiddenOrphans, setHiddenOrphans] = useState<Set<string>>(readHiddenOrphans);
 
   const load = useCallback(async () => {
     setError(null);
@@ -159,11 +191,14 @@ export default function Locker() {
         scanModelSwaps(),
         scanSoundSwaps().catch(() => [] as BikeSounds[]),
         detectLooseSwaps().catch(() => [] as LooseSwapBike[]),
-        detectOrphanedSetup().catch(() => [] as OrphanedSetup[]),
+        detectOrphanedSetup().catch(() => null),
       ]);
       setRows(mergeRows(models, sounds));
       setLoose(detected);
-      setOrphaned(broken);
+      setOrphaned(broken ?? []);
+      // Prune only off a scan that actually ran — a failed detection is no evidence the
+      // breakage is fixed, and would drop the hidden warnings for nothing.
+      if (broken) setHiddenOrphans(pruneHiddenOrphans(broken));
     } catch (e) {
       setError(String(e));
       setRows([]);
@@ -207,6 +242,10 @@ export default function Locker() {
     },
     [load],
   );
+
+  const onHideOrphan = useCallback((o: OrphanedSetup) => {
+    setHiddenOrphans(writeHiddenOrphans(new Set(readHiddenOrphans()).add(orphanKey(o))));
+  }, []);
 
   const onRepair = (bike: string) =>
     run(
@@ -253,37 +292,47 @@ export default function Locker() {
         </button>
       </header>
 
-      {orphaned.map((o) => (
-        <div
-          key={o.bike}
-          className="mx-7 mb-3.5 flex items-center gap-2.5 rounded-lg border border-destructive/30 bg-destructive/[0.07] px-3.5 py-2.5"
-        >
-          <Wrench className="size-4 flex-none text-destructive/80" />
-          <span className="min-w-0 flex-1 text-[12.5px] text-foreground/90">
-            <Trans
-              k="locker.orphanBanner"
-              values={{
-                bike: <span className="font-semibold">{o.bike}</span>,
-                files: (
-                  <span className="font-mono text-faint">{o.files.join(", ")}</span>
-                ),
-              }}
-            />
-          </span>
-          <button
-            onClick={() => void onRepair(o.bike)}
-            disabled={busy !== null}
-            className="flex flex-none items-center gap-1.5 rounded-md bg-destructive/15 px-2.5 py-1.5 text-[12px] font-semibold text-destructive transition-colors hover:bg-destructive/25 disabled:opacity-50"
+      {orphaned
+        .filter((o) => !hiddenOrphans.has(orphanKey(o)))
+        .map((o) => (
+          <div
+            key={o.bike}
+            className="mx-7 mb-3.5 flex items-center gap-2.5 rounded-lg border border-destructive/30 bg-destructive/[0.07] px-3.5 py-2.5"
           >
-            {busy === o.bike ? (
-              <Loader2 className="size-3.5 animate-spin" />
-            ) : (
-              <Wrench className="size-3.5" />
-            )}
-            {t("locker.restore")}
-          </button>
-        </div>
-      ))}
+            <Wrench className="size-4 flex-none text-destructive/80" />
+            <span className="min-w-0 flex-1 text-[12.5px] text-foreground/90">
+              <Trans
+                k="locker.orphanBanner"
+                values={{
+                  bike: <span className="font-semibold">{o.bike}</span>,
+                  files: (
+                    <span className="font-mono text-faint">{o.files.join(", ")}</span>
+                  ),
+                }}
+              />
+            </span>
+            <button
+              onClick={() => void onRepair(o.bike)}
+              disabled={busy !== null}
+              className="flex flex-none items-center gap-1.5 rounded-md bg-destructive/15 px-2.5 py-1.5 text-[12px] font-semibold text-destructive transition-colors hover:bg-destructive/25 disabled:opacity-50"
+            >
+              {busy === o.bike ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <Wrench className="size-3.5" />
+              )}
+              {t("locker.restore")}
+            </button>
+            <button
+              onClick={() => onHideOrphan(o)}
+              aria-label={t("locker.hideOrphan")}
+              title={t("locker.hideOrphan")}
+              className="flex size-7 flex-none items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/15 hover:text-destructive"
+            >
+              <X className="size-3.5" />
+            </button>
+          </div>
+        ))}
 
       {looseCount > 0 && (
         <button

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -995,6 +995,7 @@ export const de: Translation = {
     "Wechsle Modell und Motorsound jedes Motorrads zwischen den Sets, die du installiert hast.",
   "locker.rescan": "Neu scannen",
   "locker.restore": "Wiederherstellen",
+  "locker.hideOrphan": "Diesen Hinweis ausblenden",
   "locker.register": "Registrieren",
   "locker.scanning": "Motorräder werden gescannt…",
   "locker.scanForSwaps": "Nach Sets suchen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -968,6 +968,7 @@ export const en = {
     "Swap each bike's model and engine sound between the sets you've installed.",
   "locker.rescan": "Rescan",
   "locker.restore": "Restore",
+  "locker.hideOrphan": "Hide this warning",
   "locker.register": "Register",
   "locker.scanning": "Scanning bikes…",
   "locker.scanForSwaps": "Scan for swaps",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -986,6 +986,7 @@ export const es: Translation = {
     "Cambia el modelo y el sonido del motor de cada moto entre los sets que tengas instalados.",
   "locker.rescan": "Volver a analizar",
   "locker.restore": "Restaurar",
+  "locker.hideOrphan": "Ocultar este aviso",
   "locker.register": "Registrar",
   "locker.scanning": "Analizando motos…",
   "locker.scanForSwaps": "Buscar sets",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -989,6 +989,7 @@ export const fr: Translation = {
     "Changez le modèle et le son moteur de chaque moto parmi les sets que vous avez installés.",
   "locker.rescan": "Réanalyser",
   "locker.restore": "Restaurer",
+  "locker.hideOrphan": "Masquer cet avertissement",
   "locker.register": "Enregistrer",
   "locker.scanning": "Analyse des motos…",
   "locker.scanForSwaps": "Chercher des sets",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -982,6 +982,7 @@ export const it: Translation = {
     "Cambia il modello e il suono del motore di ogni moto tra i set che hai installato.",
   "locker.rescan": "Riscansiona",
   "locker.restore": "Ripristina",
+  "locker.hideOrphan": "Nascondi questo avviso",
   "locker.register": "Registra",
   "locker.scanning": "Scansione delle moto…",
   "locker.scanForSwaps": "Cerca set da scambiare",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -984,6 +984,7 @@ export const ptBR: Translation = {
     "Troque o modelo e o som do motor de cada moto entre os sets que você instalou.",
   "locker.rescan": "Varrer de novo",
   "locker.restore": "Restaurar",
+  "locker.hideOrphan": "Ocultar este aviso",
   "locker.register": "Registrar",
   "locker.scanning": "Varrendo as motos…",
   "locker.scanForSwaps": "Procurar sets",


### PR DESCRIPTION
The orphaned-setup banner — the one that says a bike is missing its setup files because an old swap moved them — had no way to be put down. A player who had decided to leave that bike alone read the same warning on every visit, and with three broken bikes it filled the top of the Locker.

## What changed

- Each banner gains a ✕ beside **Restore**. Restore itself is untouched.
- Dismissals persist in `localStorage`, keyed on the bike **and** its sorted list of missing files — so a *different* breakage on the same bike is news again.
- Every successful scan prunes hidden keys that are no longer detected. A bike you repair drops its entry, so breaking it the same way later warns afresh instead of being swallowed by a stale dismissal.
- A failed detection is not evidence of a repair, so `detectOrphanedSetup` erroring now skips the prune rather than wiping the record. (Previously it fell back to an empty list, which is still what the banner list sees.)
- New `locker.hideOrphan` string across all six locales.

## Verified

`tsc --noEmit`, `eslint` and `vite build` all clean.

Not exercised on a real install — that needs Windows and an actually-broken bike. Worth checking there: the ✕ hides just its own banner, the hide survives **Rescan** and an app restart, and **Restore** still clears the banner on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)