### PR TITLE
feat(designer): mirror a layer through the bike, and the layer tools around it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 2026-08-26
+
+### Added
+- **Mirror a layer to the other side of the bike.** Place a decal on the right shroud, hit
+  Mirror, and a copy lands at the same spot on the left one. The place is worked out from the
+  model rather than by flipping the sheet — the two flanks are unwrapped wherever the modeller
+  put them, so flipping the square lands artwork on the wrong panel about as often as not.
+  The copy stays **linked**: move, recolour, retype or reshape the original and it follows,
+  until you unlink it.
+  - It says no rather than guessing, and says which no it is: both flanks already sharing that
+    part of the sheet (so it's on both sides already), a spot on the bike's centre line, a
+    part of the model with nothing at its reflection, or no model loaded at all.
+  - Where the far side isn't unwrapped as a true reflection, the placement is still made and
+    flagged as close rather than exact.
+- **The layer handling that was missing.** Duplicate (⌘D), copy and paste (⌘C/⌘V, across
+  sheets too), Delete, and arrow-key nudging — one pixel, or ten with Shift.
+- **Several layers at once.** Shift-click to add, drag over empty canvas to lasso, ⌘A for the
+  lot. Group them with ⌘G and they move, scale and clip as one; Alt-click reaches inside a
+  group for a single layer.
+- **Snapping while dragging.** Layers catch on the sheet's centre lines and edges, on the box
+  of whatever part they're clipped to, and on each other's edges and middles, with a line drawn
+  to show what was caught. Hold Alt to place freely.
+- **Flip a layer** left-to-right or top-to-bottom, from the inspector or the new right-click
+  menu on the canvas.
+- **Type a position and size.** X, Y, size and angle now have boxes as well as sliders, and
+  they track the drag — placing a plate number no longer means nudging it by eye.
+
 ## 2026-08-26 — v0.10.2 — Liveries that belong to a model, and a Windows that starts
 
 ### Added

--- a/src/Components/Studio/Designer/CanvasStage.tsx
+++ b/src/Components/Studio/Designer/CanvasStage.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { useT } from "../../../i18n/context";
-import { layerCorners } from "./composite";
+import { layerCorners, selectionBounds } from "./composite";
 import type { Ghost } from "./ghost";
 import {
   faceAt,
   partAt,
+  partBox,
   partPath,
   partsAt,
   sideAt,
@@ -57,11 +58,84 @@ function checkerTile(): HTMLCanvasElement {
 const MIN_SCALE = 0.05;
 const MAX_SCALE = 4;
 
+/**
+ * How close a drag has to come to a line before it takes hold of it, in *view* pixels.
+ *
+ * In view pixels rather than sheet ones, so the pull feels the same however far in you are
+ * zoomed — a fixed number of texels would be an unmissable magnet at 8× and nothing at all
+ * when the whole sheet is on screen.
+ */
+const SNAP = 6;
+
+/** Held apart so a "nothing is snapped" render isn't a new object every frame. */
+const NO_SNAP: { x: number | null; y: number | null } = { x: null, y: null };
+
 /** How long after a press a second one still counts as a double-click, and how far it may move.
  *  The platform's own thresholds aren't readable from a webview; these are the usual ones, and
  *  the slop matters more than the interval on a touchpad, where a "stationary" finger drifts. */
 const DOUBLE_MS = 400;
 const DOUBLE_SLOP = 6;
+
+/**
+ * The lines a drag can catch on, in sheet pixels.
+ *
+ * Three answers to "line this up with what?", and between them they cover what anyone actually
+ * does on a livery: the sheet's own middle and edges, the box of whatever the moving layers are
+ * clipped to, and every other layer's middle and edges.
+ *
+ * Built once when a drag starts rather than per sample. Nothing here moves while the drag is
+ * running — that is exactly what makes these the things worth lining up against — and the
+ * layer array is replaced on every pointer sample, so a memo on it would rebuild the lot a
+ * hundred times a second to produce the same numbers.
+ */
+function snapLines(sheet: Sheet, parts: UvPart[], moving: Layer[]): { xs: number[]; ys: number[] } {
+  const xs = [0, sheet.width / 2, sheet.width];
+  const ys = [0, sheet.height / 2, sheet.height];
+  const held = new Set(moving.map((l) => l.id));
+
+  for (const layer of moving) {
+    const part = layer.clip ? parts.find((p) => p.label === layer.clip?.label) : null;
+    if (!part) continue;
+    const b = partBox(part, sheet.width, sheet.height);
+    xs.push(b.x, b.x + b.w / 2, b.x + b.w);
+    ys.push(b.y, b.y + b.h / 2, b.y + b.h);
+  }
+
+  for (const layer of sheet.layers) {
+    // A paint layer's box is the sheet's own, which is already in the list, and an invisible
+    // layer is not something anyone is lining anything up with.
+    if (layer.kind === "paint" || !layer.visible || held.has(layer.id)) continue;
+    const b = selectionBounds([layer]);
+    if (!b) continue;
+    xs.push(b.x, b.x + b.w / 2, b.x + b.w);
+    ys.push(b.y, b.y + b.h / 2, b.y + b.h);
+  }
+  return { xs, ys };
+}
+
+/**
+ * The nudge that puts one of `edges` onto the nearest of `lines`, and which line that was.
+ *
+ * Every edge against every line rather than the centre against the centres: butting a decal up
+ * against the edge of a shroud is as common as centring it on one, and only a box's own edges
+ * can say when that has happened.
+ */
+function snapTo(edges: number[], lines: number[], tol: number): { shift: number; line: number | null } {
+  let shift = 0;
+  let line: number | null = null;
+  let best = tol;
+  for (const edge of edges) {
+    for (const candidate of lines) {
+      const d = Math.abs(candidate - edge);
+      if (d <= best) {
+        best = d;
+        shift = candidate - edge;
+        line = candidate;
+      }
+    }
+  }
+  return { shift, line };
+}
 
 interface CanvasStageProps {
   sheet: Sheet;
@@ -82,12 +156,30 @@ interface CanvasStageProps {
    * by exactly the mistake this is here to end.
    */
   onHoverSpot?: (tris: Int32Array | null) => void;
-  selectedId: string | null;
-  onSelect: (id: string | null) => void;
-  /** Drag, in sheet pixels. */
-  onMove: (id: string, dx: number, dy: number) => void;
-  /** Corner drag, as the layer's new absolute scale. */
-  onScale: (id: string, scale: number) => void;
+  /** The selected layers, bottom-first. Empty for none. */
+  selection: string[];
+  /**
+   * What a press means for the selection.
+   *
+   * `replace` is a plain click, `toggle` a shift-click, `isolate` an alt-click — which is the
+   * one that reaches inside a group. The stage says which gesture happened and the editor
+   * decides what that means for grouped layers; a stage that expanded groups itself would need
+   * to know what a group is, and it doesn't.
+   */
+  onSelect: (ids: string[], mode: "replace" | "toggle" | "isolate") => void;
+  /** Drag of the whole selection, in sheet pixels. */
+  onMove: (dx: number, dy: number) => void;
+  /**
+   * Corner drag, as where every dragged layer ends up.
+   *
+   * Absolute rather than a factor per move: a drag is a run of samples, and a ratio applied
+   * once per sample compounds its own rounding until a logo dragged out and back is not the
+   * size it started. Scaling several layers also moves them, since they grow about the
+   * selection's centre rather than each about their own.
+   */
+  onScale: (next: { id: string; x: number; y: number; scale: number }[]) => void;
+  /** A right-click that wasn't a pan, in client coordinates. */
+  onMenu: (x: number, y: number) => void;
   /** What the pointer does here. `move` is the select-and-drag behaviour. */
   tool: PaintTool;
   /** Brush and eraser diameter in sheet pixels, for the cursor. */
@@ -131,10 +223,11 @@ export function CanvasStage({
   ghost,
   parts,
   onHoverSpot,
-  selectedId,
+  selection,
   onSelect,
   onMove,
   onScale,
+  onMenu,
   tool,
   brushSize,
   canPaint,
@@ -155,15 +248,43 @@ export function CanvasStage({
   const [box, setBox] = useState({ w: 0, h: 0 });
   const [zoom, setZoom] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
-  // Where the pointer went down, and what it was doing — a drag of a layer, or of the view.
-  const drag = useRef<{ id: string | null; x: number; y: number } | null>(null);
-  // A corner drag: the layer's centre and the distance the press was from it, both in sheet
-  // pixels, plus the scale it started at. Scale comes out as a ratio of distances, so the
-  // grabbed corner stays under the pointer however the view is zoomed or panned mid-drag.
-  const sizing = useRef<{ id: string; cx: number; cy: number; dist: number; scale: number } | null>(
-    null,
-  );
+  // Where the pointer went down, and what it was doing — a drag of the selection, or of the view.
+  const drag = useRef<{
+    moving: boolean;
+    x: number;
+    y: number;
+    /** Built on the first move rather than at the press — see the note in `onPointerDown`. */
+    lines: { xs: number[]; ys: number[] } | null;
+    /**
+     * Where the selection's box was when the drag started, and how far the pointer has
+     * travelled since, in sheet pixels.
+     *
+     * Kept apart from where the layers actually are because a snap moves those and not the
+     * pointer. Adding a snapped delta per sample would throw away the pointer travel spent
+     * held against a line, and the layer would drift out from under the hand a little further
+     * every time it caught on something.
+     */
+    origin: { x: number; y: number } | null;
+    raw: { x: number; y: number };
+  } | null>(null);
+  // A corner drag: the fixed point it grows from and the distance the press was from it, both
+  // in sheet pixels, plus what each dragged layer was at the press. Scale comes out as a ratio
+  // of distances, so the grabbed corner stays under the pointer however the view is zoomed or
+  // panned mid-drag; keeping the starting sizes means it never compounds its own rounding.
+  const sizing = useRef<{
+    cx: number;
+    cy: number;
+    dist: number;
+    from: { id: string; x: number; y: number; scale: number }[];
+  } | null>(null);
   const painting = useRef(false);
+  // A rubber band over empty canvas, in sheet pixels, while one is being pulled out.
+  const [marquee, setMarquee] = useState<{ from: Point; to: Point; add: boolean } | null>(null);
+  // Where a right press went down, so a release that never moved can be told from a pan — the
+  // native `contextmenu` event fires on the press and can't tell them apart.
+  const rightPress = useRef<{ x: number; y: number } | null>(null);
+  // The lines a drag is currently held to, in sheet coordinates, purely so they can be drawn.
+  const [snapped, setSnapped] = useState<{ x: number | null; y: number | null }>(NO_SNAP);
   // The last left press, for recognising a double-click ourselves. Null once one has been
   // recognised, so a run of fast clicks pairs up rather than firing on every press after the
   // second. See `onPointerDown` for why the DOM's own `dblclick` can't be used here.
@@ -249,19 +370,45 @@ export function CanvasStage({
   );
 
   /**
-   * The selected layer's corners in view space — what's drawn as handles, and what's grabbed.
+   * The selected layers, and of those the ones a drag can actually move.
+   *
+   * Paint layers are the sheet — see `layers.ts` — so they are selectable from the list and
+   * inert here. Kept apart rather than filtered at each use, because "what is selected" and
+   * "what a corner drag would resize" are different questions asked a dozen times below.
+   */
+  const chosen = useMemo(
+    () => sheet.layers.filter((l) => selection.includes(l.id)),
+    [sheet.layers, selection],
+  );
+  const movable = useMemo(() => chosen.filter((l) => l.kind !== "paint"), [chosen]);
+
+  /**
+   * The selection's corners in view space — what's drawn as handles, and what's grabbed.
+   *
+   * One layer gives its own rotated box, so a logo turned 30° is outlined at 30°. Several give
+   * the upright box around the lot: there is no angle several layers agree on, and a box drawn
+   * at one of their angles would say they share it.
    *
    * Computed rather than remembered from the last paint, so a handle is always tested against
    * where the corner is now. A resize moves all four while the pointer is still down, and a
    * cached set would have the grab point drift away from the square under the cursor.
    */
   const handles = useCallback((): [number, number][] => {
-    const selected = sheet.layers.find((l) => l.id === selectedId);
-    // Paint layers are the sheet — see `layers.ts`. There is nothing to resize, and the
-    // corners would sit on the sheet edge where they'd catch every click near the border.
-    if (!selected || selected.kind === "paint") return [];
-    return layerCorners(selected).map((c) => toView({ x: c[0], y: c[1] }));
-  }, [sheet.layers, selectedId, toView]);
+    if (!movable.length) return [];
+    if (movable.length === 1) {
+      return layerCorners(movable[0]).map((c) => toView({ x: c[0], y: c[1] }));
+    }
+    const b = selectionBounds(movable);
+    if (!b) return [];
+    return (
+      [
+        [b.x, b.y],
+        [b.x + b.w, b.y],
+        [b.x + b.w, b.y + b.h],
+        [b.x, b.y + b.h],
+      ] as [number, number][]
+    ).map(([x, y]) => toView({ x, y }));
+  }, [movable, toView]);
 
   /**
    * The corner under a client point, or -1.
@@ -445,6 +592,45 @@ export function CanvasStage({
       }
       ctx.restore();
     }
+
+    // The rubber band, in the same dashed idiom as the guide above — it is the same kind of
+    // thing, a gesture in progress that hasn't touched the sheet.
+    if (marquee) {
+      const [ax, ay] = toView(marquee.from);
+      const [bx, by] = toView(marquee.to);
+      ctx.save();
+      ctx.setLineDash([4, 3]);
+      ctx.strokeStyle = "rgba(59,130,246,0.9)";
+      ctx.fillStyle = "rgba(59,130,246,0.12)";
+      ctx.lineWidth = 1;
+      const rx = Math.min(ax, bx);
+      const ry = Math.min(ay, by);
+      ctx.fillRect(rx, ry, Math.abs(bx - ax), Math.abs(by - ay));
+      ctx.strokeRect(rx, ry, Math.abs(bx - ax), Math.abs(by - ay));
+      ctx.restore();
+    }
+
+    // What a drag is being held to, drawn right across the sheet. A mark beside the layer
+    // would say only that *something* was caught; the line says what, which is the half that
+    // tells you whether it's the seam you meant or the logo behind it.
+    if (snapped.x !== null || snapped.y !== null) {
+      ctx.save();
+      ctx.strokeStyle = "rgba(244,114,182,0.85)";
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      if (snapped.x !== null) {
+        const [sx] = toView({ x: snapped.x, y: 0 });
+        ctx.moveTo(sx, top);
+        ctx.lineTo(sx, top + h);
+      }
+      if (snapped.y !== null) {
+        const [, sy] = toView({ x: 0, y: snapped.y });
+        ctx.moveTo(left, sy);
+        ctx.lineTo(left + w, sy);
+      }
+      ctx.stroke();
+      ctx.restore();
+    }
   }, [
     box,
     scale,
@@ -457,6 +643,8 @@ export function CanvasStage({
     overPath,
     version,
     guide,
+    marquee,
+    snapped,
     tool,
     toView,
     handles,
@@ -545,7 +733,11 @@ export function CanvasStage({
       // Not mid-stroke, though: the view moving under a brush that is still down would drag
       // the stroke sideways across the sheet.
       if (e.button === 1 || e.button === 2) {
-        if (!painting.current) drag.current = { id: null, x: e.clientX, y: e.clientY };
+        // A right press in the move tool might be a pan or might be a menu, and which it was
+        // is only known on release. Both are set up here and the release picks one.
+        if (e.button === 2 && !paints) rightPress.current = { x: e.clientX, y: e.clientY };
+        if (!painting.current)
+          drag.current = { moving: false, x: e.clientX, y: e.clientY, lines: null, origin: null, raw: { x: 0, y: 0 } };
         return;
       }
       if (paints) {
@@ -558,34 +750,49 @@ export function CanvasStage({
       // would answer "you clicked the layer" every time and there would be no way to resize
       // anything — and the corner of a small layer often overlaps a bigger one behind it.
       const corner = handleAt(e.clientX, e.clientY);
-      const selected = sheet.layers.find((l) => l.id === selectedId);
-      if (corner >= 0 && selected) {
-        const dist = Math.hypot(at.x - selected.x, at.y - selected.y);
+      if (corner >= 0 && movable.length) {
+        // One layer grows about its own centre, which is the fixed point the inspector's
+        // slider uses. Several grow about the box they share, so their spacing scales with
+        // them rather than each drifting out from wherever it happened to be.
+        const around = movable.length === 1 ? null : selectionBounds(movable);
+        const cx = around ? around.x + around.w / 2 : movable[0].x;
+        const cy = around ? around.y + around.h / 2 : movable[0].y;
+        const dist = Math.hypot(at.x - cx, at.y - cy);
         // A press exactly on the centre has no distance to take a ratio of. Can only happen
         // on a layer scaled down to nothing, and dropping the drag beats dividing by zero.
         if (dist > 0.5) {
           sizing.current = {
-            id: selected.id,
-            cx: selected.x,
-            cy: selected.y,
+            cx,
+            cy,
             dist,
-            scale: selected.scale,
+            from: movable.map((l) => ({ id: l.id, x: l.x, y: l.y, scale: l.scale })),
           };
           return;
         }
       }
+
       const hit = hitTest(sheet.layers, at.x, at.y);
-      onSelect(hit?.id ?? null);
-      drag.current = { id: hit?.id ?? null, x: e.clientX, y: e.clientY };
+      if (!hit) {
+        // Empty canvas pulls a rubber band rather than panning the view. Panning survives the
+        // change on the middle and right buttons, where it is also the only thing they do.
+        if (!e.shiftKey) onSelect([], "replace");
+        setMarquee({ from: at, to: at, add: e.shiftKey });
+        return;
+      }
+      onSelect([hit.id], e.shiftKey ? "toggle" : e.altKey ? "isolate" : "replace");
+      // `lines` is left null on purpose. What this press selected is decided above us — a
+      // click on one member of a group takes the whole group — so the layers that are about
+      // to move aren't known until the state that says so has come back down as a prop.
+      drag.current = { moving: true, x: e.clientX, y: e.clientY, lines: null, origin: null, raw: { x: 0, y: 0 } };
     },
     [
       focusPart,
       handleAt,
+      movable,
       onPaintStart,
       onSelect,
       paints,
       parts,
-      selectedId,
       sheet.layers,
       sheet.width,
       sheet.height,
@@ -602,11 +809,25 @@ export function CanvasStage({
       if (size) {
         const p = toSheet(e.clientX, e.clientY);
         if (!p) return;
-        // Scale as the ratio of distances from the layer's centre, which is where it grows
-        // from — the same fixed point the inspector's slider uses, so dragging a corner and
-        // typing a number move the layer's pixels the same way.
-        const next = (size.scale * Math.hypot(p.x - size.cx, p.y - size.cy)) / size.dist;
-        onScale(size.id, Math.min(MAX_SCALE, Math.max(MIN_SCALE, next)));
+        // Scale as the ratio of distances from the point it grows about — the same fixed point
+        // the inspector's slider uses, so dragging a corner and typing a number move the
+        // layer's pixels the same way.
+        const ratio = Math.hypot(p.x - size.cx, p.y - size.cy) / size.dist;
+        onScale(
+          size.from.map((l) => {
+            // Clamped per layer, so one that has already hit the limit stops there instead of
+            // pinning the rest of the selection at the size it happens to be.
+            const scale = Math.min(MAX_SCALE, Math.max(MIN_SCALE, l.scale * ratio));
+            const k = l.scale ? scale / l.scale : 1;
+            return { id: l.id, x: size.cx + (l.x - size.cx) * k, y: size.cy + (l.y - size.cy) * k, scale };
+          }),
+        );
+        return;
+      }
+
+      if (marquee) {
+        const p = toSheet(e.clientX, e.clientY);
+        if (p) setMarquee((m) => (m ? { ...m, to: p } : m));
         return;
       }
 
@@ -671,11 +892,43 @@ export function CanvasStage({
       if (!dx && !dy) return;
       d.x = e.clientX;
       d.y = e.clientY;
-      if (d.id) onMove(d.id, dx / scale, -dy / scale);
-      else setPan((p) => ({ x: p.x + dx, y: p.y + dy }));
+      if (!d.moving) {
+        setPan((p) => ({ x: p.x + dx, y: p.y + dy }));
+        return;
+      }
+      if (!movable.length) return;
+
+      // First move of the drag: the selection this press made has come back down as a prop by
+      // now, so this is the first moment the layers about to move are actually known.
+      const now = selectionBounds(movable);
+      if (!now) return;
+      if (!d.lines) d.lines = snapLines(sheet, parts, movable);
+      if (!d.origin) d.origin = { x: now.x, y: now.y };
+
+      d.raw.x += dx / scale;
+      d.raw.y -= dy / scale;
+      let wantX = d.origin.x + d.raw.x;
+      let wantY = d.origin.y + d.raw.y;
+      let lineX: number | null = null;
+      let lineY: number | null = null;
+      // Alt is the escape hatch. A decal a few pixels off a seam on purpose is a real thing to
+      // want, and a magnet with no way to switch it off is worse than no magnet.
+      if (!e.altKey) {
+        const tol = SNAP / scale;
+        const sx = snapTo([wantX, wantX + now.w / 2, wantX + now.w], d.lines.xs, tol);
+        const sy = snapTo([wantY, wantY + now.h / 2, wantY + now.h], d.lines.ys, tol);
+        wantX += sx.shift;
+        wantY += sy.shift;
+        lineX = sx.line;
+        lineY = sy.line;
+      }
+      setSnapped((s) => (s.x === lineX && s.y === lineY ? s : { x: lineX, y: lineY }));
+      onMove(wantX - now.x, wantY - now.y);
     },
     [
       handleAt,
+      marquee,
+      movable,
       moveCursor,
       onHoverSpot,
       onMove,
@@ -684,8 +937,7 @@ export function CanvasStage({
       paints,
       parts,
       scale,
-      sheet.height,
-      sheet.width,
+      sheet,
       toSheet,
       tool,
     ],
@@ -698,13 +950,47 @@ export function CanvasStage({
         setGuide(null);
         onPaintEnd();
       }
+
+      const band = marquee;
+      if (band) {
+        setMarquee(null);
+        const x0 = Math.min(band.from.x, band.to.x);
+        const x1 = Math.max(band.from.x, band.to.x);
+        const y0 = Math.min(band.from.y, band.to.y);
+        const y1 = Math.max(band.from.y, band.to.y);
+        // A band with no area is a click on empty canvas, which has already cleared the
+        // selection on the way in.
+        if (x1 - x0 > 1 || y1 - y0 > 1) {
+          // Touched rather than swallowed. A band you have to draw right round a logo is a band
+          // you end up drawing twice, and the layer you wanted was under the first attempt.
+          const caught = sheet.layers.filter((l) => {
+            if (l.kind === "paint" || !l.visible) return false;
+            const b = selectionBounds([l]);
+            return !!b && b.x <= x1 && b.x + b.w >= x0 && b.y <= y1 && b.y + b.h >= y0;
+          });
+          if (caught.length) {
+            onSelect(caught.map((l) => l.id), band.add ? "toggle" : "replace");
+          }
+        }
+      }
+
+      // A right press that never moved was a menu; one that did was a pan, and it has already
+      // happened. This is the release, which is the first moment the two can be told apart —
+      // the slop is the same one a double-click gets, and for the same reason.
+      const right = rightPress.current;
+      rightPress.current = null;
+      if (right && Math.hypot(e.clientX - right.x, e.clientY - right.y) < DOUBLE_SLOP) {
+        onMenu(e.clientX, e.clientY);
+      }
+
       drag.current = null;
       sizing.current = null;
+      setSnapped((s) => (s === NO_SNAP ? s : NO_SNAP));
       if (e.currentTarget.hasPointerCapture(e.pointerId)) {
         e.currentTarget.releasePointerCapture(e.pointerId);
       }
     },
-    [onPaintEnd],
+    [marquee, onMenu, onPaintEnd, onSelect, sheet.layers],
   );
 
   const onWheel = useCallback((e: React.WheelEvent<HTMLCanvasElement>) => {

--- a/src/Components/Studio/Designer/Designer.tsx
+++ b/src/Components/Studio/Designer/Designer.tsx
@@ -1,11 +1,19 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
   Bike,
+  ClipboardPaste,
+  Copy,
+  CopyPlus,
   Eye,
   EyeOff,
   FilePlus2,
+  FlipHorizontal2,
+  FlipVertical2,
   Grid3x3,
+  Group,
   Layers as LayersIcon,
+  Link2,
+  Link2Off,
   Loader2,
   PackageOpen,
   PanelLeftClose,
@@ -13,6 +21,7 @@ import {
   Plus,
   Save,
   Trash2,
+  Ungroup,
 } from "lucide-react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { toast } from "sonner";
@@ -49,11 +58,14 @@ import {
 } from "./uv";
 import {
   blankSheet,
+  cloneLayer,
+  groupOf,
   imageLayer,
   isCompanionMap,
   layerExtent,
   newId,
   paintLayer,
+  regroup,
   shapeLayer,
   textLayer,
   unionRegion,
@@ -63,6 +75,14 @@ import {
   type Region,
   type Sheet,
 } from "./layers";
+import { buildMirror, derive, mirrorLayer, type MirrorIndex } from "./mirror";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "../../ui/dropdown-menu";
 import {
   DEFAULT_PAINT,
   PaintHistory,
@@ -96,6 +116,36 @@ import type { EdfNode, PaintTexture } from "../../../types";
 /** A blank sheet's edge. Powers of two only — the backend would resize anything else. */
 const BLANK_SIZE = 2048;
 
+/**
+ * What was last copied, and the sheet it was cut from.
+ *
+ * Outside the component because the Studio unmounts this pane when another tab is opened, and
+ * a clipboard that emptied when you went to look at something is a clipboard nobody uses. The
+ * sheet's size travels with it: a layer's position is in sheet pixels, so pasting across sheets
+ * of different sizes has to bring the artwork with it rather than leave it off the edge.
+ */
+let clipboard: { width: number; height: number; layers: Layer[] } | null = null;
+
+/** One row of the canvas menu, so a dozen of them don't each spell out the same classes. */
+function MenuRow({
+  icon: Icon,
+  label,
+  disabled,
+  onPick,
+}: {
+  icon: typeof Copy;
+  label: string;
+  disabled?: boolean;
+  onPick: () => void;
+}) {
+  return (
+    <DropdownMenuItem disabled={disabled} onSelect={onPick}>
+      <Icon className="size-3.5" />
+      {label}
+    </DropdownMenuItem>
+  );
+}
+
 interface DesignerProps {
   /**
    * Sheets handed over from Paint Studio, by path — drawn on rather than replaced.
@@ -111,7 +161,9 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   const t = useT();
   const [sheets, setSheets] = useState<Sheet[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
-  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selection, setSelection] = useState<string[]>([]);
+  // Where the canvas's right-click menu is, in client coordinates, or null for closed.
+  const [menuAt, setMenuAt] = useState<{ x: number; y: number } | null>(null);
   const [name, setName] = useState("");
   const [busy, setBusy] = useState(false);
   // The sheets/layers rail folds away, because once a paint is set up the thing worth the
@@ -144,6 +196,9 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   // The mesh the preview is showing, reported back by it. Null until one loads, and null again
   // if it fails — a UV map drawn from a model that isn't on screen would be a confident lie.
   const [geometry, setGeometry] = useState<EdfNode[] | null>(null);
+  // The same mesh, reachable without waiting for a render — see `onGeometry` for why it exists
+  // at all, and `ensureMirror` for why it has to be readable from this far up the file.
+  const geometryRef = useRef<EdfNode[] | null>(null);
   // Whether that mesh was assembled about the bike's mirror plane. Without it a position is a
   // number in some part's own frame, and the sides and facings read off it would be invented.
   const [assembled, setAssembled] = useState(false);
@@ -189,6 +244,19 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
 
   const active = sheets.find((s) => s.id === activeId) ?? null;
   const bump = useCallback(() => setVersion((v) => v + 1), []);
+
+  /**
+   * The one selected layer, where "one" is what the question means.
+   *
+   * The paint target, the part picker and the fit all act on a single layer, and null is the
+   * honest answer for a selection of three — better than picking the first and acting on a
+   * layer nobody pointed at.
+   */
+  const selectedId = selection.length === 1 ? selection[0] : null;
+  const chosen = useMemo(
+    () => active?.layers.filter((l) => selection.includes(l.id)) ?? [],
+    [active, selection],
+  );
 
   /**
    * The sheets that exist, as a string.
@@ -303,6 +371,70 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     setHistoryRev((v) => v + 1);
   }, []);
 
+  /* ── Mirroring ─────────────────────────────────────────────────────────────────────────
+     A mirrored layer is a *follower*: it holds no placement of its own worth keeping, and is
+     re-derived from the layer it reflects on every edit. That derivation hangs off `patchSheet`
+     below, which is the one road every edit but a stroke takes. ──────────────────────────── */
+
+  /**
+   * What the mirror needs, in a ref rather than a memo, and built only when something asks.
+   *
+   * `patchSheet` is defined here — long before the model's parts are — and every edit has to
+   * go through it, so the geometry arrives sideways rather than in a dependency list. Lazily,
+   * too: most paints mirror nothing, and a memo would build an index for every sheet anyone
+   * opened to answer a question that was never asked.
+   *
+   * `ready` is the model's own statement that its axes can be trusted. Without it there is no
+   * left and right to reflect between — see `uvParts`.
+   */
+  const mirrorRef = useRef<{
+    sheetId: string | null;
+    parts: UvPart[];
+    ready: boolean;
+    index: MirrorIndex | null;
+  }>({ sheetId: null, parts: [], ready: false, index: null });
+
+  const ensureMirror = useCallback((): MirrorIndex | null => {
+    const held = mirrorRef.current;
+    if (!held.ready) return null;
+    if (!held.index) held.index = buildMirror(held.parts, geometryRef.current ?? []);
+    return held.index;
+  }, []);
+
+  /**
+   * Bring every follower on a sheet back into step with the layer it reflects.
+   *
+   * Strokes don't come through here and don't need to: a paint layer is the sheet, so it can
+   * never be a source or a follower, and that is what keeps this off the one path in the
+   * editor that runs a hundred times a second.
+   */
+  const syncMirrors = useCallback(
+    (sheet: Sheet): Sheet => {
+      if (!sheet.layers.some((l) => l.mirror)) return sheet;
+      const held = mirrorRef.current;
+      const index = held.sheetId === sheet.id ? ensureMirror() : null;
+      const by = new Map(sheet.layers.map((l) => [l.id, l]));
+      return {
+        ...sheet,
+        layers: sheet.layers.map((layer) => {
+          if (!layer.mirror) return layer;
+          const from = by.get(layer.mirror.of);
+          // The source has gone — deleted, or undone away — or is something that can't be a
+          // source. The follower stops following rather than going with it: what it holds is
+          // still somebody's artwork, and it is already on the bike.
+          if (!from || from.id === layer.id || from.kind === "paint") {
+            return { ...layer, mirror: null };
+          }
+          // A null placement leaves it where it is. That is the case where the model isn't
+          // loaded, and a follower that jumped to a guess would look placed rather than stale.
+          const placed = index ? mirrorLayer(index, held.parts, from, sheet) : null;
+          return derive(layer, from, placed?.ok ? placed : null, held.parts, sheet);
+        }),
+      };
+    },
+    [ensureMirror],
+  );
+
   const patchSheet = useCallback(
     /**
      * `undoKey` names the gesture for coalescing, or `false` for an edit the history must not
@@ -315,9 +447,11 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
       // region as a promise rather than a hint: if one is there, a stroke put it there.
       if (undoKey !== false) remember(undoKey);
       dirty.current.set(id, null);
-      setSheets((prev) => prev.map((s) => (s.id === id ? fn(s) : s)));
+      // Followers re-derived on the way out, so no caller has to remember they exist. Dragging
+      // a logo and hiding one are the same kind of edit as far as the far side is concerned.
+      setSheets((prev) => prev.map((s) => (s.id === id ? syncMirrors(fn(s)) : s)));
     },
-    [remember],
+    [remember, syncMirrors],
   );
 
   const patchLayer = useCallback(
@@ -438,7 +572,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     if (!active) return;
     const layer = paintLayer(t("designer.paintLayerName"), active);
     patchSheet(active.id, (s) => ({ ...s, layers: [...s.layers, layer] }));
-    setSelectedId(layer.id);
+    setSelection([layer.id]);
     bump();
   }, [active, bump, patchSheet, t]);
 
@@ -457,7 +591,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
       const selected = active.layers.find((l) => l.id === selectedId);
       if (selected?.kind === "paint") return;
       const existing = [...active.layers].reverse().find((l) => l.kind === "paint");
-      if (existing) setSelectedId(existing.id);
+      if (existing) setSelection([existing.id]);
       else addPaintLayer();
     },
     [active, addPaintLayer, selectedId],
@@ -514,7 +648,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
             ...sh,
             layers: sh.layers.filter((l) => l.id !== drawing.id),
           }));
-          setSelectedId(null);
+          setSelection([]);
           bump();
         }
       }
@@ -566,9 +700,10 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
       write: (next: Sheet[]) => {
         setSheets(next);
         setActiveId((cur) => (cur && next.some((s) => s.id === cur) ? cur : next[0]?.id ?? null));
-        setSelectedId((cur) =>
-          cur && next.some((s) => s.layers.some((l) => l.id === cur)) ? cur : null,
-        );
+        setSelection((cur) => {
+          const alive = cur.filter((id) => next.some((s) => s.layers.some((l) => l.id === id)));
+          return alive.length === cur.length ? cur : alive;
+        });
       },
     }),
     [],
@@ -620,35 +755,6 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [paintLayerKey]);
 
-  /**
-   * Tool keys, and undo.
-   *
-   * On the window rather than on the canvas, because a brush should be one key away wherever
-   * the focus happens to be — but the Studio keeps this pane mounted behind whichever tab is
-   * open, so an invisible Designer would otherwise steal every `b` typed into Paint Studio.
-   */
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (!rootRef.current?.offsetParent) return;
-      const el = e.target as HTMLElement | null;
-      if (el && (/^(INPUT|TEXTAREA|SELECT)$/.test(el.tagName) || el.isContentEditable)) return;
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "z") {
-        e.preventDefault();
-        if (e.shiftKey) redo();
-        else undo();
-        return;
-      }
-      if (e.metaKey || e.ctrlKey || e.altKey) return;
-      const key = e.key.toLowerCase();
-      const tool = (Object.keys(TOOL_KEYS) as PaintTool[]).find((k) => TOOL_KEYS[k] === key);
-      if (tool) {
-        e.preventDefault();
-        pickTool(tool);
-      }
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [pickTool, redo, undo]);
 
   /**
    * Pixels for a file the user picked, at the sheet's own resolution.
@@ -694,7 +800,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
       remember();
       setSheets(next);
       setActiveId(next[0]?.id ?? null);
-      setSelectedId(null);
+      setSelection([]);
       if (nameHint) setName((n) => n || nameHint);
       bump();
       toast.success(t("designer.loadedSheets", { count: String(next.length) }));
@@ -760,7 +866,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     remember();
     setSheets((prev) => [...prev, sheet]);
     setActiveId(sheet.id);
-    setSelectedId(null);
+    setSelection([]);
     bump();
   }, [bump, missingHints, remember]);
 
@@ -779,7 +885,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     remember();
     setSheets((prev) => [...prev, ...made]);
     setActiveId(made[0].id);
-    setSelectedId(null);
+    setSelection([]);
     bump();
   }, [bump, missingHints, remember]);
 
@@ -798,7 +904,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
         imageLayer(layerName, bitmap, active),
       );
       patchSheet(active.id, (s) => ({ ...s, layers: [...s.layers, ...added] }));
-      setSelectedId(added[added.length - 1]?.id ?? null);
+      setSelection(added.length ? [added[added.length - 1].id] : []);
       bump();
     } catch (e) {
       toast.error(String(e).replace(/^Error:\s*/, ""));
@@ -811,35 +917,76 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     if (!active) return;
     const layer = textLayer(t("designer.newTextValue"), active);
     patchSheet(active.id, (s) => ({ ...s, layers: [...s.layers, layer] }));
-    setSelectedId(layer.id);
+    setSelection([layer.id]);
     bump();
   }, [active, bump, patchSheet, t]);
 
-  const removeLayer = useCallback(
-    (id: string) => {
-      if (!activeId) return;
-      patchSheet(activeId, (s) => ({ ...s, layers: s.layers.filter((l) => l.id !== id) }));
-      setSelectedId((cur) => (cur === id ? null : cur));
+  const removeLayers = useCallback(
+    (ids: string[]) => {
+      if (!activeId || !ids.length) return;
+      const gone = new Set(ids);
+      patchSheet(activeId, (s) => ({ ...s, layers: s.layers.filter((l) => !gone.has(l.id)) }));
+      setSelection((cur) => cur.filter((id) => !gone.has(id)));
       bump();
     },
     [activeId, bump, patchSheet],
   );
 
-  const moveLayer = useCallback(
-    (id: string, dx: number, dy: number) => {
-      patchLayer(id, (l) => ({ ...l, x: l.x + dx, y: l.y + dy }), `layer:${id}`);
+  /**
+   * Apply a change to every selected layer.
+   *
+   * Followers need no special case here, which is worth saying because it looks like they
+   * should. `patchSheet` re-derives them on the way out, so a change to something a follower
+   * takes from its source is simply put back — that *is* the lock, and it costs nothing.
+   * What a follower owns for itself, its name and its group, sticks.
+   */
+  const patchSelection = useCallback(
+    (fn: (l: Layer) => Layer, undoKey: string | null | false = null) => {
+      if (!activeId || !selection.length) return;
+      const ids = new Set(selection);
+      patchSheet(
+        activeId,
+        (s) => ({ ...s, layers: s.layers.map((l) => (ids.has(l.id) ? fn(l) : l)) }),
+        undoKey,
+      );
       bump();
     },
-    [bump, patchLayer],
+    [activeId, bump, patchSheet, selection],
   );
 
-  /** A corner drag, as an absolute scale. Clamped by the stage to the inspector's range. */
-  const scaleLayer = useCallback(
-    (id: string, scale: number) => {
-      patchLayer(id, (l) => ({ ...l, scale }), `layer:${id}`);
+  const moveSelection = useCallback(
+    (dx: number, dy: number) => {
+      if (!dx && !dy) return;
+      // One undo step per run of the same gesture, however many samples it took — see
+      // `PaintHistory.pushDoc`. Keyed on what is moving, so picking up a different layer
+      // starts a new step rather than folding into the last one.
+      patchSelection(
+        (l) => (l.kind === "paint" ? l : { ...l, x: l.x + dx, y: l.y + dy }),
+        `move:${selection.join(",")}`,
+      );
+    },
+    [patchSelection, selection],
+  );
+
+  /** A corner drag, as where each dragged layer ends up. Clamped by the stage to the range. */
+  const scaleSelection = useCallback(
+    (next: { id: string; x: number; y: number; scale: number }[]) => {
+      if (!activeId || !next.length) return;
+      const by = new Map(next.map((n) => [n.id, n]));
+      patchSheet(
+        activeId,
+        (s) => ({
+          ...s,
+          layers: s.layers.map((l) => {
+            const to = by.get(l.id);
+            return to ? { ...l, x: to.x, y: to.y, scale: to.scale } : l;
+          }),
+        }),
+        `scale:${next.map((n) => n.id).join(",")}`,
+      );
       bump();
     },
-    [bump, patchLayer],
+    [activeId, bump, patchSheet],
   );
 
   /* ── The reference underlay ────────────────────────────────────────────────────────────
@@ -893,7 +1040,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
         );
         remember();
         patchSheet(active.id, (sh) => ({ ...sh, layers: [...sh.layers, layer] }));
-        setSelectedId(layer.id);
+        setSelection([layer.id]);
         shaping.current = { id: layer.id, from: at };
         bump();
         return;
@@ -930,12 +1077,12 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     [active, activeId, bump, paint, parts, patchSheet, remember, t, target, touchPaint],
   );
 
-  /** Pin the selected layer to a piece of bodywork, or let it cover the sheet again. */
+  /** Pin the selection to a piece of bodywork, or let it cover the sheet again. */
   const clipLayer = useCallback(
     (label: string | null) => {
-      if (!active || !selectedId) return;
+      if (!active) return;
       const part = label ? parts.find((p) => p.label === label) : null;
-      patchLayer(selectedId, (l) => ({
+      patchSelection((l) => ({
         ...l,
         // Built here, at this sheet's size, so the composite never has to. Re-picking the
         // part is what rebuilds it, which is also the answer to a resized sheet.
@@ -943,9 +1090,8 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
           ? { label: part.label, path: partPath(part, active.width, active.height) }
           : null,
       }));
-      bump();
     },
-    [active, bump, parts, patchLayer, selectedId],
+    [active, parts, patchSelection],
   );
 
   /**
@@ -976,6 +1122,252 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     [active, bump, parts, patchLayer, selectedId],
   );
 
+  /**
+   * Hand the mirror the model it should answer from, and drop the index built from the last one.
+   *
+   * Dropped rather than rebuilt. Most sheets are never mirrored on, and the rebuild is a walk
+   * over the whole of the bodywork — `ensureMirror` does it the moment something actually asks.
+   *
+   * During the render rather than in an effect, the same way `sheetsRef` is kept: the button
+   * that offers a mirror is rendered from `ready`, and an effect would leave it a render behind
+   * the model — disabled, with nothing on screen to explain why.
+   */
+  if (mirrorRef.current.sheetId !== activeId || mirrorRef.current.parts !== parts) {
+    mirrorRef.current = {
+      sheetId: activeId,
+      parts,
+      // The flank codes are the model's own statement that its axes mean something; `uvParts`
+      // only produces them for a bike that arrived assembled.
+      ready: parts.some((p) => p.flanks),
+      index: null,
+    };
+  }
+
+  /* ── The selection, and what can be done to it ─────────────────────────────────────────
+     A group is a tag on its members rather than a container (see `layers.ts`), so "select the
+     group" is a question asked of the layer list right here — everything downstream, the stage
+     and the inspector both, only ever sees a list of ids. ─────────────────────────────── */
+
+  const select = useCallback(
+    (ids: string[], mode: "replace" | "toggle" | "isolate") => {
+      const layers = active?.layers ?? [];
+      // Alt reaches inside a group. Anything else takes the whole block a layer belongs to,
+      // which is the entire point of having grouped it.
+      const want =
+        mode === "isolate" ? ids : [...new Set(ids.flatMap((id) => groupOf(layers, id)))];
+      setSelection((cur) => {
+        if (mode !== "toggle") return want;
+        const next = new Set(cur);
+        // A group toggles as a block: if any of it is out, all of it comes in.
+        const add = want.some((id) => !next.has(id));
+        for (const id of want) {
+          if (add) next.add(id);
+          else next.delete(id);
+        }
+        // Kept in stacking order, so anything reading the selection reads it bottom-first.
+        return layers.filter((l) => next.has(l.id)).map((l) => l.id);
+      });
+    },
+    [active],
+  );
+
+  /** How far a duplicate lands from what it was copied from, as a fraction of the sheet. */
+  const offset = active ? Math.max(4, Math.round(Math.min(active.width, active.height) * 0.02)) : 0;
+
+  const duplicateSelection = useCallback(() => {
+    if (!active || !chosen.length) return;
+    // A duplicate of several layers is a group of its own, or the first drag takes it apart.
+    const tag = chosen.length > 1 ? newId("group") : null;
+    const copies = chosen.map((l) => ({
+      ...cloneLayer(l, t("designer.copyName", { name: l.name })),
+      group: tag,
+      // Down and to the right on screen — the sheet's y runs the other way. A copy landing
+      // exactly on its original looks like nothing happened.
+      x: l.x + offset,
+      y: l.y - offset,
+    }));
+    patchSheet(active.id, (s) => ({ ...s, layers: [...s.layers, ...copies] }));
+    setSelection(copies.map((c) => c.id));
+    bump();
+  }, [active, bump, chosen, offset, patchSheet, t]);
+
+  const copySelection = useCallback(() => {
+    if (!active || !chosen.length) return;
+    // Cloned on the way in rather than on the way out: the layers left behind go on being
+    // edited, and a clipboard holding the live ones would paste whatever they had become.
+    clipboard = {
+      width: active.width,
+      height: active.height,
+      layers: chosen.map((l) => cloneLayer(l, l.name)),
+    };
+    toast.success(t("designer.copied", { count: String(chosen.length) }));
+  }, [active, chosen, t]);
+
+  const pasteClipboard = useCallback(() => {
+    if (!active || !clipboard?.layers.length) return;
+    const kx = active.width / clipboard.width;
+    const ky = active.height / clipboard.height;
+    const sized = kx === 1 && ky === 1;
+    // A paint layer is the sheet, and its raster is the size of the sheet it was cut from.
+    // Onto a sheet of another size there is nothing sensible to do with it.
+    const keep = sized ? clipboard.layers : clipboard.layers.filter((l) => l.kind !== "paint");
+    const dropped = clipboard.layers.length - keep.length;
+    if (!keep.length) {
+      toast.error(t("designer.pasteWrongSize"));
+      return;
+    }
+    const tag = keep.length > 1 ? newId("group") : null;
+    const copies = keep.map((l) => ({
+      ...cloneLayer(l, l.name),
+      group: tag,
+      // Positions are in sheet pixels, so a decal copied off a 2048² sheet has to be brought
+      // with it or half of what was copied lands off the edge of a 1024² one.
+      x: l.x * kx,
+      y: l.y * ky,
+      scale: l.scale * Math.min(kx, ky),
+    }));
+    patchSheet(active.id, (s) => ({ ...s, layers: [...s.layers, ...copies] }));
+    setSelection(copies.map((c) => c.id));
+    if (dropped) toast.warning(t("designer.pasteDropped", { count: String(dropped) }));
+    bump();
+  }, [active, bump, patchSheet, t]);
+
+  const groupSelection = useCallback(() => {
+    if (!active || chosen.length < 2) return;
+    const tag = newId("group");
+    const ids = new Set(chosen.map((l) => l.id));
+    patchSheet(active.id, (s) => {
+      const tagged = s.layers.map((l) => (ids.has(l.id) ? { ...l, group: tag } : l));
+      // Gathered as well as tagged, so raising the group later takes it past what it sits on
+      // rather than past its own members — see `regroup`.
+      return { ...s, layers: regroup(tagged, tag) };
+    });
+    bump();
+  }, [active, bump, chosen, patchSheet]);
+
+  const ungroupSelection = useCallback(() => {
+    const tags = new Set(chosen.map((l) => l.group).filter((g): g is string => !!g));
+    if (!tags.size) return;
+    patchSelection((l) => (l.group && tags.has(l.group) ? { ...l, group: null } : l));
+  }, [chosen, patchSelection]);
+
+  const unlinkSelection = useCallback(() => {
+    patchSelection((l) => (l.mirror ? { ...l, mirror: null } : l));
+  }, [patchSelection]);
+
+  /**
+   * Put a copy of the selected layer where it lands on the far flank, and keep it there.
+   *
+   * The copy is appended with no placement worked out here on purpose: `patchSheet` derives
+   * every follower on the way through, so the same code that puts it down is the code that
+   * will keep it in step afterwards. Asking first is only to have something to say when the
+   * answer is no.
+   */
+  const mirrorSelected = useCallback(() => {
+    const layer = chosen.length === 1 ? chosen[0] : null;
+    if (!active || !layer) return;
+    if (layer.kind === "paint") {
+      toast.error(t("designer.fitNotForPaint"));
+      return;
+    }
+    const result = mirrorLayer(ensureMirror(), mirrorRef.current.parts, layer, active);
+    if (!result.ok) {
+      toast.error(t(`designer.mirrorWhy.${result.why}` as "designer.mirrorWhy.no-model"));
+      return;
+    }
+    const follower: Layer = {
+      ...cloneLayer(layer, t("designer.mirrorName", { name: layer.name })),
+      mirror: { of: layer.id },
+    };
+    patchSheet(active.id, (s) => ({ ...s, layers: [...s.layers, follower] }));
+    setSelection([follower.id]);
+    if (result.approximate) toast.warning(t("designer.mirrorRough"));
+    bump();
+  }, [active, bump, chosen, ensureMirror, patchSheet, t]);
+
+  /**
+   * Tool keys, and undo.
+   *
+   * On the window rather than on the canvas, because a brush should be one key away wherever
+   * the focus happens to be — but the Studio keeps this pane mounted behind whichever tab is
+   * open, so an invisible Designer would otherwise steal every `b` typed into Paint Studio.
+   */
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!rootRef.current?.offsetParent) return;
+      const el = e.target as HTMLElement | null;
+      if (el && (/^(INPUT|TEXTAREA|SELECT)$/.test(el.tagName) || el.isContentEditable)) return;
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "z") {
+        e.preventDefault();
+        if (e.shiftKey) redo();
+        else undo();
+        return;
+      }
+      const key = e.key.toLowerCase();
+      // Everything on a modifier, because every unmodified letter is already a tool.
+      if (e.metaKey || e.ctrlKey) {
+        const run: Record<string, (() => void) | undefined> = {
+          c: copySelection,
+          v: pasteClipboard,
+          d: duplicateSelection,
+          g: e.shiftKey ? ungroupSelection : groupSelection,
+          a: () => setSelection((sheetsRef.current.find((s) => s.id === activeId)?.layers ?? []).map((l) => l.id)),
+        };
+        const act = run[key];
+        if (act) {
+          e.preventDefault();
+          act();
+        }
+        return;
+      }
+      if (e.altKey) return;
+
+      if ((e.key === "Delete" || e.key === "Backspace") && selection.length) {
+        e.preventDefault();
+        removeLayers(selection);
+        return;
+      }
+
+      const step = e.shiftKey ? 10 : 1;
+      // Up on the keyboard is up on the *picture*. The sheet's rows run the other way (see
+      // `CanvasStage`), so the arrow that agrees with what's on screen is the one that
+      // disagrees with the array, and this is where that gets turned round.
+      const arrows: Record<string, [number, number] | undefined> = {
+        ArrowLeft: [-step, 0],
+        ArrowRight: [step, 0],
+        ArrowUp: [0, step],
+        ArrowDown: [0, -step],
+      };
+      const nudge = arrows[e.key];
+      if (nudge && selection.length) {
+        e.preventDefault();
+        moveSelection(nudge[0], nudge[1]);
+        return;
+      }
+
+      const tool = (Object.keys(TOOL_KEYS) as PaintTool[]).find((k) => TOOL_KEYS[k] === key);
+      if (tool) {
+        e.preventDefault();
+        pickTool(tool);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [
+    activeId,
+    copySelection,
+    duplicateSelection,
+    groupSelection,
+    moveSelection,
+    pasteClipboard,
+    pickTool,
+    redo,
+    removeLayers,
+    selection,
+    undo,
+    ungroupSelection,
+  ]);
+
   const ghostOf = useCallback(
     (id: string | null | undefined) => (id && ghosts.get(id)) || EMPTY_GHOST,
     [ghosts],
@@ -996,7 +1388,6 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
    * previous model would look perfectly valid over the new one while describing bodywork that
    * isn't there — the worst kind of wrong for a guide.
    */
-  const geometryRef = useRef<EdfNode[] | null>(null);
   const onGeometry = useCallback((nodes: EdfNode[] | null, assembled: boolean) => {
     // Compared against a ref rather than inside a `setState` updater: an updater has to be
     // pure, and this has to invalidate the wires as well as record the mesh.
@@ -1271,7 +1662,11 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     await write(false);
   }, [blocked, canSave, dest, name, t, write]);
 
-  const selected = active?.layers.find((l) => l.id === selectedId) ?? null;
+  // Whether the model can say where the far flank is at all, for the controls that need it.
+  const mirrorReady = mirrorRef.current.ready && mirrorRef.current.sheetId === activeId;
+  const canGroup = chosen.length > 1;
+  const canUngroup = chosen.some((l) => l.group);
+  const canUnlink = chosen.some((l) => l.mirror);
 
   return (
     <div
@@ -1335,7 +1730,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
             hints={hints}
             onPick={(id) => {
               setActiveId(id);
-              setSelectedId(null);
+              setSelection([]);
             }}
             onRename={(id, value) => {
               patchSheet(id, (s) => ({ ...s, name: value }));
@@ -1380,27 +1775,33 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
           {active && (
             <LayerList
               layers={active.layers}
-              selectedId={selectedId}
-              onSelect={setSelectedId}
+              selection={selection}
+              onSelect={select}
               onToggle={(id, visible) => {
                 patchLayer(id, (l) => ({ ...l, visible }));
                 bump();
               }}
-              onRemove={removeLayer}
+              onRemove={(id) => removeLayers([id])}
               onReorder={reorder}
               onAdd={addPaintLayer}
             />
           )}
-          {selected && (
+          {!!chosen.length && active && (
             <LayerInspector
-              layer={selected}
+              layers={chosen}
+              all={active.layers}
+              width={active.width}
+              height={active.height}
               parts={parts}
+              mirrorReady={mirrorReady}
               onClip={clipLayer}
               onFit={fitLayer}
-              onChange={(fn) => {
-                patchLayer(selected.id, fn, `layer:${selected.id}`);
-                bump();
-              }}
+              onMirror={mirrorSelected}
+              onUnlink={unlinkSelection}
+              onSelect={(id) => select([id], "replace")}
+              onGroup={groupSelection}
+              onUngroup={ungroupSelection}
+              onChange={(fn) => patchSelection(fn, `layer:${selection.join(",")}`)}
             />
           )}
         </section>
@@ -1416,10 +1817,11 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
               ghost={ghostOf(active.id)}
               parts={parts}
               onHoverSpot={setHoverIsland}
-              selectedId={selectedId}
-              onSelect={setSelectedId}
-              onMove={moveLayer}
-              onScale={scaleLayer}
+              selection={selection}
+              onSelect={select}
+              onMove={moveSelection}
+              onScale={scaleSelection}
+              onMenu={(x, y) => setMenuAt({ x, y })}
               tool={paint.tool}
               brushSize={paint.size}
               canPaint={!!target || SHAPE_TOOLS.has(paint.tool)}
@@ -1442,6 +1844,83 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
             </div>
           </div>
         )}
+
+        {/* The canvas's own menu. Anchored to a point rather than to the canvas, because what
+            it is about is whatever was under the pointer — and opened from the *release* of a
+            right press, since the native `contextmenu` event fires on the press and can't tell
+            a menu from the start of a pan. See `CanvasStage.onMenu`. */}
+        <DropdownMenu open={!!menuAt} onOpenChange={(open) => !open && setMenuAt(null)}>
+          <DropdownMenuTrigger asChild>
+            <span
+              aria-hidden
+              className="pointer-events-none fixed size-0"
+              style={{ left: menuAt?.x ?? 0, top: menuAt?.y ?? 0 }}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-52">
+            <MenuRow
+              icon={FlipHorizontal2}
+              label={t("designer.mirror")}
+              disabled={chosen.length !== 1 || !mirrorReady || !!chosen[0]?.mirror}
+              onPick={mirrorSelected}
+            />
+            {canUnlink && (
+              <MenuRow icon={Link2Off} label={t("designer.unlink")} onPick={unlinkSelection} />
+            )}
+            <DropdownMenuSeparator />
+            <MenuRow
+              icon={CopyPlus}
+              label={t("designer.duplicate")}
+              disabled={!chosen.length}
+              onPick={duplicateSelection}
+            />
+            <MenuRow
+              icon={Copy}
+              label={t("designer.copy")}
+              disabled={!chosen.length}
+              onPick={copySelection}
+            />
+            <MenuRow
+              icon={ClipboardPaste}
+              label={t("designer.paste")}
+              disabled={!clipboard?.layers.length}
+              onPick={pasteClipboard}
+            />
+            <DropdownMenuSeparator />
+            <MenuRow
+              icon={FlipHorizontal2}
+              label={t("designer.flipX")}
+              disabled={!chosen.length}
+              onPick={() => patchSelection((l) => ({ ...l, flipX: !l.flipX }))}
+            />
+            <MenuRow
+              icon={FlipVertical2}
+              label={t("designer.flipY")}
+              disabled={!chosen.length}
+              onPick={() => patchSelection((l) => ({ ...l, flipY: !l.flipY }))}
+            />
+            <DropdownMenuSeparator />
+            <MenuRow
+              icon={Group}
+              label={t("designer.group")}
+              disabled={!canGroup}
+              onPick={groupSelection}
+            />
+            <MenuRow
+              icon={Ungroup}
+              label={t("designer.ungroup")}
+              disabled={!canUngroup}
+              onPick={ungroupSelection}
+            />
+            <DropdownMenuSeparator />
+            <MenuRow
+              icon={Trash2}
+              label={t("common.remove")}
+              disabled={!chosen.length}
+              onPick={() => removeLayers(selection)}
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>
       </section>
 
       {/* ── The model ────────────────────────────────────────────────────────── */}
@@ -1791,10 +2270,17 @@ function GhostToggle({
     </button>
   );
 }
-
+/**
+ * The layer stack, with grouped layers gathered under a heading.
+ *
+ * A group is a tag rather than a container (see `layers.ts`), so this doesn't recurse — it walks
+ * the stack once and starts a block wherever the tag changes. That works because grouping also
+ * *gathers*: `regroup` puts a group's members next to each other, and everything downstream,
+ * this list included, gets to stay flat.
+ */
 function LayerList({
   layers,
-  selectedId,
+  selection,
   onSelect,
   onToggle,
   onRemove,
@@ -1802,14 +2288,88 @@ function LayerList({
   onAdd,
 }: {
   layers: Layer[];
-  selectedId: string | null;
-  onSelect: (id: string) => void;
+  selection: string[];
+  onSelect: (ids: string[], mode: "replace" | "toggle" | "isolate") => void;
   onToggle: (id: string, visible: boolean) => void;
   onRemove: (id: string) => void;
   onReorder: (id: string, delta: number) => void;
   onAdd: () => void;
 }) {
   const t = useT();
+  // Top of the list is the top of the stack, which is how a layer panel reads — the array
+  // itself is bottom-first because that's the order it's drawn in.
+  const shown = [...layers].reverse();
+  const rows: ({ tag: string; members: Layer[] } | { tag: null; members: [Layer] })[] = [];
+  for (let i = 0; i < shown.length; i += 1) {
+    const layer = shown[i];
+    if (!layer.group) {
+      rows.push({ tag: null, members: [layer] });
+      continue;
+    }
+    // The block is emitted at its first member and skipped at the rest of them.
+    if (i > 0 && shown[i - 1].group === layer.group) continue;
+    rows.push({ tag: layer.group, members: shown.filter((l) => l.group === layer.group) });
+  }
+
+  const row = (layer: Layer) => (
+    <div
+      key={layer.id}
+      className={cn(
+        "flex items-center gap-1.5 rounded-md border px-1.5 py-1 text-[11.5px] transition-colors",
+        selection.includes(layer.id) ? "border-primary bg-primary/10" : "border-border",
+      )}
+    >
+      <button
+        type="button"
+        className="flex-none text-muted-foreground hover:text-foreground"
+        onClick={() => onToggle(layer.id, !layer.visible)}
+        title={t(layer.visible ? "designer.hide" : "designer.show")}
+      >
+        {layer.visible ? <Eye className="size-3.5" /> : <EyeOff className="size-3.5" />}
+      </button>
+      {/* A follower says so here as well as in the inspector: this is the list you scan when
+          you can't work out why a layer won't move. */}
+      {layer.mirror && (
+        <Link2 className="size-3 flex-none text-primary" aria-label={t("designer.mirroredShort")} />
+      )}
+      <button
+        type="button"
+        className="min-w-0 flex-1 truncate text-left"
+        // Alt reaches inside a group, shift adds to the selection — the same two modifiers the
+        // canvas uses, because it is the same question being asked twice.
+        onClick={(e) =>
+          onSelect([layer.id], e.shiftKey ? "toggle" : e.altKey ? "isolate" : "replace")
+        }
+      >
+        {layer.kind === "text" ? layer.text || layer.name : layer.name}
+      </button>
+      <button
+        type="button"
+        className="flex-none px-0.5 text-muted-foreground hover:text-foreground"
+        onClick={() => onReorder(layer.id, 1)}
+        title={t("designer.raise")}
+      >
+        ↑
+      </button>
+      <button
+        type="button"
+        className="flex-none px-0.5 text-muted-foreground hover:text-foreground"
+        onClick={() => onReorder(layer.id, -1)}
+        title={t("designer.lower")}
+      >
+        ↓
+      </button>
+      <button
+        type="button"
+        className="flex-none text-muted-foreground hover:text-destructive"
+        onClick={() => onRemove(layer.id)}
+        title={t("common.remove")}
+      >
+        <Trash2 className="size-3.5" />
+      </button>
+    </div>
+  );
+
   return (
     <div className="rounded-lg border border-border bg-card/40 p-3.5">
       <div className="mb-2.5 flex items-center gap-2">
@@ -1827,57 +2387,44 @@ function LayerList({
         <p className="text-[11px] leading-snug text-faint">{t("designer.noLayers")}</p>
       ) : (
         <div className="flex flex-col gap-1">
-          {/* Top of the list is the top of the stack, which is how a layer panel reads —
-              the array itself is bottom-first because that's the order it's drawn in. */}
-          {[...layers].reverse().map((layer) => (
-            <div
-              key={layer.id}
-              className={cn(
-                "flex items-center gap-1.5 rounded-md border px-1.5 py-1 text-[11.5px] transition-colors",
-                layer.id === selectedId ? "border-primary bg-primary/10" : "border-border",
-              )}
-            >
-              <button
-                type="button"
-                className="flex-none text-muted-foreground hover:text-foreground"
-                onClick={() => onToggle(layer.id, !layer.visible)}
-                title={t(layer.visible ? "designer.hide" : "designer.show")}
+          {rows.map((block) =>
+            block.tag === null ? (
+              row(block.members[0])
+            ) : (
+              <div
+                key={block.tag}
+                className="flex flex-col gap-1 rounded-md border border-dashed border-border/70 p-1"
               >
-                {layer.visible ? <Eye className="size-3.5" /> : <EyeOff className="size-3.5" />}
-              </button>
-              <button
-                type="button"
-                className="min-w-0 flex-1 truncate text-left"
-                onClick={() => onSelect(layer.id)}
-              >
-                {layer.kind === "text" ? layer.text || layer.name : layer.name}
-              </button>
-              <button
-                type="button"
-                className="flex-none px-0.5 text-muted-foreground hover:text-foreground"
-                onClick={() => onReorder(layer.id, 1)}
-                title={t("designer.raise")}
-              >
-                ↑
-              </button>
-              <button
-                type="button"
-                className="flex-none px-0.5 text-muted-foreground hover:text-foreground"
-                onClick={() => onReorder(layer.id, -1)}
-                title={t("designer.lower")}
-              >
-                ↓
-              </button>
-              <button
-                type="button"
-                className="flex-none text-muted-foreground hover:text-destructive"
-                onClick={() => onRemove(layer.id)}
-                title={t("common.remove")}
-              >
-                <Trash2 className="size-3.5" />
-              </button>
-            </div>
-          ))}
+                <div className="flex items-center gap-1.5 px-0.5 text-[10.5px] text-muted-foreground">
+                  <button
+                    type="button"
+                    className="flex-none hover:text-foreground"
+                    // One toggle for the block: if any of it is showing, the whole thing hides.
+                    onClick={() => {
+                      const anyVisible = block.members.some((l) => l.visible);
+                      for (const l of block.members) onToggle(l.id, !anyVisible);
+                    }}
+                    title={t("designer.hide")}
+                  >
+                    {block.members.some((l) => l.visible) ? (
+                      <Eye className="size-3" />
+                    ) : (
+                      <EyeOff className="size-3" />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    className="flex min-w-0 flex-1 items-center gap-1 truncate text-left hover:text-foreground"
+                    onClick={() => onSelect(block.members.map((l) => l.id), "replace")}
+                  >
+                    <Group className="size-3 flex-none" />
+                    {t("designer.groupOf", { count: String(block.members.length) })}
+                  </button>
+                </div>
+                {block.members.map(row)}
+              </div>
+            ),
+          )}
         </div>
       )}
     </div>

--- a/src/Components/Studio/Designer/LayerInspector.tsx
+++ b/src/Components/Studio/Designer/LayerInspector.tsx
@@ -1,66 +1,218 @@
-import { Crop, Maximize2 } from "lucide-react";
+import { Crop, FlipHorizontal2, FlipVertical2, Group, Link2Off, Maximize2, Ungroup } from "lucide-react";
 import { Input } from "../../ui/input";
 import { useT } from "../../../i18n/context";
-import { Row, Slider } from "./controls";
+import { NumberField, Row, Slider } from "./controls";
 import { BLEND_MODES, FONTS, type BlendMode, type Layer } from "./layers";
 import type { UvPart } from "./uv";
 
+/** The size range a layer can be taken to, shared with the stage's corner drag. */
+const MIN_SCALE = 0.05;
+const MAX_SCALE = 4;
+
 /**
- * Everything about the selected layer that isn't its position on the sheet.
+ * Everything about the selection that isn't dragged directly on the sheet.
  *
- * Position is dragged directly on the canvas — putting X and Y here as well would be a second
- * way to say the same thing, and the one that doesn't show you the result.
+ * Position *is* here as well as on the canvas, which reverses an earlier call. The objection
+ * was that a typed X would be a second way to say the same thing and the one that doesn't show
+ * you the result — but the boxes below track the drag live, so they are the same way of saying
+ * it with a number attached. Placing a plate number by eye is not a thing the eye is good at.
+ *
+ * Rows that need one layer to mean anything appear only when one is selected; opacity, blend
+ * and the flips apply across the lot.
  */
 export function LayerInspector({
-  layer,
+  layers,
+  all,
+  width,
+  height,
   parts,
+  mirrorReady,
   onClip,
   onFit,
+  onMirror,
+  onUnlink,
+  onSelect,
+  onGroup,
+  onUngroup,
   onChange,
 }: {
-  layer: Layer;
+  /** The selection. Never empty — the rail leaves this out entirely when nothing is selected. */
+  layers: Layer[];
+  /** Every layer on the sheet, so a follower can name the layer it follows. */
+  all: Layer[];
+  width: number;
+  height: number;
   /** The model's bodywork for this sheet, empty when no model is loaded. */
   parts: UvPart[];
-  /** Pin the layer to a part, or unpin it with null. */
+  /** Whether the model can answer where the far flank is at all. */
+  mirrorReady: boolean;
+  /** Pin the selection to a part, or unpin it with null. */
   onClip: (label: string | null) => void;
   /** Place and scale the layer to cover a part. */
   onFit: (label: string) => void;
+  onMirror: () => void;
+  onUnlink: () => void;
+  onSelect: (id: string) => void;
+  onGroup: () => void;
+  onUngroup: () => void;
   onChange: (fn: (l: Layer) => Layer) => void;
 }) {
   const t = useT();
-  const patch = (fn: (l: Layer) => Layer) => onChange(fn);
+  const layer = layers.length === 1 ? layers[0] : null;
   // A paint layer is the sheet: strokes were put down in sheet pixels, and scaling or rotating
   // the canvas afterwards would move every one of them off the panel it was painted on.
-  const movable = layer.kind !== "paint";
+  const movable = layers.every((l) => l.kind !== "paint");
+  // A follower is derived from its source on every edit, so anything typed into it here would
+  // be overwritten by the next sync. Unlink is one click away and does exactly what's wanted.
+  const linked = layers.some((l) => l.mirror);
+  const source = layer?.mirror ? all.find((l) => l.id === layer.mirror?.of) : null;
+  const grouped = layers.some((l) => l.group);
+  const editable = movable && !linked;
 
   return (
     <div className="flex flex-col gap-2 rounded-lg border border-border bg-card/40 p-3.5">
-      <h2 className="text-[13px] font-semibold">{t("designer.layerTitle")}</h2>
+      <h2 className="text-[13px] font-semibold">
+        {layer ? t("designer.layerTitle") : t("designer.layersSelected", { count: String(layers.length) })}
+      </h2>
+
+      {/* A follower says what it is before anything else, because every disabled row below is
+          explained by this one line. */}
+      {linked && (
+        <div className="flex flex-col gap-1.5 rounded-md border border-border bg-background/50 p-2">
+          <p className="text-[11px] leading-snug text-muted-foreground">
+            {source
+              ? t("designer.mirroredFrom", { name: source.kind === "text" ? source.text || source.name : source.name })
+              : t("designer.mirroredOrphan")}
+          </p>
+          {!mirrorReady && (
+            <p className="text-[11px] leading-snug text-faint">{t("designer.mirrorPaused")}</p>
+          )}
+          <div className="flex items-center gap-1.5">
+            <button
+              type="button"
+              onClick={onUnlink}
+              title={t("designer.unlinkHint")}
+              className="flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-[11px] font-medium transition-colors hover:border-primary/60"
+            >
+              <Link2Off className="size-3.5" />
+              {t("designer.unlink")}
+            </button>
+            {source && (
+              <button
+                type="button"
+                onClick={() => onSelect(source.id)}
+                className="rounded-md border border-border px-2 py-1 text-[11px] font-medium transition-colors hover:border-primary/60"
+              >
+                {t("designer.selectSource")}
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {layer && editable && (
+        <Row label={t("designer.position")}>
+          <NumberField
+            value={layer.x}
+            min={-width}
+            max={width * 2}
+            title="X"
+            onChange={(v) => onChange((l) => ({ ...l, x: v }))}
+          />
+          {/* Counted from the bottom, because that is where the stage counts from — the sheet
+              is shown flipped and a Y that grew as the layer moved up the screen would be a
+              number that disagrees with the thing it names. */}
+          <NumberField
+            value={height - layer.y}
+            min={-height}
+            max={height * 2}
+            title="Y"
+            onChange={(v) => onChange((l) => ({ ...l, y: height - v }))}
+          />
+        </Row>
+      )}
 
       {movable && (
         <>
           <Row label={t("designer.scale")}>
             <Slider
-              value={layer.scale}
-              min={0.05}
-              max={4}
+              value={layer ? layer.scale : 1}
+              min={MIN_SCALE}
+              max={MAX_SCALE}
               step={0.01}
-              onChange={(v) => patch((l) => ({ ...l, scale: v }))}
+              onChange={(v) => onChange((l) => ({ ...l, scale: v }))}
               format={(v) => `${Math.round(v * 100)}%`}
             />
           </Row>
 
           <Row label={t("designer.rotation")}>
             <Slider
-              value={Math.round((layer.rotation * 180) / Math.PI)}
+              value={layer ? Math.round((layer.rotation * 180) / Math.PI) : 0}
               min={-180}
               max={180}
               step={1}
-              onChange={(v) => patch((l) => ({ ...l, rotation: (v * Math.PI) / 180 }))}
+              onChange={(v) => onChange((l) => ({ ...l, rotation: (v * Math.PI) / 180 }))}
               format={(v) => `${v}°`}
             />
           </Row>
+
+          <Row label={t("designer.flip")}>
+            <button
+              type="button"
+              disabled={!editable}
+              onClick={() => onChange((l) => ({ ...l, flipX: !l.flipX }))}
+              title={t("designer.flipX")}
+              className="flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-[11px] font-medium transition-colors hover:border-primary/60 disabled:opacity-35"
+            >
+              <FlipHorizontal2 className="size-3.5" />
+            </button>
+            <button
+              type="button"
+              disabled={!editable}
+              onClick={() => onChange((l) => ({ ...l, flipY: !l.flipY }))}
+              title={t("designer.flipY")}
+              className="flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-[11px] font-medium transition-colors hover:border-primary/60 disabled:opacity-35"
+            >
+              <FlipVertical2 className="size-3.5" />
+            </button>
+            {/* The mirror sits with the flips because that is where a hand goes looking for it,
+                and half its job is to be found instead of the flip that isn't what was meant. */}
+            <button
+              type="button"
+              disabled={!layer || !editable || !mirrorReady}
+              onClick={onMirror}
+              title={t(mirrorReady ? "designer.mirrorHint" : "designer.mirrorWhy.no-model")}
+              className="ml-auto flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-[11px] font-medium transition-colors hover:border-primary/60 disabled:opacity-35"
+            >
+              <FlipHorizontal2 className="size-3.5" />
+              {t("designer.mirror")}
+            </button>
+          </Row>
         </>
+      )}
+
+      {(layers.length > 1 || grouped) && (
+        <Row label={t("designer.groupRow")}>
+          <button
+            type="button"
+            disabled={layers.length < 2}
+            onClick={onGroup}
+            title={t("designer.groupHint")}
+            className="flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-[11px] font-medium transition-colors hover:border-primary/60 disabled:opacity-35"
+          >
+            <Group className="size-3.5" />
+            {t("designer.group")}
+          </button>
+          <button
+            type="button"
+            disabled={!grouped}
+            onClick={onUngroup}
+            className="flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-[11px] font-medium transition-colors hover:border-primary/60 disabled:opacity-35"
+          >
+            <Ungroup className="size-3.5" />
+            {t("designer.ungroup")}
+          </button>
+        </Row>
       )}
 
       {/* What the layer is *for*, rather than where it is: a photo dropped on a livery is
@@ -71,9 +223,10 @@ export function LayerInspector({
         <>
           <Row label={t("designer.part")}>
             <select
-              value={layer.clip?.label ?? ""}
+              value={layer?.clip?.label ?? ""}
+              disabled={linked}
               onChange={(e) => onClip(e.target.value || null)}
-              className="min-w-0 flex-1 rounded-md border border-input bg-background px-2 py-1 text-[11.5px]"
+              className="min-w-0 flex-1 rounded-md border border-input bg-background px-2 py-1 text-[11.5px] disabled:opacity-35"
             >
               <option value="">{t("designer.wholeSheet")}</option>
               {parts.map((p) => (
@@ -91,15 +244,15 @@ export function LayerInspector({
           <Row label="">
             <button
               type="button"
-              disabled={!layer.clip || !movable}
-              onClick={() => layer.clip && onFit(layer.clip.label)}
+              disabled={!layer?.clip || !editable}
+              onClick={() => layer?.clip && onFit(layer.clip.label)}
               title={t(movable ? "designer.fitToPartHint" : "designer.fitNotForPaint")}
               className="flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-[11px] font-medium transition-colors hover:border-primary/60 disabled:opacity-35"
             >
               <Maximize2 className="size-3.5" />
               {t("designer.fitToPart")}
             </button>
-            {!!layer.clip && (
+            {!!layer?.clip && (
               <span
                 className="flex items-center gap-1 text-[11px] text-faint"
                 title={t("designer.clippedHint")}
@@ -114,19 +267,19 @@ export function LayerInspector({
 
       <Row label={t("designer.opacity")}>
         <Slider
-          value={layer.opacity}
+          value={layer ? layer.opacity : 1}
           min={0}
           max={1}
           step={0.01}
-          onChange={(v) => patch((l) => ({ ...l, opacity: v }))}
+          onChange={(v) => onChange((l) => ({ ...l, opacity: v }))}
           format={(v) => `${Math.round(v * 100)}%`}
         />
       </Row>
 
       <Row label={t("designer.blend")}>
         <select
-          value={layer.blend}
-          onChange={(e) => patch((l) => ({ ...l, blend: e.target.value as BlendMode }))}
+          value={layer ? layer.blend : "normal"}
+          onChange={(e) => onChange((l) => ({ ...l, blend: e.target.value as BlendMode }))}
           className="min-w-0 flex-1 rounded-md border border-input bg-background px-2 py-1 text-[11.5px]"
         >
           {BLEND_MODES.map((m) => (
@@ -140,14 +293,14 @@ export function LayerInspector({
       {/* A shape is geometry, so it keeps its colour and its pen editable for as long as the
           paint is open — which is the whole point of it not being pixels. Size and angle are
           the shared controls above; only what it is drawn *with* is particular to it. */}
-      {layer.kind === "shape" && (
+      {layer?.kind === "shape" && !linked && (
         <>
           <Row label={t("designer.colour")}>
             <input
               type="color"
               value={layer.color}
               onChange={(e) =>
-                patch((l) => (l.kind === "shape" ? { ...l, color: e.target.value } : l))
+                onChange((l) => (l.kind === "shape" ? { ...l, color: e.target.value } : l))
               }
               className="h-7 w-full cursor-pointer rounded-md border border-input bg-background"
             />
@@ -158,10 +311,8 @@ export function LayerInspector({
               <select
                 value={layer.style}
                 onChange={(e) =>
-                  patch((l) =>
-                    l.kind === "shape"
-                      ? { ...l, style: e.target.value as "fill" | "outline" }
-                      : l,
+                  onChange((l) =>
+                    l.kind === "shape" ? { ...l, style: e.target.value as "fill" | "outline" } : l,
                   )
                 }
                 className="min-w-0 flex-1 rounded-md border border-input bg-background px-2 py-1 text-[11.5px]"
@@ -179,9 +330,7 @@ export function LayerInspector({
                 min={1}
                 max={128}
                 step={1}
-                onChange={(v) =>
-                  patch((l) => (l.kind === "shape" ? { ...l, strokeWidth: v } : l))
-                }
+                onChange={(v) => onChange((l) => (l.kind === "shape" ? { ...l, strokeWidth: v } : l))}
                 format={(v) => `${v}px`}
               />
             </Row>
@@ -189,14 +338,14 @@ export function LayerInspector({
         </>
       )}
 
-      {layer.kind === "text" && (
+      {layer?.kind === "text" && !linked && (
         <>
           <Row label={t("designer.text")}>
             <Input
               value={layer.text}
               className="h-7 text-[11.5px]"
               onChange={(e) =>
-                patch((l) => (l.kind === "text" ? { ...l, text: e.target.value } : l))
+                onChange((l) => (l.kind === "text" ? { ...l, text: e.target.value } : l))
               }
             />
           </Row>
@@ -205,7 +354,7 @@ export function LayerInspector({
             <select
               value={layer.font}
               onChange={(e) =>
-                patch((l) => (l.kind === "text" ? { ...l, font: e.target.value } : l))
+                onChange((l) => (l.kind === "text" ? { ...l, font: e.target.value } : l))
               }
               className="min-w-0 flex-1 rounded-md border border-input bg-background px-2 py-1 text-[11.5px]"
               style={{ fontFamily: layer.font }}
@@ -224,7 +373,7 @@ export function LayerInspector({
               min={8}
               max={512}
               step={1}
-              onChange={(v) => patch((l) => (l.kind === "text" ? { ...l, size: v } : l))}
+              onChange={(v) => onChange((l) => (l.kind === "text" ? { ...l, size: v } : l))}
               format={(v) => `${v}`}
             />
           </Row>
@@ -234,7 +383,7 @@ export function LayerInspector({
               type="color"
               value={layer.color}
               onChange={(e) =>
-                patch((l) => (l.kind === "text" ? { ...l, color: e.target.value } : l))
+                onChange((l) => (l.kind === "text" ? { ...l, color: e.target.value } : l))
               }
               className="h-6 w-9 flex-none rounded border border-input bg-background"
             />
@@ -242,7 +391,7 @@ export function LayerInspector({
               type="color"
               value={layer.outline}
               onChange={(e) =>
-                patch((l) => (l.kind === "text" ? { ...l, outline: e.target.value } : l))
+                onChange((l) => (l.kind === "text" ? { ...l, outline: e.target.value } : l))
               }
               className="h-6 w-9 flex-none rounded border border-input bg-background"
               title={t("designer.outline")}
@@ -252,7 +401,7 @@ export function LayerInspector({
               min={0}
               max={24}
               step={1}
-              onChange={(v) => patch((l) => (l.kind === "text" ? { ...l, outlineWidth: v } : l))}
+              onChange={(v) => onChange((l) => (l.kind === "text" ? { ...l, outlineWidth: v } : l))}
               format={(v) => `${v}`}
             />
           </Row>

--- a/src/Components/Studio/Designer/composite.ts
+++ b/src/Components/Studio/Designer/composite.ts
@@ -34,7 +34,13 @@ function drawLayer(ctx: CanvasRenderingContext2D, layer: Layer) {
   // Mirrored, because the stage is — see `mirrored`. The sheet keeps the file's row order and
   // the view turns it over, so upright content has to go in upside down to come out upright.
   ctx.rotate(sheetRotation(layer));
-  ctx.scale(layer.scale, mirrored(layer) ? -layer.scale : layer.scale);
+  // Two flips multiplied, not one chosen: the stage's, which every layer of a mirrored kind
+  // gets whether or not anyone asked, and the layer's own. Turning a logo over by hand has to
+  // work the same on a kind that was already going in upside down.
+  ctx.scale(
+    layer.scale * (layer.flipX ? -1 : 1),
+    (mirrored(layer) ? -layer.scale : layer.scale) * (layer.flipY ? -1 : 1),
+  );
 
   if (layer.kind === "image" || layer.kind === "paint") {
     // A paint layer's raster is sheet-sized and its transform is the identity, so this puts it
@@ -145,6 +151,29 @@ export function layerCorners(layer: Layer): [number, number][] {
       [-hw, hh],
     ] as [number, number][]
   ).map(([x, y]) => [layer.x + x * cos - y * sin, layer.y + x * sin + y * cos]);
+}
+
+/**
+ * The axis-aligned box around several layers in sheet space, or null for none.
+ *
+ * What a multi-layer selection is drawn and dragged as. Built from the rotated corners rather
+ * than from centres and extents, so a box around a layer turned 45° actually contains it.
+ */
+export function selectionBounds(layers: Layer[]): Region | null {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const layer of layers) {
+    for (const [x, y] of layerCorners(layer)) {
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+    }
+  }
+  if (!Number.isFinite(minX)) return null;
+  return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
 }
 
 /**

--- a/src/Components/Studio/Designer/controls.tsx
+++ b/src/Components/Studio/Designer/controls.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
+
 /**
- * The two controls the designer's side panels are made of.
+ * The controls the designer's side panels are made of.
  *
  * Shared rather than copied so the layer inspector and the paint tools stay identical instead
  * of merely similar — they sit one above the other in the same rail, and a row that lines up
@@ -46,5 +48,58 @@ export function Slider({
         {format(value)}
       </span>
     </>
+  );
+}
+
+/**
+ * A number typed rather than dragged.
+ *
+ * Held as text while it is being typed and read back as a number only on Enter or on leaving
+ * the box. Committing per keystroke sounds simpler and isn't: "-" and "" are both states you
+ * pass through on the way to `-40`, and each of them would snap the layer to zero and take the
+ * caret with it.
+ *
+ * Shows the live value whenever it isn't being typed into, so dragging on the canvas moves the
+ * number too — which is the answer to the old objection that a typed X was a second way of
+ * saying the same thing without showing the result.
+ */
+export function NumberField({
+  value,
+  min,
+  max,
+  step = 1,
+  title,
+  onChange,
+}: {
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  title?: string;
+  onChange: (v: number) => void;
+}) {
+  const [draft, setDraft] = useState<string | null>(null);
+
+  const commit = (text: string) => {
+    setDraft(null);
+    const n = Number(text);
+    if (text.trim() !== "" && Number.isFinite(n)) onChange(Math.min(max, Math.max(min, n)));
+  };
+
+  return (
+    <input
+      type="text"
+      inputMode="decimal"
+      title={title}
+      value={draft ?? String(Math.round(value / step) * step)}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={(e) => commit(e.target.value)}
+      onKeyDown={(e) => {
+        // Escape drops the draft and the live value comes back — nothing is committed.
+        if (e.key === "Enter") e.currentTarget.blur();
+        else if (e.key === "Escape") setDraft(null);
+      }}
+      className="h-6 min-w-0 flex-1 rounded-md border border-input bg-background px-1.5 text-center text-[11px] tabular-nums"
+    />
   );
 }

--- a/src/Components/Studio/Designer/layers.ts
+++ b/src/Components/Studio/Designer/layers.ts
@@ -36,8 +36,32 @@ interface LayerCommon {
   scale: number;
   /** Radians, clockwise. */
   rotation: number;
+  /**
+   * Turned over in the layer's own upright frame — the flip a painter asks for.
+   *
+   * Not to be confused with {@link mirrored}, which is the *stage's* flip and applies to every
+   * layer of a kind whether or not anyone asked. These two multiply rather than replace.
+   */
+  flipX: boolean;
+  flipY: boolean;
+  /** A tag shared by layers that move as one, or null. Stacking stays flat — see `regroup`. */
+  group: string | null;
+  /** Set on the copy that reflects another layer across the bike. Null on everything else. */
+  mirror: MirrorLink | null;
   /** Confine this layer to one piece of bodywork, or null to let it cover the sheet. */
   clip: LayerClip | null;
+}
+
+/**
+ * What makes a layer the far-flank reflection of another one.
+ *
+ * Only the source is named. Everything else about a follower — where it sits, which way it
+ * faces, what it says — is re-derived from that layer on every edit, so there is nothing here
+ * that could fall out of step with it. See `syncMirrors` in `Designer`.
+ */
+export interface MirrorLink {
+  /** The layer this one reflects, by id. */
+  of: string;
 }
 
 /**
@@ -200,6 +224,28 @@ export function newId(prefix: string): string {
   return `${prefix}-${seq}`;
 }
 
+/**
+ * What every new layer starts as, whatever kind it is.
+ *
+ * Shared rather than spelled out four times, so a field added to `LayerCommon` can't be
+ * forgotten by one constructor out of four — which is how a layer reaches the composite with
+ * `mirror: undefined` and nothing to say why.
+ */
+const FRESH: Pick<
+  LayerCommon,
+  "visible" | "opacity" | "blend" | "rotation" | "flipX" | "flipY" | "group" | "mirror" | "clip"
+> = {
+  visible: true,
+  opacity: 1,
+  blend: "normal",
+  rotation: 0,
+  flipX: false,
+  flipY: false,
+  group: null,
+  mirror: null,
+  clip: null,
+};
+
 /** A measuring context. Text extents need one, and this never draws anything. */
 let measureCtx: CanvasRenderingContext2D | null = null;
 function measurer(): CanvasRenderingContext2D | null {
@@ -271,17 +317,13 @@ export function shapeLayer(
   strokeWidth: number,
 ): ShapeLayer {
   return {
+    ...FRESH,
     id: newId("shape"),
     kind: "shape",
     name,
-    visible: true,
-    opacity: 1,
-    blend: "normal",
     x: (from.x + to.x) / 2,
     y: (from.y + to.y) / 2,
     scale: 1,
-    rotation: 0,
-    clip: null,
     shape,
     w: to.x - from.x,
     // Negated on the way in: the drag is in sheet coordinates and the layer's own frame is the
@@ -331,39 +373,64 @@ export function hitTest(layers: Layer[], px: number, py: number): Layer | null {
   return null;
 }
 
+/**
+ * The ids a click on `id` should actually select: its whole group, or just it.
+ *
+ * A group is a tag rather than a container, so "the group" is a question asked of the layer
+ * list each time rather than a thing held anywhere.
+ */
+export function groupOf(layers: Layer[], id: string): string[] {
+  const tag = layers.find((l) => l.id === id)?.group;
+  if (!tag) return [id];
+  return layers.filter((l) => l.group === tag).map((l) => l.id);
+}
+
+/**
+ * Move a group's members so they sit next to each other in the stack, at the topmost one's place.
+ *
+ * Grouping does not nest, so nothing stops a group's members from being spread through the
+ * stack with other layers between them — and then raising "the group" would raise its members
+ * past each other rather than past what they sit on. Gathering them once, when the group is
+ * made, is what lets every later reorder stay the simple one-layer-at-a-time operation it is.
+ *
+ * The topmost member's place, so a group made from a selection ends up where its front-most
+ * layer already was and nothing visibly jumps behind something else.
+ */
+export function regroup(layers: Layer[], tag: string): Layer[] {
+  const members = layers.filter((l) => l.group === tag);
+  if (members.length < 2) return layers;
+  const rest = layers.filter((l) => l.group !== tag);
+  // Counted over the layers *below* the topmost member, which is where the block goes back in.
+  const top = layers.lastIndexOf(members[members.length - 1]);
+  const at = layers.slice(0, top + 1).filter((l) => l.group !== tag).length;
+  return [...rest.slice(0, at), ...members, ...rest.slice(at)];
+}
+
 export function imageLayer(name: string, image: ImageBitmap, sheet: Sheet): ImageLayer {
   // Land it centred, and shrunk to fit if it's bigger than the sheet — a 2048² logo dropped
   // onto a 2048² livery would otherwise cover the whole thing with no visible handle to grab.
   const fit = Math.min(1, (sheet.width * 0.6) / image.width, (sheet.height * 0.6) / image.height);
   return {
+    ...FRESH,
     kind: "image",
     id: newId("layer"),
     name,
-    visible: true,
-    opacity: 1,
-    blend: "normal",
     x: sheet.width / 2,
     y: sheet.height / 2,
     scale: fit,
-    rotation: 0,
-    clip: null,
     image,
   };
 }
 
 export function textLayer(text: string, sheet: Sheet): TextLayer {
   return {
+    ...FRESH,
     kind: "text",
     id: newId("layer"),
     name: text,
-    visible: true,
-    opacity: 1,
-    blend: "normal",
     x: sheet.width / 2,
     y: sheet.height / 2,
     scale: 1,
-    rotation: 0,
-    clip: null,
     text,
     font: FONTS[0],
     // A twelfth of the sheet reads as a name across a jersey back at 2048².
@@ -379,22 +446,40 @@ export function paintLayer(name: string, sheet: Sheet): PaintLayer {
   canvas.width = sheet.width;
   canvas.height = sheet.height;
   return {
+    ...FRESH,
     kind: "paint",
     id: newId("layer"),
     name,
-    visible: true,
-    opacity: 1,
-    blend: "normal",
     // Sheet-sized and sheet-aligned: the identity transform, spelled out in the same fields
     // every other layer uses so `drawLayer` needs no special case for it.
     x: sheet.width / 2,
     y: sheet.height / 2,
     scale: 1,
-    rotation: 0,
-    clip: null,
     canvas,
     rev: 0,
   };
+}
+
+/**
+ * A copy of a layer under a new id, for duplicate and for paste.
+ *
+ * The bitmap behind an image layer is shared rather than copied — an `ImageBitmap` is
+ * immutable, and decoding a second 2048² one to hold the same pixels is pure waste. A paint
+ * layer's canvas is not immutable, so that one really is copied; strokes on the duplicate
+ * would otherwise land on the original as well.
+ *
+ * `group` and `mirror` are dropped. A copy that arrived still tagged would join a group it was
+ * never put in, and one that arrived still linked would be a second follower of a source that
+ * only knows about the first.
+ */
+export function cloneLayer(layer: Layer, name?: string): Layer {
+  const common = { id: newId("layer"), name: name ?? layer.name, group: null, mirror: null };
+  if (layer.kind !== "paint") return { ...layer, ...common };
+  const canvas = document.createElement("canvas");
+  canvas.width = layer.canvas.width;
+  canvas.height = layer.canvas.height;
+  canvas.getContext("2d")?.drawImage(layer.canvas, 0, 0);
+  return { ...layer, ...common, canvas, rev: 0 };
 }
 
 export function blankSheet(name: string, size: number): Sheet {

--- a/src/Components/Studio/Designer/mirror.ts
+++ b/src/Components/Studio/Designer/mirror.ts
@@ -1,0 +1,508 @@
+import type { EdfNode } from "../../../types";
+import { mirrored, sheetRotation, type Layer, type Sheet } from "./layers";
+import { partPath, sideAt, type UvPart } from "./uv";
+
+/**
+ * Reflecting a place on the sheet through the bike, rather than across the square.
+ *
+ * The tempting version of "mirror this decal" is to flip it about u = 0.5, and it is wrong
+ * often enough to be useless: a bike's two flanks land wherever the unwrapper put them, which
+ * is not a reflection of each other about the middle of the texture. The model is the only
+ * thing that knows where the far side of a shroud actually is, so the question is asked of it —
+ * a point on the sheet becomes a point on a triangle, that point is reflected about the bike's
+ * mirror plane, and whichever triangle wears the reflected point says where it lands back on
+ * the sheet.
+ *
+ * Everything here works in the frame `uvParts` does: assembled, with the mirror plane at x = 0.
+ */
+
+/** How far apart two corners can be and still be the same corner, as a fraction of the model. */
+const WELD = 1e-5;
+
+/**
+ * Cells per axis in the uv lookup.
+ *
+ * A follower is re-derived on every pointer sample of a drag, and each re-derivation asks
+ * where three points land. A linear scan of a bike's triangles per sample is what this is here
+ * to avoid.
+ */
+const GRID = 48;
+
+export interface MirrorIndex {
+  /** Welded corner positions, three numbers each. */
+  points: Float64Array;
+  /** Corner id → the corner at its reflection, or -1 where the model isn't symmetric there. */
+  mirrorOf: Int32Array;
+  /** Three corner ids per triangle. */
+  tris: Int32Array;
+  /** Six numbers per triangle — u0,v0,u1,v1,u2,v2 — in the same corner order as `tris`. */
+  uvs: Float32Array;
+  /** A triangle's three corner ids, sorted and joined → its index. */
+  byCorners: Map<string, number>;
+  /** uv cell → the triangles whose bounds reach it. */
+  cells: Map<number, number[]>;
+}
+
+/** What a mirror was asked for and couldn't give. Each reads as its own sentence to the user. */
+export type MirrorRefusal = "no-model" | "shared" | "centre" | "asymmetric";
+
+export interface MirrorPlacement {
+  x: number;
+  y: number;
+  rotation: number;
+  scale: number;
+  flipX: boolean;
+  flipY: boolean;
+  /**
+   * The far side's unwrap is not a clean reflection of this one, so this is the closest rigid
+   * answer rather than an exact one. Said out loud rather than quietly applied.
+   */
+  approximate: boolean;
+}
+
+export type MirrorResult = ({ ok: true } & MirrorPlacement) | { ok: false; why: MirrorRefusal };
+
+/** A hash grid over positions, for welding corners and for finding a reflection's twin. */
+class PointGrid {
+  private cells = new Map<string, number[]>();
+  private xs: number[] = [];
+
+  constructor(private eps: number) {}
+
+  /**
+   * The id of a corner within `eps` of this position, or -1.
+   *
+   * Probes the neighbouring cells as well as the point's own: two positions a hair apart can
+   * still land either side of a cell boundary, and a weld that missed those would leave a
+   * panel's shared edge as two edges that never find each other.
+   */
+  find(x: number, y: number, z: number): number {
+    const c = this.eps;
+    let best = -1;
+    let bestDist = this.eps * this.eps;
+    const i = Math.floor(x / c);
+    const j = Math.floor(y / c);
+    const k = Math.floor(z / c);
+    for (let di = -1; di <= 1; di += 1) {
+      for (let dj = -1; dj <= 1; dj += 1) {
+        for (let dk = -1; dk <= 1; dk += 1) {
+          for (const id of this.cells.get(`${i + di},${j + dj},${k + dk}`) ?? []) {
+            const dx = this.xs[id * 3] - x;
+            const dy = this.xs[id * 3 + 1] - y;
+            const dz = this.xs[id * 3 + 2] - z;
+            const d = dx * dx + dy * dy + dz * dz;
+            if (d <= bestDist) {
+              bestDist = d;
+              best = id;
+            }
+          }
+        }
+      }
+    }
+    return best;
+  }
+
+  add(x: number, y: number, z: number): number {
+    const id = this.xs.length / 3;
+    this.xs.push(x, y, z);
+    const key = `${Math.floor(x / this.eps)},${Math.floor(y / this.eps)},${Math.floor(z / this.eps)}`;
+    const cell = this.cells.get(key);
+    if (cell) cell.push(id);
+    else this.cells.set(key, [id]);
+    return id;
+  }
+
+  positions(): Float64Array {
+    return Float64Array.from(this.xs);
+  }
+}
+
+/** Which uv cell a point is in. Clamped, because uvs outside the square are legal and wrap. */
+function cell(u: number, v: number): number {
+  const i = Math.min(GRID - 1, Math.max(0, Math.floor(u * GRID)));
+  const j = Math.min(GRID - 1, Math.max(0, Math.floor(v * GRID)));
+  return j * GRID + i;
+}
+
+/**
+ * Build the reflection index for one sheet.
+ *
+ * Over the sheet's own triangles rather than the whole model: the far side of a shroud wears
+ * the same texture by definition, so anything the mirror could land on is already in `parts`,
+ * and a bike's other hundred thousand vertices are not worth welding to find that out.
+ *
+ * Corners are welded by position rather than trusted as vertex indices, because a panel split
+ * across two mesh nodes holds its own copy of the shared edge and the two need not be
+ * bit-identical — and the reflected corner is almost always in a different node from the one
+ * it came from.
+ */
+export function buildMirror(parts: UvPart[], nodes: EdfNode[]): MirrorIndex | null {
+  if (!parts.length || !nodes.length) return null;
+
+  // A tolerance in the model's own units, taken from its size — a 65 and a 450 are one shape
+  // at two sizes, and a fixed figure would weld one of them and not the other. Junk vertices
+  // are excluded the way `lateralTolerance` excludes them: a motorcycle is not 1e37 wide.
+  let span = 0;
+  for (const part of parts) {
+    for (let i = 0; i < part.src.length; i += 2) {
+      const node = nodes[part.src[i]];
+      if (!node) continue;
+      for (let c = 0; c < 3; c += 1) {
+        const v = node.indices[part.src[i + 1] * 3 + c];
+        const x = Math.abs(node.positions[v * 3]);
+        if (Number.isFinite(x) && x > span && x < 1e3) span = x;
+      }
+    }
+  }
+  if (!span) return null;
+
+  const grid = new PointGrid(Math.max(span * WELD, 1e-9));
+  const tris: number[] = [];
+  const uvs: number[] = [];
+  const byCorners = new Map<string, number>();
+  const cells = new Map<number, number[]>();
+
+  for (const part of parts) {
+    for (let n = 0; n < part.src.length / 2; n += 1) {
+      const node = nodes[part.src[n * 2]];
+      if (!node) continue;
+      const t = part.src[n * 2 + 1];
+      const corners: number[] = [];
+      for (let c = 0; c < 3; c += 1) {
+        const v = node.indices[t * 3 + c];
+        const x = node.positions[v * 3];
+        const y = node.positions[v * 3 + 1];
+        const z = node.positions[v * 3 + 2];
+        if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) break;
+        const found = grid.find(x, y, z);
+        corners.push(found >= 0 ? found : grid.add(x, y, z));
+      }
+      if (corners.length < 3) continue;
+
+      const key = [...corners].sort((a, b) => a - b).join(",");
+      // Already carrying these three corners: the same surface reached through another label.
+      // Keeping the first is enough — a second copy would answer identically.
+      if (byCorners.has(key)) continue;
+
+      const index = tris.length / 3;
+      byCorners.set(key, index);
+      tris.push(corners[0], corners[1], corners[2]);
+
+      let minU = Infinity;
+      let minV = Infinity;
+      let maxU = -Infinity;
+      let maxV = -Infinity;
+      for (let c = 0; c < 3; c += 1) {
+        const u = part.tris[n * 6 + c * 2];
+        const v = part.tris[n * 6 + c * 2 + 1];
+        uvs.push(u, v);
+        if (u < minU) minU = u;
+        if (u > maxU) maxU = u;
+        if (v < minV) minV = v;
+        if (v > maxV) maxV = v;
+      }
+      const i0 = Math.min(GRID - 1, Math.max(0, Math.floor(minU * GRID)));
+      const i1 = Math.min(GRID - 1, Math.max(0, Math.floor(maxU * GRID)));
+      const j0 = Math.min(GRID - 1, Math.max(0, Math.floor(minV * GRID)));
+      const j1 = Math.min(GRID - 1, Math.max(0, Math.floor(maxV * GRID)));
+      for (let j = j0; j <= j1; j += 1) {
+        for (let i = i0; i <= i1; i += 1) {
+          const at = j * GRID + i;
+          const run = cells.get(at);
+          if (run) run.push(index);
+          else cells.set(at, [index]);
+        }
+      }
+    }
+  }
+  if (!tris.length) return null;
+
+  const points = grid.positions();
+  const mirrorOf = new Int32Array(points.length / 3).fill(-1);
+  for (let id = 0; id < mirrorOf.length; id += 1) {
+    mirrorOf[id] = grid.find(-points[id * 3], points[id * 3 + 1], points[id * 3 + 2]);
+  }
+
+  return { points, mirrorOf, tris: Int32Array.from(tris), uvs: Float32Array.from(uvs), byCorners, cells };
+}
+
+/** Barycentric coordinates of a point in a uv triangle, or null when it falls outside. */
+function barycentric(
+  u: number,
+  v: number,
+  ax: number,
+  ay: number,
+  bx: number,
+  by: number,
+  cx: number,
+  cy: number,
+): [number, number, number] | null {
+  const det = (by - cy) * (ax - cx) + (cx - bx) * (ay - cy);
+  if (!det) return null;
+  const a = ((by - cy) * (u - cx) + (cx - bx) * (v - cy)) / det;
+  const b = ((cy - ay) * (u - cx) + (ax - cx) * (v - cy)) / det;
+  const c = 1 - a - b;
+  // A hair of slack, so a point exactly on a shared edge belongs to one of the two triangles
+  // rather than to neither.
+  const e = -1e-6;
+  return a >= e && b >= e && c >= e ? [a, b, c] : null;
+}
+
+/**
+ * Where a point on the sheet comes out when reflected through the bike, or null.
+ *
+ * Null when the point is on no triangle at all, or when the reflected place is on a part with
+ * no twin — a one-off bracket, an exhaust that only exists on one side.
+ */
+export function mirrorPoint(
+  index: MirrorIndex,
+  u: number,
+  v: number,
+): { u: number; v: number } | null {
+  const { tris, uvs, mirrorOf, byCorners } = index;
+  for (const t of index.cells.get(cell(u, v)) ?? []) {
+    const i = t * 6;
+    const bary = barycentric(u, v, uvs[i], uvs[i + 1], uvs[i + 2], uvs[i + 3], uvs[i + 4], uvs[i + 5]);
+    if (!bary) continue;
+
+    const twins = [mirrorOf[tris[t * 3]], mirrorOf[tris[t * 3 + 1]], mirrorOf[tris[t * 3 + 2]]];
+    if (twins[0] < 0 || twins[1] < 0 || twins[2] < 0) continue;
+    const far = byCorners.get([...twins].sort((a, b) => a - b).join(","));
+    if (far === undefined) continue;
+
+    // Matched by corner id rather than by position in the list: the far triangle holds the same
+    // three corners in whatever order its own winding gave them, and reading its uvs off in the
+    // wrong order is how a decal arrives on the right panel inside out.
+    let outU = 0;
+    let outV = 0;
+    let matched = true;
+    for (let c = 0; c < 3; c += 1) {
+      const at = [0, 1, 2].find((k) => tris[far * 3 + k] === twins[c]);
+      if (at === undefined) {
+        matched = false;
+        break;
+      }
+      outU += bary[c] * uvs[far * 6 + at * 2];
+      outV += bary[c] * uvs[far * 6 + at * 2 + 1];
+    }
+    if (matched) return { u: outU, v: outV };
+  }
+  return null;
+}
+
+/** A layer's content-to-sheet 2×2, flattened as [a, b, c, d] for [[a, b], [c, d]]. */
+function frameOf(layer: Layer): [number, number, number, number] {
+  const p = sheetRotation(layer);
+  const sx = layer.scale * (layer.flipX ? -1 : 1);
+  const sy = (mirrored(layer) ? -layer.scale : layer.scale) * (layer.flipY ? -1 : 1);
+  return [Math.cos(p) * sx, -Math.sin(p) * sy, Math.sin(p) * sx, Math.cos(p) * sy];
+}
+
+/** Multiply two 2×2s, both flattened as [a, b, c, d]. */
+function mul(
+  m: [number, number, number, number],
+  n: [number, number, number, number],
+): [number, number, number, number] {
+  return [
+    m[0] * n[0] + m[1] * n[2],
+    m[0] * n[1] + m[1] * n[3],
+    m[2] * n[0] + m[3] * n[2],
+    m[2] * n[1] + m[3] * n[3],
+  ];
+}
+
+/**
+ * The nearest similarity to a 2×2, and how far it had to move to get there.
+ *
+ * A rotation, a uniform scale and possibly a flip — nothing that could shear a logo. The far
+ * flank should be a rigid reflection of this one, so anything the raw map has beyond that is
+ * noise in the unwrap rather than something to reproduce. Both handednesses are fitted and
+ * the closer one wins, which is also what decides the flip.
+ */
+function nearestSimilarity(m: [number, number, number, number]): {
+  fit: [number, number, number, number];
+  residual: number;
+} {
+  const [a, b, c, d] = m;
+  // Same handedness: [[p, -q], [q, p]].
+  const keep: [number, number, number, number] = [(a + d) / 2, -(c - b) / 2, (c - b) / 2, (a + d) / 2];
+  // Turned over: [[p, q], [q, -p]].
+  const flip: [number, number, number, number] = [(a - d) / 2, (c + b) / 2, (c + b) / 2, -(a - d) / 2];
+  const err = (f: [number, number, number, number]) =>
+    Math.hypot(f[0] - a, f[1] - b, f[2] - c, f[3] - d);
+  const ek = err(keep);
+  const ef = err(flip);
+  return {
+    fit: ek <= ef ? keep : flip,
+    residual: Math.min(ek, ef) / (Math.hypot(a, b, c, d) || 1),
+  };
+}
+
+/**
+ * Read a similarity back out as the fields a layer actually stores — the inverse of `frameOf`.
+ *
+ * It has to be exactly that inverse. The fields carry two flips that multiply, the stage's and
+ * the layer's (see `mirrored`), and anything that reasoned about "the" flip here would put a
+ * mirrored logo on the far shroud upside down half the time.
+ *
+ * A reflection comes out as a turn plus a flip of the y axis. Choosing x instead would be the
+ * same transform at a different angle, there is nothing to prefer, and a follower's fields are
+ * never edited by hand.
+ */
+function fieldsFrom(
+  m: [number, number, number, number],
+  turns: boolean,
+): { rotation: number; scale: number; flipX: boolean; flipY: boolean } {
+  const [a, b, c, d] = m;
+  const det = a * d - b * c;
+  const scale = Math.sqrt(Math.abs(det));
+  // With sx pinned to +scale, the angle is whatever the first column says and sy is whatever
+  // the determinant needs it to be — which is the whole decomposition, in two lines.
+  const sy = det < 0 ? -scale : scale;
+  const base = turns ? -scale : scale;
+  const p = Math.atan2(c, a);
+  return { rotation: turns ? -p : p, scale, flipX: false, flipY: sy !== base };
+}
+
+/**
+ * Offsets to sample the layer's own axes at, as a fraction of the sheet.
+ *
+ * Tried in turn: a short step still lands on the same panel where a long one has already run
+ * off the island and onto something that is not the far side of anything.
+ */
+const PROBES = [0.03, 0.015, 0.006, 0.002];
+
+/** Beyond this, the two islands are not reflections of each other and the fit is a compromise. */
+const RESIDUAL_LIMIT = 0.2;
+
+/**
+ * Where the far-flank copy of `layer` goes, or why it can't go anywhere.
+ *
+ * Three points are mapped rather than one — the centre, and a step along each of the layer's
+ * own axes — because a position alone says nothing about which way the far island runs. The two
+ * steps are what give the angle, the size and the flip, and fitting a similarity to them is
+ * what keeps a logo a logo rather than letting a slightly-off unwrap shear it.
+ */
+export function mirrorLayer(
+  index: MirrorIndex | null,
+  parts: UvPart[],
+  layer: Layer,
+  sheet: Sheet,
+): MirrorResult {
+  if (!index) return { ok: false, why: "no-model" };
+
+  const cu = layer.x / sheet.width;
+  const cv = layer.y / sheet.height;
+  // What the sheet says about this spot, before any of the geometry below.
+  //
+  // `null` is the load-bearing case: the flank codes are exactly the model's statement that
+  // its axes can be trusted, so without them there is no left and right to reflect between and
+  // a reflection about x = 0 would be a confident invention.
+  const side = sideAt(parts, cu, cv);
+  if (!side) return { ok: false, why: "no-model" };
+  // A region both flanks share already appears on both sides, and a second copy of a decal
+  // there is not what anybody means by "mirror this".
+  if (side === "both") return { ok: false, why: "shared" };
+  if (side === "centre") return { ok: false, why: "centre" };
+
+  const centre = mirrorPoint(index, cu, cv);
+  if (!centre) return { ok: false, why: "asymmetric" };
+
+  const rot = sheetRotation(layer);
+  const ux = Math.cos(rot);
+  const uy = Math.sin(rot);
+
+  for (const probe of PROBES) {
+    const d = Math.min(sheet.width, sheet.height) * probe;
+    const along = mirrorPoint(
+      index,
+      (layer.x + d * ux) / sheet.width,
+      (layer.y + d * uy) / sheet.height,
+    );
+    const across = mirrorPoint(
+      index,
+      (layer.x - d * uy) / sheet.width,
+      (layer.y + d * ux) / sheet.height,
+    );
+    if (!along || !across) continue;
+
+    // Where the layer's own two axes went, in sheet pixels. Undoing the layer's rotation turns
+    // that into the map from sheet to sheet, which is what the far island actually is.
+    const k: [number, number, number, number] = [
+      ((along.u - centre.u) * sheet.width) / d,
+      ((across.u - centre.u) * sheet.width) / d,
+      ((along.v - centre.v) * sheet.height) / d,
+      ((across.v - centre.v) * sheet.height) / d,
+    ];
+    const unrotate: [number, number, number, number] = [ux, uy, -uy, ux];
+    const { fit, residual } = nearestSimilarity(mul(k, unrotate));
+    // A probe that fell off the island gives a map that collapses everything to a point. That
+    // is not an answer, it is a shorter step's turn.
+    if (!fit.every(Number.isFinite) || fit.every((n) => n === 0)) continue;
+
+    return {
+      ok: true,
+      x: centre.u * sheet.width,
+      y: centre.v * sheet.height,
+      ...fieldsFrom(mul(fit, frameOf(layer)), mirrored(layer)),
+      approximate: residual > RESIDUAL_LIMIT,
+    };
+  }
+
+  // The centre mapped and its neighbours didn't: the layer sits on a sliver with no room to
+  // read a direction off. Place it where the centre landed, as it is, and say so.
+  return {
+    ok: true,
+    x: centre.u * sheet.width,
+    y: centre.v * sheet.height,
+    rotation: layer.rotation,
+    scale: layer.scale,
+    flipX: layer.flipX,
+    flipY: layer.flipY,
+    approximate: true,
+  };
+}
+
+/**
+ * A follower brought back into step with the layer it reflects.
+ *
+ * Everything but the placement is copied outright — the artwork, the colours, the blend, the
+ * part it is clipped to, whether it is hidden. A follower is not a variant of its source; it is
+ * the same artwork seen from the other side of the bike, and every field that could drift is a
+ * way for it to stop being that.
+ *
+ * `placement` is null when the model can no longer say where the far side is. The follower then
+ * keeps the position it already had — a guess dressed up as a placement is worse than a stale
+ * one, because only one of the two looks wrong.
+ *
+ * The clip travels by name and is rebuilt here rather than shared: a `Path2D` is built at one
+ * sheet's size, and handing over the source's copy would pin the follower to a path built for
+ * a sheet it might not be on.
+ */
+export function derive(
+  follower: Layer,
+  source: Layer,
+  placement: MirrorPlacement | null,
+  parts: UvPart[],
+  sheet: Sheet,
+): Layer {
+  const part = source.clip ? parts.find((p) => p.label === source.clip?.label) : null;
+  // The part not being found means the model isn't loaded yet, not that the source stopped
+  // being clipped — so the follower keeps the path it already had rather than flashing
+  // unclipped until the geometry turns up.
+  const clip = source.clip ? (part ? { label: part.label, path: partPath(part, sheet.width, sheet.height) } : follower.clip) : null;
+  return {
+    ...source,
+    id: follower.id,
+    name: follower.name,
+    group: follower.group,
+    mirror: follower.mirror,
+    clip,
+    x: placement ? placement.x : follower.x,
+    y: placement ? placement.y : follower.y,
+    rotation: placement ? placement.rotation : follower.rotation,
+    scale: placement ? placement.scale : follower.scale,
+    flipX: placement ? placement.flipX : follower.flipX,
+    flipY: placement ? placement.flipY : follower.flipY,
+  };
+}

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1778,6 +1778,56 @@ export const de: Translation = {
     "Diese Fläche ist die Unterseite des Teils — hier Gemaltes zeigt zum Boden und ist von außen nie zu sehen.",
   "designer.faceHint.both":
     "Ober- und Unterseite des Teils liegen auf derselben Fläche, deshalb landet alles hier Gezeichnete auf beiden.",
+  // ── Designer › die Auswahl, und was man mit ihr machen kann ───────────────────
+  "designer.layersSelected": "{{count}} Ebenen ausgewählt",
+  "designer.position": "Position",
+  "designer.duplicate": "Duplizieren",
+  "designer.copy": "Kopieren",
+  "designer.paste": "Einfügen",
+  "designer.copyName": "{{name}} Kopie",
+  "designer.copied_one": "1 Ebene kopiert.",
+  "designer.copied_other": "{{count}} Ebenen kopiert.",
+  "designer.pasteWrongSize":
+    "Das stammt von einer Bahn anderer Größe, und eine Malebene *ist* die Bahn — hier passt nichts davon hinein.",
+  "designer.pasteDropped_one":
+    "1 Malebene wurde ausgelassen — eine Malebene ist die Bahn, und diese hat eine andere Größe.",
+  "designer.pasteDropped_other":
+    "{{count}} Malebenen wurden ausgelassen — eine Malebene ist die Bahn, und diese hat eine andere Größe.",
+  "designer.group": "Gruppieren",
+  "designer.ungroup": "Gruppierung lösen",
+  "designer.groupRow": "Zusammen",
+  "designer.groupOf": "Gruppe aus {{count}}",
+  "designer.groupHint":
+    "Bewegt sie als eins. Ein Klick auf eine davon nimmt die ganze Gruppe — halte Alt, um eine einzelne Ebene herauszugreifen.",
+  "designer.flip": "Spiegeln",
+  "designer.flipX": "Links–rechts spiegeln",
+  "designer.flipY": "Oben–unten spiegeln",
+
+  // ── Designer › auf die andere Flanke spiegeln ─────────────────────────────────
+  "designer.mirror": "Auf die andere Seite spiegeln",
+  "designer.mirrorName": "{{name}} gespiegelt",
+  "designer.mirrorHint":
+    "Legt eine Kopie dieser Ebene dorthin, wo sie auf der anderen Seite des Motorrads landet. Aus dem Modell berechnet statt durch Umklappen der Bahn, also kommt sie auf dem richtigen Teil an — und sie folgt dieser Ebene, bis du sie löst.",
+  "designer.mirroredFrom": "Gespiegelt von „{{name}}“.",
+  "designer.mirroredShort": "Gespiegelt",
+  "designer.mirroredOrphan": "Dies wurde von einer Ebene gespiegelt, die es nicht mehr gibt.",
+  "designer.unlink": "Lösen",
+  "designer.unlinkHint":
+    "Hört auf zu folgen und behält, was da ist. Es wird eine gewöhnliche Ebene, die du für sich bearbeiten kannst.",
+  "designer.selectSource": "Original auswählen",
+  "designer.mirrorPaused":
+    "Kein Modell geladen — dies bleibt, wo es zuletzt platziert wurde, statt zu folgen.",
+  "designer.mirrorRough":
+    "Die andere Seite ist nicht als Spiegelung dieser abgewickelt, daher ist die Platzierung nah statt exakt.",
+  "designer.mirrorWhy.no-model":
+    "Lade zuerst das Motorrad in die Vorschau — ohne Modell gibt es keine andere Seite zu finden.",
+  "designer.mirrorWhy.shared":
+    "Beide Flanken sind auf dieselbe Stelle abgewickelt, das hier ist also schon auf beiden Seiten. Eine zweite Kopie läge genau auf der ersten.",
+  "designer.mirrorWhy.centre":
+    "Das sitzt auf der Mittellinie des Motorrads, die ihre eigene Spiegelung ist — es gibt keine andere Seite dafür.",
+  "designer.mirrorWhy.asymmetric":
+    "Das Modell hat an der Spiegelung dieser Stelle nichts, es gibt also keine andere Seite dafür.",
+
   "designer.opacity": "Deckkraft",
   "designer.blend": "Modus",
   "designer.blend.normal": "Normal",
@@ -1836,7 +1886,7 @@ export const de: Translation = {
   "designer.tool.ellipse": "Ellipse",
   "designer.tool.line": "Linie",
   "designer.moveHint":
-    "Ziehe Ebenen auf der Bahn, um sie zu platzieren. Wähle oben ein Werkzeug, um stattdessen darauf zu malen.",
+    "Ziehe Ebenen auf der Bahn, um sie zu platzieren — sie rasten an Nähten und aneinander ein, halte Alt zum freien Platzieren. Umschalt+Klick erweitert die Auswahl, ein Zug über leere Fläche zieht ein Lasso, und der Rechtsklick hat den Rest. Wähle oben ein Werkzeug, um stattdessen darauf zu malen.",
   "designer.colourFrom": "Damit malen",
   "designer.colourTo": "Dahin verlaufen",
   "designer.swapColours": "Die beiden Farben tauschen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1735,6 +1735,56 @@ export const en = {
     "This area is the underside of the panel — painted here, it faces the ground and is never seen from outside.",
   "designer.faceHint.both":
     "A panel's outer skin and its underside share this area, so anything drawn here lands on both.",
+  // ── Designer › the selection, and what can be done to it ──────────────────────
+  "designer.layersSelected": "{{count}} layers selected",
+  "designer.position": "Position",
+  "designer.duplicate": "Duplicate",
+  "designer.copy": "Copy",
+  "designer.paste": "Paste",
+  "designer.copyName": "{{name}} copy",
+  "designer.copied_one": "1 layer copied.",
+  "designer.copied_other": "{{count}} layers copied.",
+  "designer.pasteWrongSize":
+    "That was copied from a sheet of another size, and a paint layer is the sheet — there's nothing here it would fit.",
+  "designer.pasteDropped_one":
+    "1 paint layer was left out — a paint layer is the sheet, and this one is a different size.",
+  "designer.pasteDropped_other":
+    "{{count}} paint layers were left out — a paint layer is the sheet, and this one is a different size.",
+  "designer.group": "Group",
+  "designer.ungroup": "Ungroup",
+  "designer.groupRow": "Together",
+  "designer.groupOf": "Group of {{count}}",
+  "designer.groupHint":
+    "Move these as one. Clicking any of them takes the whole group — hold Alt to pick a single layer out of it.",
+  "designer.flip": "Flip",
+  "designer.flipX": "Flip left to right",
+  "designer.flipY": "Flip top to bottom",
+
+  // ── Designer › mirroring to the far flank ─────────────────────────────────────
+  "designer.mirror": "Mirror to other side",
+  "designer.mirrorName": "{{name}} mirrored",
+  "designer.mirrorHint":
+    "Put a copy of this layer where it lands on the far side of the bike. Worked out from the model rather than by flipping the sheet, so it arrives on the panel it belongs on — and it follows this layer until you unlink it.",
+  "designer.mirroredFrom": "Mirrored from “{{name}}”.",
+  "designer.mirroredShort": "Mirrored",
+  "designer.mirroredOrphan": "This was mirrored from a layer that is no longer here.",
+  "designer.unlink": "Unlink",
+  "designer.unlinkHint":
+    "Stop following, and keep what's here. It becomes an ordinary layer you can edit on its own.",
+  "designer.selectSource": "Select the original",
+  "designer.mirrorPaused":
+    "No model is loaded, so this is sitting where it was last placed rather than following.",
+  "designer.mirrorRough":
+    "The far side isn't unwrapped as a reflection of this one, so the placement is close rather than exact.",
+  "designer.mirrorWhy.no-model":
+    "Load the bike in the preview first — without the model there is no far side to find.",
+  "designer.mirrorWhy.shared":
+    "Both flanks are unwrapped onto this same spot, so this is already on each side of the bike. A second copy would land on top of the first.",
+  "designer.mirrorWhy.centre":
+    "This sits on the bike's centre line, which is its own reflection — there is no other side to send it to.",
+  "designer.mirrorWhy.asymmetric":
+    "The model has nothing at the reflection of this spot, so there is no far side to put it on.",
+
   "designer.opacity": "Opacity",
   "designer.blend": "Blend",
   "designer.blend.normal": "Normal",
@@ -1792,7 +1842,7 @@ export const en = {
   "designer.tool.ellipse": "Ellipse",
   "designer.tool.line": "Line",
   "designer.moveHint":
-    "Drag layers on the sheet to place them. Pick a tool above to paint on it instead.",
+    "Drag layers on the sheet to place them, and they snap to the seams and to each other — hold Alt to place one freely. Shift-click adds to the selection, a drag over empty space lassoes, and right-click has the rest. Pick a tool above to paint on it instead.",
   "designer.colourFrom": "Paint with this",
   "designer.colourTo": "Run into this",
   "designer.swapColours": "Swap the two colours",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1764,6 +1764,56 @@ export const es: Translation = {
     "Esta zona es la cara interior de la pieza: lo que pintes aquí mira al suelo y nunca se ve desde fuera.",
   "designer.faceHint.both":
     "La cara exterior de la pieza y su cara interior comparten esta zona, así que lo que dibujes aquí cae en las dos.",
+  // ── Designer › la selección, y qué se puede hacer con ella ────────────────────
+  "designer.layersSelected": "{{count}} capas seleccionadas",
+  "designer.position": "Posición",
+  "designer.duplicate": "Duplicar",
+  "designer.copy": "Copiar",
+  "designer.paste": "Pegar",
+  "designer.copyName": "{{name}} copia",
+  "designer.copied_one": "1 capa copiada.",
+  "designer.copied_other": "{{count}} capas copiadas.",
+  "designer.pasteWrongSize":
+    "Eso se copió de una hoja de otro tamaño, y una capa de pintura *es* la hoja: aquí no hay nada que encaje.",
+  "designer.pasteDropped_one":
+    "Se dejó fuera 1 capa de pintura: una capa de pintura es la hoja, y esta es de otro tamaño.",
+  "designer.pasteDropped_other":
+    "Se dejaron fuera {{count}} capas de pintura: una capa de pintura es la hoja, y esta es de otro tamaño.",
+  "designer.group": "Agrupar",
+  "designer.ungroup": "Desagrupar",
+  "designer.groupRow": "Juntas",
+  "designer.groupOf": "Grupo de {{count}}",
+  "designer.groupHint":
+    "Muévelas como una. Al hacer clic en cualquiera se toma el grupo entero; mantén Alt para sacar una sola capa.",
+  "designer.flip": "Voltear",
+  "designer.flipX": "Voltear de izquierda a derecha",
+  "designer.flipY": "Voltear de arriba abajo",
+
+  // ── Designer › reflejar al otro flanco ────────────────────────────────────────
+  "designer.mirror": "Reflejar al otro lado",
+  "designer.mirrorName": "{{name}} reflejada",
+  "designer.mirrorHint":
+    "Pone una copia de esta capa donde cae en el otro lado de la moto. Se calcula con el modelo en vez de volteando la hoja, así que llega a la pieza que le toca, y sigue a esta capa hasta que la desvincules.",
+  "designer.mirroredFrom": "Reflejo de «{{name}}».",
+  "designer.mirroredShort": "Reflejada",
+  "designer.mirroredOrphan": "Esto se reflejó de una capa que ya no está.",
+  "designer.unlink": "Desvincular",
+  "designer.unlinkHint":
+    "Deja de seguir y conserva lo que hay. Pasa a ser una capa normal que puedes editar por su cuenta.",
+  "designer.selectSource": "Seleccionar la original",
+  "designer.mirrorPaused":
+    "No hay modelo cargado, así que esto se queda donde se colocó la última vez en lugar de seguir.",
+  "designer.mirrorRough":
+    "El otro lado no está desplegado como reflejo de este, así que la colocación es aproximada, no exacta.",
+  "designer.mirrorWhy.no-model":
+    "Carga primero la moto en la vista previa: sin el modelo no hay otro lado que encontrar.",
+  "designer.mirrorWhy.shared":
+    "Los dos flancos están desplegados en este mismo sitio, así que esto ya está en ambos lados de la moto. Una segunda copia caería sobre la primera.",
+  "designer.mirrorWhy.centre":
+    "Esto está en el eje de la moto, que es su propio reflejo: no hay otro lado al que mandarlo.",
+  "designer.mirrorWhy.asymmetric":
+    "El modelo no tiene nada en el reflejo de este punto, así que no hay otro lado donde ponerlo.",
+
   "designer.opacity": "Opacidad",
   "designer.blend": "Fusión",
   "designer.blend.normal": "Normal",
@@ -1822,7 +1872,7 @@ export const es: Translation = {
   "designer.tool.ellipse": "Elipse",
   "designer.tool.line": "Línea",
   "designer.moveHint":
-    "Arrastra las capas sobre la hoja para colocarlas. Elige una herramienta arriba para pintar sobre ella.",
+    "Arrastra las capas sobre la hoja para colocarlas: se enganchan a las costuras y entre sí; mantén Alt para colocarlas libremente. Mayús+clic añade a la selección, arrastrar sobre el vacío hace un lazo, y el clic derecho tiene el resto. Elige una herramienta arriba para pintar sobre ella.",
   "designer.colourFrom": "Pinta con este",
   "designer.colourTo": "Funde hacia este",
   "designer.swapColours": "Intercambiar los dos colores",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1769,6 +1769,56 @@ export const fr: Translation = {
     "Cette zone est la face intérieure de la pièce : ce que vous y peignez regarde le sol et ne se voit jamais de l'extérieur.",
   "designer.faceHint.both":
     "La face extérieure de la pièce et sa face intérieure partagent cette zone : ce que vous dessinez ici se retrouve sur les deux.",
+  // ── Designer › la sélection, et ce qu'on peut en faire ────────────────────────
+  "designer.layersSelected": "{{count}} calques sélectionnés",
+  "designer.position": "Position",
+  "designer.duplicate": "Dupliquer",
+  "designer.copy": "Copier",
+  "designer.paste": "Coller",
+  "designer.copyName": "{{name}} copie",
+  "designer.copied_one": "1 calque copié.",
+  "designer.copied_other": "{{count}} calques copiés.",
+  "designer.pasteWrongSize":
+    "Ça vient d'une planche d'une autre taille, et un calque de peinture *est* la planche — il n'y a rien ici qui puisse aller.",
+  "designer.pasteDropped_one":
+    "1 calque de peinture a été laissé de côté — un calque de peinture est la planche, et celle-ci n'a pas la même taille.",
+  "designer.pasteDropped_other":
+    "{{count}} calques de peinture ont été laissés de côté — un calque de peinture est la planche, et celle-ci n'a pas la même taille.",
+  "designer.group": "Grouper",
+  "designer.ungroup": "Dégrouper",
+  "designer.groupRow": "Ensemble",
+  "designer.groupOf": "Groupe de {{count}}",
+  "designer.groupHint":
+    "Les déplacer d'un bloc. Cliquer sur l'un d'eux prend tout le groupe — maintiens Alt pour n'en prendre qu'un.",
+  "designer.flip": "Retourner",
+  "designer.flipX": "Retourner de gauche à droite",
+  "designer.flipY": "Retourner de haut en bas",
+
+  // ── Designer › miroir vers l'autre flanc ──────────────────────────────────────
+  "designer.mirror": "Miroir de l'autre côté",
+  "designer.mirrorName": "{{name}} miroir",
+  "designer.mirrorHint":
+    "Place une copie de ce calque là où il tombe de l'autre côté de la moto. Calculé à partir du modèle plutôt qu'en retournant la planche, donc il arrive sur la bonne pièce — et il suit ce calque tant que tu ne le détaches pas.",
+  "designer.mirroredFrom": "Miroir de « {{name}} ».",
+  "designer.mirroredShort": "Miroir",
+  "designer.mirroredOrphan": "Ceci est le miroir d'un calque qui n'existe plus.",
+  "designer.unlink": "Détacher",
+  "designer.unlinkHint":
+    "Arrête de suivre, et garde ce qu'il y a. Ça devient un calque ordinaire que tu peux modifier seul.",
+  "designer.selectSource": "Sélectionner l'original",
+  "designer.mirrorPaused":
+    "Aucun modèle chargé : ceci reste là où il a été placé la dernière fois au lieu de suivre.",
+  "designer.mirrorRough":
+    "L'autre côté n'est pas déplié en miroir de celui-ci, donc le placement est approchant plutôt qu'exact.",
+  "designer.mirrorWhy.no-model":
+    "Charge d'abord la moto dans l'aperçu — sans le modèle, il n'y a pas d'autre côté à trouver.",
+  "designer.mirrorWhy.shared":
+    "Les deux flancs sont dépliés au même endroit : c'est donc déjà sur les deux côtés de la moto. Une deuxième copie tomberait sur la première.",
+  "designer.mirrorWhy.centre":
+    "Ceci est sur l'axe de la moto, qui est son propre miroir — il n'y a pas d'autre côté où l'envoyer.",
+  "designer.mirrorWhy.asymmetric":
+    "Le modèle n'a rien au miroir de cet endroit, donc il n'y a pas d'autre côté où le poser.",
+
   "designer.opacity": "Opacité",
   "designer.blend": "Fusion",
   "designer.blend.normal": "Normal",
@@ -1827,7 +1877,7 @@ export const fr: Translation = {
   "designer.tool.ellipse": "Ellipse",
   "designer.tool.line": "Ligne",
   "designer.moveHint":
-    "Fais glisser les calques sur la planche pour les placer. Choisis un outil ci-dessus pour peindre dessus.",
+    "Fais glisser les calques sur la planche pour les placer : ils s'aimantent aux coutures et entre eux — maintiens Alt pour placer librement. Maj+clic ajoute à la sélection, un glissé sur le vide fait un lasso, et le clic droit a le reste. Choisis un outil ci-dessus pour peindre dessus.",
   "designer.colourFrom": "Peindre avec cette couleur",
   "designer.colourTo": "Fondre vers cette couleur",
   "designer.swapColours": "Inverser les deux couleurs",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1758,6 +1758,56 @@ export const it: Translation = {
     "Quest'area è il lato interno del pezzo: ciò che dipingi qui guarda a terra e non si vede mai da fuori.",
   "designer.faceHint.both":
     "Il lato esterno del pezzo e quello interno condividono quest'area, quindi ciò che disegni qui finisce su entrambi.",
+  // ── Designer › la selezione, e cosa farci ─────────────────────────────────────
+  "designer.layersSelected": "{{count}} livelli selezionati",
+  "designer.position": "Posizione",
+  "designer.duplicate": "Duplica",
+  "designer.copy": "Copia",
+  "designer.paste": "Incolla",
+  "designer.copyName": "{{name}} copia",
+  "designer.copied_one": "1 livello copiato.",
+  "designer.copied_other": "{{count}} livelli copiati.",
+  "designer.pasteWrongSize":
+    "Viene da un foglio di un'altra misura, e un livello di pittura *è* il foglio: qui non c'è niente che ci stia.",
+  "designer.pasteDropped_one":
+    "1 livello di pittura è stato lasciato fuori: un livello di pittura è il foglio, e questo è di un'altra misura.",
+  "designer.pasteDropped_other":
+    "{{count}} livelli di pittura sono stati lasciati fuori: un livello di pittura è il foglio, e questo è di un'altra misura.",
+  "designer.group": "Raggruppa",
+  "designer.ungroup": "Separa",
+  "designer.groupRow": "Insieme",
+  "designer.groupOf": "Gruppo di {{count}}",
+  "designer.groupHint":
+    "Li muove come uno solo. Cliccarne uno prende tutto il gruppo — tieni Alt per prenderne uno solo.",
+  "designer.flip": "Ribalta",
+  "designer.flipX": "Ribalta da sinistra a destra",
+  "designer.flipY": "Ribalta dall'alto in basso",
+
+  // ── Designer › riflettere sull'altro fianco ───────────────────────────────────
+  "designer.mirror": "Rifletti sull'altro lato",
+  "designer.mirrorName": "{{name}} riflesso",
+  "designer.mirrorHint":
+    "Mette una copia di questo livello dove finisce sull'altro lato della moto. Calcolato dal modello invece che ribaltando il foglio, quindi arriva sul pezzo giusto — e segue questo livello finché non lo scolleghi.",
+  "designer.mirroredFrom": "Riflesso da «{{name}}».",
+  "designer.mirroredShort": "Riflesso",
+  "designer.mirroredOrphan": "Questo è il riflesso di un livello che non c'è più.",
+  "designer.unlink": "Scollega",
+  "designer.unlinkHint":
+    "Smette di seguire e tiene quello che c'è. Diventa un livello normale che puoi modificare per conto suo.",
+  "designer.selectSource": "Seleziona l'originale",
+  "designer.mirrorPaused":
+    "Nessun modello caricato: questo resta dov'era stato messo l'ultima volta invece di seguire.",
+  "designer.mirrorRough":
+    "L'altro lato non è aperto come riflesso di questo, quindi la posizione è vicina più che esatta.",
+  "designer.mirrorWhy.no-model":
+    "Carica prima la moto nell'anteprima: senza il modello non c'è nessun altro lato da trovare.",
+  "designer.mirrorWhy.shared":
+    "I due fianchi sono aperti sullo stesso punto, quindi questo è già su entrambi i lati della moto. Una seconda copia finirebbe sopra la prima.",
+  "designer.mirrorWhy.centre":
+    "Questo sta sull'asse della moto, che è il riflesso di sé stesso: non c'è un altro lato dove mandarlo.",
+  "designer.mirrorWhy.asymmetric":
+    "Il modello non ha niente al riflesso di questo punto, quindi non c'è un altro lato dove metterlo.",
+
   "designer.opacity": "Opacità",
   "designer.blend": "Fusione",
   "designer.blend.normal": "Normale",
@@ -1815,7 +1865,7 @@ export const it: Translation = {
   "designer.tool.ellipse": "Ellisse",
   "designer.tool.line": "Linea",
   "designer.moveHint":
-    "Trascina i livelli sul foglio per posizionarli. Scegli uno strumento qui sopra per dipingerci sopra.",
+    "Trascina i livelli sul foglio per posizionarli: si agganciano alle cuciture e fra loro — tieni Alt per posizionarli liberamente. Maiusc+clic aggiunge alla selezione, un trascinamento sul vuoto fa un lazo, e il tasto destro ha il resto. Scegli uno strumento qui sopra per dipingerci sopra.",
   "designer.colourFrom": "Dipingi con questo",
   "designer.colourTo": "Sfuma verso questo",
   "designer.swapColours": "Scambia i due colori",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1756,6 +1756,56 @@ export const ptBR: Translation = {
     "Esta área é o lado de baixo da peça: o que você pintar aqui fica virado para o chão e nunca é visto por fora.",
   "designer.faceHint.both":
     "O lado de cima da peça e o de baixo dividem esta área, então o que você desenha aqui cai nos dois.",
+  // ── Designer › a seleção, e o que dá para fazer com ela ───────────────────────
+  "designer.layersSelected": "{{count}} camadas selecionadas",
+  "designer.position": "Posição",
+  "designer.duplicate": "Duplicar",
+  "designer.copy": "Copiar",
+  "designer.paste": "Colar",
+  "designer.copyName": "{{name}} cópia",
+  "designer.copied_one": "1 camada copiada.",
+  "designer.copied_other": "{{count}} camadas copiadas.",
+  "designer.pasteWrongSize":
+    "Isso veio de uma folha de outro tamanho, e uma camada de pintura *é* a folha — aqui não tem nada que caiba.",
+  "designer.pasteDropped_one":
+    "1 camada de pintura ficou de fora: uma camada de pintura é a folha, e esta é de outro tamanho.",
+  "designer.pasteDropped_other":
+    "{{count}} camadas de pintura ficaram de fora: uma camada de pintura é a folha, e esta é de outro tamanho.",
+  "designer.group": "Agrupar",
+  "designer.ungroup": "Desagrupar",
+  "designer.groupRow": "Juntas",
+  "designer.groupOf": "Grupo de {{count}}",
+  "designer.groupHint":
+    "Move todas como uma. Clicar em qualquer uma pega o grupo inteiro — segure Alt para pegar só uma camada.",
+  "designer.flip": "Espelhar",
+  "designer.flipX": "Espelhar da esquerda para a direita",
+  "designer.flipY": "Espelhar de cima para baixo",
+
+  // ── Designer › espelhar para o outro lado ─────────────────────────────────────
+  "designer.mirror": "Espelhar para o outro lado",
+  "designer.mirrorName": "{{name}} espelhada",
+  "designer.mirrorHint":
+    "Coloca uma cópia desta camada onde ela cai do outro lado da moto. Calculado a partir do modelo em vez de virar a folha, então chega na peça certa — e segue esta camada até você desvincular.",
+  "designer.mirroredFrom": "Espelhada de “{{name}}”.",
+  "designer.mirroredShort": "Espelhada",
+  "designer.mirroredOrphan": "Isto foi espelhado de uma camada que não existe mais.",
+  "designer.unlink": "Desvincular",
+  "designer.unlinkHint":
+    "Para de seguir e mantém o que está aqui. Vira uma camada comum, que você edita por conta.",
+  "designer.selectSource": "Selecionar a original",
+  "designer.mirrorPaused":
+    "Nenhum modelo carregado, então isto fica onde foi colocado por último em vez de seguir.",
+  "designer.mirrorRough":
+    "O outro lado não está aberto como reflexo deste, então a posição é próxima, não exata.",
+  "designer.mirrorWhy.no-model":
+    "Carregue a moto na prévia primeiro — sem o modelo não há outro lado para achar.",
+  "designer.mirrorWhy.shared":
+    "Os dois lados estão abertos no mesmo ponto, então isto já está nos dois lados da moto. Uma segunda cópia cairia em cima da primeira.",
+  "designer.mirrorWhy.centre":
+    "Isto está na linha de centro da moto, que é o próprio reflexo — não há outro lado para onde mandar.",
+  "designer.mirrorWhy.asymmetric":
+    "O modelo não tem nada no reflexo deste ponto, então não há outro lado para colocar.",
+
   "designer.opacity": "Opacidade",
   "designer.blend": "Mesclagem",
   "designer.blend.normal": "Normal",
@@ -1812,7 +1862,7 @@ export const ptBR: Translation = {
   "designer.tool.ellipse": "Elipse",
   "designer.tool.line": "Linha",
   "designer.moveHint":
-    "Arraste as camadas na folha para posicioná-las. Escolha uma ferramenta acima para pintar nela.",
+    "Arraste as camadas na folha para posicioná-las: elas encaixam nas emendas e umas nas outras — segure Alt para posicionar livre. Shift+clique soma à seleção, arrastar no vazio faz um laço, e o botão direito tem o resto. Escolha uma ferramenta acima para pintar nela.",
   "designer.colourFrom": "Pintar com esta",
   "designer.colourTo": "Transitar para esta",
   "designer.swapColours": "Trocar as duas cores",


### PR DESCRIPTION
## What

The Designer could stack layers, clip them to a mesh part and show the result on the model live — but none of the ordinary layer handling a painter reaches for. No duplicate, no copy/paste, no nudge, no Delete, no flip, no multi-select, no snapping, no way to type an exact position. Getting a decal from the right shroud onto the left one meant eyeballing it twice.

This adds all of that, and a mirror that actually works on a motorcycle.

## The mirror

The tempting version is to flip about `u = 0.5`. It's what other paint tools offer and it's wrong here often enough to be useless: a bike's two flanks are unwrapped wherever the modeller put them, not as a reflection of each other about the middle of the texture.

So the question goes to the model instead. A point on the sheet becomes a point on a triangle; that point is reflected about the bike's mirror plane; whichever triangle wears the reflected point says where it lands back on the sheet. Three points are mapped — the layer's centre and a step along each of its own axes — and a **similarity** is fitted to them, which is what gives the copy its angle, its size and its flip without letting a slightly-off unwrap shear the artwork.

Details worth knowing when reading `mirror.ts`:

- Corners are **welded by position**, not trusted as vertex indices. A panel split across two mesh nodes holds its own copy of the shared edge, and the reflected corner is almost always in a different node from the one it came from.
- The far triangle's UVs are read back **matched by corner id**, not by position in the list. Its winding is its own, and reading them in the wrong order is how a decal arrives on the right panel inside out.
- The index is built over the **active sheet's triangles only** — the far side of a shroud wears the same texture by definition — and built lazily, since most paints never mirror anything.
- It reuses the flank work already in `uv.ts`: `sideAt` returning `null` is the model's own statement that its axes can't be trusted, and that is the `no-model` refusal.

The copy is a **live follower**: re-derived from its source inside `patchSheet`, which is the one road every edit but a stroke takes. It tracks a move, a recolour, a retype, a reshape, visibility and the clip until you unlink it. A paint layer *is* the sheet, so it can be neither source nor follower — which is also what keeps the derivation off the stroke path entirely.

It refuses with a reason rather than guessing:

| | |
|---|---|
| `shared` | Both flanks unwrap onto this spot — it's already on both sides. A second copy would land on the first. |
| `centre` | It's on the centre line, which is its own reflection. |
| `asymmetric` | The model has nothing at the reflection — a one-sided bracket, an exhaust. |
| `no-model` | No model loaded, or one whose axes mean nothing. |

Where the far side isn't a true reflection, the placement is still made and flagged as close rather than exact.

## The rest

- **Duplicate** (⌘D), **copy/paste** (⌘C/⌘V, across sheets, rescaled — a paint layer is dropped onto a sheet of another size, and says so), **Delete**, **arrow nudge** (1px, 10 with Shift).
- **Multi-select** — shift-click, lasso over empty canvas, ⌘A — and **grouping** with ⌘G. A group is a flat tag on its members rather than a container, so stacking, the composite, the save and the undo snapshots are all untouched. `regroup` gathers a group's members so a later reorder moves the block rather than shuffling members past each other. Alt-click reaches inside a group.
- **Snapping** while dragging: the sheet's centre lines and edges, the clipped part's box, and other layers' edges and middles, with the caught line drawn across the sheet. Alt places freely. The drag tracks the unsnapped pointer travel separately, so a layer held against a line doesn't drift out from under the hand.
- **Flip** left-right and top-bottom, as `flipX`/`flipY` folded into the composite's scale *alongside* the stage's existing flip rather than replacing it.
- **Typed X/Y/size/angle.** This reverses the note at the top of `LayerInspector` — that a typed X would be a second way of saying the same thing, and the one that doesn't show you the result. The boxes track the drag, so that objection no longer holds; the comment is rewritten rather than left contradicting the file. Y is counted from the bottom so the number agrees with the flipped view.
- **Right-click menu** on the canvas, opened from the *release* of a right press that didn't move — the native `contextmenu` event fires on the press and can't tell a menu from the start of a pan. Right-drag still pans, and the bucket keeps its right-click island fill.

## Verification

- `tsc --noEmit`, `eslint` and `vite build` clean. The two remaining lint warnings are pre-existing, in files this doesn't touch.
- The transform algebra was checked numerically over 25k random layers: the field decomposition is an exact inverse of the frame it comes from, and a known reflection `R` produces a follower frame equal to `R · frameOf(source)`. `nearestSimilarity` is the identity on similarities, names the handedness correctly, and shows a residual on a shear.
- The index was checked against a synthetic two-shroud model whose left island is deliberately *not* a sheet-flip of the right one — once translated, once reversed. Points map across and back, a layer lands where predicted, the reversed case turns over, and all four refusals fire.

Not covered: the app itself. A `tauri dev` was holding the port and the cargo lock, so the mirror has not been eyeballed on a real bike in the 3D preview — that's the thing to watch on first run.

No DB or schema changes. Strings added to all six locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
