### PR TITLE
feat(designer): put the stock texture in the sheet, not just under it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,19 @@ whichever release turns it on.
   half a grid in one room and half in another is the failure that looks like nothing is
   wrong.
 
+## 2026-08-30
+
+### Added
+
+- **Start a paint from the bike's own plastics rather than from nothing.** The Designer could
+  already show the texture a bike ships with faintly under your sheet, to draw against — but
+  what people actually keep asking for is that picture itself, with a number on it and nothing
+  else changed. **Stock as base** paints it into the sheet at full strength, where it becomes
+  part of what gets saved instead of a guide that never is: put your number over it, save, and
+  the paint is the bike exactly as it came with your number on the shroud. A sheet nothing has
+  been done to yet also takes the texture's own size, so the bike's artwork is never resampled
+  onto a blank that happened to be a different one.
+
 ## 2026-08-29
 
 ### Changed

--- a/src/Components/Studio/Designer/Designer.tsx
+++ b/src/Components/Studio/Designer/Designer.tsx
@@ -16,6 +16,7 @@ import {
   Link2Off,
   Loader2,
   PackageOpen,
+  PaintBucket,
   PanelLeftClose,
   PanelLeftOpen,
   Plus,
@@ -115,6 +116,18 @@ import type { EdfNode, PaintTexture } from "../../../types";
 
 /** A blank sheet's edge. Powers of two only — the backend would resize anything else. */
 const BLANK_SIZE = 2048;
+
+/**
+ * A stock texture's pixels, decoded, or null if they can't be had.
+ *
+ * Null covers both ends of it: the store evicts, and a rejected read is the same nothing to
+ * draw as a name that matched no texture at all.
+ */
+function stockBitmap(tex: PaintTexture): Promise<ImageBitmap | null> {
+  return textureBytes(tex.token)
+    .then((buf) => bitmapFromRgba(buf, tex.width, tex.height))
+    .catch(() => null);
+}
 
 /**
  * What was last copied, and the sheet it was cut from.
@@ -1471,6 +1484,21 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   }, [activeId, activeName, activeWidth, activeHeight, geometry, ghosts, parts, patchGhost]);
 
   /**
+   * The model's own texture for a sheet name, or null for a name it carries none of.
+   *
+   * The name is the whole binding here exactly as it is for the triangles — call a sheet
+   * `plastics` and it is the plastics, call it anything else and the model has nothing of its
+   * own to answer with.
+   */
+  const stockFor = useCallback(
+    (name: string): PaintTexture | null => {
+      const want = name.trim().toLowerCase();
+      return stockTextures.find((t) => t.name.trim().toLowerCase() === want) ?? null;
+    },
+    [stockTextures],
+  );
+
+  /**
    * Fetch the model's own texture for the active sheet, the same way and for the same reasons.
    *
    * Lazy and keyed on the name again — the name is what picks the texture out of the model,
@@ -1489,23 +1517,65 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     const key = `${activeId}:${activeName}`;
     if (stockFetch.current === key) return;
     stockFetch.current = key;
-    const want = activeName.trim().toLowerCase();
-    const tex = stockTextures.find((t) => t.name.trim().toLowerCase() === want);
+    const tex = stockFor(activeName);
     void (async () => {
-      // Null covers both "the model carries no such texture" and "the pixels are gone" — the
-      // store evicts, and a rejected read is the same nothing to draw as a name that missed.
-      const stock = tex
-        ? await textureBytes(tex.token)
-            .then((buf) => bitmapFromRgba(buf, tex.width, tex.height))
-            .catch(() => null)
-        : null;
+      const stock = tex ? await stockBitmap(tex) : null;
       // Written against the sheet it was asked *for*, not whichever is active now, and both
       // halves land together. So the worst a slow answer can do is describe a name the sheet
       // no longer has — which the guard above then notices, and asks again.
       patchGhost(activeId, (g) => ({ ...g, stock, stockFor: activeName }));
       if (stockFetch.current === key) stockFetch.current = null;
     })();
-  }, [activeId, activeName, ghosts, patchGhost, stockTextures]);
+  }, [activeId, activeName, ghosts, patchGhost, stockFor, stockTextures]);
+
+  /**
+   * Paint the model's own texture into the sheet, at full strength.
+   *
+   * The second thing here that touches a sheet, and the opposite of tracing: the stock plastics
+   * stop being something to draw *against* and become what is drawn. That is the whole of what
+   * most people are after — the bike as it ships, with their number on it — and until now the
+   * only route to it was to find the artwork outside the app, because a reference at 35% is
+   * deliberately not it. So this one is saved, and it goes through the history like any other
+   * edit to the sheet.
+   *
+   * The reference's copy is used when there is one, because it is the same texture read from
+   * the same store; the fetch is for the sheet whose ghost is switched off, since the button
+   * has to work without asking anyone to turn a guide on first.
+   */
+  const stockAsBase = useCallback(
+    async (sheetId: string) => {
+      const sheet = sheetsRef.current.find((s) => s.id === sheetId);
+      if (!sheet) return;
+      const tex = stockFor(sheet.name);
+      if (!tex) {
+        toast.error(t("designer.stockNoMatch", { name: sheet.name.trim() }));
+        return;
+      }
+      const held = ghostOf(sheetId);
+      const ready = held.stockFor === sheet.name ? held.stock : null;
+      setBusy(true);
+      const base = ready ?? (await stockBitmap(tex));
+      setBusy(false);
+      if (!base) {
+        toast.error(t("designer.stockReadFailed", { name: sheet.name.trim() }));
+        return;
+      }
+      patchSheet(sheetId, (s) => ({
+        ...s,
+        // The texture's own size, but only for a sheet nothing has been done to yet: a stock
+        // texture stretched onto a 2048 blank is the bike's artwork resampled for no reason,
+        // and resizing a sheet already drawn on would take every layer's placement with it.
+        ...(s.base || s.layers.length ? {} : { width: tex.width, height: tex.height }),
+        base,
+      }));
+      // The reference is drawn underneath the sheet, and the sheet is now the same picture —
+      // leaving it on would be showing the stock texture through the stock texture.
+      patchGhost(sheetId, (g) => ({ ...g, showStock: false }));
+      bump();
+      toast.success(t("designer.stockAsBaseDone", { name: sheet.name.trim() }));
+    },
+    [bump, ghostOf, patchGhost, patchSheet, stockFor, t],
+  );
 
   // Ghosts of sheets that are gone. Each holds a decoded bitmap and a raster the size of the
   // sheet, so leaving them behind would keep a closed paint's pixels alive for the session.
@@ -1755,7 +1825,10 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
               hasBase={!!active.base}
               hasGeometry={!!geometry}
               hasStock={!!stockTextures.length}
+              stockSheet={!!stockFor(active.name)}
+              busy={busy}
               onTrace={() => toggleTrace(active.id)}
+              onStockBase={() => void stockAsBase(active.id)}
               onChange={(fn) => patchGhost(active.id, fn)}
             />
           )}
@@ -2106,7 +2179,10 @@ function GhostPanel({
   hasBase,
   hasGeometry,
   hasStock,
+  stockSheet,
+  busy,
   onTrace,
+  onStockBase,
   onChange,
 }: {
   ghost: Ghost;
@@ -2116,7 +2192,12 @@ function GhostPanel({
   hasGeometry: boolean;
   /** Whether the model on screen can say which of its textures are its own — bikes can. */
   hasStock: boolean;
+  /** Whether it carries one under *this* sheet's name — what makes it something to paint on. */
+  stockSheet: boolean;
+  busy: boolean;
   onTrace: () => void;
+  /** Put that texture into the sheet for real, rather than faintly underneath it. */
+  onStockBase: () => void;
   onChange: (fn: (g: Ghost) => Ghost) => void;
 }) {
   const t = useT();
@@ -2200,6 +2281,30 @@ function GhostPanel({
           onClick={() => onChange((g) => ({ ...g, showWire: !g.showWire }))}
         />
       </div>
+
+      {/* Not a toggle and not part of the reference — what it puts in is the sheet itself, and
+          stays there through the save. It sits here because the picture it puts in is the one
+          the button above shows faintly, and wanting that at full strength with a number over
+          it is what a good half of the people who turn the reference on came for. */}
+      {hasStock && (
+        <Button
+          variant="outline"
+          size="sm"
+          className="mb-2 w-full min-w-0 justify-start"
+          disabled={!stockSheet || busy}
+          title={t(stockSheet ? "designer.stockAsBaseHint" : "designer.stockNoMatch", {
+            name: sheetName.trim(),
+          })}
+          onClick={onStockBase}
+        >
+          {busy ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <PaintBucket className="size-3.5" />
+          )}
+          <span className="truncate">{t("designer.stockAsBase")}</span>
+        </Button>
+      )}
 
       <Row label={t("designer.opacity")}>
         <Slider

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1985,6 +1985,12 @@ export const de: Translation = {
     "Nur Bikes können sagen, welche Texturen ihre eigenen sind. Ein Helm trägt die Lackierung, mit der er kam, und die ist kein Originallook zum Abpausen.",
   "designer.stockNoMatch":
     "Dieses Modell bringt keine eigene Textur namens „{{name}}“ mit, also gibt es vom Bike nichts unter diesem Blatt zu zeigen.",
+  "designer.stockAsBase": "Original als Basis",
+  "designer.stockAsBaseHint":
+    "Malt die eigene Textur des Bikes in voller Deckkraft in dieses Blatt — der Originallook als Ausgangspunkt, eine Startnummer von einer fertigen Lackierung entfernt. Anders als die Referenz darüber gehört diese zu dem, was du speicherst.",
+  "designer.stockAsBaseDone":
+    "„{{name}}“ trägt jetzt die eigene Textur des Bikes — setz deine Nummer drauf und speichere.",
+  "designer.stockReadFailed": "Die eigene Textur „{{name}}“ des Modells ließ sich nicht lesen.",
   "designer.uvMap": "UV-Karte",
   "designer.uvHint":
     "Zeigt, wo die Verkleidungsteile des Modells auf diesem Blatt landen, jedes in eigener Farbe.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1941,6 +1941,12 @@ export const en = {
     "Only bikes can say which textures are their own. A helmet wears whichever paint it shipped with, and that isn't a stock look to trace.",
   "designer.stockNoMatch":
     "This model carries no texture of its own called “{{name}}”, so there's nothing of the bike's to show under this sheet.",
+  "designer.stockAsBase": "Stock as base",
+  "designer.stockAsBaseHint":
+    "Paint the bike's own texture into this sheet at full strength — the stock look as your starting point, a number away from being a paint. Unlike the reference above, this one is part of what you save.",
+  "designer.stockAsBaseDone":
+    "“{{name}}” now holds the bike's own texture — put your number on it and save.",
+  "designer.stockReadFailed": "Couldn't read the model's own “{{name}}” texture.",
   "designer.uvMap": "UV map",
   "designer.uvHint":
     "Show where the model's bodywork lands on this sheet, each piece in its own colour.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1971,6 +1971,12 @@ export const es: Translation = {
     "Solo las motos pueden decir qué texturas son suyas. Un casco lleva la pintura con la que vino, y eso no es un aspecto de fábrica que calcar.",
   "designer.stockNoMatch":
     "Este modelo no trae ninguna textura propia llamada “{{name}}”, así que no hay nada de la moto que mostrar bajo esta hoja.",
+  "designer.stockAsBase": "Fábrica como base",
+  "designer.stockAsBaseHint":
+    "Pinta la textura propia de la moto en esta hoja a plena intensidad — el aspecto de fábrica como punto de partida, a un número de ser una pintura. A diferencia de la referencia de arriba, esta sí forma parte de lo que guardas.",
+  "designer.stockAsBaseDone":
+    "“{{name}}” ya lleva la textura propia de la moto — ponle tu número y guarda.",
+  "designer.stockReadFailed": "No se pudo leer la textura “{{name}}” del modelo.",
   "designer.uvMap": "Mapa UV",
   "designer.uvHint":
     "Muestra dónde cae en esta hoja cada pieza del carenado del modelo, cada una con su color.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1976,6 +1976,12 @@ export const fr: Translation = {
     "Seules les motos savent dire quelles textures leur appartiennent. Un casque porte la peinture avec laquelle il est arrivé, et ce n'est pas un aspect d'origine à décalquer.",
   "designer.stockNoMatch":
     "Ce modèle n'embarque aucune texture à lui nommée « {{name}} », il n'y a donc rien de la moto à montrer sous cette planche.",
+  "designer.stockAsBase": "Origine en base",
+  "designer.stockAsBaseHint":
+    "Peint la texture de la moto elle-même dans cette planche à pleine intensité — l'aspect d'origine comme point de départ, à un numéro d'être une peinture. Contrairement à la référence ci-dessus, celle-ci fait partie de ce que tu enregistres.",
+  "designer.stockAsBaseDone":
+    "« {{name}} » porte maintenant la texture de la moto elle-même — pose ton numéro dessus et enregistre.",
+  "designer.stockReadFailed": "Impossible de lire la texture « {{name}} » du modèle.",
   "designer.uvMap": "Carte UV",
   "designer.uvHint":
     "Montre où tombent sur cette planche les carrosseries du modèle, chacune dans sa couleur.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1964,6 +1964,12 @@ export const it: Translation = {
     "Solo le moto sanno dire quali texture sono le loro. Un casco indossa la vernice con cui è arrivato, e quella non è un aspetto originale da ricalcare.",
   "designer.stockNoMatch":
     "Questo modello non porta una texture sua chiamata “{{name}}”, quindi non c'è nulla della moto da mostrare sotto questa planche.",
+  "designer.stockAsBase": "Originale come base",
+  "designer.stockAsBaseHint":
+    "Dipinge la texture della moto stessa in questa planche a piena intensità — l'aspetto originale come punto di partenza, a un numero di distanza dall'essere una vernice. A differenza del riferimento qui sopra, questa fa parte di ciò che salvi.",
+  "designer.stockAsBaseDone":
+    "Ora “{{name}}” contiene la texture della moto stessa — mettici il tuo numero e salva.",
+  "designer.stockReadFailed": "Impossibile leggere la texture “{{name}}” del modello.",
   "designer.uvMap": "Mappa UV",
   "designer.uvHint":
     "Mostra dove finiscono su questa planche le carene del modello, ognuna con il suo colore.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1961,6 +1961,12 @@ export const ptBR: Translation = {
     "Só motos conseguem dizer quais texturas são delas. Um capacete usa a pintura com que veio, e isso não é um visual de fábrica para decalcar.",
   "designer.stockNoMatch":
     "Este modelo não traz nenhuma textura própria chamada “{{name}}”, então não há nada da moto para mostrar sob esta folha.",
+  "designer.stockAsBase": "Fábrica como base",
+  "designer.stockAsBaseHint":
+    "Pinta a textura da própria moto nesta folha em intensidade total — o visual de fábrica como ponto de partida, a um número de virar uma pintura. Diferente da referência acima, esta faz parte do que você salva.",
+  "designer.stockAsBaseDone":
+    "“{{name}}” agora tem a textura da própria moto — ponha o seu número e salve.",
+  "designer.stockReadFailed": "Não foi possível ler a textura “{{name}}” do modelo.",
   "designer.uvMap": "Mapa UV",
   "designer.uvHint":
     "Mostra onde as carenagens do modelo caem nesta folha, cada peça com sua cor.",


### PR DESCRIPTION
## What

The Designer's reference panel can show a bike's own texture faintly under the sheet, to draw against. It could not give you that picture *itself* — which is what most people want: the stock look, with a number on it.

**Stock as base** paints the model's own texture for this sheet into `Sheet.base`, at full strength. Unlike the reference, it is part of what gets saved. Add a number over it, save, and the `.pnt` is the bike as it ships with your number on the shroud.

## Notes

- The opposite direction to tracing, which *lifts* a template out of the sheet. This puts one in, and so it goes through the undo history like any other edit.
- A sheet with no base and no layers adopts the texture's own size — the bike's artwork is never resampled onto a 2048 blank. A sheet already drawn on keeps its size, because resizing would move every layer on it.
- The stock reference is switched off for that sheet afterwards: it would be the same picture drawn underneath itself.
- Reuses the reference's already-fetched copy when there is one, fetches when there isn't — so the button works without turning a guide on first.
- Bikes only (as the stock reference already is), and disabled with an explanation when the model carries no texture under the sheet's name.

## Verified

`tsc --noEmit`, `eslint` and `vite build` all clean. Not driven in the running app — reaching it needs a bike's stock textures loaded on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)