### PR TITLE
fix(install): probe the staged file with a real read, not `exists`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## 2026-08-22
 
 ### Fixed
+- **An install blocked by antivirus reported a bare "os error 2".** When a security product
+  blocks a freshly downloaded mod file in the temp folder, the app's check for it asked the
+  wrong question — it tested only whether the file still had a directory entry, which a
+  scanner holding the *contents* leaves untouched. The advice written for exactly this case
+  never fired, and the install failed with a raw path and an error number that reads as if
+  the mod were broken. The check now tries to read the file the same way the copy does, so a
+  blocked install names the file, says whether it was removed or locked, and points at the
+  folder to add an exclusion for.
 - **Paint sync published the wrong bike's livery.** Liveries were matched by filename alone,
   so a rider with `Race.pnt` on two bikes published whichever the folder walk reached first —
   and the file carried that bike's install path, so everyone on the grid saw it land on the

--- a/src-tauri/src/install.rs
+++ b/src-tauri/src/install.rs
@@ -1817,23 +1817,34 @@ fn worth_retrying(dst: &Path, e: &std::io::Error) -> bool {
 
 /// Turn a failed copy into something a player can act on.
 ///
-/// A staged file that has gone missing is the one case where the raw error actively
+/// A staged file the copy can no longer read is the one case where the raw error actively
 /// misleads: it reads as if the *mod* were broken, when the bytes downloaded fine and
 /// something on the machine took them away afterwards. Name the culprit and the folder to
 /// exclude, because "os error 2" leaves a player with nowhere to go.
+///
+/// The probe is a real read, not [`Path::exists`]: `exists` opens for no access at all, so a
+/// scanner blocking a file's *contents* waves it through while `fs::copy`, which asks for
+/// `GENERIC_READ`, is told "os error 2". Gating on `exists` meant this never fired.
 fn copy_failure(src: &Path, dst: &Path, e: std::io::Error) -> anyhow::Error {
-    if e.kind() == std::io::ErrorKind::NotFound && !src.exists() {
+    if let Err(probe) = File::open(src) {
         let name = src.file_name().unwrap_or_default().to_string_lossy().into_owned();
         let folder = src
             .parent()
             .map(|p| p.display().to_string())
             .unwrap_or_else(|| src.display().to_string());
+        // The copy says what it hit, the probe says why the file won't open; a report needs both.
+        log::error!("staged {name} could not be reopened: copy said {e}, opening said {probe}");
+        let fate = if probe.kind() == std::io::ErrorKind::NotFound {
+            "deleted or quarantined"
+        } else {
+            "locked against being read"
+        };
         return anyhow::anyhow!(
-            "{name} vanished from the staging folder part-way through the install. The \
-             download itself worked — something deleted or quarantined the file before it \
-             could be copied into place, which is almost always antivirus (mod .pkz files \
-             are a common false positive) or a temp-folder cleaner. Add an exclusion for \
-             {folder} and install it again."
+            "{name} could not be read back from the staging folder part-way through the \
+             install — it was {fate} after the download finished. The download itself \
+             worked, so this is almost always antivirus (mod .pkz files are a common false \
+             positive) or a temp-folder cleaner. Add an exclusion for {folder} and install \
+             it again."
         );
     }
     anyhow::Error::new(e).context(format!("copying {} to {}", src.display(), dst.display()))
@@ -3077,6 +3088,39 @@ mod tests {
         assert!(msg.contains("Scottsdale.pkz"), "{msg}");
         assert!(msg.contains(&staging.display().to_string()), "{msg}");
         assert!(msg.to_lowercase().contains("antivirus"), "{msg}");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The other half of the same trap, and the one that got past us: the staged file is
+    /// still listed, only its contents are out of reach. `Path::exists` answers yes — it
+    /// opens for no access at all — so gating the advice on it handed the player a bare
+    /// "os error 2" for a scanner hold. Unreadable has to count as gone.
+    #[cfg(unix)]
+    #[test]
+    fn an_unreadable_staged_file_blames_the_right_thing() {
+        use std::os::unix::fs::PermissionsExt;
+        let root = place_tmp("unreadable");
+        let staging = root.join("ex");
+        let mods = root.join("mods");
+        std::fs::create_dir_all(&mods).unwrap();
+        let src = staging.join("Scottsdale.pkz");
+        touch(&src);
+        std::fs::set_permissions(&src, std::fs::Permissions::from_mode(0o000)).unwrap();
+        if File::open(&src).is_ok() {
+            // Running as root, where the mode is advisory and there is nothing to stand in
+            // for the scanner.
+            let _ = std::fs::remove_dir_all(&root);
+            return;
+        }
+        assert!(src.exists(), "the entry is still there — that is the whole trap");
+
+        let err = copy_staged(&src, &mods.join("Scottsdale.pkz")).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("Scottsdale.pkz"), "{msg}");
+        assert!(msg.contains(&staging.display().to_string()), "{msg}");
+        assert!(msg.to_lowercase().contains("antivirus"), "{msg}");
+
+        std::fs::set_permissions(&src, std::fs::Permissions::from_mode(0o644)).unwrap();
         let _ = std::fs::remove_dir_all(&root);
     }
 


### PR DESCRIPTION
## The report

A player on 0.10.1 sent logs for a failed install of the track **FarmSX**. It wasn't FarmSX — three installs in that session died identically:

| time | mod | destination |
|---|---|---|
| 09:57:26 | `built-ktm250sx-f` (a `.pnt`) | `bikes\MX2OEM…\paints\` |
| 10:00:40 | `shop-263` Canada Heights | `tracks\compounds\` |
| 10:02:39 | `farmsx` | `tracks\compounds\` |

All three at the last step — the copy out of `%TEMP%\frost-*\extracted\` into the mods tree — with a bare `The system cannot find the file specified. (os error 2)`. The downloads themselves were fine (`shop download finished (success=true)`), and the 10:00:38 → 10:00:40 gap is `copy_staged`'s full 13×150 ms retry window burning down, so whatever held the file never let go.

## Why the advice never fired

`copy_failure` already has a message for exactly this — name the file, name the folder to exclude. It is gated on `!src.exists()`, and that is the wrong question.

`Path::exists()` → `fs::metadata` → opens with `access_mode(0)`, i.e. **no read access**, and falls back to reading the directory entry via `FindFirstFileExW` on `ACCESS_DENIED`. `fs::copy` → `CopyFileExW`, which opens the source for `GENERIC_READ`. A real-time scanner sitting on a freshly written mod file in `%TEMP%` blocks the second and waves through the first — so the probe reports the file present while every copy attempt returns `ERROR_FILE_NOT_FOUND`, and the player is handed a raw path and an error number that reads as if the mod were broken.

## The change

- Probe with `File::open(src)` — the same access the copy needs — instead of `exists`.
- Distinguish "deleted or quarantined" from "locked against being read", and log the probe's own error beside the copy's, so the next log bundle names the mechanism instead of leaving it to be inferred.
- New test `an_unreadable_staged_file_blames_the_right_thing`: a `chmod 000` source stands in for the scanner (entry present, contents unreachable). Only the deleted case was covered before.

This can't make the install succeed on a machine whose AV is blocking — nothing in-process can — but it turns a dead end into the one instruction that fixes it (exclude the staging folder).

## Verification

- 825/825 tests pass.
- Reverting just the probe makes the new test fail with the customer's exact string (`copying …/Scottsdale.pkz to …: … (os error 13)`), so the test pins the bug rather than the fix.
- `cargo check --target x86_64-pc-windows-gnu` clean; no new clippy warnings.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)