### PR TITLE
chore(release): v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 2026-08-25
+## 2026-08-26 — v0.10.2 — Liveries that belong to a model, and a Windows that starts
 
 ### Added
+
 - **A model swap can own its liveries.** MX Bikes gives a bike one flat `paints/` folder and
   knows nothing about model swaps, so a Yami mesh running on a KTM offered every KTM livery
   alongside the Yami ones — a long list where most entries were drawn for a mesh that isn't
@@ -18,15 +19,25 @@
   - The Presets livery dropdown now offers only the liveries that suit the model the preset
     selects, so a preset pairs a model with a livery drawn for it.
 
+- **A Locker repair warning can be dismissed.** The banner for a bike whose setup files an
+  old swap moved away sat at the top of the Locker with no way to put it down, so anyone who
+  had decided to leave that bike alone read the same three lines every visit. Each one now
+  carries a ✕. Hiding is remembered per bike *and* per set of missing files, so the same bike
+  breaking a different way still speaks up, and a bike you repair — then break again later —
+  warns afresh rather than staying quietly hidden.
+
 ### Fixed
+
 - **Liveries that came in with a model pack were invisible.** A model swap that shipped its
   own `paints/` folder left its liveries inside the swap folder once the app filed it away —
   somewhere the game never reads and no scan of ours ever looked. They were installed,
   unusable and unlistable. Opening that model's livery picker now adopts them as its own,
   which is also what makes them work.
+
 - **A livery inside a model swap was filed under the wrong owner.** The Library attributed it
   to the swap folder rather than to the bike, so it landed in a bucket no bike id ever
   matched — and a preset share code built from that bike silently shipped without the livery.
+
 - **MXB App wouldn't start at all on a freshly installed Windows,** closing the moment it
   launched with "the application was unable to start correctly (0xc000007b)" — no window, no
   log, nothing to send in. The app needs Microsoft's Visual C++ 2015–2022 (x64) runtime and
@@ -36,6 +47,7 @@
   already carried could never fire — it was on the wrong side of the door. The installer now
   checks for that runtime and puts it in before it writes the app, and tells you which one is
   missing if it can't.
+
 - **A `msvcr90.dll` in the game folder that the app wouldn't remove is no longer a silent
   crash.** A loose VC9 CRT beside `mxbikes.exe` aborts the game with *"R6034 — An application
   has made an attempt to load the C runtime library incorrectly"* the moment anything
@@ -46,18 +58,17 @@
   from somewhere else (a mod archive extracted into the game folder is the reported one), a PC
   with no VC90 installed at all, where nothing can ever match and even our own copy is
   stranded, and a file the running game is holding open.
+
 - **The app now says so, and offers the fix.** A file it won't delete on its own gets a red
   bar naming it, and a button that renames it to `msvcr90.dll.disabled` — Windows resolves an
   import by exact filename, so the rename is what defuses it, and a file somebody put there on
   purpose survives the decision. Automatic removal is unchanged: still only ever a copy this
   app can prove it made. The press is what settles provenance for everything else. When the
   game is holding the file, the bar says to close it first rather than failing at a button.
+
 - **"Repair runtimes" reports the same thing**, so a repair that installed everything and still
   found the reason the game won't start says that instead of "everything was already in place".
 
-## 2026-08-22
-
-### Fixed
 - **An install blocked by antivirus reported a bare "os error 2".** When a security product
   blocks a freshly downloaded mod file in the temp folder, the app's check for it asked the
   wrong question — it tested only whether the file still had a directory entry, which a
@@ -66,6 +77,17 @@
   the mod were broken. The check now tries to read the file the same way the copy does, so a
   blocked install names the file, says whether it was removed or locked, and points at the
   folder to add an exclusion for.
+
+- **A share code could point outside the mods folder.** Every path a preset or file-share
+  code carries is joined onto your mods root on import, and the first one picks the type
+  folder outright — so a code written by hand with `../` in it could write into the game
+  folder itself rather than into `mods/`. Nothing this app has ever produced looks like that,
+  but a code arrives as text from someone else, so every path is now checked when the code is
+  decoded and a bad one is refused at the door rather than failing partway through an install.
+  Zip extraction is swept for links that point out of the staging folder — the same sweep 7z
+  and rar archives already got — and a filename handed over by a remote server can no longer
+  name the staging folder's parent.
+
 - **Paint sync published the wrong bike's livery.** Liveries were matched by filename alone,
   so a rider with `Race.pnt` on two bikes published whichever the folder walk reached first —
   and the file carried that bike's install path, so everyone on the grid saw it land on the
@@ -73,19 +95,12 @@
   livery missing from that bike is reported as missing rather than borrowed from another one.
   The same mismatch made the live-reload watcher watch another bike's file, so a paint edited
   mid-session could refresh late or not at all.
+
 - **Helmet, goggle, boot and protection paints were never shared.** Gear paints that sit
   inside their model's folder were being folded into that folder — correct for a preset zip,
   which carries the folder whole, but a publish uploads paint files one at a time and skips
   folders, so those paints silently went nowhere. Gear paints now publish alongside bike
   liveries; preset bundles still pack the folder once.
-
-### Added
-- **A Locker repair warning can be dismissed.** The banner for a bike whose setup files an
-  old swap moved away sat at the top of the Locker with no way to put it down, so anyone who
-  had decided to leave that bike alone read the same three lines every visit. Each one now
-  carries a ✕. Hiding is remembered per bike *and* per set of missing files, so the same bike
-  breaking a different way still speaks up, and a bike you repair — then break again later —
-  warns afresh rather than staying quietly hidden.
 
 ## 2026-08-21 — v0.10.1 — Mods you deleted, remembered — and a crash we caused, undone
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.10.1",
+  "version": "0.10.2",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3181,7 +3181,7 @@ dependencies = [
 
 [[package]]
 name = "mxb-app"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # whatever cargo called it. Cargo target names can't hold a space, so this is as close as
 # it gets. The description is what Windows Task Manager shows in its Processes tab.
 name = "mxb-app"
-version = "0.10.1"
+version = "0.10.2"
 description = "MXB App — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
   "mainBinaryName": "MXB App",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/Components/Showcase/releases.ts
+++ b/src/Components/Showcase/releases.ts
@@ -43,6 +43,7 @@ import {
   History,
   Undo2,
   ShieldAlert,
+  SwatchBook,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { TKey } from "../../i18n/context";
@@ -69,6 +70,21 @@ export interface Release {
 }
 
 export const RELEASES: Release[] = [
+  {
+    version: "0.10.2",
+    hero: {
+      icon: SwatchBook,
+      title: "showcase.v0102.hero.title",
+      body: "showcase.v0102.hero.body",
+    },
+    highlights: [
+      { icon: FolderInput, text: "showcase.v0102.packs" },
+      { icon: Layers, text: "showcase.v0102.presets" },
+      { icon: Download, text: "showcase.v0102.vcredist" },
+      { icon: ShieldAlert, text: "showcase.v0102.msvcr90" },
+      { icon: Palette, text: "showcase.v0102.paintsync" },
+    ],
+  },
   {
     version: "0.10.1",
     hero: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1312,6 +1312,20 @@ export const de: Translation = {
   "showcase.supporters.title_one": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.title_other": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.more": "+{{count}} weitere",
+  "showcase.v0102.hero.title":
+    "Lackierungen gehören dem Modell, das sie trägt",
+  "showcase.v0102.hero.body":
+    "MX Bikes gibt einem Bike einen einzigen paints-Ordner und kennt keine Modell-Swaps, also bot ein Yami-Mesh auf einer KTM auch jede KTM-Lackierung an. Jedes Modell im Locker hat jetzt eine Paletten-Schaltfläche — hake die für es gezeichneten Lackierungen an, und nur die werden noch angeboten, auch in der Lackauswahl von MX Bikes selbst.",
+  "showcase.v0102.packs":
+    "Lackierungen, die in einem Modellpaket steckten, waren installiert, aber unsichtbar. Öffnest du die Auswahl dieses Modells, übernimmt es sie — und genau das macht sie nutzbar.",
+  "showcase.v0102.presets":
+    "Die Presets-Lackauswahl zeigt nur noch Lackierungen, die zum gewählten Modell passen.",
+  "showcase.v0102.vcredist":
+    "Auf einem frisch zurückgesetzten Windows schloss sich die App sofort nach dem Start — kein Fenster, kein Log. Der Installer legt jetzt erst Microsofts Visual-C++-Runtime nach und dann die App.",
+  "showcase.v0102.msvcr90":
+    "Eine übrig gebliebene msvcr90.dll, die die App nicht selbst löscht, ist kein stiller Absturz mehr: Sie benennt die Datei und deaktiviert sie auf einen Klick.",
+  "showcase.v0102.paintsync":
+    "Paint-Sync verschickte die Lackierung des falschen Bikes, wenn zwei Bikes denselben Lacknamen hatten — und Helm-, Brillen-, Stiefel- und Protektoren-Lacks wurden nie geteilt.",
   "showcase.v0101.hero.title":
     "Deine Bibliothek merkt sich, was du gelöscht hast",
   "showcase.v0101.hero.body":

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1273,6 +1273,20 @@ export const en = {
   "showcase.supporters.title_one": "Made possible by {{count}} supporter",
   "showcase.supporters.title_other": "Made possible by {{count}} supporters",
   "showcase.supporters.more": "+{{count}} more",
+  "showcase.v0102.hero.title":
+    "Liveries that belong to the model wearing them",
+  "showcase.v0102.hero.body":
+    "MX Bikes gives a bike one flat paints folder and knows nothing about model swaps, so a Yami mesh on a KTM offered every KTM livery too. Each model in the Locker now has a palette button — tick the liveries drawn for it and they become the only ones it offers, in MX Bikes' own paint picker as well as here.",
+  "showcase.v0102.packs":
+    "Liveries that arrived inside a model pack were installed but invisible. Opening that model's picker now adopts them, which is also what makes them work.",
+  "showcase.v0102.presets":
+    "The Presets livery dropdown offers only the liveries that suit the model the preset selects.",
+  "showcase.v0102.vcredist":
+    "On a freshly reset Windows the app closed the moment it launched, with no window and no log. The installer now puts Microsoft's Visual C++ runtime in before it writes the app.",
+  "showcase.v0102.msvcr90":
+    "A stray msvcr90.dll it won't delete on its own is no longer a silent crash: the app names the file and offers to disable it in one press.",
+  "showcase.v0102.paintsync":
+    "Paint sync sent the wrong bike's livery when two bikes shared a paint name — and helmet, goggle, boot and protection paints were never shared at all.",
   "showcase.v0101.hero.title":
     "Your library remembers what you deleted",
   "showcase.v0101.hero.body":

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1299,6 +1299,20 @@ export const es: Translation = {
   "showcase.supporters.title_one": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.title_other": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.more": "+{{count}} más",
+  "showcase.v0102.hero.title":
+    "Decoraciones que pertenecen al modelo que las lleva",
+  "showcase.v0102.hero.body":
+    "MX Bikes da a cada moto una sola carpeta paints y no sabe nada de los cambios de modelo, así que una malla Yami sobre una KTM ofrecía también todas las decoraciones de KTM. Cada modelo del Locker tiene ahora un botón de paleta: marca las decoraciones dibujadas para él y serán las únicas que ofrezca, también en el selector de pinturas del propio MX Bikes.",
+  "showcase.v0102.packs":
+    "Las decoraciones que venían dentro de un pack de modelo estaban instaladas pero invisibles. Al abrir el selector de ese modelo pasan a ser suyas, que es justo lo que las hace funcionar.",
+  "showcase.v0102.presets":
+    "El desplegable de decoraciones de Presets solo ofrece las que encajan con el modelo que elige el preset.",
+  "showcase.v0102.vcredist":
+    "En un Windows recién restaurado la app se cerraba nada más abrirla, sin ventana y sin registro. El instalador ahora coloca el runtime de Visual C++ de Microsoft antes de escribir la app.",
+  "showcase.v0102.msvcr90":
+    "Un msvcr90.dll suelto que la app no borra por su cuenta ya no es un fallo silencioso: nombra el archivo y ofrece desactivarlo con una pulsación.",
+  "showcase.v0102.paintsync":
+    "La sincronización de pinturas enviaba la decoración de la moto equivocada cuando dos motos compartían nombre de pintura, y las pinturas de casco, gafas, botas y protecciones no se compartían nunca.",
   "showcase.v0101.hero.title":
     "Tu biblioteca recuerda lo que borraste",
   "showcase.v0101.hero.body":

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1303,6 +1303,20 @@ export const fr: Translation = {
   "showcase.supporters.title_one": "Rendu possible par {{count}} soutien",
   "showcase.supporters.title_other": "Rendu possible par {{count}} soutiens",
   "showcase.supporters.more": "+{{count}} autres",
+  "showcase.v0102.hero.title":
+    "Des décos qui appartiennent au modèle qui les porte",
+  "showcase.v0102.hero.body":
+    "MX Bikes ne donne à une moto qu'un seul dossier paints et ignore tout des changements de modèle : un mesh Yami sur une KTM proposait donc aussi toutes les décos KTM. Chaque modèle du Locker a désormais un bouton palette — cochez les décos dessinées pour lui et ce seront les seules proposées, y compris dans le sélecteur de peintures de MX Bikes.",
+  "showcase.v0102.packs":
+    "Les décos livrées dans un pack de modèle étaient installées mais invisibles. Ouvrir le sélecteur de ce modèle les lui attribue, et c'est précisément ce qui les rend utilisables.",
+  "showcase.v0102.presets":
+    "La liste des décos dans Presets ne propose plus que celles qui conviennent au modèle choisi par le preset.",
+  "showcase.v0102.vcredist":
+    "Sur un Windows fraîchement réinstallé, l'app se fermait dès son lancement, sans fenêtre ni journal. L'installateur met maintenant le runtime Visual C++ de Microsoft en place avant d'écrire l'app.",
+  "showcase.v0102.msvcr90":
+    "Un msvcr90.dll resté sur place que l'app ne supprime pas d'elle-même n'est plus un plantage silencieux : elle nomme le fichier et propose de le désactiver en un clic.",
+  "showcase.v0102.paintsync":
+    "La synchro des peintures envoyait la déco de la mauvaise moto quand deux motos partageaient un nom de peinture — et les peintures de casque, masque, bottes et protections n'étaient jamais partagées.",
   "showcase.v0101.hero.title":
     "Ta bibliothèque se souvient de ce que tu as supprimé",
   "showcase.v0101.hero.body":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1294,6 +1294,20 @@ export const it: Translation = {
   "showcase.supporters.title_one": "Reso possibile da {{count}} sostenitore",
   "showcase.supporters.title_other": "Reso possibile da {{count}} sostenitori",
   "showcase.supporters.more": "+{{count}} altri",
+  "showcase.v0102.hero.title":
+    "Livree che appartengono al modello che le indossa",
+  "showcase.v0102.hero.body":
+    "MX Bikes dà a una moto una sola cartella paints e non sa nulla dei cambi di modello, così una mesh Yami su una KTM proponeva anche tutte le livree KTM. Ogni modello nel Locker ha ora un pulsante tavolozza: spunta le livree disegnate per lui e saranno le uniche che offre, anche nel selettore di vernici di MX Bikes.",
+  "showcase.v0102.packs":
+    "Le livree arrivate dentro un pacchetto modello erano installate ma invisibili. Aprire il selettore di quel modello le fa sue, ed è proprio questo a renderle utilizzabili.",
+  "showcase.v0102.presets":
+    "Il menu delle livree in Presets propone solo quelle adatte al modello scelto dal preset.",
+  "showcase.v0102.vcredist":
+    "Su un Windows appena reinstallato l'app si chiudeva appena avviata, senza finestra e senza log. L'installer ora mette il runtime Visual C++ di Microsoft prima di scrivere l'app.",
+  "showcase.v0102.msvcr90":
+    "Un msvcr90.dll rimasto lì che l'app non elimina da sola non è più un crash silenzioso: nomina il file e propone di disattivarlo con una pressione.",
+  "showcase.v0102.paintsync":
+    "La sincronizzazione delle vernici inviava la livrea della moto sbagliata quando due moto condividevano il nome di una vernice, e le vernici di casco, maschera, stivali e protezioni non venivano mai condivise.",
   "showcase.v0101.hero.title":
     "La libreria si ricorda cosa hai cancellato",
   "showcase.v0101.hero.body":

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1292,6 +1292,20 @@ export const ptBR: Translation = {
   "showcase.supporters.title_one": "Possível graças a {{count}} apoiador",
   "showcase.supporters.title_other": "Possível graças a {{count}} apoiadores",
   "showcase.supporters.more": "+{{count}} outros",
+  "showcase.v0102.hero.title":
+    "Pinturas que pertencem ao modelo que as veste",
+  "showcase.v0102.hero.body":
+    "O MX Bikes dá a uma moto uma única pasta paints e não sabe nada sobre trocas de modelo, então uma malha Yami numa KTM oferecia também todas as pinturas da KTM. Cada modelo no Locker agora tem um botão de paleta — marque as pinturas desenhadas para ele e serão as únicas oferecidas, inclusive no seletor de pinturas do próprio MX Bikes.",
+  "showcase.v0102.packs":
+    "Pinturas que vieram dentro de um pacote de modelo estavam instaladas, mas invisíveis. Abrir o seletor daquele modelo as adota, e é isso que as faz funcionar.",
+  "showcase.v0102.presets":
+    "A lista de pinturas em Presets oferece apenas as que combinam com o modelo que o preset seleciona.",
+  "showcase.v0102.vcredist":
+    "Num Windows recém-formatado o app fechava assim que era aberto, sem janela e sem log. O instalador agora coloca o runtime Visual C++ da Microsoft antes de gravar o app.",
+  "showcase.v0102.msvcr90":
+    "Um msvcr90.dll perdido que o app não apaga sozinho não é mais uma falha silenciosa: ele nomeia o arquivo e oferece desativá-lo num toque.",
+  "showcase.v0102.paintsync":
+    "A sincronização de pinturas enviava a pintura da moto errada quando duas motos tinham o mesmo nome de pintura — e pinturas de capacete, óculos, botas e proteções nunca eram compartilhadas.",
   "showcase.v0101.hero.title":
     "Sua biblioteca lembra o que você apagou",
   "showcase.v0101.hero.body":


### PR DESCRIPTION
Cuts **v0.10.2** — model-swap livery ownership, and the two Windows faults that stopped the app starting.

## What's in it

Seven PRs since `v0.10.1`: #208, #209, #210, #211, #212, #213, #214.

## What this PR itself does

- **Consolidates the CHANGELOG.** The unreleased work arrived as two dated sections (`2026-08-25`, `2026-08-22`) with duplicate `### Added`/`### Fixed` blocks. They're now one `## 2026-08-26 — v0.10.2 — …` heading, which is what `changelog-section.sh` needs to find the section at all. Bullets were regrouped programmatically, so the existing prose is byte-for-byte unchanged — the headline list diffs clean against `origin/main` apart from the one new entry below.
- **Documents #209, which merged with no CHANGELOG entry** and would otherwise have shipped undocumented. Share and preset codes now have every path they carry validated at decode time, zip extraction is swept for links escaping the staging folder, and a filename from a remote server can no longer name that folder's parent.
- **Bumps to 0.10.2** in `package.json`, `tauri.conf.json`, `Cargo.toml` and `Cargo.lock`.
- **Adds the in-app "What's new" entry** — hero on model-swap livery ownership, five highlights (pack-adopted liveries, Presets filtering, the VC++ runtime installer fix, the msvcr90 disable button, the paint-sync fix), plus strings in all six locales.

No DB or schema changes.

## Verified

- `changelog-section.sh v0.10.2 --heading` prints, and the body renders 99 lines — the failure mode where a consolidated section silently loses its heading and publishes with no notes.
- `release-notes.sh v0.10.2` builds the release body cleanly.
- `tsc --noEmit` passes, which is what catches a locale missing a showcase string.

## Not included

The open Linux EGL fix (#165) and share-from-Manage (#160).

🤖 Generated with [Claude Code](https://claude.com/claude-code)