### PR TITLE
fix(pose): turn the rider round and sit him on the bike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,25 @@
 
 ## 2026-08-26
 
+### Fixed
+- **The rider sat on the bike backwards, and stood bolt upright while he did it.** The Pose
+  tab worked out which way a rider faces by looking for the toes in the lowest slice of his
+  body — and a rider body has no feet: the ankles and toes belong to the boots, and the mesh
+  stops at the sock. So it was reading the bottom of a shin, calling it a toe, and turning
+  him a half-turn round on the seat. He now faces the front, and so do **Lean in** and **Left
+  leg forward**, which were quietly leaning and stepping backwards for the same reason.
+
 ### Changed
+- **On the bike, the rider now sits on it.** He settles up the seat towards the tank rather
+  than on the setup reference in the middle of it, leans into the bars, puts both hands on
+  the grips — read off the bike's own handlebar, so they land on the bars of whatever is
+  under him — and folds his knees round the machine with his boots on the pegs. **Riding
+  position** replaces "Sit on bike" in the ready-made moves, and it is applied for you the
+  first time a bike appears under an unposed rider.
+- **Joints bend as far as the joint allows.** Every bone was capped at 60°, which is a broken
+  neck and half a knee: nobody could fold a leg under a bike, because the cap cut the whole
+  turn back until its stiffest axis fitted. Hips, knees, shoulders and elbows now reach 135°,
+  wrists and collars 70°, and the neck and head stay at 45°.
 - **Voice now works whichever way you joined a server.** It used to start only when the app
   itself launched the game at a server, which left out everyone who picks one from the game's
   own browser — and quietly kept you in the old room if you moved servers without quitting.

--- a/src/Components/Rider/PoseStudio.tsx
+++ b/src/Components/Rider/PoseStudio.tsx
@@ -23,7 +23,7 @@ import {
   isRestPose,
   NO_POSE,
   QUICK_MOVES,
-  TURN_LIMIT,
+  turnLimit,
   turnOf,
   withTurn,
   type BoneGroupId,
@@ -54,7 +54,7 @@ const MOVE_LABEL: Record<QuickMoveId, TKey> = {
   leftLegForward: "pose.move.leftLegForward",
   elbowsUp: "pose.move.elbowsUp",
   leanIn: "pose.move.leanIn",
-  sitOnBike: "pose.move.sitOnBike",
+  ride: "pose.move.ride",
 };
 
 const SCENE_LABEL: Record<SceneId, TKey> = {
@@ -137,6 +137,22 @@ export default function PoseStudio() {
   useEffect(() => setPose(readSaved(profile)), [profile]);
   useEffect(() => writeSaved(profile, pose), [profile, pose]);
 
+  // A rider sat on a bike is sitting on it: put him in a riding position the first time one
+  // arrives under him, rather than stood bolt upright waiting for somebody to press a button.
+  // Once per rider and bike, and marked before it runs, so Reset means reset — this must not
+  // fire again the moment the pose it seeded is cleared.
+  const seeded = useRef<string | null>(null);
+  useEffect(() => {
+    const key = `${profile}|${bike}`;
+    if (!rig?.mount || seeded.current === key) return;
+    seeded.current = key;
+    const ride = QUICK_MOVES.find((m) => m.id === "ride");
+    if (!ride) return;
+    setPose((p) =>
+      isRestPose(p) ? applyQuickMove(p, ride, rig.bones, rig.frame, rig.mount) : p,
+    );
+  }, [profile, bike, rig]);
+
   const bikeVariant = useMemo(
     () => loadout.modelSwap || pickedModel(bike, loadout, scans),
     [bike, loadout, scans],
@@ -146,7 +162,7 @@ export default function PoseStudio() {
   const turn = useCallback((bone: string, at: 0 | 1 | 2, deg: number) => {
     setPose((p) => {
       const next = turnOf(p, bone);
-      next[at] = clampTurn(deg);
+      next[at] = clampTurn(deg, turnLimit(bone));
       return withTurn(p, bone, next);
     });
   }, []);
@@ -294,10 +310,11 @@ export default function PoseStudio() {
                 variant="outline"
                 className="h-7 px-2.5 text-[11px]"
                 // A move is a place to send a joint, so it needs the rig to say where that
-                // is — and a rig that binds no spine has nothing to lean.
-                disabled={!rig || !canMove(m, rig.bones)}
+                // is — a rig that binds no spine has nothing to lean — and the riding
+                // position needs the bike, to say where its bars and pegs are.
+                disabled={!rig || !canMove(m, rig.bones, rig.mount)}
                 onClick={() =>
-                  rig && setPose((p) => applyQuickMove(p, m, rig.bones, rig.frame))
+                  rig && setPose((p) => applyQuickMove(p, m, rig.bones, rig.frame, rig.mount))
                 }
               >
                 {t(MOVE_LABEL[m.id])}
@@ -349,8 +366,8 @@ export default function PoseStudio() {
                       <Row key={a.at} label={t(a.label)}>
                         <Slider
                           value={turnOf(pose, bone)[a.at]}
-                          min={-TURN_LIMIT}
-                          max={TURN_LIMIT}
+                          min={-turnLimit(bone)}
+                          max={turnLimit(bone)}
                           step={1}
                           onChange={(v) => turn(bone, a.at, v)}
                           format={(v) => `${v}°`}

--- a/src/Components/Viewer/ModelViewer.tsx
+++ b/src/Components/Viewer/ModelViewer.tsx
@@ -12,8 +12,7 @@ import {
   buildSkeleton,
   isRestPose,
   NO_POSE,
-  riderFrame,
-  toMatrix,
+  seatTransform,
   type RiderPose,
 } from "../../lib/riderPose";
 import { PoseHandles } from "./PoseHandles";
@@ -1585,76 +1584,6 @@ function SideBySide({
 }
 
 /**
- * Where the rider's weight goes: the underside of the pelvis, in the rider's own frame.
- *
- * The pelvis bone carries a box covering the slice of body it moves, so the bottom of that box
- * is where a seat would touch. Read off the model, because a rider is whatever height its
- * author made it.
- */
-function seatContact(bones: Bone[], up: THREE.Vector3): THREE.Vector3 | null {
-  const pelvis =
-    bones.find((b) => b.name === "riderRIG_Pelvis") ??
-    bones.find((b) => b.name === "riderRIG_LeftHip");
-  if (!pelvis) return null;
-  const bind = toMatrix(pelvis.bind);
-  const at = new THREE.Vector3(pelvis.bind[3], pelvis.bind[7], pelvis.bind[11]);
-  const { aabbLo: lo, aabbHi: hi } = pelvis;
-  let drop = 0;
-  const corner = new THREE.Vector3();
-  for (const x of [lo[0], hi[0]]) {
-    for (const y of [lo[1], hi[1]]) {
-      for (const z of [lo[2], hi[2]]) {
-        const d = corner.set(x, y, z).applyMatrix4(bind).sub(at).dot(up);
-        if (d < drop) drop = d;
-      }
-    }
-  }
-  return at.addScaledVector(up, drop);
-}
-
-/**
- * The rider stood upright, facing the way the bike does, with their seat on the bike's.
- *
- * Worked out rather than eyeballed: the bike's `.geom` names `seat_height_ref`, and the rider's
- * own up and forward come off its rig, so the two only have to be brought into one frame. Null
- * when either half won't say — a bike whose `.geom` names no seat, or a rig with no hips — and
- * then the pair falls back to standing side by side, which is honest about not knowing.
- */
-function seatTransform(
-  parts: RiderPart[],
-  seat: Vec3,
-  drop: number,
-): THREE.Matrix4 | null {
-  const body = parts.find((p) => p.part === "body" && p.nodes.length);
-  const bones = body?.skeleton;
-  if (!bones?.length) return null;
-  const rf = riderFrame(bones, body?.nodes);
-  if (!rf) return null;
-  const contact = seatContact(bones, rf.up);
-  if (!contact) return null;
-  // The rider's (forward, up) onto the bike's (+Z, +Y). Both triples are built by a cross
-  // product, so both turn the same way round and what comes out is a rotation, not a mirror.
-  const b3 = new THREE.Vector3().crossVectors(rf.forward, rf.up);
-  const from = new THREE.Matrix4().makeBasis(rf.forward, rf.up, b3);
-  const to = new THREE.Matrix4().makeBasis(
-    new THREE.Vector3(0, 0, 1),
-    new THREE.Vector3(0, 1, 0),
-    new THREE.Vector3(0, 0, 1).cross(new THREE.Vector3(0, 1, 0)),
-  );
-  const turn = to.multiply(from.transpose());
-  // Sit *on* the seat rather than with the hip joint in it — the reference is the top of the
-  // seat, and a rider's weight is carried a little way into it.
-  const at = new THREE.Vector3(seat[0], seat[1] + drop, seat[2]);
-  return new THREE.Matrix4()
-    .makeTranslation(at.x, at.y, at.z)
-    .multiply(turn)
-    .multiply(new THREE.Matrix4().makeTranslation(-contact.x, -contact.y, -contact.z));
-}
-
-/** How far into the seat the rider settles, in metres. */
-const SEAT_SINK = -0.02;
-
-/**
  * Bike and rider in one scene, the rider sitting on it.
  *
  * The bike stands on the ground exactly as it does beside the rider; only the rider moves, on
@@ -1696,9 +1625,9 @@ function OnBike({
     const bike = partBounds(nodes);
     // Dropped onto y = 0, like every other arrangement, so the ground shadow means something.
     const lift: Vec3 = [0, -bike.lo[1], 0];
-    const seated = seatTransform(parts, seat, SEAT_SINK);
+    const seated = seatTransform(parts, seat, rig ?? null);
     return { lift, seated, bikePivot: spinPivot(bike) };
-  }, [nodes, parts, seat]);
+  }, [nodes, parts, seat, rig]);
 
   return (
     <group position={at.lift}>

--- a/src/Components/Viewer/ViewerPanel.tsx
+++ b/src/Components/Viewer/ViewerPanel.tsx
@@ -16,7 +16,7 @@ import { Dialog, DialogContent } from "../ui/dialog";
 import { ModelViewer, type CaptureFn, type ViewerMode } from "./ModelViewer";
 import { loadRiderModel, previewModelSwap } from "../../api/mods";
 import type { BikeModel, Loadout, PaintTexture, RiderPart } from "../../types";
-import { riderFrame, type PosableRig, type RiderPose } from "../../lib/riderPose";
+import { riderFrame, riderMount, type PosableRig, type RiderPose } from "../../lib/riderPose";
 import type { SceneId } from "../../lib/viewerScene";
 import { useT } from "../../i18n/context";
 import { TyresPicker } from "./TyresPicker";
@@ -275,15 +275,19 @@ export function ViewerPanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [withBike, bikeId, bikeVariant, tyresPick.tyres]);
 
-  // The rig the ready-made moves are stated against. Read here because this is where the
-  // rider model is: the studio next door only ever sees a loadout.
+  // The rig the ready-made moves are stated against, and the bike they reach for. Read here
+  // because this is where both models are: the studio next door only ever sees a loadout.
   useEffect(() => {
     if (!onRiderRig) return;
     const body = riderParts?.find((p) => p.part === "body" && p.nodes.length);
     const bones = body?.skeleton;
-    const frame = bones?.length ? riderFrame(bones, body?.nodes) : null;
-    onRiderRig(bones?.length && frame ? { bones, frame } : null);
-  }, [riderParts, onRiderRig]);
+    const frame = bones?.length ? riderFrame(bones) : null;
+    const mount =
+      riderParts && bikeModel && mode === "onBike"
+        ? riderMount(riderParts, bikeModel.nodes, bikeModel.rig)
+        : null;
+    onRiderRig(bones?.length && frame ? { bones, frame, mount } : null);
+  }, [riderParts, bikeModel, mode, onRiderRig]);
 
   // One way to take a photo, whichever canvas is up. The expanded dialog wins when it is
   // open — it is the bigger frame, and the one somebody opened to compose a shot in.

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -246,7 +246,7 @@ export const de: Translation = {
   "pose.move.leftLegForward": "Linkes Bein vor",
   "pose.move.elbowsUp": "Ellbogen hoch",
   "pose.move.leanIn": "Nach vorn lehnen",
-  "pose.move.sitOnBike": "Aufs Motorrad setzen",
+  "pose.move.ride": "Sitzposition",
   "pose.axis.bend": "Beugen",
   "pose.axis.twist": "Drehen",
   "pose.axis.splay": "Spreizen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -236,7 +236,7 @@ export const en = {
   "pose.move.leftLegForward": "Left leg forward",
   "pose.move.elbowsUp": "Elbows up",
   "pose.move.leanIn": "Lean in",
-  "pose.move.sitOnBike": "Sit on bike",
+  "pose.move.ride": "Riding position",
   "pose.axis.bend": "Bend",
   "pose.axis.twist": "Twist",
   "pose.axis.splay": "Splay",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -240,7 +240,7 @@ export const es: Translation = {
   "pose.move.leftLegForward": "Pierna izquierda adelante",
   "pose.move.elbowsUp": "Codos arriba",
   "pose.move.leanIn": "Inclinarse",
-  "pose.move.sitOnBike": "Sentarse en la moto",
+  "pose.move.ride": "Posición de pilotaje",
   "pose.axis.bend": "Flexión",
   "pose.axis.twist": "Giro",
   "pose.axis.splay": "Apertura",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -243,7 +243,7 @@ export const fr: Translation = {
   "pose.move.leftLegForward": "Jambe gauche en avant",
   "pose.move.elbowsUp": "Coudes hauts",
   "pose.move.leanIn": "Se pencher",
-  "pose.move.sitOnBike": "Assis sur la moto",
+  "pose.move.ride": "Position de pilotage",
   "pose.axis.bend": "Flexion",
   "pose.axis.twist": "Rotation",
   "pose.axis.splay": "Écartement",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -239,7 +239,7 @@ export const it: Translation = {
   "pose.move.leftLegForward": "Gamba sinistra avanti",
   "pose.move.elbowsUp": "Gomiti alti",
   "pose.move.leanIn": "Sporgersi",
-  "pose.move.sitOnBike": "Seduto in sella",
+  "pose.move.ride": "Posizione di guida",
   "pose.axis.bend": "Flessione",
   "pose.axis.twist": "Torsione",
   "pose.axis.splay": "Apertura",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -242,7 +242,7 @@ export const ptBR: Translation = {
   "pose.move.leftLegForward": "Perna esquerda à frente",
   "pose.move.elbowsUp": "Cotovelos altos",
   "pose.move.leanIn": "Inclinar-se",
-  "pose.move.sitOnBike": "Sentar na moto",
+  "pose.move.ride": "Posição de pilotagem",
   "pose.axis.bend": "Flexão",
   "pose.axis.twist": "Torção",
   "pose.axis.splay": "Abertura",

--- a/src/lib/riderPose.ts
+++ b/src/lib/riderPose.ts
@@ -1,5 +1,5 @@
 import * as THREE from "three";
-import type { Bone } from "../types";
+import type { BikeRig, Bone, EdfNode, Vec3 } from "../types";
 
 /**
  * Posing a rider.
@@ -269,7 +269,11 @@ export function turnToward(
   const turned = new THREE.Quaternion();
   local.decompose(new THREE.Vector3(), turned, new THREE.Vector3());
   // `applyPose` composes the turn after the rest, so this is what it has to be handed.
-  return withTurn(pose, turns, shortenToLimit(rest.clone().invert().multiply(turned)));
+  return withTurn(
+    pose,
+    turns,
+    shortenToLimit(rest.clone().invert().multiply(turned), turnLimit(turns)),
+  );
 }
 
 /**
@@ -280,7 +284,7 @@ export function turnToward(
  * than fly off. Bisection because the three Euler angles don't grow evenly along the arc, so
  * there is no closed form to scale by.
  */
-function shortenToLimit(turn: THREE.Quaternion): [number, number, number] {
+function shortenToLimit(turn: THREE.Quaternion, limit: number): [number, number, number] {
   const scratch = new THREE.Euler();
   const q = new THREE.Quaternion();
   const worst = (t: number) => {
@@ -288,17 +292,21 @@ function shortenToLimit(turn: THREE.Quaternion): [number, number, number] {
     return Math.max(Math.abs(scratch.x), Math.abs(scratch.y), Math.abs(scratch.z)) / DEG;
   };
   let far = 1;
-  if (worst(1) > TURN_LIMIT) {
+  if (worst(1) > limit) {
     let near = 0;
     for (let i = 0; i < 16; i++) {
       const mid = (near + far) / 2;
-      if (worst(mid) > TURN_LIMIT) far = mid;
+      if (worst(mid) > limit) far = mid;
       else near = mid;
     }
     far = near;
   }
   worst(far);
-  return [clampTurn(scratch.x / DEG), clampTurn(scratch.y / DEG), clampTurn(scratch.z / DEG)];
+  return [
+    clampTurn(scratch.x / DEG, limit),
+    clampTurn(scratch.y / DEG, limit),
+    clampTurn(scratch.z / DEG, limit),
+  ];
 }
 
 // ── Which bones a person would want to move ──────────────────────────────────
@@ -385,6 +393,12 @@ export interface RiderFrame {
 export interface PosableRig {
   bones: Bone[];
   frame: RiderFrame;
+  /**
+   * The bike under him — where its grips and pegs are, in his own frame. Null whenever he
+   * isn't sitting on one, which is what makes the riding position offered only when it means
+   * something.
+   */
+  mount?: RiderMount | null;
 }
 
 /** A bone's rest position in model space, or null if the model doesn't bind it. */
@@ -405,50 +419,62 @@ function firstOrigin(bones: Bone[], names: string[]): THREE.Vector3 | null {
 /**
  * Which way the rider faces, as ±1 along `f`, or 0 when the body doesn't say.
  *
- * A foot is the one part of a standing body that is plainly asymmetric about its joint —
- * around 20 cm of it in front of the ankle and 6 cm behind — so the lowest slice of the mesh
- * settles the question on its own.
+ * From the hand: an arm hanging at rest has its palm to the thigh, which puts the index
+ * knuckle at the front of the body and the little finger at the back — 8 cm apart, and the
+ * same 8 cm on `default_mx`, `default_sm` and Rider+, because the rig is the game's own.
+ *
+ * The body mesh is not asked, and can't be: it has no feet. The ankles and toes are dropped
+ * from the rig — they belong to the boots, not the body — and the mesh stops at the sock, so
+ * a toe-and-heel reading of its lowest slice measures the bottom of a shin and answers
+ * "forward" whichever way the rider is really pointing. That reading used to be taken first,
+ * and it is why the rider sat on the bike backwards.
  */
-function facingFromFeet(
-  nodes: { positions: ArrayLike<number> }[],
-  f: THREE.Vector3,
-  up: THREE.Vector3,
-  ankle: THREE.Vector3,
-): number {
-  let lo = Infinity;
-  let hi = -Infinity;
-  for (const n of nodes) {
-    for (let i = 0; i < n.positions.length; i += 3) {
-      const t = n.positions[i] * up.x + n.positions[i + 1] * up.y + n.positions[i + 2] * up.z;
-      if (t < lo) lo = t;
-      if (t > hi) hi = t;
-    }
+function facingFromKnuckles(bones: Bone[], f: THREE.Vector3, up: THREE.Vector3): number {
+  for (const side of SIDES) {
+    const index = originOf(bones, `riderRIG_${side}Index1`);
+    const pink = firstOrigin(bones, [`riderRIG_${side}Pink1`, `riderRIG_${side}Pinky1`]);
+    if (!index || !pink) continue;
+    const d = index.clone().sub(pink);
+    d.addScaledVector(up, -d.dot(up));
+    const len = d.length();
+    if (len < 1e-4) continue;
+    const along = d.dot(f) / len;
+    if (Math.abs(along) > 0.4) return Math.sign(along);
   }
-  if (!(hi > lo)) return 0;
-  const cut = lo + (hi - lo) * 0.06;
-  const at = ankle.dot(f);
-  let toe = 0;
-  let heel = 0;
-  for (const n of nodes) {
-    for (let i = 0; i < n.positions.length; i += 3) {
-      const t = n.positions[i] * up.x + n.positions[i + 1] * up.y + n.positions[i + 2] * up.z;
-      if (t > cut) continue;
-      const d = n.positions[i] * f.x + n.positions[i + 1] * f.y + n.positions[i + 2] * f.z - at;
-      if (d > toe) toe = d;
-      if (-d > heel) heel = -d;
-    }
-  }
-  if (toe > heel * 1.35) return 1;
-  if (heel > toe * 1.35) return -1;
   return 0;
 }
 
 /**
- * The same question from the rig alone: a thumb points the way its owner does.
+ * The last resort: a body carries more of itself behind its hip joints than in front.
  *
- * Only asked when the mesh didn't answer — a rider authored already sitting on a bike has its
- * feet under it, and then the hands are the better witness.
+ * The pelvis bone's box covers the seat of the rider, which runs back from the joints it
+ * hangs off; the front of the hip barely does. Coarser than the hand, and only asked of a rig
+ * that binds no fingers at all.
  */
+function facingFromSeat(bones: Bone[], f: THREE.Vector3): number {
+  const at = bones.findIndex((b) => b.name === "riderRIG_Pelvis");
+  if (at < 0) return 0;
+  const bone = bones[at];
+  const bind = toMatrix(bone.bind);
+  const origin = new THREE.Vector3().setFromMatrixPosition(bind);
+  const corner = new THREE.Vector3();
+  let along = 0;
+  let against = 0;
+  for (const x of [bone.aabbLo[0], bone.aabbHi[0]]) {
+    for (const y of [bone.aabbLo[1], bone.aabbHi[1]]) {
+      for (const z of [bone.aabbLo[2], bone.aabbHi[2]]) {
+        const d = corner.set(x, y, z).applyMatrix4(bind).sub(origin).dot(f);
+        along = Math.max(along, d);
+        against = Math.max(against, -d);
+      }
+    }
+  }
+  if (against > along * 1.2) return 1;
+  if (along > against * 1.2) return -1;
+  return 0;
+}
+
+/** The same question, from the thumb: it points the way its owner does. */
 function facingFromThumb(bones: Bone[], f: THREE.Vector3, up: THREE.Vector3): number {
   const wrist = originOf(bones, "riderRIG_LeftWrist");
   const thumb = firstOrigin(bones, [
@@ -466,16 +492,13 @@ function facingFromThumb(bones: Bone[], f: THREE.Vector3, up: THREE.Vector3): nu
 }
 
 /**
- * Read {@link RiderFrame} off a rig, with the body mesh to settle which way it faces.
+ * Read {@link RiderFrame} off a rig.
  *
  * Null when the model binds too little to say — a rig with no hips or no spine is one the
  * ready-made moves can't be stated in, and offering them anyway would move something at
  * random.
  */
-export function riderFrame(
-  bones: Bone[],
-  body?: { positions: ArrayLike<number> }[] | null,
-): RiderFrame | null {
+export function riderFrame(bones: Bone[]): RiderFrame | null {
   if (!bones.length) return null;
   const leftHip = originOf(bones, "riderRIG_LeftHip");
   const rightHip = originOf(bones, "riderRIG_RightHip");
@@ -496,7 +519,9 @@ export function riderFrame(
   left.addScaledVector(up, -left.dot(up));
   if (left.lengthSq() < 1e-8) return null;
   left.normalize();
-  const forward = new THREE.Vector3().crossVectors(up, left).normalize();
+  // left × up, so this already points the way the rider does on a rig read the way round
+  // the game writes them; the witnesses below only ever have to confirm it.
+  const forward = new THREE.Vector3().crossVectors(left, up).normalize();
 
   const leftKnee = originOf(bones, "riderRIG_LeftKnee");
   const rightKnee = originOf(bones, "riderRIG_RightKnee");
@@ -506,14 +531,206 @@ export function riderFrame(
       ? rightKnee.distanceTo(rightHip)
       : head.distanceTo(pelvis) * 0.6;
 
-  // The knee stands over the ankle on a standing rider, which is the reference the foot test
-  // measures its toe and heel from.
-  const ankle = leftKnee ?? rightKnee ?? hips;
   const sign =
-    (body?.length ? facingFromFeet(body, forward, up, ankle) : 0) ||
-    facingFromThumb(bones, forward, up);
+    facingFromKnuckles(bones, forward, up) ||
+    facingFromThumb(bones, forward, up) ||
+    facingFromSeat(bones, forward);
   if (sign < 0) forward.negate();
   return { up, left, forward, leg: thigh || 0.36 };
+}
+
+// ── Sitting the rider on the bike ────────────────────────────────────────────
+
+/**
+ * Where the rider's weight goes: the underside of the pelvis, in the rider's own frame.
+ *
+ * The pelvis bone carries a box covering the slice of body it moves, so the bottom of that
+ * box is where a seat would touch. Read off the model, because a rider is whatever height its
+ * author made it.
+ */
+function seatContact(bones: Bone[], up: THREE.Vector3): THREE.Vector3 | null {
+  const pelvis =
+    bones.find((b) => b.name === "riderRIG_Pelvis") ??
+    bones.find((b) => b.name === "riderRIG_LeftHip");
+  if (!pelvis) return null;
+  const bind = toMatrix(pelvis.bind);
+  const at = new THREE.Vector3(pelvis.bind[3], pelvis.bind[7], pelvis.bind[11]);
+  const { aabbLo: lo, aabbHi: hi } = pelvis;
+  let drop = 0;
+  const corner = new THREE.Vector3();
+  for (const x of [lo[0], hi[0]]) {
+    for (const y of [lo[1], hi[1]]) {
+      for (const z of [lo[2], hi[2]]) {
+        const d = corner.set(x, y, z).applyMatrix4(bind).sub(at).dot(up);
+        if (d < drop) drop = d;
+      }
+    }
+  }
+  return at.addScaledVector(up, drop);
+}
+
+/** How far into the seat the rider settles, in metres. */
+const SEAT_SINK = -0.02;
+
+/**
+ * How far up the seat the rider sits, as a share of the way from the seat to the steering
+ * head.
+ *
+ * `seat_height_ref` is a setup reference in the middle of the seat, and nobody rides there:
+ * from that point the bars are about 0.56 m away and an arm is 0.46 m long, so a rider left
+ * on the reference cannot reach his own handlebars. Sitting up the seat — with the hunch that
+ * goes with it — is what closes the gap.
+ */
+const SEAT_FORWARD = 0.25;
+
+/**
+ * The rider sat on the bike's seat, facing the way it does.
+ *
+ * Worked out rather than eyeballed: the bike's `.geom` names `seat_height_ref`, and the
+ * rider's own up and forward come off its rig, so the two only have to be brought into one
+ * frame. Null when either half won't say — a bike whose `.geom` names no seat, or a rig with
+ * no hips — and then the pair falls back to standing side by side, which is honest about not
+ * knowing.
+ */
+export function seatTransform(
+  parts: { part: string; nodes: unknown[]; skeleton?: Bone[] | null }[],
+  seat: Vec3,
+  rig: BikeRig | null,
+): THREE.Matrix4 | null {
+  const bones = parts.find((p) => p.part === "body" && p.nodes.length)?.skeleton;
+  if (!bones?.length) return null;
+  const rf = riderFrame(bones);
+  if (!rf) return null;
+  const contact = seatContact(bones, rf.up);
+  if (!contact) return null;
+  // The rider's (forward, up) onto the bike's (+Z, +Y). Both triples are built by a cross
+  // product, so both turn the same way round and what comes out is a rotation, not a mirror.
+  const b3 = new THREE.Vector3().crossVectors(rf.forward, rf.up);
+  const from = new THREE.Matrix4().makeBasis(rf.forward, rf.up, b3);
+  const to = new THREE.Matrix4().makeBasis(
+    new THREE.Vector3(0, 0, 1),
+    new THREE.Vector3(0, 1, 0),
+    new THREE.Vector3(0, 0, 1).cross(new THREE.Vector3(0, 1, 0)),
+  );
+  const turn = to.multiply(from.transpose());
+  // Sit *on* the seat rather than with the hip joint in it — the reference is the top of the
+  // seat, and a rider's weight is carried a little way into it — and up the seat towards the
+  // bars, which is where a rider actually sits.
+  const at = new THREE.Vector3(seat[0], seat[1] + SEAT_SINK, seat[2] + seatShift(seat, rig));
+  return new THREE.Matrix4()
+    .makeTranslation(at.x, at.y, at.z)
+    .multiply(turn)
+    .multiply(new THREE.Matrix4().makeTranslation(-contact.x, -contact.y, -contact.z));
+}
+
+/** How far forward of `seat_height_ref` the rider sits, in metres. */
+function seatShift(seat: Vec3, rig: BikeRig | null): number {
+  if (!rig) return 0;
+  return (rig.steerHead[2] - seat[2]) * SEAT_FORWARD;
+}
+
+/**
+ * Where the rider's hands and feet go on this bike: a grip and a peg per side.
+ *
+ * Stated in the rider's own rest frame rather than the bike's, so a move can send a wrist to
+ * a grip with the same solver that sends a knee 22 cm to the left, and nothing downstream has
+ * to know a bike is involved.
+ */
+export interface RiderMount {
+  /** Left, right — the rider's own, matching the bone names. */
+  grips: [THREE.Vector3, THREE.Vector3];
+  pegs: [THREE.Vector3, THREE.Vector3];
+}
+
+/**
+ * The grips, off the bike's own mesh.
+ *
+ * The `.geom` names no handlebar, but the assembled `steer` part is the bars: the widest
+ * thing on it by a distance, so its outermost vertices on each side are the bar ends and the
+ * levers. A hand goes a little inboard of that, where the grip is.
+ *
+ * `null` for a bike whose parts didn't come back named — the same `steer` prefix the
+ * assembler keys on, so if this can't find them neither could that, and the bike is
+ * unassembled anyway.
+ */
+function barGrips(nodes: EdfNode[]): [THREE.Vector3, THREE.Vector3] | null {
+  const steer = nodes.filter((n) => n.name.toLowerCase().startsWith("steer"));
+  if (!steer.length) return null;
+  let wide = 0;
+  for (const n of steer) {
+    for (let i = 0; i < n.positions.length; i += 3) wide = Math.max(wide, Math.abs(n.positions[i]));
+  }
+  // A bar half-narrower than a rider's shoulders is not a bar; something else was named steer.
+  if (wide < 0.2) return null;
+  const band = wide - 0.1;
+  const ends = [new THREE.Vector3(), new THREE.Vector3()];
+  const seen = [0, 0];
+  for (const n of steer) {
+    for (let i = 0; i < n.positions.length; i += 3) {
+      const x = n.positions[i];
+      if (Math.abs(x) < band) continue;
+      // The rider's left is +x, and so is the bar end his left hand takes.
+      const side = x > 0 ? 0 : 1;
+      ends[side].add(new THREE.Vector3(x, n.positions[i + 1], n.positions[i + 2]));
+      seen[side]++;
+    }
+  }
+  if (!seen[0] || !seen[1]) return null;
+  ends[0].divideScalar(seen[0]);
+  ends[1].divideScalar(seen[1]);
+  // Inboard of the bar end by half a grip, so a hand lands on the rubber rather than the plug.
+  ends[0].x = wide - GRIP_INSET;
+  ends[1].x = -(wide - GRIP_INSET);
+  return [ends[0], ends[1]];
+}
+
+/** How far inboard of the widest point on the bars a hand sits, in metres. */
+const GRIP_INSET = 0.05;
+
+/**
+ * Where the footpegs are — an estimate, and the only one here.
+ *
+ * Unlike the seat and the bars, nothing in the bike says: the `.geom` names no footrest and
+ * the mesh hides them among the frame rails. What is true of every motocross bike ever built
+ * is that the pegs sit at about rear-axle height and a little way up the frame from the seat
+ * reference, about 27 cm either side of the centreline — which is what this is.
+ */
+function footPegs(rig: BikeRig, seat: Vec3): [THREE.Vector3, THREE.Vector3] {
+  // Peg height is rear-axle height, near enough to the centimetre on every bike; and a peg
+  // sits just ahead of the swingarm pivot, which is the one point down there the .geom does
+  // name.
+  const y = rig.rearAxle ? rig.rearAxle[1] : seat[1] - 0.5;
+  const z = rig.pivot[2] + PEG_AHEAD_OF_PIVOT;
+  return [new THREE.Vector3(PEG_WIDTH, y, z), new THREE.Vector3(-PEG_WIDTH, y, z)];
+}
+
+/** How far the pegs sit either side of the centreline, and ahead of the swingarm pivot. */
+const PEG_WIDTH = 0.27;
+const PEG_AHEAD_OF_PIVOT = 0.09;
+
+/**
+ * The grips and pegs of `rig`, brought into the rider's own rest frame.
+ *
+ * Null when the rider can't be sat on the bike in the first place — there is nowhere to
+ * measure from then, and a move that reached for a bar the rider isn't sitting behind would
+ * pull him inside out.
+ */
+export function riderMount(
+  parts: { part: string; nodes: unknown[]; skeleton?: Bone[] | null }[],
+  bike: EdfNode[],
+  rig: BikeRig | null,
+): RiderMount | null {
+  if (!rig?.seat) return null;
+  const seated = seatTransform(parts, rig.seat, rig);
+  if (!seated) return null;
+  const grips = barGrips(bike);
+  if (!grips) return null;
+  const intoRider = seated.clone().invert();
+  const pegs = footPegs(rig, rig.seat);
+  return {
+    grips: [grips[0].applyMatrix4(intoRider), grips[1].applyMatrix4(intoRider)],
+    pegs: [pegs[0].applyMatrix4(intoRider), pegs[1].applyMatrix4(intoRider)],
+  };
 }
 
 // ── Ready-made moves ─────────────────────────────────────────────────────────
@@ -524,7 +741,7 @@ export type QuickMoveId =
   | "leftLegForward"
   | "elbowsUp"
   | "leanIn"
-  | "sitOnBike";
+  | "ride";
 
 /** One joint sent somewhere, and the bone whose turn takes it there. */
 export interface QuickStep {
@@ -541,6 +758,11 @@ export interface QuickStep {
 export interface QuickMove {
   id: QuickMoveId;
   steps: QuickStep[];
+  /**
+   * Also put his hands on the bars and his boots on the pegs — which needs the bike under
+   * him, so a move with this set is offered only once {@link riderMount} has answered.
+   */
+  mounted?: boolean;
 }
 
 /**
@@ -597,36 +819,210 @@ export const QUICK_MOVES: QuickMove[] = [
     ],
   },
   {
-    // Thighs forward and apart, shins folded back under: a straddle, which is what makes the
-    // on-bike view worth looking at before anyone touches a slider.
-    id: "sitOnBike",
+    // Sat on the machine: weight forward over the tank, hands on the bars, knees round it and
+    // boots on the pegs. The hunch is written here; the limbs are solved against the bike,
+    // because where a grip and a peg are is the bike's business, not the rider's.
+    id: "ride",
+    mounted: true,
     steps: [
-      {
-        turns: "riderRIG_LeftHip",
-        moves: "riderRIG_LeftKnee",
-        by: { forward: 0.6, left: 0.3, up: 0.12 },
-      },
-      {
-        turns: "riderRIG_RightHip",
-        moves: "riderRIG_RightKnee",
-        by: { forward: 0.6, left: -0.3, up: 0.12 },
-      },
-      {
-        turns: "riderRIG_LeftKnee",
-        moves: "riderRIG_LeftKnee",
-        tip: true,
-        by: { forward: -0.6, left: 0.12 },
-      },
-      {
-        turns: "riderRIG_RightKnee",
-        moves: "riderRIG_RightKnee",
-        tip: true,
-        by: { forward: -0.6, left: -0.12 },
-      },
-      { turns: "riderRIG_Spine2", moves: "riderRIG_Neck1", by: { forward: 0.16 } },
+      { turns: "riderRIG_Spine1", moves: "riderRIG_Spine3", by: { forward: 0.1 } },
+      { turns: "riderRIG_Spine2", moves: "riderRIG_Neck1", by: { forward: 0.3 } },
+      // Back the other way, so leaning in doesn't take the rider's eyes off the track.
+      { turns: "riderRIG_Neck1", moves: "riderRIG_Head", by: { forward: -0.1, up: 0.05 } },
     ],
   },
 ];
+
+// ── Reaching for the bike ────────────────────────────────────────────────────
+
+/**
+ * How long a shin is, as a share of the thigh above it.
+ *
+ * An estimate, and it has to be: the rig carries no ankle — the ankles and toes belong to the
+ * boots, so the body binds neither — and the body mesh stops at the sock. Measured off the
+ * riders the game ships, where the knee stands 0.50 m up and the ankle 0.09 m.
+ */
+const SHIN_OVER_THIGH = 1.12;
+
+/** How far behind the grip the wrist sits: the width of a hand. */
+function handLength(bones: Bone[], side: string): number {
+  const wrist = originOf(bones, `riderRIG_${side}Wrist`);
+  const knuckle = originOf(bones, `riderRIG_${side}Index1`);
+  return wrist && knuckle ? wrist.distanceTo(knuckle) : 0.09;
+}
+
+/**
+ * Where the middle joint of a two-bone limb lands when its end is put on `target`.
+ *
+ * The triangle root–middle–end has all three sides known, so the middle sits on a circle
+ * about the root-to-target line and `pole` picks the point on it — which way the joint bends.
+ * A target further off than the limb is long is drawn in until it is reachable, so a limb
+ * asked for too much straightens towards it instead of tearing off.
+ */
+function midJoint(
+  root: THREE.Vector3,
+  target: THREE.Vector3,
+  near: number,
+  far: number,
+  pole: THREE.Vector3,
+): THREE.Vector3 {
+  const axis = target.clone().sub(root);
+  let d = axis.length();
+  if (d < 1e-6) return root.clone().addScaledVector(pole.clone().normalize(), near);
+  d = Math.min(Math.max(d, Math.abs(near - far) + 1e-4), near + far - 1e-4);
+  axis.normalize();
+  const along = (near * near - far * far + d * d) / (2 * d);
+  const out = Math.sqrt(Math.max(0, near * near - along * along));
+  const bend = pole.clone();
+  bend.addScaledVector(axis, -bend.dot(axis));
+  if (bend.lengthSq() < 1e-8) return root.clone().addScaledVector(axis, along);
+  bend.normalize();
+  return root.clone().addScaledVector(axis, along).addScaledVector(bend, out);
+}
+
+/** A two-bone limb, and where it is being sent. */
+interface Reach {
+  /** The joint the whole limb swings about, and the bone that turn is written on. */
+  root: string;
+  /** The joint between the two bones — and the bone the second turn is written on. */
+  mid: string;
+  /** The joint at the end, the one put on the target. */
+  end: string;
+  /**
+   * Aim the far end of `mid`'s own box instead of `end`'s joint. For a shin, whose ankle the
+   * rig doesn't carry: only the direction to the target is used, which is all it takes to
+   * point a boot at a peg.
+   */
+  tip?: boolean;
+  /** The length of the second bone, when `tip` means it can't be read off the rig. */
+  far?: number;
+}
+
+/**
+ * Swing a two-bone limb so its end lands on `to`, bending the way `pole` points.
+ *
+ * Solved rather than nudged towards it: the middle joint is placed by triangle, then each
+ * bone is turned to point at where it now has to with {@link turnToward} — the same solver a
+ * drag uses, so an arm put on a handlebar and an arm dragged there by the wrist come out
+ * saying the same thing.
+ */
+function reach(
+  order: THREE.Bone[],
+  bones: Bone[],
+  pose: RiderPose,
+  limb: Reach,
+  to: THREE.Vector3,
+  pole: THREE.Vector3,
+): RiderPose {
+  const at = (name: string) => bones.findIndex((b) => b.name === name);
+  const [r, m, e] = [at(limb.root), at(limb.mid), at(limb.end)];
+  if (r < 0 || m < 0 || (e < 0 && !limb.tip)) return pose;
+  const rest = (i: number) => new THREE.Vector3().setFromMatrixPosition(toMatrix(bones[i].bind));
+  const near = rest(r).distanceTo(rest(m));
+  const far = limb.far ?? rest(m).distanceTo(rest(e));
+  if (near < 1e-4 || far < 1e-4) return pose;
+
+  let out = pose;
+  const world = (i: number) => {
+    order[i].updateWorldMatrix(true, false);
+    return new THREE.Vector3().setFromMatrixPosition(order[i].matrixWorld);
+  };
+  // Swing the whole limb so its middle joint lands where the triangle puts it.
+  const mid = midJoint(world(r), to, near, far, pole);
+  out = turnToward(order, bones, out, limb.root, world(m), mid);
+  applyPose(order, out);
+  // Then fold it, so the end lands on the target.
+  const tail = limb.tip
+    ? new THREE.Vector3(...boneTip(bones, m)).applyMatrix4(
+        (order[m].updateWorldMatrix(true, false), order[m].matrixWorld),
+      )
+    : world(e);
+  out = turnToward(order, bones, out, limb.mid, tail, to);
+  applyPose(order, out);
+  return out;
+}
+
+/**
+ * Hands on the bars, boots on the pegs.
+ *
+ * Run after the hunch, not before: leaning the torso carries the shoulders forward, and where
+ * the shoulder is decides how much elbow the reach leaves.
+ */
+function reachTheBike(
+  order: THREE.Bone[],
+  bones: Bone[],
+  pose: RiderPose,
+  frame: RiderFrame,
+  mount: RiderMount,
+): RiderPose {
+  let out = pose;
+  SIDES.forEach((side, i) => {
+    // Which way is out for this side: +1 on his left, -1 on his right.
+    const away = i === 0 ? 1 : -1;
+    // Elbows out and up, the way a rider carries them.
+    const elbow = frame.left
+      .clone()
+      .multiplyScalar(away)
+      .addScaledVector(frame.up, 0.5)
+      .addScaledVector(frame.forward, -0.4);
+    const shoulderAt = bones.findIndex((b) => b.name === `riderRIG_${side}Shoulder`);
+    const grip = mount.grips[i];
+    if (shoulderAt >= 0) {
+      order[shoulderAt].updateWorldMatrix(true, false);
+      const shoulder = new THREE.Vector3().setFromMatrixPosition(order[shoulderAt].matrixWorld);
+      // The hand grips the bar, so the wrist stops a hand's width short of it.
+      const wristAt = grip
+        .clone()
+        .addScaledVector(
+          grip.clone().sub(shoulder).normalize(),
+          -handLength(bones, side),
+        );
+      out = reach(
+        order,
+        bones,
+        out,
+        {
+          root: `riderRIG_${side}Shoulder`,
+          mid: `riderRIG_${side}Elbow`,
+          end: `riderRIG_${side}Wrist`,
+        },
+        wristAt,
+        elbow,
+      );
+      // The forearm puts the wrist a hand's width off the bar; this closes the hand on it.
+      // A hand hangs off the arm at its own angle, so where the knuckles ended up is not
+      // where the reach was aimed.
+      const knuckle = bones.findIndex((b) => b.name === `riderRIG_${side}Index1`);
+      if (knuckle >= 0) {
+        order[knuckle].updateWorldMatrix(true, false);
+        const held = new THREE.Vector3().setFromMatrixPosition(order[knuckle].matrixWorld);
+        out = turnToward(order, bones, out, `riderRIG_${side}Wrist`, held, grip);
+        applyPose(order, out);
+      }
+    }
+    // Knees forward and out around the tank — but inside the pegs, so the shin tapers back
+    // in towards the machine rather than the rider riding bow-legged.
+    const knee = frame.forward
+      .clone()
+      .addScaledVector(frame.left, 0.34 * away)
+      .addScaledVector(frame.up, 0.15);
+    out = reach(
+      order,
+      bones,
+      out,
+      {
+        root: `riderRIG_${side}Hip`,
+        mid: `riderRIG_${side}Knee`,
+        end: `riderRIG_${side}Knee`,
+        tip: true,
+        far: frame.leg * SHIN_OVER_THIGH,
+      },
+      mount.pegs[i],
+      knee,
+    );
+  });
+  return out;
+}
 
 /**
  * Can this model make this move?
@@ -634,8 +1030,12 @@ export const QUICK_MOVES: QuickMove[] = [
  * A rig that binds no spine — `default_mx_c` is one — has nothing to lean, and a button that
  * silently does nothing is worse than one that isn't offered.
  */
-export function canMove(move: QuickMove, bones: Bone[]): boolean {
+export function canMove(move: QuickMove, bones: Bone[], mount?: RiderMount | null): boolean {
   const has = (name: string) => bones.some((b) => b.name === name);
+  // A move that reaches for the bike needs the bike, and a limb to reach with.
+  if (move.mounted) {
+    return !!mount && bones.some((b) => /(?:Hip|Shoulder)$/.test(b.name));
+  }
   return move.steps.some((s) => has(s.turns) && has(s.moves));
 }
 
@@ -651,6 +1051,7 @@ export function applyQuickMove(
   move: QuickMove,
   bones: Bone[],
   frame: RiderFrame,
+  mount?: RiderMount | null,
 ): RiderPose {
   const { order } = buildSkeleton(bones);
   let out = pose;
@@ -671,12 +1072,35 @@ export function applyQuickMove(
     out = turnToward(order, bones, out, step.turns, from, to);
     applyPose(order, out);
   }
+  if (move.mounted && mount) out = reachTheBike(order, bones, out, frame, mount);
   return out;
 }
 
-/** How far one bone may be turned. Past this a rider stops looking like one. */
+/**
+ * How far a bone nothing below names may be turned. Past this a rider stops looking like one.
+ */
 export const TURN_LIMIT = 60;
 
-export function clampTurn(deg: number): number {
-  return Math.max(-TURN_LIMIT, Math.min(TURN_LIMIT, Math.round(deg)));
+/**
+ * How far each joint may be turned, in degrees.
+ *
+ * One number can't do it. A rider sitting on a bike folds a knee past 90° and swings a hip
+ * around 65°, while a neck that went either way would be a broken one — and a single 60° stop
+ * was quietly cutting every seated pose back: {@link shortenToLimit} shortens the whole turn
+ * until its worst axis fits, so a leg meant to fold under the machine came out half folded.
+ */
+const JOINT_LIMIT: { at: RegExp; deg: number }[] = [
+  // The joints a riding position is made of.
+  { at: /(Hip|Knee|Shoulder|Elbow)$/, deg: 135 },
+  { at: /(Wrist|Collar)$/, deg: 70 },
+  { at: /(Neck\d*|Head)$/, deg: 45 },
+];
+
+/** How far `bone` may be turned. */
+export function turnLimit(bone: string): number {
+  return JOINT_LIMIT.find((r) => r.at.test(bone))?.deg ?? TURN_LIMIT;
+}
+
+export function clampTurn(deg: number, limit: number = TURN_LIMIT): number {
+  return Math.max(-limit, Math.min(limit, Math.round(deg)));
 }


### PR DESCRIPTION
In the Pose tab's **On bike** view the rider was drawn a half-turn backwards, standing bolt upright on the seat. He now faces the front and sits on the machine.

## Why he was backwards

`riderFrame()` decided which way a rider faces by measuring toe-vs-heel in the lowest slice of the body mesh. **A rider body has no feet** — `edf.rs` drops the ankles and toes from the rig ("they belong to the boots, not the body") and the mesh stops at the sock. So it was reading the bottom of a *shin*, which sits forward of the knee it measures from, and answering `+1` on `default_mx`, `default_sm` and `Rider+` alike (toe 0.118 m against heel 0.026 m). It was consulted first, overruling the thumb test — which was right.

It reads the hand now: the index knuckle sits 8 cm forward of the little finger on every rider, because they all share the game's own rig. The thumb stays as a second witness, and the pelvis box as a last resort for a rig binding no fingers.

The same wrong `forward` was sending **Lean in** and **Left leg forward** backwards too.

## Sitting on it

A new **Riding position** move replaces "Sit on bike", applied on its own the first time a bike appears under an unposed rider:

- **Up the seat** — 25% of the way to the steering head. Not cosmetic: from `seat_height_ref` the bars are 56 cm away and an arm is 46 cm, so a rider left on the reference cannot reach his own handlebars.
- **Hunched** — shoulders 19 cm forward of standing, head brought back up so his eyes stay on the track.
- **Hands on the grips** — two-bone IK to the elbow, then a wrist turn to close the hand. The grips are read off the bike's own assembled `steer` mesh, so they land on the bars of whatever is underneath him.
- **Knees round the machine, boots on the pegs** — knees forward and out but inside the pegs, shins folded back down onto them.

The pegs are the one estimate here, and are documented as one: no `.geom` names a footrest, so they come from rear-axle height (right to within 5 mm on the CR250) and 9 cm ahead of the swingarm pivot.

## Turn limits

Every bone was capped at 60°, which is a broken neck and half a knee. A seated leg needs ~95° at the knee, and `shortenToLimit` cuts the *whole* turn back until its stiffest axis fits — so a leg meant to fold under the bike came out half folded. Per joint now: hips, knees, shoulders and elbows 135°; wrists and collars 70°; neck and head 45°.

## Verification

Headless, against the real files — the rigs out of the game's own `rider.pkz` plus the loose `Rider+`, and the 1996 CR250 assembled through the same Rust the app uses. 21 checks, all passing on all three rider models: he faces the bike's front; the hands land within a millimetre of the grips; the knees sit inside the pegs (25 cm against 27 cm); the shins aim at the pegs to within a degree; the head stays 45 cm above the bars. `tsc`, `eslint` and `vite build` are clean.

macOS can't click into the Tauri webview, so the last word is a run on Windows: Pose tab → On bike, with the sliders and the drag handles.

No backend change, and nothing here touches what the game reads — posture in-game comes from a riding style in `mods/rider/animations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
