### PR TITLE
fix(library): join a bike row to its model swaps on the stripped name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2026-08-26
 
+### Fixed
+- **The Library's model-swap badge never appeared.** A bike is listed in the Library as its
+  `<Bike>.pkz` archive, so the row's name carries the extension, while a model swap is keyed by
+  the bike folder beside it — the two never matched, and the badge was invisible on every bike.
+
 ### Added
 - **A bike with no wheels to solve against now stands on its suspension.** "Level wheels"
   needs wheel meshes and axles to measure against; a model that ships neither fell back to the

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -1418,3 +1418,55 @@ mod path_case_tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 }
+
+#[cfg(test)]
+mod library_swap_join_tests {
+    use std::fs;
+
+    /// The join the Library's model-swap badge relies on.
+    ///
+    /// A bike row in the library is a `<Bike>.pkz` **file**, so its `name` carries the archive
+    /// extension, while `modelswap::scan_model_swaps` keys by the bike **folder** beside it.
+    /// Matching the two raw finds nothing — which is exactly the bug that shipped: the badge
+    /// could never appear for any bike. The frontend has to strip the extension, and this
+    /// pins which side carries it so a rename on either can't quietly break the join again.
+    #[test]
+    fn a_bike_row_joins_its_swaps_only_once_the_extension_is_stripped() {
+        let root = std::env::temp_dir().join(format!("frost-join-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        let mp = root.to_str().unwrap();
+        let bikes = super::mods_subdir(mp, "mods/bikes");
+        let bike = "MX1OEM_2023_KTM_450_SX-F";
+        fs::create_dir_all(&bikes).unwrap();
+        // The bike as the library sees it: a packed archive at the bikes root.
+        fs::write(bikes.join(format!("{bike}.pkz")), b"pkz").unwrap();
+        // And a registered model set beside it, as the Locker sees it.
+        let variant = bikes.join(bike).join(crate::modelswap::LIB_DIR).join("Factory");
+        fs::create_dir_all(&variant).unwrap();
+        fs::write(variant.join("model.edf"), b"mesh").unwrap();
+
+        let rows = super::scan_library(mp, "mods/bikes", &[], &crate::game::MXB).expect("scan");
+        let bike_rows: Vec<&super::LibraryEntry> =
+            rows.iter().filter(|e| e.category == "bike").collect();
+        assert!(!bike_rows.is_empty(), "the packed bike must be listed");
+        assert!(
+            bike_rows.iter().all(|e| e.name.ends_with(".pkz")),
+            "a bike row is the archive file, extension and all: {:?}",
+            bike_rows.iter().map(|e| &e.name).collect::<Vec<_>>(),
+        );
+
+        let swaps = crate::modelswap::scan_model_swaps(mp);
+        let key = &swaps.iter().find(|b| b.bike == bike).expect("the bike has swaps").bike;
+        assert!(!key.ends_with(".pkz"), "a swap is keyed by the folder, not the archive");
+
+        assert!(
+            !bike_rows.iter().any(|e| &e.name == key),
+            "raw names must not join — if they do, the frontend's strip is wrong",
+        );
+        assert!(
+            bike_rows.iter().any(|e| super::strip_ext(&e.name).eq_ignore_ascii_case(key)),
+            "stripped names must join, or the badge can never appear",
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+}

--- a/src/Components/Library/Library.tsx
+++ b/src/Components/Library/Library.tsx
@@ -562,7 +562,7 @@ export default function Library({
     let alive = true;
     void scanModelSwaps()
       .then((rows) => {
-        if (alive) setSwaps(new Map(rows.map((r) => [r.bike, r])));
+        if (alive) setSwaps(new Map(rows.map((r) => [r.bike.toLowerCase(), r])));
       })
       .catch(() => {});
     return () => {
@@ -1050,7 +1050,7 @@ export default function Library({
                     // A bike's model swaps. The Locker always lists the active set as a row
                     // of its own, so a bike with nothing to switch between still reports one
                     // variant — only two or more is a choice worth a badge.
-                    const models = swaps.get(item.name);
+                    const models = swaps.get(displayName(item.name).toLowerCase());
                     const showModels = !selectMode && (models?.variants.length ?? 0) > 1;
                     const swapsOpen = openSwaps.has(item.path);
                     return (


### PR DESCRIPTION
## The bug

The model-swap badge shipped in #226 **never appeared for any bike**. My fault — I could not drive the app window to check it, and the join was wrong.

## Why

`scan_library` only emits rows for `.pkz` and `.pnt` files, so a bike is listed as its **`<Bike>.pkz` archive** and the row's `name` carries the extension. `scan_model_swaps` keys by the **bike folder** beside it. So `swaps.get(item.name)` compared `"MX1OEM_2023_KTM_450_SX-F.pkz"` against `"MX1OEM_2023_KTM_450_SX-F"` and matched nothing, ever.

Measured against a real mods tree:

```
library bike rows: 60      row name = "2007_H85R.pkz"
swap keys: 1               swap bike = "MX1OEM_2023_KTM_450_SX-F" (4 variants)
joined raw = 0, joined on the stripped name = 1
```

## The fix

Look the row up by `displayName(...)` — which already strips the mod extension — and index the map lowercased, since the backend compares bike names case-insensitively.

## Test

A synthetic test pins which side of the join carries the extension: it asserts a bike row *is* the archive name, that a swap key is *not*, that the raw names do **not** join, and that the stripped ones do. It runs in CI with no real tree, so a rename on either side can't quietly break this again.

871 Rust tests pass; lint and build clean.

## Note

While tracing this I found the Library already has a `bikeModelSwap` category with its own "Model swaps" section, deliberately filtered out of the bikes tab so hundreds of paint rows don't swamp the grid. That's a *different* notion of swap — a packed `.pkz` dropped inside a bike's folder — not the registered `FrostMod Models/` variants the badge shows. The two are complementary, but worth knowing they both exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)