### PR TITLE
chore(release): v0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ whichever release turns it on.
   half a grid in one room and half in another is the failure that looks like nothing is
   wrong.
 
-## 2026-08-29
+## 2026-08-29 — v0.11.3 — A track viewer that draws the whole track
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.11.2",
+  "version": "0.11.3",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "mxb-app"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # whatever cargo called it. Cargo target names can't hold a space, so this is as close as
 # it gets. The description is what Windows Task Manager shows in its Processes tab.
 name = "mxb-app"
-version = "0.11.2"
+version = "0.11.3"
 description = "MXB App — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
   "mainBinaryName": "MXB App",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/Components/Showcase/releases.ts
+++ b/src/Components/Showcase/releases.ts
@@ -71,6 +71,20 @@ export interface Release {
 
 export const RELEASES: Release[] = [
   {
+    version: "0.11.3",
+    hero: {
+      icon: Mountain,
+      title: "showcase.v0113.hero.title",
+      body: "showcase.v0113.hero.body",
+    },
+    highlights: [
+      { icon: Sun, text: "showcase.v0113.sky" },
+      { icon: Grid3x3, text: "showcase.v0113.ground" },
+      { icon: Sparkles, text: "showcase.v0113.pick" },
+      { icon: Gauge, text: "showcase.v0113.speed" },
+    ],
+  },
+  {
     version: "0.11.2",
     hero: {
       icon: Package,

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1401,6 +1401,18 @@ export const de: Translation = {
   "showcase.supporters.title_one": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.title_other": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.more": "+{{count}} weitere",
+  "showcase.v0113.hero.title":
+    "Jede Strecke \u00f6ffnet sich als der Ort, der sie ist",
+  "showcase.v0113.hero.body":
+    "Fr\u00fcher \u00f6ffnete sich eine Strecke als nackter Boden \u2014 die richtigen Rillen, Anlieger und Sprungkanten, aber nichts, was darauf steht, sodass eine Supercross-Halle und ein Nationalkurs kaum zu unterscheiden waren. Der Betrachter zeichnet jetzt, was eine Strecke auf sich stellt: Zelte und Vord\u00e4cher, Strohballen und Reifenw\u00e4nde, Bannerreihen und Z\u00e4une, die Anh\u00e4nger im Fahrerlager und die Landschaft jenseits des eigenen Quadrats.",
+  "showcase.v0113.sky":
+    "Eine Strecke liegt unter ihrem eigenen Himmel, beleuchtet und im Dunst so, wie es ihre eigene Ambience-Datei vorgibt.",
+  "showcase.v0113.ground":
+    "Der Boden beh\u00e4lt seine Details aus der N\u00e4he \u2014 der Dreck der Strecke selbst, mit echtem Relief, wo sie eine Normal Map daf\u00fcr mitliefert.",
+  "showcase.v0113.pick":
+    "Klicke auf irgendetwas, das auf der Strecke steht, und es leuchtet einzeln auf, benannt und vermessen.",
+  "showcase.v0113.speed":
+    "Es kommt in Stufen \u2014 erst das Gel\u00e4nde, dann die Form der Objekte, dann ihre Farben \u2014 und dieselbe Strecke erneut zu \u00f6ffnen \u00fcberspringt das Archiv ganz.",
   "showcase.v0112.hero.title":
     "Ein Bike-Pack wird als die Bikes darin installiert",
   "showcase.v0112.hero.body":

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1362,6 +1362,18 @@ export const en = {
   "showcase.supporters.title_one": "Made possible by {{count}} supporter",
   "showcase.supporters.title_other": "Made possible by {{count}} supporters",
   "showcase.supporters.more": "+{{count}} more",
+  "showcase.v0113.hero.title":
+    "Every track opens as the place it is",
+  "showcase.v0113.hero.body":
+    "A track used to open as bare ground \u2014 the right ruts, berms and jump faces, but nothing standing on them, so a supercross floor and a national circuit read much the same. The viewer now draws what a track puts on itself: the tents and awnings, the hay bales and tyre walls, the banner lines and fencing, the trailers in the paddock, and the landscape beyond the track\u2019s own square.",
+  "showcase.v0113.sky":
+    "A track sits under its own sky, lit and hazed the way its own ambience file says it should be.",
+  "showcase.v0113.ground":
+    "The ground keeps its detail up close \u2014 the track\u2019s own dirt, with real relief where it ships a normal map for it.",
+  "showcase.v0113.pick":
+    "Click anything standing on the track and it lights up on its own, named and measured.",
+  "showcase.v0113.speed":
+    "It arrives in stages \u2014 the terrain first, then the shape of the scenery, then its colours \u2014 and opening the same track again skips the archive entirely.",
   "showcase.v0112.hero.title":
     "A bike pack installs as the bikes inside it",
   "showcase.v0112.hero.body":

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1388,6 +1388,18 @@ export const es: Translation = {
   "showcase.supporters.title_one": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.title_other": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.more": "+{{count}} más",
+  "showcase.v0113.hero.title":
+    "Cada pista se abre como el lugar que es",
+  "showcase.v0113.hero.body":
+    "Antes una pista se abr\u00eda como terreno desnudo: los surcos, peraltes y caras de salto correctos, pero nada encima, as\u00ed que un supercross y un circuito nacional se ve\u00edan casi igual. El visor ahora dibuja lo que la pista pone sobre s\u00ed misma: las carpas y toldos, las pacas de paja y muros de neum\u00e1ticos, las l\u00edneas de banderolas y el vallado, los remolques del paddock y el paisaje m\u00e1s all\u00e1 de su propio cuadrado.",
+  "showcase.v0113.sky":
+    "Una pista se sit\u00faa bajo su propio cielo, iluminada y con la bruma que indica su propio archivo de ambiente.",
+  "showcase.v0113.ground":
+    "El suelo conserva su detalle de cerca: la tierra de la propia pista, con relieve real cuando incluye un mapa de normales para ella.",
+  "showcase.v0113.pick":
+    "Haz clic en cualquier cosa que est\u00e9 sobre la pista y se ilumina por s\u00ed sola, con su nombre y su tama\u00f1o.",
+  "showcase.v0113.speed":
+    "Llega por etapas \u2014 primero el terreno, luego la forma de los objetos, luego sus colores \u2014 y volver a abrir la misma pista se salta el archivo por completo.",
   "showcase.v0112.hero.title":
     "Un pack de motos se instala como las motos que lleva dentro",
   "showcase.v0112.hero.body":

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1392,6 +1392,18 @@ export const fr: Translation = {
   "showcase.supporters.title_one": "Rendu possible par {{count}} soutien",
   "showcase.supporters.title_other": "Rendu possible par {{count}} soutiens",
   "showcase.supporters.more": "+{{count}} autres",
+  "showcase.v0113.hero.title":
+    "Chaque piste s\u2019ouvre comme le lieu qu\u2019elle est",
+  "showcase.v0113.hero.body":
+    "Une piste s\u2019ouvrait auparavant comme un sol nu \u2014 les orni\u00e8res, les virages relev\u00e9s et les faces de saut justes, mais rien dessus, si bien qu\u2019un supercross et un circuit national se ressemblaient. La visionneuse dessine d\u00e9sormais ce qu\u2019une piste pose sur elle-m\u00eame\u00a0: les tentes et les auvents, les bottes de paille et les murs de pneus, les lignes de banderoles et les barri\u00e8res, les remorques du paddock et le paysage au-del\u00e0 de son propre carr\u00e9.",
+  "showcase.v0113.sky":
+    "Une piste se tient sous son propre ciel, \u00e9clair\u00e9e et voil\u00e9e comme son propre fichier d\u2019ambiance le demande.",
+  "showcase.v0113.ground":
+    "Le sol garde son d\u00e9tail de pr\u00e8s \u2014 la terre de la piste elle-m\u00eame, avec un vrai relief quand elle fournit une carte de normales.",
+  "showcase.v0113.pick":
+    "Cliquez sur ce qui se dresse sur la piste et l\u2019objet s\u2019allume seul, nomm\u00e9 et mesur\u00e9.",
+  "showcase.v0113.speed":
+    "Cela arrive par \u00e9tapes \u2014 le terrain d\u2019abord, puis la forme du d\u00e9cor, puis ses couleurs \u2014 et rouvrir la m\u00eame piste \u00e9vite enti\u00e8rement l\u2019archive.",
   "showcase.v0112.hero.title":
     "Un pack de motos s'installe comme les motos qu'il contient",
   "showcase.v0112.hero.body":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1383,6 +1383,18 @@ export const it: Translation = {
   "showcase.supporters.title_one": "Reso possibile da {{count}} sostenitore",
   "showcase.supporters.title_other": "Reso possibile da {{count}} sostenitori",
   "showcase.supporters.more": "+{{count}} altri",
+  "showcase.v0113.hero.title":
+    "Ogni pista si apre come il luogo che \u00e8",
+  "showcase.v0113.hero.body":
+    "Prima una pista si apriva come terreno nudo \u2014 i solchi, i paraboliche e le facce dei salti giusti, ma nulla sopra, cos\u00ec che un supercross e un circuito nazionale si somigliavano. Il visualizzatore ora disegna ci\u00f2 che una pista mette su di s\u00e9: le tende e le tettoie, le balle di paglia e i muri di gomme, le linee di striscioni e le recinzioni, i rimorchi del paddock e il paesaggio oltre il suo stesso quadrato.",
+  "showcase.v0113.sky":
+    "Una pista sta sotto il proprio cielo, illuminata e velata come dice il suo file di ambiente.",
+  "showcase.v0113.ground":
+    "Il terreno mantiene il dettaglio da vicino \u2014 la terra della pista stessa, con vero rilievo dove ne fornisce una normal map.",
+  "showcase.v0113.pick":
+    "Clicca qualsiasi cosa in piedi sulla pista e si illumina da sola, con nome e misure.",
+  "showcase.v0113.speed":
+    "Arriva a fasi \u2014 prima il terreno, poi la forma degli oggetti, poi i loro colori \u2014 e riaprire la stessa pista salta del tutto l\u2019archivio.",
   "showcase.v0112.hero.title":
     "Un pacchetto di moto si installa come le moto che contiene",
   "showcase.v0112.hero.body":

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1381,6 +1381,18 @@ export const ptBR: Translation = {
   "showcase.supporters.title_one": "Possível graças a {{count}} apoiador",
   "showcase.supporters.title_other": "Possível graças a {{count}} apoiadores",
   "showcase.supporters.more": "+{{count}} outros",
+  "showcase.v0113.hero.title":
+    "Cada pista abre como o lugar que ela \u00e9",
+  "showcase.v0113.hero.body":
+    "Antes uma pista abria como ch\u00e3o nu \u2014 os sulcos, as curvas inclinadas e as faces de salto certas, mas nada em cima, ent\u00e3o um supercross e um circuito nacional pareciam quase iguais. O visualizador agora desenha o que a pista coloca sobre si mesma: as tendas e toldos, os fardos de palha e muros de pneus, as linhas de faixas e o alambrado, os trailers do paddock e a paisagem al\u00e9m do seu pr\u00f3prio quadrado.",
+  "showcase.v0113.sky":
+    "Uma pista fica sob o seu pr\u00f3prio c\u00e9u, iluminada e com a n\u00e9voa que o seu arquivo de ambiente pede.",
+  "showcase.v0113.ground":
+    "O ch\u00e3o mant\u00e9m o detalhe de perto \u2014 a terra da pr\u00f3pria pista, com relevo de verdade onde ela traz um normal map para isso.",
+  "showcase.v0113.pick":
+    "Clique em qualquer coisa de p\u00e9 na pista e ela acende sozinha, nomeada e medida.",
+  "showcase.v0113.speed":
+    "Chega em etapas \u2014 primeiro o terreno, depois a forma do cen\u00e1rio, depois as cores \u2014 e abrir a mesma pista de novo pula o arquivo por completo.",
   "showcase.v0112.hero.title":
     "Um pacote de motos instala como as motos que h\u00e1 dentro dele",
   "showcase.v0112.hero.body":


### PR DESCRIPTION
Patch release cutting the track viewer work that landed in #255.

- Version bumped to `0.11.3` in `package.json`, `tauri.conf.json` and `Cargo.toml` (lock refreshed).
- The unreleased CHANGELOG section is named **v0.11.3 — A track viewer that draws the whole track**; `scripts/changelog-section.sh v0.11.3 --heading` prints it and `release-notes.sh` renders. The section is ~9k characters, so Discord gets the `--summary` form.
- `RELEASES` gains a `0.11.3` entry — hero plus four highlights — with strings in all six locales, so the in-app "What's new" has something to say.

996 Rust tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)