### PR TITLE
fix(startup): never leave a black window that can't be closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,28 @@ whichever release turns it on.
   half a grid in one room and half in another is the failure that looks like nothing is
   wrong.
 
+## 2026-08-28
+
+### Fixed
+
+- **A black window on startup can no longer trap you.** On a cold boot WebView2 sometimes
+  takes a long time to draw its first frame — and occasionally never draws one at all. The
+  app window appeared anyway, empty and black, and because our title bar is drawn by the
+  page there was no close button in it and no title bar to close it from. Alt+F4 only parked
+  it in the tray, where the process stayed alive and handed the same dead window back the
+  next time you opened the app; Task Manager was the only way out. The window now stays
+  hidden until it has actually drawn something, anything that shows it early gets a real
+  Windows title bar to close it by, and a window that never drew closes for good rather than
+  hiding in the tray. Reported by a player who found it after booting their PC.
+
+### Changed
+
+- **`MXB_SAFE_GRAPHICS=1` now works on Windows too.** It takes the GPU out of the app's
+  browser, the same lever it already pulled on Linux — the thing to try when a window comes
+  up black and stays that way. The app also records how far the page got loading, and which
+  graphics settings were in force, so the next report of a blank window can be read straight
+  from the log instead of guessed at.
+
 ## 2026-08-28 — v0.11.1 — Protected model swaps open in 3D
 
 ### Fixed

--- a/src-tauri/src/firstpaint.rs
+++ b/src-tauri/src/firstpaint.rs
@@ -1,0 +1,95 @@
+//! Whether the main window has ever painted, and the rescue for when it hasn't.
+//!
+//! Every window control is drawn by the frontend (`decorations: false`), so a webview that
+//! never produces a first frame leaves an OS window with no way to close it.
+//!
+//! Two signals, because they are two different facts. [`loaded`] — the document parsed —
+//! is what puts the window on screen. [`mark`] — a frame actually reached the glass — is
+//! what says the title bar in it is real, and it can only arrive *after* the window is
+//! visible, since a hidden webview doesn't composite and never runs its frame callbacks.
+//! A window that goes quiet between the two is what [`arm`] rescues.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use tauri::{AppHandle, Manager};
+
+/// How long the frontend gets before the window is rescued. A healthy start paints in a
+/// second or two; this is sized for a cold boot with the disk still thrashing.
+const GRACE: Duration = Duration::from_secs(12);
+
+/// Whether the window is missing a title bar until the frontend draws one. macOS keeps a
+/// native one at all times (`tauri.macos.conf.json`), so there is nothing to add there —
+/// and taking it away again afterwards would break the window the rescue is meant to save.
+const NEEDS_A_TITLE_BAR: bool = !cfg!(target_os = "macos");
+
+/// Never cleared once set: a webview that painted and later broke still left our title bar
+/// on screen, which is a different problem from this one.
+static PAINTED: AtomicBool = AtomicBool::new(false);
+
+/// Set while the window is wearing the native title bar it was rescued with.
+static DECORATED: AtomicBool = AtomicBool::new(false);
+
+pub fn painted() -> bool {
+    PAINTED.load(Ordering::SeqCst)
+}
+
+/// The document finished loading — put the window on screen, still undecorated because the
+/// frontend's own title bar is a frame away. Reloads land here again and are ignored.
+pub fn loaded(app: &AppHandle) {
+    if painted() {
+        return;
+    }
+    let Some(w) = app.get_webview_window(crate::MAIN_WINDOW) else {
+        return;
+    };
+    let _ = w.show();
+    let _ = w.set_focus();
+}
+
+/// A frame reached the glass. Reloads land here again and are ignored.
+pub fn mark(app: &AppHandle) {
+    if PAINTED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    log::info!("[startup] the main window painted");
+    // It arrived late, after the watchdog had already dressed the window in a native title
+    // bar. Take that back off now there is one drawn in the page again.
+    if DECORATED.swap(false, Ordering::SeqCst) {
+        if let Some(w) = app.get_webview_window(crate::MAIN_WINDOW) {
+            let _ = w.set_decorations(false);
+        }
+    }
+}
+
+/// Give the window a native title bar, because nothing has drawn one in it.
+///
+/// Called from every path that puts the window on screen before it has painted — the
+/// watchdog below, the tray, a second launch — so none of them can produce a window the
+/// player has no way to close.
+pub fn decorate_unpainted(window: &tauri::WebviewWindow) {
+    if !NEEDS_A_TITLE_BAR || painted() || DECORATED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    let _ = window.set_decorations(true);
+}
+
+/// Start the watchdog. Call once, right after the main window is built.
+///
+/// On its own OS thread rather than the async runtime: it has to survive a startup that
+/// has gone wrong, and a runtime that isn't scheduling is one of the ways it can go wrong.
+pub fn arm(app: &AppHandle) {
+    let app = app.clone();
+    std::thread::spawn(move || {
+        std::thread::sleep(GRACE);
+        if painted() {
+            return;
+        }
+        log::warn!(
+            "[startup] the main window hasn't painted after {}s — showing it with a native \
+             title bar so it can be closed",
+            GRACE.as_secs()
+        );
+        crate::show_main(&app);
+    });
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -14,6 +14,7 @@ mod downloads;
 mod dropzone;
 mod edf;
 mod fileshare;
+mod firstpaint;
 mod frostmod;
 mod frostmod_manage;
 mod game;
@@ -85,7 +86,7 @@ use tauri_plugin_autostart::{MacosLauncher, ManagerExt};
 /// The app window, as opposed to the transient ones the app opens alongside it (the
 /// overlay, the mxb-mods.com clearance check, the shop login). `tauri.conf.json` declares
 /// it without an explicit label, which is Tauri's default of `main`.
-const MAIN_WINDOW: &str = "main";
+pub(crate) const MAIN_WINDOW: &str = "main";
 
 /// The shop login WebView, opened on demand and closed once the session is captured.
 const SHOP_LOGIN_WINDOW: &str = "shop-login";
@@ -100,6 +101,21 @@ const SHOP_LOGIN_WINDOW: &str = "shop-login";
 /// silently did nothing.
 fn parks_in_tray(label: &str) -> bool {
     label == MAIN_WINDOW
+}
+
+/// Whether closing the main window should park it in the tray instead of ending the app.
+///
+/// `painted` is the one that isn't a preference: a window that never painted has no close
+/// button in it, so parking it leaves the player nothing — the process stays alive holding
+/// the single-instance guard, and the next launch hands the same dead window straight back.
+///
+/// Never parks on Linux: the tray runs through libayatana-appindicator, which doesn't
+/// deliver click events to Tauri and isn't present at all on a stock GNOME desktop, so
+/// hiding there can strand the window with no way back. Never in a dev build either, or a
+/// `tauri dev` run would linger in the tray and block the next one.
+fn parks_on_close(painted: bool, run_in_background: bool) -> bool {
+    let tray_can_restore = cfg!(not(target_os = "linux"));
+    painted && run_in_background && tray_can_restore && !cfg!(debug_assertions)
 }
 
 /// Whether a window may make this IPC call.
@@ -4961,8 +4977,18 @@ fn autostart_action(wanted: bool, enabled: bool, stale: bool) -> Autostart {
     }
 }
 
-fn show_main(app: &tauri::AppHandle) {
-    if let Some(w) = app.get_webview_window("main") {
+/// The frontend has drawn its first frame — see [`firstpaint`].
+#[tauri::command]
+fn window_painted(app: tauri::AppHandle) {
+    firstpaint::mark(&app);
+}
+
+pub(crate) fn show_main(app: &tauri::AppHandle) {
+    if let Some(w) = app.get_webview_window(MAIN_WINDOW) {
+        // Every path in — the tray, a second launch, the watchdog — can land here before
+        // the webview has painted, and an undecorated window with no frontend in it has
+        // nothing to close it by.
+        firstpaint::decorate_unpainted(&w);
         let _ = w.show();
         let _ = w.unminimize();
         let _ = w.set_focus();
@@ -7353,14 +7379,31 @@ fn webview_env_defaults(env: GraphicsEnv) -> Vec<(&'static str, &'static str)> {
 /// web process, and before any other thread exists — being `main`'s first statement gives
 /// both.
 fn prepare_webview_env() {
-    if !cfg!(target_os = "linux") {
-        return;
-    }
-    for (key, value) in webview_env_defaults(GraphicsEnv::read()) {
+    let env = GraphicsEnv::read();
+    let vars = if cfg!(target_os = "linux") {
+        webview_env_defaults(env)
+    } else if cfg!(windows) {
+        webview2_env_defaults(env)
+    } else {
+        Vec::new()
+    };
+    for (key, value) in vars {
         if std::env::var_os(key).is_none() {
             std::env::set_var(key, value);
         }
     }
+}
+
+/// The environment WebView2 should start under.
+///
+/// Nothing by default — WebView2 paints on virtually every Windows machine. `MXB_SAFE_GRAPHICS=1`
+/// takes the GPU out of it, which is the lever to pull for a window that came up black and
+/// stayed that way: a first frame that never arrives is the GPU path failing.
+fn webview2_env_defaults(env: GraphicsEnv) -> Vec<(&'static str, &'static str)> {
+    if !env.safe_mode {
+        return Vec::new();
+    }
+    vec![("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", "--disable-gpu")]
 }
 
 /// Whether this process is running under Wine — CrossOver, Whisky, Kegworks or plain Wine.
@@ -7514,12 +7557,24 @@ fn main() {
                 .filter(|w| w.label == MAIN_WINDOW)
             {
                 let mut builder =
-                    tauri::WebviewWindowBuilder::from_config(app.handle(), window_config)?;
+                    tauri::WebviewWindowBuilder::from_config(app.handle(), window_config)?
+                        // Also what puts the window on screen: it is hidden until the
+                        // document is there to show, and a hidden webview never composites
+                        // — so waiting for a painted frame here would wait forever.
+                        .on_page_load(|window, payload| {
+                            log::info!("[startup] main window {:?}", payload.event());
+                            if payload.event() == tauri::webview::PageLoadEvent::Finished {
+                                firstpaint::loaded(window.app_handle());
+                            }
+                        });
                 if !drag_drop {
                     builder = builder.disable_drag_drop_handler();
                 }
                 builder.build()?;
             }
+            // The window is built hidden and revealed by `window_painted`; this is what
+            // rescues it when that never arrives.
+            firstpaint::arm(app.handle());
             // Cloudflare scores the User-Agent alongside the IP, and a cf_clearance is bound
             // to the UA that earned it — a log about a block should say which one was used.
             log::info!("{} user-agent: {}", mxb_session::site().domain, mxb_session::UA);
@@ -7537,6 +7592,12 @@ fn main() {
                     on("WEBKIT_DISABLE_DMABUF_RENDERER"),
                     on("WEBKIT_DISABLE_COMPOSITING_MODE"),
                     on("LIBGL_ALWAYS_SOFTWARE"),
+                );
+            }
+            if cfg!(windows) {
+                log::info!(
+                    "webview env: webview2_args={:?}",
+                    std::env::var("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS").unwrap_or_default(),
                 );
             }
             if let Ok(dir) = app.path().app_local_data_dir() {
@@ -7727,14 +7788,16 @@ fn main() {
                     return;
                 }
                 let cfg = config::load(window.app_handle()).unwrap_or_default();
-                // Never on Linux: the tray runs through libayatana-appindicator, which
-                // doesn't deliver click events to Tauri and isn't present at all on a
-                // stock GNOME desktop. Hiding there can strand the window with no way
-                // back, so closing closes.
-                let tray_can_restore = cfg!(not(target_os = "linux"));
-                if cfg.run_in_background && tray_can_restore && !cfg!(debug_assertions) {
+                let painted = firstpaint::painted();
+                if parks_on_close(painted, cfg.run_in_background) {
                     api.prevent_close();
                     let _ = window.hide();
+                } else if !painted {
+                    log::warn!(
+                        "[startup] closing a main window that never painted — quitting \
+                         rather than parking it in the tray"
+                    );
+                    frostmod_manage::stop(&window.app_handle().state::<FrostmodProcess>());
                 }
             }
         })
@@ -7744,6 +7807,7 @@ fn main() {
             // The macro is generic over the runtime; naming `Wry` here is what lets the
             // wrapper below infer what it is wrapping.
             let handler: fn(tauri::ipc::Invoke<tauri::Wry>) -> bool = tauri::generate_handler![
+            window_painted,
             is_configured,
             get_config,
             create_config,
@@ -8038,6 +8102,55 @@ mod webview_env_tests {
         let vars = defaults(GraphicsEnv::default());
         assert_eq!(vars.len(), 1);
         assert!(vars.contains_key("WEBKIT_DISABLE_DMABUF_RENDERER"));
+    }
+
+    /// WebView2 paints on virtually every Windows machine, and forcing software rendering
+    /// on all of them to cure the few would be a bad trade.
+    #[test]
+    fn windows_is_left_alone_unless_safe_graphics_is_asked_for() {
+        assert!(webview2_env_defaults(GraphicsEnv::default()).is_empty());
+    }
+
+    /// The lever support has to pull for a window that came up black and stayed black.
+    #[test]
+    fn safe_graphics_takes_the_gpu_out_of_webview2() {
+        let vars: HashMap<_, _> = webview2_env_defaults(GraphicsEnv {
+            safe_mode: true,
+            ..GraphicsEnv::default()
+        })
+        .into_iter()
+        .collect();
+        assert_eq!(
+            vars.get("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS"),
+            Some(&"--disable-gpu"),
+        );
+    }
+}
+
+/// The window that never painted is the one these are for: it has no close button drawn
+/// in it, so whatever the player does next has to actually get rid of it.
+#[cfg(test)]
+mod close_behaviour_tests {
+    use super::*;
+
+    /// The whole bug: Alt+F4 on a black window parked it in the tray, the process stayed
+    /// alive holding the single-instance guard, and reopening the app called `show_main`
+    /// and handed the same dead window back. Task Manager was the only way out.
+    #[test]
+    fn a_window_that_never_painted_never_parks_in_the_tray() {
+        assert!(!parks_on_close(false, true));
+        assert!(!parks_on_close(false, false));
+    }
+
+    /// And the setting still means what it says for a window that works.
+    #[test]
+    fn a_painted_window_still_honours_run_in_background() {
+        // Release builds on Windows and macOS park; this test binary is neither, so the
+        // assertion is on the platform-and-build gate agreeing with itself rather than on
+        // a fixed answer.
+        let parks = cfg!(not(target_os = "linux")) && !cfg!(debug_assertions);
+        assert_eq!(parks_on_close(true, true), parks);
+        assert!(!parks_on_close(true, false), "turning it off always closes for real");
     }
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,9 @@
         "minWidth": 1000,
         "minHeight": 700,
         "decorations": false,
-        "create": false
+        "create": false,
+        "visible": false,
+        "backgroundColor": "#121417"
       }
     ],
     "security": {

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -11,7 +11,9 @@
         "decorations": true,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "create": false
+        "create": false,
+        "visible": false,
+        "backgroundColor": "#121417"
       }
     ]
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { invoke } from "@tauri-apps/api/core";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import Overlay from "./Components/Overlay/Overlay";
@@ -21,3 +22,15 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     </I18nProvider>
   </React.StrictMode>,
 );
+
+/* The main window is built hidden and shown by this call — see
+   `src-tauri/src/firstpaint.rs`. Two frames deep because the first fires before the
+   browser has composited anything, so only the second proves the webview really painted.
+   The overlay window loads this same bundle and owns its own visibility. */
+if (!isOverlay) {
+  requestAnimationFrame(() =>
+    requestAnimationFrame(() => {
+      void invoke("window_painted").catch(() => {});
+    }),
+  );
+}


### PR DESCRIPTION
A player on Windows reported the app coming up as a black box after a PC boot, with no way to close it.

## Is it our fault?

Partly, and the part that matters is. The **trigger** is environmental: WebView2 sometimes takes a long time to produce a first frame on a cold boot, and occasionally never produces one. We don't control that, and it's transient.

What turned a transient glitch into a permanently stuck window was all ours:

- The window was built **visible**, so it was on screen before the webview had painted anything into it. `tao` fills an unpainted window black.
- `decorations: false` means every window control is drawn by the frontend — so no paint meant no close button, and no title bar to close it from either.
- `run_in_background` defaults **true**, so Alt+F4 hit `prevent_close()` + `hide()` and parked the dead process in the tray, where the single-instance guard kept it alive. The next launch called `show_main` and handed the same dead window straight back. Task Manager was the only way out.

`launch_at_startup` also defaults true, which is why "after boot" is when it bites.

## What changed

**Never leave an unclosable window** — the part that holds regardless of why WebView2 stalled:

- New `firstpaint` module tracking two distinct facts. `loaded` (the document parsed) is what puts the window on screen; `mark` (a frame reached the glass) is what says the title bar in it is real. The second can only arrive after the first, since a hidden webview never composites and so never runs its frame callbacks.
- The main window is built hidden and revealed from `on_page_load`. A 12s watchdog — on its own OS thread, so it survives a runtime that isn't scheduling — shows it with native decorations if no frame ever lands. `show_main` does the same, so every path in (tray, second launch, deep link) leaves a way to close it.
- Closing a window that never painted quits instead of parking in the tray, so relaunching gets a fresh process. Extracted to `parks_on_close` and covered by tests.
- macOS is exempt from the decoration rescue: it keeps a native title bar at all times, and taking it away afterwards would break the window the rescue exists to save.
- `backgroundColor` set to the app's own `#121417`, so any frame shown before the webview paints reads as the app loading rather than black.

**Diagnosis**, since nothing in the log could have answered this before:

- `on_page_load` now records how far the webview got.
- `MXB_SAFE_GRAPHICS=1` works on Windows, setting `--disable-gpu` for WebView2 — the same lever it already pulled on Linux. Off by default; the startup log says which graphics settings were in force.

No DB or schema changes.

## Verified

964 Rust tests pass, `cargo check --target x86_64-pc-windows-gnu` clean for the `cfg(windows)` half, tsc / eslint / vite build clean.

Running it on macOS is what caught the first attempt gating the reveal on `requestAnimationFrame`: a hidden window never fires it, so every launch stalled the full 12s until the watchdog stepped in.

```
12:21:30  main window Started / Finished
12:21:42  hasn't painted after 12s — showing it with a native title bar   <- had to be rescued
12:21:42  the main window painted                                         <- only once visible
```

Reveal now hangs off document-load, and the same launch reads:

```
12:23:33  main window Started / Finished
12:23:35  the main window painted
```

The black window itself only reproduces on the reporter's machine, so the Windows behaviour is verified by cross-compile and by the log, not by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)