### PR TITLE
feat(designer): open and write PSDs, and fill sheets from the model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,30 @@ whichever release turns it on.
   half a grid in one room and half in another is the failure that looks like nothing is
   wrong.
 
+## 2026-08-30
+
+### Added
+
+- **The Designer opens and writes Photoshop files.** A livery almost always starts life as a
+  layered `.psd`, and until now the only way to bring one in was to flatten it first — which
+  threw away every layer and made this a worse editor than the file it was fed. Start from a
+  PSD and its layers arrive as layers: named, stacked in order, still at their own opacity and
+  blend mode, hidden ones still hidden, folders still grouped. Export PSD goes back the other
+  way, writing each sheet out with its layers intact, into a folder you pick. One file per
+  sheet, because sheets have their own sizes and a Photoshop document has one canvas. Both
+  directions turn the sheet the right way up, so what opens in Photoshop is the template a
+  painter draws on rather than the upside-down way the game stores it.
+
+### Changed
+
+- **Picking a model fills in the sheets it wants.** The Designer used to open empty, with the
+  names the model binds printed underneath as a hint and a button to turn them into sheets —
+  so the first move of every session was the same move, and getting it wrong meant a paint
+  that loads and shows nothing. The sheets are simply there now, named the way the model reads
+  them, the moment a bike or a piece of gear is chosen. Change the model and they follow it. If
+  anything has been drawn, nothing is thrown away without asking: a warning names the sheets
+  the new model uses and waits for you to say switch.
+
 ## 2026-08-29 — v0.11.3 — A track viewer that draws the whole track
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frost",
-  "version": "0.7.0",
+  "version": "0.11.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frost",
-      "version": "0.7.0",
+      "version": "0.11.3",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.19",
         "@radix-ui/react-context-menu": "^2.3.3",
@@ -25,6 +25,7 @@
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-shell": "^2.2.0",
         "@tauri-apps/plugin-updater": "^2.10.1",
+        "ag-psd": "^31.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -4269,6 +4270,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/ag-psd": {
+      "version": "31.0.2",
+      "resolved": "https://registry.npmjs.org/ag-psd/-/ag-psd-31.0.2.tgz",
+      "integrity": "sha512-5s5PvqbomPIIJ9YjL6robz55rT4RYPiQkww4brisyZEb5jzlHB1EKh47IJg7gIFj0RUrD0cMgdntM907qaZjXA==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "1.5.1",
+        "pako": "2.1.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -7226,6 +7237,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-shell": "^2.2.0",
     "@tauri-apps/plugin-updater": "^2.10.1",
+    "ag-psd": "^31.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1406,6 +1406,80 @@ async fn photo_save(request: tauri::ipc::Request<'_>) -> Result<String, String> 
     .map_err(|e| format!("photo_save task failed: {e}"))?
 }
 
+/// How big a `.psd` this will open. A 4096² sheet with a couple of dozen layers is well
+/// inside this; the cap exists so a mistyped path at a 4 GB video doesn't try to cross the
+/// IPC channel as one allocation.
+const PSD_LIMIT: u64 = 512 * 1024 * 1024;
+
+/// The bytes of a `.psd`, for the Designer to take apart in the webview.
+///
+/// Parsing happens up there rather than here, because that is where the pixels have to end
+/// up: a layer becomes an `ImageBitmap` on a canvas, and a Rust-side decode would only mean
+/// re-encoding every layer to cross back. So this is the whole of the backend's part —
+/// hand over the file.
+///
+/// Restricted to the two Photoshop extensions on purpose. Nothing else has any business
+/// being read wholesale into the webview, and a command that would do it for any path is a
+/// wider door than this feature needs.
+#[tauri::command]
+async fn psd_read(path: String) -> Result<tauri::ipc::Response, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let path = std::path::PathBuf::from(&path);
+        let ok = path
+            .extension()
+            .is_some_and(|e| e.eq_ignore_ascii_case("psd") || e.eq_ignore_ascii_case("psb"));
+        if !ok {
+            return Err(format!("{path:?} is not a .psd"));
+        }
+        let len = std::fs::metadata(&path).map_err(|e| format!("{path:?}: {e}"))?.len();
+        if len > PSD_LIMIT {
+            return Err(format!("{path:?} is {} MB — too large to open", len / (1024 * 1024)));
+        }
+        let bytes = std::fs::read(&path).map_err(|e| format!("{path:?}: {e}"))?;
+        Ok(tauri::ipc::Response::new(bytes))
+    })
+    .await
+    .map_err(|e| format!("psd_read task failed: {e}"))?
+}
+
+/// Write one sheet's `.psd` to a path the user picked.
+///
+/// Same shape as [`photo_save`], and for the same reason: a 4096² document with its layers
+/// still separate runs to tens of megabytes, so the file is the request body and the
+/// destination rides in a percent-encoded header.
+///
+/// Nothing is resolved or relocated — the dialog already asked. The extension is enforced so
+/// a typed name can't leave PSD bytes in a file Photoshop won't offer to open.
+#[tauri::command]
+async fn psd_save(request: tauri::ipc::Request<'_>) -> Result<String, String> {
+    let tauri::ipc::InvokeBody::Raw(psd) = request.body() else {
+        return Err("psd_save expects the PSD bytes as the request body".into());
+    };
+    let raw = request
+        .headers()
+        .get("x-dest")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+    let dest = percent_encoding::percent_decode_str(raw).decode_utf8_lossy().into_owned();
+    if dest.is_empty() {
+        return Err("psd_save needs a destination".into());
+    }
+    let psd = psd.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let mut path = std::path::PathBuf::from(&dest);
+        if !path.extension().is_some_and(|e| e.eq_ignore_ascii_case("psd")) {
+            path.set_extension("psd");
+        }
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir).map_err(|e| format!("{dir:?}: {e}"))?;
+        }
+        std::fs::write(&path, &psd).map_err(|e| format!("{path:?}: {e}"))?;
+        Ok(path.to_string_lossy().into_owned())
+    })
+    .await
+    .map_err(|e| format!("psd_save task failed: {e}"))?
+}
+
 /// The file a save would write, resolved but not written — so the UI can ask before
 /// replacing a paint that's already there.
 #[tauri::command]
@@ -8056,6 +8130,8 @@ fn main() {
             paint_studio_pixels,
             paint_studio_stage,
             photo_save,
+            psd_read,
+            psd_save,
             paint_studio_target,
             paint_studio_save,
             paint_studio_extract,

--- a/src/Components/Studio/Designer/Designer.tsx
+++ b/src/Components/Studio/Designer/Designer.tsx
@@ -6,6 +6,7 @@ import {
   CopyPlus,
   Eye,
   EyeOff,
+  FileImage,
   FilePlus2,
   FlipHorizontal2,
   FlipVertical2,
@@ -35,6 +36,8 @@ import {
   paintStudioSave,
   paintStudioStage,
   paintStudioTarget,
+  psdRead,
+  psdSave,
   textureBytes,
 } from "../../../api/mods";
 import { useT } from "../../../i18n/context";
@@ -207,7 +210,7 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   const [stockTextures, setStockTextures] = useState<PaintTexture[]>([]);
 
   const destState = usePaintDest();
-  const { dest, hints } = destState;
+  const { dest, hints, hintsFor } = destState;
 
   // Composites, one per sheet, owned here and reused: they're the size of the sheet, and
   // reallocating a 4096² canvas on every pointer move is not a thing to do.
@@ -772,6 +775,44 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
   }, []);
 
   /**
+   * Which destination the sheets on screen belong to, and which one has already been asked
+   * about — see the effect below `destKey` for what each of them stops from happening twice.
+   *
+   * `destKeyRef` is the same string as `destKey`, readable from up here: `installSheets` is
+   * defined long before the destination is, and every caller of it means "these are the sheets
+   * for wherever this is aimed right now".
+   */
+  const filled = useRef<string | null>(null);
+  const warned = useRef<string | null>(null);
+  const destKeyRef = useRef("");
+
+  /**
+   * Make `next` the sheets, whatever they were made out of.
+   *
+   * Every way into the editor ends here — an unpacked `.pnt`, a Photoshop file, the sheets a
+   * model asks for — because they all mean the same thing: what was open is gone and this is
+   * open instead. One undo step covers it, which is what makes a wrong choice of starting
+   * point cost a keystroke rather than the work.
+   *
+   * Whatever arrives is recorded against the destination that is chosen. A paint opened for
+   * this bike is *for* this bike, and without that the warning below would fire on the way in
+   * — sheets handed over by Paint Studio land here before the model's own list has been
+   * fetched, which is indistinguishable from having switched models unless somebody says so.
+   */
+  const installSheets = useCallback(
+    (next: Sheet[], nameHint?: string) => {
+      remember();
+      setSheets(next);
+      setActiveId(next[0]?.id ?? null);
+      setSelection([]);
+      if (nameHint) setName((n) => n || nameHint);
+      filled.current = destKeyRef.current;
+      bump();
+    },
+    [bump, remember],
+  );
+
+  /**
    * Start from an installed paint.
    *
    * This is the template step, and it matters more than it looks: the sheets come back named
@@ -789,23 +830,20 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
         return;
       }
       const loaded = await Promise.all(paths.map((f) => readImage(f)));
-      const next: Sheet[] = loaded.map(({ name: sheetName, bitmap }) => ({
-        id: newId("sheet"),
-        name: sheetName,
-        width: bitmap.width,
-        height: bitmap.height,
-        base: bitmap,
-        layers: [],
-      }));
-      remember();
-      setSheets(next);
-      setActiveId(next[0]?.id ?? null);
-      setSelection([]);
-      if (nameHint) setName((n) => n || nameHint);
-      bump();
-      toast.success(t("designer.loadedSheets", { count: String(next.length) }));
+      installSheets(
+        loaded.map(({ name: sheetName, bitmap }) => ({
+          id: newId("sheet"),
+          name: sheetName,
+          width: bitmap.width,
+          height: bitmap.height,
+          base: bitmap,
+          layers: [],
+        })),
+        nameHint,
+      );
+      toast.success(t("designer.loadedSheets", { count: String(paths.length) }));
     },
-    [bump, readImage, remember, t],
+    [installSheets, readImage, t],
   );
 
   const startFromPaint = useCallback(async () => {
@@ -831,6 +869,85 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
       setBusy(false);
     }
   }, [loadSheets]);
+
+  /**
+   * Start from a Photoshop file — one sheet per document.
+   *
+   * The layers survive the crossing, which is the whole point: a livery that arrives flattened
+   * is a picture of somebody's work rather than the work, and every adjustment after that is
+   * repainting. Sizes and names come from the file, so a `plastics.psd` lands as a sheet called
+   * `plastics` at whatever the artist drew it at — the save resizes to an edge the game takes.
+   *
+   * One at a time rather than in parallel: a 4096² document with two dozen layers is decoded
+   * into as many bitmaps, and several of those in flight at once is how a webview runs out of
+   * memory partway through.
+   */
+  const startFromPsd = useCallback(async () => {
+    const picked = await openDialog({
+      multiple: true,
+      filters: [{ name: "Photoshop", extensions: ["psd", "psb"] }],
+    });
+    const paths = Array.isArray(picked) ? picked : picked ? [picked] : [];
+    if (!paths.length) return;
+    setBusy(true);
+    try {
+      // Loaded on demand, here and in the export below. The PSD codec is a quarter of a
+      // megabyte and most sessions never open one — see `psd.ts`.
+      const { psdToSheet } = await import("./psd");
+      const next: Sheet[] = [];
+      for (const path of paths) {
+        const stem = (path.replace(/\\/g, "/").split("/").pop() ?? "").replace(/\.ps[db]$/i, "");
+        next.push(await psdToSheet(await psdRead(path), stem));
+      }
+      installSheets(next, next[0]?.name);
+      toast.success(t("designer.loadedSheets", { count: String(next.length) }));
+    } catch (e) {
+      toast.error(String(e).replace(/^Error:\s*/, ""));
+    } finally {
+      setBusy(false);
+    }
+  }, [installSheets, t]);
+
+  /**
+   * Write every sheet out as a `.psd`, into a folder the picker chose.
+   *
+   * A folder and not a file, because a sheet is a document: they have their own sizes, and a
+   * PSD has one canvas — so a paint with a 4096² `plastics` and a 1024² `number` cannot be one
+   * file without resampling one of them. One `.psd` each says what is true.
+   *
+   * Composited on the way out for the same reason the save does it: the layers only exist as
+   * canvases until something asks, and asking here is what stops an export shipping a frame
+   * older than the screen.
+   */
+  const exportPsd = useCallback(async () => {
+    if (!sheets.length) return;
+    const picked = await openDialog({ directory: true });
+    const dir = Array.isArray(picked) ? picked[0] : picked;
+    if (!dir) return;
+    setBusy(true);
+    try {
+      const { sheetToPsd } = await import("./psd");
+      // The picker answers in the platform's own separator, and a path with both in it is a
+      // path some Windows API will refuse. Follow whatever it handed back.
+      const sep = dir.includes("\\") ? "\\" : "/";
+      const prefix = name.trim() ? `${name.trim()} - ` : "";
+      let written = 0;
+      for (const sheet of sheets) {
+        const canvas = canvasFor(sheet);
+        composite(canvas, sheet);
+        // A sheet is named after a texture, and a texture name is not obliged to be a legal
+        // file name. Nothing is renamed on the sheet — only on the file it is written to.
+        const label = (sheet.name.trim() || `sheet-${written + 1}`).replace(/[\\/:*?"<>|]/g, "_");
+        await psdSave(`${dir}${sep}${prefix}${label}.psd`, sheetToPsd(sheet, canvas));
+        written += 1;
+      }
+      toast.success(t("designer.exportedPsd", { count: written, dir }));
+    } catch (e) {
+      toast.error(String(e).replace(/^Error:\s*/, ""));
+    } finally {
+      setBusy(false);
+    }
+  }, [canvasFor, name, sheets, t]);
 
   // Sheets sent over from Paint Studio. Same path as unpacking a paint here, because it is the
   // same thing — that tab has already done the unpacking.
@@ -888,6 +1005,70 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     setSelection([]);
     bump();
   }, [bump, missingHints, remember]);
+
+  /**
+   * The destination as one string, for comparing one against another.
+   *
+   * A model, not a folder path, is what decides which sheets a paint is made of — but a paint
+   * aimed at a folder of the player's own has no model behind it and no hints either, so the
+   * two share a key and the empty answer takes care of the difference.
+   */
+  const destKey = useMemo(
+    () => (dest ? (dest.kind === "mods" ? dest.rel : dest.path) : ""),
+    [dest],
+  );
+  destKeyRef.current = destKey;
+
+  /**
+   * Whether there is anything here worth not throwing away.
+   *
+   * "Blank sheets with the right names" is the state this editor now opens in, and replacing
+   * those costs nothing — they are a fact about the model, not somebody's work. A base or a
+   * layer is the first thing that isn't.
+   */
+  const pristine = useMemo(() => sheets.every((s) => !s.base && !s.layers.length), [sheets]);
+
+  /**
+   * Keep the sheet list on the model that's chosen.
+   *
+   * The names are the entire binding — a sheet called anything else paints nothing — and until
+   * now they were on screen as a hint line with a button beside it, which made the first move
+   * in every session the same move. So the sheets a model wants are simply *there* when it is
+   * picked, and they follow when it is changed.
+   *
+   * Two refs, not one. `filled` is which destination the sheets on screen belong to, and stops
+   * this from refilling a list the user has since emptied on purpose. `warned` is which one has
+   * already been asked about, and stops the warning below from being raised again by the next
+   * unrelated render — this effect follows the sheets, so there are many.
+   */
+  useEffect(() => {
+    // Not until the hints are about the destination that's actually chosen: they're fetched,
+    // and acting on the last model's list would fill a KTM with a Yamaha's sheet names.
+    if (!destKey || hintsFor !== destKey || filled.current === destKey) return;
+    const wanted = hints.filter((h) => !isCompanionMap(h));
+    if (!wanted.length) return;
+    const make = () => wanted.map((h) => blankSheet(h, BLANK_SIZE));
+    if (pristine) {
+      const switching = sheets.length > 0;
+      warned.current = destKey;
+      installSheets(make());
+      // Said out loud when it replaces something, silent when it fills an empty editor. A
+      // list that changed under you is worth a line; one that arrived is what was asked for.
+      if (switching) toast.info(t("designer.sheetsSwitched", { dest: destKey }));
+      return;
+    }
+    if (warned.current === destKey) return;
+    warned.current = destKey;
+    // Asked rather than done. Everything on screen would go, and a model picker is not a
+    // control anybody expects to lose an afternoon's drawing to.
+    toast.warning(t("designer.switchSheetsTitle"), {
+      description: t("designer.switchSheetsBody", { dest: destKey, names: wanted.join(", ") }),
+      action: {
+        label: t("designer.switchSheets"),
+        onClick: () => installSheets(make()),
+      },
+    });
+  }, [destKey, hints, hintsFor, installSheets, pristine, sheets.length, t]);
 
   const addImage = useCallback(async () => {
     if (!active) return;
@@ -1710,6 +1891,18 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
           {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Save className="size-3.5" />}
           {t("paints.save")}
         </Button>
+        {/* Beside Save rather than buried in a menu: it is the other way out of here, and the
+            one somebody finishing a job in Photoshop is looking for. */}
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={busy || !sheets.length}
+          title={t("designer.exportPsdHint")}
+          onClick={() => void exportPsd()}
+        >
+          <FileImage className="size-3.5" />
+          {t("designer.exportPsd")}
+        </Button>
         {blocked && (
           <span className="ml-auto max-w-[40%] truncate text-[11px] text-faint" title={blocked}>
             {blocked}
@@ -1745,6 +1938,8 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
             onAddBlank={addBlankSheet}
             onAddHintSheets={addHintSheets}
             onStartFromPaint={() => void startFromPaint()}
+            onStartFromPsd={() => void startFromPsd()}
+            pristine={pristine}
             busy={busy}
           />
 
@@ -1840,6 +2035,14 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
               <div className="flex gap-2">
                 <Button size="sm" disabled={busy} onClick={() => void startFromPaint()}>
                   <PackageOpen className="size-3.5" /> {t("designer.startFromPaint")}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={busy}
+                  onClick={() => void startFromPsd()}
+                >
+                  <FileImage className="size-3.5" /> {t("designer.startFromPsd")}
                 </Button>
                 <Button variant="outline" size="sm" onClick={addBlankSheet}>
                   <FilePlus2 className="size-3.5" /> {t("designer.blankSheet")}
@@ -1955,6 +2158,8 @@ function SheetList({
   onAddBlank,
   onAddHintSheets,
   onStartFromPaint,
+  onStartFromPsd,
+  pristine,
   busy,
 }: {
   sheets: Sheet[];
@@ -1970,6 +2175,9 @@ function SheetList({
   onAddBlank: () => void;
   onAddHintSheets: () => void;
   onStartFromPaint: () => void;
+  onStartFromPsd: () => void;
+  /** Nothing has been drawn yet — see the Designer's own `pristine`. */
+  pristine: boolean;
   busy: boolean;
 }) {
   const t = useT();
@@ -2071,10 +2279,12 @@ function SheetList({
         </div>
       )}
 
-      {/* Only while there is nothing to draw on. Starting from a paint *replaces* every sheet
-          — that's what makes it a template step — so offering it beside work in progress is
-          offering to throw that work away. Adding another sheet is the ＋ above. */}
-      {!sheets.length && (
+      {/* Only while there is nothing to lose. Starting from a paint or a `.psd` *replaces*
+          every sheet — that's what makes it a template step — so offering it beside work in
+          progress is offering to throw that work away. The blank sheets a model arrives with
+          are not work, which is why this reaches past "the list is empty" to "nothing has been
+          drawn on it". Adding another sheet is the ＋ above. */}
+      {pristine && (
         <div className="mt-2.5 flex flex-wrap gap-1.5">
           <Button variant="outline" size="sm" disabled={busy} onClick={onStartFromPaint}>
             {busy ? (
@@ -2083,6 +2293,9 @@ function SheetList({
               <PackageOpen className="size-3.5" />
             )}
             {t("designer.startFromPaint")}
+          </Button>
+          <Button variant="outline" size="sm" disabled={busy} onClick={onStartFromPsd}>
+            <FileImage className="size-3.5" /> {t("designer.startFromPsd")}
           </Button>
           <Button variant="outline" size="sm" onClick={onAddBlank}>
             <FilePlus2 className="size-3.5" /> {t("designer.blankSheet")}

--- a/src/Components/Studio/Designer/psd.ts
+++ b/src/Components/Studio/Designer/psd.ts
@@ -1,0 +1,258 @@
+import { readPsd, writePsd, type Layer as PsdLayer, type Psd } from "ag-psd";
+import { clampRegion, newId, type BlendMode, type Layer, type Sheet } from "./layers";
+import { composite, selectionBounds } from "./composite";
+
+/**
+ * Photoshop, in both directions: a `.psd` opened as sheets, and sheets written back out as one.
+ *
+ * The Designer draws liveries, and almost every livery in circulation started life as a layered
+ * Photoshop file. Until now the only way in was to flatten one first — which threw away the
+ * layers and made the app a worse editor than the file it was fed — and the only way out was a
+ * packed `.pnt`, which no image editor opens. Both ends of that are here.
+ *
+ * **The sheet is upside down and the PSD is not.** A `.pnt` stores its rows in the order the
+ * mesh samples them; the 2D stage turns that over for display, and the PSD is written the way
+ * the stage shows it, because that is the way a painter's template is drawn. So every crossing
+ * in this file flips, and the flip is the only place the two spaces are allowed to meet — see
+ * `CanvasStage` for the same rule stated from the view's side.
+ *
+ * **A sheet is a document, not a layer group.** Sheets have their own sizes, and a PSD has one
+ * canvas, so a paint with a `plastics` and a `number` becomes two files rather than one with
+ * two folders in it. Anything else would have to resample one of them to fit the other.
+ */
+
+/** Blend modes the two formats agree on. Everything else in a PSD lands as `normal`. */
+const FROM_PSD: Record<string, BlendMode> = {
+  normal: "normal",
+  multiply: "multiply",
+  screen: "screen",
+  overlay: "overlay",
+};
+
+/** Room around a layer's measured bounds, for the antialiasing that lands just outside them. */
+const BLEED = 2;
+
+function canvasOf(width: number, height: number): HTMLCanvasElement {
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  return canvas;
+}
+
+/**
+ * A copy of `src`'s `region` turned top-to-bottom — sheet space in, stage space out.
+ *
+ * One call does the crop and the flip together, because doing them separately would mean
+ * allocating a sheet-sized canvas per layer to hold the intermediate. A bike's `plastics` is
+ * 4096² and a paint carries a dozen of them; that difference is measured in gigabytes.
+ */
+function cropFlipped(
+  src: HTMLCanvasElement,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): HTMLCanvasElement {
+  const out = canvasOf(w, h);
+  const ctx = out.getContext("2d");
+  if (!ctx) return out;
+  ctx.translate(0, h);
+  ctx.scale(1, -1);
+  ctx.drawImage(src, x, y, w, h, 0, 0, w, h);
+  return out;
+}
+
+/**
+ * One Designer layer as one PSD layer, or null when none of it lands on the sheet.
+ *
+ * Rendered through `composite` rather than re-derived, so what Photoshop opens is drawn by the
+ * same code as what the game gets — a second implementation of the transform stack is a second
+ * chance to disagree with it. Opacity and blending are lifted *out* of the render and handed to
+ * Photoshop as layer properties instead: baked in, they would stop being adjustable, which is
+ * the whole reason for exporting layers rather than a flat image.
+ */
+function layerToPsd(sheet: Sheet, layer: Layer, scratch: HTMLCanvasElement): PsdLayer | null {
+  const bounds = selectionBounds([layer]);
+  if (!bounds) return null;
+  const region = clampRegion(
+    { x: bounds.x - BLEED, y: bounds.y - BLEED, w: bounds.w + BLEED * 2, h: bounds.h + BLEED * 2 },
+    sheet.width,
+    sheet.height,
+  );
+  if (!region) return null;
+  composite(scratch, {
+    ...sheet,
+    base: null,
+    layers: [{ ...layer, visible: true, opacity: 1, blend: "normal" }],
+  });
+  const canvas = cropFlipped(scratch, region.x, region.y, region.w, region.h);
+  // The flip, as coordinates: a band `region.y` up from the bottom of the sheet is the same
+  // band `height - (y + h)` down from the top of the document.
+  const top = sheet.height - (region.y + region.h);
+  return {
+    name: layer.name,
+    top,
+    left: region.x,
+    bottom: top + region.h,
+    right: region.x + region.w,
+    opacity: layer.opacity,
+    blendMode: layer.blend,
+    hidden: !layer.visible,
+    canvas,
+  };
+}
+
+/**
+ * A sheet as a Photoshop document, layers intact.
+ *
+ * `flat` is the sheet already composited — the editor keeps one per sheet and the save path
+ * has just drawn it, so this takes it rather than making a second one. It becomes the
+ * document's own image: the flattened picture every viewer that isn't Photoshop shows.
+ *
+ * Groups come across as groups. A Designer group is a tag rather than a container, but
+ * `regroup` keeps a tag's members next to each other in the stack, so a run of them is exactly
+ * a folder — and one that comes back as a group when the file is opened again here.
+ */
+export function sheetToPsd(sheet: Sheet, flat: HTMLCanvasElement): ArrayBuffer {
+  const scratch = canvasOf(sheet.width, sheet.height);
+  const children: PsdLayer[] = [];
+
+  // The template the sheet was opened from, underneath everything, as a layer of its own —
+  // it is what the paint contains, so leaving it out would export a livery with no bike
+  // under it.
+  if (sheet.base) {
+    const under = canvasOf(sheet.width, sheet.height);
+    const ctx = under.getContext("2d");
+    if (ctx) {
+      ctx.translate(0, sheet.height);
+      ctx.scale(1, -1);
+      ctx.drawImage(sheet.base, 0, 0, sheet.width, sheet.height);
+    }
+    children.push({
+      name: sheet.name || "base",
+      top: 0,
+      left: 0,
+      bottom: sheet.height,
+      right: sheet.width,
+      canvas: under,
+    });
+  }
+
+  // Bottom-first, which is the order both sides already keep — `Sheet.layers` and a PSD's
+  // `children` agree about which end of the array is the back of the stack.
+  let i = 0;
+  while (i < sheet.layers.length) {
+    const tag = sheet.layers[i].group;
+    if (!tag) {
+      const one = layerToPsd(sheet, sheet.layers[i], scratch);
+      if (one) children.push(one);
+      i += 1;
+      continue;
+    }
+    const members: PsdLayer[] = [];
+    while (i < sheet.layers.length && sheet.layers[i].group === tag) {
+      const one = layerToPsd(sheet, sheet.layers[i], scratch);
+      if (one) members.push(one);
+      i += 1;
+    }
+    if (members.length) children.push({ name: tag, opened: true, children: members });
+  }
+
+  const psd: Psd = {
+    width: sheet.width,
+    height: sheet.height,
+    canvas: cropFlipped(flat, 0, 0, sheet.width, sheet.height),
+    children,
+  };
+  // Trimmed, because every layer above was rendered into a box measured from its transform
+  // rather than from its ink — a rotated logo fills a little over half of one.
+  return writePsd(psd, { trimImageData: true, generateThumbnail: true });
+}
+
+/** A PSD layer's pixels as an `ImageBitmap`, or null for a layer that carries none. */
+async function bitmapOf(layer: PsdLayer): Promise<ImageBitmap | null> {
+  const data = layer.imageData;
+  if (!data || !data.width || !data.height) return null;
+  // Copied rather than wrapped: the reader hands back a view into its own buffer, and an
+  // `ImageData` over that would keep the whole decoded document alive behind one layer.
+  return createImageBitmap(new ImageData(new Uint8ClampedArray(data.data), data.width, data.height));
+}
+
+/** Every leaf of a PSD's layer tree, bottom-first, each carrying the folder it came out of. */
+function flatten(
+  children: PsdLayer[],
+  tag: string | null,
+  out: { layer: PsdLayer; tag: string | null }[],
+) {
+  for (const child of children) {
+    if (child.children) {
+      // One tag per folder, however deep — the Designer's grouping doesn't nest, and a nested
+      // folder flattened into its parent's tag still moves as one, which is what a group is for.
+      flatten(child.children, tag ?? newId("group"), out);
+    } else {
+      out.push({ layer: child, tag });
+    }
+  }
+}
+
+/**
+ * A `.psd` as a sheet: its layers, in place, still separate.
+ *
+ * Every layer arrives as an image, type included. A PSD's text is a font, a size and a
+ * transform this app has no way to resolve — the family may not be installed, and Photoshop's
+ * layout is not the canvas's — so the rasterised pixels Photoshop already stored are the only
+ * honest reading of what the file looks like. They are also, importantly, editable *as pixels*
+ * here: moved, scaled, masked to a part.
+ *
+ * The sheet is named after the file, because that is how a `.tga` template names a sheet too,
+ * and the name is the entire binding to the model.
+ */
+export async function psdToSheet(bytes: ArrayBuffer, fileName: string): Promise<Sheet> {
+  // `useImageData` rather than canvases: a canvas premultiplies, and a livery's soft edges are
+  // exactly the pixels that lose precision on the way through one.
+  const psd = readPsd(bytes, {
+    useImageData: true,
+    skipCompositeImageData: true,
+    skipThumbnail: true,
+    skipLinkedFilesData: true,
+  });
+  const flat: { layer: PsdLayer; tag: string | null }[] = [];
+  flatten(psd.children ?? [], null, flat);
+
+  const layers: Layer[] = [];
+  for (const { layer, tag } of flat) {
+    const image = await bitmapOf(layer);
+    if (!image) continue;
+    const left = layer.left ?? 0;
+    const top = layer.top ?? 0;
+    layers.push({
+      id: newId("layer"),
+      kind: "image",
+      name: layer.name || fileName,
+      visible: !layer.hidden,
+      opacity: layer.opacity ?? 1,
+      blend: FROM_PSD[layer.blendMode ?? "normal"] ?? "normal",
+      x: left + image.width / 2,
+      // Back into the sheet's row order. An image layer goes into the composite mirrored
+      // (see `mirrored`), so the bitmap itself needs no turning — only where its centre sits.
+      y: psd.height - (top + image.height / 2),
+      scale: 1,
+      rotation: 0,
+      flipX: false,
+      flipY: false,
+      group: tag,
+      mirror: null,
+      clip: null,
+      image,
+    });
+  }
+
+  return {
+    id: newId("sheet"),
+    name: fileName,
+    width: psd.width,
+    height: psd.height,
+    base: null,
+    layers,
+  };
+}

--- a/src/Components/Studio/paintDest.tsx
+++ b/src/Components/Studio/paintDest.tsx
@@ -169,6 +169,15 @@ export interface PaintDestState {
   dest: PaintDest | null;
   /** The sheet names this model binds — from its own mesh and from the paints installed for it. */
   hints: string[];
+  /**
+   * The destination `hints` describe, or `""` while none has been answered for.
+   *
+   * Hints are fetched, so between picking a model and hearing back, `hints` still holds the
+   * *previous* model's answer. Anything that acts on them — the Designer fills a sheet list
+   * from these — has to be able to tell the two apart, or it acts on the old bike's list and
+   * records it against the new bike's name.
+   */
+  hintsFor: string;
   /** This build can decode bike geometry — false on public builds, which have no bike mesh. */
   bikePreview: boolean;
   modelLabel: TKey;
@@ -193,6 +202,7 @@ export function usePaintDest(onChange?: () => void): PaintDestState {
   const [targets, setTargets] = useState<RiderTargets>(EMPTY_RIDER_TARGETS);
   const [bikePreview, setBikePreview] = useState(true);
   const [hints, setHints] = useState<string[]>([]);
+  const [hintsFor, setHintsFor] = useState("");
 
   useEffect(() => {
     let alive = true;
@@ -244,12 +254,17 @@ export function usePaintDest(onChange?: () => void): PaintDestState {
   useEffect(() => {
     if (folder || !model) {
       setHints([]);
+      setHintsFor(folder ?? "");
       return;
     }
     let alive = true;
-    paintStudioHints(relFor(kind, model))
-      .then((h) => alive && setHints(h))
-      .catch(() => alive && setHints([]));
+    const rel = relFor(kind, model);
+    // Both halves land together, and `hintsFor` is what says which model the list is about —
+    // see the field's note. Set on the way out whether or not the read found anything, because
+    // "this model expects nothing" is an answer and has to be distinguishable from "not yet".
+    paintStudioHints(rel)
+      .then((h) => alive && (setHints(h), setHintsFor(rel)))
+      .catch(() => alive && (setHints([]), setHintsFor(rel)));
     return () => {
       alive = false;
     };
@@ -298,6 +313,7 @@ export function usePaintDest(onChange?: () => void): PaintDestState {
     clearFolder,
     dest,
     hints,
+    hintsFor,
     bikePreview,
     // A rider folder holds profiles (MX Bikes) or rider models (GP Bikes); everything else
     // holds models. Naming it right is the difference between "For" reading as a question

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -667,6 +667,24 @@ export function photoSave(dest: string, png: ArrayBuffer): Promise<string> {
   });
 }
 
+/**
+ * The raw bytes of a `.psd`, for the Designer to take apart itself.
+ *
+ * The parsing lives in the webview because that is where the pixels have to end up — a PSD
+ * layer becomes a canvas — so the backend's whole part is handing the file over. Rejects
+ * anything that isn't a `.psd`/`.psb`.
+ */
+export function psdRead(path: string): Promise<ArrayBuffer> {
+  return invoke<ArrayBuffer>("psd_read", { path });
+}
+
+/** Write a sheet's `.psd` to a path the user picked. Body and header, as {@link photoSave}. */
+export function psdSave(dest: string, psd: ArrayBuffer): Promise<string> {
+  return invoke<string>("psd_save", psd, {
+    headers: { "x-dest": encodeURIComponent(dest) },
+  });
+}
+
 /** The file a save would write, resolved but not written — so we can ask before replacing. */
 export function paintStudioTarget(
   fileName: string,

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1856,10 +1856,19 @@ export const de: Translation = {
 
   // ── Designer (der Ebenen-Editor) ──────────────────────────────────────────────
   "designer.help":
-    "Zeichne ein Design auf die Bahnen, die das Spiel wirklich liest, und sieh es dabei am Modell. Fang bei einem installierten Design an, damit die Bahnennamen stimmen, male mit Pinsel, Verlauf oder Formen darauf, leg Bilder und Text darüber und speichere: heraus kommt eine .pnt, die das Spiel lädt — kein Export, den noch jemand umwandeln muss.",
+    "Zeichne ein Design auf die Bahnen, die das Spiel wirklich liest, und sieh es dabei am Modell. Wähl ein Modell und seine Bahnen sind schon da, unter den Namen, die es nutzt — oder fang bei einem installierten Design oder einer Photoshop-Datei an und bring deine Arbeit mit. Male mit Pinsel, Verlauf oder Formen, leg Bilder und Text darüber und speichere: heraus kommt eine .pnt, die das Spiel lädt — kein Export, den noch jemand umwandeln muss.",
   "designer.empty":
-    "Noch nichts zum Zeichnen da. Fang bei einem für dieses Modell installierten Design an — dann hast du seine Bahnen samt Namen — oder füge eine leere hinzu.",
+    "Noch nichts zum Zeichnen da. Fang bei einem für dieses Modell installierten Design an, öffne eine Photoshop-Datei, um ihre Ebenen zu behalten, oder füge eine leere Bahn hinzu.",
   "designer.startFromPaint": "Von einem Design ausgehen…",
+  "designer.startFromPsd": "Von einer PSD ausgehen…",
+  "designer.exportPsd": "Als PSD exportieren",
+  "designer.exportPsdHint": "Schreibt jede Bahn als PSD mit Ebenen in einen Ordner deiner Wahl.",
+  "designer.exportedPsd_one": "1 Bahn nach {{dir}} geschrieben",
+  "designer.exportedPsd_other": "{{count}} Bahnen nach {{dir}} geschrieben",
+  "designer.sheetsSwitched": "Auf die Bahnen von {{dest}} gewechselt.",
+  "designer.switchSheetsTitle": "Diese Bahnen gehören zu einem anderen Modell",
+  "designer.switchSheetsBody": "{{dest}} nutzt {{names}}. Beim Wechseln werden alle offenen Bahnen ersetzt.",
+  "designer.switchSheets": "Bahnen wechseln",
   "designer.blankSheet": "Leere Bahn",
   "designer.addSheet": "Bahn hinzufügen",
   "designer.nothingToSave": "Alle Bahnen sind leer — zeichne etwas, bevor du speicherst.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1814,10 +1814,19 @@ export const en = {
 
   // ── Designer (the layer editor) ───────────────────────────────────────────────
   "designer.help":
-    "Draw a paint on the sheets the game actually reads, and watch it on the model as you go. Start from an installed paint to get the sheet names right, paint on it with a brush, a gradient or a shape, stack images and text on top, then save — what comes out is a .pnt the game loads, not an export to convert.",
+    "Draw a paint on the sheets the game actually reads, and watch it on the model as you go. Pick a model and its sheets are already there under the names it binds — or start from an installed paint or a Photoshop file to bring artwork with you. Paint with a brush, a gradient or a shape, stack images and text on top, then save: what comes out is a .pnt the game loads, not an export to convert.",
   "designer.empty":
-    "Nothing to draw on yet. Start from a paint installed for this model to get its real sheets and their names, or add a blank one.",
+    "Nothing to draw on yet. Start from a paint installed for this model, open a Photoshop file to keep its layers, or add a blank sheet.",
   "designer.startFromPaint": "Start from a paint…",
+  "designer.startFromPsd": "Start from a PSD…",
+  "designer.exportPsd": "Export PSD",
+  "designer.exportPsdHint": "Write every sheet out as a layered .psd, into a folder you pick.",
+  "designer.exportedPsd_one": "Wrote 1 sheet to {{dir}}",
+  "designer.exportedPsd_other": "Wrote {{count}} sheets to {{dir}}",
+  "designer.sheetsSwitched": "Switched to the sheets {{dest}} uses.",
+  "designer.switchSheetsTitle": "These sheets are for another model",
+  "designer.switchSheetsBody": "{{dest}} uses {{names}}. Switching replaces every sheet you have open.",
+  "designer.switchSheets": "Switch sheets",
   "designer.blankSheet": "Blank sheet",
   "designer.addSheet": "Add a sheet",
   "designer.nothingToSave": "Every sheet is empty — draw something before saving.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1842,10 +1842,19 @@ export const es: Translation = {
 
   // ── Designer (el editor por capas) ────────────────────────────────────────────
   "designer.help":
-    "Dibuja una pintura sobre las hojas que el juego lee de verdad y mírala en el modelo mientras trabajas. Empieza desde una pintura instalada para acertar con los nombres de las hojas, píntala con pincel, degradado o formas, apila imágenes y texto encima y guarda: lo que sale es un .pnt que el juego carga, no una exportación que convertir.",
+    "Dibuja una pintura sobre las hojas que el juego lee de verdad y mírala en el modelo mientras trabajas. Elige un modelo y sus hojas ya están ahí, con los nombres que él usa — o empieza desde una pintura instalada o un archivo de Photoshop para traerte el trabajo. Pinta con pincel, degradado o formas, apila imágenes y texto encima y guarda: lo que sale es un .pnt que el juego carga, no una exportación que convertir.",
   "designer.empty":
-    "Todavía no hay nada sobre lo que dibujar. Empieza desde una pintura instalada para este modelo — así obtienes sus hojas y sus nombres — o añade una en blanco.",
+    "Todavía no hay nada sobre lo que dibujar. Empieza desde una pintura instalada para este modelo, abre un archivo de Photoshop para conservar sus capas, o añade una hoja en blanco.",
   "designer.startFromPaint": "Empezar desde una pintura…",
+  "designer.startFromPsd": "Empezar desde un PSD…",
+  "designer.exportPsd": "Exportar PSD",
+  "designer.exportPsdHint": "Guarda cada hoja como un .psd con capas, en una carpeta que elijas.",
+  "designer.exportedPsd_one": "1 hoja guardada en {{dir}}",
+  "designer.exportedPsd_other": "{{count}} hojas guardadas en {{dir}}",
+  "designer.sheetsSwitched": "Cambiado a las hojas que usa {{dest}}.",
+  "designer.switchSheetsTitle": "Estas hojas son de otro modelo",
+  "designer.switchSheetsBody": "{{dest}} usa {{names}}. Cambiar sustituye todas las hojas abiertas.",
+  "designer.switchSheets": "Cambiar hojas",
   "designer.blankSheet": "Hoja en blanco",
   "designer.addSheet": "Añadir una hoja",
   "designer.nothingToSave": "Todas las hojas están vacías: dibuja algo antes de guardar.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1847,10 +1847,19 @@ export const fr: Translation = {
 
   // ── Designer (l'éditeur par calques) ──────────────────────────────────────────
   "designer.help":
-    "Dessine une déco sur les planches que le jeu lit vraiment, et regarde-la sur le modèle au fur et à mesure. Pars d'une déco installée pour avoir les bons noms de planches, peins dessus au pinceau, au dégradé ou avec des formes, empile images et textes par-dessus, puis enregistre : ce qui sort est un .pnt que le jeu charge, pas un export à convertir.",
+    "Dessine une déco sur les planches que le jeu lit vraiment, et regarde-la sur le modèle au fur et à mesure. Choisis un modèle et ses planches sont déjà là, sous les noms qu'il utilise — ou pars d'une déco installée ou d'un fichier Photoshop pour amener ton travail avec toi. Peins au pinceau, au dégradé ou avec des formes, empile images et textes par-dessus, puis enregistre : ce qui sort est un .pnt que le jeu charge, pas un export à convertir.",
   "designer.empty":
-    "Rien sur quoi dessiner pour l'instant. Pars d'une déco installée pour ce modèle — tu récupères ses planches et leurs noms — ou ajoute une planche vierge.",
+    "Rien sur quoi dessiner pour l'instant. Pars d'une déco installée pour ce modèle, ouvre un fichier Photoshop pour en garder les calques, ou ajoute une planche vierge.",
   "designer.startFromPaint": "Partir d'une déco…",
+  "designer.startFromPsd": "Partir d'un PSD…",
+  "designer.exportPsd": "Exporter en PSD",
+  "designer.exportPsdHint": "Écrit chaque planche en .psd avec ses calques, dans un dossier de votre choix.",
+  "designer.exportedPsd_one": "1 planche écrite dans {{dir}}",
+  "designer.exportedPsd_other": "{{count}} planches écrites dans {{dir}}",
+  "designer.sheetsSwitched": "Passé aux planches utilisées par {{dest}}.",
+  "designer.switchSheetsTitle": "Ces planches sont celles d'un autre modèle",
+  "designer.switchSheetsBody": "{{dest}} utilise {{names}}. Changer remplace toutes les planches ouvertes.",
+  "designer.switchSheets": "Changer de planches",
   "designer.blankSheet": "Planche vierge",
   "designer.addSheet": "Ajouter une planche",
   "designer.nothingToSave": "Toutes les planches sont vides : dessinez quelque chose avant d'enregistrer.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1836,10 +1836,19 @@ export const it: Translation = {
 
   // ── Designer (l'editor a livelli) ─────────────────────────────────────────────
   "designer.help":
-    "Disegna una livrea sui fogli che il gioco legge davvero e guardala sul modello mentre lavori. Parti da una livrea installata per avere i nomi giusti dei fogli, dipingici sopra con pennello, sfumatura o forme, aggiungi immagini e testo, poi salva: quello che esce è un .pnt che il gioco carica, non un export da convertire.",
+    "Disegna una livrea sui fogli che il gioco legge davvero e guardala sul modello mentre lavori. Scegli un modello e i suoi fogli ci sono già, con i nomi che lui usa — oppure parti da una livrea installata o da un file di Photoshop per portarti dietro il lavoro. Dipingi con pennello, sfumatura o forme, aggiungi immagini e testo, poi salva: quello che esce è un .pnt che il gioco carica, non un export da convertire.",
   "designer.empty":
-    "Non c'è ancora niente su cui disegnare. Parti da una livrea installata per questo modello — così ottieni i suoi fogli e i loro nomi — oppure aggiungine uno vuoto.",
+    "Non c'è ancora niente su cui disegnare. Parti da una livrea installata per questo modello, apri un file di Photoshop per conservarne i livelli, oppure aggiungi un foglio vuoto.",
   "designer.startFromPaint": "Parti da una livrea…",
+  "designer.startFromPsd": "Parti da un PSD…",
+  "designer.exportPsd": "Esporta PSD",
+  "designer.exportPsdHint": "Salva ogni foglio come .psd a livelli, in una cartella scelta da te.",
+  "designer.exportedPsd_one": "1 foglio salvato in {{dir}}",
+  "designer.exportedPsd_other": "{{count}} fogli salvati in {{dir}}",
+  "designer.sheetsSwitched": "Passato ai fogli usati da {{dest}}.",
+  "designer.switchSheetsTitle": "Questi fogli sono di un altro modello",
+  "designer.switchSheetsBody": "{{dest}} usa {{names}}. Cambiando sostituisci tutti i fogli aperti.",
+  "designer.switchSheets": "Cambia fogli",
   "designer.blankSheet": "Foglio vuoto",
   "designer.addSheet": "Aggiungi un foglio",
   "designer.nothingToSave": "Ogni foglio è vuoto: disegna qualcosa prima di salvare.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1835,10 +1835,19 @@ export const ptBR: Translation = {
 
   // ── Designer (o editor de camadas) ────────────────────────────────────────────
   "designer.help":
-    "Desenhe uma pintura nas folhas que o jogo realmente lê e veja no modelo enquanto trabalha. Comece de uma pintura instalada para acertar os nomes das folhas, pinte nela com pincel, gradiente ou formas, empilhe imagens e texto por cima e salve: o que sai é um .pnt que o jogo carrega, não uma exportação para converter.",
+    "Desenhe uma pintura nas folhas que o jogo realmente lê e veja no modelo enquanto trabalha. Escolha um modelo e as folhas dele já estão aí, com os nomes que ele usa — ou comece de uma pintura instalada ou de um arquivo do Photoshop para trazer o trabalho junto. Pinte com pincel, gradiente ou formas, empilhe imagens e texto por cima e salve: o que sai é um .pnt que o jogo carrega, não uma exportação para converter.",
   "designer.empty":
-    "Ainda não há nada para desenhar. Comece de uma pintura instalada para este modelo — assim você pega as folhas e os nomes delas — ou adicione uma em branco.",
+    "Ainda não há nada para desenhar. Comece de uma pintura instalada para este modelo, abra um arquivo do Photoshop para manter as camadas dele, ou adicione uma folha em branco.",
   "designer.startFromPaint": "Começar de uma pintura…",
+  "designer.startFromPsd": "Começar de um PSD…",
+  "designer.exportPsd": "Exportar PSD",
+  "designer.exportPsdHint": "Grava cada folha como um .psd com camadas, em uma pasta que você escolher.",
+  "designer.exportedPsd_one": "1 folha gravada em {{dir}}",
+  "designer.exportedPsd_other": "{{count}} folhas gravadas em {{dir}}",
+  "designer.sheetsSwitched": "Trocado para as folhas que {{dest}} usa.",
+  "designer.switchSheetsTitle": "Estas folhas são de outro modelo",
+  "designer.switchSheetsBody": "{{dest}} usa {{names}}. Trocar substitui todas as folhas abertas.",
+  "designer.switchSheets": "Trocar folhas",
   "designer.blankSheet": "Folha em branco",
   "designer.addSheet": "Adicionar uma folha",
   "designer.nothingToSave": "Todas as folhas estão vazias — desenhe algo antes de salvar.",


### PR DESCRIPTION
## Photoshop, both directions

A livery almost always starts life as a layered `.psd`, and until now the only way to bring one into the Designer was to flatten it first — which threw away every layer and made this a worse editor than the file it was fed.

- **Start from a PSD…** (sheets rail and the empty canvas) reads a `.psd`/`.psb` and turns each document into a sheet with its layers intact: name, stacking order, opacity, blend mode, hidden state, and PSD folders as Designer group tags.
- **Export PSD** (beside Save) writes every sheet out with its layers separate, into a folder the picker chose. One file per sheet — sheets carry their own sizes and a Photoshop document has one canvas, so anything else would resample one of them.

New `psd.ts`, on `ag-psd`, loaded with a dynamic `import()` so it lands in its own 295 kB chunk (89 kB gzip) and the startup bundle is unchanged. Each layer is rendered through `composite` rather than a second copy of the transform stack, so what Photoshop opens is drawn by the same code as what the game gets; opacity and blending are handed over as PSD layer properties instead of being baked in, which is the whole point of exporting layers.

**The flip is the risky part.** A `.pnt` stores rows the way the mesh samples them, which is upside down from a painter's template, so the PSD is written the way `CanvasStage` shows the sheet and read back the same way.

Backend: `psd_read` (extension-gated, size-capped) and `psd_save` (raw body, percent-encoded destination header), alongside `photo_save`.

## Sheets follow the model

The Designer used to open empty, with the names the model binds printed underneath as a hint and a button to turn them into sheets — so the first move of every session was the same move, and getting it wrong meant a paint that loads and shows nothing.

The sheets are now simply there when a bike or a piece of gear is chosen, named the way the model reads them. Changing the model swaps them when nothing has been drawn (with a line saying so), and raises a warning naming the new model's sheets when something has — nothing is thrown away without being asked.

`usePaintDest` gained `hintsFor`, the destination its `hints` describe. Hints are fetched, so without it the fill would act on the previous model's list and file it under the new model's name.

Two consequences worth noting:
- The starting-point buttons now show while the sheets are *pristine* rather than only while the list is empty — auto-filled blanks are a fact about the model, not somebody's work.
- `installSheets` records which destination the sheets on screen belong to, so sheets handed over by Paint Studio don't trip the warning on the way in.

## Verification

`tsc`, `eslint`, `cargo check` and `npm run build` are clean. The PSD conversion was checked headlessly against a real `ag-psd` round trip:

- **pixel-identical** — 0 of 131,072 bytes differ after export → re-import → recomposite, over image, rotated-and-scaled, hidden and shape layers
- opacity survives as a layer property (0.5 → 128/255), blend mode, hidden state, names and stacking order all preserved
- PSD groups ↔ Designer group tags round-trip; `Sheet.base` comes back as its own layer
- orientation asserted directly: a marker at sheet row 6 lands at PSD `top = 54` of 64 — the painter's way up

Not covered: the file dialogs and the two Rust commands are compile-checked only. Worth opening a real bike, exporting, and confirming the PSD opens the right way up in Photoshop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)