### PR TITLE
feat(browse): install the download that matches the bike, not the first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,19 @@ whichever release turns it on.
   half a grid in one room and half in another is the failure that looks like nothing is
   wrong.
 
+## 2026-08-29
+
+### Fixed
+
+- **A paint that ships a separate file per bike now installs the right one.** Some pages offer
+  one download per machine the paint fits — *pitfactory 250f pub* beside *pitfactory 125t pub* —
+  and mark **both** as the recommended file. Nothing about that says "different file" to a picker
+  built for mirrors, so it took the first one and put the 250's paint in the 125's folder. Those
+  pages are now read for what they are: every file is listed rather than folded away, the one for
+  the bike you picked is the one flagged, and choosing a different file moves the destination to
+  the bike that file is for. One-click installs from Browse follow the same match, so they stop
+  quietly grabbing the wrong machine's paint.
+
 ## 2026-08-28 — v0.11.1 — Protected model swaps open in 3D
 
 ### Fixed

--- a/src/Components/ModDetail/InstallDialog.tsx
+++ b/src/Components/ModDetail/InstallDialog.tsx
@@ -15,13 +15,18 @@ import { labelOf } from "../../i18n/core";
 import { Badge } from "@/Components/ui/badge";
 import { cn } from "@/lib/utils";
 import {
+  bikeNamesFromDest,
+  bikeOfDest,
+  bikeVariants,
   defaultMirrorIndex,
+  destForVariant,
   installsOutsideMods,
   isBlockedDownload,
   isServerOnly,
   pickDownloadForBike,
   playableMirrors,
   sortMirrors,
+  variantForBike,
   type DestOption,
   type ModType,
 } from "../../api/mods";
@@ -121,15 +126,28 @@ export default function InstallDialog({
     }
   }, [open, mirrors]);
 
-  // Sound mods: the chosen bike (the folder value, minus any `/paints`) decides
-  // which *download* to grab — the links are per-bike, not mirrors of one file.
-  const bikeName = sound ? folder.replace(/[/\\]paints$/i, "") : "";
+  // The bikes this picker can install to, for reading the downloads against.
+  const bikeNames = useMemo(
+    () => (modType.id === "bikes" ? bikeNamesFromDest(destOptions) : []),
+    [modType.id, destOptions],
+  );
+  // A page that offers one file per bike rather than mirrors of one — the author labels the
+  // blocks `250f` and `125t` and the site flags both as the default.
+  const variants = useMemo(() => bikeVariants(mirrors, bikeNames), [mirrors, bikeNames]);
+  // Sound packs are per-bike by category; a livery has to be read off its own downloads.
+  const perBike = sound || variants.perBike;
+
+  // The chosen bike (the folder value, minus any `/paints`) decides which *download* to
+  // grab, since the links are per-bike rather than mirrors of one file.
+  const bikeName = perBike ? bikeOfDest(folder) : "";
   useEffect(() => {
-    if (!sound || !bikeName) return;
-    const picked = pickDownloadForBike(mirrors, bikeName);
+    if (!perBike || !bikeName) return;
+    const picked = sound
+      ? pickDownloadForBike(mirrors, bikeName)
+      : variantForBike(mirrors, variants, bikeName);
     const idx = picked ? mirrors.indexOf(picked) : -1;
     if (idx >= 0) setMirrorIdx(idx);
-  }, [sound, bikeName, mirrors]);
+  }, [perBike, sound, bikeName, mirrors, variants]);
 
   const folderLabel = useMemo(() => {
     if (creating && newFolder.trim()) return newFolder.trim();
@@ -219,10 +237,22 @@ export default function InstallDialog({
   const serverOnly = isServerOnly(mirrors);
   const mainList = serverOnly ? mirrors : playable;
 
-  // Show every option for sound mods (each is a different bike, not a mirror);
+  // Show every option when they're per-bike files (each is a different bike, not a mirror);
   // otherwise list the first few and fold the rest away.
-  const shownMirrors = mirrorsOpen || sound ? mainList : mainList.slice(0, MIRRORS_SHOWN);
+  const shownMirrors = mirrorsOpen || perBike ? mainList : mainList.slice(0, MIRRORS_SHOWN);
   const hiddenCount = mainList.length - shownMirrors.length;
+
+  /**
+   * Picking a per-bike file moves the destination to the bike it's for — the mismatch this
+   * whole path exists to prevent is just as easy to create from the link side.
+   */
+  const chooseMirror = (idx: number) => {
+    setMirrorIdx(idx);
+    if (!perBike || sound || creating) return;
+    if (variants.bikes[idx]?.has(bikeName)) return;
+    const dest = destForVariant(variants, idx, suggestions);
+    if (dest) setFolder(dest);
+  };
 
   const renderMirror = (m: DownloadOption) => {
     const idx = mirrors.indexOf(m);
@@ -233,12 +263,20 @@ export default function InstallDialog({
     // build the parser had to guess at.
     const fileLabel =
       m.label && m.label.toLowerCase() !== m.host.toLowerCase() ? m.label : "";
+    // Whether this file is the one for the bike being installed to. A sound pack is judged
+    // by what the matcher settled on; a per-bike page says outright which bike each file is
+    // for, so its rows are judged by that rather than by which one happens to be selected.
+    const forThisBike = sound ? on : !!variants.bikes[idx]?.has(bikeName);
+    // With no bike picked yet — the destination is still the bikes root — there is nothing to
+    // match against, and calling every file "different" would be answering a question nobody
+    // asked. Those rows read as they always have until a bike is chosen.
+    const saysWhichBike = perBike && (sound || !!bikeName);
     const note = blocked
       ? t("installDialog.opensInBrowser")
       : m.isServer
         ? t("installDialog.serverBuildNote")
-        : sound
-          ? on
+        : saysWhichBike
+          ? forThisBike
             ? t("installDialog.matchedBike")
             : t("installDialog.differentBike")
           : m.isDefault
@@ -247,7 +285,7 @@ export default function InstallDialog({
     return (
       <button
         key={`${m.url}-${idx}`}
-        onClick={() => setMirrorIdx(idx)}
+        onClick={() => chooseMirror(idx)}
         className={cn(
           "flex cursor-default items-center gap-[11px] rounded-[9px] border bg-background px-3 py-2.5 text-left transition-colors",
           on ? "border-primary/50" : "border-input hover:border-white/20",
@@ -274,6 +312,15 @@ export default function InstallDialog({
           <Badge variant="warning" className="flex-none">
             {t("installDialog.browserBadge")}
           </Badge>
+        ) : saysWhichBike ? (
+          // Every block on a per-bike page carries the site's "Default" flag, so the badge
+          // that meant "this is the one" said it about both files. Which bike it's for is
+          // the thing worth flagging instead.
+          forThisBike ? (
+            <Badge variant="success" className="flex-none border-primary/35 text-primary">
+              {t("installDialog.matchedBadge")}
+            </Badge>
+          ) : null
         ) : m.isDefault ? (
           <Badge variant="success" className="flex-none border-primary/35 text-primary">
             {t("installDialog.recommendedBadge")}
@@ -429,7 +476,7 @@ export default function InstallDialog({
           {mirrors.length > 0 && (
             <section className="flex flex-col gap-2">
               <span className="text-[11px] font-bold uppercase tracking-[1.2px] text-faint">
-                {sound
+                {perBike
                   ? t("installDialog.downloadPerBike")
                   : t("installDialog.downloadFrom")}
               </span>

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -1558,6 +1558,122 @@ export function isServerOnly(mirrors: DownloadOption[]): boolean {
   return mirrors.length > 0 && mirrors.every((m) => m.isServer);
 }
 
+/**
+ * The displacement-shaped numbers a piece of text carries — two or three digits, so a year
+ * can never pass for a machine ("2026 CLUBMX Redbud" names no bike). Whole runs only: `250`
+ * is in `CR250`, and is not in `2023` or `1250`.
+ */
+const displacements = (s: string): Set<string> =>
+  new Set(digitRuns(s).filter((n) => n.length >= 2 && n.length <= 3));
+
+/** `MX1OEM_2023_KTM_250_SX-F/paints` → `MX1OEM_2023_KTM_250_SX-F`. */
+export function bikeOfDest(dest: string): string {
+  return dest.replace(/[/\\]paints$/i, "");
+}
+
+/** The bikes a destination list offers, taken from the `<bike>/paints` entry each one gets. */
+export function bikeNamesFromDest(destOptions: DestOption[]): string[] {
+  const out = new Set<string>();
+  for (const o of destOptions) {
+    const m = /^(.+)[/\\]paints$/i.exec(o.value);
+    if (m) out.add(m[1]);
+  }
+  return [...out];
+}
+
+export interface BikeVariants {
+  /** The bikes each download names, in `mirrors` order. Empty where it names none. */
+  bikes: Set<string>[];
+  /**
+   * Whether these are per-bike *files* rather than mirrors of one — i.e. whether the file
+   * to grab depends on which bike it's being installed for.
+   */
+  perBike: boolean;
+}
+
+/**
+ * Which bike each download on a page is for, where the page has one file per bike.
+ *
+ * Authors label those blocks with the displacement and nothing else — `pitfactory 250f pub`
+ * beside `pitfactory 125t pub`, or plain `250` beside `450` — while the site flags *both* as
+ * the default file. Nothing about that says "different file" to a picker built for mirrors,
+ * so the first block wins and the 250's paint lands in the 125's folder.
+ *
+ * A number in a label only counts when a bike actually installed carries that same run of
+ * digits, which is what keeps a rider number ("Gieck 18") or a pack's name ("288essentials")
+ * from reading as a machine. The page then only counts as per-bike when *every* playable
+ * download names one and at least two of them disagree: pages that mix one paint with a
+ * couple of model-swap links, or offer the same paint per rider, are mirrors as far as this
+ * is concerned and keep the behaviour they had. Measured over 240 livery posts this picks out
+ * the 7 real cases among the 64 with more than one download, and nothing else.
+ */
+export function bikeVariants(mirrors: DownloadOption[], bikes: string[]): BikeVariants {
+  const bikeNums = bikes.map((b) => new Set(digitRuns(b)));
+  const sets = mirrors.map((m) => {
+    const want = displacements(m.label);
+    const out = new Set<string>();
+    if (want.size === 0) return out;
+    bikes.forEach((b, i) => {
+      for (const n of want)
+        if (bikeNums[i].has(n)) {
+          out.add(b);
+          break;
+        }
+    });
+    return out;
+  });
+
+  // Server builds are named after the bike too, but nobody rides one — they say nothing
+  // about whether the *playable* files differ.
+  const idx = mirrors.map((_, i) => i).filter((i) => !mirrors[i].isServer);
+  const disjoint = (a: Set<string>, b: Set<string>) => ![...a].some((v) => b.has(v));
+  const perBike =
+    idx.length >= 2 &&
+    idx.every((i) => sets[i].size > 0) &&
+    idx.some((i, n) => idx.slice(n + 1).some((j) => disjoint(sets[i], sets[j])));
+
+  return { bikes: sets, perBike };
+}
+
+/**
+ * The download meant for `bike`, or `null` when no block names it.
+ *
+ * The narrowest match wins: a file labelled for one bike beats one labelled for several.
+ */
+export function variantForBike(
+  mirrors: DownloadOption[],
+  variants: BikeVariants,
+  bike: string,
+): DownloadOption | null {
+  let best: DownloadOption | null = null;
+  let bestSize = Infinity;
+  for (let i = 0; i < mirrors.length; i++) {
+    const set = variants.bikes[i];
+    if (mirrors[i].isServer || !set?.has(bike) || set.size >= bestSize) continue;
+    best = mirrors[i];
+    bestSize = set.size;
+  }
+  return best;
+}
+
+/**
+ * The destination a per-bike download is asking for, out of the ones the post itself names,
+ * or `null` where that's ambiguous.
+ *
+ * A label reading `250` fits every 250 in the library, so only the post's own bikes can say
+ * which one was meant — and only when exactly one of them is on offer.
+ */
+export function destForVariant(
+  variants: BikeVariants,
+  index: number,
+  suggestions: string[],
+): string | null {
+  const set = variants.bikes[index];
+  if (!set) return null;
+  const hits = suggestions.filter((v) => set.has(bikeOfDest(v)));
+  return hits.length === 1 ? hits[0] : null;
+}
+
 export function pickDownloadForBike(
   mirrors: DownloadOption[],
   bikeName: string,
@@ -1571,6 +1687,9 @@ export function pickDownloadForBike(
   const want = tokens(bikeName);
   if (want.size === 0) return fallback();
 
+  // Deliberately word-matching only, no displacement pass: sound packs are labelled by
+  // brand ("Just KTM 250SX-F") and a bare 250 would hand a Honda the KTM's sound. A livery's
+  // per-bike files are read by {@link bikeVariants} instead, which has the bikes to check against.
   let best: { m: DownloadOption; score: number } | null = null;
   for (const m of pool) {
     const fname = m.url.split(/[/\\]/).pop() ?? "";
@@ -1727,6 +1846,19 @@ export async function resolveQuickInstall(
   );
   const destFolder = resolveInitialFolder(game, modType, options, guess, livery);
 
+  // A page with a file per bike has no single "the download": one click otherwise installs
+  // the 250's paint into the folder it just picked for the 125. The file follows the folder.
+  const variants =
+    modType.id === "bikes"
+      ? bikeVariants(mirrors, bikeNames(installed, bikeTargets))
+      : { bikes: [], perBike: false };
+  const match = variants.perBike
+    ? variantForBike(mirrors, variants, bikeOfDest(destFolder))
+    : null;
+  const file = match ?? primary;
+  if (isBlockedDownload(file))
+    return { ok: false, reason: "blocked", title: detail.title, host: file.host };
+
   return {
     ok: true,
     params: {
@@ -1734,8 +1866,8 @@ export async function resolveQuickInstall(
       title: detail.title,
       subpath: modType.installSubpath,
       destFolder,
-      url: primary.url,
-      host: primary.host,
+      url: file.url,
+      host: file.host,
     },
   };
 }

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -581,6 +581,7 @@ export const de: Translation = {
   "installDialog.directFastest": "Direkt · am schnellsten",
   "installDialog.direct": "Direkt",
   "installDialog.recommendedBadge": "Empfohlen",
+  "installDialog.matchedBadge": "Dein Motorrad",
   "installDialog.browserBadge": "Browser",
   "installDialog.serverBadge": "Server",
   "installDialog.serverBuildNote": "Build für dedizierte Server — nicht zum Spielen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -567,6 +567,7 @@ export const en = {
   "installDialog.directFastest": "Direct · fastest",
   "installDialog.direct": "Direct",
   "installDialog.recommendedBadge": "Recommended",
+  "installDialog.matchedBadge": "Your bike",
   "installDialog.browserBadge": "Browser",
   "installDialog.serverBadge": "Server",
   "installDialog.serverBuildNote": "Dedicated server build — not for playing",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -573,6 +573,7 @@ export const es: Translation = {
   "installDialog.directFastest": "Directo · el más rápido",
   "installDialog.direct": "Directo",
   "installDialog.recommendedBadge": "Recomendado",
+  "installDialog.matchedBadge": "Tu moto",
   "installDialog.browserBadge": "Navegador",
   "installDialog.serverBadge": "Servidor",
   "installDialog.serverBuildNote": "Compilación para servidor dedicado — no sirve para jugar",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -577,6 +577,7 @@ export const fr: Translation = {
   "installDialog.directFastest": "Direct · le plus rapide",
   "installDialog.direct": "Direct",
   "installDialog.recommendedBadge": "Recommandé",
+  "installDialog.matchedBadge": "Votre moto",
   "installDialog.browserBadge": "Navigateur",
   "installDialog.serverBadge": "Serveur",
   "installDialog.serverBuildNote": "Version serveur dédié — pas pour jouer",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -572,6 +572,7 @@ export const it: Translation = {
   "installDialog.directFastest": "Diretto · il più veloce",
   "installDialog.direct": "Diretto",
   "installDialog.recommendedBadge": "Consigliato",
+  "installDialog.matchedBadge": "La tua moto",
   "installDialog.browserBadge": "Browser",
   "installDialog.serverBadge": "Server",
   "installDialog.serverBuildNote": "Build per server dedicato — non per giocare",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -575,6 +575,7 @@ export const ptBR: Translation = {
   "installDialog.directFastest": "Direto · o mais rápido",
   "installDialog.direct": "Direto",
   "installDialog.recommendedBadge": "Recomendado",
+  "installDialog.matchedBadge": "Sua moto",
   "installDialog.browserBadge": "Navegador",
   "installDialog.serverBadge": "Servidor",
   "installDialog.serverBuildNote": "Versão para servidor dedicado — não serve para jogar",


### PR DESCRIPTION
## The case

`ktm-pitfactory` in Browse offers two Google Drive links — `pitfactory 250f pub` and
`pitfactory 125t pub` — and the site flags **both** with its `Default` ("recommended") badge.
They are different files for different machines, not mirrors of one, and nothing in the picker
said so: it took the first `Default` and installed the 250's paint into whichever bike folder
it had preselected.

## What this does

- `bikeVariants` reads a page's downloads against the bikes you actually have installed. A
  number in a label only counts as a machine when an installed bike carries that same whole run
  of digits — which is what keeps a rider number (`Gieck 18`) or a pack name (`288essentials`)
  from reading as one — and the page only counts as per-bike when **every** playable download
  names a bike and at least two of them disagree.
- The install dialog lists every file on such a page rather than folding the rest behind
  "N more", follows the destination bike, and badges the file for that bike instead of calling
  both of them recommended.
- Picking a file moves the destination to the bike it's for, where the post names exactly one.
  The same mismatch was just as easy to create from the link side.
- One-click installs from the Browse grid take the matching file too.

## Verification

No JS test runner in this repo, so the matcher was replayed over the live catalog: 300 real mod
pages (240 liveries + 60 sounds), 64 of them with more than one download.

| | |
|---|---|
| flagged per-bike | **7**, all genuine — `250f`/`125t`, `450`/`250`, `Yamaha Sakura Yzf 450 2023`/`… 250 2024`, … |
| false positives | **0** — per-rider paints (`Tyler Lynn`/`Mikayla Nielsen`), bike+rider pairs, `gear`/`bike`/`Modelswap`, mirror + shop-model-link pages all keep the behaviour they had |
| sound picks changed | **0** |

`tsc --noEmit`, eslint and `vite build` clean.

A displacement pass was tried on the **sound** matcher too and backed out: it handed a Honda
CRF250R a KTM-only sound pack because both are 250s. Sounds keep their word-only matcher; only
the badge on the selected row changes wording.

## Known gap

Two files for the same displacement (`250f` beside `250t`) aren't told apart — detection
declines and you get the previous behaviour rather than a guess.

## Not covered

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)