### PR TITLE
feat(rider): move the bike and rider around, and widen the preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 ## 2026-08-26
 
 ### Added
+- **Move the bike and the rider around in the Rider tab.** The pair stood where the viewer put
+  them — shoulder to shoulder, a fixed gap apart — which is the one arrangement nobody was
+  composing for. A **Placement** panel now moves either model: side, up, forward and turn, in
+  metres and degrees, so the rider can stand at the bike's shoulder, sit on it, or face the
+  camera with the bike behind them. **Reset** puts the pair back the way it opened.
+- **The bike's pose panel, in the Rider tab.** Rear, Front, Steering and Level wheels were in
+  the library's viewer and the expanded preview only; the tab where a look is actually built
+  now carries them too, in the panel beside the pickers.
+- **A 3D preview you can drag wider.** The Rider tab's preview was a fixed 420px onto a bike
+  and a rider side by side. Drag the handle on its left edge to give it as much of the tab as
+  you want — double-click to put it back — and the width is remembered per machine.
+
 - **Stand a bike the way you want to see it.** The 3D preview drew every bike in the frame it
   was *authored* in, which is not a stance it ever holds on the ground — a `.geom` carries no
   suspension travel at all, and ride height falls out of physics the viewer doesn't run. So

--- a/src/Components/Rider/RiderStudio.tsx
+++ b/src/Components/Rider/RiderStudio.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { RefreshCw, AlertTriangle, Save, Loader2, FolderInput } from "lucide-react";
 import { toast } from "sonner";
 import { useT, type TKey } from "../../i18n/context";
@@ -29,6 +29,18 @@ import { useConfig } from "../../Context/Config";
 import { Combobox } from "../ui/combobox";
 
 const RIDER_GROUPS = SLOT_GROUPS.filter((g) => g.id !== "bike");
+
+/**
+ * How wide the preview column is, in px, and where that is remembered.
+ *
+ * Machine-local, like the app's other bits of remembered layout — a window that is 1400px
+ * on the desktop and 1024 on the laptop wants a different answer on each, and neither is
+ * worth a round trip to the config file.
+ */
+const PREVIEW_W_KEY = "mxb.rider.previewWidth";
+const PREVIEW_W = { min: 320, max: 900, initial: 420 };
+/** What the picker column keeps for itself, however far the preview is dragged. */
+const PICKERS_MIN = 300;
 
 /**
  * The bike slots the preview actually draws.
@@ -84,6 +96,44 @@ export default function RiderStudio({
   const [repairing, setRepairing] = useState<string | null>(null);
   // Paints the chosen models carry, merged with the loose ones the scan found.
   const { optionsFor, missingFor } = useGearPaints(loadout);
+  // The preview column's width, dragged by the handle on its left edge. A 420px window onto
+  // a bike and a rider side by side is a small one, and this tab is where a look is composed.
+  const row = useRef<HTMLDivElement>(null);
+  const [previewW, setPreviewW] = useState(() => {
+    const saved = Number(localStorage.getItem(PREVIEW_W_KEY));
+    return saved >= PREVIEW_W.min && saved <= PREVIEW_W.max ? saved : PREVIEW_W.initial;
+  });
+  const drag = useRef<{ from: number; was: number } | null>(null);
+
+  // Clamped against the row as it is now, not just the fixed limits: on a narrow window the
+  // pickers have to stay usable, and they're the half that can't be scrolled sideways.
+  const widen = useCallback((to: number) => {
+    const room = (row.current?.clientWidth ?? PREVIEW_W.max) - PICKERS_MIN;
+    setPreviewW(Math.max(PREVIEW_W.min, Math.min(to, Math.min(PREVIEW_W.max, room))));
+  }, []);
+
+  const onDragMove = useCallback(
+    (e: React.PointerEvent) => {
+      // Dragging left grows the preview, since it's the right-hand column.
+      if (drag.current) widen(drag.current.was + (drag.current.from - e.clientX));
+    },
+    [widen],
+  );
+
+  // Remembered wherever the width came from — the drag, the double-click, the arrow keys.
+  useEffect(() => {
+    localStorage.setItem(PREVIEW_W_KEY, String(previewW));
+  }, [previewW]);
+
+  // A width dragged out on a wide window would otherwise squeeze the pickers to nothing when
+  // the window is made small again — re-clamp against the room there actually is.
+  useEffect(() => {
+    const el = row.current;
+    if (!el) return;
+    const ro = new ResizeObserver(() => widen(previewW));
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [widen, previewW]);
 
   const setSlot = useCallback((key: keyof Loadout, value: string) => {
     setLoadout((prev) => ({ ...prev, [key]: value }));
@@ -274,7 +324,7 @@ export default function RiderStudio({
         </div>
       ))}
 
-      <div className="flex min-h-0 flex-1 gap-5 overflow-hidden px-7 pb-6">
+      <div ref={row} className="flex min-h-0 flex-1 gap-5 overflow-hidden px-7 pb-6">
         {/* Picker column */}
         <section className="flex min-w-0 flex-1 flex-col gap-4 overflow-y-auto pr-1">
           {/* Show-on-model toggles */}
@@ -353,14 +403,42 @@ export default function RiderStudio({
         </section>
 
         {/* Live render — the rider, and the bike beside them when this build can draw one */}
-        <ViewerPanel
-          loadout={loadout}
-          riderOnly={!showBike}
-          bikeId={showBike ? bike : undefined}
-          bikeVariant={bikeVariant}
-          hiddenParts={hidden}
-          className="w-[420px] flex-none"
-        />
+        <div className="relative flex-none" style={{ width: previewW }}>
+          {/* Drag the preview wider. It sits in the gap between the two columns rather than
+              inside either, so neither loses a pixel to it. */}
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label={t("viewer.resizePanel")}
+            title={t("viewer.resizePanel")}
+            tabIndex={0}
+            onPointerDown={(e) => {
+              e.currentTarget.setPointerCapture(e.pointerId);
+              drag.current = { from: e.clientX, was: previewW };
+            }}
+            onPointerMove={onDragMove}
+            onPointerUp={() => (drag.current = null)}
+            onPointerCancel={() => (drag.current = null)}
+            onDoubleClick={() => widen(PREVIEW_W.initial)}
+            onKeyDown={(e) => {
+              const step = e.key === "ArrowLeft" ? 24 : e.key === "ArrowRight" ? -24 : 0;
+              if (!step) return;
+              e.preventDefault();
+              widen(previewW + step);
+            }}
+            className="group absolute -left-3.5 top-0 z-10 h-full w-3 cursor-col-resize touch-none focus:outline-none"
+          >
+            <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 rounded bg-white/[0.07] transition-colors group-hover:bg-primary/60 group-focus:bg-primary/60" />
+          </div>
+          <ViewerPanel
+            loadout={loadout}
+            riderOnly={!showBike}
+            bikeId={showBike ? bike : undefined}
+            bikeVariant={bikeVariant}
+            hiddenParts={hidden}
+            className="h-full"
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/Components/Viewer/ModelViewer.tsx
+++ b/src/Components/Viewer/ModelViewer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Canvas, useThree } from "@react-three/fiber";
 import { OrbitControls, Center, ContactShadows } from "@react-three/drei";
-import { ChevronDown, Move, Rotate3d, SlidersHorizontal, ZoomIn } from "lucide-react";
+import { ChevronDown, Move, Move3d, Rotate3d, SlidersHorizontal, ZoomIn } from "lucide-react";
 import * as THREE from "three";
 import { cn } from "@/lib/utils";
 import { Row, Slider } from "@/Components/ui/controls";
@@ -1018,6 +1018,7 @@ function poseGroup(name: string): PoseGroup {
 }
 
 const X_AXIS = new THREE.Vector3(1, 0, 0);
+const Y_AXIS = new THREE.Vector3(0, 1, 0);
 
 /** The fork/steering axis: straight up, tilted back by the rake. */
 function forkAxis(rake: number): THREE.Vector3 {
@@ -1211,6 +1212,67 @@ function riderBounds(parts: RiderPart[]) {
   return drawn.length ? partBounds(drawn) : { lo: [0, 0, 0], hi: [0, 0, 0] };
 }
 
+/** Which model a placement is for. */
+export type PlaceTarget = "bike" | "rider";
+
+/**
+ * Where a model stands, on top of the arrangement the scene already puts it in.
+ *
+ * All zero is that arrangement untouched — the pair shoulder to shoulder on the ground — so
+ * resetting returns the scene to what it drew before anyone moved anything, rather than
+ * dropping both models on the origin.
+ */
+export interface Placement {
+  /** Metres along X, the axis the pair is laid out on. */
+  x: number;
+  /** Metres up. Both models rest on y=0, so this is height off the ground. */
+  y: number;
+  /** Metres along Z, the way the models face. */
+  z: number;
+  /** Degrees about the up axis. */
+  yaw: number;
+}
+
+/** A model where the layout left it. */
+export const HOME: Placement = { x: 0, y: 0, z: 0, yaw: 0 };
+
+/** Both models at rest — one object, so resetting is an assignment rather than two. */
+const HOME_BOTH: Record<PlaceTarget, Placement> = { bike: HOME, rider: HOME };
+
+/**
+ * The point a model turns about: the centre of its footprint, on the ground.
+ *
+ * Not its authored origin — a bike's sits near the swingarm pivot, and turning about that
+ * swings the model across the scene instead of spinning it where it stands.
+ */
+function spinPivot(b: { lo: number[]; hi: number[] }): Vec3 {
+  return [(b.lo[0] + b.hi[0]) / 2, b.lo[1], (b.lo[2] + b.hi[2]) / 2];
+}
+
+/** A model under its placement. At {@link HOME} this is the identity — nothing moves. */
+function Placed({
+  at = HOME,
+  pivot,
+  children,
+}: {
+  at?: Placement;
+  /** Turn about this, in the model's own frame — see {@link spinPivot}. */
+  pivot: Vec3;
+  children: React.ReactNode;
+}) {
+  const q = useMemo(
+    () => new THREE.Quaternion().setFromAxisAngle(Y_AXIS, at.yaw * THREE.MathUtils.DEG2RAD),
+    [at.yaw],
+  );
+  return (
+    <group position={[at.x, at.y, at.z]}>
+      <About at={pivot} q={q}>
+        {children}
+      </About>
+    </group>
+  );
+}
+
 /**
  * Bike and rider in one scene, standing beside each other.
  *
@@ -1230,6 +1292,7 @@ function SideBySide({
   overrides,
   rig,
   pose,
+  place,
 }: {
   nodes: EdfNode[];
   textures: Map<string, THREE.Texture>;
@@ -1238,6 +1301,8 @@ function SideBySide({
   overrides?: Map<string, THREE.Texture>;
   rig?: BikeRig | null;
   pose?: BikePose;
+  /** Where each half has been moved to, on top of the arrangement below. */
+  place?: Record<PlaceTarget, Placement>;
 }) {
   const at = useMemo(() => {
     const bike = partBounds(nodes);
@@ -1247,22 +1312,29 @@ function SideBySide({
       // sizes they never intersect.
       bike: [-PAIR_GAP / 2 - bike.hi[0], -bike.lo[1], 0] as [number, number, number],
       rider: [PAIR_GAP / 2 - rider.lo[0], -rider.lo[1], 0] as [number, number, number],
+      // Each model's own spin point, so turning one leaves the other where it stands.
+      bikePivot: spinPivot(bike),
+      riderPivot: spinPivot(rider),
     };
   }, [nodes, parts]);
 
   return (
     <group>
       <group position={at.bike}>
-        <EdfMesh
-          nodes={nodes}
-          textures={textures}
-          highlight={highlight}
-          rig={rig}
-          pose={pose}
-        />
+        <Placed at={place?.bike} pivot={at.bikePivot}>
+          <EdfMesh
+            nodes={nodes}
+            textures={textures}
+            highlight={highlight}
+            rig={rig}
+            pose={pose}
+          />
+        </Placed>
       </group>
       <group position={at.rider}>
-        <RiderComposite parts={parts} overrides={overrides} />
+        <Placed at={place?.rider} pivot={at.riderPivot}>
+          <RiderComposite parts={parts} overrides={overrides} />
+        </Placed>
       </group>
     </group>
   );
@@ -1303,8 +1375,146 @@ function CameraRig({ frame }: { frame: Framing }) {
   return null;
 }
 
-// Legend for the OrbitControls gestures below — the canvas gives no other clue
-// that it's draggable. Kept muted so it reads as chrome, never competing with the model.
+/**
+ * The shell both side panels are made of: a title you click to open, and a body.
+ *
+ * Shared rather than copied — two panels sitting one above the other have to be identical
+ * down to the padding, or the stack reads as a mistake.
+ */
+function Panel({
+  icon: Icon,
+  title,
+  children,
+}: {
+  icon: typeof SlidersHorizontal;
+  title: string;
+  children: React.ReactNode;
+}) {
+  // Closed to start: a preview nobody is adjusting keeps its whole canvas.
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="w-[230px] rounded-md border border-white/10 bg-black/60 text-white/80 backdrop-blur-sm">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center gap-1.5 px-2 py-1.5 text-[11px] font-medium leading-none text-white/70 hover:text-white"
+      >
+        <Icon className="h-3.5 w-3.5" />
+        {title}
+        <ChevronDown
+          className={cn("ml-auto h-3.5 w-3.5 transition-transform", open && "rotate-180")}
+        />
+      </button>
+      {open && (
+        <div className="flex flex-col gap-1.5 border-t border-white/10 px-2 py-2">{children}</div>
+      )}
+    </div>
+  );
+}
+
+/** How far a model can be moved from where the layout put it, in metres and degrees. */
+const PLACE_LIMIT = { x: 2, y: 1.5, z: 2, yaw: 180 };
+
+/**
+ * The placement panel: where each model stands.
+ *
+ * One set of sliders and a target to point them at, rather than a set per model — the pair
+ * is two models today, and a panel that grows a section per half would be taller than the
+ * canvas it sits on.
+ */
+function PlaceControls({
+  targets,
+  place,
+  onChange,
+  onReset,
+}: {
+  /** The halves actually on screen, in the order they're offered. Never empty. */
+  targets: PlaceTarget[];
+  place: Record<PlaceTarget, Placement>;
+  onChange: (who: PlaceTarget, at: Placement) => void;
+  onReset: () => void;
+}) {
+  const t = useT();
+  const [picked, setPicked] = useState<PlaceTarget>(targets[0]);
+  // The scene can lose the half being moved — a mode switch, a model that stopped resolving
+  // — so fall back rather than sliding something nothing is drawing.
+  const who = targets.includes(picked) ? picked : targets[0];
+  const at = place[who];
+  const m = (v: number) => `${v.toFixed(2)}m`;
+  const set = (part: Partial<Placement>) => onChange(who, { ...at, ...part });
+  return (
+    <Panel icon={Move3d} title={t("viewer.place")}>
+      {/* Only worth a chooser when there are two of them: a lone model is the target. */}
+      {targets.length > 1 && (
+        <div className="mb-0.5 inline-flex rounded border border-white/15 p-0.5">
+          {targets.map((tg) => (
+            <button
+              key={tg}
+              type="button"
+              onClick={() => setPicked(tg)}
+              className={cn(
+                "flex-1 rounded px-2 py-1 text-[11px] leading-none transition-colors",
+                who === tg ? "bg-white/85 text-black" : "text-white/70 hover:text-white",
+              )}
+            >
+              {t(tg === "bike" ? "category.bike" : "nav.rider")}
+            </button>
+          ))}
+        </div>
+      )}
+      <Row label={t("viewer.placeSide")}>
+        <Slider
+          value={at.x}
+          min={-PLACE_LIMIT.x}
+          max={PLACE_LIMIT.x}
+          step={0.01}
+          onChange={(v) => set({ x: v })}
+          format={m}
+        />
+      </Row>
+      <Row label={t("viewer.placeUp")}>
+        <Slider
+          value={at.y}
+          min={-PLACE_LIMIT.y}
+          max={PLACE_LIMIT.y}
+          step={0.01}
+          onChange={(v) => set({ y: v })}
+          format={m}
+        />
+      </Row>
+      <Row label={t("viewer.placeFwd")}>
+        <Slider
+          value={at.z}
+          min={-PLACE_LIMIT.z}
+          max={PLACE_LIMIT.z}
+          step={0.01}
+          onChange={(v) => set({ z: v })}
+          format={m}
+        />
+      </Row>
+      <Row label={t("viewer.placeTurn")}>
+        <Slider
+          value={at.yaw}
+          min={-PLACE_LIMIT.yaw}
+          max={PLACE_LIMIT.yaw}
+          step={1}
+          onChange={(v) => set({ yaw: v })}
+          format={(v) => `${Math.round(v)}°`}
+        />
+      </Row>
+      <div className="mt-0.5 flex items-center gap-1.5">
+        <button
+          type="button"
+          onClick={onReset}
+          className="rounded border border-white/15 px-2 py-1 text-[11px] leading-none text-white/75 hover:bg-white/10 hover:text-white"
+        >
+          {t("viewer.poseReset")}
+        </button>
+      </div>
+    </Panel>
+  );
+}
+
 /**
  * The pose panel: the bike's own joints, on sliders.
  *
@@ -1325,78 +1535,64 @@ function PoseControls({
   onReset: () => void;
 }) {
   const t = useT();
-  const [open, setOpen] = useState(false);
   const mm = (v: number) => `${Math.round(v)}mm`;
   return (
-    <div className="absolute bottom-2 right-2 w-[230px] rounded-md border border-white/10 bg-black/60 text-white/80 backdrop-blur-sm">
-      <button
-        type="button"
-        onClick={() => setOpen((o) => !o)}
-        className="flex w-full items-center gap-1.5 px-2 py-1.5 text-[11px] font-medium leading-none text-white/70 hover:text-white"
-      >
-        <SlidersHorizontal className="h-3.5 w-3.5" />
-        {t("viewer.pose")}
-        <ChevronDown
-          className={cn("ml-auto h-3.5 w-3.5 transition-transform", open && "rotate-180")}
+    <Panel icon={SlidersHorizontal} title={t("viewer.pose")}>
+      <Row label={t("viewer.poseRear")}>
+        <Slider
+          value={pose.rearDrop}
+          min={-REAR_LIMIT_MM}
+          max={REAR_LIMIT_MM}
+          step={1}
+          onChange={(v) => onChange({ ...pose, rearDrop: v })}
+          format={mm}
         />
-      </button>
-      {open && (
-        <div className="flex flex-col gap-1.5 border-t border-white/10 px-2 py-2">
-          <Row label={t("viewer.poseRear")}>
-            <Slider
-              value={pose.rearDrop}
-              min={-REAR_LIMIT_MM}
-              max={REAR_LIMIT_MM}
-              step={1}
-              onChange={(v) => onChange({ ...pose, rearDrop: v })}
-              format={mm}
-            />
-          </Row>
-          <Row label={t("viewer.poseFront")}>
-            <Slider
-              value={pose.forkUp}
-              min={-60}
-              max={180}
-              step={1}
-              onChange={(v) => onChange({ ...pose, forkUp: v })}
-              format={mm}
-            />
-          </Row>
-          <Row label={t("viewer.poseSteer")}>
-            <Slider
-              value={pose.steer}
-              min={-40}
-              max={40}
-              step={1}
-              onChange={(v) => onChange({ ...pose, steer: v })}
-              format={(v) => `${Math.round(v)}°`}
-            />
-          </Row>
-          <div className="mt-0.5 flex items-center gap-1.5">
-            {onLevel && (
-              <button
-                type="button"
-                onClick={onLevel}
-                className="rounded border border-white/15 px-2 py-1 text-[11px] leading-none text-white/75 hover:bg-white/10 hover:text-white"
-              >
-                {t("viewer.poseLevel")}
-              </button>
-            )}
-            <button
-              type="button"
-              onClick={onReset}
-              className="rounded border border-white/15 px-2 py-1 text-[11px] leading-none text-white/75 hover:bg-white/10 hover:text-white"
-            >
-              {t("viewer.poseReset")}
-            </button>
-          </div>
-        </div>
-      )}
-    </div>
+      </Row>
+      <Row label={t("viewer.poseFront")}>
+        <Slider
+          value={pose.forkUp}
+          min={-60}
+          max={180}
+          step={1}
+          onChange={(v) => onChange({ ...pose, forkUp: v })}
+          format={mm}
+        />
+      </Row>
+      <Row label={t("viewer.poseSteer")}>
+        <Slider
+          value={pose.steer}
+          min={-40}
+          max={40}
+          step={1}
+          onChange={(v) => onChange({ ...pose, steer: v })}
+          format={(v) => `${Math.round(v)}°`}
+        />
+      </Row>
+      <div className="mt-0.5 flex items-center gap-1.5">
+        {onLevel && (
+          <button
+            type="button"
+            onClick={onLevel}
+            className="rounded border border-white/15 px-2 py-1 text-[11px] leading-none text-white/75 hover:bg-white/10 hover:text-white"
+          >
+            {t("viewer.poseLevel")}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onReset}
+          className="rounded border border-white/15 px-2 py-1 text-[11px] leading-none text-white/75 hover:bg-white/10 hover:text-white"
+        >
+          {t("viewer.poseReset")}
+        </button>
+      </div>
+    </Panel>
   );
 }
 
-function ControlsHint() {
+// Legend for the OrbitControls gestures — the canvas gives no other clue that it's
+// draggable. Kept muted so it reads as chrome, never competing with the model.
+function ControlsHint({ tight }: { tight?: boolean }) {
   const t = useT();
   const items = [
     { Icon: Rotate3d, label: t("viewer.dragToRotate") },
@@ -1404,7 +1600,14 @@ function ControlsHint() {
     { Icon: Move, label: t("viewer.rightDragToPan") },
   ];
   return (
-    <div className="pointer-events-none absolute bottom-2 left-2 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md bg-white/[0.06] px-2 py-1 text-[11px] leading-none text-white/45">
+    <div
+      className={cn(
+        "pointer-events-none absolute bottom-2 left-2 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md bg-white/[0.06] px-2 py-1 text-[11px] leading-none text-white/45",
+        // Panels on the other corner: wrap onto more lines rather than run under them. A
+        // 320px-wide preview has room for one or the other, not both side by side.
+        tight && "max-w-[calc(100%-248px)]",
+      )}
+    >
       {items.map(({ Icon, label }) => (
         <span key={label} className="flex items-center gap-1">
           <Icon className="h-3.5 w-3.5" />
@@ -1467,6 +1670,13 @@ export interface ModelViewerProps {
   rig?: BikeRig | null;
   /** Offer the pose panel. Off by default: a preview nobody is posing shouldn't grow chrome. */
   poseControls?: boolean;
+  /**
+   * Offer the placement panel — moving each model about the scene.
+   *
+   * Off by default, for the same reason `poseControls` is. Independent of it: a rider has no
+   * joints to pose but can still be walked over to the bike.
+   */
+  placeControls?: boolean;
   loading?: boolean;
   noStandIn?: boolean;
   className?: string;
@@ -1483,6 +1693,7 @@ export function ModelViewer({
   riderParts,
   rig,
   poseControls = false,
+  placeControls = false,
   loading = false,
   noStandIn = false,
   className,
@@ -1496,6 +1707,12 @@ export function ModelViewer({
   const [posed, setPosed] = useState<BikePose | null>(null);
   useEffect(() => setPosed(null), [settled]);
   const pose = posed ?? settled;
+  // Where each model has been moved to. Unlike the pose, this survives a re-resolve: the
+  // rider is rebuilt on every slot edit, and having the arrangement someone just composed
+  // spring apart because they picked a helmet would be its own bug.
+  const [place, setPlace] = useState<Record<PlaceTarget, Placement>>(HOME_BOTH);
+  const moveTo = (who: PlaceTarget, at: Placement) =>
+    setPlace((prev) => ({ ...prev, [who]: at }));
   // Solved against the fork where it is now, so "level" still means level after the front
   // has been moved.
   const level = useMemo(
@@ -1514,6 +1731,18 @@ export function ModelViewer({
   const gearSolo =
     hasRider && !riderParts!.some((p) => p.part === "body" && p.nodes.length);
   const frame: Framing = pair ? "pair" : gearSolo ? "solo" : "default";
+  // The models a solo view has to turn about — the pair works its own out, since it measures
+  // both to lay them out anyway.
+  const soloPivot = useMemo(() => {
+    if (hasReal) return spinPivot(partBounds(nodes!));
+    if (hasRider) return spinPivot(riderBounds(riderParts!));
+    return [0, 0, 0] as Vec3;
+  }, [hasReal, hasRider, nodes, riderParts]);
+  // Only the halves on screen can be moved. Bike first, matching the pair's left-to-right.
+  const placeTargets: PlaceTarget[] = [
+    ...(showBike ? (["bike"] as const) : []),
+    ...(showRider ? (["rider"] as const) : []),
+  ];
   return (
     <div className={cn("relative", className)}>
       <ErrorBoundary compact label="model-viewer">
@@ -1568,17 +1797,22 @@ export function ModelViewer({
                 overrides={overrides}
                 rig={rig}
                 pose={pose}
+                place={place}
               />
             ) : hasReal ? (
-              <EdfMesh
-                nodes={nodes!}
-                textures={texMap}
-                highlight={highlight}
-                rig={rig}
-                pose={pose}
-              />
+              <Placed at={place.bike} pivot={soloPivot}>
+                <EdfMesh
+                  nodes={nodes!}
+                  textures={texMap}
+                  highlight={highlight}
+                  rig={rig}
+                  pose={pose}
+                />
+              </Placed>
             ) : hasRider ? (
-              <RiderComposite parts={riderParts!} overrides={overrides} />
+              <Placed at={place.rider} pivot={soloPivot}>
+                <RiderComposite parts={riderParts!} overrides={overrides} />
+              </Placed>
             ) : loading || noStandIn ? null : mode === "bike" ? (
               <BikeStandIn map={map} />
             ) : (
@@ -1604,16 +1838,30 @@ export function ModelViewer({
           />
         </Canvas>
       </ErrorBoundary>
-      {!loading && <ControlsHint />}
-      {poseControls && showBike && !!rig && !loading && (
-        <PoseControls
-          pose={pose}
-          onChange={setPosed}
-          onLevel={
-            level === null ? undefined : () => setPosed({ ...pose, rearDrop: level })
-          }
-          onReset={() => setPosed(NEUTRAL_POSE)}
-        />
+      {!loading && <ControlsHint tight={placeControls || poseControls} />}
+      {/* One stack, so the two panels line up on the same edge whether both are offered or
+          only one — placement above, because moving a model comes before fussing its joints. */}
+      {!loading && (placeControls || poseControls) && (
+        <div className="absolute bottom-2 right-2 flex flex-col items-end gap-1.5">
+          {placeControls && placeTargets.length > 0 && (
+            <PlaceControls
+              targets={placeTargets}
+              place={place}
+              onChange={moveTo}
+              onReset={() => setPlace(HOME_BOTH)}
+            />
+          )}
+          {poseControls && showBike && !!rig && (
+            <PoseControls
+              pose={pose}
+              onChange={setPosed}
+              onLevel={
+                level === null ? undefined : () => setPosed({ ...pose, rearDrop: level })
+              }
+              onReset={() => setPosed(NEUTRAL_POSE)}
+            />
+          )}
+        </div>
       )}
     </div>
   );

--- a/src/Components/Viewer/ViewerPanel.tsx
+++ b/src/Components/Viewer/ViewerPanel.tsx
@@ -316,7 +316,9 @@ export function ViewerPanel({
           </div>
         </div>
         <div className="relative min-h-[280px] flex-1">
-          <ModelViewer {...view} className="absolute inset-0" />
+          {/* Both panels are a single collapsed row until someone opens one, so the inline
+              canvas only gives up its corner to a person who asked for it. */}
+          <ModelViewer {...view} poseControls placeControls className="absolute inset-0" />
           {overlay}
         </div>
       </div>
@@ -337,9 +339,7 @@ export function ViewerPanel({
             </div>
           </div>
           <div className="relative min-h-0 flex-1">
-            {/* Posing only in the expanded view: the inline panel is 280px tall, and a
-                control stack in it would cover the bike it is posing. */}
-            <ModelViewer {...view} poseControls className="absolute inset-0" />
+            <ModelViewer {...view} poseControls placeControls className="absolute inset-0" />
             {overlay}
           </div>
         </DialogContent>

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -365,6 +365,12 @@ export const de: Translation = {
   "viewer.poseSteer": "Lenkung",
   "viewer.poseLevel": "Räder ausrichten",
   "viewer.poseReset": "Zurücksetzen",
+  "viewer.place": "Platzierung",
+  "viewer.placeSide": "Seite",
+  "viewer.placeUp": "Höhe",
+  "viewer.placeFwd": "Vorwärts",
+  "viewer.placeTurn": "Drehen",
+  "viewer.resizePanel": "Ziehen zum Anpassen · Doppelklick setzt zurück",
 
   // ── Combobox ───────────────────────────────────────────────────────────────
   "combobox.search": "Suchen…",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -352,6 +352,12 @@ export const en = {
   "viewer.poseSteer": "Steering",
   "viewer.poseLevel": "Level wheels",
   "viewer.poseReset": "Reset",
+  "viewer.place": "Placement",
+  "viewer.placeSide": "Side",
+  "viewer.placeUp": "Up",
+  "viewer.placeFwd": "Forward",
+  "viewer.placeTurn": "Turn",
+  "viewer.resizePanel": "Drag to resize · double-click to reset",
 
   // ── Combobox ───────────────────────────────────────────────────────────────
   "combobox.search": "Search…",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -359,6 +359,12 @@ export const es: Translation = {
   "viewer.poseSteer": "Dirección",
   "viewer.poseLevel": "Nivelar ruedas",
   "viewer.poseReset": "Restablecer",
+  "viewer.place": "Colocación",
+  "viewer.placeSide": "Lateral",
+  "viewer.placeUp": "Altura",
+  "viewer.placeFwd": "Adelante",
+  "viewer.placeTurn": "Girar",
+  "viewer.resizePanel": "Arrastra para ajustar · doble clic para restablecer",
 
   // ── Combobox ───────────────────────────────────────────────────────────────
   "combobox.search": "Buscar…",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -362,6 +362,12 @@ export const fr: Translation = {
   "viewer.poseSteer": "Direction",
   "viewer.poseLevel": "Aligner les roues",
   "viewer.poseReset": "Réinitialiser",
+  "viewer.place": "Placement",
+  "viewer.placeSide": "Côté",
+  "viewer.placeUp": "Hauteur",
+  "viewer.placeFwd": "Avancer",
+  "viewer.placeTurn": "Pivoter",
+  "viewer.resizePanel": "Glisser pour redimensionner · double-clic pour réinitialiser",
 
   // ── Combobox ───────────────────────────────────────────────────────────────
   "combobox.search": "Rechercher…",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -358,6 +358,12 @@ export const it: Translation = {
   "viewer.poseSteer": "Sterzo",
   "viewer.poseLevel": "Allinea le ruote",
   "viewer.poseReset": "Ripristina",
+  "viewer.place": "Posizione",
+  "viewer.placeSide": "Lato",
+  "viewer.placeUp": "Altezza",
+  "viewer.placeFwd": "Avanti",
+  "viewer.placeTurn": "Ruota",
+  "viewer.resizePanel": "Trascina per ridimensionare · doppio clic per ripristinare",
 
   // ── Combobox ───────────────────────────────────────────────────────────────
   "combobox.search": "Cerca…",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -361,6 +361,12 @@ export const ptBR: Translation = {
   "viewer.poseSteer": "Direção",
   "viewer.poseLevel": "Nivelar rodas",
   "viewer.poseReset": "Redefinir",
+  "viewer.place": "Posicionamento",
+  "viewer.placeSide": "Lado",
+  "viewer.placeUp": "Altura",
+  "viewer.placeFwd": "Frente",
+  "viewer.placeTurn": "Girar",
+  "viewer.resizePanel": "Arraste para redimensionar · clique duplo para redefinir",
 
   // ── Combobox ───────────────────────────────────────────────────────────────
   "combobox.search": "Pesquisar…",


### PR DESCRIPTION
The Rider tab draws the bike and the rider shoulder to shoulder, a fixed gap apart, in a fixed 420px column — the one arrangement, at the one size, that nobody composing a look actually wants. This gives that panel the library viewer's posing, and adds moving the models about and resizing the panel.

## What's new

**Placement panel.** Pick Bike or Rider, then side / up / forward / turn, in metres and degrees. Applied *on top of* the side-by-side layout rather than replacing it, so Reset returns the pair to exactly what the viewer drew before anyone touched it. Each model turns about the centre of its own footprint, on the ground — not its authored origin, which for a bike sits near the swingarm pivot and would swing the model across the scene instead of spinning it in place.

**Pose, in the Rider tab.** Rear / Front / Steering / Level wheels were in the library viewer and this panel's expanded dialog only. They're now in the inline panel too, beside the pickers. Both panels are collapsed until clicked, so a preview nobody is adjusting keeps its whole canvas.

**A preview you can drag wider.** Handle on the panel's left edge; double-click resets, arrow keys step it. Clamped so the picker column keeps 300px, re-clamped when the window shrinks, and the width is remembered per machine in `localStorage`.

## Notes

- Both panels are behind opt-in props (`poseControls`, `placeControls`), so the library viewer and the Designer's preview are untouched.
- The panel shell was lifted out of `PoseControls` and shared, so the two stacked panels are identical rather than merely similar.
- Placement deliberately survives a re-resolve: the rider model is rebuilt on every slot edit, and having a composed arrangement spring apart because you picked a helmet would be its own bug.
- The inline and expanded canvases are separate mounts, so each keeps its own arrangement — same as pose has always behaved.

## Verified

`bun run typecheck`, `bun run lint` (only the two pre-existing warnings) and `bun run build` are green. The models need a real mods folder, so the on-screen check is the reviewer's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)