### PR TITLE
chore(viewer): log which GPU the 3D views land on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,15 @@ whichever release turns it on.
 
 - **Sly** credited on Settings → Supporters.
 
+### Changed
+
+- **The log now records which GPU the 3D views are drawing on.** Both viewers draw through
+  the graphics card, but a Windows machine with a driver Windows doesn't trust drops them to
+  a software renderer instead — same picture, a fraction of the speed — and nothing said so.
+  Opening a 3D view now writes the adapter it got into the app log, flagged as a warning when
+  it turns out to be software, so "the viewer is slow" can be answered from the log a player
+  already sends.
+
 ### Fixed
 
 - **A paint that ships a separate file per bike now installs the right one.** Some pages offer

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4687,6 +4687,24 @@ fn reveal_in_explorer(path: String) -> Result<(), String> {
     library::reveal_in_explorer(&path).map_err(|e| format!("{e:#}"))
 }
 
+/// Put a line from the webview into the app's own log file.
+///
+/// `tauri_plugin_log` writes what Rust logs; nothing the frontend prints to its console
+/// reaches the file a player sends us. Facts only the webview knows — which GPU its WebGL
+/// context landed on, say — would otherwise be invisible in exactly the report that needs
+/// them.
+#[tauri::command]
+fn log_client(level: String, message: String) {
+    // A log line is not a transport for arbitrary payloads. Trim rather than reject: a
+    // truncated fact still reads, and a dropped one is a support thread that goes nowhere.
+    let msg: String = message.chars().take(2000).collect();
+    match level.as_str() {
+        "error" => log::error!("[webview] {msg}"),
+        "warn" => log::warn!("[webview] {msg}"),
+        _ => log::info!("[webview] {msg}"),
+    }
+}
+
 /// Where MXB App's own logs are, where the game's are, and what's currently in each.
 ///
 /// Read fresh on every call rather than cached: the whole reason someone opens this is
@@ -7927,6 +7945,7 @@ fn main() {
             move_mod,
             uninstall_mod,
             reveal_in_explorer,
+            log_client,
             logs_info,
             share_logs,
             open_logs_folder,

--- a/src/Components/Viewer/ModelViewer.tsx
+++ b/src/Components/Viewer/ModelViewer.tsx
@@ -20,6 +20,7 @@ import { textureBytes } from "../../api/mods";
 import { ErrorBoundary } from "../ErrorBoundary";
 import { useT } from "../../i18n/context";
 import { sceneOf, skyTexture, type SceneId } from "../../lib/viewerScene";
+import { reportRenderer } from "../../lib/glInfo";
 
 /**
  * `both` draws the bike and the rider in one scene, side by side — see {@link SideBySide};
@@ -2194,6 +2195,7 @@ export function ModelViewer({
           // nothing next to having no way to save what's on screen.
           gl={{ preserveDrawingBuffer: true }}
           onCreated={({ gl, invalidate }) => {
+            reportRenderer(gl, "model-viewer");
             // A lost GPU context otherwise leaves a black canvas; preventDefault lets the browser restore it.
             gl.domElement.addEventListener(
               "webglcontextlost",

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import type { TrackOverview, TrackTerrain } from "../../types";
 import { ErrorBoundary } from "../ErrorBoundary";
 import { useT } from "../../i18n/context";
+import { reportRenderer } from "../../lib/glInfo";
 
 /** The terrain is scaled to sit this many units across, whatever its real size. */
 const VIEW_SPAN = 10;
@@ -455,6 +456,7 @@ export function TrackViewer({ terrain, overview = null, className }: TrackViewer
           dpr={[1, 1.5]}
           camera={{ position: [0, 7.5, 11], fov: 45, near: 0.01, far: 200 }}
           onCreated={({ gl, invalidate }) => {
+            reportRenderer(gl, "track-viewer");
             gl.domElement.addEventListener(
               "webglcontextlost",
               (e) => {

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -878,6 +878,17 @@ export function logsInfo(): Promise<LogsInfo> {
   return invoke<LogsInfo>("logs_info");
 }
 
+/**
+ * Write a line into MXB App's own log file from here.
+ *
+ * The webview's console goes nowhere a player can send us — only what Rust logs reaches
+ * the file behind Settings → Logs. Anything the frontend alone can see has to come back
+ * through this to survive a bug report.
+ */
+export function logClient(level: "info" | "warn" | "error", message: string): Promise<void> {
+  return invoke<void>("log_client", { level, message });
+}
+
 /** Open the folder a log set lives in, newest file selected where the OS can. */
 export function openLogsFolder(which: LogsKind): Promise<void> {
   return invoke<void>("open_logs_folder", { which });

--- a/src/lib/glInfo.ts
+++ b/src/lib/glInfo.ts
@@ -1,0 +1,58 @@
+import type * as THREE from "three";
+import { logClient } from "../api/mods";
+
+/**
+ * Renderer names that mean no GPU is involved — the context is a CPU rasteriser standing in
+ * for one, at a fraction of the speed.
+ */
+const SOFTWARE = [
+  // Chromium's own, which WebView2 falls back to when the driver is missing or blocklisted.
+  "swiftshader",
+  // Mesa's, the same fallback on Linux.
+  "llvmpipe",
+  "softpipe",
+  // Microsoft's, on a machine with no usable display driver.
+  "basic render driver",
+  "warp",
+  "software adapter",
+];
+
+/** The adapter is a property of the machine, not of the canvas — one report says it. */
+let reported = false;
+
+/**
+ * Put the GPU this WebGL context actually landed on into the app log.
+ *
+ * Both viewers draw through WebGL, which is only fast if the webview got a hardware
+ * context. A blocklisted driver drops it to a software rasteriser silently — same picture,
+ * a fraction of the frame rate — and nothing in a bug report would say so.
+ */
+export function reportRenderer(gl: THREE.WebGLRenderer, label: string): void {
+  if (reported) return;
+  reported = true;
+  try {
+    const ctx = gl.getContext();
+    // WebKit removed this extension, so on macOS/Linux the names come back masked
+    // ("WebKit WebGL"). Chromium — every Windows install — still answers it.
+    const dbg = ctx.getExtension("WEBGL_debug_renderer_info");
+    const vendor = String(
+      ctx.getParameter(dbg ? dbg.UNMASKED_VENDOR_WEBGL : ctx.VENDOR) ?? "?",
+    );
+    const renderer = String(
+      ctx.getParameter(dbg ? dbg.UNMASKED_RENDERER_WEBGL : ctx.RENDERER) ?? "?",
+    );
+    const software = SOFTWARE.some((s) => renderer.toLowerCase().includes(s));
+    const line = [
+      `${label}: WebGL${gl.capabilities.isWebGL2 ? "2" : "1"}`,
+      `${vendor} / ${renderer}${dbg ? "" : " (masked)"}`,
+      `max texture ${ctx.getParameter(ctx.MAX_TEXTURE_SIZE)}px`,
+      `anisotropy ${gl.capabilities.getMaxAnisotropy()}`,
+      software ? "SOFTWARE RENDERING — no GPU" : "hardware",
+    ].join(", ");
+    if (software) console.warn(`[gl] ${line}`);
+    else console.info(`[gl] ${line}`);
+    void logClient(software ? "warn" : "info", `gl — ${line}`).catch(() => {});
+  } catch (e) {
+    console.warn("[gl] could not read the renderer:", e);
+  }
+}


### PR DESCRIPTION
Answers "are the 3D viewers actually on the GPU?" — a question nothing in the tree could answer, because the webview's console reaches no file a player can send.

## What this adds

- **`src/lib/glInfo.ts`** — reads the WebGL context's vendor and renderer once per run, flags known software rasterisers by name (SwiftShader, llvmpipe, WARP, Basic Render Driver), and reports max texture size + anisotropy alongside them as corroboration.
- Called from both `onCreated` handlers — `ModelViewer` and `TrackViewer`. First canvas to open reports; the adapter is a property of the machine, not the canvas.
- **`log_client`** command, so a webview line reaches the app's own log file. Capped at 2000 chars — a log line is not a transport for arbitrary payloads.

Complements `MXB_SAFE_GRAPHICS`, which records the knobs *we* turned; this records the adapter WebGL actually got.

## Verified

Ran the branch on macOS, opened Locker → View 3D:

```
[webview] gl — model-viewer: WebGL2, Apple Inc. / Apple GPU, max texture 16384px, anisotropy 16, hardware
```

`tsc --noEmit` and `cargo check` clean. No DB or schema changes.

Windows is the platform that can actually come back *software* — a blocklisted driver drops WebView2 to SwiftShader silently, same picture at a fraction of the speed. That reading arrives with the first user log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)