### PR TITLE
chore(release): v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ whichever release turns it on.
   half a grid in one room and half in another is the failure that looks like nothing is
   wrong.
 
-## 2026-08-29
+## 2026-08-29 — v0.11.2 — Install a pack one bike at a time, and a preview that fills the window
 
 ### Added
 
@@ -63,6 +63,14 @@ whichever release turns it on.
 
 - **Sly** credited on Settings → Supporters.
 
+### Changed
+
+- **`MXB_SAFE_GRAPHICS=1` now works on Windows too.** It takes the GPU out of the app's
+  browser, the same lever it already pulled on Linux — the thing to try when a window comes
+  up black and stays that way. The app also records how far the page got loading, and which
+  graphics settings were in force, so the next report of a blank window can be read straight
+  from the log instead of guessed at.
+
 ### Fixed
 
 - **A paint that ships a separate file per bike now installs the right one.** Some pages offer
@@ -79,10 +87,6 @@ whichever release turns it on.
   53 OEM bikes installed that was 18.9 seconds of nothing happening before the sheet drew, on
   every single drop. It is 1.2 seconds now. The same read backs the bike pickers throughout
   the app, so they all get quicker.
-
-## 2026-08-28
-
-### Fixed
 
 - **The 3D viewer no longer hoards a bike's textures each time it redraws one.** Two things
   asking for the same bike at the same moment — a preview panel and a dialog drawing it
@@ -104,14 +108,6 @@ whichever release turns it on.
   hidden until it has actually drawn something, anything that shows it early gets a real
   Windows title bar to close it by, and a window that never drew closes for good rather than
   hiding in the tray. Reported by a player who found it after booting their PC.
-
-### Changed
-
-- **`MXB_SAFE_GRAPHICS=1` now works on Windows too.** It takes the GPU out of the app's
-  browser, the same lever it already pulled on Linux — the thing to try when a window comes
-  up black and stays that way. The app also records how far the page got loading, and which
-  graphics settings were in force, so the next report of a blank window can be read straight
-  from the log instead of guessed at.
 
 ## 2026-08-28 — v0.11.1 — Protected model swaps open in 3D
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.11.1",
+  "version": "0.11.2",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "mxb-app"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # whatever cargo called it. Cargo target names can't hold a space, so this is as close as
 # it gets. The description is what Windows Task Manager shows in its Processes tab.
 name = "mxb-app"
-version = "0.11.1"
+version = "0.11.2"
 description = "MXB App — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
   "mainBinaryName": "MXB App",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/Components/Showcase/releases.ts
+++ b/src/Components/Showcase/releases.ts
@@ -71,6 +71,21 @@ export interface Release {
 
 export const RELEASES: Release[] = [
   {
+    version: "0.11.2",
+    hero: {
+      icon: Package,
+      title: "showcase.v0112.hero.title",
+      body: "showcase.v0112.hero.body",
+    },
+    highlights: [
+      { icon: Maximize2, text: "showcase.v0112.fullscreen" },
+      { icon: Download, text: "showcase.v0112.review" },
+      { icon: Palette, text: "showcase.v0112.paint" },
+      { icon: Gauge, text: "showcase.v0112.speed" },
+      { icon: Monitor, text: "showcase.v0112.window" },
+    ],
+  },
+  {
     version: "0.11.1",
     hero: {
       icon: Package,

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1401,6 +1401,20 @@ export const de: Translation = {
   "showcase.supporters.title_one": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.title_other": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.more": "+{{count}} weitere",
+  "showcase.v0112.hero.title":
+    "Ein Bike-Pack wird als die Bikes darin installiert",
+  "showcase.v0112.hero.body":
+    "Das OEM-Pack sind 54 Maschinen in einem 3,8-GB-Archiv, und bislang kam es als eine einzige Zeile mit der Aufschrift \u201eMods-Ordner\u201c \u2014 alles oder nichts. Jetzt steht es so da, wie es gebaut ist: jedes Bike mit echtem Namen und Klasse, mit Kontrollk\u00e4stchen. Nimm die vier, die du f\u00e4hrst, und lass die anderen f\u00fcnfzig liegen.",
+  "showcase.v0112.fullscreen":
+    "Die 3D-Vorschau im Designer \u00f6ffnet sich im Vollbild \u2014 ein Knopf f\u00fcllt das Fenster mit dem Modell, das du gerade lackierst.",
+  "showcase.v0112.review":
+    "Ein Download, der sich als mehrere Mods entpuppt, h\u00e4lt an und zeigt dir seinen Inhalt, bevor irgendetwas in deinem Mods-Ordner landet.",
+  "showcase.v0112.paint":
+    "Ein Paint mit einer Datei je Maschine installiert jetzt die f\u00fcr das gew\u00e4hlte Bike \u2014 nicht einfach die erste auf der Seite.",
+  "showcase.v0112.speed":
+    "Das Pr\u00fcffenster \u00f6ffnet sich mit installierten OEM-Bikes in etwa einer Sekunde statt in knapp zwanzig.",
+  "showcase.v0112.window":
+    "Ein schwarzes Fenster beim Start kann dich nicht mehr festsetzen: Es bleibt verborgen, bis es etwas gezeichnet hat, und l\u00e4sst sich immer schlie\u00dfen.",
   "showcase.v0111.hero.title":
     "Geschützte Modell-Swaps öffnen sich in 3D",
   "showcase.v0111.hero.body":

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1362,6 +1362,20 @@ export const en = {
   "showcase.supporters.title_one": "Made possible by {{count}} supporter",
   "showcase.supporters.title_other": "Made possible by {{count}} supporters",
   "showcase.supporters.more": "+{{count}} more",
+  "showcase.v0112.hero.title":
+    "A bike pack installs as the bikes inside it",
+  "showcase.v0112.hero.body":
+    "The OEM pack is 54 machines in one 3.8 GB archive, and it used to arrive as a single row reading \u201cMods folder\u201d \u2014 all of it or none of it. It is now listed the way it is built: every bike by its real name and class, with a checkbox. Take the four you race and leave the other fifty.",
+  "showcase.v0112.fullscreen":
+    "The Designer's 3D preview opens fullscreen \u2014 one button fills the window with the model you are painting.",
+  "showcase.v0112.review":
+    "A download that turns out to hold several mods stops and shows you what is in it before anything reaches your mods folder.",
+  "showcase.v0112.paint":
+    "A paint that offers one file per machine now installs the one for the bike you picked, not the first on the page.",
+  "showcase.v0112.speed":
+    "The review sheet opens in about a second with the OEM bikes installed, where it used to take nearly twenty.",
+  "showcase.v0112.window":
+    "A black window on startup can no longer trap you: it stays hidden until it has drawn, and always has a way to close it.",
   "showcase.v0111.hero.title":
     "Protected model swaps open in 3D",
   "showcase.v0111.hero.body":

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1388,6 +1388,20 @@ export const es: Translation = {
   "showcase.supporters.title_one": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.title_other": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.more": "+{{count}} más",
+  "showcase.v0112.hero.title":
+    "Un pack de motos se instala como las motos que lleva dentro",
+  "showcase.v0112.hero.body":
+    "El pack OEM son 54 m\u00e1quinas en un archivo de 3,8 GB, y hasta ahora llegaba como una sola fila que dec\u00eda \u00abCarpeta de mods\u00bb: todo o nada. Ahora aparece tal como est\u00e1 hecho: cada moto con su nombre y su clase reales, con su casilla. Coge las cuatro con las que corres y deja las otras cincuenta.",
+  "showcase.v0112.fullscreen":
+    "La vista 3D del Dise\u00f1ador se abre a pantalla completa: un bot\u00f3n llena la ventana con el modelo que est\u00e1s pintando.",
+  "showcase.v0112.review":
+    "Una descarga que resulta contener varios mods se detiene y te ense\u00f1a qu\u00e9 lleva dentro antes de que nada llegue a tu carpeta de mods.",
+  "showcase.v0112.paint":
+    "Un paint que ofrece un archivo por m\u00e1quina instala ahora el de la moto que elegiste, no el primero de la p\u00e1gina.",
+  "showcase.v0112.speed":
+    "La hoja de revisi\u00f3n se abre en aproximadamente un segundo con las motos OEM instaladas, cuando antes tardaba casi veinte.",
+  "showcase.v0112.window":
+    "Una ventana en negro al arrancar ya no puede atraparte: no aparece hasta haber dibujado algo y siempre tiene una forma de cerrarse.",
   "showcase.v0111.hero.title":
     "Los cambios de modelo protegidos se abren en 3D",
   "showcase.v0111.hero.body":

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1392,6 +1392,20 @@ export const fr: Translation = {
   "showcase.supporters.title_one": "Rendu possible par {{count}} soutien",
   "showcase.supporters.title_other": "Rendu possible par {{count}} soutiens",
   "showcase.supporters.more": "+{{count}} autres",
+  "showcase.v0112.hero.title":
+    "Un pack de motos s'installe comme les motos qu'il contient",
+  "showcase.v0112.hero.body":
+    "Le pack OEM, c'est 54 machines dans une archive de 3,8 Go, et il arrivait jusqu'ici sous la forme d'une seule ligne intitul\u00e9e \u00ab\u00a0Dossier mods\u00a0\u00bb\u00a0: tout ou rien. Il est maintenant list\u00e9 tel qu'il est fait\u00a0: chaque moto avec son vrai nom et sa cat\u00e9gorie, et sa case \u00e0 cocher. Prends les quatre que tu pilotes et laisse les cinquante autres.",
+  "showcase.v0112.fullscreen":
+    "L'aper\u00e7u 3D du Designer s'ouvre en plein \u00e9cran\u00a0: un bouton remplit la fen\u00eatre avec le mod\u00e8le que tu es en train de peindre.",
+  "showcase.v0112.review":
+    "Un t\u00e9l\u00e9chargement qui contient plusieurs mods s'arr\u00eate et te montre ce qu'il y a dedans avant que quoi que ce soit n'atteigne ton dossier mods.",
+  "showcase.v0112.paint":
+    "Un paint qui propose un fichier par machine installe d\u00e9sormais celui de la moto choisie, et non le premier de la page.",
+  "showcase.v0112.speed":
+    "La fiche de v\u00e9rification s'ouvre en une seconde environ avec les motos OEM install\u00e9es, l\u00e0 o\u00f9 elle prenait pr\u00e8s de vingt.",
+  "showcase.v0112.window":
+    "Une fen\u00eatre noire au d\u00e9marrage ne peut plus te bloquer\u00a0: elle reste cach\u00e9e tant qu'elle n'a rien dessin\u00e9, et il y a toujours de quoi la fermer.",
   "showcase.v0111.hero.title":
     "Les modèles protégés s'ouvrent en 3D",
   "showcase.v0111.hero.body":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1383,6 +1383,20 @@ export const it: Translation = {
   "showcase.supporters.title_one": "Reso possibile da {{count}} sostenitore",
   "showcase.supporters.title_other": "Reso possibile da {{count}} sostenitori",
   "showcase.supporters.more": "+{{count}} altri",
+  "showcase.v0112.hero.title":
+    "Un pacchetto di moto si installa come le moto che contiene",
+  "showcase.v0112.hero.body":
+    "Il pacchetto OEM sono 54 macchine in un archivio da 3,8 GB, e finora arrivava come una sola riga con scritto \u201cCartella mods\u201d: tutto o niente. Ora \u00e8 elencato per com'\u00e8 fatto: ogni moto col suo nome e la sua classe, con la casella. Prendi le quattro con cui corri e lascia le altre cinquanta.",
+  "showcase.v0112.fullscreen":
+    "L'anteprima 3D del Designer si apre a schermo intero: un pulsante riempie la finestra con il modello che stai dipingendo.",
+  "showcase.v0112.review":
+    "Un download che si rivela contenere pi\u00f9 mod si ferma e ti mostra cosa c'\u00e8 dentro prima che qualcosa finisca nella cartella mods.",
+  "showcase.v0112.paint":
+    "Una livrea che offre un file per macchina installa ora quello della moto che hai scelto, non il primo della pagina.",
+  "showcase.v0112.speed":
+    "Il foglio di revisione si apre in circa un secondo con le moto OEM installate, dove prima ci metteva quasi venti.",
+  "showcase.v0112.window":
+    "Una finestra nera all'avvio non pu\u00f2 pi\u00f9 intrappolarti: resta nascosta finch\u00e9 non ha disegnato qualcosa e ha sempre un modo per essere chiusa.",
   "showcase.v0111.hero.title":
     "I model swap protetti si aprono in 3D",
   "showcase.v0111.hero.body":

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1381,6 +1381,20 @@ export const ptBR: Translation = {
   "showcase.supporters.title_one": "Possível graças a {{count}} apoiador",
   "showcase.supporters.title_other": "Possível graças a {{count}} apoiadores",
   "showcase.supporters.more": "+{{count}} outros",
+  "showcase.v0112.hero.title":
+    "Um pacote de motos instala como as motos que h\u00e1 dentro dele",
+  "showcase.v0112.hero.body":
+    "O pacote OEM s\u00e3o 54 m\u00e1quinas em um arquivo de 3,8 GB, e at\u00e9 agora chegava como uma \u00fanica linha escrita \u201cPasta de mods\u201d \u2014 tudo ou nada. Agora ele aparece do jeito que \u00e9 feito: cada moto com seu nome e sua classe de verdade, com uma caixinha. Pegue as quatro em que voc\u00ea corre e deixe as outras cinquenta.",
+  "showcase.v0112.fullscreen":
+    "A pr\u00e9-visualiza\u00e7\u00e3o 3D do Designer abre em tela cheia \u2014 um bot\u00e3o preenche a janela com o modelo que voc\u00ea est\u00e1 pintando.",
+  "showcase.v0112.review":
+    "Um download que acaba trazendo v\u00e1rios mods para e mostra o que h\u00e1 dentro antes que qualquer coisa chegue \u00e0 sua pasta de mods.",
+  "showcase.v0112.paint":
+    "Uma pintura que oferece um arquivo por m\u00e1quina agora instala o da moto que voc\u00ea escolheu, e n\u00e3o o primeiro da p\u00e1gina.",
+  "showcase.v0112.speed":
+    "A folha de revis\u00e3o abre em cerca de um segundo com as motos OEM instaladas, onde antes levava quase vinte.",
+  "showcase.v0112.window":
+    "Uma janela preta na inicializa\u00e7\u00e3o n\u00e3o consegue mais prender voc\u00ea: ela fica escondida at\u00e9 ter desenhado algo e sempre tem como ser fechada.",
   "showcase.v0111.hero.title":
     "Trocas de modelo protegidas abrem em 3D",
   "showcase.v0111.hero.body":


### PR DESCRIPTION
Patch release cutting everything merged since v0.11.1.

- **CHANGELOG consolidated** into one `## 2026-08-29 — v0.11.2 — Install a pack one bike at a time, and a preview that fills the window` heading; the bare `## 2026-08-28` block's Fixed and Changed entries are folded in so nothing merged since the last tag is left out of the notes. `scripts/changelog-section.sh v0.11.2 --heading` prints and `scripts/release-notes.sh v0.11.2` renders.
- **Version bumped** in `package.json`, `Cargo.toml`, `Cargo.lock` and `tauri.conf.json`.
- **What's-new entry for 0.11.2**: the bike pack install as the hero, with the fullscreen Designer preview, the download review sheet, the per-bike paint file, the review sheet's speed and the black window as highlights — plus strings in all six locales (`tsc` confirms none is missing).
- The parked `## Unannounced — voice chat` block carries no version marker, so it stays out of the notes and out of Discord.

Merge, then tag `v0.11.2` on main to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)