### PR TITLE
fix(viewer): keep the packed bike under a model-swap preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,22 @@
 
 ### Fixed
 
+- **A model swap previewed as a white bike in pieces.** A model set is a mesh and little
+  else — the `.geom` that mounts the parts to each other, the `gfx.cfg` and `.hrc`s that say
+  which mesh each part uses, and the stock paint all belong to the bike, and on an OEM bike
+  they never leave its `.pkz`. The preview skipped that archive the moment the swap brought a
+  mesh of its own, so it drew the swap's `model.edf` and nothing else: every part stacked at
+  the origin with no texture on any of it. The packed bike now goes underneath every preview,
+  with the loose files over it and the swap's over those — the order the game itself reads a
+  bike in. The same skip was on the ordinary load path, so an extracted bike whose `.geom`
+  stayed behind in its archive rendered unassembled too, swap or no swap.
+- **A model swap could carry off the bike's own setup files.** A variant folder holding copies
+  of the `.hrc`s, `.cfg` or `.geom` — with no mesh of its own — made the swapper treat those
+  files as the model's, so they were parked along with it and the bike was left a mesh with
+  nothing to assemble or texture it. They're the bike's, never a model's; only a variant that
+  actually brings its own replacement displaces them now. Bikes already recorded that way are
+  read correctly without anything having to be repaired on disk.
+
 - **A packed mod with a version in its name told the Designer nothing.** A model installed as
   an archive is found by the `<Model>.pkz` sitting where its folder would be — and that name
   was built by replacing the model's file extension, which a name like `Fox Instinct 2.0 by

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1557,7 +1557,23 @@ fn mtime_nanos(path: &std::path::Path) -> u128 {
 fn bike_cache_key(source: &str) -> String {
     let path = std::path::Path::new(source);
     let size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
-    format!("{source}:{}:{size}", mtime_nanos(path))
+    format!("{source}:{}:{size}{}", mtime_nanos(path), packed_stamp(path))
+}
+
+/// The bike's packed archive, as a cache key fragment. It's a real input to every bike now
+/// — the loose folder layers over it — and updating a bike replaces the `.pkz` without
+/// necessarily touching the folder above it.
+fn packed_stamp(bike_dir: &std::path::Path) -> String {
+    if !bike_dir.is_dir() {
+        return String::new(); // the source *is* the archive; its own mtime is already in the key
+    }
+    match packed_bike(bike_dir) {
+        Some(pkz) => {
+            let size = std::fs::metadata(&pkz).map(|m| m.len()).unwrap_or(0);
+            format!("#z{}:{size}", mtime_nanos(&pkz))
+        }
+        None => String::new(),
+    }
 }
 
 /// A swap preview is keyed by both folders it's built from — the same bike renders
@@ -1567,12 +1583,13 @@ fn swap_cache_key(set: &modelswap::PreviewSet) -> String {
     // without touching either folder — so key on the resolved paths, not just the mtimes.
     let paints: Vec<String> = set.paints.iter().map(|p| p.display().to_string()).collect();
     format!(
-        "{}#{}:{}:{}:{}",
+        "{}#{}:{}:{}:{}{}",
         set.bike_dir.display(),
         set.variant_dir.display(),
         mtime_nanos(&set.bike_dir),
         mtime_nanos(&set.variant_dir),
         paints.join(","),
+        packed_stamp(&set.bike_dir),
     )
 }
 
@@ -2070,25 +2087,26 @@ fn gather_bike_files(p: &std::path::Path) -> anyhow::Result<Vec<(String, Vec<u8>
         return pkz::read_selected(p, wanted_bike_file);
     }
     if p.is_dir() {
-        let mut out = Vec::new();
+        let mut loose = Vec::new();
         for entry in std::fs::read_dir(p).with_context(|| format!("read dir {p:?}"))? {
             let path = entry?.path();
             let name = path.file_name().and_then(|n| n.to_str()).map(str::to_string);
             if path.is_file() && name.as_deref().is_some_and(wanted_bike_file) {
                 if let (Some(name), Ok(bytes)) = (name, std::fs::read(&path)) {
-                    out.push((name, bytes));
+                    loose.push((name, bytes));
                 }
             }
         }
+        // Packed first, loose over it. A folder holding only a swapped-in mesh still draws
+        // with the `.geom`, `gfx.cfg` and stock paint that never left the archive; taking
+        // the loose files alone left every part stacked at the origin and untextured.
+        let mut out = packed_layer(p);
+        overlay_files(&mut out, loose);
         // A mesh of any name will do — `model.edf` is the convention, not a rule.
-        if out.iter().any(|(n, _)| n.to_ascii_lowercase().ends_with(".edf")) {
-            return Ok(out);
+        if !out.iter().any(|(n, _)| bikefiles::is_mesh(n)) {
+            bail!("no .edf mesh for bike folder {p:?}");
         }
-        let sibling = library::sibling_pkz(p);
-        if sibling.exists() {
-            return pkz::read_selected(&sibling, wanted_bike_file);
-        }
-        bail!("no .edf mesh for bike folder {p:?}");
+        return Ok(out);
     }
     bail!("can't load a bike model from {p:?}")
 }
@@ -2133,24 +2151,33 @@ fn packed_bike(bike_dir: &std::path::Path) -> Option<std::path::PathBuf> {
     sibling.exists().then_some(sibling)
 }
 
-/// The bytes behind a `PreviewSet`: the loose files that stay, with the variant's laid over
-/// them. Reverting to Stock parks every loose mesh, so the packed model goes underneath —
-/// otherwise there'd be nothing to draw, which is precisely what Stock means.
+/// The bike's packed layer, or nothing at all.
+///
+/// An archive that won't read — a locked one, or a stub iCloud has evicted — must not take
+/// down a bike whose loose folder can still be drawn. Callers bail later if what's left
+/// holds no mesh.
+fn packed_layer(bike_dir: &std::path::Path) -> Vec<(String, Vec<u8>)> {
+    let Some(pkz) = packed_bike(bike_dir) else { return Vec::new() };
+    match pkz::read_selected(&pkz, wanted_bike_file) {
+        Ok(files) => files,
+        Err(e) => {
+            log::warn!("[viewer] couldn't read {pkz:?} ({e:#}) — drawing the loose files alone");
+            Vec::new()
+        }
+    }
+}
+
+/// The bytes behind a `PreviewSet`: the packed bike, with the loose files that stay laid
+/// over it and the variant's over those. Stock parks every loose mesh and so draws the
+/// packed model itself; every other variant draws its own mesh on the same foundation.
 fn gather_preview_files(
     set: &modelswap::PreviewSet,
 ) -> anyhow::Result<Vec<(String, Vec<u8>)>> {
     use anyhow::bail;
-    let mut out: Vec<(String, Vec<u8>)> = Vec::new();
-    let loose_mesh = set
-        .root_keep
-        .iter()
-        .chain(set.variant_files.iter())
-        .any(|f| bikefiles::is_mesh(f));
-    if !loose_mesh {
-        if let Some(pkz) = packed_bike(&set.bike_dir) {
-            overlay_files(&mut out, pkz::read_selected(&pkz, wanted_bike_file)?);
-        }
-    }
+    // Packed, then the loose root, then the variant — the game's own order. The archive is
+    // never skipped: a swap ships a mesh and little else, so the bike's `.geom`, `gfx.cfg`
+    // and `.hrc`s have nowhere else to come from.
+    let mut out = packed_layer(&set.bike_dir);
     overlay_files(&mut out, read_named(&set.bike_dir, &set.root_keep));
     overlay_files(&mut out, read_named(&set.variant_dir, &set.variant_files));
     if !out.iter().any(|(n, _)| bikefiles::is_mesh(n)) {
@@ -8071,6 +8098,101 @@ mod viewer_tests {
                 )
             })
             .collect()
+    }
+
+    /// Write a plain-zip `.pkz` — `pkz::read_selected` reads those natively, so the packed
+    /// half of a bike can be fixtured without the sidecar.
+    fn write_pkz(path: &Path, entries: &[(&str, &[u8])]) {
+        use std::io::Write;
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let mut z = zip::ZipWriter::new(std::fs::File::create(path).unwrap());
+        let opts = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored);
+        for (name, data) in entries {
+            z.start_file(*name, opts).unwrap();
+            z.write_all(data).unwrap();
+        }
+        z.finish().unwrap();
+    }
+
+    fn named<'a>(files: &'a [(String, Vec<u8>)], base: &str) -> Option<&'a [u8]> {
+        files
+            .iter()
+            .find(|(n, _)| {
+                n.rsplit('/').next().unwrap_or(n).eq_ignore_ascii_case(base)
+            })
+            .map(|(_, d)| d.as_slice())
+    }
+
+    /// The fault behind a swap that renders white with every part stacked at the origin: a
+    /// model set is a mesh and little else, so the bike's `.geom`, `gfx.cfg`, `.hrc`s and
+    /// stock paint have nowhere to come from but the archive — which the preview used to
+    /// skip the moment the variant brought a mesh.
+    #[test]
+    fn a_swap_preview_keeps_the_packed_bike_under_it() {
+        let root: PathBuf =
+            std::env::temp_dir().join(format!("frost-packed-under-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let mp = root.to_str().unwrap();
+        let bike = "MX1OEM_2023_KTM_450_SX-F";
+        let bikes = crate::library::mods_subdir(mp, "mods/bikes");
+        std::fs::create_dir_all(bikes.join(bike)).unwrap();
+        write_pkz(
+            &bikes.join(format!("{bike}.pkz")),
+            &[
+                (&format!("{bike}/model.edf"), b"packed mesh"),
+                (&format!("{bike}/gfx.cfg"), b"packed gfx"),
+                (&format!("{bike}/chassis.hrc"), b"packed hrc"),
+                (&format!("{bike}/{bike}.geom"), b"packed geom"),
+                (&format!("{bike}/paints/stock.pnt"), b"packed paint"),
+            ],
+        );
+        let variant = bikes.join(bike).join(super::modelswap::LIB_DIR).join("Factory");
+        std::fs::create_dir_all(&variant).unwrap();
+        std::fs::write(variant.join("model.edf"), b"swap mesh").unwrap();
+
+        let set = super::modelswap::preview_set(mp, bike, "Factory").expect("preview set");
+        let files = super::gather_preview_files(&set).expect("preview files");
+
+        // The bike comes through underneath...
+        for base in ["gfx.cfg", "chassis.hrc", &format!("{bike}.geom"), "stock.pnt"] {
+            assert!(named(&files, base).is_some(), "{base} missing from {:?}",
+                files.iter().map(|(n, _)| n.as_str()).collect::<Vec<_>>());
+        }
+        // ...and the swap's mesh, not the packed one, is what gets drawn.
+        assert_eq!(named(&files, "model.edf"), Some(&b"swap mesh"[..]));
+        assert_eq!(
+            files.iter().filter(|(n, _)| crate::bikefiles::is_mesh(n)).count(),
+            1,
+            "the packed mesh must be replaced, not added alongside",
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The same law on the ordinary load path: an extracted bike whose folder holds only a
+    /// mesh still draws with the setup and paint left behind in its archive.
+    #[test]
+    fn a_loose_bike_still_reads_its_packed_setup() {
+        let root: PathBuf =
+            std::env::temp_dir().join(format!("frost-loose-packed-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let bikes = root.join("bikes");
+        std::fs::create_dir_all(bikes.join("KTM450")).unwrap();
+        write_pkz(
+            &bikes.join("KTM450.pkz"),
+            &[
+                ("KTM450/model.edf", b"packed mesh"),
+                ("KTM450/gfx.cfg", b"packed gfx"),
+                ("KTM450/wheel.geom", b"packed geom"),
+            ],
+        );
+        std::fs::write(bikes.join("KTM450").join("model.edf"), b"loose mesh").unwrap();
+
+        let files = super::gather_bike_files(&bikes.join("KTM450")).expect("gather");
+        assert_eq!(named(&files, "model.edf"), Some(&b"loose mesh"[..]), "loose wins");
+        assert!(named(&files, "gfx.cfg").is_some(), "packed gfx.cfg comes through");
+        assert!(named(&files, "wheel.geom").is_some(), "packed .geom comes through");
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// The contract behind the Locker's 3D preview: what it shows is what applying the

--- a/src-tauri/src/modelswap.rs
+++ b/src-tauri/src/modelswap.rs
@@ -252,6 +252,12 @@ fn active_set_files(mods_path: &str, bike: &str, active: &str, incoming: &[Strin
             m
         }
     };
+    // The bike's own setup is never a model's to own. A variant folder holding copies of
+    // the `.hrc`s/`.cfg`/`.geom` — or a manifest written back when one did — would park
+    // them, leaving the bike a mesh with nothing to say how it is assembled. Only a variant
+    // that actually brings its own replacement displaces them, via `incoming` below.
+    let owned: Vec<String> =
+        owned.into_iter().filter(|f| !crate::bikefiles::is_bike_setup(f)).collect();
 
     root_files
         .into_iter()
@@ -736,12 +742,12 @@ pub fn apply_model_swap_reporting(
     // Only the files that belong to the model move. The bike's own setup stays put.
     let mut root_files = active_set_files(mods_path, bike, &active_label, &target_files);
 
-    // Reverting to Stock has to clear every loose override, not just the meshes. A swap
-    // dropped straight at the bike root was never registered, so it has no manifest and
-    // `active_set_files` finds only its meshes — leaving its `.hrc`/`.cfg` behind, still
-    // overriding the `.pkz` but now naming meshes that are gone. Nothing is deleted: it
-    // parks with the rest, and the manifest written below makes the way back exact.
-    if is_stock && read_manifest(&backup_dir).is_none() {
+    // Reverting to Stock has to clear every loose override, not just the meshes.
+    // `active_set_files` never reports the bike's setup — that is the point of it — so a
+    // swap's `.hrc`/`.cfg` would stay behind, still overriding the `.pkz` but now naming
+    // meshes that are gone. Nothing is deleted: it parks with the rest, and the manifest
+    // written below makes the way back exact.
+    if is_stock {
         for f in root_setup_files(mods_path, bike) {
             if !contains_ci(&root_files, &f) {
                 root_files.push(f);
@@ -827,7 +833,7 @@ pub fn preview_set(mods_path: &str, bike: &str, variant: &str) -> anyhow::Result
     }
 
     let mut parked = active_set_files(mods_path, bike, &active, &variant_files);
-    if is_stock && read_manifest(&variant_dir(mods_path, bike, &active)).is_none() {
+    if is_stock {
         for f in root_setup_files(mods_path, bike) {
             if !contains_ci(&parked, &f) {
                 parked.push(f);
@@ -1580,6 +1586,76 @@ mod tests {
         let parked = names_at(&variant_dir(mp, "KTM450", ORIGINAL));
         assert!(parked.contains(&"model.edf".to_string()), "old mesh parked");
         assert!(!parked.contains(&"chassis.hrc".to_string()), "setup never parked");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// The KTM 450 shape: a variant folder holding *only* copies of the setup files — no
+    /// mesh — used to make `files_known_to_other_variants` call the bike's own `.hrc`s and
+    /// `.cfg` model-owned. The preview then kept nothing at the root, and the swap drew a
+    /// mesh with nothing to assemble or texture it.
+    #[test]
+    fn a_setup_only_variant_never_claims_the_bikes_own_files() {
+        let root = tmp("setup-only-variant");
+        let mp = root.to_str().unwrap();
+        make_bike(mp, "KTM450", "model.edf");
+        // The bogus variant: the bike's setup, copied, with no mesh of its own.
+        for f in ["chassis.hrc", "bike.cfg", "wheel.geom"] {
+            touch(&variant_dir(mp, "KTM450", "new model").join(f));
+        }
+        // A real swap: one mesh, nothing else.
+        touch(&variant_dir(mp, "KTM450", "Factory").join("model.edf"));
+
+        let set = preview_set(mp, "KTM450", "Factory").unwrap();
+        for keep in ["chassis.hrc", "bike.cfg", "wheel.geom"] {
+            assert!(
+                contains_ci(&set.root_keep, keep),
+                "{keep} must stay at the root: {:?}",
+                set.root_keep,
+            );
+        }
+        assert!(!contains_ci(&set.root_keep, "model.edf"), "the old mesh is parked");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// The same damage once it has been written down: a manifest from a build that treated
+    /// the whole folder as the model set. Nothing migrates it, so it has to be ignored where
+    /// it is read.
+    #[test]
+    fn a_manifest_claiming_the_bikes_setup_is_ignored() {
+        let root = tmp("poisoned-manifest");
+        let mp = root.to_str().unwrap();
+        make_bike(mp, "KTM450", "model.edf");
+        write_manifest(
+            &variant_dir(mp, "KTM450", ORIGINAL),
+            &["model.edf", "chassis.hrc", "bike.cfg", "wheel.geom"].map(String::from),
+        );
+        touch(&variant_dir(mp, "KTM450", "Factory").join("model.edf"));
+
+        let set = preview_set(mp, "KTM450", "Factory").unwrap();
+        for keep in ["chassis.hrc", "bike.cfg", "wheel.geom"] {
+            assert!(contains_ci(&set.root_keep, keep), "{keep}: {:?}", set.root_keep);
+        }
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// A swap that ships its own setup still displaces the bike's, or applying it would
+    /// overwrite files nothing had parked and the way back would be lost.
+    #[test]
+    fn a_variant_bringing_its_own_setup_still_displaces_the_roots() {
+        let root = tmp("variant-brings-setup");
+        let mp = root.to_str().unwrap();
+        make_bike(mp, "KTM450", "model.edf");
+        touch(&variant_dir(mp, "KTM450", "Factory").join("model.edf"));
+        touch(&variant_dir(mp, "KTM450", "Factory").join("chassis.hrc"));
+
+        apply_model_swap(mp, "KTM450", "Factory").unwrap();
+        let parked = names_at(&variant_dir(mp, "KTM450", ORIGINAL));
+        assert!(contains_ci(&parked, "chassis.hrc"), "the overwritten .hrc parked: {parked:?}");
+        assert!(!contains_ci(&parked, "bike.cfg"), "untouched setup stays put: {parked:?}");
+
+        apply_model_swap(mp, "KTM450", ORIGINAL).unwrap();
+        let at_root = names_at(&bike_dir(mp, "KTM450"));
+        assert!(contains_ci(&at_root, "chassis.hrc"), "restored on the way back: {at_root:?}");
         let _ = fs::remove_dir_all(&root);
     }
 


### PR DESCRIPTION
## The bug

Previewing a model swap on the KTM 450 SX-F drew a white bike in pieces — every part stacked at the origin, no texture on any of it.

## Why

A model set is a mesh and little else. The `.geom` that mounts the parts to each other, the `gfx.cfg` and `.hrc`s that say which mesh each part uses, and the stock paint all belong to the *bike*, and on an OEM bike they never leave its `.pkz`.

`gather_preview_files` skipped that archive the moment the variant brought a mesh of its own, so the preview was assembled from the swap's `model.edf` **alone**. `gather_bike_files` had the same skip on the ordinary load path, so an extracted bike whose `.geom` stayed behind in its archive rendered unassembled too — swap or no swap.

Compounding it, `active_set_files` let a model own the bike's setup: a variant folder holding only copies of the `.hrc`s/`.cfg`/`.geom` (no mesh) made `files_known_to_other_variants` claim them, so they were parked along with the swap and `root_keep` came back empty.

## The fix

`overlay_files`' own doc comment already stated the law — *loose files layer over the packed archive, and a swap's files layer over the loose ones*. Both gather paths now follow it: **packed → loose root → variant**, composed through `overlay_files`. No gate.

- New `packed_layer()`: an archive that won't read (locked, or an iCloud stub) warns and leaves the loose files to draw alone rather than failing the load.
- `active_set_files` filters `bikefiles::is_bike_setup` out of `owned`, covering the manifest path and the `files_known_to_other_variants` path at once — so bikes already recorded that way read correctly with nothing repaired on disk. `incoming` is untouched: a variant that ships its own setup still displaces the bike's.
- Stock's special-case no longer waits on `read_manifest(..).is_none()`; with setup never model-owned, the manifest branch had the same gap.
- `packed_stamp()` folded into both cache keys — the archive is an input to every bike model now, and a bike update replaces the `.pkz` without necessarily touching the folder above it.

## Measured, on the real KTM 450 SX-F

| | before | after |
|---|---|---|
| preview file set | `["model.edf"]` | packed bike + `gfx.cfg` + 4 `.hrc` + `.geom` + `stock.pnt` |
| `root_keep` | `[]` | `gfx.cfg, rsusp.hrc, fsusp.hrc, chassis.hrc, steer.hrc` |
| `assembled` | `false` | `true` |
| fsusp / rsusp | z −0.14..0.08 / −0.64..0.01 (stacked) | z 0.58..0.84 (front) / −0.77..−0.12 (rear) |

Cost: `packed_layer` reads the 70 MB archive in **175 ms**, once per bike, then LRU-cached — about a tenth of a cold bike load (1.79 s).

## Tests

858 pass, 0 fail. Five new — three in `modelswap::tests` (setup-only variant, poisoned manifest, a variant that legitimately brings its own setup) and two in `viewer_tests` built on a real plain-zip `.pkz` fixture, since `pkz::read_selected` reads plain zips without the sidecar. Both real-tree `#[ignore]` contract tests pass against an actual mods folder.

## Note

A swap shipping a differently-named mesh (`ktm450.edf` while the packed `.hrc` says `model.edf`) now previews as the stock bike, because the packed `.hrc` wins. That looks like a regression but isn't — it is what the game would do, and preview-equals-applied is the contract `preview_matches_the_applied_swap` asserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)