### PR TITLE
fix(installer): install the VC++ runtime the app can't start without

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026-08-25
+
+### Fixed
+- **MXB App wouldn't start at all on a freshly installed Windows,** closing the moment it
+  launched with "the application was unable to start correctly (0xc000007b)" — no window, no
+  log, nothing to send in. The app needs Microsoft's Visual C++ 2015–2022 (x64) runtime and
+  has since v0.3.2; Windows doesn't ship it, but some other game nearly always installs it
+  first, so the gap only shows on a PC that has just been reset. It fails inside Windows'
+  loader, before a line of the app's own code runs, which is why the runtime check the app
+  already carried could never fire — it was on the wrong side of the door. The installer now
+  checks for that runtime and puts it in before it writes the app, and tells you which one is
+  missing if it can't.
+
 ## 2026-08-22
 
 ### Fixed

--- a/src-tauri/installer-hooks.nsh
+++ b/src-tauri/installer-hooks.nsh
@@ -28,6 +28,10 @@
 ; `PageLeaveReinstall` checks before deciding the uninstall failed. Freeing the name there
 ; is what stops the install loop from recurring.
 
+; `x64.nsh` for `${RunningX64}` and the WOW64 redirection switches `EnsureVc140` needs.
+; Guarded internally, so including it here is safe next to whatever the template pulls in.
+!include x64.nsh
+
 !macro CloseRunningApp
   ; `/F` because a window that only exists in the tray won't answer a polite close. No
   ; `/T`: the in-app updater launches this installer from inside the app, so the installer
@@ -102,10 +106,105 @@
   ${EndIf}
 !macroend
 
+; The Visual C++ 2015-2022 x64 runtime, which the app cannot start without.
+;
+; `MXB App.exe` imports exactly two symbols from `MSVCP140.dll` — `std::_Xout_of_range` and
+; `std::_Xlength_error`, the STL's throw helpers — by way of UnRAR's C++ sources, which
+; `unrar_sys` builds against the dynamic CRT. `MSVCP140.dll` is not an inbox Windows file;
+; it arrives only with the redistributable. On a machine that has never had it the first
+; launch dies in the loader with
+;
+;   The application was unable to start correctly (0xc000007b)
+;
+; and nothing else — no window, no log line, nothing the app can report, because this
+; happens before `main`. Every build since v0.3.2 has carried the import; it stays invisible
+; because some other game nearly always brings the runtime in first. What exposes it is a
+; clean Windows: reported by a player who had been running MXB App for weeks and hit this
+; the day after resetting their PC.
+;
+; `crate::vcruntime` already detects and installs this exact package and cannot help here —
+; it runs inside the process that can't start. The installer is the last thing that runs
+; before the dependency matters, so the check belongs here.
+
+!define VC140_URL "https://aka.ms/vs/17/release/vc_redist.x64.exe"
+
+; Sets `$0` to 1 when the runtime is present, 0 when any part of it is missing.
+;
+; The same three files `VC140_DLLS` probes, not just the one we import: FrostMod needs the
+; other two, one package carries all three, and this is the one moment we are already
+; fetching it. `vcruntime140_1.dll` is the one that catches a machine still on the original
+; 2015 package.
+!macro ProbeVc140
+  ; NSIS builds 32-bit installers, so under WOW64 every `$SYSDIR` read is redirected to
+  ; `SysWOW64` — the *32-bit* runtime's home, and the wrong question. Left alone, this
+  ; probe would report the x64 runtime missing on a machine that has it and present on a
+  ; machine that only has the x86 package. Unredirected, `$SYSDIR` means what it says.
+  ${DisableX64FSRedirection}
+  StrCpy $0 1
+  ${IfNot} ${FileExists} "$SYSDIR\vcruntime140.dll"
+    StrCpy $0 0
+  ${ElseIfNot} ${FileExists} "$SYSDIR\vcruntime140_1.dll"
+    StrCpy $0 0
+  ${ElseIfNot} ${FileExists} "$SYSDIR\msvcp140.dll"
+    StrCpy $0 0
+  ${EndIf}
+  ${EnableX64FSRedirection}
+!macroend
+
+; Inserted once, from `NSIS_HOOK_PREINSTALL`. The label below makes a second insertion a
+; compile error rather than a quiet duplicate-symbol surprise.
+!macro EnsureVc140
+  ; A 32-bit Windows can't run this app at all, so there is nothing to preflight there.
+  ${If} ${RunningX64}
+    !insertmacro ProbeVc140
+    ${If} $0 == 0
+      DetailPrint "Installing the Microsoft Visual C++ 2015-2022 (x64) runtime..."
+
+      ; `NSISdl`, the downloader the template carries, speaks plain HTTP; this URL is HTTPS
+      ; and redirects. PowerShell is inbox on every Windows the app supports. `$\'` is a
+      ; literal quote — the command below reaches PowerShell as ordinary single-quoted
+      ; arguments.
+      ;
+      ; `-TimeoutSec` because an install that hangs on a dead connection is worse than one
+      ; that fails: the failure has a message box behind it and a user who can act on it.
+      nsExec::ExecToLog 'powershell -NoProfile -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -UseBasicParsing -TimeoutSec 120 -Uri $\'${VC140_URL}$\' -OutFile $\'$PLUGINSDIR\vc_redist.x64.exe$\'"'
+      Pop $1
+
+      ${If} ${FileExists} "$PLUGINSDIR\vc_redist.x64.exe"
+        ; Burn bundle switches, which are not the 2008 package's — it treats a bare `/q` as
+        ; unknown and does nothing.
+        nsExec::ExecToLog '"$PLUGINSDIR\vc_redist.x64.exe" /install /quiet /norestart'
+        Pop $1
+      ${EndIf}
+
+      ; Re-probe rather than read an exit code. A captive portal answers 200 with an HTML
+      ; page that is not an installer, and the package itself exits 1638 when a newer build
+      ; is already in — neither number means what it looks like. The files either exist now
+      ; or they don't.
+      !insertmacro ProbeVc140
+      ${If} $0 == 0
+        ; Never `Abort`. A half-installed folder helps nobody, and someone who fetches the
+        ; runtime by hand afterwards should find the app already waiting for it.
+        ;
+        ; Silent is the in-app updater running this installer from inside the app. A modal
+        ; there would hang an update with no window to answer it.
+        ${IfNot} ${Silent}
+          MessageBox MB_YESNO|MB_ICONEXCLAMATION "MXB App needs the Microsoft Visual C++ 2015-2022 (x64) runtime, and this PC doesn't have it. Installing it just now didn't work.$\r$\n$\r$\nMXB App is installed either way, but it will close on launch with error 0xc000007b until the runtime is in. Open Microsoft's download page?" IDNO vc140_declined
+          ExecShell "open" "${VC140_URL}"
+          vc140_declined:
+        ${EndIf}
+      ${EndIf}
+    ${EndIf}
+  ${EndIf}
+!macroend
+
 !macro NSIS_HOOK_PREINSTALL
   !insertmacro CloseRunningApp
   !insertmacro CloseLegacyApp
   !insertmacro FreeMainBinary
+  ; Last: freeing the binary is a race against a process that just died, while this can
+  ; spend a minute on the wire.
+  !insertmacro EnsureVc140
 !macroend
 
 ; By now anything we moved aside is dead, so this is the pass that usually clears it and

--- a/src-tauri/src/vcruntime.rs
+++ b/src-tauri/src/vcruntime.rs
@@ -56,6 +56,16 @@
 //! to miss: it only ships from the 2019 redistributable onward, so a machine still on the
 //! original 2015 package has the other two and not it.
 //!
+//! **The app's own image needs VC140 as well, and nothing in this module can say so.**
+//! `MXB App.exe` imports `std::_Xout_of_range` and `std::_Xlength_error` from
+//! `MSVCP140.dll` — the STL's throw helpers, by way of the C++ sources `unrar_sys` builds
+//! against the dynamic CRT. Without the redistributable the loader gives up before `main`
+//! with *"the application was unable to start correctly (0xc000007b)"*, and none of the
+//! code below ever runs. That check has to live outside the process, and does:
+//! `installer-hooks.nsh` probes for the same three files before the app is written. See
+//! `tests::the_installer_probes_the_same_runtime_we_do` for what keeps the two copies
+//! from drifting.
+//!
 //! We detect both, and can install either. Detection is deliberately conservative: when
 //! we can't tell, we report nothing missing. Telling a working player their PC is broken
 //! is worse than staying quiet.
@@ -885,6 +895,34 @@ mod tests {
         assert!(
             VC140_DLLS.contains(&"vcruntime140_1.dll"),
             "frostmod.dll imports vcruntime140_1.dll, so it has to be probed: {VC140_DLLS:?}"
+        );
+    }
+
+    /// The installer carries a second copy of this probe, and it has to stay this probe.
+    ///
+    /// Nothing off Windows can run NSIS, so the check that actually rescues a player — the
+    /// one that runs before the app exists — is the one we cannot exercise. This is the
+    /// next best thing: move the list, the URL or the switches here and the `.nsh` stops
+    /// matching, which is the moment to go and change it there too.
+    ///
+    /// `DisableX64FSRedirection` is asserted because it is the part most likely to be
+    /// tidied away by someone who doesn't know it's load-bearing: NSIS builds 32-bit
+    /// installers, and without it every `$SYSDIR` read lands in `SysWOW64` and answers
+    /// about the wrong architecture.
+    #[test]
+    fn the_installer_probes_the_same_runtime_we_do() {
+        let nsh = include_str!("../installer-hooks.nsh");
+        for dll in VC140_DLLS {
+            assert!(nsh.contains(dll), "installer-hooks.nsh should probe {dll}");
+        }
+        assert!(nsh.contains(Runtime::Vc140.url()), "and fetch it from the same place");
+        assert!(
+            nsh.contains(Runtime::Vc140.installer_args()),
+            "with the same silent switches"
+        );
+        assert!(
+            nsh.contains("DisableX64FSRedirection"),
+            "a 32-bit installer probing $SYSDIR reads SysWOW64 without it"
         );
     }
 


### PR DESCRIPTION
## The report

> Everytime i launch the app it says the application was unable to start correctly. I had the app before then i reset my computer to clear up some space redownloaded mx bikes and then launched it then tried to download mxb app and it keeps giving me this error

`frost.exe - Application Error — The application was unable to start correctly (0xc000007b)`

## What it actually is

`MXB App.exe` imports exactly two symbols from `MSVCP140.dll`:

```
?_Xout_of_range@std@@YAXPEBD@Z
?_Xlength_error@std@@YAXPEBD@Z
```

They're the MSVC STL throw helpers, pulled in by `unrar_sys` — UnRAR's C++ sources, built by `cc` against the dynamic CRT. `MSVCP140.dll` is not an inbox Windows file; it arrives only with the Visual C++ 2015–2022 (x64) redistributable.

Checked every shipped installer back to v0.3.2 — all x64, all importing `MSVCP140.dll`. So this is not a regression. It stays invisible because some other game nearly always installs the runtime first, and a Windows reset is what strips it back out.

The failure happens in the loader, before `main`, so there is no window, no log, and nothing the app can report. `vcruntime.rs` has detected and installed this exact package for a while now — but only for FrostMod, and only from inside the process that can't start.

(The reporter's dialog says `frost.exe`, which is the binary name up to v0.9.2 — so they also ran a stale installer. That part is a support answer, not a code change.)

## The change

`EnsureVc140` in `NSIS_HOOK_PREINSTALL`, the last thing before the app is written:

- probes `vcruntime140.dll`, `vcruntime140_1.dll` and `msvcp140.dll` — the same list as `VC140_DLLS`, so FrostMod's needs ride along on a package we're already fetching
- **unredirected**. NSIS builds 32-bit installers, so a bare `$SYSDIR` read lands in `SysWOW64` and answers about the wrong architecture: the x64 runtime reported missing on a machine that has it, present on a machine that only has x86
- downloads through PowerShell, because `NSISdl` speaks plain HTTP and the URL is HTTPS with redirects; `-TimeoutSec 120`, since an installer hung on a dead connection is worse than one that fails
- re-probes rather than reading an exit code — a captive portal answers 200 with an HTML page, and the package exits 1638 when a newer build is already in
- never aborts, and skips the message box under `${Silent}` so an in-app update can't hang on a modal with no window to answer it

A test in `vcruntime.rs` asserts the `.nsh` names the same DLLs, URL and switches, and still calls `DisableX64FSRedirection` — nothing off Windows can execute NSIS, so this is what keeps the two copies from drifting.

## Verification

- `cargo test --bin mxb-app` — 825 passed, 0 failed
- `cargo check --target x86_64-pc-windows-gnu` — clean
- `makensis` 3.12 compile of the hooks against a stand-in Tauri template — no errors, no warnings — then read the strings back out of the built installer to confirm the escaping resolves to a well-formed command line

**Still needs a Windows check.** On a clean VM: the installer should fetch the runtime and the app should launch. On a machine that already has it, the details log should show no "Installing the Microsoft Visual C++…" line — if the WOW64 guard misbehaves, every install pulls 25 MB it doesn't need.

## Not here

`-Ctarget-feature=+crt-static` would drop the dependency outright rather than paper over it — two throw helpers is a thin reason to require a 25 MB redistributable. Real risk with Tauri/WebView2 and unverifiable from macOS; wants its own branch and a Windows smoke test.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
