### PR TITLE
feat(rider): search the bike picker, and default to the stock model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@
   The Bike / Rider / Both toggle picks what's on screen; either half stays up while the other
   one re-reads, and a bike that won't resolve says so instead of quietly leaving the rider alone.
 
+### Changed
+- **The Rider tab's bike picker is searchable.** It was a plain dropdown, which is a long
+  scroll past dozens of bikes for a name you already know. It's now the same searchable
+  field as the Paint and Model swap slots beside it — type to filter. Unlike those, it
+  won't take a name you made up or an empty value, because neither is a bike.
+- **The Rider preview starts from the stock model.** With no model swap picked it drew
+  whatever swap happened to be on the bike, so the same look rendered differently on
+  everyone's machine. It now draws the game's own model unless you pick one — for a bike
+  whose files are all packed that was already what you were seeing, so nothing changes there.
+
 ## 2026-08-26 — v0.10.2 — Liveries that belong to a model, and a Windows that starts
 
 ### Added

--- a/src/Components/Rider/RiderStudio.tsx
+++ b/src/Components/Rider/RiderStudio.tsx
@@ -26,13 +26,7 @@ import {
 } from "../../lib/presets";
 import { useGearPaints } from "../../lib/useGearPaints";
 import { useConfig } from "../../Context/Config";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "../ui/select";
+import { Combobox } from "../ui/combobox";
 
 const RIDER_GROUPS = SLOT_GROUPS.filter((g) => g.id !== "bike");
 
@@ -187,7 +181,18 @@ export default function RiderStudio({
     [],
   );
 
-  const bikeVariant = pickedModel(bike, loadout, scans);
+  // With no model picked, preview the game's own model rather than whatever swap happens to
+  // be on the bike right now. A look composed here is meant to be shared, and "what's on my
+  // disk" renders differently on everyone else's.
+  //
+  // Only when the scan actually offers Stock. A bike whose files are all packed has nothing
+  // loose to park, so no Stock row is listed for it — and its active model already *is* the
+  // packed one, which is what asking for Stock would have shown anyway.
+  const offersStock = (scans?.modelSwaps[bike] ?? []).some(
+    (v) => v.toLowerCase() === "stock",
+  );
+  const bikeVariant =
+    loadout.modelSwap || (offersStock ? "Stock" : pickedModel(bike, loadout, scans));
   const showBike = bikePreview && !!bike;
   // A bike handed over by Presets comes from the profile's own list, which the target scan
   // should already cover — but if it doesn't, keep it pickable rather than showing an empty
@@ -292,23 +297,23 @@ export default function RiderStudio({
                 {t("slotGroup.bike")}
               </h2>
               <div className="grid grid-cols-1 gap-x-3.5 gap-y-2 sm:grid-cols-2">
-                <label className="flex flex-col gap-1">
+                {/* Searchable, and matching the two slot fields beside it. A mods folder
+                    runs to dozens of bikes, which is a long way to scroll for a name you
+                    already know. Neither free text nor empty is a bike, so both are off. */}
+                <div className="flex flex-col gap-0.5">
                   <span className="text-[11px] font-medium text-muted-foreground">
                     {t("slotGroup.bike")}
                   </span>
-                  <Select value={bike} onValueChange={setBike}>
-                    <SelectTrigger className="h-8">
-                      <SelectValue placeholder={t("slotGroup.bike")} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {bikeOptions.map((b) => (
-                        <SelectItem key={b} value={b}>
-                          {b}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </label>
+                  <Combobox
+                    value={bike}
+                    options={bikeOptions}
+                    onChange={setBike}
+                    placeholder={t("slotGroup.bike")}
+                    allowCreate={false}
+                    allowEmpty={false}
+                    className="h-7 text-[12px]"
+                  />
+                </div>
                 {BIKE_SLOTS.map((slot) => (
                   <SlotField
                     key={slot.key}

--- a/src/Components/ui/combobox.tsx
+++ b/src/Components/ui/combobox.tsx
@@ -20,6 +20,15 @@ interface ComboboxProps {
   placeholder?: string;
   /** Amber "missing" styling on the trigger. */
   invalid?: boolean;
+  /**
+   * Offer the "Use …" row that commits whatever was typed. On by default.
+   *
+   * Off for a slot whose value has to name something that exists — a bike id the backend
+   * resolves a model out of, where a typed-in name is only ever a preview that fails.
+   */
+  allowCreate?: boolean;
+  /** Offer the row that clears the slot back to empty/stock. On by default. */
+  allowEmpty?: boolean;
   className?: string;
 }
 
@@ -30,6 +39,10 @@ interface ComboboxProps {
  * slot back to the empty/stock value, which no amount of typing can produce. Built on the shadcn
  * Popover + Command (cmdk) primitives. cmdk lowercases the value it hands `onSelect`,
  * so each item commits its own original-cased string from the closure instead.
+ *
+ * Both of those extra rows are for a *slot*, where an unknown name and an empty value are
+ * both legitimate answers. `allowCreate` and `allowEmpty` turn them off for a picker that
+ * has to name one of the things in the list — leaving a plain searchable select.
  */
 export function Combobox({
   value,
@@ -37,6 +50,8 @@ export function Combobox({
   onChange,
   placeholder,
   invalid,
+  allowCreate = true,
+  allowEmpty = true,
   className,
 }: ComboboxProps) {
   const t = useT();
@@ -50,7 +65,8 @@ export function Combobox({
   };
 
   const q = query.trim();
-  const canCreate = q.length > 0 && !options.some((o) => o.toLowerCase() === q.toLowerCase());
+  const canCreate =
+    allowCreate && q.length > 0 && !options.some((o) => o.toLowerCase() === q.toLowerCase());
 
   return (
     <Popover
@@ -94,16 +110,18 @@ export function Combobox({
                 a slot is one-way: once set, nothing typeable commits "" again.
                 The extra words in `value` are just cmdk filter fodder.
               */}
-              <CommandItem
-                value={`__stock__ ${placeholder} none clear`}
-                onSelect={() => commit("")}
-                className="text-[12.5px]"
-              >
-                <Check
-                  className={cn("mr-2 h-3.5 w-3.5 flex-none", !value ? "opacity-100" : "opacity-0")}
-                />
-                <span className="truncate text-muted-foreground">{placeholder} (none)</span>
-              </CommandItem>
+              {allowEmpty && (
+                <CommandItem
+                  value={`__stock__ ${placeholder} none clear`}
+                  onSelect={() => commit("")}
+                  className="text-[12.5px]"
+                >
+                  <Check
+                    className={cn("mr-2 h-3.5 w-3.5 flex-none", !value ? "opacity-100" : "opacity-0")}
+                  />
+                  <span className="truncate text-muted-foreground">{placeholder} (none)</span>
+                </CommandItem>
+              )}
               {options.map((o) => (
                 <CommandItem
                   key={o}


### PR DESCRIPTION
Two bits of polish on the Rider tab's bike group, from #216.

## Searchable bike picker

It was a plain dropdown — a long scroll past dozens of bikes for a name you already know, and the odd one out sitting between two comboboxes. It now uses the same searchable field as the **Bike livery** and **Model swap** slots beside it.

Rather than adding a second searchable select, the shared `Combobox` grew two props:

- `allowCreate` — the "Use …" row that commits whatever you typed.
- `allowEmpty` — the "(none)" row that clears the slot.

Both are right for a *slot*, where an unknown name and an empty value are legitimate answers, and both are wrong for a picker that has to name one of the things in the list: a typed-in bike id resolves to no model, and an empty one blanks the preview. They default to `true`, so `SlotField` and the Paint Studio's destination picker are unchanged.

## Stock is the default model

With no model swap picked, the preview drew whatever swap happened to be on the bike. A look composed here is meant to be shared, and "what's on my disk right now" renders differently on everyone else's machine — so it now draws the game's own model unless you pick one.

Guarded on the scan actually offering Stock. A bike whose files are all packed has nothing loose to park, so no Stock row is listed for it — and its active model already *is* the packed one, which is what asking for Stock would have shown anyway. That also keeps a folder-installed bike with no `.pkz` behind it from asking for a Stock model that has no mesh to draw.

**Trade-off worth naming:** the preview is no longer a mirror of your install. A bike with a swap applied on disk previews as the stock model until you pick that swap in the slot.

## Verification

`bun run typecheck` and `eslint` clean over the touched files. No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)