### PR TITLE
feat(viewer): let a bike be posed on its own joints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 ## 2026-08-26
 
 ### Added
+- **Stand a bike the way you want to see it.** The 3D preview drew every bike in the frame it
+  was *authored* in, which is not a stance it ever holds on the ground — a `.geom` carries no
+  suspension travel at all, and ride height falls out of physics the viewer doesn't run. So
+  bikes stood with the shock apparently collapsed and the rear wheel riding high. The preview
+  now knows the bike's own joints and lets you move them: **Rear** swings the swingarm about
+  its pivot, **Front** slides the fork up its own raked axis, **Steering** turns the bars and
+  the front wheel with them, all in millimetres and degrees of the real thing.
+  - **Level wheels** solves the rear for you — both tyres touching the same ground, measured
+    at the contact patches rather than the axles, since a 21" front and a 19" rear aren't level
+    when their axles are. A bike wearing wheels is drawn that way to begin with, so it stands
+    right without anyone touching a slider; **Reset** puts it back as authored.
+  - The panel is in the expanded preview and the full-screen viewer. A bike whose `.geom`
+    names no mounts has no joints to move and renders exactly as it did before.
+
 - **Mirror a layer to the other side of the bike.** Place a decal on the right shroud, hit
   Mirror, and a copy lands at the same spot on the left one. The place is worked out from the
   model rather than by flipping the sheet — the two flanks are unwrapped wherever the modeller

--- a/src-tauri/src/edf.rs
+++ b/src-tauri/src/edf.rs
@@ -276,24 +276,119 @@ fn rot_x(p: [f32; 3], deg: f32) -> [f32; 3] {
     [p[0], p[1] * c - p[2] * s, p[1] * s + p[2] * c]
 }
 
+// Where every part of a bike hangs off, resolved from the .geom once.
+struct Mounts {
+    // Rake tilts the steering head back, i.e. toward -Z (front is +Z). Degrees, as rot_x takes.
+    rake: f32,
+    head: [f32; 3],
+    pivot: [f32; 3],
+    steer_joint: [f32; 3],
+    rsusp_joint: [f32; 3],
+    fork_origin: [f32; 3],
+}
+
+fn mounts(
+    g: &std::collections::HashMap<String, [f32; 3]>,
+    sc: &std::collections::HashMap<String, f32>,
+) -> Option<Mounts> {
+    let head = *g.get("chassis_steer")?;
+    let pivot = *g.get("chassis_rsusp_min")?;
+    let steer_joint = *g.get("steer_joint")?;
+    let rsusp_joint = *g.get("rsusp_joint")?;
+    let front_upper = *g.get("front_upper")?;
+    let rake = -sc.get("rakeangle_min").copied().unwrap_or(0.0);
+    let fork_origin = v_add(rot_x(v_sub(front_upper, steer_joint), rake), head);
+    Some(Mounts { rake, head, pivot, steer_joint, rsusp_joint, fork_origin })
+}
+
+impl Mounts {
+    /// (front, rear) axle, in the assembled bike's frame.
+    ///
+    /// Front is the fork's `fwheel` point carried down the raked fork. Rear is the swingarm's,
+    /// taken at the midpoint of the chain-adjuster range the .geom gives as `rwheel_min`/
+    /// `rwheel_max`. `None` when the .geom names neither — a bike we can still assemble but
+    /// can't say where the wheels ride on.
+    fn axles(&self, g: &std::collections::HashMap<String, [f32; 3]>) -> Option<([f32; 3], [f32; 3])> {
+        let fwheel = *g.get("fwheel")?;
+        let lo = *g.get("rwheel_min")?;
+        let hi = g.get("rwheel_max").copied().unwrap_or(lo);
+        let rear = [(lo[0] + hi[0]) * 0.5, (lo[1] + hi[1]) * 0.5, (lo[2] + hi[2]) * 0.5];
+        Some((
+            v_add(rot_x(fwheel, self.rake), self.fork_origin),
+            v_add(rear, v_sub(self.pivot, self.rsusp_joint)),
+        ))
+    }
+}
+
+/// The joints an assembled bike can be posed about, in the frame its vertices come back in.
+///
+/// The .geom places the parts in the frame the bike was *authored* in, and says nothing about
+/// where the suspension rides at rest — there is no travel in the file, only a setup range
+/// (`chassis_rsusp_min`/`_max`, tenths of a millimetre apart) and the chain-adjuster slot
+/// (`rwheel_min`/`_max`). Ride height falls out of the physics, which the viewer doesn't run.
+/// So the viewer is handed the joints instead and lets the user move them: the swingarm turns
+/// about `pivot`, the fork slides along the axis `rake` tilts through `steer_head`, and the
+/// axles say where the wheels ride so a pose can be solved for level.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BikeRig {
+    /// Swingarm pivot.
+    pub pivot: [f32; 3],
+    /// A point on the steering axis (the head itself).
+    pub steer_head: [f32; 3],
+    /// Rake, in degrees, tilting the steering axis back from vertical.
+    pub rake: f32,
+    pub front_axle: Option<[f32; 3]>,
+    pub rear_axle: Option<[f32; 3]>,
+}
+
+impl BikeRig {
+    /// Shift every point by the same amount the vertices were shifted by when the assembled
+    /// bike was centred, so the rig and the mesh stay in one frame.
+    fn recentre(&mut self, c: [f32; 3]) {
+        self.pivot = v_sub(self.pivot, c);
+        self.steer_head = v_sub(self.steer_head, c);
+        self.front_axle = self.front_axle.map(|p| v_sub(p, c));
+        self.rear_axle = self.rear_axle.map(|p| v_sub(p, c));
+    }
+
+    /// Follow the mesh into three.js' frame — see [`to_right_handed`], which must have been
+    /// run on the nodes for this to be the right thing to do.
+    ///
+    /// Points mirror; `rake` doesn't. The mirror negates x alone, and both the fork axis
+    /// (x = 0) and the rotation about it act purely on y/z, so the angle carries over as it
+    /// stands and reads as a three.js `rotation.x` of the same sign.
+    pub fn to_right_handed(&mut self) {
+        self.pivot[0] = -self.pivot[0];
+        self.steer_head[0] = -self.steer_head[0];
+        if let Some(p) = self.front_axle.as_mut() {
+            p[0] = -p[0];
+        }
+        if let Some(p) = self.rear_axle.as_mut() {
+            p[0] = -p[0];
+        }
+    }
+}
+
 // Assemble a bike's parts onto its chassis via the .geom mount points, then centre
-// on the origin. Returns false (nodes untouched) if the .geom lacks the mounts.
-pub fn assemble_bike(nodes: &mut [EdfNode], geom_bytes: &[u8]) -> bool {
+// on the origin. `None` (nodes untouched) if the .geom lacks the mounts.
+pub fn assemble_bike(nodes: &mut [EdfNode], geom_bytes: &[u8]) -> Option<BikeRig> {
     let g = parse_geom(geom_bytes);
     let sc = parse_geom_scalars(geom_bytes);
-    let (Some(&head), Some(&pivot), Some(&steer_joint), Some(&rsusp_joint), Some(&front_upper)) = (
-        g.get("chassis_steer"),
-        g.get("chassis_rsusp_min"),
-        g.get("steer_joint"),
-        g.get("rsusp_joint"),
-        g.get("front_upper"),
-    ) else {
-        return false;
+    let Some(m) = mounts(&g, &sc) else {
+        return None;
     };
-    // Rake tilts the steering head back, i.e. toward -Z (front is +Z).
-    let rake = -sc.get("rakeangle_min").copied().unwrap_or(0.0);
-    let place_steer = |p: [f32; 3]| v_add(rot_x(v_sub(p, steer_joint), rake), head);
-    let fork_origin = place_steer(front_upper);
+    let (head, pivot, steer_joint, rsusp_joint, rake) =
+        (m.head, m.pivot, m.steer_joint, m.rsusp_joint, m.rake);
+    let fork_origin = m.fork_origin;
+    let axles = m.axles(&g);
+    let mut rig = BikeRig {
+        pivot,
+        steer_head: head,
+        rake,
+        front_axle: axles.map(|(f, _)| f),
+        rear_axle: axles.map(|(_, r)| r),
+    };
 
     for n in nodes.iter_mut() {
         // An unplaced part is still in raw authored space — the .geom mounts don't apply.
@@ -334,7 +429,7 @@ pub fn assemble_bike(nodes: &mut [EdfNode], geom_bytes: &[u8]) -> bool {
         }
     }
     if lo[0] > hi[0] {
-        return true;
+        return Some(rig);
     }
     let c = [
         (lo[0] + hi[0]) * 0.5,
@@ -348,7 +443,8 @@ pub fn assemble_bike(nodes: &mut [EdfNode], geom_bytes: &[u8]) -> bool {
             }
         }
     }
-    true
+    rig.recentre(c);
+    Some(rig)
 }
 
 // A node name at `o`: 2-31 name-safe chars starting with a letter, else None.
@@ -1437,6 +1533,105 @@ mod tests {
         assert_eq!(m.get("steer_joint"), Some(&[0.0, 0.0412, -0.0372]));
         assert!(!m.contains_key("rsusp_type")); // non-vector line ignored
         assert!(!m.contains_key("chain_pitch")); // single scalar ignored
+    }
+
+    /// The mount points of a real bike (MX1OEM_1996_Honda_CR250), trimmed to the lines the
+    /// rig is built from. Kept verbatim so the numbers below can be checked against the
+    /// bike's published spec rather than against this test.
+    const CR250_GEOM: &[u8] = b"type = bike\n\
+chassis_steer = 0, 0.9591, 0.3317\n\
+chassis_rsusp_min = 0, 0.401, -0.219\n\
+rakeangle_min = 27.2\n\
+steer_joint = 0, 0.0025, -0.0229\n\
+front_upper = 0, -0.4032, -0.0026\n\
+fwheel = 0, -0.2046, 0.0147\n\
+rsusp_joint = 0, 0.0004, 0.0558\n\
+rwheel_min = 0, 0.0118, -0.4985\n\
+rwheel_max = 0, 0.0122, -0.5359\n";
+
+    /// A node of loose points, already in its part's local frame — the shape `assemble_bike`
+    /// mounts. What comes back is where those points landed.
+    fn mount_node(name: &str, points: &[[f32; 3]]) -> EdfNode {
+        EdfNode {
+            name: name.into(),
+            positions: points.iter().flatten().copied().collect(),
+            uvs: Vec::new(),
+            normals: Vec::new(),
+            indices: Vec::new(),
+            submeshes: Vec::new(),
+            texture: None,
+            placed: true,
+            materials: Vec::new(),
+        }
+    }
+
+    fn vertex(n: &EdfNode, i: usize) -> [f32; 3] {
+        [n.positions[i * 3], n.positions[i * 3 + 1], n.positions[i * 3 + 2]]
+    }
+
+    fn close(a: [f32; 3], b: [f32; 3], tol: f32) -> bool {
+        (0..3).all(|k| (a[k] - b[k]).abs() < tol)
+    }
+
+    /// The axles are what a stance is solved against, and nothing in the mesh says where they
+    /// are — only the .geom does. Checked against the real bike: a 1996 CR250R's wheelbase is
+    /// about 1450 mm.
+    #[test]
+    fn rig_axles_land_a_real_wheelbase_apart() {
+        let mut nodes = [mount_node("chassis", &[[0.0, 0.0, 0.0], [0.0, 1.0, 0.5]])];
+        let rig = assemble_bike(&mut nodes, CR250_GEOM).expect("the .geom has every mount");
+        let (front, rear) = (rig.front_axle.expect("front"), rig.rear_axle.expect("rear"));
+        let wheelbase = front[2] - rear[2];
+        assert!(
+            (wheelbase - 1.434).abs() < 0.03,
+            "wheelbase {wheelbase} m is not a 250's"
+        );
+        // Both axles on the bike's centreline, and within a wheel's worth of the same height —
+        // a rig that had the rear swung out would pass the wheelbase check and nothing else.
+        assert!(front[0].abs() < 1e-4 && rear[0].abs() < 1e-4);
+        assert!((front[1] - rear[1]).abs() < 0.05, "axles {front:?} {rear:?}");
+    }
+
+    /// The rig names points *on the mesh*, so it has to survive the centring the mesh gets:
+    /// a vertex sitting exactly on the swingarm pivot must still be on `rig.pivot` afterwards.
+    /// Off by the centring shift, every pose would swing about a point in mid-air.
+    #[test]
+    fn rig_lands_in_the_frame_the_mesh_came_back_in() {
+        let g = parse_geom(CR250_GEOM);
+        // The swingarm's own joint: assembly puts this vertex on the chassis' pivot.
+        let joint = g["rsusp_joint"];
+        let mut nodes = [
+            mount_node("chassis", &[[0.0, 0.0, 0.0], [0.0, 1.2, 0.9]]),
+            mount_node("rsusp", &[joint]),
+        ];
+        let rig = assemble_bike(&mut nodes, CR250_GEOM).expect("assembled");
+        assert!(
+            close(vertex(&nodes[1], 0), rig.pivot, 1e-4),
+            "pivot {:?} left the mesh's {:?}",
+            rig.pivot,
+            vertex(&nodes[1], 0)
+        );
+    }
+
+    /// …and the same again through the mirror into three.js' frame.
+    #[test]
+    fn rig_follows_the_mesh_into_the_right_handed_frame() {
+        let g = parse_geom(CR250_GEOM);
+        let joint = g["rsusp_joint"];
+        let mut nodes = [
+            // Off the centreline, so a mirror that did nothing would be caught.
+            mount_node("chassis", &[[0.3, 0.0, 0.0], [-0.1, 1.2, 0.9]]),
+            mount_node("rsusp", &[[joint[0] + 0.25, joint[1], joint[2]]]),
+        ];
+        let mut rig = assemble_bike(&mut nodes, CR250_GEOM).expect("assembled");
+        let before = rig.pivot;
+        to_right_handed(&mut nodes);
+        rig.to_right_handed();
+        assert!((rig.pivot[0] + before[0]).abs() < 1e-6, "x should have flipped");
+        assert_eq!(rig.pivot[1], before[1]);
+        // The swingarm vertex sits 0.25 m off the pivot either side of the mirror.
+        let d = vertex(&nodes[1], 0)[0] - rig.pivot[0];
+        assert!((d + 0.25).abs() < 1e-4, "mesh and rig disagree after mirroring: {d}");
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1467,6 +1467,12 @@ struct BikeModel {
     /// nothing about where it is on the bike. The Designer names the flank a sheet region
     /// paints from the sign of x, and that answer is only worth giving once this is true.
     assembled: bool,
+    /// The joints this bike can be posed about, in the frame `nodes` came back in.
+    ///
+    /// `None` for a bike that wasn't assembled — there is nothing to pose a pile of parts
+    /// that are each still in their own frame. See [`edf::BikeRig`] for why the viewer poses
+    /// at all rather than drawing one settled stance.
+    rig: Option<edf::BikeRig>,
 }
 
 impl BikeModel {
@@ -1733,22 +1739,27 @@ fn build_bike_model(
     // Whether the parts ended up in one frame. Logged rather than printed: it decides what the
     // Designer may say about a sheet's flanks, so "was this bike assembled?" has to be
     // answerable from the log file after the fact, not only from a terminal nobody kept.
-    let assembled = match geom {
+    let mut rig = match geom {
         Some(g) => {
-            let ok = edf::assemble_bike(&mut nodes, g);
-            if !ok {
+            let rig = edf::assemble_bike(&mut nodes, g);
+            if rig.is_none() {
                 log::warn!("[viewer] {label}: .geom present but missing mount points — parts unassembled");
             }
-            ok
+            rig
         }
         None => {
             if !nodes.is_empty() {
                 log::warn!("[viewer] {label}: no .geom alongside the mesh — parts unassembled");
             }
-            false
+            None
         }
     };
+    let assembled = rig.is_some();
     edf::to_right_handed(&mut nodes);
+    // The rig names points on the mesh, so it goes through the same mirror the mesh does.
+    if let Some(r) = rig.as_mut() {
+        r.to_right_handed();
+    }
     // Nothing to draw. Returning a model with no nodes is worse than failing: the viewer reads
     // it as a successful load and puts its stand-in bike on screen, which reads as "this is your
     // bike" rather than "none of this bike arrived". A cloud-synced archive that hasn't been
@@ -1880,7 +1891,7 @@ fn build_bike_model(
         log::info!("  node '{}' placed={} {}", n.name, n.placed, subs.join(", "));
     }
 
-    let model = BikeModel { nodes, paints, base: model_base, assembled };
+    let model = BikeModel { nodes, paints, base: model_base, assembled, rig };
     if let Ok(mut c) = bike_cache().lock() {
         // The evicted bike's pixels go with it — nothing else references them.
         if let Some(dropped) = c.insert(key, model.clone()) {
@@ -8136,6 +8147,7 @@ mod viewer_tests {
             }],
             base: vec![tex("plastics", "t-own"), tex("wheel", "t-shared")],
             assembled: true,
+            rig: None,
         };
         let tokens = model.tokens();
         assert!(tokens.contains(&"t-own".to_string()), "the overridden one is still released");

--- a/src/Components/Studio/Designer/controls.tsx
+++ b/src/Components/Studio/Designer/controls.tsx
@@ -1,55 +1,8 @@
 import { useState } from "react";
 
-/**
- * The controls the designer's side panels are made of.
- *
- * Shared rather than copied so the layer inspector and the paint tools stay identical instead
- * of merely similar — they sit one above the other in the same rail, and a row that lines up
- * differently in each reads as a bug.
- */
-
-/** A labelled row. The panels are nothing but these, so it earns its own component. */
-export function Row({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <label className="flex items-center gap-2">
-      <span className="w-[68px] flex-none text-[11px] text-muted-foreground">{label}</span>
-      <span className="flex min-w-0 flex-1 items-center gap-1.5">{children}</span>
-    </label>
-  );
-}
-
-export function Slider({
-  value,
-  min,
-  max,
-  step,
-  onChange,
-  format,
-}: {
-  value: number;
-  min: number;
-  max: number;
-  step: number;
-  onChange: (v: number) => void;
-  format: (v: number) => string;
-}) {
-  return (
-    <>
-      <input
-        type="range"
-        min={min}
-        max={max}
-        step={step}
-        value={value}
-        onChange={(e) => onChange(Number(e.target.value))}
-        className="h-1 min-w-0 flex-1 accent-primary"
-      />
-      <span className="w-[44px] flex-none text-right text-[11px] tabular-nums text-muted-foreground">
-        {format(value)}
-      </span>
-    </>
-  );
-}
+// `Row` and `Slider` moved to the shared ui controls once the 3D viewer's pose panel wanted
+// the same rows; re-exported here so the Designer's own imports read as they always have.
+export { Row, Slider } from "@/Components/ui/controls";
 
 /**
  * A number typed rather than dragged.

--- a/src/Components/Viewer/ModelViewer.tsx
+++ b/src/Components/Viewer/ModelViewer.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Canvas, useThree } from "@react-three/fiber";
 import { OrbitControls, Center, ContactShadows } from "@react-three/drei";
-import { Move, Rotate3d, ZoomIn } from "lucide-react";
+import { ChevronDown, Move, Rotate3d, SlidersHorizontal, ZoomIn } from "lucide-react";
 import * as THREE from "three";
 import { cn } from "@/lib/utils";
-import type { EdfNode, PaintTexture, RiderPart } from "../../types";
+import { Row, Slider } from "@/Components/ui/controls";
+import type { BikeRig, EdfNode, PaintTexture, RiderPart, Vec3 } from "../../types";
 import { textureBytes } from "../../api/mods";
 import { ErrorBoundary } from "../ErrorBoundary";
 import { useT } from "../../i18n/context";
@@ -899,13 +900,25 @@ function useEdfMeshes(
  * the parts in front of it: a panel glowing *through* the bike would read as being on the near
  * side whichever flank it is actually on, which is the confusion this exists to settle.
  */
-function HighlightMesh({ nodes, tris }: { nodes: EdfNode[]; tris: Int32Array }) {
+function HighlightMesh({
+  nodes,
+  tris,
+  groups,
+  want,
+}: {
+  nodes: EdfNode[];
+  tris: Int32Array;
+  /** Each node's pose group — see {@link poseGroup}. */
+  groups: PoseGroup[];
+  /** Draw only the triangles of nodes in this group, so the rest stay with their own part. */
+  want: PoseGroup;
+}) {
   const geom = useMemo(() => {
     const pos = new Float32Array((tris.length / 2) * 9);
     let o = 0;
     for (let i = 0; i < tris.length; i += 2) {
       const node = nodes[tris[i]];
-      if (!node) continue;
+      if (!node || groups[tris[i]] !== want) continue;
       const t = tris[i + 1];
       for (let c = 0; c < 3; c += 1) {
         const v = node.indices[t * 3 + c];
@@ -919,7 +932,7 @@ function HighlightMesh({ nodes, tris }: { nodes: EdfNode[]; tris: Int32Array }) 
     g.setAttribute("position", new THREE.Float32BufferAttribute(pos.subarray(0, o), 3));
     g.computeBoundingSphere();
     return g;
-  }, [nodes, tris]);
+  }, [nodes, tris, groups, want]);
   useEffect(() => () => geom.dispose(), [geom]);
 
   const mat = useMemo(
@@ -943,29 +956,212 @@ function HighlightMesh({ nodes, tris }: { nodes: EdfNode[]; tris: Int32Array }) 
   return <mesh geometry={geom} material={mat} renderOrder={2} />;
 }
 
+/**
+ * How a bike is standing: the three joints its `.geom` gives, in the units the controls show.
+ *
+ * All zero is the bike exactly as the `.geom` assembled it — the frame it was *authored* in,
+ * which is not a stance it ever holds on the ground. See {@link BikeRig}.
+ */
+export interface BikePose {
+  /** How far the rear axle hangs below where it was authored, in mm. */
+  rearDrop: number;
+  /** How far the fork is pushed up its own axis, in mm. */
+  forkUp: number;
+  /** Steering angle, in degrees. */
+  steer: number;
+}
+
+export const NEUTRAL_POSE: BikePose = { rearDrop: 0, forkUp: 0, steer: 0 };
+
+/** Which part of the bike moves with which joint. */
+type PoseGroup = "static" | "swing" | "steer" | "fork";
+
+/**
+ * Which pose group a node belongs to, read off the same name prefixes `assemble_bike` mounts
+ * it by — so the two can only agree. `steer` is the triple clamps and bars; `fork` is the
+ * sliding leg the wheel hangs off, which is why it moves inside the steering group.
+ */
+function poseGroup(name: string): PoseGroup {
+  const n = name.toLowerCase();
+  if (n.startsWith("rsusp") || n.startsWith("rwheel")) return "swing";
+  if (n.startsWith("fsusp") || n.startsWith("fwheel")) return "fork";
+  if (n.startsWith("steer")) return "steer";
+  return "static";
+}
+
+const X_AXIS = new THREE.Vector3(1, 0, 0);
+
+/** The fork/steering axis: straight up, tilted back by the rake. */
+function forkAxis(rake: number): THREE.Vector3 {
+  const r = rake * THREE.MathUtils.DEG2RAD;
+  return new THREE.Vector3(0, Math.cos(r), Math.sin(r));
+}
+
+function wrapPi(a: number): number {
+  return Math.atan2(Math.sin(a), Math.cos(a));
+}
+
+/**
+ * The swingarm rotation that puts the rear axle at `targetY`, or null where it can't reach.
+ *
+ * The axle rides a circle about the pivot, so `y(θ) = pivotY + dy·cosθ − dz·sinθ` — a single
+ * cosine of amplitude `hypot(dy, dz)`. Two rotations hit any height inside that; the one
+ * nearest as-authored is the one meant, the other swings the wheel over the seat.
+ */
+function swingAngleForAxleY(rig: BikeRig, targetY: number): number | null {
+  if (!rig.rearAxle) return null;
+  const dy = rig.rearAxle[1] - rig.pivot[1];
+  const dz = rig.rearAxle[2] - rig.pivot[2];
+  const r = Math.hypot(dy, dz);
+  const k = targetY - rig.pivot[1];
+  if (r < 1e-6 || Math.abs(k) > r) return null;
+  const phi = Math.atan2(dz, dy);
+  const a = Math.acos(k / r);
+  const both = [wrapPi(a - phi), wrapPi(-a - phi)];
+  return both.reduce((best, x) => (Math.abs(x) < Math.abs(best) ? x : best));
+}
+
+/**
+ * A wheel's radius, off the mesh rather than off a number we'd have to keep: the tyre is
+ * authored about its own axle, so half its height is what it rolls on. Null when the bike
+ * has no such wheel — a mod whose tyres aren't installed, or any bike before the wheels went
+ * on at all.
+ */
+function wheelRadius(nodes: EdfNode[], prefix: string): number | null {
+  let lo = Infinity;
+  let hi = -Infinity;
+  for (const n of nodes) {
+    if (!n.name.toLowerCase().startsWith(prefix)) continue;
+    for (let i = 1; i < n.positions.length; i += 3) {
+      lo = Math.min(lo, n.positions[i]);
+      hi = Math.max(hi, n.positions[i]);
+    }
+  }
+  return hi > lo ? (hi - lo) / 2 : null;
+}
+
+/** As far as the rear may be dropped or squatted from as-authored, in mm. */
+const REAR_LIMIT_MM = 140;
+
+/**
+ * The rear drop that stands the bike level — both tyres touching the same ground.
+ *
+ * Contact points, not axles: a 21" front and a 19" rear are not level when their axles are.
+ * Null when there is nothing to solve against — no axles in the `.geom`, no wheel meshes, or
+ * a bike whose swingarm can't reach that far — and the bike then stands as it was authored,
+ * which is exactly how it stood before any of this.
+ */
+function levelRearDrop(
+  rig: BikeRig | null | undefined,
+  nodes: EdfNode[],
+  forkUpM: number,
+): number | null {
+  if (!rig?.frontAxle || !rig.rearAxle) return null;
+  const rf = wheelRadius(nodes, "fwheel");
+  const rr = wheelRadius(nodes, "rwheel");
+  if (rf == null || rr == null) return null;
+  const frontY = rig.frontAxle[1] + forkAxis(rig.rake).y * forkUpM;
+  const targetY = frontY - rf + rr;
+  const angle = swingAngleForAxleY(rig, targetY);
+  if (angle == null) return null;
+  const drop = (rig.rearAxle[1] - targetY) * 1000;
+  return Math.abs(drop) > REAR_LIMIT_MM ? null : drop;
+}
+
+/** The stance a bike is first drawn in: level if it can be solved, as-authored if not. */
+function settledPose(rig: BikeRig | null | undefined, nodes: EdfNode[]): BikePose {
+  if (!rig) return NEUTRAL_POSE;
+  const drop = levelRearDrop(rig, nodes, 0);
+  return drop == null ? NEUTRAL_POSE : { ...NEUTRAL_POSE, rearDrop: drop };
+}
+
+/** Turn a group about a point that isn't the origin. */
+function About({
+  at,
+  q,
+  children,
+}: {
+  at: Vec3;
+  q: THREE.Quaternion;
+  children: React.ReactNode;
+}) {
+  return (
+    <group position={at}>
+      <group quaternion={q}>
+        <group position={[-at[0], -at[1], -at[2]]}>{children}</group>
+      </group>
+    </group>
+  );
+}
+
 // MX Bikes meshes are authored Y-up, +Z forward (three.js' convention) — no rotation.
 function EdfMesh({
   nodes,
   textures,
   highlight,
+  rig,
+  pose = NEUTRAL_POSE,
 }: {
   nodes: EdfNode[];
   textures: Map<string, THREE.Texture>;
   highlight?: Int32Array | null;
+  /** The joints to pose about. Absent (an unassembled bike, or gear) draws one rigid group. */
+  rig?: BikeRig | null;
+  pose?: BikePose;
 }) {
   const { geoms, materials } = useEdfMeshes(nodes, textures);
+  const groups = useMemo<PoseGroup[]>(
+    () => nodes.map((n) => (rig ? poseGroup(n.name) : "static")),
+    [nodes, rig],
+  );
+
+  const swingQ = useMemo(() => {
+    const target = rig?.rearAxle ? rig.rearAxle[1] - pose.rearDrop / 1000 : null;
+    const a = rig && target !== null ? swingAngleForAxleY(rig, target) : null;
+    return new THREE.Quaternion().setFromAxisAngle(X_AXIS, a ?? 0);
+  }, [rig, pose.rearDrop]);
+  const axis = useMemo(() => forkAxis(rig?.rake ?? 0), [rig?.rake]);
+  const steerQ = useMemo(
+    () => new THREE.Quaternion().setFromAxisAngle(axis, pose.steer * THREE.MathUtils.DEG2RAD),
+    [axis, pose.steer],
+  );
+  const forkAt = useMemo<Vec3>(() => {
+    const v = axis.clone().multiplyScalar(pose.forkUp / 1000);
+    return [v.x, v.y, v.z];
+  }, [axis, pose.forkUp]);
+
+  const part = (want: PoseGroup) => (
+    <>
+      {geoms.map((g, i) =>
+        groups[i] === want ? (
+          <mesh
+            key={i}
+            geometry={g}
+            material={materials[i].length === 1 ? materials[i][0] : materials[i]}
+            castShadow
+            receiveShadow
+          />
+        ) : null,
+      )}
+      {!!highlight?.length && (
+        <HighlightMesh nodes={nodes} tris={highlight} groups={groups} want={want} />
+      )}
+    </>
+  );
+
+  // No rig: every node is "static", so this is the one flat group it has always been.
+  if (!rig) return <group>{part("static")}</group>;
   return (
     <group>
-      {geoms.map((g, i) => (
-        <mesh
-          key={i}
-          geometry={g}
-          material={materials[i].length === 1 ? materials[i][0] : materials[i]}
-          castShadow
-          receiveShadow
-        />
-      ))}
-      {!!highlight?.length && <HighlightMesh nodes={nodes} tris={highlight} />}
+      {part("static")}
+      <About at={rig.pivot} q={swingQ}>
+        {part("swing")}
+      </About>
+      <About at={rig.steerHead} q={steerQ}>
+        {part("steer")}
+        {/* Inside the steering group: the fork slides along the axis the bars turn about. */}
+        <group position={forkAt}>{part("fork")}</group>
+      </About>
     </group>
   );
 }
@@ -1004,12 +1200,16 @@ function SideBySide({
   highlight,
   parts,
   overrides,
+  rig,
+  pose,
 }: {
   nodes: EdfNode[];
   textures: Map<string, THREE.Texture>;
   highlight?: Int32Array | null;
   parts: RiderPart[];
   overrides?: Map<string, THREE.Texture>;
+  rig?: BikeRig | null;
+  pose?: BikePose;
 }) {
   const at = useMemo(() => {
     const bike = partBounds(nodes);
@@ -1025,7 +1225,13 @@ function SideBySide({
   return (
     <group>
       <group position={at.bike}>
-        <EdfMesh nodes={nodes} textures={textures} highlight={highlight} />
+        <EdfMesh
+          nodes={nodes}
+          textures={textures}
+          highlight={highlight}
+          rig={rig}
+          pose={pose}
+        />
       </group>
       <group position={at.rider}>
         <RiderComposite parts={parts} overrides={overrides} />
@@ -1071,6 +1277,97 @@ function CameraRig({ frame }: { frame: Framing }) {
 
 // Legend for the OrbitControls gestures below — the canvas gives no other clue
 // that it's draggable. Kept muted so it reads as chrome, never competing with the model.
+/**
+ * The pose panel: the bike's own joints, on sliders.
+ *
+ * Sliders in millimetres of wheel movement rather than in joint angles — how far the rear
+ * wheel hangs is a thing anyone can see, where "8.4° of swingarm" is a thing only the maths
+ * knows. {@link swingAngleForAxleY} turns the one into the other.
+ */
+function PoseControls({
+  pose,
+  onChange,
+  onLevel,
+  onReset,
+}: {
+  pose: BikePose;
+  onChange: (p: BikePose) => void;
+  /** Absent when the bike gives nothing to level against — no axles, or no wheels on it. */
+  onLevel?: () => void;
+  onReset: () => void;
+}) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  const mm = (v: number) => `${Math.round(v)}mm`;
+  return (
+    <div className="absolute bottom-2 right-2 w-[230px] rounded-md border border-white/10 bg-black/60 text-white/80 backdrop-blur-sm">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center gap-1.5 px-2 py-1.5 text-[11px] font-medium leading-none text-white/70 hover:text-white"
+      >
+        <SlidersHorizontal className="h-3.5 w-3.5" />
+        {t("viewer.pose")}
+        <ChevronDown
+          className={cn("ml-auto h-3.5 w-3.5 transition-transform", open && "rotate-180")}
+        />
+      </button>
+      {open && (
+        <div className="flex flex-col gap-1.5 border-t border-white/10 px-2 py-2">
+          <Row label={t("viewer.poseRear")}>
+            <Slider
+              value={pose.rearDrop}
+              min={-REAR_LIMIT_MM}
+              max={REAR_LIMIT_MM}
+              step={1}
+              onChange={(v) => onChange({ ...pose, rearDrop: v })}
+              format={mm}
+            />
+          </Row>
+          <Row label={t("viewer.poseFront")}>
+            <Slider
+              value={pose.forkUp}
+              min={-60}
+              max={180}
+              step={1}
+              onChange={(v) => onChange({ ...pose, forkUp: v })}
+              format={mm}
+            />
+          </Row>
+          <Row label={t("viewer.poseSteer")}>
+            <Slider
+              value={pose.steer}
+              min={-40}
+              max={40}
+              step={1}
+              onChange={(v) => onChange({ ...pose, steer: v })}
+              format={(v) => `${Math.round(v)}°`}
+            />
+          </Row>
+          <div className="mt-0.5 flex items-center gap-1.5">
+            {onLevel && (
+              <button
+                type="button"
+                onClick={onLevel}
+                className="rounded border border-white/15 px-2 py-1 text-[11px] leading-none text-white/75 hover:bg-white/10 hover:text-white"
+              >
+                {t("viewer.poseLevel")}
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onReset}
+              className="rounded border border-white/15 px-2 py-1 text-[11px] leading-none text-white/75 hover:bg-white/10 hover:text-white"
+            >
+              {t("viewer.poseReset")}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function ControlsHint() {
   const t = useT();
   const items = [
@@ -1133,6 +1430,15 @@ export interface ModelViewerProps {
    */
   highlight?: Int32Array | null;
   riderParts?: RiderPart[] | null;
+  /**
+   * The bike's joints, from the model that carried `nodes`.
+   *
+   * Absent leaves the bike rigid, exactly as it was drawn before it could be posed — which is
+   * also what an unassembled bike gets, since there is nothing to pose a pile of loose parts.
+   */
+  rig?: BikeRig | null;
+  /** Offer the pose panel. Off by default: a preview nobody is posing shouldn't grow chrome. */
+  poseControls?: boolean;
   loading?: boolean;
   noStandIn?: boolean;
   className?: string;
@@ -1147,12 +1453,27 @@ export function ModelViewer({
   nodes,
   highlight,
   riderParts,
+  rig,
+  poseControls = false,
   loading = false,
   noStandIn = false,
   className,
 }: ModelViewerProps) {
   const map = useDataTexture(texture);
   const texMap = useTextureMapWith(textures, overrides);
+  // The stance the bike is drawn in until someone moves a slider. Held as "no answer yet"
+  // rather than as a copy of `settled`, so a new bike settles on its own instead of inheriting
+  // the pose the last one was left in.
+  const settled = useMemo(() => settledPose(rig, nodes ?? []), [rig, nodes]);
+  const [posed, setPosed] = useState<BikePose | null>(null);
+  useEffect(() => setPosed(null), [settled]);
+  const pose = posed ?? settled;
+  // Solved against the fork where it is now, so "level" still means level after the front
+  // has been moved.
+  const level = useMemo(
+    () => levelRearDrop(rig, nodes ?? [], pose.forkUp / 1000),
+    [rig, nodes, pose.forkUp],
+  );
   // What `mode` asks for, narrowed to what actually arrived. In `both`, either half can be
   // missing — a bike that wouldn't resolve, a rider still loading — and the scene falls back
   // to whichever one is here rather than to a stand-in.
@@ -1217,9 +1538,17 @@ export function ModelViewer({
                 highlight={highlight}
                 parts={riderParts!}
                 overrides={overrides}
+                rig={rig}
+                pose={pose}
               />
             ) : hasReal ? (
-              <EdfMesh nodes={nodes!} textures={texMap} highlight={highlight} />
+              <EdfMesh
+                nodes={nodes!}
+                textures={texMap}
+                highlight={highlight}
+                rig={rig}
+                pose={pose}
+              />
             ) : hasRider ? (
               <RiderComposite parts={riderParts!} overrides={overrides} />
             ) : loading || noStandIn ? null : mode === "bike" ? (
@@ -1248,6 +1577,16 @@ export function ModelViewer({
         </Canvas>
       </ErrorBoundary>
       {!loading && <ControlsHint />}
+      {poseControls && showBike && !!rig && !loading && (
+        <PoseControls
+          pose={pose}
+          onChange={setPosed}
+          onLevel={
+            level === null ? undefined : () => setPosed({ ...pose, rearDrop: level })
+          }
+          onReset={() => setPosed(NEUTRAL_POSE)}
+        />
+      )}
     </div>
   );
 }

--- a/src/Components/Viewer/ViewerDialog.tsx
+++ b/src/Components/Viewer/ViewerDialog.tsx
@@ -115,6 +115,7 @@ export function ViewerDialog({
   const [reloads, setReloads] = useState(0);
 
   const nodes = model?.nodes ?? null;
+  const rig = model?.rig ?? null;
   const paints = model?.paints ?? [];
 
   // The names behind each picker, in order — the labels shown are decorated versions of
@@ -460,6 +461,8 @@ export function ViewerDialog({
             textures={activeTextures}
             nodes={nodes}
             riderParts={riderParts}
+            rig={rig}
+            poseControls
             loading={loading}
             noStandIn={isBike}
             className="absolute inset-0"

--- a/src/Components/Viewer/ViewerPanel.tsx
+++ b/src/Components/Viewer/ViewerPanel.tsx
@@ -277,6 +277,7 @@ export function ViewerPanel({
     texture,
     textures: drawsBike ? bikeTextures : undefined,
     nodes: drawsBike ? bikeModel?.nodes ?? null : null,
+    rig: drawsBike ? bikeModel?.rig ?? null : null,
     riderParts: drawsRider ? shownParts : null,
     loading: riderLoading,
     // With a real bike on the way, the cartoon stand-in beside the rider is worse than
@@ -329,7 +330,9 @@ export function ViewerPanel({
             {!riderOnly && <ModeToggle mode={mode} modes={modes} onChange={setMode} />}
           </div>
           <div className="relative min-h-0 flex-1">
-            <ModelViewer {...view} className="absolute inset-0" />
+            {/* Posing only in the expanded view: the inline panel is 280px tall, and a
+                control stack in it would cover the bike it is posing. */}
+            <ModelViewer {...view} poseControls className="absolute inset-0" />
             {overlay}
           </div>
         </DialogContent>

--- a/src/Components/ui/controls.tsx
+++ b/src/Components/ui/controls.tsx
@@ -1,0 +1,49 @@
+/**
+ * The small labelled controls a side panel is made of.
+ *
+ * Shared rather than copied so the Designer's rails and the viewer's pose panel stay identical
+ * instead of merely similar — a row that lines up differently in each reads as a bug.
+ */
+
+/** A labelled row. The panels are nothing but these, so it earns its own component. */
+export function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex items-center gap-2">
+      <span className="w-[68px] flex-none text-[11px] text-muted-foreground">{label}</span>
+      <span className="flex min-w-0 flex-1 items-center gap-1.5">{children}</span>
+    </label>
+  );
+}
+
+export function Slider({
+  value,
+  min,
+  max,
+  step,
+  onChange,
+  format,
+}: {
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (v: number) => void;
+  format: (v: number) => string;
+}) {
+  return (
+    <>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="h-1 min-w-0 flex-1 accent-primary"
+      />
+      <span className="w-[44px] flex-none text-right text-[11px] tabular-nums text-muted-foreground">
+        {format(value)}
+      </span>
+    </>
+  );
+}

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -357,6 +357,12 @@ export const de: Translation = {
   "viewer.scrollToZoom": "Scrollen zum Zoomen",
   "viewer.rightDragToPan": "Rechts ziehen zum Verschieben",
   "viewer.paintReloaded": "Lackierung neu geladen",
+  "viewer.pose": "Haltung",
+  "viewer.poseRear": "Hinten",
+  "viewer.poseFront": "Vorne",
+  "viewer.poseSteer": "Lenkung",
+  "viewer.poseLevel": "Räder ausrichten",
+  "viewer.poseReset": "Zurücksetzen",
 
   // ── Combobox ───────────────────────────────────────────────────────────────
   "combobox.search": "Suchen…",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -344,6 +344,12 @@ export const en = {
   "viewer.scrollToZoom": "Scroll to zoom",
   "viewer.rightDragToPan": "Right-drag to pan",
   "viewer.paintReloaded": "Paint reloaded",
+  "viewer.pose": "Pose",
+  "viewer.poseRear": "Rear",
+  "viewer.poseFront": "Front",
+  "viewer.poseSteer": "Steering",
+  "viewer.poseLevel": "Level wheels",
+  "viewer.poseReset": "Reset",
 
   // ── Combobox ───────────────────────────────────────────────────────────────
   "combobox.search": "Search…",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -351,6 +351,12 @@ export const es: Translation = {
   "viewer.scrollToZoom": "Desplaza para hacer zoom",
   "viewer.rightDragToPan": "Arrastra con el botón derecho para mover",
   "viewer.paintReloaded": "Pintura recargada",
+  "viewer.pose": "Postura",
+  "viewer.poseRear": "Trasera",
+  "viewer.poseFront": "Delantera",
+  "viewer.poseSteer": "Dirección",
+  "viewer.poseLevel": "Nivelar ruedas",
+  "viewer.poseReset": "Restablecer",
 
   // ── Combobox ───────────────────────────────────────────────────────────────
   "combobox.search": "Buscar…",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -354,6 +354,12 @@ export const fr: Translation = {
   "viewer.scrollToZoom": "Molette pour zoomer",
   "viewer.rightDragToPan": "Clic droit glissé pour déplacer",
   "viewer.paintReloaded": "Déco rechargée",
+  "viewer.pose": "Position",
+  "viewer.poseRear": "Arrière",
+  "viewer.poseFront": "Avant",
+  "viewer.poseSteer": "Direction",
+  "viewer.poseLevel": "Aligner les roues",
+  "viewer.poseReset": "Réinitialiser",
 
   // ── Combobox ───────────────────────────────────────────────────────────────
   "combobox.search": "Rechercher…",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -350,6 +350,12 @@ export const it: Translation = {
   "viewer.scrollToZoom": "Scorri per zoomare",
   "viewer.rightDragToPan": "Trascina col destro per spostare",
   "viewer.paintReloaded": "Livrea ricaricata",
+  "viewer.pose": "Posa",
+  "viewer.poseRear": "Posteriore",
+  "viewer.poseFront": "Anteriore",
+  "viewer.poseSteer": "Sterzo",
+  "viewer.poseLevel": "Allinea le ruote",
+  "viewer.poseReset": "Ripristina",
 
   // ── Combobox ───────────────────────────────────────────────────────────────
   "combobox.search": "Cerca…",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -353,6 +353,12 @@ export const ptBR: Translation = {
   "viewer.scrollToZoom": "Role para dar zoom",
   "viewer.rightDragToPan": "Arraste com o botão direito para mover",
   "viewer.paintReloaded": "Pintura recarregada",
+  "viewer.pose": "Postura",
+  "viewer.poseRear": "Traseira",
+  "viewer.poseFront": "Dianteira",
+  "viewer.poseSteer": "Direção",
+  "viewer.poseLevel": "Nivelar rodas",
+  "viewer.poseReset": "Redefinir",
 
   // ── Combobox ───────────────────────────────────────────────────────────────
   "combobox.search": "Pesquisar…",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -392,6 +392,30 @@ export interface BikePaint {
   changesPreview: boolean;
 }
 
+/** A point in the bike's frame — the same one `EdfNode.positions` are in. */
+export type Vec3 = [number, number, number];
+
+/**
+ * The joints an assembled bike can be posed about.
+ *
+ * A bike's `.geom` places its parts in the frame it was *authored* in and says nothing about
+ * where the suspension rides at rest — there is no travel in the file, and ride height falls
+ * out of physics the viewer doesn't run. So the viewer poses instead: the swingarm turns about
+ * `pivot`, the fork slides along the axis `rake` tilts through `steerHead`, and the axles say
+ * where the wheels ride so a stance can be solved for level.
+ */
+export interface BikeRig {
+  /** Swingarm pivot. */
+  pivot: Vec3;
+  /** A point on the steering axis (the head itself). */
+  steerHead: Vec3;
+  /** Rake in degrees, tilting the steering axis back from vertical. */
+  rake: number;
+  /** Where the wheels ride. Null when the `.geom` names no axles. */
+  frontAxle: Vec3 | null;
+  rearAxle: Vec3 | null;
+}
+
 export interface BikeModel {
   nodes: EdfNode[];
   paints: BikePaint[];
@@ -412,6 +436,8 @@ export interface BikeModel {
    * facing from exactly those, and stays quiet rather than guessing when this is false.
    */
   assembled: boolean;
+  /** The joints to pose about. Null for a bike that wasn't assembled. */
+  rig: BikeRig | null;
 }
 
 export interface RiderPart {


### PR DESCRIPTION
## Why

The 3D preview drew every bike in the frame it was *authored* in, which is not a stance it ever holds on the ground. A `.geom` carries no suspension travel at all — `chassis_rsusp_min`/`_max` are tenths of a millimetre apart (a setup range) and `rwheel_min`/`_max` is the chain-adjuster slot — and ride height falls out of physics the viewer doesn't run. So bikes stood with the shock apparently collapsed and the rear wheel riding high, and there is no number in any file to fix that with. Hand the viewer the joints the bike actually has and let them be moved.

## What

- **`assemble_bike` returns a `BikeRig`** — swingarm pivot, steering head, rake, and both axles — rather than a bool. The points are emitted *after* the centring shift and mirrored alongside `to_right_handed`, so the rig and the mesh are always in one frame. `assembled` is now `rig.is_some()`.
- **The viewer poses with nested three.js groups**, keyed on the same name prefixes the assembly mounts by (`rsusp`/`rwheel` swing, `steer` turns, `fsusp`/`fwheel` slide inside the steering group). Nothing is re-baked, there's no round-trip per slider, and a bike with no rig renders on exactly the path it always did.
- **Three sliders**, in units of the real thing: rear travel and fork travel in millimetres of wheel movement, steering in degrees. `swingAngleForAxleY` turns a requested drop into the swingarm rotation that reaches it.
- **Level wheels** solves the rear against the *contact patches*, not the axles — a 21" front and a 19" rear are not level when their axles are. A bike wearing wheels is drawn levelled to begin with, so it stands right with nobody touching a slider; **Reset** returns it as authored.
- `Row`/`Slider` lifted out of the Designer into `ui/controls`, so the pose panel and the Designer's rails are the same rows rather than two that merely look alike.

The panel is in the full-screen viewer and the expanded preview; the Designer's preview gets the settled stance but no chrome.

## Verification

- `cargo test` — 847 pass, including three new rig tests: the axles land a real wheelbase apart (checked against a '96 CR250's published spec), and a vertex sitting on the pivot is still on `rig.pivot` after both the centring and the right-handed mirror. Off by either, every pose would swing about a point in mid-air.
- The group nesting was driven through three.js outside React: 40 mm of requested drop moves the rear axle 40.0 mm, fork travel measures true along its own raked axis even with the bars turned, and 30° of steering turns the front wheel exactly 30° about the head while leaving the rear alone.
- `tsc --noEmit` and `eslint` clean (two pre-existing warnings untouched).

## Notes

- Wheels aren't merged yet, so on this branch the swingarm, fork and steering move but there are no wheels to level. The wheel nodes join the right groups by name the moment that lands. `edf.rs` will conflict with it — same `Mounts`/`axles()` shape, so it should resolve cheaply.
- No DB or schema changes.
- Rider posing is deliberately out: the body arrives as a single mesh node with no bones, so arms and legs need either hand-rolled vertex skinning or an RE pass to find the skeleton the game animates with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)