### PR TITLE
feat(install): review a bike pack as the bikes inside it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,40 @@ whichever release turns it on.
   half a grid in one room and half in another is the failure that looks like nothing is
   wrong.
 
+## 2026-08-28
+
+### Added
+
+- **A bike pack installs as the bikes inside it.** The OEM bike pack is 54 machines and a
+  tyre set in one 3.8 GB archive, and until now it arrived as a single row reading "Mods
+  folder" — all of it or none of it, with no way to see what was in there. It is now listed
+  the way it is built: every bike by its real name and class (*KTM 450 SX-F 2023 · MX1 OEM*),
+  its size, and a checkbox. Take the four you race and leave the other fifty. **Select all**
+  and **Select none** sit in the header, because a fifty-five-row list is not a list you tick
+  by hand.
+
+  Where each piece goes is read from the pack itself rather than guessed at, which matters
+  more than it sounds: the tyre set that carries every one of those bikes' wheels is
+  described inside its own file exactly like a bike, and filing it under `mods/bikes` on that
+  evidence would take the wheels off all 54. A pack the app can't read confidently is left
+  exactly as it was — one row, installed whole — rather than split into pieces it would have
+  to guess destinations for.
+
+- **A pack you download is shown to you before it installs.** Downloads used to go straight
+  to disk, which for a pack meant 3.8 GB of bikes landing without anyone being asked. One
+  that turns out to hold several mods now stops and opens the same review sheet a dropped
+  file gets. An ordinary single-mod download is untouched — it installs exactly as before,
+  with nothing extra to click.
+
+### Fixed
+
+- **The review sheet took twenty seconds to open, for anyone with the OEM bikes installed.**
+  Every drop reads the bikes already in your folder so it can offer them as destinations, and
+  each bike was opened twice over to get its name — 310 ms a bike where 14 ms would do. With
+  53 OEM bikes installed that was 18.9 seconds of nothing happening before the sheet drew, on
+  every single drop. It is 1.2 seconds now. The same read backs the bike pickers throughout
+  the app, so they all get quicker.
+
 ## 2026-08-28 — v0.11.1 — Protected model swaps open in 3D
 
 ### Fixed

--- a/src-tauri/src/bikeswap.rs
+++ b/src-tauri/src/bikeswap.rs
@@ -85,8 +85,30 @@ pub fn read_identity(path: &Path) -> Option<BikeIdentity> {
         (stem, ini, cfg)
     } else {
         let stem = path.file_stem()?.to_string_lossy().into_owned();
-        let ini = pkz::read_entry(path, &format!("{stem}.ini")).ok().flatten();
-        let cfg = pkz::read_entry(path, &format!("{stem}.cfg")).ok().flatten();
+        // Both files in one pass, which is not the small saving it looks like. Measured
+        // against a real OEM bike `.pkz`: two `read_entry` calls cost 310 ms, the one
+        // `read_selected` below costs 14 ms. That runs once per bike in the folder, so
+        // listing this author's 53 installed OEM bikes went from 18.9 s to 1.2 s — a stall
+        // the drop review paid in full, every drop, before anything was drawn.
+        let want_ini = format!("{}.ini", stem.to_ascii_lowercase());
+        let want_cfg = format!("{}.cfg", stem.to_ascii_lowercase());
+        let found = pkz::read_selected(path, |n| {
+            let base = n.replace('\\', "/");
+            let base = base.rsplit('/').next().unwrap_or(&base).to_ascii_lowercase();
+            base == want_ini || base == want_cfg
+        })
+        .unwrap_or_default();
+        let take = |want: &str| {
+            found
+                .iter()
+                .find(|(n, _)| {
+                    let base = n.rsplit('/').next().unwrap_or(n);
+                    base.eq_ignore_ascii_case(want)
+                })
+                .map(|(_, b)| b.clone())
+        };
+        let ini = take(&want_ini);
+        let cfg = take(&want_cfg);
         (stem, ini, cfg)
     };
 

--- a/src-tauri/src/dropzone.rs
+++ b/src-tauri/src/dropzone.rs
@@ -41,6 +41,11 @@ pub enum ContentKind {
     BikePaint,
     SoundSet,
     RiderGear,
+    /// A tyre set — `mods/tyres`. Only ever produced by [`split_tree`]: read on its own a
+    /// tyre `.pkz` looks like nothing in particular, and it is the tree it arrived in that
+    /// says what it is. The OEM bike pack ships one (`oem_mx`), and the wheel meshes of
+    /// every bike in it live there rather than in the bikes.
+    Tyres,
     /// A ReShade preset `.ini`. The one kind that doesn't live in the mods tree at all —
     /// see [`crate::reshade`].
     ReshadePreset,
@@ -60,6 +65,7 @@ impl ContentKind {
             ContentKind::Bike | ContentKind::BikePaint | ContentKind::SoundSet => {
                 Some("mods/bikes")
             }
+            ContentKind::Tyres => Some("mods/tyres"),
             ContentKind::RiderGear => Some("mods/rider"),
             ContentKind::ReshadePreset => Some(crate::reshade::SUBPATH),
             ContentKind::Unknown => None,
@@ -99,6 +105,11 @@ pub enum DetectReason {
     GearTexture,
     /// An `.ini` listing ReShade techniques.
     ReshadePreset,
+    /// The pack it came in filed it here. Used for a row inside a split `mods/` tree that
+    /// the classifier had no confident opinion about on its own — the destination is still a
+    /// fact, because the tree stated it, and saying "not recognised" about a row we are
+    /// about to install correctly would be a lie.
+    PackLayout,
     /// Nothing identified it.
     Unrecognised,
 }
@@ -252,6 +263,14 @@ struct Verdict {
     keep_folder: String,
     /// The content named its category but not its destination — the user must finish it.
     needs_choice: bool,
+    /// The category this unit came out of, when the tree it arrived in said so outright.
+    ///
+    /// A `mods/` tree is self-describing, and [`split_tree`] must not throw that away:
+    /// `mods/tyres/oem_mx.pkz` belongs in `mods/tyres` because of where it sits, not because
+    /// of what [`classify_pkz`] makes of it — read on its own that file says very little.
+    /// Set only by the split, and it overrides both the kind's own subpath and any request
+    /// for a choice: there is nothing left to ask.
+    fixed_subpath: Option<String>,
 }
 
 impl Verdict {
@@ -263,6 +282,7 @@ impl Verdict {
             dest_folder: String::new(),
             keep_folder: String::new(),
             needs_choice: false,
+            fixed_subpath: None,
         }
     }
     fn detail(mut self, d: Option<String>) -> Self {
@@ -280,6 +300,18 @@ impl Verdict {
     }
     fn ask(mut self) -> Self {
         self.needs_choice = true;
+        self
+    }
+    /// Route this unit by the tree it came out of rather than by its kind, and stop asking
+    /// where it goes — the pack already answered. A classifier that came back unsure keeps
+    /// its kind (there is nothing better to show) but trades `Unrecognised` for
+    /// [`DetectReason::PackLayout`], which is what actually decided the destination.
+    fn in_pack(mut self, subpath: impl Into<String>) -> Self {
+        if self.needs_choice || self.reason == DetectReason::Unrecognised {
+            self.reason = DetectReason::PackLayout;
+        }
+        self.needs_choice = false;
+        self.fixed_subpath = Some(subpath.into());
         self
     }
 }
@@ -606,6 +638,132 @@ fn profile_dest(profile: &str, sub: &str) -> String {
     format!("{}/{profile}/{sub}", crate::game::RIDERS_DIR)
 }
 
+/// The most rows a split may produce.
+///
+/// The OEM bike pack — the archive this exists for — is 55. A `mods/` tree far past that is
+/// somebody's whole game folder, and a review sheet with hundreds of checkboxes is worse than
+/// the one row it replaced, so over the cap the tree stays whole. That row still says exactly
+/// what it is ("Mods folder — contains a full mods folder") and installs everything, which is
+/// the behaviour every version before this had: nothing is hidden, only ungrouped.
+const MAX_SPLIT_UNITS: usize = 120;
+
+/// Whether anything under `dir` would actually be written.
+///
+/// An empty folder is not content. The OEM pack ships 54 of them — a `paints/` beside every
+/// bike, waiting for liveries that aren't there yet — and `walk_merge` carries files only, so
+/// installing the pack whole has never created them either. Skipping them here is what lets
+/// the split see `mods/bikes` as 54 packaged bikes rather than 54 bikes plus 54 folders it
+/// can't identify.
+fn holds_no_files(dir: &Path) -> bool {
+    files_in(dir).is_empty() && dirs_in(dir).iter().all(|d| holds_no_files(d))
+}
+
+/// Split a self-describing `mods/` tree into the mods it holds.
+///
+/// A pack arrives as one row otherwise: all of it or none of it, no way to see what is in it
+/// and no way to leave a bike out. The OEM bike pack is 3.8 GB of exactly that — 54 bikes and
+/// a tyre set, which is 55 decisions presented as one.
+///
+/// **The category a child sits under is its destination.** A `mods/` tree states where its
+/// contents go, and splitting it must not throw that away in favour of re-deriving it:
+/// `mods/tyres/oem_mx.pkz` is a tyre set because of where it sits, and read on its own it
+/// looks like nothing much. So the classifier is asked only for the *label* — the kind, and
+/// the bike's real name and class — while the route comes from the tree. That is the whole
+/// of what `a_mods_tree_keeps_its_own_layout` has always claimed; only the row count changes.
+///
+/// Returns `None`, leaving the tree as the single row it has always been, unless every child
+/// is either a unit that can be named or an empty folder. Anything else and a split would have
+/// to either drop content or invent a destination for it, and one honest row beats both.
+fn split_tree(rule: RouteRule, placement: &install::Placement, ctx: Ctx) -> Option<Vec<Unit>> {
+    // Both self-describing rules resolved their own paths already — the `mods` folder for a
+    // whole tree, the category folders for the looser shape — so take them rather than
+    // walking to them again and risking a different answer.
+    let cats: Vec<(String, PathBuf)> = match (rule, placement) {
+        (RouteRule::ModsTree, install::Placement::Merge { src, .. }) => {
+            // A child of `mods/` that isn't a category is content with nowhere to go. Bail
+            // rather than drop it: `walk_merge` would have copied it as part of the tree.
+            for d in dirs_in(src) {
+                let name = d.file_name()?.to_string_lossy().into_owned();
+                if !install::CATEGORY_DIRS
+                    .iter()
+                    .any(|c| c.eq_ignore_ascii_case(&name))
+                    && !holds_no_files(&d)
+                {
+                    return None;
+                }
+            }
+            if files_in(src).iter().any(|f| {
+                !install::is_junk(&f.file_name().unwrap_or_default().to_string_lossy())
+            }) {
+                return None;
+            }
+            install::CATEGORY_DIRS
+                .iter()
+                .filter_map(|c| install::child_dir(src, c).map(|p| ((*c).to_string(), p)))
+                .collect()
+        }
+        (RouteRule::CategoryDirs, install::Placement::MergeEach { pairs }) => pairs
+            .iter()
+            .filter_map(|(src, _)| {
+                let name = src.file_name()?.to_string_lossy().to_ascii_lowercase();
+                Some((name, src.clone()))
+            })
+            .collect(),
+        _ => return None,
+    };
+
+    let mut units = Vec::new();
+    for (cat, dir) in cats {
+        let subpath = format!("mods/{cat}");
+        for child in dirs_in(&dir) {
+            if holds_no_files(&child) {
+                continue;
+            }
+            // A folder the classifier can't name is one we'd have to guess about — and a
+            // category of them (a rider tree's `helmets/`, a track pack's `EU/`) is a
+            // container, not a row. Keep the tree whole instead.
+            let verdict = classify_typed(&child, ctx)?;
+            units.push(Unit {
+                path: child,
+                verdict: verdict.in_pack(subpath.as_str()),
+            });
+        }
+        for child in files_in(&dir) {
+            let name = child.file_name()?.to_string_lossy().into_owned();
+            // Readmes and the like. Splitting drops these where installing the tree whole
+            // would have copied them, which is the one behaviour this changes — and it
+            // changes it towards what every other placement in the installer already does
+            // (`walk_plain`), rather than leaving a `README.txt` loose in `mods/bikes`.
+            if install::is_junk(&name) {
+                continue;
+            }
+            // Only a package stands alone. A loose file in a category root is part of some
+            // larger arrangement we haven't understood, and splitting around it would leave
+            // it homeless.
+            if !install::has_ext(&child, "pkz") {
+                return None;
+            }
+            // `classify_pkz` knows tracks and bikes, and reads a bike's real name out of it.
+            // Where the category has a kind of its own it wins outright, exactly as it does
+            // for the destination: a tyre set carries a bike-shaped `<stem>.cfg`, so asking
+            // the classifier gets back "Bike" — a true statement about the file's shape and
+            // the wrong answer about what it is.
+            let verdict = match cat.as_str() {
+                "tyres" => Verdict::new(ContentKind::Tyres, DetectReason::PackLayout),
+                _ => classify_pkz(&child),
+            };
+            units.push(Unit {
+                path: child,
+                verdict: verdict.in_pack(subpath.as_str()),
+            });
+        }
+    }
+
+    // One unit is the tree itself by another name, and zero means an empty tree — in both
+    // cases the row it replaces is the better one.
+    (units.len() > 1 && units.len() <= MAX_SPLIT_UNITS).then_some(units)
+}
+
 /// Split a staged root into the units the user will see as rows.
 fn units_in(
     dir: &Path,
@@ -616,6 +774,9 @@ fn units_in(
 ) -> Vec<Unit> {
     let route = install::plan_placement(dir, mods_dir, PROBE_TYPE, "", slug);
     if let Some(verdict) = from_route_rule(route.rule) {
+        if let Some(units) = split_tree(route.rule, &route.placement, ctx) {
+            return units;
+        }
         return vec![Unit {
             path: dir.to_path_buf(),
             verdict,
@@ -839,7 +1000,12 @@ fn to_item(
 
     // Every row gets a picker: identifying content correctly is not the same as knowing
     // which folder the user files it under.
-    let choices = if matches!(
+    let choices = if verdict.fixed_subpath.is_some() {
+        // A row split out of a `mods/` tree. The pack laid its own contents out and the row
+        // is being installed back into that layout, so there is no folder left to choose —
+        // the only decision still open is whether to take it at all.
+        Vec::new()
+    } else if matches!(
         verdict.kind,
         ContentKind::ModsTree | ContentKind::ReshadePreset
     ) {
@@ -869,6 +1035,8 @@ fn to_item(
 
     let subpath = if needs_choice {
         String::new()
+    } else if let Some(fixed) = &verdict.fixed_subpath {
+        fixed.clone()
     } else {
         verdict.kind.subpath().unwrap_or("mods/misc").to_string()
     };
@@ -1027,6 +1195,71 @@ pub fn plan(mods_path: &str, paths: &[String]) -> anyhow::Result<DropPlan> {
         skipped,
         total_bytes,
     })
+}
+
+/// Put an already-extracted **pack** up for review, or say it isn't one.
+///
+/// The download path can't ask "which of these do you want?" before it has the bytes: an
+/// archive only says what it holds once it is open. So by the time the question can be put,
+/// the staging is done — and re-staging through [`plan`] would extract the OEM pack's 3.8 GB
+/// a second time. This registers the tree exactly where it already sits and takes ownership
+/// of `work`, which [`commit`] and [`cancel`] then clean up as they do for any drop.
+///
+/// `Ok(None)` means this is an ordinary single-mod download and the caller should place it
+/// the way it always has. The test is deliberately narrow: only a tree that [`split_tree`]
+/// takes apart becomes a review. A three-livery zip still installs without interrupting
+/// anyone, because nothing about it was ever ambiguous.
+pub fn plan_extracted(
+    mods_path: &str,
+    root: &Path,
+    work: PathBuf,
+    source_name: &str,
+) -> anyhow::Result<Option<DropPlan>> {
+    if mods_path.trim().is_empty() {
+        anyhow::bail!("no MX Bikes folder configured");
+    }
+    let mods_dir = library::mods_subdir(mods_path, "mods");
+    let scans = Scans::new(mods_path);
+    let ctx = Ctx::new(mods_path, &scans);
+    let slug = Path::new(source_name)
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| source_name.to_string());
+
+    let route = install::plan_placement(root, &mods_dir, PROBE_TYPE, "", &slug);
+    if from_route_rule(route.rule).is_none() {
+        return Ok(None);
+    }
+    let Some(units) = split_tree(route.rule, &route.placement, ctx) else {
+        return Ok(None);
+    };
+
+    let plan_id = next_id("pack");
+    let mut items = Vec::new();
+    let mut staged = HashMap::new();
+    for unit in units {
+        let (item, st) = to_item(unit, ctx, &mods_dir, &slug, source_name);
+        staged.insert(item.id.clone(), st);
+        items.push(item);
+    }
+    let total_bytes = items.iter().map(|i| i.bytes).sum();
+
+    with_plans(|m| {
+        m.insert(
+            plan_id.clone(),
+            StagedPlan {
+                work: Some(work),
+                items: staged,
+            },
+        )
+    });
+
+    Ok(Some(DropPlan {
+        id: plan_id,
+        items,
+        skipped: Vec::new(),
+        total_bytes,
+    }))
 }
 
 /// Re-price one row after the user changed its destination.
@@ -1367,10 +1600,252 @@ mod tests {
         let mods = root.join("mods");
         write(&root.join("drop/mods/tracks/Hangtown/Hangtown.map"), "m");
 
+        // One thing in the tree is still one row: splitting would only rename it.
         let units = units_in(&root.join("drop"), &mods, mx(""), "drop", 0);
         assert_eq!(units.len(), 1);
         assert_eq!(units[0].verdict.kind, ContentKind::ModsTree);
         assert_eq!(units[0].verdict.reason, DetectReason::ModsTree);
+    }
+
+    /// Split a real pack and report what came out.
+    ///
+    /// Synthetic `.pkz` files are plain zips holding two tiny config entries; the real ones
+    /// are 21–184 MB in a format of PiBoSo's own, some of them sealed. Whether the classifier
+    /// can name 54 of those, and what it costs to do it once per row, is not a thing the
+    /// fixtures above can answer.
+    ///
+    /// `MXB_REAL_PACK=<dir> cargo test real_pack_splits -- --ignored --nocapture`, where the
+    /// directory holds a `mods/` tree.
+    #[test]
+    #[ignore]
+    fn real_pack_splits() {
+        let Ok(dir) = std::env::var("MXB_REAL_PACK") else {
+            eprintln!("set MXB_REAL_PACK to a folder holding a mods/ tree");
+            return;
+        };
+        let root = PathBuf::from(dir);
+        // Where the time goes, one layer at a time.
+        let t0 = std::time::Instant::now();
+        let installed = crate::bikeswap::scan_installed_bikes(&root.to_string_lossy());
+        println!(
+            "scan_installed_bikes: {} bike(s) in {:?}  (what `Scans::new` costs every drop)",
+            installed.len(),
+            t0.elapsed()
+        );
+
+        let bikes = root.join("mods/bikes");
+        let one = files_in(&bikes).into_iter().find(|p| install::has_ext(p, "pkz"));
+        if let Some(p) = &one {
+            let t = std::time::Instant::now();
+            let n = crate::pkz::entry_names(p).map(|v| v.len()).unwrap_or(0);
+            println!("  entry_names on one .pkz: {n} entries in {:?}", t.elapsed());
+            let t = std::time::Instant::now();
+            let _ = crate::bikeswap::read_identity(p);
+            println!("  read_identity on one .pkz: {:?}", t.elapsed());
+        }
+
+        let started = std::time::Instant::now();
+        let units = units_in(&root, &root.join("__nowhere__"), mx(""), "pack", 0);
+        let elapsed = started.elapsed();
+
+        println!("{} row(s) in {elapsed:?}", units.len());
+        let mut by_kind: std::collections::BTreeMap<String, usize> =
+            std::collections::BTreeMap::new();
+        for u in &units {
+            *by_kind.entry(format!("{:?}", u.verdict.kind)).or_default() += 1;
+        }
+        println!("by kind: {by_kind:?}");
+        for u in units.iter().take(60) {
+            println!(
+                "  {:>8} -> {:<12} {}{}",
+                format!("{:?}", u.verdict.kind),
+                u.verdict.fixed_subpath.as_deref().unwrap_or("(by kind)"),
+                u.path.file_name().unwrap_or_default().to_string_lossy(),
+                u.verdict
+                    .detail
+                    .as_deref()
+                    .map(|d| format!("  — {d}"))
+                    .unwrap_or_default(),
+            );
+        }
+    }
+
+    /// A packaged bike, as a `.pkz` holding the two config files that name it.
+    fn write_bike_pkz(path: &Path, stem: &str, name: &str, class: &str) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        make_zip(
+            path,
+            &[
+                (
+                    Box::leak(format!("{stem}.ini").into_boxed_str()),
+                    Box::leak(format!("[info]\nname = {name}\n[data]\ncat = {class}\n").into_boxed_str()),
+                ),
+                (
+                    Box::leak(format!("{stem}.cfg").into_boxed_str()),
+                    Box::leak(format!("ID = {stem}\n").into_boxed_str()),
+                ),
+            ],
+        );
+    }
+
+    /// The shape of the OEM bike pack, in miniature: a `mods/` tree carrying several packaged
+    /// bikes, an empty `paints/` folder beside each one, and the tyre set the bikes' wheels
+    /// actually live in. The whole point of the split — 3.8 GB and 55 mods arrived as one
+    /// take-it-or-leave-it row.
+    fn write_oem_pack(drop: &Path, bikes: &[&str]) {
+        for b in bikes {
+            write_bike_pkz(
+                &drop.join(format!("mods/bikes/{b}.pkz")),
+                b,
+                &format!("{b} display"),
+                "MX1 OEM",
+            );
+            // Ships empty, waiting for liveries. Nothing to install, and never was.
+            fs::create_dir_all(drop.join(format!("mods/bikes/{b}/paints"))).unwrap();
+        }
+        // Shaped like a bike on purpose. The real `oem_mx.pkz` carries `oem_mx.ini` and
+        // `oem_mx.cfg`, so `classify_pkz` reads it as a bike — and landing it in `mods/bikes`
+        // would take the wheels off all 54 of them. Only the tree knows better.
+        make_zip(
+            &drop.join("mods/tyres/oem_mx.pkz"),
+            &[
+                ("oem_mx.ini", "[info]\nname = OEM MX Tyres\n"),
+                ("oem_mx.cfg", "ID = oem_mx\n"),
+            ],
+        );
+    }
+
+    #[test]
+    fn a_bike_pack_splits_into_the_bikes_it_holds() {
+        let root = tmp("packsplit");
+        let mods = root.join("mods");
+        let drop = root.join("drop");
+        fs::create_dir_all(drop.join("mods/tyres")).unwrap();
+        write_oem_pack(&drop, &["MX1OEM_2023_KTM_450", "MX2OEM_2023_KTM_250"]);
+
+        let units = units_in(&drop, &mods, mx(""), "drop", 0);
+
+        // Two bikes and the tyre set — not one "mods folder", and not five rows either: the
+        // empty `paints/` folders are not content.
+        assert_eq!(units.len(), 3, "two bikes and a tyre set");
+
+        let bikes: Vec<&Unit> = units
+            .iter()
+            .filter(|u| u.verdict.kind == ContentKind::Bike)
+            .collect();
+        assert_eq!(bikes.len(), 2);
+        for b in &bikes {
+            assert_eq!(b.verdict.fixed_subpath.as_deref(), Some("mods/bikes"));
+            assert!(!b.verdict.needs_choice, "the pack already said where it goes");
+            // The row is named by the bike, not by the file.
+            assert!(
+                b.verdict.detail.as_deref().unwrap_or("").contains("display"),
+                "expected the bike's own name, got {:?}",
+                b.verdict.detail
+            );
+        }
+
+        let tyres = units
+            .iter()
+            .find(|u| u.verdict.kind == ContentKind::Tyres)
+            .expect("the tyre set is a row of its own");
+        // The whole reason the tree routes rather than the classifier: read on its own this
+        // file says nothing, and landing it in `mods/bikes` would break every wheel in the pack.
+        assert_eq!(tyres.verdict.fixed_subpath.as_deref(), Some("mods/tyres"));
+        assert_eq!(tyres.verdict.reason, DetectReason::PackLayout);
+        assert!(!tyres.verdict.needs_choice);
+    }
+
+    #[test]
+    fn a_split_row_offers_no_destination_and_installs_where_the_pack_said() {
+        let root = tmp("packrow");
+        let mods = root.join("mods");
+        let drop = root.join("drop");
+        fs::create_dir_all(drop.join("mods/tyres")).unwrap();
+        write_oem_pack(&drop, &["MX1OEM_2023_KTM_450", "MX2OEM_2023_KTM_250"]);
+
+        let units = units_in(&drop, &mods, mx(""), "drop", 0);
+        let tyres = units
+            .into_iter()
+            .find(|u| u.verdict.kind == ContentKind::Tyres)
+            .unwrap();
+        let (item, staged) = to_item(tyres, mx(""), &mods, "drop", "MX_OEM.zip");
+
+        assert_eq!(item.subpath, "mods/tyres");
+        assert!(item.choices.is_empty(), "nothing left to choose");
+        assert!(!item.needs_choice);
+        assert_eq!(item.file_count, 1, "one package, previewed as one write");
+        assert!(item.bytes > 0, "a single-file unit still reports its size");
+
+        let wrote = install_one(&mods, &root.to_string_lossy(), &staged.path, &item.subpath, &item.dest_folder, "drop")
+            .unwrap();
+        assert_eq!(wrote, 1);
+        assert!(
+            mods.join("tyres/oem_mx.pkz").is_file(),
+            "the tyre set lands in mods/tyres"
+        );
+        assert!(!mods.join("bikes/oem_mx.pkz").exists());
+    }
+
+    #[test]
+    fn a_tree_holding_something_it_cannot_name_stays_one_row() {
+        let root = tmp("packunknown");
+        let mods = root.join("mods");
+        let drop = root.join("drop");
+        fs::create_dir_all(drop.join("mods/tyres")).unwrap();
+        write_oem_pack(&drop, &["MX1OEM_2023_KTM_450", "MX2OEM_2023_KTM_250"]);
+        // A loose file in a category root belongs to some arrangement we haven't understood.
+        write(&drop.join("mods/bikes/spare_model.edf"), "e");
+
+        let units = units_in(&drop, &mods, mx(""), "drop", 0);
+        assert_eq!(units.len(), 1, "one honest row beats a split that drops content");
+        assert_eq!(units[0].verdict.kind, ContentKind::ModsTree);
+    }
+
+    /// A readme is not what stops a split. Every other placement in the installer drops these
+    /// (`install::is_junk`), and a pack that ships one beside its bikes — most of them do — is
+    /// the ordinary case, not the ambiguous one.
+    #[test]
+    fn a_readme_beside_the_bikes_does_not_stop_the_split() {
+        let root = tmp("packreadme");
+        let mods = root.join("mods");
+        let drop = root.join("drop");
+        fs::create_dir_all(drop.join("mods/tyres")).unwrap();
+        write_oem_pack(&drop, &["MX1OEM_2023_KTM_450", "MX2OEM_2023_KTM_250"]);
+        write(&drop.join("mods/bikes/README.txt"), "install me");
+
+        let units = units_in(&drop, &mods, mx(""), "drop", 0);
+        assert_eq!(units.len(), 3);
+    }
+
+    #[test]
+    fn a_tree_with_a_folder_outside_the_categories_stays_one_row() {
+        let root = tmp("packstray");
+        let mods = root.join("mods");
+        let drop = root.join("drop");
+        fs::create_dir_all(drop.join("mods/tyres")).unwrap();
+        write_oem_pack(&drop, &["MX1OEM_2023_KTM_450", "MX2OEM_2023_KTM_250"]);
+        write(&drop.join("mods/documentation/changelog.txt"), "v1");
+
+        let units = units_in(&drop, &mods, mx(""), "drop", 0);
+        assert_eq!(units.len(), 1);
+        assert_eq!(units[0].verdict.kind, ContentKind::ModsTree);
+    }
+
+    #[test]
+    fn a_tree_past_the_cap_stays_one_row() {
+        let root = tmp("packcap");
+        let mods = root.join("mods");
+        let drop = root.join("drop");
+        fs::create_dir_all(drop.join("mods/bikes")).unwrap();
+        for i in 0..=MAX_SPLIT_UNITS {
+            let stem = format!("Bike{i:04}");
+            write_bike_pkz(&drop.join(format!("mods/bikes/{stem}.pkz")), &stem, &stem, "MX1");
+        }
+
+        let units = units_in(&drop, &mods, mx(""), "drop", 0);
+        assert_eq!(units.len(), 1, "hundreds of checkboxes is worse than one row");
+        assert_eq!(units[0].verdict.kind, ContentKind::ModsTree);
     }
 
     /// A dropped preset is staged as `<slug>/<slug>.ini`, which is exactly the shape

--- a/src-tauri/src/install.rs
+++ b/src-tauri/src/install.rs
@@ -126,7 +126,7 @@ pub async fn add_to_library(
     host: &str,
     subpath: &str,
     dest_folder: &str,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Placed> {
     let client = build_download_client()?;
 
     // MEGA is end-to-end encrypted — no direct URL; use the fetch-and-decrypt path.
@@ -156,7 +156,7 @@ pub async fn download_and_place(
     direct_url: &str,
     subpath: &str,
     dest_folder: &str,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Placed> {
     let work = staging_dir("dl");
     std::fs::create_dir_all(&work)?;
 
@@ -169,7 +169,7 @@ pub async fn download_and_place(
             return Err(e);
         }
     };
-    extract_and_place_blocking(app, cfg, slug, archive, work, subpath, dest_folder).await
+    extract_and_place_blocking(app, cfg, slug, archive, work, subpath, dest_folder, Packs::Offer).await
 }
 
 /// [`extract_and_place`] on a blocking thread.
@@ -177,6 +177,7 @@ pub async fn download_and_place(
 /// Unpacking a track is minutes of synchronous disk work, and inline on an `async` command it
 /// pins a runtime worker for all of it. The shop and import commands already spawn it; the
 /// site download was the one that didn't.
+#[allow(clippy::too_many_arguments)]
 async fn extract_and_place_blocking(
     app: &AppHandle,
     cfg: &AppConfig,
@@ -185,21 +186,56 @@ async fn extract_and_place_blocking(
     work: PathBuf,
     subpath: &str,
     dest_folder: &str,
-) -> anyhow::Result<()> {
+    packs: Packs,
+) -> anyhow::Result<Placed> {
     let app = app.clone();
     let cfg = cfg.clone();
     let slug = slug.to_string();
     let subpath = subpath.to_string();
     let dest_folder = dest_folder.to_string();
     tauri::async_runtime::spawn_blocking(move || {
-        extract_and_place(&app, &cfg, &slug, &archive, &work, &subpath, &dest_folder)
+        extract_and_place(&app, &cfg, &slug, &archive, &work, &subpath, &dest_folder, packs)
     })
     .await
     .map_err(|e| anyhow::anyhow!("install task failed: {e}"))?
 }
 
+/// Whether a download that turns out to hold several mods should be offered for review.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Packs {
+    /// Offer it, and let the user pick which of them to install.
+    Offer,
+    /// Place it whole. The shop takes this: a purchase is one product rather than a
+    /// community pack of fifty, and that path deletes its own staging directory the moment
+    /// this call returns — which a review, still pointing into it, would need kept.
+    PlaceWhole,
+}
+
+/// What an install did once the archive was open.
+#[derive(Debug, Clone)]
+pub(crate) enum Placed {
+    /// Installed, the ordinary outcome.
+    Done,
+    /// The archive turned out to hold several mods, and the user is being asked which of
+    /// them they want. Nothing has been written; the plan owns the staging directory from
+    /// here and frees it on commit or cancel.
+    Review { plan: crate::dropzone::DropPlan },
+}
+
+impl Placed {
+    /// The plan the caller has to put up for review, if any. `None` is an ordinary install
+    /// that is already finished.
+    pub(crate) fn review(self) -> Option<crate::dropzone::DropPlan> {
+        match self {
+            Placed::Done => None,
+            Placed::Review { plan } => Some(plan),
+        }
+    }
+}
+
 /// Extract a downloaded archive and place it. `pub(crate)` for the shop, whose bytes come
 /// through a WebView rather than `reqwest` but which finishes exactly the same way.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn extract_and_place(
     app: &AppHandle,
     cfg: &AppConfig,
@@ -208,11 +244,32 @@ pub(crate) fn extract_and_place(
     work: &Path,
     subpath: &str,
     dest_folder: &str,
-) -> anyhow::Result<()> {
+    packs: Packs,
+) -> anyhow::Result<Placed> {
     emit(app, slug, "extracting", None, None);
     let extracted = work.join("extracted");
     std::fs::create_dir_all(&extracted)?;
     extract_archive(archive, &extracted)?;
+
+    // A pack is several mods in one download, and only now — with the archive open — can it
+    // be seen to be one. Hand it to the review sheet rather than placing 3.8 GB of bikes the
+    // user was never shown. An ordinary single-mod download answers `None` and carries on.
+    if packs == Packs::Offer && !crate::reshade::is_reshade_subpath(subpath) {
+        let name = archive
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| slug.to_string());
+        match crate::dropzone::plan_extracted(&cfg.mods_path, &extracted, work.to_path_buf(), &name)
+        {
+            Ok(Some(plan)) => {
+                emit(app, slug, "review", None, None);
+                return Ok(Placed::Review { plan });
+            }
+            Ok(None) => {}
+            // Never fail an install over the offer to split it — place it whole instead.
+            Err(e) => log::warn!("could not offer {slug} as a pack: {e:#}"),
+        }
+    }
 
     emit(app, slug, "placing", None, None);
 
@@ -222,7 +279,7 @@ pub(crate) fn extract_and_place(
         crate::reshade::install_extracted(&extracted, &cfg.reshade_dir())?;
         let _ = std::fs::remove_dir_all(work);
         emit(app, slug, "done", None, None);
-        return Ok(());
+        return Ok(Placed::Done);
     }
 
     let mods_dir = crate::library::mods_subdir(&cfg.mods_path, "mods");
@@ -257,7 +314,7 @@ pub(crate) fn extract_and_place(
     emit(app, slug, "done", None, None);
 
     notify_frostmod(app, slug);
-    Ok(())
+    Ok(Placed::Done)
 }
 
 async fn download_mega_and_place(
@@ -268,7 +325,7 @@ async fn download_mega_and_place(
     url: &str,
     subpath: &str,
     dest_folder: &str,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Placed> {
     let work = staging_dir("dl");
     std::fs::create_dir_all(&work)?;
 
@@ -279,7 +336,7 @@ async fn download_mega_and_place(
             return Err(e);
         }
     };
-    extract_and_place_blocking(app, cfg, slug, archive, work, subpath, dest_folder).await
+    extract_and_place_blocking(app, cfg, slug, archive, work, subpath, dest_folder, Packs::Offer).await
 }
 
 pub(crate) async fn download_mega(
@@ -1992,6 +2049,16 @@ fn walk_plain(
     wrap_loose: bool,
     out: &mut Vec<(PathBuf, PathBuf)>,
 ) {
+    // A single file is a unit in its own right. Every other caller hands this a directory —
+    // a staged archive, a dropped folder — but the dropzone splits a pack into the mods it
+    // holds (`dropzone::split_tree`), and one of those is a lone `.pkz` sitting among its
+    // fifty siblings. There is no folder to point at, and copying it into one to make a
+    // directory would mean 3.8 GB of staging for a pack this size.
+    if base.is_file() {
+        let name = base.file_name().unwrap_or_default();
+        out.push((base.to_path_buf(), type_dir.join(name)));
+        return;
+    }
     let Ok(rd) = std::fs::read_dir(base) else {
         return;
     };
@@ -3099,6 +3166,28 @@ mod tests {
         place_mod(&ex, &mods, "tracks", "", "slug").unwrap();
         assert!(mods.join("bikes/KTM.pkz").exists());
         assert!(mods.join("tracks/T.pkz").exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A lone file is a placement in its own right — what the dropzone hands over when it
+    /// splits a pack into the mods inside it and one of those is a single `.pkz` among
+    /// fifty siblings. Its neighbours must not come with it.
+    #[test]
+    fn places_a_single_file_without_its_siblings() {
+        let root = place_tmp("onefile");
+        let ex = root.join("ex");
+        touch(&ex.join("MX1OEM_KTM.pkz"));
+        touch(&ex.join("MX2OEM_KTM.pkz"));
+        let mods = root.join("mods");
+
+        let wrote = place_mod(&ex.join("MX1OEM_KTM.pkz"), &mods, "bikes", "", "slug").unwrap();
+
+        assert_eq!(wrote, 1);
+        assert!(mods.join("bikes/MX1OEM_KTM.pkz").exists());
+        assert!(
+            !mods.join("bikes/MX2OEM_KTM.pkz").exists(),
+            "the sibling was not asked for"
+        );
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4456,6 +4456,14 @@ fn read_paint_file(dir: &std::path::Path, paint: &str) -> Option<Vec<u8>> {
     std::fs::read(first).ok()
 }
 
+/// Download a mod and install it.
+///
+/// Answers `null` for the ordinary case — one mod, downloaded and placed. A download that
+/// turns out to be a *pack* (several mods in one self-describing tree, like the OEM bike
+/// pack's 54 bikes and its tyre set) answers with a plan instead, and nothing has been
+/// written yet: the caller puts it up for review and commits it through `commit_drop`,
+/// exactly as it would a dropped file. Until then the plan owns the staged bytes, and
+/// `cancel_drop` is what frees them.
 #[tauri::command]
 async fn add_to_library(
     app: tauri::AppHandle,
@@ -4464,11 +4472,12 @@ async fn add_to_library(
     host: String,
     subpath: String,
     dest_folder: String,
-) -> Result<(), String> {
+) -> Result<Option<dropzone::DropPlan>, String> {
     let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
     let _cancel = cancel::begin(&slug);
     install::add_to_library(&app, &cfg, &slug, &url, &host, &subpath, &dest_folder)
         .await
+        .map(install::Placed::review)
         .map_err(|e| format!("{e:#}"))
 }
 
@@ -6587,8 +6596,17 @@ async fn shop_install(
         let cfg = cfg.clone();
         let slug = item.slug.clone();
         let work = work.clone();
-        move || install::extract_and_place(&app, &cfg, &slug, &archive, &work, &subpath, &dest_folder)
-            .map(|()| dest_folder)
+        move || install::extract_and_place(
+            &app,
+            &cfg,
+            &slug,
+            &archive,
+            &work,
+            &subpath,
+            &dest_folder,
+            install::Packs::PlaceWhole,
+        )
+        .map(|_| dest_folder)
     })
     .await
     .map_err(|e| format!("shop_install task failed: {e}"))?;

--- a/src/Components/Dashboard/Dashboard.tsx
+++ b/src/Components/Dashboard/Dashboard.tsx
@@ -153,10 +153,12 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
     <TourContext.Provider value={{ startTour }}>
     {/* Outside the installers: both of them write to the history, and the sidebar reads it. */}
     <DownloadsProvider>
+    {/* Above the installer, not below it: a *download* stages a plan too now — a pack like
+        the OEM bikes arrives as fifty-five mods in one archive — so `InstallProvider` has to
+        be able to hand one over. It wraps the views for the same reason it always did: a drop
+        anywhere in the window and the Shop's purchases grid both finish in this one sheet. */}
+    <DropReviewProvider onInstalled={onInstalled}>
     <InstallProvider onInstalled={onInstalled} onOpenMod={openModTarget}>
-      {/* Wraps the views because two of them stage plans: a drop anywhere in the window, and
-          the Shop's purchases grid. Both finish in the one review sheet this renders. */}
-      <DropReviewProvider onInstalled={onInstalled}>
       {/* Mounted here rather than in `App` so a drop only works once the app is set up —
           there is nowhere to install to before the MX Bikes folder is known. The overlay
           window renders its own tree and deliberately gets no drop target. */}
@@ -237,8 +239,8 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
           onOpenSettings={openSettingsSection}
         />
       )}
-      </DropReviewProvider>
-    </InstallProvider>
+      </InstallProvider>
+    </DropReviewProvider>
     </DownloadsProvider>
     </TourContext.Provider>
   );

--- a/src/Components/Dropzone/DropReview.tsx
+++ b/src/Components/Dropzone/DropReview.tsx
@@ -5,6 +5,7 @@ import {
   Boxes,
   Check,
   ChevronsUpDown,
+  CircleDot,
   FileQuestion,
   Layers,
   Loader2,
@@ -56,6 +57,7 @@ const KIND_LABEL: Record<DropKind, TKey> = {
   bikePaint: "drop.kind.bikePaint",
   soundSet: "drop.kind.soundSet",
   riderGear: "drop.kind.riderGear",
+  tyres: "drop.kind.tyres",
   reshadePreset: "drop.kind.reshadePreset",
   unknown: "drop.kind.unknown",
 };
@@ -73,6 +75,7 @@ const REASON_LABEL: Record<DropReason, TKey> = {
   riderTexture: "drop.reason.riderTexture",
   gearTexture: "drop.reason.gearTexture",
   reshadePreset: "drop.reason.reshadePreset",
+  packLayout: "drop.reason.packLayout",
   unrecognised: "drop.reason.unrecognised",
 };
 
@@ -83,6 +86,7 @@ const KIND_ICON: Record<DropKind, typeof BikeIcon> = {
   bikePaint: Palette,
   soundSet: Volume2,
   riderGear: Shirt,
+  tyres: CircleDot,
   reshadePreset: Sparkles,
   unknown: FileQuestion,
 };
@@ -328,6 +332,7 @@ export default function DropReview({
   rows,
   installing,
   onToggle,
+  onToggleAll,
   onPick,
   onCancel,
   onInstall,
@@ -336,6 +341,7 @@ export default function DropReview({
   rows: RowState[];
   installing: boolean;
   onToggle: (id: string) => void;
+  onToggleAll: (keep: boolean) => void;
   onPick: (id: string, value: string) => void;
   onCancel: () => void;
   onInstall: () => void;
@@ -354,6 +360,7 @@ export default function DropReview({
     () => ready.reduce((n, r) => n + r.collisions.length, 0),
     [ready],
   );
+  const allKept = useMemo(() => rows.every((r) => r.keep), [rows]);
 
   return (
     <Dialog open>
@@ -375,6 +382,20 @@ export default function DropReview({
               {t("drop.reviewHint")}
             </p>
           </div>
+          {/* A split pack runs to dozens of rows, and picking four of fifty-five is a lot of
+              clicking from a sheet that starts with everything checked. Hidden on the short
+              lists, where it would only be one more thing to read. */}
+          {rows.length > 3 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="flex-none text-[11.5px]"
+              disabled={installing}
+              onClick={() => onToggleAll(!allKept)}
+            >
+              {allKept ? t("drop.selectNone") : t("drop.selectAll")}
+            </Button>
+          )}
         </div>
 
         <div className="min-h-0 flex-1 space-y-2 overflow-y-auto px-5 py-4">

--- a/src/Components/ModDetail/ModDetail.tsx
+++ b/src/Components/ModDetail/ModDetail.tsx
@@ -84,6 +84,9 @@ function stageIndex(stage: InstallStage): number {
       return 2;
     case "placing":
       return 3;
+    // The bytes are down and classified; what is left is the user's decision, not ours.
+    case "review":
+      return 3;
     case "done":
       return 4;
     default:
@@ -589,9 +592,11 @@ function InstallProgress({
         ? t("update.downloading")
         : stage === "extracting"
           ? t("modDetail.extracting")
-          : stage === "placing"
-            ? t("modDetail.addingToLibrary")
-            : t("modDetail.resolving");
+          : stage === "review"
+            ? t("modDetail.chooseWhatToInstall")
+            : stage === "placing"
+              ? t("modDetail.addingToLibrary")
+              : t("modDetail.resolving");
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-baseline justify-between">

--- a/src/Components/Shell/DownloadQueue.tsx
+++ b/src/Components/Shell/DownloadQueue.tsx
@@ -18,12 +18,15 @@ import { displayName, formatBytes } from "../../lib/mods";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import { cn } from "@/lib/utils";
 
-/** Stages that mean an install is still moving — anything else is done, failed, or idle. */
+/** Stages that mean an install is still moving — anything else is done, failed, or idle.
+ *  `review` counts: the bytes are down but nothing is installed, and dropping the card would
+ *  leave a staged pack with nothing on screen pointing at it. */
 const IN_PROGRESS = new Set<InstallStage>([
   "resolving",
   "downloading",
   "extracting",
   "placing",
+  "review",
 ]);
 
 /** Only the transfer can be stopped. Once the bytes are down, extraction and placement are
@@ -44,6 +47,7 @@ const STAGE_LABEL: Record<string, TKey> = {
   downloading: "downloads.stageDownloading",
   extracting: "downloads.stageExtracting",
   placing: "downloads.stagePlacing",
+  review: "downloads.stageReview",
 };
 
 export default function DownloadQueue({ collapsed }: { collapsed: boolean }) {

--- a/src/Context/DropReview.tsx
+++ b/src/Context/DropReview.tsx
@@ -27,7 +27,8 @@ import DropReview, { type RowState } from "../Components/Dropzone/DropReview";
  * warnings, the same destination override and the same commit. Hoisting the state was the
  * alternative to a second, parallel install path that would drift.
  *
- * One plan at a time: each holds a staging directory, so staging a second releases the first.
+ * One sheet at a time. A plan that arrives while another is up waits its turn rather than
+ * replacing it: each one holds a staging directory, and a download's plan can be gigabytes.
  */
 interface DropReviewContextValue {
   /**
@@ -63,25 +64,19 @@ export function DropReviewProvider({
   const planRef = useRef<DropPlan | null>(null);
   planRef.current = plan;
 
-  const reset = useCallback(() => {
-    setPlan(null);
-    setRows([]);
+  /**
+   * Plans that arrived while a sheet was already up, shown in turn.
+   *
+   * The sheet has always handled one plan at a time, and used to make room by releasing the
+   * previous one's staging. That was fair enough while every plan came from a gesture the
+   * user had just made — a drop, a purchase — but a *download* produces one now, from a
+   * background queue running two at a time, and throwing that away discards a transfer that
+   * may have been gigabytes. The OEM bike pack is 3.8 GB. So they wait their turn instead.
+   */
+  const waitingRef = useRef<DropPlan[]>([]);
+
+  const show = useCallback((next: DropPlan) => {
     setInstalling(false);
-  }, []);
-
-  const discard = useCallback(() => {
-    const current = planRef.current;
-    if (current) void cancelDrop(current.id).catch(() => {});
-    reset();
-  }, [reset]);
-
-  const reviewPlan = useCallback<DropReviewContextValue["reviewPlan"]>((next) => {
-    // Only one plan may be staged at a time — drop the previous one's temp files.
-    const previous = planRef.current;
-    if (previous && previous.id !== next.id) {
-      void cancelDrop(previous.id).catch(() => {});
-    }
-
     if (next.items.length === 0) {
       setPlan(null);
       setRows([]);
@@ -117,10 +112,46 @@ export function DropReviewProvider({
     );
   }, []);
 
+  /** Close the current sheet and open whatever was waiting behind it. */
+  const reset = useCallback(() => {
+    const next = waitingRef.current.shift();
+    if (next) {
+      show(next);
+      return;
+    }
+    setPlan(null);
+    setRows([]);
+    setInstalling(false);
+  }, [show]);
+
+  const discard = useCallback(() => {
+    const current = planRef.current;
+    if (current) void cancelDrop(current.id).catch(() => {});
+    reset();
+  }, [reset]);
+
+  const reviewPlan = useCallback<DropReviewContextValue["reviewPlan"]>(
+    (next) => {
+      const current = planRef.current;
+      if (current && current.id !== next.id) {
+        waitingRef.current.push(next);
+        return;
+      }
+      show(next);
+    },
+    [show],
+  );
+
   const toggle = useCallback((id: string) => {
     setRows((rs) =>
       rs.map((r) => (r.item.id === id ? { ...r, keep: !r.keep } : r)),
     );
+  }, []);
+
+  /** Check or uncheck every row at once. A split pack is 55 rows — the OEM bike pack is
+   *  exactly that — and "I want four of these" is thirty-one clicks without it. */
+  const toggleAll = useCallback((keep: boolean) => {
+    setRows((rs) => rs.map((r) => ({ ...r, keep })));
   }, []);
 
   /** Picking a destination re-costs the row on the backend — file count and collisions
@@ -269,6 +300,7 @@ export function DropReviewProvider({
           rows={rows}
           installing={installing}
           onToggle={toggle}
+          onToggleAll={toggleAll}
           onPick={pick}
           onCancel={discard}
           onInstall={() => void install()}

--- a/src/Context/Install.tsx
+++ b/src/Context/Install.tsx
@@ -21,6 +21,7 @@ import {
 } from "../api/mods";
 import type { DownloadSource, InstallStage, ReloadOutcome } from "../types";
 import { useDownloads } from "./Downloads";
+import { useDropReview } from "./DropReview";
 import { useT } from "../i18n/context";
 
 /** Where the bytes come from — a resolvable host, a file the user picked, or a shop purchase
@@ -198,6 +199,11 @@ export function InstallProvider({
   tRef.current = t;
   // Same reason: the history is written from inside `run`, which must not be rebuilt.
   const { note } = useDownloads();
+  // A download that turns out to be a pack is handed over rather than installed. Held in a
+  // ref for the same reason as the rest: `run` keeps its empty dep list.
+  const { reviewPlan } = useDropReview();
+  const reviewRef = useRef(reviewPlan);
+  reviewRef.current = reviewPlan;
   const noteRef = useRef(note);
   noteRef.current = note;
   const clearTimers = useRef<Map<string, number>>(new Map());
@@ -303,7 +309,16 @@ export function InstallProvider({
 
     try {
       if (source.kind === "download") {
-        await addToLibrary(slug, source.url, source.host, subpath, destFolder);
+        const pack = await addToLibrary(slug, source.url, source.host, subpath, destFolder);
+        if (pack) {
+          // Not one mod but several — a pack, and nothing has been written. The review sheet
+          // owns the staged bytes from here, and records its own history rows when the user
+          // commits, so this run is finished: the lane frees and the queue moves on. The card
+          // stays up saying what is waiting, because the sheet may be behind another one.
+          patch(key, (cur) => ({ ...cur, stage: "review" }));
+          reviewRef.current(pack);
+          return;
+        }
       } else if (source.kind === "shop") {
         await shopInstall(source.item, subpath, destFolder);
       } else {

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -998,15 +998,28 @@ export function setLaunchAtStartup(enabled: boolean): Promise<void> {
   return invoke<void>("set_launch_at_startup", { enabled });
 }
 
-/** Kick off download → extract → place. Progress arrives via `onInstallProgress`. */
+/**
+ * Kick off download → extract → place. Progress arrives via `onInstallProgress`.
+ *
+ * Resolves to `null` when the mod is installed — the ordinary case. A download that turns
+ * out to hold *several* mods (the OEM bike pack is 54 bikes and a tyre set in one archive)
+ * resolves to a plan instead, with nothing yet written: put it up for review and finish it
+ * through `commitDrop`, or free the staged bytes with `cancelDrop`.
+ */
 export function addToLibrary(
   slug: string,
   url: string,
   host: string,
   subpath: string,
   destFolder: string,
-): Promise<void> {
-  return invoke<void>("add_to_library", { slug, url, host, subpath, destFolder });
+): Promise<DropPlan | null> {
+  return invoke<DropPlan | null>("add_to_library", {
+    slug,
+    url,
+    host,
+    subpath,
+    destFolder,
+  });
 }
 
 /** Stop the install in flight for `slug`. `false` when nothing is running under it — only the

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -641,6 +641,7 @@ export const de: Translation = {
   "modDetail.addedToLibrary": "Zu deiner Bibliothek hinzugefügt",
   "modDetail.extracting": "Wird entpackt…",
   "modDetail.addingToLibrary": "Wird zur Bibliothek hinzugefügt…",
+  "modDetail.chooseWhatToInstall": "Wähle aus, was installiert wird",
   "modDetail.resolving": "Download wird aufgelöst…",
   "modDetail.finishInBrowser": "Im Browser abschließen",
   "modDetail.viewOnSite": "Auf {{site}} ansehen",
@@ -1242,6 +1243,7 @@ export const de: Translation = {
   "downloads.stageDownloading": "Wird heruntergeladen",
   "downloads.stageExtracting": "Wird entpackt",
   "downloads.stagePlacing": "Wird installiert",
+  "downloads.stageReview": "Wartet auf dich",
 
   // ── Downloads (Verlauf) ────────────────────────────────────────────────────
   "downloads.help":
@@ -1614,6 +1616,8 @@ export const de: Translation = {
   "drop.scanning": "Wird geprüft …",
   "drop.found_one": "{{count}} Element gefunden",
   "drop.found_other": "{{count}} Elemente gefunden",
+  "drop.selectAll": "Alle auswählen",
+  "drop.selectNone": "Keine auswählen",
   "drop.reviewHint": "Prüf die Ziele und installiere dann.",
   "drop.install_one": "{{count}} installieren",
   "drop.install_other": "{{count}} installieren",
@@ -1648,6 +1652,7 @@ export const de: Translation = {
   "drop.kind.bikePaint": "Lackierung",
   "drop.kind.soundSet": "Sound",
   "drop.kind.riderGear": "Fahrer-Ausrüstung",
+  "drop.kind.tyres": "Reifen",
   "drop.kind.reshadePreset": "ReShade-Preset",
   "drop.kind.unknown": "Unbekannt",
   "drop.reason.modsTree": "Enthält einen kompletten Mods-Ordner",
@@ -1662,6 +1667,7 @@ export const de: Translation = {
   "drop.reason.riderTexture": "Bemalt den Fahrerkörper — ein Outfit",
   "drop.reason.gearTexture": "Bemalt ein Teil der Fahrer-Ausrüstung",
   "drop.reason.reshadePreset": "Listet ReShade-Techniken auf",
+  "drop.reason.packLayout": "Vom Paket hier einsortiert",
   "drop.reason.unrecognised": "Nicht erkannt — du musst es zuordnen",
 
   // ── Import (derselbe Ablauf wie Ablegen, nur per Auswahl) ──────────────────

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -627,6 +627,7 @@ export const en = {
   "modDetail.addedToLibrary": "Added to your library",
   "modDetail.extracting": "Extracting…",
   "modDetail.addingToLibrary": "Adding to library…",
+  "modDetail.chooseWhatToInstall": "Choose what to install",
   "modDetail.resolving": "Resolving download…",
   "modDetail.finishInBrowser": "Finish in your browser",
   "modDetail.viewOnSite": "View on {{site}}",
@@ -1204,6 +1205,7 @@ export const en = {
   "downloads.stageDownloading": "Downloading",
   "downloads.stageExtracting": "Extracting",
   "downloads.stagePlacing": "Installing",
+  "downloads.stageReview": "Waiting for you",
 
   // ── Downloads (history) ────────────────────────────────────────────────────
   "downloads.help":
@@ -1575,6 +1577,8 @@ export const en = {
   "drop.scanning": "Working out what this is…",
   "drop.found_one": "Found {{count}} item",
   "drop.found_other": "Found {{count}} items",
+  "drop.selectAll": "Select all",
+  "drop.selectNone": "Select none",
   "drop.reviewHint": "Check the destinations, then install.",
   "drop.install_one": "Install {{count}}",
   "drop.install_other": "Install {{count}}",
@@ -1609,6 +1613,7 @@ export const en = {
   "drop.kind.bikePaint": "Paint",
   "drop.kind.soundSet": "Sound",
   "drop.kind.riderGear": "Rider gear",
+  "drop.kind.tyres": "Tyres",
   "drop.kind.reshadePreset": "ReShade preset",
   "drop.kind.unknown": "Unknown",
   "drop.reason.modsTree": "Contains a full mods folder",
@@ -1623,6 +1628,7 @@ export const en = {
   "drop.reason.riderTexture": "Paints the rider body — an outfit",
   "drop.reason.gearTexture": "Paints a piece of rider gear",
   "drop.reason.reshadePreset": "Lists ReShade techniques",
+  "drop.reason.packLayout": "Filed here by the pack it came in",
   "drop.reason.unrecognised": "Not recognised — you'll need to place it",
 
   // ── Import (the same install flow, reached by picking instead of dropping) ──

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -633,6 +633,7 @@ export const es: Translation = {
   "modDetail.addedToLibrary": "Añadido a tu biblioteca",
   "modDetail.extracting": "Extrayendo…",
   "modDetail.addingToLibrary": "Añadiendo a la biblioteca…",
+  "modDetail.chooseWhatToInstall": "Elige qué instalar",
   "modDetail.resolving": "Resolviendo la descarga…",
   "modDetail.finishInBrowser": "Termina en tu navegador",
   "modDetail.viewOnSite": "Ver en {{site}}",
@@ -1230,6 +1231,7 @@ export const es: Translation = {
   "downloads.stageDownloading": "Descargando",
   "downloads.stageExtracting": "Extrayendo",
   "downloads.stagePlacing": "Instalando",
+  "downloads.stageReview": "Esperándote",
 
   // ── Descargas (historial) ──────────────────────────────────────────────────
   "downloads.help":
@@ -1601,6 +1603,8 @@ export const es: Translation = {
   "drop.scanning": "Viendo qué es esto…",
   "drop.found_one": "{{count}} elemento encontrado",
   "drop.found_other": "{{count}} elementos encontrados",
+  "drop.selectAll": "Seleccionar todo",
+  "drop.selectNone": "No seleccionar nada",
   "drop.reviewHint": "Revisa los destinos y luego instala.",
   "drop.install_one": "Instalar {{count}}",
   "drop.install_other": "Instalar {{count}}",
@@ -1635,6 +1639,7 @@ export const es: Translation = {
   "drop.kind.bikePaint": "Gráficos",
   "drop.kind.soundSet": "Sonido",
   "drop.kind.riderGear": "Equipación",
+  "drop.kind.tyres": "Neumáticos",
   "drop.kind.reshadePreset": "Ajuste de ReShade",
   "drop.kind.unknown": "Desconocido",
   "drop.reason.modsTree": "Contiene una carpeta mods completa",
@@ -1649,6 +1654,7 @@ export const es: Translation = {
   "drop.reason.riderTexture": "Pinta el cuerpo del piloto — una equipación",
   "drop.reason.gearTexture": "Pinta una pieza de equipación",
   "drop.reason.reshadePreset": "Enumera técnicas de ReShade",
+  "drop.reason.packLayout": "El paquete lo coloca aquí",
   "drop.reason.unrecognised": "No reconocido — tendrás que colocarlo tú",
 
   // ── Import (el mismo flujo que soltar, pero eligiendo) ─────────────────────

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -637,6 +637,7 @@ export const fr: Translation = {
   "modDetail.addedToLibrary": "Ajouté à votre bibliothèque",
   "modDetail.extracting": "Extraction…",
   "modDetail.addingToLibrary": "Ajout à la bibliothèque…",
+  "modDetail.chooseWhatToInstall": "Choisissez quoi installer",
   "modDetail.resolving": "Résolution du téléchargement…",
   "modDetail.finishInBrowser": "Terminez dans votre navigateur",
   "modDetail.viewOnSite": "Voir sur {{site}}",
@@ -1233,6 +1234,7 @@ export const fr: Translation = {
   "downloads.stageDownloading": "Téléchargement",
   "downloads.stageExtracting": "Extraction",
   "downloads.stagePlacing": "Installation",
+  "downloads.stageReview": "En attente de vous",
 
   // ── Téléchargements (historique) ───────────────────────────────────────────
   "downloads.help":
@@ -1605,6 +1607,8 @@ export const fr: Translation = {
   "drop.scanning": "Analyse en cours…",
   "drop.found_one": "{{count}} élément trouvé",
   "drop.found_other": "{{count}} éléments trouvés",
+  "drop.selectAll": "Tout sélectionner",
+  "drop.selectNone": "Tout désélectionner",
   "drop.reviewHint": "Vérifiez les destinations, puis installez.",
   "drop.install_one": "Installer {{count}}",
   "drop.install_other": "Installer {{count}}",
@@ -1639,6 +1643,7 @@ export const fr: Translation = {
   "drop.kind.bikePaint": "Déco",
   "drop.kind.soundSet": "Son",
   "drop.kind.riderGear": "Équipement",
+  "drop.kind.tyres": "Pneus",
   "drop.kind.reshadePreset": "Préréglage ReShade",
   "drop.kind.unknown": "Inconnu",
   "drop.reason.modsTree": "Contient un dossier mods complet",
@@ -1653,6 +1658,7 @@ export const fr: Translation = {
   "drop.reason.riderTexture": "Peint le corps du pilote — une tenue",
   "drop.reason.gearTexture": "Peint un élément d'équipement",
   "drop.reason.reshadePreset": "Liste des techniques ReShade",
+  "drop.reason.packLayout": "Rangé ici par le pack",
   "drop.reason.unrecognised": "Non reconnu — à vous de le placer",
 
   // ── Import (le même flux que le dépôt, en le sélectionnant) ────────────────

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -632,6 +632,7 @@ export const it: Translation = {
   "modDetail.addedToLibrary": "Aggiunta alla tua libreria",
   "modDetail.extracting": "Estrazione…",
   "modDetail.addingToLibrary": "Aggiunta alla libreria…",
+  "modDetail.chooseWhatToInstall": "Scegli cosa installare",
   "modDetail.resolving": "Risoluzione del download…",
   "modDetail.finishInBrowser": "Completa nel browser",
   "modDetail.viewOnSite": "Apri su {{site}}",
@@ -1225,6 +1226,7 @@ export const it: Translation = {
   "downloads.stageDownloading": "Download in corso",
   "downloads.stageExtracting": "Estrazione",
   "downloads.stagePlacing": "Installazione",
+  "downloads.stageReview": "In attesa di te",
 
   // ── Download (cronologia) ──────────────────────────────────────────────────
   "downloads.help":
@@ -1596,6 +1598,8 @@ export const it: Translation = {
   "drop.scanning": "Sto capendo di cosa si tratta…",
   "drop.found_one": "Trovato {{count}} elemento",
   "drop.found_other": "Trovati {{count}} elementi",
+  "drop.selectAll": "Seleziona tutto",
+  "drop.selectNone": "Deseleziona tutto",
   "drop.reviewHint": "Controlla le destinazioni, poi installa.",
   "drop.install_one": "Installa {{count}}",
   "drop.install_other": "Installa {{count}}",
@@ -1630,6 +1634,7 @@ export const it: Translation = {
   "drop.kind.bikePaint": "Grafica",
   "drop.kind.soundSet": "Suono",
   "drop.kind.riderGear": "Attrezzatura",
+  "drop.kind.tyres": "Pneumatici",
   "drop.kind.reshadePreset": "Preset ReShade",
   "drop.kind.unknown": "Sconosciuto",
   "drop.reason.modsTree": "Contiene una cartella mods completa",
@@ -1644,6 +1649,7 @@ export const it: Translation = {
   "drop.reason.riderTexture": "Colora il corpo del pilota — una tuta",
   "drop.reason.gearTexture": "Colora un pezzo di attrezzatura",
   "drop.reason.reshadePreset": "Elenca tecniche ReShade",
+  "drop.reason.packLayout": "Collocato qui dal pacchetto",
   "drop.reason.unrecognised": "Non riconosciuto — dovrai collocarlo tu",
 
   // ── Import (lo stesso flusso del rilascio, ma scegliendo) ──────────────────

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -635,6 +635,7 @@ export const ptBR: Translation = {
   "modDetail.addedToLibrary": "Adicionado à sua biblioteca",
   "modDetail.extracting": "Extraindo…",
   "modDetail.addingToLibrary": "Adicionando à biblioteca…",
+  "modDetail.chooseWhatToInstall": "Escolha o que instalar",
   "modDetail.resolving": "Resolvendo o download…",
   "modDetail.finishInBrowser": "Conclua no seu navegador",
   "modDetail.viewOnSite": "Ver em {{site}}",
@@ -1223,6 +1224,7 @@ export const ptBR: Translation = {
   "downloads.stageDownloading": "Baixando",
   "downloads.stageExtracting": "Extraindo",
   "downloads.stagePlacing": "Instalando",
+  "downloads.stageReview": "Aguardando você",
 
   // ── Downloads (histórico) ──────────────────────────────────────────────────
   "downloads.help":
@@ -1594,6 +1596,8 @@ export const ptBR: Translation = {
   "drop.scanning": "Descobrindo o que é isso…",
   "drop.found_one": "{{count}} item encontrado",
   "drop.found_other": "{{count}} itens encontrados",
+  "drop.selectAll": "Selecionar tudo",
+  "drop.selectNone": "Não selecionar nada",
   "drop.reviewHint": "Confira os destinos e depois instale.",
   "drop.install_one": "Instalar {{count}}",
   "drop.install_other": "Instalar {{count}}",
@@ -1628,6 +1632,7 @@ export const ptBR: Translation = {
   "drop.kind.bikePaint": "Pintura",
   "drop.kind.soundSet": "Som",
   "drop.kind.riderGear": "Equipamento",
+  "drop.kind.tyres": "Pneus",
   "drop.kind.reshadePreset": "Preset do ReShade",
   "drop.kind.unknown": "Desconhecido",
   "drop.reason.modsTree": "Contém uma pasta mods completa",
@@ -1642,6 +1647,7 @@ export const ptBR: Translation = {
   "drop.reason.riderTexture": "Pinta o corpo do piloto — um equipamento",
   "drop.reason.gearTexture": "Pinta uma peça de equipamento",
   "drop.reason.reshadePreset": "Lista técnicas do ReShade",
+  "drop.reason.packLayout": "Colocado aqui pelo pacote",
   "drop.reason.unrecognised": "Não reconhecido — você precisa colocá-lo",
 
   // ── Import (o mesmo fluxo de soltar, mas escolhendo) ───────────────────────

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -646,6 +646,9 @@ export type DropKind =
   | "bikePaint"
   | "soundSet"
   | "riderGear"
+  /** A tyre set (`mods/tyres`). Only ever comes out of a split pack — on its own a tyre
+   *  package says too little to be recognised. */
+  | "tyres"
   | "reshadePreset"
   | "unknown";
 
@@ -663,6 +666,8 @@ export type DropReason =
   | "riderTexture"
   | "gearTexture"
   | "reshadePreset"
+  /** The pack it arrived in filed it here. */
+  | "packLayout"
   | "unrecognised";
 
 export interface DropChoice {
@@ -818,6 +823,9 @@ export type InstallStage =
   | "downloading"
   | "extracting"
   | "placing"
+  /** The download held several mods and the user is picking which of them to install.
+   *  Nothing is written yet, and the queue lane has already moved on. */
+  | "review"
   | "done"
   | "error";
 


### PR DESCRIPTION
The OEM bike pack — [MX OEM Bike Pack v0.19.1](https://mxb-mods.com/oem-bike-pack/) — is 54 machines and a tyre set in one 3.8 GB archive. Both entrances treated it as a single thing: the drop review showed one row reading *"Mods folder"*, all-or-nothing with no picker, and a download placed it blind without asking at all.

## What changed

**A pack is listed as the mods it holds.** Every bike by its real name and class (*KTM 450 SX-F 2023 · MX1 OEM*), its size, and a checkbox. Take the four you race and leave the other fifty. **Select all** / **Select none** in the header, because 55 rows is not a list you tick by hand.

**The pack's own tree decides where each piece goes — not the classifier.** This is the load-bearing part. The real `oem_mx.pkz` carries `oem_mx.ini` and `oem_mx.cfg`, so read on its own evidence it *is* a bike; filing it under `mods/bikes` on that basis takes the wheels off all 54. `Verdict::fixed_subpath` carries the tree's answer, `to_item` honours it, and no picker is offered because nothing is left to ask. A test pins exactly that case.

**A pack you download stops and asks.** `extract_and_place` returns `Placed::{Done,Review}` behind a `Packs` switch, and `dropzone::plan_extracted` registers the already-extracted tree rather than re-staging 3.8 GB. Only a tree `split_tree` takes apart becomes a review, so an ordinary single-mod download installs exactly as before, with nothing extra to click.

**It bails rather than guessing.** An unnameable child, a folder outside the categories, a loose non-`.pkz`, one unit or fewer, or past 120 rows — all fall back to today's single row. Empty folders are skipped: the pack ships a `paints/` beside every bike and `walk_merge` never created them either.

Also: `install::walk_plain` accepts a single file as a placement (a split row is one `.pkz` among fifty siblings, with no folder to point at); shop purchases pass `Packs::PlaceWhole` because that path deletes its own staging as soon as the call returns; `DropReviewProvider` moves above `InstallProvider` and now queues a second plan instead of releasing the first.

## A stall this branch didn't introduce but couldn't live with

`bikeswap::read_identity` opened each `.pkz` **twice** to read its name and class — 310 ms a bike, against 14 ms for one `read_selected` that keeps both. `Scans::new` runs that over every installed bike on every drop, so the review sheet took **18.9 s to open** for anyone with the OEM bikes installed, whatever they dropped. **Now 1.2 s.** The split's own 54 classifications cost 1.2 s rather than 19.5 s for the same reason.

## Verified

Against 53 real sealed OEM `.pkz` (21–184 MB) hard-linked into a pack-shaped tree, via the `#[ignore]`d `real_pack_splits` diagnostic — 54 rows, 53 `Bike` + 1 `Tyres`, every bike named from its own `[info]`/`[data]`, bikes to `mods/bikes` and the tyre set to `mods/tyres`.

`cargo test` 960 pass (955 with the sidecar removed, as CI builds it) · `tsc` clean · `eslint` 0 errors · `vite build` clean.

Not checked from here: the sheet itself — macOS won't allow clicking into the Tauri webview.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)