### PR TITLE
fix(viewer): build a bike once when two callers want it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,17 @@ whichever release turns it on.
 
 ### Fixed
 
+- **The 3D viewer no longer hoards a bike's textures each time it redraws one.** Two things
+  asking for the same bike at the same moment — a preview panel and a dialog drawing it
+  together, or a picker that re-asks before the first answer lands — read and decoded it from
+  scratch twice over, and the copy that lost the race left its textures behind with nothing
+  able to free them. Three passes over one bike put 200 MB in the texture store and none of
+  it came back. Far enough down that road the store starts dropping its oldest textures to
+  stay under its ceiling, and the oldest can be the bike you are looking at — which is how
+  parts of a bike turn grey for no reason. Two callers that want the same bike now share one
+  read: the second waits for the first and takes its answer, so it arrives in milliseconds
+  instead of seconds. Found in a player's log.
+
 - **A black window on startup can no longer trap you.** On a cold boot WebView2 sometimes
   takes a long time to draw its first frame — and occasionally never draws one at all. The
   app window appeared anyway, empty and black, and because our title bar is drawn by the

--- a/src-tauri/src/gate.rs
+++ b/src-tauri/src/gate.rs
@@ -1,0 +1,102 @@
+//! One build per key at a time.
+//!
+//! A cache in front of expensive work only helps the caller that arrives second. Two that
+//! arrive together both miss, both pay, and the loser's result is displaced from the cache
+//! the moment it inserts — so the duplicate work is worse than wasted, it strands the pixels
+//! hanging off whichever model lost. The viewer really does ask twice: a panel and a dialog
+//! can draw the same bike, and an effect can re-fire before the first answer lands.
+//!
+//! Callers check their cache, take the gate, then check again. Whoever waited finds the
+//! answer the first one just put there.
+
+use std::collections::HashSet;
+use std::sync::{Condvar, Mutex, OnceLock};
+
+#[derive(Default)]
+struct Gates {
+    building: Mutex<HashSet<String>>,
+    done: Condvar,
+}
+
+fn gates() -> &'static Gates {
+    static G: OnceLock<Gates> = OnceLock::new();
+    G.get_or_init(Gates::default)
+}
+
+/// Held while its key is being built. Dropping it — including on the `?` out of a build that
+/// failed — lets the next caller through.
+pub struct Gate(String);
+
+impl Drop for Gate {
+    fn drop(&mut self) {
+        let g = gates();
+        // Poisoned means a build panicked while holding the set, not that the set is wrong.
+        let mut set = g.building.lock().unwrap_or_else(|p| p.into_inner());
+        set.remove(&self.0);
+        drop(set);
+        g.done.notify_all();
+    }
+}
+
+/// Wait until nobody else is building `key`, then claim it.
+///
+/// Re-check the cache once this returns: the whole point of having waited is that the build
+/// you were queued behind has just finished.
+pub fn enter(key: &str) -> Gate {
+    let g = gates();
+    let mut set = g.building.lock().unwrap_or_else(|p| p.into_inner());
+    while set.contains(key) {
+        set = g.done.wait(set).unwrap_or_else(|p| p.into_inner());
+    }
+    set.insert(key.to_string());
+    Gate(key.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn the_second_caller_waits_and_takes_the_first_one_s_answer() {
+        static CACHE: Mutex<Option<u32>> = Mutex::new(None);
+        static BUILDS: AtomicUsize = AtomicUsize::new(0);
+
+        let callers: Vec<_> = (0..4)
+            .map(|_| {
+                std::thread::spawn(|| {
+                    if let Some(v) = *CACHE.lock().expect("cache") {
+                        return v;
+                    }
+                    let _gate = enter("a-bike");
+                    if let Some(v) = *CACHE.lock().expect("cache") {
+                        return v;
+                    }
+                    BUILDS.fetch_add(1, Ordering::SeqCst);
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                    *CACHE.lock().expect("cache") = Some(7);
+                    7
+                })
+            })
+            .collect();
+
+        for c in callers {
+            assert_eq!(c.join().expect("caller finished"), 7);
+        }
+        assert_eq!(BUILDS.load(Ordering::SeqCst), 1, "one build, three waiters");
+    }
+
+    #[test]
+    fn different_keys_do_not_wait_on_each_other() {
+        let held = enter("one");
+        // Would block forever if the gate were global rather than per key.
+        drop(enter("two"));
+        drop(held);
+    }
+
+    #[test]
+    fn a_failed_build_does_not_wedge_the_key() {
+        drop(enter("wedged")); // as the `?` out of a build that errored would
+        drop(enter("wedged"));
+    }
+}

--- a/src-tauri/src/lru.rs
+++ b/src-tauri/src/lru.rs
@@ -33,11 +33,17 @@ impl<V> Lru<V> {
         self.map.get(key)
     }
 
-    /// Insert `value`, returning whatever was evicted to make room for it.
+    /// Insert `value`, returning whatever it displaced — the coldest entry, evicted to make
+    /// room, or the value that was already under `key`.
+    ///
+    /// Both cases hand back something the caller is now the only owner of. A replaced entry
+    /// used to be dropped here instead, which silently stranded whatever hung off it: a bike
+    /// built twice under one key leaked the first build's pixels, because the texture store
+    /// frees only what this returns.
     pub fn insert(&mut self, key: String, value: V) -> Option<V> {
-        if self.map.insert(key.clone(), value).is_some() {
+        if let Some(replaced) = self.map.insert(key.clone(), value) {
             self.touch(&key);
-            return None; // replaced in place, nothing left the cache
+            return Some(replaced); // nothing left the cache, but the old value left the map
         }
         self.order.push_back(key);
         if self.map.len() > self.cap {
@@ -82,11 +88,11 @@ mod tests {
     }
 
     #[test]
-    fn replacing_a_key_evicts_nothing() {
+    fn replacing_a_key_hands_back_the_old_value() {
         let mut lru = Lru::new(2);
         lru.insert("a".into(), 1);
         lru.insert("b".into(), 2);
-        assert_eq!(lru.insert("a".into(), 9), None);
+        assert_eq!(lru.insert("a".into(), 9), Some(1), "the caller still owns what it displaced");
         assert_eq!(lru.get("a"), Some(&9));
         assert_eq!(lru.get("b"), Some(&2), "both still resident");
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -19,6 +19,7 @@ mod frostmod;
 mod frostmod_manage;
 mod game;
 mod gameproc;
+mod gate;
 mod gearrepair;
 mod heightfield;
 mod imgcache;
@@ -1087,12 +1088,22 @@ fn paint_cache() -> &'static std::sync::Mutex<lru::Lru<Vec<paint::PaintTexture>>
     CACHE.get_or_init(|| std::sync::Mutex::new(lru::Lru::new(PAINT_CACHE_CAP)))
 }
 
+/// As [`cached_bike`], for the paints: looked up and released without holding the lock.
+fn cached_paint(key: &str) -> Option<Vec<paint::PaintTexture>> {
+    paint_cache().lock().ok().and_then(|mut c| c.get(key).cloned())
+}
+
 fn unpack_paint_blocking(path: String) -> Result<Vec<paint::PaintTexture>, String> {
     let t0 = std::time::Instant::now();
     // Path *and* mtime, as the bike cache does, so a paint re-saved under the same name misses.
     let key = bike_cache_key(&path);
-    if let Some(t) = paint_cache().lock().ok().and_then(|mut c| c.get(&key).cloned()) {
+    if let Some(t) = cached_paint(&key) {
         log::info!("unpack_paint {path}: cache hit ({:?})", t0.elapsed());
+        return Ok(t);
+    }
+    let _gate = gate::enter(&key);
+    if let Some(t) = cached_paint(&key) {
+        log::info!("unpack_paint {path}: cache hit, waited ({:?})", t0.elapsed());
         return Ok(t);
     }
 
@@ -1105,7 +1116,7 @@ fn unpack_paint_blocking(path: String) -> Result<Vec<paint::PaintTexture>, Strin
     );
     if let Ok(mut c) = paint_cache().lock() {
         // Cloning an entry copies names, sizes and tokens — never pixels, which stay in the
-        // texture store. The evicted paint's go with it; nothing else holds those tokens.
+        // texture store. The displaced paint's go with it; nothing else holds those tokens.
         if let Some(dropped) = c.insert(key, textures.clone()) {
             let tokens: Vec<String> = dropped.iter().map(|t| t.token.clone()).collect();
             texstore::release(&tokens);
@@ -1657,6 +1668,12 @@ fn bike_cache() -> &'static std::sync::Mutex<lru::Lru<BikeModel>> {
     CACHE.get_or_init(|| std::sync::Mutex::new(lru::Lru::new(BIKE_CACHE_CAP)))
 }
 
+/// The cached bike under `key`, if it's still resident. Taken and released in one step so
+/// no caller holds the cache lock while it waits on [`gate::enter`].
+fn cached_bike(key: &str) -> Option<BikeModel> {
+    bike_cache().lock().ok().and_then(|mut c| c.get(key).cloned())
+}
+
 fn mtime_nanos(path: &std::path::Path) -> u128 {
     std::fs::metadata(path)
         .and_then(|m| m.modified())
@@ -1756,8 +1773,15 @@ fn preview_model_swap_blocking(
         tyres_stamp(&tyres),
         pick.as_deref().unwrap_or(""),
     );
-    if let Some(m) = bike_cache().lock().ok().and_then(|mut c| c.get(&key).cloned()) {
+    if let Some(m) = cached_bike(&key) {
         log::info!("preview_model_swap {label}: cache hit ({:?})", t0.elapsed());
+        return Ok(m);
+    }
+    // Somebody may already be building this exact preview — the panel and a dialog can both
+    // be drawing it. Wait for them and take their answer instead of paying a second time.
+    let _gate = gate::enter(&key);
+    if let Some(m) = cached_bike(&key) {
+        log::info!("preview_model_swap {label}: cache hit, waited ({:?})", t0.elapsed());
         return Ok(m);
     }
 
@@ -1849,8 +1873,13 @@ fn load_bike_model_blocking(
         tyres.as_deref().map(tyres_stamp).unwrap_or(0),
         pick.as_deref().unwrap_or(""),
     );
-    if let Some(m) = bike_cache().lock().ok().and_then(|mut c| c.get(&key).cloned()) {
+    if let Some(m) = cached_bike(&key) {
         log::info!("load_bike_model {source}: cache hit ({:?})", t0.elapsed());
+        return Ok(m);
+    }
+    let _gate = gate::enter(&key);
+    if let Some(m) = cached_bike(&key) {
+        log::info!("load_bike_model {source}: cache hit, waited ({:?})", t0.elapsed());
         return Ok(m);
     }
 
@@ -2181,7 +2210,8 @@ fn build_bike_model(
 
     let model = BikeModel { nodes, paints, base: model_base, tyres, assembled, rig };
     if let Ok(mut c) = bike_cache().lock() {
-        // The evicted bike's pixels go with it — nothing else references them.
+        // The pixels of whatever this displaced go with it — evicted or replaced in place,
+        // nothing else references them; tokens are minted per build.
         if let Some(dropped) = c.insert(key, model.clone()) {
             texstore::release(&dropped.tokens());
         }

--- a/src-tauri/src/texstore.rs
+++ b/src-tauri/src/texstore.rs
@@ -11,7 +11,8 @@
 //!
 //! Ownership: `to_texture` is called once per texture per source load, so a token belongs
 //! to exactly one `bike_cache` entry — no refcounting. That entry calls [`release`] when it
-//! is evicted. Paths with no cache of their own (a gear `.pnt` re-decoded on every pick)
+//! leaves the cache, which means evicted *or* replaced in place: a bike built twice under
+//! one key displaces the first build, and its pixels are freed by nothing else. Paths with no cache of their own (a gear `.pnt` re-decoded on every pick)
 //! rely on [`CAP_BYTES`] reaping the oldest blobs.
 
 use std::collections::{HashMap, VecDeque};


### PR DESCRIPTION
## What a player's log showed

A reporter bundle from MXB App 0.11.1 has one bike — `MX1OEM_2023_Suzuki_RM-Z450 · Stock` — read, parsed and decoded three times in ten seconds, two of those builds overlapping:

```
14:22:27  load_bike_model … total 2.0352587s |  94.4 MB resident in the texture store
14:22:36  preview_model_swap … cache hit (5.0103ms)
14:22:36  load_bike_model … total 2.0798773s | 144.7 MB resident in the texture store
14:22:37  load_bike_model … total 2.0794898s | 195.0 MB resident in the texture store
14:22:42  preview_model_swap … cache hit (5.1195ms)
[mem] 275 MB — up 275 MB in a minute. Textures 203 MB
```

The interleaved `cache hit (5ms)` lines prove the hit path itself was fine. Two faults sat behind it.

## 1. A same-key insert stranded the displaced model's pixels

`lru::insert` discarded the value it replaced (`map.insert(…).is_some()`) and returned `None`. But `build_bike_model` is the only thing that ever frees a model's textures, and it only frees what `insert` hands back. Texture tokens are minted per build from a monotonic counter — they are not content-addressed — so a rebuilt bike's pixels are an entirely new set and the old set was orphaned.

Where that ends up matters more than the megabytes: `texstore::CAP_BYTES` is 384 MB, and when `put` crosses it the store reaps its **oldest** blobs, which can be the bike currently on screen. `bytes_or_missing` then serves grey. The reporter was at 230 MB of textures in a 366 MB process — walking toward "parts of my bike turned grey", not just high memory.

`insert` now returns the replaced value. `paint_cache` has the identical release-what-was-returned pattern, so it stops leaking the same way for free.

## 2. Nothing deduplicated in-flight builds

Both entry points checked the cache and, on a miss, went straight to `build_bike_model`. Two callers for the same key both missed (neither had inserted yet), both paid ~2s and ~50 MB, and the loser's textures leaked via fault 1.

New `gate` module: check the cache, take a per-key gate, check again. Whoever waited finds the answer the first caller just put there — milliseconds instead of seconds. Per key rather than global, so two different bikes still build in parallel. The `Gate` frees its key on drop, including on the `?` out of a build that errored, so a failure can't wedge a key.

Wired into `load_bike_model`, `preview_model_swap` and `unpack_paint`.

## On ordering

Releasing a displaced model's tokens while the webview still holds them would grey that view. The gate makes that window essentially unreachable, which is why the two changes ship together rather than fix 1 alone.

## Tests

- `lru`: a replaced entry is handed back to the caller.
- `gate`: four threads on one key build once; different keys don't block each other; a failed build doesn't wedge the key.
- `cargo test` — 967 pass, 0 fail.
- `cargo check --target x86_64-pc-windows-gnu` — clean; `cargo clippy --all-targets` — no errors.

## Not in this PR

The duplicate requests plausibly originate in the frontend — `ViewerPanel` and `ViewerDialog` both firing the same effect, or `tyresPick.tyres` flipping when config lands and re-firing an effect whose `alive` flag only discards the *result*, never cancels the backend work. The log can't tell us which, and the backend should be stampede-proof either way, so no frontend change here.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)