### PR TITLE
fix(runtime): report the stray msvcr90.dll we won't delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 2026-08-25
+
+### Fixed
+- **A `msvcr90.dll` in the game folder that the app wouldn't remove is no longer a silent
+  crash.** A loose VC9 CRT beside `mxbikes.exe` aborts the game with *"R6034 — An application
+  has made an attempt to load the C runtime library incorrectly"* the moment anything
+  plain-imports it, and v0.10.1 began taking back the copies this app itself planted. It only
+  ever deletes a file whose bytes match a Visual C++ 2008 assembly already on the PC, which is
+  what stops it reaching for somebody else's file — but everything it declined to touch it
+  swallowed, in three cases that all end with a dead game and no explanation: a copy that came
+  from somewhere else (a mod archive extracted into the game folder is the reported one), a PC
+  with no VC90 installed at all, where nothing can ever match and even our own copy is
+  stranded, and a file the running game is holding open.
+- **The app now says so, and offers the fix.** A file it won't delete on its own gets a red
+  bar naming it, and a button that renames it to `msvcr90.dll.disabled` — Windows resolves an
+  import by exact filename, so the rename is what defuses it, and a file somebody put there on
+  purpose survives the decision. Automatic removal is unchanged: still only ever a copy this
+  app can prove it made. The press is what settles provenance for everything else. When the
+  game is holding the file, the bar says to close it first rather than failing at a button.
+- **"Repair runtimes" reports the same thing**, so a repair that installed everything and still
+  found the reason the game won't start says that instead of "everything was already in place".
+
 ## 2026-08-22
 
 ### Fixed

--- a/src-tauri/src/frostmod_manage.rs
+++ b/src-tauri/src/frostmod_manage.rs
@@ -47,6 +47,11 @@ pub struct FrostmodStatus {
     /// which machines inject fine, and refusing to launch would take FrostMod away from
     /// anyone the detection is wrong about. It's a warning with a fix attached.
     pub missing_runtimes: Vec<crate::vcruntime::Runtime>,
+    /// A loose `msvcr90.dll` beside the game exe that we didn't remove. `Clear`/`Removed`
+    /// mean there is nothing to say; the other two mean the game will die with R6034 the
+    /// next time something plain-imports the CRT, and only the player can authorise the
+    /// fix — see `crate::vcruntime::disable_stray_msvcr90`.
+    pub stray_msvcr90: crate::vcruntime::Stray,
 }
 
 /// The folder we install FrostMod into and run it from — so also where anything it
@@ -238,9 +243,13 @@ pub async fn status(app: &AppHandle) -> FrostmodStatus {
     // Take back the loose `msvcr90.dll` versions 0.9.2–0.10.0 laid beside the exe. It kills
     // the game with R6034 — see `crate::vcruntime` — and the status poll is the only thing
     // that reaches a player who never opens Settings, so the cleanup rides along here.
-    if let Some(dir) = game_dir.as_deref() {
-        crate::vcruntime::remove_stray_msvcr90(dir);
-    }
+    //
+    // Its verdict travels on: what the sweep declines to delete is still a file that stops
+    // the game dead, and reporting it is the only way the player ever learns why.
+    let stray_msvcr90 = game_dir
+        .as_deref()
+        .map(crate::vcruntime::remove_stray_msvcr90)
+        .unwrap_or_default();
 
     FrostmodStatus {
         installed,
@@ -250,6 +259,7 @@ pub async fn status(app: &AppHandle) -> FrostmodStatus {
         running: crate::frostmod::is_running(),
         supported_for_game,
         missing_runtimes: crate::vcruntime::missing(game_dir.as_deref()),
+        stray_msvcr90,
     }
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5339,20 +5339,42 @@ async fn frostmod_install(
 /// Raises a UAC prompt — Microsoft's redistributables require admin, and only the shell
 /// can ask. A declined prompt comes back as `cancelled`, not an error, so the UI can fall
 /// back to handing over the download link instead of reading as broken.
-/// Install every Visual C++ runtime this machine is short of, and finish the VC90 job by
-/// placing `msvcr90.dll` beside the game exe.
+/// Install every Visual C++ runtime this machine is short of, and sweep the game folder for
+/// the loose `msvcr90.dll` older builds of this app left there.
 ///
 /// Deliberately not gated on `frostmod_status` having reported anything missing. The
 /// machine this exists for reported everything present and still couldn't start the game,
 /// so a repair reachable only from the warning bar would never have run there.
 #[tauri::command]
 async fn frostmod_repair_runtimes(app: tauri::AppHandle) -> vcruntime::RepairReport {
-    let game_dir = config::load(&app)
+    vcruntime::repair(&app, game_dir_for_runtimes(&app).as_deref()).await
+}
+
+/// Move a loose `msvcr90.dll` beside the game exe out of the loader's way.
+///
+/// The player-consented counterpart to the sweep, which only ever deletes a copy this app
+/// made. Reachable only once `frostmod_status` has reported a `foreign` or `locked` stray,
+/// because that report is what put the file in front of them to agree to.
+#[tauri::command]
+async fn frostmod_clear_stray_msvcr90(app: tauri::AppHandle) -> Result<String, String> {
+    let Some(dir) = game_dir_for_runtimes(&app) else {
+        return Err("No game folder is set, so there's nowhere to look.".into());
+    };
+    vcruntime::disable_stray_msvcr90(&dir)
+        .map(|p| p.display().to_string())
+        .map_err(|e| format!("{e:#}"))
+}
+
+/// Where the active title is installed, or `None` when we don't know.
+///
+/// `install_dir` hands back an empty string for "unset", which must not become the path
+/// `""` — every runtime path that touches the game folder needs the same guard.
+fn game_dir_for_runtimes(app: &tauri::AppHandle) -> Option<std::path::PathBuf> {
+    config::load(app)
         .ok()
         .map(|c| c.install_dir())
         .filter(|d| !d.trim().is_empty())
-        .map(std::path::PathBuf::from);
-    vcruntime::repair(&app, game_dir.as_deref()).await
+        .map(std::path::PathBuf::from)
 }
 
 /// Microsoft's download page links for every runtime, so the UI can always offer the
@@ -5371,13 +5393,9 @@ async fn frostmod_install_runtime(
     app: tauri::AppHandle,
     runtime: vcruntime::Runtime,
 ) -> Result<vcruntime::InstallOutcome, String> {
-    // VC90 isn't finished by the installer alone: the copy that serves plain imports has
-    // to land beside the game exe, so the install needs to know where that is.
-    let game_dir = config::load(&app)
-        .ok()
-        .map(|c| c.install_dir())
-        .filter(|d| !d.trim().is_empty())
-        .map(std::path::PathBuf::from);
+    // The game folder is part of the VC90 answer — a private assembly can sit there — so
+    // the post-install re-check has to be asked the same question the banner was.
+    let game_dir = game_dir_for_runtimes(&app);
     vcruntime::install(&app, runtime, game_dir.as_deref())
         .await
         .map_err(|e| format!("{e:#}"))
@@ -7047,6 +7065,7 @@ fn main() {
             frostmod_install,
             frostmod_install_runtime,
             frostmod_repair_runtimes,
+            frostmod_clear_stray_msvcr90,
             runtime_downloads,
             frostmod_start,
             frostmod_stop,

--- a/src-tauri/src/vcruntime.rs
+++ b/src-tauri/src/vcruntime.rs
@@ -88,6 +88,36 @@ pub enum Runtime {
     Vc140X86,
 }
 
+/// What is left of a loose `msvcr90.dll` beside the game exe, after the sweep has had its
+/// go.
+///
+/// The two "still there" arms are the ones that matter: a file we won't delete unasked is
+/// still a file that aborts the game with R6034, so the app reports it and offers
+/// [`disable_stray_msvcr90`] rather than logging a line nobody reads. Serialized into
+/// `FrostmodStatus`, so the strings are a UI contract.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Stray {
+    /// Nothing loose beside the exe. The overwhelmingly common case.
+    #[default]
+    Clear,
+    /// There was one, it was ours, and it's gone now.
+    Removed,
+    /// A `msvcr90.dll` matching no VC90 assembly on this PC. Equally fatal, but not ours
+    /// to delete on our own say-so — the player is shown it and offered the move.
+    Foreign,
+    /// Ours, and the delete failed. Something holds it open, which in practice is the game
+    /// running with it mapped: closing the game and trying again is the whole fix.
+    Locked,
+}
+
+impl Stray {
+    /// Is there still a file there that will kill the game? The question the banner asks.
+    pub fn needs_the_player(self) -> bool {
+        matches!(self, Stray::Foreign | Stray::Locked)
+    }
+}
+
 /// What an install attempt actually did.
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -345,11 +375,15 @@ fn vc90_present(game_dir: Option<&std::path::Path>) -> bool {
 ///
 /// A `Microsoft.VC90.CRT` folder beside the exe is left strictly alone: that one works.
 ///
+/// What it *won't* delete, it now reports: a [`Stray::Foreign`] or [`Stray::Locked`] verdict
+/// travels up to the player as a banner offering [`disable_stray_msvcr90`]. Silence here was
+/// its own bug — the app knew there was a file that kills the game and only said so in a log.
+///
 /// Best-effort, and safe on a hot path. The settled case costs one failed `read`. A locked
 /// file — the game running with the DLL mapped — just means the next poll tries again, and
 /// only the first failure per folder is logged so a stuck one doesn't fill the log.
 #[cfg(windows)]
-pub fn remove_stray_msvcr90(game_dir: &std::path::Path) -> bool {
+pub fn remove_stray_msvcr90(game_dir: &std::path::Path) -> Stray {
     remove_stray_msvcr90_against(game_dir, &sxs_vc90_dirs())
 }
 
@@ -361,10 +395,10 @@ pub fn remove_stray_msvcr90(game_dir: &std::path::Path) -> bool {
 fn remove_stray_msvcr90_against(
     game_dir: &std::path::Path,
     sxs_dirs: &[std::path::PathBuf],
-) -> bool {
+) -> Stray {
     let stray = app_local_msvcr90(game_dir);
     let Ok(found) = std::fs::read(&stray) else {
-        return false;
+        return Stray::Clear;
     };
     let ours = sxs_dirs
         .iter()
@@ -376,7 +410,7 @@ fn remove_stray_msvcr90_against(
                 stray.display()
             );
         }
-        return false;
+        return Stray::Foreign;
     }
     match std::fs::remove_file(&stray) {
         Ok(()) => {
@@ -384,7 +418,7 @@ fn remove_stray_msvcr90_against(
                 "removed {} — a loose VC9 CRT there aborts the game with R6034",
                 stray.display()
             );
-            true
+            Stray::Removed
         }
         Err(e) => {
             if first_time(&MOANED, game_dir) {
@@ -393,7 +427,7 @@ fn remove_stray_msvcr90_against(
                     stray.display()
                 );
             }
-            false
+            Stray::Locked
         }
     }
 }
@@ -416,8 +450,72 @@ static LEFT_ALONE: Folders = std::sync::Mutex::new(std::collections::BTreeSet::n
 static MOANED: Folders = std::sync::Mutex::new(std::collections::BTreeSet::new());
 
 #[cfg(not(windows))]
-pub fn remove_stray_msvcr90(_game_dir: &std::path::Path) -> bool {
-    false
+pub fn remove_stray_msvcr90(_game_dir: &std::path::Path) -> Stray {
+    Stray::Clear
+}
+
+/// What a defused copy is parked under. Windows resolves an import by exact filename, so
+/// the rename alone is what makes it harmless — nothing will ever look for this name.
+const DISABLED_SUFFIX: &str = "disabled";
+
+/// Move a loose `msvcr90.dll` out of the loader's way, whoever put it there.
+///
+/// The consenting half of [`remove_stray_msvcr90`]. That one only ever touches a copy this
+/// app made, because reaching for a file of unknown provenance is not a decision to take on
+/// someone's behalf. This runs when the player has been shown the file and asked for it to
+/// go, which settles the provenance question the only way it can be settled.
+///
+/// A rename rather than a delete, for the same reason: it stops being loadable the moment
+/// the name changes, and if it turns out to have been wanted, it is right there. Returns
+/// where it went, so the UI can say.
+///
+/// Not `cfg(windows)`: it is ordinary file work, and keeping it buildable everywhere is
+/// what lets the tests cover it from a Mac.
+pub fn disable_stray_msvcr90(game_dir: &std::path::Path) -> anyhow::Result<std::path::PathBuf> {
+    let stray = app_local_msvcr90(game_dir);
+    if !stray.is_file() {
+        anyhow::bail!(
+            "There's no loose msvcr90.dll in {} any more — nothing to move.",
+            game_dir.display()
+        );
+    }
+    let target = free_disabled_name(game_dir)?;
+    // A sharing violation here is the game holding it mapped, and that is the one failure
+    // the player can do something about, so it gets named rather than passed through raw.
+    std::fs::rename(&stray, &target).map_err(|e| {
+        anyhow::anyhow!(
+            "Couldn't move {} aside ({e}). If the game is open, close it and try again — \
+             Windows won't move a file something has loaded.",
+            stray.display()
+        )
+    })?;
+    log::info!(
+        "moved {} aside to {} at the player's request",
+        stray.display(),
+        target.display()
+    );
+    Ok(target)
+}
+
+/// A parking name nothing is using yet.
+///
+/// Pressing the button twice — two archives, two strays, months apart — must not have the
+/// second copy overwrite the first, because the whole point of a rename is that the file
+/// survives the decision.
+fn free_disabled_name(game_dir: &std::path::Path) -> anyhow::Result<std::path::PathBuf> {
+    let base = game_dir.join(format!("{MSVCR90_DLL}.{DISABLED_SUFFIX}"));
+    if !base.exists() {
+        return Ok(base);
+    }
+    (1..=50)
+        .map(|n| game_dir.join(format!("{MSVCR90_DLL}.{DISABLED_SUFFIX}.{n}")))
+        .find(|c| !c.exists())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "There are already 50 disabled copies in {} — clear some out first.",
+                game_dir.display()
+            )
+        })
 }
 
 /// The 2015–2022 runtime installs into `System32` rather than WinSxS. This process is
@@ -538,9 +636,10 @@ pub struct RepairReport {
     /// Still absent afterwards — a declined UAC prompt, a failed download, an install that
     /// needs a reboot to finish. Each one is a link the UI hands over.
     pub still_missing: Vec<Runtime>,
-    /// Whether a stray `msvcr90.dll` beside the game exe was cleaned up — see
-    /// [`remove_stray_msvcr90`]. Left by 0.9.2–0.10.0, and fatal to the game.
-    pub msvcr90_removed: bool,
+    /// What the sweep of the game folder found — see [`remove_stray_msvcr90`]. `Removed`
+    /// is a repair that did something; the two "still there" arms are a repair that found
+    /// the likeliest reason the game won't start and needs the player to say the word.
+    pub stray_msvcr90: Stray,
     /// Set when we had nowhere to place it — no game folder configured.
     pub game_dir_known: bool,
 }
@@ -587,15 +686,15 @@ pub async fn repair(
     // as well as on the status poll: a player pressing repair is a player whose game is
     // already misbehaving, and this is the likeliest reason.
     if let Some(dir) = game_dir {
-        report.msvcr90_removed = remove_stray_msvcr90(dir);
+        report.stray_msvcr90 = remove_stray_msvcr90(dir);
     }
 
     invalidate();
     log::info!(
-        "repair: installed {:?}, still missing {:?}, stray msvcr90 removed: {}",
+        "repair: installed {:?}, still missing {:?}, stray msvcr90: {:?}",
         report.installed,
         report.still_missing,
-        report.msvcr90_removed
+        report.stray_msvcr90
     );
     report
 }
@@ -730,10 +829,10 @@ fn run_elevated(exe: &std::path::Path, args: &str) -> anyhow::Result<bool> {
 
 /// Download Microsoft's redistributable and install it, then prove it worked.
 ///
-/// For VC90 the redistributable is only half the job — it registers the side-by-side
-/// assembly and leaves the ordinary search path untouched — so this finishes by placing a
-/// copy beside the game exe. See the module docs for why that second half is the one that
-/// stops the "MSVCR90.dll was not found" box.
+/// `game_dir` is only here for that last part: the VC90 probe reads the game folder too, so
+/// the re-check needs it to reach the same verdict the banner did. Nothing is written there
+/// — an earlier version placed a copy of the CRT beside the exe and that is exactly the
+/// R6034 trap the module docs open with.
 #[cfg(windows)]
 pub async fn install(
     app: &tauri::AppHandle,
@@ -966,6 +1065,20 @@ mod tests {
             serde_json::to_string(&InstallOutcome::Cancelled).unwrap(),
             "\"cancelled\""
         );
+        assert_eq!(serde_json::to_string(&Stray::Clear).unwrap(), "\"clear\"");
+        assert_eq!(serde_json::to_string(&Stray::Removed).unwrap(), "\"removed\"");
+        assert_eq!(serde_json::to_string(&Stray::Foreign).unwrap(), "\"foreign\"");
+        assert_eq!(serde_json::to_string(&Stray::Locked).unwrap(), "\"locked\"");
+    }
+
+    /// Only the arms that leave a file behind are the player's problem — banner on the
+    /// other two would be an alarm about a folder that is already fine.
+    #[test]
+    fn only_a_surviving_file_asks_for_the_player() {
+        assert!(!Stray::Clear.needs_the_player());
+        assert!(!Stray::Removed.needs_the_player());
+        assert!(Stray::Foreign.needs_the_player());
+        assert!(Stray::Locked.needs_the_player());
     }
 
     /// A scratch tree, named per test so a parallel run doesn't collide. The house pattern
@@ -996,22 +1109,22 @@ mod tests {
         let sxs = fake_sxs(&root, b"the real VC9 CRT");
         std::fs::write(game.join(MSVCR90_DLL), b"the real VC9 CRT").unwrap();
 
-        assert!(remove_stray_msvcr90_against(&game, &[sxs]));
+        assert_eq!(remove_stray_msvcr90_against(&game, &[sxs]), Stray::Removed);
         assert!(!game.join(MSVCR90_DLL).exists(), "the stray copy must be gone");
     }
 
-    /// A `msvcr90.dll` we didn't put there is somebody else's decision. It is still an R6034
-    /// waiting to happen, but deleting a file of unknown provenance out of someone's game
-    /// folder is not ours to do.
+    /// A `msvcr90.dll` we didn't put there is somebody else's decision, so we don't delete
+    /// it — but it is still an R6034 waiting to happen, so we say so. Reporting `Foreign`
+    /// is what puts the file in front of the player, who *can* authorise the move.
     #[test]
-    fn a_file_we_didnt_place_is_left_alone() {
+    fn a_file_we_didnt_place_is_reported_not_deleted() {
         let root = scratch("theirs");
         let game = root.join("game");
         std::fs::create_dir_all(&game).unwrap();
         let sxs = fake_sxs(&root, b"the real VC9 CRT");
         std::fs::write(game.join(MSVCR90_DLL), b"something else entirely").unwrap();
 
-        assert!(!remove_stray_msvcr90_against(&game, &[sxs]));
+        assert_eq!(remove_stray_msvcr90_against(&game, &[sxs]), Stray::Foreign);
         assert!(game.join(MSVCR90_DLL).exists(), "an unrecognised file must survive");
     }
 
@@ -1030,19 +1143,33 @@ mod tests {
         let newest = fake_sxs(&root, b"the newest servicing build");
         std::fs::write(game.join(MSVCR90_DLL), b"the older servicing build").unwrap();
 
-        assert!(remove_stray_msvcr90_against(&game, &[newest, old_dir]));
+        assert_eq!(
+            remove_stray_msvcr90_against(&game, &[newest, old_dir]),
+            Stray::Removed
+        );
         assert!(!game.join(MSVCR90_DLL).exists());
     }
 
-    /// Nothing to do, and no source to compare against, are both quiet no-ops.
+    /// An empty folder is a quiet no-op. A machine with no VC90 at all is not: nothing can
+    /// ever match, so even our own copy is stranded there — and that is precisely the PC
+    /// someone drops a loose CRT into, having been told it fixes the missing-DLL box. It
+    /// reports `Foreign` rather than the silence it used to, because the file is still
+    /// going to kill the game and somebody has to be told.
     #[test]
-    fn an_empty_game_folder_is_a_no_op() {
+    fn nothing_there_is_clear_and_no_winsxs_still_reports() {
         let root = scratch("empty");
         let game = root.join("game");
         std::fs::create_dir_all(&game).unwrap();
-        assert!(!remove_stray_msvcr90_against(&game, &[fake_sxs(&root, b"crt")]));
+        assert_eq!(
+            remove_stray_msvcr90_against(&game, &[fake_sxs(&root, b"crt")]),
+            Stray::Clear
+        );
         std::fs::write(game.join(MSVCR90_DLL), b"crt").unwrap();
-        assert!(!remove_stray_msvcr90_against(&game, &[]), "no WinSxS means no verdict");
+        assert_eq!(
+            remove_stray_msvcr90_against(&game, &[]),
+            Stray::Foreign,
+            "a PC with no VC90 must still hear about the file"
+        );
         assert!(game.join(MSVCR90_DLL).exists());
     }
 
@@ -1057,8 +1184,46 @@ mod tests {
         std::fs::write(private.join(MSVCR90_DLL), b"the real VC9 CRT").unwrap();
         let sxs = fake_sxs(&root, b"the real VC9 CRT");
 
-        assert!(!remove_stray_msvcr90_against(&game, &[sxs]));
+        assert_eq!(remove_stray_msvcr90_against(&game, &[sxs]), Stray::Clear);
         assert!(private.join(MSVCR90_DLL).is_file(), "a working private assembly must survive");
+
+        // And the player-pressed move doesn't reach into it either.
+        assert!(disable_stray_msvcr90(&game).is_err(), "there is no loose file to move");
+        assert!(private.join(MSVCR90_DLL).is_file());
+    }
+
+    /// The button the banner offers: the file stops being loadable, and it still exists.
+    #[test]
+    fn the_move_renames_rather_than_deletes() {
+        let root = scratch("disable");
+        let game = root.join("game");
+        std::fs::create_dir_all(&game).unwrap();
+        std::fs::write(game.join(MSVCR90_DLL), b"somebody else's CRT").unwrap();
+
+        let moved = disable_stray_msvcr90(&game).unwrap();
+        assert!(!game.join(MSVCR90_DLL).exists(), "the loadable name must be gone");
+        assert_eq!(std::fs::read(&moved).unwrap(), b"somebody else's CRT");
+        assert_eq!(moved, game.join("msvcr90.dll.disabled"));
+    }
+
+    /// Twice over — two archives, months apart — must not have the second copy overwrite
+    /// the first. A rename that destroys the file it parked isn't a rename.
+    #[test]
+    fn a_second_move_parks_beside_the_first() {
+        let root = scratch("disable-twice");
+        let game = root.join("game");
+        std::fs::create_dir_all(&game).unwrap();
+
+        std::fs::write(game.join(MSVCR90_DLL), b"the first one").unwrap();
+        disable_stray_msvcr90(&game).unwrap();
+        std::fs::write(game.join(MSVCR90_DLL), b"the second one").unwrap();
+        let second = disable_stray_msvcr90(&game).unwrap();
+
+        assert_eq!(second, game.join("msvcr90.dll.disabled.1"));
+        assert_eq!(
+            std::fs::read(game.join("msvcr90.dll.disabled")).unwrap(),
+            b"the first one"
+        );
     }
 
     /// A private assembly is a route to the CRT; a loose DLL beside the exe is the R6034

--- a/src/Components/RuntimeBanner/RuntimeBanner.tsx
+++ b/src/Components/RuntimeBanner/RuntimeBanner.tsx
@@ -1,4 +1,12 @@
-import { AlertTriangle, Download, Loader2, X } from "lucide-react";
+import {
+  AlertTriangle,
+  Download,
+  FolderInput,
+  Loader2,
+  OctagonAlert,
+  X,
+} from "lucide-react";
+import type { ReactNode } from "react";
 import { Button } from "@/Components/ui/button";
 import { RUNTIME_NAME_KEY } from "@/api/mods";
 import { useFrostmod } from "@/Context/FrostmodContext";
@@ -6,20 +14,60 @@ import { Trans } from "@/i18n";
 import { useT } from "@/i18n/context";
 
 /**
- * Slim bar shown when Windows is missing a Visual C++ runtime the FrostMod chain needs.
+ * Slim bar for the two things that stop FrostMod reaching the game and can't be fixed
+ * behind the player's back.
  *
- * This is the one problem the app can't fix behind the player's back: installing a
- * Microsoft redistributable needs admin rights, so it has to be a button they press. It
- * earns a banner rather than living only in Settings because the symptom — FrostMod
- * silently failing to attach, or a bare "…dll was not found" box over the game — gives no
- * hint that Settings is where to look.
+ * **A stray `msvcr90.dll`** beside the game exe, which aborts MX Bikes with R6034 the
+ * moment anything plain-imports the CRT. The app deletes the copies it planted itself, but
+ * a file it can't prove it planted is somebody else's, and moving it aside has to be a
+ * press. This one is red and outranks the other: it is an active crash, not a gap.
  *
- * Renders nothing when there's nothing missing, which is the overwhelmingly common case.
+ * **A missing Visual C++ runtime**, which needs admin rights to install, so it likewise has
+ * to be a button. It earns a bar rather than living only in Settings because the symptom —
+ * FrostMod silently failing to attach, or a bare "…dll was not found" box over the game —
+ * gives no hint that Settings is where to look.
+ *
+ * Renders nothing when neither applies, which is the overwhelmingly common case.
  */
 export default function RuntimeBanner() {
   const t = useT();
-  const { runtimeWarning, installingRuntime, installRuntime, dismissRuntimeWarning } =
-    useFrostmod();
+  const {
+    runtimeWarning,
+    installingRuntime,
+    installRuntime,
+    dismissRuntimeWarning,
+    strayWarning,
+    clearingStray,
+    clearStrayMsvcr90,
+  } = useFrostmod();
+
+  if (strayWarning) {
+    // `locked` is ours and the game is holding it open, so the fix is theirs to make in
+    // the right order — pressing again before closing the game just fails again.
+    const isLocked = strayWarning === "locked";
+    return (
+      <Bar
+        tone="danger"
+        body={
+          <Trans
+            k={isLocked ? "runtime.strayLocked" : "runtime.strayForeign"}
+            values={{
+              what: <span className="font-semibold">msvcr90.dll</span>,
+            }}
+          />
+        }
+        pitch={t(isLocked ? "runtime.strayLockedPitch" : "runtime.strayPitch")}
+        action={t("runtime.strayFix")}
+        actionIcon={FolderInput}
+        busyLabel={t("runtime.strayClearing")}
+        busy={clearingStray}
+        onAction={() => void clearStrayMsvcr90()}
+        onDismiss={dismissRuntimeWarning}
+        dismissLabel={t("runtime.dismiss")}
+      />
+    );
+  }
+
   if (!runtimeWarning) return null;
 
   // vc90 is the *game's* runtime and vc140 is FrostMod's own, so they need different
@@ -33,38 +81,86 @@ export default function RuntimeBanner() {
   const nameKey = RUNTIME_NAME_KEY[runtimeWarning];
 
   return (
-    <div className="flex items-center gap-3 border-b border-amber-500/25 bg-amber-500/10 px-4 py-2 text-sm text-foreground">
-      <AlertTriangle className="size-4 shrink-0 text-amber-500" />
-      <span className="min-w-0 truncate">
+    <Bar
+      tone="warning"
+      body={
         <Trans
           k={bodyKey}
-          values={{
-            what: <span className="font-semibold">{t(nameKey)}</span>,
-          }}
+          values={{ what: <span className="font-semibold">{t(nameKey)}</span> }}
         />
-        <span className="ml-1 text-muted-foreground">{t("runtime.pitch")}</span>
+      }
+      pitch={t("runtime.pitch")}
+      action={t("runtime.fixIt")}
+      actionIcon={Download}
+      busyLabel={t("runtime.installing")}
+      busy={installingRuntime}
+      onAction={() => void installRuntime(runtimeWarning)}
+      onDismiss={dismissRuntimeWarning}
+      dismissLabel={t("runtime.dismiss")}
+    />
+  );
+}
+
+/**
+ * The bar itself, so the two cases differ in their words and colour rather than in their
+ * markup. `danger` is a file crashing the game right now; `warning` is something that
+ * won't work when it's reached.
+ */
+function Bar({
+  tone,
+  body,
+  pitch,
+  action,
+  actionIcon: ActionIcon,
+  busyLabel,
+  busy,
+  onAction,
+  onDismiss,
+  dismissLabel,
+}: {
+  tone: "danger" | "warning";
+  body: ReactNode;
+  pitch: string;
+  action: string;
+  actionIcon: typeof Download;
+  busyLabel: string;
+  busy: boolean;
+  onAction: () => void;
+  onDismiss: () => void;
+  dismissLabel: string;
+}) {
+  const danger = tone === "danger";
+  const Icon = danger ? OctagonAlert : AlertTriangle;
+  return (
+    <div
+      className={`flex items-center gap-3 border-b px-4 py-2 text-sm text-foreground ${
+        danger
+          ? "border-red-500/25 bg-red-500/10"
+          : "border-amber-500/25 bg-amber-500/10"
+      }`}
+    >
+      <Icon className={`size-4 shrink-0 ${danger ? "text-red-500" : "text-amber-500"}`} />
+      <span className="min-w-0 truncate">
+        {body}
+        <span className="ml-1 text-muted-foreground">{pitch}</span>
       </span>
 
       <div className="ml-auto flex shrink-0 items-center gap-1.5">
-        <Button
-          size="sm"
-          onClick={() => void installRuntime(runtimeWarning)}
-          disabled={installingRuntime}
-        >
-          {installingRuntime ? (
+        <Button size="sm" onClick={onAction} disabled={busy}>
+          {busy ? (
             <Loader2 className="size-3.5 animate-spin" />
           ) : (
-            <Download className="size-3.5" />
+            <ActionIcon className="size-3.5" />
           )}
-          {installingRuntime ? t("runtime.installing") : t("runtime.fixIt")}
+          {busy ? busyLabel : action}
         </Button>
         <Button
           size="icon"
           variant="ghost"
           className="size-8"
-          onClick={dismissRuntimeWarning}
-          disabled={installingRuntime}
-          aria-label={t("runtime.dismiss")}
+          onClick={onDismiss}
+          disabled={busy}
+          aria-label={dismissLabel}
         >
           <X className="size-4" />
         </Button>

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -279,7 +279,7 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
   // bottle on macOS. The app starts FrostMod in whichever prefix holds the game.
   const hasFrostmod = isWindows || platform === "linux" || isMac;
   const { theme, setTheme } = useTheme();
-  const { running, reload, status, installing, checking, statusError, install, start, stop, refreshStatus, missingRuntime, installRuntime, installingRuntime, repairRuntimes, repairingRuntimes } =
+  const { running, reload, status, installing, checking, statusError, install, start, stop, refreshStatus, missingRuntime, installRuntime, installingRuntime, repairRuntimes, repairingRuntimes, strayMsvcr90, clearingStray, clearStrayMsvcr90 } =
     useFrostmod();
   const { check: checkForUpdates } = useUpdate();
   const { startTour } = useTour();
@@ -1521,9 +1521,14 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
                     ? t("settings.checkingGitHub")
                     : statusError
                       ? t("settings.updateCheckFailed")
-                      : // Above everything else: a missing Visual C++ runtime stops
-                        // FrostMod attaching at all, and no amount of repairing or
-                        // updating FrostMod puts one on the machine.
+                      : // Above everything else: a file in the game folder that aborts
+                        // MX Bikes with R6034 the moment anything loads the VC9 CRT. The
+                        // game not starting at all outranks FrostMod not attaching.
+                        strayMsvcr90
+                        ? t("settings.frostmodStrayMsvcr90")
+                        : // Then a missing Visual C++ runtime, which stops FrostMod
+                          // attaching at all — and no amount of repairing or updating
+                          // FrostMod puts one on the machine.
                         missingRuntime
                         ? t("settings.frostmodRuntimeMissing")
                         : status?.needsRepair
@@ -1541,6 +1546,22 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
                 </span>
               </div>
               <div className="flex items-center gap-1.5">
+                {/* The banner carries this too, but a dismissed bar shouldn't take the
+                    only explanation with it — and this is the one press that moves a file
+                    out of somebody's game folder, so it stays somewhere they can find it
+                    again. */}
+                {strayMsvcr90 && (
+                  <Button
+                    size="sm"
+                    onClick={() => void clearStrayMsvcr90()}
+                    disabled={clearingStray || repairingRuntimes}
+                    title={t("runtime.strayFixHint")}
+                  >
+                    {clearingStray
+                      ? t("runtime.strayClearing")
+                      : t("runtime.strayFix")}
+                  </Button>
+                )}
                 {/* Its own button rather than a mode of the one below: the FrostMod
                     install and the Windows component are separate things to fix, and
                     someone can genuinely need both. */}

--- a/src/Context/Frostmod.tsx
+++ b/src/Context/Frostmod.tsx
@@ -9,6 +9,7 @@ import {
 import { toast } from "sonner";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
 import {
+  frostmodClearStrayMsvcr90,
   frostmodInstall,
   frostmodInstallRuntime,
   frostmodRepairRuntimes,
@@ -64,6 +65,7 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
   const [statusError, setStatusError] = useState(false);
   const [installingRuntime, setInstallingRuntime] = useState(false);
   const [repairingRuntimes, setRepairingRuntimes] = useState(false);
+  const [clearingStray, setClearingStray] = useState(false);
   const [runtimeDismissed, setRuntimeDismissed] = useState(false);
   const mounted = useRef(true);
 
@@ -266,7 +268,8 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
       const report = await frostmodRepairRuntimes();
       await refreshStatus();
 
-      const fixed = report.installed.length > 0 || report.msvcr90Removed;
+      const fixed =
+        report.installed.length > 0 || report.strayMsvcr90 === "removed";
       if (report.stillMissing.length > 0) {
         // Partly done at best, and every remaining item has a link. Offer the first —
         // opening three tabs at once would be its own kind of unhelpful.
@@ -308,6 +311,36 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
       setRepairingRuntimes(false);
     }
   }, [refreshStatus, t]);
+
+  /**
+   * Move the stray `msvcr90.dll` aside, now that the player has asked for it.
+   *
+   * The one file-destroying thing in here, which is why it is only ever reachable from a
+   * bar that has already named the file: the backend refuses to delete a `msvcr90.dll` it
+   * can't prove this app planted, and a press is the only other thing that settles it.
+   */
+  const clearStrayMsvcr90 = useCallback(async () => {
+    setClearingStray(true);
+    try {
+      await frostmodClearStrayMsvcr90();
+      await refreshStatus();
+      toast.success(t("runtime.strayCleared"), {
+        description: t("runtime.strayClearedDesc"),
+      });
+    } catch (e) {
+      // Almost always the game holding the file open, and the backend's message says so.
+      toast.error(t("runtime.strayClearFailed"), { description: String(e) });
+    } finally {
+      setClearingStray(false);
+    }
+  }, [refreshStatus, t]);
+
+  // A file that crashes the game outranks a runtime that isn't installed, so this is
+  // checked before `missingRuntime` wherever one bar has to win. `clear`/`removed` mean
+  // there is nothing there — only the two arms that leave a file behind reach the UI.
+  const stray = status?.strayMsvcr90;
+  const strayMsvcr90 = stray === "foreign" || stray === "locked" ? stray : null;
+  const strayWarning = runtimeDismissed ? null : strayMsvcr90;
 
   // Only ever surface one at a time: two banners stacked over the app is noise, and the
   // game's own runtime (vc90) is the one that produces the error people actually report,
@@ -371,11 +404,15 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
       installRuntime,
       repairingRuntimes,
       repairRuntimes,
+      strayMsvcr90,
+      strayWarning,
+      clearingStray,
+      clearStrayMsvcr90,
       dismissRuntimeWarning,
       runtimeWarning,
       missingRuntime,
     }),
-    [running, attachment, status, installing, checking, statusError, reload, probe, refreshStatus, install, start, stop, installingRuntime, installRuntime, repairingRuntimes, repairRuntimes, dismissRuntimeWarning, runtimeWarning, missingRuntime],
+    [running, attachment, status, installing, checking, statusError, reload, probe, refreshStatus, install, start, stop, installingRuntime, installRuntime, repairingRuntimes, repairRuntimes, strayMsvcr90, strayWarning, clearingStray, clearStrayMsvcr90, dismissRuntimeWarning, runtimeWarning, missingRuntime],
   );
 
   return (

--- a/src/Context/FrostmodContext.ts
+++ b/src/Context/FrostmodContext.ts
@@ -3,6 +3,7 @@ import type {
   Attachment,
   FrostmodStatus,
   ReloadOutcome,
+  StrayMsvcr90,
   VcRuntime,
 } from "../types";
 
@@ -43,8 +44,8 @@ export interface FrostmodContextValue {
   /** True while a full runtime repair is in flight. */
   repairingRuntimes: boolean;
   /**
-   * Install every Visual C++ runtime this PC is short of, and remove a stray `msvcr90.dll`
-   * beside the game executable if an older build of this app left one there.
+   * Install every Visual C++ runtime this PC is short of, and sweep up a stray
+   * `msvcr90.dll` beside the game executable if an older build of this app left one there.
    *
    * Unlike {@link installRuntime} this isn't gated on anything having been detected as
    * missing, which is the point of it: a PC can report every runtime present and still
@@ -54,6 +55,31 @@ export interface FrostmodContextValue {
    * it couldn't do.
    */
   repairRuntimes: () => Promise<void>;
+  /**
+   * A loose `msvcr90.dll` beside the game exe that the app won't remove on its own —
+   * `"foreign"` (somebody else's file) or `"locked"` (the game is holding ours open).
+   * `null` when there's nothing to report, which is nearly always.
+   *
+   * It outranks {@link runtimeWarning} in the banner: a missing runtime is a thing that
+   * won't work, this is a file actively crashing the game with R6034.
+   */
+  strayMsvcr90: Exclude<StrayMsvcr90, "clear" | "removed"> | null;
+  /**
+   * The same thing the banner should show — `null` once dismissed this session. Paired
+   * with {@link strayMsvcr90} the way {@link runtimeWarning} is with
+   * {@link missingRuntime}: Settings keeps explaining what a dismissed bar stopped saying.
+   */
+  strayWarning: Exclude<StrayMsvcr90, "clear" | "removed"> | null;
+  /** True while the stray file is being moved aside. */
+  clearingStray: boolean;
+  /**
+   * Rename the stray `msvcr90.dll` to `msvcr90.dll.disabled`, on the player's say-so.
+   *
+   * The consenting counterpart to {@link repairRuntimes}, which only ever deletes a copy
+   * this app made. Never throws — a failure (the game holding the file) comes back as a
+   * toast telling them what to do about it.
+   */
+  clearStrayMsvcr90: () => Promise<void>;
   /** Hide the runtime banner for this session (the Settings panel keeps showing it). */
   dismissRuntimeWarning: () => void;
   /** What the banner should warn about — `null` once dismissed this session. */

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -1814,6 +1814,16 @@ export function frostmodRepairRuntimes(): Promise<RuntimeRepairReport> {
   return invoke<RuntimeRepairReport>("frostmod_repair_runtimes");
 }
 
+/** Move a loose `msvcr90.dll` beside the game exe out of the loader's way.
+ *
+ *  Renames it to `msvcr90.dll.disabled` rather than deleting: the loader matches the exact
+ *  filename, so the rename is what defuses it, and a file somebody else put there survives
+ *  the decision. Resolves to where it went; rejects with a message worth showing — a file
+ *  the running game holds open is the common one. */
+export function frostmodClearStrayMsvcr90(): Promise<string> {
+  return invoke<string>("frostmod_clear_stray_msvcr90");
+}
+
 /** Where to send someone whose UAC prompt we can't raise (or who declined it).
  *
  *  Microsoft's own direct downloads, the same ones the backend fetches — a download page

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -325,6 +325,20 @@ export const de: Translation = {
   "runtime.repairNoGameFolderDesc":
     "Die Laufzeitkomponenten sind installiert, aber ohne Installationsordner können wir den Spielordner selbst nicht prüfen. Lege ihn oben fest und repariere erneut.",
   "runtime.repairFailed": "Laufzeitkomponenten konnten nicht repariert werden",
+  "runtime.strayForeign": "Eine Datei in deinem Spielordner ({{what}}) lässt MX Bikes abstürzen.",
+  "runtime.strayLocked": "{{what}} in deinem Spielordner lässt MX Bikes abstürzen.",
+  "runtime.strayPitch":
+    "Sie verursacht den Fehler \"R6034\" beim Start. Beiseitelegen genügt — gelöscht wird nichts.",
+  "runtime.strayLockedPitch":
+    "Sie verursacht den Fehler \"R6034\" beim Start. Schließe zuerst MX Bikes, dann leg sie beiseite.",
+  "runtime.strayFix": "Beiseitelegen",
+  "runtime.strayFixHint":
+    "Benennt sie in msvcr90.dll.disabled um, damit Windows sie nicht mehr lädt. Gelöscht wird nichts.",
+  "runtime.strayClearing": "Wird verschoben…",
+  "runtime.strayCleared": "Aus dem Weg geräumt",
+  "runtime.strayClearedDesc":
+    "Sie heißt jetzt msvcr90.dll.disabled und liegt im selben Ordner. Starte MX Bikes neu.",
+  "runtime.strayClearFailed": "Datei konnte nicht verschoben werden",
   "update.checkFailed": "Updates konnten nicht geprüft werden",
   "update.failed": "Update fehlgeschlagen",
 
@@ -629,6 +643,8 @@ export const de: Translation = {
   "settings.updateCheckFailed":
     "Updates konnten nicht geprüft werden — offline oder GitHub nicht erreichbar.",
   "settings.latestVersion": "Neueste: {{version}}",
+  "settings.frostmodStrayMsvcr90":
+    "Eine Datei in deinem Spielordner lässt MX Bikes mit \"R6034\" abstürzen — leg sie beiseite, dann ist es behoben.",
   "settings.frostmodRuntimeMissing":
     "Windows fehlt eine Visual-C++-Komponente, die FrostMod braucht — installiere sie, um den Fehler „dll was not found“ loszuwerden.",
   "settings.repairRuntimes": "Laufzeit reparieren",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -312,6 +312,20 @@ export const en = {
   "runtime.repairNoGameFolderDesc":
     "The runtimes are installed, but without the install folder we can't check the game folder itself. Set it above, then repair again.",
   "runtime.repairFailed": "Couldn't repair the runtimes",
+  "runtime.strayForeign": "A file in your game folder ({{what}}) crashes MX Bikes.",
+  "runtime.strayLocked": "{{what}} in your game folder crashes MX Bikes.",
+  "runtime.strayPitch":
+    "It's what causes the \"R6034\" error at launch. Moving it aside fixes it, and deletes nothing.",
+  "runtime.strayLockedPitch":
+    "It's what causes the \"R6034\" error at launch. Close MX Bikes first, then move it aside.",
+  "runtime.strayFix": "Move it aside",
+  "runtime.strayFixHint":
+    "Renames it to msvcr90.dll.disabled so Windows stops loading it. Nothing is deleted.",
+  "runtime.strayClearing": "Moving…",
+  "runtime.strayCleared": "Moved out of the way",
+  "runtime.strayClearedDesc":
+    "It's now msvcr90.dll.disabled, in the same folder. Start MX Bikes again.",
+  "runtime.strayClearFailed": "Couldn't move the file",
   "update.checkFailed": "Couldn't check for updates",
   "update.failed": "Update failed",
 
@@ -614,6 +628,8 @@ export const en = {
   "settings.updateCheckFailed":
     "Couldn't check for updates — offline or GitHub unavailable.",
   "settings.latestVersion": "Latest: {{version}}",
+  "settings.frostmodStrayMsvcr90":
+    "A file in your game folder crashes MX Bikes with \"R6034\" — move it aside to fix it.",
   "settings.frostmodRuntimeMissing":
     "Windows is missing a Visual C++ component FrostMod needs — install it to stop the \"dll was not found\" error.",
   "settings.repairRuntimes": "Repair runtimes",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -319,6 +319,20 @@ export const es: Translation = {
   "runtime.repairNoGameFolderDesc":
     "Los componentes están instalados, pero sin la carpeta de instalación no podemos revisar la carpeta del juego. Indícala arriba y repara otra vez.",
   "runtime.repairFailed": "No se pudieron reparar los componentes",
+  "runtime.strayForeign": "Un archivo de tu carpeta del juego ({{what}}) hace que MX Bikes falle.",
+  "runtime.strayLocked": "{{what}}, en tu carpeta del juego, hace que MX Bikes falle.",
+  "runtime.strayPitch":
+    "Es lo que provoca el error \"R6034\" al arrancar. Apartarlo lo soluciona, y no se borra nada.",
+  "runtime.strayLockedPitch":
+    "Es lo que provoca el error \"R6034\" al arrancar. Cierra MX Bikes primero y luego apártalo.",
+  "runtime.strayFix": "Apartarlo",
+  "runtime.strayFixHint":
+    "Lo renombra a msvcr90.dll.disabled para que Windows deje de cargarlo. No se borra nada.",
+  "runtime.strayClearing": "Moviendo…",
+  "runtime.strayCleared": "Apartado del camino",
+  "runtime.strayClearedDesc":
+    "Ahora se llama msvcr90.dll.disabled, en la misma carpeta. Vuelve a abrir MX Bikes.",
+  "runtime.strayClearFailed": "No se pudo mover el archivo",
   "update.checkFailed": "No se pudieron comprobar las actualizaciones",
   "update.failed": "La actualización falló",
 
@@ -621,6 +635,8 @@ export const es: Translation = {
   "settings.updateCheckFailed":
     "No se pudieron comprobar las actualizaciones — sin conexión o GitHub no disponible.",
   "settings.latestVersion": "Última: {{version}}",
+  "settings.frostmodStrayMsvcr90":
+    "Un archivo de tu carpeta del juego hace que MX Bikes falle con \"R6034\" — apártalo para solucionarlo.",
   "settings.frostmodRuntimeMissing":
     "A Windows le falta un componente de Visual C++ que FrostMod necesita — instálalo para quitar el error «dll was not found».",
   "settings.repairRuntimes": "Reparar componentes",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -322,6 +322,20 @@ export const fr: Translation = {
   "runtime.repairNoGameFolderDesc":
     "Les composants sont installés, mais sans le dossier d'installation nous ne pouvons pas vérifier le dossier du jeu lui-même. Indiquez-le ci-dessus, puis réparez à nouveau.",
   "runtime.repairFailed": "Impossible de réparer les composants",
+  "runtime.strayForeign": "Un fichier de votre dossier de jeu ({{what}}) fait planter MX Bikes.",
+  "runtime.strayLocked": "{{what}}, dans votre dossier de jeu, fait planter MX Bikes.",
+  "runtime.strayPitch":
+    "C'est l'origine de l'erreur « R6034 » au lancement. Le mettre de côté suffit, et rien n'est supprimé.",
+  "runtime.strayLockedPitch":
+    "C'est l'origine de l'erreur « R6034 » au lancement. Fermez d'abord MX Bikes, puis mettez-le de côté.",
+  "runtime.strayFix": "Le mettre de côté",
+  "runtime.strayFixHint":
+    "Le renomme en msvcr90.dll.disabled pour que Windows cesse de le charger. Rien n'est supprimé.",
+  "runtime.strayClearing": "Déplacement…",
+  "runtime.strayCleared": "Fichier mis de côté",
+  "runtime.strayClearedDesc":
+    "Il s'appelle désormais msvcr90.dll.disabled, dans le même dossier. Relancez MX Bikes.",
+  "runtime.strayClearFailed": "Impossible de déplacer le fichier",
   "update.checkFailed": "Impossible de vérifier les mises à jour",
   "update.failed": "Échec de la mise à jour",
 
@@ -626,6 +640,8 @@ export const fr: Translation = {
   "settings.updateCheckFailed":
     "Impossible de vérifier les mises à jour — hors ligne ou GitHub indisponible.",
   "settings.latestVersion": "Dernière : {{version}}",
+  "settings.frostmodStrayMsvcr90":
+    "Un fichier de votre dossier de jeu fait planter MX Bikes avec « R6034 » — mettez-le de côté pour régler ça.",
   "settings.frostmodRuntimeMissing":
     "Il manque à Windows un composant Visual C++ dont FrostMod a besoin — installez-le pour faire disparaître l'erreur « dll was not found ».",
   "settings.repairRuntimes": "Réparer les composants",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -318,6 +318,20 @@ export const it: Translation = {
   "runtime.repairNoGameFolderDesc":
     "I componenti sono installati, ma senza la cartella di installazione non possiamo controllare la cartella del gioco. Impostala qui sopra, poi ripara di nuovo.",
   "runtime.repairFailed": "Impossibile riparare i componenti",
+  "runtime.strayForeign": "Un file nella cartella del gioco ({{what}}) fa crashare MX Bikes.",
+  "runtime.strayLocked": "{{what}}, nella cartella del gioco, fa crashare MX Bikes.",
+  "runtime.strayPitch":
+    "È la causa dell'errore \"R6034\" all'avvio. Spostarlo da parte basta, e non cancella nulla.",
+  "runtime.strayLockedPitch":
+    "È la causa dell'errore \"R6034\" all'avvio. Chiudi prima MX Bikes, poi spostalo da parte.",
+  "runtime.strayFix": "Spostalo da parte",
+  "runtime.strayFixHint":
+    "Lo rinomina in msvcr90.dll.disabled così Windows smette di caricarlo. Non viene cancellato nulla.",
+  "runtime.strayClearing": "Spostamento…",
+  "runtime.strayCleared": "Tolto di mezzo",
+  "runtime.strayClearedDesc":
+    "Ora si chiama msvcr90.dll.disabled, nella stessa cartella. Riavvia MX Bikes.",
+  "runtime.strayClearFailed": "Impossibile spostare il file",
   "update.checkFailed": "Impossibile controllare gli aggiornamenti",
   "update.failed": "Aggiornamento non riuscito",
 
@@ -619,6 +633,8 @@ export const it: Translation = {
   "settings.updateCheckFailed":
     "Impossibile controllare gli aggiornamenti — offline o GitHub non raggiungibile.",
   "settings.latestVersion": "Ultima: {{version}}",
+  "settings.frostmodStrayMsvcr90":
+    "Un file nella cartella del gioco fa crashare MX Bikes con \"R6034\" — spostalo da parte per risolvere.",
   "settings.frostmodRuntimeMissing":
     "A Windows manca un componente Visual C++ che serve a FrostMod — installalo per togliere l'errore «dll was not found».",
   "settings.repairRuntimes": "Ripara i componenti",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -321,6 +321,20 @@ export const ptBR: Translation = {
   "runtime.repairNoGameFolderDesc":
     "Os componentes estão instalados, mas sem a pasta de instalação não dá para verificar a pasta do jogo. Defina-a acima e repare de novo.",
   "runtime.repairFailed": "Não foi possível reparar os componentes",
+  "runtime.strayForeign": "Um arquivo na pasta do jogo ({{what}}) faz o MX Bikes travar.",
+  "runtime.strayLocked": "{{what}}, na pasta do jogo, faz o MX Bikes travar.",
+  "runtime.strayPitch":
+    "É o que causa o erro \"R6034\" ao iniciar. Tirá-lo do caminho resolve, e nada é apagado.",
+  "runtime.strayLockedPitch":
+    "É o que causa o erro \"R6034\" ao iniciar. Feche o MX Bikes primeiro e depois tire-o do caminho.",
+  "runtime.strayFix": "Tirar do caminho",
+  "runtime.strayFixHint":
+    "Renomeia para msvcr90.dll.disabled para o Windows parar de carregá-lo. Nada é apagado.",
+  "runtime.strayClearing": "Movendo…",
+  "runtime.strayCleared": "Tirado do caminho",
+  "runtime.strayClearedDesc":
+    "Agora ele se chama msvcr90.dll.disabled, na mesma pasta. Abra o MX Bikes de novo.",
+  "runtime.strayClearFailed": "Não foi possível mover o arquivo",
   "update.checkFailed": "Não foi possível verificar as atualizações",
   "update.failed": "A atualização falhou",
 
@@ -622,6 +636,8 @@ export const ptBR: Translation = {
   "settings.updateCheckFailed":
     "Não foi possível verificar as atualizações — sem conexão ou GitHub indisponível.",
   "settings.latestVersion": "Última: {{version}}",
+  "settings.frostmodStrayMsvcr90":
+    "Um arquivo na pasta do jogo faz o MX Bikes travar com \"R6034\" — tire-o do caminho para resolver.",
   "settings.frostmodRuntimeMissing":
     "Falta ao Windows um componente do Visual C++ que o FrostMod precisa — instale-o para acabar com o erro \"dll was not found\".",
   "settings.repairRuntimes": "Reparar componentes",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -904,6 +904,13 @@ export interface FrostmodStatus {
    * FrostMod starting — it's a warning with a one-click fix attached.
    */
   missingRuntimes: VcRuntime[];
+  /**
+   * A loose `msvcr90.dll` beside the game exe that the app didn't remove on its own.
+   *
+   * `clear`/`removed` mean there's nothing to say. `foreign` and `locked` mean a file that
+   * aborts MX Bikes with R6034 is still sitting there — see {@link StrayMsvcr90}.
+   */
+  strayMsvcr90: StrayMsvcr90;
 }
 
 /**
@@ -915,6 +922,22 @@ export interface FrostmodStatus {
  * out, and for the manual download links.
  */
 export type VcRuntime = "vc90" | "vc140" | "vc140_x86";
+
+/**
+ * What's left of a loose `msvcr90.dll` beside the game exe. Mirrors `vcruntime::Stray`.
+ *
+ * A loose VC9 CRT there kills the game with *"R6034 — An application has made an attempt to
+ * load the C runtime library incorrectly"*, because the CRT refuses to initialise outside a
+ * `Microsoft.VC90.CRT` activation context and a loose copy is never in one.
+ *
+ * - `clear` — nothing there. The normal case, and always the case off Windows.
+ * - `removed` — there was one, it was this app's (0.9.2–0.10.0 planted them), it's gone.
+ * - `foreign` — one matching no VC90 assembly on this PC. Someone else put it there, so the
+ *   app won't delete it unasked; the player is shown it and offered the move.
+ * - `locked` — ours, but something holds it open. That something is the game: closing it
+ *   and pressing again is the fix.
+ */
+export type StrayMsvcr90 = "clear" | "removed" | "foreign" | "locked";
 
 /** What a runtime install did. `cancelled` is the user dismissing the UAC prompt. */
 export type RuntimeInstallOutcome = "installed" | "cancelled";
@@ -932,9 +955,10 @@ export interface RuntimeRepairReport {
   alreadyPresent: VcRuntime[];
   /** Still absent afterwards: a declined UAC prompt, a failed download, a pending reboot. */
   stillMissing: VcRuntime[];
-  /** Whether a stray `msvcr90.dll` beside the game executable was cleaned up. Versions
-   *  0.9.2–0.10.0 put one there, and it aborts the game with R6034. */
-  msvcr90Removed: boolean;
+  /** What the sweep of the game folder found. `removed` is a repair that did something;
+   *  `foreign`/`locked` is one that found the likeliest reason the game won't start and
+   *  needs the player to say the word. */
+  strayMsvcr90: StrayMsvcr90;
   /** False when no game folder is configured, so there was nowhere to look. */
   gameDirKnown: boolean;
 }


### PR DESCRIPTION
A player's MX Bikes died at launch with **R6034 — "An application has made an attempt to load the C runtime library incorrectly"**, right after extracting a mod `.rar` into the game folder.

A loose `msvcr90.dll` beside `mxbikes.exe` is the cause: the VC9 CRT checks at load time that it was resolved through a `Microsoft.VC90.CRT` activation context, and a loose copy never is. v0.10.1 stopped this app planting one and added a sweep that takes back the copies 0.9.2–0.10.0 made.

**The sweep only fires when the file's bytes match a VC90 assembly in that PC's `WinSxS`** — the compare that stops us reaching for somebody else's file. Everything it declined went into one log line, in three cases that all end with a dead game and no explanation:

1. **Foreign bytes** — a copy from a mod archive, an old tool, another PC. The reported case.
2. **No VC90 on the machine at all** — nothing can ever match, so even *our own* copy is stranded. That is exactly the PC someone drops a loose CRT into.
3. **Locked** — the game is running with it mapped; the delete fails and retries silently.

## What this does

Auto-removal is unchanged: still only ever a file whose bytes prove this app made it. What changes is that everything else is now *reported* rather than swallowed, and the player gets a press.

- `remove_stray_msvcr90` returns a `Stray` verdict — `clear` / `removed` / `foreign` / `locked` — which rides on `FrostmodStatus`.
- `disable_stray_msvcr90` renames the file to `msvcr90.dll.disabled` (`.1`, `.2`… on collision). A rename, not a delete: Windows resolves an import by exact filename, so the rename is what defuses it, and a file somebody put there on purpose survives the decision.
- A red banner names the file and offers **Move it aside**, ranked above the amber missing-runtime bar — one is an active crash, the other a latent gap. `locked` says to close the game first rather than failing at a button. Settings mirrors it, so a dismissed bar doesn't take the only explanation with it.
- `RepairReport.msvcr90_removed` becomes `stray_msvcr90`; the bool was derivable from the verdict. Two comments still describing the CRT being placed beside the exe — which stopped in v0.10.1 — are gone.

No DB or schema changes.

## Verification

- `cargo test vcruntime` — 25 pass, 6 new or rewritten, covering the no-WinSxS hole, the foreign-file report, the rename, and a second press parking beside the first rather than clobbering it.
- `cargo check --target x86_64-pc-windows-gnu` — type-checks the `cfg(windows)` half a macOS build skips.
- `bun run typecheck`, `bun run lint` — clean (2 pre-existing warnings in untouched files).

**Unverified: the banner on screen.** It was run in `tauri dev` with the state forced, but this machine allows neither a screen capture (screen-recording permission denied) nor a truthful accessibility read — the AX tree didn't reflect a plain `<div>` added at the same spot. Worth an eye before release. The R6034 path itself wants a Windows tester.

## Out of scope

The same treatment under Proton/Wine. A loose CRT is equally fatal in a bottle, but nothing there can answer "is this ours" — every file would read `foreign` and every Linux player with one would get a bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)