### PR TITLE
fix(designer): find a packed model whose name carries a version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,19 @@
   The Bike / Rider / Both toggle picks what's on screen; either half stays up while the other
   one re-reads, and a bike that won't resolve says so instead of quietly leaving the rider alone.
 
+### Fixed
+
+- **A packed mod with a version in its name told the Designer nothing.** A model installed as
+  an archive is found by the `<Model>.pkz` sitting where its folder would be — and that name
+  was built by replacing the model's file extension, which a name like `Fox Instinct 2.0 by
+  Aeffertz` appears to have. The app went looking for `Fox Instinct 2.pkz`, a file nobody has.
+  So a packed bike, helmet or boot whose name carries a version number offered no sheet names
+  in the Designer: no "expected names" line, nothing for **Create the sheets this model asks
+  for** to create, and no suggested name on a blank sheet — and a sheet named by guesswork
+  paints nothing, which is only discovered in game. That boots mod now offers `fox` and
+  `fox_n`, as it always should have. The same lookup answers whether a bike exists at all when
+  it's installed as a bare `.pkz`, so a model-swap preview for one resolves too.
+
 ## 2026-08-26 — v0.10.2 — Liveries that belong to a model, and a Windows that starts
 
 ### Added

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -412,6 +412,18 @@ pub struct RiderTargets {
     pub profiles: Vec<String>,
 }
 
+/// The `<Model>.pkz` that sits beside a model's folder, whether or not either exists.
+///
+/// Not `with_extension("pkz")`: a mod named `Fox Instinct 2.0 by Aeffertz` has
+/// `0 by Aeffertz` for an extension, so replacing it asks for `Fox Instinct 2.pkz` — a file
+/// nobody has. A model's name is the whole name; the archive appends to it, which is also
+/// how `models_in` reads one back.
+pub fn sibling_pkz(model_dir: &Path) -> PathBuf {
+    let mut name = model_dir.file_name().unwrap_or_default().to_os_string();
+    name.push(".pkz");
+    model_dir.with_file_name(name)
+}
+
 /// Installable content sitting directly in `dir`, by the name you'd address it as: a
 /// sub-folder verbatim, a `.pkz` by its stem. Sorted, case-insensitively deduped.
 fn models_in(dir: &Path) -> Vec<String> {
@@ -877,6 +889,30 @@ mod tests {
         let d = std::env::temp_dir().join(format!("frost-lib-{name}-{}", std::process::id()));
         let _ = fs::remove_dir_all(&d);
         d
+    }
+
+    /// A mod with a version in its name — `Fox Instinct 2.0 by Aeffertz` — has an
+    /// "extension" as far as the path types are concerned, and replacing it asks for an
+    /// archive nobody has. The name is the whole name.
+    #[test]
+    fn a_packed_model_is_found_beside_a_dotted_name() {
+        let boots = Path::new("/mods/rider/boots");
+        assert_eq!(
+            sibling_pkz(&boots.join("Fox Instinct 2.0 by Aeffertz")),
+            boots.join("Fox Instinct 2.0 by Aeffertz.pkz"),
+        );
+        assert_eq!(
+            sibling_pkz(&boots.join("TLD SE4 - Oakley Airbrake")),
+            boots.join("TLD SE4 - Oakley Airbrake.pkz"),
+            "and an undotted one is unchanged",
+        );
+        // What `models_in` reads back out of the archive is the name we started from.
+        assert_eq!(
+            sibling_pkz(&boots.join("Fox Instinct 2.0 by Aeffertz"))
+                .file_stem()
+                .unwrap(),
+            "Fox Instinct 2.0 by Aeffertz",
+        );
     }
 
     /// The guard every share code is checked against. A rel that climbs, starts at a root,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1340,7 +1340,7 @@ fn paint_hints(dir: &std::path::Path) -> Vec<String> {
     // lives in — for a bike as much as for a helmet.
     if names.is_empty() {
         if let (Some(sub), Some(model_dir)) = (dir.file_name(), dir.parent()) {
-            let pkz = model_dir.with_extension("pkz");
+            let pkz = library::sibling_pkz(model_dir);
             let tail = format!("/{}/", sub.to_string_lossy().to_ascii_lowercase());
             if pkz.is_file() {
                 let want = |n: &str| {
@@ -1386,7 +1386,7 @@ fn mesh_texture_names(model_dir: &std::path::Path) -> Vec<String> {
         }
     }
     if meshes.is_empty() {
-        let pkz = model_dir.with_extension("pkz");
+        let pkz = library::sibling_pkz(model_dir);
         if pkz.is_file() {
             for (_, d) in pkz::read_selected(&pkz, bikefiles::is_mesh).unwrap_or_default() {
                 meshes.push(pkz::read_sidecar_blob(&d).unwrap_or(d));
@@ -2036,7 +2036,7 @@ fn gather_bike_files(p: &std::path::Path) -> anyhow::Result<Vec<(String, Vec<u8>
         if out.iter().any(|(n, _)| n.to_ascii_lowercase().ends_with(".edf")) {
             return Ok(out);
         }
-        let sibling = p.with_extension("pkz");
+        let sibling = library::sibling_pkz(p);
         if sibling.exists() {
             return pkz::read_selected(&sibling, wanted_bike_file);
         }
@@ -2081,7 +2081,7 @@ fn packed_bike(bike_dir: &std::path::Path) -> Option<std::path::PathBuf> {
             }
         }
     }
-    let sibling = bike_dir.with_extension("pkz");
+    let sibling = library::sibling_pkz(bike_dir);
     sibling.exists().then_some(sibling)
 }
 
@@ -7658,6 +7658,33 @@ mod mesh_texture_tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
+    /// A packed model whose name carries a version number: `Fox Instinct 2.0 by Aeffertz`
+    /// has no folder on disk at all, only the archive beside where one would be, and the
+    /// dot in the name is not an extension to be replaced. Getting that wrong asked for
+    /// `Fox Instinct 2.pkz`, and the Designer offered no sheet names for the boots — so
+    /// nothing suggested `fox`, and a sheet named anything else paints nothing.
+    #[test]
+    fn a_packed_model_with_a_dot_in_its_name_still_names_its_sheets() {
+        use std::io::Write;
+        let root = std::env::temp_dir().join(format!("frost-dotted-pkz-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+
+        let packed = root.join("Fox Instinct 2.0 by Aeffertz.pkz");
+        {
+            let mut w = zip::ZipWriter::new(std::fs::File::create(&packed).unwrap());
+            w.start_file::<_, ()>("boots.edf", zip::write::SimpleFileOptions::default()).unwrap();
+            w.write_all(&mesh_naming("fox")).unwrap();
+            w.finish().unwrap();
+        }
+
+        // The destination the picker aims at: a `paints` folder under a model folder that
+        // was never unpacked, which is where a paint for a packed mod has to go.
+        let dest = root.join("Fox Instinct 2.0 by Aeffertz").join("paints");
+        assert_eq!(paint_hints(&dest), vec!["fox".to_string()]);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     /// The whole hint list for a real destination:
     /// `MXB_PAINT_DEST='…/mods/bikes/MX1OEM_2023_Husqvarna_FC_450/paints' \
     ///   cargo test paint_hints_from_env -- --ignored --nocapture`
@@ -8045,7 +8072,7 @@ mod viewer_tests {
             .find(|(_, p)| {
                 p.is_dir()
                     && crate::bikefiles::dir_has_mesh(p)
-                    && p.with_extension("pkz").exists()
+                    && crate::library::sibling_pkz(p).exists()
             })
         else {
             eprintln!("no bike with both a loose mesh and a .pkz found");
@@ -8059,7 +8086,8 @@ mod viewer_tests {
         let mp = root.to_str().unwrap();
         let bikes = crate::library::mods_subdir(mp, "mods/bikes");
         copy_tree(&src_dir, &bikes.join(&bike));
-        std::fs::copy(src_dir.with_extension("pkz"), bikes.join(format!("{bike}.pkz"))).unwrap();
+        std::fs::copy(crate::library::sibling_pkz(&src_dir), bikes.join(format!("{bike}.pkz")))
+            .unwrap();
 
         let set = super::modelswap::preview_set(mp, &bike, "Stock").expect("preview set");
         eprintln!("keeps {:?}", set.root_keep);

--- a/src-tauri/src/modelswap.rs
+++ b/src-tauri/src/modelswap.rs
@@ -800,7 +800,7 @@ pub fn preview_set(mods_path: &str, bike: &str, variant: &str) -> anyhow::Result
     // reader downstream finds it by the sibling name, so a missing folder alone isn't a missing
     // bike: it just means every file comes out of the archive. Only the read path is relaxed —
     // applying a swap still needs somewhere to park the files it displaces.
-    if !dir_exists(&root) && !root.with_extension("pkz").is_file() {
+    if !dir_exists(&root) && !crate::library::sibling_pkz(&root).is_file() {
         anyhow::bail!("bike '{bike}' not found");
     }
     let active = current_active(mods_path, bike);


### PR DESCRIPTION
## What

A model installed as an archive is found by the `<Model>.pkz` sitting where its folder would be. That path was built with `with_extension("pkz")`, which replaces everything after the last dot — so `Fox Instinct 2.0 by Aeffertz` was looked for as `Fox Instinct 2.pkz`, a file nobody has. Any packed bike, helmet or boot with a version number in its name was invisible to every lookup of that shape.

Adds `library::sibling_pkz`, which appends `.pkz` to the whole name, and uses it at all five sites:

- `paint_hints` — the packed-paints fallback and `mesh_texture_names`
- `gather_bike_files` and `packed_bike` — the bike model and Stock preview readers
- `modelswap::preview_set` — which decides a bike exists at all; a bike installed as a bare dotted `.pkz` was reported "not found"

## Why it mattered

The Designer is where it showed up. With no hints, the destination offers no expected-names line, **Create the sheets this model asks for** has nothing to make, and a blank sheet gets no suggested name. Names *are* the binding — a sheet called anything the mesh didn't ask for paints nothing — so the failure is only discovered in game.

Found while checking whether the Designer works for boots and helmets. It does: helmets bind correctly from both a folder install and a `.pkz`, and the boots mesh (`boot_l`/`boot_r`) loads and previews fine. Only the hints were missing, and only because of the name.

## Verification

- Real mod, the actual failing case: `mods/rider/boots/Fox Instinct 2.0 by Aeffertz/paints` now expects `["fox", "fox_n"]` — it returned `[]` before.
- New regression test packs a dotted `.pkz` with no folder beside it and asserts the mesh's sheet name comes back; a path-level test in `library.rs` covers dotted and undotted names.
- `cargo test --bin mxb-app`: 849 passed, 0 failed. `cargo check --target x86_64-pc-windows-gnu`: clean.

No schema or migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)