### PR TITLE
fix(studio): give a rider profile's kit and gloves their sheet names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,28 @@
   paints nothing, which is only discovered in game. That boots mod now offers `fox` and
   `fox_n`, as it always should have. The same lookup answers whether a bike exists at all when
   it's installed as a bare `.pkz`, so a model-swap preview for one resolves too.
+- **A rider kit or a pair of gloves had no sheet names to start from.** `Rider+` and
+  `Rider+RolledUp` ship their `paints/` and `gloves/` folders empty on purpose — the kits
+  installed under the stock rider are the ones meant to be worn on them, which is already how
+  the preview dresses one. The Designer didn't know that, so painting for either profile began
+  with an empty expected-names line and nothing to create sheets from, and gloves had no source
+  of names at all. Both now read the stock profile's paints: `rider`, `rider_n`, `rider_r` for
+  a kit, `gloves`, `gloves_n`, `gloves_r` for gloves.
+- **Picking a rider profile could hang the Designer for a minute and a half.** With no paints
+  of its own to read, the app fell back to walking the profile's mesh for texture names — and
+  those two files are 67 MB each. Where iCloud or OneDrive had evicted them, asking what a
+  profile expects quietly kicked off a 134 MB download and answered 84 seconds later. Sheet
+  names are a convenience; an evicted mesh is now left alone and the paints answer instead, in
+  about a tenth of a second. The preview still fetches the model when it draws it, where the
+  wait buys a picture.
+
+### Removed
+
+- **The second "Goggles" destination.** The Studio offered goggles twice — the pair bought with
+  a helmet, and a pair shipped with the rider profile — and two buttons with the same word on
+  them is a coin toss over which folder a paint lands in. The helmet's is the one anybody means:
+  it's where a goggle mod installs and where every goggle paint in the shop is filed. Gloves,
+  which have no twin, are untouched.
 
 ## 2026-08-26 — v0.10.2 — Liveries that belong to a model, and a Windows that starts
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1305,6 +1305,33 @@ async fn paint_studio_hints(app: tauri::AppHandle, rel: String) -> Result<Vec<St
     .map_err(|e| format!("paint_studio_hints task failed: {e}"))?
 }
 
+/// How many paints are read for their names. A handful is plenty: paints for one model
+/// overwhelmingly supply the same names, and this runs every time the destination changes.
+const PAINT_SAMPLE: usize = 8;
+
+/// The texture names of the `.pnt` files sitting loose in `dir`, sampled.
+fn loose_paint_names(dir: &std::path::Path) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut seen = 0usize;
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return out;
+    };
+    for entry in rd.flatten() {
+        let p = entry.path();
+        if seen >= PAINT_SAMPLE || !p.extension().is_some_and(|e| e.eq_ignore_ascii_case("pnt")) {
+            continue;
+        }
+        // Seeked, not read: a bike's paints are tens of megabytes each and the names are
+        // in their headers. Reading eight of them whole put nineteen seconds between
+        // picking a model and being told what it wants.
+        if let Ok(found) = paint::texture_names_at(&p) {
+            out.extend(found);
+            seen += 1;
+        }
+    }
+    out
+}
+
 /// [`paint_studio_hints`] for a destination folder that's already been resolved.
 fn paint_hints(dir: &std::path::Path) -> Vec<String> {
     let mut names: Vec<String> = Vec::new();
@@ -1316,25 +1343,7 @@ fn paint_hints(dir: &std::path::Path) -> Vec<String> {
         }
     }
 
-    // A handful is plenty: paints for one model overwhelmingly supply the same names,
-    // and this runs every time the destination changes.
-    const SAMPLE: usize = 8;
-    let mut seen = 0usize;
-    if let Ok(rd) = std::fs::read_dir(dir) {
-        for entry in rd.flatten() {
-            let p = entry.path();
-            if seen >= SAMPLE || !p.extension().is_some_and(|e| e.eq_ignore_ascii_case("pnt")) {
-                continue;
-            }
-            // Seeked, not read: a bike's paints are tens of megabytes each and the names are
-            // in their headers. Reading eight of them whole put nineteen seconds between
-            // picking a model and being told what it wants.
-            if let Ok(found) = paint::texture_names_at(&p) {
-                add(&mut names, found);
-                seen += 1;
-            }
-        }
-    }
+    add(&mut names, loose_paint_names(dir));
     // Nothing installed loose: the model may be packed, and its own paints are the
     // same evidence. `<Model>.pkz` sits beside the `<Model>` folder this destination
     // lives in — for a bike as much as for a helmet.
@@ -1348,8 +1357,28 @@ fn paint_hints(dir: &std::path::Path) -> Vec<String> {
                     n.contains(&tail) && n.ends_with(".pnt")
                 };
                 let packed = pkz::read_selected(&pkz, want).unwrap_or_default();
-                for (_, bytes) in packed.iter().take(SAMPLE) {
+                for (_, bytes) in packed.iter().take(PAINT_SAMPLE) {
                     add(&mut names, paint::texture_names_any(bytes).unwrap_or_default());
+                }
+            }
+        }
+    }
+    // A rider profile that ships its folders empty wears the stock profile's kits.
+    //
+    // `Rider+` and `Rider+RolledUp` do exactly that on purpose — the kits installed under
+    // `default_mx` are meant to work on them, which is why `read_rider_paint_file` reaches
+    // there to render one. The names are the same names, so the hints have to reach there
+    // too, or painting for one of those profiles starts with nothing to call a sheet. It
+    // also spares the walk over the profile's own mesh, which for `Rider+` is 67 MB of
+    // rider read to learn what nine installed kits already say.
+    if names.is_empty() {
+        if let Some((sub, riders)) = dir.file_name().zip(dir.parent().and_then(|p| p.parent())) {
+            if riders.file_name().is_some_and(|n| n.eq_ignore_ascii_case(game::RIDERS_DIR)) {
+                for stock in game::active().rider.stock_profiles {
+                    add(&mut names, loose_paint_names(&riders.join(stock).join(&sub)));
+                    if !names.is_empty() {
+                        break;
+                    }
                 }
             }
         }
@@ -1381,13 +1410,21 @@ fn mesh_texture_names(model_dir: &std::path::Path) -> Vec<String> {
             let p = entry.path();
             if p.is_file() && p.file_name().and_then(|n| n.to_str()).is_some_and(bikefiles::is_mesh)
             {
+                // Reading one back from iCloud or OneDrive costs minutes, and this is a
+                // convenience: a rider profile whose two 67 MB meshes had been evicted put
+                // 84 seconds between picking it and seeing any sheet names. The preview
+                // fetches the model when it actually draws it — that wait buys a picture.
+                if cloudfiles::is_placeholder(&p) {
+                    log::info!("[paint studio] skipping evicted mesh {}", p.display());
+                    continue;
+                }
                 meshes.extend(read_gear_file(&p));
             }
         }
     }
     if meshes.is_empty() {
         let pkz = library::sibling_pkz(model_dir);
-        if pkz.is_file() {
+        if pkz.is_file() && !cloudfiles::is_placeholder(&pkz) {
             for (_, d) in pkz::read_selected(&pkz, bikefiles::is_mesh).unwrap_or_default() {
                 meshes.push(pkz::read_sidecar_blob(&d).unwrap_or(d));
             }
@@ -7682,6 +7719,51 @@ mod mesh_texture_tests {
         // was never unpacked, which is where a paint for a packed mod has to go.
         let dest = root.join("Fox Instinct 2.0 by Aeffertz").join("paints");
         assert_eq!(paint_hints(&dest), vec!["fox".to_string()]);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// `Rider+` and `Rider+RolledUp` ship `paints/` and `gloves/` empty on purpose: the kits
+    /// installed under the stock profile are the ones meant to be worn on them, which is
+    /// what `read_rider_paint_file` already does when it renders one. So the sheet names
+    /// have to come from there too — otherwise painting a kit or a pair of gloves for such
+    /// a profile starts with nothing to call the sheet, and a sheet named by guesswork
+    /// binds to nothing.
+    #[test]
+    fn a_profile_that_ships_no_paints_borrows_the_stock_ones() {
+        let root = std::env::temp_dir().join(format!("frost-stock-kit-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let riders = root.join("riders");
+        let mine = riders.join("Rider+");
+        std::fs::create_dir_all(mine.join("paints")).unwrap();
+        std::fs::create_dir_all(mine.join("gloves")).unwrap();
+
+        let pnt = |name: &str| {
+            crate::paint::encode(
+                "Stock",
+                &[crate::paint::PntTexture {
+                    name: name.to_string(),
+                    width: 4,
+                    height: 4,
+                    rgba: vec![0u8; 4 * 4 * 4],
+                }],
+            )
+            .unwrap()
+        };
+        let stock = riders.join("default_mx");
+        std::fs::create_dir_all(stock.join("paints")).unwrap();
+        std::fs::create_dir_all(stock.join("gloves")).unwrap();
+        std::fs::write(stock.join("paints").join("Kit.pnt"), pnt("rider")).unwrap();
+        std::fs::write(stock.join("gloves").join("Gloves.pnt"), pnt("gloves")).unwrap();
+
+        assert_eq!(paint_hints(&mine.join("paints")), vec!["rider".to_string()]);
+        assert_eq!(
+            paint_hints(&mine.join("gloves")),
+            vec!["gloves".to_string()],
+            "a gloves folder is never offered the mesh's names, so this is its only source",
+        );
+        // A profile with kits of its own is answered by those, not by the stock ones.
+        std::fs::write(mine.join("paints").join("Mine.pnt"), pnt("rider_mine")).unwrap();
+        assert_eq!(paint_hints(&mine.join("paints")), vec!["rider_mine".to_string()]);
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src/Components/Studio/paintDest.tsx
+++ b/src/Components/Studio/paintDest.tsx
@@ -68,19 +68,6 @@ const AREA_LABEL: Record<string, TKey> = {
   goggles: "paints.kind.goggles",
 };
 
-/**
- * Labels for the folders that hang off a rider profile, where the folder name alone would
- * collide with a gear area's.
- *
- * MX Bikes has goggles in two places and they are genuinely different destinations: a pair
- * bought with a helmet lives in `helmets/<helmet>/goggles`, and a pair that came with the rider
- * lives in `riders/<profile>/goggles`. Both are offered — two buttons reading "Goggles" would
- * be a coin toss over which folder a paint lands in.
- */
-const EXTRA_LABEL: Record<string, TKey> = {
-  goggles: "paints.kind.profileGoggles",
-};
-
 /** Which `RiderTargets` list holds the models of a gear folder. */
 const AREA_TARGETS: Record<string, keyof RiderTargets> = {
   helmets: "helmets",
@@ -152,13 +139,15 @@ export function kindsFor(game: GameInfo): PaintKindDef[] {
     }
   }
   kinds.push({ id: "kit", label: label(RIDERS), area: RIDERS, sub: "paints" });
-  for (const extra of game.riderProfileExtras) {
-    kinds.push({
-      id: `extra:${extra}`,
-      label: EXTRA_LABEL[extra] ?? label(extra),
-      area: RIDERS,
-      sub: extra,
-    });
+  // A profile's extras, minus the ones a gear area already offers under the same name.
+  //
+  // MX Bikes keeps goggles in two places — bought with a helmet, and shipped with the rider —
+  // and both are real folders, but two buttons reading "Goggles" is a coin toss over which one
+  // a paint lands in. The helmet's is the one anybody means: it's where a goggle mod installs,
+  // and where every goggle paint in the shop is filed. Gloves have no such twin, so they stay.
+  const offered = new Set(kinds.map((k) => k.sub));
+  for (const extra of game.riderProfileExtras.filter((e) => !offered.has(e))) {
+    kinds.push({ id: `extra:${extra}`, label: label(extra), area: RIDERS, sub: extra });
   }
   return kinds;
 }

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1688,7 +1688,6 @@ export const de: Translation = {
   "paints.kind.bike": "Bike-Design",
   "paints.kind.helmet": "Helm",
   "paints.kind.goggles": "Brille",
-  "paints.kind.profileGoggles": "Brille (Fahrer)",
   "paints.kind.boots": "Stiefel",
   "paints.kind.protection": "Protektoren",
   "paints.kind.kit": "Fahrer-Outfit",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1646,7 +1646,6 @@ export const en = {
   "paints.kind.bike": "Bike livery",
   "paints.kind.helmet": "Helmet",
   "paints.kind.goggles": "Goggles",
-  "paints.kind.profileGoggles": "Goggles (rider)",
   "paints.kind.boots": "Boots",
   "paints.kind.protection": "Protection",
   "paints.kind.kit": "Rider kit",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1674,7 +1674,6 @@ export const es: Translation = {
   "paints.kind.bike": "Decoración de moto",
   "paints.kind.helmet": "Casco",
   "paints.kind.goggles": "Gafas",
-  "paints.kind.profileGoggles": "Gafas (piloto)",
   "paints.kind.boots": "Botas",
   "paints.kind.protection": "Protecciones",
   "paints.kind.kit": "Equipación",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1679,7 +1679,6 @@ export const fr: Translation = {
   "paints.kind.bike": "Déco de moto",
   "paints.kind.helmet": "Casque",
   "paints.kind.goggles": "Masque",
-  "paints.kind.profileGoggles": "Masque (pilote)",
   "paints.kind.boots": "Bottes",
   "paints.kind.protection": "Protections",
   "paints.kind.kit": "Tenue du pilote",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1668,7 +1668,6 @@ export const it: Translation = {
   "paints.kind.bike": "Livrea moto",
   "paints.kind.helmet": "Casco",
   "paints.kind.goggles": "Maschera",
-  "paints.kind.profileGoggles": "Maschera (pilota)",
   "paints.kind.boots": "Stivali",
   "paints.kind.protection": "Protezioni",
   "paints.kind.kit": "Completo pilota",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1667,7 +1667,6 @@ export const ptBR: Translation = {
   "paints.kind.bike": "Pintura da moto",
   "paints.kind.helmet": "Capacete",
   "paints.kind.goggles": "Óculos",
-  "paints.kind.profileGoggles": "Óculos (piloto)",
   "paints.kind.boots": "Botas",
   "paints.kind.protection": "Proteções",
   "paints.kind.kit": "Kit do piloto",


### PR DESCRIPTION
Follow-up to #218, from the same round of testing: the Designer's sheet-name hints for rider profiles.

## Three things

**A profile that ships its folders empty had no names.** `Rider+` and `Rider+RolledUp` leave `paints/` and `gloves/` empty on purpose — the kits installed under the stock profile are what they wear, and `read_rider_paint_file` already reaches there to render one. The hints didn't, so a kit for either profile started with an empty expected-names line, and gloves had no source of names at all. Both now read the stock profile's paints.

**Picking a profile could stall for a minute and a half.** With nothing installed to read, hints fell through to walking the profile's own mesh — two 67MB files. Where iCloud or OneDrive had evicted them, that quietly kicked off a 134MB download and answered 84 seconds later. Sheet names are a convenience, so an evicted mesh is now skipped (`cloudfiles::is_placeholder`, which both platforms already answer) and the paints answer instead. The preview still fetches the model when it draws it, where the wait buys a picture.

**Goggles appeared twice.** The Studio offered the pair bought with a helmet and the pair shipped with the rider profile, both labelled Goggles — a coin toss over which folder a paint lands in. A profile extra whose folder a gear area already offers is no longer listed. Gloves have no twin and are untouched.

## Verified on a real tree

| destination | before | after |
|---|---|---|
| `riders/Rider+RolledUp/paints` | ~2 min iCloud fetch | `rider, rider_n, rider_r` — 119ms |
| `riders/Rider+RolledUp/gloves` | `[]` | `gloves, gloves_n, gloves_r` — 407ms |
| `riders/Rider+/gloves` | `[]` | `gloves, gloves_n, gloves_r` — 370ms |
| `riders/Rider+/paints` | 84s | those names plus `face_parts`, `rider_r` — 430ms |
| `boots/Fox Instinct 2.0…/paints` | `[]` (fixed by #218) | `fox, fox_n` — 150ms |
| `helmets/Airoh_Aviator_3_Armega/paints` | unchanged | unchanged — 130ms |

`Rider+/paints` gains rather than loses: the stock names and the mesh's names union, since the mesh walk still runs when the file is local.

New test `a_profile_that_ships_no_paints_borrows_the_stock_ones` covers the fallback and that a profile with kits of its own is still answered by those. 850 tests pass, `tsc` and eslint clean, `cargo check --target x86_64-pc-windows-gnu` clean.

No schema or migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)