### PR TITLE
feat(rider): pose the rider in the preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@
   the bike folder beside it — the two never matched, and the badge was invisible on every bike.
 
 ### Added
+- **Pose the rider.** A new **Pose** view in the Studio opens on a preset as it stands — bike,
+  model swap, rider, gear and paints, all read-only — and lets you move the rider's limbs:
+  where the hands sit, how far the legs are spread, one leg forward, elbows up, lean in. Quick
+  moves stack, and every joint has bend/twist/splay sliders under Torso, Arms, Hands and Legs.
+  The pose is remembered per rider profile on this machine, and **Reset** returns the model
+  exactly as it was authored.
+
+  This reads the skeleton `rider.edf` has carried all along and nobody was using: 98 named
+  bones, of which 65 bind the mesh. The file stores no vertex weights — the game rebuilds the
+  binding at load — so the app rebuilds it too, from the per-bone boxes the file *does* carry
+  plus the distance to the limb each bone actually swings. Helmet, boots and body armour ride
+  along on the bones their own `gfx.cfg` names, so the kit follows the pose.
+
+  Preview only, deliberately: MX Bikes takes a rider's posture from its riding style, an
+  animation set in `mods/rider/animations`, and nothing here writes to the game.
+
 - **A bike with no wheels to solve against now stands on its suspension.** "Level wheels"
   needs wheel meshes and axles to measure against; a model that ships neither fell back to the
   authored frame, which carries no suspension travel at all — so the bike stood with its shock

--- a/src-tauri/src/edf.rs
+++ b/src-tauri/src/edf.rs
@@ -1317,6 +1317,479 @@ fn submesh_transform(
     chain
 }
 
+// ── The rider's rig ───────────────────────────────────────────────────────────
+
+/// One bone of a rider's rig.
+///
+/// A rider `.edf` carries a skeleton alongside its mesh — 98 bones on every model the game
+/// ships or a modder builds on, named `riderRIG_Pelvis`, `riderRIG_LeftElbow` and so on. The
+/// game references those names itself, in each rider's `gfx.cfg`, to hang the helmet off the
+/// head and the boots off the knees.
+///
+/// Only the bones the mesh actually binds to are returned: 65 of the 98. The rest are markers
+/// — every `_end` tip, and the ankles and toes, which belong to the boots rather than the body
+/// and so carry no region of this mesh.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Bone {
+    pub name: String,
+    /// Index into the same list. `None` for the root, and only for the root.
+    pub parent: Option<usize>,
+    /// Bone space → model space, at rest.
+    pub bind: Mat4,
+    /// Model space → bone space, at rest. Stored in the file; `bind` is derived from it.
+    pub inv_bind: Mat4,
+    /// The slice of the mesh this bone covers, **in bone space** — so it must be taken through
+    /// `bind` before it means anything in the model's frame.
+    pub aabb_lo: [f32; 3],
+    pub aabb_hi: [f32; 3],
+}
+
+impl Bone {
+    /// Where the bone sits at rest, in model space.
+    pub fn origin(&self) -> [f32; 3] {
+        [self.bind[3], self.bind[7], self.bind[11]]
+    }
+}
+
+// A record runs `[marker][matrix ×1 or ×2][index words][AABB]`, and the name of the bone it
+// belongs to sits *before* it — the name that trails a record is the next bone's. The marker
+// says how many matrices follow; with two, the second is the inverse bind.
+//
+// The index words are variable-length and not all zero at the end — `Rider+` ends every run
+// with three zero words, `Rider+RolledUp` puts a count in the last of them — so the record is
+// closed by finding the box instead: 24 bytes that read as a real AABB, immediately followed
+// by a name.
+const BONE_ONE_MATRIX: u32 = 0x1000;
+const BONE_AABB_BACK: usize = 24;
+// The longest index-word run seen is the root's, at 22 words.
+const BONE_FIELDS_MAX: usize = 200;
+
+struct BoneBlock {
+    /// The name that follows this record — which belongs to the *next* bone, not this one.
+    next_name: String,
+    inv_bind: Option<Mat4>,
+    aabb_lo: [f32; 3],
+    aabb_hi: [f32; 3],
+    name_end: usize,
+}
+
+/// Read the rig out of a rider `.edf`. Bikes and gear carry none, and give an empty list.
+///
+/// Bones come back in file order, which is depth-first from the root.
+pub fn parse_skeleton(b: &[u8]) -> Vec<Bone> {
+    if b.len() < HEADER_START || &b[0..4] != b"EDF\0" {
+        return Vec::new();
+    }
+    let mut blocks: Vec<BoneBlock> = Vec::new();
+    let mut o = 0usize;
+    while o + 16 <= b.len() {
+        match read_block(b, o) {
+            Some(bl) => {
+                o = bl.name_end;
+                blocks.push(bl);
+            }
+            // A name is variable-length, so the next record starts at no fixed step from
+            // this one — walk a byte at a time. The marker word turns nearly every offset
+            // away immediately.
+            None => o += 1,
+        }
+    }
+    // Pair each name with the record that follows it, and keep the bones that bind.
+    let mut names = Vec::new();
+    let mut binds = Vec::new();
+    for pair in blocks.windows(2) {
+        let (Some(inv_bind), name) = (pair[1].inv_bind, &pair[0].next_name) else {
+            continue;
+        };
+        names.push(name.clone());
+        binds.push((inv_bind, pair[1].aabb_lo, pair[1].aabb_hi));
+    }
+    let parents = rig_parents(&names);
+    names
+        .into_iter()
+        .zip(binds)
+        .zip(parents)
+        .map(|((name, (inv_bind, aabb_lo, aabb_hi)), parent)| Bone {
+            name,
+            parent,
+            bind: rigid_inverse(&inv_bind),
+            inv_bind,
+            aabb_lo,
+            aabb_hi,
+        })
+        .collect()
+}
+
+/// One record starting at `o`, or `None` if that isn't one.
+///
+/// Anchored on the marker word and the matrix that follows it, then read forward to the three
+/// zero words, the AABB and the name — the only combination that pins down a variable-length
+/// index run without guessing where it ends.
+fn read_block(b: &[u8], o: usize) -> Option<BoneBlock> {
+    let marker = u32le(b, o);
+    let two = match marker {
+        BONE_ONE_MATRIX => false,
+        0x1800 => true,
+        _ => return None,
+    };
+    let first = o + 4;
+    // The first matrix is the bone's own placement relative to its parent. It is never read —
+    // the inverse bind that follows already says where the bone is in the model — and it is
+    // deliberately *not* required to be rigid: `Rider+RolledUp` scales some of its bones, and
+    // insisting on a rigid one there threw away the whole rig.
+    if !affine_at(b, first) {
+        return None;
+    }
+    let inv_bind = if two { Some(read_mat4(b, first + 64)?) } else { None };
+    let fields = first + if two { 128 } else { 64 };
+    // Step over the index words: the name is the first thing that reads as one with three zero
+    // words and a finite AABB in front of it.
+    let mut step = 0usize;
+    while step <= BONE_FIELDS_MAX {
+        let name_off = fields + step + BONE_AABB_BACK;
+        if name_off >= b.len() {
+            return None;
+        }
+        if let Some(bone) = read_tail(b, name_off, inv_bind) {
+            return Some(bone);
+        }
+        step += 4;
+    }
+    None
+}
+
+/// The `[AABB][name]` that closes a record, read backwards from the name.
+fn read_tail(b: &[u8], name_off: usize, inv_bind: Option<Mat4>) -> Option<BoneBlock> {
+    let aabb = name_off.checked_sub(BONE_AABB_BACK)?;
+    let mut corner = [0f32; 6];
+    for (i, slot) in corner.iter_mut().enumerate() {
+        *slot = f32le(b, aabb + i * 4);
+        if !slot.is_finite() || slot.abs() > 10.0 {
+            return None;
+        }
+    }
+    // A box, not just six floats: the low corner is low on every axis. Index words that happen
+    // to read as small floats almost never do this, and a bone with no region reads all zeros,
+    // which passes.
+    if (0..3).any(|i| corner[i] > corner[i + 3]) {
+        return None;
+    }
+    let name = bone_name(b, name_off)?;
+    Some(BoneBlock {
+        name_end: name_off + name.len(),
+        next_name: name,
+        inv_bind,
+        aabb_lo: [corner[0], corner[1], corner[2]],
+        aabb_hi: [corner[3], corner[4], corner[5]],
+    })
+}
+
+/// Is there a placement matrix at `o` — finite, sane in size, bottom row `0, 0, 0, 1`?
+///
+/// Weaker than [`read_mat4`] on purpose: it admits a matrix that scales as well as turns.
+fn affine_at(b: &[u8], o: usize) -> bool {
+    if o + 64 > b.len() {
+        return false;
+    }
+    (0..16).all(|i| {
+        let v = f32le(b, o + i * 4);
+        v.is_finite() && v.abs() < 100.0
+    }) && (0..3).all(|i| f32le(b, o + 48 + i * 4) == 0.0)
+        && f32le(b, o + 60) == 1.0
+}
+
+/// A bone's name, NUL-terminated.
+///
+/// Not [`plausible_name`]: that caps at 31 characters, which is right for the mesh-node names
+/// it was written for and two characters short of `riderRIG_RightShoulderTwist1_end`. Reading
+/// the rig with that cap silently drops the two bones whose *records* those names close.
+fn bone_name(b: &[u8], o: usize) -> Option<String> {
+    if o >= b.len() || !b[o].is_ascii_alphabetic() {
+        return None;
+    }
+    let mut e = o;
+    while e < b.len() && e - o < 64 {
+        let c = b[e];
+        if c == 0 {
+            break;
+        }
+        if !(c.is_ascii_alphanumeric() || matches!(c, b'.' | b'_' | b'-')) {
+            return None;
+        }
+        e += 1;
+    }
+    (2..=63).contains(&(e - o)).then(|| String::from_utf8_lossy(&b[o..e]).into_owned())
+}
+
+/// Rebuild the bone tree from the names.
+///
+/// The rig is the game's own: every rider model carries the same bones under the same names,
+/// and `gfx.cfg` spells several of them out, so the naming is a contract rather than a habit.
+/// A bone whose named parent isn't in the list — the ankles and the `_end` markers are dropped
+/// before this runs — climbs to the nearest named ancestor that is. Anything the rules don't
+/// recognise falls back to the bone listed before it, which can't cycle: the file lists a rig
+/// depth-first, so a parent always precedes its children.
+fn rig_parents(names: &[String]) -> Vec<Option<usize>> {
+    let stems: Vec<String> = names.iter().map(|n| bone_stem(n).to_ascii_lowercase()).collect();
+    let index: std::collections::HashMap<&str, usize> =
+        stems.iter().enumerate().map(|(i, s)| (s.as_str(), i)).collect();
+    (0..names.len())
+        .map(|i| {
+            if i == 0 {
+                return None;
+            }
+            // Climb past ancestors this model doesn't bind to.
+            let mut want = named_parent(&stems[i]);
+            for _ in 0..8 {
+                match want {
+                    None => break,
+                    Some(ref w) => match index.get(w.as_str()) {
+                        Some(&p) if p != i => return Some(p),
+                        _ => want = named_parent(w),
+                    },
+                }
+            }
+            Some(i - 1)
+        })
+        .collect()
+}
+
+/// The part of a bone's name that describes the joint: `riderRIG_LeftKnee` → `LeftKnee`.
+fn bone_stem(name: &str) -> &str {
+    match name.to_ascii_lowercase().find("rig_") {
+        Some(at) => &name[at + 4..],
+        None => name,
+    }
+}
+
+/// The name of the bone this one hangs off, by the rig's own naming.
+fn named_parent(stem: &str) -> Option<String> {
+    // `LeftToe_end` hangs off `LeftToe`, and so does every other tip marker.
+    if let Some(base) = stem.strip_suffix("_end") {
+        return Some(base.to_string());
+    }
+    // `LeftHipTwist1` and `LeftKneeTwist` both hang off the joint they twist about.
+    if let Some(at) = stem.find("twist") {
+        return Some(stem[..at].to_string());
+    }
+    let (side, joint) = match stem.strip_prefix("left") {
+        Some(rest) => ("left", rest),
+        None => match stem.strip_prefix("right") {
+            Some(rest) => ("right", rest),
+            None => ("", stem),
+        },
+    };
+    // The links the rig's own numbering doesn't spell out.
+    let fixed = match joint {
+        "root" => return None,
+        "pelvis" => "root",
+        "spine1" => "pelvis",
+        "neck1" => "spine4",
+        "head" => "neck2",
+        "armour" => "spine4",
+        "collar" => "neck1",
+        "shoulder" => return Some(format!("{side}collar")),
+        "elbow" => return Some(format!("{side}shoulder")),
+        "wrist" => return Some(format!("{side}elbow")),
+        "hip" => "pelvis",
+        "knee" => return Some(format!("{side}hip")),
+        "ankle" => return Some(format!("{side}knee")),
+        "toe" => return Some(format!("{side}ankle")),
+        _ => "",
+    };
+    if !fixed.is_empty() {
+        return Some(fixed.to_string());
+    }
+    // Everything numbered counts down its own chain: `Spine3` → `Spine2`, `LeftIndex2` →
+    // `LeftIndex1`. The first link of a finger hangs off the wrist.
+    let digit = joint.chars().last().filter(char::is_ascii_digit)?;
+    let base = &joint[..joint.len() - 1];
+    if digit == '1' {
+        return matches!(base, "thumb" | "index" | "middle" | "ring" | "pink" | "pinky")
+            .then(|| format!("{side}wrist"));
+    }
+    let prev = (digit as u8 - 1) as char;
+    Some(format!("{side}{base}{prev}"))
+}
+
+/// Put every bone through the same orthogonal transform, in place.
+///
+/// Used to bring a rig into the frame the viewer draws its mesh in. Both turns the mesh takes
+/// go through here — the mirror into right-handed space and, for a Z-up model, the turn that
+/// stands it up — and the rig must take exactly the same ones, or the skeleton ends up
+/// mirrored, or lying beside a standing body. A mirror is allowed: `r` only has to be
+/// orthogonal, not a rotation, and the inverse bind is rebuilt from the result either way.
+///
+/// The bone-space boxes are left alone: they are already in each bone's own frame, which moves
+/// with it.
+pub fn transform_skeleton(bones: &mut [Bone], r: [[f32; 3]; 3]) {
+    for bone in bones.iter_mut() {
+        let m = bone.bind;
+        let mut out = [0f32; 16];
+        for i in 0..3 {
+            for j in 0..4 {
+                out[i * 4 + j] = (0..3).map(|k| r[i][k] * m[k * 4 + j]).sum();
+            }
+        }
+        out[15] = 1.0;
+        bone.bind = out;
+        bone.inv_bind = rigid_inverse(&out);
+    }
+}
+
+/// How many bones one vertex may be shared between. Four is what every engine that skins on
+/// the GPU settles on, and what three.js takes.
+pub const SKIN_BONES_PER_VERTEX: usize = 4;
+
+/// The mesh's binding to its rig: four bones and four weights for every vertex, in the same
+/// order as the node's `positions`.
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Skin {
+    /// `4 * vertex count` indices into the bone list.
+    pub indices: Vec<u16>,
+    /// `4 * vertex count` weights, each vertex's four summing to 1.
+    pub weights: Vec<f32>,
+}
+
+/// Work out which bones move which vertices.
+///
+/// The file doesn't say. A rider `.edf` stores its rig and its mesh and nothing that joins
+/// them: there is no weight anywhere in the 72 bytes a vertex occupies, and no table beside
+/// the rig either — the game rebuilds the binding at load, and so must we.
+///
+/// What the file *does* give is a box per bone, in that bone's own space, covering the part of
+/// the mesh it is responsible for. Those boxes cover the body — barely a vertex in a thousand
+/// falls outside all of them — but they overlap far too much to name a bone on their own: nine
+/// vertices in ten sit inside three or more. So they are used as a filter rather than an
+/// answer, and the choice among the bones that claim a vertex is made on distance: to the limb
+/// each bone actually swings, which is the run from that bone to its children, so that the
+/// thigh follows the hip and the shin follows the knee.
+pub fn skin_mesh(nodes: &[EdfNode], bones: &[Bone]) -> Skin {
+    let verts: usize = nodes.iter().map(|n| n.positions.len() / 3).sum();
+    let mut skin = Skin {
+        indices: vec![0; verts * SKIN_BONES_PER_VERTEX],
+        weights: vec![0.0; verts * SKIN_BONES_PER_VERTEX],
+    };
+    if bones.is_empty() || verts == 0 {
+        // Nothing to bind to: hang the whole mesh off bone zero so it still draws.
+        for i in 0..verts {
+            skin.weights[i * SKIN_BONES_PER_VERTEX] = 1.0;
+        }
+        return skin;
+    }
+    let limbs = limb_segments(bones);
+    let mut v = 0usize;
+    for node in nodes {
+        for p in node.positions.chunks_exact(3) {
+            let point = [p[0], p[1], p[2]];
+            weigh_vertex(&point, bones, &limbs, &mut skin, v);
+            v += 1;
+        }
+    }
+    skin
+}
+
+/// The run of flesh each bone swings: from the bone to each of its children, or the bone
+/// itself where it has none.
+fn limb_segments(bones: &[Bone]) -> Vec<Vec<([f32; 3], [f32; 3])>> {
+    let mut out: Vec<Vec<([f32; 3], [f32; 3])>> = vec![Vec::new(); bones.len()];
+    for bone in bones.iter() {
+        if let Some(p) = bone.parent {
+            out[p].push((bones[p].origin(), bone.origin()));
+        }
+    }
+    for (i, segs) in out.iter_mut().enumerate() {
+        if segs.is_empty() {
+            let o = bones[i].origin();
+            segs.push((o, o));
+        }
+    }
+    out
+}
+
+/// Pick this vertex's four bones and their shares.
+fn weigh_vertex(
+    point: &[f32; 3],
+    bones: &[Bone],
+    limbs: &[Vec<([f32; 3], [f32; 3])>],
+    skin: &mut Skin,
+    v: usize,
+) {
+    // Closeness, not distance, so the sums below stay well behaved where a vertex sits exactly
+    // on a bone. 1 mm is finer than any rider mesh resolves.
+    const EPS: f32 = 1e-3;
+    let mut best: Vec<(usize, f32)> = Vec::new();
+    let mut fallback = (0usize, f32::MAX);
+    for (i, bone) in bones.iter().enumerate() {
+        let d = limbs[i]
+            .iter()
+            .map(|(a, b)| point_to_segment(point, a, b))
+            .fold(f32::MAX, f32::min);
+        if d < fallback.1 {
+            fallback = (i, d);
+        }
+        if !claims(bone, point) {
+            continue;
+        }
+        best.push((i, 1.0 / (d + EPS).powi(2)));
+    }
+    // A vertex no box claims — a thousandth of them — goes to the nearest limb outright.
+    if best.is_empty() {
+        best.push((fallback.0, 1.0));
+    }
+    best.sort_by(|a, b| b.1.total_cmp(&a.1));
+    best.truncate(SKIN_BONES_PER_VERTEX);
+    let total: f32 = best.iter().map(|(_, w)| w).sum();
+    let base = v * SKIN_BONES_PER_VERTEX;
+    for (slot, (i, w)) in best.iter().enumerate() {
+        skin.indices[base + slot] = *i as u16;
+        skin.weights[base + slot] = w / total;
+    }
+}
+
+/// Does this bone's own box cover the point? The box is in bone space, so the point goes
+/// through the inverse bind first.
+fn claims(bone: &Bone, point: &[f32; 3]) -> bool {
+    if bone.aabb_lo == bone.aabb_hi {
+        return false; // a bone with no region of its own claims nothing
+    }
+    let m = &bone.inv_bind;
+    (0..3).all(|a| {
+        let p = m[a * 4] * point[0] + m[a * 4 + 1] * point[1] + m[a * 4 + 2] * point[2] + m[a * 4 + 3];
+        p >= bone.aabb_lo[a] && p <= bone.aabb_hi[a]
+    })
+}
+
+fn point_to_segment(p: &[f32; 3], a: &[f32; 3], b: &[f32; 3]) -> f32 {
+    let ab = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+    let ap = [p[0] - a[0], p[1] - a[1], p[2] - a[2]];
+    let len2 = ab[0] * ab[0] + ab[1] * ab[1] + ab[2] * ab[2];
+    let t = if len2 <= f32::EPSILON {
+        0.0
+    } else {
+        ((ap[0] * ab[0] + ap[1] * ab[1] + ap[2] * ab[2]) / len2).clamp(0.0, 1.0)
+    };
+    let d = [ap[0] - ab[0] * t, ap[1] - ab[1] * t, ap[2] - ab[2] * t];
+    (d[0] * d[0] + d[1] * d[1] + d[2] * d[2]).sqrt()
+}
+
+/// The inverse of a rigid placement: transpose the rotation, and turn the translation back
+/// through it.
+fn rigid_inverse(m: &Mat4) -> Mat4 {
+    let t = [m[3], m[7], m[11]];
+    let mut out = [0f32; 16];
+    for i in 0..3 {
+        for j in 0..3 {
+            out[i * 4 + j] = m[j * 4 + i];
+        }
+        out[i * 4 + 3] = -(0..3).map(|k| m[k * 4 + i] * t[k]).sum::<f32>();
+    }
+    out[15] = 1.0;
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1959,4 +2432,432 @@ rwheel_max = 0, -0.001, -0.5683\n";
             assert!(verts >= 8 && tris >= 1);
         }
     }
+
+
+
+
+    // ── The rig ───────────────────────────────────────────────────────────────
+
+    /// One record: `[marker][matrix ×1 or ×2][index words][0, 0, 0][AABB][name]`. The name that
+    /// closes a record belongs to the *next* bone, which is why the builder takes it that way.
+    fn bone_block(
+        next_name: &str,
+        inv_bind: Option<[f32; 16]>,
+        words: &[u32],
+        lo: [f32; 3],
+        hi: [f32; 3],
+    ) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.extend_from_slice(&(if inv_bind.is_some() { 0x1800u32 } else { 0x1000 }).to_le_bytes());
+        let local = placed(0.0, 0.0, 0.0);
+        for m in std::iter::once(local).chain(inv_bind) {
+            for f in m {
+                v.extend_from_slice(&f.to_le_bytes());
+            }
+        }
+        for w in words.iter().chain(&[0, 0, 0]) {
+            v.extend_from_slice(&w.to_le_bytes());
+        }
+        for f in lo.iter().chain(&hi) {
+            v.extend_from_slice(&f.to_le_bytes());
+        }
+        v.extend_from_slice(next_name.as_bytes());
+        v.push(0);
+        v
+    }
+
+    fn placed(x: f32, y: f32, z: f32) -> [f32; 16] {
+        [1.0, 0.0, 0.0, x, 0.0, 1.0, 0.0, y, 0.0, 0.0, 1.0, z, 0.0, 0.0, 0.0, 1.0]
+    }
+
+    /// A bone at `(x, y, z)` stores the transform that takes the model *into* its frame.
+    fn bind_at(x: f32, y: f32, z: f32) -> [f32; 16] {
+        placed(-x, -y, -z)
+    }
+
+    fn rig_file(blocks: &[Vec<u8>]) -> Vec<u8> {
+        let mut v = b"EDF\0".to_vec();
+        v.resize(HEADER_START, 0);
+        for b in blocks {
+            v.extend_from_slice(b);
+        }
+        v
+    }
+
+    #[test]
+    fn reads_the_rig() {
+        // Index-word runs of different lengths, because the real file has both. The first
+        // record belongs to the mesh node, so it carries no bind of its own.
+        let bytes = rig_file(&[
+            bone_block("riderRIG_Root", None, &[0, 1, 1], [0.0; 3], [0.0; 3]),
+            bone_block("riderRIG_Pelvis", Some(bind_at(0.0, 0.0, 0.0)), &[1, 1, 2], [0.0; 3], [0.0; 3]),
+            bone_block(
+                "riderRIG_LeftHip",
+                Some(bind_at(0.0, 0.0, -0.887)),
+                &[2, 2, 3, 14],
+                [-0.11, -0.14, -0.10],
+                [0.14, 0.14, 0.13],
+            ),
+            bone_block(
+                "riderRIG_LeftKnee",
+                Some(bind_at(0.085, 0.0, -0.864)),
+                &[3, 1, 4],
+                [-0.13, -0.13, -0.16],
+                [0.24, 0.10, 0.16],
+            ),
+        ]);
+        let rig = parse_skeleton(&bytes);
+        let names: Vec<&str> = rig.iter().map(|b| b.name.as_str()).collect();
+        assert_eq!(names, ["riderRIG_Root", "riderRIG_Pelvis", "riderRIG_LeftHip"]);
+        assert_eq!(rig[0].parent, None, "only the root is parentless");
+        assert_eq!(rig[1].parent, Some(0), "the pelvis hangs off the root");
+        assert_eq!(rig[2].parent, Some(1), "and the hip off the pelvis");
+        // The bind is derived from the stored inverse, so a bone reports where it really is.
+        let hip = rig[2].origin();
+        assert!((hip[2] + 0.864).abs() < 1e-5 && (hip[0] - 0.085).abs() < 1e-5, "{hip:?}");
+        assert_eq!(rig[1].origin(), [0.0, 0.0, -0.887]);
+    }
+
+    #[test]
+    fn a_bone_that_binds_nothing_is_left_out() {
+        // The ankles and every `_end` marker carry a local matrix and no inverse bind: they
+        // belong to the boots, not to this mesh, so they are not bones the body can be posed by.
+        let bytes = rig_file(&[
+            bone_block("riderRIG_Pelvis", None, &[0], [0.0; 3], [0.0; 3]),
+            bone_block("riderRIG_LeftAnkle", Some(bind_at(0.0, 0.0, -0.887)), &[1], [0.0; 3], [0.0; 3]),
+            bone_block("riderRIG_LeftToe", None, &[2], [0.0; 3], [0.0; 3]),
+            bone_block("riderRIG_Head", None, &[3], [0.0; 3], [0.0; 3]),
+        ]);
+        let rig = parse_skeleton(&bytes);
+        assert_eq!(
+            rig.iter().map(|b| b.name.as_str()).collect::<Vec<_>>(),
+            ["riderRIG_Pelvis"],
+            "only the bone whose record carries an inverse bind survives"
+        );
+    }
+
+    #[test]
+    fn a_bike_has_no_rig() {
+        // Vertex and index soup must not read as bone records.
+        let mut v = b"EDF\0".to_vec();
+        v.resize(HEADER_START, 0);
+        for i in 0..4000u32 {
+            v.extend_from_slice(&(i as f32 * 0.001).to_le_bytes());
+        }
+        assert!(parse_skeleton(&v).is_empty());
+        assert!(parse_skeleton(b"not an edf").is_empty());
+    }
+
+    #[test]
+    fn the_rig_naming_is_the_hierarchy() {
+        let p = |s: &str| super::named_parent(s);
+        assert_eq!(p("root"), None);
+        assert_eq!(p("pelvis").as_deref(), Some("root"));
+        // Numbered chains count themselves down.
+        assert_eq!(p("spine3").as_deref(), Some("spine2"));
+        assert_eq!(p("spine1").as_deref(), Some("pelvis"));
+        assert_eq!(p("neck1").as_deref(), Some("spine4"));
+        assert_eq!(p("head").as_deref(), Some("neck2"));
+        // Arms, both sides, down to the fingers.
+        assert_eq!(p("leftshoulder").as_deref(), Some("leftcollar"));
+        assert_eq!(p("leftelbow").as_deref(), Some("leftshoulder"));
+        assert_eq!(p("leftwrist").as_deref(), Some("leftelbow"));
+        assert_eq!(p("rightindex1").as_deref(), Some("rightwrist"));
+        assert_eq!(p("rightindex3").as_deref(), Some("rightindex2"));
+        // Legs.
+        assert_eq!(p("lefthip").as_deref(), Some("pelvis"));
+        assert_eq!(p("leftknee").as_deref(), Some("lefthip"));
+        assert_eq!(p("leftankle").as_deref(), Some("leftknee"));
+        assert_eq!(p("lefttoe").as_deref(), Some("leftankle"));
+        // Markers and twist bones hang off what they mark and what they twist about.
+        assert_eq!(p("lefttoe_end").as_deref(), Some("lefttoe"));
+        assert_eq!(p("leftkneetwist").as_deref(), Some("leftknee"));
+        assert_eq!(p("lefthiptwist1").as_deref(), Some("lefthip"));
+        assert_eq!(p("leftshouldertwist2").as_deref(), Some("leftshoulder"));
+        assert_eq!(p("leftkneetwist_end").as_deref(), Some("leftkneetwist"));
+        // The body armour hangs off the upper spine, which is where `gfx.cfg` puts the neck brace.
+        assert_eq!(p("armour").as_deref(), Some("spine4"));
+    }
+
+    #[test]
+    fn standing_the_rig_up_turns_it_with_the_mesh() {
+        // The same turn `stand_body_upright` gives a Z-up body: x = -x, y = -z, z = -y.
+        let r = [[-1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, -1.0, 0.0]];
+        let mut rig = parse_skeleton(&rig_file(&[
+            bone_block("riderRIG_Root", None, &[0], [0.0; 3], [0.0; 3]),
+            bone_block("riderRIG_Pelvis", Some(bind_at(0.0, 0.0, 0.0)), &[1], [0.0; 3], [0.0; 3]),
+            bone_block("riderRIG_Head", Some(bind_at(0.0, 0.0, -0.9)), &[2], [0.0; 3], [0.0; 3]),
+        ]));
+        transform_skeleton(&mut rig, r);
+        let o = rig[1].origin();
+        assert!((o[1] - 0.9).abs() < 1e-5, "the pelvis stands up at y=0.9, got {o:?}");
+        assert!(o[0].abs() < 1e-5 && o[2].abs() < 1e-5, "and nowhere else: {o:?}");
+        // The inverse was rebuilt from the turned bind, not carried over.
+        let back = super::rigid_inverse(&rig[1].bind);
+        assert!(rig[1].inv_bind.iter().zip(back).all(|(a, b)| (a - b).abs() < 1e-5));
+    }
+
+    /// Investigation aid: print a rider's rig.
+    /// MXB_EDF_FILE=~/…/rider.edf cargo test rig_dump -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn rig_dump() {
+        let path = std::env::var("MXB_EDF_FILE").expect("set MXB_EDF_FILE");
+        let bytes = std::fs::read(&path).expect("read edf");
+        let rig = parse_skeleton(&bytes);
+        eprintln!("bones: {}", rig.len());
+        for (i, b) in rig.iter().enumerate() {
+            let p = b.parent.map(|p| rig[p].name.as_str()).unwrap_or("—");
+            let o = b.origin();
+            eprintln!("{i:3} {:32} parent={:28} at ({:7.3},{:7.3},{:7.3})", b.name, p, o[0], o[1], o[2]);
+        }
+    }
+
+    /// The real rig, against the model on disk.
+    ///
+    /// Checks it three ways, because a skeleton that parses is not the same as a skeleton that
+    /// is *right*: the tree the game's own `gfx.cfg` implies, limb lengths that belong to a
+    /// person, and every joint landing inside the body it is supposed to move.
+    #[test]
+    #[ignore]
+    fn real_rider_rig() {
+        let Ok(path) = std::env::var("MXB_EDF_FILE") else {
+            eprintln!("set MXB_EDF_FILE to run");
+            return;
+        };
+        let bytes = std::fs::read(&path).expect("read edf");
+        let rig = parse_skeleton(&bytes);
+        let nodes = parse(&bytes);
+        eprintln!("{}: {} bones bind of the rig's 98", path, rig.len());
+        assert!(rig.len() >= 40, "a rider binds most of its rig, got {}", rig.len());
+        assert_eq!(rig[0].name, "riderRIG_Root");
+        assert_eq!(rig[0].parent, None);
+        assert!(rig[1..].iter().all(|b| b.parent.is_some()), "only the root is parentless");
+
+        let at = |n: &str| rig.iter().position(|b| b.name == n).unwrap_or_else(|| panic!("no {n}"));
+        let ancestors = |n: &str| {
+            let (mut out, mut k) = (Vec::new(), rig[at(n)].parent);
+            while let Some(i) = k {
+                assert!(out.len() < rig.len(), "{n} loops");
+                out.push(rig[i].name.clone());
+                k = rig[i].parent;
+            }
+            out
+        };
+        // `lefthand { refobj = LeftWrist; endeffector = LeftElbow; root = LeftShoulder }`.
+        let arm = ancestors("riderRIG_LeftWrist");
+        assert!(arm.contains(&"riderRIG_LeftElbow".to_string()), "{arm:?}");
+        assert!(arm.contains(&"riderRIG_LeftShoulder".to_string()), "{arm:?}");
+        for b in &rig[1..] {
+            let up = ancestors(&b.name);
+            assert_eq!(up.last().map(String::as_str), Some("riderRIG_Root"), "{} → {up:?}", b.name);
+        }
+
+        // Limbs the length a person's are.
+        let span = |a: &str, c: &str| {
+            let (x, y) = (rig[at(a)].origin(), rig[at(c)].origin());
+            ((x[0] - y[0]).powi(2) + (x[1] - y[1]).powi(2) + (x[2] - y[2]).powi(2)).sqrt()
+        };
+        for (a, c, lo, hi) in [
+            ("riderRIG_LeftHip", "riderRIG_LeftKnee", 0.30, 0.45),
+            ("riderRIG_LeftShoulder", "riderRIG_LeftElbow", 0.18, 0.32),
+            ("riderRIG_LeftElbow", "riderRIG_LeftWrist", 0.18, 0.32),
+        ] {
+            let d = span(a, c);
+            assert!((lo..hi).contains(&d), "{a} → {c} is {d:.3} m");
+        }
+        // Left and right are mirrors of each other.
+        for (l, r) in [("riderRIG_LeftHip", "riderRIG_RightHip"), ("riderRIG_LeftElbow", "riderRIG_RightElbow")] {
+            let (a, b) = (rig[at(l)].origin(), rig[at(r)].origin());
+            assert!((a[0] + b[0]).abs() < 1e-3, "{l}/{r} are not mirrored: {a:?} {b:?}");
+        }
+
+        // Every joint inside the body it moves.
+        let (mut lo, mut hi) = ([f32::MAX; 3], [f32::MIN; 3]);
+        for n in &nodes {
+            for v in n.positions.chunks_exact(3) {
+                for a in 0..3 {
+                    lo[a] = lo[a].min(v[a]);
+                    hi[a] = hi[a].max(v[a]);
+                }
+            }
+        }
+        for b in &rig {
+            let o = b.origin();
+            for a in 0..3 {
+                assert!(
+                    o[a] >= lo[a] - 0.02 && o[a] <= hi[a] + 0.02,
+                    "{} sits outside the mesh on axis {a}: {o:?} vs {lo:?}..{hi:?}",
+                    b.name
+                );
+            }
+        }
+    }
+
+
+    // ── Skinning ──────────────────────────────────────────────────────────────
+
+    fn boxed(name: &str, at: [f32; 3], half: f32) -> Vec<u8> {
+        bone_block(
+            name,
+            Some(bind_at(at[0], at[1], at[2])),
+            &[0],
+            [-half, -half, -half],
+            [half, half, half],
+        )
+    }
+
+    fn node_of(points: &[[f32; 3]]) -> EdfNode {
+        EdfNode {
+            name: "body".into(),
+            positions: points.iter().flatten().copied().collect(),
+            uvs: vec![0.0; points.len() * 2],
+            normals: vec![0.0; points.len() * 3],
+            indices: vec![],
+            submeshes: vec![],
+            texture: None,
+            placed: false,
+            materials: vec![],
+        }
+    }
+
+    /// A two-link arm along X: shoulder at the origin, elbow at 1, wrist at 2. A name leads
+    /// its record, so each block carries the *next* bone's name — see `bone_block`.
+    fn arm_rig() -> Vec<Bone> {
+        let rig = parse_skeleton(&rig_file(&[
+            bone_block("riderRIG_LeftShoulder", None, &[0], [0.0; 3], [0.0; 3]),
+            boxed("riderRIG_LeftElbow", [0.0, 0.0, 0.0], 1.2),
+            boxed("riderRIG_LeftWrist", [1.0, 0.0, 0.0], 1.2),
+            boxed("riderRIG_LeftThumb1", [2.0, 0.0, 0.0], 1.2),
+        ]));
+        assert_eq!(
+            rig.iter().map(|b| b.name.as_str()).collect::<Vec<_>>(),
+            ["riderRIG_LeftShoulder", "riderRIG_LeftElbow", "riderRIG_LeftWrist"]
+        );
+        assert_eq!(rig[0].origin(), [0.0, 0.0, 0.0]);
+        assert_eq!(rig[1].origin(), [1.0, 0.0, 0.0]);
+        rig
+    }
+
+    #[test]
+    fn every_vertex_is_bound_and_its_weights_add_up() {
+        let rig = arm_rig();
+        let nodes = [node_of(&[[0.2, 0.0, 0.0], [0.9, 0.1, 0.0], [1.5, 0.0, 0.0], [40.0, 40.0, 40.0]])];
+        let skin = skin_mesh(&nodes, &rig);
+        assert_eq!(skin.indices.len(), 4 * SKIN_BONES_PER_VERTEX);
+        for v in 0..4 {
+            let w: f32 = skin.weights[v * SKIN_BONES_PER_VERTEX..][..SKIN_BONES_PER_VERTEX].iter().sum();
+            assert!((w - 1.0).abs() < 1e-5, "vertex {v} weights sum to {w}");
+            assert!(
+                skin.indices[v * SKIN_BONES_PER_VERTEX..][..SKIN_BONES_PER_VERTEX]
+                    .iter()
+                    .all(|&i| (i as usize) < rig.len()),
+                "vertex {v} names a bone that isn't there"
+            );
+        }
+    }
+
+    #[test]
+    fn a_vertex_follows_the_limb_it_sits_on() {
+        let rig = arm_rig();
+        let shoulder = rig.iter().position(|b| b.name.ends_with("Shoulder")).unwrap();
+        let elbow = rig.iter().position(|b| b.name.ends_with("Elbow")).unwrap();
+        // Upper arm, forearm, and a point right on the elbow.
+        let nodes = [node_of(&[[0.5, 0.0, 0.0], [1.5, 0.0, 0.0], [1.0, 0.0, 0.0]])];
+        let skin = skin_mesh(&nodes, &rig);
+        let heaviest = |v: usize| {
+            let s = &skin.weights[v * SKIN_BONES_PER_VERTEX..][..SKIN_BONES_PER_VERTEX];
+            let at = s.iter().enumerate().max_by(|a, b| a.1.total_cmp(b.1)).unwrap().0;
+            skin.indices[v * SKIN_BONES_PER_VERTEX + at] as usize
+        };
+        assert_eq!(heaviest(0), shoulder, "the upper arm swings from the shoulder");
+        assert_eq!(heaviest(1), elbow, "the forearm swings from the elbow");
+        // At the joint the vertex is shared rather than snapped to one side.
+        let at_joint = &skin.weights[2 * SKIN_BONES_PER_VERTEX..][..SKIN_BONES_PER_VERTEX];
+        assert!(at_joint.iter().filter(|w| **w > 0.05).count() >= 2, "{at_joint:?}");
+    }
+
+    #[test]
+    fn a_far_vertex_still_lands_on_a_limb() {
+        // No box claims it, so it goes to the nearest limb outright rather than nowhere: a
+        // vertex bound to nothing would sit still while the rest of the body moved.
+        let rig = arm_rig();
+        let nodes = [node_of(&[[9.0, 9.0, 0.0]])];
+        let skin = skin_mesh(&nodes, &rig);
+        assert_eq!(skin.weights[0], 1.0);
+        assert!(skin.weights[1..SKIN_BONES_PER_VERTEX].iter().all(|w| *w == 0.0));
+        assert!((skin.indices[0] as usize) < rig.len());
+    }
+
+    #[test]
+    fn a_mesh_with_no_rig_still_draws() {
+        let nodes = [node_of(&[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])];
+        let skin = skin_mesh(&nodes, &[]);
+        assert_eq!(skin.weights[0], 1.0);
+        assert_eq!(skin.weights[SKIN_BONES_PER_VERTEX], 1.0);
+    }
+
+    /// The real body against its real rig.
+    #[test]
+    #[ignore]
+    fn real_rider_skin() {
+        let Ok(path) = std::env::var("MXB_EDF_FILE") else {
+            eprintln!("set MXB_EDF_FILE to run");
+            return;
+        };
+        let bytes = std::fs::read(&path).expect("read edf");
+        let rig = parse_skeleton(&bytes);
+        let nodes = parse(&bytes);
+        let skin = skin_mesh(&nodes, &rig);
+        let verts: usize = nodes.iter().map(|n| n.positions.len() / 3).sum();
+        assert_eq!(skin.weights.len(), verts * SKIN_BONES_PER_VERTEX);
+
+        let mut used = std::collections::HashSet::new();
+        let mut shared = 0usize;
+        for v in 0..verts {
+            let w = &skin.weights[v * SKIN_BONES_PER_VERTEX..][..SKIN_BONES_PER_VERTEX];
+            let total: f32 = w.iter().sum();
+            assert!((total - 1.0).abs() < 1e-4, "vertex {v} sums to {total}");
+            if w.iter().filter(|x| **x > 0.05).count() > 1 {
+                shared += 1;
+            }
+            for slot in 0..SKIN_BONES_PER_VERTEX {
+                if w[slot] > 0.0 {
+                    used.insert(skin.indices[v * SKIN_BONES_PER_VERTEX + slot]);
+                }
+            }
+        }
+        eprintln!("{verts} vertices, {} of the {} bones used, {shared} shared between bones", used.len(), rig.len());
+        // A skin that puts everything on one bone, or leaves limbs unbound, is not a skin.
+        assert!(used.len() > rig.len() / 2, "only {} bones move anything", used.len());
+        assert!(shared * 4 > verts, "hardly any vertex is shared — the seams will tear");
+
+        // Left stays left: no vertex on one side of the body may be pulled by the other's arm.
+        let at = |n: &str| rig.iter().position(|b| b.name == n);
+        if let (Some(l), Some(r)) = (at("riderRIG_LeftWrist"), at("riderRIG_RightWrist")) {
+            for (side, other) in [(l, r), (r, l)] {
+                let reach: Vec<f32> = (0..verts)
+                    .filter(|v| {
+                        (0..SKIN_BONES_PER_VERTEX)
+                            .any(|s| skin.indices[v * SKIN_BONES_PER_VERTEX + s] as usize == side
+                                && skin.weights[v * SKIN_BONES_PER_VERTEX + s] > 0.2)
+                    })
+                    .map(|v| nodes[0].positions[v * 3])
+                    .collect();
+                if reach.is_empty() {
+                    continue;
+                }
+                let x = rig[side].origin()[0];
+                let wrong = reach.iter().filter(|v| v.signum() != x.signum()).count();
+                assert!(
+                    wrong * 20 < reach.len().max(20),
+                    "{} pulls {wrong} of {} vertices from the other side",
+                    rig[side].name,
+                    reach.len()
+                );
+                let _ = other;
+            }
+        }
+    }
+
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2514,6 +2514,13 @@ struct RiderPart {
     part: String,
     nodes: Vec<edf::EdfNode>,
     textures: Vec<paint::PaintTexture>,
+    /// The body's rig, in the frame `nodes` came back in. Only the body has one — gear is
+    /// rigid and hangs off a bone rather than carrying any.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    skeleton: Vec<edf::Bone>,
+    /// Which bones move which vertices. Empty unless `skeleton` is filled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    skin: Option<edf::Skin>,
 }
 
 #[derive(serde::Serialize)]
@@ -2660,10 +2667,14 @@ fn load_rider_body(
         nodes.len(),
         textures.iter().map(|t| t.name.as_str()).collect::<Vec<_>>(),
     );
+    let skeleton = body_rig(&src, profile);
+    let skin = (!skeleton.is_empty()).then(|| body_skin(&src, profile, &nodes, &skeleton));
     Some(RiderPart {
         part: "body".into(),
         nodes,
         textures,
+        skeleton,
+        skin,
     })
 }
 
@@ -2686,6 +2697,16 @@ fn load_rider_body(
 /// construction — they sit behind its centre. On the Z-up meshes a bare quarter turn puts
 /// them in front. Both halves are needed together: `y = -z, z = -y` on its own mirrors the
 /// mesh rather than turning it, which would swap the rider's left and right hands.
+/// The turn a Z-up body takes: a half turn about Y on top of a quarter turn about X.
+/// Named here because the rig has to take exactly the same one — see [`body_rig`].
+const BODY_STAND_UP: [[f32; 3]; 3] =
+    [[-1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, -1.0, 0.0]];
+
+/// Is this body authored Z-up — lying on its back, longest axis in Z?
+fn body_is_z_up(ext: [f32; 3]) -> bool {
+    ext[2] > ext[1] && ext[2] > ext[0]
+}
+
 fn stand_body_upright(nodes: &mut [edf::EdfNode]) {
     let (mut lo, mut hi) = ([f32::MAX; 3], [f32::MIN; 3]);
     for n in nodes.iter() {
@@ -2697,17 +2718,18 @@ fn stand_body_upright(nodes: &mut [edf::EdfNode]) {
         }
     }
     let ext = [hi[0] - lo[0], hi[1] - lo[1], hi[2] - lo[2]];
-    if ext[2] <= ext[1] || ext[2] <= ext[0] {
+    if !body_is_z_up(ext) {
         return;
     }
     for n in nodes.iter_mut() {
         for v in n.positions.chunks_exact_mut(3).chain(n.normals.chunks_exact_mut(3)) {
             let (x, y, z) = (v[0], v[1], v[2]);
-            v[0] = -x;
+            let r = BODY_STAND_UP;
             // Negated, not taken as-is: these meshes lie head-away, with the head at the
             // most negative Z, so this is what puts it at the top.
-            v[1] = -z;
-            v[2] = -y;
+            v[0] = r[0][0] * x + r[0][1] * y + r[0][2] * z;
+            v[1] = r[1][0] * x + r[1][1] * y + r[1][2] * z;
+            v[2] = r[2][0] * x + r[2][1] * y + r[2][2] * z;
         }
     }
     log::info!("[rider] body was authored Z-up ({ext:?}); stood it upright");
@@ -2797,6 +2819,74 @@ fn pkz_mesh_cache() -> &'static std::sync::Mutex<lru::Lru<Vec<edf::EdfNode>>> {
 fn keep_lod0(nodes: &mut Vec<edf::EdfNode>) {
     let mut seen = std::collections::HashSet::new();
     nodes.retain(|n| n.name.is_empty() || seen.insert(n.name.clone()));
+}
+
+/// Rigs are tiny — 65 bones of two matrices each — so this holds more than the mesh cache.
+fn rig_cache() -> &'static std::sync::Mutex<lru::Lru<Vec<edf::Bone>>> {
+    static C: std::sync::OnceLock<std::sync::Mutex<lru::Lru<Vec<edf::Bone>>>> =
+        std::sync::OnceLock::new();
+    C.get_or_init(|| std::sync::Mutex::new(lru::Lru::new(MESH_CACHE_CAP * 2)))
+}
+
+/// A rider body's rig, in the same frame the viewer gets its mesh in, memoised.
+///
+/// The mesh takes two turns on the way out of the file — [`edf::to_right_handed`] mirrors X,
+/// then [`stand_body_upright`] stands a Z-up body up — and the rig has to take both, or the
+/// skeleton ends up mirrored or lying beside a standing body. Whether the second one applies
+/// is decided from the rig's own extents rather than the mesh's: both are authored in the
+/// same frame, so they agree, and asking the rig costs nothing where asking the mesh would
+/// mean parsing 67 MB a second time.
+fn body_rig(src: &BodySource, profile: &str) -> Vec<edf::Bone> {
+    let key = format!("rig:{}", src.cache_key(profile));
+    if let Some(r) = rig_cache().lock().ok().and_then(|mut c| c.get(&key).cloned()) {
+        return r;
+    }
+    let mut rig = src.read(profile).map(|b| edf::parse_skeleton(&b)).unwrap_or_default();
+    if !rig.is_empty() {
+        edf::transform_skeleton(&mut rig, [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]);
+        let (mut lo, mut hi) = ([f32::MAX; 3], [f32::MIN; 3]);
+        for b in rig.iter() {
+            let o = b.origin();
+            for a in 0..3 {
+                lo[a] = lo[a].min(o[a]);
+                hi[a] = hi[a].max(o[a]);
+            }
+        }
+        if body_is_z_up([hi[0] - lo[0], hi[1] - lo[1], hi[2] - lo[2]]) {
+            edf::transform_skeleton(&mut rig, BODY_STAND_UP);
+        }
+        log::info!("[rider] body '{profile}' rig: {} bones", rig.len());
+    }
+    if let Ok(mut c) = rig_cache().lock() {
+        c.insert(key, rig.clone());
+    }
+    rig
+}
+
+/// The body's binding to its rig, memoised. Working it out is quick — a third of a million
+/// point-to-segment distances — but it depends only on the model, and a loadout change must
+/// not pay for it again.
+fn body_skin(
+    src: &BodySource,
+    profile: &str,
+    nodes: &[edf::EdfNode],
+    rig: &[edf::Bone],
+) -> edf::Skin {
+    let key = format!("skin:{}", src.cache_key(profile));
+    if let Some(s) = skin_cache().lock().ok().and_then(|mut c| c.get(&key).cloned()) {
+        return s;
+    }
+    let skin = edf::skin_mesh(nodes, rig);
+    if let Ok(mut c) = skin_cache().lock() {
+        c.insert(key, skin.clone());
+    }
+    skin
+}
+
+fn skin_cache() -> &'static std::sync::Mutex<lru::Lru<edf::Skin>> {
+    static C: std::sync::OnceLock<std::sync::Mutex<lru::Lru<edf::Skin>>> =
+        std::sync::OnceLock::new();
+    C.get_or_init(|| std::sync::Mutex::new(lru::Lru::new(MESH_CACHE_CAP)))
 }
 
 fn cached_mesh(key: &str) -> Option<Vec<edf::EdfNode>> {
@@ -3034,6 +3124,8 @@ async fn load_stock_gear_model(
             part: spec.part.into(),
             nodes,
             textures,
+            skeleton: Vec::new(),
+        skin: None,
         })
     })
     .await
@@ -3463,7 +3555,7 @@ fn load_gear_model_blocking(
         goggle_side.primary,
         out.len(),
     );
-    Ok(RiderPart { part, nodes, textures: out })
+    Ok(RiderPart { part, nodes, textures: out, skeleton: Vec::new(), skin: None })
 }
 
 /// One file out of a gear folder or archive, by base name.
@@ -3946,6 +4038,8 @@ fn load_gear(
         part: spec.part.into(),
         nodes,
         textures,
+        skeleton: Vec::new(),
+        skin: None,
     })
 }
 
@@ -4106,6 +4200,8 @@ fn load_rider_paint(
         part: part.into(),
         nodes: Vec::new(),
         textures,
+        skeleton: Vec::new(),
+        skin: None,
     })
 }
 

--- a/src/Components/Rider/PoseStudio.tsx
+++ b/src/Components/Rider/PoseStudio.tsx
@@ -1,0 +1,261 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { RotateCcw, User } from "lucide-react";
+import { useT, type TKey } from "../../i18n/context";
+import { Button } from "../ui/button";
+import { Row, Slider } from "../ui/controls";
+import type { Loadout } from "../../types";
+import { ViewerPanel } from "../Viewer/ViewerPanel";
+import { EMPTY_LOADOUT, loadScans, pickedModel, type Scans } from "../../lib/presets";
+import { useConfig } from "../../Context/Config";
+import {
+  applyQuickMove,
+  BONE_GROUPS,
+  boneLabel,
+  clampTurn,
+  isRestPose,
+  NO_POSE,
+  QUICK_MOVES,
+  TURN_LIMIT,
+  turnOf,
+  withTurn,
+  type BoneGroupId,
+  type QuickMoveId,
+  type RiderPose,
+} from "../../lib/riderPose";
+
+/**
+ * Where a rider's pose is remembered, keyed by the profile it was built for.
+ *
+ * Machine-local rather than part of the preset: a pose is a preview, and nothing the game
+ * reads. Putting it in a preset would put it in share codes too, and those have to keep
+ * meaning the same thing to an older build.
+ */
+const POSE_KEY = "mxb.pose.v1";
+
+const GROUP_LABEL: Record<BoneGroupId, TKey> = {
+  torso: "pose.group.torso",
+  arms: "pose.group.arms",
+  hands: "pose.group.hands",
+  legs: "pose.group.legs",
+};
+
+const MOVE_LABEL: Record<QuickMoveId, TKey> = {
+  legsWide: "pose.move.legsWide",
+  legsNarrow: "pose.move.legsNarrow",
+  leftLegForward: "pose.move.leftLegForward",
+  elbowsUp: "pose.move.elbowsUp",
+  leanIn: "pose.move.leanIn",
+};
+
+/** The three turns of a bone, in the order the sliders show them. */
+const AXES: { at: 0 | 1 | 2; label: TKey }[] = [
+  { at: 0, label: "pose.axis.bend" },
+  { at: 1, label: "pose.axis.twist" },
+  { at: 2, label: "pose.axis.splay" },
+];
+
+function readSaved(profile: string): RiderPose {
+  try {
+    const all = JSON.parse(localStorage.getItem(POSE_KEY) ?? "{}") as Record<string, RiderPose>;
+    return all[profile] ?? NO_POSE;
+  } catch {
+    return NO_POSE;
+  }
+}
+
+function writeSaved(profile: string, pose: RiderPose): void {
+  try {
+    const all = JSON.parse(localStorage.getItem(POSE_KEY) ?? "{}") as Record<string, RiderPose>;
+    if (isRestPose(pose)) delete all[profile];
+    else all[profile] = pose;
+    localStorage.setItem(POSE_KEY, JSON.stringify(all));
+  } catch {
+    // A browser with storage turned off still poses; it just forgets between visits.
+  }
+}
+
+interface PoseStudioProps {
+  /** The preset to show. The Pose view never edits it — see the note on the summary below. */
+  initialLoadout?: Loadout | null;
+  initialBike?: string | null;
+  onLoaded?: () => void;
+}
+
+/**
+ * The Pose studio.
+ *
+ * A preset as it stands — bike, model swap, rider, gear, paints — with one thing you can
+ * change: where the rider's limbs are. Everything else is deliberately read-only. The Rider
+ * tab next door is where a look is composed; this is where it is stood in a position, and a
+ * second set of pickers here would only be a second place to change the same slots.
+ *
+ * The pose reaches the preview and nothing else. MX Bikes takes the rider's posture from a
+ * riding style — an animation set in `mods/rider/animations` — and nothing this writes could
+ * change that.
+ */
+export default function PoseStudio({
+  initialLoadout,
+  initialBike,
+  onLoaded,
+}: PoseStudioProps) {
+  const t = useT();
+  const { bikePreview } = useConfig();
+  const [scans, setScans] = useState<Scans | null>(null);
+  const [loadout, setLoadout] = useState<Loadout>(EMPTY_LOADOUT);
+  const [bike, setBike] = useState("");
+  const [pose, setPose] = useState<RiderPose>(NO_POSE);
+  const [open, setOpen] = useState<BoneGroupId | null>("legs");
+
+  useEffect(() => {
+    let alive = true;
+    loadScans()
+      .then((s) => alive && setScans(s))
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  // A preset handed over by Presets or the Rider tab.
+  useEffect(() => {
+    if (!initialLoadout) return;
+    setLoadout(initialLoadout);
+    if (initialBike) setBike(initialBike);
+    onLoaded?.();
+  }, [initialLoadout, initialBike, onLoaded]);
+
+  // Each rider profile keeps its own pose: the rigs differ in what they bind, and a turn that
+  // suits one model's shoulders is not the same turn on another's.
+  const profile = loadout.rider || "default";
+  useEffect(() => setPose(readSaved(profile)), [profile]);
+  useEffect(() => writeSaved(profile, pose), [profile, pose]);
+
+  const bikeVariant = useMemo(
+    () => loadout.modelSwap || pickedModel(bike, loadout, scans),
+    [bike, loadout, scans],
+  );
+  const showBike = bikePreview && !!bike;
+
+  const turn = useCallback(
+    (bone: string, at: 0 | 1 | 2, deg: number) => {
+      setPose((p) => {
+        const next = turnOf(p, bone);
+        next[at] = clampTurn(deg);
+        return withTurn(p, bone, next);
+      });
+    },
+    [],
+  );
+
+  const summary: { label: TKey; value: string }[] = [
+    { label: "pose.bike", value: bike },
+    { label: "slot.modelSwap", value: loadout.modelSwap },
+    { label: "slot.rider", value: loadout.rider },
+    { label: "slot.helmet", value: loadout.helmet },
+    { label: "slot.boots", value: loadout.boots },
+    { label: "slot.protection", value: loadout.protection },
+  ];
+
+  return (
+    <div className="flex min-h-0 flex-1 gap-4 px-7 pb-6">
+      <div className="flex min-w-[300px] flex-1 flex-col gap-4 overflow-y-auto">
+        {/* What is being posed. Read-only on purpose — see the component note. */}
+        <section className="rounded-lg border border-border bg-card/40 p-3">
+          <header className="mb-2 flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground">
+            <User className="h-3.5 w-3.5" />
+            {t("pose.showing")}
+          </header>
+          <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-[11px]">
+            {summary.map((s) => (
+              <div key={s.label} className="flex min-w-0 justify-between gap-2">
+                <dt className="text-muted-foreground">{t(s.label)}</dt>
+                <dd className="truncate font-medium" title={s.value}>
+                  {s.value || t("pose.none")}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+
+        <section>
+          <header className="mb-2 flex items-center justify-between">
+            <h2 className="text-[11px] font-medium text-muted-foreground">{t("pose.quick")}</h2>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-6 gap-1 px-2 text-[11px]"
+              disabled={isRestPose(pose)}
+              onClick={() => setPose(NO_POSE)}
+            >
+              <RotateCcw className="h-3 w-3" />
+              {t("pose.reset")}
+            </Button>
+          </header>
+          <div className="flex flex-wrap gap-1.5">
+            {QUICK_MOVES.map((m) => (
+              <Button
+                key={m.id}
+                size="sm"
+                variant="outline"
+                className="h-7 px-2.5 text-[11px]"
+                onClick={() => setPose((p) => applyQuickMove(p, m))}
+              >
+                {t(MOVE_LABEL[m.id])}
+              </Button>
+            ))}
+          </div>
+          <p className="mt-1.5 text-[10px] leading-snug text-muted-foreground">
+            {t("pose.quickHint")}
+          </p>
+        </section>
+
+        {BONE_GROUPS.map((g) => (
+          <section key={g.id} className="rounded-lg border border-border">
+            <button
+              type="button"
+              className="flex w-full items-center justify-between px-3 py-2 text-left text-[12px] font-medium"
+              onClick={() => setOpen((o) => (o === g.id ? null : g.id))}
+            >
+              {t(GROUP_LABEL[g.id])}
+              <span className="text-[10px] text-muted-foreground">
+                {g.bones.filter((b) => pose[b]).length || ""}
+              </span>
+            </button>
+            {open === g.id && (
+              <div className="flex flex-col gap-3 border-t border-border px-3 py-2.5">
+                {g.bones.map((bone) => (
+                  <div key={bone} className="flex flex-col gap-1">
+                    <div className="text-[11px] font-medium">{boneLabel(bone)}</div>
+                    {AXES.map((a) => (
+                      <Row key={a.at} label={t(a.label)}>
+                        <Slider
+                          value={turnOf(pose, bone)[a.at]}
+                          min={-TURN_LIMIT}
+                          max={TURN_LIMIT}
+                          step={1}
+                          onChange={(v) => turn(bone, a.at, v)}
+                          format={(v) => `${v}°`}
+                        />
+                      </Row>
+                    ))}
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+        ))}
+      </div>
+
+      <div className="min-h-0 w-[46%] min-w-[320px] flex-none">
+        <ViewerPanel
+          loadout={loadout}
+          riderOnly={!showBike}
+          bikeId={showBike ? bike : undefined}
+          bikeVariant={bikeVariant}
+          riderPose={pose}
+          className="h-full"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/Components/Studio/Studio.tsx
+++ b/src/Components/Studio/Studio.tsx
@@ -8,6 +8,7 @@ import type { Loadout } from "../../types";
 import Designer from "./Designer/Designer";
 import PaintStudio from "../PaintStudio/PaintStudio";
 import RiderStudio from "../Rider/RiderStudio";
+import PoseStudio from "../Rider/PoseStudio";
 
 /**
  * The Studio: everything that makes something, under one tab.
@@ -22,7 +23,7 @@ import RiderStudio from "../Rider/RiderStudio";
  * first-run tour both need to open the Studio *at* a particular one.
  */
 
-export type StudioTab = "designer" | "paints" | "rider";
+export type StudioTab = "designer" | "paints" | "rider" | "pose";
 
 interface StudioProps {
   tab: StudioTab;
@@ -58,7 +59,7 @@ export default function Studio({
 
   // Switching titles can take the Rider away underneath us.
   useEffect(() => {
-    if (!hasRider && tab === "rider") onTab("designer");
+    if (!hasRider && (tab === "rider" || tab === "pose")) onTab("designer");
   }, [hasRider, tab, onTab]);
 
   // One help hint, on whichever sub-view is open. Each had its own before they shared a tab,
@@ -68,7 +69,9 @@ export default function Studio({
       ? { title: t("nav.designer"), body: t("designer.help") }
       : tab === "paints"
         ? { title: t("nav.paints"), body: t("paints.help") }
-        : { title: t("nav.rider"), body: t("rider.help") };
+        : tab === "pose"
+          ? { title: t("nav.pose"), body: t("pose.help") }
+          : { title: t("nav.rider"), body: t("rider.help") };
 
   return (
     <div className="flex h-full flex-col">
@@ -83,7 +86,12 @@ export default function Studio({
           options={[
             { value: "designer", label: t("nav.designer") },
             { value: "paints", label: t("nav.paints") },
-            ...(hasRider ? [{ value: "rider" as const, label: t("nav.rider") }] : []),
+            ...(hasRider
+              ? [
+                  { value: "rider" as const, label: t("nav.rider") },
+                  { value: "pose" as const, label: t("nav.pose") },
+                ]
+              : []),
           ]}
         />
       </header>
@@ -110,6 +118,17 @@ export default function Studio({
       {hasRider && visited.has("rider") && (
         <Pane active={tab === "rider"}>
           <RiderStudio
+            initialLoadout={riderPreset}
+            initialBike={riderBike}
+            onLoaded={onRiderPresetLoaded}
+          />
+        </Pane>
+      )}
+      {/* Same handoff as the Rider sub-view: whichever of the two is open takes the preset,
+          and both being mounted is fine — `onLoaded` clears it once. */}
+      {hasRider && visited.has("pose") && (
+        <Pane active={tab === "pose"}>
+          <PoseStudio
             initialLoadout={riderPreset}
             initialBike={riderBike}
             onLoaded={onRiderPresetLoaded}

--- a/src/Components/Viewer/ModelViewer.tsx
+++ b/src/Components/Viewer/ModelViewer.tsx
@@ -5,7 +5,14 @@ import { ChevronDown, Move, Move3d, Rotate3d, SlidersHorizontal, ZoomIn } from "
 import * as THREE from "three";
 import { cn } from "@/lib/utils";
 import { Row, Slider } from "@/Components/ui/controls";
-import type { BikeRig, EdfNode, PaintTexture, RiderPart, Vec3 } from "../../types";
+import type { BikeRig, Bone, EdfNode, PaintTexture, RiderPart, Skin, Vec3 } from "../../types";
+import {
+  applyPose,
+  boneDelta,
+  buildSkeleton,
+  NO_POSE,
+  type RiderPose,
+} from "../../lib/riderPose";
 import { textureBytes } from "../../api/mods";
 import { ErrorBoundary } from "../ErrorBoundary";
 import { useT } from "../../i18n/context";
@@ -594,8 +601,13 @@ function straightenYaw(geom: THREE.BufferGeometry, rotM: THREE.Matrix4): number 
  * model does, so a paint switch has no business rebuilding vertex buffers and re-uploading
  * a whole bike to the GPU.
  */
-function useNodeGeometries(nodes: EdfNode[]) {
+/**
+ * `skin` binds the vertices to a rig. Its four-per-vertex arrays run across every node in
+ * order, so each node takes the slice that belongs to it.
+ */
+function useNodeGeometries(nodes: EdfNode[], skin?: Skin | null) {
   const geoms = useMemo(() => {
+    let vertsSoFar = 0;
     return nodes.map((n) => {
       const g = new THREE.BufferGeometry();
       g.setAttribute(
@@ -613,11 +625,25 @@ function useNodeGeometries(nodes: EdfNode[]) {
       if (!n.normals.length) g.computeVertexNormals();
       // Material groups so a multi-submesh node can wear one texture per submesh.
       n.submeshes.forEach((sm, i) => g.addGroup(sm.triStart * 3, sm.triCount * 3, i));
+      const count = n.positions.length / 3;
+      if (skin) {
+        const from = vertsSoFar * 4;
+        const to = from + count * 4;
+        g.setAttribute(
+          "skinIndex",
+          new THREE.Uint16BufferAttribute(Uint16Array.from(skin.indices.slice(from, to)), 4),
+        );
+        g.setAttribute(
+          "skinWeight",
+          new THREE.Float32BufferAttribute(Float32Array.from(skin.weights.slice(from, to)), 4),
+        );
+      }
+      vertsSoFar += count;
       g.computeBoundingBox();
       g.computeBoundingSphere();
       return g;
     });
-  }, [nodes]);
+  }, [nodes, skin]);
   useEffect(() => () => geoms.forEach((g) => g.dispose()), [geoms]);
   return geoms;
 }
@@ -657,15 +683,26 @@ function makeBodyMaterial(name: string | null | undefined, tex: Map<string, THRE
   });
 }
 
+/**
+ * The rider's body.
+ *
+ * With a rig and a skin it draws as a skinned mesh, so a turn at the hip carries the thigh
+ * with it. Without one — a model whose `.edf` carries no skeleton — it draws exactly as it
+ * did before, rigid, which is also what happens when nobody is posing.
+ */
 function RiderBodyMesh({
   part,
   overrides,
+  pose = NO_POSE,
 }: {
   part: RiderPart;
   overrides?: Map<string, THREE.Texture>;
+  pose?: RiderPose;
 }) {
   const tex = useTextureMapWith(part.textures, overrides);
-  const geoms = useNodeGeometries(part.nodes);
+  const rig = part.skeleton;
+  const skin = rig?.length ? part.skin : null;
+  const geoms = useNodeGeometries(part.nodes, skin);
   // One material per submesh; a node with no submesh table takes a single suit material.
   const mats = useMemo(
     () =>
@@ -677,19 +714,101 @@ function RiderBodyMesh({
     [part, tex],
   );
   useEffect(() => () => mats.forEach((a) => a.forEach((m) => m.dispose())), [mats]);
+
+  const built = useMemo(() => (skin && rig?.length ? buildSkeleton(rig) : null), [rig, skin]);
+  useEffect(() => () => built?.skeleton.dispose(), [built]);
+  const invalidate = useThree((s) => s.invalidate);
+  useEffect(() => {
+    if (!built) return;
+    applyPose(built.order, pose);
+    // `frameloop="demand"`: turning bones mutates three.js objects and commits no React state
+    // of its own, so nothing would redraw.
+    invalidate();
+  }, [built, pose, invalidate]);
+
+  if (!built) {
+    return (
+      <group>
+        {geoms.map((g, i) => (
+          <mesh
+            key={i}
+            geometry={g}
+            material={mats[i].length === 1 ? mats[i][0] : mats[i]}
+            castShadow
+            receiveShadow
+          />
+        ))}
+      </group>
+    );
+  }
   return (
     <group>
+      {/* The bone tree lives in the scene beside the mesh it drives. */}
+      {built.roots.map((b, i) => (
+        <primitive key={i} object={b} />
+      ))}
       {geoms.map((g, i) => (
-        <mesh
+        <skinnedMesh
           key={i}
           geometry={g}
           material={mats[i].length === 1 ? mats[i][0] : mats[i]}
+          skeleton={built.skeleton}
+          // Bound with an identity matrix: the geometry is already in the frame the bind
+          // matrices are written in, so there is nothing to reconcile.
+          ref={(m: THREE.SkinnedMesh | null) => m?.bind(built.skeleton, new THREE.Matrix4())}
+          // A posed limb leaves the bounds the mesh was measured at, and would be culled.
+          frustumCulled={false}
           castShadow
           receiveShadow
         />
       ))}
     </group>
   );
+}
+
+/**
+ * Where each piece of gear's bone has travelled to.
+ *
+ * Gear is placed against the body's proportions, and that placement is tuned piece by piece.
+ * Rather than redo it against the rig, each piece keeps the placement it had and is moved by
+ * however far its bone has moved from rest — nothing at all until somebody poses the rider.
+ *
+ * One skeleton for all of them: building it per piece would make four bone trees where one
+ * will do, and they would all be answering the same question.
+ */
+function useBoneDeltas(
+  rig: Bone[] | undefined,
+  pose: RiderPose,
+  wanted: readonly (readonly string[])[],
+): (THREE.Matrix4 | null)[] {
+  return useMemo(() => {
+    if (!rig?.length) return wanted.map(() => null);
+    const built = buildSkeleton(rig);
+    applyPose(built.order, pose);
+    return wanted.map(
+      (names) => names.map((n) => boneDelta(built.order, rig, n)).find(Boolean) ?? null,
+    );
+  }, [rig, pose, wanted]);
+}
+
+/** Hold `children` wherever `matrix` puts them. A null matrix leaves them alone entirely. */
+function PosedGroup({
+  matrix,
+  children,
+}: {
+  matrix: THREE.Matrix4 | null;
+  children: React.ReactNode;
+}) {
+  const group = useRef<THREE.Group>(null);
+  useEffect(() => {
+    const g = group.current;
+    if (!g || !matrix) return;
+    g.matrixAutoUpdate = false;
+    g.matrix.copy(matrix);
+    g.updateMatrixWorld(true);
+  }, [matrix]);
+  if (!matrix) return <>{children}</>;
+  return <group ref={group}>{children}</group>;
 }
 
 function RiderGearSolo({
@@ -763,12 +882,27 @@ function RiderGearSolo({
   );
 }
 
+/**
+ * Which bone each piece of kit rides on, by the names the rider's own `gfx.cfg` gives them:
+ * `helmetlinkobj = riderRIG_Head`, `left/rightbootlinkobj = riderRIG_*KneeTwist`,
+ * `neckbracelinkobj = riderRIG_Spine4`. Each entry falls back down its own chain, since a
+ * model that binds fewer bones may not carry the first choice.
+ */
+const GEAR_BONES = [
+  ["riderRIG_Head", "riderRIG_Neck2", "riderRIG_Neck1"],
+  ["riderRIG_Spine4", "riderRIG_Spine3"],
+  ["riderRIG_LeftKneeTwist", "riderRIG_LeftKnee"],
+  ["riderRIG_RightKneeTwist", "riderRIG_RightKnee"],
+] as const;
+
 function RiderComposite({
   parts,
   overrides,
+  pose = NO_POSE,
 }: {
   parts: RiderPart[];
   overrides?: Map<string, THREE.Texture>;
+  pose?: RiderPose;
 }) {
   const byPart = (p: RiderPart["part"]) => parts.find((x) => x.part === p);
   const body = byPart("body");
@@ -810,54 +944,64 @@ function RiderComposite({
   // i.e. around the base of the neck.
   const protAnchor: [number, number, number] = b ? [cx, b.lo[1] + 0.74 * h, cz] : [0, 1.16, 0.03];
   const bootTarget = hasBody ? 0.44 * h : 0.32;
+  const [headAt, chestAt, leftFootAt, rightFootAt] = useBoneDeltas(
+    body?.skeleton,
+    pose,
+    GEAR_BONES,
+  );
 
   if (solo) return <RiderGearSolo part={solo} overrides={overrides} />;
 
   return (
     <group>
       {hasBody ? (
-        <RiderBodyMesh part={body!} overrides={overrides} />
+        <RiderBodyMesh part={body!} overrides={overrides} pose={pose} />
       ) : (
         <RiderBody suit={suit} gloves={gloves} showHead={!hasHelmet} />
       )}
       {hasHelmet && (
-        <RiderGearMesh
-          overrides={overrides}
-          part={helmet!}
-          anchor={helmetAnchor}
-          target={hasBody ? 0.38 * h : 0.52}
-          yaw={hasBody ? Math.PI : 0}
-          pitch={hasBody ? HELMET_PITCH : 0}
-          alignY={hasBody ? "bottom" : "center"}
-        />
+        <PosedGroup matrix={headAt}>
+          <RiderGearMesh
+            overrides={overrides}
+            part={helmet!}
+            anchor={helmetAnchor}
+            target={hasBody ? 0.38 * h : 0.52}
+            yaw={hasBody ? Math.PI : 0}
+            pitch={hasBody ? HELMET_PITCH : 0}
+            alignY={hasBody ? "bottom" : "center"}
+          />
+        </PosedGroup>
       )}
       {/* Native, not fitted: the protection slot spans a full chest protector and a thin
           necklace, and scaling each to one size inflated the chain to vest proportions and
           threw away the offset a piece like a chain or a hood hangs at deliberately. */}
       {!!protection?.nodes.length && (
-        <RiderGearMesh
-          overrides={overrides}
-          part={protection!}
-          anchor={protAnchor}
-          yaw={PROT_YAW}
-          fit="native"
-        />
+        <PosedGroup matrix={chestAt}>
+          <RiderGearMesh
+            overrides={overrides}
+            part={protection!}
+            anchor={protAnchor}
+            yaw={PROT_YAW}
+            fit="native"
+          />
+        </PosedGroup>
       )}
       {/* Two feet as separate nodes → split left/right; a single-node boot renders centred. */}
       {!!boots?.nodes.length &&
         (boots!.nodes.length === 2 ? (
           bootSides(boots!).map(({ node, side }, i) => (
-            <RiderGearMesh
-          overrides={overrides}
-              key={i}
-              part={{ ...boots!, nodes: [node] }}
-              anchor={[cx + side * legX, footY, bootZ]}
-              target={bootTarget}
-              rot={BOOT_ROT}
-              pitch={hasBody ? BOOT_PITCH : 0}
-              yaw={hasBody ? side * BOOT_SPLAY : 0}
-              alignY={hasBody ? "top" : "center"}
-            />
+            <PosedGroup key={i} matrix={side > 0 ? leftFootAt : rightFootAt}>
+              <RiderGearMesh
+                overrides={overrides}
+                part={{ ...boots!, nodes: [node] }}
+                anchor={[cx + side * legX, footY, bootZ]}
+                target={bootTarget}
+                rot={BOOT_ROT}
+                pitch={hasBody ? BOOT_PITCH : 0}
+                yaw={hasBody ? side * BOOT_SPLAY : 0}
+                alignY={hasBody ? "top" : "center"}
+              />
+            </PosedGroup>
           ))
         ) : (
           <RiderGearMesh
@@ -1300,6 +1444,7 @@ function SideBySide({
   overrides,
   rig,
   pose,
+  riderPose,
   place,
 }: {
   nodes: EdfNode[];
@@ -1309,6 +1454,8 @@ function SideBySide({
   overrides?: Map<string, THREE.Texture>;
   rig?: BikeRig | null;
   pose?: BikePose;
+  /** The rider's own pose — a turn per bone. Unrelated to the bike's `pose`. */
+  riderPose?: RiderPose;
   /** Where each half has been moved to, on top of the arrangement below. */
   place?: Record<PlaceTarget, Placement>;
 }) {
@@ -1341,7 +1488,7 @@ function SideBySide({
       </group>
       <group position={at.rider}>
         <Placed at={place?.rider} pivot={at.riderPivot}>
-          <RiderComposite parts={parts} overrides={overrides} />
+          <RiderComposite parts={parts} overrides={overrides} pose={riderPose} />
         </Placed>
       </group>
     </group>
@@ -1676,6 +1823,13 @@ export interface ModelViewerProps {
    * also what an unassembled bike gets, since there is nothing to pose a pile of loose parts.
    */
   rig?: BikeRig | null;
+  /**
+   * The rider's pose — a turn per bone of the body's rig, in degrees.
+   *
+   * Absent draws the rider exactly as the model was authored, which is what every view but
+   * the Pose studio wants.
+   */
+  riderPose?: RiderPose;
   /** Offer the pose panel. Off by default: a preview nobody is posing shouldn't grow chrome. */
   poseControls?: boolean;
   /**
@@ -1700,6 +1854,7 @@ export function ModelViewer({
   highlight,
   riderParts,
   rig,
+  riderPose,
   poseControls = false,
   placeControls = false,
   loading = false,
@@ -1805,6 +1960,7 @@ export function ModelViewer({
                 overrides={overrides}
                 rig={rig}
                 pose={pose}
+                riderPose={riderPose}
                 place={place}
               />
             ) : hasReal ? (
@@ -1819,7 +1975,7 @@ export function ModelViewer({
               </Placed>
             ) : hasRider ? (
               <Placed at={place.rider} pivot={soloPivot}>
-                <RiderComposite parts={riderParts!} overrides={overrides} />
+                <RiderComposite parts={riderParts!} overrides={overrides} pose={riderPose} />
               </Placed>
             ) : loading || noStandIn ? null : mode === "bike" ? (
               <BikeStandIn map={map} />

--- a/src/Components/Viewer/ViewerPanel.tsx
+++ b/src/Components/Viewer/ViewerPanel.tsx
@@ -7,6 +7,7 @@ import { Dialog, DialogContent } from "../ui/dialog";
 import { ModelViewer, type ViewerMode } from "./ModelViewer";
 import { loadRiderModel, previewModelSwap } from "../../api/mods";
 import type { BikeModel, Loadout, PaintTexture, RiderPart } from "../../types";
+import type { RiderPose } from "../../lib/riderPose";
 import { useT } from "../../i18n/context";
 import { TyresPicker } from "./TyresPicker";
 import { useTyresPick } from "./tyresPick";
@@ -29,6 +30,11 @@ interface ViewerPanelProps {
    */
   bikeVariant?: string;
   hiddenParts?: RiderPart["part"][];
+  /**
+   * The rider's pose — a turn per bone. Absent draws the body as the model was authored,
+   * which is what every caller but the Pose studio wants.
+   */
+  riderPose?: RiderPose;
   className?: string;
 }
 
@@ -77,6 +83,7 @@ export function ViewerPanel({
   bikeId,
   bikeVariant,
   hiddenParts,
+  riderPose,
   className,
 }: ViewerPanelProps) {
   const t = useT();
@@ -318,7 +325,13 @@ export function ViewerPanel({
         <div className="relative min-h-[280px] flex-1">
           {/* Both panels are a single collapsed row until someone opens one, so the inline
               canvas only gives up its corner to a person who asked for it. */}
-          <ModelViewer {...view} poseControls placeControls className="absolute inset-0" />
+          <ModelViewer
+            {...view}
+            riderPose={riderPose}
+            poseControls
+            placeControls
+            className="absolute inset-0"
+          />
           {overlay}
         </div>
       </div>
@@ -339,7 +352,13 @@ export function ViewerPanel({
             </div>
           </div>
           <div className="relative min-h-0 flex-1">
-            <ModelViewer {...view} poseControls placeControls className="absolute inset-0" />
+            <ModelViewer
+              {...view}
+              riderPose={riderPose}
+              poseControls
+              placeControls
+              className="absolute inset-0"
+            />
             {overlay}
           </div>
         </DialogContent>

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -55,6 +55,7 @@ export const de: Translation = {
   "nav.locker": "Spind",
   "nav.presets": "Presets",
   "nav.rider": "Fahrer",
+  "nav.pose": "Pose",
   "nav.designer": "Designer",
   "nav.paints": "Designs",
   "nav.studio": "Studio",
@@ -224,6 +225,28 @@ export const de: Translation = {
   "slotGroup.rider": "Fahrer",
   "slotGroup.head": "Kopf",
   "slotGroup.body": "Körper",
+
+
+  // ── Pose studio ────────────────────────────────────────────────────────────
+  "pose.help": "Bring den Fahrer in Position — wo die Hände sitzen, wie weit die Beine stehen, ein Bein nach vorn. Nur für die Vorschau; MX Bikes nimmt die Haltung aus dem Fahrstil.",
+  "pose.showing": "Angezeigt",
+  "pose.none": "—",
+  "pose.bike": "Motorrad",
+  "pose.quick": "Schnelle Posen",
+  "pose.quickHint": "Jede kommt zur Pose hinzu, sie lassen sich also stapeln. Feinschliff unten.",
+  "pose.reset": "Zurücksetzen",
+  "pose.group.torso": "Rumpf und Kopf",
+  "pose.group.arms": "Arme",
+  "pose.group.hands": "Hände",
+  "pose.group.legs": "Beine",
+  "pose.move.legsWide": "Beine weiter",
+  "pose.move.legsNarrow": "Beine enger",
+  "pose.move.leftLegForward": "Linkes Bein vor",
+  "pose.move.elbowsUp": "Ellbogen hoch",
+  "pose.move.leanIn": "Nach vorn lehnen",
+  "pose.axis.bend": "Beugen",
+  "pose.axis.twist": "Drehen",
+  "pose.axis.splay": "Spreizen",
 
   // ── Fahrer-Studio ──────────────────────────────────────────────────────────
   "rider.help":

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -49,6 +49,7 @@ export const en = {
   "nav.locker": "Locker",
   "nav.presets": "Presets",
   "nav.rider": "Rider",
+  "nav.pose": "Pose",
   "nav.designer": "Designer",
   "nav.paints": "Paints",
   "nav.studio": "Studio",
@@ -214,6 +215,28 @@ export const en = {
   "slotGroup.rider": "Rider",
   "slotGroup.head": "Head",
   "slotGroup.body": "Body",
+
+
+  // ── Pose studio ────────────────────────────────────────────────────────────
+  "pose.help": "Stand the rider in a position — where the hands sit, how the legs are spread, one leg forward. The preview only; MX Bikes takes a rider's posture from its riding style.",
+  "pose.showing": "Showing",
+  "pose.none": "—",
+  "pose.bike": "Bike",
+  "pose.quick": "Quick moves",
+  "pose.quickHint": "Each one adds to the pose, so they stack. Fine-tune below.",
+  "pose.reset": "Reset",
+  "pose.group.torso": "Torso and head",
+  "pose.group.arms": "Arms",
+  "pose.group.hands": "Hands",
+  "pose.group.legs": "Legs",
+  "pose.move.legsWide": "Legs wider",
+  "pose.move.legsNarrow": "Legs closer",
+  "pose.move.leftLegForward": "Left leg forward",
+  "pose.move.elbowsUp": "Elbows up",
+  "pose.move.leanIn": "Lean in",
+  "pose.axis.bend": "Bend",
+  "pose.axis.twist": "Twist",
+  "pose.axis.splay": "Splay",
 
   // ── Rider studio ───────────────────────────────────────────────────────────
   "rider.help":

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -50,6 +50,7 @@ export const es: Translation = {
   "nav.locker": "Taquilla",
   "nav.presets": "Presets",
   "nav.rider": "Piloto",
+  "nav.pose": "Postura",
   "nav.designer": "Designer",
   "nav.paints": "Pinturas",
   "nav.studio": "Studio",
@@ -218,6 +219,28 @@ export const es: Translation = {
   "slotGroup.rider": "Piloto",
   "slotGroup.head": "Cabeza",
   "slotGroup.body": "Cuerpo",
+
+
+  // ── Pose studio ────────────────────────────────────────────────────────────
+  "pose.help": "Coloca al piloto — dónde van las manos, cuánto se abren las piernas, una pierna adelante. Solo la vista previa; MX Bikes toma la postura del estilo de pilotaje.",
+  "pose.showing": "Mostrando",
+  "pose.none": "—",
+  "pose.bike": "Moto",
+  "pose.quick": "Posturas rápidas",
+  "pose.quickHint": "Cada una se suma a la postura, así que se acumulan. Ajusta abajo.",
+  "pose.reset": "Restablecer",
+  "pose.group.torso": "Torso y cabeza",
+  "pose.group.arms": "Brazos",
+  "pose.group.hands": "Manos",
+  "pose.group.legs": "Piernas",
+  "pose.move.legsWide": "Piernas más abiertas",
+  "pose.move.legsNarrow": "Piernas más juntas",
+  "pose.move.leftLegForward": "Pierna izquierda adelante",
+  "pose.move.elbowsUp": "Codos arriba",
+  "pose.move.leanIn": "Inclinarse",
+  "pose.axis.bend": "Flexión",
+  "pose.axis.twist": "Giro",
+  "pose.axis.splay": "Apertura",
 
   // ── Estudio del piloto ─────────────────────────────────────────────────────
   "rider.help":

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -52,6 +52,7 @@ export const fr: Translation = {
   "nav.locker": "Casier",
   "nav.presets": "Presets",
   "nav.rider": "Pilote",
+  "nav.pose": "Posture",
   "nav.designer": "Designer",
   "nav.paints": "Décos",
   "nav.studio": "Studio",
@@ -221,6 +222,28 @@ export const fr: Translation = {
   "slotGroup.rider": "Pilote",
   "slotGroup.head": "Tête",
   "slotGroup.body": "Corps",
+
+
+  // ── Pose studio ────────────────────────────────────────────────────────────
+  "pose.help": "Place le pilote — où sont les mains, l'écartement des jambes, une jambe en avant. L'aperçu seulement ; MX Bikes tire la posture du style de pilotage.",
+  "pose.showing": "Affiché",
+  "pose.none": "—",
+  "pose.bike": "Moto",
+  "pose.quick": "Postures rapides",
+  "pose.quickHint": "Chacune s'ajoute à la posture, elles se cumulent. Ajuste en dessous.",
+  "pose.reset": "Réinitialiser",
+  "pose.group.torso": "Buste et tête",
+  "pose.group.arms": "Bras",
+  "pose.group.hands": "Mains",
+  "pose.group.legs": "Jambes",
+  "pose.move.legsWide": "Jambes plus écartées",
+  "pose.move.legsNarrow": "Jambes plus serrées",
+  "pose.move.leftLegForward": "Jambe gauche en avant",
+  "pose.move.elbowsUp": "Coudes hauts",
+  "pose.move.leanIn": "Se pencher",
+  "pose.axis.bend": "Flexion",
+  "pose.axis.twist": "Rotation",
+  "pose.axis.splay": "Écartement",
 
   // ── Studio pilote ──────────────────────────────────────────────────────────
   "rider.help":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -50,6 +50,7 @@ export const it: Translation = {
   "nav.locker": "Armadietto",
   "nav.presets": "Preset",
   "nav.rider": "Pilota",
+  "nav.pose": "Posa",
   "nav.designer": "Designer",
   "nav.paints": "Livree",
   "nav.studio": "Studio",
@@ -217,6 +218,28 @@ export const it: Translation = {
   "slotGroup.rider": "Pilota",
   "slotGroup.head": "Testa",
   "slotGroup.body": "Corpo",
+
+
+  // ── Pose studio ────────────────────────────────────────────────────────────
+  "pose.help": "Metti il pilota in posizione — dove stanno le mani, quanto sono aperte le gambe, una gamba avanti. Solo l'anteprima; MX Bikes prende la postura dallo stile di guida.",
+  "pose.showing": "In mostra",
+  "pose.none": "—",
+  "pose.bike": "Moto",
+  "pose.quick": "Pose rapide",
+  "pose.quickHint": "Ognuna si somma alla posa, quindi si accumulano. Rifinisci sotto.",
+  "pose.reset": "Reimposta",
+  "pose.group.torso": "Busto e testa",
+  "pose.group.arms": "Braccia",
+  "pose.group.hands": "Mani",
+  "pose.group.legs": "Gambe",
+  "pose.move.legsWide": "Gambe più aperte",
+  "pose.move.legsNarrow": "Gambe più chiuse",
+  "pose.move.leftLegForward": "Gamba sinistra avanti",
+  "pose.move.elbowsUp": "Gomiti alti",
+  "pose.move.leanIn": "Sporgersi",
+  "pose.axis.bend": "Flessione",
+  "pose.axis.twist": "Torsione",
+  "pose.axis.splay": "Apertura",
 
   // ── Studio pilota ──────────────────────────────────────────────────────────
   "rider.help":

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -53,6 +53,7 @@ export const ptBR: Translation = {
   "nav.locker": "Armário",
   "nav.presets": "Presets",
   "nav.rider": "Piloto",
+  "nav.pose": "Pose",
   "nav.designer": "Designer",
   "nav.paints": "Pinturas",
   "nav.studio": "Studio",
@@ -220,6 +221,28 @@ export const ptBR: Translation = {
   "slotGroup.rider": "Piloto",
   "slotGroup.head": "Cabeça",
   "slotGroup.body": "Corpo",
+
+
+  // ── Pose studio ────────────────────────────────────────────────────────────
+  "pose.help": "Coloque o piloto em posição — onde ficam as mãos, a abertura das pernas, uma perna à frente. Só a prévia; o MX Bikes tira a postura do estilo de pilotagem.",
+  "pose.showing": "Mostrando",
+  "pose.none": "—",
+  "pose.bike": "Moto",
+  "pose.quick": "Poses rápidas",
+  "pose.quickHint": "Cada uma soma à pose, então elas se acumulam. Ajuste abaixo.",
+  "pose.reset": "Redefinir",
+  "pose.group.torso": "Tronco e cabeça",
+  "pose.group.arms": "Braços",
+  "pose.group.hands": "Mãos",
+  "pose.group.legs": "Pernas",
+  "pose.move.legsWide": "Pernas mais abertas",
+  "pose.move.legsNarrow": "Pernas mais juntas",
+  "pose.move.leftLegForward": "Perna esquerda à frente",
+  "pose.move.elbowsUp": "Cotovelos altos",
+  "pose.move.leanIn": "Inclinar-se",
+  "pose.axis.bend": "Flexão",
+  "pose.axis.twist": "Torção",
+  "pose.axis.splay": "Abertura",
 
   // ── Estúdio do piloto ──────────────────────────────────────────────────────
   "rider.help":

--- a/src/lib/riderPose.ts
+++ b/src/lib/riderPose.ts
@@ -1,0 +1,264 @@
+import * as THREE from "three";
+import type { Bone } from "../types";
+
+/**
+ * Posing a rider.
+ *
+ * A pose is a turn per bone, in that bone's own frame, on top of the rest the model was
+ * authored in — so an empty pose is the model exactly as it came, and every control here
+ * starts at zero. Angles are degrees, because that is what the sliders show and what a saved
+ * pose should still read as in a year.
+ */
+export type RiderPose = Record<string, [number, number, number]>;
+
+export const NO_POSE: RiderPose = {};
+
+/** Is this pose the model as authored? */
+export function isRestPose(pose: RiderPose): boolean {
+  return Object.values(pose).every((t) => t[0] === 0 && t[1] === 0 && t[2] === 0);
+}
+
+/** Drop the bones that were turned back to zero, so a saved pose stays small and readable. */
+export function trimPose(pose: RiderPose): RiderPose {
+  const out: RiderPose = {};
+  for (const [bone, t] of Object.entries(pose)) {
+    if (t[0] || t[1] || t[2]) out[bone] = t;
+  }
+  return out;
+}
+
+/** The bone's turn, or three zeros. Never returns the caller a shared array to mutate. */
+export function turnOf(pose: RiderPose, bone: string): [number, number, number] {
+  const t = pose[bone];
+  return t ? [t[0], t[1], t[2]] : [0, 0, 0];
+}
+
+export function withTurn(
+  pose: RiderPose,
+  bone: string,
+  turn: [number, number, number],
+): RiderPose {
+  return trimPose({ ...pose, [bone]: turn });
+}
+
+// ── The rig, as three.js wants it ────────────────────────────────────────────
+
+const DEG = Math.PI / 180;
+
+/** A row-major `number[16]` from the backend as a three.js matrix. */
+export function toMatrix(m: number[]): THREE.Matrix4 {
+  const out = new THREE.Matrix4();
+  // `set` takes its arguments row-major, which is how the file stores them.
+  out.set(
+    m[0], m[1], m[2], m[3],
+    m[4], m[5], m[6], m[7],
+    m[8], m[9], m[10], m[11],
+    m[12], m[13], m[14], m[15],
+  );
+  return out;
+}
+
+/**
+ * A three.js bone tree matching `bones`, plus the skeleton that binds a mesh to it.
+ *
+ * Each bone's *local* transform is its rest placement seen from its parent, so the tree at
+ * rest reproduces the bind matrices exactly and an unposed body draws as it always did.
+ */
+export function buildSkeleton(bones: Bone[]): {
+  roots: THREE.Bone[];
+  order: THREE.Bone[];
+  skeleton: THREE.Skeleton;
+} {
+  const made = bones.map(() => new THREE.Bone());
+  const roots: THREE.Bone[] = [];
+  bones.forEach((b, i) => {
+    const bone = made[i];
+    bone.name = b.name;
+    const world = toMatrix(b.bind);
+    const local =
+      b.parent === null || b.parent === undefined
+        ? world
+        : toMatrix(bones[b.parent].bind).invert().multiply(world);
+    local.decompose(bone.position, bone.quaternion, bone.scale);
+    // Kept so a pose can turn the bone without losing the rest it turns from.
+    bone.userData.restQuaternion = bone.quaternion.clone();
+    if (b.parent === null || b.parent === undefined) roots.push(bone);
+    else made[b.parent].add(bone);
+  });
+  const skeleton = new THREE.Skeleton(
+    made,
+    bones.map((b) => toMatrix(b.invBind)),
+  );
+  return { roots, order: made, skeleton };
+}
+
+/**
+ * Turn the tree to `pose`.
+ *
+ * Every bone is reset to its rest first, so removing a bone from the pose puts it back rather
+ * than leaving the last turn applied. The turn is composed after the rest, which is what makes
+ * an elbow bend about the forearm's own axes instead of the model's.
+ */
+export function applyPose(order: THREE.Bone[], pose: RiderPose): void {
+  const turn = new THREE.Quaternion();
+  const euler = new THREE.Euler();
+  for (const bone of order) {
+    const rest = bone.userData.restQuaternion as THREE.Quaternion | undefined;
+    if (!rest) continue;
+    const t = pose[bone.name];
+    if (!t) {
+      bone.quaternion.copy(rest);
+      continue;
+    }
+    euler.set(t[0] * DEG, t[1] * DEG, t[2] * DEG, "XYZ");
+    turn.setFromEuler(euler);
+    bone.quaternion.copy(rest).multiply(turn);
+  }
+  for (const bone of order) {
+    if (!bone.parent) bone.updateMatrixWorld(true);
+  }
+}
+
+/**
+ * How far a bone has moved from where it was authored: posed world × rest world⁻¹.
+ *
+ * Gear is placed against the body's proportions rather than its rig, and that placement is
+ * tuned. Rather than redo it, each piece is moved by this — identity at rest, so an unposed
+ * rider wears its kit exactly where it did before, and a posed one carries it along.
+ */
+export function boneDelta(
+  order: THREE.Bone[],
+  bones: Bone[],
+  name: string,
+): THREE.Matrix4 | null {
+  const at = bones.findIndex((b) => b.name === name);
+  if (at < 0) return null;
+  const rest = toMatrix(bones[at].bind);
+  return order[at].matrixWorld.clone().multiply(rest.invert());
+}
+
+// ── Which bones a person would want to move ──────────────────────────────────
+
+export type BoneGroupId = "torso" | "arms" | "hands" | "legs";
+
+export interface BoneGroup {
+  id: BoneGroupId;
+  /** Rig names, in the order they should be listed. Any the model lacks are skipped. */
+  bones: string[];
+}
+
+/**
+ * The rig has 65 bones and most of them are knuckles. These are the ones worth a control,
+ * grouped the way someone thinks about a rider rather than the way the file lists them.
+ */
+export const BONE_GROUPS: BoneGroup[] = [
+  {
+    id: "torso",
+    bones: [
+      "riderRIG_Pelvis",
+      "riderRIG_Spine1",
+      "riderRIG_Spine2",
+      "riderRIG_Spine3",
+      "riderRIG_Spine4",
+      "riderRIG_Neck1",
+      "riderRIG_Head",
+    ],
+  },
+  {
+    id: "arms",
+    bones: [
+      "riderRIG_LeftCollar",
+      "riderRIG_LeftShoulder",
+      "riderRIG_LeftElbow",
+      "riderRIG_RightCollar",
+      "riderRIG_RightShoulder",
+      "riderRIG_RightElbow",
+    ],
+  },
+  { id: "hands", bones: ["riderRIG_LeftWrist", "riderRIG_RightWrist"] },
+  {
+    id: "legs",
+    bones: [
+      "riderRIG_LeftHip",
+      "riderRIG_LeftKnee",
+      "riderRIG_RightHip",
+      "riderRIG_RightKnee",
+    ],
+  },
+];
+
+/** A short label for a bone: `riderRIG_LeftElbow` → `Left elbow`. */
+export function boneLabel(name: string): string {
+  const stem = name.replace(/^.*RIG_/, "");
+  const spaced = stem
+    .replace(/([a-z])([A-Z0-9])/g, "$1 $2")
+    .replace(/_end$/, " tip")
+    .replace(/_/g, " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase();
+}
+
+// ── Ready-made moves ─────────────────────────────────────────────────────────
+
+export type QuickMoveId = "legsWide" | "legsNarrow" | "leftLegForward" | "elbowsUp" | "leanIn";
+
+export interface QuickMove {
+  id: QuickMoveId;
+  /** Added to whatever the pose already holds, so two moves can be stacked. */
+  turns: Record<string, [number, number, number]>;
+}
+
+/**
+ * The moves the rig can actually make, as turns on real bones.
+ *
+ * Deliberately small: a hip swings out on one axis and forward on another, and naming those
+ * two "wider" and "one leg forward" is most of what anyone wants from a leg. Everything finer
+ * is a slider away in the bone list.
+ */
+export const QUICK_MOVES: QuickMove[] = [
+  {
+    id: "legsWide",
+    turns: { riderRIG_LeftHip: [0, 0, 12], riderRIG_RightHip: [0, 0, -12] },
+  },
+  {
+    id: "legsNarrow",
+    turns: { riderRIG_LeftHip: [0, 0, -8], riderRIG_RightHip: [0, 0, 8] },
+  },
+  {
+    id: "leftLegForward",
+    turns: { riderRIG_LeftHip: [-14, 0, 0], riderRIG_RightHip: [10, 0, 0] },
+  },
+  {
+    id: "elbowsUp",
+    turns: {
+      riderRIG_LeftShoulder: [0, 0, -14],
+      riderRIG_RightShoulder: [0, 0, 14],
+      riderRIG_LeftElbow: [0, 0, -8],
+      riderRIG_RightElbow: [0, 0, 8],
+    },
+  },
+  {
+    id: "leanIn",
+    turns: { riderRIG_Spine2: [-8, 0, 0], riderRIG_Spine3: [-6, 0, 0], riderRIG_Neck1: [8, 0, 0] },
+  },
+];
+
+/** Stack a ready-made move onto a pose, clamped to the same limits the sliders use. */
+export function applyQuickMove(pose: RiderPose, move: QuickMove): RiderPose {
+  const out: RiderPose = { ...pose };
+  for (const [bone, turn] of Object.entries(move.turns)) {
+    const at = turnOf(out, bone);
+    out[bone] = [
+      clampTurn(at[0] + turn[0]),
+      clampTurn(at[1] + turn[1]),
+      clampTurn(at[2] + turn[2]),
+    ];
+  }
+  return trimPose(out);
+}
+
+/** How far one bone may be turned. Past this a rider stops looking like one. */
+export const TURN_LIMIT = 60;
+
+export function clampTurn(deg: number): number {
+  return Math.max(-TURN_LIMIT, Math.min(TURN_LIMIT, Math.round(deg)));
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -451,10 +451,37 @@ export interface BikeModel {
   rig: BikeRig | null;
 }
 
+/**
+ * One bone of a rider's rig, as `rider.edf` stores it, already turned into the frame the
+ * viewer draws the body in.
+ */
+export interface Bone {
+  /** The rig's own name, e.g. `riderRIG_LeftElbow`. The game references these in `gfx.cfg`. */
+  name: string;
+  /** Index into the same array. Null for the root, and only for the root. */
+  parent: number | null;
+  /** Bone space → model space at rest. Row-major, translation in the fourth column. */
+  bind: number[];
+  /** Model space → bone space at rest. */
+  invBind: number[];
+  /** The slice of the mesh this bone covers, in bone space. */
+  aabbLo: Vec3;
+  aabbHi: Vec3;
+}
+
+/** Which bones move which vertices: four of each per vertex, in `nodes` order. */
+export interface Skin {
+  indices: number[];
+  weights: number[];
+}
+
 export interface RiderPart {
   part: "body" | "helmet" | "boots" | "protection" | "suit" | "gloves";
   nodes: EdfNode[];
   textures: PaintTexture[];
+  /** Only the body carries a rig; gear is rigid and hangs off a bone. */
+  skeleton?: Bone[];
+  skin?: Skin | null;
 }
 
 /** The rider's real 3D preview, assembled from a loadout's installed gear + paints. */


### PR DESCRIPTION
A new **Pose** view in the Studio: it opens on a preset as it stands — bike, model swap, rider,
gear and paints, all read-only — and the one thing you can change is where the rider's limbs
are. Five stacking quick moves (legs wider/closer, left leg forward, elbows up, lean in), plus
bend/twist/splay per bone under Torso, Arms, Hands and Legs. **Reset** returns the model exactly
as authored.

## The rig was already in the file

`rider.edf` has always carried a 98-bone skeleton — `riderRIG_Pelvis`, `riderRIG_LeftElbow` and
so on, the same names the game references in each rider's `gfx.cfg` to hang the helmet off the
head and the boots off the knees. 65 of the 98 bind the mesh; the rest are `_end` markers plus
the ankles and toes, which belong to the boots.

Three parts of the layout read as the opposite of what they are, and are commented where they
are decoded:

- **The bone's name sits before its record.** A name that trails a record belongs to the *next*
  bone. Read the other way it produces a skeleton that parses, looks plausible, and is wrong by
  one joint the whole way down each limb.
- **The second matrix is the model-space inverse bind**, not the first one's inverse — only the
  root's pair happens to be mutually inverse.
- **The record closes on the AABB**, not on a run of zero words: `Rider+` ends every index run
  with three zeros, `Rider+RolledUp` puts a count in the last of them.

## There are no vertex weights

Nowhere in the file — 72 bytes a vertex is position, uv, three all-zero/all-one arrays, normal
and tangent, and geometry plus rig is 488 KB of the 67 MB. The game rebuilds the binding at
load, so `edf::skin_mesh` does too. The per-bone boxes cover the mesh (13 of 5089 vertices fall
outside every box) but 93% of vertices sit inside three or more, so they filter rather than
decide; distance to the limb each bone actually swings picks among the bones that claim a
vertex.

## No regression at rest

The viewer draws a `SkinnedMesh` where a rig and skin are present and the old rigid mesh
otherwise. Helmet, body armour and boots ride their `gfx.cfg` bones through a delta that is
**exactly the identity at rest**, so an unposed rider renders precisely as before and the tuned
gear placement is untouched.

## Scope

Preview only, deliberately. MX Bikes takes a rider's posture from a riding style — an animation
set in `mods/rider/animations` — and nothing here writes to the game. The pose is remembered per
rider profile in `localStorage` rather than in a preset: a `Loadout` is what share codes encode,
and it has to keep serializing byte-identically to one saved before a field existed.

No DB changes.

## Verification

- 875 Rust tests pass, 12 of them new. The real-file tests (`--ignored`, `MXB_EDF_FILE`) check
  the tree against the IK chain `gfx.cfg` declares, limb lengths a person would have, left/right
  mirroring, and every joint landing inside the mesh. Both installed rider profiles pass; a
  188 MB bike mesh yields no false rig.
- `tsc --noEmit` and `eslint src` clean; production build fine.
- The pose maths was checked against three.js headlessly: rest reproduces the bind matrices, a
  turn propagates down the chain, removing a bone restores it, and the gear delta is the
  identity at rest.

**Worth a look on Windows:** how far the rebuilt skin stretches before a shoulder creases. The
data path is verified end to end, but macOS can't click into the webview, so the pose has not
been eyeballed on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)