### PR TITLE
perf(viewer): send mesh arrays as bytes instead of JSON numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-08-28
+
+### Changed
+- **Models reach the 3D view without being spelled out as text.** A mesh's vertices used to
+  cross to the viewer as JSON numbers — 5.9 MB of digits for a small bike, and every one of
+  them parsed back into a number on arrival. They travel as their own bytes now: **the app
+  spends 12.4 ms preparing a bike's mesh instead of 2.2 ms**, and the viewer unpacks it
+  **6.8x faster** (31 ms → 4.6 ms), which grows with the model — a detailed bike or a gear
+  mesh is several times the size of the one measured. Bikes, rider gear, helmets, the rider
+  body and model-swap previews all arrive the same way.
+
 ## 2026-08-27
 
 ### Fixed

--- a/src-tauri/src/edf.rs
+++ b/src-tauri/src/edf.rs
@@ -24,14 +24,50 @@ pub struct Submesh {
     pub mat: Option<u32>,
 }
 
+/// A mesh's bulk arrays, base64'd rather than written out as JSON numbers.
+///
+/// Tauri hands a command's return value to the webview as JSON, and a float spelled out as
+/// text costs about fifteen characters and a parse. A real bike is a few hundred thousand of
+/// them: measured at 5.9 MB of text for a small one, 12 ms to encode here and ~20 ms for the
+/// webview to `JSON.parse` — and 147 ms of parsing alone for a mesh eight times the size,
+/// which an ordinary detailed bike or a gear mesh reaches.
+///
+/// Base64 of the raw little-endian bytes is 4/3 of the binary size instead of ~10x, and the
+/// webview adopts it into a typed array with one decode rather than parsing every number.
+/// `src/api/mods.ts` does that decode, so nothing downstream sees a string.
+mod mesh_b64 {
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use serde::Serializer;
+
+    pub fn f32s<S: Serializer>(v: &[f32], s: S) -> Result<S::Ok, S::Error> {
+        let mut bytes = Vec::with_capacity(v.len() * 4);
+        for f in v {
+            bytes.extend_from_slice(&f.to_le_bytes());
+        }
+        s.serialize_str(&STANDARD.encode(&bytes))
+    }
+
+    pub fn u32s<S: Serializer>(v: &[u32], s: S) -> Result<S::Ok, S::Error> {
+        let mut bytes = Vec::with_capacity(v.len() * 4);
+        for n in v {
+            bytes.extend_from_slice(&n.to_le_bytes());
+        }
+        s.serialize_str(&STANDARD.encode(&bytes))
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EdfNode {
     pub name: String,
+    #[serde(serialize_with = "mesh_b64::f32s")]
     pub positions: Vec<f32>, // 3 * vcount, local space
-    pub uvs: Vec<f32>,       // 2 * vcount
-    pub normals: Vec<f32>,   // 3 * vcount
-    pub indices: Vec<u32>,   // 3 * kept triangles
+    #[serde(serialize_with = "mesh_b64::f32s")]
+    pub uvs: Vec<f32>, // 2 * vcount
+    #[serde(serialize_with = "mesh_b64::f32s")]
+    pub normals: Vec<f32>, // 3 * vcount
+    #[serde(serialize_with = "mesh_b64::u32s")]
+    pub indices: Vec<u32>, // 3 * kept triangles
     pub submeshes: Vec<Submesh>,
     pub texture: Option<String>, // node-wide texture, used when submeshes is empty
     // True once positions are in the part's .geom LOCAL frame rather than raw authored space.
@@ -1835,6 +1871,49 @@ fn rigid_inverse(m: &Mat4) -> Mat4 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The mesh arrays cross as base64 of their raw bytes, and the webview reads them back as
+    /// typed arrays. A silent mismatch here would not fail anything — it would draw a bike
+    /// made of noise — so the round trip is asserted rather than assumed.
+    #[test]
+    fn mesh_arrays_survive_the_base64_round_trip() {
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
+
+        let node = EdfNode {
+            name: "part".into(),
+            // Values a naive encoder gets wrong: negatives, fractions, and a payload length
+            // that isn't a multiple of three.
+            positions: vec![0.0, -1.5, 2.25, f32::MIN_POSITIVE, -0.1, 1e6],
+            uvs: vec![0.0, 1.0, 0.5, 0.25],
+            normals: vec![0.0, 1.0, 0.0],
+            indices: vec![0, 1, 2, u32::MAX],
+            submeshes: Vec::new(),
+            texture: None,
+            placed: false,
+            materials: Vec::new(),
+        };
+
+        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&node).unwrap())
+            .unwrap();
+
+        let floats = |key: &str| -> Vec<f32> {
+            let b = STANDARD.decode(v[key].as_str().unwrap()).unwrap();
+            b.chunks_exact(4)
+                .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
+                .collect()
+        };
+        assert_eq!(floats("positions"), node.positions);
+        assert_eq!(floats("uvs"), node.uvs);
+        assert_eq!(floats("normals"), node.normals);
+
+        let idx: Vec<u32> = STANDARD
+            .decode(v["indices"].as_str().unwrap())
+            .unwrap()
+            .chunks_exact(4)
+            .map(|c| u32::from_le_bytes(c.try_into().unwrap()))
+            .collect();
+        assert_eq!(idx, node.indices);
+    }
 
     /// A record that claims to be a small texture but whose payload inflates to far more than
     /// that. Everything past `width * height * 4` was always thrown away — the bug was that it

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9267,7 +9267,22 @@ mod viewer_tests {
                 }
             }
         }
-        println!("\n  base textures total {total:.2?}\n");
+        println!("\n  base textures total {total:.2?}");
+
+        // The other half of the parse phase: the geometry in the same files.
+        let mut mesh = std::time::Duration::ZERO;
+        for (name, data) in &files {
+            let bn = name.rsplit('/').next().unwrap_or(name).to_ascii_lowercase();
+            if !bn.ends_with(".edf") {
+                continue;
+            }
+            let t = std::time::Instant::now();
+            let nodes = super::edf::parse(data);
+            let d = t.elapsed();
+            mesh += d;
+            println!("  parse {bn:<20}{d:>9.2?}  -> {} node(s)", nodes.len());
+        }
+        println!("  mesh parse total    {mesh:.2?}\n");
     }
 
     /// Where a bike view's time goes, uncached.

--- a/src/Components/Viewer/ModelViewer.tsx
+++ b/src/Components/Viewer/ModelViewer.tsx
@@ -620,16 +620,16 @@ function useNodeGeometries(nodes: EdfNode[], skin?: Skin | null) {
       const g = new THREE.BufferGeometry();
       g.setAttribute(
         "position",
-        new THREE.Float32BufferAttribute(Float32Array.from(n.positions), 3),
+        new THREE.Float32BufferAttribute(n.positions, 3),
       );
       if (n.uvs.length)
-        g.setAttribute("uv", new THREE.Float32BufferAttribute(Float32Array.from(n.uvs), 2));
+        g.setAttribute("uv", new THREE.Float32BufferAttribute(n.uvs, 2));
       if (n.normals.length)
         g.setAttribute(
           "normal",
-          new THREE.Float32BufferAttribute(Float32Array.from(n.normals), 3),
+          new THREE.Float32BufferAttribute(n.normals, 3),
         );
-      g.setIndex(n.indices);
+      g.setIndex(new THREE.Uint32BufferAttribute(n.indices, 1));
       if (!n.normals.length) g.computeVertexNormals();
       // Material groups so a multi-submesh node can wear one texture per submesh.
       n.submeshes.forEach((sm, i) => g.addGroup(sm.triStart * 3, sm.triCount * 3, i));

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -472,7 +472,11 @@ export function previewModelSwap(
   variant: string,
   tyres?: string,
 ): Promise<BikeModel> {
-  return invoke<BikeModel>("preview_model_swap", { bike, variant, tyres: tyres || null });
+  return invoke<BikeModel>("preview_model_swap", {
+    bike,
+    variant,
+    tyres: tyres || null,
+  }).then(reviveMesh);
 }
 
 /**
@@ -715,16 +719,76 @@ export function unpackPkz(path: string, outDir: string): Promise<string[]> {
  * name that isn't installed falls back to the bike's own rather than losing the wheels.
  * Omit it (or pass `""`) for whatever the bike itself asks for.
  */
+/**
+ * Turn a mesh's base64 bulk arrays back into typed arrays, in place.
+ *
+ * The backend sends `positions`/`uvs`/`normals`/`indices` as base64 of their raw bytes
+ * rather than as JSON numbers — see `EdfNode` in `edf.rs` for why. Everything downstream
+ * reads them by index and by `.length`, which a typed array answers exactly as an array did,
+ * so this is the only place that knows the difference.
+ *
+ * Walks the payload rather than naming a path into it, because five commands return meshes
+ * under four different shapes, and a sixth would otherwise arrive silently broken.
+ */
+function reviveMesh<T>(value: T): T {
+  const seen = new Set<object>();
+  const walk = (v: unknown): void => {
+    if (v === null || typeof v !== "object") return;
+    if (seen.has(v as object)) return;
+    seen.add(v as object);
+    if (Array.isArray(v)) {
+      v.forEach(walk);
+      return;
+    }
+    const o = v as Record<string, unknown>;
+    if (typeof o.positions === "string") {
+      o.positions = f32(o.positions);
+      o.uvs = f32(o.uvs as string);
+      o.normals = f32(o.normals as string);
+      o.indices = u32(o.indices as string);
+      // `submeshes` and the rest still need walking — a node can hold further meshes.
+    }
+    Object.values(o).forEach(walk);
+  };
+  walk(value);
+  return value;
+}
+
+/** Base64 → bytes. `atob` is the fastest thing the webview offers for this. */
+function bytesOf(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i += 1) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+/** The buffer from `bytesOf` is freshly allocated, so it starts aligned and a view is free.
+ *  A length that isn't a whole number of values means a truncated payload — hand back an
+ *  empty array, which every consumer already handles, rather than throwing. */
+function f32(b64: string): Float32Array {
+  const b = bytesOf(b64);
+  if (b.byteLength % 4) return new Float32Array(0);
+  return new Float32Array(b.buffer, 0, b.byteLength / 4);
+}
+
+function u32(b64: string): Uint32Array {
+  const b = bytesOf(b64);
+  if (b.byteLength % 4) return new Uint32Array(0);
+  return new Uint32Array(b.buffer, 0, b.byteLength / 4);
+}
+
 export function loadBikeModel(source: string, tyres?: string): Promise<BikeModel> {
-  return invoke<BikeModel>("load_bike_model", { source, tyres: tyres || null });
+  return invoke<BikeModel>("load_bike_model", { source, tyres: tyres || null }).then(
+    reviveMesh,
+  );
 }
 
 export function loadRiderModel(loadout: Loadout): Promise<RiderModel> {
-  return invoke<RiderModel>("load_rider_model", { loadout });
+  return invoke<RiderModel>("load_rider_model", { loadout }).then(reviveMesh);
 }
 
 export function loadRiderBodyModel(profile: string): Promise<EdfNode[]> {
-  return invoke<EdfNode[]>("load_rider_body_model", { profile });
+  return invoke<EdfNode[]>("load_rider_body_model", { profile }).then(reviveMesh);
 }
 
 export function loadGearModel(
@@ -743,7 +807,7 @@ export function loadGearModel(
     goggles,
     stock,
     stockGoggles,
-  });
+  }).then(reviveMesh);
 }
 
 export function listGearPaints(path: string): Promise<GearPaints> {
@@ -761,7 +825,7 @@ export function loadStockGearModel(
   part: RiderPart["part"],
   paintPath?: string,
 ): Promise<RiderPart> {
-  return invoke<RiderPart>("load_stock_gear_model", { part, paintPath });
+  return invoke<RiderPart>("load_stock_gear_model", { part, paintPath }).then(reviveMesh);
 }
 
 /** Move an installed mod file into a different folder (relative to the type dir). */

--- a/src/lib/riderPose.ts
+++ b/src/lib/riderPose.ts
@@ -410,7 +410,7 @@ function firstOrigin(bones: Bone[], names: string[]): THREE.Vector3 | null {
  * settles the question on its own.
  */
 function facingFromFeet(
-  nodes: { positions: number[] }[],
+  nodes: { positions: ArrayLike<number> }[],
   f: THREE.Vector3,
   up: THREE.Vector3,
   ankle: THREE.Vector3,
@@ -474,7 +474,7 @@ function facingFromThumb(bones: Bone[], f: THREE.Vector3, up: THREE.Vector3): nu
  */
 export function riderFrame(
   bones: Bone[],
-  body?: { positions: number[] }[] | null,
+  body?: { positions: ArrayLike<number> }[] | null,
 ): RiderFrame | null {
   if (!bones.length) return null;
   const leftHip = originOf(bones, "riderRIG_LeftHip");

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -357,13 +357,13 @@ export interface Submesh {
 export interface EdfNode {
   name: string;
   /** `3 * vertexCount` — positions (local space). */
-  positions: number[];
+  positions: Float32Array;
   /** `2 * vertexCount` — uv0 per vertex (empty if none). */
-  uvs: number[];
+  uvs: Float32Array;
   /** `3 * vertexCount` — normals per vertex (empty if none). */
-  normals: number[];
+  normals: Float32Array;
   /** `3 * triangleCount` — u32 indices, a plain triangle list. */
-  indices: number[];
+  indices: Uint32Array;
   /** Material groups over the kept triangle list (empty if not resolved). */
   submeshes: Submesh[];
   texture: string | null;


### PR DESCRIPTION
Tauri hands a command's return value to the webview as JSON. A mesh's vertices were going across as spelled-out decimal numbers — about fifteen characters and a parse each, a few hundred thousand times per model. Textures were moved off this path long ago (`PaintTexture.token` + `textureBytes`); geometry never was.

`positions`, `uvs`, `normals` and `indices` now serialise as base64 of their raw little-endian bytes.

## Measured

On a real bike mod (BBR Super Pro CRF50 — 59 252 vertices, 40 788 triangles):

```
                        before     after
encode (Rust)          12.4 ms    2.2 ms
payload                 5.9 MB    3.2 MB
unpack (webview)       31.3 ms    4.6 ms     6.8x
```

That bike is at the small end. The webview cost scales with the model, and the same measurement at 8x the vertices was **147 ms of `JSON.parse` alone** — ordinary for a detailed bike, and gear meshes are the largest models the app reads.

Base64 is 4/3 of the binary size rather than ~10x of it, and the webview turns it into a typed array with one `atob` instead of parsing every number individually.

## Scope

Every command that returns a mesh: bikes, rider gear, stock gear, the rider body, and model-swap previews. `reviveMesh` walks the payload looking for mesh-shaped objects rather than naming a path into each response — five commands return meshes under four different shapes, and a sixth would otherwise arrive silently broken.

**Consumers are untouched.** Everything downstream reads these arrays by index and by `.length`, which a `Float32Array` answers exactly as an array did. The only edits outside the decode were widening two `riderPose` signatures to `ArrayLike<number>`, and `ModelViewer` now adopting the arrays straight into three.js instead of copying them through `Float32Array.from`.

## Verification

A mismatch here would not throw — it would draw a bike made of noise — so both halves were checked independently:

- **Rust**: a round-trip unit test over negatives, fractions, `f32::MIN_POSITIVE` and `u32::MAX`.
- **JS**: the decoders from `mods.ts`, verbatim, checked against base64 generated by Python's `struct` — an independent implementation that agrees with Rust on IEEE-754 little-endian.

896 Rust tests pass · `tsc --noEmit` clean · `eslint src` clean (2 warnings, both pre-existing in untouched files) · `vite build` clean · `cargo check --target x86_64-pc-windows-gnu` clean.

Not run in the app. Worth opening a bike, a helmet and a model-swap preview by hand before trusting it.

## Where bike rendering stands

```
read archive      23.3 ms
parse mesh        62.0 ms   <- now the largest phase
decode textures   45.3 ms
-------------------------
open, cold       123.4 ms   (was 201 ms two PRs ago)
open, cached       0.27 ms
mesh -> webview    2.2 ms + 4.6 ms   (was 12.4 + 31.3)
```

Of the remaining 62 ms, 28 ms is EDF parsing across three files — done serially, so it could be parallelised — and the rest is rig assembly and skinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
