### PR TITLE
chore(release): v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ whichever release turns it on.
   half a grid in one room and half in another is the failure that looks like nothing is
   wrong.
 
-## 2026-08-28
+## 2026-08-28 — v0.11.1 — Protected model swaps open in 3D
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.11.1",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "mxb-app"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # whatever cargo called it. Cargo target names can't hold a space, so this is as close as
 # it gets. The description is what Windows Task Manager shows in its Processes tab.
 name = "mxb-app"
-version = "0.11.0"
+version = "0.11.1"
 description = "MXB App — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
   "mainBinaryName": "MXB App",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/Components/Showcase/releases.ts
+++ b/src/Components/Showcase/releases.ts
@@ -71,6 +71,15 @@ export interface Release {
 
 export const RELEASES: Release[] = [
   {
+    version: "0.11.1",
+    hero: {
+      icon: Package,
+      title: "showcase.v0111.hero.title",
+      body: "showcase.v0111.hero.body",
+    },
+    highlights: [{ icon: Wrench, text: "showcase.v0111.messages" }],
+  },
+  {
     version: "0.11.0",
     hero: {
       icon: PersonStanding,

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1396,6 +1396,12 @@ export const de: Translation = {
   "showcase.supporters.title_one": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.title_other": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.more": "+{{count}} weitere",
+  "showcase.v0111.hero.title":
+    "Geschützte Modell-Swaps öffnen sich in 3D",
+  "showcase.v0111.hero.body":
+    "Ein bei einem Creator gekauftes Modell liefert sein Mesh versiegelt aus, und der Viewer konnte es nicht lesen — „In 3D ansehen“ meldete, der Swap enthalte kein lesbares Mesh, obwohl er im Spiel einwandfrei läuft. Jetzt öffnet er sich wie jedes andere Bike.",
+  "showcase.v0111.messages":
+    "Lässt sich ein Bike trotzdem nicht öffnen, nennt die App den tatsächlichen Fehler, statt alles der Cloud-Synchronisierung anzulasten.",
   "showcase.v0110.hero.title":
     "Nimm den Fahrer und bring ihn in Position",
   "showcase.v0110.hero.body":

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1357,6 +1357,12 @@ export const en = {
   "showcase.supporters.title_one": "Made possible by {{count}} supporter",
   "showcase.supporters.title_other": "Made possible by {{count}} supporters",
   "showcase.supporters.more": "+{{count}} more",
+  "showcase.v0111.hero.title":
+    "Protected model swaps open in 3D",
+  "showcase.v0111.hero.body":
+    "A model bought from a creator ships its mesh sealed, and the viewer couldn't read it — View 3D said the swap held no readable mesh, on a model that runs perfectly in game. It opens now, like any other bike.",
+  "showcase.v0111.messages":
+    "When a bike still won't open, the app names the fault it actually hit instead of blaming cloud sync for everything.",
   "showcase.v0110.hero.title":
     "Take hold of the rider and pose him",
   "showcase.v0110.hero.body":

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1383,6 +1383,12 @@ export const es: Translation = {
   "showcase.supporters.title_one": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.title_other": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.more": "+{{count}} más",
+  "showcase.v0111.hero.title":
+    "Los cambios de modelo protegidos se abren en 3D",
+  "showcase.v0111.hero.body":
+    "Un modelo comprado a un creador trae su malla sellada y el visor no podía leerla: al pulsar Ver en 3D decía que el modelo no tenía ninguna malla legible, aunque funciona perfectamente en el juego. Ahora se abre como cualquier otra moto.",
+  "showcase.v0111.messages":
+    "Si una moto sigue sin abrirse, la app dice qué ha fallado en realidad en vez de culpar siempre a la sincronización en la nube.",
   "showcase.v0110.hero.title":
     "Agarra al piloto y colócalo",
   "showcase.v0110.hero.body":

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1387,6 +1387,12 @@ export const fr: Translation = {
   "showcase.supporters.title_one": "Rendu possible par {{count}} soutien",
   "showcase.supporters.title_other": "Rendu possible par {{count}} soutiens",
   "showcase.supporters.more": "+{{count}} autres",
+  "showcase.v0111.hero.title":
+    "Les modèles protégés s'ouvrent en 3D",
+  "showcase.v0111.hero.body":
+    "Un modèle acheté chez un créateur livre son maillage scellé, et la visionneuse ne pouvait pas le lire : « Voir en 3D » annonçait un modèle sans maillage lisible, alors qu'il fonctionne parfaitement en jeu. Il s'ouvre désormais comme n'importe quelle moto.",
+  "showcase.v0111.messages":
+    "Si une moto refuse toujours de s'ouvrir, l'app indique la vraie panne au lieu d'accuser la synchronisation cloud à chaque fois.",
   "showcase.v0110.hero.title":
     "Attrapez le pilote et positionnez-le",
   "showcase.v0110.hero.body":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1378,6 +1378,12 @@ export const it: Translation = {
   "showcase.supporters.title_one": "Reso possibile da {{count}} sostenitore",
   "showcase.supporters.title_other": "Reso possibile da {{count}} sostenitori",
   "showcase.supporters.more": "+{{count}} altri",
+  "showcase.v0111.hero.title":
+    "I model swap protetti si aprono in 3D",
+  "showcase.v0111.hero.body":
+    "Un modello acquistato da un creator arriva con la mesh sigillata e il visualizzatore non riusciva a leggerla: premendo Vedi in 3D diceva che lo swap non conteneva alcuna mesh leggibile, pur funzionando benissimo in gioco. Ora si apre come qualsiasi altra moto.",
+  "showcase.v0111.messages":
+    "Se una moto continua a non aprirsi, l'app dice qual è davvero il problema invece di dare sempre la colpa alla sincronizzazione cloud.",
   "showcase.v0110.hero.title":
     "Afferra il pilota e mettilo in posa",
   "showcase.v0110.hero.body":

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1376,6 +1376,12 @@ export const ptBR: Translation = {
   "showcase.supporters.title_one": "Possível graças a {{count}} apoiador",
   "showcase.supporters.title_other": "Possível graças a {{count}} apoiadores",
   "showcase.supporters.more": "+{{count}} outros",
+  "showcase.v0111.hero.title":
+    "Trocas de modelo protegidas abrem em 3D",
+  "showcase.v0111.hero.body":
+    "Um modelo comprado de um criador vem com a malha selada, e o visualizador não conseguia lê-la — ao tocar em Ver em 3D, dizia que a troca não tinha nenhuma malha legível, mesmo funcionando perfeitamente no jogo. Agora ela abre como qualquer outra moto.",
+  "showcase.v0111.messages":
+    "Se uma moto ainda não abrir, o app diz qual foi a falha de verdade em vez de culpar a sincronização na nuvem por tudo.",
   "showcase.v0110.hero.title":
     "Pegue o piloto e posicione-o",
   "showcase.v0110.hero.body":


### PR DESCRIPTION
Patch release for the protected-model-swap fix in #245.

- Changelog section marked `v0.11.1` — `changelog-section.sh v0.11.1 --heading` prints, full notes render, and the Discord summary is two items, well inside the 3500-char cap.
- Version bumped in `package.json`, `Cargo.toml`, `Cargo.lock`, `tauri.conf.json`.
- What's-new entry for 0.11.1 with strings in all six locales; `tsc --noEmit` clean.
- Nothing to consolidate — one PR's work, and the parked `## Unannounced — voice chat` block has no version marker, so it stays out of the notes and Discord.

Tag `v0.11.1` (unsuffixed) goes on `main` after merge: full release, `releases/latest`, main Discord channel, offered by the in-app updater.

🤖 Generated with [Claude Code](https://claude.com/claude-code)