### PR TITLE
feat(library): view a model swap in 3D from the bike card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
   the bike folder beside it — the two never matched, and the badge was invisible on every bike.
 
 ### Added
+- **View a model swap in 3D straight from the Library.** Each variant in a bike card's model
+  list now carries its own **View 3D**, drawing the bike as that swap would leave it — the
+  same preview the Locker offers, without having to go there to find it. Nothing on disk
+  moves. Sets with no mesh have nothing to draw and don't offer it.
+
 - **A bike with no wheels to solve against now stands on its suspension.** "Level wheels"
   needs wheel meshes and axles to measure against; a model that ships neither fell back to the
   authored frame, which carries no suspension travel at all — so the bike stood with its shock

--- a/src/Components/Library/Library.tsx
+++ b/src/Components/Library/Library.tsx
@@ -240,7 +240,16 @@ function LibraryCardBody({
  * for two views to disagree about which model is live. Mirrors the Locker's own vocabulary —
  * same icons, same states — so a variant reads the same wherever you meet it.
  */
-function ModelSwapList({ variants, t }: { variants: ModelVariant[]; t: TFunc }) {
+function ModelSwapList({
+  variants,
+  t,
+  onPreview,
+}: {
+  variants: ModelVariant[];
+  t: TFunc;
+  /** Undefined when this build can't draw bike geometry — then no row offers a preview. */
+  onPreview?: (variant: string) => void;
+}) {
   return (
     <ul
       onClick={(e) => e.stopPropagation()}
@@ -273,6 +282,21 @@ function ModelSwapList({ variants, t }: { variants: ModelVariant[]; t: TFunc }) 
                   ? t("library.modelIncomplete")
                   : t("swaps.fileCount", { count: v.fileCount })}
           </span>
+          {/* A set with a mesh can be drawn; so can Stock, which shows the packed model the
+              loose files are covering. A "no model" set has nothing to show. */}
+          {onPreview && (v.valid || v.name.toLowerCase() === "stock") && (
+            <button
+              title={t("locker.preview3d", { name: v.name })}
+              onClick={(e) => {
+                e.stopPropagation();
+                onPreview(v.name);
+              }}
+              className="flex flex-none cursor-default items-center gap-1 rounded px-1 py-0.5 text-[10.5px] text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-primary"
+            >
+              <Box className="size-3" />
+              {t("locker.view3d")}
+            </button>
+          )}
         </li>
       ))}
     </ul>
@@ -494,6 +518,9 @@ export default function Library({
   const [busy, setBusy] = useState(false);
   const [detail, setDetail] = useState<LibraryEntry | null>(null);
   const [view3d, setView3d] = useState<LibraryEntry | null>(null);
+  // A model swap being previewed in 3D, by bike + variant. Separate from `view3d`, which is
+  // keyed by library entry: a swap has no entry of its own to point at.
+  const [swapView, setSwapView] = useState<{ bike: string; variant: string } | null>(null);
   const [moveTarget, setMoveTarget] = useState<LibraryEntry | null>(null);
   // Model swaps per bike folder, for the expandable row on a bike card. Bikes only — no
   // other mod type has them — and read-only: switching stays in the Locker.
@@ -1163,7 +1190,16 @@ export default function Library({
                             )}
                             </div>
                             {showModels && swapsOpen && (
-                              <ModelSwapList variants={models!.variants} t={t} />
+                              <ModelSwapList
+                                variants={models!.variants}
+                                t={t}
+                                onPreview={
+                                  bikePreview
+                                    ? (variant) =>
+                                        setSwapView({ bike: models!.bike, variant })
+                                    : undefined
+                                }
+                              />
                             )}
                           </div>
                         </ContextMenuTrigger>
@@ -1249,6 +1285,12 @@ export default function Library({
         </>
       )}
 
+      <ViewerDialog
+        open={swapView !== null}
+        onOpenChange={(o) => !o && setSwapView(null)}
+        title={swapView ? `${swapView.bike} · ${swapView.variant}` : undefined}
+        modelSwap={swapView ?? undefined}
+      />
       <ViewerDialog
         open={Boolean(view3d)}
         onOpenChange={(o) => !o && setView3d(null)}


### PR DESCRIPTION
The card's model list named each variant but gave no way to look at one — seeing a swap meant leaving for the Locker to find it.

Each row now carries its own **View 3D**, opening the same `previewModelSwap` the Locker uses: the bike drawn as that swap would leave it, with nothing moved on disk.

Gated exactly as the Locker gates it — a set with a mesh can be drawn, so can Stock (the packed model the loose files are covering), and a "no model" set has nothing to show.

Typecheck, lint and build clean.

**Known, not fixed here:** a swap whose mesh ships `_n`/`_s` companion sheets still renders untextured. That's the material index-space issue in `tasks/edf-mod-mesh-materials.md` — unrelated to this change, and deliberately unshipped until the index space is solved, since the half-fix binds the wrong sheets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)