### PR TITLE
chore(supporters): list Bøddi in place of Thomas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
   one re-reads, and a bike that won't resolve says so instead of quietly leaving the rider alone.
 
 ### Changed
+- Settings → Supporters lists **Bøddi** in place of **Thomas**.
+
 - **The Rider tab's bike picker is searchable.** It was a plain dropdown, which is a long
   scroll past dozens of bikes for a name you already know. It's now the same searchable
   field as the Paint and Model swap slots beside it — type to filter. Unlike those, it

--- a/src/Components/Settings/supporters.ts
+++ b/src/Components/Settings/supporters.ts
@@ -67,7 +67,7 @@ export const BUNDLED_SUPPORTERS: SupportersManifest = {
     { name: "Qwest" },
     { name: "RodaksRevivalYT | Black Rifle" },
     { name: "MintyFlow" },
-    { name: "Thomas" },
+    { name: "Bøddi" },
     { name: "Kelso" },
   ],
 };

--- a/supporters.json
+++ b/supporters.json
@@ -11,7 +11,7 @@
     "Qwest",
     "RodaksRevivalYT | Black Rifle",
     "MintyFlow",
-    "Thomas",
+    "Bøddi",
     "Kelso"
   ]
 }


### PR DESCRIPTION
Bøddi takes Thomas's slot on Settings → Supporters.

- `supporters.json` — the list every installed copy reads off `main`, so the credits page updates without a release.
- `BUNDLED_SUPPORTERS` — same swap, so an install that has never reached the network doesn't show a stale name.
- Plain name, no tier or `since`; the entry keeps its position in the hand-ordered list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)