### PR TITLE
feat(viewer): render a bike's wheels, and let you pick which tyres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,26 @@
   The Bike / Rider / Both toggle picks what's on screen; either half stays up while the other
   one re-reads, and a bike that won't resolve says so instead of quietly leaving the rider alone.
 
+
+- **Bikes render with their wheels on.** The 3D preview drew the frame, the forks, the
+  swingarm and the bars, then stopped — every bike stood on bare fork tips and a swingarm
+  stub. The wheels were never in the bike's mesh to begin with: a bike's `gfx.cfg` names a
+  tyres mod (`tyres = oem_mx`), the wheel meshes live in that mod, and the axle points they
+  hang off have been sitting in the bike's `.geom` all along. Both are read now, so the front
+  wheel sits on the fork and the rear on the swingarm, wearing the rim, disc, sprocket and
+  tyre they ship with.
+  - **A livery that paints the wheels finally shows it.** An OEM bike's stock livery replaces
+    the wheels and the chain and nothing else, so picking it changed nothing on screen — and
+    the app said so, in a note apologising for the parts it couldn't draw. Those sheets land
+    on real parts now.
+  - The chain is still left off. It ships as a straight template strip that the game bends
+    onto the sprockets as it runs, and drawn where it sits it is a bar standing out of the
+    rear wheel.
+  - A bike whose tyres mod isn't installed — or whose `.geom` names no axles — renders
+    exactly as it did before.
+
 ### Changed
+
 - **The Rider tab's bike picker is searchable.** It was a plain dropdown, which is a long
   scroll past dozens of bikes for a name you already know. It's now the same searchable
   field as the Paint and Model swap slots beside it — type to filter. Unlike those, it
@@ -85,6 +104,14 @@
   names are a convenience; an evicted mesh is now left alone and the paints answer instead, in
   about a tenth of a second. The preview still fetches the model when it draws it, where the
   wait buys a picture.
+
+
+- **A square where each brake disc should be.** A wheel's front disc, rear disc and sprocket
+  are drawn as a masked square on a flat quad — two thirds of `fdisc` is fully transparent —
+  and the bike preview had never needed to cut a mask out before, so each one arrived as the
+  square. The mask is honoured now, but only where a sheet's alpha actually varies: a bike's
+  `w_plate` carries an alpha channel nobody filled in, transparent on every pixel, and
+  treating that as a mask would have erased the number plates instead.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,16 @@
   one re-reads, and a bike that won't resolve says so instead of quietly leaving the rider alone.
 
 
+- **Pick which tyres a bike is previewed on.** A bike's `gfx.cfg` names exactly one tyre
+  pack, so seeing it on another was impossible — the preview fitted what the file said and
+  that was that. A **Tyres** picker now sits beside the livery one in all three previews (the
+  Viewer, the Rider tab and the Designer), listing what's installed under `mods/tyres`. It
+  substitutes the name the wheels are looked up under and nothing else: no file is renamed,
+  no mod is touched, and the bike's own `gfx.cfg` still reads exactly as the game reads it.
+  The choice is remembered, and it's one choice — pick it in the Viewer and the Designer
+  agrees. Picking a pack that isn't installed leaves the bike on its own rather than taking
+  its wheels off.
+
 - **Bikes render with their wheels on.** The 3D preview drew the frame, the forks, the
   swingarm and the bars, then stopped — every bike stood on bare fork tips and a swingarm
   stub. The wheels were never in the bike's mesh to begin with: a bike's `gfx.cfg` names a

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -85,6 +85,13 @@ pub struct AppConfig {
     /// The combo that toggles the overlay, in Tauri accelerator syntax
     /// (`"CommandOrControl+Shift+X"`). Blank falls back to [`DEFAULT_OVERLAY_HOTKEY`].
     pub overlay_hotkey: String,
+    /// Which tyre pack the 3D previews put a bike on. **Blank means "the one the bike's own
+    /// `gfx.cfg` names"**, which is what the game itself would fit.
+    ///
+    /// A bike names exactly one pack, so seeing it on another is only possible by
+    /// substituting the name we look up — nothing on disk is touched. Remembered rather than
+    /// asked each time: it's a way you like looking at bikes, not a per-bike decision.
+    pub preview_tyres: String,
     /// Voice chat is off until the player turns it on. A feature that opens a microphone
     /// is not something anyone should discover by accident.
     pub voice_enabled: bool,
@@ -233,6 +240,7 @@ impl Default for AppConfig {
             tour_done: false,
             overlay_enabled: true,
             overlay_hotkey: DEFAULT_OVERLAY_HOTKEY.to_string(),
+            preview_tyres: String::new(),
             voice_enabled: false,
             voice_input_device: String::new(),
             voice_output_device: String::new(),

--- a/src-tauri/src/edf.rs
+++ b/src-tauri/src/edf.rs
@@ -372,6 +372,18 @@ impl BikeRig {
 
 // Assemble a bike's parts onto its chassis via the .geom mount points, then centre
 // on the origin. `None` (nodes untouched) if the .geom lacks the mounts.
+/// Where a bike's axles land, for a caller deciding whether it has anywhere to hang wheels.
+///
+/// The same two points [`BikeRig`] carries, asked for before the bike is assembled: a bike
+/// ships no wheel of its own — the mesh comes from the tyres mod its `gfx.cfg` names — and
+/// reading that mod is only worth doing once there is somewhere to put what's in it. `None`
+/// when the .geom is missing a mount, where the wheels are better left off than dropped on
+/// the origin.
+pub fn wheel_axles(geom_bytes: &[u8]) -> Option<([f32; 3], [f32; 3])> {
+    let g = parse_geom(geom_bytes);
+    mounts(&g, &parse_geom_scalars(geom_bytes))?.axles(&g)
+}
+
 pub fn assemble_bike(nodes: &mut [EdfNode], geom_bytes: &[u8]) -> Option<BikeRig> {
     let g = parse_geom(geom_bytes);
     let sc = parse_geom_scalars(geom_bytes);
@@ -405,6 +417,18 @@ pub fn assemble_bike(nodes: &mut [EdfNode], geom_bytes: &[u8]) -> Option<BikeRig
             (rake, v_sub(head, rot_x(steer_joint, rake)))
         } else if name.starts_with("fsusp") {
             (rake, fork_origin)
+        // A wheel is authored about its own axle, and how far it has spun is arbitrary —
+        // so it only ever wants moving, never turning.
+        } else if name.starts_with("fwheel") {
+            match axles {
+                Some((front, _)) => (0.0, front),
+                None => continue,
+            }
+        } else if name.starts_with("rwheel") {
+            match axles {
+                Some((_, rear)) => (0.0, rear),
+                None => continue,
+            }
         } else {
             continue;
         };
@@ -1632,6 +1656,103 @@ rwheel_max = 0, 0.0122, -0.5359\n";
         // The swingarm vertex sits 0.25 m off the pivot either side of the mirror.
         let d = vertex(&nodes[1], 0)[0] - rig.pivot[0];
         assert!((d + 0.25).abs() < 1e-4, "mesh and rig disagree after mirroring: {d}");
+    }
+
+    /// The mount points of a real bike (MX1OEM_2023_Honda_CRF450R), trimmed to the lines
+    /// the wheels are hung off. Kept verbatim so the numbers below can be checked against
+    /// the bike's published spec rather than against this test.
+    const CRF450R_GEOM: &[u8] = b"type = bike\n\
+chassis_steer = 0, 0.9935, 0.2982\n\
+chassis_rsusp_min = 0, 0.4599, -0.2118\n\
+rakeangle_min = 27.1\n\
+steer_joint = 0, 0.0412, -0.0372\n\
+front_upper = 0, -0.4048, -0.0153\n\
+fwheel = 0, -0.2468, 0.0481\n\
+rsusp_joint = 0, -0.0042, 0.0399\n\
+rwheel_min = 0, -0.0011, -0.5282\n\
+rwheel_max = 0, -0.001, -0.5683\n";
+
+    fn wheel_node(name: &str) -> EdfNode {
+        EdfNode {
+            name: name.into(),
+            // One vertex on the axle: what comes back is where the axle landed.
+            positions: vec![0.0, 0.0, 0.0],
+            uvs: Vec::new(),
+            normals: Vec::new(),
+            indices: Vec::new(),
+            submeshes: Vec::new(),
+            texture: None,
+            placed: true,
+            materials: Vec::new(),
+        }
+    }
+
+    /// The wheels aren't in the bike's mesh, so the `.geom` is the only thing that says
+    /// where they go. Checked against the real bike: a 2023 CRF450R's wheelbase is 1481 mm.
+    #[test]
+    fn wheel_axles_land_a_real_wheelbase_apart() {
+        let (front, rear) = wheel_axles(CRF450R_GEOM).expect("the mounts are all there");
+        assert!((front[1] - 0.4086).abs() < 5e-3, "front axle height: {front:?}");
+        assert!((front[2] - 0.6761).abs() < 5e-3, "front axle reach: {front:?}");
+        assert!((rear[1] - 0.4631).abs() < 5e-3, "rear axle height: {rear:?}");
+        assert!((rear[2] + 0.7999).abs() < 5e-3, "rear axle reach: {rear:?}");
+        let wheelbase = front[2] - rear[2];
+        assert!(
+            (wheelbase - 1.481).abs() < 0.02,
+            "wheelbase {wheelbase} is nowhere near the real 1.481 m",
+        );
+        // Both on the bike's centreline, and the front ahead of the rear.
+        assert!(front[0].abs() < 1e-6 && rear[0].abs() < 1e-6);
+        assert!(front[2] > rear[2]);
+    }
+
+    /// The rear axle sits at the midpoint of the chain-adjuster range, which is what the
+    /// `.geom`'s own collision notes tell a modder to use. Taking `rwheel_min` alone put
+    /// the wheel 20 mm forward of where the bike is measured.
+    #[test]
+    fn rear_axle_splits_the_chain_adjuster_range() {
+        let (_, rear) = wheel_axles(CRF450R_GEOM).unwrap();
+        let g = parse_geom(CRF450R_GEOM);
+        let mid = (g["rwheel_min"][2] + g["rwheel_max"][2]) * 0.5;
+        let off = g["chassis_rsusp_min"][2] - g["rsusp_joint"][2];
+        assert!((rear[2] - (mid + off)).abs() < 1e-6, "rear: {rear:?}");
+    }
+
+    #[test]
+    fn assemble_puts_the_wheels_on_their_axles() {
+        let (front, rear) = wheel_axles(CRF450R_GEOM).unwrap();
+        // A chassis vertex at the origin, so the centring pass has a third point to work
+        // with and the two wheels keep their real separation.
+        let mut nodes = vec![wheel_node("chassis"), wheel_node("fwheel"), wheel_node("rwheela")];
+        assert!(assemble_bike(&mut nodes, CRF450R_GEOM).is_some());
+        // Everything is shifted by the same centring offset, so compare the gap.
+        let at = |i: usize| [nodes[i].positions[0], nodes[i].positions[1], nodes[i].positions[2]];
+        let (f, r) = (at(1), at(2));
+        for k in 0..3 {
+            assert!(
+                ((f[k] - r[k]) - (front[k] - rear[k])).abs() < 1e-5,
+                "axle {k}: got {:?}, want {:?}",
+                (f[k] - r[k]),
+                (front[k] - rear[k]),
+            );
+        }
+    }
+
+    /// A `.geom` with no `fwheel`/`rwheel` lines has nowhere to hang a wheel. The bike's
+    /// own parts must still assemble — the wheels are the only thing that goes missing.
+    #[test]
+    fn a_geom_without_wheel_mounts_still_assembles_the_bike() {
+        let geom: Vec<u8> = CRF450R_GEOM
+            .split(|b| *b == b'\n')
+            .filter(|line| !line.starts_with(b"fwheel") && !line.starts_with(b"rwheel"))
+            .map(|line| [line, b"\n"].concat())
+            .collect::<Vec<_>>()
+            .concat();
+        assert!(wheel_axles(&geom).is_none());
+        let mut nodes = vec![wheel_node("chassis"), wheel_node("steer"), wheel_node("fwheel")];
+        assert!(assemble_bike(&mut nodes, &geom).is_some(), "the bike still assembles");
+        // The steering head moved; the wheel, having no mount, did not.
+        assert_ne!(nodes[1].positions, nodes[0].positions, "steer was placed");
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1498,6 +1498,12 @@ struct BikeModel {
     /// Designer's reference underlay needs the distinction: an OEM bike's stock `.pnt`
     /// replaces the wheels and the chain, so `plastics` is only ever in here.
     base: Vec<paint::PaintTexture>,
+    /// The tyres mod the wheels came out of, or `None` when the bike drew none.
+    ///
+    /// What was *actually* fitted, not what was asked for: a pick that names nothing
+    /// installed falls back to the bike's own, and the picker has to show that rather than
+    /// claim a pack that isn't on screen.
+    tyres: Option<String>,
     /// Whether the parts were placed into one frame by the bike's `.geom`.
     ///
     /// False means every node still sits in its own local frame, so a vertex's position says
@@ -1577,8 +1583,8 @@ fn swap_cache_key(set: &modelswap::PreviewSet) -> String {
 }
 
 #[tauri::command]
-async fn load_bike_model(source: String) -> Result<BikeModel, String> {
-    tauri::async_runtime::spawn_blocking(move || load_bike_model_blocking(source))
+async fn load_bike_model(source: String, tyres: Option<String>) -> Result<BikeModel, String> {
+    tauri::async_runtime::spawn_blocking(move || load_bike_model_blocking(source, tyres))
         .await
         .map_err(|e| format!("load_bike_model task failed: {e}"))?
 }
@@ -1591,16 +1597,20 @@ async fn preview_model_swap(
     app: tauri::AppHandle,
     bike: String,
     variant: String,
+    tyres: Option<String>,
 ) -> Result<BikeModel, String> {
-    tauri::async_runtime::spawn_blocking(move || preview_model_swap_blocking(app, bike, variant))
-        .await
-        .map_err(|e| format!("preview_model_swap task failed: {e}"))?
+    tauri::async_runtime::spawn_blocking(move || {
+        preview_model_swap_blocking(app, bike, variant, tyres)
+    })
+    .await
+    .map_err(|e| format!("preview_model_swap task failed: {e}"))?
 }
 
 fn preview_model_swap_blocking(
     app: tauri::AppHandle,
     bike: String,
     variant: String,
+    pick: Option<String>,
 ) -> Result<BikeModel, String> {
     let t0 = std::time::Instant::now();
     let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
@@ -1609,10 +1619,11 @@ fn preview_model_swap_blocking(
     let label = format!("{bike} · {variant}");
     let tyres = library::mods_subdir(&cfg.mods_path, "mods/tyres");
     let key = format!(
-        "{}#p{:x}#t{:x}",
+        "{}#p{:x}#t{:x}#w{}",
         swap_cache_key(&set),
         paints_stamp(&set.bike_dir),
         tyres_stamp(&tyres),
+        pick.as_deref().unwrap_or(""),
     );
     if let Some(m) = bike_cache().lock().ok().and_then(|mut c| c.get(&key).cloned()) {
         log::info!("preview_model_swap {label}: cache hit ({:?})", t0.elapsed());
@@ -1621,7 +1632,7 @@ fn preview_model_swap_blocking(
 
     let files = gather_preview_files(&set).map_err(|e| format!("{e:#}"))?;
     let installed = paints_at(&set.paints);
-    build_bike_model(&label, key, files, installed, Some(tyres), t0)
+    build_bike_model(&label, key, files, installed, Some(tyres), pick, t0)
 }
 
 /// A stamp over the loose paints beside a bike, for the cache key to carry.
@@ -1694,14 +1705,18 @@ fn fnv1a(rows: &[String]) -> u64 {
     h
 }
 
-fn load_bike_model_blocking(source: String) -> Result<BikeModel, String> {
+fn load_bike_model_blocking(
+    source: String,
+    pick: Option<String>,
+) -> Result<BikeModel, String> {
     let t0 = std::time::Instant::now();
     let tyres = tyres_dir_for(std::path::Path::new(&source));
     let key = format!(
-        "{}#p{:x}#t{:x}",
+        "{}#p{:x}#t{:x}#w{}",
         bike_cache_key(&source),
         paints_stamp(std::path::Path::new(&source)),
         tyres.as_deref().map(tyres_stamp).unwrap_or(0),
+        pick.as_deref().unwrap_or(""),
     );
     if let Some(m) = bike_cache().lock().ok().and_then(|mut c| c.get(&key).cloned()) {
         log::info!("load_bike_model {source}: cache hit ({:?})", t0.elapsed());
@@ -1710,7 +1725,7 @@ fn load_bike_model_blocking(source: String) -> Result<BikeModel, String> {
 
     let files = gather_bike_files(std::path::Path::new(&source)).map_err(|e| format!("{e:#}"))?;
     let installed = installed_paints(std::path::Path::new(&source));
-    build_bike_model(&source, key, files, installed, tyres, t0)
+    build_bike_model(&source, key, files, installed, tyres, pick, t0)
 }
 
 /// Turn a bike's files into the viewer's model: resolve each part's mesh through the
@@ -1724,6 +1739,8 @@ fn build_bike_model(
     installed: Vec<(String, String, Vec<u8>)>,
     // Where the tyre mods live, for the wheels this bike wears. `None` skips them.
     tyres_dir: Option<std::path::PathBuf>,
+    // The tyre pack the player picked, if any. Blank/absent → the one the bike names.
+    tyres_pick: Option<String>,
     t0: std::time::Instant,
 ) -> Result<BikeModel, String> {
     let t_read = t0.elapsed();
@@ -1761,16 +1778,16 @@ fn build_bike_model(
     // Read before `used` borrows anything, so the wheel meshes outlive the borrows taken of
     // them below. `edfs` is only consulted so an unreadable bike doesn't pay for a tyre
     // archive it will never draw.
-    let wheel_files = match (tyres_dir, gfx_bytes, geom) {
+    let tyre_set = match (tyres_dir, gfx_bytes, geom) {
         (Some(dir), Some(bytes), Some(g)) if !edfs.is_empty() => {
             if edf::wheel_axles(g).is_some() {
-                gather_tyre_files(&dir, bytes)
+                gather_tyre_files(&dir, bytes, tyres_pick.as_deref())
             } else {
                 log::warn!("[viewer] {label}: the .geom names no axles — no wheels");
-                Vec::new()
+                None
             }
         }
-        _ => Vec::new(),
+        _ => None,
     };
     // Group each part's level0 node under the mesh its `.hrc` names. Bikes that point
     // every part at one `model.edf` collapse to a single group — the original path.
@@ -1823,10 +1840,13 @@ fn build_bike_model(
     }
     // Wheels last, and only onto a bike that arrived: a mesh that didn't read has to go on
     // reading as "none of this bike arrived", not as a pair of wheels hanging in the air.
-    if !nodes.is_empty() && !wheel_files.is_empty() {
-        let (mut wheels, meshes) = wheel_nodes(&wheel_files);
+    let mut tyres = None;
+    if let Some(set) = tyre_set.as_ref().filter(|_| !nodes.is_empty()) {
+        let (mut wheels, meshes) = wheel_nodes(&set.files);
         if wheels.is_empty() {
-            log::warn!("[viewer] {label}: the tyres mod holds no readable wheel mesh");
+            log::warn!("[viewer] {label}: tyres '{}' hold no readable wheel mesh", set.name);
+        } else {
+            tyres = Some(set.name.clone());
         }
         nodes.append(&mut wheels);
         used.extend(meshes);
@@ -1989,7 +2009,7 @@ fn build_bike_model(
         log::info!("  node '{}' placed={} {}", n.name, n.placed, subs.join(", "));
     }
 
-    let model = BikeModel { nodes, paints, base: model_base, assembled, rig };
+    let model = BikeModel { nodes, paints, base: model_base, tyres, assembled, rig };
     if let Ok(mut c) = bike_cache().lock() {
         // The evicted bike's pixels go with it — nothing else references them.
         if let Some(dropped) = c.insert(key, model.clone()) {
@@ -2132,19 +2152,48 @@ fn tyres_dir_for(source: &std::path::Path) -> Option<std::path::PathBuf> {
     Some(library::resolve_child(source.parent()?.parent()?, "tyres"))
 }
 
-/// The files a tyres mod holds that a wheel resolves through: its own `gfx.cfg`, an `.hrc`
-/// per wheel, and the meshes those name.
+/// Whether `mods/tyres/<name>` is installed, as a folder or as the `.pkz` beside it.
+fn tyres_mod_exists(tyres_dir: &std::path::Path, name: &str) -> bool {
+    library::resolve_child(tyres_dir, name).is_dir()
+        || library::resolve_child(tyres_dir, &format!("{name}.pkz")).is_file()
+}
+
+/// A tyres mod, opened: the name it goes by and the files a wheel resolves through.
+struct TyreSet {
+    name: String,
+    files: Vec<(String, Vec<u8>)>,
+}
+
+/// Open the tyres mod a bike will wear — its own `gfx.cfg`, an `.hrc` per wheel, and the
+/// meshes those name.
 ///
 /// A bike ships no wheel of its own. Its `gfx.cfg` ends with one line — `tyres = oem_mx` —
 /// and `mods/tyres/oem_mx`, a folder or the `.pkz` beside it, is where the mesh actually
-/// lives. Empty when there is no line, no mod, or nothing readable in one: that is the bike
-/// the viewer drew before wheels, not a failure.
-fn gather_tyre_files(tyres_dir: &std::path::Path, gfx_bytes: &[u8]) -> Vec<(String, Vec<u8>)> {
+/// lives. `pick` substitutes that name so a bike can be *seen* on another pack; nothing on
+/// disk moves and the bike's own `gfx.cfg` still reads as the game will read it.
+///
+/// `None` when there is no line, no mod, or nothing readable in one — the bike the viewer
+/// drew before wheels, not a failure.
+fn gather_tyre_files(
+    tyres_dir: &std::path::Path,
+    gfx_bytes: &[u8],
+    // The pack the player picked, if they picked one. Blank or absent → the bike's own.
+    pick: Option<&str>,
+) -> Option<TyreSet> {
     let root = cfg::parse(gfx_bytes);
-    let Some(name) = root.get("tyres").map(str::trim).filter(|n| library::is_simple_name(n))
-    else {
-        return Vec::new();
-    };
+    let own = root.get("tyres").map(str::trim).filter(|n| library::is_simple_name(n));
+    // A pick that names nothing installed falls back to the bike's own rather than taking
+    // the wheels away: the picker is a way to look at a bike, not a way to break it.
+    let name = match pick.map(str::trim).filter(|n| !n.is_empty()) {
+        Some(p) if library::is_simple_name(p) && tyres_mod_exists(tyres_dir, p) => p,
+        Some(p) => {
+            log::warn!("[viewer] tyres '{p}' isn't installed — falling back to the bike's own");
+            own?
+        }
+        None => own?,
+    }
+    .to_string();
+
     // The `.tyre` parameter files, the previews and the shadow meshes all sit beside these
     // and none of them are drawn — read only what a wheel is resolved through.
     let want = |n: &str| {
@@ -2152,7 +2201,7 @@ fn gather_tyre_files(tyres_dir: &std::path::Path, gfx_bytes: &[u8]) -> Vec<(Stri
         n.ends_with(".edf") || n.ends_with(".hrc") || n.ends_with(".cfg")
     };
 
-    let dir = library::resolve_child(tyres_dir, name);
+    let dir = library::resolve_child(tyres_dir, &name);
     let mut loose = Vec::new();
     if let Ok(entries) = std::fs::read_dir(&dir) {
         for e in entries.flatten() {
@@ -2166,19 +2215,19 @@ fn gather_tyre_files(tyres_dir: &std::path::Path, gfx_bytes: &[u8]) -> Vec<(Stri
         }
     }
     if !loose.is_empty() {
-        return loose;
+        return Some(TyreSet { name, files: loose });
     }
 
     let pkz = library::resolve_child(tyres_dir, &format!("{name}.pkz"));
     if !pkz.is_file() {
-        log::warn!("[viewer] gfx.cfg wants tyres '{name}', which isn't installed — no wheels");
-        return Vec::new();
+        log::warn!("[viewer] tyres '{name}' isn't installed — no wheels");
+        return None;
     }
     match pkz::read_selected(&pkz, want) {
-        Ok(files) => files,
+        Ok(files) => Some(TyreSet { name, files }),
         Err(e) => {
             log::warn!("[viewer] tyres '{name}' wouldn't read: {e:#} — no wheels");
-            Vec::new()
+            None
         }
     }
 }
@@ -5888,6 +5937,14 @@ fn set_voice_enabled(
     overlay::register(&app, &cfg)
 }
 
+/// Pick the tyre pack the 3D previews fit. A blank name means "whatever the bike names".
+#[tauri::command]
+fn set_preview_tyres(app: tauri::AppHandle, tyres: String) -> Result<(), String> {
+    let mut cfg = config::load(&app).unwrap_or_default();
+    cfg.preview_tyres = tyres;
+    config::save(&app, &cfg).map_err(|e| format!("{e:#}"))
+}
+
 /// Pick the microphone. A blank name means "follow the system default".
 #[tauri::command]
 fn set_voice_input_device(app: tauri::AppHandle, device: String) -> Result<(), String> {
@@ -7442,6 +7499,7 @@ fn main() {
             set_overlay_hotkey,
             voice_devices,
             set_voice_enabled,
+            set_preview_tyres,
             set_voice_input_device,
             set_voice_output_device,
             set_voice_ptt_hotkey,
@@ -8401,13 +8459,14 @@ mod viewer_tests {
             super::installed_paints(&set.bike_dir),
             // What `load_bike_model_blocking` derives for the bike it's compared against.
             Some(crate::library::mods_subdir(mp, "mods/tyres")),
+            None,
             std::time::Instant::now(),
         )
         .expect("preview builds");
         assert!(!previewed.nodes.is_empty(), "the preview drew nothing");
 
         super::modelswap::apply_model_swap(mp, &bike, "Factory").expect("swap applies");
-        let applied = super::load_bike_model_blocking(dst.to_string_lossy().to_string())
+        let applied = super::load_bike_model_blocking(dst.to_string_lossy().to_string(), None)
             .expect("the swapped bike loads");
 
         assert_eq!(shape(&previewed), shape(&applied), "preview differs from the real swap");
@@ -8470,6 +8529,7 @@ mod viewer_tests {
             files,
             super::installed_paints(&set.bike_dir),
             Some(crate::library::mods_subdir(mp, "mods/tyres")),
+            None,
             std::time::Instant::now(),
         )
         .expect("stock preview builds");
@@ -8504,6 +8564,7 @@ mod viewer_tests {
                 changes_preview: true,
             }],
             base: vec![tex("plastics", "t-own"), tex("wheel", "t-shared")],
+            tyres: None,
             assembled: true,
             rig: None,
         };
@@ -8694,12 +8755,11 @@ mod viewer_tests {
         root
     }
 
-    #[test]
-    fn tyre_files_come_from_the_mod_the_bike_names() {
-        let root = tyres_tmp("loose");
-        let mod_dir = root.join("oem_mx");
-        std::fs::create_dir_all(&mod_dir).unwrap();
-        for (name, body) in [
+    /// Lay down a minimal but real tyres mod under `<root>/<name>`.
+    fn write_tyres_mod(root: &Path, name: &str) {
+        let dir = root.join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        for (file, body) in [
             ("gfx.cfg", "front_wheel\n{\n\tmodel\n\t{\n\t\tfile = fwheel.hrc\n\t}\n}\n"),
             ("fwheel.hrc", "level0\n{\n\tscene = model.edf\n}\n"),
             ("model.edf", "EDF\0"),
@@ -8707,13 +8767,57 @@ mod viewer_tests {
             ("OEM_MXf_is80100-21.tyre", "params"),
             ("preview.tga", "pixels"),
         ] {
-            std::fs::write(mod_dir.join(name), body).unwrap();
+            std::fs::write(dir.join(file), body).unwrap();
         }
+    }
 
-        let found = super::gather_tyre_files(&root, b"tyres = oem_mx\n");
-        let mut names: Vec<&str> = found.iter().map(|(n, _)| n.as_str()).collect();
+    fn tyre_file_names(set: &super::TyreSet) -> Vec<&str> {
+        let mut names: Vec<&str> = set.files.iter().map(|(n, _)| n.as_str()).collect();
         names.sort_unstable();
-        assert_eq!(names, ["fwheel.hrc", "gfx.cfg", "model.edf"]);
+        names
+    }
+
+    #[test]
+    fn tyre_files_come_from_the_mod_the_bike_names() {
+        let root = tyres_tmp("loose");
+        write_tyres_mod(&root, "oem_mx");
+
+        let set = super::gather_tyre_files(&root, b"tyres = oem_mx\n", None).expect("found");
+        assert_eq!(set.name, "oem_mx");
+        assert_eq!(tyre_file_names(&set), ["fwheel.hrc", "gfx.cfg", "model.edf"]);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The whole point of the picker: a bike names one pack, and picking another has to
+    /// beat it — without anything on disk being renamed.
+    #[test]
+    fn a_picked_pack_beats_the_one_the_bike_names() {
+        let root = tyres_tmp("pick");
+        write_tyres_mod(&root, "oem_mx");
+        write_tyres_mod(&root, "p_mx");
+
+        let own = super::gather_tyre_files(&root, b"tyres = oem_mx\n", None).unwrap();
+        assert_eq!(own.name, "oem_mx");
+        let picked = super::gather_tyre_files(&root, b"tyres = oem_mx\n", Some("p_mx")).unwrap();
+        assert_eq!(picked.name, "p_mx", "the pick wins");
+        // Blank is "no pick", not "a pack called nothing".
+        let blank = super::gather_tyre_files(&root, b"tyres = oem_mx\n", Some("  ")).unwrap();
+        assert_eq!(blank.name, "oem_mx");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A pick that names nothing installed must not cost the bike its wheels — it falls back
+    /// to the pack the bike itself names.
+    #[test]
+    fn a_pick_that_isnt_installed_falls_back_to_the_bikes_own() {
+        let root = tyres_tmp("fallback");
+        write_tyres_mod(&root, "oem_mx");
+
+        for pick in ["uninstalled_pack", "../bikes", "sub/dir"] {
+            let set = super::gather_tyre_files(&root, b"tyres = oem_mx\n", Some(pick))
+                .unwrap_or_else(|| panic!("still wheels for pick {pick:?}"));
+            assert_eq!(set.name, "oem_mx", "pick {pick:?}");
+        }
         let _ = std::fs::remove_dir_all(&root);
     }
 
@@ -8722,10 +8826,15 @@ mod viewer_tests {
     #[test]
     fn no_tyres_mod_means_no_wheels_and_no_fuss() {
         let root = tyres_tmp("empty");
-        assert!(super::gather_tyre_files(&root, b"tyres = oem_mx\n").is_empty(), "not installed");
-        assert!(super::gather_tyre_files(&root, b"chassis\n{\n}\n").is_empty(), "no tyres line");
+        let none = |gfx: &[u8], pick: Option<&str>| {
+            super::gather_tyre_files(&root, gfx, pick).is_none()
+        };
+        assert!(none(b"tyres = oem_mx\n", None), "not installed");
+        assert!(none(b"chassis\n{\n}\n", None), "no tyres line");
         // The name is read out of a mod's own file, so it never gets to walk out of `tyres/`.
-        assert!(super::gather_tyre_files(&root, b"tyres = ../bikes\n").is_empty(), "traversal");
+        assert!(none(b"tyres = ../bikes\n", None), "traversal");
+        // A pick can't rescue a bike that names nothing installed either.
+        assert!(none(b"chassis\n{\n}\n", Some("p_mx")), "pick, but nothing installed");
         let _ = std::fs::remove_dir_all(&root);
     }
 
@@ -8736,7 +8845,7 @@ mod viewer_tests {
             eprintln!("set MXB_REAL_PKZ to run");
             return;
         };
-        let m = super::load_bike_model_blocking(path).expect("load bike");
+        let m = super::load_bike_model_blocking(path, std::env::var("MXB_TYRES").ok()).expect("load bike");
         for n in &m.nodes {
             // Where the part ended up. Printed because placement is the half of this that a
             // texture listing can't show: a part bound to the right sheet and hung in the
@@ -9504,7 +9613,7 @@ mod viewer_tests {
             .unwrap_or_default();
 
         // What the viewer renders today.
-        let model = super::load_bike_model_blocking(path.clone()).expect("load bike");
+        let model = super::load_bike_model_blocking(path.clone(), None).expect("load bike");
         // Keyed on the triangle range too: one group name can appear twice in a node,
         // once per material, and those two are exactly the interesting case.
         let bound: std::collections::HashMap<(String, String, u32), Option<String>> = model

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1607,7 +1607,13 @@ fn preview_model_swap_blocking(
     let set =
         modelswap::preview_set(&cfg.mods_path, &bike, &variant).map_err(|e| format!("{e:#}"))?;
     let label = format!("{bike} · {variant}");
-    let key = format!("{}#p{:x}", swap_cache_key(&set), paints_stamp(&set.bike_dir));
+    let tyres = library::mods_subdir(&cfg.mods_path, "mods/tyres");
+    let key = format!(
+        "{}#p{:x}#t{:x}",
+        swap_cache_key(&set),
+        paints_stamp(&set.bike_dir),
+        tyres_stamp(&tyres),
+    );
     if let Some(m) = bike_cache().lock().ok().and_then(|mut c| c.get(&key).cloned()) {
         log::info!("preview_model_swap {label}: cache hit ({:?})", t0.elapsed());
         return Ok(m);
@@ -1615,7 +1621,7 @@ fn preview_model_swap_blocking(
 
     let files = gather_preview_files(&set).map_err(|e| format!("{e:#}"))?;
     let installed = paints_at(&set.paints);
-    build_bike_model(&label, key, files, installed, t0)
+    build_bike_model(&label, key, files, installed, Some(tyres), t0)
 }
 
 /// A stamp over the loose paints beside a bike, for the cache key to carry.
@@ -1650,9 +1656,36 @@ fn paints_stamp(source: &std::path::Path) -> u64 {
         }
     }
     rows.sort_unstable();
-    // FNV-1a. Not a security question — this only has to change when the folder does.
+    fnv1a(&rows)
+}
+
+/// A stamp over the installed tyre mods, for the cache key to carry.
+///
+/// The hole [`paints_stamp`] fills, one folder out. A bike's wheels come from
+/// `mods/tyres/<name>`, which nothing on the bike's own path can see: swapping that mod
+/// changes what the viewer should draw while the bike's mtime, size and paints all stay
+/// exactly as they were.
+fn tyres_stamp(dir: &std::path::Path) -> u64 {
+    let mut rows: Vec<String> = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for e in entries.flatten() {
+            let len = e.metadata().map(|m| m.len()).unwrap_or(0);
+            rows.push(format!(
+                "{}:{len}:{}",
+                e.file_name().to_string_lossy(),
+                mtime_nanos(&e.path()),
+            ));
+        }
+    }
+    rows.sort_unstable();
+    fnv1a(&rows)
+}
+
+/// FNV-1a over the rows a stamp is built from. Not a security question — this only has to
+/// change when the folder does.
+fn fnv1a(rows: &[String]) -> u64 {
     let mut h: u64 = 0xcbf2_9ce4_8422_2325;
-    for row in &rows {
+    for row in rows {
         for b in row.as_bytes() {
             h ^= *b as u64;
             h = h.wrapping_mul(0x1000_0000_01b3);
@@ -1663,10 +1696,12 @@ fn paints_stamp(source: &std::path::Path) -> u64 {
 
 fn load_bike_model_blocking(source: String) -> Result<BikeModel, String> {
     let t0 = std::time::Instant::now();
+    let tyres = tyres_dir_for(std::path::Path::new(&source));
     let key = format!(
-        "{}#p{:x}",
+        "{}#p{:x}#t{:x}",
         bike_cache_key(&source),
         paints_stamp(std::path::Path::new(&source)),
+        tyres.as_deref().map(tyres_stamp).unwrap_or(0),
     );
     if let Some(m) = bike_cache().lock().ok().and_then(|mut c| c.get(&key).cloned()) {
         log::info!("load_bike_model {source}: cache hit ({:?})", t0.elapsed());
@@ -1675,7 +1710,7 @@ fn load_bike_model_blocking(source: String) -> Result<BikeModel, String> {
 
     let files = gather_bike_files(std::path::Path::new(&source)).map_err(|e| format!("{e:#}"))?;
     let installed = installed_paints(std::path::Path::new(&source));
-    build_bike_model(&source, key, files, installed, t0)
+    build_bike_model(&source, key, files, installed, tyres, t0)
 }
 
 /// Turn a bike's files into the viewer's model: resolve each part's mesh through the
@@ -1687,6 +1722,8 @@ fn build_bike_model(
     files: Vec<(String, Vec<u8>)>,
     // The loose paints beside the bike, as `installed_paints` answers them.
     installed: Vec<(String, String, Vec<u8>)>,
+    // Where the tyre mods live, for the wheels this bike wears. `None` skips them.
+    tyres_dir: Option<std::path::PathBuf>,
     t0: std::time::Instant,
 ) -> Result<BikeModel, String> {
     let t_read = t0.elapsed();
@@ -1721,6 +1758,20 @@ fn build_bike_model(
     }
 
     let gfx = gfx_bytes.map(|b| cfg::parse_gfx(b)).unwrap_or_default();
+    // Read before `used` borrows anything, so the wheel meshes outlive the borrows taken of
+    // them below. `edfs` is only consulted so an unreadable bike doesn't pay for a tyre
+    // archive it will never draw.
+    let wheel_files = match (tyres_dir, gfx_bytes, geom) {
+        (Some(dir), Some(bytes), Some(g)) if !edfs.is_empty() => {
+            if edf::wheel_axles(g).is_some() {
+                gather_tyre_files(&dir, bytes)
+            } else {
+                log::warn!("[viewer] {label}: the .geom names no axles — no wheels");
+                Vec::new()
+            }
+        }
+        _ => Vec::new(),
+    };
     // Group each part's level0 node under the mesh its `.hrc` names. Bikes that point
     // every part at one `model.edf` collapse to a single group — the original path.
     let mut scenes: Vec<(String, Vec<String>)> = Vec::new();
@@ -1769,6 +1820,16 @@ fn build_bike_model(
             bind_textures(&mut nodes, data, &gfx, &node_part);
             used.push(data);
         }
+    }
+    // Wheels last, and only onto a bike that arrived: a mesh that didn't read has to go on
+    // reading as "none of this bike arrived", not as a pair of wheels hanging in the air.
+    if !nodes.is_empty() && !wheel_files.is_empty() {
+        let (mut wheels, meshes) = wheel_nodes(&wheel_files);
+        if wheels.is_empty() {
+            log::warn!("[viewer] {label}: the tyres mod holds no readable wheel mesh");
+        }
+        nodes.append(&mut wheels);
+        used.extend(meshes);
     }
     for (fname, path, data) in &installed {
         pnt_jobs.push((paint_display_name(fname), data.as_slice(), false, Some(path)));
@@ -2058,6 +2119,218 @@ fn base_edf<'a>(
         .min_by_key(|(name, _)| (name.len(), name.to_string()))
         .or_else(|| edfs.iter().min_by_key(|(name, _)| (name.len(), name.to_string())))
         .map(|(_, data)| *data)
+}
+
+/// The `tyres` folder beside a bike, where the wheels it wears come from.
+///
+/// A bike source is `<mods>/bikes/<Bike>` or `<mods>/bikes/<Bike>.pkz`, so the sibling
+/// folder is two levels up. Derived rather than configured: `load_bike_model` is handed a
+/// path and nothing else, and that path already says where the mods tree is.
+fn tyres_dir_for(source: &std::path::Path) -> Option<std::path::PathBuf> {
+    // Resolved, not joined: under Proton the tree is case-sensitive and a `Tyres` folder is
+    // a different path from `tyres`.
+    Some(library::resolve_child(source.parent()?.parent()?, "tyres"))
+}
+
+/// The files a tyres mod holds that a wheel resolves through: its own `gfx.cfg`, an `.hrc`
+/// per wheel, and the meshes those name.
+///
+/// A bike ships no wheel of its own. Its `gfx.cfg` ends with one line — `tyres = oem_mx` —
+/// and `mods/tyres/oem_mx`, a folder or the `.pkz` beside it, is where the mesh actually
+/// lives. Empty when there is no line, no mod, or nothing readable in one: that is the bike
+/// the viewer drew before wheels, not a failure.
+fn gather_tyre_files(tyres_dir: &std::path::Path, gfx_bytes: &[u8]) -> Vec<(String, Vec<u8>)> {
+    let root = cfg::parse(gfx_bytes);
+    let Some(name) = root.get("tyres").map(str::trim).filter(|n| library::is_simple_name(n))
+    else {
+        return Vec::new();
+    };
+    // The `.tyre` parameter files, the previews and the shadow meshes all sit beside these
+    // and none of them are drawn — read only what a wheel is resolved through.
+    let want = |n: &str| {
+        let n = n.rsplit(['/', '\\']).next().unwrap_or(n).to_ascii_lowercase();
+        n.ends_with(".edf") || n.ends_with(".hrc") || n.ends_with(".cfg")
+    };
+
+    let dir = library::resolve_child(tyres_dir, name);
+    let mut loose = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for e in entries.flatten() {
+            let path = e.path();
+            let Some(fname) = path.file_name().and_then(|n| n.to_str()) else { continue };
+            if path.is_file() && want(fname) {
+                if let Ok(bytes) = std::fs::read(&path) {
+                    loose.push((fname.to_string(), bytes));
+                }
+            }
+        }
+    }
+    if !loose.is_empty() {
+        return loose;
+    }
+
+    let pkz = library::resolve_child(tyres_dir, &format!("{name}.pkz"));
+    if !pkz.is_file() {
+        log::warn!("[viewer] gfx.cfg wants tyres '{name}', which isn't installed — no wheels");
+        return Vec::new();
+    }
+    match pkz::read_selected(&pkz, want) {
+        Ok(files) => files,
+        Err(e) => {
+            log::warn!("[viewer] tyres '{name}' wouldn't read: {e:#} — no wheels");
+            Vec::new()
+        }
+    }
+}
+
+/// The wheel nodes out of a tyres mod, textured and ready for the `.geom` to mount.
+///
+/// Same shape as a bike's own parts — `gfx.cfg` names an `.hrc` per wheel, and the `.hrc`'s
+/// level0 names both the node and the mesh it lives in — so the bike's own resolution reads
+/// it unchanged. Returns the nodes and the meshes they came out of, which the caller needs
+/// in order to lift the wheel textures out of them.
+fn wheel_nodes(files: &[(String, Vec<u8>)]) -> (Vec<edf::EdfNode>, Vec<&Vec<u8>>) {
+    let mut edfs: std::collections::HashMap<String, &Vec<u8>> = std::collections::HashMap::new();
+    let mut hrcs: std::collections::HashMap<String, &Vec<u8>> = std::collections::HashMap::new();
+    let mut gfx_bytes: Option<&Vec<u8>> = None;
+    for (name, data) in files {
+        let bn = name.rsplit(['/', '\\']).next().unwrap_or(name).to_ascii_lowercase();
+        if bn.ends_with(".edf") {
+            edfs.insert(bn, data);
+        } else if let Some(stem) = bn.strip_suffix(".hrc") {
+            hrcs.insert(stem.to_string(), data);
+        } else if bn.ends_with("gfx.cfg") {
+            gfx_bytes = Some(data);
+        }
+    }
+    let Some(gfx_bytes) = gfx_bytes else {
+        log::warn!("[viewer] the tyres mod ships no gfx.cfg — no wheels");
+        return (Vec::new(), Vec::new());
+    };
+    let gfx = cfg::parse(gfx_bytes);
+
+    let mut nodes = Vec::new();
+    let mut used: Vec<&Vec<u8>> = Vec::new();
+    let mut seen: Vec<String> = Vec::new();
+    // Front then rear, fixed: node order must not shuffle between runs.
+    for part in ["front_wheel", "rear_wheel"] {
+        let Some(hrc_file) = gfx
+            .block(part)
+            .and_then(|p| p.block("model"))
+            .and_then(|m| m.get("file"))
+        else {
+            continue;
+        };
+        let stem = hrc_file
+            .trim_end_matches(".hrc")
+            .trim_end_matches(".HRC")
+            .to_ascii_lowercase();
+        let Some(bytes) = hrcs.get(&stem) else {
+            log::warn!("[viewer] tyres '{part}' wants {hrc_file}, which the mod doesn't ship");
+            continue;
+        };
+        let hrc = cfg::parse(bytes);
+        let Some(node) = cfg::hrc_level0(&hrc, &stem) else { continue };
+        let scene = cfg::hrc_level0_scene(&hrc)
+            .map(|s| s.replace('\\', "/"))
+            .and_then(|s| s.rsplit('/').next().map(str::to_ascii_lowercase))
+            .unwrap_or_else(|| "model.edf".to_string());
+        let Some(data) = edfs.get(&scene) else {
+            log::warn!("[viewer] a tyres .hrc wants {scene}, which the mod doesn't ship");
+            continue;
+        };
+        let mut part_nodes = edf::parse_with_levels(data, &[node]);
+        // No gfx overrides: a wheel binds straight off its own material table.
+        bind_textures(
+            &mut part_nodes,
+            data,
+            &std::collections::HashMap::new(),
+            &std::collections::HashMap::new(),
+        );
+        drop_chain(&mut part_nodes);
+        nodes.append(&mut part_nodes);
+        if !seen.contains(&scene) {
+            seen.push(scene);
+            used.push(data);
+        }
+    }
+    (nodes, used)
+}
+
+fn is_chain(sm: &edf::Submesh) -> bool {
+    sm.texture.as_deref().is_some_and(|t| t.eq_ignore_ascii_case("chain"))
+}
+
+/// Take the chain off the wheels — the one thing the wheel mesh carries that the viewer
+/// can't draw.
+///
+/// It ships as a straight template strip that the game bends onto the sprockets from the
+/// `pos`/`engine`/`ratio` the *bike's* `gfx.cfg` gives, geometry we don't build. Drawn where
+/// it sits it is a bar standing 0.7 m out of the rear wheel.
+///
+/// A node that was nothing but chain goes entirely, since one left with no groups at all is
+/// drawn whole on a single texture rather than not at all.
+fn drop_chain(nodes: &mut Vec<edf::EdfNode>) {
+    nodes.retain_mut(|n| {
+        // No submesh table: a whole-node binding, and not ours to judge.
+        if n.submeshes.is_empty() || !n.submeshes.iter().any(is_chain) {
+            return true;
+        }
+        n.submeshes.retain(|sm| !is_chain(sm));
+        if n.submeshes.is_empty() {
+            return false;
+        }
+        compact_to_submeshes(n);
+        true
+    });
+}
+
+/// Rebuild a node around the submeshes it has left, so what it no longer draws stops
+/// counting for anything else either.
+///
+/// Dropping a submesh on its own leaves its triangles — and their vertices — in the buffers.
+/// Nothing draws them, but everything that *measures* the model still sees them, and the
+/// chain's 0.7 m of template was enough to move where the viewer centres the bike and how
+/// far `SideBySide` drops it onto the ground.
+fn compact_to_submeshes(n: &mut edf::EdfNode) {
+    let old_idx = std::mem::take(&mut n.indices);
+    let old_pos = std::mem::take(&mut n.positions);
+    let old_uv = std::mem::take(&mut n.uvs);
+    let old_nrm = std::mem::take(&mut n.normals);
+    let mut remap: std::collections::HashMap<u32, u32> = std::collections::HashMap::new();
+    let mut indices: Vec<u32> = Vec::with_capacity(old_idx.len());
+    let mut tri_start = 0u32;
+
+    for sm in n.submeshes.iter_mut() {
+        let from = (sm.tri_start as usize).saturating_mul(3);
+        let to = from.saturating_add((sm.tri_count as usize).saturating_mul(3));
+        let range = old_idx.get(from..to).unwrap_or(&[]);
+        for &v in range {
+            let slot = match remap.get(&v) {
+                Some(&slot) => slot,
+                None => {
+                    let slot = (n.positions.len() / 3) as u32;
+                    let o = v as usize;
+                    n.positions
+                        .extend_from_slice(old_pos.get(o * 3..o * 3 + 3).unwrap_or(&[0.0; 3]));
+                    if !old_uv.is_empty() {
+                        n.uvs.extend_from_slice(old_uv.get(o * 2..o * 2 + 2).unwrap_or(&[0.0; 2]));
+                    }
+                    if !old_nrm.is_empty() {
+                        n.normals
+                            .extend_from_slice(old_nrm.get(o * 3..o * 3 + 3).unwrap_or(&[0.0; 3]));
+                    }
+                    remap.insert(v, slot);
+                    slot
+                }
+            };
+            indices.push(slot);
+        }
+        sm.tri_start = tri_start;
+        sm.tri_count = (range.len() / 3) as u32;
+        tri_start += sm.tri_count;
+    }
+    n.indices = indices;
 }
 
 fn gather_bike_files(p: &std::path::Path) -> anyhow::Result<Vec<(String, Vec<u8>)>> {
@@ -8126,6 +8399,8 @@ mod viewer_tests {
             "preview-test".into(),
             files,
             super::installed_paints(&set.bike_dir),
+            // What `load_bike_model_blocking` derives for the bike it's compared against.
+            Some(crate::library::mods_subdir(mp, "mods/tyres")),
             std::time::Instant::now(),
         )
         .expect("preview builds");
@@ -8194,6 +8469,7 @@ mod viewer_tests {
             "stock-preview-test".into(),
             files,
             super::installed_paints(&set.bike_dir),
+            Some(crate::library::mods_subdir(mp, "mods/tyres")),
             std::time::Instant::now(),
         )
         .expect("stock preview builds");
@@ -8305,6 +8581,152 @@ mod viewer_tests {
 
         assert_eq!(found.len(), 1);
         assert_eq!(std::path::Path::new(&found[0].1), paints.join("Frost.pnt"));
+    }
+
+    fn sub(name: &str, texture: Option<&str>) -> crate::edf::Submesh {
+        crate::edf::Submesh {
+            name: name.into(),
+            tri_start: 0,
+            tri_count: 1,
+            texture: texture.map(str::to_string),
+            uv_tile: None,
+            mat: None,
+        }
+    }
+
+    fn node(name: &str, subs: Vec<crate::edf::Submesh>) -> crate::edf::EdfNode {
+        crate::edf::EdfNode {
+            name: name.into(),
+            positions: vec![0.0; 3],
+            uvs: Vec::new(),
+            normals: Vec::new(),
+            indices: vec![0, 0, 0],
+            submeshes: subs,
+            texture: None,
+            placed: true,
+            materials: Vec::new(),
+        }
+    }
+
+    /// The rear wheel arrives with the chain in it, and the chain is a template strip the
+    /// game bends — a metre-long bar if it's drawn where it sits. Everything else on the
+    /// wheel has to survive.
+    #[test]
+    fn the_chain_comes_off_the_rear_wheel() {
+        let mut nodes = vec![
+            node("fwheel", vec![sub("thefwheel", Some("wheel")), sub("thefwheel", Some("fgeomax"))]),
+            node(
+                "rwheela",
+                vec![
+                    sub("thechain", Some("chain")),
+                    sub("therwheela", Some("wheel")),
+                    sub("therwheela", Some("sprocket")),
+                    sub("therwheela", Some("rgeomax")),
+                ],
+            ),
+        ];
+        super::drop_chain(&mut nodes);
+        assert_eq!(nodes.len(), 2, "both wheels stay");
+        assert_eq!(nodes[0].submeshes.len(), 2, "the front wheel is untouched");
+        let rear: Vec<&str> =
+            nodes[1].submeshes.iter().filter_map(|s| s.texture.as_deref()).collect();
+        assert_eq!(rear, ["wheel", "sprocket", "rgeomax"], "rim, sprocket and tyre stay");
+    }
+
+    /// The bug the first cut of this had: the submesh went, its vertices stayed, and the
+    /// chain's 0.7 m of template still counted towards the bounds everything else is
+    /// measured against — where the viewer centres the bike, where `SideBySide` stands it.
+    #[test]
+    fn the_chains_vertices_go_with_it() {
+        let mut n = node(
+            "rwheela",
+            vec![sub("therwheela", Some("wheel")), sub("thechain", Some("chain"))],
+        );
+        // Two triangles: the wheel's on the axle, the chain's a long way above it.
+        n.positions = vec![0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.7, 0.0];
+        n.uvs = vec![0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.5, 0.5];
+        n.indices = vec![0, 1, 2, 1, 2, 3];
+        n.submeshes[0].tri_start = 0;
+        n.submeshes[1].tri_start = 1;
+        let mut nodes = vec![n];
+
+        super::drop_chain(&mut nodes);
+        let n = &nodes[0];
+        assert_eq!(n.submeshes.len(), 1);
+        assert_eq!(n.submeshes[0].texture.as_deref(), Some("wheel"));
+        assert_eq!(n.submeshes[0].tri_start, 0, "the survivor is renumbered from zero");
+        assert_eq!(n.submeshes[0].tri_count, 1);
+        assert_eq!(n.indices, vec![0, 1, 2], "vertices remapped onto what's left");
+        assert_eq!(n.positions.len(), 9, "the chain's lone vertex is gone");
+        assert_eq!(n.uvs.len(), 6, "uvs are compacted alongside");
+        let top = n.positions.chunks_exact(3).map(|p| p[1]).fold(f32::MIN, f32::max);
+        assert!(top < 0.2, "nothing left standing 0.7 m up: {top}");
+    }
+
+    /// A node with nothing but chain in it has to go entirely: left with no groups, the
+    /// frontend draws the whole node on one texture rather than nothing at all.
+    #[test]
+    fn a_node_that_is_only_chain_is_dropped() {
+        let mut nodes = vec![
+            node("chain", vec![sub("thechain", Some("CHAIN"))]),
+            // No submesh table at all — a whole-node binding, and not ours to judge.
+            node("rwheela", Vec::new()),
+        ];
+        super::drop_chain(&mut nodes);
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].name, "rwheela");
+    }
+
+    /// The bike source is `<mods>/bikes/<Bike>`; the tyres sit beside `bikes`, not inside it.
+    #[test]
+    fn tyres_sit_beside_the_bikes_folder() {
+        let dir = super::tyres_dir_for(Path::new("/games/mods/bikes/MX1OEM_2023_Honda_CRF450R"));
+        assert_eq!(dir.as_deref(), Some(Path::new("/games/mods/tyres")));
+        let packed = super::tyres_dir_for(Path::new("/games/mods/bikes/Some_Bike.pkz"));
+        assert_eq!(packed.as_deref(), Some(Path::new("/games/mods/tyres")));
+    }
+
+    fn tyres_tmp(tag: &str) -> PathBuf {
+        let root = std::env::temp_dir()
+            .join(format!("frost-tyres-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    #[test]
+    fn tyre_files_come_from_the_mod_the_bike_names() {
+        let root = tyres_tmp("loose");
+        let mod_dir = root.join("oem_mx");
+        std::fs::create_dir_all(&mod_dir).unwrap();
+        for (name, body) in [
+            ("gfx.cfg", "front_wheel\n{\n\tmodel\n\t{\n\t\tfile = fwheel.hrc\n\t}\n}\n"),
+            ("fwheel.hrc", "level0\n{\n\tscene = model.edf\n}\n"),
+            ("model.edf", "EDF\0"),
+            // Beside them and never drawn — must not be read.
+            ("OEM_MXf_is80100-21.tyre", "params"),
+            ("preview.tga", "pixels"),
+        ] {
+            std::fs::write(mod_dir.join(name), body).unwrap();
+        }
+
+        let found = super::gather_tyre_files(&root, b"tyres = oem_mx\n");
+        let mut names: Vec<&str> = found.iter().map(|(n, _)| n.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(names, ["fwheel.hrc", "gfx.cfg", "model.edf"]);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Every way a bike can end up with no wheels. None of them is an error: that is the
+    /// bike the viewer drew before wheels existed.
+    #[test]
+    fn no_tyres_mod_means_no_wheels_and_no_fuss() {
+        let root = tyres_tmp("empty");
+        assert!(super::gather_tyre_files(&root, b"tyres = oem_mx\n").is_empty(), "not installed");
+        assert!(super::gather_tyre_files(&root, b"chassis\n{\n}\n").is_empty(), "no tyres line");
+        // The name is read out of a mod's own file, so it never gets to walk out of `tyres/`.
+        assert!(super::gather_tyre_files(&root, b"tyres = ../bikes\n").is_empty(), "traversal");
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/src-tauri/src/modelswap.rs
+++ b/src-tauri/src/modelswap.rs
@@ -1973,7 +1973,7 @@ mod tests {
 
         let before = names_at(&dst);
         eprintln!("root before: {before:?}");
-        let nodes_before = crate::load_bike_model_blocking(dst.to_string_lossy().to_string())
+        let nodes_before = crate::load_bike_model_blocking(dst.to_string_lossy().to_string(), None)
             .expect("the bike loads before the swap")
             .nodes
             .len();
@@ -1987,7 +1987,7 @@ mod tests {
             assert!(after.contains(f), "{f} must still be at the bike root after a swap");
         }
         let model =
-            crate::load_bike_model_blocking(dst.to_string_lossy().to_string())
+            crate::load_bike_model_blocking(dst.to_string_lossy().to_string(), None)
                 .expect("the bike still loads after the swap");
         assert_eq!(model.nodes.len(), nodes_before, "same parts resolve after the swap");
 

--- a/src/Components/Studio/Designer/PreviewPanel.tsx
+++ b/src/Components/Studio/Designer/PreviewPanel.tsx
@@ -3,6 +3,8 @@ import { Box, Loader2, TriangleAlert } from "lucide-react";
 import type * as THREE from "three";
 import { cn } from "@/lib/utils";
 import { ModelViewer } from "../../Viewer/ModelViewer";
+import { TyresPicker } from "../../Viewer/TyresPicker";
+import { useTyresPick } from "../../Viewer/tyresPick";
 import { loadBikeModel, loadRiderModel, scanLibrary } from "../../../api/mods";
 import { displayName } from "../../../lib/mods";
 import { EMPTY_LOADOUT } from "../../../lib/presets";
@@ -89,6 +91,7 @@ export function PreviewPanel({
   const [textures, setTextures] = useState<PaintTexture[]>([]);
   // The model's own textures, kept apart from the ones it is currently wearing.
   const [stock, setStock] = useState<PaintTexture[]>([]);
+  const tyresPick = useTyresPick();
   const [riderParts, setRiderParts] = useState<RiderPart[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -158,7 +161,7 @@ export function PreviewPanel({
         // something else, and it is still the right path to try — the load then fails with
         // the accurate reason (no mesh) instead of this claiming it isn't installed.
         if (!found) throw new Error(t("designer.noModelFound", { model }));
-        return loadBikeModel(found.path);
+        return loadBikeModel(found.path, tyresPick.tyres);
       })
       .then((m) => {
         if (!alive) return;
@@ -183,7 +186,7 @@ export function PreviewPanel({
     return () => {
       alive = false;
     };
-  }, [isBike, model, bikePreview, t]);
+  }, [isBike, model, bikePreview, t, tyresPick.tyres]);
 
   useEffect(() => {
     if (!loadout) {
@@ -261,6 +264,7 @@ export function PreviewPanel({
         {t("viewer.preview3d")}
         {/* What you're looking at, and what's in the way of it. A kit is worn under a chest
             protector, and judging a jersey you can only see half of is judging the protector. */}
+        {isBike && <TyresPicker pick={tyresPick} className="ml-auto" />}
         {!isBike && (
           <div className="ml-auto flex items-center gap-1">
             {/* A helmet on a rider is a small thing across the canvas with half of it turned

--- a/src/Components/Viewer/ModelViewer.tsx
+++ b/src/Components/Viewer/ModelViewer.tsx
@@ -38,12 +38,9 @@ async function loadTexture(t: PaintTexture): Promise<THREE.DataTexture | null> {
     );
     return null;
   }
-  const tex = new THREE.DataTexture(
-    new Uint8Array(buf),
-    t.width,
-    t.height,
-    THREE.RGBAFormat,
-  );
+  const rgba = new Uint8Array(buf);
+  const tex = new THREE.DataTexture(rgba, t.width, t.height, THREE.RGBAFormat);
+  tex.userData.maskedAlpha = hasMaskedAlpha(rgba);
   tex.colorSpace = THREE.SRGBColorSpace;
   // MX Bikes paints use a top-left UV origin, which is `DataTexture`'s own default.
   tex.flipY = false;
@@ -56,6 +53,32 @@ async function loadTexture(t: PaintTexture): Promise<THREE.DataTexture | null> {
   tex.anisotropy = 4;
   tex.needsUpdate = true;
   return tex;
+}
+
+/**
+ * Whether a sheet's alpha channel is a cut-out mask, or just a channel nobody filled in.
+ *
+ * A wheel's brake discs and its sprocket are flat quads wearing a masked square — two thirds
+ * of `fdisc` is fully transparent — so drawn without a mask each one is a square sitting on
+ * the wheel. A naive "does it have alpha" test can't be used, though: a bike's `w_plate` is
+ * alpha-0 on *every* pixel, an unused channel, and masking on that erases the number plates
+ * outright. So the channel only counts as a mask when it varies.
+ *
+ * Sampled, not scanned: a 4096² sheet is 16M pixels and this runs per texture per load,
+ * while a real mask covers a third of the image or more and turns up in the first few
+ * samples. A mask smaller than one part in 65536 is missed, and renders as it always did.
+ */
+function hasMaskedAlpha(rgba: Uint8Array): boolean {
+  const pixels = rgba.length / 4;
+  const step = Math.max(1, Math.floor(pixels / 65536));
+  let clear = false;
+  let solid = false;
+  for (let i = 0; i < pixels; i += step) {
+    if (rgba[i * 4 + 3] < 128) clear = true;
+    else solid = true;
+    if (clear && solid) return true;
+  }
+  return false;
 }
 
 /**
@@ -857,6 +880,11 @@ function makeEdfMaterial(t: THREE.Texture | null) {
     color: t ? 0xffffff : 0xb7bcc4,
     metalness: 0.2,
     roughness: 0.55,
+    // Cut the mask out where a sheet carries one (see `hasMaskedAlpha`) — a brake disc and a
+    // sprocket are a masked square on a flat quad, and the square is what shows otherwise.
+    // Tested rather than blended: the mask is hard-edged, and `transparent` would drag the
+    // quad into the sorted pass and let it disappear behind the wheel it sits on.
+    alphaTest: t?.userData.maskedAlpha ? 0.5 : 0,
     // Inconsistent winding — render both sides so the bike isn't see-through.
     side: THREE.DoubleSide,
   });

--- a/src/Components/Viewer/TyresPicker.tsx
+++ b/src/Components/Viewer/TyresPicker.tsx
@@ -1,0 +1,34 @@
+import { useT } from "../../i18n/context";
+import { cn } from "../../lib/utils";
+import { BIKE_OWN_TYRES, type TyresPick } from "./tyresPick";
+
+/**
+ * Which tyre pack to draw a bike on — the same control in each of the three previews.
+ *
+ * Hidden when nothing is installed under `mods/tyres`: with no pack to switch to, the only
+ * entry would be the one the bike already names, which is a dropdown that does nothing.
+ * The pick itself lives in {@link TyresPick} so the caller can load the model with it.
+ */
+export function TyresPicker({ pick, className }: { pick: TyresPick; className?: string }) {
+  const t = useT();
+  if (!pick.options.length) return null;
+  return (
+    <label
+      className={cn("flex items-center gap-1.5 text-xs text-muted-foreground", className)}
+    >
+      {t("viewer.tyres")}
+      <select
+        value={pick.tyres}
+        onChange={(e) => pick.choose(e.target.value)}
+        className="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground"
+      >
+        <option value={BIKE_OWN_TYRES}>{t("viewer.tyresOwn")}</option>
+        {pick.options.map((name) => (
+          <option key={name} value={name}>
+            {name}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/src/Components/Viewer/ViewerDialog.tsx
+++ b/src/Components/Viewer/ViewerDialog.tsx
@@ -15,6 +15,8 @@ import {
 } from "../../api/mods";
 import type { PaintTexture, BikeModel, EdfNode, RiderPart, GearPaints } from "../../types";
 import { useT } from "../../i18n/context";
+import { TyresPicker } from "./TyresPicker";
+import { useTyresPick } from "./tyresPick";
 
 interface ViewerDialogProps {
   open: boolean;
@@ -94,6 +96,7 @@ export function ViewerDialog({
   // Deriving it rather than storing it is what lets a late-arriving list still land on
   // the right paint without ever overriding a pick made in the meantime.
   const [paintPick, setPaintPick] = useState<number | null>(null);
+  const tyresPick = useTyresPick();
   const [gogglesPick, setGogglesPick] = useState<number | null>(null);
   const [model, setModel] = useState<BikeModel | null>(null);
   const [loadingModel, setLoadingModel] = useState(false);
@@ -142,9 +145,9 @@ export function ViewerDialog({
     }
     const load =
       swapBike && swapVariant
-        ? previewModelSwap(swapBike, swapVariant)
+        ? previewModelSwap(swapBike, swapVariant, tyresPick.tyres)
         : modelSource
-          ? loadBikeModel(modelSource)
+          ? loadBikeModel(modelSource, tyresPick.tyres)
           : null;
     if (!load) {
       setModel(null);
@@ -165,7 +168,7 @@ export function ViewerDialog({
     return () => {
       alive = false;
     };
-  }, [open, modelSource, swapBike, swapVariant]);
+  }, [open, modelSource, swapBike, swapVariant, tyresPick.tyres]);
 
   // Drop any pick each time it opens, so the next thing shown starts from its own paint
   // rather than the index left behind by the last one.
@@ -431,6 +434,7 @@ export function ViewerDialog({
                 </select>
               </label>
             )}
+            {isBike && <TyresPicker pick={tyresPick} />}
             {goggleOptions.length > 0 && (
               <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
                 {t("category.goggles")}

--- a/src/Components/Viewer/ViewerPanel.tsx
+++ b/src/Components/Viewer/ViewerPanel.tsx
@@ -8,6 +8,8 @@ import { ModelViewer, type ViewerMode } from "./ModelViewer";
 import { loadRiderModel, previewModelSwap } from "../../api/mods";
 import type { BikeModel, Loadout, PaintTexture, RiderPart } from "../../types";
 import { useT } from "../../i18n/context";
+import { TyresPicker } from "./TyresPicker";
+import { useTyresPick } from "./tyresPick";
 
 interface ViewerPanelProps {
   texture?: PaintTexture | null;
@@ -89,6 +91,7 @@ export function ViewerPanel({
   // The bike half. Kept whole rather than as bare nodes: the model carries every paint
   // installed for it, so switching livery is a pick out of this and not another resolve.
   const [bikeModel, setBikeModel] = useState<BikeModel | null>(null);
+  const tyresPick = useTyresPick();
   const [bikeLoading, setBikeLoading] = useState(false);
   const [bikeError, setBikeError] = useState<string | null>(null);
   const bikeFirst = useRef(true);
@@ -181,7 +184,7 @@ export function ViewerPanel({
     const timer = setTimeout(() => {
       // "Stock" is the fallback the backend understands for a bike whose active variant the
       // caller couldn't name — the model packed in the archive.
-      previewModelSwap(bikeId!, bikeVariant || "Stock")
+      previewModelSwap(bikeId!, bikeVariant || "Stock", tyresPick.tyres)
         .then((m) => {
           if (!alive) return;
           setBikeModel(m);
@@ -205,7 +208,7 @@ export function ViewerPanel({
       clearTimeout(timer);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [withBike, bikeId, bikeVariant]);
+  }, [withBike, bikeId, bikeVariant, tyresPick.tyres]);
 
   // The livery the loadout names, out of what the bike carries. Nothing named, or a name
   // nothing installed answers to, leaves the model in the look it ships with.
@@ -299,6 +302,7 @@ export function ViewerPanel({
             {t("viewer.preview3d")}
           </div>
           <div className="flex items-center gap-2">
+            {withBike && <TyresPicker pick={tyresPick} />}
             {!riderOnly && <ModeToggle mode={mode} modes={modes} onChange={setMode} />}
             <Button
               variant="chip"
@@ -327,7 +331,10 @@ export function ViewerPanel({
               <Box className="h-4 w-4 text-muted-foreground" />
               {t("viewer.preview3d")}
             </div>
-            {!riderOnly && <ModeToggle mode={mode} modes={modes} onChange={setMode} />}
+            <div className="flex items-center gap-2">
+              {withBike && <TyresPicker pick={tyresPick} />}
+              {!riderOnly && <ModeToggle mode={mode} modes={modes} onChange={setMode} />}
+            </div>
           </div>
           <div className="relative min-h-0 flex-1">
             {/* Posing only in the expanded view: the inline panel is 280px tall, and a

--- a/src/Components/Viewer/tyresPick.ts
+++ b/src/Components/Viewer/tyresPick.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useState } from "react";
+import { scanLibrary, setPreviewTyres } from "../../api/mods";
+import { useConfig } from "../../Context/Config";
+
+/** The value that means "whatever the bike's own `gfx.cfg` names". */
+export const BIKE_OWN_TYRES = "";
+
+export interface TyresPick {
+  /** The pack to render on, or {@link BIKE_OWN_TYRES}. */
+  tyres: string;
+  /** Installed packs, without extension. Empty while scanning, and on a machine with none. */
+  options: string[];
+  choose: (name: string) => void;
+}
+
+/**
+ * Which tyre pack the 3D previews fit, shared by every place that draws a bike.
+ *
+ * A bike's `gfx.cfg` names exactly one pack, so seeing it on another means substituting that
+ * name — which the backend does in memory, leaving the mod folder alone. The choice lives in
+ * the app config rather than in each preview's own state, because it's a way you like looking
+ * at bikes, not a decision per dialog: pick in the Viewer and the Designer agrees.
+ *
+ * Options come from the same `mods/tyres` scan the Presets tyre slot uses. Deliberately not
+ * the built-in names that slot also offers (`p_mx`): the game accepts those, but there are no
+ * files on disk to draw, so offering one here would be a pick that silently changes nothing.
+ */
+export function useTyresPick(): TyresPick {
+  const { config, reloadConfig } = useConfig();
+  const saved = config.previewTyres ?? BIKE_OWN_TYRES;
+  const [tyres, setTyres] = useState(saved);
+  const [options, setOptions] = useState<string[]>([]);
+
+  // Follow the config when it changes under us — another preview's pick, or a reload.
+  useEffect(() => setTyres(saved), [saved]);
+
+  useEffect(() => {
+    let alive = true;
+    scanLibrary("mods/tyres")
+      .then((entries) => {
+        if (!alive) return;
+        const names = [
+          ...new Set(entries.map((e) => e.name.replace(/\.(pkz|zip)$/i, ""))),
+        ].sort((a, b) => a.localeCompare(b));
+        setOptions(names);
+      })
+      .catch(() => alive && setOptions([]));
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const choose = useCallback(
+    (name: string) => {
+      // Shown before it's saved: the reload behind this is a whole-app re-read, and waiting
+      // on it would leave the dropdown showing the old pack while the bike reloads.
+      setTyres(name);
+      void setPreviewTyres(name)
+        .then(reloadConfig)
+        .catch((e) => console.warn("[viewer] couldn't remember the tyres pick:", e));
+    },
+    [reloadConfig],
+  );
+
+  return { tyres, options, choose };
+}

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -437,8 +437,12 @@ export function applyModelSwap(bike: string, target: string): Promise<SwapApplyO
  * assembled in memory, so nothing moves on disk and the game can stay open. "Stock" shows
  * the packed model the loose files are hiding.
  */
-export function previewModelSwap(bike: string, variant: string): Promise<BikeModel> {
-  return invoke<BikeModel>("preview_model_swap", { bike, variant });
+export function previewModelSwap(
+  bike: string,
+  variant: string,
+  tyres?: string,
+): Promise<BikeModel> {
+  return invoke<BikeModel>("preview_model_swap", { bike, variant, tyres: tyres || null });
 }
 
 /**
@@ -660,8 +664,16 @@ export function unpackPkz(path: string, outDir: string): Promise<string[]> {
   return invoke<string[]>("unpack_pkz", { path, outDir });
 }
 
-export function loadBikeModel(source: string): Promise<BikeModel> {
-  return invoke<BikeModel>("load_bike_model", { source });
+/**
+ * A bike's geometry, its paints, and the wheels it wears.
+ *
+ * `tyres` substitutes the pack the bike's own `gfx.cfg` names — a bike names exactly one, so
+ * that substitution is the only way to see it on another. Nothing on disk is renamed, and a
+ * name that isn't installed falls back to the bike's own rather than losing the wheels.
+ * Omit it (or pass `""`) for whatever the bike itself asks for.
+ */
+export function loadBikeModel(source: string, tyres?: string): Promise<BikeModel> {
+  return invoke<BikeModel>("load_bike_model", { source, tyres: tyres || null });
 }
 
 export function loadRiderModel(loadout: Loadout): Promise<RiderModel> {
@@ -1957,6 +1969,11 @@ export function voiceDevices(): Promise<VoiceDevices> {
 
 export function setVoiceEnabled(enabled: boolean): Promise<void> {
   return invoke<void>("set_voice_enabled", { enabled });
+}
+
+/** Pick the tyre pack the 3D previews fit. `""` means "whatever the bike names". */
+export function setPreviewTyres(tyres: string): Promise<void> {
+  return invoke<void>("set_preview_tyres", { tyres });
 }
 
 /** Pick the microphone. `""` means "follow the system default". */

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -346,6 +346,8 @@ export const de: Translation = {
   "viewer.preview3d": "3D-Vorschau",
   "viewer.expand": "Vergrößern",
   "viewer.paint": "Design",
+  "viewer.tyres": "Reifen",
+  "viewer.tyresOwn": "Die des Bikes",
   "viewer.loadingModel": "Modell wird geladen…",
   "viewer.loadingPaint": "Design wird geladen…",
   "viewer.loadingRider": "Fahrer wird geladen…",

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -909,7 +909,7 @@ export const de: Translation = {
   "viewer.stockGearNote":
     "Auf dem Standard-{{part}} des Spiels gezeigt. Ein Design für ein anderes Modell passt möglicherweise nicht exakt.",
   "viewer.paintNoChange":
-    "Keine der Texturen dieses Designs wird von den hier gezeigten Teilen verwendet, deshalb ändert sich die Vorschau nicht. Es kann trotzdem Räder oder Kette einfärben, die diese Ansicht nicht darstellt.",
+    "Keine der Texturen dieses Designs wird von den hier gezeigten Teilen verwendet, deshalb ändert sich die Vorschau nicht. Es kann trotzdem die Kette einfärben, die diese Ansicht nicht darstellt.",
   "viewer.noPaintPreview": "Keine Design-Vorschau ({{err}})",
 
   // ── Bibliothek ─────────────────────────────────────────────────────────────

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -333,6 +333,8 @@ export const en = {
   "viewer.preview3d": "3D Preview",
   "viewer.expand": "Expand",
   "viewer.paint": "Paint",
+  "viewer.tyres": "Tyres",
+  "viewer.tyresOwn": "Bike's own",
   "viewer.loadingModel": "Loading model…",
   "viewer.loadingPaint": "Loading paint…",
   "viewer.loadingRider": "Loading rider…",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -886,7 +886,7 @@ export const en = {
   "viewer.stockGearNote":
     "Shown on the game's stock {{part}}. A paint made for a different model may not line up perfectly.",
   "viewer.paintNoChange":
-    "None of this paint's textures are used by the parts shown here, so the preview doesn't change. It may still paint the wheels or chain, which this view doesn't render.",
+    "None of this paint's textures are used by the parts shown here, so the preview doesn't change. It may still paint the chain, which this view doesn't render.",
   "viewer.noPaintPreview": "No paint preview ({{err}})",
 
   // ── Library (installed mods) ───────────────────────────────────────────────

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -340,6 +340,8 @@ export const es: Translation = {
   "viewer.preview3d": "Vista previa 3D",
   "viewer.expand": "Ampliar",
   "viewer.paint": "Gráficos",
+  "viewer.tyres": "Neumáticos",
+  "viewer.tyresOwn": "Los de la moto",
   "viewer.loadingModel": "Cargando modelo…",
   "viewer.loadingPaint": "Cargando gráficos…",
   "viewer.loadingRider": "Cargando piloto…",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -902,7 +902,7 @@ export const es: Translation = {
   "viewer.stockGearNote":
     "Mostrado sobre el {{part}} de serie del juego. Unos gráficos hechos para otro modelo pueden no encajar del todo.",
   "viewer.paintNoChange":
-    "Ninguna de las texturas de estos gráficos la usan las piezas que se muestran aquí, así que la vista previa no cambia. Aun así puede pintar las ruedas o la cadena, que esta vista no representa.",
+    "Ninguna de las texturas de estos gráficos la usan las piezas que se muestran aquí, así que la vista previa no cambia. Aun así puede pintar la cadena, que esta vista no representa.",
   "viewer.noPaintPreview": "Sin vista previa de los gráficos ({{err}})",
 
   // ── Biblioteca ─────────────────────────────────────────────────────────────

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -343,6 +343,8 @@ export const fr: Translation = {
   "viewer.preview3d": "Aperçu 3D",
   "viewer.expand": "Agrandir",
   "viewer.paint": "Déco",
+  "viewer.tyres": "Pneus",
+  "viewer.tyresOwn": "Ceux de la moto",
   "viewer.loadingModel": "Chargement du modèle…",
   "viewer.loadingPaint": "Chargement de la déco…",
   "viewer.loadingRider": "Chargement du pilote…",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -907,7 +907,7 @@ export const fr: Translation = {
   "viewer.stockGearNote":
     "Affiché sur le {{part}} d'origine du jeu. Une déco faite pour un autre modèle peut ne pas s'aligner parfaitement.",
   "viewer.paintNoChange":
-    "Aucune texture de cette déco n'est utilisée par les pièces affichées ici, donc l'aperçu ne change pas. Elle peut tout de même peindre les roues ou la chaîne, que cette vue n'affiche pas.",
+    "Aucune texture de cette déco n'est utilisée par les pièces affichées ici, donc l'aperçu ne change pas. Elle peut tout de même peindre la chaîne, que cette vue n'affiche pas.",
   "viewer.noPaintPreview": "Pas d'aperçu de la déco ({{err}})",
 
   // ── Bibliothèque ───────────────────────────────────────────────────────────

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -339,6 +339,8 @@ export const it: Translation = {
   "viewer.preview3d": "Anteprima 3D",
   "viewer.expand": "Ingrandisci",
   "viewer.paint": "Grafica",
+  "viewer.tyres": "Gomme",
+  "viewer.tyresOwn": "Quelle della moto",
   "viewer.loadingModel": "Caricamento modello…",
   "viewer.loadingPaint": "Caricamento grafica…",
   "viewer.loadingRider": "Caricamento pilota…",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -900,7 +900,7 @@ export const it: Translation = {
   "viewer.stockGearNote":
     "Mostrato sul {{part}} stock del gioco. Una grafica fatta per un altro modello potrebbe non combaciare alla perfezione.",
   "viewer.paintNoChange":
-    "Nessuna delle texture di questa grafica è usata dalle parti mostrate qui, quindi l'anteprima non cambia. Potrebbe comunque colorare ruote o catena, che questa vista non mostra.",
+    "Nessuna delle texture di questa grafica è usata dalle parti mostrate qui, quindi l'anteprima non cambia. Potrebbe comunque colorare la catena, che questa vista non mostra.",
   "viewer.noPaintPreview": "Nessuna anteprima della grafica ({{err}})",
 
   // ── Libreria ───────────────────────────────────────────────────────────────

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -902,7 +902,7 @@ export const ptBR: Translation = {
   "viewer.stockGearNote":
     "Mostrado no {{part}} original do jogo. Uma pintura feita para outro modelo pode não encaixar perfeitamente.",
   "viewer.paintNoChange":
-    "Nenhuma das texturas desta pintura é usada pelas peças mostradas aqui, então a prévia não muda. Ela ainda pode pintar as rodas ou a corrente, que esta visão não renderiza.",
+    "Nenhuma das texturas desta pintura é usada pelas peças mostradas aqui, então a prévia não muda. Ela ainda pode pintar a corrente, que esta visão não renderiza.",
   "viewer.noPaintPreview": "Sem prévia da pintura ({{err}})",
 
   // ── Biblioteca ─────────────────────────────────────────────────────────────

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -342,6 +342,8 @@ export const ptBR: Translation = {
   "viewer.preview3d": "Prévia 3D",
   "viewer.expand": "Expandir",
   "viewer.paint": "Pintura",
+  "viewer.tyres": "Pneus",
+  "viewer.tyresOwn": "Os da moto",
   "viewer.loadingModel": "Carregando o modelo…",
   "viewer.loadingPaint": "Carregando a pintura…",
   "viewer.loadingRider": "Carregando o piloto…",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -109,6 +109,10 @@ export interface Config {
   overlayEnabled?: boolean;
   /** Overlay toggle combo in Tauri accelerator syntax, e.g. `"CommandOrControl+Shift+X"`. */
   overlayHotkey?: string;
+  /** Which tyre pack the 3D previews fit a bike with. **Blank means the pack the bike's own
+   *  `gfx.cfg` names**, which is what the game would fit. Substituting the name is all it
+   *  takes to see a bike on another pack — nothing on disk is touched. */
+  previewTyres?: string;
   /** Voice chat is off until turned on — a feature that opens a microphone shouldn't be
    *  something anyone discovers by accident. */
   voiceEnabled?: boolean;
@@ -428,6 +432,13 @@ export interface BikeModel {
    * Designer's reference underlay is the one place that difference matters.
    */
   base: PaintTexture[];
+  /**
+   * The tyres mod the wheels were drawn from, or `null` when the bike drew none.
+   *
+   * What was actually fitted, not what was asked for: a pick naming a pack that isn't
+   * installed falls back to the bike's own, and the picker shows what's on screen.
+   */
+  tyres: string | null;
   /**
    * Whether the bike's `.geom` placed the parts into one frame.
    *


### PR DESCRIPTION
A bike ships no wheel of its own. Its `gfx.cfg` names a tyres mod on one line — `tyres = oem_mx` — the wheel meshes live in that mod, and the axle points they hang off have been sitting unread in the bike's `.geom` all along. The preview drew the frame, the forks, the swingarm and the bars, then stopped: every bike stood on bare fork tips.

Both are read now, and you can pick which pack a bike wears.

## Wheels

- `edf::wheel_axles` resolves the two axles from the `.geom` mounts, through the same `Mounts` struct `assemble_bike` uses, so the wheels are placed in the frames the suspension already is. The rear sits at the midpoint of the `rwheel_min`/`rwheel_max` chain-adjuster range — what the `.geom`'s own collision notes tell a modder to use. Checked against a real bike: a 2023 CRF450R comes out **1.476 m** between axles against a published 1.481 m.
- **The chain is dropped.** It ships as a straight template strip the game bends onto the sprockets at runtime, so drawn where it sits it is a bar standing 0.7 m out of the rear wheel. Its *vertices* are compacted out too, not just its submesh — the bounds feed `<Center>` and the ground drop in `SideBySide`, so geometry nothing draws has to stop counting.
- **Fixes a square where each brake disc should be.** `fdisc`, `rdisc` and `sprocket` are cut-out masks on flat quads (two thirds of `fdisc` is fully transparent) and the bike material never alpha-tested. It does now — but only where a sheet's alpha actually *varies*: a bike's `w_plate` is alpha-0 on every pixel, an unused channel, and masking on that would have erased the number plates instead.
- The wheel textures join `BikeModel.base`, which is what lets a paint replacing `wheel` or `chain` show it. Every OEM bike's stock livery replaces those and nothing else, so it used to change nothing on screen; the note apologising for that is reworded in all six locales.

## Picking the tyres

- A bike names exactly one pack, so the pick **substitutes the name the wheels are looked up under** — nothing on disk is renamed, no mod is touched, and the bike's own `gfx.cfg` still reads exactly as the game reads it. No geometry is spliced.
- One `useTyresPick` hook behind `TyresPicker`, used by the Viewer dialog, the Rider tab and the Designer preview, so the three are one setting rather than three that disagree. Remembered in `AppConfig.preview_tyres`.
- Options come from the `mods/tyres` scan the Presets tyre slot already uses. The built-in names that slot also offers (`p_mx`) are deliberately left out — the game accepts them, but there are no files on disk to draw.
- A pick naming a pack that isn't installed falls back to the bike's own and logs why, rather than costing the bike its wheels.

## Never an error

A tyres mod that isn't installed, an archive that won't read, or a `.geom` with no axle points all log why and render the bike exactly as before. The bike cache key gains a `tyres_stamp` and the pick — the same hole `paints_stamp` fills, one folder out.

## Verification

- 865 tests pass; 9 new (axle placement against the real CRF450R numbers, the rear-axle midpoint rule, a `.geom` with no wheel mounts, the chain's submesh *and* vertices going, the pick beating the bike's name, a bad pick falling back, traversal rejected).
- Real files: `MXB_REAL_PKZ=… cargo test bike_model_from_pkz -- --ignored` shows both wheels bound and no chain, identically under `MXB_TYRES` unset, `oem_mx`, and a name that isn't installed.
- Run in the app against the real mods tree.

Note: only `oem_mx` is installed on this machine, so the picker is proven by tests and by the fallback paths rather than by a visible switch.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)