### PR TITLE
fix(library): keep a bike's name on its card next to the models badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## 2026-08-26
 
 ### Fixed
+- **The model-swap badge squeezed a bike's name off its card.** Sitting in the row beside the
+  name, it competed with it for width — and the name is what gave, collapsing to nothing on
+  the one bike that had swaps. It now sits under the name instead, where nothing else is
+  fighting for the space.
+
 - **The Library's model-swap badge never appeared.** A bike is listed in the Library as its
   `<Bike>.pkz` archive, so the row's name carries the extension, while a model swap is keyed by
   the bike folder beside it — the two never matched, and the badge was invisible on every bike.

--- a/src/Components/Library/Library.tsx
+++ b/src/Components/Library/Library.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
-import type { ComponentType } from "react";
+import type { ComponentType, ReactNode } from "react";
 import {
   Search,
   RefreshCw,
@@ -133,9 +133,14 @@ interface RowAction {
 function LibraryCardBody({
   item,
   typeIcon: TypeIcon,
+  footer,
 }: {
   item: LibraryEntry;
   typeIcon: LucideIcon;
+  /** Rendered under the subtitle, inside the name column. Anything put in the row *beside*
+   *  the name competes with it for width, and the name is what loses — it collapsed to
+   *  nothing the moment a second control landed next to "View in 3D". */
+  footer?: ReactNode;
 }) {
   const t = useT();
   const cacheKey = metaKey(item);
@@ -222,6 +227,7 @@ function LibraryCardBody({
         <span className="truncate text-[11px] text-muted-foreground" title={subtitle}>
           {subtitle}
         </span>
+        {footer}
       </div>
     </>
   );
@@ -1083,34 +1089,39 @@ export default function Library({
                                 )}
                               </span>
                             )}
-                            <LibraryCardBody item={item} typeIcon={Icon} />
-                            {showModels && (
-                              <button
-                                title={t("library.modelsHint")}
-                                aria-expanded={swapsOpen}
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  setOpenSwaps((prev) => {
-                                    const next = new Set(prev);
-                                    if (!next.delete(item.path)) next.add(item.path);
-                                    return next;
-                                  });
-                                }}
-                                className={cn(
-                                  "flex flex-none cursor-default items-center gap-1 whitespace-nowrap rounded-md px-1.5 py-1 text-[11px] font-semibold transition-colors hover:bg-foreground/[0.06]",
-                                  swapsOpen ? "text-primary" : "text-faint hover:text-primary",
-                                )}
-                              >
-                                <Layers className="size-3.5" />
-                                {t("library.models", { count: models!.variants.length })}
-                                <ChevronDown
-                                  className={cn(
-                                    "size-3 transition-transform",
-                                    swapsOpen && "rotate-180",
-                                  )}
-                                />
-                              </button>
-                            )}
+                            <LibraryCardBody
+                              item={item}
+                              typeIcon={Icon}
+                              footer={
+                                showModels ? (
+                                  <button
+                                    title={t("library.modelsHint")}
+                                    aria-expanded={swapsOpen}
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      setOpenSwaps((prev) => {
+                                        const next = new Set(prev);
+                                        if (!next.delete(item.path)) next.add(item.path);
+                                        return next;
+                                      });
+                                    }}
+                                    className={cn(
+                                      "-ml-1 mt-0.5 flex w-fit max-w-full cursor-default items-center gap-1 truncate rounded px-1 py-0.5 text-[10.5px] font-semibold transition-colors hover:bg-foreground/[0.06]",
+                                      swapsOpen ? "text-primary" : "text-faint hover:text-primary",
+                                    )}
+                                  >
+                                    <Layers className="size-3 flex-none" />
+                                    {t("library.models", { count: models!.variants.length })}
+                                    <ChevronDown
+                                      className={cn(
+                                        "size-3 flex-none transition-transform",
+                                        swapsOpen && "rotate-180",
+                                      )}
+                                    />
+                                  </button>
+                                ) : undefined
+                              }
+                            />
                             {!selectMode && canView3d && (
                               <button
                                 title={t("library.quick3d")}


### PR DESCRIPTION
## The bug

With the badge finally showing (#227), it pushed the bike's name and size clean off the card — the one bike with swaps rendered as a thumbnail, a badge, and nothing else.

## Why

The badge was a **sibling of the name** in the card's flex row:

```
[thumb] [ name / size ]  [4 models ▾]  [View in 3D]  [...]
         ^ flex-1 min-w-0
```

The name column is `flex-1 min-w-0`, so when the row runs out of room it is the thing that shrinks — all the way to zero. Adding a fourth control to a card in a three-column grid was always going to spend the name's width.

## The fix

Put the badge **under** the name rather than beside it, via a new `footer` slot on `LibraryCardBody` rendered inside the name column:

```
[thumb] [ name           ]  [View in 3D]  [...]
        [ 69 MB          ]
        [ ⧉ 4 models ▾   ]
```

Nothing in that column competes with the title, so the card reads name / size / models in order and the row goes back to the same shape as every other card. Smaller type and tighter padding to suit a second line, and the badge truncates rather than widening the row.

Typecheck, lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)