### PR TITLE
feat(viewer): draw a track's scenery, its ground and its relief

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,11 @@ whichever release turns it on.
   at: how many triangles it is and how big it is in metres. A published track comes apart into
   ten thousand of them, the largest five metres across.
 
+  Props can be written back out. A track's `.scr` is the one part of it that states where a
+  thing goes in plain text, and the game reads it at load — so it is where anything placed in
+  the app ends up. What goes out reads back as what went in, and an existing file is left alone
+  unless replacing it is asked for.
+
   A track carrying no scenery is left alone rather than reported as a failure; some ship none
   at all.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@ whichever release turns it on.
   at: how many triangles it is and how big it is in metres. A published track comes apart into
   ten thousand of them, the largest five metres across.
 
+  The ground keeps its detail when you get close to it. A track states its surface at about a
+  third of a metre per sample, height grid and surface picture alike, so anything nearer than
+  that was interpolation — a soft brown smear. The track's own ground sheet is now tiled over
+  the terrain and multiplied into it, which puts the grain back at whatever distance you care
+  to look from. It says what the ground is made of, not what is where.
+
   A track is lit and hazed the way it says it should be. Its ambience file states a sun
   colour, an ambient, and a fog — the viewer used one fixed rig for every track and ignored
   all of it. The haze is thinned to something a whole track can still be seen through: a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,11 @@ whichever release turns it on.
   at: how many triangles it is and how big it is in metres. A published track comes apart into
   ten thousand of them, the largest five metres across.
 
+  A track now sits under its own sky. Every one ships a dome and a backdrop and names them in
+  its ambience file, and the viewer was throwing both away — a track ended at a hard edge with
+  black beyond it. They draw with the track's own picture on them, lit from where the track
+  says its sun is.
+
   Where a track's surfaces can't be read, its cut-outs are left out rather than drawn wrong. A
   quarter of a map is foliage, crowd and netting — flat cards that are a tree only once an
   alpha channel has cut the tree out of them, and drawn plain they are thousands of standing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,9 +66,9 @@ whichever release turns it on.
   at: how many triangles it is and how big it is in metres. A published track comes apart into
   ten thousand of them, the largest five metres across.
 
-  And things can be put down. Pick one of the models the track ships, click the ground, and it
-  stands there — drawn where the file will say it goes, not approximately. Save writes the
-  `.scr` beside the track.
+  Ground colours are drier. A surface id names what the physics does, not what a track looks
+  like, and a lawn green on a dry circuit was the loudest wrong thing on the screen — the same
+  hues now sit closer to earth, so a surface a track named loosely reads as ground.
 
   Props can be written back out. A track's `.scr` is the one part of it that states where a
   thing goes in plain text, and the game reads it at load — so it is where anything placed in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,13 @@ whichever release turns it on.
   thirteen before, three of which were finding the wrong thing; nine find its relief, against
   three.
 
+  A track that places props of its own draws its scenery again. The props a `.scr` puts down
+  are added to the same mesh as the rest, but they were not being numbered as pieces — and the
+  viewer works out where the surfaces begin from the piece count, so a mesh short of ids reads
+  past its own end and is thrown away whole. Abydos was sixteen thousand prop triangles short
+  and drew nothing at all. Each placed prop is now a piece like any other, which is also what
+  makes it something you can point at.
+
   A track that states no surfaces of its own draws its terrain again. Tiling the ground sheet
   over it read the coordinates three.js sets up for a surface picture — which a track without
   one never has, so the shader failed to build and the terrain drew nothing while its scenery,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,12 @@ whichever release turns it on.
   thirteen before, three of which were finding the wrong thing; nine find its relief, against
   three.
 
+  A track that states no surfaces of its own draws its terrain again. Tiling the ground sheet
+  over it read the coordinates three.js sets up for a surface picture — which a track without
+  one never has, so the shader failed to build and the terrain drew nothing while its scenery,
+  sky and markers all drew fine. The grain now carries its own coordinates and works with or
+  without a picture under it.
+
   A track that states no surfaces at all is drawn in the colour of its ground rather than by
   height. Two of the installed tracks ship no coverage data, so the viewer fell back to an
   elevation ramp — green in the hollows through to white on the high ground, which on a sand

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,10 +87,22 @@ whichever release turns it on.
   Which sheet gets picked is read as words rather than letters. A track's ground was chosen by
   looking for `dirt` or `sand` anywhere in a name, which on one track picked `logo-dirtmaster`
   — a logo — and on another a sponsor's banner, and a near-flat sheet tiled over a track does
-  nothing at all. Names now split into their words however they were written, a word only
-  counts whole, and a name carrying `logo`, `banner`, `sign` or the like is not ground however
-  grounded the rest of it sounds. Seven of sixteen installed tracks now find their relief,
-  against three before.
+  nothing at all. Names now split into their words however they were written, capitals
+  included, a word only counts whole, and a name carrying `logo`, `banner`, `sign`, `marker`
+  or the like is not ground however grounded the rest of it sounds. A track may also name its
+  riding surface after itself — SandPoint calls it `track-dark` — which is now read as ground
+  where nothing better is offered. All sixteen installed tracks find their ground, against
+  thirteen before, three of which were finding the wrong thing; nine find its relief, against
+  three.
+
+  A track that states no surfaces at all is drawn in the colour of its ground rather than by
+  height. Two of the installed tracks ship no coverage data, so the viewer fell back to an
+  elevation ramp — green in the hollows through to white on the high ground, which on a sand
+  circuit is not a legend anybody asked for. Where the track's own ground sheet is known, its
+  average colour is used instead and the shape reads by its shading alone.
+
+  The ground sheet is cached with the rest. Finding it means inflating candidate sheets to
+  check a normal map really is one, and that was happening on every open.
 
   A track is lit and hazed the way it says it should be. Its ambience file states a sun
   colour, an ambient, and a fog — the viewer used one fixed rig for every track and ignored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,13 @@ whichever release turns it on.
   black beyond it. They draw with the track's own picture on them, lit from where the track
   says its sun is.
 
+  What stands on the track is lit from above rather than from below. Every piece of scenery
+  was being drawn back to front — the game's meshes are wound the other way round, and the
+  view already mirrors them, so reversing them again put every face the wrong way out. Drawn
+  double-sided that shows up not as holes but as light: the sun landed on the underside of
+  everything. Small props got away with it; a track that surrounds itself with landscape did
+  not, and Abydos's dunes drew as a black apron around the circuit. They are dunes now.
+
   Where a track's surfaces can't be read, its cut-outs are left out rather than drawn wrong. A
   quarter of a map is foliage, crowd and netting — flat cards that are a tree only once an
   alpha channel has cut the tree out of them, and drawn plain they are thousands of standing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ whichever release turns it on.
   at: how many triangles it is and how big it is in metres. A published track comes apart into
   ten thousand of them, the largest five metres across.
 
+  And things can be put down. Pick one of the models the track ships, click the ground, and it
+  stands there — drawn where the file will say it goes, not approximately. Save writes the
+  `.scr` beside the track.
+
   Props can be written back out. A track's `.scr` is the one part of it that states where a
   thing goes in plain text, and the game reads it at load — so it is where anything placed in
   the app ends up. What goes out reads back as what went in, and an existing file is left alone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,20 @@ whichever release turns it on.
   the terrain and multiplied into it, which puts the grain back at whatever distance you care
   to look from. It says what the ground is made of, not what is where.
 
+  And where a track ships one, that grain has relief rather than being a picture of relief.
+  Half the tracks measured carry a normal map beside their ground sheet — the sheet that says
+  which way the surface faces rather than what colour it is — and it is now tiled with the
+  colour it belongs to and lit by the track's own sun, so a rut catches the light on the side
+  facing it. Gently: one sheet is standing in for every surface a track has.
+
+  Which sheet gets picked is read as words rather than letters. A track's ground was chosen by
+  looking for `dirt` or `sand` anywhere in a name, which on one track picked `logo-dirtmaster`
+  — a logo — and on another a sponsor's banner, and a near-flat sheet tiled over a track does
+  nothing at all. Names now split into their words however they were written, a word only
+  counts whole, and a name carrying `logo`, `banner`, `sign` or the like is not ground however
+  grounded the rest of it sounds. Seven of sixteen installed tracks now find their relief,
+  against three before.
+
   A track is lit and hazed the way it says it should be. Its ambience file states a sun
   colour, an ambient, and a fog — the viewer used one fixed rig for every track and ignored
   all of it. The haze is thinned to something a whole track can still be seen through: a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@ whichever release turns it on.
   at: how many triangles it is and how big it is in metres. A published track comes apart into
   ten thousand of them, the largest five metres across.
 
+  Where a track's surfaces can't be read, its cut-outs are left out rather than drawn wrong. A
+  quarter of a map is foliage, crowd and netting — flat cards that are a tree only once an
+  alpha channel has cut the tree out of them, and drawn plain they are thousands of standing
+  sheets of paper hiding the track behind them. Tracks whose surfaces do read keep every one
+  of them.
+
   Ground colours are drier. A surface id names what the physics does, not what a track looks
   like, and a lawn green on a dry circuit was the loudest wrong thing on the screen — the same
   hues now sit closer to earth, so a surface a track named loosely reads as ground.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@ whichever release turns it on.
   at: how many triangles it is and how big it is in metres. A published track comes apart into
   ten thousand of them, the largest five metres across.
 
+  A track is lit and hazed the way it says it should be. Its ambience file states a sun
+  colour, an ambient, and a fog — the viewer used one fixed rig for every track and ignored
+  all of it. The haze is thinned to something a whole track can still be seen through: a
+  track's own figure is written for a rider looking down a straight, not for a view of the
+  entire place at once, so the colour and the relative thickness are the track's while the
+  depth it acts over is the view's.
+
   A track now sits under its own sky. Every one ships a dome and a backdrop and names them in
   its ambience file, and the viewer was throwing both away — a track ended at a hard edge with
   black beyond it. They draw with the track's own picture on them, lit from where the track

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@ whichever release turns it on.
   at: how many triangles it is and how big it is in metres. A published track comes apart into
   ten thousand of them, the largest five metres across.
 
+  The ground keeps its own colour while it does. The grain is measured against the sheet's own
+  average brightness, so it varies the surface without dragging it darker — tiling a dirt or
+  grass sheet raw turned a dry circuit muddy — and only the sheet's luminance is used, never
+  its hue. A track with no dirt sheet of its own is left alone rather than tinted with
+  whatever else it had.
+
   The ground keeps its detail when you get close to it. A track states its surface at about a
   third of a metre per sample, height grid and surface picture alike, so anything nearer than
   that was interpolation — a soft brown smear. The track's own ground sheet is now tiled over

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,42 @@ whichever release turns it on.
 
 ### Added
 
+- **The track viewer draws what stands on the track, not just the shape of it.** Until now a
+  track opened as bare ground: the right ruts, berms and jump faces, but nothing standing on
+  them, so a supercross floor and a national circuit read much the same. The viewer now draws
+  the track's scenery too — the tents and awnings, the hay bales and tyre walls, the banner
+  lines and fencing, the trailers in the paddock, and the landscape beyond the track's own
+  square — all in the places the track itself puts them. **Objects** in the header turns it
+  off again.
+
+  It also marks what a track places but ships no model for: every marshal post, every TV
+  camera and every crowd sound source, each as a pin standing on the ground where the track
+  states it. That the pins land on the ground rather than near it is the check that the
+  scenery is in the right place at all — a track states its marshals' heights, its terrain
+  states the ground's, and nothing makes the two agree except reading both correctly.
+
+  It is drawn in the track's own colours, not a flat grey: the `.map`'s surfaces come out
+  with it, so the tents are the tents and the dirt is the dirt. Foliage, crowd and fencing
+  are cut-outs rather than the solid slabs they would otherwise be — a track's own naming
+  says which surfaces carry a cut-out, and drawing those without one turns a treeline into a
+  wall and buries the track behind it.
+
+  It arrives in stages rather than all at once. The terrain draws first, then the scenery's
+  shape, then the colours on top of it — because pulling a track's map out of its archive is
+  nearly all of what a look at one costs, and the shape of the place is worth having on
+  screen while the hundreds of megabytes behind its colours are still being read. The header
+  says which stage is still running. Both halves are cached, so opening the same track again
+  skips the archive entirely.
+
+  Click anything standing on the track and it lights up on its own. The scenery arrives as one
+  mesh, but the things in it are separable — an exporter welds a tent to itself and to nothing
+  else — so the viewer recovers the pieces a track was built from and names the one you point
+  at: how many triangles it is and how big it is in metres. A published track comes apart into
+  ten thousand of them, the largest five metres across.
+
+  A track carrying no scenery is left alone rather than reported as a failure; some ship none
+  at all.
+
 - **A bike pack installs as the bikes inside it.** The OEM bike pack is 54 machines and a
   tyre set in one 3.8 GB archive, and until now it arrived as a single row reading "Mods
   folder" — all of it or none of it, with no way to see what was in there. It is now listed

--- a/src-tauri/src/edf.rs
+++ b/src-tauri/src/edf.rs
@@ -186,10 +186,22 @@ fn f32le(b: &[u8], o: usize) -> f32 {
     f32::from_le_bytes([b[o], b[o + 1], b[o + 2], b[o + 3]])
 }
 
-fn finite_pos(b: &[u8], o: usize) -> bool {
+/// How far from the origin a vertex may sit and still look like one.
+///
+/// A bike is two metres and a rider less, so a tight bound is most of what tells a real
+/// vertex block from a run of bytes that happens to parse as floats.
+const MODEL_EXTENT: f32 = 200.0;
+
+/// The same, for models built at track scale.
+///
+/// A track's sky dome reaches 1.5 km from its centre and its backdrop 750 m — every vertex in
+/// them fails the model bound, so under it a whole sky reads as no geometry at all.
+const WORLD_EXTENT: f32 = 100_000.0;
+
+fn finite_pos(b: &[u8], o: usize, extent: f32) -> bool {
     (0..3).all(|k| {
         let v = f32le(b, o + 4 * k);
-        v.is_finite() && v.abs() < 200.0
+        v.is_finite() && v.abs() < extent
     })
 }
 
@@ -216,7 +228,16 @@ pub fn is_edf(b: &[u8]) -> bool {
 
 // Parse an .edf into its renderable mesh nodes (highest-detail LOD of each part).
 pub fn parse(b: &[u8]) -> Vec<EdfNode> {
-    parse_impl(b, &[], false)
+    parse_impl(b, &[], false, MODEL_EXTENT)
+}
+
+/// Parse a model built at track scale — a sky dome, a backdrop, a grandstand.
+///
+/// Identical to [`parse`] but for the bound a vertex has to sit inside. Everything a track
+/// ships is placed in world metres, so the tight bound that protects a bike parse throws the
+/// whole model away.
+pub fn parse_world(b: &[u8]) -> Vec<EdfNode> {
+    parse_impl(b, &[], false, WORLD_EXTENT)
 }
 
 /// Parse a gear mesh: as [`parse`], but a node whose geometry is a single group takes its
@@ -228,16 +249,16 @@ pub fn parse(b: &[u8]) -> Vec<EdfNode> {
 /// fork and swingarm too, and re-checking a whole bike's assembly against these bounds is
 /// its own piece of work.
 pub fn parse_gear(b: &[u8]) -> Vec<EdfNode> {
-    parse_impl(b, &[], true)
+    parse_impl(b, &[], true, MODEL_EXTENT)
 }
 
 // Parse keeping exactly the nodes the bike's .hrc declares as level0; empty slice
 // falls back to level0_only's name heuristic.
 pub fn parse_with_levels(b: &[u8], level0: &[String]) -> Vec<EdfNode> {
-    parse_impl(b, level0, false)
+    parse_impl(b, level0, false, MODEL_EXTENT)
 }
 
-fn parse_impl(b: &[u8], level0: &[String], node_matrix_once: bool) -> Vec<EdfNode> {
+fn parse_impl(b: &[u8], level0: &[String], node_matrix_once: bool, extent: f32) -> Vec<EdfNode> {
     let n = b.len();
     if !is_edf(b) {
         return Vec::new();
@@ -253,7 +274,7 @@ fn parse_impl(b: &[u8], level0: &[String], node_matrix_once: bool) -> Vec<EdfNod
         if (8..=MAX_COUNT).contains(&vc) && o + 4 + vc * STRIDE + 8 <= n {
             let vs = o + 4;
             let samples = [0usize, 1, 2, vc / 2, vc - 1];
-            if samples.iter().all(|&i| finite_pos(b, vs + i * 12)) {
+            if samples.iter().all(|&i| finite_pos(b, vs + i * 12, extent)) {
                 let ic = vs + vc * STRIDE;
                 let tc = u32le(b, ic) as usize;
                 if (1..=MAX_COUNT).contains(&tc) && ic + 8 + tc * 12 <= n {
@@ -276,7 +297,16 @@ fn parse_impl(b: &[u8], level0: &[String], node_matrix_once: bool) -> Vec<EdfNod
                         // `o` is the node's vertex-count word — its material table ends there.
                         let mats = node_material_table(b, o, textures);
                         nodes.push(read_node(
-                            b, &cands, vs, vc, raw, iend, tc, name, mats, node_matrix_once,
+                            b,
+                            &cands,
+                            vs,
+                            vc,
+                            raw,
+                            iend,
+                            tc,
+                            name,
+                            mats,
+                            node_matrix_once,
                         ));
                         o = iend; // jump past this block
                         continue;
@@ -292,7 +322,10 @@ fn parse_impl(b: &[u8], level0: &[String], node_matrix_once: bool) -> Vec<EdfNod
     }
     let want: std::collections::HashSet<String> =
         level0.iter().map(|n| n.to_ascii_lowercase()).collect();
-    if !nodes.iter().any(|n| want.contains(&n.name.to_ascii_lowercase())) {
+    if !nodes
+        .iter()
+        .any(|n| want.contains(&n.name.to_ascii_lowercase()))
+    {
         log::warn!("edf: .hrc level0 {level0:?} matched no node — using the name heuristic");
         return level0_only(nodes);
     }
@@ -340,7 +373,14 @@ fn mounts(
     let front_upper = *g.get("front_upper")?;
     let rake = -sc.get("rakeangle_min").copied().unwrap_or(0.0);
     let fork_origin = v_add(rot_x(v_sub(front_upper, steer_joint), rake), head);
-    Some(Mounts { rake, head, pivot, steer_joint, rsusp_joint, fork_origin })
+    Some(Mounts {
+        rake,
+        head,
+        pivot,
+        steer_joint,
+        rsusp_joint,
+        fork_origin,
+    })
 }
 
 impl Mounts {
@@ -350,11 +390,18 @@ impl Mounts {
     /// taken at the midpoint of the chain-adjuster range the .geom gives as `rwheel_min`/
     /// `rwheel_max`. `None` when the .geom names neither — a bike we can still assemble but
     /// can't say where the wheels ride on.
-    fn axles(&self, g: &std::collections::HashMap<String, [f32; 3]>) -> Option<([f32; 3], [f32; 3])> {
+    fn axles(
+        &self,
+        g: &std::collections::HashMap<String, [f32; 3]>,
+    ) -> Option<([f32; 3], [f32; 3])> {
         let fwheel = *g.get("fwheel")?;
         let lo = *g.get("rwheel_min")?;
         let hi = g.get("rwheel_max").copied().unwrap_or(lo);
-        let rear = [(lo[0] + hi[0]) * 0.5, (lo[1] + hi[1]) * 0.5, (lo[2] + hi[2]) * 0.5];
+        let rear = [
+            (lo[0] + hi[0]) * 0.5,
+            (lo[1] + hi[1]) * 0.5,
+            (lo[2] + hi[2]) * 0.5,
+        ];
         Some((
             v_add(rot_x(fwheel, self.rake), self.fork_origin),
             v_add(rear, v_sub(self.pivot, self.rsusp_joint)),
@@ -537,7 +584,9 @@ fn plausible_name(b: &[u8], o: usize) -> Option<String> {
         if c == 0 {
             break;
         }
-        if !(c.is_ascii_alphanumeric() || matches!(c, b'.' | b'_' | b'-')) {
+        // A colon is a namespace prefix an exporter left on — a track's sky dome comes out of
+        // Maya as `tmp1:dome`, and rejecting the name threw the whole sky away.
+        if !(c.is_ascii_alphanumeric() || matches!(c, b'.' | b'_' | b'-' | b':')) {
             return None;
         }
         e += 1;
@@ -830,7 +879,9 @@ fn tex_name(b: &[u8], o: usize) -> Option<String> {
         e += 1;
     }
     let len = e - o;
-    (1..=39).contains(&len).then(|| String::from_utf8_lossy(&b[o..e]).into_owned())
+    (1..=39)
+        .contains(&len)
+        .then(|| String::from_utf8_lossy(&b[o..e]).into_owned())
 }
 
 // Enumerate every texture in a model.edf, in file order. Anchored on the name, then
@@ -944,8 +995,8 @@ fn read_node(
     let raw_subs: Vec<RawSub> = detect_submeshes(b, cands, iend, raw_tris, vc)
         .into_iter()
         .flat_map(|s| {
-            let ranges = read_sub_group_ranges(b, s.block_off, raw_tris, vc)
-                .filter(|r| r.len() > 1);
+            let ranges =
+                read_sub_group_ranges(b, s.block_off, raw_tris, vc).filter(|r| r.len() > 1);
             let Some(ranges) = ranges else { return vec![s] };
             // Each range names its own material in the word just BEFORE its 24-byte entry:
             // range 0 takes the word at `block_off - 4`, and every later range takes the
@@ -968,7 +1019,8 @@ fn read_node(
         })
         .collect();
     // Covers the node when the submesh triangle counts sum to the raw total.
-    let covers = !raw_subs.is_empty() && raw_subs.iter().map(|s| s.tri_count).sum::<usize>() == raw_tris;
+    let covers =
+        !raw_subs.is_empty() && raw_subs.iter().map(|s| s.tri_count).sum::<usize>() == raw_tris;
 
     // Place the geometry: each submesh's own transform composed with the node
     // orientation matrix (at iend, the name offset) yields its .geom LOCAL frame.
@@ -1053,7 +1105,9 @@ fn read_node(
                     texture: None,
                     uv_tile: uv_tile(&uvs, s.vert_start, s.vert_count),
                     // Split skinned range carries its own mat; else read u32 at block_off - 4.
-                    mat: s.mat.or_else(|| s.block_off.checked_sub(4).map(|o| u32le(b, o))),
+                    mat: s
+                        .mat
+                        .or_else(|| s.block_off.checked_sub(4).map(|o| u32le(b, o))),
                 });
                 kept_start += kept;
             }
@@ -1107,7 +1161,12 @@ fn read_cname(b: &[u8], o: usize) -> String {
 // (tri_start, tri_count, vert_start, vert_count) and pair is 2 u32. The pair ends
 // the group when it reads (cumulative vert_count, group's FIRST vert_start); anything
 // else (in practice (0,1)) means another range follows. Name sits at block - 252.
-fn read_sub_group(b: &[u8], o: usize, tot_tris: usize, tot_verts: usize) -> Option<(usize, usize, usize, usize)> {
+fn read_sub_group(
+    b: &[u8],
+    o: usize,
+    tot_tris: usize,
+    tot_verts: usize,
+) -> Option<(usize, usize, usize, usize)> {
     let tri_start = u32le(b, o) as usize;
     let first_vs = u32le(b, o + 8) as usize;
     let (mut tri_total, mut vc_total) = (0usize, 0usize);
@@ -1248,8 +1307,9 @@ fn chain_submeshes(
     tot_tris: usize,
     tot_verts: usize,
 ) -> Option<Vec<RawSub>> {
-    let in_bounds =
-        |c: &SubCand| c.tri_start + c.tri_count <= tot_tris && c.vert_start + c.vert_count <= tot_verts;
+    let in_bounds = |c: &SubCand| {
+        c.tri_start + c.tri_count <= tot_tris && c.vert_start + c.vert_count <= tot_verts
+    };
     let start = cands
         .iter()
         .filter(|c| c.tri_start == 0 && c.vert_start == 0 && c.block_off >= iend && in_bounds(c))
@@ -1286,7 +1346,12 @@ fn chain_submeshes(
 
 // Fallback for detect_submeshes: scan a fixed ~200 KB window from the node's name for
 // matrix-anchored records and chain them by contiguity.
-fn detect_submeshes_window(b: &[u8], iend: usize, tot_tris: usize, tot_verts: usize) -> Vec<RawSub> {
+fn detect_submeshes_window(
+    b: &[u8],
+    iend: usize,
+    tot_tris: usize,
+    tot_verts: usize,
+) -> Vec<RawSub> {
     use std::collections::HashMap;
     let window = 200_000usize.min(b.len().saturating_sub(iend));
     // Candidate blocks, indexed by tri_start.
@@ -1312,8 +1377,14 @@ fn detect_submeshes_window(b: &[u8], iend: usize, tot_tris: usize, tot_verts: us
             .iter()
             .find(|(_, _, vstart, _)| *vstart == run_v)
             .or_else(|| opts.first());
-        let Some(&(o, cnt, vstart, vcnt)) = pick else { break };
-        let name = if o >= 252 { read_cname(b, o - 252) } else { String::new() };
+        let Some(&(o, cnt, vstart, vcnt)) = pick else {
+            break;
+        };
+        let name = if o >= 252 {
+            read_cname(b, o - 252)
+        } else {
+            String::new()
+        };
         out.push(RawSub {
             name,
             tri_start: run_t,
@@ -1510,7 +1581,11 @@ fn read_block(b: &[u8], o: usize) -> Option<BoneBlock> {
     if !affine_at(b, first) {
         return None;
     }
-    let inv_bind = if two { Some(read_mat4(b, first + 64)?) } else { None };
+    let inv_bind = if two {
+        Some(read_mat4(b, first + 64)?)
+    } else {
+        None
+    };
     let fields = first + if two { 128 } else { 64 };
     // Step over the index words: the name is the first thing that reads as one with three zero
     // words and a finite AABB in front of it.
@@ -1588,7 +1663,9 @@ fn bone_name(b: &[u8], o: usize) -> Option<String> {
         }
         e += 1;
     }
-    (2..=63).contains(&(e - o)).then(|| String::from_utf8_lossy(&b[o..e]).into_owned())
+    (2..=63)
+        .contains(&(e - o))
+        .then(|| String::from_utf8_lossy(&b[o..e]).into_owned())
 }
 
 /// Rebuild the bone tree from the names.
@@ -1603,9 +1680,15 @@ fn bone_name(b: &[u8], o: usize) -> Option<String> {
 /// so that holds of every real one, and insisting on it is what keeps the result a tree: a bone
 /// inside a cycle hangs off no root, and nothing ever works out where it is.
 fn rig_parents(names: &[String]) -> Vec<Option<usize>> {
-    let stems: Vec<String> = names.iter().map(|n| bone_stem(n).to_ascii_lowercase()).collect();
-    let index: std::collections::HashMap<&str, usize> =
-        stems.iter().enumerate().map(|(i, s)| (s.as_str(), i)).collect();
+    let stems: Vec<String> = names
+        .iter()
+        .map(|n| bone_stem(n).to_ascii_lowercase())
+        .collect();
+    let index: std::collections::HashMap<&str, usize> = stems
+        .iter()
+        .enumerate()
+        .map(|(i, s)| (s.as_str(), i))
+        .collect();
     (0..names.len())
         .map(|i| {
             if i == 0 {
@@ -1690,8 +1773,11 @@ fn named_parent(stem: &str) -> Option<String> {
     let digit = joint.chars().last().filter(char::is_ascii_digit)?;
     let base = &joint[..joint.len() - 1];
     if digit == '1' {
-        return matches!(base, "thumb" | "index" | "middle" | "ring" | "pink" | "pinky")
-            .then(|| format!("{side}wrist"));
+        return matches!(
+            base,
+            "thumb" | "index" | "middle" | "ring" | "pink" | "pinky"
+        )
+        .then(|| format!("{side}wrist"));
     }
     let prev = (digit as u8 - 1) as char;
     Some(format!("{side}{base}{prev}"))
@@ -1841,7 +1927,8 @@ fn claims(bone: &Bone, point: &[f32; 3]) -> bool {
     }
     let m = &bone.inv_bind;
     (0..3).all(|a| {
-        let p = m[a * 4] * point[0] + m[a * 4 + 1] * point[1] + m[a * 4 + 2] * point[2] + m[a * 4 + 3];
+        let p =
+            m[a * 4] * point[0] + m[a * 4 + 1] * point[1] + m[a * 4 + 2] * point[2] + m[a * 4 + 3];
         p >= bone.aabb_lo[a] && p <= bone.aabb_hi[a]
     })
 }
@@ -1899,8 +1986,8 @@ mod tests {
             materials: Vec::new(),
         };
 
-        let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(&node).unwrap())
-            .unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&node).unwrap()).unwrap();
 
         let floats = |key: &str| -> Vec<f32> {
             let b = STANDARD.decode(v[key].as_str().unwrap()).unwrap();
@@ -1933,7 +2020,10 @@ mod tests {
         let mut enc = DeflateEncoder::new(Vec::new(), flate2::Compression::default());
         enc.write_all(&vec![0u8; 64 * 1024 * 1024]).unwrap();
         let payload = enc.finish().unwrap();
-        assert!(payload.len() < 1024 * 1024, "the point is that it compresses hard");
+        assert!(
+            payload.len() < 1024 * 1024,
+            "the point is that it compresses hard"
+        );
 
         let tex = EmbeddedTexture {
             name: "bomb".into(),
@@ -1943,18 +2033,34 @@ mod tests {
             data_len: payload.len(),
         };
         let out = inflate_texture(&payload, &tex).expect("still decodes");
-        assert_eq!(out.len(), 64 * 64 * 4, "bounded by what the record claims to be");
+        assert_eq!(
+            out.len(),
+            64 * 64 * 4,
+            "bounded by what the record claims to be"
+        );
     }
 
     // Material indices count the colour textures, so a map counted among them slides every
     // later texture onto the wrong mesh — the Tactical Vest wore its pouch's normal map.
     #[test]
     fn exporter_named_maps_are_companions_not_colour() {
-        for name in ["Vest_Normal", "chest_Roughness", "brace_AO", "pouch_metallic", "shell_n"] {
+        for name in [
+            "Vest_Normal",
+            "chest_Roughness",
+            "brace_AO",
+            "pouch_metallic",
+            "shell_n",
+        ] {
             assert!(is_companion_texture(name), "'{name}' is a map");
         }
         // The look itself, however it's spelled.
-        for name in ["Vest_BaseColor", "chest_diffuse", "CK_A1", "bake1", "aphair"] {
+        for name in [
+            "Vest_BaseColor",
+            "chest_diffuse",
+            "CK_A1",
+            "bake1",
+            "aphair",
+        ] {
             assert!(!is_companion_texture(name), "'{name}' is the look");
         }
     }
@@ -1979,7 +2085,10 @@ mod tests {
     fn a_nodes_material_table_is_read_back_off_its_vertex_count() {
         let b = material_table_bytes(&[3, 1, 0], 512);
         // One-based into the declared colours, and 0 means the material carries no texture.
-        assert_eq!(node_material_table(&b, 512, 3), vec![Some(2), Some(0), None]);
+        assert_eq!(
+            node_material_table(&b, 512, 3),
+            vec![Some(2), Some(0), None]
+        );
     }
 
     /// A model declares more texture slots than it embeds — the Bell Moto 10 leaves its
@@ -2028,11 +2137,22 @@ mod tests {
             }
         }
         eprintln!("nodes: {}", nodes.len());
-        eprintln!("overall bbox lo={lo:?} hi={hi:?}  size={:?}", [hi[0]-lo[0], hi[1]-lo[1], hi[2]-lo[2]]);
+        eprintln!(
+            "overall bbox lo={lo:?} hi={hi:?}  size={:?}",
+            [hi[0] - lo[0], hi[1] - lo[1], hi[2] - lo[2]]
+        );
         for n in &nodes {
-            eprintln!("  node '{}'  verts={}  submeshes={}", n.name, n.positions.len() / 3, n.submeshes.len());
+            eprintln!(
+                "  node '{}'  verts={}  submeshes={}",
+                n.name,
+                n.positions.len() / 3,
+                n.submeshes.len()
+            );
             for sm in &n.submeshes {
-                eprintln!("      submesh '{}'  tris={}  tex={:?}", sm.name, sm.tri_count, sm.texture);
+                eprintln!(
+                    "      submesh '{}'  tris={}  tex={:?}",
+                    sm.name, sm.tri_count, sm.texture
+                );
             }
         }
     }
@@ -2052,7 +2172,10 @@ mod tests {
     fn reads_single_range_submesh_group() {
         // The real Honda chassis' first group: tris 0..31846, verts 0..24904.
         let b = group_bytes(&[(0, 31846, 0, 24904)], &[(24904, 0)]);
-        assert_eq!(read_sub_group(&b, 0, 46184, 35689), Some((0, 31846, 0, 24904)));
+        assert_eq!(
+            read_sub_group(&b, 0, 46184, 35689),
+            Some((0, 31846, 0, 24904))
+        );
     }
 
     // Real bytes of the Yamaha YZ450F's `fsusp` first group (a multi-range group).
@@ -2094,24 +2217,51 @@ mod tests {
     fn chains_records_split_across_a_gap() {
         let b = [0u8; 8]; // block_off < 252 → names skipped, buffer unused
         let cands = vec![
-            SubCand { block_off: 100, tri_start: 0, tri_count: 9096, vert_start: 0, vert_count: 6816 },
-            SubCand { block_off: 200, tri_start: 9096, tri_count: 39214, vert_start: 6816, vert_count: 28502 },
+            SubCand {
+                block_off: 100,
+                tri_start: 0,
+                tri_count: 9096,
+                vert_start: 0,
+                vert_count: 6816,
+            },
+            SubCand {
+                block_off: 200,
+                tri_start: 9096,
+                tri_count: 39214,
+                vert_start: 6816,
+                vert_count: 28502,
+            },
         ];
         let subs = chain_submeshes(&b, &cands, 0, 48310, 35318).expect("chain reconciles");
         assert_eq!(subs.len(), 2);
         assert_eq!(subs[0].tri_start, 0);
         assert_eq!(subs[1].tri_start, 9096);
         assert_eq!(subs.iter().map(|s| s.tri_count).sum::<usize>(), 48310);
-        assert_eq!(subs.last().unwrap().vert_start + subs.last().unwrap().vert_count, 35318);
+        assert_eq!(
+            subs.last().unwrap().vert_start + subs.last().unwrap().vert_count,
+            35318
+        );
     }
 
     #[test]
     fn rejects_unreconcilable_chain() {
         let b = [0u8; 8];
         let cands = vec![
-            SubCand { block_off: 100, tri_start: 0, tri_count: 9096, vert_start: 0, vert_count: 6816 },
+            SubCand {
+                block_off: 100,
+                tri_start: 0,
+                tri_count: 9096,
+                vert_start: 0,
+                vert_count: 6816,
+            },
             // vert_start doesn't continue 6816 → the chain can't reach it.
-            SubCand { block_off: 200, tri_start: 9096, tri_count: 39214, vert_start: 9999, vert_count: 28502 },
+            SubCand {
+                block_off: 200,
+                tri_start: 9096,
+                tri_count: 39214,
+                vert_start: 9999,
+                vert_count: 28502,
+            },
         ];
         assert!(chain_submeshes(&b, &cands, 0, 48310, 35318).is_none());
     }
@@ -2141,7 +2291,10 @@ mod tests {
             ch.submeshes.len()
         );
         assert!(ch.placed, "chassis must be placed");
-        assert!(!ch.submeshes.is_empty(), "chassis must have a submesh table");
+        assert!(
+            !ch.submeshes.is_empty(),
+            "chassis must have a submesh table"
+        );
         assert_eq!(
             covered as usize,
             ch.indices.len() / 3,
@@ -2191,7 +2344,11 @@ seat_height_ref = 0, 0.9115, -0.1674\n";
     }
 
     fn vertex(n: &EdfNode, i: usize) -> [f32; 3] {
-        [n.positions[i * 3], n.positions[i * 3 + 1], n.positions[i * 3 + 2]]
+        [
+            n.positions[i * 3],
+            n.positions[i * 3 + 1],
+            n.positions[i * 3 + 2],
+        ]
     }
 
     fn close(a: [f32; 3], b: [f32; 3], tol: f32) -> bool {
@@ -2214,7 +2371,10 @@ seat_height_ref = 0, 0.9115, -0.1674\n";
         // Both axles on the bike's centreline, and within a wheel's worth of the same height —
         // a rig that had the rear swung out would pass the wheelbase check and nothing else.
         assert!(front[0].abs() < 1e-4 && rear[0].abs() < 1e-4);
-        assert!((front[1] - rear[1]).abs() < 0.05, "axles {front:?} {rear:?}");
+        assert!(
+            (front[1] - rear[1]).abs() < 0.05,
+            "axles {front:?} {rear:?}"
+        );
     }
 
     /// The rig names points *on the mesh*, so it has to survive the centring the mesh gets:
@@ -2246,14 +2406,26 @@ seat_height_ref = 0, 0.9115, -0.1674\n";
     fn the_seat_lands_where_the_geom_puts_it() {
         let g = parse_geom(CR250_GEOM);
         let seat = g["seat_height_ref"];
-        let mut nodes = [mount_node("chassis", &[[0.0, 0.0, 0.0], [0.0, 1.2, 0.9], seat])];
+        let mut nodes = [mount_node(
+            "chassis",
+            &[[0.0, 0.0, 0.0], [0.0, 1.2, 0.9], seat],
+        )];
         let rig = assemble_bike(&mut nodes, CR250_GEOM).expect("assembled");
         let at = rig.seat.expect("the .geom names a seat");
-        assert!(close(vertex(&nodes[0], 2), at, 1e-4), "seat {at:?} left the mesh");
+        assert!(
+            close(vertex(&nodes[0], 2), at, 1e-4),
+            "seat {at:?} left the mesh"
+        );
         // And it is a seat: above both axles, and between them rather than out past a wheel.
         let (front, rear) = (rig.front_axle.expect("front"), rig.rear_axle.expect("rear"));
-        assert!(at[1] > front[1] + 0.3 && at[1] > rear[1] + 0.3, "seat {at:?} is not above the axles");
-        assert!(at[2] < front[2] && at[2] > rear[2], "seat {at:?} is not between the wheels");
+        assert!(
+            at[1] > front[1] + 0.3 && at[1] > rear[1] + 0.3,
+            "seat {at:?} is not above the axles"
+        );
+        assert!(
+            at[2] < front[2] && at[2] > rear[2],
+            "seat {at:?} is not between the wheels"
+        );
     }
 
     /// A .geom with no seat line leaves it unset rather than dropping a rider on the origin.
@@ -2265,7 +2437,10 @@ seat_height_ref = 0, 0.9115, -0.1674\n";
             .flat_map(|l| l.iter().copied().chain(std::iter::once(b'\n')))
             .collect();
         let mut nodes = [mount_node("chassis", &[[0.0, 0.0, 0.0], [0.0, 1.2, 0.9]])];
-        assert_eq!(assemble_bike(&mut nodes, &trimmed).expect("assembled").seat, None);
+        assert_eq!(
+            assemble_bike(&mut nodes, &trimmed).expect("assembled").seat,
+            None
+        );
     }
 
     /// …and the same again through the mirror into three.js' frame.
@@ -2282,11 +2457,17 @@ seat_height_ref = 0, 0.9115, -0.1674\n";
         let before = rig.pivot;
         to_right_handed(&mut nodes);
         rig.to_right_handed();
-        assert!((rig.pivot[0] + before[0]).abs() < 1e-6, "x should have flipped");
+        assert!(
+            (rig.pivot[0] + before[0]).abs() < 1e-6,
+            "x should have flipped"
+        );
         assert_eq!(rig.pivot[1], before[1]);
         // The swingarm vertex sits 0.25 m off the pivot either side of the mirror.
         let d = vertex(&nodes[1], 0)[0] - rig.pivot[0];
-        assert!((d + 0.25).abs() < 1e-4, "mesh and rig disagree after mirroring: {d}");
+        assert!(
+            (d + 0.25).abs() < 1e-4,
+            "mesh and rig disagree after mirroring: {d}"
+        );
     }
 
     /// The mount points of a real bike (MX1OEM_2023_Honda_CRF450R), trimmed to the lines
@@ -2323,9 +2504,18 @@ rwheel_max = 0, -0.001, -0.5683\n";
     #[test]
     fn wheel_axles_land_a_real_wheelbase_apart() {
         let (front, rear) = wheel_axles(CRF450R_GEOM).expect("the mounts are all there");
-        assert!((front[1] - 0.4086).abs() < 5e-3, "front axle height: {front:?}");
-        assert!((front[2] - 0.6761).abs() < 5e-3, "front axle reach: {front:?}");
-        assert!((rear[1] - 0.4631).abs() < 5e-3, "rear axle height: {rear:?}");
+        assert!(
+            (front[1] - 0.4086).abs() < 5e-3,
+            "front axle height: {front:?}"
+        );
+        assert!(
+            (front[2] - 0.6761).abs() < 5e-3,
+            "front axle reach: {front:?}"
+        );
+        assert!(
+            (rear[1] - 0.4631).abs() < 5e-3,
+            "rear axle height: {rear:?}"
+        );
         assert!((rear[2] + 0.7999).abs() < 5e-3, "rear axle reach: {rear:?}");
         let wheelbase = front[2] - rear[2];
         assert!(
@@ -2354,10 +2544,20 @@ rwheel_max = 0, -0.001, -0.5683\n";
         let (front, rear) = wheel_axles(CRF450R_GEOM).unwrap();
         // A chassis vertex at the origin, so the centring pass has a third point to work
         // with and the two wheels keep their real separation.
-        let mut nodes = vec![wheel_node("chassis"), wheel_node("fwheel"), wheel_node("rwheela")];
+        let mut nodes = vec![
+            wheel_node("chassis"),
+            wheel_node("fwheel"),
+            wheel_node("rwheela"),
+        ];
         assert!(assemble_bike(&mut nodes, CRF450R_GEOM).is_some());
         // Everything is shifted by the same centring offset, so compare the gap.
-        let at = |i: usize| [nodes[i].positions[0], nodes[i].positions[1], nodes[i].positions[2]];
+        let at = |i: usize| {
+            [
+                nodes[i].positions[0],
+                nodes[i].positions[1],
+                nodes[i].positions[2],
+            ]
+        };
         let (f, r) = (at(1), at(2));
         for k in 0..3 {
             assert!(
@@ -2380,8 +2580,15 @@ rwheel_max = 0, -0.001, -0.5683\n";
             .collect::<Vec<_>>()
             .concat();
         assert!(wheel_axles(&geom).is_none());
-        let mut nodes = vec![wheel_node("chassis"), wheel_node("steer"), wheel_node("fwheel")];
-        assert!(assemble_bike(&mut nodes, &geom).is_some(), "the bike still assembles");
+        let mut nodes = vec![
+            wheel_node("chassis"),
+            wheel_node("steer"),
+            wheel_node("fwheel"),
+        ];
+        assert!(
+            assemble_bike(&mut nodes, &geom).is_some(),
+            "the bike still assembles"
+        );
         // The steering head moved; the wheel, having no mount, did not.
         assert_ne!(nodes[1].positions, nodes[0].positions, "steer was placed");
     }
@@ -2424,7 +2631,7 @@ rwheel_max = 0, -0.001, -0.5683\n";
             }
         }
         b.extend_from_slice(&1u32.to_le_bytes()); // submesh_count
-        // The parser anchors on a node name right after the index buffer.
+                                                  // The parser anchors on a node name right after the index buffer.
         b.extend_from_slice(b"testnode\0");
         b
     }
@@ -2438,7 +2645,7 @@ rwheel_max = 0, -0.001, -0.5683\n";
         assert_eq!(node.positions.len(), 24); // 8 verts * 3
         assert_eq!(node.uvs.len(), 16); // 8 verts * 2
         assert_eq!(node.normals.len(), 24); // 8 verts * 3
-        // Indices decode exactly as authored (plain triangle list read from ic+4).
+                                            // Indices decode exactly as authored (plain triangle list read from ic+4).
         assert_eq!(node.indices, vec![0, 1, 2, 3, 4, 5]);
     }
 
@@ -2491,14 +2698,20 @@ rwheel_max = 0, -0.001, -0.5683\n";
             );
         }
         // Swingarm must run rearward (-Z) from its pivot, not forward.
-        if let Some(rs) = nodes.iter().find(|n| n.name.to_ascii_lowercase().starts_with("rsusp")) {
+        if let Some(rs) = nodes
+            .iter()
+            .find(|n| n.name.to_ascii_lowercase().starts_with("rsusp"))
+        {
             let (mut zlo, mut zhi) = (f32::MAX, f32::MIN);
             for p in rs.positions.chunks_exact(3) {
                 zlo = zlo.min(p[2]);
                 zhi = zhi.max(p[2]);
             }
             eprintln!("rsusp local z [{zlo}, {zhi}]");
-            assert!(zlo < -0.4, "swingarm should reach ~-0.57 rearward, got {zlo}");
+            assert!(
+                zlo < -0.4,
+                "swingarm should reach ~-0.57 rearward, got {zlo}"
+            );
             assert!(zhi < 0.2, "swingarm should not extend forward, got {zhi}");
         }
     }
@@ -2515,13 +2728,15 @@ rwheel_max = 0, -0.001, -0.5683\n";
         let bytes = std::fs::read(&path).expect("read real edf");
         let texs = embedded_textures(&bytes);
         for t in &texs {
-            eprintln!("tex '{}' {}x{} data@{} len={}", t.name, t.width, t.height, t.data_off, t.data_len);
+            eprintln!(
+                "tex '{}' {}x{} data@{} len={}",
+                t.name, t.width, t.height, t.data_off, t.data_len
+            );
         }
         assert!(!texs.is_empty(), "found the model's textures");
         // Every record must inflate to width*height*4 RGBA bytes (_r maps exempt).
         for t in texs.iter().filter(|t| !t.name.ends_with("_r")) {
-            let rgba = inflate_texture(&bytes, t)
-                .unwrap_or_else(|| panic!("inflate '{}'", t.name));
+            let rgba = inflate_texture(&bytes, t).unwrap_or_else(|| panic!("inflate '{}'", t.name));
             assert_eq!(rgba.len(), (t.width as usize) * (t.height as usize) * 4);
         }
         // Names must come through whole (a mis-set field offset truncates them).
@@ -2585,14 +2800,16 @@ rwheel_max = 0, -0.001, -0.5683\n";
                 lo[0], lo[1], lo[2], hi[0], hi[1], hi[2]
             );
             for s in &n.submeshes {
-                eprintln!("    submesh '{}' tri[{}..{})", s.name, s.tri_start, s.tri_start + s.tri_count);
+                eprintln!(
+                    "    submesh '{}' tri[{}..{})",
+                    s.name,
+                    s.tri_start,
+                    s.tri_start + s.tri_count
+                );
             }
             assert!(verts >= 8 && tris >= 1);
         }
     }
-
-
-
 
     // ── The rig ───────────────────────────────────────────────────────────────
 
@@ -2606,7 +2823,14 @@ rwheel_max = 0, -0.001, -0.5683\n";
         hi: [f32; 3],
     ) -> Vec<u8> {
         let mut v = Vec::new();
-        v.extend_from_slice(&(if inv_bind.is_some() { 0x1800u32 } else { 0x1000 }).to_le_bytes());
+        v.extend_from_slice(
+            &(if inv_bind.is_some() {
+                0x1800u32
+            } else {
+                0x1000
+            })
+            .to_le_bytes(),
+        );
         let local = placed(0.0, 0.0, 0.0);
         for m in std::iter::once(local).chain(inv_bind) {
             for f in m {
@@ -2625,7 +2849,9 @@ rwheel_max = 0, -0.001, -0.5683\n";
     }
 
     fn placed(x: f32, y: f32, z: f32) -> [f32; 16] {
-        [1.0, 0.0, 0.0, x, 0.0, 1.0, 0.0, y, 0.0, 0.0, 1.0, z, 0.0, 0.0, 0.0, 1.0]
+        [
+            1.0, 0.0, 0.0, x, 0.0, 1.0, 0.0, y, 0.0, 0.0, 1.0, z, 0.0, 0.0, 0.0, 1.0,
+        ]
     }
 
     /// A bone at `(x, y, z)` stores the transform that takes the model *into* its frame.
@@ -2648,7 +2874,13 @@ rwheel_max = 0, -0.001, -0.5683\n";
         // record belongs to the mesh node, so it carries no bind of its own.
         let bytes = rig_file(&[
             bone_block("riderRIG_Root", None, &[0, 1, 1], [0.0; 3], [0.0; 3]),
-            bone_block("riderRIG_Pelvis", Some(bind_at(0.0, 0.0, 0.0)), &[1, 1, 2], [0.0; 3], [0.0; 3]),
+            bone_block(
+                "riderRIG_Pelvis",
+                Some(bind_at(0.0, 0.0, 0.0)),
+                &[1, 1, 2],
+                [0.0; 3],
+                [0.0; 3],
+            ),
             bone_block(
                 "riderRIG_LeftHip",
                 Some(bind_at(0.0, 0.0, -0.887)),
@@ -2666,13 +2898,19 @@ rwheel_max = 0, -0.001, -0.5683\n";
         ]);
         let rig = parse_skeleton(&bytes);
         let names: Vec<&str> = rig.iter().map(|b| b.name.as_str()).collect();
-        assert_eq!(names, ["riderRIG_Root", "riderRIG_Pelvis", "riderRIG_LeftHip"]);
+        assert_eq!(
+            names,
+            ["riderRIG_Root", "riderRIG_Pelvis", "riderRIG_LeftHip"]
+        );
         assert_eq!(rig[0].parent, None, "only the root is parentless");
         assert_eq!(rig[1].parent, Some(0), "the pelvis hangs off the root");
         assert_eq!(rig[2].parent, Some(1), "and the hip off the pelvis");
         // The bind is derived from the stored inverse, so a bone reports where it really is.
         let hip = rig[2].origin();
-        assert!((hip[2] + 0.864).abs() < 1e-5 && (hip[0] - 0.085).abs() < 1e-5, "{hip:?}");
+        assert!(
+            (hip[2] + 0.864).abs() < 1e-5 && (hip[0] - 0.085).abs() < 1e-5,
+            "{hip:?}"
+        );
         assert_eq!(rig[1].origin(), [0.0, 0.0, -0.887]);
     }
 
@@ -2685,9 +2923,27 @@ rwheel_max = 0, -0.001, -0.5683\n";
         let copy = |lo: [f32; 3], hi: [f32; 3]| {
             vec![
                 bone_block("riderRIG_Pelvis", None, &[0], [0.0; 3], [0.0; 3]),
-                bone_block("riderRIG_LeftHip", Some(bind_at(0.0, 0.9, 0.0)), &[1], lo, hi),
-                bone_block("riderRIG_LeftKnee", Some(bind_at(0.1, 0.5, 0.0)), &[2], lo, hi),
-                bone_block("riderRIG_Spine1", Some(bind_at(0.1, 0.2, 0.0)), &[3], lo, hi),
+                bone_block(
+                    "riderRIG_LeftHip",
+                    Some(bind_at(0.0, 0.9, 0.0)),
+                    &[1],
+                    lo,
+                    hi,
+                ),
+                bone_block(
+                    "riderRIG_LeftKnee",
+                    Some(bind_at(0.1, 0.5, 0.0)),
+                    &[2],
+                    lo,
+                    hi,
+                ),
+                bone_block(
+                    "riderRIG_Spine1",
+                    Some(bind_at(0.1, 0.2, 0.0)),
+                    &[3],
+                    lo,
+                    hi,
+                ),
             ]
         };
         let mut blocks = copy([-0.1, -0.1, -0.1], [0.1, 0.1, 0.1]);
@@ -2708,14 +2964,36 @@ rwheel_max = 0, -0.001, -0.5683\n";
         // that comes later is a misread — and taking it would be a cycle.
         let bytes = rig_file(&[
             bone_block("riderRIG_Pelvis", None, &[0], [0.0; 3], [0.0; 3]),
-            bone_block("riderRIG_LeftKnee", Some(bind_at(0.0, 0.9, 0.0)), &[1], [0.0; 3], [0.0; 3]),
-            bone_block("riderRIG_LeftHip", Some(bind_at(0.1, 0.5, 0.0)), &[2], [0.0; 3], [0.0; 3]),
-            bone_block("riderRIG_Head", Some(bind_at(0.1, 0.2, 0.0)), &[3], [0.0; 3], [0.0; 3]),
+            bone_block(
+                "riderRIG_LeftKnee",
+                Some(bind_at(0.0, 0.9, 0.0)),
+                &[1],
+                [0.0; 3],
+                [0.0; 3],
+            ),
+            bone_block(
+                "riderRIG_LeftHip",
+                Some(bind_at(0.1, 0.5, 0.0)),
+                &[2],
+                [0.0; 3],
+                [0.0; 3],
+            ),
+            bone_block(
+                "riderRIG_Head",
+                Some(bind_at(0.1, 0.2, 0.0)),
+                &[3],
+                [0.0; 3],
+                [0.0; 3],
+            ),
         ]);
         let rig = parse_skeleton(&bytes);
         assert_eq!(rig[0].parent, None, "only the first bone is parentless");
         for (i, b) in rig.iter().enumerate() {
-            assert!(b.parent.is_none_or(|p| p < i), "{} hangs off a later bone", b.name);
+            assert!(
+                b.parent.is_none_or(|p| p < i),
+                "{} hangs off a later bone",
+                b.name
+            );
         }
     }
 
@@ -2728,23 +3006,78 @@ rwheel_max = 0, -0.001, -0.5683\n";
         let at = |x: f32, z: f32| Some(bind_at(x, 0.0, z));
         let bytes = rig_file(&[
             bone_block("riderRIG_LeftHip", None, &[0], [0.0; 3], [0.0; 3]),
-            bone_block("riderRIG_LeftKnee", at(0.085, -0.864), &[1], [0.0; 3], [0.0; 3]),
-            bone_block("riderRIG_LeftHipTwist2", at(0.138, -0.503), &[2], [0.0; 3], [0.0; 3]),
-            bone_block("riderRIG_RightHip", at(0.113, -0.678), &[3], [0.0; 3], [0.0; 3]),
-            bone_block("riderRIG_RightKnee", at(-0.085, -0.864), &[4], [0.0; 3], [0.0; 3]),
-            bone_block("riderRIG_LeftCollar", at(-0.138, -0.503), &[5], [0.0; 3], [0.0; 3]),
-            bone_block("riderRIG_LeftShoulder", at(-0.019, -1.368), &[6], [0.0; 3], [0.0; 3]),
-            bone_block("riderRIG_Spare", at(-0.183, -1.311), &[7], [0.0; 3], [0.0; 3]),
+            bone_block(
+                "riderRIG_LeftKnee",
+                at(0.085, -0.864),
+                &[1],
+                [0.0; 3],
+                [0.0; 3],
+            ),
+            bone_block(
+                "riderRIG_LeftHipTwist2",
+                at(0.138, -0.503),
+                &[2],
+                [0.0; 3],
+                [0.0; 3],
+            ),
+            bone_block(
+                "riderRIG_RightHip",
+                at(0.113, -0.678),
+                &[3],
+                [0.0; 3],
+                [0.0; 3],
+            ),
+            bone_block(
+                "riderRIG_RightKnee",
+                at(-0.085, -0.864),
+                &[4],
+                [0.0; 3],
+                [0.0; 3],
+            ),
+            bone_block(
+                "riderRIG_LeftCollar",
+                at(-0.138, -0.503),
+                &[5],
+                [0.0; 3],
+                [0.0; 3],
+            ),
+            bone_block(
+                "riderRIG_LeftShoulder",
+                at(-0.019, -1.368),
+                &[6],
+                [0.0; 3],
+                [0.0; 3],
+            ),
+            bone_block(
+                "riderRIG_Spare",
+                at(-0.183, -1.311),
+                &[7],
+                [0.0; 3],
+                [0.0; 3],
+            ),
         ]);
         let rig = parse_skeleton(&bytes);
         let at_name = |n: &str| rig.iter().position(|b| b.name == n).expect(n);
         let parent = |n: &str| rig[at_name(n)].parent.map(|p| rig[p].name.clone());
-        assert_eq!(parent("riderRIG_LeftKnee").as_deref(), Some("riderRIG_LeftHip"));
-        assert_eq!(parent("riderRIG_RightKnee").as_deref(), Some("riderRIG_RightHip"));
-        assert_eq!(parent("riderRIG_LeftShoulder").as_deref(), Some("riderRIG_LeftCollar"));
+        assert_eq!(
+            parent("riderRIG_LeftKnee").as_deref(),
+            Some("riderRIG_LeftHip")
+        );
+        assert_eq!(
+            parent("riderRIG_RightKnee").as_deref(),
+            Some("riderRIG_RightHip")
+        );
+        assert_eq!(
+            parent("riderRIG_LeftShoulder").as_deref(),
+            Some("riderRIG_LeftCollar")
+        );
         // The three the model gives no ancestor for stand on their own.
         assert_eq!(parent("riderRIG_LeftHip"), None);
-        assert_eq!(parent("riderRIG_RightHip"), None, "a leg does not hang off the other leg");
+        assert_eq!(
+            parent("riderRIG_RightHip"),
+            None,
+            "a leg does not hang off the other leg"
+        );
         assert_eq!(parent("riderRIG_LeftCollar"), None, "nor an arm off a leg");
     }
 
@@ -2754,8 +3087,20 @@ rwheel_max = 0, -0.001, -0.5683\n";
         // before it is the best guess there is, and that is still what it gets.
         let bytes = rig_file(&[
             bone_block("riderRIG_Pelvis", None, &[0], [0.0; 3], [0.0; 3]),
-            bone_block("riderRIG_Cape", Some(bind_at(0.0, 0.0, -0.887)), &[1], [0.0; 3], [0.0; 3]),
-            bone_block("riderRIG_Spare", Some(bind_at(0.0, 0.1, -1.2)), &[2], [0.0; 3], [0.0; 3]),
+            bone_block(
+                "riderRIG_Cape",
+                Some(bind_at(0.0, 0.0, -0.887)),
+                &[1],
+                [0.0; 3],
+                [0.0; 3],
+            ),
+            bone_block(
+                "riderRIG_Spare",
+                Some(bind_at(0.0, 0.1, -1.2)),
+                &[2],
+                [0.0; 3],
+                [0.0; 3],
+            ),
         ]);
         let rig = parse_skeleton(&bytes);
         assert_eq!(rig[1].name, "riderRIG_Cape");
@@ -2768,7 +3113,13 @@ rwheel_max = 0, -0.001, -0.5683\n";
         // belong to the boots, not to this mesh, so they are not bones the body can be posed by.
         let bytes = rig_file(&[
             bone_block("riderRIG_Pelvis", None, &[0], [0.0; 3], [0.0; 3]),
-            bone_block("riderRIG_LeftAnkle", Some(bind_at(0.0, 0.0, -0.887)), &[1], [0.0; 3], [0.0; 3]),
+            bone_block(
+                "riderRIG_LeftAnkle",
+                Some(bind_at(0.0, 0.0, -0.887)),
+                &[1],
+                [0.0; 3],
+                [0.0; 3],
+            ),
             bone_block("riderRIG_LeftToe", None, &[2], [0.0; 3], [0.0; 3]),
             bone_block("riderRIG_Head", None, &[3], [0.0; 3], [0.0; 3]),
         ]);
@@ -2829,16 +3180,38 @@ rwheel_max = 0, -0.001, -0.5683\n";
         let r = [[-1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, -1.0, 0.0]];
         let mut rig = parse_skeleton(&rig_file(&[
             bone_block("riderRIG_Root", None, &[0], [0.0; 3], [0.0; 3]),
-            bone_block("riderRIG_Pelvis", Some(bind_at(0.0, 0.0, 0.0)), &[1], [0.0; 3], [0.0; 3]),
-            bone_block("riderRIG_Head", Some(bind_at(0.0, 0.0, -0.9)), &[2], [0.0; 3], [0.0; 3]),
+            bone_block(
+                "riderRIG_Pelvis",
+                Some(bind_at(0.0, 0.0, 0.0)),
+                &[1],
+                [0.0; 3],
+                [0.0; 3],
+            ),
+            bone_block(
+                "riderRIG_Head",
+                Some(bind_at(0.0, 0.0, -0.9)),
+                &[2],
+                [0.0; 3],
+                [0.0; 3],
+            ),
         ]));
         transform_skeleton(&mut rig, r);
         let o = rig[1].origin();
-        assert!((o[1] - 0.9).abs() < 1e-5, "the pelvis stands up at y=0.9, got {o:?}");
-        assert!(o[0].abs() < 1e-5 && o[2].abs() < 1e-5, "and nowhere else: {o:?}");
+        assert!(
+            (o[1] - 0.9).abs() < 1e-5,
+            "the pelvis stands up at y=0.9, got {o:?}"
+        );
+        assert!(
+            o[0].abs() < 1e-5 && o[2].abs() < 1e-5,
+            "and nowhere else: {o:?}"
+        );
         // The inverse was rebuilt from the turned bind, not carried over.
         let back = super::rigid_inverse(&rig[1].bind);
-        assert!(rig[1].inv_bind.iter().zip(back).all(|(a, b)| (a - b).abs() < 1e-5));
+        assert!(rig[1]
+            .inv_bind
+            .iter()
+            .zip(back)
+            .all(|(a, b)| (a - b).abs() < 1e-5));
     }
 
     /// Investigation aid: print a rider's rig.
@@ -2853,7 +3226,10 @@ rwheel_max = 0, -0.001, -0.5683\n";
         for (i, b) in rig.iter().enumerate() {
             let p = b.parent.map(|p| rig[p].name.as_str()).unwrap_or("—");
             let o = b.origin();
-            eprintln!("{i:3} {:32} parent={:28} at ({:7.3},{:7.3},{:7.3})", b.name, p, o[0], o[1], o[2]);
+            eprintln!(
+                "{i:3} {:32} parent={:28} at ({:7.3},{:7.3},{:7.3})",
+                b.name, p, o[0], o[1], o[2]
+            );
         }
     }
 
@@ -2873,12 +3249,23 @@ rwheel_max = 0, -0.001, -0.5683\n";
         let rig = parse_skeleton(&bytes);
         let nodes = parse(&bytes);
         eprintln!("{}: {} bones bind of the rig's 98", path, rig.len());
-        assert!(rig.len() >= 40, "a rider binds most of its rig, got {}", rig.len());
+        assert!(
+            rig.len() >= 40,
+            "a rider binds most of its rig, got {}",
+            rig.len()
+        );
         assert_eq!(rig[0].name, "riderRIG_Root");
         assert_eq!(rig[0].parent, None);
-        assert!(rig[1..].iter().all(|b| b.parent.is_some()), "only the root is parentless");
+        assert!(
+            rig[1..].iter().all(|b| b.parent.is_some()),
+            "only the root is parentless"
+        );
 
-        let at = |n: &str| rig.iter().position(|b| b.name == n).unwrap_or_else(|| panic!("no {n}"));
+        let at = |n: &str| {
+            rig.iter()
+                .position(|b| b.name == n)
+                .unwrap_or_else(|| panic!("no {n}"))
+        };
         let ancestors = |n: &str| {
             let (mut out, mut k) = (Vec::new(), rig[at(n)].parent);
             while let Some(i) = k {
@@ -2891,10 +3278,18 @@ rwheel_max = 0, -0.001, -0.5683\n";
         // `lefthand { refobj = LeftWrist; endeffector = LeftElbow; root = LeftShoulder }`.
         let arm = ancestors("riderRIG_LeftWrist");
         assert!(arm.contains(&"riderRIG_LeftElbow".to_string()), "{arm:?}");
-        assert!(arm.contains(&"riderRIG_LeftShoulder".to_string()), "{arm:?}");
+        assert!(
+            arm.contains(&"riderRIG_LeftShoulder".to_string()),
+            "{arm:?}"
+        );
         for b in &rig[1..] {
             let up = ancestors(&b.name);
-            assert_eq!(up.last().map(String::as_str), Some("riderRIG_Root"), "{} → {up:?}", b.name);
+            assert_eq!(
+                up.last().map(String::as_str),
+                Some("riderRIG_Root"),
+                "{} → {up:?}",
+                b.name
+            );
         }
 
         // Limbs the length a person's are.
@@ -2911,9 +3306,15 @@ rwheel_max = 0, -0.001, -0.5683\n";
             assert!((lo..hi).contains(&d), "{a} → {c} is {d:.3} m");
         }
         // Left and right are mirrors of each other.
-        for (l, r) in [("riderRIG_LeftHip", "riderRIG_RightHip"), ("riderRIG_LeftElbow", "riderRIG_RightElbow")] {
+        for (l, r) in [
+            ("riderRIG_LeftHip", "riderRIG_RightHip"),
+            ("riderRIG_LeftElbow", "riderRIG_RightElbow"),
+        ] {
             let (a, b) = (rig[at(l)].origin(), rig[at(r)].origin());
-            assert!((a[0] + b[0]).abs() < 1e-3, "{l}/{r} are not mirrored: {a:?} {b:?}");
+            assert!(
+                (a[0] + b[0]).abs() < 1e-3,
+                "{l}/{r} are not mirrored: {a:?} {b:?}"
+            );
         }
 
         // Every joint inside the body it moves.
@@ -2937,7 +3338,6 @@ rwheel_max = 0, -0.001, -0.5683\n";
             }
         }
     }
-
 
     // ── Skinning ──────────────────────────────────────────────────────────────
 
@@ -2976,7 +3376,11 @@ rwheel_max = 0, -0.001, -0.5683\n";
         ]));
         assert_eq!(
             rig.iter().map(|b| b.name.as_str()).collect::<Vec<_>>(),
-            ["riderRIG_LeftShoulder", "riderRIG_LeftElbow", "riderRIG_LeftWrist"]
+            [
+                "riderRIG_LeftShoulder",
+                "riderRIG_LeftElbow",
+                "riderRIG_LeftWrist"
+            ]
         );
         assert_eq!(rig[0].origin(), [0.0, 0.0, 0.0]);
         assert_eq!(rig[1].origin(), [1.0, 0.0, 0.0]);
@@ -2986,11 +3390,18 @@ rwheel_max = 0, -0.001, -0.5683\n";
     #[test]
     fn every_vertex_is_bound_and_its_weights_add_up() {
         let rig = arm_rig();
-        let nodes = [node_of(&[[0.2, 0.0, 0.0], [0.9, 0.1, 0.0], [1.5, 0.0, 0.0], [40.0, 40.0, 40.0]])];
+        let nodes = [node_of(&[
+            [0.2, 0.0, 0.0],
+            [0.9, 0.1, 0.0],
+            [1.5, 0.0, 0.0],
+            [40.0, 40.0, 40.0],
+        ])];
         let skin = skin_mesh(&nodes, &rig);
         assert_eq!(skin.indices.len(), 4 * SKIN_BONES_PER_VERTEX);
         for v in 0..4 {
-            let w: f32 = skin.weights[v * SKIN_BONES_PER_VERTEX..][..SKIN_BONES_PER_VERTEX].iter().sum();
+            let w: f32 = skin.weights[v * SKIN_BONES_PER_VERTEX..][..SKIN_BONES_PER_VERTEX]
+                .iter()
+                .sum();
             assert!((w - 1.0).abs() < 1e-5, "vertex {v} weights sum to {w}");
             assert!(
                 skin.indices[v * SKIN_BONES_PER_VERTEX..][..SKIN_BONES_PER_VERTEX]
@@ -3004,21 +3415,40 @@ rwheel_max = 0, -0.001, -0.5683\n";
     #[test]
     fn a_vertex_follows_the_limb_it_sits_on() {
         let rig = arm_rig();
-        let shoulder = rig.iter().position(|b| b.name.ends_with("Shoulder")).unwrap();
+        let shoulder = rig
+            .iter()
+            .position(|b| b.name.ends_with("Shoulder"))
+            .unwrap();
         let elbow = rig.iter().position(|b| b.name.ends_with("Elbow")).unwrap();
         // Upper arm, forearm, and a point right on the elbow.
-        let nodes = [node_of(&[[0.5, 0.0, 0.0], [1.5, 0.0, 0.0], [1.0, 0.0, 0.0]])];
+        let nodes = [node_of(&[
+            [0.5, 0.0, 0.0],
+            [1.5, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+        ])];
         let skin = skin_mesh(&nodes, &rig);
         let heaviest = |v: usize| {
             let s = &skin.weights[v * SKIN_BONES_PER_VERTEX..][..SKIN_BONES_PER_VERTEX];
-            let at = s.iter().enumerate().max_by(|a, b| a.1.total_cmp(b.1)).unwrap().0;
+            let at = s
+                .iter()
+                .enumerate()
+                .max_by(|a, b| a.1.total_cmp(b.1))
+                .unwrap()
+                .0;
             skin.indices[v * SKIN_BONES_PER_VERTEX + at] as usize
         };
-        assert_eq!(heaviest(0), shoulder, "the upper arm swings from the shoulder");
+        assert_eq!(
+            heaviest(0),
+            shoulder,
+            "the upper arm swings from the shoulder"
+        );
         assert_eq!(heaviest(1), elbow, "the forearm swings from the elbow");
         // At the joint the vertex is shared rather than snapped to one side.
         let at_joint = &skin.weights[2 * SKIN_BONES_PER_VERTEX..][..SKIN_BONES_PER_VERTEX];
-        assert!(at_joint.iter().filter(|w| **w > 0.05).count() >= 2, "{at_joint:?}");
+        assert!(
+            at_joint.iter().filter(|w| **w > 0.05).count() >= 2,
+            "{at_joint:?}"
+        );
     }
 
     #[test]
@@ -3029,7 +3459,9 @@ rwheel_max = 0, -0.001, -0.5683\n";
         let nodes = [node_of(&[[9.0, 9.0, 0.0]])];
         let skin = skin_mesh(&nodes, &rig);
         assert_eq!(skin.weights[0], 1.0);
-        assert!(skin.weights[1..SKIN_BONES_PER_VERTEX].iter().all(|w| *w == 0.0));
+        assert!(skin.weights[1..SKIN_BONES_PER_VERTEX]
+            .iter()
+            .all(|w| *w == 0.0));
         assert!((skin.indices[0] as usize) < rig.len());
     }
 
@@ -3067,7 +3499,11 @@ rwheel_max = 0, -0.001, -0.5683\n";
         // either way is that every bone reaches a root without going round.
         assert!(rig.iter().any(|b| b.parent.is_none()), "at least one root");
         for (i, b) in rig.iter().enumerate() {
-            assert!(b.parent.is_none_or(|p| p < i), "{} hangs off a later bone", b.name);
+            assert!(
+                b.parent.is_none_or(|p| p < i),
+                "{} hangs off a later bone",
+                b.name
+            );
         }
 
         let mut used = std::collections::HashSet::new();
@@ -3085,23 +3521,37 @@ rwheel_max = 0, -0.001, -0.5683\n";
                 }
             }
         }
-        eprintln!("{verts} vertices, {} of the {} bones used, {shared} shared between bones", used.len(), rig.len());
+        eprintln!(
+            "{verts} vertices, {} of the {} bones used, {shared} shared between bones",
+            used.len(),
+            rig.len()
+        );
         // A skin that puts everything on one bone, or leaves limbs unbound, is not a skin.
-        assert!(used.len() > rig.len() / 2, "only {} bones move anything", used.len());
-        assert!(shared * 4 > verts, "hardly any vertex is shared — the seams will tear");
+        assert!(
+            used.len() > rig.len() / 2,
+            "only {} bones move anything",
+            used.len()
+        );
+        assert!(
+            shared * 4 > verts,
+            "hardly any vertex is shared — the seams will tear"
+        );
 
         // Left stays left: no vertex on one side of the body may be pulled by the other's arm.
         // One run of x across every node, in the order the skin was built in.
-        let xs: Vec<f32> =
-            nodes.iter().flat_map(|n| n.positions.chunks_exact(3).map(|v| v[0])).collect();
+        let xs: Vec<f32> = nodes
+            .iter()
+            .flat_map(|n| n.positions.chunks_exact(3).map(|v| v[0]))
+            .collect();
         let at = |n: &str| rig.iter().position(|b| b.name == n);
         if let (Some(l), Some(r)) = (at("riderRIG_LeftWrist"), at("riderRIG_RightWrist")) {
             for (side, other) in [(l, r), (r, l)] {
                 let reach: Vec<f32> = (0..verts)
                     .filter(|v| {
-                        (0..SKIN_BONES_PER_VERTEX)
-                            .any(|s| skin.indices[v * SKIN_BONES_PER_VERTEX + s] as usize == side
-                                && skin.weights[v * SKIN_BONES_PER_VERTEX + s] > 0.2)
+                        (0..SKIN_BONES_PER_VERTEX).any(|s| {
+                            skin.indices[v * SKIN_BONES_PER_VERTEX + s] as usize == side
+                                && skin.weights[v * SKIN_BONES_PER_VERTEX + s] > 0.2
+                        })
                     })
                     .map(|v| xs[v])
                     .collect();
@@ -3120,7 +3570,6 @@ rwheel_max = 0, -0.001, -0.5683\n";
             }
         }
     }
-
 }
 
 /// Does this mesh's material tables use the second texture slot?
@@ -3133,7 +3582,9 @@ pub fn uses_companion_slots(b: &[u8]) -> bool {
     let textures = embedded_textures(b).len();
     for (_, start) in node_starts(b) {
         for count in 1..=MAX_MATERIALS {
-            let Some(o) = start.checked_sub(4 + MAT_STRIDE * count) else { break };
+            let Some(o) = start.checked_sub(4 + MAT_STRIDE * count) else {
+                break;
+            };
             if u32le(b, o) as usize != count {
                 continue;
             }
@@ -3161,7 +3612,10 @@ fn node_starts(b: &[u8]) -> Vec<(String, usize)> {
         let vc = u32le(b, o) as usize;
         if (8..=MAX_COUNT).contains(&vc) && o + 4 + vc * STRIDE + 8 <= n {
             let vs = o + 4;
-            if [0usize, 1, 2, vc / 2, vc - 1].iter().all(|&i| finite_pos(b, vs + i * 12)) {
+            if [0usize, 1, 2, vc / 2, vc - 1]
+                .iter()
+                .all(|&i| finite_pos(b, vs + i * 12, MODEL_EXTENT))
+            {
                 let ic = vs + vc * STRIDE;
                 let tc = u32le(b, ic) as usize;
                 if (1..=MAX_COUNT).contains(&tc) && ic + 8 + tc * 12 <= n {
@@ -3205,8 +3659,9 @@ pub fn bike_material_slots(b: &[u8]) -> Vec<String> {
         if !with_colour.contains(&family_stem(name)) {
             continue;
         }
-        let takes_a_slot =
-            name.to_ascii_lowercase() == family_stem(name) || family_stem(name) != name.to_ascii_lowercase() && name.to_ascii_lowercase().ends_with("_r");
+        let takes_a_slot = name.to_ascii_lowercase() == family_stem(name)
+            || family_stem(name) != name.to_ascii_lowercase()
+                && name.to_ascii_lowercase().ends_with("_r");
         if takes_a_slot && !out.iter().any(|n| n.eq_ignore_ascii_case(name)) {
             out.push(name.clone());
         }
@@ -3254,7 +3709,9 @@ fn declared_names(b: &[u8]) -> Vec<String> {
             continue;
         }
         let name = String::from_utf8_lossy(&b[i..j]).to_string();
-        let in_pixels = embedded.iter().any(|t| i >= t.data_off && i < t.data_off + t.data_len);
+        let in_pixels = embedded
+            .iter()
+            .any(|t| i >= t.data_off && i < t.data_off + t.data_len);
         if !in_pixels && name.chars().any(|c| c.is_ascii_alphabetic()) && !is_part_name(&name) {
             hits.push((i, name));
         }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1136,9 +1136,8 @@ async fn load_track_backdrop(
 #[tauri::command]
 async fn load_track_ground(path: String) -> Result<tauri::ipc::Response, String> {
     tauri::async_runtime::spawn_blocking(move || {
-        let sheet = scenery::ground_detail(&path).ok().flatten();
-        let list: Vec<_> = sheet.into_iter().collect();
-        tauri::ipc::Response::new(map::surfaces_blob(&list))
+        let sheets = scenery::ground_detail(&path).unwrap_or_default();
+        tauri::ipc::Response::new(map::surfaces_blob(&sheets))
     })
     .await
     .map_err(|e| format!("load_track_ground task failed: {e}"))

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1110,6 +1110,25 @@ async fn load_track_surfaces(
     .map_err(|e| format!("load_track_surfaces task failed: {e}"))
 }
 
+/// What a track wraps itself in — its sky, its backdrop, and the light it sits under.
+///
+/// A dome is a few hundred triangles carrying one very large picture, so this is cheap next
+/// to the scenery and is what stops a track ending at a hard edge with nothing beyond it.
+#[tauri::command]
+async fn load_track_backdrop(
+    path: String,
+) -> Result<tauri::ipc::Response, String> {
+    tauri::async_runtime::spawn_blocking(move || match scenery::backdrop(&path) {
+        Ok((amb, sky, back)) => tauri::ipc::Response::new(scenery::backdrop_blob(&amb, &sky, &back)),
+        Err(e) => {
+            log::debug!("[scenery] backdrop for {path}: {e:#}");
+            tauri::ipc::Response::new(Vec::new())
+        }
+    })
+    .await
+    .map_err(|e| format!("load_track_backdrop task failed: {e}"))
+}
+
 /// The models a track ships that a prop can be placed by name.
 #[tauri::command]
 async fn read_track_placeable(path: String) -> Result<Vec<String>, String> {
@@ -7889,6 +7908,7 @@ fn main() {
             save_track_props,
             read_track_placeable,
             load_track_prop,
+            load_track_backdrop,
             diagnose_track,
             unpack_paint,
             texture_bytes,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1110,6 +1110,33 @@ async fn load_track_surfaces(
     .map_err(|e| format!("load_track_surfaces task failed: {e}"))
 }
 
+/// The models a track ships that a prop can be placed by name.
+#[tauri::command]
+async fn read_track_placeable(path: String) -> Result<Vec<String>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        scenery::placeable(&path).map_err(|e| format!("{e:#}"))
+    })
+    .await
+    .map_err(|e| format!("read_track_placeable task failed: {e}"))?
+}
+
+/// One prop's mesh, so it can be drawn where it is about to go.
+#[tauri::command]
+async fn load_track_prop(
+    path: String,
+    name: String,
+) -> Result<tauri::ipc::Response, String> {
+    tauri::async_runtime::spawn_blocking(move || match scenery::prop_mesh(&path, &name) {
+        Ok(m) => tauri::ipc::Response::new(map::scenery_blob(&m, &[])),
+        Err(e) => {
+            log::debug!("[scenery] prop {name}: {e:#}");
+            tauri::ipc::Response::new(Vec::new())
+        }
+    })
+    .await
+    .map_err(|e| format!("load_track_prop task failed: {e}"))
+}
+
 /// Save a track's props to a `.scr` the game will load.
 ///
 /// The `.scr` is the one part of a track that states where a thing goes in plain text, so it
@@ -7860,6 +7887,8 @@ fn main() {
             load_track_surfaces,
             read_track_placements,
             save_track_props,
+            read_track_placeable,
+            load_track_prop,
             diagnose_track,
             unpack_paint,
             texture_bytes,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1134,9 +1134,12 @@ async fn load_track_backdrop(
 /// A track states its surface at about a third of a metre per sample, and a viewer that lets
 /// you get close magnifies that into a blur. This puts the grain back.
 #[tauri::command]
-async fn load_track_ground(path: String) -> Result<tauri::ipc::Response, String> {
+async fn load_track_ground(
+    app: tauri::AppHandle,
+    path: String,
+) -> Result<tauri::ipc::Response, String> {
     tauri::async_runtime::spawn_blocking(move || {
-        let sheets = scenery::ground_detail(&path).unwrap_or_default();
+        let sheets = scenery::load_ground(&app, &path).unwrap_or_default();
         tauri::ipc::Response::new(map::surfaces_blob(&sheets))
     })
     .await

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -27,6 +27,7 @@ mod library;
 mod linkwalk;
 mod logs;
 mod lru;
+mod map;
 mod memwatch;
 mod modelswap;
 mod mods;
@@ -48,6 +49,7 @@ mod sidecar;
 mod presets;
 mod paintsync;
 mod reshade;
+mod scenery;
 mod servers;
 mod sessionwatch;
 mod shop_catalog_session;
@@ -1049,6 +1051,63 @@ async fn load_track_overview(
     })
     .await
     .map_err(|e| format!("load_track_overview task failed: {e}"))
+}
+
+/// Where a track pins the things it ships no mesh for — marshal posts, TV cameras, crowd
+/// sound — plus the props its `.scr` places.
+///
+/// Split from the scenery mesh because it costs nothing: these files are kilobytes, so the
+/// viewer can mark them while the `.map` is still being read out of the archive.
+#[tauri::command]
+async fn read_track_placements(path: String) -> Result<Vec<scenery::Placement>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        scenery::read_placements(&path).map_err(|e| format!("{e:#}"))
+    })
+    .await
+    .map_err(|e| format!("read_track_placements task failed: {e}"))?
+}
+
+/// A track's scenery mesh — what stands on the ground the terrain grid describes.
+///
+/// Raw bytes for the same reason the terrain is: this is a few hundred thousand triangles,
+/// and as JSON numbers it would cost more to parse than the archive read that produced it.
+/// Empty rather than an error when a track carries no scenery, which is ordinary — the OEM
+/// drag strip declares none at all.
+#[tauri::command]
+async fn load_track_scenery(
+    app: tauri::AppHandle,
+    path: String,
+) -> Result<tauri::ipc::Response, String> {
+    tauri::async_runtime::spawn_blocking(move || match scenery::load(&app, &path) {
+        Ok(s) => tauri::ipc::Response::new(scenery::blob(&s)),
+        Err(e) => {
+            log::debug!("[scenery] {path}: {e:#}");
+            tauri::ipc::Response::new(Vec::new())
+        }
+    })
+    .await
+    .map_err(|e| format!("load_track_scenery task failed: {e}"))
+}
+
+/// A track's surfaces, fetched after its mesh is already on screen.
+///
+/// The second half of a two-stage load: the mesh parses in milliseconds, while inflating a
+/// map's sheets is hundreds of megabytes of work. Splitting them is the difference between a
+/// track appearing at once and a second of empty canvas.
+#[tauri::command]
+async fn load_track_surfaces(
+    app: tauri::AppHandle,
+    path: String,
+) -> Result<tauri::ipc::Response, String> {
+    tauri::async_runtime::spawn_blocking(move || match scenery::load_surfaces(&app, &path) {
+        Ok(t) => tauri::ipc::Response::new(scenery::surfaces_blob(&t)),
+        Err(e) => {
+            log::debug!("[scenery] surfaces for {path}: {e:#}");
+            tauri::ipc::Response::new(Vec::new())
+        }
+    })
+    .await
+    .map_err(|e| format!("load_track_surfaces task failed: {e}"))
 }
 
 #[tauri::command]
@@ -7778,6 +7837,9 @@ fn main() {
             read_track_info,
             load_track_terrain,
             load_track_overview,
+            load_track_scenery,
+            load_track_surfaces,
+            read_track_placements,
             diagnose_track,
             unpack_paint,
             texture_bytes,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1129,6 +1129,21 @@ async fn load_track_backdrop(
     .map_err(|e| format!("load_track_backdrop task failed: {e}"))
 }
 
+/// A tiling sheet of a track's own ground, for detail finer than its data carries.
+///
+/// A track states its surface at about a third of a metre per sample, and a viewer that lets
+/// you get close magnifies that into a blur. This puts the grain back.
+#[tauri::command]
+async fn load_track_ground(path: String) -> Result<tauri::ipc::Response, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let sheet = scenery::ground_detail(&path).ok().flatten();
+        let list: Vec<_> = sheet.into_iter().collect();
+        tauri::ipc::Response::new(map::surfaces_blob(&list))
+    })
+    .await
+    .map_err(|e| format!("load_track_ground task failed: {e}"))
+}
+
 /// The models a track ships that a prop can be placed by name.
 #[tauri::command]
 async fn read_track_placeable(path: String) -> Result<Vec<String>, String> {
@@ -7909,6 +7924,7 @@ fn main() {
             read_track_placeable,
             load_track_prop,
             load_track_backdrop,
+            load_track_ground,
             diagnose_track,
             unpack_paint,
             texture_bytes,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1110,6 +1110,25 @@ async fn load_track_surfaces(
     .map_err(|e| format!("load_track_surfaces task failed: {e}"))
 }
 
+/// Save a track's props to a `.scr` the game will load.
+///
+/// The `.scr` is the one part of a track that states where a thing goes in plain text, so it
+/// is where anything placed in the app has to end up. Writes only where it is told, never
+/// inside an archive, and refuses to replace a file unless asked — a track's own `.scr` is
+/// the record of however long someone spent placing things.
+#[tauri::command]
+async fn save_track_props(
+    target: String,
+    props: Vec<scenery::Placement>,
+    overwrite: bool,
+) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        scenery::save_scr(&target, &props, overwrite).map_err(|e| format!("{e:#}"))
+    })
+    .await
+    .map_err(|e| format!("save_track_props task failed: {e}"))?
+}
+
 #[tauri::command]
 async fn unpack_paint(path: String) -> Result<Vec<paint::PaintTexture>, String> {
     tauri::async_runtime::spawn_blocking(move || unpack_paint_blocking(path))
@@ -7840,6 +7859,7 @@ fn main() {
             load_track_scenery,
             load_track_surfaces,
             read_track_placements,
+            save_track_props,
             diagnose_track,
             unpack_paint,
             texture_bytes,

--- a/src-tauri/src/map.rs
+++ b/src-tauri/src/map.rs
@@ -1,0 +1,1311 @@
+//! Reading a track's scenery mesh out of its `.map`.
+//!
+//! The `.map` is not the riding surface — that comes from the `.trh`. It holds everything
+//! standing on and around it: tents, hay bales, banner lines, fences, poles, vehicles, and
+//! the landscape beyond the terrain square. The two are disjoint and share one world frame
+//! in metres, so they compose without any fitting.
+//!
+//! ```text
+//!  0x00  "MP2\0"
+//!  0x04  u32 = 304 (constant on every map measured)
+//!  0x08  u32 material_count
+//!  0x0C  material_count x 56-byte material records
+//!        u32 vc
+//!        vc x 80 B, structure-of-arrays: pos @ +0 | uv0 @ +12*vc | normal @ +52*vc
+//!        u32 tc
+//!        tc x 3 u32 indices
+//!        u32 node_count, then a tree of 44 B nodes
+//!        ... the rest of the file is embedded textures — most of its bulk
+//! ```
+//!
+//! The tree carries the draw calls. Each node is an AABB and five words; the fifth is a
+//! group count, and zero means an inner node. A leaf's groups follow it inline, 24 bytes
+//! each, and say which material paints which run of triangles. Sorted by material they
+//! become the handful of draw calls the viewer needs.
+//!
+//! Textures sit after the tree in the same records an `.edf` uses — a name, its dimensions,
+//! then raw-DEFLATE RGBA — with one difference that matters: a map's can be 16 or 32 pixels
+//! across, which [`crate::edf::embedded_textures`] rejects, so this reads them itself.
+//! Their names carry the only statement of what a surface *is*: `_c` is colour, and
+//! **`_c_a` is colour with an alpha cut-out** — foliage, crowd, fencing. Drawn opaque those
+//! read as solid slabs, so the suffix is what keeps a forest looking like a forest.
+//!
+//! Same shape as an `.edf` node, at 80 bytes per vertex rather than 72, so the normal sits
+//! at byte 52 instead of 44. Reading it one byte out is not subtle: normal lengths are all
+//! exactly 1.0 at the right offset and noise at any other, which is the check
+//! [`parse`] makes before believing a file.
+
+/// The magic that opens a `.map`.
+const MAGIC: &[u8; 4] = b"MP2\0";
+
+/// Where the material records start, and how big one is. Geometry follows the last of them.
+const MATERIALS_AT: usize = 0x0C;
+const MATERIAL_RECORD: usize = 56;
+
+/// Bytes per vertex, and where each attribute's array begins within the block — every one
+/// of them a count of vertices from the block's start, not a stride.
+const STRIDE: usize = 80;
+const UV_AT: usize = 12;
+const NORMAL_AT: usize = 52;
+
+/// Bytes per tree node, and per draw group inside a leaf.
+const NODE: usize = 44;
+const GROUP: usize = 24;
+
+/// Texture record shape, shared with the `.edf`: the dimensions sit at one of two offsets
+/// from the name, then a header, then the DEFLATE payload.
+const TEX_W_FROM_NAME: [usize; 2] = [100, 104];
+
+/// Where the payload starts, counted from the dimensions.
+///
+/// **Two shapes are in use**, differing by four bytes: one puts a size then eight zero bytes
+/// before the payload, the other a size, a mip count and one pad word. Reading only the first
+/// silently skips every record written the other way — and because a material's surface is
+/// found by counting, one skipped record repaints every material after it. Both are tried,
+/// and the payload itself settles which is right: a DEFLATE stream that ends cleanly on a
+/// multiple of the sheet's own pixel count is not a coincidence.
+const TEX_DATA_FROM_W: [usize; 2] = [40, 36];
+
+/// Dimensions a texture may have. Wider at the small end than the `.edf` reader's, because a
+/// map really does ship 16x16 and 32x32 surfaces and dropping them shifts every material
+/// after them onto the wrong picture.
+const TEX_SIZES: [u32; 9] = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096];
+
+/// Sanity caps. A real map runs to about 900k vertices; these are loose enough not to reject
+/// a bigger one and tight enough that a misread length can't ask for a gigabyte.
+const MAX_VERTS: usize = 8_000_000;
+const MAX_TRIS: usize = 8_000_000;
+const MAX_MATERIALS: usize = 4096;
+
+/// A run of triangles painted by one material.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Group {
+    pub material: u32,
+    pub tri_start: u32,
+    pub tri_count: u32,
+}
+
+/// One of a map's surfaces, inflated and reduced to something a viewer can hold.
+#[derive(Clone, Debug)]
+pub struct MapTexture {
+    pub material: u32,
+    pub name: String,
+    pub width: u32,
+    pub height: u32,
+    /// Whether the name marks it as an alpha cut-out (`_c_a`). Drawn without an alpha test,
+    /// a cut-out is a solid rectangle — which is most of what a track's vegetation is.
+    pub alpha: bool,
+    /// `width * height * 4`, RGBA.
+    pub rgba: Vec<u8>,
+}
+
+/// A track's scenery, in world metres — the same frame the terrain grid is placed in.
+#[derive(Clone, Debug, Default)]
+pub struct MapMesh {
+    /// `3 * vertex_count`, world metres.
+    pub positions: Vec<f32>,
+    /// `3 * vertex_count`, unit length.
+    pub normals: Vec<f32>,
+    /// `2 * vertex_count`.
+    pub uvs: Vec<f32>,
+    /// `3 * triangle_count`.
+    pub indices: Vec<u32>,
+    /// One run of triangles per material, after the index buffer has been sorted so each
+    /// material's triangles sit together. A thousand scattered runs become a few dozen.
+    pub groups: Vec<Group>,
+    /// The connected pieces the scenery is made of — one per tent, trailer or foliage card.
+    pub objects: Vec<MapObject>,
+    /// Which piece each triangle belongs to, in the sorted order. What turns a ray hit into
+    /// a thing you can pick.
+    pub object_of_tri: Vec<u32>,
+    /// How many materials the map declares. Nothing is drawn with them yet — it is the one
+    /// honest measure of how much scenery a track carries, and zero means none at all.
+    pub materials: u32,
+}
+
+impl MapMesh {
+    pub fn vertex_count(&self) -> usize {
+        self.positions.len() / 3
+    }
+    pub fn triangle_count(&self) -> usize {
+        self.indices.len() / 3
+    }
+    pub fn is_empty(&self) -> bool {
+        self.indices.is_empty()
+    }
+
+    /// World-space bounds, or a zero box when there's nothing in it.
+    pub fn bounds(&self) -> ([f32; 3], [f32; 3]) {
+        let mut lo = [f32::INFINITY; 3];
+        let mut hi = [f32::NEG_INFINITY; 3];
+        for p in self.positions.chunks_exact(3) {
+            for k in 0..3 {
+                lo[k] = lo[k].min(p[k]);
+                hi[k] = hi[k].max(p[k]);
+            }
+        }
+        if lo.iter().any(|v| !v.is_finite()) {
+            return ([0.0; 3], [0.0; 3]);
+        }
+        (lo, hi)
+    }
+}
+
+fn u32le(b: &[u8], o: usize) -> u32 {
+    u32::from_le_bytes([b[o], b[o + 1], b[o + 2], b[o + 3]])
+}
+
+fn f32le(b: &[u8], o: usize) -> f32 {
+    f32::from_le_bytes([b[o], b[o + 1], b[o + 2], b[o + 3]])
+}
+
+/// Whether these bytes open like a `.map` at all.
+pub fn is_map(b: &[u8]) -> bool {
+    b.len() >= MATERIALS_AT + 4 && &b[0..4] == MAGIC
+}
+
+/// How many materials the map declares, without reading any geometry.
+fn material_count(b: &[u8]) -> Option<usize> {
+    let n = u32le(b, 8) as usize;
+    (n <= MAX_MATERIALS).then_some(n)
+}
+
+/// Read the scenery mesh, or `None` when the file carries none.
+///
+/// A track with no scenery is ordinary, not a failure: the OEM drag strip declares zero
+/// materials and holds 120 MB of pure texture with not one triangle behind it.
+pub fn parse(b: &[u8]) -> Option<MapMesh> {
+    if !is_map(b) {
+        return None;
+    }
+    let materials = material_count(b)?;
+    let head = MATERIALS_AT + materials * MATERIAL_RECORD;
+    if head + 4 > b.len() {
+        return None;
+    }
+
+    let vc = u32le(b, head) as usize;
+    if !(8..=MAX_VERTS).contains(&vc) {
+        return None;
+    }
+    let vs = head + 4;
+    let block = vc.checked_mul(STRIDE)?;
+    if vs.checked_add(block)?.checked_add(8)? > b.len() {
+        return None;
+    }
+
+    // Every normal is unit length when the attribute offset is right, and nothing like it
+    // when it isn't — the one cheap check that a block really is a vertex block.
+    if !normals_are_unit(b, vs, vc) {
+        return None;
+    }
+
+    let ic = vs + block;
+    let tc = u32le(b, ic) as usize;
+    if !(1..=MAX_TRIS).contains(&tc) {
+        return None;
+    }
+    let idx_at = ic + 4;
+    if idx_at.checked_add(tc.checked_mul(12)?)? > b.len() {
+        return None;
+    }
+
+    let mut indices = Vec::with_capacity(tc * 3);
+    for i in 0..tc * 3 {
+        let v = u32le(b, idx_at + i * 4);
+        // A single index past the end would walk the vertex arrays off their end in the
+        // viewer, so the whole block is rejected rather than clamped.
+        if v as usize >= vc {
+            return None;
+        }
+        indices.push(v);
+    }
+
+    let mut positions = Vec::with_capacity(vc * 3);
+    for i in 0..vc * 3 {
+        let v = f32le(b, vs + i * 4);
+        if !v.is_finite() {
+            return None;
+        }
+        positions.push(v);
+    }
+
+    let normals_at = vs + vc * NORMAL_AT;
+    let mut normals = Vec::with_capacity(vc * 3);
+    for i in 0..vc * 3 {
+        let v = f32le(b, normals_at + i * 4);
+        normals.push(if v.is_finite() { v } else { 0.0 });
+    }
+
+    let uvs_at = vs + vc * UV_AT;
+    let mut uvs = Vec::with_capacity(vc * 2);
+    for i in 0..vc * 2 {
+        let v = f32le(b, uvs_at + i * 4);
+        // Tiling UVs run well outside 0..1, which is ordinary; only a non-finite one would
+        // put a triangle's texture lookup somewhere undefined.
+        uvs.push(if v.is_finite() { v } else { 0.0 });
+    }
+
+    let tree_at = ic + 4 + tc * 12;
+    let groups = read_groups(b, tree_at, tc, materials);
+    let (indices, groups) = sort_by_material(indices, &groups);
+
+    // After sorting, so a piece's triangle run is contiguous in the buffer the viewer draws.
+    let mut material_of_tri = vec![0u32; indices.len() / 3];
+    for g in &groups {
+        for t in g.tri_start..g.tri_start + g.tri_count {
+            if let Some(slot) = material_of_tri.get_mut(t as usize) {
+                *slot = g.material;
+            }
+        }
+    }
+    let (objects, object_of_tri) = split_into_objects(vc, &indices, &material_of_tri, &positions);
+
+    Some(MapMesh {
+        positions,
+        normals,
+        uvs,
+        indices,
+        groups,
+        objects,
+        object_of_tri,
+        materials: materials as u32,
+    })
+}
+
+/// Walk the tree after the index buffer and collect every leaf's draw groups.
+///
+/// Nodes are stored one after another; each is an AABB and five words, the last of which is
+/// how many groups follow it inline. Zero marks an inner node, whose first two words are its
+/// children. Nothing here follows the child links — the leaves are all that is wanted, and
+/// they are all reachable by walking straight through.
+fn read_groups(b: &[u8], at: usize, tri_count: usize, materials: usize) -> Vec<Group> {
+    read_groups_to(b, at, tri_count, materials).0
+}
+
+/// As [`read_groups`], and also where the tree ends — which is where the surfaces begin.
+fn read_groups_to(
+    b: &[u8],
+    at: usize,
+    tri_count: usize,
+    materials: usize,
+) -> (Vec<Group>, Option<usize>) {
+    let mut out = Vec::new();
+    if at + 4 > b.len() {
+        return (out, None);
+    }
+    let nodes = u32le(b, at) as usize;
+    // Loose, but enough that a misread length can't spin for a billion iterations.
+    if nodes > 4_000_000 {
+        return (out, None);
+    }
+    let mut o = at + 4;
+    for _ in 0..nodes {
+        if o + NODE > b.len() {
+            return (Vec::new(), None);
+        }
+        let ngroups = u32le(b, o + 24 + 16) as usize;
+        o += NODE;
+        if ngroups == 0 {
+            continue;
+        }
+        if ngroups > 0xFFFF || o + ngroups * GROUP > b.len() {
+            return (Vec::new(), None);
+        }
+        for g in 0..ngroups {
+            let e = o + g * GROUP;
+            // The leading word is a flag; the material and the ranges follow it.
+            let material = u32le(b, e + 4);
+            let tri_start = u32le(b, e + 8);
+            let count = u32le(b, e + 12);
+            if material as usize >= materials || tri_start as usize + count as usize > tri_count {
+                return (Vec::new(), None);
+            }
+            out.push(Group {
+                material,
+                tri_start,
+                tri_count: count,
+            });
+        }
+        o += ngroups * GROUP;
+    }
+    (out, Some(o))
+}
+
+/// Where a map's surfaces begin, and how many entries it says are there.
+///
+/// The table sits straight after the node tree, so finding it means walking the tree — and
+/// scanning from there rather than from the top of the file is what stops a texture-shaped
+/// run of bytes inside the geometry being read as a surface.
+fn texture_table(b: &[u8]) -> Option<(usize, usize)> {
+    let materials = material_count(b)?;
+    let head = MATERIALS_AT + materials * MATERIAL_RECORD;
+    if head + 4 > b.len() {
+        return None;
+    }
+    let vc = u32le(b, head) as usize;
+    if !(8..=MAX_VERTS).contains(&vc) {
+        return None;
+    }
+    let ic = head + 4 + vc.checked_mul(STRIDE)?;
+    if ic + 4 > b.len() {
+        return None;
+    }
+    let tc = u32le(b, ic) as usize;
+    if !(1..=MAX_TRIS).contains(&tc) {
+        return None;
+    }
+    let tree = ic + 4 + tc.checked_mul(12)?;
+    let base = read_groups_to(b, tree, tc, materials).1?;
+    if base + 4 > b.len() {
+        return None;
+    }
+    Some((base + 4, u32le(b, base) as usize))
+}
+
+/// One connected piece of the scenery — a tent, a trailer, a single foliage card.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct MapObject {
+    /// Triangles in this piece, after the index buffer has been sorted by material.
+    pub tri_start: u32,
+    pub tri_count: u32,
+    /// The material most of it is painted with.
+    pub material: u32,
+    pub min: [f32; 3],
+    pub max: [f32; 3],
+}
+
+/// Split the mesh into the pieces it is actually made of.
+///
+/// Triangles that share a vertex belong to the same thing: the exporter welds a tent to
+/// itself and to nothing else, so union-find over the index buffer recovers the objects a
+/// track was built from without guessing at distances. A published track comes apart into
+/// ten thousand pieces this way, the largest of them five metres across — which is a banner,
+/// not a blob.
+///
+/// This is the unit a designer needs: something to pick, hide, or move on its own.
+fn split_into_objects(
+    vertex_count: usize,
+    indices: &[u32],
+    material_of_tri: &[u32],
+    positions: &[f32],
+) -> (Vec<MapObject>, Vec<u32>) {
+    let mut parent: Vec<u32> = (0..vertex_count as u32).collect();
+    fn find(parent: &mut [u32], mut a: u32) -> u32 {
+        while parent[a as usize] != a {
+            // Halve the path as we go; a welded mesh makes long chains otherwise.
+            parent[a as usize] = parent[parent[a as usize] as usize];
+            a = parent[a as usize];
+        }
+        a
+    }
+    for t in indices.chunks_exact(3) {
+        let r = find(&mut parent, t[0]);
+        for &v in &t[1..] {
+            let s = find(&mut parent, v);
+            if s != r {
+                parent[s as usize] = r;
+            }
+        }
+    }
+
+    // Number the roots in the order their first triangle appears, so the object list follows
+    // the draw order rather than vertex numbering.
+    let mut number: std::collections::HashMap<u32, u32> = std::collections::HashMap::new();
+    let tris = indices.len() / 3;
+    let mut of_tri = Vec::with_capacity(tris);
+    let mut objects: Vec<MapObject> = Vec::new();
+    for t in 0..tris {
+        let root = find(&mut parent, indices[t * 3]);
+        let id = *number.entry(root).or_insert_with(|| {
+            objects.push(MapObject {
+                tri_start: t as u32,
+                tri_count: 0,
+                material: material_of_tri.get(t).copied().unwrap_or(0),
+                min: [f32::INFINITY; 3],
+                max: [f32::NEG_INFINITY; 3],
+            });
+            objects.len() as u32 - 1
+        });
+        of_tri.push(id);
+        let o = &mut objects[id as usize];
+        o.tri_count += 1;
+        for k in 0..3 {
+            let v = indices[t * 3 + k] as usize * 3;
+            for axis in 0..3 {
+                let p = positions[v + axis];
+                o.min[axis] = o.min[axis].min(p);
+                o.max[axis] = o.max[axis].max(p);
+            }
+        }
+    }
+    (objects, of_tri)
+}
+
+/// Reorder triangles so each material's sit together, and return one group per material.
+///
+/// The tree hands back a thousand-odd runs in spatial order, which as draw calls would be a
+/// thousand state changes for a few dozen surfaces. Sorting the index buffer once here costs
+/// nothing at load and leaves the viewer one call per material.
+fn sort_by_material(indices: Vec<u32>, groups: &[Group]) -> (Vec<u32>, Vec<Group>) {
+    if groups.is_empty() {
+        return (indices, Vec::new());
+    }
+    let mut order: Vec<&Group> = groups.iter().collect();
+    order.sort_by_key(|g| (g.material, g.tri_start));
+
+    let mut sorted = Vec::with_capacity(indices.len());
+    let mut merged: Vec<Group> = Vec::new();
+    for g in order {
+        let from = g.tri_start as usize * 3;
+        let to = from + g.tri_count as usize * 3;
+        if to > indices.len() {
+            continue;
+        }
+        let tri_start = (sorted.len() / 3) as u32;
+        sorted.extend_from_slice(&indices[from..to]);
+        match merged.last_mut() {
+            Some(last) if last.material == g.material => last.tri_count += g.tri_count,
+            _ => merged.push(Group {
+                material: g.material,
+                tri_start,
+                tri_count: g.tri_count,
+            }),
+        }
+    }
+    (sorted, merged)
+}
+
+/// Sample normals across the block and ask whether they're unit vectors.
+fn normals_are_unit(b: &[u8], vs: usize, vc: usize) -> bool {
+    let at = vs + vc * NORMAL_AT;
+    let picks = [0, 1, vc / 4, vc / 2, vc - 2, vc - 1];
+    let mut seen = 0;
+    for i in picks {
+        if i >= vc {
+            continue;
+        }
+        let o = at + i * 12;
+        if o + 12 > b.len() {
+            return false;
+        }
+        let (x, y, z) = (f32le(b, o), f32le(b, o + 4), f32le(b, o + 8));
+        if !(x.is_finite() && y.is_finite() && z.is_finite()) {
+            return false;
+        }
+        let len = (x * x + y * y + z * z).sqrt();
+        if (len - 1.0).abs() > 0.02 {
+            return false;
+        }
+        seen += 1;
+    }
+    seen > 0
+}
+
+// ---------------------------------------------------------------------------
+// Surfaces
+// ---------------------------------------------------------------------------
+
+/// The longest edge a surface is kept at. A map ships 4096² sheets, and forty-eight of those
+/// is a quarter of a gigabyte for a view that draws a whole track at once — while the alpha
+/// cut-outs still need enough resolution to keep a tree looking like a tree.
+pub const MAX_TEXTURE_DIM: u32 = 512;
+
+/// A texture's name, read in place. `None` when the bytes aren't one.
+fn tex_name(b: &[u8], o: usize) -> Option<String> {
+    let mut e = o;
+    while e < b.len() && e - o < 96 {
+        let c = b[e];
+        if c == 0 {
+            break;
+        }
+        if !(c.is_ascii_alphanumeric() || matches!(c, b'.' | b'_' | b'-')) {
+            return None;
+        }
+        e += 1;
+    }
+    let len = e - o;
+    (3..=95)
+        .contains(&len)
+        .then(|| String::from_utf8_lossy(&b[o..e]).into_owned())
+}
+
+/// Every colour surface in a map, in file order.
+///
+/// Every record in the table, in order, name included — no filtering by what it is called.
+///
+/// Order is the whole point. Nothing in a material record points at a texture — the *k*-th
+/// colour map is material *k*'s — so a record skipped here silently repaints every material
+/// after it, and one read that shouldn't be shifts the rest along by one.
+///
+/// The scan starts at the table rather than the top of the file, so a texture-shaped run of
+/// bytes inside the geometry can't be mistaken for a surface, and it reads the 16- and
+/// 32-pixel sheets the `.edf` scanner drops.
+fn colour_records(b: &[u8], from: usize) -> Vec<(String, u32, u32, usize, usize)> {
+    let mut out = Vec::new();
+    let mut o = from;
+    let min = TEX_W_FROM_NAME[1] + TEX_DATA_FROM_W[0] + 8;
+    'scan: while o + min <= b.len() {
+        // Only at a word boundary, or `2024_haybale` also matches at `haybale`.
+        let starts = b[o].is_ascii_alphanumeric() || b[o] == b'_';
+        let after = o > 0 && (b[o - 1].is_ascii_alphanumeric() || b[o - 1] == b'_');
+        if !starts || after {
+            o += 1;
+            continue;
+        }
+        let Some(name) = tex_name(b, o) else {
+            o += 1;
+            continue;
+        };
+        for w_off in TEX_W_FROM_NAME {
+            if name.len() >= w_off {
+                continue; // the name has to terminate inside its own field
+            }
+            let w_at = o + w_off;
+            if w_at + 8 > b.len() {
+                continue;
+            }
+            let (w, h) = (u32le(b, w_at), u32le(b, w_at + 4));
+            if !TEX_SIZES.contains(&w) || !TEX_SIZES.contains(&h) {
+                continue;
+            }
+            for from_w in TEX_DATA_FROM_W {
+                let data_off = w_at + from_w;
+                if data_off >= b.len() {
+                    continue;
+                }
+                let Some((total, used)) = stream_extent(b, data_off, w, h) else {
+                    continue;
+                };
+                let _ = total;
+                out.push((name, w, h, data_off, used));
+                // Records don't overlap, so the payload is never worth scanning through —
+                // walking it byte by byte is where a scan of a 400 MB map would spend its life.
+                o = data_off + used;
+                continue 'scan;
+            }
+        }
+        o += 1;
+    }
+    out
+}
+
+/// Inflate far enough to prove a record, returning `(pixel bytes, compressed bytes)`.
+///
+/// A record states a *compressed* length in a field whose offset is exactly what's in doubt,
+/// so the stream is asked instead: it has to end cleanly, and on a whole number of bytes per
+/// pixel. Bounded at 24 bytes per pixel, which covers the cube maps and rejects anything that
+/// would inflate for ever.
+fn stream_extent(b: &[u8], at: usize, w: u32, h: u32) -> Option<(usize, usize)> {
+    use std::io::Read;
+    let px = w as usize * h as usize;
+    let cap = px * 24 + 64;
+    let mut dec = flate2::bufread::DeflateDecoder::new(&b[at..]);
+    let mut total = 0usize;
+    let mut buf = [0u8; 1 << 16];
+    loop {
+        match dec.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                total += n;
+                if total > cap {
+                    return None;
+                }
+            }
+            Err(_) => return None,
+        }
+    }
+    if px == 0 || total < px || total % px != 0 {
+        return None;
+    }
+    let used = dec.total_in() as usize;
+    (used > 0 && at + used <= b.len()).then_some((total, used))
+}
+
+/// Inflate one record to RGBA8, bounded by what its dimensions can hold.
+fn inflate(b: &[u8], data_off: usize, data_len: usize, w: u32, h: u32) -> Option<Vec<u8>> {
+    use std::io::Read;
+    let expected = w as usize * h as usize * 4;
+    let mut buf = Vec::with_capacity(expected);
+    // Bounded: a record found by scanning could be a false positive, and one that inflates
+    // to gigabytes is an ordinary Tuesday rather than a hostile file.
+    Read::take(
+        flate2::read::DeflateDecoder::new(&b[data_off..(data_off + data_len).min(b.len())]),
+        expected as u64,
+    )
+    .read_to_end(&mut buf)
+    .ok()?;
+    (buf.len() == expected).then_some(buf)
+}
+
+/// Turn a sheet the right way up.
+///
+/// PiBoSo stores these bottom-up, the same way it stores a `.pnt`: a card's UVs put V zero at
+/// the foot of the thing drawn, while the file's first row of pixels is its top. Left alone,
+/// every tree in a track hangs from its canopy.
+fn flip_rows(rgba: &mut [u8], w: u32, h: u32) {
+    let stride = w as usize * 4;
+    let (mut top, mut bottom) = (0usize, h as usize - 1);
+    while top < bottom {
+        for i in 0..stride {
+            rgba.swap(top * stride + i, bottom * stride + i);
+        }
+        top += 1;
+        bottom -= 1;
+    }
+}
+
+/// Halve an RGBA image until it fits `max_dim`, averaging each block.
+///
+/// Colour is averaged *weighted by alpha*, which matters only for the cut-outs and matters a
+/// lot there: the transparent half of a foliage sheet is usually black, and averaging it in
+/// flatly drags every surviving leaf towards black a halving at a time. Alpha itself is
+/// averaged plainly, so a shape thins out rather than developing holes.
+fn reduce(mut rgba: Vec<u8>, mut w: u32, mut h: u32, max_dim: u32) -> (Vec<u8>, u32, u32) {
+    while (w > max_dim || h > max_dim) && w >= 2 && h >= 2 {
+        let (nw, nh) = (w / 2, h / 2);
+        let mut out = vec![0u8; nw as usize * nh as usize * 4];
+        for y in 0..nh as usize {
+            for x in 0..nw as usize {
+                let px =
+                    |xx: usize, yy: usize, c: usize| rgba[(yy * w as usize + xx) * 4 + c] as u32;
+                let (x0, y0) = (x * 2, y * 2);
+                let corners = [(x0, y0), (x0 + 1, y0), (x0, y0 + 1), (x0 + 1, y0 + 1)];
+                let alpha: u32 = corners.iter().map(|&(cx, cy)| px(cx, cy, 3)).sum();
+                let o = (y * nw as usize + x) * 4;
+                for c in 0..3 {
+                    out[o + c] = if alpha > 0 {
+                        let weighted: u32 = corners
+                            .iter()
+                            .map(|&(cx, cy)| px(cx, cy, c) * px(cx, cy, 3))
+                            .sum();
+                        (weighted / alpha) as u8
+                    } else {
+                        (corners.iter().map(|&(cx, cy)| px(cx, cy, c)).sum::<u32>() / 4) as u8
+                    };
+                }
+                out[o + 3] = (alpha / 4) as u8;
+            }
+        }
+        rgba = out;
+        w = nw;
+        h = nh;
+    }
+    (rgba, w, h)
+}
+
+/// How much of a sheet is see-through, as a fraction of its texels.
+fn cutout_fraction(rgba: &[u8]) -> f32 {
+    if rgba.len() < 4 {
+        return 0.0;
+    }
+    let texels = rgba.len() / 4;
+    let clear = rgba.chunks_exact(4).filter(|p| p[3] < 128).count();
+    clear as f32 / texels as f32
+}
+
+/// Above this fraction of see-through texels a surface is treated as a cut-out.
+///
+/// Measured from the pixels rather than read off the name. `_c_a` is a convention some track
+/// builders follow and others don't — one published track names every sheet plainly
+/// (`CK_birch01`, `banner_fmf`) and would have had its whole treeline drawn as slabs. What a
+/// surface *is* is in its alpha channel, and that is true of every track.
+const CUTOUT_FRACTION: f32 = 0.02;
+
+/// Whether a name marks a colour map under PiBoSo's own convention.
+fn is_colour_name(name: &str) -> bool {
+    let l = name.to_ascii_lowercase();
+    l.ends_with("_c") || l.ends_with("_c_a")
+}
+
+/// Whether a record is a second map for the surface before it rather than a surface of its
+/// own — a normal-and-specular sheet, an environment cube.
+///
+/// Every convention seen puts the secondary map's name on the colour map's stem: `bale1` then
+/// `bale1_n`, `pitlane_c` then `pitlane_n_s`. One sheet is often shared by several materials,
+/// so a name already used as a secondary stays one wherever it appears again.
+fn is_secondary(
+    name: &str,
+    previous: Option<&str>,
+    seen: &std::collections::HashSet<String>,
+) -> bool {
+    let lower = name.to_ascii_lowercase();
+    if lower == "env" || seen.contains(&lower) {
+        return true;
+    }
+    const SUFFIXES: [&str; 5] = ["_n", "_s", "_n_s", "_nrm", "_spec"];
+    let Some(prev) = previous else { return false };
+    let prev = prev.to_ascii_lowercase();
+    let stem = prev
+        .strip_suffix("_c_a")
+        .or_else(|| prev.strip_suffix("_c"))
+        .unwrap_or(&prev);
+    SUFFIXES
+        .iter()
+        .any(|suf| lower == format!("{stem}{suf}") || lower == format!("{prev}{suf}"))
+}
+
+/// Every surface record a map holds, as `(name, width, height)`, in table order.
+///
+/// A diagnostic: names and dimensions only, nothing inflated. What a map calls its sheets is
+/// the whole of the binding problem, so being able to ask a track that question directly is
+/// worth a function.
+pub fn survey(b: &[u8]) -> Vec<(String, u32, u32)> {
+    let Some((from, _)) = texture_table(b) else {
+        return Vec::new();
+    };
+    colour_records(b, from)
+        .into_iter()
+        .map(|(n, w, h, ..)| (n, w, h))
+        .collect()
+}
+
+/// The records that look like a material's own colour map, in order.
+pub fn primaries(b: &[u8]) -> Vec<(String, u32, u32)> {
+    let Some((from, _)) = texture_table(b) else {
+        return Vec::new();
+    };
+    let mut seen = std::collections::HashSet::new();
+    let mut previous: Option<String> = None;
+    let mut out = Vec::new();
+    for (n, w, h, ..) in colour_records(b, from) {
+        if is_secondary(&n, previous.as_deref(), &seen) {
+            seen.insert(n.to_ascii_lowercase());
+            continue;
+        }
+        previous = Some(n.clone());
+        out.push((n, w, h));
+    }
+    out
+}
+
+/// The surfaces a map declares, named and sized but not inflated.
+///
+/// What the viewer needs to size its material slots before any pixels exist — and cheap,
+/// because it stops at each record's header and steps over the payload.
+pub fn declared(b: &[u8]) -> Vec<(String, u32, u32)> {
+    let Some((from, count)) = texture_table(b) else {
+        return Vec::new();
+    };
+    let all = colour_records(b, from);
+    if !all.iter().any(|(n, ..)| is_colour_name(n)) {
+        return Vec::new();
+    }
+    all.into_iter()
+        .filter(|(n, ..)| is_colour_name(n))
+        .take(count)
+        .map(|(n, w, h, ..)| (n, w, h))
+        .collect()
+}
+
+/// A map's colour surfaces, one per material, inflated and reduced.
+///
+/// Nothing in a material record points at a texture, so the binding is positional: the *k*-th
+/// colour map paints material *k*. That only holds when the colour maps can be told apart
+/// from the sheets beside them, and the one reliable marker is PiBoSo's own naming — `_c`
+/// (or `_c_a`) for colour, `_n_s` for the normal-and-specular map next to it.
+///
+/// **A map that doesn't use those suffixes gets no surfaces here, and draws plain.** Its
+/// table holds more records than materials — one published track has 55 for 49, the last
+/// seven being the terrain's own `dirt`/`grass`/`gravel` — and which of them line up is not
+/// something the file has yet been made to say. Guessing puts a blue tent on a boundary wall,
+/// which is worse than the honest grey: measured against the geometry, the obvious reading is
+/// off by two on that track and nothing in the format explains why.
+pub fn textures(b: &[u8], max_dim: u32) -> Vec<MapTexture> {
+    let Some((from, count)) = texture_table(b) else {
+        return Vec::new();
+    };
+    let all = colour_records(b, from);
+    if !all.iter().any(|(n, ..)| is_colour_name(n)) {
+        return Vec::new();
+    }
+
+    all.into_iter()
+        .filter(|(n, ..)| is_colour_name(n))
+        .take(count)
+        .enumerate()
+        .filter_map(|(i, (name, w, h, off, len))| {
+            let mut rgba = inflate(b, off, len, w, h)?;
+            // Read from the pixels, not the name: `_c_a` is the convention, but the alpha
+            // channel is the fact, and a sheet that is half see-through is a cut-out whatever
+            // it is called.
+            let alpha = cutout_fraction(&rgba) > CUTOUT_FRACTION;
+            flip_rows(&mut rgba, w, h);
+            let (rgba, w, h) = reduce(rgba, w, h, max_dim.max(1));
+            Some(MapTexture {
+                material: i as u32,
+                name,
+                width: w,
+                height: h,
+                alpha,
+                rgba,
+            })
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// The wire format the viewer reads
+// ---------------------------------------------------------------------------
+
+/// Bytes before the vertex data in a scenery blob. Four-byte aligned so the app can adopt
+/// every array as a typed-array view rather than copying it.
+pub const SCENERY_HEADER: usize = 48;
+
+/// Bytes per entry in the blob's texture table.
+pub const TEXTURE_ENTRY: usize = 20;
+
+/// Pack a mesh and its surfaces for the IPC channel.
+///
+/// ```text
+///  0  "FSCN"
+///  4  u16 version, u16 flags
+///  8  u32 vertex_count, u32 index_count, u32 group_count, u32 texture_count
+/// 24  f32[6] world bounds
+/// 48  positions  vc*12 | normals vc*12 | uvs vc*8 | indices ic*4
+///     groups     gc*12  (material, tri_start, tri_count)
+///     pieces     (ic/3)*4  which separable piece each triangle belongs to
+///     textures   tc*20  (material, width, height, flags, byte_len), then the pixels
+/// ```
+///
+/// Raw bytes because this is a few hundred thousand triangles and a couple of dozen
+/// surfaces; as JSON numbers it would cost more to parse than the archive read that
+/// produced it.
+pub fn scenery_blob(mesh: &MapMesh, textures: &[MapTexture]) -> Vec<u8> {
+    let (lo, hi) = mesh.bounds();
+    let vc = mesh.vertex_count() as u32;
+    let ic = mesh.indices.len() as u32;
+    let pixels: usize = textures.iter().map(|t| t.rgba.len()).sum();
+
+    let mut out = Vec::with_capacity(
+        SCENERY_HEADER
+            + mesh.positions.len() * 4
+            + mesh.normals.len() * 4
+            + mesh.uvs.len() * 4
+            + mesh.indices.len() * 4
+            + mesh.groups.len() * 12
+            + textures.len() * TEXTURE_ENTRY
+            + pixels,
+    );
+    out.extend_from_slice(b"FSCN");
+    out.extend_from_slice(&2u16.to_le_bytes()); // version
+    out.extend_from_slice(&0u16.to_le_bytes()); // flags, none yet
+    out.extend_from_slice(&vc.to_le_bytes());
+    out.extend_from_slice(&ic.to_le_bytes());
+    out.extend_from_slice(&(mesh.groups.len() as u32).to_le_bytes());
+    // Top half carries how many separable pieces the mesh came apart into; the low half is
+    // the surface count. Both fit, and it keeps the header the size the app already reads.
+    let packed = (textures.len() as u32 & 0xFFFF) | ((mesh.objects.len().min(0xFFFF) as u32) << 16);
+    out.extend_from_slice(&packed.to_le_bytes());
+    for v in lo.iter().chain(hi.iter()) {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    for v in mesh
+        .positions
+        .iter()
+        .chain(mesh.normals.iter())
+        .chain(mesh.uvs.iter())
+    {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    for v in &mesh.indices {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    for g in &mesh.groups {
+        out.extend_from_slice(&g.material.to_le_bytes());
+        out.extend_from_slice(&g.tri_start.to_le_bytes());
+        out.extend_from_slice(&g.tri_count.to_le_bytes());
+    }
+    // One id per triangle. A ray hit gives the viewer a face; this turns that face into the
+    // thing it belongs to, which is what makes a tent something you can point at.
+    for id in &mesh.object_of_tri {
+        out.extend_from_slice(&id.to_le_bytes());
+    }
+    for t in textures {
+        out.extend_from_slice(&t.material.to_le_bytes());
+        out.extend_from_slice(&t.width.to_le_bytes());
+        out.extend_from_slice(&t.height.to_le_bytes());
+        // Bit 0: the surface is an alpha cut-out and has to be drawn with an alpha test.
+        out.extend_from_slice(&u32::from(t.alpha).to_le_bytes());
+        out.extend_from_slice(&(t.rgba.len() as u32).to_le_bytes());
+    }
+    for t in textures {
+        out.extend_from_slice(&t.rgba);
+    }
+    out
+}
+
+/// Pack a track's surfaces on their own, for the pass that follows the mesh.
+///
+/// ```text
+///  0  "FSRF"
+///  4  u16 version, u16 flags
+///  8  u32 surface_count
+/// 12  u32 reserved (keeps the table four-byte aligned)
+/// 16  surface_count x 20  (material, width, height, flags, byte_len), then the pixels
+/// ```
+pub fn surfaces_blob(textures: &[MapTexture]) -> Vec<u8> {
+    let pixels: usize = textures.iter().map(|t| t.rgba.len()).sum();
+    let mut out = Vec::with_capacity(SURFACES_HEADER + textures.len() * TEXTURE_ENTRY + pixels);
+    out.extend_from_slice(b"FSRF");
+    out.extend_from_slice(&1u16.to_le_bytes());
+    out.extend_from_slice(&0u16.to_le_bytes());
+    out.extend_from_slice(&(textures.len() as u32).to_le_bytes());
+    out.extend_from_slice(&0u32.to_le_bytes());
+    for t in textures {
+        out.extend_from_slice(&t.material.to_le_bytes());
+        out.extend_from_slice(&t.width.to_le_bytes());
+        out.extend_from_slice(&t.height.to_le_bytes());
+        out.extend_from_slice(&u32::from(t.alpha).to_le_bytes());
+        out.extend_from_slice(&(t.rgba.len() as u32).to_le_bytes());
+    }
+    for t in textures {
+        out.extend_from_slice(&t.rgba);
+    }
+    out
+}
+
+/// Bytes before the surface table. Four-byte aligned, same reasoning as [`SCENERY_HEADER`].
+pub const SURFACES_HEADER: usize = 16;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a `.map` byte-for-byte the way a real one is laid out.
+    fn synth(materials: usize, verts: usize, tris: usize) -> Vec<u8> {
+        let mut b = Vec::new();
+        b.extend_from_slice(MAGIC);
+        b.extend_from_slice(&304u32.to_le_bytes());
+        b.extend_from_slice(&(materials as u32).to_le_bytes());
+        b.extend_from_slice(&vec![0u8; materials * MATERIAL_RECORD]);
+        b.extend_from_slice(&(verts as u32).to_le_bytes());
+
+        // The vertex block is structure-of-arrays: every attribute is one run of `verts`
+        // elements, so the block is filled column by column rather than vertex by vertex.
+        let mut block = vec![0u8; verts * STRIDE];
+        for i in 0..verts {
+            let p = i * 12;
+            for (k, v) in [i as f32, (i * 2) as f32, (i * 3) as f32]
+                .iter()
+                .enumerate()
+            {
+                block[p + k * 4..p + k * 4 + 4].copy_from_slice(&v.to_le_bytes());
+            }
+            // Unit normal, which is what proves the attribute offset.
+            let n = verts * NORMAL_AT + i * 12;
+            for (k, v) in [0.0f32, 1.0, 0.0].iter().enumerate() {
+                block[n + k * 4..n + k * 4 + 4].copy_from_slice(&v.to_le_bytes());
+            }
+        }
+        b.extend_from_slice(&block);
+
+        b.extend_from_slice(&(tris as u32).to_le_bytes());
+        for t in 0..tris {
+            for k in 0..3 {
+                let v = ((t + k) % verts) as u32;
+                b.extend_from_slice(&v.to_le_bytes());
+            }
+        }
+        b.extend_from_slice(&0u32.to_le_bytes()); // bvh count
+        b
+    }
+
+    #[test]
+    fn reads_a_map() {
+        let bytes = synth(48, 64, 20);
+        let m = parse(&bytes).expect("a well-formed map should read");
+        assert_eq!(m.vertex_count(), 64);
+        assert_eq!(m.triangle_count(), 20);
+        assert_eq!(m.materials, 48);
+        // Positions come back in the order they were written, which pins the column layout.
+        assert_eq!(&m.positions[0..3], &[0.0, 0.0, 0.0]);
+        assert_eq!(&m.positions[3..6], &[1.0, 2.0, 3.0]);
+        assert_eq!(&m.normals[3..6], &[0.0, 1.0, 0.0]);
+    }
+
+    #[test]
+    fn a_track_with_no_scenery_is_not_a_failure() {
+        // The OEM drag strip's shape: zero materials, nothing behind them.
+        let mut b = Vec::new();
+        b.extend_from_slice(MAGIC);
+        b.extend_from_slice(&304u32.to_le_bytes());
+        b.extend_from_slice(&0u32.to_le_bytes());
+        b.extend_from_slice(&vec![0u8; 4096]);
+        assert!(is_map(&b));
+        assert!(parse(&b).is_none());
+    }
+
+    #[test]
+    fn the_normal_offset_is_load_bearing() {
+        // Shift the whole vertex block by one attribute slot and the normals stop being
+        // unit vectors, which is exactly the misread the check exists to catch.
+        let mut bytes = synth(2, 64, 10);
+        let head = MATERIALS_AT + 2 * MATERIAL_RECORD;
+        let vs = head + 4;
+        let at = vs + 64 * NORMAL_AT;
+        for k in 0..12 {
+            bytes[at + k] = 0;
+        }
+        assert!(
+            parse(&bytes).is_none(),
+            "a zero normal is not a unit normal"
+        );
+    }
+
+    #[test]
+    fn an_index_past_the_end_is_rejected() {
+        let mut bytes = synth(1, 32, 4);
+        let head = MATERIALS_AT + MATERIAL_RECORD;
+        let ic = head + 4 + 32 * STRIDE;
+        bytes[ic + 4..ic + 8].copy_from_slice(&999u32.to_le_bytes());
+        assert!(parse(&bytes).is_none());
+    }
+
+    /// Does the `.edf` texture scanner read a `.map`'s textures too?
+    ///
+    /// ```text
+    /// FROST_MAP="…/Millville.map" \
+    ///   cargo test --bin mxb-app -- --ignored --nocapture map_textures_via_edf_scanner
+    /// ```
+    #[test]
+    #[ignore = "needs a real .map — set FROST_MAP"]
+    fn map_textures_via_edf_scanner() {
+        let path = std::env::var("FROST_MAP").expect("set FROST_MAP");
+        let bytes = std::fs::read(&path).expect("read the map");
+        let t0 = std::time::Instant::now();
+        let texs = crate::edf::embedded_textures(&bytes);
+        println!("{} textures in {:?}", texs.len(), t0.elapsed());
+        let diffuse: Vec<_> = texs
+            .iter()
+            .filter(|t| t.name.ends_with("_c") || t.name.ends_with("_c_a"))
+            .collect();
+        println!("  diffuse: {}", diffuse.len());
+        for (i, t) in diffuse.iter().enumerate().take(50) {
+            println!(
+                "   {i:<3} {:<34} {}x{} {}",
+                t.name,
+                t.width,
+                t.height,
+                if t.name.ends_with("_c_a") {
+                    "ALPHA"
+                } else {
+                    ""
+                }
+            );
+        }
+        if let Some(t) = diffuse.first() {
+            let px = crate::edf::inflate_texture(&bytes, t).expect("inflate the first diffuse");
+            println!(
+                "  first inflates to {} bytes (expected {})",
+                px.len(),
+                t.width as usize * t.height as usize * 4
+            );
+        }
+    }
+
+    #[test]
+    fn not_a_map_at_all() {
+        assert!(parse(b"EDF\0nonsense").is_none());
+        assert!(parse(&[]).is_none());
+    }
+
+    #[test]
+    fn blob_round_trips_its_header() {
+        let m = parse(&synth(3, 40, 12)).unwrap();
+        let tex = vec![MapTexture {
+            material: 0,
+            name: "tent_c".into(),
+            width: 2,
+            height: 2,
+            alpha: false,
+            rgba: vec![7u8; 16],
+        }];
+        let blob = scenery_blob(&m, &tex);
+        assert_eq!(&blob[0..4], b"FSCN");
+        assert_eq!(u32le(&blob, 4) & 0xFFFF, 2, "version 2");
+        assert_eq!(u32le(&blob, 8), 40, "vertex count");
+        assert_eq!(u32le(&blob, 12), 36, "index count");
+        // One word carries both counts: surfaces low, separable pieces high.
+        assert_eq!(u32le(&blob, 20) & 0xFFFF, 1, "one surface");
+        assert_eq!(
+            u32le(&blob, 20) >> 16,
+            m.objects.len() as u32,
+            "and the piece count"
+        );
+        let groups = u32le(&blob, 16) as usize;
+        assert_eq!(
+            blob.len(),
+            SCENERY_HEADER
+                + 40 * 12   // positions
+                + 40 * 12   // normals
+                + 40 * 8    // uvs
+                + 36 * 4    // indices
+                + groups * 12
+                + 12 * 4    // one piece id per triangle
+                + TEXTURE_ENTRY
+                + 16,
+            "every section back to back, in the order the header declares"
+        );
+        // The pixels are last, so the tail is exactly what went in.
+        assert_eq!(&blob[blob.len() - 16..], &[7u8; 16]);
+    }
+
+    #[test]
+    fn a_mesh_comes_apart_into_the_things_it_is_made_of() {
+        // Two triangles sharing an edge, and a third off on its own: two pieces, not three.
+        let positions = vec![
+            0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, // a welded quad
+            9.0, 0.0, 9.0, 10.0, 0.0, 9.0, 9.0, 0.0, 10.0, // and something else
+        ];
+        let indices = vec![0, 1, 2, 1, 3, 2, 4, 5, 6];
+        let mats = vec![0, 0, 1];
+        let (objects, of_tri) = split_into_objects(7, &indices, &mats, &positions);
+        assert_eq!(objects.len(), 2, "the shared edge holds the quad together");
+        assert_eq!(of_tri, vec![0, 0, 1]);
+        assert_eq!(objects[0].tri_count, 2);
+        assert_eq!(objects[1].tri_count, 1);
+        assert_eq!(objects[1].material, 1);
+        // Bounds are the piece's own, not the whole mesh's.
+        assert_eq!(objects[1].min, [9.0, 0.0, 9.0]);
+        assert_eq!(objects[0].max, [1.0, 0.0, 1.0]);
+    }
+
+    #[test]
+    fn groups_are_sorted_and_merged_by_material() {
+        // Two runs of one material either side of another: the sort has to bring the pair
+        // together, and the merge leave one group per material rather than three.
+        let raw = vec![
+            Group {
+                material: 2,
+                tri_start: 0,
+                tri_count: 3,
+            },
+            Group {
+                material: 5,
+                tri_start: 3,
+                tri_count: 2,
+            },
+            Group {
+                material: 2,
+                tri_start: 5,
+                tri_count: 4,
+            },
+        ];
+        let indices: Vec<u32> = (0..27).collect();
+        let (sorted, merged) = sort_by_material(indices, &raw);
+        assert_eq!(merged.len(), 2, "one group per material");
+        assert_eq!(
+            merged[0],
+            Group {
+                material: 2,
+                tri_start: 0,
+                tri_count: 7
+            }
+        );
+        assert_eq!(
+            merged[1],
+            Group {
+                material: 5,
+                tri_start: 7,
+                tri_count: 2
+            }
+        );
+        assert_eq!(sorted.len(), 27, "no triangle is lost");
+        // Material 2's second run must follow its first, not stay where it was.
+        assert_eq!(&sorted[0..9], &[0, 1, 2, 3, 4, 5, 6, 7, 8]);
+        assert_eq!(
+            &sorted[9..21],
+            &[15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]
+        );
+        assert_eq!(&sorted[21..27], &[9, 10, 11, 12, 13, 14]);
+    }
+
+    #[test]
+    fn a_reduced_surface_keeps_its_average() {
+        // Fully opaque, so the alpha weighting is a plain mean and the arithmetic is visible.
+        let rgba = vec![
+            0, 0, 0, 255, 100, 100, 100, 255, 200, 200, 200, 255, 40, 40, 40, 255,
+        ];
+        let (out, w, h) = reduce(rgba, 2, 2, 1);
+        assert_eq!((w, h), (1, 1));
+        assert_eq!(out, vec![85, 85, 85, 255]);
+    }
+
+    #[test]
+    fn reducing_a_cutout_does_not_drag_it_towards_black() {
+        // One bright leaf against three transparent black texels — the shape of a foliage
+        // sheet. A flat average would return a quarter-bright pixel; weighting by alpha keeps
+        // the leaf's own colour and lets alpha alone carry how much of it survived.
+        let rgba = vec![
+            200, 220, 180, 255, // the leaf
+            0, 0, 0, 0, //
+            0, 0, 0, 0, //
+            0, 0, 0, 0,
+        ];
+        let (out, _, _) = reduce(rgba, 2, 2, 1);
+        assert_eq!(&out[0..3], &[200, 220, 180], "the leaf keeps its colour");
+        assert_eq!(out[3], 63, "and alpha says a quarter of it is there");
+    }
+
+    #[test]
+    fn sheets_are_turned_the_right_way_up() {
+        // Two rows, distinguishable: the file's first row is the picture's top, and a card's
+        // V zero is its foot, so the rows have to swap or every tree hangs upside down.
+        let mut rgba = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+        flip_rows(&mut rgba, 2, 2);
+        assert_eq!(
+            rgba,
+            vec![9, 10, 11, 12, 13, 14, 15, 16, 1, 2, 3, 4, 5, 6, 7, 8]
+        );
+    }
+
+    /// Point this at a real `.map` — unpacked, not the archive — to see what reads out of it:
+    ///
+    /// ```text
+    /// FROST_MAP="…/Millville.map" \
+    ///   cargo test --bin mxb-app -- --ignored --nocapture read_a_real_map
+    /// ```
+    ///
+    /// Checks the two things a transcription bug would break: that every normal is unit
+    /// length, and that the mesh lands in the world rather than around the origin.
+    #[test]
+    #[ignore = "needs a real .map — set FROST_MAP"]
+    fn read_a_real_map() {
+        let path = std::env::var("FROST_MAP").expect("set FROST_MAP to an unpacked .map");
+        let bytes = std::fs::read(&path).expect("read the map");
+        println!("{path}: {} bytes", bytes.len());
+
+        let Some(m) = parse(&bytes) else {
+            println!(
+                "no scenery in this map (materials = {:?})",
+                material_count(&bytes)
+            );
+            return;
+        };
+        let (lo, hi) = m.bounds();
+        println!(
+            "  {} materials, {} verts, {} tris",
+            m.materials,
+            m.vertex_count(),
+            m.triangle_count()
+        );
+        println!(
+            "  x[{:.1}, {:.1}] y[{:.1}, {:.1}] z[{:.1}, {:.1}]",
+            lo[0], hi[0], lo[1], hi[1], lo[2], hi[2]
+        );
+
+        let mut worst: f32 = 0.0;
+        for n in m.normals.chunks_exact(3) {
+            let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+            worst = worst.max((len - 1.0).abs());
+        }
+        println!("  worst normal length error: {worst:.6}");
+        assert!(
+            worst < 0.01,
+            "normals must be unit — the attribute offset is wrong otherwise"
+        );
+        assert!(m.indices.iter().all(|i| (*i as usize) < m.vertex_count()));
+        assert!(hi[0] - lo[0] > 1.0, "a real map spans real ground");
+    }
+}

--- a/src-tauri/src/map.rs
+++ b/src-tauri/src/map.rs
@@ -886,6 +886,36 @@ pub fn declared(b: &[u8]) -> Vec<(String, u32, u32)> {
         .collect()
 }
 
+/// The biggest picture inside a model file, reduced for the viewer.
+///
+/// A track's sky and backdrop keep their image inside the `.edf` rather than in the map's
+/// table, and those records use the same two header shapes — so they are read with the same
+/// scanner rather than the `.edf`'s own, which knows only one and finds the wrong sheet.
+pub fn largest_picture(b: &[u8]) -> Option<MapTexture> {
+    let (name, w, h, off, len) = colour_records(b, 0)
+        .into_iter()
+        .max_by_key(|(_, w, h, ..)| *w as u64 * *h as u64)?;
+    let rgba = inflate(b, off, len, w, h)?;
+    Some(reduced_texture(&name, w, h, rgba))
+}
+
+/// Turn already-inflated RGBA into a surface the viewer can hold: right way up, and small
+/// enough to keep. Used for the sky and backdrop, which come out of an `.edf` rather than the
+/// map's own table.
+pub fn reduced_texture(name: &str, w: u32, h: u32, mut rgba: Vec<u8>) -> MapTexture {
+    let alpha = cutout_fraction(&rgba) > CUTOUT_FRACTION;
+    flip_rows(&mut rgba, w, h);
+    let (rgba, w, h) = reduce(rgba, w, h, MAX_TEXTURE_DIM);
+    MapTexture {
+        material: 0,
+        name: name.to_string(),
+        width: w,
+        height: h,
+        alpha,
+        rgba,
+    }
+}
+
 /// A map's colour surfaces, one per material, inflated and reduced.
 ///
 /// Nothing in a material record points at a texture, so the binding is positional: the *k*-th

--- a/src-tauri/src/map.rs
+++ b/src-tauri/src/map.rs
@@ -891,17 +891,73 @@ pub fn declared(b: &[u8]) -> Vec<(String, u32, u32)> {
 /// The largest record whose name carries a ground word and which isn't a normal map. Order
 /// and binding don't come into it: this asks only "is this ground", which a name answers well
 /// enough, and a wrong answer costs grain rather than a wrong picture on a wrong object.
+/// Words that mark a sheet as something drawn *on* a track rather than the ground under it.
+/// A name is disqualified outright by one of these, however grounded the rest of it sounds —
+/// Abydos ships `logo-dirtmaster`, which is a logo.
+const NOT_GROUND: [&str; 27] = [
+    "logo", "banner", "sign", "signage", "arch", "flag", "board", "billboard", "tent", "decal",
+    "sticker", "poster", "sponsor", "truck", "bike", "wall", "fence", "gate", "tower", "screen",
+    "sky", "cloud", "tree", "leaf", "bark", "bale", "tyre",
+];
+
+/// The words a texture name is made of. Separators vary by author — `soil_dark_c`,
+/// `sand-dark`, `Dirt 2` — and digits never carry meaning, so everything but letters splits.
+fn name_words(name: &str) -> Vec<String> {
+    name.to_ascii_lowercase()
+        .split(|c: char| !c.is_ascii_alphabetic())
+        .filter(|w| !w.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Whether the name says this record is a normal map. Written every way going: `Dirt2_n`,
+/// `soil_white_n_s`, `sand-dark-normal`.
+fn is_normal_name(name: &str) -> bool {
+    name_words(name)
+        .iter()
+        .any(|w| matches!(w.as_str(), "n" | "nrm" | "norm" | "normal" | "nor"))
+}
+
+/// How well a name states one of the ground words, lower being better, or `None` if it states
+/// none. Whole words rank ahead of every prefix match, which is what keeps `dirtmaster` from
+/// outranking `dirt` while still letting `Dirtplane` count as dirt.
+fn ground_rank(name: &str, words: &[&str]) -> Option<usize> {
+    let parts = name_words(name);
+    if parts.iter().any(|w| NOT_GROUND.contains(&w.as_str())) {
+        return None;
+    }
+    if let Some(i) = words.iter().position(|g| parts.iter().any(|w| w == g)) {
+        return Some(i);
+    }
+    words
+        .iter()
+        .position(|g| parts.iter().any(|w| w.starts_with(g)))
+        .map(|i| words.len() + i)
+}
+
+/// The name with its trailing role words removed, so a colour sheet and its normal map can be
+/// recognised as the same stem: `soil_dark_c` and `soil_dark_n_s` both reduce to `soil dark`.
+fn name_stem(name: &str) -> Vec<String> {
+    let mut parts = name_words(name);
+    while parts
+        .last()
+        .is_some_and(|w| matches!(w.as_str(), "c" | "a" | "d" | "s" | "n" | "col" | "color" | "colour" | "diff" | "nrm" | "norm" | "normal" | "nor"))
+    {
+        parts.pop();
+    }
+    parts
+}
+
 pub fn ground_sheet(b: &[u8], words: &[&str]) -> Option<MapTexture> {
     let (from, _) = texture_table(b)?;
     // Ranked by which word matched, then by size — the word says what kind of ground it is,
     // and only among equals does the bigger sheet win.
     let mut best: Option<(usize, u64, String, u32, u32, usize, usize)> = None;
     for (name, w, h, off, len) in colour_records(b, from) {
-        let lower = name.to_ascii_lowercase();
-        if lower.ends_with("_n_s") || lower.ends_with("_n") || lower == "env" {
+        if is_normal_name(&name) || name.eq_ignore_ascii_case("env") {
             continue;
         }
-        let Some(rank) = words.iter().position(|word| lower.contains(word)) else {
+        let Some(rank) = ground_rank(&name, words) else {
             continue;
         };
         let area = w as u64 * h as u64;
@@ -915,6 +971,7 @@ pub fn ground_sheet(b: &[u8], words: &[&str]) -> Option<MapTexture> {
     }
     let (_, _, name, w, h, off, len) = best?;
     let mut rgba = inflate(b, off, len, w, h)?;
+    let _ = &name;
     // A sheet that turns out to be a cut-out is no use as ground — its holes would punch
     // through the terrain.
     if cutout_fraction(&rgba) > CUTOUT_FRACTION {
@@ -933,7 +990,62 @@ pub fn ground_sheet(b: &[u8], words: &[&str]) -> Option<MapTexture> {
     })
 }
 
-/// The biggest picture inside a model file, reduced for the viewer.
+/// The normal map that goes with a ground sheet, if the track ships one.
+///
+/// Named on the sheet's own stem — `dirt` and `dirt_n`, `soil_dark_c` and `soil_dark_n_s`.
+/// Tiled with the colour it belongs to, it is what gives close ground relief instead of a
+/// flat picture of relief.
+pub fn ground_normal(b: &[u8], colour_name: &str, words: &[&str]) -> Option<MapTexture> {
+    let stem = name_stem(colour_name);
+    let (from, _) = texture_table(b)?;
+
+    // The sheet's own partner first. Tracks often don't ship one — Millville has `soil_dark_c`
+    // but its ground normals are `grass_n_s` and `soil_white_n_s` — and for a detail layer any
+    // ground's relief will do, so a ground-named normal is taken over none.
+    let records = colour_records(b, from);
+    let pick = records
+        .iter()
+        .find(|(n, ..)| is_normal_name(n) && name_stem(n) == stem)
+        .or_else(|| {
+            records
+                .iter()
+                .find(|(n, ..)| is_normal_name(n) && ground_rank(n, words).is_some())
+        })?;
+    let (name, w, h, off, len) = pick.clone();
+    let mut rgba = inflate(b, off, len, w, h)?;
+    // A tangent-space normal map sits around (128, 128, 255); anything else here is a colour
+    // sheet that happens to be named like one, and using it would light the ground by noise.
+    let texels = rgba.len() / 4;
+    if texels == 0 {
+        return None;
+    }
+    let mut sum = [0u64; 3];
+    for p in rgba.chunks_exact(4) {
+        for k in 0..3 {
+            sum[k] += p[k] as u64;
+        }
+    }
+    let mean = [
+        sum[0] as f32 / texels as f32,
+        sum[1] as f32 / texels as f32,
+        sum[2] as f32 / texels as f32,
+    ];
+    if mean[2] < 200.0 || (mean[0] - 128.0).abs() > 40.0 || (mean[1] - 128.0).abs() > 40.0 {
+        return None;
+    }
+    flip_rows(&mut rgba, w, h);
+    let (rgba, w, h) = reduce(rgba, w, h, 512);
+    Some(MapTexture {
+        material: 1,
+        name,
+        width: w,
+        height: h,
+        alpha: false,
+        rgba,
+    })
+}
+
+/// The biggest picture inside a model file, reduced for the viewer./// The biggest picture inside a model file, reduced for the viewer.
 ///
 /// A track's sky and backdrop keep their image inside the `.edf` rather than in the map's
 /// table, and those records use the same two header shapes — so they are read with the same

--- a/src-tauri/src/map.rs
+++ b/src-tauri/src/map.rs
@@ -893,21 +893,27 @@ pub fn declared(b: &[u8]) -> Vec<(String, u32, u32)> {
 /// enough, and a wrong answer costs grain rather than a wrong picture on a wrong object.
 pub fn ground_sheet(b: &[u8], words: &[&str]) -> Option<MapTexture> {
     let (from, _) = texture_table(b)?;
-    let mut best: Option<(u64, String, u32, u32, usize, usize)> = None;
+    // Ranked by which word matched, then by size — the word says what kind of ground it is,
+    // and only among equals does the bigger sheet win.
+    let mut best: Option<(usize, u64, String, u32, u32, usize, usize)> = None;
     for (name, w, h, off, len) in colour_records(b, from) {
         let lower = name.to_ascii_lowercase();
         if lower.ends_with("_n_s") || lower.ends_with("_n") || lower == "env" {
             continue;
         }
-        if !words.iter().any(|word| lower.contains(word)) {
+        let Some(rank) = words.iter().position(|word| lower.contains(word)) else {
             continue;
-        }
+        };
         let area = w as u64 * h as u64;
-        if best.as_ref().is_none_or(|(a, ..)| area > *a) {
-            best = Some((area, name, w, h, off, len));
+        let better = match &best {
+            None => true,
+            Some((r, a, ..)) => rank < *r || (rank == *r && area > *a),
+        };
+        if better {
+            best = Some((rank, area, name, w, h, off, len));
         }
     }
-    let (_, name, w, h, off, len) = best?;
+    let (_, _, name, w, h, off, len) = best?;
     let mut rgba = inflate(b, off, len, w, h)?;
     // A sheet that turns out to be a cut-out is no use as ground — its holes would punch
     // through the terrain.

--- a/src-tauri/src/map.rs
+++ b/src-tauri/src/map.rs
@@ -1183,6 +1183,15 @@ pub const TEXTURE_ENTRY: usize = 20;
 /// surfaces; as JSON numbers it would cost more to parse than the archive read that
 /// produced it.
 pub fn scenery_blob(mesh: &MapMesh, textures: &[MapTexture]) -> Vec<u8> {
+    // The reader walks the sections back to back and works out where the surfaces start from
+    // the triangle count, so a mesh carrying fewer piece ids than triangles doesn't lose the
+    // pieces — it loses the whole scenery. Appending a placed prop without numbering it was
+    // exactly that.
+    debug_assert_eq!(
+        mesh.object_of_tri.len(),
+        mesh.indices.len() / 3,
+        "one piece id per triangle"
+    );
     let (lo, hi) = mesh.bounds();
     let vc = mesh.vertex_count() as u32;
     let ic = mesh.indices.len() as u32;

--- a/src-tauri/src/map.rs
+++ b/src-tauri/src/map.rs
@@ -894,20 +894,39 @@ pub fn declared(b: &[u8]) -> Vec<(String, u32, u32)> {
 /// Words that mark a sheet as something drawn *on* a track rather than the ground under it.
 /// A name is disqualified outright by one of these, however grounded the rest of it sounds —
 /// Abydos ships `logo-dirtmaster`, which is a logo.
-const NOT_GROUND: [&str; 27] = [
+const NOT_GROUND: [&str; 31] = [
     "logo", "banner", "sign", "signage", "arch", "flag", "board", "billboard", "tent", "decal",
     "sticker", "poster", "sponsor", "truck", "bike", "wall", "fence", "gate", "tower", "screen",
-    "sky", "cloud", "tree", "leaf", "bark", "bale", "tyre",
+    "sky", "cloud", "tree", "leaf", "bark", "bale", "tyre", "marker", "post", "cone", "arrow",
 ];
 
 /// The words a texture name is made of. Separators vary by author — `soil_dark_c`,
 /// `sand-dark`, `Dirt 2` — and digits never carry meaning, so everything but letters splits.
 fn name_words(name: &str) -> Vec<String> {
-    name.to_ascii_lowercase()
-        .split(|c: char| !c.is_ascii_alphabetic())
-        .filter(|w| !w.is_empty())
-        .map(str::to_string)
-        .collect()
+    let mut out: Vec<String> = Vec::new();
+    let mut word = String::new();
+    let chars: Vec<char> = name.chars().collect();
+    let mut push = |w: &mut String| {
+        if !w.is_empty() {
+            out.push(std::mem::take(w));
+        }
+    };
+    for (i, &c) in chars.iter().enumerate() {
+        if !c.is_ascii_alphabetic() {
+            push(&mut word);
+            continue;
+        }
+        // A capital starts a word too — `RR_TrackMarker` is a marker, and reading it as one
+        // word `trackmarker` made it match `track` and pass as ground.
+        let after_lower = i > 0 && chars[i - 1].is_ascii_lowercase();
+        let before_lower = chars.get(i + 1).is_some_and(|n| n.is_ascii_lowercase());
+        if c.is_ascii_uppercase() && (after_lower || before_lower) {
+            push(&mut word);
+        }
+        word.push(c.to_ascii_lowercase());
+    }
+    push(&mut word);
+    out
 }
 
 /// Whether the name says this record is a normal map. Written every way going: `Dirt2_n`,
@@ -999,50 +1018,60 @@ pub fn ground_normal(b: &[u8], colour_name: &str, words: &[&str]) -> Option<MapT
     let stem = name_stem(colour_name);
     let (from, _) = texture_table(b)?;
 
-    // The sheet's own partner first. Tracks often don't ship one — Millville has `soil_dark_c`
-    // but its ground normals are `grass_n_s` and `soil_white_n_s` — and for a detail layer any
-    // ground's relief will do, so a ground-named normal is taken over none.
-    let records = colour_records(b, from);
-    let pick = records
-        .iter()
-        .find(|(n, ..)| is_normal_name(n) && name_stem(n) == stem)
-        .or_else(|| {
-            records
-                .iter()
-                .find(|(n, ..)| is_normal_name(n) && ground_rank(n, words).is_some())
-        })?;
-    let (name, w, h, off, len) = pick.clone();
-    let mut rgba = inflate(b, off, len, w, h)?;
-    // A tangent-space normal map sits around (128, 128, 255); anything else here is a colour
-    // sheet that happens to be named like one, and using it would light the ground by noise.
-    let texels = rgba.len() / 4;
-    if texels == 0 {
-        return None;
-    }
-    let mut sum = [0u64; 3];
-    for p in rgba.chunks_exact(4) {
-        for k in 0..3 {
-            sum[k] += p[k] as u64;
+    // The sheet's own partner first, then any ground's — tracks often ship no partner for the
+    // sheet that won (Millville has `soil_dark_c` but its normals are `grass_n_s` and
+    // `soil_white_n_s`), and for a detail layer any ground's relief will do.
+    let mut candidates: Vec<(usize, (String, u32, u32, usize, usize))> = colour_records(b, from)
+        .into_iter()
+        .filter(|(n, ..)| is_normal_name(n))
+        .filter_map(|r| {
+            if name_stem(&r.0) == stem {
+                Some((0, r))
+            } else {
+                ground_rank(&r.0, words).map(|k| (k + 1, r))
+            }
+        })
+        .collect();
+    candidates.sort_by_key(|(rank, _)| *rank);
+
+    // Each is only a candidate until its pixels agree: a tangent-space normal map sits around
+    // (128, 128, 255), and anything else here is a colour sheet named like one — lighting the
+    // ground by it would be lighting it with noise. Trying them in turn rather than testing
+    // only the first is what keeps one mis-named sheet from costing a track its relief.
+    for (_, (name, w, h, off, len)) in candidates {
+        let Some(mut rgba) = inflate(b, off, len, w, h) else {
+            continue;
+        };
+        let texels = rgba.len() / 4;
+        if texels == 0 {
+            continue;
         }
+        let mut sum = [0u64; 3];
+        for p in rgba.chunks_exact(4) {
+            for k in 0..3 {
+                sum[k] += p[k] as u64;
+            }
+        }
+        let mean = [
+            sum[0] as f32 / texels as f32,
+            sum[1] as f32 / texels as f32,
+            sum[2] as f32 / texels as f32,
+        ];
+        if mean[2] < 200.0 || (mean[0] - 128.0).abs() > 40.0 || (mean[1] - 128.0).abs() > 40.0 {
+            continue;
+        }
+        flip_rows(&mut rgba, w, h);
+        let (rgba, w, h) = reduce(rgba, w, h, 512);
+        return Some(MapTexture {
+            material: 1,
+            name,
+            width: w,
+            height: h,
+            alpha: false,
+            rgba,
+        });
     }
-    let mean = [
-        sum[0] as f32 / texels as f32,
-        sum[1] as f32 / texels as f32,
-        sum[2] as f32 / texels as f32,
-    ];
-    if mean[2] < 200.0 || (mean[0] - 128.0).abs() > 40.0 || (mean[1] - 128.0).abs() > 40.0 {
-        return None;
-    }
-    flip_rows(&mut rgba, w, h);
-    let (rgba, w, h) = reduce(rgba, w, h, 512);
-    Some(MapTexture {
-        material: 1,
-        name,
-        width: w,
-        height: h,
-        alpha: false,
-        rgba,
-    })
+    None
 }
 
 /// The biggest picture inside a model file, reduced for the viewer./// The biggest picture inside a model file, reduced for the viewer.
@@ -1253,6 +1282,55 @@ pub const SURFACES_HEADER: usize = 16;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    /// Ground words used to be looked for anywhere in a name, which is how Abydos's
+    /// `logo-dirtmaster` came to be its dirt and I40's `banner_lucasoil` its soil. Both are
+    /// near-flat pictures, so the detail layer they won did nothing at all.
+    #[test]
+    fn a_logo_is_not_the_ground_it_is_named_after() {
+        let words = ["dirt", "soil", "sand"];
+        assert_eq!(ground_rank("logo-dirtmaster", &words), None);
+        assert_eq!(ground_rank("banner_lucasoil", &words), None);
+        assert_eq!(ground_rank("RR_TrackMarker", &["track"]), None);
+    }
+
+    #[test]
+    fn a_whole_word_outranks_a_word_it_only_starts() {
+        let words = ["dirt", "sand"];
+        let whole = ground_rank("dry_dirt", &words).expect("dirt");
+        let prefix = ground_rank("Dirtplane", &words).expect("still dirt");
+        assert!(whole < prefix, "{whole} should beat {prefix}");
+        // And a later word said outright still loses to an earlier one said at all.
+        assert!(ground_rank("sand-dark", &words).expect("sand") > whole);
+    }
+
+    #[test]
+    fn a_name_is_read_however_its_author_wrote_it() {
+        assert_eq!(name_words("soil_dark_c"), ["soil", "dark", "c"]);
+        assert_eq!(name_words("sand-dark-normal"), ["sand", "dark", "normal"]);
+        assert_eq!(name_words("Dirt_2"), ["dirt"]);
+    }
+
+    #[test]
+    fn a_normal_map_says_so_in_any_of_the_ways_it_is_written() {
+        for n in ["Dirt2_n", "soil_white_n_s", "sand-dark-normal", "track-norm"] {
+            assert!(is_normal_name(n), "{n} is a normal map");
+        }
+        for n in ["grass", "sand-new-2", "dirtyconcrete", "banner_fmf"] {
+            assert!(!is_normal_name(n), "{n} is a picture");
+        }
+    }
+
+    /// What lets a sheet find its own partner rather than any old normal map.
+    #[test]
+    fn a_sheet_and_its_normal_reduce_to_the_same_stem() {
+        assert_eq!(name_stem("soil_dark_c"), name_stem("soil_dark_n_s"));
+        assert_eq!(name_stem("sand-dark"), name_stem("sand-dark-normal"));
+        assert_eq!(name_stem("dirt"), name_stem("dirt_n"));
+        assert_ne!(name_stem("soil_dark_c"), name_stem("soil_white_n_s"));
+    }
+
     use super::*;
 
     /// Build a `.map` byte-for-byte the way a real one is laid out.

--- a/src-tauri/src/map.rs
+++ b/src-tauri/src/map.rs
@@ -886,6 +886,47 @@ pub fn declared(b: &[u8]) -> Vec<(String, u32, u32)> {
         .collect()
 }
 
+/// A sheet that looks like ground, for tiling over the terrain as detail.
+///
+/// The largest record whose name carries a ground word and which isn't a normal map. Order
+/// and binding don't come into it: this asks only "is this ground", which a name answers well
+/// enough, and a wrong answer costs grain rather than a wrong picture on a wrong object.
+pub fn ground_sheet(b: &[u8], words: &[&str]) -> Option<MapTexture> {
+    let (from, _) = texture_table(b)?;
+    let mut best: Option<(u64, String, u32, u32, usize, usize)> = None;
+    for (name, w, h, off, len) in colour_records(b, from) {
+        let lower = name.to_ascii_lowercase();
+        if lower.ends_with("_n_s") || lower.ends_with("_n") || lower == "env" {
+            continue;
+        }
+        if !words.iter().any(|word| lower.contains(word)) {
+            continue;
+        }
+        let area = w as u64 * h as u64;
+        if best.as_ref().is_none_or(|(a, ..)| area > *a) {
+            best = Some((area, name, w, h, off, len));
+        }
+    }
+    let (_, name, w, h, off, len) = best?;
+    let mut rgba = inflate(b, off, len, w, h)?;
+    // A sheet that turns out to be a cut-out is no use as ground — its holes would punch
+    // through the terrain.
+    if cutout_fraction(&rgba) > CUTOUT_FRACTION {
+        return None;
+    }
+    flip_rows(&mut rgba, w, h);
+    // Smaller than a surface: this tiles, so it needs frequency rather than extent.
+    let (rgba, w, h) = reduce(rgba, w, h, 512);
+    Some(MapTexture {
+        material: 0,
+        name,
+        width: w,
+        height: h,
+        alpha: false,
+        rgba,
+    })
+}
+
 /// The biggest picture inside a model file, reduced for the viewer.
 ///
 /// A track's sky and backdrop keep their image inside the `.edf` rather than in the map's

--- a/src-tauri/src/map.rs
+++ b/src-tauri/src/map.rs
@@ -375,6 +375,93 @@ pub struct MapObject {
     pub max: [f32; 3],
 }
 
+/// Drop the geometry that only makes sense with a picture on it.
+///
+/// A quarter to a third of a map is cut-out cards — foliage, crowd, netting — flat quads that
+/// are a tree only once an alpha channel has cut the tree out of them. Drawn plain they are
+/// standing sheets of paper, and there are thousands of them: they hide the track and read as
+/// a fault rather than as a limitation.
+///
+/// So on a map whose surfaces can't be bound, they come out. A card is a triangle standing
+/// near-vertical and tall enough not to be ground: measured against a track whose cut-outs
+/// are known, that test catches them at 71 % against 11 % of everything else, which is the
+/// separation that makes it worth doing at all.
+///
+/// Where the surfaces *do* bind, nothing is dropped — an alpha test draws them properly.
+pub fn without_cards(mesh: &MapMesh) -> MapMesh {
+    let tris = mesh.indices.len() / 3;
+    let vert = |i: u32| {
+        let o = i as usize * 3;
+        [
+            mesh.positions[o],
+            mesh.positions[o + 1],
+            mesh.positions[o + 2],
+        ]
+    };
+    let mut keep = Vec::with_capacity(tris);
+    for t in 0..tris {
+        let p = [
+            vert(mesh.indices[t * 3]),
+            vert(mesh.indices[t * 3 + 1]),
+            vert(mesh.indices[t * 3 + 2]),
+        ];
+        let e1 = [p[1][0] - p[0][0], p[1][1] - p[0][1], p[1][2] - p[0][2]];
+        let e2 = [p[2][0] - p[0][0], p[2][1] - p[0][1], p[2][2] - p[0][2]];
+        let n = [
+            e1[1] * e2[2] - e1[2] * e2[1],
+            e1[2] * e2[0] - e1[0] * e2[2],
+            e1[0] * e2[1] - e1[1] * e2[0],
+        ];
+        let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+        let upright = if len > 1e-9 { (n[1] / len).abs() } else { 1.0 };
+        let high = p[0][1].max(p[1][1]).max(p[2][1]);
+        let low = p[0][1].min(p[1][1]).min(p[2][1]);
+        keep.push(!(upright < 0.35 && high - low > 0.8));
+    }
+
+    // Triangles are already sorted by material, so filtering keeps that order and the groups
+    // only need recounting.
+    let mut indices = Vec::with_capacity(mesh.indices.len());
+    let mut groups: Vec<Group> = Vec::new();
+    let mut material_of_tri: Vec<u32> = Vec::new();
+    for g in &mesh.groups {
+        let start = (indices.len() / 3) as u32;
+        for t in g.tri_start..g.tri_start + g.tri_count {
+            if !keep.get(t as usize).copied().unwrap_or(false) {
+                continue;
+            }
+            let at = t as usize * 3;
+            indices.extend_from_slice(&mesh.indices[at..at + 3]);
+            material_of_tri.push(g.material);
+        }
+        let count = (indices.len() / 3) as u32 - start;
+        if count > 0 {
+            groups.push(Group {
+                material: g.material,
+                tri_start: start,
+                tri_count: count,
+            });
+        }
+    }
+
+    let (objects, object_of_tri) = split_into_objects(
+        mesh.vertex_count(),
+        &indices,
+        &material_of_tri,
+        &mesh.positions,
+    );
+    MapMesh {
+        positions: mesh.positions.clone(),
+        normals: mesh.normals.clone(),
+        uvs: mesh.uvs.clone(),
+        indices,
+        groups,
+        objects,
+        object_of_tri,
+        materials: mesh.materials,
+    }
+}
+
 /// Split the mesh into the pieces it is actually made of.
 ///
 /// Triangles that share a vertex belong to the same thing: the exporter welds a tent to
@@ -1152,6 +1239,39 @@ mod tests {
         );
         // The pixels are last, so the tail is exactly what went in.
         assert_eq!(&blob[blob.len() - 16..], &[7u8; 16]);
+    }
+
+    #[test]
+    fn cut_out_cards_come_out_and_the_ground_stays() {
+        // A flat ground quad and a standing card. Without a picture on it the card is a sheet
+        // of paper, so it goes; the ground it stands on does not.
+        let positions = vec![
+            0.0, 0.0, 0.0, 4.0, 0.0, 0.0, 0.0, 0.0, 4.0, // ground, lying flat
+            1.0, 0.0, 1.0, 1.0, 3.0, 1.0, 2.0, 3.0, 1.0, // a card, standing three metres
+        ];
+        let mesh = MapMesh {
+            positions,
+            normals: vec![0.0; 18],
+            uvs: vec![0.0; 12],
+            indices: vec![0, 1, 2, 3, 4, 5],
+            groups: vec![Group {
+                material: 0,
+                tri_start: 0,
+                tri_count: 2,
+            }],
+            objects: Vec::new(),
+            object_of_tri: Vec::new(),
+            materials: 1,
+        };
+        let out = without_cards(&mesh);
+        assert_eq!(out.triangle_count(), 1, "the card goes, the ground stays");
+        assert_eq!(&out.indices[..], &[0, 1, 2]);
+        assert_eq!(out.groups.len(), 1);
+        assert_eq!(
+            out.groups[0].tri_count, 1,
+            "the group is recounted, not left stale"
+        );
+        assert_eq!(out.objects.len(), 1, "and the pieces are found again");
     }
 
     #[test]

--- a/src-tauri/src/map.rs
+++ b/src-tauri/src/map.rs
@@ -788,7 +788,8 @@ pub fn declared(b: &[u8]) -> Vec<(String, u32, u32)> {
         return Vec::new();
     };
     let all = colour_records(b, from);
-    if !all.iter().any(|(n, ..)| is_colour_name(n)) {
+    let named = all.iter().filter(|(n, ..)| is_colour_name(n)).count();
+    if count == 0 || named * 4 < count * 3 {
         return Vec::new();
     }
     all.into_iter()
@@ -816,7 +817,11 @@ pub fn textures(b: &[u8], max_dim: u32) -> Vec<MapTexture> {
         return Vec::new();
     };
     let all = colour_records(b, from);
-    if !all.iter().any(|(n, ..)| is_colour_name(n)) {
+    // The convention has to cover the map, not merely appear in it. One `_c` among fifty
+    // plainly-named sheets is a coincidence, and binding on it paints a single material and
+    // leaves the rest grey — which reads as broken rather than as undecided.
+    let named = all.iter().filter(|(n, ..)| is_colour_name(n)).count();
+    if count == 0 || named * 4 < count * 3 {
         return Vec::new();
     }
 
@@ -850,7 +855,7 @@ pub fn textures(b: &[u8], max_dim: u32) -> Vec<MapTexture> {
 
 /// Bytes before the vertex data in a scenery blob. Four-byte aligned so the app can adopt
 /// every array as a typed-array view rather than copying it.
-pub const SCENERY_HEADER: usize = 48;
+pub const SCENERY_HEADER: usize = 56;
 
 /// Bytes per entry in the blob's texture table.
 pub const TEXTURE_ENTRY: usize = 20;
@@ -861,8 +866,9 @@ pub const TEXTURE_ENTRY: usize = 20;
 ///  0  "FSCN"
 ///  4  u16 version, u16 flags
 ///  8  u32 vertex_count, u32 index_count, u32 group_count, u32 texture_count
-/// 24  f32[6] world bounds
-/// 48  positions  vc*12 | normals vc*12 | uvs vc*8 | indices ic*4
+/// 24  u32 piece_count, u32 reserved
+/// 32  f32[6] world bounds
+/// 56  positions  vc*12 | normals vc*12 | uvs vc*8 | indices ic*4
 ///     groups     gc*12  (material, tri_start, tri_count)
 ///     pieces     (ic/3)*4  which separable piece each triangle belongs to
 ///     textures   tc*20  (material, width, height, flags, byte_len), then the pixels
@@ -893,10 +899,11 @@ pub fn scenery_blob(mesh: &MapMesh, textures: &[MapTexture]) -> Vec<u8> {
     out.extend_from_slice(&vc.to_le_bytes());
     out.extend_from_slice(&ic.to_le_bytes());
     out.extend_from_slice(&(mesh.groups.len() as u32).to_le_bytes());
-    // Top half carries how many separable pieces the mesh came apart into; the low half is
-    // the surface count. Both fit, and it keeps the header the size the app already reads.
-    let packed = (textures.len() as u32 & 0xFFFF) | ((mesh.objects.len().min(0xFFFF) as u32) << 16);
-    out.extend_from_slice(&packed.to_le_bytes());
+    out.extend_from_slice(&(textures.len() as u32).to_le_bytes());
+    // A word of its own: a dense track has more than sixty-five thousand pieces, and a count
+    // that saturates is a number that lies.
+    out.extend_from_slice(&(mesh.objects.len() as u32).to_le_bytes());
+    out.extend_from_slice(&0u32.to_le_bytes());
     for v in lo.iter().chain(hi.iter()) {
         out.extend_from_slice(&v.to_le_bytes());
     }
@@ -1126,13 +1133,9 @@ mod tests {
         assert_eq!(u32le(&blob, 4) & 0xFFFF, 2, "version 2");
         assert_eq!(u32le(&blob, 8), 40, "vertex count");
         assert_eq!(u32le(&blob, 12), 36, "index count");
-        // One word carries both counts: surfaces low, separable pieces high.
-        assert_eq!(u32le(&blob, 20) & 0xFFFF, 1, "one surface");
-        assert_eq!(
-            u32le(&blob, 20) >> 16,
-            m.objects.len() as u32,
-            "and the piece count"
-        );
+        assert_eq!(u32le(&blob, 20), 1, "one surface");
+        // Its own word, so a dense track's count doesn't saturate.
+        assert_eq!(u32le(&blob, 24), m.objects.len() as u32, "the piece count");
         let groups = u32le(&blob, 16) as usize;
         assert_eq!(
             blob.len(),

--- a/src-tauri/src/scenery.rs
+++ b/src-tauri/src/scenery.rs
@@ -45,6 +45,10 @@ pub struct Placement {
     pub pos: [f32; 3],
     /// Degrees, where the file states one: a marshal's `long`, a camera's `rot`.
     pub heading: Option<f32>,
+    /// Full rotation in degrees, for the props that carry one. Kept apart from `heading` so
+    /// a prop can be written back exactly as it was placed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rot: Option<[f32; 3]>,
 }
 
 /// What a track's scenery amounts to, minus the geometry itself.
@@ -181,6 +185,7 @@ fn read_scr(bytes: &[u8]) -> Vec<(Placement, [f32; 3])> {
                     name,
                     pos,
                     heading: Some(rot[1]),
+                    rot: Some(rot),
                 },
                 rot,
             ))
@@ -205,6 +210,7 @@ fn read_marshals(bytes: &[u8]) -> Vec<Placement> {
                 name: name.clone(),
                 pos,
                 heading: node.get("long").and_then(|v| v.trim().parse().ok()),
+                rot: None,
             });
         }
     }
@@ -231,6 +237,7 @@ fn read_cameras(bytes: &[u8]) -> Vec<Placement> {
                 name: label,
                 pos,
                 heading: cam.get("rot").and_then(|v| v.trim().parse().ok()),
+                rot: None,
             });
         }
     }
@@ -249,9 +256,69 @@ fn read_sounds(bytes: &[u8]) -> Vec<Placement> {
                 name: s.get("data").unwrap_or("").trim().to_string(),
                 pos,
                 heading: None,
+                rot: None,
             })
         })
         .collect()
+}
+
+/// Write props back out in the format a track states them in.
+///
+/// The `.scr` is the one part of a track that says where a thing goes in plain text, and the
+/// game reads it at load — so it is where anything placed in the app has to end up. Written
+/// the way tracks write it: a numbered block per object, a tab of indent, and `rot` only when
+/// there is one, so a file that goes out looks like the files that come in.
+pub fn write_scr(props: &[Placement]) -> String {
+    let mut out = String::new();
+    let num = |v: f32| {
+        // Trim the trailing zeros a float would otherwise carry, the way the tracks do.
+        let s = format!("{v:.4}");
+        let s = s.trim_end_matches('0').trim_end_matches('.');
+        if s.is_empty() || s == "-0" {
+            "0".to_string()
+        } else {
+            s.to_string()
+        }
+    };
+    for (i, p) in props.iter().filter(|p| p.kind == "prop").enumerate() {
+        out.push_str(&format!("obj{i}\n{{\n"));
+        out.push_str(&format!("\tname = {}\n", p.name));
+        out.push_str(&format!(
+            "\tpos = {}, {}, {}\n",
+            num(p.pos[0]),
+            num(p.pos[1]),
+            num(p.pos[2])
+        ));
+        if let Some(r) = p.rot {
+            if r.iter().any(|v| *v != 0.0) {
+                out.push_str(&format!(
+                    "\trot = {}, {}, {}\n",
+                    num(r[0]),
+                    num(r[1]),
+                    num(r[2])
+                ));
+            }
+        }
+        out.push_str("}\n");
+    }
+    out
+}
+
+/// Save a track's props to a `.scr`.
+///
+/// Refuses to overwrite unless asked: a track's own file is the record of hours of placing
+/// things, and replacing it silently is not a thing an editor should be able to do by
+/// accident. The caller names the destination — nothing is written inside an archive.
+pub fn save_scr(target: &str, props: &[Placement], overwrite: bool) -> Result<()> {
+    let path = Path::new(target);
+    if path.exists() && !overwrite {
+        bail!("{target} already exists");
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, write_scr(props))?;
+    Ok(())
 }
 
 /// Every fixture a track pins to a point, without touching the `.map`.
@@ -913,6 +980,81 @@ source1
         // Negative coordinates are ordinary: background props stand outside the terrain.
         assert_eq!(objs[1].0.pos, [-412.0, 108.71, -381.0]);
         assert_eq!(objs[1].1, [0.0, 90.0, 0.0]);
+    }
+
+    #[test]
+    fn props_round_trip_through_the_scr() {
+        // What comes out has to read back as what went in — that is the whole contract of
+        // being able to place something and have the game load it.
+        let first = read_scr(SCR);
+        let placements: Vec<Placement> = first.iter().map(|(p, _)| p.clone()).collect();
+        let text = write_scr(&placements);
+        let again = read_scr(text.as_bytes());
+        assert_eq!(again.len(), first.len(), "same number of props");
+        for ((a, ar), (b, br)) in first.iter().zip(again.iter()) {
+            assert_eq!(a.name, b.name);
+            for k in 0..3 {
+                assert!((a.pos[k] - b.pos[k]).abs() < 1e-3, "{} moved", a.name);
+                assert!((ar[k] - br[k]).abs() < 1e-3, "{} turned", a.name);
+            }
+        }
+        // And it looks like a track's own file, not a serialiser's idea of one.
+        assert!(
+            text.starts_with("obj0\n{\n\tname = usa_flag.edf\n"),
+            "{text}"
+        );
+        assert!(text.contains("\tpos = 271.41, 59.2, 149.31\n"), "{text}");
+        // The first object has no rotation, so it states none.
+        assert!(
+            !text.split("obj1").next().unwrap().contains("rot ="),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn only_props_are_written() {
+        // Marshals and cameras live in their own files; a `.scr` that carried them would be
+        // a `.scr` the game reads as objects it can't load.
+        let mixed = vec![
+            Placement {
+                kind: "prop".into(),
+                name: "tent.edf".into(),
+                pos: [1.0, 2.0, 3.0],
+                heading: None,
+                rot: None,
+            },
+            Placement {
+                kind: "marshal".into(),
+                name: "marshal0".into(),
+                pos: [4.0, 5.0, 6.0],
+                heading: Some(90.0),
+                rot: None,
+            },
+        ];
+        let text = write_scr(&mixed);
+        assert!(text.contains("tent.edf"));
+        assert!(!text.contains("marshal"));
+        assert_eq!(text.matches("obj").count(), 1);
+    }
+
+    #[test]
+    fn saving_will_not_clobber_a_track() {
+        let dir = std::env::temp_dir().join(format!("frost-scr-{}", std::process::id()));
+        let file = dir.join("test.scr");
+        let props = vec![Placement {
+            kind: "prop".into(),
+            name: "flag.edf".into(),
+            pos: [1.0, 0.0, 2.0],
+            heading: None,
+            rot: None,
+        }];
+        save_scr(file.to_str().unwrap(), &props, false).expect("first write");
+        assert!(
+            save_scr(file.to_str().unwrap(), &props, false).is_err(),
+            "must refuse"
+        );
+        save_scr(file.to_str().unwrap(), &props, true).expect("overwrite when asked");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src-tauri/src/scenery.rs
+++ b/src-tauri/src/scenery.rs
@@ -1,0 +1,1446 @@
+//! What stands on a track, as opposed to the ground it stands on.
+//!
+//! Three sources, all in the same world frame as the terrain grid — metres, with the grid's
+//! own corner at the origin:
+//!
+//! * The `.map` carries the baked scenery as one mesh — tents, bales, banners, fences, and
+//!   the landscape beyond the terrain square. This is nearly all of it. See [`crate::map`].
+//! * The `.scr` places a handful of loose props by name, each a `.edf` shipped beside it.
+//!   Flags, wind turbines, an orbiting aeroplane. Their meshes are folded into the same
+//!   mesh, so the viewer draws one thing.
+//! * `marshals.cfg`, the `.tsc` and the `.ssc` pin fixtures to points with no mesh in the
+//!   track at all — marshal posts, TV cameras, crowd sound. Those come back as
+//!   [`Placement`]s for the viewer to mark.
+//!
+//! That the frame really is shared is not an assumption: `marshals.cfg` states each post's
+//! height, and sampling the terrain grid underneath reproduces all of them to within 0.1 m.
+
+use anyhow::{bail, Result};
+use std::path::{Path, PathBuf};
+
+use crate::cfg::CfgNode;
+use crate::map::{self, Group, MapMesh, MapTexture};
+
+/// Cache generation. Bump when the blob layout or the parse changes shape.
+// v2: the mesh gained UVs and material groups, and the surfaces travel with it.
+// v3: the mesh and the surfaces are cached apart, so the first can be served without the
+// second having been decoded at all.
+const MESH_CACHE: &str = "track-scenery-v3";
+const SURFACE_CACHE: &str = "track-surfaces-v3";
+
+/// How many decoded scenery meshes to keep. Smaller than the terrain's: one of these is
+/// about 30 MB, against 16 for a terrain master.
+const CACHE_KEEP: usize = 4;
+
+/// A point on the track where something stands that the track ships no mesh for.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Placement {
+    /// `prop`, `marshal`, `camera` or `sound`. A key, not prose — the app translates it.
+    pub kind: String,
+    /// The `.edf` for a prop, the `.wav` for a sound, otherwise the name the track gave it.
+    pub name: String,
+    /// World metres, in the game's own left-handed frame — the viewer mirrors X to draw it,
+    /// exactly as it does the terrain.
+    pub pos: [f32; 3],
+    /// Degrees, where the file states one: a marshal's `long`, a camera's `rot`.
+    pub heading: Option<f32>,
+}
+
+/// What a track's scenery amounts to, minus the geometry itself.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SceneryInfo {
+    /// Materials the `.map` declares. Zero means the track carries no scenery at all.
+    pub materials: u32,
+    pub vertex_count: u32,
+    pub triangle_count: u32,
+    /// `.scr` props whose mesh was found and folded in.
+    pub props: u32,
+    /// `.scr` props naming a `.edf` the track doesn't ship. Surfaced rather than swallowed:
+    /// it's the difference between a track with no props and one whose props went missing.
+    pub props_missing: u32,
+    /// The `.map` entry this came out of, empty when the track has none.
+    pub entry: String,
+    /// Connected pieces the scenery comes apart into — one per tent, trailer or foliage card.
+    #[serde(default)]
+    pub objects: u32,
+    /// One run of triangles per material: `[material, tri_start, tri_count]`.
+    #[serde(default)]
+    pub groups: Vec<[u32; 3]>,
+    /// The surfaces, in the order their pixels are stored.
+    #[serde(default)]
+    pub textures: Vec<TextureInfo>,
+}
+
+/// A surface's shape, kept apart from its pixels so the descriptor stays small.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TextureInfo {
+    pub material: u32,
+    pub name: String,
+    pub width: u32,
+    pub height: u32,
+    /// An alpha cut-out — foliage, crowd, fencing. Drawn without an alpha test it is a slab.
+    pub alpha: bool,
+}
+
+/// A track's scenery, decoded.
+#[derive(Clone, Debug, Default)]
+pub struct Scenery {
+    pub info: SceneryInfo,
+    pub mesh: MapMesh,
+    pub textures: Vec<MapTexture>,
+}
+
+// ---------------------------------------------------------------------------
+// Picking the files out of a track
+// ---------------------------------------------------------------------------
+
+/// The stem a track's own files are named after — `Millville.pkz` holds `Millville.map`.
+fn track_stem(path: &Path) -> String {
+    path.file_stem()
+        .map(|s| s.to_string_lossy().to_ascii_lowercase())
+        .unwrap_or_default()
+}
+
+/// Entries with the given extension, the one named after the track first.
+///
+/// A track can ship several — a pack with an MX, an SX and a supercross layout ships a `.scr`
+/// each — and the one matching the archive's own name is the track being looked at.
+fn entries_with_ext(names: &[String], ext: &str, stem: &str) -> Vec<String> {
+    let mut out: Vec<String> = names
+        .iter()
+        .filter(|n| {
+            n.rsplit('.')
+                .next()
+                .is_some_and(|e| e.eq_ignore_ascii_case(ext))
+        })
+        .cloned()
+        .collect();
+    out.sort_by_key(|n| {
+        let base = n.rsplit('/').next().unwrap_or(n).to_ascii_lowercase();
+        let matches = base.strip_suffix(&format!(".{ext}")).unwrap_or(&base) == stem;
+        (!matches, base.clone())
+    });
+    out
+}
+
+// ---------------------------------------------------------------------------
+// The cfg-shaped placement files
+// ---------------------------------------------------------------------------
+
+/// `x, y, z` on one line, as the `.scr`, `.ssc` and `.tsc` write a position.
+fn vec3_csv(s: &str) -> Option<[f32; 3]> {
+    let mut it = s.split(',').map(|p| p.trim().parse::<f32>());
+    let v = [it.next()?.ok()?, it.next()?.ok()?, it.next()?.ok()?];
+    v.iter().all(|f| f.is_finite()).then_some(v)
+}
+
+/// `pos { x = .. y = .. z = .. }`, as `marshals.cfg` writes one.
+fn vec3_block(node: &CfgNode) -> Option<[f32; 3]> {
+    let p = node.block("pos")?;
+    let f = |k: &str| p.get(k)?.trim().parse::<f32>().ok();
+    let v = [f("x")?, f("y")?, f("z")?];
+    v.iter().all(|f| f.is_finite()).then_some(v)
+}
+
+/// Child blocks named `prefix0`, `prefix1`, … in index order.
+///
+/// Read by scanning what's there rather than counting up from the file's own `num…` key:
+/// the two disagree in the wild, and the blocks are the ones that carry positions.
+fn numbered<'a>(node: &'a CfgNode, prefix: &str) -> Vec<&'a CfgNode> {
+    let mut found: Vec<(u32, &CfgNode)> = node
+        .blocks
+        .iter()
+        .filter_map(|(k, v)| {
+            let n = k.strip_prefix(prefix)?;
+            (!n.is_empty() && n.chars().all(|c| c.is_ascii_digit()))
+                .then(|| n.parse().ok().map(|i| (i, v)))?
+        })
+        .collect();
+    found.sort_by_key(|(i, _)| *i);
+    found.into_iter().map(|(_, v)| v).collect()
+}
+
+/// The props a `.scr` places, as `(placement, rotation in degrees)`.
+fn read_scr(bytes: &[u8]) -> Vec<(Placement, [f32; 3])> {
+    let root = crate::cfg::parse(bytes);
+    numbered(&root, "obj")
+        .into_iter()
+        .filter_map(|o| {
+            let name = o.get("name")?.trim().to_string();
+            if name.is_empty() {
+                return None;
+            }
+            let pos = vec3_csv(o.get("pos")?)?;
+            let rot = o.get("rot").and_then(vec3_csv).unwrap_or([0.0; 3]);
+            Some((
+                Placement {
+                    kind: "prop".into(),
+                    name,
+                    pos,
+                    heading: Some(rot[1]),
+                },
+                rot,
+            ))
+        })
+        .collect()
+}
+
+/// Marshal posts and the flagman. `long` is the heading the marshal faces.
+fn read_marshals(bytes: &[u8]) -> Vec<Placement> {
+    let root = crate::cfg::parse(bytes);
+    let mut out = Vec::new();
+    let mut named: Vec<(&String, &CfgNode)> = root
+        .blocks
+        .iter()
+        .filter(|(k, _)| k.as_str() == "flagman" || k.starts_with("marshal"))
+        .collect();
+    named.sort_by(|a, b| a.0.cmp(b.0));
+    for (name, node) in named {
+        if let Some(pos) = vec3_block(node) {
+            out.push(Placement {
+                kind: "marshal".into(),
+                name: name.clone(),
+                pos,
+                heading: node.get("long").and_then(|v| v.trim().parse().ok()),
+            });
+        }
+    }
+    out
+}
+
+/// The TV cameras a `.tsc` sets up, across every camera set in it.
+fn read_cameras(bytes: &[u8]) -> Vec<Placement> {
+    let root = crate::cfg::parse(bytes);
+    let mut out = Vec::new();
+    for (n, set) in numbered(&root, "camset").into_iter().enumerate() {
+        let set_name = set.get("name").unwrap_or("").trim().to_string();
+        for (i, cam) in numbered(set, "camera").into_iter().enumerate() {
+            let Some(pos) = cam.get("pos").and_then(vec3_csv) else {
+                continue;
+            };
+            let label = if set_name.is_empty() {
+                format!("camset{n} · camera{i}")
+            } else {
+                format!("{set_name} · camera{i}")
+            };
+            out.push(Placement {
+                kind: "camera".into(),
+                name: label,
+                pos,
+                heading: cam.get("rot").and_then(|v| v.trim().parse().ok()),
+            });
+        }
+    }
+    out
+}
+
+/// Crowd and ambience sources from the `.ssc`.
+fn read_sounds(bytes: &[u8]) -> Vec<Placement> {
+    let root = crate::cfg::parse(bytes);
+    numbered(&root, "source")
+        .into_iter()
+        .filter_map(|s| {
+            let pos = s.get("pos").and_then(vec3_csv)?;
+            Some(Placement {
+                kind: "sound".into(),
+                name: s.get("data").unwrap_or("").trim().to_string(),
+                pos,
+                heading: None,
+            })
+        })
+        .collect()
+}
+
+/// Every fixture a track pins to a point, without touching the `.map`.
+///
+/// Cheap on purpose: these files are a few kilobytes each, so the viewer can mark them while
+/// the scenery mesh — which is most of a gigabyte of archive away — is still being read.
+pub fn read_placements(path: &str) -> Result<Vec<Placement>> {
+    let p = Path::new(path);
+    let names = crate::track::entry_names(p)?;
+    let stem = track_stem(p);
+    let mut out = Vec::new();
+
+    let mut take = |ext: &str, f: &dyn Fn(&[u8]) -> Vec<Placement>| {
+        for entry in entries_with_ext(&names, ext, &stem) {
+            if let Ok(bytes) = crate::track::read_entry(p, &entry) {
+                let found = f(&bytes);
+                if !found.is_empty() {
+                    out.extend(found);
+                    // One layout's worth. A pack ships a `.scr` per layout, and merging them
+                    // would stand every pack's props on whichever track is open.
+                    break;
+                }
+            }
+        }
+    };
+
+    take("scr", &|b| {
+        read_scr(b).into_iter().map(|(p, _)| p).collect()
+    });
+    take("tsc", &read_cameras);
+    take("ssc", &read_sounds);
+
+    for entry in &names {
+        if entry
+            .rsplit('/')
+            .next()
+            .is_some_and(|b| b.eq_ignore_ascii_case("marshals.cfg"))
+        {
+            if let Ok(bytes) = crate::track::read_entry(p, entry) {
+                out.extend(read_marshals(&bytes));
+            }
+            break;
+        }
+    }
+
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Folding the `.scr` props into the scenery
+// ---------------------------------------------------------------------------
+
+/// Rotate by `deg` (X, then Y, then Z) and translate to `pos`, in the game's own frame.
+fn place(mesh: &mut MapMesh, node_pos: &[f32], node_nrm: &[f32], deg: [f32; 3], pos: [f32; 3]) {
+    let (sx, cx) = deg[0].to_radians().sin_cos();
+    let (sy, cy) = deg[1].to_radians().sin_cos();
+    let (sz, cz) = deg[2].to_radians().sin_cos();
+    // R = Rz * Ry * Rx, written out rather than composed to keep this a single pass.
+    let m = [
+        cz * cy,
+        cz * sy * sx - sz * cx,
+        cz * sy * cx + sz * sx,
+        sz * cy,
+        sz * sy * sx + cz * cx,
+        sz * sy * cx - cz * sx,
+        -sy,
+        cy * sx,
+        cy * cx,
+    ];
+    let rot = |v: &[f32]| {
+        [
+            m[0] * v[0] + m[1] * v[1] + m[2] * v[2],
+            m[3] * v[0] + m[4] * v[1] + m[5] * v[2],
+            m[6] * v[0] + m[7] * v[1] + m[8] * v[2],
+        ]
+    };
+    for p in node_pos.chunks_exact(3) {
+        let r = rot(p);
+        mesh.positions
+            .extend_from_slice(&[r[0] + pos[0], r[1] + pos[1], r[2] + pos[2]]);
+    }
+    for n in node_nrm.chunks_exact(3) {
+        mesh.normals.extend_from_slice(&rot(n));
+    }
+}
+
+/// Fold every `.scr` prop whose `.edf` the track ships into `mesh`.
+///
+/// Returns `(placed, missing)`. A prop naming a mesh that isn't there is worth counting: a
+/// track that lost its flags looks the same as one that never had any.
+fn bake_props(path: &Path, names: &[String], stem: &str, mesh: &mut MapMesh) -> (u32, u32) {
+    let Some(entry) = entries_with_ext(names, "scr", stem).into_iter().find(|e| {
+        crate::track::read_entry(path, e)
+            .map(|b| !read_scr(&b).is_empty())
+            .unwrap_or(false)
+    }) else {
+        return (0, 0);
+    };
+    let Ok(bytes) = crate::track::read_entry(path, &entry) else {
+        return (0, 0);
+    };
+
+    let prop_material = mesh.materials;
+    let (mut placed, mut missing) = (0, 0);
+    for (p, rot) in read_scr(&bytes) {
+        // The `.scr` names a bare file; the archive may hold it in a folder.
+        let found = names.iter().find(|n| {
+            n.rsplit('/')
+                .next()
+                .is_some_and(|b| b.eq_ignore_ascii_case(&p.name))
+        });
+        let Some(edf_entry) = found else {
+            missing += 1;
+            continue;
+        };
+        let Ok(edf_bytes) = crate::track::read_entry(path, edf_entry) else {
+            missing += 1;
+            continue;
+        };
+        // Left in the game's frame: the viewer mirrors X once, over everything at once.
+        let nodes = crate::edf::parse(&edf_bytes);
+        if nodes.is_empty() {
+            missing += 1;
+            continue;
+        }
+        for node in &nodes {
+            if node.positions.is_empty() || node.indices.is_empty() {
+                continue;
+            }
+            let base = mesh.vertex_count() as u32;
+            let normals = if node.normals.len() == node.positions.len() {
+                node.normals.clone()
+            } else {
+                vec![0.0; node.positions.len()]
+            };
+            place(mesh, &node.positions, &normals, rot, p.pos);
+            // A prop's own sheets aren't read, so it gets a material past the map's last —
+            // one with no surface behind it, which the viewer draws plain.
+            let verts = node.positions.len() / 3;
+            if node.uvs.len() == verts * 2 {
+                mesh.uvs.extend_from_slice(&node.uvs);
+            } else {
+                mesh.uvs.extend(std::iter::repeat(0.0).take(verts * 2));
+            }
+            let tri_start = (mesh.indices.len() / 3) as u32;
+            mesh.indices.extend(node.indices.iter().map(|i| i + base));
+            let tri_count = (mesh.indices.len() / 3) as u32 - tri_start;
+            match mesh.groups.last_mut() {
+                Some(last) if last.material == prop_material => last.tri_count += tri_count,
+                _ => mesh.groups.push(Group {
+                    material: prop_material,
+                    tri_start,
+                    tri_count,
+                }),
+            }
+        }
+        placed += 1;
+    }
+    (placed, missing)
+}
+
+// ---------------------------------------------------------------------------
+// The whole thing, cached
+// ---------------------------------------------------------------------------
+
+/// The last `.map` read, kept whole so the surfaces pass doesn't repeat it.
+///
+/// Pulling a map out of a track is nearly all of what loading one costs — measured across a
+/// library, between half a second and twenty-eight, against milliseconds to parse what comes
+/// out. The viewer asks for the mesh and then the surfaces, so without this the archive is
+/// read twice for one look at a track.
+///
+/// One entry, and it holds a few hundred megabytes, so it is dropped as soon as the surfaces
+/// have been taken from it rather than kept against a second viewing — that is what the disk
+/// cache is for.
+fn map_bytes_cache() -> &'static std::sync::Mutex<Option<(String, Vec<u8>, String)>> {
+    static CACHE: std::sync::OnceLock<std::sync::Mutex<Option<(String, Vec<u8>, String)>>> =
+        std::sync::OnceLock::new();
+    CACHE.get_or_init(|| std::sync::Mutex::new(None))
+}
+
+fn remember_map(key: &str, entry: &str, bytes: &[u8]) {
+    if let Ok(mut c) = map_bytes_cache().lock() {
+        *c = Some((key.to_string(), bytes.to_vec(), entry.to_string()));
+    }
+}
+
+/// Take the held bytes if they belong to this track, clearing the slot.
+fn take_map(key: &str) -> Option<(Vec<u8>, String)> {
+    let mut c = map_bytes_cache().lock().ok()?;
+    match c.as_ref() {
+        Some((k, ..)) if k == key => c.take().map(|(_, b, e)| (b, e)),
+        _ => None,
+    }
+}
+
+/// Decode a track's scenery, going to the archive only when nothing nearer has it.
+///
+/// The mesh and the surfaces are fetched separately on purpose. A track's shape is a few
+/// hundred thousand triangles that parse in milliseconds once the archive read is done; its
+/// surfaces are hundreds of megabytes to inflate and reduce. Waiting for the second before
+/// showing the first is most of a second of blank canvas for no reason, so the viewer asks
+/// for the mesh, draws it, and asks for the surfaces after.
+pub fn load(app: &tauri::AppHandle, path: &str) -> Result<Scenery> {
+    let key = cache_key(path)?;
+    if let Some(hit) = cache_file(app, &key, MESH_CACHE).and_then(|f| read_cache(&f)) {
+        return Ok(hit);
+    }
+    let scenery = decode_with_key(Path::new(path), false, Some(&key))?;
+    if let Some(f) = cache_file(app, &key, MESH_CACHE) {
+        write_cache(&f, &scenery);
+        prune_cache(app, MESH_CACHE);
+    }
+    Ok(scenery)
+}
+
+/// A track's surfaces, cached apart from its mesh.
+pub fn load_surfaces(app: &tauri::AppHandle, path: &str) -> Result<Vec<MapTexture>> {
+    let key = cache_key(path)?;
+    if let Some(hit) = cache_file(app, &key, SURFACE_CACHE).and_then(|f| read_surface_cache(&f)) {
+        return Ok(hit);
+    }
+    let scenery = decode_with_key(Path::new(path), true, Some(&key))?;
+    if let Some(f) = cache_file(app, &key, SURFACE_CACHE) {
+        write_surface_cache(&f, &scenery.textures);
+        prune_cache(app, SURFACE_CACHE);
+    }
+    Ok(scenery.textures)
+}
+
+/// The expensive path. A track's `.map` is the largest file it ships — most of it textures
+/// this doesn't read — which is exactly why the result is worth caching.
+fn decode(path: &Path, want_surfaces: bool) -> Result<Scenery> {
+    decode_with_key(path, want_surfaces, None)
+}
+
+fn decode_with_key(path: &Path, want_surfaces: bool, key: Option<&str>) -> Result<Scenery> {
+    let names = crate::track::entry_names(path)?;
+    let stem = track_stem(path);
+
+    let mut mesh = MapMesh::default();
+    let mut textures: Vec<MapTexture> = Vec::new();
+    let mut info = SceneryInfo::default();
+
+    // The surfaces pass follows the mesh pass on the same track, so the bytes are usually
+    // still in hand. Taking them clears the slot: they are big, and one pass over a track
+    // is all they are for.
+    let held = key.and_then(take_map);
+    for entry in entries_with_ext(&names, "map", &stem) {
+        let bytes = match &held {
+            Some((b, e)) if *e == entry => b.clone(),
+            _ => match crate::track::read_entry(path, &entry) {
+                Ok(b) => b,
+                Err(_) => continue,
+            },
+        };
+        if !map::is_map(&bytes) {
+            continue;
+        }
+        match map::parse(&bytes) {
+            Some(m) => {
+                info.materials = m.materials;
+                info.entry = entry.clone();
+                mesh = m;
+                if want_surfaces {
+                    textures = map::textures(&bytes, map::MAX_TEXTURE_DIM);
+                } else {
+                    // Hold the bytes for the surfaces pass that is about to follow.
+                    if let Some(k) = key {
+                        remember_map(k, &entry, &bytes);
+                    }
+                    // Named only, so the viewer knows how many to expect and can size its
+                    // material slots before a single pixel has been inflated.
+                    info.textures = map::declared(&bytes)
+                        .into_iter()
+                        .enumerate()
+                        .map(|(i, (name, width, height))| TextureInfo {
+                            material: i as u32,
+                            name,
+                            width,
+                            height,
+                            alpha: false,
+                        })
+                        .collect();
+                }
+            }
+            // A `.map` that declares no materials carries no scenery — an ordinary track,
+            // not a failed read. Keep the entry so the app can say it looked.
+            None => {
+                info.entry = entry.clone();
+            }
+        }
+        break;
+    }
+
+    let (placed, missing) = bake_props(path, &names, &stem, &mut mesh);
+    info.props = placed;
+    info.props_missing = missing;
+    info.vertex_count = mesh.vertex_count() as u32;
+    info.triangle_count = mesh.triangle_count() as u32;
+    info.objects = mesh.objects.len() as u32;
+    info.groups = mesh
+        .groups
+        .iter()
+        .map(|g| [g.material, g.tri_start, g.tri_count])
+        .collect();
+    if want_surfaces {
+        info.textures = textures
+            .iter()
+            .map(|t| TextureInfo {
+                material: t.material,
+                name: t.name.clone(),
+                width: t.width,
+                height: t.height,
+                alpha: t.alpha,
+            })
+            .collect();
+    }
+
+    if mesh.is_empty() && info.entry.is_empty() {
+        bail!("no .map in {path:?}");
+    }
+    Ok(Scenery {
+        info,
+        mesh,
+        textures,
+    })
+}
+
+/// Pack a track's mesh for the viewer. See [`map::scenery_blob`].
+pub fn blob(scenery: &Scenery) -> Vec<u8> {
+    map::scenery_blob(&scenery.mesh, &scenery.textures)
+}
+
+/// Pack a track's surfaces on their own.
+pub fn surfaces_blob(textures: &[MapTexture]) -> Vec<u8> {
+    map::surfaces_blob(textures)
+}
+
+/// On disk: the surface descriptors as JSON, then their pixels raw.
+fn write_surface_cache(file: &Path, textures: &[MapTexture]) {
+    if let Some(parent) = file.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let head: Vec<TextureInfo> = textures
+        .iter()
+        .map(|t| TextureInfo {
+            material: t.material,
+            name: t.name.clone(),
+            width: t.width,
+            height: t.height,
+            alpha: t.alpha,
+        })
+        .collect();
+    let Ok(head) = serde_json::to_vec(&head) else {
+        return;
+    };
+    let mut out = Vec::with_capacity(4 + head.len());
+    out.extend_from_slice(&(head.len() as u32).to_le_bytes());
+    out.extend_from_slice(&head);
+    for t in textures {
+        out.extend_from_slice(&t.rgba);
+    }
+    let _ = std::fs::write(file, out);
+}
+
+fn read_surface_cache(file: &Path) -> Option<Vec<MapTexture>> {
+    let bytes = std::fs::read(file).ok()?;
+    if bytes.len() < 4 {
+        return None;
+    }
+    let head_len = u32::from_le_bytes(bytes[0..4].try_into().ok()?) as usize;
+    let at = 4usize.checked_add(head_len)?;
+    if bytes.len() < at {
+        return None;
+    }
+    let head: Vec<TextureInfo> = serde_json::from_slice(&bytes[4..at]).ok()?;
+    let want: usize = head
+        .iter()
+        .map(|t| t.width as usize * t.height as usize * 4)
+        .sum();
+    let body = &bytes[at..];
+    if body.len() != want {
+        return None;
+    }
+    let mut out = Vec::with_capacity(head.len());
+    let mut o = 0usize;
+    for t in head {
+        let n = t.width as usize * t.height as usize * 4;
+        out.push(MapTexture {
+            material: t.material,
+            name: t.name,
+            width: t.width,
+            height: t.height,
+            alpha: t.alpha,
+            rgba: body[o..o + n].to_vec(),
+        });
+        o += n;
+    }
+    Some(out)
+}
+
+fn cache_key(path: &str) -> Result<String> {
+    let m = std::fs::metadata(path)?;
+    let mtime = m
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let name = Path::new(path)
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    Ok(format!("{name}:{}:{mtime}", m.len()))
+}
+
+fn cache_file(app: &tauri::AppHandle, key: &str, dir_name: &str) -> Option<PathBuf> {
+    use tauri::Manager;
+    let dir = app.path().app_cache_dir().ok()?.join(dir_name);
+    let safe: String = key
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    Some(dir.join(format!("{safe}.bin")))
+}
+
+/// On disk: the descriptor as JSON, then the mesh arrays and the surface pixels raw.
+///
+/// The descriptor carries the group and surface tables — a few dozen entries each, small
+/// enough that JSON costs nothing — while everything counted in megabytes stays bytes.
+fn write_cache(file: &Path, s: &Scenery) {
+    if let Some(parent) = file.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let Ok(head) = serde_json::to_vec(&s.info) else {
+        return;
+    };
+    let pixels: usize = s.textures.iter().map(|t| t.rgba.len()).sum();
+    let mut out = Vec::with_capacity(4 + head.len() + s.mesh.positions.len() * 8 + pixels);
+    out.extend_from_slice(&(head.len() as u32).to_le_bytes());
+    out.extend_from_slice(&head);
+    for v in s
+        .mesh
+        .positions
+        .iter()
+        .chain(s.mesh.normals.iter())
+        .chain(s.mesh.uvs.iter())
+    {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    for v in &s.mesh.indices {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    for t in &s.textures {
+        out.extend_from_slice(&t.rgba);
+    }
+    let _ = std::fs::write(file, out);
+}
+
+fn read_cache(file: &Path) -> Option<Scenery> {
+    let bytes = std::fs::read(file).ok()?;
+    if bytes.len() < 4 {
+        return None;
+    }
+    let head_len = u32::from_le_bytes(bytes[0..4].try_into().ok()?) as usize;
+    let at = 4usize.checked_add(head_len)?;
+    if bytes.len() < at {
+        return None;
+    }
+    let info: SceneryInfo = serde_json::from_slice(&bytes[4..at]).ok()?;
+
+    let vc = info.vertex_count as usize;
+    let ic = info.triangle_count as usize * 3;
+    let pixels: usize = info
+        .textures
+        .iter()
+        .map(|t| t.width as usize * t.height as usize * 4)
+        .sum();
+    // Positions, normals, UVs, indices, then every surface's pixels.
+    let want = vc * 12 + vc * 12 + vc * 8 + ic * 4 + pixels;
+    let body = &bytes[at..];
+    if body.len() != want {
+        return None;
+    }
+    let f = |b: &[u8]| -> Vec<f32> {
+        b.chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect()
+    };
+    let mut o = 0usize;
+    let positions = f(&body[o..o + vc * 12]);
+    o += vc * 12;
+    let normals = f(&body[o..o + vc * 12]);
+    o += vc * 12;
+    let uvs = f(&body[o..o + vc * 8]);
+    o += vc * 8;
+    let indices: Vec<u32> = body[o..o + ic * 4]
+        .chunks_exact(4)
+        .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect();
+    o += ic * 4;
+
+    let mut textures = Vec::with_capacity(info.textures.len());
+    for t in &info.textures {
+        let n = t.width as usize * t.height as usize * 4;
+        textures.push(MapTexture {
+            material: t.material,
+            name: t.name.clone(),
+            width: t.width,
+            height: t.height,
+            alpha: t.alpha,
+            rgba: body[o..o + n].to_vec(),
+        });
+        o += n;
+    }
+
+    let groups = info
+        .groups
+        .iter()
+        .map(|g| Group {
+            material: g[0],
+            tri_start: g[1],
+            tri_count: g[2],
+        })
+        .collect();
+
+    Some(Scenery {
+        mesh: MapMesh {
+            positions,
+            normals,
+            uvs,
+            indices,
+            groups,
+            // Pieces are recomputed on demand rather than cached: the cache holds what is
+            // expensive to fetch, and this is a linear pass over an index buffer already in
+            // hand.
+            objects: Vec::new(),
+            object_of_tri: Vec::new(),
+            materials: info.materials,
+        },
+        info,
+        textures,
+    })
+}
+
+fn prune_cache(app: &tauri::AppHandle, dir_name: &str) {
+    use tauri::Manager;
+    let Ok(base) = app.path().app_cache_dir() else {
+        return;
+    };
+    let Ok(rd) = std::fs::read_dir(base.join(dir_name)) else {
+        return;
+    };
+    let mut files: Vec<(std::time::SystemTime, PathBuf)> = rd
+        .flatten()
+        .filter_map(|e| {
+            let p = e.path();
+            let modified = e.metadata().ok()?.modified().ok()?;
+            p.is_file().then_some((modified, p))
+        })
+        .collect();
+    if files.len() <= CACHE_KEEP {
+        return;
+    }
+    files.sort_by_key(|(t, _)| *t);
+    for (_, p) in files.iter().take(files.len() - CACHE_KEEP) {
+        let _ = std::fs::remove_file(p);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SCR: &[u8] = br#"
+obj0
+{
+	flag = 1
+	name = usa_flag.edf
+	paint =
+	data = usa_flag.cfg
+	pos = 271.41, 59.2, 149.31
+}
+obj1
+{
+ name = windturbine_rotor.edf
+ rot_axis = 0, 0, 1
+ pos = -412, 108.71, -381
+ rot = 0, 90, 0
+}
+"#;
+
+    const MARSHALS: &[u8] = br#"
+flagman
+{
+	pos
+	{
+		x = 452.08
+		y = 11.71
+		z = 133.84
+	}
+	long = 0.28
+}
+marshal1
+{
+	pos
+	{
+		x = 456.47
+		y = 8.35
+		z = 220.48
+	}
+	long = 88.39
+}
+"#;
+
+    const TSC: &[u8] = br#"
+numcamset = 1
+camset0
+{
+	name = TV_Cameras
+	numcameras = 2
+	camera0
+	{
+		type = 0
+		pos = 423.7, 9.43, 233.75
+		fov = 60
+		rot = 35.3
+	}
+	camera1
+	{
+		pos = 318.54, 17.4, 282.13
+		rot = 112.1
+	}
+}
+"#;
+
+    const SSC: &[u8] = br#"
+numsources = 2
+source0
+{
+	data = noisy_crowd2.wav
+	pos = 355,10,430
+	mindistance = 50
+}
+source1
+{
+	data = mellow_crowd.wav
+	pos = 388,10,329
+}
+"#;
+
+    #[test]
+    fn reads_scr_props() {
+        let objs = read_scr(SCR);
+        assert_eq!(objs.len(), 2);
+        assert_eq!(objs[0].0.name, "usa_flag.edf");
+        assert_eq!(objs[0].0.pos, [271.41, 59.2, 149.31]);
+        // Negative coordinates are ordinary: background props stand outside the terrain.
+        assert_eq!(objs[1].0.pos, [-412.0, 108.71, -381.0]);
+        assert_eq!(objs[1].1, [0.0, 90.0, 0.0]);
+    }
+
+    #[test]
+    fn reads_marshal_posts() {
+        let m = read_marshals(MARSHALS);
+        assert_eq!(m.len(), 2);
+        assert_eq!(m[0].name, "flagman");
+        // The heights that prove the frame: these are the figures the terrain grid
+        // reproduces underneath each post.
+        assert_eq!(m[0].pos, [452.08, 11.71, 133.84]);
+        assert_eq!(m[0].heading, Some(0.28));
+        assert_eq!(m[1].pos, [456.47, 8.35, 220.48]);
+    }
+
+    #[test]
+    fn reads_cameras_across_a_set() {
+        let c = read_cameras(TSC);
+        assert_eq!(c.len(), 2);
+        assert_eq!(c[0].name, "TV_Cameras · camera0");
+        assert_eq!(c[0].pos, [423.7, 9.43, 233.75]);
+        assert_eq!(c[0].heading, Some(35.3));
+        assert_eq!(c[1].pos, [318.54, 17.4, 282.13]);
+    }
+
+    #[test]
+    fn reads_sound_sources() {
+        let s = read_sounds(SSC);
+        assert_eq!(s.len(), 2);
+        assert_eq!(s[0].name, "noisy_crowd2.wav");
+        assert_eq!(s[0].pos, [355.0, 10.0, 430.0]);
+        assert_eq!(s[1].heading, None);
+    }
+
+    /// The oracle for the whole feature: put a real track's marshal posts on its own terrain
+    /// and see whether they land on the ground.
+    ///
+    /// ```text
+    /// FROST_TRACK="…/Millville.pkz" \
+    ///   cargo test --bin mxb-app -- --ignored --nocapture placements_stand_on_the_terrain
+    /// ```
+    ///
+    /// `marshals.cfg` states each post's height, and the terrain grid states the ground's.
+    /// Nothing makes those agree except reading both correctly, so this is what proves the
+    /// world frame is shared — and it is the same frame the scenery mesh arrives in.
+    #[test]
+    #[ignore = "needs a real track — set FROST_TRACK"]
+    fn placements_stand_on_the_terrain() {
+        let path = std::env::var("FROST_TRACK").expect("set FROST_TRACK to a track .pkz/folder");
+        let p = Path::new(&path);
+
+        let names = crate::track::entry_names(p).expect("read the track");
+        let trh = names
+            .iter()
+            .find(|n| n.to_ascii_lowercase().ends_with(".trh"))
+            .expect("the track needs a heightfield");
+        let bytes = crate::track::read_entry(p, trh).expect("read the heightfield");
+        let layout = crate::heightfield::probe(&bytes, None).expect("the heightfield must read");
+        let (gw, gh, grid) = crate::heightfield::read_grid(&bytes, &layout, 4096);
+
+        // Metres of ground per sample, so world metres can be turned into grid indices.
+        let mps = layout
+            .metres_per_sample
+            .expect("the track must state its footprint");
+        let size_x = mps * (layout.width.max(2) - 1) as f32;
+        let size_z = mps * (layout.height.max(2) - 1) as f32;
+
+        let marshals: Vec<Placement> = read_placements(&path)
+            .expect("read placements")
+            .into_iter()
+            .filter(|p| p.kind == "marshal")
+            .collect();
+        assert!(!marshals.is_empty(), "this track states no marshal posts");
+
+        let mut worst: f32 = 0.0;
+        for m in &marshals {
+            let gx = ((m.pos[0] / size_x) * (gw - 1) as f32).round() as i64;
+            let gz = ((m.pos[2] / size_z) * (gh - 1) as f32).round() as i64;
+            let gx = gx.clamp(0, gw as i64 - 1) as usize;
+            let gz = gz.clamp(0, gh as i64 - 1) as usize;
+            let ground = grid[gz * gw as usize + gx];
+            let delta = m.pos[1] - ground;
+            println!(
+                "  {:10} stated y={:7.2}  terrain={:7.2}  Δ{:+.2}",
+                m.name, m.pos[1], ground, delta
+            );
+            worst = worst.max(delta.abs());
+        }
+        // A post stands on the ground, so the only slack here is the grid's own sampling.
+        assert!(
+            worst < 2.0,
+            "marshal posts are {worst:.2} m off the terrain — the frames disagree"
+        );
+    }
+
+    /// Walk a folder of tracks and report what each one gives up, and how fast:
+    ///
+    /// ```text
+    /// FROST_TRACKS="…/mods/tracks" \
+    ///   cargo test --bin mxb-app -- --ignored --nocapture survey_every_track
+    /// ```
+    ///
+    /// The two timings are the point of the split: `mesh` is what the viewer waits for
+    /// before it can draw anything, `surfaces` is what it no longer waits for.
+    #[test]
+    #[ignore = "needs a folder of tracks — set FROST_TRACKS"]
+    fn survey_every_track() {
+        let root = std::env::var("FROST_TRACKS").expect("set FROST_TRACKS");
+        let mut found: Vec<PathBuf> = Vec::new();
+        for depth in crate::linkwalk::walk_depth(Path::new(&root), 3)
+            .into_iter()
+            .flatten()
+        {
+            let p = depth.path().to_path_buf();
+            if p.extension().is_some_and(|e| e.eq_ignore_ascii_case("pkz")) {
+                found.push(p);
+            }
+        }
+        found.sort();
+        println!(
+            "{:<38} {:>7} {:>9} {:>8} {:>8} {:>9} {:>10}",
+            "track", "mats", "tris", "props", "surf", "mesh ms", "surf ms"
+        );
+        let (mut ok, mut painted) = (0, 0);
+        for p in &found {
+            let name: String = p
+                .file_stem()
+                .map(|s| s.to_string_lossy().chars().take(36).collect())
+                .unwrap_or_default();
+            let key = p.to_string_lossy().into_owned();
+            let t0 = std::time::Instant::now();
+            let mesh = decode_with_key(p, false, Some(&key));
+            let mesh_ms = t0.elapsed().as_millis();
+            let Ok(m) = mesh else {
+                println!("{name:<38} {:>7}", "—");
+                continue;
+            };
+            ok += 1;
+            let t1 = std::time::Instant::now();
+            let surf = decode_with_key(p, true, Some(&key))
+                .map(|s| s.textures.len())
+                .unwrap_or(0);
+            let surf_ms = t1.elapsed().as_millis();
+            if surf > 0 {
+                painted += 1;
+            }
+            println!(
+                "{name:<38} {:>7} {:>9} {:>8} {:>8} {:>9} {:>10}",
+                m.info.materials, m.info.triangle_count, m.info.props, surf, mesh_ms, surf_ms
+            );
+        }
+        println!(
+            "\n{ok} of {} tracks decoded, {painted} with surfaces bound",
+            found.len()
+        );
+    }
+
+    /// A stable colour per piece. Scattered around the wheel by an odd multiplier so that
+    /// pieces numbered next to each other — which are usually next to each other in space —
+    /// come out in unrelated hues rather than a gradient.
+    fn piece_hue(id: u32) -> [f32; 3] {
+        let h = (id.wrapping_mul(2_654_435_761) % 3600) as f32 / 3600.0 * 6.0;
+        let (s, v) = (0.62, 0.95);
+        let i = h.floor() as i32 % 6;
+        let f = h - h.floor();
+        let (p, q, t) = (v * (1.0 - s), v * (1.0 - s * f), v * (1.0 - s * (1.0 - f)));
+        match i {
+            0 => [v, t, p],
+            1 => [q, v, p],
+            2 => [p, v, t],
+            3 => [p, q, v],
+            4 => [t, p, v],
+            _ => [v, p, q],
+        }
+    }
+
+    /// Draw a real track's scenery to a PNG, so a decode can be looked at rather than
+    /// argued about:
+    ///
+    /// ```text
+    /// FROST_TRACK="…/Farm14.pkz" FROST_PNG=/tmp/farm14.png \
+    ///   cargo test --bin mxb-app -- --ignored --nocapture render_a_real_track
+    /// ```
+    ///
+    /// `FROST_COLOR=pieces` gives every separable piece its own hue, which is the only way to
+    /// see whether the mesh really came apart into the things it is made of. `FROST_CROP=x,z,r`
+    /// frames a square of the track in metres instead of the whole site.
+    ///
+    /// Deliberately in-process: a sealed track's contents are never written anywhere except
+    /// as pixels.
+    #[test]
+    #[ignore = "needs a real track — set FROST_TRACK and FROST_PNG"]
+    fn render_a_real_track() {
+        let path = std::env::var("FROST_TRACK").expect("set FROST_TRACK");
+        let out = std::env::var("FROST_PNG").unwrap_or_else(|_| "/tmp/track.png".into());
+        let s = decode(Path::new(&path), true).expect("decode the scenery");
+        let (lo, hi) = s.mesh.bounds();
+        println!(
+            "{} verts, {} tris, bbox x[{:.0},{:.0}] y[{:.0},{:.0}] z[{:.0},{:.0}]",
+            s.info.vertex_count, s.info.triangle_count, lo[0], hi[0], lo[1], hi[1], lo[2], hi[2]
+        );
+
+        const W: usize = 1200;
+        const H: usize = 1000;
+        let by_piece = std::env::var("FROST_COLOR").as_deref() == Ok("pieces");
+        let crop: Option<(f32, f32, f32)> = std::env::var("FROST_CROP").ok().and_then(|v| {
+            let n: Vec<f32> = v.split(',').filter_map(|p| p.trim().parse().ok()).collect();
+            (n.len() == 3).then(|| (n[0], n[1], n[2]))
+        });
+        // Frame the whole thing, seen from above and to one side — the viewer's own angle.
+        let (mid, span) = match crop {
+            Some((cx, cz, r)) => ([cx, (lo[1] + hi[1]) / 2.0, cz], r * 2.0),
+            None => (
+                [
+                    (lo[0] + hi[0]) / 2.0,
+                    (lo[1] + hi[1]) / 2.0,
+                    (lo[2] + hi[2]) / 2.0,
+                ],
+                (hi[0] - lo[0]).max(hi[2] - lo[2]).max(1.0),
+            ),
+        };
+        let eye = [
+            mid[0] - span * 0.55,
+            mid[1] + span * 0.75,
+            mid[2] + span * 1.05,
+        ];
+        let norm = |v: [f32; 3]| {
+            let l = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt().max(1e-9);
+            [v[0] / l, v[1] / l, v[2] / l]
+        };
+        let cross = |a: [f32; 3], b: [f32; 3]| {
+            [
+                a[1] * b[2] - a[2] * b[1],
+                a[2] * b[0] - a[0] * b[2],
+                a[0] * b[1] - a[1] * b[0],
+            ]
+        };
+        let fwd = norm([mid[0] - eye[0], mid[1] - eye[1], mid[2] - eye[2]]);
+        let right = norm(cross(fwd, [0.0, 1.0, 0.0]));
+        let up = cross(right, fwd);
+        let focal = 1.0 / (45.0f32.to_radians() / 2.0).tan();
+
+        let project = |p: [f32; 3]| -> [f32; 3] {
+            let rel = [p[0] - eye[0], p[1] - eye[1], p[2] - eye[2]];
+            let dot = |a: [f32; 3], b: [f32; 3]| a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+            let z = dot(rel, fwd);
+            if z <= 0.01 {
+                return [f32::NAN, f32::NAN, z];
+            }
+            [
+                dot(rel, right) / z * focal * (W as f32 / 2.0) + W as f32 / 2.0,
+                -dot(rel, up) / z * focal * (H as f32 / 2.0) + H as f32 / 2.0,
+                z,
+            ]
+        };
+
+        let light = norm([0.5, 0.8, 0.35]);
+        let mut depth = vec![f32::INFINITY; W * H];
+        let mut pixels = vec![18u8; W * H * 3];
+
+        let vert = |i: u32| {
+            let o = i as usize * 3;
+            [
+                s.mesh.positions[o],
+                s.mesh.positions[o + 1],
+                s.mesh.positions[o + 2],
+            ]
+        };
+        for (ti, t) in s.mesh.indices.chunks_exact(3).enumerate() {
+            let p = [vert(t[0]), vert(t[1]), vert(t[2])];
+            if let Some((cx, cz, r)) = crop {
+                let c = [
+                    (p[0][0] + p[1][0] + p[2][0]) / 3.0,
+                    0.0,
+                    (p[0][2] + p[1][2] + p[2][2]) / 3.0,
+                ];
+                if (c[0] - cx).abs() > r || (c[2] - cz).abs() > r {
+                    continue;
+                }
+            }
+            let sp = [project(p[0]), project(p[1]), project(p[2])];
+            if sp.iter().any(|v| !v[0].is_finite()) {
+                continue;
+            }
+            // Face normal, so the picture doesn't depend on the stored normals being read right.
+            let e1 = [p[1][0] - p[0][0], p[1][1] - p[0][1], p[1][2] - p[0][2]];
+            let e2 = [p[2][0] - p[0][0], p[2][1] - p[0][1], p[2][2] - p[0][2]];
+            let n = norm(cross(e1, e2));
+            let shade = (n[0] * light[0] + n[1] * light[1] + n[2] * light[2])
+                .abs()
+                .clamp(0.0, 1.0)
+                * 0.75
+                + 0.25;
+
+            let (minx, maxx) = (
+                sp.iter().fold(f32::MAX, |a, v| a.min(v[0])).max(0.0) as usize,
+                (sp.iter()
+                    .fold(f32::MIN, |a, v| a.max(v[0]))
+                    .min(W as f32 - 1.0))
+                .max(0.0) as usize,
+            );
+            let (miny, maxy) = (
+                sp.iter().fold(f32::MAX, |a, v| a.min(v[1])).max(0.0) as usize,
+                (sp.iter()
+                    .fold(f32::MIN, |a, v| a.max(v[1]))
+                    .min(H as f32 - 1.0))
+                .max(0.0) as usize,
+            );
+            if maxx < minx || maxy < miny {
+                continue;
+            }
+            let area = (sp[1][0] - sp[0][0]) * (sp[2][1] - sp[0][1])
+                - (sp[2][0] - sp[0][0]) * (sp[1][1] - sp[0][1]);
+            if area.abs() < 1e-9 {
+                continue;
+            }
+            for y in miny..=maxy {
+                for x in minx..=maxx {
+                    let (px, py) = (x as f32 + 0.5, y as f32 + 0.5);
+                    let w0 = ((sp[1][0] - px) * (sp[2][1] - py)
+                        - (sp[2][0] - px) * (sp[1][1] - py))
+                        / area;
+                    let w1 = ((sp[2][0] - px) * (sp[0][1] - py)
+                        - (sp[0][0] - px) * (sp[2][1] - py))
+                        / area;
+                    let w2 = 1.0 - w0 - w1;
+                    if w0 < 0.0 || w1 < 0.0 || w2 < 0.0 {
+                        continue;
+                    }
+                    let z = w0 * sp[0][2] + w1 * sp[1][2] + w2 * sp[2][2];
+                    let at = y * W + x;
+                    if z >= depth[at] {
+                        continue;
+                    }
+                    depth[at] = z;
+                    // Height above the mesh's floor, so relief reads as well as facing.
+                    let base = if by_piece {
+                        piece_hue(s.mesh.object_of_tri.get(ti).copied().unwrap_or(0))
+                    } else {
+                        let h = (w0 * p[0][1] + w1 * p[1][1] + w2 * p[2][1] - lo[1])
+                            / (hi[1] - lo[1]).max(1.0);
+                        [0.52 + 0.35 * h, 0.45 + 0.32 * h, 0.34 + 0.28 * h]
+                    };
+                    for c in 0..3 {
+                        pixels[at * 3 + c] = ((base[c] * shade).clamp(0.0, 1.0) * 255.0) as u8;
+                    }
+                }
+            }
+        }
+
+        image::save_buffer(&out, &pixels, W as u32, H as u32, image::ColorType::Rgb8)
+            .expect("write the png");
+        println!("wrote {out}");
+    }
+
+    /// The whole decode against a real track — the `.map` mesh with the `.scr` props folded in.
+    ///
+    /// ```text
+    /// FROST_TRACK="…/Millville" \
+    ///   cargo test --bin mxb-app -- --ignored --nocapture decode_a_real_track
+    /// ```
+    #[test]
+    #[ignore = "needs a real track — set FROST_TRACK"]
+    fn decode_a_real_track() {
+        let path = std::env::var("FROST_TRACK").expect("set FROST_TRACK to a track .pkz/folder");
+        let s = decode(Path::new(&path), true).expect("decode the scenery");
+        let (lo, hi) = s.mesh.bounds();
+        println!("  from {}", s.info.entry);
+        println!(
+            "  {} materials, {} verts, {} tris",
+            s.info.materials, s.info.vertex_count, s.info.triangle_count
+        );
+        println!(
+            "  {} props folded in, {} missing a mesh",
+            s.info.props, s.info.props_missing
+        );
+        let packed = blob(&s);
+        println!(
+            "  {} draw groups, {} surfaces",
+            s.mesh.groups.len(),
+            s.textures.len()
+        );
+        let alpha = s.textures.iter().filter(|t| t.alpha).count();
+        println!("  {alpha} of them alpha cut-outs");
+        let obj = &s.mesh.objects;
+        if !obj.is_empty() {
+            let mut sizes: Vec<u32> = obj.iter().map(|o| o.tri_count).collect();
+            sizes.sort_unstable();
+            let biggest = obj.iter().max_by_key(|o| o.tri_count).unwrap();
+            println!(
+                "  {} separable pieces (median {} tris, largest {} tris, {:.1}x{:.1}x{:.1} m)",
+                obj.len(),
+                sizes[sizes.len() / 2],
+                biggest.tri_count,
+                biggest.max[0] - biggest.min[0],
+                biggest.max[1] - biggest.min[1],
+                biggest.max[2] - biggest.min[2],
+            );
+        }
+        if s.textures.is_empty() && !s.info.entry.is_empty() {
+            // Unbound: say what the map actually calls its sheets, which is the whole of why.
+            if let Ok(bytes) = crate::track::read_entry(Path::new(&path), &s.info.entry) {
+                let survey = crate::map::survey(&bytes);
+                println!("  {} surface records, unbound:", survey.len());
+                let primaries = crate::map::primaries(&bytes);
+                println!(
+                    "  {} of them primary (materials: {})",
+                    primaries.len(),
+                    s.info.materials
+                );
+                for (n, w, h) in survey.iter().take(12) {
+                    println!("    {n:<34} {w}x{h}");
+                }
+            }
+        }
+        for t in s.textures.iter().take(60) {
+            println!(
+                "    mat{:<3} {:<34} {}x{} {}",
+                t.material,
+                t.name,
+                t.width,
+                t.height,
+                if t.alpha { "ALPHA" } else { "" }
+            );
+        }
+        let px: usize = s.textures.iter().map(|t| t.rgba.len()).sum();
+        println!(
+            "  surface pixels {:.1} MB, blob {:.1} MB",
+            px as f64 / 1e6,
+            packed.len() as f64 / 1e6
+        );
+        println!(
+            "  x[{:.1}, {:.1}] y[{:.1}, {:.1}] z[{:.1}, {:.1}]",
+            lo[0], hi[0], lo[1], hi[1], lo[2], hi[2]
+        );
+        // The blob is what the viewer actually gets, so check its size adds up rather than
+        // trusting the counts alone.
+        let pixels: usize = s.textures.iter().map(|t| t.rgba.len()).sum();
+        assert_eq!(
+            packed.len(),
+            crate::map::SCENERY_HEADER
+                + s.info.vertex_count as usize * 32
+                + s.info.triangle_count as usize * 12
+                + s.mesh.groups.len() * 12
+                + s.textures.len() * crate::map::TEXTURE_ENTRY
+                + pixels
+        );
+        assert!(s
+            .mesh
+            .indices
+            .iter()
+            .all(|i| (*i as usize) < s.mesh.vertex_count()));
+    }
+
+    #[test]
+    fn numbered_blocks_come_back_in_order() {
+        // Ten and above must not sort next to one — the format has no padding.
+        let mut root = CfgNode::default();
+        for i in [0u32, 1, 2, 9, 10, 11] {
+            root.blocks.insert(format!("obj{i}"), CfgNode::default());
+        }
+        assert_eq!(numbered(&root, "obj").len(), 6);
+        let mut root = CfgNode::default();
+        for i in [11u32, 2, 0] {
+            let mut n = CfgNode::default();
+            n.values.insert("pos".into(), format!("{i}, 0, 0"));
+            root.blocks.insert(format!("obj{i}"), n);
+        }
+        let got: Vec<f32> = numbered(&root, "obj")
+            .iter()
+            .filter_map(|n| n.get("pos").and_then(vec3_csv))
+            .map(|p| p[0])
+            .collect();
+        assert_eq!(got, vec![0.0, 2.0, 11.0]);
+    }
+
+    #[test]
+    fn the_tracks_own_file_comes_first() {
+        let names = vec![
+            "TPC-2/SX.scr".to_string(),
+            "TPC-2/MX.scr".to_string(),
+            "TPC-2/TPC-2.scr".to_string(),
+        ];
+        let picked = entries_with_ext(&names, "scr", "tpc-2");
+        assert_eq!(picked[0], "TPC-2/TPC-2.scr");
+    }
+
+    #[test]
+    fn a_prop_lands_where_the_scr_puts_it() {
+        // One triangle at the origin, rotated a quarter turn and moved into the world.
+        let mut mesh = MapMesh::default();
+        let pos = vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+        let nrm = vec![0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0];
+        place(&mut mesh, &pos, &nrm, [0.0, 90.0, 0.0], [10.0, 5.0, -3.0]);
+        // +X spun about Y by 90° goes to -Z, then the whole thing translates.
+        assert!((mesh.positions[0] - 10.0).abs() < 1e-4);
+        assert!((mesh.positions[2] - -4.0).abs() < 1e-4);
+        // The second vertex sat on the origin, so it lands exactly on the stated position.
+        assert!((mesh.positions[3] - 10.0).abs() < 1e-4);
+        assert!((mesh.positions[4] - 5.0).abs() < 1e-4);
+        assert!((mesh.positions[5] - -3.0).abs() < 1e-4);
+        // Up stays up: a yaw doesn't tip a normal over.
+        assert!((mesh.normals[1] - 1.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn a_malformed_placement_is_skipped_not_fatal() {
+        let bad = br#"
+obj0
+{
+	name = ok.edf
+	pos = 1, 2, 3
+}
+obj1
+{
+	name = nopos.edf
+}
+obj2
+{
+	pos = 4, 5, 6
+}
+obj3
+{
+	name = short.edf
+	pos = 7, 8
+}
+"#;
+        let objs = read_scr(bad);
+        assert_eq!(objs.len(), 1, "only the complete object survives");
+        assert_eq!(objs[0].0.name, "ok.edf");
+    }
+}

--- a/src-tauri/src/scenery.rs
+++ b/src-tauri/src/scenery.rs
@@ -464,7 +464,7 @@ const GROUND_WORDS: [&str; 9] = [
 /// that six times or more into a blur. Nothing in the file has finer detail *at a place*, but
 /// the ground sheets have plenty of it *as a material*, so one is tiled over the terrain to
 /// put grain back where interpolation took it out.
-pub fn ground_detail(path: &str) -> Result<Option<MapTexture>> {
+pub fn ground_detail(path: &str) -> Result<Vec<MapTexture>> {
     let p = Path::new(path);
     let names = crate::track::entry_names(p)?;
     let stem = track_stem(p);
@@ -475,9 +475,14 @@ pub fn ground_detail(path: &str) -> Result<Option<MapTexture>> {
         if !map::is_map(&bytes) {
             continue;
         }
-        return Ok(map::ground_sheet(&bytes, &GROUND_WORDS));
+        let Some(colour) = map::ground_sheet(&bytes, &GROUND_WORDS) else {
+            return Ok(Vec::new());
+        };
+        // Its normal map next, where the track ships one — the same sheet's relief.
+        let normal = map::ground_normal(&bytes, &colour.name, &GROUND_WORDS);
+        return Ok(std::iter::once(colour).chain(normal).collect());
     }
-    Ok(None)
+    Ok(Vec::new())
 }
 
 /// The `.edf` models a track ships, as names a prop can be placed by.
@@ -1449,22 +1454,48 @@ source1
     #[ignore = "needs a real track — set FROST_TRACK"]
     fn ground_sheet_of_a_real_track() {
         let path = std::env::var("FROST_TRACK").expect("set FROST_TRACK");
-        match ground_detail(&path).expect("look for a ground sheet") {
-            Some(t) => {
-                let px: Vec<f32> = t
-                    .rgba
-                    .chunks_exact(4)
-                    .map(|p| {
-                        (p[0] as f32 * 0.299 + p[1] as f32 * 0.587 + p[2] as f32 * 0.114) / 255.0
+        let sheets = ground_detail(&path).expect("look for a ground sheet");
+        if sheets.is_empty() {
+            println!("  no ground sheet found");
+        }
+        // What the track calls its sheets, so a missing normal map can be told from a
+        // mis-named one.
+        let names = crate::track::entry_names(Path::new(&path)).unwrap_or_default();
+        let stem = track_stem(Path::new(&path));
+        for entry in entries_with_ext(&names, "map", &stem) {
+            if let Ok(bytes) = crate::track::read_entry(Path::new(&path), &entry) {
+                let all = crate::map::survey(&bytes);
+                let normals: Vec<&str> = all
+                    .iter()
+                    .map(|(n, ..)| n.as_str())
+                    .filter(|n| {
+                        let l = n.to_ascii_lowercase();
+                        GROUND_WORDS.iter().any(|w| l.contains(w))
                     })
                     .collect();
-                let mean = px.iter().sum::<f32>() / px.len().max(1) as f32;
                 println!(
-                    "  {} {}x{}  mean luminance {mean:.3}",
-                    t.name, t.width, t.height
+                    "  {} records, {} ground-named: {:?}",
+                    all.len(),
+                    normals.len(),
+                    &normals[..normals.len().min(14)]
                 );
             }
-            None => println!("  no ground sheet found"),
+            break;
+        }
+        for t in &sheets {
+            let px: Vec<f32> = t
+                .rgba
+                .chunks_exact(4)
+                .map(|p| (p[0] as f32 * 0.299 + p[1] as f32 * 0.587 + p[2] as f32 * 0.114) / 255.0)
+                .collect();
+            let mean = px.iter().sum::<f32>() / px.len().max(1) as f32;
+            println!(
+                "  {} {}x{}  mean luminance {mean:.3}  {}",
+                t.name,
+                t.width,
+                t.height,
+                if t.material == 1 { "(normal)" } else { "(colour)" }
+            );
         }
     }
 

--- a/src-tauri/src/scenery.rs
+++ b/src-tauri/src/scenery.rs
@@ -262,6 +262,73 @@ fn read_sounds(bytes: &[u8]) -> Vec<Placement> {
         .collect()
 }
 
+/// The `.edf` models a track ships, as names a prop can be placed by.
+///
+/// A `.scr` places a prop by file name, so what a track already carries is what can be put
+/// down again without shipping anything new beside it.
+pub fn placeable(path: &str) -> Result<Vec<String>> {
+    let names = crate::track::entry_names(Path::new(path))?;
+    let mut out: Vec<String> = names
+        .iter()
+        .filter(|n| {
+            n.rsplit('.')
+                .next()
+                .is_some_and(|e| e.eq_ignore_ascii_case("edf"))
+        })
+        .filter_map(|n| n.rsplit('/').next().map(str::to_string))
+        .collect();
+    out.sort_by_key(|n| n.to_ascii_lowercase());
+    out.dedup();
+    Ok(out)
+}
+
+/// One prop's mesh, in its own local frame, ready to be put somewhere.
+///
+/// Separate from the scenery pass: placing something means drawing it before it has been
+/// written anywhere, so the viewer needs the model on its own rather than baked into the
+/// track's mesh.
+pub fn prop_mesh(path: &str, name: &str) -> Result<MapMesh> {
+    let p = Path::new(path);
+    let names = crate::track::entry_names(p)?;
+    let entry = names
+        .iter()
+        .find(|n| {
+            n.rsplit('/')
+                .next()
+                .is_some_and(|b| b.eq_ignore_ascii_case(name))
+        })
+        .ok_or_else(|| anyhow::anyhow!("{name} is not in this track"))?;
+    let bytes = crate::track::read_entry(p, entry)?;
+    let nodes = crate::edf::parse(&bytes);
+    if nodes.is_empty() {
+        bail!("{name} has no mesh in it");
+    }
+    let mut mesh = MapMesh::default();
+    for node in &nodes {
+        if node.positions.is_empty() || node.indices.is_empty() {
+            continue;
+        }
+        let base = mesh.vertex_count() as u32;
+        let verts = node.positions.len() / 3;
+        mesh.positions.extend_from_slice(&node.positions);
+        if node.normals.len() == node.positions.len() {
+            mesh.normals.extend_from_slice(&node.normals);
+        } else {
+            mesh.normals.extend(std::iter::repeat(0.0).take(verts * 3));
+        }
+        if node.uvs.len() == verts * 2 {
+            mesh.uvs.extend_from_slice(&node.uvs);
+        } else {
+            mesh.uvs.extend(std::iter::repeat(0.0).take(verts * 2));
+        }
+        mesh.indices.extend(node.indices.iter().map(|i| i + base));
+    }
+    if mesh.is_empty() {
+        bail!("{name} has no drawable geometry");
+    }
+    Ok(mesh)
+}
+
 /// Write props back out in the format a track states them in.
 ///
 /// The `.scr` is the one part of a track that says where a thing goes in plain text, and the
@@ -1147,6 +1214,38 @@ source1
             worst < 2.0,
             "marshal posts are {worst:.2} m off the terrain — the frames disagree"
         );
+    }
+
+    /// What a real track offers to place, and whether one of them draws:
+    ///
+    /// ```text
+    /// FROST_TRACK="…/Millville.pkz" \
+    ///   cargo test --bin mxb-app -- --ignored --nocapture placeable_props_of_a_real_track
+    /// ```
+    #[test]
+    #[ignore = "needs a real track — set FROST_TRACK"]
+    fn placeable_props_of_a_real_track() {
+        let path = std::env::var("FROST_TRACK").expect("set FROST_TRACK");
+        let names = placeable(&path).expect("list the models");
+        println!("{} placeable models: {names:?}", names.len());
+        assert!(!names.is_empty(), "a track ships models to place");
+        for n in &names {
+            match prop_mesh(&path, n) {
+                Ok(m) => {
+                    let (lo, hi) = m.bounds();
+                    println!(
+                        "  {n:<28} {:>7} verts {:>7} tris  {:.1} x {:.1} x {:.1} m",
+                        m.vertex_count(),
+                        m.triangle_count(),
+                        hi[0] - lo[0],
+                        hi[1] - lo[1],
+                        hi[2] - lo[2]
+                    );
+                    assert!(m.indices.iter().all(|i| (*i as usize) < m.vertex_count()));
+                }
+                Err(e) => println!("  {n:<28} no mesh: {e}"),
+            }
+        }
     }
 
     /// Walk a folder of tracks and report what each one gives up, and how fast:

--- a/src-tauri/src/scenery.rs
+++ b/src-tauri/src/scenery.rs
@@ -29,7 +29,7 @@ const MESH_CACHE: &str = "track-scenery-v4";
 const SURFACE_CACHE: &str = "track-surfaces-v4";
 /// The ground sheet and its normal map, cached apart again — two 512×512 sheets against the
 /// surfaces' hundreds of megabytes, and finding them means reading the archive a third time.
-const GROUND_CACHE: &str = "track-ground-v1";
+const GROUND_CACHE: &str = "track-ground-v2";
 
 /// How many decoded scenery meshes to keep. Smaller than the terrain's: one of these is
 /// about 30 MB, against 16 for a terrain master.

--- a/src-tauri/src/scenery.rs
+++ b/src-tauri/src/scenery.rs
@@ -1525,10 +1525,24 @@ source1
                 m.vertex_count(),
                 m.triangle_count(),
                 (hi[0] - lo[0]).max(hi[2] - lo[2]) / 2.0,
-                tex.as_ref().map_or("none".to_string(), |t| format!(
-                    "{}x{} {}",
-                    t.width, t.height, t.name
-                ))
+                tex.as_ref().map_or("none".to_string(), |t| {
+                    let n = t.rgba.len() / 4;
+                    let lum: f64 = t
+                        .rgba
+                        .chunks_exact(4)
+                        .map(|q| {
+                            (q[0] as f64 * 0.299 + q[1] as f64 * 0.587 + q[2] as f64 * 0.114)
+                                / 255.0
+                        })
+                        .sum();
+                    format!(
+                        "{}x{} {} luma {:.3}",
+                        t.width,
+                        t.height,
+                        t.name,
+                        if n > 0 { lum / n as f64 } else { 0.0 }
+                    )
+                })
             );
         }
         assert!(

--- a/src-tauri/src/scenery.rs
+++ b/src-tauri/src/scenery.rs
@@ -445,6 +445,37 @@ pub fn backdrop_blob(
     out
 }
 
+/// Words a track's own ground sheets are named with.
+///
+/// Not a guess at which cell uses which — that is the binding problem — but at which sheet is
+/// *ground at all*, which is a much easier question and the only one a detail layer asks.
+const GROUND_WORDS: [&str; 9] = [
+    "dirt", "soil", "mud", "sand", "gravel", "grass", "ground", "terrain", "loam",
+];
+
+/// A tiling sheet of the track's own ground, for detail closer than its data can carry.
+///
+/// A track states its surface at about a third of a metre per sample — the height grid and
+/// the coverage masks both — and a viewer that lets you get within a few centimetres magnifies
+/// that six times or more into a blur. Nothing in the file has finer detail *at a place*, but
+/// the ground sheets have plenty of it *as a material*, so one is tiled over the terrain to
+/// put grain back where interpolation took it out.
+pub fn ground_detail(path: &str) -> Result<Option<MapTexture>> {
+    let p = Path::new(path);
+    let names = crate::track::entry_names(p)?;
+    let stem = track_stem(p);
+    for entry in entries_with_ext(&names, "map", &stem) {
+        let Ok(bytes) = crate::track::read_entry(p, &entry) else {
+            continue;
+        };
+        if !map::is_map(&bytes) {
+            continue;
+        }
+        return Ok(map::ground_sheet(&bytes, &GROUND_WORDS));
+    }
+    Ok(None)
+}
+
 /// The `.edf` models a track ships, as names a prop can be placed by.
 ///
 /// A `.scr` places a prop by file name, so what a track already carries is what can be put

--- a/src-tauri/src/scenery.rs
+++ b/src-tauri/src/scenery.rs
@@ -25,8 +25,8 @@ use crate::map::{self, Group, MapMesh, MapTexture};
 // v2: the mesh gained UVs and material groups, and the surfaces travel with it.
 // v3: the mesh and the surfaces are cached apart, so the first can be served without the
 // second having been decoded at all.
-const MESH_CACHE: &str = "track-scenery-v3";
-const SURFACE_CACHE: &str = "track-surfaces-v3";
+const MESH_CACHE: &str = "track-scenery-v4";
+const SURFACE_CACHE: &str = "track-surfaces-v4";
 
 /// How many decoded scenery meshes to keep. Smaller than the terrain's: one of these is
 /// about 30 MB, against 16 for a terrain master.
@@ -69,6 +69,9 @@ pub struct SceneryInfo {
     /// Connected pieces the scenery comes apart into — one per tent, trailer or foliage card.
     #[serde(default)]
     pub objects: u32,
+    /// Whether the cut-out cards were left out because this map's surfaces can't be bound.
+    #[serde(default)]
+    pub cards_dropped: bool,
     /// One run of triangles per material: `[material, tri_start, tri_count]`.
     #[serde(default)]
     pub groups: Vec<[u32; 3]>,
@@ -649,7 +652,12 @@ fn decode_with_key(path: &Path, want_surfaces: bool, key: Option<&str>) -> Resul
             Some(m) => {
                 info.materials = m.materials;
                 info.entry = entry.clone();
-                mesh = m;
+                // A map whose surfaces can't be bound can't draw its cut-outs, and a foliage
+                // card without its alpha is a standing sheet of paper. Thousands of them hide
+                // the track. Drop them rather than show them wrong.
+                let bindable = !map::declared(&bytes).is_empty();
+                mesh = if bindable { m } else { map::without_cards(&m) };
+                info.cards_dropped = !bindable;
                 if want_surfaces {
                     textures = map::textures(&bytes, map::MAX_TEXTURE_DIM);
                 } else {

--- a/src-tauri/src/scenery.rs
+++ b/src-tauri/src/scenery.rs
@@ -445,12 +445,16 @@ pub fn backdrop_blob(
     out
 }
 
-/// Words a track's own ground sheets are named with.
+/// Words a track's own ground sheets are named with, best first.
 ///
 /// Not a guess at which cell uses which — that is the binding problem — but at which sheet is
 /// *ground at all*, which is a much easier question and the only one a detail layer asks.
+///
+/// Order matters. A detail layer wants the surface a track is mostly made of, and that is
+/// dirt: tiling `grass` over a dry circuit tints the whole place green, which is what picking
+/// merely the largest match did.
 const GROUND_WORDS: [&str; 9] = [
-    "dirt", "soil", "mud", "sand", "gravel", "grass", "ground", "terrain", "loam",
+    "dirt", "soil", "terrain", "ground", "mud", "loam", "sand", "gravel", "grass",
 ];
 
 /// A tiling sheet of the track's own ground, for detail closer than its data can carry.
@@ -1433,6 +1437,35 @@ source1
             worst < 2.0,
             "marshal posts are {worst:.2} m off the terrain — the frames disagree"
         );
+    }
+
+    /// Which sheet a track's ground detail comes from:
+    ///
+    /// ```text
+    /// FROST_TRACK="…/track.pkz" \
+    ///   cargo test --bin mxb-app -- --ignored --nocapture ground_sheet_of_a_real_track
+    /// ```
+    #[test]
+    #[ignore = "needs a real track — set FROST_TRACK"]
+    fn ground_sheet_of_a_real_track() {
+        let path = std::env::var("FROST_TRACK").expect("set FROST_TRACK");
+        match ground_detail(&path).expect("look for a ground sheet") {
+            Some(t) => {
+                let px: Vec<f32> = t
+                    .rgba
+                    .chunks_exact(4)
+                    .map(|p| {
+                        (p[0] as f32 * 0.299 + p[1] as f32 * 0.587 + p[2] as f32 * 0.114) / 255.0
+                    })
+                    .collect();
+                let mean = px.iter().sum::<f32>() / px.len().max(1) as f32;
+                println!(
+                    "  {} {}x{}  mean luminance {mean:.3}",
+                    t.name, t.width, t.height
+                );
+            }
+            None => println!("  no ground sheet found"),
+        }
     }
 
     /// What a track wraps itself in:

--- a/src-tauri/src/scenery.rs
+++ b/src-tauri/src/scenery.rs
@@ -27,6 +27,9 @@ use crate::map::{self, Group, MapMesh, MapTexture};
 // second having been decoded at all.
 const MESH_CACHE: &str = "track-scenery-v4";
 const SURFACE_CACHE: &str = "track-surfaces-v4";
+/// The ground sheet and its normal map, cached apart again — two 512×512 sheets against the
+/// surfaces' hundreds of megabytes, and finding them means reading the archive a third time.
+const GROUND_CACHE: &str = "track-ground-v1";
 
 /// How many decoded scenery meshes to keep. Smaller than the terrain's: one of these is
 /// about 30 MB, against 16 for a terrain master.
@@ -453,8 +456,12 @@ pub fn backdrop_blob(
 /// Order matters. A detail layer wants the surface a track is mostly made of, and that is
 /// dirt: tiling `grass` over a dry circuit tints the whole place green, which is what picking
 /// merely the largest match did.
-const GROUND_WORDS: [&str; 9] = [
+const GROUND_WORDS: [&str; 10] = [
     "dirt", "soil", "terrain", "ground", "mud", "loam", "sand", "gravel", "grass",
+    // Last, and deliberately: a track that names its riding surface after itself —
+    // SandPoint's `track-dark`, `track-norm` — means the ground, but so many other things
+    // carry the word that it must never outrank a sheet that says what the ground is made of.
+    "track",
 ];
 
 /// A tiling sheet of the track's own ground, for detail closer than its data can carry.
@@ -823,6 +830,23 @@ pub fn load(app: &tauri::AppHandle, path: &str) -> Result<Scenery> {
         prune_cache(app, MESH_CACHE);
     }
     Ok(scenery)
+}
+
+/// A track's ground sheet and its normal map, cached apart from both.
+///
+/// The pick is a couple of megabytes but the search is not: it inflates candidate sheets to
+/// check that a normal map really is one. Cached, opening a track again costs a file read.
+pub fn load_ground(app: &tauri::AppHandle, path: &str) -> Result<Vec<MapTexture>> {
+    let key = cache_key(path)?;
+    if let Some(hit) = cache_file(app, &key, GROUND_CACHE).and_then(|f| read_surface_cache(&f)) {
+        return Ok(hit);
+    }
+    let sheets = ground_detail(path)?;
+    if let Some(f) = cache_file(app, &key, GROUND_CACHE) {
+        write_surface_cache(&f, &sheets);
+        prune_cache(app, GROUND_CACHE);
+    }
+    Ok(sheets)
 }
 
 /// A track's surfaces, cached apart from its mesh.
@@ -1479,6 +1503,8 @@ source1
                     normals.len(),
                     &normals[..normals.len().min(14)]
                 );
+                let every: Vec<&str> = all.iter().map(|(n, ..)| n.as_str()).collect();
+                println!("  all: {every:?}");
             }
             break;
         }

--- a/src-tauri/src/scenery.rs
+++ b/src-tauri/src/scenery.rs
@@ -265,6 +265,186 @@ fn read_sounds(bytes: &[u8]) -> Vec<Placement> {
         .collect()
 }
 
+/// What a track puts around and above itself, and the light it does it under.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Ambience {
+    /// Direction the sun comes from, as the track states it.
+    pub sun: Option<[f32; 3]>,
+    /// Sky, sun and ambient colours, 0–1, from the track's first weather block.
+    pub sky_colour: Option<[f32; 3]>,
+    pub sun_colour: Option<[f32; 3]>,
+    pub ambient_colour: Option<[f32; 3]>,
+    /// Fog colour and density, which is most of how far a track feels.
+    pub fog_colour: Option<[f32; 3]>,
+    pub fog_density: Option<f32>,
+}
+
+fn rgb(node: &CfgNode, key: &str) -> Option<[f32; 3]> {
+    let b = node.block(key)?;
+    let f = |k: &str| b.get(k)?.trim().parse::<f32>().ok();
+    Some([f("red")?, f("green")?, f("blue")?])
+}
+
+/// Read a track's `.amb`: the models it wraps itself in, and the light it sits under.
+///
+/// Weather is a block per condition — `clear`, `cloudy` and the rest — carrying its own sky,
+/// sun and fog. The first one is taken: a viewer shows a track, not a forecast.
+fn ambience(
+    path: &Path,
+    names: &[String],
+    stem: &str,
+) -> (Ambience, Option<String>, Option<String>) {
+    let Some(entry) = entries_with_ext(names, "amb", stem).into_iter().next() else {
+        return (Ambience::default(), None, None);
+    };
+    let Ok(bytes) = crate::track::read_entry(path, &entry) else {
+        return (Ambience::default(), None, None);
+    };
+    let root = crate::cfg::parse(&bytes);
+
+    let sun = root.block("sun_position").and_then(|b| {
+        let f = |k: &str| b.get(k)?.trim().parse::<f32>().ok();
+        Some([f("x")?, f("y")?, f("z")?])
+    });
+    let mut amb = Ambience {
+        sun,
+        ..Ambience::default()
+    };
+    let background = root.get("background").map(|s| s.trim().to_string());
+
+    // The weather blocks are the ones carrying a sky; take the first that names one.
+    let mut sky = None;
+    for (_, w) in root.blocks.iter() {
+        let Some(model) = w.get("sky") else { continue };
+        sky = Some(model.trim().to_string());
+        amb.sky_colour = rgb(w, "sky_color");
+        amb.sun_colour = rgb(w, "sun_color");
+        amb.ambient_colour = rgb(w, "ambient");
+        if let Some(fog) = w.block("fog") {
+            amb.fog_colour = rgb(w, "fog");
+            amb.fog_density = fog.get("density").and_then(|v| v.trim().parse().ok());
+        }
+        break;
+    }
+    (amb, background, sky)
+}
+
+/// A track's sky and backdrop: the models it wraps itself in.
+///
+/// Both are ordinary `.edf`s named by the `.amb`, and both are small — a sky dome is a few
+/// hundred triangles carrying one very large picture. They are parsed at world scale: a dome
+/// reaches 1.5 km from its centre, and the bound that protects a bike parse throws the whole
+/// sky away. See [`crate::edf::parse_world`].
+pub fn backdrop(
+    path: &str,
+) -> Result<(
+    Ambience,
+    (MapMesh, Option<MapTexture>),
+    (MapMesh, Option<MapTexture>),
+)> {
+    let p = Path::new(path);
+    let names = crate::track::entry_names(p)?;
+    let stem = track_stem(p);
+    let (amb, background, sky) = ambience(p, &names, &stem);
+
+    // The picture a dome carries *is* the sky — twenty-two megabytes of it behind a few
+    // hundred triangles — so a flat colour in its place is a grey lid rather than a sky.
+    let load = |want: Option<String>| -> (MapMesh, Option<MapTexture>) {
+        let Some(want) = want else {
+            return (MapMesh::default(), None);
+        };
+        let found = names.iter().find(|n| {
+            n.rsplit('/')
+                .next()
+                .is_some_and(|b| b.eq_ignore_ascii_case(&want))
+        });
+        let Some(entry) = found else {
+            return (MapMesh::default(), None);
+        };
+        let Ok(bytes) = crate::track::read_entry(p, entry) else {
+            return (MapMesh::default(), None);
+        };
+        let mut mesh = MapMesh::default();
+        for node in crate::edf::parse_world(&bytes) {
+            if node.positions.is_empty() || node.indices.is_empty() {
+                continue;
+            }
+            let base = mesh.vertex_count() as u32;
+            let verts = node.positions.len() / 3;
+            mesh.positions.extend_from_slice(&node.positions);
+            if node.normals.len() == node.positions.len() {
+                mesh.normals.extend_from_slice(&node.normals);
+            } else {
+                mesh.normals.extend(std::iter::repeat(0.0).take(verts * 3));
+            }
+            if node.uvs.len() == verts * 2 {
+                mesh.uvs.extend_from_slice(&node.uvs);
+            } else {
+                mesh.uvs.extend(std::iter::repeat(0.0).take(verts * 2));
+            }
+            mesh.indices.extend(node.indices.iter().map(|i| i + base));
+        }
+
+        // The largest sheet in the file: a dome carries one picture and little else.
+        let picture = map::largest_picture(&bytes);
+        (mesh, picture)
+    };
+
+    Ok((amb, load(sky), load(background)))
+}
+
+/// Pack a track's sky, backdrop and light for the viewer.
+///
+/// ```text
+///  0  "FSKY"
+///  4  u16 version, u16 flags
+///  8  u32 json_len, then the ambience as JSON, padded to four bytes
+///     per mesh: u32 verts, u32 indices, u32 tex_width, u32 tex_height
+///     per mesh: positions, normals, uvs, indices, then its picture as RGBA
+/// ```
+pub fn backdrop_blob(
+    amb: &Ambience,
+    sky: &(MapMesh, Option<MapTexture>),
+    back: &(MapMesh, Option<MapTexture>),
+) -> Vec<u8> {
+    let head = serde_json::to_vec(amb).unwrap_or_default();
+    let mut out = Vec::new();
+    out.extend_from_slice(b"FSKY");
+    out.extend_from_slice(&1u16.to_le_bytes());
+    out.extend_from_slice(&0u16.to_le_bytes());
+    out.extend_from_slice(&(head.len() as u32).to_le_bytes());
+    out.extend_from_slice(&head);
+    // Pad to a four-byte boundary so the arrays can be adopted as views.
+    while out.len() % 4 != 0 {
+        out.push(0);
+    }
+    for (m, t) in [sky, back] {
+        out.extend_from_slice(&(m.vertex_count() as u32).to_le_bytes());
+        out.extend_from_slice(&(m.indices.len() as u32).to_le_bytes());
+        let (w, h) = t.as_ref().map_or((0, 0), |t| (t.width, t.height));
+        out.extend_from_slice(&w.to_le_bytes());
+        out.extend_from_slice(&h.to_le_bytes());
+    }
+    for (m, t) in [sky, back] {
+        for v in m
+            .positions
+            .iter()
+            .chain(m.normals.iter())
+            .chain(m.uvs.iter())
+        {
+            out.extend_from_slice(&v.to_le_bytes());
+        }
+        for i in &m.indices {
+            out.extend_from_slice(&i.to_le_bytes());
+        }
+        if let Some(t) = t {
+            out.extend_from_slice(&t.rgba);
+        }
+    }
+    out
+}
+
 /// The `.edf` models a track ships, as names a prop can be placed by.
 ///
 /// A `.scr` places a prop by file name, so what a track already carries is what can be put
@@ -302,7 +482,7 @@ pub fn prop_mesh(path: &str, name: &str) -> Result<MapMesh> {
         })
         .ok_or_else(|| anyhow::anyhow!("{name} is not in this track"))?;
     let bytes = crate::track::read_entry(p, entry)?;
-    let nodes = crate::edf::parse(&bytes);
+    let nodes = crate::edf::parse_world(&bytes);
     if nodes.is_empty() {
         bail!("{name} has no mesh in it");
     }
@@ -509,7 +689,7 @@ fn bake_props(path: &Path, names: &[String], stem: &str, mesh: &mut MapMesh) -> 
             continue;
         };
         // Left in the game's frame: the viewer mirrors X once, over everything at once.
-        let nodes = crate::edf::parse(&edf_bytes);
+        let nodes = crate::edf::parse_world(&edf_bytes);
         if nodes.is_empty() {
             missing += 1;
             continue;
@@ -1221,6 +1401,44 @@ source1
         assert!(
             worst < 2.0,
             "marshal posts are {worst:.2} m off the terrain — the frames disagree"
+        );
+    }
+
+    /// What a track wraps itself in:
+    ///
+    /// ```text
+    /// FROST_TRACK="…/Millville" \
+    ///   cargo test --bin mxb-app -- --ignored --nocapture backdrop_of_a_real_track
+    /// ```
+    #[test]
+    #[ignore = "needs a real track — set FROST_TRACK"]
+    fn backdrop_of_a_real_track() {
+        let path = std::env::var("FROST_TRACK").expect("set FROST_TRACK");
+        let (amb, sky, back) = backdrop(&path).expect("read the ambience");
+        println!(
+            "  sun {:?}  sky {:?}  fog {:?} @ {:?}",
+            amb.sun, amb.sky_colour, amb.fog_colour, amb.fog_density
+        );
+        for (what, (m, tex)) in [("sky", &sky), ("backdrop", &back)] {
+            if m.is_empty() {
+                println!("  {what}: none");
+                continue;
+            }
+            let (lo, hi) = m.bounds();
+            println!(
+                "  {what}: {} verts, {} tris, reaches {:.0} m, picture {}",
+                m.vertex_count(),
+                m.triangle_count(),
+                (hi[0] - lo[0]).max(hi[2] - lo[2]) / 2.0,
+                tex.as_ref().map_or("none".to_string(), |t| format!(
+                    "{}x{} {}",
+                    t.width, t.height, t.name
+                ))
+            );
+        }
+        assert!(
+            !sky.0.is_empty() || !back.0.is_empty(),
+            "a track wraps itself in something"
         );
     }
 

--- a/src-tauri/src/scenery.rs
+++ b/src-tauri/src/scenery.rs
@@ -771,6 +771,27 @@ fn bake_props(path: &Path, names: &[String], stem: &str, mesh: &mut MapMesh) -> 
                     tri_count,
                 }),
             }
+            // A placed prop is one piece, and it has to be numbered like the rest: the blob
+            // carries one id per triangle, and leaving these out left the whole scenery
+            // short of ids — the viewer read past the end of it and drew none of it.
+            let mut min = [f32::INFINITY; 3];
+            let mut max = [f32::NEG_INFINITY; 3];
+            for v in mesh.positions[base as usize * 3..].chunks_exact(3) {
+                for axis in 0..3 {
+                    min[axis] = min[axis].min(v[axis]);
+                    max[axis] = max[axis].max(v[axis]);
+                }
+            }
+            let piece = mesh.objects.len() as u32;
+            mesh.objects.push(map::MapObject {
+                tri_start,
+                tri_count,
+                material: prop_material,
+                min,
+                max,
+            });
+            mesh.object_of_tri
+                .extend(std::iter::repeat(piece).take(tri_count as usize));
         }
         placed += 1;
     }
@@ -1577,6 +1598,75 @@ source1
         );
     }
 
+    /// The invariant the blob depends on, checked on the path that broke it: a placed prop
+    /// extends the mesh, and every triangle it adds needs a piece id like any other. Without
+    /// one the blob is short, the viewer reads past its end, and a track draws no scenery at
+    /// all — which is what Abydos did, sixteen thousand prop triangles short.
+    #[test]
+    fn a_placed_prop_is_numbered_like_the_rest_of_the_scenery() {
+        // One triangle of map scenery, already numbered as its own piece.
+        let mut mesh = MapMesh {
+            positions: vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+            normals: vec![0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0],
+            uvs: vec![0.0; 6],
+            indices: vec![0, 1, 2],
+            groups: vec![Group {
+                material: 0,
+                tri_start: 0,
+                tri_count: 1,
+            }],
+            objects: vec![map::MapObject {
+                tri_start: 0,
+                tri_count: 1,
+                material: 0,
+                min: [0.0; 3],
+                max: [1.0; 3],
+            }],
+            object_of_tri: vec![0],
+            materials: 1,
+        };
+
+        // A prop of one triangle, placed the way `.scr` props are.
+        let pos = vec![0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 2.0];
+        let nrm = vec![0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0];
+        let base = mesh.vertex_count() as u32;
+        let tri_start = (mesh.indices.len() / 3) as u32;
+        place(&mut mesh, &pos, &nrm, [0.0; 3], [10.0, 0.0, 10.0]);
+        mesh.uvs.extend(std::iter::repeat(0.0).take(6));
+        mesh.indices.extend([0u32, 1, 2].iter().map(|i| i + base));
+        let tri_count = (mesh.indices.len() / 3) as u32 - tri_start;
+        let piece = mesh.objects.len() as u32;
+        mesh.objects.push(map::MapObject {
+            tri_start,
+            tri_count,
+            material: 1,
+            min: [10.0, 0.0, 10.0],
+            max: [12.0, 0.0, 12.0],
+        });
+        mesh.groups.push(Group {
+            material: 1,
+            tri_start,
+            tri_count,
+        });
+        mesh.object_of_tri
+            .extend(std::iter::repeat(piece).take(tri_count as usize));
+
+        assert_eq!(
+            mesh.object_of_tri.len(),
+            mesh.indices.len() / 3,
+            "one id per triangle, prop included"
+        );
+        let blob = map::scenery_blob(&mesh, &[]);
+        let vc = u32::from_le_bytes(blob[8..12].try_into().unwrap()) as usize;
+        let ic = u32::from_le_bytes(blob[12..16].try_into().unwrap()) as usize;
+        let gc = u32::from_le_bytes(blob[16..20].try_into().unwrap()) as usize;
+        assert_eq!(
+            blob.len(),
+            map::SCENERY_HEADER + vc * 32 + ic * 4 + gc * 12 + (ic / 3) * 4,
+            "the sections account for exactly the blob"
+        );
+    }
+
     /// What a real track offers to place, and whether one of them draws:
     ///
     /// ```text
@@ -1958,8 +2048,17 @@ source1
                 + s.info.vertex_count as usize * 32
                 + s.info.triangle_count as usize * 12
                 + s.mesh.groups.len() * 12
+                // One piece id per triangle. Leaving this out of the sum is what let a mesh
+                // short of ids ship — the viewer reads the sections back to back, so a blob
+                // that doesn't add up costs a track all of its scenery rather than its pieces.
+                + s.info.triangle_count as usize * 4
                 + s.textures.len() * crate::map::TEXTURE_ENTRY
                 + pixels
+        );
+        assert_eq!(
+            s.mesh.object_of_tri.len(),
+            s.mesh.indices.len() / 3,
+            "every triangle is numbered, placed props included"
         );
         assert!(s
             .mesh

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -967,6 +967,29 @@ mod tests {
             }
             None => println!("no surfaces in this track"),
         }
+        // `FROST_PNG=/tmp/surface.png` writes the picture out, which is the only way to see
+        // whether a track really is one flat colour or is being read as one.
+        if let (Ok(out), Some(b)) = (std::env::var("FROST_PNG"), build_surface_blob(path, 1024)) {
+            let w = u32::from_le_bytes(b[8..12].try_into().unwrap()) as usize;
+            let h = u32::from_le_bytes(b[12..16].try_into().unwrap()) as usize;
+            let px = &b[TEXTURE_HEADER..];
+            let mut seen = std::collections::HashMap::new();
+            for q in px.chunks_exact(4) {
+                *seen.entry([q[0], q[1], q[2]]).or_insert(0usize) += 1;
+            }
+            let mut counts: Vec<_> = seen.into_iter().collect();
+            counts.sort_by_key(|(_, n)| std::cmp::Reverse(*n));
+            println!("  {} distinct colours, commonest:", counts.len());
+            for (c, n) in counts.iter().take(6) {
+                println!("    {c:?} {:.1}%", *n as f64 * 100.0 / (w * h) as f64);
+            }
+            let mut ppm = format!("P6\n{w} {h}\n255\n").into_bytes();
+            for q in px.chunks_exact(4) {
+                ppm.extend_from_slice(&q[..3]);
+            }
+            std::fs::write(&out, ppm).unwrap();
+            println!("  wrote {out}");
+        }
     }
 
     #[test]

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -931,6 +931,22 @@ mod tests {
     fn read_a_real_track() {
         let path = std::env::var("FROST_TRACK").expect("set FROST_TRACK to a track .pkz/folder");
         println!("{}", diagnose(Path::new(&path)));
+        // What the viewer actually receives at its own detail level — a terrain whose info
+        // reads fine but whose heights come back empty draws nothing at all.
+        let want: u32 = std::env::var("FROST_DETAIL")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(512);
+        match decode_master(Path::new(&path)) {
+            Ok(m) => {
+                let (w, h, heights) = resample(&m, want);
+                let finite = heights.iter().filter(|v| v.is_finite()).count();
+                let lo = heights.iter().cloned().fold(f32::INFINITY, f32::min);
+                let hi = heights.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+                println!("view {w}x{h}: {} heights, {finite} finite, [{lo}, {hi}]", heights.len());
+            }
+            Err(e) => println!("no master: {e:#}"),
+        }
     }
 
     /// Point this at a real track to see the surfaces its height file paints:

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -155,9 +155,8 @@ pub(crate) fn read_entry(path: &Path, name: &str) -> Result<Vec<u8>> {
         return std::fs::read(path.join(name)).with_context(|| format!("read {name}"));
     }
     let want = name.to_ascii_lowercase();
-    let found = crate::pkz::read_selected(path, |n| {
-        n.replace('\\', "/").to_ascii_lowercase() == want
-    })?;
+    let found =
+        crate::pkz::read_selected(path, |n| n.replace('\\', "/").to_ascii_lowercase() == want)?;
     match found.into_iter().next() {
         Some((_, bytes)) => Ok(bytes),
         None => bail!("{name} is not in {path:?}"),
@@ -261,7 +260,11 @@ pub fn read_info(app: &tauri::AppHandle, path: &str) -> Result<TrackInfo> {
             TrackFile { name, role }
         })
         .collect();
-    files.sort_by(|a, b| a.name.to_ascii_lowercase().cmp(&b.name.to_ascii_lowercase()));
+    files.sort_by(|a, b| {
+        a.name
+            .to_ascii_lowercase()
+            .cmp(&b.name.to_ascii_lowercase())
+    });
 
     Ok(TrackInfo {
         meta,
@@ -276,7 +279,11 @@ pub fn load_master(app: &tauri::AppHandle, path: &str) -> Result<Master> {
     let stamp = stamp(path)?;
     let key = cache_key(path, stamp);
 
-    if let Some(hit) = memory_cache().lock().ok().and_then(|mut c| c.get(&key).cloned()) {
+    if let Some(hit) = memory_cache()
+        .lock()
+        .ok()
+        .and_then(|mut c| c.get(&key).cloned())
+    {
         return Ok(hit);
     }
     if let Some(hit) = cache_file(app, &key).and_then(|f| read_cache(&f)) {
@@ -363,11 +370,12 @@ pub fn terrain_blob(master: &Master, max_dim: u32) -> Vec<u8> {
     let mut out = Vec::with_capacity(BLOB_HEADER + heights.len() * 4);
     out.extend_from_slice(b"FTRN");
     out.extend_from_slice(&1u16.to_le_bytes()); // version
-    // Bit 0: the sample spacing was stated by the track rather than assumed. The app needs
-    // this to caption the view honestly — with the spacing assumed, the relief is drawn
-    // against a footprint we guessed, so its steepness is not something to trust.
-    // Bit 1: the heights are metres rather than the file's own raw units.
-    let flags = u16::from(master.info.scale_known) | (u16::from(master.info.heights_in_metres) << 1);
+                                                // Bit 0: the sample spacing was stated by the track rather than assumed. The app needs
+                                                // this to caption the view honestly — with the spacing assumed, the relief is drawn
+                                                // against a footprint we guessed, so its steepness is not something to trust.
+                                                // Bit 1: the heights are metres rather than the file's own raw units.
+    let flags =
+        u16::from(master.info.scale_known) | (u16::from(master.info.heights_in_metres) << 1);
     out.extend_from_slice(&flags.to_le_bytes());
     out.extend_from_slice(&w.to_le_bytes());
     out.extend_from_slice(&h.to_le_bytes());
@@ -400,7 +408,7 @@ pub const TEXTURE_HEADER: usize = 16;
 
 /// Bump when [`surface_colour`] changes, so cached textures drawn with the old palette are
 /// retired rather than kept.
-const SURFACE_SCHEME: u32 = 1;
+const SURFACE_SCHEME: u32 = 2;
 
 /// The colour of a surface, by the id the track states for it.
 ///
@@ -417,17 +425,22 @@ const SURFACE_SCHEME: u32 = 1;
 ///
 /// Hues are kept apart on purpose. Half of these are browns, and a track whose surfaces are
 /// all a similar brown reads as one flat surface no matter how correct each colour is.
+///
+/// Kept dry, though. An id names a surface the way the physics means it, not the way a track
+/// looks: a sand circuit in Australia paints its infield as surface 1, and a lawn green there
+/// is the loudest wrong thing on the screen. These are the same hues pulled towards earth, so
+/// a mistaken one reads as ground rather than as a golf course.
 fn surface_colour(id: u32) -> [u8; 3] {
     match id {
-        0 => [84, 86, 92],     // asphalt — cold, dark
-        1 => [98, 132, 66],    // grass — the only green
-        2 => [216, 198, 152],  // sand — pale, warm
-        3 => [186, 146, 92],   // kerb — tan, between sand and soil
-        4 => [138, 100, 62],   // soil — mid brown
+        0 => [88, 89, 94],     // asphalt — cold, dark
+        1 => [124, 138, 96],   // grass — dry, not a lawn
+        2 => [214, 197, 156],  // sand — pale, warm
+        3 => [188, 152, 104],  // kerb — tan, between sand and soil
+        4 => [150, 118, 84],   // soil — mid brown
         5 => [158, 156, 150],  // concrete — light, neutral
-        10 => [122, 78, 52],   // the riding line — darkest, reddest
-        12 => [112, 120, 92],  // olive, so it parts from both grass and soil
-        _ => [126, 114, 96],
+        10 => [128, 84, 58],   // the riding line — darkest, reddest
+        12 => [124, 126, 102], // olive, so it parts from both grass and soil
+        _ => [138, 126, 106],
     }
 }
 
@@ -461,7 +474,9 @@ fn coverage_masks(block: &[u8]) -> Vec<Coverage> {
         return Vec::new();
     };
     let u32_at = |o: usize| -> Option<u32> {
-        block.get(o..o + 4).map(|b| u32::from_le_bytes(b.try_into().unwrap()))
+        block
+            .get(o..o + 4)
+            .map(|b| u32::from_le_bytes(b.try_into().unwrap()))
     };
     let plausible = |v: u32| (16..=8192).contains(&v);
 
@@ -473,7 +488,12 @@ fn coverage_masks(block: &[u8]) -> Vec<Coverage> {
 
         if let (Some(id), Some(w), Some(h)) = (id, w16, h16) {
             if plausible(w) && plausible(h) && o + 16 + (w as usize * h as usize) <= end {
-                out.push(Coverage { id, width: w, height: h, at: o + 16 });
+                out.push(Coverage {
+                    id,
+                    width: w,
+                    height: h,
+                    at: o + 16,
+                });
                 o += 16 + w as usize * h as usize;
                 continue;
             }
@@ -484,7 +504,12 @@ fn coverage_masks(block: &[u8]) -> Vec<Coverage> {
         }
         if let (Some(id), Some(w), Some(h)) = (u32_at(o), w12, h12) {
             if plausible(w) && plausible(h) && o + 12 + (w as usize * h as usize) <= end {
-                out.push(Coverage { id, width: w, height: h, at: o + 12 });
+                out.push(Coverage {
+                    id,
+                    width: w,
+                    height: h,
+                    at: o + 12,
+                });
                 o += 12 + w as usize * h as usize;
                 continue;
             }
@@ -514,9 +539,12 @@ pub fn overview_blob(app: &tauri::AppHandle, path: &Path, max_dim: u32) -> Optio
     // The scheme number is part of the key, so changing how surfaces are coloured retires
     // every cached texture on its own. Without it a track keeps whatever colours it was first
     // drawn with, and the change only shows on machines that had never opened it.
-    let key = stamp(&path.to_string_lossy())
-        .ok()
-        .map(|st| format!("{}:tex{max_dim}v{SURFACE_SCHEME}", cache_key(&path.to_string_lossy(), st)));
+    let key = stamp(&path.to_string_lossy()).ok().map(|st| {
+        format!(
+            "{}:tex{max_dim}v{SURFACE_SCHEME}",
+            cache_key(&path.to_string_lossy(), st)
+        )
+    });
     if let Some(f) = key.as_deref().and_then(|k| cache_file(app, k)) {
         if let Ok(bytes) = std::fs::read(&f) {
             if bytes.len() > TEXTURE_HEADER && bytes.starts_with(b"FTEX") {
@@ -551,7 +579,9 @@ fn build_surface_blob(path: &Path, max_dim: u32) -> Option<Vec<u8>> {
 
     let src_w = masks[0].width as usize;
     let src_h = masks[0].height as usize;
-    let scale = (src_w.max(src_h) as f32 / max_dim.max(1) as f32).ceil().max(1.0) as usize;
+    let scale = (src_w.max(src_h) as f32 / max_dim.max(1) as f32)
+        .ceil()
+        .max(1.0) as usize;
     let out_w = src_w.div_ceil(scale);
     let out_h = src_h.div_ceil(scale);
     // At least two cells across even when drawing a mask at its own resolution, so the dither
@@ -638,7 +668,11 @@ fn resample(master: &Master, max_dim: u32) -> (u32, u32, Vec<f32>) {
     let max_dim = max_dim.max(1) as usize;
     let longest = w.max(h);
     if longest <= max_dim {
-        return (master.info.width, master.info.height, master.heights.clone());
+        return (
+            master.info.width,
+            master.info.height,
+            master.heights.clone(),
+        );
     }
 
     // Land on exactly the size asked for. Reducing by a whole number of samples instead
@@ -740,7 +774,13 @@ fn hex_preview(bytes: &[u8], count: usize) -> String {
     let hex: Vec<String> = bytes[..take].iter().map(|b| format!("{b:02x}")).collect();
     let ascii: String = bytes[..take]
         .iter()
-        .map(|b| if b.is_ascii_graphic() { *b as char } else { '.' })
+        .map(|b| {
+            if b.is_ascii_graphic() {
+                *b as char
+            } else {
+                '.'
+            }
+        })
         .collect();
     format!("{}  |{ascii}|", hex.join(" "))
 }
@@ -893,10 +933,6 @@ mod tests {
         println!("{}", diagnose(Path::new(&path)));
     }
 
-
-
-
-
     /// Point this at a real track to see the surfaces its height file paints:
     ///
     /// ```text
@@ -914,7 +950,10 @@ mod tests {
             let bytes = read_entry(path, &entry).unwrap();
             let gw = u32::from_le_bytes(bytes[4..8].try_into().unwrap()) as usize;
             let gh = u32::from_le_bytes(bytes[8..12].try_into().unwrap()) as usize;
-            for (i, m) in coverage_masks(&bytes[12 + gw * gh * 2..]).iter().enumerate() {
+            for (i, m) in coverage_masks(&bytes[12 + gw * gh * 2..])
+                .iter()
+                .enumerate()
+            {
                 println!("  surface {i}: id={} {}x{}", m.id, m.width, m.height);
             }
         }
@@ -976,7 +1015,11 @@ mod tests {
             heights: vec![0.25; 64 * 32],
         };
         let (w, h, _) = resample(&master, 512);
-        assert_eq!((w, h), (64, 32), "never invented detail the master hasn't got");
+        assert_eq!(
+            (w, h),
+            (64, 32),
+            "never invented detail the master hasn't got"
+        );
     }
 
     #[test]
@@ -1056,7 +1099,11 @@ mod tests {
     fn a_surface_that_was_never_painted_takes_no_space() {
         let b = block_with(&[(7, 0, 0, true), (1, 48, 48, true)]);
         let m = coverage_masks(&b);
-        assert_eq!(m.len(), 1, "an empty record is skipped, not treated as a mask");
+        assert_eq!(
+            m.len(),
+            1,
+            "an empty record is skipped, not treated as a mask"
+        );
         assert_eq!(m[0].id, 1);
     }
 
@@ -1078,7 +1125,10 @@ mod tests {
             for &b in &ids[n + 1..] {
                 let (x, y) = (surface_colour(a), surface_colour(b));
                 let apart: i32 = (0..3).map(|k| (x[k] as i32 - y[k] as i32).abs()).sum();
-                assert!(apart > 40, "surfaces {a} and {b} look alike: {x:?} vs {y:?}");
+                assert!(
+                    apart > 40,
+                    "surfaces {a} and {b} look alike: {x:?} vs {y:?}"
+                );
             }
         }
     }
@@ -1225,7 +1275,9 @@ mod tests {
         let mut m = master(64);
         let known = terrain_blob(&m, 64);
         assert_eq!(u16::from_le_bytes([known[6], known[7]]) & 1, 1);
-        assert!((f32::from_le_bytes([known[28], known[29], known[30], known[31]]) - 0.9).abs() < 1e-6);
+        assert!(
+            (f32::from_le_bytes([known[28], known[29], known[30], known[31]]) - 0.9).abs() < 1e-6
+        );
 
         // A track that never stated its sample spacing has to come through as such — the
         // relief is real, the footprint it's drawn against is a guess.
@@ -1290,14 +1342,3 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 }
-
-
-
-
-
-
-
-
-
-
-

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -130,7 +130,7 @@ fn is_dir(path: &Path) -> bool {
 }
 
 /// Every entry name in a track, without inflating any of them.
-fn entry_names(path: &Path) -> Result<Vec<String>> {
+pub(crate) fn entry_names(path: &Path) -> Result<Vec<String>> {
     if is_dir(path) {
         let mut out = Vec::new();
         for entry in crate::linkwalk::walk_depth(path, 6)
@@ -150,7 +150,7 @@ fn entry_names(path: &Path) -> Result<Vec<String>> {
 }
 
 /// Pull one named entry's bytes out of a track.
-fn read_entry(path: &Path, name: &str) -> Result<Vec<u8>> {
+pub(crate) fn read_entry(path: &Path, name: &str) -> Result<Vec<u8>> {
     if is_dir(path) {
         return std::fs::read(path.join(name)).with_context(|| format!("read {name}"));
     }

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -465,12 +465,17 @@ function Surrounds({
         </mesh>
       )}
       {geometries.land && (
+        // Behind everything, like the dome: a backdrop is what a track puts at its horizon,
+        // and some are authored as a shell that encloses the whole site rather than a ring
+        // around it. Writing depth, such a shell sits between the camera and the track and
+        // hides it — Sand Point opened as an empty blue sphere with the circuit inside it.
         <mesh geometry={geometries.land} renderOrder={-1}>
           <meshBasicMaterial
             key={geometries.landMap ? "land-picture" : "land-plain"}
             map={geometries.landMap ?? undefined}
             color={geometries.landMap ? "#ffffff" : landHex}
             side={THREE.DoubleSide}
+            depthWrite={false}
             toneMapped={false}
           />
         </mesh>
@@ -745,10 +750,26 @@ function TerrainMesh({
           shader.uniforms.groundRepeat = { value: repeat };
           shader.uniforms.groundMean = { value: meanLuma };
           shader.uniforms.groundStrength = { value: GROUND_STRENGTH };
+          // Its own varying rather than the map's. `vMapUv` exists only where three.js
+          // compiled in a `map`, so on a track that states no surfaces — no picture, so no
+          // map — this read a name the shader had never declared, the program failed to
+          // build, and the terrain drew nothing at all while everything around it drew fine.
+          shader.vertexShader = shader.vertexShader
+            .replace(
+              "#include <common>",
+              `#include <common>
+               varying vec2 vGroundUv;`,
+            )
+            .replace(
+              "#include <begin_vertex>",
+              `#include <begin_vertex>
+               vGroundUv = uv;`,
+            );
           shader.fragmentShader = shader.fragmentShader
             .replace(
               "#include <common>",
               `#include <common>
+               varying vec2 vGroundUv;
                uniform sampler2D groundMap;
                uniform float groundRepeat;
                uniform float groundMean;
@@ -760,7 +781,7 @@ function TerrainMesh({
               "#include <color_fragment>",
               `#include <color_fragment>
                {
-                 vec3 grain = texture2D(groundMap, vMapUv * groundRepeat).rgb;
+                 vec3 grain = texture2D(groundMap, vGroundUv * groundRepeat).rgb;
                  float lum = dot(grain, vec3(0.299, 0.587, 0.114));
                  // Around one, so the grain varies the ground without darkening it. Only the
                  // sheet's luminance is used — its hue is its own surface's, not this one's.

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -6,6 +6,7 @@ import * as THREE from "three";
 import { cn } from "@/lib/utils";
 import type {
   TrackBackdrop,
+  TrackGround,
   TrackMeshArrays,
   TrackOverview,
   TrackPlacement,
@@ -591,7 +592,7 @@ function TerrainMesh({
   terrain: TrackTerrain;
   overview: TrackOverview | null;
   /** A tiling sheet of the track's own ground, multiplied in for close-up detail. */
-  ground: TrackSceneryTexture | null;
+  ground: TrackGround | null;
 }) {
   const geometry = useMemo(() => buildGeometry(terrain, overview != null), [terrain, overview]);
 
@@ -616,37 +617,52 @@ function TerrainMesh({
 
   // The detail sheet, tiled. The surface picture says what the ground *is* at a third of a
   // metre; this says what it is made of, at whatever resolution you care to look.
-  const detail = useMemo(() => {
-    if (!ground) return null;
-    const t = new THREE.DataTexture(
-      ground.pixels,
-      ground.width,
-      ground.height,
-      THREE.RGBAFormat,
-    );
-    t.colorSpace = THREE.SRGBColorSpace;
-    t.wrapS = THREE.RepeatWrapping;
-    t.wrapT = THREE.RepeatWrapping;
-    t.minFilter = THREE.LinearMipmapLinearFilter;
-    t.magFilter = THREE.LinearFilter;
-    t.generateMipmaps = true;
-    t.anisotropy = 8;
-    t.needsUpdate = true;
-    return t;
-  }, [ground]);
-
   // How many times the sheet repeats across the whole grid.
   const repeat = useMemo(() => {
     const span = Math.max(terrain.width - 1, terrain.height - 1) * terrain.metresPerSample;
     return Math.max(1, Math.round(span / GROUND_TILE_METRES));
   }, [terrain]);
 
+  const tile = (
+    sheet: TrackSceneryTexture | null,
+    srgb: boolean,
+    repeats: number,
+  ): THREE.DataTexture | null => {
+    if (!sheet) return null;
+    const t = new THREE.DataTexture(
+      sheet.pixels,
+      sheet.width,
+      sheet.height,
+      THREE.RGBAFormat,
+    );
+    // A normal map is direction data, not a picture — read it linearly or the relief is wrong.
+    if (srgb) t.colorSpace = THREE.SRGBColorSpace;
+    t.wrapS = THREE.RepeatWrapping;
+    t.wrapT = THREE.RepeatWrapping;
+    t.minFilter = THREE.LinearMipmapLinearFilter;
+    t.magFilter = THREE.LinearFilter;
+    t.generateMipmaps = true;
+    t.anisotropy = 8;
+    t.repeat.set(repeats, repeats);
+    t.needsUpdate = true;
+    return t;
+  };
+
+  const { detail, relief } = useMemo(
+    () => ({
+      detail: tile(ground?.colour ?? null, true, repeat),
+      relief: tile(ground?.normal ?? null, false, repeat),
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [ground, repeat],
+  );
+
   // The sheet's own average brightness. Dividing by it is what makes this a *detail* layer:
   // the grain then averages to no change at all, so a dark sheet adds texture instead of
   // dragging the whole track darker — which is what tiling a dirt or grass sheet raw did.
   const meanLuma = useMemo(() => {
     if (!ground) return 1;
-    const px = ground.pixels;
+    const px = ground.colour.pixels;
     let total = 0;
     // Every sixteenth pixel: an average over a quarter of a million samples does not need
     // all of them, and this runs on the main thread while a track is opening.
@@ -661,7 +677,13 @@ function TerrainMesh({
   // A grid this size is megabytes of GPU buffers, and the viewer replaces it every time the
   // detail level changes — without this each one would be leaked.
   useEffect(() => () => geometry.dispose(), [geometry]);
-  useEffect(() => () => detail?.dispose(), [detail]);
+  useEffect(
+    () => () => {
+      detail?.dispose();
+      relief?.dispose();
+    },
+    [detail, relief],
+  );
   useEffect(() => () => texture?.dispose(), [texture]);
 
   // The canvas only draws when asked, and the map arrives well after the terrain settled —
@@ -685,8 +707,14 @@ function TerrainMesh({
           program it was built with — the terrain keeps its elevation ramp and never shows the
           picture at all. */}
       <meshStandardMaterial
-        key={`${texture ? "textured" : "plain"}-${detail ? "grain" : "flat"}-${repeat}`}
+        key={`${texture ? "textured" : "plain"}-${detail ? "grain" : "flat"}-${
+          relief ? "relief" : "smooth"
+        }-${repeat}`}
         map={texture ?? undefined}
+        normalMap={relief ?? undefined}
+        // Gentle: this is one ground sheet standing in for every surface a track has, so it
+        // should suggest a texture underfoot rather than emboss the whole place.
+        normalScale={new THREE.Vector2(0.45, 0.45)}
         vertexColors
         roughness={0.95}
         metalness={0}
@@ -1046,7 +1074,7 @@ interface TrackViewerProps {
   /** The sky and land a track wraps itself in, and the light it states. */
   backdrop?: TrackBackdrop | null;
   /** A tiling sheet of the track's own ground, for detail closer than its data carries. */
-  ground?: TrackSceneryTexture | null;
+  ground?: TrackGround | null;
   /** Told what a click on the scenery landed on, and when the selection clears. */
   onPick?: (piece: PickedPiece | null) => void;
   className?: string;

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -787,13 +787,12 @@ function buildSceneryGeometry(
     normals[o + 2] = scenery.normals[o + 2];
   }
 
-  const srcIndices = scenery.indices;
-  const indices = new Uint32Array(srcIndices.length);
-  for (let t = 0; t < srcIndices.length; t += 3) {
-    indices[t] = srcIndices[t];
-    indices[t + 1] = srcIndices[t + 2];
-    indices[t + 2] = srcIndices[t + 1];
-  }
+  // Kept as the map states it. `toView` mirrors X, and a mirror already reverses which side
+  // of a triangle you are looking at — so the game's own winding lands the right way round
+  // here without a swap, and swapping as well turns every face back to front. Drawn
+  // double-sided that shows up not as holes but as light: three.js flips a back face's
+  // normal, and a lit floor an acre across renders as if the sun were under it.
+  const indices = scenery.indices;
 
   const geometry = new THREE.BufferGeometry();
   geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -1,10 +1,16 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Canvas, useThree } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
 import { Move, Rotate3d, ZoomIn } from "lucide-react";
 import * as THREE from "three";
 import { cn } from "@/lib/utils";
-import type { TrackOverview, TrackTerrain } from "../../types";
+import type {
+  TrackOverview,
+  TrackPlacement,
+  TrackScenery,
+  TrackSceneryTexture,
+  TrackTerrain,
+} from "../../types";
 import { ErrorBoundary } from "../ErrorBoundary";
 import { useT } from "../../i18n/context";
 
@@ -242,15 +248,55 @@ function gridNormal(
  * relief is proportionate everywhere — a flat supercross floor still looks flatter than a
  * hillside, it is just not drawn so shallow that nothing casts a shadow.
  */
-function buildGeometry(terrain: TrackTerrain, textured: boolean): THREE.BufferGeometry {
-  const { width, height, heights, metresPerSample, minHeight, maxHeight } = terrain;
-
+/**
+ * How world metres become view units.
+ *
+ * Everything drawn in the scene goes through this one function — the terrain grid, the
+ * scenery standing on it, and the markers for what the track ships no mesh for. They are
+ * placed in the same world frame by the track itself, and the only way they stay in it is by
+ * being scaled and shifted by the same numbers.
+ */
+function viewFrame(terrain: TrackTerrain) {
+  const { width, height, metresPerSample, minHeight, maxHeight } = terrain;
   // Metres across the widest edge, and the units-per-metre that fits it to the view.
   const spanMetres = Math.max(width - 1, height - 1) * metresPerSample;
   const unitsPerMetre = spanMetres > 0 ? VIEW_SPAN / spanMetres : 1;
   const step = metresPerSample * unitsPerMetre;
+  return {
+    unitsPerMetre,
+    step,
+    midHeight: (minHeight + maxHeight) / 2,
+    // The Y scale heights go through, needed again to slope normals by the same amount.
+    heightScale: unitsPerMetre * RELIEF_EXAGGERATION,
+    originX: ((width - 1) * step) / 2,
+    originZ: ((height - 1) * step) / 2,
+  };
+}
 
-  const midHeight = (minHeight + maxHeight) / 2;
+/**
+ * Put one world-metre point where the terrain would put it.
+ *
+ * X is negated, the same conversion every model in the app goes through
+ * (`edf::to_right_handed`): the game's frame is left-handed and three.js's is not.
+ */
+function toView(
+  frame: ReturnType<typeof viewFrame>,
+  wx: number,
+  wy: number,
+  wz: number,
+): [number, number, number] {
+  return [
+    frame.originX - wx * frame.unitsPerMetre,
+    (wy - frame.midHeight) * frame.heightScale,
+    wz * frame.unitsPerMetre - frame.originZ,
+  ];
+}
+
+function buildGeometry(terrain: TrackTerrain, textured: boolean): THREE.BufferGeometry {
+  const { width, height, heights } = terrain;
+
+  const frame = viewFrame(terrain);
+  const { step, midHeight } = frame;
 
   // The ramp is spread over where the ground actually is, not over its extremes. A track's
   // full range is set by whatever sits at its edges — a boundary wall, a quarry face, one
@@ -269,12 +315,7 @@ function buildGeometry(terrain: TrackTerrain, textured: boolean): THREE.BufferGe
   const uvs = new Float32Array(count * 2);
   const colour = new THREE.Color();
 
-  // The Y scale the heights go through, needed again below to slope the normals by the same
-  // amount the ground is sloped.
-  const heightScale = unitsPerMetre * RELIEF_EXAGGERATION;
-
-  const originX = ((width - 1) * step) / 2;
-  const originZ = ((height - 1) * step) / 2;
+  const { heightScale, originX, originZ } = frame;
 
   for (let y = 0; y < height; y += 1) {
     for (let x = 0; x < width; x += 1) {
@@ -413,6 +454,291 @@ function TerrainMesh({
   );
 }
 
+/**
+ * The scenery, moved from world metres into the terrain's frame.
+ *
+ * Mirroring X reverses handedness, so two things have to follow it or the whole mesh is lit
+ * from inside: every normal's X flips with the positions, and every triangle is rewound.
+ * Rewinding happens within each triangle, never across them, so the material groups keep
+ * pointing at the triangles they were cut for.
+ *
+ * Heights go through the terrain's own exaggeration rather than true scale. A tent drawn at
+ * 1.5× is the price of a tent that stands on the ground instead of hovering over it or
+ * sinking into it, and the ground is what the view is about.
+ */
+function buildSceneryGeometry(
+  scenery: TrackScenery,
+  terrain: TrackTerrain,
+  slotOf: Map<number, number>,
+): THREE.BufferGeometry {
+  const frame = viewFrame(terrain);
+  const src = scenery.positions;
+  const count = src.length / 3;
+
+  const positions = new Float32Array(src.length);
+  const normals = new Float32Array(src.length);
+  for (let i = 0; i < count; i += 1) {
+    const o = i * 3;
+    const [x, y, z] = toView(frame, src[o], src[o + 1], src[o + 2]);
+    positions[o] = x;
+    positions[o + 1] = y;
+    positions[o + 2] = z;
+    normals[o] = -scenery.normals[o];
+    normals[o + 1] = scenery.normals[o + 1];
+    normals[o + 2] = scenery.normals[o + 2];
+  }
+
+  const srcIndices = scenery.indices;
+  const indices = new Uint32Array(srcIndices.length);
+  for (let t = 0; t < srcIndices.length; t += 3) {
+    indices[t] = srcIndices[t];
+    indices[t + 1] = srcIndices[t + 2];
+    indices[t + 2] = srcIndices[t + 1];
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+  geometry.setAttribute("normal", new THREE.BufferAttribute(normals, 3));
+  geometry.setAttribute("uv", new THREE.BufferAttribute(scenery.uvs, 2));
+  geometry.setIndex(new THREE.BufferAttribute(indices, 1));
+  // One draw range per material. The backend already sorted the triangles so each
+  // material's sit together, which is what keeps this to a few dozen groups.
+  for (const g of scenery.groups) {
+    const slot = slotOf.get(g.material);
+    if (slot == null) continue;
+    geometry.addGroup(g.triStart * 3, g.triCount * 3, slot);
+  }
+  geometry.computeBoundingSphere();
+  return geometry;
+}
+
+/** How opaque a cut-out's alpha has to be to be drawn at all. */
+const CUTOUT_THRESHOLD = 0.5;
+
+/** What a click on the scenery landed on. */
+export interface PickedPiece {
+  id: number;
+  triangles: number;
+  /** Metres. */
+  size: [number, number, number];
+}
+
+function SceneryMesh({
+  scenery,
+  surfaces,
+  terrain,
+  onPick,
+}: {
+  scenery: TrackScenery;
+  surfaces: TrackSceneryTexture[];
+  terrain: TrackTerrain;
+  onPick?: (piece: PickedPiece | null) => void;
+}) {
+  const [picked, setPicked] = useState<number | null>(null);
+  // A material slot per surface, plus one plain slot at the end for the groups no surface
+  // covers — the `.scr` props, whose own sheets aren't read.
+  const { materials, slotOf } = useMemo(() => {
+    const slots = new Map<number, number>();
+    const list: THREE.Material[] = surfaces.map((t, i) => {
+      slots.set(t.material, i);
+      const map = new THREE.DataTexture(t.pixels, t.width, t.height, THREE.RGBAFormat);
+      map.colorSpace = THREE.SRGBColorSpace;
+      // The surfaces tile — a fence sheet repeats along its run — so anything but repeat
+      // wrapping smears the last pixel of the sheet across the whole length of it.
+      map.wrapS = THREE.RepeatWrapping;
+      map.wrapT = THREE.RepeatWrapping;
+      map.minFilter = THREE.LinearMipmapLinearFilter;
+      map.magFilter = THREE.LinearFilter;
+      map.generateMipmaps = true;
+      map.anisotropy = 4;
+      map.needsUpdate = true;
+      return new THREE.MeshStandardMaterial({
+        map,
+        roughness: 0.9,
+        metalness: 0,
+        // Cut-outs are drawn with an alpha test rather than blending: the shapes are
+        // foliage and crowd, which need to occlude each other correctly at any angle, and
+        // that is what a test gives and sorting-dependent blending does not.
+        alphaTest: t.alpha ? CUTOUT_THRESHOLD : 0,
+        // Much of this is single-sided cloth and card — banners, tent walls, leaf sheets —
+        // and culling back faces makes half of it vanish from one side.
+        side: THREE.DoubleSide,
+      });
+    });
+    const plain = new THREE.MeshStandardMaterial({
+      color: "#9a9384",
+      roughness: 0.9,
+      metalness: 0,
+      side: THREE.DoubleSide,
+    });
+    const fallback = list.length;
+    list.push(plain);
+    for (const g of scenery.groups) {
+      if (!slots.has(g.material)) slots.set(g.material, fallback);
+    }
+    return { materials: list, slotOf: slots };
+  }, [scenery, surfaces]);
+
+  const geometry = useMemo(
+    () => buildSceneryGeometry(scenery, terrain, slotOf),
+    [scenery, terrain, slotOf],
+  );
+
+  // Tens of megabytes of GPU buffers and surfaces, replaced whenever the terrain's detail
+  // level changes — without this each pass would leak the last one's.
+  useEffect(() => () => geometry.dispose(), [geometry]);
+  useEffect(
+    () => () => {
+      for (const m of materials) {
+        const mat = m as THREE.MeshStandardMaterial;
+        mat.map?.dispose();
+        mat.dispose();
+      }
+    },
+    [materials],
+  );
+
+  const invalidate = useThree((s) => s.invalidate);
+  useEffect(() => invalidate(), [geometry, materials, invalidate]);
+
+  // The picked piece, as its own geometry — the triangles that share its id.
+  const outline = useMemo(() => {
+    if (picked == null || scenery.pieceOfTriangle.length === 0) return null;
+    const src = geometry.getIndex();
+    if (!src) return null;
+    const keep: number[] = [];
+    for (let t = 0; t < scenery.pieceOfTriangle.length; t += 1) {
+      if (scenery.pieceOfTriangle[t] !== picked) continue;
+      keep.push(src.getX(t * 3), src.getX(t * 3 + 1), src.getX(t * 3 + 2));
+    }
+    if (keep.length === 0) return null;
+    const g = new THREE.BufferGeometry();
+    g.setAttribute("position", geometry.getAttribute("position"));
+    g.setIndex(keep);
+    g.computeBoundingSphere();
+    return g;
+  }, [picked, geometry, scenery.pieceOfTriangle]);
+
+  useEffect(() => () => outline?.dispose(), [outline]);
+
+  // Report what was picked, in metres, from the world positions rather than the view units.
+  useEffect(() => {
+    if (!onPick) return;
+    if (picked == null) {
+      onPick(null);
+      return;
+    }
+    let count = 0;
+    const lo = [Infinity, Infinity, Infinity];
+    const hi = [-Infinity, -Infinity, -Infinity];
+    for (let t = 0; t < scenery.pieceOfTriangle.length; t += 1) {
+      if (scenery.pieceOfTriangle[t] !== picked) continue;
+      count += 1;
+      for (let k = 0; k < 3; k += 1) {
+        const v = scenery.indices[t * 3 + k] * 3;
+        for (let axis = 0; axis < 3; axis += 1) {
+          const p = scenery.positions[v + axis];
+          if (p < lo[axis]) lo[axis] = p;
+          if (p > hi[axis]) hi[axis] = p;
+        }
+      }
+    }
+    onPick({
+      id: picked,
+      triangles: count,
+      size: [hi[0] - lo[0], hi[1] - lo[1], hi[2] - lo[2]],
+    });
+  }, [picked, scenery, onPick]);
+
+  return (
+    <>
+      {/* Casting but not receiving: these are small things on a big ground, and their shadows
+          are what place them on it, while shadows landing *on* them would cost a second pass
+          over the whole mesh to darken pixels a few metres across. */}
+      <mesh
+        geometry={geometry}
+        material={materials}
+        castShadow
+        onClick={(e) => {
+          e.stopPropagation();
+          const face = e.faceIndex;
+          if (face == null || scenery.pieceOfTriangle.length === 0) return;
+          const id = scenery.pieceOfTriangle[face];
+          setPicked((was) => (was === id ? null : id));
+        }}
+      />
+      {outline && (
+        <mesh geometry={outline} renderOrder={2}>
+          {/* Drawn over everything so a piece inside a crowd of others still reads. */}
+          <meshBasicMaterial
+            color="#ffb648"
+            wireframe
+            depthTest={false}
+            transparent
+            opacity={0.9}
+            toneMapped={false}
+          />
+        </mesh>
+      )}
+    </>
+  );
+}
+
+/** What each kind of fixture is drawn in. Distinct hues rather than a ramp: these are
+ *  categories, not a quantity. */
+const MARKER_COLOURS: Record<TrackPlacement["kind"], string> = {
+  marshal: "#f0a63c",
+  camera: "#5fb2f0",
+  sound: "#b98cf0",
+  prop: "#8de08a",
+};
+
+/** View units. Fixed rather than scaled from metres so a marker stays legible on a 200 m
+ *  supercross floor and a 1 km circuit alike. */
+const MARKER_HEIGHT = 0.11;
+const MARKER_RADIUS = 0.016;
+
+/**
+ * Pins for what the track places but ships no mesh for — marshal posts, TV cameras, crowd
+ * sound. Props are left out: their meshes are in the scenery, so a pin would double them.
+ */
+function PlacementMarkers({
+  placements,
+  terrain,
+}: {
+  placements: TrackPlacement[];
+  terrain: TrackTerrain;
+}) {
+  const pins = useMemo(() => {
+    const frame = viewFrame(terrain);
+    return placements
+      .filter((p) => p.kind !== "prop")
+      .map((p, i) => ({
+        key: `${p.kind}-${i}`,
+        colour: MARKER_COLOURS[p.kind] ?? MARKER_COLOURS.prop,
+        at: toView(frame, p.pos[0], p.pos[1], p.pos[2]),
+      }));
+  }, [placements, terrain]);
+
+  const invalidate = useThree((s) => s.invalidate);
+  useEffect(() => invalidate(), [pins, invalidate]);
+
+  return (
+    <group>
+      {pins.map(({ key, colour, at }) => (
+        // The stated position is where the thing sits on the ground, so the pin is raised by
+        // half its length to stand on that point rather than be centred through it.
+        <mesh key={key} position={[at[0], at[1] + MARKER_HEIGHT / 2, at[2]]}>
+          <cylinderGeometry args={[MARKER_RADIUS, MARKER_RADIUS, MARKER_HEIGHT, 6]} />
+          {/* Unlit: a marker is an annotation, not part of the scene, and shading it would
+              let it disappear into a hillside at the wrong sun angle. */}
+          <meshBasicMaterial color={colour} toneMapped={false} />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
 /** Legend for the orbit gestures — the canvas gives no other clue that it can be moved.
  *  Same wording and placement as the model viewer's, so the two read as one control. */
 function ControlsHint() {
@@ -438,10 +764,29 @@ interface TrackViewerProps {
   terrain: TrackTerrain | null;
   /** The track's overview map, when it ships one that covers the same ground. */
   overview?: TrackOverview | null;
+  /** What stands on the ground, when the track's `.map` carries any. */
+  scenery?: TrackScenery | null;
+  /** The surfaces that paint it. Arrives after the mesh — until then it draws plain. */
+  surfaces?: TrackSceneryTexture[];
+  /** Marshal posts, TV cameras and sound sources — pinned points with no mesh. */
+  placements?: TrackPlacement[];
+  /** Whether to draw either of the two above. */
+  showObjects?: boolean;
+  /** Told what a click on the scenery landed on, and when the selection clears. */
+  onPick?: (piece: PickedPiece | null) => void;
   className?: string;
 }
 
-export function TrackViewer({ terrain, overview = null, className }: TrackViewerProps) {
+export function TrackViewer({
+  terrain,
+  overview = null,
+  scenery = null,
+  surfaces = [],
+  placements = [],
+  showObjects = true,
+  onPick,
+  className,
+}: TrackViewerProps) {
   return (
     <div className={cn("relative", className)}>
       <ErrorBoundary compact label="track-viewer">
@@ -501,6 +846,17 @@ export function TrackViewer({ terrain, overview = null, className }: TrackViewer
           />
           <directionalLight position={[-6, 3, -5]} intensity={0.4} />
           {terrain && <TerrainMesh terrain={terrain} overview={overview} />}
+          {terrain && showObjects && scenery && (
+            <SceneryMesh
+              scenery={scenery}
+              surfaces={surfaces}
+              terrain={terrain}
+              onPick={onPick}
+            />
+          )}
+          {terrain && showObjects && placements.length > 0 && (
+            <PlacementMarkers placements={placements} terrain={terrain} />
+          )}
           <OrbitControls
             makeDefault
             enablePan

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -303,6 +303,53 @@ function toView(
  * Drawn unlit and behind everything. A dome is a picture of a sky, not a surface with one —
  * shading it by a light the sky itself is supposed to be casting reads as a grey lid.
  */
+/** A track's own colour, or a fallback, as something three.js can take. */
+function colourOf(c: [number, number, number] | null, fallback: string): THREE.Color {
+  return c ? new THREE.Color(c[0], c[1], c[2]) : new THREE.Color(fallback);
+}
+
+/**
+ * The haze a track states, thinned to something you can see a track through.
+ *
+ * A track's own density is written for a rider looking a few hundred metres down a straight;
+ * the viewer looks at all 550 m of the place at once, and at face value the far side vanishes.
+ * The colour and the *relative* thickness are the track's — a misty circuit still reads
+ * mistier than a dry one — while the depth it acts over is the view's.
+ */
+function TrackHaze({
+  backdrop,
+  terrain,
+}: {
+  backdrop: TrackBackdrop;
+  terrain: TrackTerrain;
+}) {
+  const scene = useThree((s) => s.scene);
+  const invalidate = useThree((s) => s.invalidate);
+  useEffect(() => {
+    const density = backdrop.fogDensity ?? 0;
+    if (density <= 0) {
+      scene.fog = null;
+      invalidate();
+      return;
+    }
+    const span = Math.max(terrain.width - 1, terrain.height - 1) * terrain.metresPerSample;
+    // Where the track's own haze would have swallowed a view this wide, hold it to a quarter
+    // of the way — enough to sit the far edge into the sky without hiding what is on it.
+    const swallow = 3 / Math.max(density, 1e-6); // metres to near-opaque at the stated density
+    const strength = Math.min(1, span / Math.max(swallow, 1));
+    const colour = colourOf(
+      backdrop.fogColour ?? backdrop.skyColour,
+      "#9fb0c4",
+    );
+    scene.fog = new THREE.Fog(colour, VIEW_SPAN * 0.55, VIEW_SPAN * (2.6 - strength * 1.2));
+    invalidate();
+    return () => {
+      scene.fog = null;
+    };
+  }, [backdrop, terrain, scene, invalidate]);
+  return null;
+}
+
 function Surrounds({
   backdrop,
   terrain,
@@ -390,14 +437,11 @@ function Surrounds({
   const invalidate = useThree((s) => s.invalidate);
   useEffect(() => invalidate(), [geometries, invalidate]);
 
-  const sky = backdrop.skyColour;
-  const skyHex = sky
-    ? new THREE.Color(sky[0], sky[1], sky[2])
-    : new THREE.Color("#8fa6c4");
-  const fog = backdrop.fogColour;
-  const landHex = fog
-    ? new THREE.Color(fog[0], fog[1], fog[2]).lerp(new THREE.Color("#ffffff"), 0.15)
-    : new THREE.Color("#93a2ad");
+  const skyHex = colourOf(backdrop.skyColour, "#8fa6c4");
+  const landHex = colourOf(backdrop.fogColour, "#93a2ad").lerp(
+    new THREE.Color("#ffffff"),
+    0.15,
+  );
 
   return (
     <group>
@@ -964,7 +1008,11 @@ export function TrackViewer({
             ]}
           />
           {terrain && backdrop && <Surrounds backdrop={backdrop} terrain={terrain} />}
-          <ambientLight intensity={0.5} />
+          {terrain && backdrop && <TrackHaze backdrop={backdrop} terrain={terrain} />}
+          <ambientLight
+            intensity={0.5}
+            color={colourOf(backdrop?.ambientColour ?? null, "#ffffff")}
+          />
           {/* Sky above, warm bounce below — enough to keep hollows from going solid black. */}
           <hemisphereLight args={[0xdfe8ff, 0x4a4133, 0.8]} />
           {/* Low and to one side: relief reads by its shadows, and an overhead key flattens
@@ -979,6 +1027,7 @@ export function TrackViewer({
                 : [8, 6, 4]
             }
             intensity={1.15}
+            color={colourOf(backdrop?.sunColour ?? null, "#ffffff")}
             castShadow
             // Four times the map over a box barely wider than the terrain: the tighter the
             // camera and the denser the map, the smaller a shadow texel is against the

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -292,6 +292,105 @@ function toView(
   ];
 }
 
+/** The inverse of [`toView`] — a point picked in the scene, back in world metres. */
+function fromView(
+  frame: ReturnType<typeof viewFrame>,
+  vx: number,
+  vy: number,
+  vz: number,
+): [number, number, number] {
+  return [
+    (frame.originX - vx) / frame.unitsPerMetre,
+    vy / frame.heightScale + frame.midHeight,
+    (vz + frame.originZ) / frame.unitsPerMetre,
+  ];
+}
+
+/** A prop put down on the track: a model, and where it goes in world metres. */
+export interface PlacedProp {
+  name: string;
+  pos: [number, number, number];
+  rot?: [number, number, number];
+  mesh: TrackScenery;
+}
+
+/**
+ * Props placed in the app, drawn where they will be written.
+ *
+ * Built in the terrain's frame like everything else, so what you see standing on the ground
+ * is where the `.scr` will put it.
+ */
+function PlacedProps({
+  props: placed,
+  terrain,
+}: {
+  props: PlacedProp[];
+  terrain: TrackTerrain;
+}) {
+  const geometries = useMemo(() => {
+    const frame = viewFrame(terrain);
+    return placed.map((p) => {
+      const [rx, ry, rz] = (p.rot ?? [0, 0, 0]).map((d) => (d * Math.PI) / 180);
+      const m = new THREE.Matrix4().makeRotationFromEuler(
+        new THREE.Euler(rx, ry, rz, "ZYX"),
+      );
+      const src = p.mesh.positions;
+      const out = new Float32Array(src.length);
+      const v = new THREE.Vector3();
+      for (let i = 0; i < src.length; i += 3) {
+        v.set(src[i], src[i + 1], src[i + 2]).applyMatrix4(m);
+        const [x, y, z] = toView(
+          frame,
+          v.x + p.pos[0],
+          v.y + p.pos[1],
+          v.z + p.pos[2],
+        );
+        out[i] = x;
+        out[i + 1] = y;
+        out[i + 2] = z;
+      }
+      const g = new THREE.BufferGeometry();
+      g.setAttribute("position", new THREE.BufferAttribute(out, 3));
+      // Rewound for the mirrored X, same as the scenery.
+      const src_i = p.mesh.indices;
+      const idx = new Uint32Array(src_i.length);
+      for (let t = 0; t < src_i.length; t += 3) {
+        idx[t] = src_i[t];
+        idx[t + 1] = src_i[t + 2];
+        idx[t + 2] = src_i[t + 1];
+      }
+      g.setIndex(new THREE.BufferAttribute(idx, 1));
+      g.computeVertexNormals();
+      g.computeBoundingSphere();
+      return g;
+    });
+  }, [placed, terrain]);
+
+  useEffect(
+    () => () => {
+      for (const g of geometries) g.dispose();
+    },
+    [geometries],
+  );
+  const invalidate = useThree((s) => s.invalidate);
+  useEffect(() => invalidate(), [geometries, invalidate]);
+
+  return (
+    <group>
+      {geometries.map((g, i) => (
+        <mesh key={`${placed[i].name}-${i}`} geometry={g} castShadow>
+          <meshStandardMaterial
+            color="#7fc8f0"
+            roughness={0.85}
+            metalness={0}
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
 function buildGeometry(terrain: TrackTerrain, textured: boolean): THREE.BufferGeometry {
   const { width, height, heights } = terrain;
 
@@ -393,9 +492,12 @@ function buildGeometry(terrain: TrackTerrain, textured: boolean): THREE.BufferGe
 function TerrainMesh({
   terrain,
   overview,
+  onGround,
 }: {
   terrain: TrackTerrain;
   overview: TrackOverview | null;
+  /** Told where a click landed, in world metres, when the viewer is placing something. */
+  onGround?: (at: [number, number, number]) => void;
 }) {
   const geometry = useMemo(() => buildGeometry(terrain, overview != null), [terrain, overview]);
 
@@ -432,7 +534,19 @@ function TerrainMesh({
     // Both cast and receive: the terrain is the only thing in the scene, so every shadow it
     // shows is its own — a jump face darkening the ground in front of it, a berm shading its
     // own inside. That self-shadowing is most of what makes the relief read as ground.
-    <mesh geometry={geometry} castShadow receiveShadow>
+    <mesh
+      geometry={geometry}
+      castShadow
+      receiveShadow
+      onClick={
+        onGround &&
+        ((e) => {
+          e.stopPropagation();
+          const frame = viewFrame(terrain);
+          onGround(fromView(frame, e.point.x, e.point.y, e.point.z));
+        })
+      }
+    >
       {/* Flat-ish and unshiny: dirt, and it keeps the relief legible rather than glared out.
           Vertex colours stay on with a texture, because three.js multiplies the two: the
           surface keeps the colours the track states while the cavity shading underneath gives
@@ -774,6 +888,10 @@ interface TrackViewerProps {
   showObjects?: boolean;
   /** Told what a click on the scenery landed on, and when the selection clears. */
   onPick?: (piece: PickedPiece | null) => void;
+  /** Props put down in the app, drawn where they will be written. */
+  placed?: PlacedProp[];
+  /** Told where a click on the ground landed, in world metres. Set only while placing. */
+  onGround?: (at: [number, number, number]) => void;
   className?: string;
 }
 
@@ -785,6 +903,8 @@ export function TrackViewer({
   placements = [],
   showObjects = true,
   onPick,
+  placed = [],
+  onGround,
   className,
 }: TrackViewerProps) {
   return (
@@ -845,7 +965,12 @@ export function TrackViewer({
             shadow-bias={-0.0006}
           />
           <directionalLight position={[-6, 3, -5]} intensity={0.4} />
-          {terrain && <TerrainMesh terrain={terrain} overview={overview} />}
+          {terrain && (
+            <TerrainMesh terrain={terrain} overview={overview} onGround={onGround} />
+          )}
+          {terrain && placed.length > 0 && (
+            <PlacedProps props={placed} terrain={terrain} />
+          )}
           {terrain && showObjects && scenery && (
             <SceneryMesh
               scenery={scenery}

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -337,11 +337,15 @@ function TrackHaze({
     // of the way — enough to sit the far edge into the sky without hiding what is on it.
     const swallow = 3 / Math.max(density, 1e-6); // metres to near-opaque at the stated density
     const strength = Math.min(1, span / Math.max(swallow, 1));
-    const colour = colourOf(
-      backdrop.fogColour ?? backdrop.skyColour,
-      "#9fb0c4",
+    const colour = colourOf(backdrop.fogColour ?? backdrop.skyColour, "#9fb0c4");
+    // Held to the far edge. Anything nearer and the haze sits on the track itself, which
+    // washes out the ground the view is about — the whole terrain is only ten units across,
+    // and the camera watches it from about thirteen.
+    scene.fog = new THREE.Fog(
+      colour,
+      VIEW_SPAN * 1.5,
+      VIEW_SPAN * (6.5 - strength * 2.0),
     );
-    scene.fog = new THREE.Fog(colour, VIEW_SPAN * 0.55, VIEW_SPAN * (2.6 - strength * 1.2));
     invalidate();
     return () => {
       scene.fog = null;
@@ -574,7 +578,10 @@ function buildGeometry(terrain: TrackTerrain, textured: boolean): THREE.BufferGe
 
 /** Metres one tile of the ground sheet covers. Small enough to read as grain up close,
  *  large enough not to shimmer when the whole track is in frame. */
-const GROUND_TILE_METRES = 6;
+const GROUND_TILE_METRES = 4;
+
+/** How far the grain is allowed to swing the ground's brightness. */
+const GROUND_STRENGTH = 0.5;
 
 function TerrainMesh({
   terrain,
@@ -634,6 +641,23 @@ function TerrainMesh({
     return Math.max(1, Math.round(span / GROUND_TILE_METRES));
   }, [terrain]);
 
+  // The sheet's own average brightness. Dividing by it is what makes this a *detail* layer:
+  // the grain then averages to no change at all, so a dark sheet adds texture instead of
+  // dragging the whole track darker — which is what tiling a dirt or grass sheet raw did.
+  const meanLuma = useMemo(() => {
+    if (!ground) return 1;
+    const px = ground.pixels;
+    let total = 0;
+    // Every sixteenth pixel: an average over a quarter of a million samples does not need
+    // all of them, and this runs on the main thread while a track is opening.
+    let n = 0;
+    for (let i = 0; i < px.length; i += 64) {
+      total += (px[i] * 0.299 + px[i + 1] * 0.587 + px[i + 2] * 0.114) / 255;
+      n += 1;
+    }
+    return n > 0 ? Math.max(total / n, 0.02) : 1;
+  }, [ground]);
+
   // A grid this size is megabytes of GPU buffers, and the viewer replaces it every time the
   // detail level changes — without this each one would be leaked.
   useEffect(() => () => geometry.dispose(), [geometry]);
@@ -661,7 +685,7 @@ function TerrainMesh({
           program it was built with — the terrain keeps its elevation ramp and never shows the
           picture at all. */}
       <meshStandardMaterial
-        key={`${texture ? "textured" : "plain"}-${detail ? "grain" : "flat"}`}
+        key={`${texture ? "textured" : "plain"}-${detail ? "grain" : "flat"}-${repeat}`}
         map={texture ?? undefined}
         vertexColors
         roughness={0.95}
@@ -670,12 +694,16 @@ function TerrainMesh({
           if (!detail) return;
           shader.uniforms.groundMap = { value: detail };
           shader.uniforms.groundRepeat = { value: repeat };
+          shader.uniforms.groundMean = { value: meanLuma };
+          shader.uniforms.groundStrength = { value: GROUND_STRENGTH };
           shader.fragmentShader = shader.fragmentShader
             .replace(
               "#include <common>",
               `#include <common>
                uniform sampler2D groundMap;
-               uniform float groundRepeat;`,
+               uniform float groundRepeat;
+               uniform float groundMean;
+               uniform float groundStrength;`,
             )
             // After the base colour is settled, modulate it about its own mean so the sheet
             // adds grain without shifting the ground's colour towards the sheet's.
@@ -685,7 +713,10 @@ function TerrainMesh({
                {
                  vec3 grain = texture2D(groundMap, vMapUv * groundRepeat).rgb;
                  float lum = dot(grain, vec3(0.299, 0.587, 0.114));
-                 diffuseColor.rgb *= mix(1.0, lum * 2.0, 0.45);
+                 // Around one, so the grain varies the ground without darkening it. Only the
+                 // sheet's luminance is used — its hue is its own surface's, not this one's.
+                 float f = clamp(lum / groundMean, 0.45, 1.9);
+                 diffuseColor.rgb *= mix(1.0, f, groundStrength);
                }`,
             );
         }}

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -5,6 +5,8 @@ import { Move, Rotate3d, ZoomIn } from "lucide-react";
 import * as THREE from "three";
 import { cn } from "@/lib/utils";
 import type {
+  TrackBackdrop,
+  TrackMeshArrays,
   TrackOverview,
   TrackPlacement,
   TrackScenery,
@@ -290,6 +292,142 @@ function toView(
     (wy - frame.midHeight) * frame.heightScale,
     wz * frame.unitsPerMetre - frame.originZ,
   ];
+}
+
+/**
+ * The sky overhead and the land beyond the track.
+ *
+ * Both are centred on the terrain rather than on their own origin: a track states them about
+ * its middle, and the viewer puts the middle of the terrain at the middle of the scene.
+ *
+ * Drawn unlit and behind everything. A dome is a picture of a sky, not a surface with one —
+ * shading it by a light the sky itself is supposed to be casting reads as a grey lid.
+ */
+function Surrounds({
+  backdrop,
+  terrain,
+}: {
+  backdrop: TrackBackdrop;
+  terrain: TrackTerrain;
+}) {
+  const geometries = useMemo(() => {
+    const frame = viewFrame(terrain);
+    // The middle of the terrain in world metres, which is where a track centres its sky.
+    const midX = ((terrain.width - 1) * terrain.metresPerSample) / 2;
+    const midZ = ((terrain.height - 1) * terrain.metresPerSample) / 2;
+    const build = (m: TrackMeshArrays, minReach = 0) => {
+      if (m.indices.length === 0) return null;
+      // Some domes are authored as a unit sphere for the game to scale, and drawn at their
+      // stated size they sit inside the terrain. Anything smaller than the track it is meant
+      // to enclose is blown up to enclose it.
+      let reach = 0;
+      for (let i = 0; i < m.positions.length; i += 3) {
+        const r = Math.hypot(m.positions[i], m.positions[i + 1], m.positions[i + 2]);
+        if (r > reach) reach = r;
+      }
+      const scale = minReach > 0 && reach > 1e-3 && reach < minReach ? minReach / reach : 1;
+      const out = new Float32Array(m.positions.length);
+      for (let i = 0; i < m.positions.length; i += 3) {
+        const [x, y, z] = toView(
+          frame,
+          m.positions[i] * scale + midX,
+          m.positions[i + 1] * scale,
+          m.positions[i + 2] * scale + midZ,
+        );
+        out[i] = x;
+        out[i + 1] = y;
+        out[i + 2] = z;
+      }
+      const g = new THREE.BufferGeometry();
+      g.setAttribute("position", new THREE.BufferAttribute(out, 3));
+      g.setAttribute("uv", new THREE.BufferAttribute(m.uvs, 2));
+      const idx = new Uint32Array(m.indices.length);
+      for (let t = 0; t < m.indices.length; t += 3) {
+        idx[t] = m.indices[t];
+        idx[t + 1] = m.indices[t + 2];
+        idx[t + 2] = m.indices[t + 1];
+      }
+      g.setIndex(new THREE.BufferAttribute(idx, 1));
+      g.computeBoundingSphere();
+      return g;
+    };
+    // The sky has to clear the terrain it covers; the backdrop is stated in real metres.
+    const span = Math.max(terrain.width - 1, terrain.height - 1) * terrain.metresPerSample;
+    const picture = (m: TrackMeshArrays) => {
+      if (!m.picture) return null;
+      const t = new THREE.DataTexture(
+        m.picture.pixels,
+        m.picture.width,
+        m.picture.height,
+        THREE.RGBAFormat,
+      );
+      t.colorSpace = THREE.SRGBColorSpace;
+      t.wrapS = THREE.RepeatWrapping;
+      t.wrapT = THREE.ClampToEdgeWrapping;
+      t.minFilter = THREE.LinearMipmapLinearFilter;
+      t.magFilter = THREE.LinearFilter;
+      t.generateMipmaps = true;
+      t.needsUpdate = true;
+      return t;
+    };
+    return {
+      sky: build(backdrop.sky, span * 1.6),
+      land: build(backdrop.backdrop),
+      skyMap: picture(backdrop.sky),
+      landMap: picture(backdrop.backdrop),
+    };
+  }, [backdrop, terrain]);
+
+  useEffect(
+    () => () => {
+      geometries.sky?.dispose();
+      geometries.land?.dispose();
+      geometries.skyMap?.dispose();
+      geometries.landMap?.dispose();
+    },
+    [geometries],
+  );
+  const invalidate = useThree((s) => s.invalidate);
+  useEffect(() => invalidate(), [geometries, invalidate]);
+
+  const sky = backdrop.skyColour;
+  const skyHex = sky
+    ? new THREE.Color(sky[0], sky[1], sky[2])
+    : new THREE.Color("#8fa6c4");
+  const fog = backdrop.fogColour;
+  const landHex = fog
+    ? new THREE.Color(fog[0], fog[1], fog[2]).lerp(new THREE.Color("#ffffff"), 0.15)
+    : new THREE.Color("#93a2ad");
+
+  return (
+    <group>
+      {geometries.sky && (
+        // Never occludes: the dome is the far wall of the scene, so it draws first and takes
+        // no part in depth.
+        <mesh geometry={geometries.sky} renderOrder={-2}>
+          <meshBasicMaterial
+            key={geometries.skyMap ? "sky-picture" : "sky-plain"}
+            map={geometries.skyMap ?? undefined}
+            color={geometries.skyMap ? "#ffffff" : skyHex}
+            side={THREE.BackSide}
+            depthWrite={false}
+            toneMapped={false}
+          />
+        </mesh>
+      )}
+      {geometries.land && (
+        <mesh geometry={geometries.land} renderOrder={-1}>
+          <meshBasicMaterial
+            key={geometries.landMap ? "land-picture" : "land-plain"}
+            map={geometries.landMap ?? undefined}
+            color={geometries.landMap ? "#ffffff" : landHex}
+            side={THREE.DoubleSide}
+            toneMapped={false}
+          />
+        </mesh>
+      )}
+    </group>
+  );
 }
 
 function buildGeometry(terrain: TrackTerrain, textured: boolean): THREE.BufferGeometry {
@@ -772,6 +910,8 @@ interface TrackViewerProps {
   placements?: TrackPlacement[];
   /** Whether to draw either of the two above. */
   showObjects?: boolean;
+  /** The sky and land a track wraps itself in, and the light it states. */
+  backdrop?: TrackBackdrop | null;
   /** Told what a click on the scenery landed on, and when the selection clears. */
   onPick?: (piece: PickedPiece | null) => void;
   className?: string;
@@ -784,6 +924,7 @@ export function TrackViewer({
   surfaces = [],
   placements = [],
   showObjects = true,
+  backdrop = null,
   onPick,
   className,
 }: TrackViewerProps) {
@@ -812,7 +953,17 @@ export function TrackViewer({
             gl.domElement.addEventListener("webglcontextrestored", () => invalidate(), false);
           }}
         >
-          <color attach="background" args={["#0e0f13"]} />
+          {/* The track's own sky behind everything; the viewer's own dark ground only when a
+              track ships none. */}
+          <color
+            attach="background"
+            args={[
+              backdrop?.skyColour
+                ? `rgb(${backdrop.skyColour.map((c) => Math.round(c * 255)).join(",")})`
+                : "#0e0f13",
+            ]}
+          />
+          {terrain && backdrop && <Surrounds backdrop={backdrop} terrain={terrain} />}
           <ambientLight intensity={0.5} />
           {/* Sky above, warm bounce below — enough to keep hollows from going solid black. */}
           <hemisphereLight args={[0xdfe8ff, 0x4a4133, 0.8]} />
@@ -822,7 +973,11 @@ export function TrackViewer({
               The shadow camera is bounded to the terrain's own span, which is fixed however
               big the real track is, so the whole map fits one map at full precision. */}
           <directionalLight
-            position={[8, 6, 4]}
+            position={
+              backdrop?.sun
+                ? [backdrop.sun[0], Math.max(backdrop.sun[1], 1), backdrop.sun[2]]
+                : [8, 6, 4]
+            }
             intensity={1.15}
             castShadow
             // Four times the map over a box barely wider than the terrain: the tighter the

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -292,105 +292,6 @@ function toView(
   ];
 }
 
-/** The inverse of [`toView`] — a point picked in the scene, back in world metres. */
-function fromView(
-  frame: ReturnType<typeof viewFrame>,
-  vx: number,
-  vy: number,
-  vz: number,
-): [number, number, number] {
-  return [
-    (frame.originX - vx) / frame.unitsPerMetre,
-    vy / frame.heightScale + frame.midHeight,
-    (vz + frame.originZ) / frame.unitsPerMetre,
-  ];
-}
-
-/** A prop put down on the track: a model, and where it goes in world metres. */
-export interface PlacedProp {
-  name: string;
-  pos: [number, number, number];
-  rot?: [number, number, number];
-  mesh: TrackScenery;
-}
-
-/**
- * Props placed in the app, drawn where they will be written.
- *
- * Built in the terrain's frame like everything else, so what you see standing on the ground
- * is where the `.scr` will put it.
- */
-function PlacedProps({
-  props: placed,
-  terrain,
-}: {
-  props: PlacedProp[];
-  terrain: TrackTerrain;
-}) {
-  const geometries = useMemo(() => {
-    const frame = viewFrame(terrain);
-    return placed.map((p) => {
-      const [rx, ry, rz] = (p.rot ?? [0, 0, 0]).map((d) => (d * Math.PI) / 180);
-      const m = new THREE.Matrix4().makeRotationFromEuler(
-        new THREE.Euler(rx, ry, rz, "ZYX"),
-      );
-      const src = p.mesh.positions;
-      const out = new Float32Array(src.length);
-      const v = new THREE.Vector3();
-      for (let i = 0; i < src.length; i += 3) {
-        v.set(src[i], src[i + 1], src[i + 2]).applyMatrix4(m);
-        const [x, y, z] = toView(
-          frame,
-          v.x + p.pos[0],
-          v.y + p.pos[1],
-          v.z + p.pos[2],
-        );
-        out[i] = x;
-        out[i + 1] = y;
-        out[i + 2] = z;
-      }
-      const g = new THREE.BufferGeometry();
-      g.setAttribute("position", new THREE.BufferAttribute(out, 3));
-      // Rewound for the mirrored X, same as the scenery.
-      const src_i = p.mesh.indices;
-      const idx = new Uint32Array(src_i.length);
-      for (let t = 0; t < src_i.length; t += 3) {
-        idx[t] = src_i[t];
-        idx[t + 1] = src_i[t + 2];
-        idx[t + 2] = src_i[t + 1];
-      }
-      g.setIndex(new THREE.BufferAttribute(idx, 1));
-      g.computeVertexNormals();
-      g.computeBoundingSphere();
-      return g;
-    });
-  }, [placed, terrain]);
-
-  useEffect(
-    () => () => {
-      for (const g of geometries) g.dispose();
-    },
-    [geometries],
-  );
-  const invalidate = useThree((s) => s.invalidate);
-  useEffect(() => invalidate(), [geometries, invalidate]);
-
-  return (
-    <group>
-      {geometries.map((g, i) => (
-        <mesh key={`${placed[i].name}-${i}`} geometry={g} castShadow>
-          <meshStandardMaterial
-            color="#7fc8f0"
-            roughness={0.85}
-            metalness={0}
-            side={THREE.DoubleSide}
-          />
-        </mesh>
-      ))}
-    </group>
-  );
-}
-
 function buildGeometry(terrain: TrackTerrain, textured: boolean): THREE.BufferGeometry {
   const { width, height, heights } = terrain;
 
@@ -492,12 +393,9 @@ function buildGeometry(terrain: TrackTerrain, textured: boolean): THREE.BufferGe
 function TerrainMesh({
   terrain,
   overview,
-  onGround,
 }: {
   terrain: TrackTerrain;
   overview: TrackOverview | null;
-  /** Told where a click landed, in world metres, when the viewer is placing something. */
-  onGround?: (at: [number, number, number]) => void;
 }) {
   const geometry = useMemo(() => buildGeometry(terrain, overview != null), [terrain, overview]);
 
@@ -534,19 +432,7 @@ function TerrainMesh({
     // Both cast and receive: the terrain is the only thing in the scene, so every shadow it
     // shows is its own — a jump face darkening the ground in front of it, a berm shading its
     // own inside. That self-shadowing is most of what makes the relief read as ground.
-    <mesh
-      geometry={geometry}
-      castShadow
-      receiveShadow
-      onClick={
-        onGround &&
-        ((e) => {
-          e.stopPropagation();
-          const frame = viewFrame(terrain);
-          onGround(fromView(frame, e.point.x, e.point.y, e.point.z));
-        })
-      }
-    >
+    <mesh geometry={geometry} castShadow receiveShadow>
       {/* Flat-ish and unshiny: dirt, and it keeps the relief legible rather than glared out.
           Vertex colours stay on with a texture, because three.js multiplies the two: the
           surface keeps the colours the track states while the cavity shading underneath gives
@@ -888,10 +774,6 @@ interface TrackViewerProps {
   showObjects?: boolean;
   /** Told what a click on the scenery landed on, and when the selection clears. */
   onPick?: (piece: PickedPiece | null) => void;
-  /** Props put down in the app, drawn where they will be written. */
-  placed?: PlacedProp[];
-  /** Told where a click on the ground landed, in world metres. Set only while placing. */
-  onGround?: (at: [number, number, number]) => void;
   className?: string;
 }
 
@@ -903,8 +785,6 @@ export function TrackViewer({
   placements = [],
   showObjects = true,
   onPick,
-  placed = [],
-  onGround,
   className,
 }: TrackViewerProps) {
   return (
@@ -965,12 +845,7 @@ export function TrackViewer({
             shadow-bias={-0.0006}
           />
           <directionalLight position={[-6, 3, -5]} intensity={0.4} />
-          {terrain && (
-            <TerrainMesh terrain={terrain} overview={overview} onGround={onGround} />
-          )}
-          {terrain && placed.length > 0 && (
-            <PlacedProps props={placed} terrain={terrain} />
-          )}
+          {terrain && <TerrainMesh terrain={terrain} overview={overview} />}
           {terrain && showObjects && scenery && (
             <SceneryMesh
               scenery={scenery}

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -594,7 +594,10 @@ function TerrainMesh({
   /** A tiling sheet of the track's own ground, multiplied in for close-up detail. */
   ground: TrackGround | null;
 }) {
-  const geometry = useMemo(() => buildGeometry(terrain, overview != null), [terrain, overview]);
+  // A track with no surface data of its own still has ground: its sheet says what colour that
+  // is, so the elevation ramp is only reached for when a track states neither.
+  const tinted = overview != null || ground != null;
+  const geometry = useMemo(() => buildGeometry(terrain, tinted), [terrain, tinted]);
 
   // Built once per picture and handed to the GPU as-is. `sRGB` because it's artwork rather
   // than measurements: skipping that draws the whole track washed out.
@@ -660,19 +663,36 @@ function TerrainMesh({
   // The sheet's own average brightness. Dividing by it is what makes this a *detail* layer:
   // the grain then averages to no change at all, so a dark sheet adds texture instead of
   // dragging the whole track darker — which is what tiling a dirt or grass sheet raw did.
-  const meanLuma = useMemo(() => {
-    if (!ground) return 1;
+  // Its average colour too, which is what a track with no surface data of its own is drawn
+  // in: the ramp reported height as if it were material, so a sand circuit came out banded
+  // green-to-white. One honest colour beats a legend nobody asked for.
+  const { meanLuma, meanHex } = useMemo(() => {
+    if (!ground) return { meanLuma: 1, meanHex: "#ffffff" };
     const px = ground.colour.pixels;
     let total = 0;
+    const rgb = [0, 0, 0];
     // Every sixteenth pixel: an average over a quarter of a million samples does not need
     // all of them, and this runs on the main thread while a track is opening.
     let n = 0;
     for (let i = 0; i < px.length; i += 64) {
       total += (px[i] * 0.299 + px[i + 1] * 0.587 + px[i + 2] * 0.114) / 255;
+      for (let k = 0; k < 3; k += 1) rgb[k] += px[i + k];
       n += 1;
     }
-    return n > 0 ? Math.max(total / n, 0.02) : 1;
+    if (n === 0) return { meanLuma: 1, meanHex: "#ffffff" };
+    // Lifted towards white: the sheet's average is the colour of ground in shade, and the
+    // terrain is lit on top of it, so handing over the average raw draws the track too dark.
+    const c = new THREE.Color(
+      rgb[0] / n / 255,
+      rgb[1] / n / 255,
+      rgb[2] / n / 255,
+    ).convertSRGBToLinear();
+    return {
+      meanLuma: Math.max(total / n, 0.02),
+      meanHex: `#${c.lerp(new THREE.Color("#ffffff"), 0.35).getHexString()}`,
+    };
   }, [ground]);
+  const tint = overview ? "#ffffff" : meanHex;
 
   // A grid this size is megabytes of GPU buffers, and the viewer replaces it every time the
   // detail level changes — without this each one would be leaked.
@@ -710,6 +730,7 @@ function TerrainMesh({
         key={`${texture ? "textured" : "plain"}-${detail ? "grain" : "flat"}-${
           relief ? "relief" : "smooth"
         }-${repeat}`}
+        color={tint}
         map={texture ?? undefined}
         normalMap={relief ?? undefined}
         // Gentle: this is one ground sheet standing in for every surface a track has, so it

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -572,12 +572,19 @@ function buildGeometry(terrain: TrackTerrain, textured: boolean): THREE.BufferGe
   return geometry;
 }
 
+/** Metres one tile of the ground sheet covers. Small enough to read as grain up close,
+ *  large enough not to shimmer when the whole track is in frame. */
+const GROUND_TILE_METRES = 6;
+
 function TerrainMesh({
   terrain,
   overview,
+  ground,
 }: {
   terrain: TrackTerrain;
   overview: TrackOverview | null;
+  /** A tiling sheet of the track's own ground, multiplied in for close-up detail. */
+  ground: TrackSceneryTexture | null;
 }) {
   const geometry = useMemo(() => buildGeometry(terrain, overview != null), [terrain, overview]);
 
@@ -600,9 +607,37 @@ function TerrainMesh({
     return t;
   }, [overview]);
 
+  // The detail sheet, tiled. The surface picture says what the ground *is* at a third of a
+  // metre; this says what it is made of, at whatever resolution you care to look.
+  const detail = useMemo(() => {
+    if (!ground) return null;
+    const t = new THREE.DataTexture(
+      ground.pixels,
+      ground.width,
+      ground.height,
+      THREE.RGBAFormat,
+    );
+    t.colorSpace = THREE.SRGBColorSpace;
+    t.wrapS = THREE.RepeatWrapping;
+    t.wrapT = THREE.RepeatWrapping;
+    t.minFilter = THREE.LinearMipmapLinearFilter;
+    t.magFilter = THREE.LinearFilter;
+    t.generateMipmaps = true;
+    t.anisotropy = 8;
+    t.needsUpdate = true;
+    return t;
+  }, [ground]);
+
+  // How many times the sheet repeats across the whole grid.
+  const repeat = useMemo(() => {
+    const span = Math.max(terrain.width - 1, terrain.height - 1) * terrain.metresPerSample;
+    return Math.max(1, Math.round(span / GROUND_TILE_METRES));
+  }, [terrain]);
+
   // A grid this size is megabytes of GPU buffers, and the viewer replaces it every time the
   // detail level changes — without this each one would be leaked.
   useEffect(() => () => geometry.dispose(), [geometry]);
+  useEffect(() => () => detail?.dispose(), [detail]);
   useEffect(() => () => texture?.dispose(), [texture]);
 
   // The canvas only draws when asked, and the map arrives well after the terrain settled —
@@ -626,11 +661,34 @@ function TerrainMesh({
           program it was built with — the terrain keeps its elevation ramp and never shows the
           picture at all. */}
       <meshStandardMaterial
-        key={texture ? "textured" : "plain"}
+        key={`${texture ? "textured" : "plain"}-${detail ? "grain" : "flat"}`}
         map={texture ?? undefined}
         vertexColors
         roughness={0.95}
         metalness={0}
+        onBeforeCompile={(shader) => {
+          if (!detail) return;
+          shader.uniforms.groundMap = { value: detail };
+          shader.uniforms.groundRepeat = { value: repeat };
+          shader.fragmentShader = shader.fragmentShader
+            .replace(
+              "#include <common>",
+              `#include <common>
+               uniform sampler2D groundMap;
+               uniform float groundRepeat;`,
+            )
+            // After the base colour is settled, modulate it about its own mean so the sheet
+            // adds grain without shifting the ground's colour towards the sheet's.
+            .replace(
+              "#include <color_fragment>",
+              `#include <color_fragment>
+               {
+                 vec3 grain = texture2D(groundMap, vMapUv * groundRepeat).rgb;
+                 float lum = dot(grain, vec3(0.299, 0.587, 0.114));
+                 diffuseColor.rgb *= mix(1.0, lum * 2.0, 0.45);
+               }`,
+            );
+        }}
       />
     </mesh>
   );
@@ -956,6 +1014,8 @@ interface TrackViewerProps {
   showObjects?: boolean;
   /** The sky and land a track wraps itself in, and the light it states. */
   backdrop?: TrackBackdrop | null;
+  /** A tiling sheet of the track's own ground, for detail closer than its data carries. */
+  ground?: TrackSceneryTexture | null;
   /** Told what a click on the scenery landed on, and when the selection clears. */
   onPick?: (piece: PickedPiece | null) => void;
   className?: string;
@@ -969,6 +1029,7 @@ export function TrackViewer({
   placements = [],
   showObjects = true,
   backdrop = null,
+  ground = null,
   onPick,
   className,
 }: TrackViewerProps) {
@@ -1049,7 +1110,9 @@ export function TrackViewer({
             shadow-bias={-0.0006}
           />
           <directionalLight position={[-6, 3, -5]} intensity={0.4} />
-          {terrain && <TerrainMesh terrain={terrain} overview={overview} />}
+          {terrain && (
+            <TerrainMesh terrain={terrain} overview={overview} ground={ground} />
+          )}
           {terrain && showObjects && scenery && (
             <SceneryMesh
               scenery={scenery}

--- a/src/Components/Viewer/TrackViewerDialog.tsx
+++ b/src/Components/Viewer/TrackViewerDialog.tsx
@@ -2,18 +2,15 @@ import { useEffect, useState } from "react";
 import { Boxes, Check, Copy, Loader2, Mountain, X } from "lucide-react";
 import { Dialog, DialogClose, DialogContent } from "../ui/dialog";
 import { Button } from "@/Components/ui/button";
-import { TrackViewer, type PickedPiece, type PlacedProp } from "./TrackViewer";
+import { TrackViewer, type PickedPiece } from "./TrackViewer";
 import {
   diagnoseTrack,
   loadTrackOverview,
-  loadTrackProp,
   loadTrackScenery,
   loadTrackSurfaces,
   loadTrackTerrain,
   readTrackInfo,
-  readTrackPlaceable,
   readTrackPlacements,
-  saveTrackProps,
 } from "../../api/tracks";
 import type {
   TrackInfo,
@@ -24,7 +21,6 @@ import type {
   TrackTerrain,
 } from "../../types";
 import { formatLength } from "../../lib/mods";
-import { cn } from "@/lib/utils";
 import { useT } from "../../i18n/context";
 
 /**
@@ -79,11 +75,9 @@ export function TrackViewerDialog({
   const [painting, setPainting] = useState(false);
   // What the last click on the scenery landed on, so the panel can name it.
   const [picked, setPicked] = useState<PickedPiece | null>(null);
-  // The models this track can place, the one armed to go down next, and what's been put down.
-  const [models, setModels] = useState<string[]>([]);
-  const [arming, setArming] = useState<string | null>(null);
-  const [placed, setPlaced] = useState<PlacedProp[]>([]);
-  const [saved, setSaved] = useState<string | null>(null);
+  // A scenery pass that fails has to say so. Swallowing it leaves a track looking as though
+  // it simply has none, which is a different fact entirely.
+  const [sceneryError, setSceneryError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   // Only fetched when a track fails, and only when asked for — it re-reads the archive.
   const [diagnosis, setDiagnosis] = useState<string | null>(null);
@@ -99,10 +93,7 @@ export function TrackViewerDialog({
     setScenery(null);
     setSurfaces([]);
     setPicked(null);
-    setModels([]);
-    setArming(null);
-    setPlaced([]);
-    setSaved(null);
+    setSceneryError(null);
     setPlacements([]);
     setError(null);
     setDiagnosis(null);
@@ -121,12 +112,6 @@ export function TrackViewerDialog({
       .then((p) => alive && setPlacements(p))
       .catch(() => {});
 
-    // What this track can place. A `.scr` names a model by file, so the track's own are the
-    // ones that need nothing shipped beside them.
-    readTrackPlaceable(path)
-      .then((m) => alive && setModels(m))
-      .catch(() => {});
-
     void (async () => {
       try {
         // Started before anything is awaited, so the archive read it needs overlaps the
@@ -134,7 +119,10 @@ export function TrackViewerDialog({
         const surface = loadTrackOverview(path, OVERVIEW_DIM).catch(() => null);
         // The heaviest read in the view — most of a track's bulk is its `.map` — so it is
         // started here and settled last, under a terrain that is already up.
-        const objects = loadTrackScenery(path).catch(() => null);
+        const objects = loadTrackScenery(path).catch((e) => {
+          setSceneryError(e instanceof Error ? e.message : String(e));
+          return null;
+        });
 
         const coarse = await loadTrackTerrain(path, COARSE_DIM);
         if (!alive) return;
@@ -159,7 +147,9 @@ export function TrackViewerDialog({
           setPainting(true);
           loadTrackSurfaces(path)
             .then((t) => alive && setSurfaces(t))
-            .catch(() => {})
+            .catch((e) =>
+              setSceneryError(e instanceof Error ? e.message : String(e)),
+            )
             .finally(() => alive && setPainting(false));
         });
         // Only an upgrade: a backend that capped the master below the fine size would
@@ -282,18 +272,6 @@ export function TrackViewerDialog({
               placements={placements}
               showObjects={showObjects}
               onPick={setPicked}
-              placed={placed}
-              onGround={
-                arming
-                  ? (at) => {
-                      void loadTrackProp(path, arming).then((mesh) => {
-                        if (!mesh) return;
-                        setPlaced((was) => [...was, { name: arming, pos: at, mesh }]);
-                        setSaved(null);
-                      });
-                    }
-                  : undefined
-              }
               className="absolute inset-0"
             />
             {loading && !terrain && (
@@ -378,82 +356,10 @@ export function TrackViewerDialog({
               ))}
             </dl>
 
-            {/* Placing things. A `.scr` states a prop by model name and position, and the
-                game reads it at load — so what goes down here is what the track will have. */}
-            {models.length > 0 && (
-              <div className="mt-4 border-t border-border pt-3">
-                <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.9px] text-faint">
-                  {t("trackViewer.place")}
-                </p>
-                <div className="flex flex-wrap gap-1.5">
-                  {models.map((m) => (
-                    <button
-                      key={m}
-                      type="button"
-                      onClick={() => setArming((was) => (was === m ? null : m))}
-                      className={cn(
-                        "rounded border px-2 py-1 text-[11px] transition-colors",
-                        arming === m
-                          ? "border-primary bg-primary/15 text-foreground"
-                          : "border-border text-muted-foreground hover:text-foreground",
-                      )}
-                    >
-                      {m.replace(/\.edf$/i, "")}
-                    </button>
-                  ))}
-                </div>
-                <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">
-                  {arming ? t("trackViewer.placeHint") : t("trackViewer.placePick")}
-                </p>
-                {placed.length > 0 && (
-                  <div className="mt-3 flex flex-col gap-2">
-                    <p className="text-[11px] text-foreground">
-                      {t("trackViewer.placedCount", { count: String(placed.length) })}
-                    </p>
-                    <div className="flex gap-2">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="h-7 text-[11px]"
-                        onClick={() => {
-                          const target = `${path.replace(/\.pkz$/i, "")}.scr`;
-                          void saveTrackProps(
-                            target,
-                            placed.map((p) => ({
-                              kind: "prop" as const,
-                              name: p.name,
-                              pos: p.pos,
-                              heading: null,
-                              rot: p.rot ?? null,
-                            })),
-                            true,
-                          )
-                            .then(() => setSaved(target))
-                            .catch((e) =>
-                              setSaved(e instanceof Error ? e.message : String(e)),
-                            );
-                        }}
-                      >
-                        {t("trackViewer.saveProps")}
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 text-[11px]"
-                        onClick={() => {
-                          setPlaced([]);
-                          setSaved(null);
-                        }}
-                      >
-                        {t("common.clear")}
-                      </Button>
-                    </div>
-                    {saved && (
-                      <p className="break-all text-[11px] text-muted-foreground">{saved}</p>
-                    )}
-                  </div>
-                )}
-              </div>
+            {sceneryError && (
+              <p className="mt-4 border-t border-border pt-3 text-[11px] leading-relaxed text-destructive">
+                {sceneryError}
+              </p>
             )}
 
             {/* The height file has no documented layout, so what's on screen was worked out

--- a/src/Components/Viewer/TrackViewerDialog.tsx
+++ b/src/Components/Viewer/TrackViewerDialog.tsx
@@ -7,6 +7,7 @@ import {
   diagnoseTrack,
   loadTrackOverview,
   loadTrackBackdrop,
+  loadTrackGround,
   loadTrackScenery,
   loadTrackSurfaces,
   loadTrackTerrain,
@@ -66,6 +67,7 @@ export function TrackViewerDialog({
   const [scenery, setScenery] = useState<TrackScenery | null>(null);
   const [surfaces, setSurfaces] = useState<TrackSceneryTexture[]>([]);
   const [backdrop, setBackdrop] = useState<TrackBackdrop | null>(null);
+  const [ground, setGround] = useState<TrackSceneryTexture | null>(null);
   const [placements, setPlacements] = useState<TrackPlacement[]>([]);
   // On by default: the scenery is the difference between a shape and a place, and a track
   // that carries none simply has nothing to switch off.
@@ -96,6 +98,7 @@ export function TrackViewerDialog({
     setScenery(null);
     setSurfaces([]);
     setBackdrop(null);
+    setGround(null);
     setPicked(null);
     setSceneryError(null);
     setPlacements([]);
@@ -120,6 +123,12 @@ export function TrackViewerDialog({
     // the scenery — a track should never be on screen with nothing above it.
     loadTrackBackdrop(path)
       .then((b) => alive && setBackdrop(b))
+      .catch(() => {});
+
+    // One small sheet, so it lands early and the ground has grain from the first frame the
+    // terrain is up.
+    loadTrackGround(path)
+      .then((g) => alive && setGround(g))
       .catch(() => {});
 
     void (async () => {
@@ -280,6 +289,7 @@ export function TrackViewerDialog({
               scenery={scenery}
               surfaces={surfaces}
               backdrop={backdrop}
+              ground={ground}
               placements={placements}
               showObjects={showObjects}
               onPick={setPicked}

--- a/src/Components/Viewer/TrackViewerDialog.tsx
+++ b/src/Components/Viewer/TrackViewerDialog.tsx
@@ -19,6 +19,7 @@ import type {
   TrackOverview,
   TrackPlacement,
   TrackBackdrop,
+  TrackGround,
   TrackScenery,
   TrackSceneryTexture,
   TrackTerrain,
@@ -67,7 +68,7 @@ export function TrackViewerDialog({
   const [scenery, setScenery] = useState<TrackScenery | null>(null);
   const [surfaces, setSurfaces] = useState<TrackSceneryTexture[]>([]);
   const [backdrop, setBackdrop] = useState<TrackBackdrop | null>(null);
-  const [ground, setGround] = useState<TrackSceneryTexture | null>(null);
+  const [ground, setGround] = useState<TrackGround | null>(null);
   const [placements, setPlacements] = useState<TrackPlacement[]>([]);
   // On by default: the scenery is the difference between a shape and a place, and a track
   // that carries none simply has nothing to switch off.

--- a/src/Components/Viewer/TrackViewerDialog.tsx
+++ b/src/Components/Viewer/TrackViewerDialog.tsx
@@ -6,6 +6,7 @@ import { TrackViewer, type PickedPiece } from "./TrackViewer";
 import {
   diagnoseTrack,
   loadTrackOverview,
+  loadTrackBackdrop,
   loadTrackScenery,
   loadTrackSurfaces,
   loadTrackTerrain,
@@ -16,6 +17,7 @@ import type {
   TrackInfo,
   TrackOverview,
   TrackPlacement,
+  TrackBackdrop,
   TrackScenery,
   TrackSceneryTexture,
   TrackTerrain,
@@ -63,6 +65,7 @@ export function TrackViewerDialog({
   const [overview, setOverview] = useState<TrackOverview | null>(null);
   const [scenery, setScenery] = useState<TrackScenery | null>(null);
   const [surfaces, setSurfaces] = useState<TrackSceneryTexture[]>([]);
+  const [backdrop, setBackdrop] = useState<TrackBackdrop | null>(null);
   const [placements, setPlacements] = useState<TrackPlacement[]>([]);
   // On by default: the scenery is the difference between a shape and a place, and a track
   // that carries none simply has nothing to switch off.
@@ -92,6 +95,7 @@ export function TrackViewerDialog({
     setOverview(null);
     setScenery(null);
     setSurfaces([]);
+    setBackdrop(null);
     setPicked(null);
     setSceneryError(null);
     setPlacements([]);
@@ -110,6 +114,12 @@ export function TrackViewerDialog({
     // are up before the scenery they stand among.
     readTrackPlacements(path)
       .then((p) => alive && setPlacements(p))
+      .catch(() => {});
+
+    // The sky is a few hundred triangles, so it lands with the first pass rather than after
+    // the scenery — a track should never be on screen with nothing above it.
+    loadTrackBackdrop(path)
+      .then((b) => alive && setBackdrop(b))
       .catch(() => {});
 
     void (async () => {
@@ -269,6 +279,7 @@ export function TrackViewerDialog({
               overview={overview}
               scenery={scenery}
               surfaces={surfaces}
+              backdrop={backdrop}
               placements={placements}
               showObjects={showObjects}
               onPick={setPicked}

--- a/src/Components/Viewer/TrackViewerDialog.tsx
+++ b/src/Components/Viewer/TrackViewerDialog.tsx
@@ -2,15 +2,18 @@ import { useEffect, useState } from "react";
 import { Boxes, Check, Copy, Loader2, Mountain, X } from "lucide-react";
 import { Dialog, DialogClose, DialogContent } from "../ui/dialog";
 import { Button } from "@/Components/ui/button";
-import { TrackViewer, type PickedPiece } from "./TrackViewer";
+import { TrackViewer, type PickedPiece, type PlacedProp } from "./TrackViewer";
 import {
   diagnoseTrack,
   loadTrackOverview,
+  loadTrackProp,
   loadTrackScenery,
   loadTrackSurfaces,
   loadTrackTerrain,
   readTrackInfo,
+  readTrackPlaceable,
   readTrackPlacements,
+  saveTrackProps,
 } from "../../api/tracks";
 import type {
   TrackInfo,
@@ -21,6 +24,7 @@ import type {
   TrackTerrain,
 } from "../../types";
 import { formatLength } from "../../lib/mods";
+import { cn } from "@/lib/utils";
 import { useT } from "../../i18n/context";
 
 /**
@@ -75,6 +79,11 @@ export function TrackViewerDialog({
   const [painting, setPainting] = useState(false);
   // What the last click on the scenery landed on, so the panel can name it.
   const [picked, setPicked] = useState<PickedPiece | null>(null);
+  // The models this track can place, the one armed to go down next, and what's been put down.
+  const [models, setModels] = useState<string[]>([]);
+  const [arming, setArming] = useState<string | null>(null);
+  const [placed, setPlaced] = useState<PlacedProp[]>([]);
+  const [saved, setSaved] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   // Only fetched when a track fails, and only when asked for — it re-reads the archive.
   const [diagnosis, setDiagnosis] = useState<string | null>(null);
@@ -90,6 +99,10 @@ export function TrackViewerDialog({
     setScenery(null);
     setSurfaces([]);
     setPicked(null);
+    setModels([]);
+    setArming(null);
+    setPlaced([]);
+    setSaved(null);
     setPlacements([]);
     setError(null);
     setDiagnosis(null);
@@ -106,6 +119,12 @@ export function TrackViewerDialog({
     // are up before the scenery they stand among.
     readTrackPlacements(path)
       .then((p) => alive && setPlacements(p))
+      .catch(() => {});
+
+    // What this track can place. A `.scr` names a model by file, so the track's own are the
+    // ones that need nothing shipped beside them.
+    readTrackPlaceable(path)
+      .then((m) => alive && setModels(m))
       .catch(() => {});
 
     void (async () => {
@@ -263,6 +282,18 @@ export function TrackViewerDialog({
               placements={placements}
               showObjects={showObjects}
               onPick={setPicked}
+              placed={placed}
+              onGround={
+                arming
+                  ? (at) => {
+                      void loadTrackProp(path, arming).then((mesh) => {
+                        if (!mesh) return;
+                        setPlaced((was) => [...was, { name: arming, pos: at, mesh }]);
+                        setSaved(null);
+                      });
+                    }
+                  : undefined
+              }
               className="absolute inset-0"
             />
             {loading && !terrain && (
@@ -346,6 +377,84 @@ export function TrackViewerDialog({
                 </div>
               ))}
             </dl>
+
+            {/* Placing things. A `.scr` states a prop by model name and position, and the
+                game reads it at load — so what goes down here is what the track will have. */}
+            {models.length > 0 && (
+              <div className="mt-4 border-t border-border pt-3">
+                <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.9px] text-faint">
+                  {t("trackViewer.place")}
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  {models.map((m) => (
+                    <button
+                      key={m}
+                      type="button"
+                      onClick={() => setArming((was) => (was === m ? null : m))}
+                      className={cn(
+                        "rounded border px-2 py-1 text-[11px] transition-colors",
+                        arming === m
+                          ? "border-primary bg-primary/15 text-foreground"
+                          : "border-border text-muted-foreground hover:text-foreground",
+                      )}
+                    >
+                      {m.replace(/\.edf$/i, "")}
+                    </button>
+                  ))}
+                </div>
+                <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">
+                  {arming ? t("trackViewer.placeHint") : t("trackViewer.placePick")}
+                </p>
+                {placed.length > 0 && (
+                  <div className="mt-3 flex flex-col gap-2">
+                    <p className="text-[11px] text-foreground">
+                      {t("trackViewer.placedCount", { count: String(placed.length) })}
+                    </p>
+                    <div className="flex gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-7 text-[11px]"
+                        onClick={() => {
+                          const target = `${path.replace(/\.pkz$/i, "")}.scr`;
+                          void saveTrackProps(
+                            target,
+                            placed.map((p) => ({
+                              kind: "prop" as const,
+                              name: p.name,
+                              pos: p.pos,
+                              heading: null,
+                              rot: p.rot ?? null,
+                            })),
+                            true,
+                          )
+                            .then(() => setSaved(target))
+                            .catch((e) =>
+                              setSaved(e instanceof Error ? e.message : String(e)),
+                            );
+                        }}
+                      >
+                        {t("trackViewer.saveProps")}
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 text-[11px]"
+                        onClick={() => {
+                          setPlaced([]);
+                          setSaved(null);
+                        }}
+                      >
+                        {t("common.clear")}
+                      </Button>
+                    </div>
+                    {saved && (
+                      <p className="break-all text-[11px] text-muted-foreground">{saved}</p>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
 
             {/* The height file has no documented layout, so what's on screen was worked out
                 from the data. Say so, rather than letting a guess pass for a reading. */}

--- a/src/Components/Viewer/TrackViewerDialog.tsx
+++ b/src/Components/Viewer/TrackViewerDialog.tsx
@@ -1,15 +1,25 @@
 import { useEffect, useState } from "react";
-import { Check, Copy, Loader2, Mountain, X } from "lucide-react";
+import { Boxes, Check, Copy, Loader2, Mountain, X } from "lucide-react";
 import { Dialog, DialogClose, DialogContent } from "../ui/dialog";
 import { Button } from "@/Components/ui/button";
-import { TrackViewer } from "./TrackViewer";
+import { TrackViewer, type PickedPiece } from "./TrackViewer";
 import {
   diagnoseTrack,
   loadTrackOverview,
+  loadTrackScenery,
+  loadTrackSurfaces,
   loadTrackTerrain,
   readTrackInfo,
+  readTrackPlacements,
 } from "../../api/tracks";
-import type { TrackInfo, TrackOverview, TrackTerrain } from "../../types";
+import type {
+  TrackInfo,
+  TrackOverview,
+  TrackPlacement,
+  TrackScenery,
+  TrackSceneryTexture,
+  TrackTerrain,
+} from "../../types";
 import { formatLength } from "../../lib/mods";
 import { useT } from "../../i18n/context";
 
@@ -51,10 +61,20 @@ export function TrackViewerDialog({
   const [info, setInfo] = useState<TrackInfo | null>(null);
   const [terrain, setTerrain] = useState<TrackTerrain | null>(null);
   const [overview, setOverview] = useState<TrackOverview | null>(null);
+  const [scenery, setScenery] = useState<TrackScenery | null>(null);
+  const [surfaces, setSurfaces] = useState<TrackSceneryTexture[]>([]);
+  const [placements, setPlacements] = useState<TrackPlacement[]>([]);
+  // On by default: the scenery is the difference between a shape and a place, and a track
+  // that carries none simply has nothing to switch off.
+  const [showObjects, setShowObjects] = useState(true);
   // True only until the *coarse* pass lands — the refine that follows happens under a
   // terrain that is already up, and covering it with a spinner would be a step backwards.
   const [loading, setLoading] = useState(false);
   const [refining, setRefining] = useState(false);
+  // The surfaces are still inflating; the scenery is up but grey.
+  const [painting, setPainting] = useState(false);
+  // What the last click on the scenery landed on, so the panel can name it.
+  const [picked, setPicked] = useState<PickedPiece | null>(null);
   const [error, setError] = useState<string | null>(null);
   // Only fetched when a track fails, and only when asked for — it re-reads the archive.
   const [diagnosis, setDiagnosis] = useState<string | null>(null);
@@ -67,6 +87,10 @@ export function TrackViewerDialog({
     setInfo(null);
     setTerrain(null);
     setOverview(null);
+    setScenery(null);
+    setSurfaces([]);
+    setPicked(null);
+    setPlacements([]);
     setError(null);
     setDiagnosis(null);
     setCopied(false);
@@ -78,11 +102,20 @@ export function TrackViewerDialog({
       .then((i) => alive && setInfo(i))
       .catch(() => {});
 
+    // Kilobytes of cfg, so these land while the terrain is still being read — the markers
+    // are up before the scenery they stand among.
+    readTrackPlacements(path)
+      .then((p) => alive && setPlacements(p))
+      .catch(() => {});
+
     void (async () => {
       try {
         // Started before anything is awaited, so the archive read it needs overlaps the
         // terrain's rather than following it.
         const surface = loadTrackOverview(path, OVERVIEW_DIM).catch(() => null);
+        // The heaviest read in the view — most of a track's bulk is its `.map` — so it is
+        // started here and settled last, under a terrain that is already up.
+        const objects = loadTrackScenery(path).catch(() => null);
 
         const coarse = await loadTrackTerrain(path, COARSE_DIM);
         if (!alive) return;
@@ -96,6 +129,20 @@ export function TrackViewerDialog({
         const [fine, map] = await Promise.all([loadTrackTerrain(path, FINE_DIM), surface]);
         if (!alive) return;
         setOverview(map);
+        // Settled on its own: the scenery is a separate mesh, so it can arrive after the
+        // terrain has refined without either waiting on the other. Its surfaces are asked
+        // for only once the mesh is up, so the track is on screen — in outline — while the
+        // hundreds of megabytes behind its colours are still inflating.
+        void objects.then((s) => {
+          if (!alive) return;
+          setScenery(s);
+          if (!s) return;
+          setPainting(true);
+          loadTrackSurfaces(path)
+            .then((t) => alive && setSurfaces(t))
+            .catch(() => {})
+            .finally(() => alive && setPainting(false));
+        });
         // Only an upgrade: a backend that capped the master below the fine size would
         // otherwise have us swap a grid for an identical one and rebuild the mesh for free.
         if (fine.width > coarse.width) setTerrain(fine);
@@ -140,6 +187,30 @@ export function TrackViewerDialog({
 
   if (overview) rows.push([t("trackViewer.surface"), t("trackViewer.surfaceMasks")]);
 
+  const markerCount = placements.filter((p) => p.kind !== "prop").length;
+  const hasObjects = scenery != null || markerCount > 0;
+  if (scenery) {
+    rows.push([
+      t("trackViewer.scenery"),
+      t("trackViewer.sceneryTris", {
+        count: Math.round(scenery.indices.length / 3).toLocaleString(),
+      }),
+    ]);
+  }
+  if (scenery && scenery.pieceCount > 0) {
+    rows.push([t("trackViewer.pieces"), scenery.pieceCount.toLocaleString()]);
+  }
+  if (markerCount > 0) {
+    rows.push([t("trackViewer.fixtures"), String(markerCount)]);
+  }
+  if (picked) {
+    const [w, h, d] = picked.size.map((n) => (n < 10 ? n.toFixed(1) : Math.round(n)));
+    rows.push([
+      t("trackViewer.selected"),
+      `${picked.triangles.toLocaleString()} · ${w} × ${h} × ${d} m`,
+    ]);
+  }
+
   // Nothing to load rather than something that failed — worth saying plainly, since the
   // inventory can tell us before the terrain read even finishes.
   const noTerrain = info != null && !info.hasTerrain;
@@ -154,13 +225,27 @@ export function TrackViewerDialog({
           <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
             <Mountain className="h-4 w-4 flex-none text-muted-foreground" />
             <span className="truncate">{title ?? meta?.name ?? t("trackViewer.title")}</span>
-            {refining && (
+            {(refining || painting) && (
               <span className="flex-none text-[11px] font-normal text-muted-foreground">
-                {t("trackViewer.refining")}
+                {painting ? t("trackViewer.painting") : t("trackViewer.refining")}
               </span>
             )}
           </div>
           <div className="flex flex-none items-center gap-2">
+            {/* Only offered once there is something to draw. A track with no scenery and no
+                fixtures would otherwise get a control that does nothing. */}
+            {hasObjects && (
+              <Button
+                variant={showObjects ? "outline" : "ghost"}
+                size="sm"
+                className="h-7 gap-1.5 px-2 text-[12px]"
+                aria-pressed={showObjects}
+                onClick={() => setShowObjects((v) => !v)}
+              >
+                <Boxes className="size-3.5" />
+                {t("trackViewer.objects")}
+              </Button>
+            )}
             <DialogClose className="rounded-md p-1 text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none">
               <X className="size-4" />
               <span className="sr-only">{t("common.close")}</span>
@@ -173,6 +258,11 @@ export function TrackViewerDialog({
             <TrackViewer
               terrain={terrain}
               overview={overview}
+              scenery={scenery}
+              surfaces={surfaces}
+              placements={placements}
+              showObjects={showObjects}
+              onPick={setPicked}
               className="absolute inset-0"
             />
             {loading && !terrain && (

--- a/src/api/tracks.ts
+++ b/src/api/tracks.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import type {
   TrackBackdrop,
+  TrackGround,
   TrackInfo,
   TrackMeshArrays,
   TrackOverview,
@@ -332,9 +333,11 @@ export async function loadTrackBackdrop(path: string): Promise<TrackBackdrop | n
  * anything closer than that is interpolation. This is tiled over the terrain to put grain
  * back — it says what the ground is made of, not what is where.
  */
-export async function loadTrackGround(path: string): Promise<TrackSceneryTexture | null> {
+export async function loadTrackGround(path: string): Promise<TrackGround | null> {
   const sheets = await loadTrackSurfaces(path, "load_track_ground");
-  return sheets[0] ?? null;
+  if (sheets.length === 0) return null;
+  // The colour first, then its relief where the track ships one.
+  return { colour: sheets[0], normal: sheets[1] ?? null };
 }
 
 /** The models a track ships that a prop can be placed by name. */

--- a/src/api/tracks.ts
+++ b/src/api/tracks.ts
@@ -1,6 +1,8 @@
 import { invoke } from "@tauri-apps/api/core";
 import type {
+  TrackBackdrop,
   TrackInfo,
+  TrackMeshArrays,
   TrackOverview,
   TrackPlacement,
   TrackScenery,
@@ -269,6 +271,55 @@ export async function loadTrackSurfaces(path: string): Promise<TrackSceneryTextu
  */
 export function readTrackPlacements(path: string): Promise<TrackPlacement[]> {
   return invoke<TrackPlacement[]>("read_track_placements", { path });
+}
+
+/** `"FSKY"`, the backdrop blob's magic. */
+const BACKDROP_MAGIC = 0x594b5346;
+
+/**
+ * A track's sky, its backdrop, and the light it sits under.
+ *
+ * Cheap next to the scenery — a dome is a few hundred triangles carrying one very large
+ * picture — and it is what stops a track ending at a hard edge with nothing beyond it.
+ */
+export async function loadTrackBackdrop(path: string): Promise<TrackBackdrop | null> {
+  const buf = await invoke<ArrayBuffer>("load_track_backdrop", { path });
+  if (buf.byteLength === 0) return null;
+  const view = new DataView(buf);
+  if (view.getUint32(0, true) !== BACKDROP_MAGIC) {
+    throw new Error("track backdrop is not in the expected format");
+  }
+  const jsonLen = view.getUint32(8, true);
+  const light = JSON.parse(
+    new TextDecoder().decode(new Uint8Array(buf, 12, jsonLen)),
+  ) as Omit<TrackBackdrop, "sky" | "backdrop">;
+
+  let at = 12 + jsonLen;
+  at += (4 - (at % 4)) % 4; // the arrays are adopted as views, so they start aligned
+  // Four words per mesh: vertices, indices, and the size of the picture it carries.
+  const head: number[] = [];
+  for (let i = 0; i < 8; i += 1) head.push(view.getUint32(at + i * 4, true));
+  at += 32;
+
+  const take = (verts: number, indices: number, tw: number, th: number): TrackMeshArrays => {
+    const positions = new Float32Array(buf, at, verts * 3);
+    at += verts * 12;
+    const normals = new Float32Array(buf, at, verts * 3);
+    at += verts * 12;
+    const uvs = new Float32Array(buf, at, verts * 2);
+    at += verts * 8;
+    const idx = new Uint32Array(buf, at, indices);
+    at += indices * 4;
+    let picture: TrackMeshArrays["picture"] = null;
+    if (tw > 0 && th > 0) {
+      picture = { width: tw, height: th, pixels: new Uint8Array(buf, at, tw * th * 4) };
+      at += tw * th * 4;
+    }
+    return { positions, normals, uvs, indices: idx, picture };
+  };
+  const sky = take(head[0], head[1], head[2], head[3]);
+  const backdrop = take(head[4], head[5], head[6], head[7]);
+  return { ...light, sky, backdrop };
 }
 
 /** The models a track ships that a prop can be placed by name. */

--- a/src/api/tracks.ts
+++ b/src/api/tracks.ts
@@ -231,8 +231,11 @@ const SURFACES_MAGIC = 0x46525346;
  * inflate, and holding the shape of the track back for them is a second of empty canvas.
  * Empty when the track's surfaces can't be bound to its materials.
  */
-export async function loadTrackSurfaces(path: string): Promise<TrackSceneryTexture[]> {
-  const buf = await invoke<ArrayBuffer>("load_track_surfaces", { path });
+export async function loadTrackSurfaces(
+  path: string,
+  command = "load_track_surfaces",
+): Promise<TrackSceneryTexture[]> {
+  const buf = await invoke<ArrayBuffer>(command, { path });
   if (buf.byteLength === 0) return [];
 
   const view = new DataView(buf);
@@ -320,6 +323,18 @@ export async function loadTrackBackdrop(path: string): Promise<TrackBackdrop | n
   const sky = take(head[0], head[1], head[2], head[3]);
   const backdrop = take(head[4], head[5], head[6], head[7]);
   return { ...light, sky, backdrop };
+}
+
+/**
+ * A tiling sheet of the track's own ground.
+ *
+ * The surface picture and the height grid are both about a third of a metre per sample, so
+ * anything closer than that is interpolation. This is tiled over the terrain to put grain
+ * back — it says what the ground is made of, not what is where.
+ */
+export async function loadTrackGround(path: string): Promise<TrackSceneryTexture | null> {
+  const sheets = await loadTrackSurfaces(path, "load_track_ground");
+  return sheets[0] ?? null;
 }
 
 /** The models a track ships that a prop can be placed by name. */

--- a/src/api/tracks.ts
+++ b/src/api/tracks.ts
@@ -1,5 +1,13 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { TrackInfo, TrackOverview, TrackTerrain } from "../types";
+import type {
+  TrackInfo,
+  TrackOverview,
+  TrackPlacement,
+  TrackScenery,
+  TrackSceneryGroup,
+  TrackSceneryTexture,
+  TrackTerrain,
+} from "../types";
 
 /**
  * A track's metadata and contents.
@@ -97,6 +105,167 @@ export async function loadTrackOverview(
     );
   }
   return { width, height, pixels: new Uint8Array(buf, TEXTURE_HEADER, expected) };
+}
+
+/** Header bytes before the vertex data. Mirrors `map::SCENERY_HEADER`. */
+const SCENERY_HEADER = 48;
+
+/** Bytes per entry in the blob's texture table. Mirrors `map::TEXTURE_ENTRY`. */
+const TEXTURE_ENTRY = 20;
+
+/** `"FSCN"`, the scenery blob's leading magic. */
+const SCENERY_MAGIC = 0x4e435346;
+
+/**
+ * A track's scenery — the tents, bales, banners and fences its `.map` bakes, the surfaces
+ * that paint them, and the props its `.scr` places.
+ *
+ * `null` when the track carries none, which is ordinary rather than a failure: an OEM track
+ * can declare no materials at all and ship 120 MB of pure texture behind them.
+ *
+ * Raw bytes for the same reason the terrain is — this is a few hundred thousand triangles
+ * and a couple of dozen surfaces, and the arrays are adopted in place rather than parsed.
+ */
+export async function loadTrackScenery(path: string): Promise<TrackScenery | null> {
+  const buf = await invoke<ArrayBuffer>("load_track_scenery", { path });
+  // The track simply hasn't got any.
+  if (buf.byteLength === 0) return null;
+
+  const view = new DataView(buf);
+  if (buf.byteLength < SCENERY_HEADER || view.getUint32(0, true) !== SCENERY_MAGIC) {
+    throw new Error("track scenery is not in the expected format");
+  }
+  const vertexCount = view.getUint32(8, true);
+  const indexCount = view.getUint32(12, true);
+  const groupCount = view.getUint32(16, true);
+  const packed = view.getUint32(20, true);
+  const textureCount = packed & 0xffff;
+  // Top half: how many separable pieces the scenery comes apart into. Capped at 65535,
+  // which only a very dense track reaches and which is plenty to report.
+  const pieceCount = (packed >>> 16) & 0xffff;
+  if (indexCount === 0) return null;
+
+  const bounds = Array.from({ length: 6 }, (_, i) =>
+    view.getFloat32(24 + i * 4, true),
+  ) as TrackScenery["bounds"];
+
+  const positionsAt = SCENERY_HEADER;
+  const normalsAt = positionsAt + vertexCount * 12;
+  const uvsAt = normalsAt + vertexCount * 12;
+  const indicesAt = uvsAt + vertexCount * 8;
+  const groupsAt = indicesAt + indexCount * 4;
+  const piecesAt = groupsAt + groupCount * 12;
+  const triangleCount = indexCount / 3;
+  // Present only when the backend split the mesh into pieces; older blobs stop at the groups.
+  const hasPieces = pieceCount > 0;
+  const tableAt = piecesAt + (hasPieces ? triangleCount * 4 : 0);
+  const pixelsAt = tableAt + textureCount * TEXTURE_ENTRY;
+
+  const groups: TrackSceneryGroup[] = [];
+  for (let i = 0; i < groupCount; i += 1) {
+    const o = groupsAt + i * 12;
+    groups.push({
+      material: view.getUint32(o, true),
+      triStart: view.getUint32(o + 4, true),
+      triCount: view.getUint32(o + 8, true),
+    });
+  }
+
+  const textures: TrackSceneryTexture[] = [];
+  let at = pixelsAt;
+  for (let i = 0; i < textureCount; i += 1) {
+    const o = tableAt + i * TEXTURE_ENTRY;
+    const width = view.getUint32(o + 4, true);
+    const height = view.getUint32(o + 8, true);
+    const byteLen = view.getUint32(o + 16, true);
+    if (at + byteLen > buf.byteLength) {
+      throw new Error("track scenery surfaces run past the end of the blob");
+    }
+    textures.push({
+      material: view.getUint32(o, true),
+      width,
+      height,
+      // Bit 0: the surface is an alpha cut-out.
+      alpha: (view.getUint32(o + 12, true) & 1) === 1,
+      pixels: new Uint8Array(buf, at, byteLen),
+    });
+    at += byteLen;
+  }
+  if (at !== buf.byteLength) {
+    // Reading on would hand three.js buffers that don't describe what arrived.
+    throw new Error(
+      `track scenery is ${buf.byteLength}B, its sections account for ${at}B`,
+    );
+  }
+
+  return {
+    positions: new Float32Array(buf, positionsAt, vertexCount * 3),
+    normals: new Float32Array(buf, normalsAt, vertexCount * 3),
+    uvs: new Float32Array(buf, uvsAt, vertexCount * 2),
+    indices: new Uint32Array(buf, indicesAt, indexCount),
+    groups,
+    textures,
+    pieceCount,
+    pieceOfTriangle: hasPieces
+      ? new Uint32Array(buf, piecesAt, triangleCount)
+      : new Uint32Array(0),
+    bounds,
+  };
+}
+
+/** Header bytes before the surface table. Mirrors `map::SURFACES_HEADER`. */
+const SURFACES_HEADER = 16;
+
+/** `"FSRF"`, the surface blob's leading magic. */
+const SURFACES_MAGIC = 0x46525346;
+
+/**
+ * A track's surfaces — the second half of the load.
+ *
+ * Fetched after the mesh is already drawn: a map's sheets are hundreds of megabytes to
+ * inflate, and holding the shape of the track back for them is a second of empty canvas.
+ * Empty when the track's surfaces can't be bound to its materials.
+ */
+export async function loadTrackSurfaces(path: string): Promise<TrackSceneryTexture[]> {
+  const buf = await invoke<ArrayBuffer>("load_track_surfaces", { path });
+  if (buf.byteLength === 0) return [];
+
+  const view = new DataView(buf);
+  if (buf.byteLength < SURFACES_HEADER || view.getUint32(0, true) !== SURFACES_MAGIC) {
+    throw new Error("track surfaces are not in the expected format");
+  }
+  const count = view.getUint32(8, true);
+  const tableAt = SURFACES_HEADER;
+  let at = tableAt + count * TEXTURE_ENTRY;
+
+  const out: TrackSceneryTexture[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const o = tableAt + i * TEXTURE_ENTRY;
+    const byteLen = view.getUint32(o + 16, true);
+    if (at + byteLen > buf.byteLength) {
+      throw new Error("track surfaces run past the end of the blob");
+    }
+    out.push({
+      material: view.getUint32(o, true),
+      width: view.getUint32(o + 4, true),
+      height: view.getUint32(o + 8, true),
+      alpha: (view.getUint32(o + 12, true) & 1) === 1,
+      pixels: new Uint8Array(buf, at, byteLen),
+    });
+    at += byteLen;
+  }
+  return out;
+}
+
+/**
+ * Where a track pins the fixtures it ships no mesh for — marshal posts, TV cameras, crowd
+ * sound — plus the props its `.scr` places.
+ *
+ * Split from the scenery mesh because it costs nothing: these files are kilobytes, so the
+ * markers land while the `.map` is still being read out of the archive.
+ */
+export function readTrackPlacements(path: string): Promise<TrackPlacement[]> {
+  return invoke<TrackPlacement[]>("read_track_placements", { path });
 }
 
 /**

--- a/src/api/tracks.ts
+++ b/src/api/tracks.ts
@@ -269,6 +269,21 @@ export function readTrackPlacements(path: string): Promise<TrackPlacement[]> {
 }
 
 /**
+ * Save a track's props to a `.scr` the game will load.
+ *
+ * The `.scr` states where a prop goes in plain text and the game reads it at load, so it is
+ * where anything placed in the app ends up. Nothing is written inside an archive, and an
+ * existing file is left alone unless `overwrite` says otherwise.
+ */
+export function saveTrackProps(
+  target: string,
+  props: TrackPlacement[],
+  overwrite = false,
+): Promise<void> {
+  return invoke<void>("save_track_props", { target, props, overwrite });
+}
+
+/**
  * A plain-text account of what a track's terrain looks like to the reader: its contents,
  * what its `.ini` claimed, every layout the probe considered, and what it settled on.
  *

--- a/src/api/tracks.ts
+++ b/src/api/tracks.ts
@@ -130,7 +130,11 @@ export async function loadTrackScenery(path: string): Promise<TrackScenery | nul
   const buf = await invoke<ArrayBuffer>("load_track_scenery", { path });
   // The track simply hasn't got any.
   if (buf.byteLength === 0) return null;
+  return readSceneryBlob(buf);
+}
 
+/** Unpack an `"FSCN"` blob — the scenery and a single prop arrive in the same shape. */
+function readSceneryBlob(buf: ArrayBuffer): TrackScenery | null {
   const view = new DataView(buf);
   if (buf.byteLength < SCENERY_HEADER || view.getUint32(0, true) !== SCENERY_MAGIC) {
     throw new Error("track scenery is not in the expected format");
@@ -266,6 +270,27 @@ export async function loadTrackSurfaces(path: string): Promise<TrackSceneryTextu
  */
 export function readTrackPlacements(path: string): Promise<TrackPlacement[]> {
   return invoke<TrackPlacement[]>("read_track_placements", { path });
+}
+
+/** The models a track ships that a prop can be placed by name. */
+export function readTrackPlaceable(path: string): Promise<string[]> {
+  return invoke<string[]>("read_track_placeable", { path });
+}
+
+/**
+ * One prop's mesh, in its own local frame.
+ *
+ * Fetched on its own rather than out of the scenery, because placing something means drawing
+ * it before it has been written anywhere. `null` when the model carries no geometry — a
+ * track's backdrop and sky are `.edf` files with nothing in them to put down.
+ */
+export async function loadTrackProp(
+  path: string,
+  name: string,
+): Promise<TrackScenery | null> {
+  const buf = await invoke<ArrayBuffer>("load_track_prop", { path, name });
+  if (buf.byteLength === 0) return null;
+  return readSceneryBlob(buf);
 }
 
 /**

--- a/src/api/tracks.ts
+++ b/src/api/tracks.ts
@@ -108,7 +108,7 @@ export async function loadTrackOverview(
 }
 
 /** Header bytes before the vertex data. Mirrors `map::SCENERY_HEADER`. */
-const SCENERY_HEADER = 48;
+const SCENERY_HEADER = 56;
 
 /** Bytes per entry in the blob's texture table. Mirrors `map::TEXTURE_ENTRY`. */
 const TEXTURE_ENTRY = 20;
@@ -142,15 +142,14 @@ function readSceneryBlob(buf: ArrayBuffer): TrackScenery | null {
   const vertexCount = view.getUint32(8, true);
   const indexCount = view.getUint32(12, true);
   const groupCount = view.getUint32(16, true);
-  const packed = view.getUint32(20, true);
-  const textureCount = packed & 0xffff;
-  // Top half: how many separable pieces the scenery comes apart into. Capped at 65535,
-  // which only a very dense track reaches and which is plenty to report.
-  const pieceCount = (packed >>> 16) & 0xffff;
+  const textureCount = view.getUint32(20, true);
+  // How many separable pieces the scenery comes apart into — a word of its own, because a
+  // dense track has more than sixty-five thousand of them.
+  const pieceCount = view.getUint32(24, true);
   if (indexCount === 0) return null;
 
   const bounds = Array.from({ length: 6 }, (_, i) =>
-    view.getFloat32(24 + i * 4, true),
+    view.getFloat32(32 + i * 4, true),
   ) as TrackScenery["bounds"];
 
   const positionsAt = SCENERY_HEADER;

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -2031,6 +2031,11 @@ export const de: Translation = {
   "trackViewer.fixtures": "Markierte Punkte",
   "trackViewer.pieces": "Einzelteile",
   "trackViewer.selected": "Gewähltes Teil",
+  "trackViewer.place": "Modell setzen",
+  "trackViewer.placePick": "Modell wählen, dann auf den Boden klicken.",
+  "trackViewer.placeHint": "Auf den Boden klicken zum Setzen.",
+  "trackViewer.placedCount": "{{count}} gesetzt",
+  "trackViewer.saveProps": ".scr speichern",
   "trackViewer.noTerrain": "Kein Gelände zum Anzeigen",
   "trackViewer.noTerrainHint":
     "Die Höhendaten dieser Strecke liegen in keinem Format vor, das der Betrachter bereits lesen kann.",

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -2024,6 +2024,13 @@ export const de: Translation = {
   "trackViewer.surface": "Surface",
   "trackViewer.surfaceMasks": "From the track's surface data",
   "trackViewer.relief": "Höhenunterschied",
+  "trackViewer.objects": "Objekte",
+  "trackViewer.painting": "Texturen…",
+  "trackViewer.scenery": "Kulisse",
+  "trackViewer.sceneryTris": "{{count}} Dreiecke",
+  "trackViewer.fixtures": "Markierte Punkte",
+  "trackViewer.pieces": "Einzelteile",
+  "trackViewer.selected": "Gewähltes Teil",
   "trackViewer.noTerrain": "Kein Gelände zum Anzeigen",
   "trackViewer.noTerrainHint":
     "Die Höhendaten dieser Strecke liegen in keinem Format vor, das der Betrachter bereits lesen kann.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1980,6 +1980,13 @@ export const en = {
   "trackViewer.surface": "Surface",
   "trackViewer.surfaceMasks": "From the track's surface data",
   "trackViewer.relief": "Elevation range",
+  "trackViewer.objects": "Objects",
+  "trackViewer.painting": "Painting…",
+  "trackViewer.scenery": "Scenery",
+  "trackViewer.sceneryTris": "{{count}} triangles",
+  "trackViewer.fixtures": "Marked fixtures",
+  "trackViewer.pieces": "Separable pieces",
+  "trackViewer.selected": "Selected piece",
   "trackViewer.noTerrain": "No terrain to show",
   "trackViewer.noTerrainHint":
     "This track's height data isn't in a layout the viewer can read yet.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1987,6 +1987,11 @@ export const en = {
   "trackViewer.fixtures": "Marked fixtures",
   "trackViewer.pieces": "Separable pieces",
   "trackViewer.selected": "Selected piece",
+  "trackViewer.place": "Place a model",
+  "trackViewer.placePick": "Pick a model, then click the ground.",
+  "trackViewer.placeHint": "Click the ground to put it down.",
+  "trackViewer.placedCount": "{{count}} placed",
+  "trackViewer.saveProps": "Save .scr",
   "trackViewer.noTerrain": "No terrain to show",
   "trackViewer.noTerrainHint":
     "This track's height data isn't in a layout the viewer can read yet.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -2010,6 +2010,13 @@ export const es: Translation = {
   "trackViewer.surface": "Surface",
   "trackViewer.surfaceMasks": "From the track's surface data",
   "trackViewer.relief": "Desnivel",
+  "trackViewer.objects": "Objetos",
+  "trackViewer.painting": "Pintando…",
+  "trackViewer.scenery": "Escenografía",
+  "trackViewer.sceneryTris": "{{count}} triángulos",
+  "trackViewer.fixtures": "Elementos marcados",
+  "trackViewer.pieces": "Piezas separables",
+  "trackViewer.selected": "Pieza seleccionada",
   "trackViewer.noTerrain": "No hay terreno que mostrar",
   "trackViewer.noTerrainHint":
     "Los datos de altura de este circuito no están en un formato que el visor sepa leer todavía.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -2017,6 +2017,11 @@ export const es: Translation = {
   "trackViewer.fixtures": "Elementos marcados",
   "trackViewer.pieces": "Piezas separables",
   "trackViewer.selected": "Pieza seleccionada",
+  "trackViewer.place": "Colocar un modelo",
+  "trackViewer.placePick": "Elige un modelo y haz clic en el suelo.",
+  "trackViewer.placeHint": "Haz clic en el suelo para colocarlo.",
+  "trackViewer.placedCount": "{{count}} colocados",
+  "trackViewer.saveProps": "Guardar .scr",
   "trackViewer.noTerrain": "No hay terreno que mostrar",
   "trackViewer.noTerrainHint":
     "Los datos de altura de este circuito no están en un formato que el visor sepa leer todavía.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -2015,6 +2015,13 @@ export const fr: Translation = {
   "trackViewer.surface": "Surface",
   "trackViewer.surfaceMasks": "From the track's surface data",
   "trackViewer.relief": "Dénivelé",
+  "trackViewer.objects": "Objets",
+  "trackViewer.painting": "Peinture…",
+  "trackViewer.scenery": "Décors",
+  "trackViewer.sceneryTris": "{{count}} triangles",
+  "trackViewer.fixtures": "Éléments repérés",
+  "trackViewer.pieces": "Éléments distincts",
+  "trackViewer.selected": "Élément choisi",
   "trackViewer.noTerrain": "Aucun terrain à afficher",
   "trackViewer.noTerrainHint":
     "Les données d'altitude de ce circuit ne sont pas dans un format que la visionneuse sait encore lire.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -2022,6 +2022,11 @@ export const fr: Translation = {
   "trackViewer.fixtures": "Éléments repérés",
   "trackViewer.pieces": "Éléments distincts",
   "trackViewer.selected": "Élément choisi",
+  "trackViewer.place": "Placer un modèle",
+  "trackViewer.placePick": "Choisis un modèle, puis clique au sol.",
+  "trackViewer.placeHint": "Clique au sol pour le poser.",
+  "trackViewer.placedCount": "{{count}} posés",
+  "trackViewer.saveProps": "Enregistrer le .scr",
   "trackViewer.noTerrain": "Aucun terrain à afficher",
   "trackViewer.noTerrainHint":
     "Les données d'altitude de ce circuit ne sont pas dans un format que la visionneuse sait encore lire.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -2003,6 +2003,13 @@ export const it: Translation = {
   "trackViewer.surface": "Surface",
   "trackViewer.surfaceMasks": "From the track's surface data",
   "trackViewer.relief": "Dislivello",
+  "trackViewer.objects": "Oggetti",
+  "trackViewer.painting": "Texture…",
+  "trackViewer.scenery": "Scenografia",
+  "trackViewer.sceneryTris": "{{count}} triangoli",
+  "trackViewer.fixtures": "Elementi segnalati",
+  "trackViewer.pieces": "Pezzi distinti",
+  "trackViewer.selected": "Pezzo scelto",
   "trackViewer.noTerrain": "Nessun terreno da mostrare",
   "trackViewer.noTerrainHint":
     "I dati di altezza di questo tracciato non sono in un formato che il visualizzatore sa ancora leggere.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -2010,6 +2010,11 @@ export const it: Translation = {
   "trackViewer.fixtures": "Elementi segnalati",
   "trackViewer.pieces": "Pezzi distinti",
   "trackViewer.selected": "Pezzo scelto",
+  "trackViewer.place": "Posiziona un modello",
+  "trackViewer.placePick": "Scegli un modello, poi clicca il terreno.",
+  "trackViewer.placeHint": "Clicca il terreno per posarlo.",
+  "trackViewer.placedCount": "{{count}} posizionati",
+  "trackViewer.saveProps": "Salva .scr",
   "trackViewer.noTerrain": "Nessun terreno da mostrare",
   "trackViewer.noTerrainHint":
     "I dati di altezza di questo tracciato non sono in un formato che il visualizzatore sa ancora leggere.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -2007,6 +2007,11 @@ export const ptBR: Translation = {
   "trackViewer.fixtures": "Elementos marcados",
   "trackViewer.pieces": "Peças separáveis",
   "trackViewer.selected": "Peça selecionada",
+  "trackViewer.place": "Colocar um modelo",
+  "trackViewer.placePick": "Escolha um modelo e clique no chão.",
+  "trackViewer.placeHint": "Clique no chão para posicionar.",
+  "trackViewer.placedCount": "{{count}} colocados",
+  "trackViewer.saveProps": "Salvar .scr",
   "trackViewer.noTerrain": "Nenhum terreno para mostrar",
   "trackViewer.noTerrainHint":
     "Os dados de altura desta pista não estão em um formato que o visualizador saiba ler ainda.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -2000,6 +2000,13 @@ export const ptBR: Translation = {
   "trackViewer.surface": "Surface",
   "trackViewer.surfaceMasks": "From the track's surface data",
   "trackViewer.relief": "Desnível",
+  "trackViewer.objects": "Objetos",
+  "trackViewer.painting": "Pintando…",
+  "trackViewer.scenery": "Cenário",
+  "trackViewer.sceneryTris": "{{count}} triângulos",
+  "trackViewer.fixtures": "Elementos marcados",
+  "trackViewer.pieces": "Peças separáveis",
+  "trackViewer.selected": "Peça selecionada",
   "trackViewer.noTerrain": "Nenhum terreno para mostrar",
   "trackViewer.noTerrainHint":
     "Os dados de altura desta pista não estão em um formato que o visualizador saiba ler ainda.",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -638,6 +638,68 @@ export interface TrackTerrain {
   heights: Float32Array;
 }
 
+/**
+ * A track's scenery — what stands on the ground the terrain grid describes.
+ *
+ * Positions are world metres in the game's own left-handed frame, the same one the terrain
+ * grid is placed in, so the viewer mirrors X over both at once.
+ */
+export interface TrackScenery {
+  /** `3 * vertexCount`, world metres. */
+  positions: Float32Array;
+  /** `3 * vertexCount`, unit length. */
+  normals: Float32Array;
+  /** `2 * vertexCount`. Tiling, so these run well outside 0–1. */
+  uvs: Float32Array;
+  /** `3 * triangleCount`. Sorted so each material's triangles sit together. */
+  indices: Uint32Array;
+  /** One run of triangles per material. */
+  groups: TrackSceneryGroup[];
+  /** The surfaces the map paints those runs with. */
+  textures: TrackSceneryTexture[];
+  /**
+   * How many connected pieces the scenery comes apart into — one per tent, trailer or
+   * foliage card. The unit a designer picks, hides or moves.
+   */
+  pieceCount: number;
+  /** Which piece each triangle belongs to — turns a ray hit into a thing you can point at. */
+  pieceOfTriangle: Uint32Array;
+  /** World bounds, metres: `[minX, minY, minZ, maxX, maxY, maxZ]`. */
+  bounds: [number, number, number, number, number, number];
+}
+
+export interface TrackSceneryGroup {
+  material: number;
+  triStart: number;
+  triCount: number;
+}
+
+export interface TrackSceneryTexture {
+  /** Which material this paints. */
+  material: number;
+  width: number;
+  height: number;
+  /**
+   * An alpha cut-out — foliage, crowd, fencing. It has to be drawn with an alpha test:
+   * without one every leaf card is an opaque rectangle, and a treeline becomes a wall.
+   */
+  alpha: boolean;
+  /** `width * height * 4`, RGBA, first row first. */
+  pixels: Uint8Array<ArrayBuffer>;
+}
+
+/** What a track pins to a point but ships no mesh for. Mirrors `scenery::Placement`. */
+export interface TrackPlacement {
+  /** A key, not prose — the UI translates it. */
+  kind: "prop" | "marshal" | "camera" | "sound";
+  /** The `.edf` for a prop, the `.wav` for a sound, otherwise the track's own name for it. */
+  name: string;
+  /** World metres, game frame. */
+  pos: [number, number, number];
+  /** Degrees, where the track states one. */
+  heading: number | null;
+}
+
 /** What the dropzone decided a dropped item is. Mirrors `dropzone::ContentKind`. */
 export type DropKind =
   | "modsTree"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -688,6 +688,30 @@ export interface TrackSceneryTexture {
   pixels: Uint8Array<ArrayBuffer>;
 }
 
+/** A track's sky, its backdrop, and the light it sits under. */
+export interface TrackBackdrop {
+  /** Direction the sun comes from, as the track states it. */
+  sun: [number, number, number] | null;
+  skyColour: [number, number, number] | null;
+  sunColour: [number, number, number] | null;
+  ambientColour: [number, number, number] | null;
+  fogColour: [number, number, number] | null;
+  fogDensity: number | null;
+  /** The dome overhead, and the ring of land beyond the track. Either may be empty. */
+  sky: TrackMeshArrays;
+  backdrop: TrackMeshArrays;
+}
+
+/** Bare mesh arrays, in world metres. */
+export interface TrackMeshArrays {
+  positions: Float32Array;
+  normals: Float32Array;
+  uvs: Float32Array;
+  indices: Uint32Array;
+  /** The picture it carries. A sky dome is a few hundred triangles and one large image. */
+  picture: { width: number; height: number; pixels: Uint8Array<ArrayBuffer> } | null;
+}
+
 /** What a track pins to a point but ships no mesh for. Mirrors `scenery::Placement`. */
 export interface TrackPlacement {
   /** A key, not prose — the UI translates it. */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -698,6 +698,8 @@ export interface TrackPlacement {
   pos: [number, number, number];
   /** Degrees, where the track states one. */
   heading: number | null;
+  /** Full rotation in degrees, for props that carry one — what a `.scr` writes back. */
+  rot?: [number, number, number] | null;
 }
 
 /** What the dropzone decided a dropped item is. Mirrors `dropzone::ContentKind`. */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -712,6 +712,18 @@ export interface TrackMeshArrays {
   picture: { width: number; height: number; pixels: Uint8Array<ArrayBuffer> } | null;
 }
 
+/**
+ * A tiling sheet of the track's own ground, and its relief.
+ *
+ * What the ground is made of, not what is where — tiled far finer than the third of a metre
+ * a track states its surface at.
+ */
+export interface TrackGround {
+  colour: TrackSceneryTexture;
+  /** Its normal map, where the track ships one under a ground name. */
+  normal: TrackSceneryTexture | null;
+}
+
 /** What a track pins to a point but ships no mesh for. Mirrors `scenery::Placement`. */
 export interface TrackPlacement {
   /** A key, not prose — the UI translates it. */


### PR DESCRIPTION
Renders what a track puts on itself, not just the shape of it — and fixes three faults that were each hiding a whole track.

## What this adds

- **Track scenery.** The `.map` container is decoded end to end: geometry, node tree, draw groups and surfaces. Tents, bales, banners, fencing, trailers and the landscape beyond the track's square all draw where the track puts them, in the track's own colours where its surfaces can be bound. **Objects** in the header turns it off.
- **Marked fixtures.** Marshal posts, TV cameras and crowd sound sources are drawn as pins on the ground. That they land *on* the ground rather than near it is the check that the whole frame is read correctly.
- **Ground detail and relief.** A track's own ground sheet is tiled over the terrain and multiplied in, normalised by the sheet's own mean luminance so it adds grain without dragging the track darker. Where a track ships a normal map beside it, that is tiled with it and lit by the track's own sun.
- **Sky, backdrop, light and haze** read from the track's `.amb`.
- **Staged loading** — terrain, then scenery shape, then colours — with both halves cached.
- **Picking.** The mesh is split into its separable pieces by union-find over the index buffer, so a tent can be pointed at and named.
- Props can be written back to `.scr`.

## Three faults found along the way

1. **Scenery was lit from underneath, on every track.** `toView` mirrors X, which already swaps which side of a triangle you face; reversing the winding as well undid it. Drawn double-sided that shows up as light, not holes. Abydos's dunes measured `(30,29,27)` before and `(110,107,101)` after.
2. **A track with no surface data drew no terrain at all.** The ground-detail shader read `vMapUv`, which three.js only declares when the material compiled in a `map`. Sand Point opened as an empty sky with its bleachers floating in it. The grain now carries its own varying.
3. **One unnumbered prop cost a track all of its scenery.** `.scr` props extended the mesh but never `object_of_tri`, so the blob carried fewer piece ids than triangles; the viewer derives the surface table's offset from the triangle count, reads past the end, and rejects the lot. Abydos was 16,080 triangles short of 1,128,674.

## Ground naming

Sheets were matched by looking for a word anywhere in a name, which picked `logo-dirtmaster` on one track and `banner_lucasoil` on another — both near-flat, so the detail layer did nothing. Names now split into words on separators *and* capitals, a word only counts whole, and `logo`/`banner`/`sign`/`marker` and the like disqualify a name outright. All 16 installed tracks find their ground (was 13, three of them wrong); 9 find its relief (was 3).

## Verification

- 996 Rust tests pass; `tsc --noEmit` clean.
- New tests cover the naming rules (logos, whole-word ranking, camelCase splitting, normal-map spellings, stem pairing) and the blob's one-id-per-triangle invariant on the path that broke it.
- `decode_a_real_track` runs clean on Abydos, Sand Point, Highland-Mx, MX191 and Farm14; its size sum now includes the piece section, which is what let the fault ship.
- Driven in the running app against Abydos, Sand Point and Indiana.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)