### PR TITLE
fix(install): validate the paths carried by an imported code

### DIFF
--- a/src-tauri/src/fileshare.rs
+++ b/src-tauri/src/fileshare.rs
@@ -261,6 +261,17 @@ pub fn decode(text: &str) -> anyhow::Result<FileShare> {
     if share.items.is_empty() {
         anyhow::bail!("this share code carries no files");
     }
+    // Every `rel` is joined onto the receiver's mods root on import, and the first segment
+    // of the first one picks the type folder outright — so a code written by hand with
+    // `../` in it would install into the game folder itself. Nothing this app produces
+    // looks like that: `plan` derives every rel from a real path under the mods root.
+    if let Some(bad) = share.items.iter().find(|i| !library::is_safe_rel(&i.rel)) {
+        anyhow::bail!(
+            "this share code points outside the mods folder ('{}') — don't import it",
+            bad.rel
+        );
+    }
+    crate::presets::check_bundle_ref(&share.bundle)?;
     Ok(share)
 }
 
@@ -389,6 +400,40 @@ mod tests {
         assert_eq!(p.items[0].rel, "tracks/Loose Track");
         assert!(p.items[0].is_dir);
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The import target is picked from the first segment of the first item's `rel`, so a
+    /// hand-written code with `../` in it would install into the game folder itself.
+    #[test]
+    fn a_code_that_points_outside_the_mods_folder_is_refused() {
+        let item = |rel: &str| ShareItem {
+            name: "x.pkz".into(),
+            rel: rel.into(),
+            size: 1,
+            is_dir: false,
+        };
+        let share = |items: Vec<ShareItem>, url: &str| FileShare {
+            items,
+            total_size: 1,
+            bundle: BundleRef {
+                url: url.into(),
+                host: "catbox".into(),
+                size: 1,
+                parts: Vec::new(),
+            },
+        };
+        let good = "https://files.catbox.moe/a.zip";
+        for hostile in [
+            share(vec![item("../evil.dll")], good),
+            share(vec![item("tracks/../../evil.dll")], good),
+            share(vec![item("/etc/passwd")], good),
+            // The first item routes the install; a climb hiding behind a good one still lands.
+            share(vec![item("tracks/EU/RedBud.pkz"), item("../evil.dll")], good),
+            share(vec![item("tracks/EU/RedBud.pkz")], "file:///etc/passwd"),
+        ] {
+            let code = encode(&hostile);
+            assert!(decode(&code).is_err(), "should be refused: {:?}", hostile.items);
+        }
     }
 
     #[test]

--- a/src-tauri/src/install.rs
+++ b/src-tauri/src/install.rs
@@ -8,7 +8,7 @@ use scraper::{Html, Selector};
 use serde::Serialize;
 use std::fs::File;
 use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -1192,7 +1192,7 @@ fn filename_from(resp: &reqwest::Response, url: &str) -> String {
             .captures(cd)
         {
             let name = c[1].trim().trim_matches('"');
-            if !name.is_empty() {
+            if is_usable_filename(name) {
                 return sanitize(name);
             }
         }
@@ -1205,11 +1205,21 @@ fn filename_from(resp: &reqwest::Response, url: &str) -> String {
         .next()
         .unwrap_or("")
         .to_string();
-    if from_url.is_empty() {
-        "download.bin".to_string()
-    } else {
+    if is_usable_filename(&from_url) {
         sanitize(&from_url)
+    } else {
+        "download.bin".to_string()
     }
+}
+
+/// Whether a name a server handed us can be used as a file name at all.
+///
+/// `sanitize` strips separators but leaves dots alone, so `..` would survive it and name the
+/// staging folder's parent. Both sources here are remote — a `Content-Disposition` header and
+/// the URL — and a share code chooses the URL.
+fn is_usable_filename(name: &str) -> bool {
+    let name = name.trim();
+    !name.is_empty() && name != "." && name != ".."
 }
 
 pub(crate) fn extract_archive(archive: &Path, dest: &Path) -> anyhow::Result<()> {
@@ -1217,6 +1227,10 @@ pub(crate) fn extract_archive(archive: &Path, dest: &Path) -> anyhow::Result<()>
         "zip" => {
             let file = File::open(archive)?;
             zip::ZipArchive::new(file)?.extract(dest)?;
+            // `zip` filters `..` out of entry names, but a symlink entry is the escape a
+            // name filter can't see: the link lands inside `dest` and points anywhere, and
+            // the entries after it are written straight through it. Sweep it like the rest.
+            purge_escapees(archive, dest)?;
         }
         "7z" => {
             sevenz_rust::decompress_file(archive, dest)
@@ -1626,6 +1640,7 @@ pub(crate) fn place_mod_with(
     on_conflict: OnConflict,
 ) -> anyhow::Result<usize> {
     let route = plan_placement(extracted, mods_dir, type_folder, dest_folder, slug);
+    guard_placement(mods_dir, &route.placement)?;
     apply(&route.placement, on_conflict).inspect_err(|e| {
         // The one place every install — download, import, drop — funnels through, so one
         // log line here covers all three. Without it a failed install left no trace at all
@@ -1680,6 +1695,33 @@ fn roots_for(placement: &Placement) -> Vec<PathBuf> {
 /// or even whether it was the source or the destination. Every step says what it was doing
 /// to what, and a failure is logged as well as returned — the toast is transient, the log
 /// is what a player can send back.
+/// Refuse a placement that would write outside the mods folder.
+///
+/// `type_folder` and `dest_folder` are joined onto `mods_dir`, and `Path::join` is happy to
+/// accept `..` in either — a file-share code picks its type folder from a path the sender
+/// wrote, and the dropzone's destination comes back from the frontend. Every install funnels
+/// through [`place_mod_with`], so the check belongs here rather than at each of its doors.
+fn guard_placement(mods_dir: &Path, placement: &Placement) -> anyhow::Result<()> {
+    let dsts = roots_for(placement)
+        .into_iter()
+        .chain(writes_for(placement).into_iter().map(|(_, dst)| dst));
+    for dst in dsts {
+        // `starts_with` alone would pass `<mods>/..`: joining never normalises, so the
+        // climb is still sitting there as a component.
+        let inside = dst
+            .strip_prefix(mods_dir)
+            .map(|rel| !rel.components().any(|c| c == Component::ParentDir))
+            .unwrap_or(false);
+        if !inside {
+            anyhow::bail!(
+                "refusing to install to {} — that's outside the mods folder",
+                dst.display()
+            );
+        }
+    }
+    Ok(())
+}
+
 fn apply(placement: &Placement, on_conflict: OnConflict) -> anyhow::Result<usize> {
     for root in roots_for(placement) {
         std::fs::create_dir_all(&root)
@@ -2695,6 +2737,26 @@ mod tests {
             .join("bikes/MX1OEM_2023_KTM_450_SX-F/paints/cool.pnt")
             .exists());
         assert!(!mods.join("tracks/MX1OEM_2023_KTM_450_SX-F").exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The type folder is not always ours to trust — a file-share code picks it from a path
+    /// the sender wrote. `mods_dir.join("..")` is the MX Bikes folder itself, next to the
+    /// executable, so the placement has to be refused rather than merely misrouted.
+    #[test]
+    fn refuses_a_destination_outside_the_mods_folder() {
+        let root = place_tmp("escape-place");
+        let ex = root.join("ex");
+        touch(&ex.join("evil.dll"));
+        let mods = root.join("game/mods");
+        std::fs::create_dir_all(&mods).unwrap();
+
+        for (type_folder, dest_folder) in [("..", ""), ("tracks", "../.."), ("../..", "x")] {
+            let err = place_mod(&ex, &mods, type_folder, dest_folder, "slug").unwrap_err();
+            assert!(err.to_string().contains("outside the mods folder"), "{err}");
+        }
+        assert!(!root.join("game/evil.dll").exists(), "a placement escaped the mods folder");
+        assert!(!root.join("evil.dll").exists(), "a placement escaped the mods folder");
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -120,6 +120,25 @@ pub fn is_simple_name(s: &str) -> bool {
         && !s.contains(':')
 }
 
+/// True when `rel` is a relative path that cannot leave the folder it is joined onto —
+/// no `..`, no absolute or UNC root, no drive letter, no control characters.
+///
+/// [`is_simple_name`] guards a single segment; this guards a whole `mods/`-relative path,
+/// which is the shape a share code carries (`tracks/EU/RedBud.pkz`). A code is written by
+/// whoever hands it to you, so every path out of one is checked with this before it reaches
+/// anything that joins it onto the mods root.
+pub fn is_safe_rel(rel: &str) -> bool {
+    // A trailing separator is just how some senders write a folder; a leading one is a path
+    // that means to start from the root, which this must never accept.
+    let rel = rel.trim().trim_end_matches(['/', '\\']);
+    if rel.is_empty() || rel.chars().any(|c| c.is_control()) {
+        return false;
+    }
+    // Split on both separators so a Windows-shaped path is judged the same way a POSIX one
+    // is: any empty segment left is a leading separator (absolute, or a UNC root).
+    rel.split(['/', '\\']).all(is_simple_name)
+}
+
 fn sanitize_seg(seg: &str) -> String {
     seg.chars()
         .map(|c| match c {
@@ -827,6 +846,34 @@ mod tests {
         let d = std::env::temp_dir().join(format!("frost-lib-{name}-{}", std::process::id()));
         let _ = fs::remove_dir_all(&d);
         d
+    }
+
+    /// The guard every share code is checked against. A rel that climbs, starts at a root,
+    /// or names a drive can never be joined onto the mods folder.
+    #[test]
+    fn safe_rels_are_the_ones_that_stay_put() {
+        for ok in [
+            "tracks/EU/RedBud.pkz",
+            "rider/helmets/AGV/paints/Blue.pnt",
+            "bikes\\KTM\\paints",
+            "tracks/EU/",
+            " tracks/RedBud.pkz ",
+        ] {
+            assert!(is_safe_rel(ok), "should be safe: {ok:?}");
+        }
+        for bad in [
+            "",
+            "..",
+            "../mxbikes.exe",
+            "tracks/../../evil",
+            "tracks\\..\\evil",
+            "/etc/passwd",
+            "\\\\server\\share",
+            "C:/Windows/System32",
+            "tracks/\nRedBud.pkz",
+        ] {
+            assert!(!is_safe_rel(bad), "should be refused: {bad:?}");
+        }
     }
 
     #[test]

--- a/src-tauri/src/presets.rs
+++ b/src-tauri/src/presets.rs
@@ -605,7 +605,78 @@ pub fn encode_code_public(preset: &Preset) -> String {
     encode_code(preset)
 }
 
+/// Reject a decoded preset that could reach outside the folders a preset is meant to touch.
+///
+/// A code is written by whoever hands it over, and its fields all end up somewhere real: the
+/// content paths are joined onto the mods root, `model_swap` names a folder under a bike,
+/// the slot values become `profile.ini` lines, and the bundle links get fetched. Checking
+/// here means every caller of [`decode_code`] gets the same guarantee from one place.
+fn check_code(preset: &Preset) -> anyhow::Result<()> {
+    let clean = |s: &str| !s.chars().any(|c| c.is_control());
+    if !clean(&preset.name) {
+        anyhow::bail!("share code has a malformed preset name");
+    }
+
+    // A slot value is written verbatim as `bikeid=value`. A newline in one would inject
+    // whatever lines the sender liked into the receiver's `profile.ini`.
+    for section in SLOT_SECTIONS {
+        if let Some(v) = preset.loadout.slot(section) {
+            if !clean(v) {
+                anyhow::bail!("share code has a malformed '{section}' value");
+            }
+        }
+    }
+    for (section, value) in &preset.loadout.extra {
+        // Keys become `[section]` headers, so brackets are as dangerous as newlines here.
+        if !clean(section) || !clean(value) || section.contains(['[', ']']) {
+            anyhow::bail!("share code has a malformed '{section}' slot");
+        }
+    }
+    if !clean(&preset.loadout.race_number) {
+        anyhow::bail!("share code has a malformed race number");
+    }
+
+    // The variant folder brought in under `<bike>/FrostMod Models/`. `apply_model_swap`
+    // checks this too — this rejects the code rather than letting it sit in the list until
+    // the day someone applies it.
+    let swap = preset.loadout.model_swap.trim();
+    if !swap.is_empty() && !crate::library::is_simple_name(swap) {
+        anyhow::bail!("share code names an unsafe model swap ('{swap}')");
+    }
+
+    if let Some(content) = preset.content.as_ref() {
+        for rel in content.tracks.iter().chain(content.keep.iter()) {
+            if !rel.trim().is_empty() && !crate::library::is_safe_rel(rel) {
+                anyhow::bail!("share code carries an unsafe path ('{rel}')");
+            }
+        }
+    }
+    if let Some(bundle) = preset.bundle.as_ref() {
+        check_bundle_ref(bundle)?;
+    }
+    Ok(())
+}
+
+/// Every link in a bundle has to be one the app would fetch over the network — never a
+/// `file://` URL or a local path dressed up as one.
+pub fn check_bundle_ref(bundle: &BundleRef) -> anyhow::Result<()> {
+    let http = |u: &str| {
+        let u = u.trim().to_ascii_lowercase();
+        u.starts_with("https://") || u.starts_with("http://")
+    };
+    if !http(&bundle.url) || bundle.parts.iter().any(|p| !http(p)) {
+        anyhow::bail!("share code points at something that isn't a download link");
+    }
+    Ok(())
+}
+
 pub fn decode_code(text: &str) -> anyhow::Result<Preset> {
+    let preset = parse_code(text)?;
+    check_code(&preset)?;
+    Ok(preset)
+}
+
+fn parse_code(text: &str) -> anyhow::Result<Preset> {
     let t = text.trim();
     if let Some(b64) = t.strip_prefix(CODE_PREFIX) {
         let bytes = STANDARD
@@ -1030,6 +1101,37 @@ BSB23_Ducati_V4R=BS_Racing_Battlax
         assert_eq!(back.loadout.helmet_paint, "CLUTCH Deeg F REDB");
         assert_eq!(back.content.unwrap().tracks, vec!["mods/tracks/RedBud.pkz"]);
         let _ = round_trip_raw_json(&preset);
+    }
+
+    /// A code is a string someone pastes in from Discord, so every path it carries is
+    /// hostile until checked. These are the shapes that reached a real file operation:
+    /// `content` paths join onto the mods root, `model_swap` names a folder under a bike,
+    /// and a slot value is written verbatim as a `profile.ini` line.
+    #[test]
+    fn a_code_that_climbs_out_is_refused() {
+        let hostile = [
+            r#"{"name":"x","loadout":{},"content":{"tracks":["../../mxbikes.exe"],"keep":[]}}"#,
+            r#"{"name":"x","loadout":{},"content":{"tracks":[],"keep":["/etc/passwd"]}}"#,
+            r#"{"name":"x","loadout":{},"content":{"tracks":["C:/Windows/System32"],"keep":[]}}"#,
+            r#"{"name":"x","loadout":{"modelSwap":"../../../Startup"}}"#,
+            r#"{"name":"x","loadout":{"paint":"a\n[info]\nbikeid=b"}}"#,
+            r#"{"name":"x","loadout":{"extra":{"[info]\nbikeid":"b"}}}"#,
+            r#"{"name":"x","loadout":{},"bundle":{"url":"file:///etc/passwd","host":"x","size":1}}"#,
+            r#"{"name":"x","loadout":{},"bundle":{"url":"https://x/a.zip","host":"x","size":1,"parts":["file:///etc/passwd"]}}"#,
+        ];
+        for json in hostile {
+            assert!(decode_code(json).is_err(), "should be refused: {json}");
+        }
+    }
+
+    /// And the ordinary shapes still decode — a relative content path, a plain model swap,
+    /// and slot values with the punctuation real paint names carry.
+    #[test]
+    fn an_ordinary_code_still_decodes() {
+        let json = r#"{"name":"RedBud #92","loadout":{"paint":"CLUTCH Deeg F REDB","modelSwap":"2024 Factory"},"content":{"tracks":["mods/tracks/EU/RedBud.pkz"],"keep":["mods/bikes/OEM Pack.pkz"]},"bundle":{"url":"https://files.catbox.moe/a.zip","host":"catbox","size":10}}"#;
+        let back = decode_code(json).unwrap();
+        assert_eq!(back.loadout.model_swap, "2024 Factory");
+        assert_eq!(back.content.unwrap().tracks, vec!["mods/tracks/EU/RedBud.pkz"]);
     }
 
     /// Presets saved before Manage existed have no `content` key at all. They have to keep


### PR DESCRIPTION
Tightens how imported codes are handled.

- `library::is_safe_rel` — the whole-path companion to `is_simple_name`: no `..`, no absolute or UNC root, no drive letter, no control characters.
- Preset and file-share codes are checked at decode time, so a malformed one is refused at the door instead of partway through an install.
- `place_mod_with` verifies its destinations stay under the mods folder — the single point every install (download, drop, import) funnels through.
- Zip extraction gets the `purge_escapees` sweep 7z and rar already had, and a remote filename can no longer name the staging folder's parent.

Tests: 5 added, 821 pass. Each guard was disabled in turn to confirm its test fails without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)