### PR TITLE
feat(mods): credit the creator on a mod's detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ whichever release turns it on.
   half a grid in one room and half in another is the failure that looks like nothing is
   wrong.
 
+## 2026-08-30
+
+### Added
+
+- **A mod's page now says who made it.** Open a track, a bike or a set of gear and the
+  creator's name sits directly under the title, exactly as the site credits it. Click it to
+  open their page on the catalog, which is where the rest of their work is. The name is read
+  off the mod's own page rather than asked for over the catalog's API — the API stopped
+  answering who posted anything some time ago, which is why the browse cards have been
+  showing a date and nothing else.
+
 ## 2026-08-29 — v0.11.3 — A track viewer that draws the whole track
 
 ### Added

--- a/src-tauri/src/mods/mod.rs
+++ b/src-tauri/src/mods/mod.rs
@@ -127,6 +127,12 @@ pub struct ModDetail {
     pub description_html: String,
     pub images: Vec<String>,
     pub version: Option<String>,
+    /// Who the catalog credits the post to — the byline it prints above the title. `None`
+    /// when the page carries none; the site is the only thing that knows, and a mod page
+    /// without a byline must still open.
+    pub author: Option<String>,
+    /// The author's profile page on the catalog, so the byline can link to it.
+    pub author_url: Option<String>,
     pub downloads: Vec<DownloadOption>,
     /// The post's category names, verbatim ("2023 KTM 450 SX-F OEM", "Liveries", "KTM").
     /// A livery's model category names the bike it's for far more precisely than its title

--- a/src-tauri/src/mods/mxb.rs
+++ b/src-tauri/src/mods/mxb.rs
@@ -659,6 +659,7 @@ pub async fn detail(slug: &str) -> anyhow::Result<ModDetail> {
     }
     let html = resp.body;
     let (downloads, version) = (parse_downloads(&html), parse_version(&html));
+    let author = parse_author(&html);
     // Only call it a challenge when the page also yielded nothing, so a marker that turns
     // up in a page that actually parsed can never turn a working mod into an error.
     if downloads.is_empty() {
@@ -680,6 +681,8 @@ pub async fn detail(slug: &str) -> anyhow::Result<ModDetail> {
         description_html,
         images,
         version,
+        author: author.as_ref().map(|(name, _)| name.clone()),
+        author_url: author.and_then(|(_, url)| url),
         downloads,
         categories: term_names(&post),
     })
@@ -996,6 +999,33 @@ fn parse_version(html: &str) -> Option<String> {
     (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
+/// The byline the theme prints above the post title, and the profile page it links to.
+///
+/// mxb-mods and gpb-mods run the same theme: `<p class="post-date">posted by
+/// <a href="…/author/<slug>/"><b id="authorName">Name</b></a>`. Scoped to the post header
+/// because every comment below the page names an author too, and the first `/author/` link
+/// in the document is only the byline by luck of layout.
+fn parse_author(html: &str) -> Option<(String, Option<String>)> {
+    let doc = Html::parse_document(html);
+
+    if let Ok(sel) = Selector::parse(r#".post-header a[href*="/author/"]"#) {
+        if let Some(el) = doc.select(&sel).next() {
+            let name = el.text().collect::<String>();
+            let name = name.trim();
+            if !name.is_empty() {
+                return Some((name.to_string(), el.value().attr("href").map(str::to_string)));
+            }
+        }
+    }
+
+    // The name without its link — the theme's own id for it, which still stands when the
+    // profile isn't linkable.
+    let sel = Selector::parse("#authorName").ok()?;
+    let name = doc.select(&sel).next()?.text().collect::<String>();
+    let name = name.trim();
+    (!name.is_empty()).then(|| (name.to_string(), None))
+}
+
 fn host_from_url(url: &str) -> String {
     reqwest::Url::parse(url)
         .ok()
@@ -1085,6 +1115,56 @@ mod tests {
 
         // A post fetched without `_embed`, or one with no terms, must not blow up.
         assert!(term_names(&serde_json::json!({})).is_empty());
+    }
+
+    #[test]
+    fn reads_the_byline_from_the_post_header() {
+        // mxb-mods: byline and date in one paragraph.
+        let mxb = r#"
+            <div class="post-header">
+              <p class="post-date">posted by
+                <a href="https://mxb-mods.com/author/kenziesaunders/"><b id="authorName">Macks Tracks</b></a>
+                on Aug. 29, 2026</p>
+              <h1 class="post-title">Highland-Mx</h1>
+            </div>"#;
+        assert_eq!(
+            parse_author(mxb),
+            Some((
+                "Macks Tracks".to_string(),
+                Some("https://mxb-mods.com/author/kenziesaunders/".to_string())
+            ))
+        );
+
+        // gpb-mods: same theme, date split into its own paragraph.
+        let gpb = r#"
+            <div class="post-header"><p class="post-date">Aug. 21, 2026</p>
+              <p class="post-date">posted by
+                <a href="https://gpb-mods.com/author/kalat/"><b id="authorName">Kalat le Nul</b></a></p>
+            </div>"#;
+        assert_eq!(
+            parse_author(gpb).unwrap().0,
+            "Kalat le Nul",
+            "the same parse has to serve both catalogs"
+        );
+    }
+
+    #[test]
+    fn a_commenter_is_never_mistaken_for_the_byline() {
+        // Discussion sits outside `.post-header` and names an author on every comment. A
+        // document-wide search for the first `/author/` link would credit the mod to
+        // whoever happened to be rendered first.
+        let html = r#"
+            <div class="wpd-comment">
+              <a href="https://mxb-mods.com/author/somecommenter/">SomeCommenter</a>
+            </div>
+            <div class="post-header">
+              <p class="post-date">posted by
+                <a href="https://mxb-mods.com/author/dr-phdeez/"><b id="authorName">Dr.PhDeez</b></a></p>
+            </div>"#;
+        assert_eq!(parse_author(html).unwrap().0, "Dr.PhDeez");
+
+        // No byline at all — a page must still parse rather than inventing one.
+        assert_eq!(parse_author("<div class=\"post-header\"></div>"), None);
     }
 
     #[test]
@@ -1493,8 +1573,14 @@ mod client_tests {
         assert!(!mods.is_empty(), "the tracks category should not be empty");
 
         let d = detail(&mods[0].slug).await.expect("detail works");
-        eprintln!("detail '{}': {} downloads, version {:?}", d.title, d.downloads.len(), d.version);
+        eprintln!(
+            "detail '{}': {} downloads, version {:?}, by {:?} ({:?})",
+            d.title, d.downloads.len(), d.version, d.author, d.author_url
+        );
         assert!(!d.title.is_empty());
+        // The byline is scraped off the rendered page, not the REST API — the site answers
+        // `_embed=author` with an empty user, so nothing else would notice a theme change.
+        assert!(d.author.is_some(), "every post on the catalog carries a byline");
     }
 
     /// The ReShade Presets category the Settings card sends people to is real, populated,

--- a/src/Components/ModDetail/ModDetail.tsx
+++ b/src/Components/ModDetail/ModDetail.tsx
@@ -350,6 +350,25 @@ export default function ModDetail({
             <h1 className="text-[24px] font-bold leading-tight tracking-[-0.3px]">
               {detail.title}
             </h1>
+            {/* Who made it, right under the name — the same byline the browse card carries.
+                Clickable through to their profile, which is where their other mods are. */}
+            {detail.author &&
+              (detail.authorUrl ? (
+                <button
+                  onClick={() => open(detail.authorUrl!)}
+                  className="flex cursor-default items-center gap-1 self-start text-[12.5px] text-primary hover:brightness-110"
+                  title={detail.authorUrl}
+                >
+                  <span className="truncate">
+                    {t("browse.byAuthor", { author: detail.author })}
+                  </span>
+                  <ExternalLink className="size-3 flex-none" />
+                </button>
+              ) : (
+                <span className="truncate text-[12.5px] text-muted-foreground">
+                  {t("browse.byAuthor", { author: detail.author })}
+                </span>
+              ))}
             <div className="flex flex-wrap items-center gap-2 text-[12px] text-muted-foreground">
               <span>{formatDate(detail.date)}</span>
               {detail.version && (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -188,6 +188,11 @@ export interface ModDetail {
   images: string[];
   /** e.g. "Beta 19", when the page states it. */
   version: string | null;
+  /** Who the catalog credits the mod to, from the byline on its page. `null` when the
+   *  page carries none — same meaning as `ModSummary.author`. */
+  author: string | null;
+  /** The author's profile page on the catalog, for the byline link. */
+  authorUrl: string | null;
   downloads: DownloadOption[];
   /**
    * The post's category names ("2023 KTM 450 SX-F OEM", "Liveries", "KTM"). A livery is


### PR DESCRIPTION
## What

The creator's name now sits directly under the title on a mod's detail page — a track, a bike, a set of gear — and clicks through to that author's page on the catalog.

```
Basiltry MX
by jhamer ↗
Aug 23, 2026 · Beta 19
```

## Why it's scraped and not fetched

The obvious route — `_embed=author` on the REST API — is already wired up for `ModSummary.author`, and it is dead. Both catalogs answer the users endpoint with:

```
{"code":"rest_forbidden","message":"User profiling via REST API is strictly prohibited.","data":{"status":401}}
```

and the embed comes back as one entry with no `name`. That is why the browse cards have been showing a date and nothing else.

The byline *is* on the rendered page, in the same theme on both sites:

```html
<p class="post-date">posted by
  <a href="https://mxb-mods.com/author/jacobjb/"><b id="authorName">jhamer</b></a>
  on Aug. 23, 2026</p>
```

`detail()` already fetches that page for the download mirrors and the beta version, so reading the byline out of the same HTML costs no extra request.

The parse is scoped to `.post-header`. Every comment below a mod page also links an `/author/` URL, so a document-wide search for the first one would credit the mod to whoever happened to render first — there is a test for exactly that.

## Scope

Detail page only. The browse cards are left as they are: giving each card a byline would mean one page fetch per card, which is a different change with a different cost.

## Testing

- `parse_author` unit tests over the real markup from both catalogs, plus the commenter case and a page with no byline at all.
- The `#[ignore]`d live test now asserts the byline comes back:
  `detail 'WDR: MX ’26 (RD 00)': 2 downloads, version Some("Beta 19"), by Some("Dr.PhDeez") (Some("https://mxb-mods.com/author/dr-phdeez/"))`
- Ran the app and opened a track — screenshot above; the byline matches what the page says.
- `tsc --noEmit`, `eslint`, `cargo clippy` clean on the changed files.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
