### PR TITLE
fix(sync): resolve a paint under the thing that actually wears it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## 2026-08-22
 
+### Fixed
+- **Paint sync published the wrong bike's livery.** Liveries were matched by filename alone,
+  so a rider with `Race.pnt` on two bikes published whichever the folder walk reached first —
+  and the file carried that bike's install path, so everyone on the grid saw it land on the
+  wrong bike as well. A livery is now resolved under the bike that actually wears it, and a
+  livery missing from that bike is reported as missing rather than borrowed from another one.
+  The same mismatch made the live-reload watcher watch another bike's file, so a paint edited
+  mid-session could refresh late or not at all.
+- **Helmet, goggle, boot and protection paints were never shared.** Gear paints that sit
+  inside their model's folder were being folded into that folder — correct for a preset zip,
+  which carries the folder whole, but a publish uploads paint files one at a time and skips
+  folders, so those paints silently went nowhere. Gear paints now publish alongside bike
+  liveries; preset bundles still pack the folder once.
+
 ### Added
 - **A Locker repair warning can be dismissed.** The banner for a bike whose setup files an
   old swap moved away sat at the top of the Locker with no way to put it down, so anyone who

--- a/src-tauri/src/bundle.rs
+++ b/src-tauri/src/bundle.rs
@@ -49,7 +49,33 @@ struct Spec {
     value: String,
     scan: Scan,
     cats: &'static [&'static str],
-    parent: Option<String>,
+    owner: Owner,
+}
+
+/// Which installed thing a slot's file has to sit under.
+///
+/// A bike livery and a gear paint both name a file that lives inside something else, but they
+/// differ in how much that containment can be trusted, so they get different rules rather than
+/// one flag that has to be remembered at every call site.
+enum Owner {
+    /// Nothing to check — the value names the thing itself.
+    Any,
+    /// Prefer this owner, fall back to a match elsewhere. A rider model's folder name and the
+    /// profile's value for it do not always agree, and refusing the paint over that would lose
+    /// a livery the game itself finds.
+    Prefer(String),
+    /// Must be this owner. A bike livery belongs to one bike: `Race.pnt` under another bike is
+    /// a different file with a different destination, so a near miss is worse than a miss.
+    Require(String),
+}
+
+impl Owner {
+    fn name(&self) -> Option<&str> {
+        match self {
+            Owner::Any => None,
+            Owner::Prefer(p) | Owner::Require(p) => Some(p.trim()).filter(|p| !p.is_empty()),
+        }
+    }
 }
 
 fn strip_ext(name: &str) -> String {
@@ -83,32 +109,32 @@ fn rel_dest(type_folder: &str, e: &LibraryEntry) -> String {
 }
 
 pub fn plan(cfg: &AppConfig, loadout: &Loadout) -> anyhow::Result<BundlePlan> {
-    let mut p = resolve(cfg, loadout)?;
+    let mut p = resolve(cfg, loadout, None)?;
     dedup_assets(&mut p.assets);
     p.total_size = p.assets.iter().map(|a| a.size).sum();
     Ok(p)
 }
 
-/// [`plan`] for several loadouts, paying for the library walk once.
+/// Every bike in a profile, resolved for publishing, paying for the library walk once.
 ///
 /// Resolving a slot means matching it against every installed file, and gathering those files
 /// means a full recursive walk of `mods/bikes` — which on a real install is every livery the
 /// player owns. One walk per loadout is fine for the one-at-a-time callers; it is not fine for
 /// "publish this rider's whole profile", where the loadout count is the number of bikes they
 /// have ever sat on. Same resolution, same order, one scan.
-pub fn plan_many(cfg: &AppConfig, loadouts: &[Loadout]) -> Vec<BundlePlan> {
+///
+/// Two things differ from [`plan`], both because the publisher uploads file by file rather
+/// than zipping a folder: each loadout's livery is pinned to the bike it was read under, and
+/// assets stay individually addressed as they do in [`plan_detailed`] — collapsing a gear
+/// paint into the model folder containing it would drop it from a publish entirely.
+pub fn plan_profile(cfg: &AppConfig, loadouts: &[(String, Loadout)]) -> Vec<BundlePlan> {
     if loadouts.is_empty() {
         return Vec::new();
     }
     let libs = Libraries::scan(cfg);
     loadouts
         .iter()
-        .map(|loadout| {
-            let mut p = resolve_with(cfg, &libs, loadout);
-            dedup_assets(&mut p.assets);
-            p.total_size = p.assets.iter().map(|a| a.size).sum();
-            p
-        })
+        .map(|(bike, loadout)| resolve_with(cfg, &libs, loadout, Some(bike)))
         .collect()
 }
 
@@ -118,14 +144,18 @@ pub fn plan_many(cfg: &AppConfig, loadouts: &[Loadout]) -> Vec<BundlePlan> {
 /// carries `rider/helmets/AGV` carries the liveries under it for free. Manage needs the
 /// opposite: it keeps that helmet by moving nothing at all, and decides livery by livery
 /// which ones the game still gets to offer — so the paint has to be named, not implied.
-pub fn plan_detailed(cfg: &AppConfig, loadout: &Loadout) -> anyhow::Result<BundlePlan> {
-    resolve(cfg, loadout)
+pub fn plan_detailed(
+    cfg: &AppConfig,
+    loadout: &Loadout,
+    bike: Option<&str>,
+) -> anyhow::Result<BundlePlan> {
+    resolve(cfg, loadout, bike)
 }
 
 /// The three scans a resolution reads from, gathered once.
 ///
-/// Exists so [`plan_many`] can hand the same walk to every loadout. A scan is infallible from
-/// the caller's point of view — an unreadable folder resolves to nothing, exactly as it did
+/// Exists so [`plan_profile`] can hand the same walk to every loadout. A scan is infallible
+/// from the caller's point of view — an unreadable folder resolves to nothing, exactly as it did
 /// when each `resolve` did its own `unwrap_or_default`.
 struct Libraries {
     bikes: Vec<LibraryEntry>,
@@ -146,29 +176,36 @@ impl Libraries {
     }
 }
 
-fn resolve(cfg: &AppConfig, loadout: &Loadout) -> anyhow::Result<BundlePlan> {
-    Ok(resolve_with(cfg, &Libraries::scan(cfg), loadout))
+fn resolve(cfg: &AppConfig, loadout: &Loadout, bike: Option<&str>) -> anyhow::Result<BundlePlan> {
+    Ok(resolve_with(cfg, &Libraries::scan(cfg), loadout, bike))
 }
 
-fn resolve_with(cfg: &AppConfig, libs: &Libraries, loadout: &Loadout) -> BundlePlan {
+/// `bike` is the bike id the loadout was read under, where the caller knows it. A preset does
+/// not have one — it dresses whichever bike it is applied to — so the livery stays loose there.
+fn resolve_with(
+    cfg: &AppConfig,
+    libs: &Libraries,
+    loadout: &Loadout,
+    bike: Option<&str>,
+) -> BundlePlan {
     let Libraries { bikes, rider, tyres } = libs;
 
     let specs = vec![
-        Spec { slot: "paint", value: loadout.paint.clone(), scan: Scan::Bikes, cats: &["bikePaint"], parent: None },
-        Spec { slot: "helmet", value: loadout.helmet.clone(), scan: Scan::Rider, cats: &["helmet"], parent: None },
-        Spec { slot: "helmet_paint", value: loadout.helmet_paint.clone(), scan: Scan::Rider, cats: &["helmetPaint"], parent: Some(loadout.helmet.clone()) },
-        Spec { slot: "goggles_paint", value: loadout.goggles_paint.clone(), scan: Scan::Rider, cats: &["goggles"], parent: Some(loadout.helmet.clone()) },
-        Spec { slot: "suit_paint", value: loadout.suit_paint.clone(), scan: Scan::Rider, cats: &["outfit"], parent: Some(loadout.rider.clone()) },
-        Spec { slot: "gloves_paint", value: loadout.gloves_paint.clone(), scan: Scan::Rider, cats: &["gloves"], parent: None },
-        Spec { slot: "boots", value: loadout.boots.clone(), scan: Scan::Rider, cats: &["boots"], parent: None },
-        Spec { slot: "boots_paint", value: loadout.boots_paint.clone(), scan: Scan::Rider, cats: &["bootPaint"], parent: Some(loadout.boots.clone()) },
-        Spec { slot: "protection", value: loadout.protection.clone(), scan: Scan::Rider, cats: &["protection"], parent: None },
-        Spec { slot: "protection_paint", value: loadout.protection_paint.clone(), scan: Scan::Rider, cats: &["protectionPaint"], parent: Some(loadout.protection.clone()) },
+        Spec { slot: "paint", value: loadout.paint.clone(), scan: Scan::Bikes, cats: &["bikePaint"], owner: bike.map_or(Owner::Any, |b| Owner::Require(b.to_string())) },
+        Spec { slot: "helmet", value: loadout.helmet.clone(), scan: Scan::Rider, cats: &["helmet"], owner: Owner::Any },
+        Spec { slot: "helmet_paint", value: loadout.helmet_paint.clone(), scan: Scan::Rider, cats: &["helmetPaint"], owner: Owner::Prefer(loadout.helmet.clone()) },
+        Spec { slot: "goggles_paint", value: loadout.goggles_paint.clone(), scan: Scan::Rider, cats: &["goggles"], owner: Owner::Prefer(loadout.helmet.clone()) },
+        Spec { slot: "suit_paint", value: loadout.suit_paint.clone(), scan: Scan::Rider, cats: &["outfit"], owner: Owner::Prefer(loadout.rider.clone()) },
+        Spec { slot: "gloves_paint", value: loadout.gloves_paint.clone(), scan: Scan::Rider, cats: &["gloves"], owner: Owner::Any },
+        Spec { slot: "boots", value: loadout.boots.clone(), scan: Scan::Rider, cats: &["boots"], owner: Owner::Any },
+        Spec { slot: "boots_paint", value: loadout.boots_paint.clone(), scan: Scan::Rider, cats: &["bootPaint"], owner: Owner::Prefer(loadout.boots.clone()) },
+        Spec { slot: "protection", value: loadout.protection.clone(), scan: Scan::Rider, cats: &["protection"], owner: Owner::Any },
+        Spec { slot: "protection_paint", value: loadout.protection_paint.clone(), scan: Scan::Rider, cats: &["protectionPaint"], owner: Owner::Prefer(loadout.protection.clone()) },
         // A custom riding style is a mod like any other. The two stock ones live in
         // `rider.pkz` and leave nothing on disk, which `is_builtin` skips rather than
         // reporting unresolved.
-        Spec { slot: "riding_style", value: loadout.riding_style.clone(), scan: Scan::Rider, cats: &["animation"], parent: None },
-        Spec { slot: "tyres", value: loadout.tyres.clone(), scan: Scan::Tyres, cats: &["misc"], parent: None },
+        Spec { slot: "riding_style", value: loadout.riding_style.clone(), scan: Scan::Rider, cats: &["animation"], owner: Owner::Any },
+        Spec { slot: "tyres", value: loadout.tyres.clone(), scan: Scan::Tyres, cats: &["misc"], owner: Owner::Any },
     ];
 
     let mut assets: Vec<AssetRef> = Vec::new();
@@ -193,13 +230,15 @@ fn resolve_with(cfg: &AppConfig, libs: &Libraries, loadout: &Loadout) -> BundleP
             })
             .collect();
 
-        if let Some(parent) = spec.parent.as_ref().map(|p| p.trim()).filter(|p| !p.is_empty()) {
-            if matches.iter().any(|e| {
-                e.parent.as_deref().map(|p| p.eq_ignore_ascii_case(parent)).unwrap_or(false)
-            }) {
-                matches.retain(|e| {
-                    e.parent.as_deref().map(|p| p.eq_ignore_ascii_case(parent)).unwrap_or(false)
-                });
+        if let Some(owner) = spec.owner.name() {
+            let under_owner = |e: &LibraryEntry| {
+                e.parent.as_deref().map(|p| p.eq_ignore_ascii_case(owner)).unwrap_or(false)
+            };
+            // `Require` keeps the filter even when it empties the list. Reporting the slot
+            // unresolved is the honest answer there; falling back would hand back another
+            // bike's livery, which also carries that bike's destination path.
+            if matches!(spec.owner, Owner::Require(_)) || matches.iter().any(|e| under_owner(e)) {
+                matches.retain(|e| under_owner(e));
             }
         }
 
@@ -674,7 +713,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
-    // Publishing a rider's whole profile plans every bike they own. `plan_many` exists to
+    // Publishing a rider's whole profile plans every bike they own. `plan_profile` exists to
     // make that one library walk instead of one per bike, so the thing worth pinning is that
     // it still answers exactly what planning them separately would have.
     #[test]
@@ -691,11 +730,15 @@ mod tests {
         let mut yam = Loadout::default();
         yam.paint = "Southwick".into();
 
-        let loadouts = vec![ktm.clone(), yam.clone()];
-        let many = plan_many(&cfg, &loadouts);
+        let loadouts =
+            vec![("KTM450".to_string(), ktm.clone()), ("YZ250".to_string(), yam.clone())];
+        let many = plan_profile(&cfg, &loadouts);
         assert_eq!(many.len(), 2);
-        for (batched, one) in many.iter().zip([plan(&cfg, &ktm).unwrap(), plan(&cfg, &yam).unwrap()])
-        {
+        let each = [
+            plan_detailed(&cfg, &ktm, Some("KTM450")).unwrap(),
+            plan_detailed(&cfg, &yam, Some("YZ250")).unwrap(),
+        ];
+        for (batched, one) in many.iter().zip(each) {
             let dests = |p: &BundlePlan| {
                 p.assets.iter().map(|a| a.rel_dest.clone()).collect::<Vec<_>>()
             };
@@ -705,11 +748,100 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
+    // Livery names repeat across bikes — `default`, `race`, a team name. Matching on the
+    // filename alone published whichever one the walk reached first, and `rel_dest` carries
+    // that bike's folder, so the receiver installed it onto the wrong bike too.
+    #[test]
+    fn a_livery_resolves_under_the_bike_that_wears_it() {
+        let root = tmp("livery-owner");
+        touch(&root.join("mods/bikes/KTM450/paints/Race.pnt"));
+        touch(&root.join("mods/bikes/YZ250/paints/Race.pnt"));
+
+        let cfg = AppConfig { mods_path: root.to_string_lossy().into_owned(), ..Default::default() };
+        let mut lo = Loadout::default();
+        lo.paint = "Race".into();
+
+        for bike in ["YZ250", "KTM450"] {
+            let plans = plan_profile(&cfg, &[(bike.to_string(), lo.clone())]);
+            let paints = plans[0]
+                .assets
+                .iter()
+                .filter(|a| a.slot == "paint")
+                .map(|a| a.rel_dest.as_str())
+                .collect::<Vec<_>>();
+            assert_eq!(paints, vec![format!("bikes/{bike}/paints/Race.pnt")]);
+        }
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    // The other half of that rule: when the owning bike has no such livery, the answer is
+    // "unresolved", not "here is someone else's". Unlike a rider model — whose folder name and
+    // profile value genuinely disagree sometimes — a bike livery has one correct home.
+    #[test]
+    fn a_livery_missing_from_its_own_bike_is_never_borrowed() {
+        let root = tmp("livery-no-borrow");
+        touch(&root.join("mods/bikes/KTM450/paints/Race.pnt"));
+        touch(&root.join("mods/bikes/YZ250/paints/Southwick.pnt"));
+
+        let cfg = AppConfig { mods_path: root.to_string_lossy().into_owned(), ..Default::default() };
+        let mut lo = Loadout::default();
+        lo.paint = "Race".into();
+
+        let plans = plan_profile(&cfg, &[("YZ250".to_string(), lo)]);
+        assert!(!plans[0].assets.iter().any(|a| a.slot == "paint"));
+        assert!(plans[0].unresolved.iter().any(|u| u.slot == "paint"));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    // A gear paint usually lives inside the model folder that binds it. `plan` folds it into
+    // that folder on purpose — a zip carrying `rider/helmets/AGV` carries the liveries free —
+    // but a publish uploads `.pnt` files one at a time and skips folders, so folding them in
+    // meant every helmet, boot and protection paint silently went unshared.
+    #[test]
+    fn gear_paints_nested_in_their_model_stay_addressable() {
+        let root = tmp("nested-gear");
+        touch(&root.join("mods/rider/helmets/AGV/model.edf"));
+        touch(&root.join("mods/rider/helmets/AGV/paints/Blue.pnt"));
+        touch(&root.join("mods/rider/helmets/AGV/goggles/Smoke.pnt"));
+        touch(&root.join("mods/rider/boots/Tech10/model.edf"));
+        touch(&root.join("mods/rider/boots/Tech10/paints/White.pnt"));
+        touch(&root.join("mods/rider/protections/Leatt/model.edf"));
+        touch(&root.join("mods/rider/protections/Leatt/paints/Carbon.pnt"));
+
+        let cfg = AppConfig { mods_path: root.to_string_lossy().into_owned(), ..Default::default() };
+        let mut lo = Loadout::default();
+        lo.helmet = "AGV".into();
+        lo.helmet_paint = "Blue".into();
+        lo.goggles_paint = "Smoke".into();
+        lo.boots = "Tech10".into();
+        lo.boots_paint = "White".into();
+        lo.protection = "Leatt".into();
+        lo.protection_paint = "Carbon".into();
+
+        let plans = plan_profile(&cfg, &[("YZ250".to_string(), lo.clone())]);
+        let dest = |slot: &str| {
+            plans[0]
+                .assets
+                .iter()
+                .find(|a| a.slot == slot)
+                .map(|a| a.rel_dest.as_str())
+        };
+        assert_eq!(dest("helmet_paint"), Some("rider/helmets/AGV/paints/Blue.pnt"));
+        assert_eq!(dest("goggles_paint"), Some("rider/helmets/AGV/goggles/Smoke.pnt"));
+        assert_eq!(dest("boots_paint"), Some("rider/boots/Tech10/paints/White.pnt"));
+        assert_eq!(dest("protection_paint"), Some("rider/protections/Leatt/paints/Carbon.pnt"));
+
+        // The zip path still collapses them, which is what makes it a smaller archive.
+        let zipped = plan(&cfg, &lo).unwrap();
+        assert!(!zipped.assets.iter().any(|a| a.slot == "helmet_paint"));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     #[test]
     fn planning_nothing_walks_nothing() {
         // Guards the early return: a profile with no bikes must not pay for a library scan.
         let cfg = AppConfig { mods_path: "/nowhere".into(), ..Default::default() };
-        assert!(plan_many(&cfg, &[]).is_empty());
+        assert!(plan_profile(&cfg, &[]).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -574,7 +574,7 @@ fn worn_paints(cfg: &AppConfig) -> Vec<String> {
     let Ok(loadout) = presets::read_loadout(&profiles_dir, &profile, &bike) else {
         return Vec::new();
     };
-    let Ok(plan) = bundle::plan_detailed(cfg, &loadout) else {
+    let Ok(plan) = bundle::plan_detailed(cfg, &loadout, Some(&bike)) else {
         return Vec::new();
     };
     plan.assets

--- a/src-tauri/src/modstate.rs
+++ b/src-tauri/src/modstate.rs
@@ -271,7 +271,7 @@ fn keep_keys(cfg: &AppConfig, preset: &Preset) -> (BTreeSet<String>, Vec<bundle:
     let mut keys = BTreeSet::new();
     let mut unresolved = Vec::new();
 
-    if let Ok(plan) = bundle::plan_detailed(cfg, &preset.loadout) {
+    if let Ok(plan) = bundle::plan_detailed(cfg, &preset.loadout, None) {
         for a in &plan.assets {
             keys.insert(key(&format!("mods/{}", a.rel_dest)));
         }

--- a/src-tauri/src/paintsync.rs
+++ b/src-tauri/src/paintsync.rs
@@ -244,7 +244,7 @@ pub const MAX_BIKES: usize = 32;
 /// Read every bike in a profile and hash what each one is wearing.
 ///
 /// One `profile.ini` parse ([`presets::read_all_loadouts`]) and one library walk
-/// ([`bundle::plan_many`]) for the whole profile — doing either per bike turns publishing
+/// ([`bundle::plan_profile`]) for the whole profile — doing either per bike turns publishing
 /// into dozens of recursive scans of a folder holding every livery the player owns.
 pub fn local_look(cfg: &AppConfig, profile: &str) -> anyhow::Result<LocalLook> {
     let profiles_dir = cfg.profiles_dir();
@@ -259,7 +259,7 @@ pub fn local_look(cfg: &AppConfig, profile: &str) -> anyhow::Result<LocalLook> {
     let skipped = loadouts.len().saturating_sub(MAX_BIKES);
     loadouts.truncate(MAX_BIKES);
 
-    let plans = bundle::plan_many(cfg, &loadouts.iter().map(|(_, l)| l.clone()).collect::<Vec<_>>());
+    let plans = bundle::plan_profile(cfg, &loadouts);
 
     let mut sources = std::collections::HashMap::new();
     let mut oversized = 0usize;


### PR DESCRIPTION
## Summary

Two defects in paint sync, one root cause: a slot spec could say which folder a file should *prefer*, but not that the folder was the only correct answer — and the publish path reused the zip path's folder collapsing.

Surfaced while reviewing a downstream fork's PR against this foundation. The fixes here are ours; the fork's session-bridge work is not included and remains blocked on FrostMod.

## The defects

**A bike livery could publish from the wrong bike.** `plan_many` gave the `paint` slot no owner, so `Race` matched every bike's `Race.pnt` and the first match won. Worse than a wrong texture: `rel_dest` carries the matched bike's folder, so the receiver installed it onto the wrong bike as well.

**Helmet, goggle, boot and protection paints were never shared.** `dedup_assets` folds `rider/helmets/AGV/paints/Blue.pnt` into the AGV folder asset — correct for a zip, which carries the folder whole. `paints_of` then skips folders, so a publish uploaded nothing for those slots. Silent since the feature shipped.

**The live-reload watcher watched the wrong file.** `worn_paints` had `active_bike` in scope and wasn't passing it — the same mismatch, third call site.

## Approach

`Spec.parent: Option<String>` becomes an `Owner` enum:

- `Any` — nothing to check
- `Prefer(x)` — the existing fall-back-elsewhere behaviour, kept for rider models whose folder name and profile value genuinely disagree
- `Require(x)` — must be that owner; unresolved beats borrowed

A `strict: bool` beside the old `Option` would have let `strict && parent.is_none()` be constructed and silently do nothing. The enum can't express it.

`plan_many` becomes `plan_profile`, taking the `(bike_id, Loadout)` pairs `local_look` already had and resolving without the collapse — the same "addressed in its own right" contract `plan_detailed` already exists for, so no second dedup function was needed. Presets pass `None`: a preset has no bike id by design, it dresses whichever bike it is applied to.

## Testing

824 tests pass. Three new regression tests:

- duplicate livery names across two bikes each resolve to their own bike
- a livery missing from its own bike is unresolved, not borrowed
- nested helmet/goggle/boot/protection paints stay individually addressable — and the zip path still collapses them, so bundles stay small

`cargo check --target x86_64-pc-windows-gnu` is clean, no new warnings.

## Notes

No DB or schema change. Existing riders republish once on next sync: the digest moves and gear paints upload for the first time. Worth confirming on Windows that a duplicate livery name lands on the right bike, and that a helmet paint inside its model folder now reaches another rider.

Not addressed: the registry fan-out in `pull_rosters`, which needs to know which server the rider actually joined. That remains blocked on FrostMod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)