### PR TITLE
chore(supporters): credit Sly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ whichever release turns it on.
   file gets. An ordinary single-mod download is untouched — it installs exactly as before,
   with nothing extra to click.
 
+- **Sly** credited on Settings → Supporters.
+
 ### Fixed
 
 - **A paint that ships a separate file per bike now installs the right one.** Some pages offer

--- a/src/Components/Settings/supporters.ts
+++ b/src/Components/Settings/supporters.ts
@@ -62,6 +62,7 @@ export const BUNDLED_SUPPORTERS: SupportersManifest = {
     { name: "OHTEA - MXB HUB" },
     { name: "HottPie" },
     { name: "Mouk" },
+    { name: "Sly" },
     { name: "SoggySwisher" },
     { name: "LupaHo" },
     { name: "Qwest" },

--- a/supporters.json
+++ b/supporters.json
@@ -6,6 +6,7 @@
     "OHTEA - MXB HUB",
     "HottPie",
     "Mouk",
+    "Sly",
     "SoggySwisher",
     "LupaHo",
     "Qwest",


### PR DESCRIPTION
Adds **Sly** to the supporters list, fourth in the hand-ordered list.

- `supporters.json` — the manifest every installed copy reads off `main`, so the credits page picks it up without waiting on a release.
- `BUNDLED_SUPPORTERS` — same entry, so an install that has never reached the network shows the current list.
- Plain name, no tier or `since`, matching every other entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)