### PR TITLE
feat(hub): browse and install from MXB Hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-08-30
+### Added
+- MXB Hub support: a new sidebar tab that browses the shop.mxb-hub.com marketplace and installs what your account already owns, free mods included
+- MXB Hub sign-in, purchases grid and one-click install, reusing the existing destination dialog, install queue and "Installed" badges
+- MXB Hub product images are served through the app's image cache
+
 ## Unannounced — voice chat
 
 Kept out of the release notes on purpose: voice is off by default and has not yet been

--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ cargo test           # unit tests (REST/HTML parsing, download resolution)
 > launches it on macOS through a CrossOver, Whisky or Wine bottle, and on Linux
 > under Proton. The cross-platform logic builds and tests on any OS.
 
+### MXB Hub
+
+The **MXB Hub** tab browses [shop.mxb-hub.com](https://shop.mxb-hub.com) — the community
+marketplace `mxbhub.com` redirects to — and installs what the signed-in account owns, free
+mods included. Neither half needs a build-time credential: the store publishes a public
+WooCommerce Store API, and installing needs nothing but the user's own sign-in.
+
 ### Building with the shop catalog
 
 The **Shop** tab has two halves. **My purchases** signs in to

--- a/src-tauri/src/hub_clearance.rs
+++ b/src-tauri/src/hub_clearance.rs
@@ -1,0 +1,144 @@
+//! Getting past MXB Hub's robot challenge, by running it in a real browser.
+//!
+//! `shop.mxb-hub.com` is on SiteGround, whose bot protection fires on **request rate** rather
+//! than on anything about the client. That is why it is invisible to a handful of probes and
+//! entirely reproducible the moment a grid asks for a page of twenty-four thumbnails: the
+//! store starts answering every path — API and images alike — with a `202` carrying a "Robot
+//! Challenge Screen", and keeps doing so until something solves it. Solving it means computing
+//! a proof of work in a Web Worker and posting it back, so an HTTP client cannot; a browser
+//! can, and gets a cookie for its trouble.
+//!
+//! So: park a hidden window on the store, let it do that, and hand its cookies to the clients.
+//!
+//! Deliberately much smaller than [`crate::mxb_fetch`] and [`crate::shop_fetch`], which solve
+//! the same shape of problem for the two Cloudflare-fronted sites. Those two have to *read
+//! pages* out of the browser, so they inject a script, take a result back over IPC, and pay
+//! for that with a capability file granting a remote origin the right to talk to us. Nothing
+//! here does: the only thing taken from this window is its cookie jar, which Rust reads from
+//! the outside. The page is never given a way to call the app, so there is no IPC surface to
+//! get wrong.
+
+use crate::hub_session::{HUB_BASE, HUB_SITE};
+use crate::{cookie_session, mods};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
+
+/// The window's label. Transient — it must be destroyed on close, never parked in the tray,
+/// or its label stays registered and the next handshake silently cannot build one.
+pub const WINDOW: &str = "hub-clearance";
+
+/// How long the browser gets to run the challenge. The proof of work is a second or two on a
+/// modern machine; the rest is page load, and being generous costs nothing when it succeeds.
+const SOLVE_TIMEOUT: Duration = Duration::from_secs(40);
+
+const POLL: Duration = Duration::from_millis(500);
+
+/// Unix seconds of the last successful handshake, or 0.
+///
+/// Not a "we are cleared" flag: the clearance can lapse at any time and only the store knows.
+/// It is a throttle. Without it, a page whose twenty-four thumbnails are all being refused
+/// would queue twenty-four handshakes, which is both pointless and precisely the request storm
+/// that got us challenged.
+static LAST: AtomicU64 = AtomicU64::new(0);
+
+/// Don't hand out a second handshake within this of the last one succeeding.
+const REUSE_WITHIN: u64 = 20;
+
+fn now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+/// Run the challenge in a hidden window and give the result to both hub clients.
+///
+/// One at a time, and cheap to call again: a caller that lost the race for the lock finds the
+/// work already done and returns without opening anything.
+pub async fn earn(app: &AppHandle) -> anyhow::Result<()> {
+    static LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+    let _guard = LOCK.lock().await;
+
+    if now().saturating_sub(LAST.load(Ordering::Relaxed)) < REUSE_WITHIN {
+        log::info!("an MXB Hub clearance was just earned; reusing it");
+        return Ok(());
+    }
+
+    // A window left over from a previous attempt is on a page that has already been decided
+    // one way or the other, so it is dropped rather than reused: the point is a fresh
+    // navigation, which is what re-serves the challenge and lets the browser answer it.
+    close(app);
+
+    let url: tauri::Url = HUB_BASE.parse()?;
+    log::info!("opening the hidden MXB Hub window to answer the robot challenge");
+    let window = WebviewWindowBuilder::new(app, WINDOW, WebviewUrl::External(url))
+        .title("MXB Hub")
+        // Never shown, and never given a way to talk to the app — see the module comment.
+        .visible(false)
+        .inner_size(1.0, 1.0)
+        .position(-32000.0, -32000.0)
+        .skip_taskbar(true)
+        .decorations(false)
+        .focused(false)
+        .build()?;
+
+    let deadline = std::time::Instant::now() + SOLVE_TIMEOUT;
+    let mut last_seen = Vec::new();
+    while std::time::Instant::now() < deadline {
+        tokio::time::sleep(POLL).await;
+
+        let cookies = cookie_session::cookies_from_window(&window, &HUB_SITE);
+        if cookies.is_empty() {
+            continue;
+        }
+        // What "solved" means is asked of the store, not guessed from a cookie name. The
+        // challenge sets more than one cookie and renames them between SiteGround versions, so
+        // matching on a name is a check that silently stops working; a request that comes back
+        // as the thing we asked for cannot.
+        if cookies != last_seen {
+            last_seen = cookies.clone();
+            mods::hub::adopt_clearance(&cookies)?;
+            if probe().await {
+                crate::hub_session::adopt_clearance(app, &cookies);
+                LAST.store(now(), Ordering::Relaxed);
+                log::info!(
+                    "MXB Hub clearance earned ({})",
+                    crate::hub_session::cookie_names(&cookies)
+                );
+                close(app);
+                return Ok(());
+            }
+        }
+    }
+
+    close(app);
+    log::warn!(
+        "the MXB Hub challenge was not answered within {}s (cookies: {})",
+        SOLVE_TIMEOUT.as_secs(),
+        crate::hub_session::cookie_names(&last_seen)
+    );
+    anyhow::bail!("MXB Hub is still asking the app to prove it isn't a robot. Try again shortly.")
+}
+
+/// The cheapest request the store answers, used only to ask "are we still challenged?".
+///
+/// One product, and no parsing: all that matters is whether what came back is the challenge.
+async fn probe() -> bool {
+    let Ok(client) = mods::hub::client() else {
+        return false;
+    };
+    match client
+        .get(format!("{HUB_BASE}/wp-json/wc/store/v1/products?per_page=1"))
+        .send()
+        .await
+    {
+        Ok(resp) => !mods::hub::challenged(&resp) && resp.status().is_success(),
+        Err(_) => false,
+    }
+}
+
+pub fn close(app: &AppHandle) {
+    if let Some(win) = app.get_webview_window(WINDOW) {
+        let _ = win.close();
+    }
+}

--- a/src-tauri/src/hub_clearance.rs
+++ b/src-tauri/src/hub_clearance.rs
@@ -34,6 +34,14 @@ const SOLVE_TIMEOUT: Duration = Duration::from_secs(40);
 
 const POLL: Duration = Duration::from_millis(500);
 
+/// How long to let the page settle before asking the store anything. Probing instantly only
+/// spends a request confirming what we already know — we are here because we were refused.
+const FIRST_PROBE: Duration = Duration::from_secs(3);
+
+/// And how often after that. Deliberately unhurried: this runs while a page is refusing us,
+/// and hammering the thing that rate-limited us is how we got here.
+const PROBE_EVERY: Duration = Duration::from_secs(4);
+
 /// Unix seconds of the last successful handshake, or 0.
 ///
 /// Not a "we are cleared" flag: the clearance can lapse at any time and only the store knows.
@@ -73,6 +81,12 @@ pub async fn earn(app: &AppHandle) -> anyhow::Result<()> {
     log::info!("opening the hidden MXB Hub window to answer the robot challenge");
     let window = WebviewWindowBuilder::new(app, WINDOW, WebviewUrl::External(url))
         .title("MXB Hub")
+        // Deliberately **no** `.user_agent()` override. Forcing `HUB_SITE.ua` on it here was
+        // tried and was worse than doing nothing: the string claims Chrome on Windows while
+        // the window is WKWebView on macOS, and the challenge fingerprints the browser — so a
+        // page that had been serving a solvable challenge started answering 403 outright.
+        // [`crate::shop_session::UA`] records the same lesson for Cloudflare. The window
+        // introduces itself honestly and earns what it can.
         // Never shown, and never given a way to talk to the app — see the module comment.
         .visible(false)
         .inner_size(1.0, 1.0)
@@ -83,31 +97,45 @@ pub async fn earn(app: &AppHandle) -> anyhow::Result<()> {
         .build()?;
 
     let deadline = std::time::Instant::now() + SOLVE_TIMEOUT;
-    let mut last_seen = Vec::new();
+    let mut last_seen: Vec<(String, String)> = Vec::new();
+    let mut next_probe = std::time::Instant::now() + FIRST_PROBE;
     while std::time::Instant::now() < deadline {
         tokio::time::sleep(POLL).await;
 
         let cookies = cookie_session::cookies_from_window(&window, &HUB_SITE);
-        if cookies.is_empty() {
+        let changed = cookies != last_seen;
+        if changed {
+            log::debug!(
+                "MXB Hub window cookies now: {}",
+                crate::hub_session::cookie_names(&cookies)
+            );
+            last_seen = cookies.clone();
+            if !cookies.is_empty() {
+                mods::hub::adopt_clearance(&cookies)?;
+            }
+        }
+        // Probed on a timer as well as on a cookie, because the clearance need not arrive as
+        // one. SiteGround is just as free to stop refusing this *address* once its script has
+        // run, and a loop that only looks when a cookie moves would sit out the whole timeout
+        // next to a store that had already let us back in.
+        if std::time::Instant::now() < next_probe && !changed {
             continue;
         }
+        next_probe = std::time::Instant::now() + PROBE_EVERY;
+
         // What "solved" means is asked of the store, not guessed from a cookie name. The
         // challenge sets more than one cookie and renames them between SiteGround versions, so
         // matching on a name is a check that silently stops working; a request that comes back
         // as the thing we asked for cannot.
-        if cookies != last_seen {
-            last_seen = cookies.clone();
-            mods::hub::adopt_clearance(&cookies)?;
-            if probe().await {
-                crate::hub_session::adopt_clearance(app, &cookies);
-                LAST.store(now(), Ordering::Relaxed);
-                log::info!(
-                    "MXB Hub clearance earned ({})",
-                    crate::hub_session::cookie_names(&cookies)
-                );
-                close(app);
-                return Ok(());
-            }
+        if probe().await {
+            crate::hub_session::adopt_clearance(app, &cookies);
+            LAST.store(now(), Ordering::Relaxed);
+            log::info!(
+                "MXB Hub clearance earned ({})",
+                crate::hub_session::cookie_names(&cookies)
+            );
+            close(app);
+            return Ok(());
         }
     }
 

--- a/src-tauri/src/hub_session.rs
+++ b/src-tauri/src/hub_session.rs
@@ -26,7 +26,13 @@ pub const HUB_SITE: Site = Site {
     base: HUB_BASE,
     domain: "shop.mxb-hub.com",
     file: "hub_session.json",
-    ua: crate::shop_session::UA,
+    // The realistic full-version string, not [`crate::shop_session::UA`], whose two-part
+    // `Chrome/126.0` is documented over there as a bot-filter signal in its own right. It
+    // matters more here than anywhere else in the app: the clearance window is opened wearing
+    // this exact string, so what the browser earns is what the HTTP client presents. A token
+    // minted under one User-Agent and replayed under another is simply refused, which reads
+    // from the outside as a challenge that never clears.
+    ua: crate::mxb_session::UA,
     // Purchased tracks run to hundreds of megabytes; `install::download` streams with this
     // client, so the ceiling has to cover a whole transfer rather than a page load.
     timeout: Duration::from_secs(60 * 30),

--- a/src-tauri/src/hub_session.rs
+++ b/src-tauri/src/hub_session.rs
@@ -1,0 +1,192 @@
+//! The signed-in MXB Hub session — cookies for `shop.mxb-hub.com`, and the client that uses
+//! them.
+//!
+//! The shape is [`crate::shop_session`]'s, with one large simplification: **MXB Hub is not
+//! behind Cloudflare** (measured: `server: nginx`, no `cf-ray`, no interstitial on
+//! `/my-account/`). That is what lets this keep a real `reqwest` client built from the
+//! captured cookies, which mxbikes-shop.com had to give up — there, every signed-in path is a
+//! managed challenge an HTTP client cannot clear, so its pages are read out of a parked
+//! WebView instead ([`crate::shop_fetch`]). None of that machinery is needed here: a WebView
+//! is opened once, for the user to type their password into, and everything after that is
+//! ordinary HTTP.
+
+use crate::cookie_session::{self, Cookies, Site};
+use reqwest::cookie::Jar;
+use reqwest::Client;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tauri::{AppHandle, Manager, WebviewWindow};
+
+pub const HUB_BASE: &str = "https://shop.mxb-hub.com";
+
+/// The store is one host — `mxbhub.com` and `mxb-hub.com` both redirect here — so the cookie
+/// domain is the full subdomain rather than the registrable one. Scoping it wider would put
+/// the session cookie on requests to any other `mxb-hub.com` host we ever add.
+const SITE: Site = Site {
+    base: HUB_BASE,
+    domain: "shop.mxb-hub.com",
+    file: "hub_session.json",
+    ua: crate::shop_session::UA,
+    // Purchased tracks run to hundreds of megabytes; `install::download` streams with this
+    // client, so the ceiling has to cover a whole transfer rather than a page load.
+    timeout: Duration::from_secs(60 * 30),
+};
+
+/// The captured session: the cookies, and the client that carries them.
+///
+/// Holding the built client rather than rebuilding per call is what keeps the connection pool
+/// (and so the TLS handshake) shared between the downloads page read and the file transfer
+/// that follows it.
+#[derive(Default)]
+pub struct HubSession(Mutex<Option<Client>>);
+
+impl HubSession {
+    pub fn client(&self) -> Option<Client> {
+        self.0.lock().unwrap_or_else(|e| e.into_inner()).clone()
+    }
+
+    pub fn logged_in(&self) -> bool {
+        self.0
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .is_some()
+    }
+
+    fn set(&self, client: Option<Client>) {
+        *self.0.lock().unwrap_or_else(|e| e.into_inner()) = client;
+    }
+}
+
+fn build_client(cookies: &Cookies) -> anyhow::Result<Client> {
+    let jar = Arc::new(Jar::default());
+    cookie_session::fill(&jar, &SITE, cookies)?;
+    Ok(cookie_session::client_builder(&SITE, jar).build()?)
+}
+
+pub fn set_session(app: &AppHandle, cookies: Cookies) -> anyhow::Result<()> {
+    let client = build_client(&cookies)?;
+    cookie_session::write(app, &SITE, &cookies)?;
+    app.state::<HubSession>().set(Some(client));
+    Ok(())
+}
+
+/// Restore a sign-in captured in an earlier run, if the file still holds a login cookie.
+///
+/// Whether the *server* still honours it is not knowable without asking, and asking at startup
+/// would put a network call on the launch path. A dead cookie surfaces on the first read as the
+/// login form, which [`crate::mods::hubaccount`] turns into "sign in again".
+pub fn load_session(app: &AppHandle) {
+    let Some(cookies) = cookie_session::read(app, &SITE) else {
+        return;
+    };
+    if !is_authenticated(&cookies) {
+        log::info!("a stored MXB Hub session had no login cookie; ignoring it");
+        return;
+    }
+    match build_client(&cookies) {
+        Ok(client) => {
+            app.state::<HubSession>().set(Some(client));
+            log::info!("restored MXB Hub session ({} cookies)", cookies.len());
+        }
+        Err(e) => log::warn!("could not rebuild the stored MXB Hub session: {e:#}"),
+    }
+}
+
+/// Drop the session because the *store* said it is over — the downloads page came back as the
+/// login form. Nothing is revoked, because there is nothing left to revoke.
+pub fn forget(app: &AppHandle) {
+    cookie_session::remove(app, &SITE);
+    app.state::<HubSession>().set(None);
+}
+
+/// "Log out" as the user means it: end the session on the server too.
+///
+/// Deliberately **not** `clear_all_browsing_data`, which is what the shop's sign-out uses. That
+/// call is app-wide — it would take the mxbikes-shop.com session down with it, and signing out
+/// of one store must not sign you out of the other. Calling WooCommerce's own logout URL from
+/// our client kills the session token instead, which makes the copy of the cookie still sitting
+/// in the WebView's jar inert: the next sign-in lands on the login form, not on the account.
+pub async fn clear_session(app: &AppHandle) {
+    let client = app.state::<HubSession>().client();
+    cookie_session::remove(app, &SITE);
+    app.state::<HubSession>().set(None);
+
+    let Some(client) = client else { return };
+    match crate::mods::hubaccount::logout(&client).await {
+        Ok(true) => log::info!("signed out of MXB Hub on the server"),
+        // The account page didn't offer a logout link — already signed out, most likely.
+        Ok(false) => log::info!("MXB Hub had no logout link to follow; dropped the session"),
+        Err(e) => log::warn!("could not sign out of MXB Hub on the server: {e:#}"),
+    }
+}
+
+pub fn cookies_from_window(window: &WebviewWindow) -> Cookies {
+    cookie_session::cookies_from_window(window, &SITE)
+}
+
+pub fn is_authenticated(cookies: &[(String, String)]) -> bool {
+    cookie_session::has_prefix(cookies, "wordpress_logged_in")
+}
+
+/// Which cookies a sign-in ended up with, by name — never by value. Same discipline as
+/// [`crate::shop_session::cookie_names`]: a session cookie is a bearer token and a log file is
+/// something users paste into Discord.
+pub fn cookie_names(cookies: &[(String, String)]) -> String {
+    if cookies.is_empty() {
+        return "none".to_string();
+    }
+    cookies
+        .iter()
+        .map(|(n, _)| n.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_wordpress_login_cookie_is_what_counts_as_signed_in() {
+        assert!(is_authenticated(&[(
+            "wordpress_logged_in_9f2".into(),
+            "x".into()
+        )]));
+        // WooCommerce sets these for anyone who touches a cart, signed in or not.
+        assert!(!is_authenticated(&[
+            ("woocommerce_items_in_cart".into(), "1".into()),
+            ("wp_woocommerce_session_9f2".into(), "x".into()),
+        ]));
+    }
+
+    #[test]
+    fn cookie_names_never_carry_values() {
+        let names = cookie_names(&[("wordpress_logged_in_9f2".into(), "supersecret".into())]);
+        assert_eq!(names, "wordpress_logged_in_9f2");
+        assert_eq!(cookie_names(&[]), "none");
+    }
+
+    /// The hub's cookies must never ride along on a request to either of the other two
+    /// WordPress sites the app talks to.
+    #[test]
+    fn the_jar_is_scoped_to_the_hub() {
+        use reqwest::cookie::CookieStore;
+
+        let jar = Jar::default();
+        cookie_session::fill(&jar, &SITE, &[("wordpress_logged_in_9f2".into(), "x".into())])
+            .unwrap();
+
+        assert!(jar
+            .cookies(&"https://shop.mxb-hub.com/my-account/downloads/".parse().unwrap())
+            .is_some());
+        for other in [
+            "https://mxbikes-shop.com/all-my-downloads/",
+            "https://mxb-mods.com/wp-json",
+        ] {
+            assert!(
+                jar.cookies(&other.parse().unwrap()).is_none(),
+                "hub cookies leaked to {other}"
+            );
+        }
+    }
+}

--- a/src-tauri/src/hub_session.rs
+++ b/src-tauri/src/hub_session.rs
@@ -22,7 +22,7 @@ pub const HUB_BASE: &str = "https://shop.mxb-hub.com";
 /// The store is one host — `mxbhub.com` and `mxb-hub.com` both redirect here — so the cookie
 /// domain is the full subdomain rather than the registrable one. Scoping it wider would put
 /// the session cookie on requests to any other `mxb-hub.com` host we ever add.
-const SITE: Site = Site {
+pub const HUB_SITE: Site = Site {
     base: HUB_BASE,
     domain: "shop.mxb-hub.com",
     file: "hub_session.json",
@@ -59,13 +59,45 @@ impl HubSession {
 
 fn build_client(cookies: &Cookies) -> anyhow::Result<Client> {
     let jar = Arc::new(Jar::default());
-    cookie_session::fill(&jar, &SITE, cookies)?;
-    Ok(cookie_session::client_builder(&SITE, jar).build()?)
+    cookie_session::fill(&jar, &HUB_SITE, cookies)?;
+    Ok(cookie_session::client_builder(&HUB_SITE, jar).build()?)
+}
+
+/// Rebuild the signed-in client with a clearance folded in.
+///
+/// The account half is challenged by the same filter as the catalog, and the two keep separate
+/// jars — so a clearance earned for browsing has to be handed over explicitly or every
+/// purchases read after one goes on failing. Cookies captured from the WebView are a superset:
+/// the login cookie and the clearance arrive together.
+pub fn adopt_clearance(app: &AppHandle, cookies: &Cookies) {
+    let state = app.state::<HubSession>();
+    if !state.logged_in() {
+        return;
+    }
+    let Some(stored) = cookie_session::read(app, &HUB_SITE) else {
+        return;
+    };
+    let mut merged = stored;
+    for (name, value) in cookies {
+        if let Some(slot) = merged.iter_mut().find(|(n, _)| n == name) {
+            slot.1 = value.clone();
+        } else {
+            merged.push((name.clone(), value.clone()));
+        }
+    }
+    match build_client(&merged) {
+        Ok(client) => {
+            let _ = cookie_session::write(app, &HUB_SITE, &merged);
+            state.set(Some(client));
+            log::info!("folded an MXB Hub clearance into the signed-in session");
+        }
+        Err(e) => log::warn!("could not rebuild the MXB Hub session with a clearance: {e:#}"),
+    }
 }
 
 pub fn set_session(app: &AppHandle, cookies: Cookies) -> anyhow::Result<()> {
     let client = build_client(&cookies)?;
-    cookie_session::write(app, &SITE, &cookies)?;
+    cookie_session::write(app, &HUB_SITE, &cookies)?;
     app.state::<HubSession>().set(Some(client));
     Ok(())
 }
@@ -76,7 +108,7 @@ pub fn set_session(app: &AppHandle, cookies: Cookies) -> anyhow::Result<()> {
 /// would put a network call on the launch path. A dead cookie surfaces on the first read as the
 /// login form, which [`crate::mods::hubaccount`] turns into "sign in again".
 pub fn load_session(app: &AppHandle) {
-    let Some(cookies) = cookie_session::read(app, &SITE) else {
+    let Some(cookies) = cookie_session::read(app, &HUB_SITE) else {
         return;
     };
     if !is_authenticated(&cookies) {
@@ -95,7 +127,7 @@ pub fn load_session(app: &AppHandle) {
 /// Drop the session because the *store* said it is over — the downloads page came back as the
 /// login form. Nothing is revoked, because there is nothing left to revoke.
 pub fn forget(app: &AppHandle) {
-    cookie_session::remove(app, &SITE);
+    cookie_session::remove(app, &HUB_SITE);
     app.state::<HubSession>().set(None);
 }
 
@@ -108,7 +140,7 @@ pub fn forget(app: &AppHandle) {
 /// in the WebView's jar inert: the next sign-in lands on the login form, not on the account.
 pub async fn clear_session(app: &AppHandle) {
     let client = app.state::<HubSession>().client();
-    cookie_session::remove(app, &SITE);
+    cookie_session::remove(app, &HUB_SITE);
     app.state::<HubSession>().set(None);
 
     let Some(client) = client else { return };
@@ -121,7 +153,7 @@ pub async fn clear_session(app: &AppHandle) {
 }
 
 pub fn cookies_from_window(window: &WebviewWindow) -> Cookies {
-    cookie_session::cookies_from_window(window, &SITE)
+    cookie_session::cookies_from_window(window, &HUB_SITE)
 }
 
 pub fn is_authenticated(cookies: &[(String, String)]) -> bool {
@@ -173,7 +205,7 @@ mod tests {
         use reqwest::cookie::CookieStore;
 
         let jar = Jar::default();
-        cookie_session::fill(&jar, &SITE, &[("wordpress_logged_in_9f2".into(), "x".into())])
+        cookie_session::fill(&jar, &HUB_SITE, &[("wordpress_logged_in_9f2".into(), "x".into())])
             .unwrap();
 
         assert!(jar

--- a/src-tauri/src/imgcache.rs
+++ b/src-tauri/src/imgcache.rs
@@ -29,11 +29,16 @@ pub const SCHEME: &str = "imgcache";
 /// Bumped when the on-disk layout changes, so old entries are dropped rather than misread.
 const CACHE_DIR: &str = "img-v1";
 
-/// The store's hosts. `mxbikes-shop.b-cdn.net` is its own Bunny pull zone, named in full
-/// rather than as `b-cdn.net` — that suffix is shared by every Bunny customer, and matching
-/// it would open the proxy to all of them. A few dozen product descriptions embed images
-/// from it.
-const SHOP_HOSTS: [&str; 2] = ["mxbikes-shop.com", "mxbikes-shop.b-cdn.net"];
+/// The stores' hosts. `mxbikes-shop.b-cdn.net` is that store's own Bunny pull zone, named in
+/// full rather than as `b-cdn.net` — that suffix is shared by every Bunny customer, and
+/// matching it would open the proxy to all of them. A few dozen product descriptions embed
+/// images from it.
+///
+/// MXB Hub serves everything from its own origin: a sweep of 40 listings, thumbnails, srcsets
+/// and description markup included, found no host but `shop.mxb-hub.com`. It is listed as the
+/// registrable domain anyway, which covers the subdomain it actually uses and any sibling the
+/// store adds later.
+const SHOP_HOSTS: [&str; 3] = ["mxbikes-shop.com", "mxbikes-shop.b-cdn.net", "mxb-hub.com"];
 
 /// Is `host` one we're willing to fetch from?
 ///
@@ -634,8 +639,24 @@ mod tests {
             "https://cdn.mxbikes-shop.com/img/1.png",
             // The store's Bunny pull zone — where some product descriptions embed from.
             "https://mxbikes-shop.b-cdn.net/wp-content/uploads/2024/05/a.jpg",
+            // MXB Hub serves its product images from its own origin.
+            "https://shop.mxb-hub.com/wp-content/uploads/2026/08/a.png",
+            "https://mxb-hub.com/wp-content/uploads/2026/08/a.png",
         ] {
             assert_eq!(source_url(&encoded(url)).as_deref(), Some(url), "{url}");
+        }
+    }
+
+    /// A lookalike host must not ride in on a store's name — the handler fetches whatever it
+    /// is handed, and product descriptions are markup written by other people.
+    #[test]
+    fn a_lookalike_store_host_is_refused() {
+        for url in [
+            "https://mxb-hub.com.evil.com/x.png",
+            "https://evil-mxb-hub.com/x.png",
+            "https://mxb-hub.co/x.png",
+        ] {
+            assert!(source_url(&encoded(url)).is_none(), "{url} must be refused");
         }
     }
 

--- a/src-tauri/src/imgcache.rs
+++ b/src-tauri/src/imgcache.rs
@@ -66,6 +66,10 @@ const PRUNE_TO: f64 = 0.8;
 /// sockets — the same reasoning as `mods::mxb`'s rating concurrency.
 const MAX_CONCURRENT_FETCHES: usize = 8;
 
+/// …and how many of those may be MXB Hub's at once. See the gate in [`handle`] for why this
+/// store gets its own, far smaller, number.
+const MAX_CONCURRENT_HUB_FETCHES: usize = 2;
+
 /// Ceiling on a single download.
 ///
 /// The whole body is held in memory to be sniffed and downscaled, and being on the allowlist
@@ -240,6 +244,17 @@ async fn load(app: &AppHandle, url: &str, width: Option<u32>) -> Option<(Vec<u8>
 
     let bytes = {
         let _permit = fetch_semaphore().acquire().await.ok()?;
+        // A second, much tighter gate for the store that counts requests. Everything else here
+        // is fetched eight at a time, which is what a grid of twenty-four thumbnails wants;
+        // MXB Hub answers that burst by deciding we are a robot and refusing the whole site,
+        // images and API alike, for everyone on this address. Two at a time costs a moment on
+        // the first paint of a page and nothing at all afterwards, because the entry is then
+        // on disk — and it is the difference between a grid that loads and one that cannot.
+        let _polite = if is_hub(url) {
+            Some(hub_semaphore().acquire().await.ok()?)
+        } else {
+            None
+        };
         fetch(url).await
     };
 
@@ -390,6 +405,18 @@ fn touch(path: &Path) {
 /// keep separate jars precisely because a clearance is scoped to the host that minted it, so
 /// serving a gpb-mods.com thumbnail through mxb-mods.com's session — or, as it did before,
 /// through the store's — sends a cookie that can only fail.
+fn is_hub(url: &str) -> bool {
+    reqwest::Url::parse(url)
+        .ok()
+        .and_then(|u| u.host_str().map(|h| h.to_ascii_lowercase()))
+        .is_some_and(|h| h == "mxb-hub.com" || h.ends_with(".mxb-hub.com"))
+}
+
+fn hub_semaphore() -> &'static tokio::sync::Semaphore {
+    static SEM: OnceLock<tokio::sync::Semaphore> = OnceLock::new();
+    SEM.get_or_init(|| tokio::sync::Semaphore::new(MAX_CONCURRENT_HUB_FETCHES))
+}
+
 fn client_for(url: &str) -> Option<&'static reqwest::Client> {
     static MXB: OnceLock<Option<reqwest::Client>> = OnceLock::new();
     static GPB: OnceLock<Option<reqwest::Client>> = OnceLock::new();

--- a/src-tauri/src/imgcache.rs
+++ b/src-tauri/src/imgcache.rs
@@ -406,6 +406,12 @@ fn client_for(url: &str) -> Option<&'static reqwest::Client> {
         catalog(&MXB, &crate::mxb_session::MXB_SITE)
     } else if under(crate::mxb_session::GPB_SITE.domain) {
         catalog(&GPB, &crate::mxb_session::GPB_SITE)
+    } else if under("mxb-hub.com") {
+        // MXB Hub's images are behind the same rate-based robot challenge as its API, so they
+        // have to be fetched with the client that holds the clearance. Sending them through
+        // the store client below is what left the grid full of placeholder icons: every
+        // thumbnail came back as a 202 of challenge HTML.
+        crate::mods::hub::client().ok()
     } else {
         SHOP.get_or_init(|| crate::shop_catalog_session::client_builder().build().ok())
             .as_ref()
@@ -421,6 +427,15 @@ async fn fetch(url: &str) -> Option<Vec<u8>> {
         .send()
         .await
         .ok()?;
+    // A robot challenge is a `202` full of HTML, which `is_success` waves through — so
+    // without this the cache would happily store a web page under an image's name and keep
+    // serving it long after the challenge was cleared. Refused rather than retried: the
+    // catalog request alongside it is what triggers the handshake, and a page of thumbnails
+    // all trying to solve the same challenge is the request storm that caused it.
+    if crate::mods::hub::challenged(&resp) {
+        log::debug!("imgcache: {url} came back as a robot challenge — not caching it");
+        return None;
+    }
     if !resp.status().is_success() {
         return None;
     }

--- a/src-tauri/src/install.rs
+++ b/src-tauri/src/install.rs
@@ -113,6 +113,15 @@ const READ_TIMEOUT: Duration = Duration::from_secs(30);
 /// [`download`]'s resume loop only wakes when the stream *errors*, and a silent socket never
 /// does — so without this a host that stops sending hangs forever. Not on [`build_client`]
 /// itself: an upload sees no response until its last byte is sent, which looks identical.
+/// Tell the queue this install is working out where the file actually is.
+///
+/// The same stage Browse emits before resolving a host link, exposed because the MXB Hub
+/// install does the same thing for a purchase whose file lives on MediaFire — without it the
+/// card sits at 0% through a folder lookup with nothing to say why.
+pub(crate) fn emit_resolving(app: &AppHandle, slug: &str) {
+    emit(app, slug, "resolving", None, None);
+}
+
 pub(crate) fn build_download_client() -> anyhow::Result<Client> {
     Ok(client_builder().read_timeout(READ_TIMEOUT).build()?)
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6764,10 +6764,9 @@ async fn hub_login(app: tauri::AppHandle) -> Result<(), String> {
         return Ok(());
     }
 
-    let target = format!(
-        "{base}/my-account/?redirect={base}%2Fmy-account%2Fdownloads%2F",
-        base = hub_session::HUB_BASE
-    );
+    // The account page, plainly. It is both the login form when signed out and the proof of a
+    // sign-in when not, so there is nothing to redirect to and no parameter worth inventing.
+    let target = format!("{base}/my-account/", base = hub_session::HUB_BASE);
     let url = tauri::WebviewUrl::External(target.parse().map_err(|e| format!("{e}"))?);
     let window = tauri::WebviewWindowBuilder::new(&app, HUB_LOGIN_WINDOW, url)
         .title("Sign in to MXB Hub")

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -22,6 +22,7 @@ mod gameproc;
 mod gate;
 mod gearrepair;
 mod heightfield;
+mod hub_session;
 mod imgcache;
 mod install;
 mod ledger;
@@ -91,6 +92,9 @@ pub(crate) const MAIN_WINDOW: &str = "main";
 
 /// The shop login WebView, opened on demand and closed once the session is captured.
 const SHOP_LOGIN_WINDOW: &str = "shop-login";
+/// The MXB Hub sign-in window. Transient like the shop's: it is the user typing a password
+/// into the store's own page, and it closes the moment the cookie appears.
+const HUB_LOGIN_WINDOW: &str = "hub-login";
 
 /// Whether closing this window should park it in the tray rather than destroy it.
 ///
@@ -6698,6 +6702,246 @@ async fn shop_install(
     Ok(())
 }
 
+// ─────────────────────────────────── MXB Hub ───────────────────────────────────
+//
+// shop.mxb-hub.com — the community marketplace `mxbhub.com` redirects to. Two halves, like
+// the shop: a public catalog anyone can browse, and the files this account owns.
+//
+// It is markedly simpler than the shop's equivalent because the store is not behind
+// Cloudflare (measured 2026-08-30: `server: nginx`, no `cf-ray`, no interstitial on
+// `/my-account/`). So there is no clearance to earn, no parked WebView reading pages out of
+// the DOM, and no `with_clearance` wrapper: `reqwest` talks to it directly, browsing needs no
+// credential at all, and the only window ever opened is the sign-in one.
+
+#[tauri::command]
+async fn hub_search(
+    query: String,
+    category_id: Option<u64>,
+    page: u32,
+    sort: mods::hub::HubSort,
+    on_sale_only: bool,
+) -> Result<mods::hub::HubPage, String> {
+    mods::hub::search(&query, category_id, page, sort, on_sale_only)
+        .await
+        .map_err(|e| format!("{e:#}"))
+}
+
+#[tauri::command]
+async fn hub_categories() -> Result<Vec<mods::hub::HubCategory>, String> {
+    mods::hub::categories().await.map_err(|e| format!("{e:#}"))
+}
+
+#[tauri::command]
+async fn hub_detail(id: u64) -> Result<mods::hub::HubModDetail, String> {
+    mods::hub::detail(id).await.map_err(|e| format!("{e:#}"))
+}
+
+#[tauri::command]
+fn hub_status(state: State<hub_session::HubSession>) -> bool {
+    state.logged_in()
+}
+
+#[tauri::command]
+async fn hub_logout(app: tauri::AppHandle) {
+    hub_session::clear_session(&app).await;
+}
+
+/// Open the store's own sign-in page and wait for the login cookie to appear.
+///
+/// The password is typed into WooCommerce's page, in a window of its own — the app never sees
+/// it, and never asks for it. What we take is the cookie the store sets afterwards.
+///
+/// Two things the shop's version has to do are deliberately absent. It clears the whole
+/// WebView's cookies first, because a stale `cf_clearance` there is worse than none; there is
+/// no Cloudflare here, and clearing is app-wide, so doing it would sign the user out of the
+/// *other* store on their way into this one. And it lands on `/robots.txt` to dodge a second
+/// challenge; this one can land on the account page, which is also the page that proves the
+/// sign-in worked.
+#[tauri::command]
+async fn hub_login(app: tauri::AppHandle) -> Result<(), String> {
+    if let Some(w) = app.get_webview_window(HUB_LOGIN_WINDOW) {
+        let _ = w.set_focus();
+        return Ok(());
+    }
+
+    let target = format!(
+        "{base}/my-account/?redirect={base}%2Fmy-account%2Fdownloads%2F",
+        base = hub_session::HUB_BASE
+    );
+    let url = tauri::WebviewUrl::External(target.parse().map_err(|e| format!("{e}"))?);
+    let window = tauri::WebviewWindowBuilder::new(&app, HUB_LOGIN_WINDOW, url)
+        .title("Sign in to MXB Hub")
+        .inner_size(520.0, 760.0)
+        .build()
+        .map_err(|e| format!("{e:#}"))?;
+    let _ = window;
+
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        // ~5 minutes at 500 ms. Long enough for a password reset mid-flow; the user can retry.
+        let mut last_seen = Vec::new();
+        for _ in 0..600u32 {
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            let Some(win) = app.get_webview_window(HUB_LOGIN_WINDOW) else {
+                // Closed by hand — a cancel, not a failure. Logged all the same, because "the
+                // user gave up" and "the app stopped watching" are indistinguishable later.
+                log::info!(
+                    "the MXB Hub login window was closed before sign-in finished (cookies: {})",
+                    hub_session::cookie_names(&last_seen)
+                );
+                return;
+            };
+            let cookies = hub_session::cookies_from_window(&win);
+            if !hub_session::is_authenticated(&cookies) {
+                last_seen = cookies;
+                continue;
+            }
+            let ok = match hub_session::set_session(&app, cookies) {
+                Ok(()) => {
+                    log::info!("captured MXB Hub session");
+                    true
+                }
+                Err(e) => {
+                    log::error!("failed to save the MXB Hub session: {e:#}");
+                    false
+                }
+            };
+            let _ = app.emit("hub-auth", ok);
+            let _ = win.close();
+            return;
+        }
+
+        log::warn!(
+            "MXB Hub sign-in did not complete within 5 minutes (cookies: {})",
+            hub_session::cookie_names(&last_seen)
+        );
+        let _ = app.emit("hub-auth", false);
+        // Closed rather than left up: nothing is watching it any more, so a sign-in finished
+        // afterwards would go unnoticed. Retry reopens it.
+        if let Some(win) = app.get_webview_window(HUB_LOGIN_WINDOW) {
+            let _ = win.close();
+        }
+    });
+    Ok(())
+}
+
+/// What this account owns, with the catalog's artwork already attached.
+///
+/// The artwork is folded in here rather than left to a second command the way the shop's is:
+/// a Hub download row links to its product page, so the lookup is one request keyed on exact
+/// slugs, and splitting that across two round trips would only make the grid pop in twice.
+/// Best-effort — a catalog that won't answer costs the cards their pictures, not the list.
+#[tauri::command]
+async fn hub_my_downloads(
+    app: tauri::AppHandle,
+    state: State<'_, hub_session::HubSession>,
+) -> Result<Vec<mods::hubaccount::HubItem>, String> {
+    let Some(client) = state.client() else {
+        return Err("Not signed in to MXB Hub.".to_string());
+    };
+    let mut items = mods::hubaccount::fetch_my_downloads(&app, &client)
+        .await
+        .map_err(|e| format!("{e:#}"))?;
+
+    match mods::hubaccount::match_products(&items).await {
+        Ok(matches) => {
+            for (item, found) in items.iter_mut().zip(matches) {
+                item.image = found.and_then(|m| m.image);
+            }
+        }
+        Err(e) => log::warn!("could not match MXB Hub purchases to the catalog: {e:#}"),
+    }
+    Ok(items)
+}
+
+/// Download a file this account owns and install it, to a destination the caller already chose.
+///
+/// The whole body after the client lookup is [`install`]'s — `download` streams with progress,
+/// resume and cancellation, and `extract_and_place` does what every other install does. That
+/// reuse is the point of the store having no Cloudflare in front of it: the shop needed a
+/// WebView download path ([`shop_fetch::download`]) precisely because its file URLs are
+/// challenged, and none of that is needed here.
+#[tauri::command]
+async fn hub_install(
+    app: tauri::AppHandle,
+    state: State<'_, hub_session::HubSession>,
+    item: mods::hubaccount::HubItem,
+    subpath: String,
+    dest_folder: String,
+) -> Result<(), String> {
+    let Some(client) = state.client() else {
+        return Err("Not signed in to MXB Hub.".to_string());
+    };
+    let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
+    // Asked before the download: a track archive is several hundred megabytes to waste.
+    if cfg.mods_path.trim().is_empty() {
+        return Err("No MX Bikes folder is configured yet.".to_string());
+    }
+
+    let work = install::staging_dir("hub");
+    std::fs::create_dir_all(&work).map_err(|e| format!("{e:#}"))?;
+
+    let _cancel = cancel::begin(&item.slug);
+    let archive = match install::download(&app, &client, &item.slug, &item.download_url, &work).await
+    {
+        Ok(path) => path,
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&work);
+            // A dead cookie doesn't 401 here — WooCommerce answers a download link it won't
+            // honour with an HTML page, which `install::download` reports as "a web page
+            // instead of a file". Left as it is rather than translated: guessing "session
+            // expired" from a content type would sign the user out on a server hiccup.
+            return Err(format!("{e:#}"));
+        }
+    };
+
+    // What identifies this purchase on disk afterwards. Both forms, because a `.pkz` is placed
+    // under its own file name while an archive that extracts lands in a folder named for its
+    // stem.
+    let names: Vec<String> = [archive.file_name(), archive.file_stem()]
+        .into_iter()
+        .flatten()
+        .map(|s| s.to_string_lossy().into_owned())
+        .collect();
+
+    let placed = tauri::async_runtime::spawn_blocking({
+        let app = app.clone();
+        let cfg = cfg.clone();
+        let slug = item.slug.clone();
+        let work = work.clone();
+        let subpath = subpath.clone();
+        let dest_folder = dest_folder.clone();
+        move || {
+            install::extract_and_place(
+                &app,
+                &cfg,
+                &slug,
+                &archive,
+                &work,
+                &subpath,
+                &dest_folder,
+                install::Packs::PlaceWhole,
+            )
+            .map(|_| ())
+        }
+    })
+    .await
+    .map_err(|e| format!("hub_install task failed: {e}"))?;
+
+    let _ = std::fs::remove_dir_all(&work);
+    placed.map_err(|e| format!("{e:#}"))?;
+
+    // Same record the shop's installs write, so both stores' grids get their badge from one
+    // place — it is a claim about a product name and the folders it put on disk, and nothing
+    // in it is specific to which store sold the thing.
+    if let Ok(dir) = app.path().app_local_data_dir() {
+        if let Err(e) = shop_installed::record(&dir, &item.product, &names) {
+            log::warn!("could not record what {} installed: {e:#}", item.product);
+        }
+    }
+    Ok(())
+}
+
 /// Which purchased products have a recorded install, and the folders they claim.
 ///
 /// The claim is not checked against disk here — the purchases grid already scans the library
@@ -7601,6 +7845,7 @@ fn main() {
         .manage(LookWatcher::default())
         .manage(CloudServers::default())
         .manage(shop_session::ShopSession::default())
+        .manage(hub_session::HubSession::default())
         .manage(voice::Monitor::default())
         .manage(voice::session::Session::default())
         .setup(|app| {
@@ -7819,6 +8064,7 @@ fn main() {
             // There is nothing to press: the supervisor is the whole of "joining a room".
             voice::session::start(handle);
             shop_session::load_session(handle);
+            hub_session::load_session(handle);
             shop_catalog_session::load(handle);
             mxb_session::load(handle);
             imgcache::start_maintenance(handle);
@@ -8028,6 +8274,14 @@ fn main() {
             shop_match_catalog,
             shop_install,
             shop_installed_map,
+            hub_search,
+            hub_categories,
+            hub_detail,
+            hub_login,
+            hub_status,
+            hub_logout,
+            hub_my_downloads,
+            hub_install,
             record_download,
             download_history,
             forget_download,
@@ -8308,6 +8562,7 @@ mod window_tests {
             mxb_fetch::WINDOW,
             shop_fetch::WINDOW,
             SHOP_LOGIN_WINDOW,
+            HUB_LOGIN_WINDOW,
             overlay::LABEL, // handled earlier by its own branch, but never by this one
         ] {
             assert!(
@@ -8358,7 +8613,7 @@ mod window_tests {
     /// their capability files grant.
     #[test]
     fn the_apps_own_windows_are_unaffected_by_the_guard() {
-        for label in [MAIN_WINDOW, overlay::LABEL, SHOP_LOGIN_WINDOW] {
+        for label in [MAIN_WINDOW, overlay::LABEL, SHOP_LOGIN_WINDOW, HUB_LOGIN_WINDOW] {
             for command in ["create_config", "install_mod", "plugin:event|emit"] {
                 assert!(ipc_allowed(label, command), "{label} / {command}");
             }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -22,6 +22,7 @@ mod gameproc;
 mod gate;
 mod gearrepair;
 mod heightfield;
+mod hub_clearance;
 mod hub_session;
 mod imgcache;
 mod install;
@@ -6713,27 +6714,65 @@ async fn shop_install(
 // the DOM, and no `with_clearance` wrapper: `reqwest` talks to it directly, browsing needs no
 // credential at all, and the only window ever opened is the sign-in one.
 
+/// Run a hub read, and if the store answers with its robot challenge, solve it and try again.
+///
+/// The sibling of [`with_clearance`] above, and the difference is where the browser comes in.
+/// mxb-mods.com's fix is to move the *request* into a WebView and keep it there for the
+/// session, because Cloudflare judges the client. SiteGround judges the request rate and hands
+/// out a cookie once its script has run — so the browser is needed exactly once, and every
+/// request after it is an ordinary one again.
+async fn with_hub_clearance<T, F, Fut>(
+    app: &tauri::AppHandle,
+    what: &str,
+    op: F,
+) -> Result<T, String>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<T>>,
+{
+    let err = match op().await {
+        Ok(value) => return Ok(value),
+        Err(err) => err,
+    };
+    if err.downcast_ref::<mods::Blocked>().is_none() {
+        log::warn!("{what} failed and a browser wouldn't help: {err:#}");
+        return Err(format!("{err:#}"));
+    }
+    log::info!("{what} hit the MXB Hub robot challenge — answering it in a browser");
+    if let Err(e) = hub_clearance::earn(app).await {
+        return Err(format!("{e:#}"));
+    }
+    op().await.map_err(|e| format!("{e:#}"))
+}
+
 #[tauri::command]
 async fn hub_search(
+    app: tauri::AppHandle,
     query: String,
     category_id: Option<u64>,
     page: u32,
     sort: mods::hub::HubSort,
     on_sale_only: bool,
 ) -> Result<mods::hub::HubPage, String> {
-    mods::hub::search(&query, category_id, page, sort, on_sale_only)
-        .await
-        .map_err(|e| format!("{e:#}"))
+    with_hub_clearance(&app, "hub search", || {
+        mods::hub::search(&query, category_id, page, sort, on_sale_only)
+    })
+    .await
 }
 
 #[tauri::command]
-async fn hub_categories() -> Result<Vec<mods::hub::HubCategory>, String> {
-    mods::hub::categories().await.map_err(|e| format!("{e:#}"))
+async fn hub_categories(
+    app: tauri::AppHandle,
+) -> Result<Vec<mods::hub::HubCategory>, String> {
+    with_hub_clearance(&app, "hub categories", mods::hub::categories).await
 }
 
 #[tauri::command]
-async fn hub_detail(id: u64) -> Result<mods::hub::HubModDetail, String> {
-    mods::hub::detail(id).await.map_err(|e| format!("{e:#}"))
+async fn hub_detail(
+    app: tauri::AppHandle,
+    id: u64,
+) -> Result<mods::hub::HubModDetail, String> {
+    with_hub_clearance(&app, "hub detail", || mods::hub::detail(id)).await
 }
 
 #[tauri::command]
@@ -6840,12 +6879,19 @@ async fn hub_my_downloads(
     app: tauri::AppHandle,
     state: State<'_, hub_session::HubSession>,
 ) -> Result<HubDownloads, String> {
-    let Some(client) = state.client() else {
+    if !state.logged_in() {
         return Err("Not signed in to MXB Hub.".to_string());
-    };
-    let mut items = mods::hubaccount::fetch_my_downloads(&app, &client)
-        .await
-        .map_err(|e| format!("{e:#}"))?;
+    }
+    let mut items = with_hub_clearance(&app, "hub purchases", || {
+        // Re-read the client each attempt: answering the challenge rebuilds the signed-in one
+        // with the clearance folded in, and the stale handle would just be challenged again.
+        let client = state.client();
+        async {
+            let client = client.ok_or_else(|| anyhow::anyhow!("Not signed in to MXB Hub."))?;
+            mods::hubaccount::fetch_my_downloads(&app, &client).await
+        }
+    })
+    .await?;
 
     let listings = match mods::hubaccount::match_products(&items).await {
         Ok(found) => found,
@@ -6890,7 +6936,7 @@ async fn hub_install(
     subpath: String,
     dest_folder: String,
 ) -> Result<(), String> {
-    let Some(client) = state.client() else {
+    let Some(session) = state.client() else {
         return Err("Not signed in to MXB Hub.".to_string());
     };
     let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
@@ -6903,15 +6949,34 @@ async fn hub_install(
     std::fs::create_dir_all(&work).map_err(|e| format!("{e:#}"))?;
 
     let _cancel = cancel::begin(&item.slug);
-    let archive = match install::download(&app, &client, &item.slug, &item.download_url, &work).await
-    {
+
+    // Where the bytes come from decides both the client and whether the link needs resolving.
+    //
+    // A store-issued `?download_file=` URL is authorised by the user's session, so it is
+    // fetched with it and is already a file. A handed-off link — MediaFire and friends, which
+    // WooCommerce allows for any product and MXB Hub uses for a number of its free mods — is
+    // fetched with the ordinary download client instead: sending the user's store cookies to a
+    // third party would be wrong whichever way it turned out. It also has to be resolved
+    // first, because a MediaFire *folder* is a web page listing files, not a file.
+    let fetch = async {
+        if item.external {
+            let client = install::build_download_client()?;
+            install::emit_resolving(&app, &item.slug);
+            let direct = install::resolve_direct_url(&client, &item.download_url, &item.host)
+                .await?;
+            install::download(&app, &client, &item.slug, &direct, &work).await
+        } else {
+            // A dead cookie doesn't 401 here — WooCommerce answers a link it won't honour with
+            // an HTML page, which `install::download` reports as "a web page instead of a
+            // file". Left as it is rather than translated: guessing "session expired" from a
+            // content type would sign the user out on a server hiccup.
+            install::download(&app, &session, &item.slug, &item.download_url, &work).await
+        }
+    };
+    let archive = match fetch.await {
         Ok(path) => path,
         Err(e) => {
             let _ = std::fs::remove_dir_all(&work);
-            // A dead cookie doesn't 401 here — WooCommerce answers a download link it won't
-            // honour with an HTML page, which `install::download` reports as "a web page
-            // instead of a file". Left as it is rather than translated: guessing "session
-            // expired" from a content type would sign the user out on a server hiccup.
             return Err(format!("{e:#}"));
         }
     };
@@ -8584,6 +8649,7 @@ mod window_tests {
             shop_fetch::WINDOW,
             SHOP_LOGIN_WINDOW,
             HUB_LOGIN_WINDOW,
+            hub_clearance::WINDOW,
             overlay::LABEL, // handled earlier by its own branch, but never by this one
         ] {
             assert!(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6825,17 +6825,22 @@ async fn hub_login(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-/// What this account owns, with the catalog's artwork already attached.
+/// What this account owns, with its catalog entries alongside.
 ///
-/// The artwork is folded in here rather than left to a second command the way the shop's is:
-/// a Hub download row links to its product page, so the lookup is one request keyed on exact
-/// slugs, and splitting that across two round trips would only make the grid pop in twice.
-/// Best-effort — a catalog that won't answer costs the cards their pictures, not the list.
+/// One command rather than the shop's two. A Hub download row links to its product page, so
+/// the catalog lookup is a single request keyed on exact slugs — where the shop has to fold
+/// product *names* together and match approximately, which is why its match is a separate
+/// call the grid makes after the fact. Doing both here means the grid renders once, complete,
+/// instead of popping in twice.
+///
+/// The listings are positional: `listings[i]` is `items[i]`'s catalog entry, or `null` where
+/// the product has since been unlisted. Best-effort — a catalog that won't answer costs the
+/// cards their artwork, not the list.
 #[tauri::command]
 async fn hub_my_downloads(
     app: tauri::AppHandle,
     state: State<'_, hub_session::HubSession>,
-) -> Result<Vec<mods::hubaccount::HubItem>, String> {
+) -> Result<HubDownloads, String> {
     let Some(client) = state.client() else {
         return Err("Not signed in to MXB Hub.".to_string());
     };
@@ -6843,15 +6848,32 @@ async fn hub_my_downloads(
         .await
         .map_err(|e| format!("{e:#}"))?;
 
-    match mods::hubaccount::match_products(&items).await {
-        Ok(matches) => {
-            for (item, found) in items.iter_mut().zip(matches) {
-                item.image = found.and_then(|m| m.image);
-            }
+    let listings = match mods::hubaccount::match_products(&items).await {
+        Ok(found) => found,
+        Err(e) => {
+            log::warn!("could not match MXB Hub purchases to the catalog: {e:#}");
+            vec![None; items.len()]
         }
-        Err(e) => log::warn!("could not match MXB Hub purchases to the catalog: {e:#}"),
+    };
+    // Mirrored onto the rows themselves as well, because a purchase is handed to the install
+    // queue on its own and has to still know what it is once the listing is out of scope.
+    for (item, found) in items.iter_mut().zip(&listings) {
+        let Some(found) = found else { continue };
+        item.image = found.image.clone();
+        item.author = found.author.clone();
+        item.category_id = found.category_ids.first().copied().unwrap_or(0) as u32;
     }
-    Ok(items)
+
+    Ok(HubDownloads { items, listings })
+}
+
+/// The purchases page and the catalog, joined, in one answer.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HubDownloads {
+    items: Vec<mods::hubaccount::HubItem>,
+    /// Positional against `items`.
+    listings: Vec<Option<mods::hub::HubMod>>,
 }
 
 /// Download a file this account owns and install it, to a destination the caller already chose.

--- a/src-tauri/src/mods/fixtures/hub-categories.sample.json
+++ b/src-tauri/src/mods/fixtures/hub-categories.sample.json
@@ -1,0 +1,695 @@
+[
+ {
+  "id": 206,
+  "name": "2025 Honda CRF Modelswap",
+  "slug": "2025-honda-crf-modelswap",
+  "parent": 51,
+  "count": 1
+ },
+ {
+  "id": 205,
+  "name": "AB Designs 2027 CRF",
+  "slug": "ab-designs-2027-crf",
+  "parent": 51,
+  "count": 1
+ },
+ {
+  "id": 38,
+  "name": "Alpinestars",
+  "slug": "alpinestars",
+  "parent": 36,
+  "count": 14
+ },
+ {
+  "id": 50,
+  "name": "Arin",
+  "slug": "arin",
+  "parent": 49,
+  "count": 90
+ },
+ {
+  "id": 168,
+  "name": "Bike Paints",
+  "slug": "bike-paints",
+  "parent": 163,
+  "count": 48
+ },
+ {
+  "id": 136,
+  "name": "Bike PNT Creation",
+  "slug": "bike-pnt-creation",
+  "parent": 135,
+  "count": 5
+ },
+ {
+  "id": 51,
+  "name": "Bike PSD&#8217;s",
+  "slug": "bike-psds",
+  "parent": 0,
+  "count": 7
+ },
+ {
+  "id": 108,
+  "name": "Bike Setups",
+  "slug": "bike-setups",
+  "parent": 0,
+  "count": 31
+ },
+ {
+  "id": 191,
+  "name": "Blend Brands",
+  "slug": "blend-brands",
+  "parent": 100,
+  "count": 176
+ },
+ {
+  "id": 100,
+  "name": "Blends",
+  "slug": "blends",
+  "parent": 0,
+  "count": 198
+ },
+ {
+  "id": 63,
+  "name": "Bundles",
+  "slug": "bundles",
+  "parent": 36,
+  "count": 2
+ },
+ {
+  "id": 220,
+  "name": "CarterMala",
+  "slug": "cartermala",
+  "parent": 49,
+  "count": 2
+ },
+ {
+  "id": 129,
+  "name": "CONCEPTGRAFF",
+  "slug": "conceptgraff",
+  "parent": 49,
+  "count": 2
+ },
+ {
+  "id": 49,
+  "name": "Creators",
+  "slug": "creators",
+  "parent": 0,
+  "count": 435
+ },
+ {
+  "id": 121,
+  "name": "CSTAR",
+  "slug": "cstar",
+  "parent": 49,
+  "count": 118
+ },
+ {
+  "id": 144,
+  "name": "Ctursky45",
+  "slug": "ctursky45",
+  "parent": 49,
+  "count": 3
+ },
+ {
+  "id": 221,
+  "name": "DAN99",
+  "slug": "dan99",
+  "parent": 49,
+  "count": 1
+ },
+ {
+  "id": 175,
+  "name": "DayCare",
+  "slug": "daycare",
+  "parent": 49,
+  "count": 9
+ },
+ {
+  "id": 218,
+  "name": "Deevo",
+  "slug": "deevo",
+  "parent": 49,
+  "count": 1
+ },
+ {
+  "id": 104,
+  "name": "Devices",
+  "slug": "devices",
+  "parent": 100,
+  "count": 21
+ },
+ {
+  "id": 213,
+  "name": "DUCATI",
+  "slug": "ducati",
+  "parent": 191,
+  "count": 7
+ },
+ {
+  "id": 188,
+  "name": "DYLAN",
+  "slug": "dylan",
+  "parent": 49,
+  "count": 9
+ },
+ {
+  "id": 101,
+  "name": "Exhausts",
+  "slug": "exhausts",
+  "parent": 100,
+  "count": 24
+ },
+ {
+  "id": 169,
+  "name": "Eyezaya",
+  "slug": "eyezaya",
+  "parent": 49,
+  "count": 32
+ },
+ {
+  "id": 126,
+  "name": "FANTIC",
+  "slug": "fantic",
+  "parent": 109,
+  "count": 2
+ },
+ {
+  "id": 201,
+  "name": "FANTIC",
+  "slug": "fantic-blend-brands",
+  "parent": 191,
+  "count": 6
+ },
+ {
+  "id": 45,
+  "name": "Fasthouse",
+  "slug": "fasthouse",
+  "parent": 36,
+  "count": 3
+ },
+ {
+  "id": 120,
+  "name": "Fluffy",
+  "slug": "fluffy",
+  "parent": 49,
+  "count": 12
+ },
+ {
+  "id": 41,
+  "name": "Fly",
+  "slug": "fly",
+  "parent": 36,
+  "count": 4
+ },
+ {
+  "id": 37,
+  "name": "FOX",
+  "slug": "fox",
+  "parent": 36,
+  "count": 32
+ },
+ {
+  "id": 163,
+  "name": "Free Mods",
+  "slug": "free-mods",
+  "parent": 0,
+  "count": 49
+ },
+ {
+  "id": 115,
+  "name": "GasGas",
+  "slug": "gasgas",
+  "parent": 109,
+  "count": 1
+ },
+ {
+  "id": 197,
+  "name": "GASGAS",
+  "slug": "gasgas-blend-brands",
+  "parent": 191,
+  "count": 23
+ },
+ {
+  "id": 137,
+  "name": "Gear PNT Creation",
+  "slug": "gear-pnt-creation",
+  "parent": 135,
+  "count": 5
+ },
+ {
+  "id": 36,
+  "name": "Gear PSD&#8217;s",
+  "slug": "gear-psds",
+  "parent": 0,
+  "count": 87
+ },
+ {
+  "id": 106,
+  "name": "Handguards",
+  "slug": "handguards",
+  "parent": 100,
+  "count": 9
+ },
+ {
+  "id": 223,
+  "name": "Helmet",
+  "slug": "helmet",
+  "parent": 160,
+  "count": 5
+ },
+ {
+  "id": 118,
+  "name": "Honda",
+  "slug": "honda",
+  "parent": 109,
+  "count": 1
+ },
+ {
+  "id": 128,
+  "name": "HONDA",
+  "slug": "honda-mx2-oem",
+  "parent": 110,
+  "count": 4
+ },
+ {
+  "id": 192,
+  "name": "HONDA",
+  "slug": "honda-blend-brands",
+  "parent": 191,
+  "count": 27
+ },
+ {
+  "id": 119,
+  "name": "Husk",
+  "slug": "husk",
+  "parent": 49,
+  "count": 7
+ },
+ {
+  "id": 116,
+  "name": "Husqvarna",
+  "slug": "husqvarna",
+  "parent": 109,
+  "count": 1
+ },
+ {
+  "id": 123,
+  "name": "HUSQVARNA",
+  "slug": "husqvarna-mx2-oem-bike-setups",
+  "parent": 110,
+  "count": 4
+ },
+ {
+  "id": 196,
+  "name": "HUSQVARNA",
+  "slug": "husqvarna-blend-brands",
+  "parent": 191,
+  "count": 26
+ },
+ {
+  "id": 203,
+  "name": "Jez",
+  "slug": "jez",
+  "parent": 49,
+  "count": 7
+ },
+ {
+  "id": 215,
+  "name": "JP DESIGNS",
+  "slug": "jp-designs",
+  "parent": 49,
+  "count": 1
+ },
+ {
+  "id": 139,
+  "name": "KAWASAKI",
+  "slug": "kawasaki-mx2-oem",
+  "parent": 110,
+  "count": 2
+ },
+ {
+  "id": 193,
+  "name": "KAWASAKI",
+  "slug": "kawasaki-blend-brands",
+  "parent": 191,
+  "count": 19
+ },
+ {
+  "id": 122,
+  "name": "KELSO",
+  "slug": "kelso",
+  "parent": 49,
+  "count": 17
+ },
+ {
+  "id": 42,
+  "name": "Kenny",
+  "slug": "kenny",
+  "parent": 36,
+  "count": 1
+ },
+ {
+  "id": 113,
+  "name": "KTM",
+  "slug": "ktm",
+  "parent": 109,
+  "count": 3
+ },
+ {
+  "id": 127,
+  "name": "KTM",
+  "slug": "ktm-mx2-oem-bike-setups",
+  "parent": 110,
+  "count": 4
+ },
+ {
+  "id": 195,
+  "name": "KTM",
+  "slug": "ktm-blend-brands",
+  "parent": 191,
+  "count": 26
+ },
+ {
+  "id": 26,
+  "name": "KTM MX1 OEM",
+  "slug": "ktm-mx1-oem",
+  "parent": 24,
+  "count": 13
+ },
+ {
+  "id": 29,
+  "name": "KTM MX2 OEM",
+  "slug": "ktm-mx2-oem",
+  "parent": 28,
+  "count": 13
+ },
+ {
+  "id": 52,
+  "name": "KTM OEM",
+  "slug": "ktm-oem",
+  "parent": 51,
+  "count": 2
+ },
+ {
+  "id": 46,
+  "name": "Leatt",
+  "slug": "leatt",
+  "parent": 36,
+  "count": 3
+ },
+ {
+  "id": 103,
+  "name": "Levers",
+  "slug": "levers",
+  "parent": 100,
+  "count": 5
+ },
+ {
+  "id": 142,
+  "name": "Lin",
+  "slug": "lin",
+  "parent": 49,
+  "count": 12
+ },
+ {
+  "id": 23,
+  "name": "Modelswaps",
+  "slug": "modelswaps",
+  "parent": 0,
+  "count": 54
+ },
+ {
+  "id": 24,
+  "name": "MX1 4T OEM",
+  "slug": "mx1-4t-oem",
+  "parent": 23,
+  "count": 54
+ },
+ {
+  "id": 109,
+  "name": "MX1 OEM",
+  "slug": "mx1-oem",
+  "parent": 108,
+  "count": 12
+ },
+ {
+  "id": 28,
+  "name": "MX2 4T OEM",
+  "slug": "mx2-4t-oem",
+  "parent": 23,
+  "count": 54
+ },
+ {
+  "id": 110,
+  "name": "MX2 OEM",
+  "slug": "mx2-oem",
+  "parent": 108,
+  "count": 19
+ },
+ {
+  "id": 161,
+  "name": "Neck Brace",
+  "slug": "neck-brace",
+  "parent": 160,
+  "count": 1
+ },
+ {
+  "id": 182,
+  "name": "No Fear",
+  "slug": "no-fear",
+  "parent": 36,
+  "count": 1
+ },
+ {
+  "id": 48,
+  "name": "Numbskull",
+  "slug": "numbskull",
+  "parent": 36,
+  "count": 1
+ },
+ {
+  "id": 61,
+  "name": "OHTEA",
+  "slug": "ohtea",
+  "parent": 49,
+  "count": 111
+ },
+ {
+  "id": 44,
+  "name": "ONE",
+  "slug": "one",
+  "parent": 36,
+  "count": 2
+ },
+ {
+  "id": 105,
+  "name": "OneTwoEight",
+  "slug": "onetwoeight",
+  "parent": 49,
+  "count": 23
+ },
+ {
+  "id": 107,
+  "name": "Parts",
+  "slug": "parts",
+  "parent": 100,
+  "count": 131
+ },
+ {
+  "id": 135,
+  "name": "PNT Creation",
+  "slug": "pnt-creation",
+  "parent": 0,
+  "count": 10
+ },
+ {
+  "id": 225,
+  "name": "Protection PSDs",
+  "slug": "protection-psds",
+  "parent": 160,
+  "count": 5
+ },
+ {
+  "id": 160,
+  "name": "Rider Protection",
+  "slug": "rider-protection",
+  "parent": 0,
+  "count": 11
+ },
+ {
+  "id": 217,
+  "name": "Ryder",
+  "slug": "ryder",
+  "parent": 49,
+  "count": 1
+ },
+ {
+  "id": 179,
+  "name": "Sean",
+  "slug": "sean",
+  "parent": 49,
+  "count": 6
+ },
+ {
+  "id": 212,
+  "name": "SEB",
+  "slug": "seb",
+  "parent": 49,
+  "count": 2
+ },
+ {
+  "id": 43,
+  "name": "Seven",
+  "slug": "seven",
+  "parent": 36,
+  "count": 4
+ },
+ {
+  "id": 186,
+  "name": "Slim",
+  "slug": "slim",
+  "parent": 49,
+  "count": 3
+ },
+ {
+  "id": 138,
+  "name": "Suspension",
+  "slug": "suspension",
+  "parent": 100,
+  "count": 11
+ },
+ {
+  "id": 125,
+  "name": "SUZUKI",
+  "slug": "suzuki-mx2-oem",
+  "parent": 110,
+  "count": 1
+ },
+ {
+  "id": 194,
+  "name": "SUZUKI",
+  "slug": "suzuki-blend-brands",
+  "parent": 191,
+  "count": 16
+ },
+ {
+  "id": 210,
+  "name": "SUZUKI MX1 OEM",
+  "slug": "suzuki-mx1-oem",
+  "parent": 24,
+  "count": 1
+ },
+ {
+  "id": 211,
+  "name": "SUZUKI MX2 OEM",
+  "slug": "suzuki-mx2-oem-mx2-4t-oem",
+  "parent": 28,
+  "count": 1
+ },
+ {
+  "id": 40,
+  "name": "Thor",
+  "slug": "thor",
+  "parent": 36,
+  "count": 7
+ },
+ {
+  "id": 200,
+  "name": "TM",
+  "slug": "tm",
+  "parent": 191,
+  "count": 3
+ },
+ {
+  "id": 166,
+  "name": "Tracks",
+  "slug": "tracks",
+  "parent": 163,
+  "count": 1
+ },
+ {
+  "id": 202,
+  "name": "TRIUMPH",
+  "slug": "triumph",
+  "parent": 191,
+  "count": 10
+ },
+ {
+  "id": 39,
+  "name": "Troy Lee Design",
+  "slug": "troy-lee-design",
+  "parent": 36,
+  "count": 13
+ },
+ {
+  "id": 219,
+  "name": "Tyrone",
+  "slug": "tyrone",
+  "parent": 49,
+  "count": 2
+ },
+ {
+  "id": 15,
+  "name": "Uncategorized",
+  "slug": "uncategorized",
+  "parent": 0,
+  "count": 20
+ },
+ {
+  "id": 199,
+  "name": "UNIVERSAL",
+  "slug": "universal",
+  "parent": 191,
+  "count": 64
+ },
+ {
+  "id": 134,
+  "name": "Vini VJR",
+  "slug": "vini-designs",
+  "parent": 49,
+  "count": 3
+ },
+ {
+  "id": 111,
+  "name": "YAMAHA",
+  "slug": "yamaha",
+  "parent": 109,
+  "count": 4
+ },
+ {
+  "id": 112,
+  "name": "YAMAHA",
+  "slug": "yamaha-mx2-oem-bike-setups",
+  "parent": 110,
+  "count": 4
+ },
+ {
+  "id": 198,
+  "name": "YAMAHA",
+  "slug": "yamaha-blend-brands",
+  "parent": 191,
+  "count": 29
+ },
+ {
+  "id": 17,
+  "name": "YAMAHA MX1 OEM",
+  "slug": "yamaha-mx1-oem",
+  "parent": 24,
+  "count": 40
+ },
+ {
+  "id": 35,
+  "name": "YAMAHA MX2 OEM",
+  "slug": "yamaha-mx2-oem",
+  "parent": 28,
+  "count": 40
+ },
+ {
+  "id": 53,
+  "name": "Yamaha OEM",
+  "slug": "yamaha-oem",
+  "parent": 51,
+  "count": 3
+ }
+]

--- a/src-tauri/src/mods/fixtures/hub-products.sample.json
+++ b/src-tauri/src/mods/fixtures/hub-products.sample.json
@@ -1,0 +1,243 @@
+[
+ {
+  "id": 16727,
+  "name": "BELL MOTO 10 [FOX VUE ROLLOFF]",
+  "slug": "bell-moto-10-fox-vue-rolloff",
+  "permalink": "https://shop.mxb-hub.com/product/bell-moto-10-fox-vue-rolloff/",
+  "short_description": "",
+  "description": "<p><strong>Bell Moto 10 equipped with Fox Vue Roll Off goggles.</strong></p>\n<p>This is a in-game ready PKZ file.</p>\n<p>This purchase includes:</p>\n<ul>\n<li>Bell Moto 10 Carbon [Carbon and RB colorways]</li>\n<li>Fox Vue [4 colorways]</li>\n<li>LITPro Device on helmet</li>\n</ul>\n<p><em><strong>Once purchased, this product will be available to download from the &#8216;Rider Protection&#8217; area in my account.</strong></em></p>\n<p>To put this file in game, place the downloaded .PKZ file in: <strong>MX Bikes/mods/rider/helmets</strong></p>\n<p>You can purchase the PSD for this helmet by <a href=\"https://shop.mxb-hub.com/product/bell-moto-10-oakley-airbrake-copy/\">clicking here.</a></p>\n<p>Helmet &amp; goggles modeled by <a href=\"https://www.instagram.com/studio.ate/\">aeffertz.</a></p>",
+  "on_sale": false,
+  "prices": {
+   "price": "400",
+   "regular_price": "400",
+   "sale_price": "400",
+   "price_range": null,
+   "currency_code": "USD",
+   "currency_symbol": "$",
+   "currency_minor_unit": 2,
+   "currency_decimal_separator": ".",
+   "currency_thousand_separator": ",",
+   "currency_prefix": "$",
+   "currency_suffix": ""
+  },
+  "images": [
+   {
+    "id": 16728,
+    "src": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/BELLMOTO10VUEROLLOFF-scaled.png",
+    "thumbnail": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/BELLMOTO10VUEROLLOFF-300x300.png",
+    "srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/BELLMOTO10VUEROLLOFF-scaled.png 1080w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/BELLMOTO10VUEROLLOFF-300x300.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/BELLMOTO10VUEROLLOFF-1024x1024.png 1024w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/BELLMOTO10VUEROLLOFF-150x150.png 150w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/BELLMOTO10VUEROLLOFF-768x768.png 768w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/BELLMOTO10VUEROLLOFF-1536x1536.png 1536w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/BELLMOTO10VUEROLLOFF-600x600.png 600w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/BELLMOTO10VUEROLLOFF-100x100.png 100w",
+    "sizes": "(max-width: 1080px) 100vw, 1080px",
+    "thumbnail_srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/BELLMOTO10VUEROLLOFF-300x300.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/BELLMOTO10VUEROLLOFF-1024x1024.png 1024w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/BELLMOTO10VUEROLLOFF-150x150.png 150w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/BELLMOTO10VUEROLLOFF-768x768.png 768w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/BELLMOTO10VUEROLLOFF-1536x1536.png 1536w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/BELLMOTO10VUEROLLOFF-600x600.png 600w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/BELLMOTO10VUEROLLOFF-100x100.png 100w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/BELLMOTO10VUEROLLOFF-scaled.png 1080w",
+    "thumbnail_sizes": "(max-width: 300px) 100vw, 300px",
+    "name": "BELLMOTO10VUEROLLOFF",
+    "alt": ""
+   },
+   {
+    "id": 16729,
+    "src": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-19-scaled.png",
+    "thumbnail": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-19-300x300.png",
+    "srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-19-scaled.png 1080w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-19-300x169.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-19-1024x576.png 1024w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-19-768x432.png 768w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-19-1536x864.png 1536w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-19-600x338.png 600w",
+    "sizes": "(max-width: 1080px) 100vw, 1080px",
+    "thumbnail_srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-19-300x300.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-19-150x150.png 150w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-19-100x100.png 100w",
+    "thumbnail_sizes": "(max-width: 300px) 100vw, 300px",
+    "name": "mxbikes 2026-08-30 17-08-19",
+    "alt": ""
+   },
+   {
+    "id": 16730,
+    "src": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-09-scaled.png",
+    "thumbnail": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-09-300x300.png",
+    "srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-09-scaled.png 1080w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-09-300x169.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-09-1024x576.png 1024w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-09-768x432.png 768w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-09-1536x864.png 1536w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-09-600x338.png 600w",
+    "sizes": "(max-width: 1080px) 100vw, 1080px",
+    "thumbnail_srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-09-300x300.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-09-150x150.png 150w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-30-17-08-09-100x100.png 100w",
+    "thumbnail_sizes": "(max-width: 300px) 100vw, 300px",
+    "name": "mxbikes 2026-08-30 17-08-09",
+    "alt": ""
+   }
+  ],
+  "categories": [
+   {
+    "id": 223,
+    "name": "Helmet",
+    "slug": "helmet",
+    "link": "https://shop.mxb-hub.com/product-category/rider-protection/helmet/"
+   },
+   {
+    "id": 160,
+    "name": "Rider Protection",
+    "slug": "rider-protection",
+    "link": "https://shop.mxb-hub.com/product-category/rider-protection/"
+   }
+  ],
+  "is_purchasable": true,
+  "type": "simple"
+ },
+ {
+  "id": 16696,
+  "name": "TLD SE5 [PSD]",
+  "slug": "tld-se5-psd",
+  "permalink": "https://shop.mxb-hub.com/product/tld-se5-psd/",
+  "short_description": "",
+  "description": "<p><strong>TLD SE5 Helmet PSD.</strong></p>\n<p>This is a Photoshop Document.</p>\n<p>This purchase includes:</p>\n<ul>\n<li>TLD SE5 PSD &amp; TGA.</li>\n</ul>\n<p><em><strong>Once purchased, this product will be available to download from the \u2018\u2b07\ufe0f\u00a0PSD Downloads\u2019 area in my account.</strong></em></p>\n<p>Modeled by <a href=\"https://www.instagram.com/studio.ate/\">aeffertz.</a></p>",
+  "on_sale": false,
+  "prices": {
+   "price": "1000",
+   "regular_price": "1000",
+   "sale_price": "1000",
+   "price_range": null,
+   "currency_code": "USD",
+   "currency_symbol": "$",
+   "currency_minor_unit": 2,
+   "currency_decimal_separator": ".",
+   "currency_thousand_separator": ",",
+   "currency_prefix": "$",
+   "currency_suffix": ""
+  },
+  "images": [
+   {
+    "id": 16697,
+    "src": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5AirbrakePSD-scaled.png",
+    "thumbnail": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5AirbrakePSD-300x300.png",
+    "srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5AirbrakePSD-scaled.png 1080w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5AirbrakePSD-300x300.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5AirbrakePSD-1024x1024.png 1024w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5AirbrakePSD-150x150.png 150w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5AirbrakePSD-768x768.png 768w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5AirbrakePSD-1536x1536.png 1536w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5AirbrakePSD-600x600.png 600w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5AirbrakePSD-100x100.png 100w",
+    "sizes": "(max-width: 1080px) 100vw, 1080px",
+    "thumbnail_srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5AirbrakePSD-300x300.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5AirbrakePSD-1024x1024.png 1024w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5AirbrakePSD-150x150.png 150w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5AirbrakePSD-768x768.png 768w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5AirbrakePSD-1536x1536.png 1536w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5AirbrakePSD-600x600.png 600w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5AirbrakePSD-100x100.png 100w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5AirbrakePSD-scaled.png 1080w",
+    "thumbnail_sizes": "(max-width: 300px) 100vw, 300px",
+    "name": "TLDSE5AirbrakePSD",
+    "alt": ""
+   }
+  ],
+  "categories": [
+   {
+    "id": 225,
+    "name": "Protection PSDs",
+    "slug": "protection-psds",
+    "link": "https://shop.mxb-hub.com/product-category/rider-protection/protection-psds/"
+   },
+   {
+    "id": 160,
+    "name": "Rider Protection",
+    "slug": "rider-protection",
+    "link": "https://shop.mxb-hub.com/product-category/rider-protection/"
+   }
+  ],
+  "is_purchasable": true,
+  "type": "simple"
+ },
+ {
+  "id": 16688,
+  "name": "TLD SE5 [OAKLEY AIRBAKE]",
+  "slug": "tld-se5-oakley-airbake",
+  "permalink": "https://shop.mxb-hub.com/product/tld-se5-oakley-airbake/",
+  "short_description": "",
+  "description": "<p><strong>TLD SE5 helmet equipped with Oakley Airbrake goggles.</strong></p>\n<p>This is a in-game ready PKZ file.</p>\n<p>This purchase includes:</p>\n<ul>\n<li>TLD SE5 Helmet [7 colorways]</li>\n<li>Oakley Airbrake [5 colorways]</li>\n</ul>\n<p><em><strong>Once purchased, this product will be available to download from the &#8216;Rider Protection&#8217; area in my account.</strong></em></p>\n<p>To put this file in game, place the downloaded .PKZ file in: <strong>MX Bikes/mods/rider/helmets</strong></p>\n<p>You can purchase the PSD for this helmet by <a href=\"https://shop.mxb-hub.com/product/tld-se5-psd/\">clicking here.</a></p>\n<p>Helmet &amp; goggles modeled by <a href=\"https://www.instagram.com/studio.ate/\">aeffertz.</a></p>",
+  "on_sale": false,
+  "prices": {
+   "price": "400",
+   "regular_price": "400",
+   "sale_price": "400",
+   "price_range": null,
+   "currency_code": "USD",
+   "currency_symbol": "$",
+   "currency_minor_unit": 2,
+   "currency_decimal_separator": ".",
+   "currency_thousand_separator": ",",
+   "currency_prefix": "$",
+   "currency_suffix": ""
+  },
+  "images": [
+   {
+    "id": 16689,
+    "src": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5Airbrake-scaled.png",
+    "thumbnail": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5Airbrake-300x300.png",
+    "srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5Airbrake-scaled.png 1080w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5Airbrake-300x300.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5Airbrake-1024x1024.png 1024w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5Airbrake-150x150.png 150w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5Airbrake-768x768.png 768w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5Airbrake-1536x1536.png 1536w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5Airbrake-600x600.png 600w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5Airbrake-100x100.png 100w",
+    "sizes": "(max-width: 1080px) 100vw, 1080px",
+    "thumbnail_srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5Airbrake-300x300.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5Airbrake-1024x1024.png 1024w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5Airbrake-150x150.png 150w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5Airbrake-768x768.png 768w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5Airbrake-1536x1536.png 1536w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5Airbrake-600x600.png 600w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5Airbrake-100x100.png 100w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/TLDSE5Airbrake-scaled.png 1080w",
+    "thumbnail_sizes": "(max-width: 300px) 100vw, 300px",
+    "name": "TLDSE5Airbrake",
+    "alt": ""
+   },
+   {
+    "id": 16690,
+    "src": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-51-58-scaled.png",
+    "thumbnail": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-51-58-300x300.png",
+    "srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-51-58-scaled.png 1080w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-51-58-300x169.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-51-58-1024x576.png 1024w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-51-58-768x432.png 768w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-51-58-1536x864.png 1536w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-51-58-600x338.png 600w",
+    "sizes": "(max-width: 1080px) 100vw, 1080px",
+    "thumbnail_srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-51-58-300x300.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-51-58-150x150.png 150w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-51-58-100x100.png 100w",
+    "thumbnail_sizes": "(max-width: 300px) 100vw, 300px",
+    "name": "mxbikes 2026-08-29 20-51-58",
+    "alt": ""
+   },
+   {
+    "id": 16691,
+    "src": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-50-57-scaled.png",
+    "thumbnail": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-50-57-300x300.png",
+    "srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-50-57-scaled.png 1080w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-50-57-300x169.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-50-57-1024x576.png 1024w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-50-57-768x432.png 768w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-50-57-1536x864.png 1536w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-50-57-600x338.png 600w",
+    "sizes": "(max-width: 1080px) 100vw, 1080px",
+    "thumbnail_srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-50-57-300x300.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-50-57-150x150.png 150w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-50-57-100x100.png 100w",
+    "thumbnail_sizes": "(max-width: 300px) 100vw, 300px",
+    "name": "mxbikes 2026-08-29 20-50-57",
+    "alt": ""
+   },
+   {
+    "id": 16692,
+    "src": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-49-43-scaled.png",
+    "thumbnail": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-49-43-300x300.png",
+    "srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-49-43-scaled.png 1080w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-49-43-300x169.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-49-43-1024x576.png 1024w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-49-43-768x432.png 768w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-49-43-1536x864.png 1536w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-49-43-600x338.png 600w",
+    "sizes": "(max-width: 1080px) 100vw, 1080px",
+    "thumbnail_srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-49-43-300x300.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-49-43-150x150.png 150w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-49-43-100x100.png 100w",
+    "thumbnail_sizes": "(max-width: 300px) 100vw, 300px",
+    "name": "mxbikes 2026-08-29 20-49-43",
+    "alt": ""
+   },
+   {
+    "id": 16693,
+    "src": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-48-43-scaled.png",
+    "thumbnail": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-48-43-300x300.png",
+    "srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-48-43-scaled.png 1080w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-48-43-300x169.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-48-43-1024x576.png 1024w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-48-43-768x432.png 768w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-48-43-1536x864.png 1536w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-48-43-600x338.png 600w",
+    "sizes": "(max-width: 1080px) 100vw, 1080px",
+    "thumbnail_srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-48-43-300x300.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-48-43-150x150.png 150w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-48-43-100x100.png 100w",
+    "thumbnail_sizes": "(max-width: 300px) 100vw, 300px",
+    "name": "mxbikes 2026-08-29 20-48-43",
+    "alt": ""
+   },
+   {
+    "id": 16694,
+    "src": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-47-36-scaled.png",
+    "thumbnail": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-47-36-300x300.png",
+    "srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-47-36-scaled.png 1080w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-47-36-300x169.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-47-36-1024x576.png 1024w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-47-36-768x432.png 768w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-47-36-1536x864.png 1536w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-47-36-600x338.png 600w",
+    "sizes": "(max-width: 1080px) 100vw, 1080px",
+    "thumbnail_srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-47-36-300x300.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-47-36-150x150.png 150w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-47-36-100x100.png 100w",
+    "thumbnail_sizes": "(max-width: 300px) 100vw, 300px",
+    "name": "mxbikes 2026-08-29 20-47-36",
+    "alt": ""
+   },
+   {
+    "id": 16695,
+    "src": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-46-18-scaled.png",
+    "thumbnail": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-46-18-300x300.png",
+    "srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-46-18-scaled.png 1080w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-46-18-300x169.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-46-18-1024x576.png 1024w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-46-18-768x432.png 768w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-46-18-1536x864.png 1536w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-46-18-600x338.png 600w",
+    "sizes": "(max-width: 1080px) 100vw, 1080px",
+    "thumbnail_srcset": "https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-46-18-300x300.png 300w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-46-18-150x150.png 150w, https://shop.mxb-hub.com/wp-content/uploads/2026/08/mxbikes-2026-08-29-20-46-18-100x100.png 100w",
+    "thumbnail_sizes": "(max-width: 300px) 100vw, 300px",
+    "name": "mxbikes 2026-08-29 20-46-18",
+    "alt": ""
+   }
+  ],
+  "categories": [
+   {
+    "id": 223,
+    "name": "Helmet",
+    "slug": "helmet",
+    "link": "https://shop.mxb-hub.com/product-category/rider-protection/helmet/"
+   },
+   {
+    "id": 160,
+    "name": "Rider Protection",
+    "slug": "rider-protection",
+    "link": "https://shop.mxb-hub.com/product-category/rider-protection/"
+   }
+  ],
+  "is_purchasable": true,
+  "type": "simple"
+ }
+]

--- a/src-tauri/src/mods/hub.rs
+++ b/src-tauri/src/mods/hub.rs
@@ -18,10 +18,13 @@
 //! are converted here, once, so nothing downstream has to remember that.
 
 use super::shop_catalog::{parse_date_str, safe_image_url, sanitize_html, ShopPrice};
-use crate::hub_session::HUB_BASE;
-use reqwest::Client;
+use super::Blocked;
+use crate::cookie_session;
+use crate::hub_session::{HUB_BASE, HUB_SITE};
+use reqwest::cookie::Jar;
+use reqwest::{Client, Response};
 use serde::{Deserialize, Serialize};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 /// Matches `HUB_PAGE_SIZE` in `src/api/hub.ts`.
@@ -219,25 +222,78 @@ struct ApiDates {
 
 // ───────────────────────────────── the client ─────────────────────────────────
 
+/// The clearance jar.
+///
+/// Holds whatever cookies [`crate::hub_clearance`] earned in a real browser, and nothing else —
+/// this is emphatically *not* the signed-in jar. Keeping the two apart is what lets a catalog
+/// request stay anonymous: browsing must work whether or not anyone has ever signed in, and a
+/// public listing has no business carrying the user's session. The account half lives in
+/// [`crate::hub_session`], which gets its own copy of the same clearance.
+pub(crate) fn jar() -> &'static Arc<Jar> {
+    static JAR: std::sync::OnceLock<Arc<Jar>> = std::sync::OnceLock::new();
+    JAR.get_or_init(|| Arc::new(Jar::default()))
+}
+
+/// Take on a clearance earned in the WebView, so this client stops being challenged.
+pub fn adopt_clearance(cookies: &[(String, String)]) -> anyhow::Result<()> {
+    cookie_session::fill(jar(), &HUB_SITE, cookies)
+}
+
 /// One client for the session — connection reuse matters most for the search box, where a fast
 /// typist would otherwise pay a TLS handshake per debounced keystroke.
 ///
-/// Note what it is *not*: the signed-in client. This one carries no cookies at all, so a
-/// catalog request can never leak the user's session to the storefront, and browsing works
-/// whether or not anyone has ever signed in. The account half lives in [`crate::hub_session`].
-fn client() -> anyhow::Result<&'static Client> {
+/// Public because the image cache fetches this store's thumbnails with it: they are challenged
+/// by exactly the same filter as the API, so serving them through any other client means a
+/// grid of blank cards the moment the store decides we are a robot.
+pub fn client() -> anyhow::Result<&'static Client> {
     static CLIENT: std::sync::OnceLock<Result<Client, String>> = std::sync::OnceLock::new();
     CLIENT
         .get_or_init(|| {
-            Client::builder()
-                .user_agent(crate::shop_session::UA)
-                .connect_timeout(Duration::from_secs(15))
-                .timeout(Duration::from_secs(45))
+            cookie_session::client_builder(&HUB_SITE, jar().clone())
                 .build()
                 .map_err(|e| format!("{e:#}"))
         })
         .as_ref()
         .map_err(|e| anyhow::anyhow!("{e}"))
+}
+
+/// Whether this response is SiteGround's robot challenge rather than what we asked for.
+///
+/// The store is on SiteGround, whose bot protection fires on **request rate** — which is why
+/// it is invisible to a few hand probes and perfectly reproducible the moment a grid asks for
+/// twenty-four thumbnails at once. What comes back is a `202` carrying an HTML "Robot
+/// Challenge Screen" that computes a proof of work in a Web Worker, so no HTTP client can
+/// answer it; only a real browser can. Detected here so it surfaces as something the command
+/// layer can act on, rather than as "expected value at line 1 column 1".
+///
+/// Deliberately checked on the *response*, before the body is parsed: a challenge served in
+/// place of an image is a 202 full of HTML, and caching that would poison the thumbnail cache
+/// with a page.
+pub fn challenged(resp: &Response) -> bool {
+    if resp.headers().contains_key("sg-captcha") {
+        return true;
+    }
+    // A 202 for a GET is already odd; a 202 of HTML where JSON or an image was asked for is
+    // the challenge. Status alone is not enough — the header above is the reliable marker, and
+    // this is the belt to its braces.
+    let html = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.starts_with("text/html"));
+    resp.status().as_u16() == 202 && html
+}
+
+/// The challenge as an error the command layer knows to run the handshake for.
+///
+/// `None` for the status, which is what [`Blocked::clearable`] reads as "a browser could fix
+/// this" — and here it genuinely can, because the challenge is solved by running its script.
+fn blocked() -> anyhow::Error {
+    Blocked::new(
+        None,
+        "MXB Hub is asking the app to prove it isn't a robot.",
+    )
+    .into()
 }
 
 fn store_api(path: &str) -> String {
@@ -272,6 +328,9 @@ pub async fn search(
     }
 
     let resp = req.send().await?;
+    if challenged(&resp) {
+        return Err(blocked());
+    }
     let status = resp.status();
     // Past the last page WooCommerce answers 400 `rest_post_invalid_page_number` rather than an
     // empty list. That is the end of the grid, not an error to put on screen.
@@ -314,6 +373,9 @@ pub async fn detail(id: u64) -> anyhow::Result<HubModDetail> {
         .get(store_api(&format!("products/{id}")))
         .send()
         .await?;
+    if challenged(&resp) {
+        return Err(blocked());
+    }
     if !resp.status().is_success() {
         anyhow::bail!("MXB Hub answered {} for product {id}", resp.status());
     }
@@ -361,6 +423,9 @@ pub async fn by_slugs(slugs: &[String]) -> anyhow::Result<Vec<HubMod>> {
         ])
         .send()
         .await?;
+    if challenged(&resp) {
+        return Err(blocked());
+    }
     if !resp.status().is_success() {
         anyhow::bail!("MXB Hub answered {} for a product lookup", resp.status());
     }
@@ -389,6 +454,9 @@ pub async fn categories() -> anyhow::Result<Vec<HubCategory>> {
         .query(&[("per_page", "100")])
         .send()
         .await?;
+    if challenged(&resp) {
+        return Err(blocked());
+    }
     if !resp.status().is_success() {
         anyhow::bail!("MXB Hub answered {} for the categories", resp.status());
     }
@@ -493,6 +561,9 @@ async fn fill_dates(items: &mut [HubMod]) {
             .send()
             .await
             .ok()?;
+        if challenged(&resp) {
+            return None;
+        }
         resp.json::<Vec<ApiDates>>().await.ok()
     }
     .await;

--- a/src-tauri/src/mods/hub.rs
+++ b/src-tauri/src/mods/hub.rs
@@ -44,6 +44,11 @@ pub struct HubMod {
     /// see [`safe_hub_url`]. `None` hides the Buy button.
     pub url: Option<String>,
     pub image: Option<String>,
+    /// The creator, where the product sits under one. MXB Hub is organised by creator — a
+    /// whole top-level category tree of them — so this is real attribution taken from the
+    /// product's own categories, not a placeholder. See [`fill_authors`].
+    pub author: Option<String>,
+    pub author_url: Option<String>,
     pub category_ids: Vec<u64>,
     pub category_names: Vec<String>,
     /// Unix seconds. The Store API carries no date, so this is filled in from `wp/v2` — see
@@ -72,6 +77,9 @@ pub struct HubCategory {
     pub name: String,
     pub slug: String,
     pub parent: Option<u64>,
+    /// The category's page on the store. Doubles as the creator's page for the rows under
+    /// [`CREATORS_SLUG`].
+    pub link: Option<String>,
     /// 0 for top level, so the UI can indent without walking the tree.
     pub depth: u8,
     pub count: u32,
@@ -195,6 +203,8 @@ struct ApiCategory {
     parent: u64,
     #[serde(default)]
     count: u32,
+    #[serde(default)]
+    permalink: String,
 }
 
 /// The `wp/v2` half of a listing: the only place a product's dates are published.
@@ -289,6 +299,7 @@ pub async fn search(
 
     let mut items: Vec<HubMod> = products.iter().map(map_product).collect();
     fill_dates(&mut items).await;
+    fill_authors(&mut items).await;
 
     Ok(HubPage {
         items,
@@ -310,6 +321,7 @@ pub async fn detail(id: u64) -> anyhow::Result<HubModDetail> {
 
     let mut item = map_product(&product);
     fill_dates(std::slice::from_mut(&mut item)).await;
+    fill_authors(std::slice::from_mut(&mut item)).await;
 
     // Every image the listing carries, largest form first, deduplicated — a Hub product often
     // repeats its hero shot as the gallery's first entry.
@@ -353,7 +365,9 @@ pub async fn by_slugs(slugs: &[String]) -> anyhow::Result<Vec<HubMod>> {
         anyhow::bail!("MXB Hub answered {} for a product lookup", resp.status());
     }
     let products: Vec<ApiProduct> = resp.json().await?;
-    Ok(products.iter().map(map_product).collect())
+    let mut items: Vec<HubMod> = products.iter().map(map_product).collect();
+    fill_authors(&mut items).await;
+    Ok(items)
 }
 
 /// The category tree, flattened depth-first with a `depth` on each row.
@@ -397,6 +411,8 @@ fn map_product(p: &ApiProduct) -> HubMod {
             .images
             .first()
             .and_then(|i| safe_image_url(&i.thumbnail).or_else(|| safe_image_url(&i.src))),
+        author: None,
+        author_url: None,
         category_ids: p.categories.iter().map(|c| c.id).collect(),
         category_names: p.categories.iter().map(|c| decode(&c.name)).collect(),
         updated: None,
@@ -497,6 +513,42 @@ async fn fill_dates(items: &mut [HubMod]) {
     }
 }
 
+/// The top-level category every creator's own category hangs off.
+const CREATORS_SLUG: &str = "creators";
+
+/// Attribute each item to its creator, from the category tree.
+///
+/// MXB Hub files a product under both what it is ("Helmet") and who made it ("CSTAR"), the
+/// latter as a child of a `creators` root. That makes the creator recoverable from data the
+/// product already carries, which is the only place it is published — the Store API has no
+/// author field, and the storefront prints the name nowhere else a listing can reach.
+///
+/// Reads the tree through [`categories`], so after the first call this costs nothing. Silent
+/// on failure: an unattributed card is a card, and no product is worth failing a search over.
+async fn fill_authors(items: &mut [HubMod]) {
+    if items.is_empty() {
+        return;
+    }
+    let Ok(tree) = categories().await else {
+        return;
+    };
+    let Some(root) = tree.iter().find(|c| c.slug == CREATORS_SLUG) else {
+        return;
+    };
+
+    for item in items {
+        let creator = item
+            .category_ids
+            .iter()
+            .filter_map(|id| tree.iter().find(|c| c.id == *id))
+            .find(|c| c.parent == Some(root.id));
+        if let Some(creator) = creator {
+            item.author = Some(creator.name.clone());
+            item.author_url = creator.link.clone();
+        }
+    }
+}
+
 /// WordPress prints `2026-08-30T16:20:55` with no zone on a `_gmt` field — it *is* UTC, and
 /// the marker is simply missing. [`parse_date_str`] already reads that form as UTC, which is
 /// why this delegates rather than growing a second date parser next to it.
@@ -526,6 +578,7 @@ fn flatten(raw: &[ApiCategory]) -> Vec<HubCategory> {
                 name: decode(&child.name),
                 slug: child.slug.clone(),
                 parent: (child.parent != 0).then_some(child.parent),
+                link: safe_hub_url(&child.permalink),
                 depth,
                 count: child.count,
             });
@@ -744,6 +797,12 @@ mod tests {
         let slugs: Vec<String> = page.items.iter().take(3).map(|i| i.slug.clone()).collect();
         let found = by_slugs(&slugs).await.unwrap();
         assert_eq!(found.len(), 3);
+
+        // Creators are recovered from the category tree; most of the store is filed under one.
+        assert!(
+            page.items.iter().filter(|i| i.author.is_some()).count() >= 10,
+            "creator attribution stopped working"
+        );
 
         // Dates come from `wp/v2`, and the whole point of that request is that they arrive.
         assert!(

--- a/src-tauri/src/mods/hub.rs
+++ b/src-tauri/src/mods/hub.rs
@@ -357,7 +357,11 @@ pub async fn search(
         .unwrap_or_else(|| "USD".into());
 
     let mut items: Vec<HubMod> = products.iter().map(map_product).collect();
-    fill_dates(&mut items).await;
+    // Deliberately no `fill_dates` here. A card shows a title, a price and a creator — the
+    // date appears only on the detail page — so paying a second request per page of results
+    // for a field nobody sees is a third of this view's traffic spent on nothing. It matters
+    // more than it sounds: this store counts requests, and answers too many by refusing the
+    // whole site. `detail` still fills it, for the one item that displays it.
     fill_authors(&mut items).await;
 
     Ok(HubPage {
@@ -875,10 +879,12 @@ mod tests {
             "creator attribution stopped working"
         );
 
-        // Dates come from `wp/v2`, and the whole point of that request is that they arrive.
+        // Dates come from `wp/v2`, and are filled for the detail page only — the listing
+        // deliberately doesn't pay for them.
+        assert!(detail.item.updated.is_some(), "wp/v2 date enrichment stopped working");
         assert!(
-            page.items.iter().filter(|i| i.updated.is_some()).count() >= 20,
-            "wp/v2 date enrichment stopped working"
+            page.items.iter().all(|i| i.updated.is_none()),
+            "the listing should not be spending a request on dates it never shows"
         );
     }
 

--- a/src-tauri/src/mods/hub.rs
+++ b/src-tauri/src/mods/hub.rs
@@ -1,0 +1,773 @@
+//! MXB Hub's public catalog — `shop.mxb-hub.com`, over the WooCommerce Store API.
+//!
+//! The third catalog in the app, and by some distance the easiest of the three.
+//!
+//!  - **mxb-mods.com** ([`super::mxb`]) is scraped and Cloudflare-fronted, and its REST API
+//!    accepts `orderby` and then ignores it.
+//!  - **mxbikes-shop.com** ([`super::shop_catalog`]) has no public API at all, so it is served
+//!    from a credentialed JSON dump refreshed in the background.
+//!  - **MXB Hub** publishes `/wp-json/wc/store/v1/`, which is WooCommerce's own read-only
+//!    storefront API: unauthenticated, paged with `X-WP-Total`, and honouring `search`,
+//!    `category`, `on_sale` and `orderby` for real. Measured 2026-08-30: no Cloudflare
+//!    (`server: nginx`), so plain `reqwest` is enough and nothing here needs a WebView.
+//!
+//! So this queries live rather than caching a dump. There is no credential to hide, no
+//! staleness to report, and a search is one request.
+//!
+//! Prices come back in **minor units** — `"400"` with `currency_minor_unit: 2` is $4.00 — and
+//! are converted here, once, so nothing downstream has to remember that.
+
+use super::shop_catalog::{parse_date_str, safe_image_url, sanitize_html, ShopPrice};
+use crate::hub_session::HUB_BASE;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// Matches `HUB_PAGE_SIZE` in `src/api/hub.ts`.
+pub const PER_PAGE: u32 = 24;
+
+// ───────────────────────────────── what we hand out ─────────────────────────────────
+
+/// One product as the grid shows it.
+///
+/// Field-for-field the shape of [`super::shop_catalog::ShopMod`] where the two overlap, and
+/// deliberately so: it lets the Hub grid reuse `PriceTag` and the money formatting rather than
+/// growing a second, subtly different way to render a price.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HubMod {
+    pub id: u64,
+    pub slug: String,
+    pub title: String,
+    /// The product page, or `None` when the store handed us a URL we won't pass to the OS —
+    /// see [`safe_hub_url`]. `None` hides the Buy button.
+    pub url: Option<String>,
+    pub image: Option<String>,
+    pub category_ids: Vec<u64>,
+    pub category_names: Vec<String>,
+    /// Unix seconds. The Store API carries no date, so this is filled in from `wp/v2` — see
+    /// [`fill_dates`] — and stays `None` when that lookup fails.
+    pub updated: Option<i64>,
+    pub price: ShopPrice,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HubModDetail {
+    #[serde(flatten)]
+    pub item: HubMod,
+    /// Sanitised in Rust — see [`sanitize_html`]. Rendered with `dangerouslySetInnerHTML`.
+    pub description_html: Option<String>,
+    pub images: Vec<String>,
+    /// What the store says this product ships, verbatim from its short description. Useful
+    /// because Hub listings say "in-game ready PKZ" or "PSD" there and nowhere else.
+    pub summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HubCategory {
+    pub id: u64,
+    pub name: String,
+    pub slug: String,
+    pub parent: Option<u64>,
+    /// 0 for top level, so the UI can indent without walking the tree.
+    pub depth: u8,
+    pub count: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HubPage {
+    pub items: Vec<HubMod>,
+    pub total: u32,
+    pub has_more: bool,
+    pub currency: String,
+}
+
+/// The orders the Store API actually honours.
+///
+/// Checked against the live API rather than assumed: `date`, `price`, `popularity`, `title` and
+/// `menu_order` all work, and `relevance` — which WooCommerce documents — is rejected with
+/// `rest_invalid_param` on this install. Sorting a search by relevance is therefore not on
+/// offer, and asking for it would 400 the whole page.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum HubSort {
+    #[default]
+    Newest,
+    Popular,
+    PriceAsc,
+    PriceDesc,
+    NameAsc,
+}
+
+impl HubSort {
+    fn params(self) -> (&'static str, &'static str) {
+        match self {
+            HubSort::Newest => ("date", "desc"),
+            HubSort::Popular => ("popularity", "desc"),
+            HubSort::PriceAsc => ("price", "asc"),
+            HubSort::PriceDesc => ("price", "desc"),
+            HubSort::NameAsc => ("title", "asc"),
+        }
+    }
+}
+
+// ───────────────────────────────── what the API sends ─────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct ApiProduct {
+    id: u64,
+    name: String,
+    slug: String,
+    permalink: String,
+    #[serde(default)]
+    short_description: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    prices: ApiPrices,
+    #[serde(default)]
+    images: Vec<ApiImage>,
+    #[serde(default)]
+    categories: Vec<ApiCategoryRef>,
+    #[serde(default)]
+    on_sale: bool,
+}
+
+/// Every figure is a string of *minor units* — `"1999"` is 19.99 at `currency_minor_unit: 2`.
+/// `price_range` is `null` for a simple product and an object for a variable one; the Hub sells
+/// only simple products today, but a bundle listed as variable would otherwise print its
+/// cheapest option as if it were the price.
+#[derive(Debug, Default, Deserialize)]
+struct ApiPrices {
+    #[serde(default)]
+    price: String,
+    #[serde(default)]
+    regular_price: String,
+    #[serde(default)]
+    sale_price: String,
+    #[serde(default)]
+    price_range: Option<ApiPriceRange>,
+    #[serde(default)]
+    currency_code: String,
+    #[serde(default = "two")]
+    currency_minor_unit: u32,
+}
+
+fn two() -> u32 {
+    2
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiPriceRange {
+    #[serde(default)]
+    min_amount: String,
+    #[serde(default)]
+    max_amount: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiImage {
+    #[serde(default)]
+    src: String,
+    #[serde(default)]
+    thumbnail: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiCategoryRef {
+    id: u64,
+    #[serde(default)]
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiCategory {
+    id: u64,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    slug: String,
+    #[serde(default)]
+    parent: u64,
+    #[serde(default)]
+    count: u32,
+}
+
+/// The `wp/v2` half of a listing: the only place a product's dates are published.
+#[derive(Debug, Deserialize)]
+struct ApiDates {
+    id: u64,
+    #[serde(default)]
+    date_gmt: Option<String>,
+    #[serde(default)]
+    modified_gmt: Option<String>,
+}
+
+// ───────────────────────────────── the client ─────────────────────────────────
+
+/// One client for the session — connection reuse matters most for the search box, where a fast
+/// typist would otherwise pay a TLS handshake per debounced keystroke.
+///
+/// Note what it is *not*: the signed-in client. This one carries no cookies at all, so a
+/// catalog request can never leak the user's session to the storefront, and browsing works
+/// whether or not anyone has ever signed in. The account half lives in [`crate::hub_session`].
+fn client() -> anyhow::Result<&'static Client> {
+    static CLIENT: std::sync::OnceLock<Result<Client, String>> = std::sync::OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            Client::builder()
+                .user_agent(crate::shop_session::UA)
+                .connect_timeout(Duration::from_secs(15))
+                .timeout(Duration::from_secs(45))
+                .build()
+                .map_err(|e| format!("{e:#}"))
+        })
+        .as_ref()
+        .map_err(|e| anyhow::anyhow!("{e}"))
+}
+
+fn store_api(path: &str) -> String {
+    format!("{HUB_BASE}/wp-json/wc/store/v1/{path}")
+}
+
+// ───────────────────────────────── search ─────────────────────────────────
+
+pub async fn search(
+    query: &str,
+    category_id: Option<u64>,
+    page: u32,
+    sort: HubSort,
+    on_sale_only: bool,
+) -> anyhow::Result<HubPage> {
+    let page = page.max(1);
+    let (orderby, order) = sort.params();
+    let mut req = client()?
+        .get(store_api("products"))
+        .query(&[("per_page", PER_PAGE.to_string()), ("page", page.to_string())])
+        .query(&[("orderby", orderby), ("order", order)]);
+
+    let query = query.trim();
+    if !query.is_empty() {
+        req = req.query(&[("search", query)]);
+    }
+    if let Some(id) = category_id {
+        req = req.query(&[("category", id.to_string())]);
+    }
+    if on_sale_only {
+        req = req.query(&[("on_sale", "true")]);
+    }
+
+    let resp = req.send().await?;
+    let status = resp.status();
+    // Past the last page WooCommerce answers 400 `rest_post_invalid_page_number` rather than an
+    // empty list. That is the end of the grid, not an error to put on screen.
+    if status.as_u16() == 400 {
+        return Ok(HubPage {
+            items: vec![],
+            total: 0,
+            has_more: false,
+            currency: "USD".into(),
+        });
+    }
+    if !status.is_success() {
+        anyhow::bail!("MXB Hub answered {status} for the catalog");
+    }
+
+    let total = header_u32(&resp, "x-wp-total").unwrap_or(0);
+    let total_pages = header_u32(&resp, "x-wp-totalpages").unwrap_or(0);
+    let products: Vec<ApiProduct> = resp.json().await?;
+
+    let currency = products
+        .first()
+        .map(|p| p.prices.currency_code.clone())
+        .filter(|c| !c.is_empty())
+        .unwrap_or_else(|| "USD".into());
+
+    let mut items: Vec<HubMod> = products.iter().map(map_product).collect();
+    fill_dates(&mut items).await;
+
+    Ok(HubPage {
+        items,
+        total,
+        has_more: page < total_pages,
+        currency,
+    })
+}
+
+pub async fn detail(id: u64) -> anyhow::Result<HubModDetail> {
+    let resp = client()?
+        .get(store_api(&format!("products/{id}")))
+        .send()
+        .await?;
+    if !resp.status().is_success() {
+        anyhow::bail!("MXB Hub answered {} for product {id}", resp.status());
+    }
+    let product: ApiProduct = resp.json().await?;
+
+    let mut item = map_product(&product);
+    fill_dates(std::slice::from_mut(&mut item)).await;
+
+    // Every image the listing carries, largest form first, deduplicated — a Hub product often
+    // repeats its hero shot as the gallery's first entry.
+    let mut images: Vec<String> = Vec::new();
+    for img in &product.images {
+        let Some(url) = safe_image_url(&img.src).or_else(|| safe_image_url(&img.thumbnail)) else {
+            continue;
+        };
+        if !images.contains(&url) {
+            images.push(url);
+        }
+    }
+
+    Ok(HubModDetail {
+        item,
+        description_html: sanitize_html(&product.description),
+        images,
+        summary: sanitize_html(&product.short_description),
+    })
+}
+
+/// Catalog entries for a set of product slugs, in one request.
+///
+/// The Store API takes `slug` as a comma-separated list, so a whole purchases grid resolves in
+/// a single round trip and on an exact match — no name-similarity fold like the shop's, which
+/// exists only because that store's purchases page gives nothing else to key on. Slugs it does
+/// not know are simply absent from the answer.
+pub async fn by_slugs(slugs: &[String]) -> anyhow::Result<Vec<HubMod>> {
+    if slugs.is_empty() {
+        return Ok(vec![]);
+    }
+    let resp = client()?
+        .get(store_api("products"))
+        .query(&[
+            ("slug", slugs.join(",")),
+            ("per_page", "100".to_string()),
+        ])
+        .send()
+        .await?;
+    if !resp.status().is_success() {
+        anyhow::bail!("MXB Hub answered {} for a product lookup", resp.status());
+    }
+    let products: Vec<ApiProduct> = resp.json().await?;
+    Ok(products.iter().map(map_product).collect())
+}
+
+/// The category tree, flattened depth-first with a `depth` on each row.
+///
+/// Cached for the session with a short TTL: the list is 99 rows that change when a creator is
+/// added, and the filter row asks for it on every mount.
+pub async fn categories() -> anyhow::Result<Vec<HubCategory>> {
+    const TTL: Duration = Duration::from_secs(10 * 60);
+    static CACHE: Mutex<Option<(Instant, Vec<HubCategory>)>> = Mutex::new(None);
+
+    if let Some((at, cached)) = CACHE.lock().unwrap_or_else(|e| e.into_inner()).as_ref() {
+        if at.elapsed() < TTL {
+            return Ok(cached.clone());
+        }
+    }
+
+    let resp = client()?
+        .get(store_api("products/categories"))
+        .query(&[("per_page", "100")])
+        .send()
+        .await?;
+    if !resp.status().is_success() {
+        anyhow::bail!("MXB Hub answered {} for the categories", resp.status());
+    }
+    let raw: Vec<ApiCategory> = resp.json().await?;
+    let tree = flatten(&raw);
+
+    *CACHE.lock().unwrap_or_else(|e| e.into_inner()) = Some((Instant::now(), tree.clone()));
+    Ok(tree)
+}
+
+// ───────────────────────────────── mapping ─────────────────────────────────
+
+fn map_product(p: &ApiProduct) -> HubMod {
+    HubMod {
+        id: p.id,
+        slug: p.slug.clone(),
+        title: decode(&p.name),
+        url: safe_hub_url(&p.permalink),
+        image: p
+            .images
+            .first()
+            .and_then(|i| safe_image_url(&i.thumbnail).or_else(|| safe_image_url(&i.src))),
+        category_ids: p.categories.iter().map(|c| c.id).collect(),
+        category_names: p.categories.iter().map(|c| decode(&c.name)).collect(),
+        updated: None,
+        price: map_price(&p.prices, p.on_sale),
+    }
+}
+
+/// Minor units to a real number, e.g. `("1999", 2)` → `19.99`.
+fn amount(raw: &str, minor_unit: u32) -> Option<f64> {
+    let value: f64 = raw.trim().parse().ok()?;
+    Some(value / 10f64.powi(minor_unit as i32))
+}
+
+fn map_price(prices: &ApiPrices, on_sale: bool) -> ShopPrice {
+    let unit = prices.currency_minor_unit;
+    let regular = amount(&prices.regular_price, unit);
+    let sale = amount(&prices.sale_price, unit);
+    let live = amount(&prices.price, unit);
+
+    // A variable product prices as a span. Both ends have to travel together or the struck-out
+    // figure stops corresponding to the live one — see `PriceTag`.
+    let (base_max, has_range) = match prices.price_range.as_ref() {
+        Some(range) => (amount(&range.max_amount, unit), true),
+        None => (None, false),
+    };
+    let base = match prices.price_range.as_ref() {
+        Some(range) => amount(&range.min_amount, unit).or(regular),
+        None => regular.or(live),
+    };
+
+    // `on_sale` is the store's own flag; a sale price equal to the regular one is not a sale.
+    let on_sale = on_sale && sale.is_some() && sale != regular;
+    let discount_pct = match (on_sale, base, sale) {
+        (true, Some(b), Some(s)) if b > 0.0 && s < b => Some((((b - s) / b) * 100.0) as u32),
+        _ => None,
+    };
+
+    ShopPrice {
+        base,
+        base_max,
+        sale: on_sale.then_some(sale).flatten(),
+        sale_max: None,
+        on_sale,
+        has_range,
+        // WooCommerce has no pay-what-you-want price, so free here really is a price of zero —
+        // which is what the store's own Free Mods category is made of.
+        free: live == Some(0.0) && !on_sale,
+        discount_pct,
+        // The Store API publishes no sale window, and the UI must never invent one.
+        sale_ends: None,
+    }
+}
+
+/// Fill in `updated` from `wp/v2/product`, which is the only endpoint that publishes dates.
+///
+/// One extra request per page of 24, asking for three fields — not per item. Best-effort by
+/// design: a failure leaves every `updated` at `None`, the cards simply show no date, and the
+/// grid still renders. Never worth failing a search over.
+async fn fill_dates(items: &mut [HubMod]) {
+    if items.is_empty() {
+        return;
+    }
+    let ids = items
+        .iter()
+        .map(|i| i.id.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let fetched = async {
+        let resp = client()
+            .ok()?
+            .get(format!("{HUB_BASE}/wp-json/wp/v2/product"))
+            .query(&[
+                ("include", ids.as_str()),
+                ("_fields", "id,date_gmt,modified_gmt"),
+                ("per_page", "100"),
+            ])
+            .send()
+            .await
+            .ok()?;
+        resp.json::<Vec<ApiDates>>().await.ok()
+    }
+    .await;
+
+    let Some(dates) = fetched else {
+        log::debug!("MXB Hub dates unavailable for this page; cards will show none");
+        return;
+    };
+    for row in dates {
+        let stamp = row
+            .modified_gmt
+            .as_deref()
+            .or(row.date_gmt.as_deref())
+            .and_then(parse_wp_date);
+        if let Some(item) = items.iter_mut().find(|i| i.id == row.id) {
+            item.updated = stamp;
+        }
+    }
+}
+
+/// WordPress prints `2026-08-30T16:20:55` with no zone on a `_gmt` field — it *is* UTC, and
+/// the marker is simply missing. [`parse_date_str`] already reads that form as UTC, which is
+/// why this delegates rather than growing a second date parser next to it.
+fn parse_wp_date(raw: &str) -> Option<i64> {
+    parse_date_str(raw)
+}
+
+/// A paging header as a number. Absent or unparseable means "the store didn't say", which the
+/// callers treat as zero rather than as an error.
+fn header_u32(resp: &reqwest::Response, name: &str) -> Option<u32> {
+    resp.headers().get(name)?.to_str().ok()?.trim().parse().ok()
+}
+
+/// Depth-first, parents before their children, so the filter row reads as the tree it is.
+fn flatten(raw: &[ApiCategory]) -> Vec<HubCategory> {
+    fn walk(raw: &[ApiCategory], parent: u64, depth: u8, out: &mut Vec<HubCategory>) {
+        // More than three levels would mean a cycle or a tree deeper than any storefront needs;
+        // stopping is better than recursing forever on malformed input.
+        if depth > 3 {
+            return;
+        }
+        let mut children: Vec<&ApiCategory> = raw.iter().filter(|c| c.parent == parent).collect();
+        children.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.name.cmp(&b.name)));
+        for child in children {
+            out.push(HubCategory {
+                id: child.id,
+                name: decode(&child.name),
+                slug: child.slug.clone(),
+                parent: (child.parent != 0).then_some(child.parent),
+                depth,
+                count: child.count,
+            });
+            walk(raw, child.id, depth + 1, out);
+        }
+    }
+
+    let mut out = Vec::with_capacity(raw.len());
+    walk(raw, 0, 0, &mut out);
+    out
+}
+
+/// True for a URL we're willing to hand to the operating system's browser.
+///
+/// Same rule as the shop's, against this store's host. The Buy button feeds it straight into
+/// `shell:allow-open`, which launches whatever handler the OS has registered — so a permalink
+/// that isn't https on MXB Hub is dropped and the button goes with it.
+fn safe_hub_url(raw: &str) -> Option<String> {
+    let url = reqwest::Url::parse(raw.trim()).ok()?;
+    if url.scheme() != "https" {
+        return None;
+    }
+    let host = url.host_str()?.to_ascii_lowercase();
+    (host == "mxb-hub.com" || host.ends_with(".mxb-hub.com")).then(|| url.to_string())
+}
+
+/// WordPress publishes titles pre-escaped — `Gear PSD&#8217;s`, `Yamaha &amp; Honda`.
+fn decode(raw: &str) -> String {
+    html_escape::decode_html_entities(raw.trim()).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PRODUCTS: &str = include_str!("fixtures/hub-products.sample.json");
+    const CATEGORIES: &str = include_str!("fixtures/hub-categories.sample.json");
+
+    fn products() -> Vec<ApiProduct> {
+        serde_json::from_str(PRODUCTS).expect("the products fixture must still parse")
+    }
+
+    /// The fixtures are real responses, captured 2026-08-30. If the store changes shape, this
+    /// is what says so.
+    #[test]
+    fn the_live_shape_maps_to_a_card() {
+        let items: Vec<HubMod> = products().iter().map(map_product).collect();
+        assert_eq!(items.len(), 3);
+
+        let first = &items[0];
+        assert!(!first.title.is_empty());
+        assert!(!first.slug.is_empty());
+        assert!(first.url.as_deref().unwrap().starts_with("https://shop.mxb-hub.com/"));
+        assert!(first.image.as_deref().unwrap().starts_with("https://"));
+        assert!(!first.category_names.is_empty());
+    }
+
+    /// The one conversion everything else rides on: the API's `"400"` is $4.00, not $400.
+    #[test]
+    fn prices_are_minor_units() {
+        assert_eq!(amount("400", 2), Some(4.0));
+        assert_eq!(amount("1999", 2), Some(19.99));
+        assert_eq!(amount("0", 2), Some(0.0));
+        // A currency without minor units (JPY) must not be divided.
+        assert_eq!(amount("400", 0), Some(400.0));
+        assert_eq!(amount("", 2), None);
+        assert_eq!(amount("free", 2), None);
+
+        let priced = products()
+            .iter()
+            .map(|p| map_price(&p.prices, p.on_sale))
+            .collect::<Vec<_>>();
+        assert!(
+            priced.iter().all(|p| p.base.unwrap_or(0.0) < 1000.0),
+            "a four-figure price means the minor-unit divide was skipped: {priced:#?}"
+        );
+    }
+
+    #[test]
+    fn a_zero_price_reads_as_free() {
+        let prices = ApiPrices {
+            price: "0".into(),
+            regular_price: "0".into(),
+            sale_price: "0".into(),
+            currency_minor_unit: 2,
+            currency_code: "USD".into(),
+            price_range: None,
+        };
+        let price = map_price(&prices, false);
+        assert!(price.free);
+        assert!(!price.on_sale);
+        assert_eq!(price.base, Some(0.0));
+    }
+
+    #[test]
+    fn a_sale_carries_both_figures_and_a_percentage() {
+        let prices = ApiPrices {
+            price: "800".into(),
+            regular_price: "1000".into(),
+            sale_price: "800".into(),
+            currency_minor_unit: 2,
+            currency_code: "USD".into(),
+            price_range: None,
+        };
+        let price = map_price(&prices, true);
+        assert!(price.on_sale);
+        assert_eq!(price.base, Some(10.0));
+        assert_eq!(price.sale, Some(8.0));
+        assert_eq!(price.discount_pct, Some(20));
+        assert!(!price.free);
+    }
+
+    /// The store's flag is what decides, not the numbers: `on_sale: false` with a sale price
+    /// equal to the regular one is an ordinary product, and must not print a −0% badge.
+    #[test]
+    fn a_sale_price_equal_to_the_regular_one_is_not_a_sale() {
+        let prices = ApiPrices {
+            price: "400".into(),
+            regular_price: "400".into(),
+            sale_price: "400".into(),
+            currency_minor_unit: 2,
+            currency_code: "USD".into(),
+            price_range: None,
+        };
+        let price = map_price(&prices, true);
+        assert!(!price.on_sale);
+        assert_eq!(price.discount_pct, None);
+    }
+
+    #[test]
+    fn categories_flatten_parents_before_children() {
+        let raw: Vec<ApiCategory> =
+            serde_json::from_str(CATEGORIES).expect("the categories fixture must still parse");
+        let tree = flatten(&raw);
+
+        assert_eq!(tree.len(), raw.len(), "every category must appear exactly once");
+        assert!(tree.first().unwrap().depth == 0);
+
+        // A child never precedes its parent, and its depth is one deeper.
+        let mut seen: Vec<u64> = Vec::new();
+        for row in &tree {
+            if let Some(parent) = row.parent {
+                let at = seen.iter().position(|id| *id == parent);
+                assert!(at.is_some(), "{} came before its parent {parent}", row.name);
+                let parent_depth = tree.iter().find(|c| c.id == parent).unwrap().depth;
+                assert_eq!(row.depth, parent_depth + 1, "{}", row.name);
+            } else {
+                assert_eq!(row.depth, 0, "{}", row.name);
+            }
+            seen.push(row.id);
+        }
+
+        // The store escapes its own names; the UI must not print "Gear PSD&#8217;s".
+        assert!(
+            tree.iter().all(|c| !c.name.contains("&#")),
+            "an HTML entity survived into a category name"
+        );
+    }
+
+    #[test]
+    fn only_the_stores_own_https_urls_are_openable() {
+        assert!(safe_hub_url("https://shop.mxb-hub.com/product/x/").is_some());
+        assert!(safe_hub_url("https://mxb-hub.com/product/x/").is_some());
+        for bad in [
+            "http://shop.mxb-hub.com/product/x/",
+            "https://evil.com/product/x/",
+            "https://mxb-hub.com.evil.com/x",
+            "javascript:alert(1)",
+            "",
+        ] {
+            assert!(safe_hub_url(bad).is_none(), "{bad} must not be openable");
+        }
+    }
+
+    #[test]
+    fn wordpress_gmt_dates_are_read_as_utc() {
+        // 2026-08-30T16:20:55Z
+        assert_eq!(parse_wp_date("2026-08-30T16:20:55"), Some(1_788_106_855));
+        assert_eq!(
+            parse_wp_date("2026-08-30T16:20:55Z"),
+            parse_wp_date("2026-08-30T16:20:55")
+        );
+        assert_eq!(parse_wp_date("not a date"), None);
+    }
+
+    /// The whole read path against the real store. Ignored by default — it needs the network,
+    /// and a CI run must not fail because a shop is down. Run it when the store changes shape:
+    /// `cargo test --bin mxb-app -- --ignored --nocapture hub_live`
+    #[tokio::test]
+    #[ignore = "hits shop.mxb-hub.com"]
+    async fn hub_live_catalog_answers() {
+        let page = search("", None, 1, HubSort::Newest, false).await.unwrap();
+        assert_eq!(page.items.len(), PER_PAGE as usize);
+        assert!(page.total > 100, "total was {}", page.total);
+        assert!(page.has_more);
+        assert_eq!(page.currency, "USD");
+
+        let cats = categories().await.unwrap();
+        assert!(cats.len() > 50, "only {} categories", cats.len());
+        assert!(cats.iter().any(|c| c.slug == "free-mods"));
+
+        // Search, category filter and paging all narrow what comes back.
+        let free = search("", Some(163), 1, HubSort::PriceAsc, false).await.unwrap();
+        assert!(free.total > 0 && free.total < page.total);
+        assert!(free.items.iter().all(|i| i.price.free), "{:#?}", free.items);
+
+        let searched = search("honda", None, 1, HubSort::Newest, false).await.unwrap();
+        assert!(searched.total > 0 && searched.total < page.total);
+
+        // Detail, on whatever the newest item happens to be.
+        let detail = detail(page.items[0].id).await.unwrap();
+        assert_eq!(detail.item.id, page.items[0].id);
+        assert!(!detail.images.is_empty());
+
+        // …and the by-slug lookup the purchases grid uses for artwork.
+        let slugs: Vec<String> = page.items.iter().take(3).map(|i| i.slug.clone()).collect();
+        let found = by_slugs(&slugs).await.unwrap();
+        assert_eq!(found.len(), 3);
+
+        // Dates come from `wp/v2`, and the whole point of that request is that they arrive.
+        assert!(
+            page.items.iter().filter(|i| i.updated.is_some()).count() >= 20,
+            "wp/v2 date enrichment stopped working"
+        );
+    }
+
+    #[test]
+    fn every_sort_maps_to_a_parameter_the_api_accepts() {
+        // `relevance` is rejected by this install, so it must never appear here.
+        for sort in [
+            HubSort::Newest,
+            HubSort::Popular,
+            HubSort::PriceAsc,
+            HubSort::PriceDesc,
+            HubSort::NameAsc,
+        ] {
+            let (orderby, order) = sort.params();
+            assert!(
+                ["date", "popularity", "price", "title", "menu_order"].contains(&orderby),
+                "{orderby} is not an order the Store API accepts"
+            );
+            assert!(["asc", "desc"].contains(&order));
+        }
+    }
+}

--- a/src-tauri/src/mods/hubaccount.rs
+++ b/src-tauri/src/mods/hubaccount.rs
@@ -1,0 +1,546 @@
+//! The signed-in half of MXB Hub — what this account owns, and how to let go of the session.
+//!
+//! WooCommerce keeps a customer's files on `/my-account/downloads/`, one row per purchased
+//! file, each linking to a signed `?download_file=…&order=…&key=…` URL. That page is ordinary
+//! HTML behind an ordinary login cookie: no Cloudflare, so [`crate::hub_session`]'s `reqwest`
+//! client reads it directly and streams the file itself. Contrast [`super::mxbshop`], which
+//! does the same job for mxbikes-shop.com through a parked WebView because every path there is
+//! a managed challenge.
+//!
+//! The parsing is deliberately layered — the themed table, then the list form some themes use,
+//! then any `download_file` link on the page. A storefront is free to restyle its account area,
+//! and a purchases grid that empties itself the day it does is worse than one that finds the
+//! links wherever they ended up. When all three find nothing, the page is dumped to the cache
+//! directory so the selectors can be re-tuned against what the store actually served.
+
+use crate::hub_session::HUB_BASE;
+use reqwest::Client;
+use scraper::{ElementRef, Html, Selector};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use tauri::{AppHandle, Manager};
+
+const DOWNLOADS_PATH: &str = "/my-account/downloads/";
+const ACCOUNT_PATH: &str = "/my-account/";
+
+/// One purchased file.
+///
+/// Mirrors [`super::mxbshop::ShopItem`] field for field. That is not an accident: the two
+/// stores' purchase grids do the same job, the install command takes the same shape, and a
+/// second set of near-identical names would make every shared UI decision a translation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HubItem {
+    pub id: u64,
+    /// Identity for the install queue and the staging directory — the product's own URL slug
+    /// where the page gave one, else a slug made from the title.
+    pub slug: String,
+    /// What the card is titled: the product, plus the file label when a product ships several.
+    pub title: String,
+    /// The product's own name, kept whole and separate rather than recovered by splitting
+    /// `title` — a product may contain an em-dash of its own, and this is the string the
+    /// artwork lookup and the card grouping key on.
+    pub product: String,
+    /// Which file of the product this row is. Empty when the product ships a single file.
+    pub file_label: String,
+    /// The product page, when the row linked to one.
+    pub link: String,
+    /// Kept for shape-compatibility with the shop's grid. WooCommerce's downloads table
+    /// carries no purchase date, so this is empty rather than invented.
+    pub date: String,
+    /// Filled in later from the catalog, by slug — see [`match_products`].
+    pub image: Option<String>,
+    /// The signed WooCommerce download URL. Only ever an `https` URL on the store itself.
+    pub download_url: String,
+}
+
+/// Fetch and parse the signed-in account's downloads.
+pub async fn fetch_my_downloads(app: &AppHandle, client: &Client) -> anyhow::Result<Vec<HubItem>> {
+    let resp = client
+        .get(format!("{HUB_BASE}{DOWNLOADS_PATH}"))
+        .send()
+        .await?;
+    let status = resp.status();
+    let html = resp.text().await?;
+
+    if !status.is_success() {
+        anyhow::bail!("MXB Hub answered {status} for your downloads");
+    }
+    // WooCommerce serves the login form in place of the account page for a dead cookie — a 200,
+    // not a redirect, so the status says nothing. Dropping the session here is what turns the
+    // next visit into a "Sign in" button rather than a grid that fails the same way forever.
+    if looks_like_login(&html) {
+        crate::hub_session::forget(app);
+        anyhow::bail!("Your MXB Hub session expired — please sign in again.");
+    }
+
+    let items = parse_downloads(&html);
+    if items.is_empty() {
+        // An account with no purchases is not a parse failure, and must not be reported as one.
+        if has_empty_state(&html) {
+            log::info!("MXB Hub reports no downloads on this account");
+            return Ok(vec![]);
+        }
+        if let Ok(dir) = app.path().app_cache_dir() {
+            let _ = std::fs::create_dir_all(&dir);
+            let dump = dir.join("hub-downloads.html");
+            let _ = std::fs::write(&dump, &html);
+            log::warn!(
+                "parsed 0 MXB Hub downloads; dumped the page to {}",
+                dump.display()
+            );
+        }
+    } else {
+        log::info!("fetched {} MXB Hub downloads", items.len());
+    }
+    Ok(items)
+}
+
+/// End the session on the server, so the copy of the cookie left in the WebView's own jar is
+/// dead too. `Ok(false)` means the account page offered no logout link — already signed out.
+pub async fn logout(client: &Client) -> anyhow::Result<bool> {
+    let html = client
+        .get(format!("{HUB_BASE}{ACCOUNT_PATH}"))
+        .send()
+        .await?
+        .text()
+        .await?;
+    let Some(url) = logout_url(&html) else {
+        return Ok(false);
+    };
+    // The URL carries WordPress's nonce, so it is only ever followed, never constructed.
+    client.get(url).send().await?;
+    Ok(true)
+}
+
+// ───────────────────────────────── parsing ─────────────────────────────────
+
+/// True when this is the login form rather than the account area.
+///
+/// Both fields, not either: WooCommerce's account pages carry a search form of their own, and
+/// matching on a lone `name="password"` condemned every signed-in page the moment the theme
+/// added a newsletter box.
+fn looks_like_login(html: &str) -> bool {
+    (html.contains("woocommerce-form-login") || html.contains("class=\"login\""))
+        && html.contains("name=\"username\"")
+        && html.contains("name=\"password\"")
+}
+
+/// WooCommerce's own copy for an account that has bought nothing downloadable yet.
+fn has_empty_state(html: &str) -> bool {
+    html.contains("no-downloads")
+        || html.contains("No downloads available yet")
+        || html.contains("woocommerce-Message--info")
+}
+
+pub fn parse_downloads(html: &str) -> Vec<HubItem> {
+    let doc = Html::parse_document(html);
+    let rows = parse_table(&doc);
+    if !rows.is_empty() {
+        return finish(rows);
+    }
+    finish(parse_any_links(&doc))
+}
+
+/// One row before its title has been decided — the title depends on whether the product turns
+/// out to ship more than one file, which is only knowable once every row is in.
+struct Row {
+    product: String,
+    file_label: String,
+    link: String,
+    download_url: String,
+}
+
+/// The themed table (and the `<ul>` some themes render instead): a product cell and a file
+/// cell, so the product name survives even when the link text is just "Download".
+fn parse_table(doc: &Html) -> Vec<Row> {
+    let row_sel = match Selector::parse("tr, li.woocommerce-MyAccount-downloads-file, li") {
+        Ok(sel) => sel,
+        Err(_) => return vec![],
+    };
+    let product_sel = Selector::parse(".download-product, .woocommerce-table__product-name").unwrap();
+    let file_sel = Selector::parse("a[href*=\"download_file=\"]").unwrap();
+
+    let mut rows = Vec::new();
+    for row in doc.select(&row_sel) {
+        let Some(anchor) = row.select(&file_sel).next() else {
+            continue;
+        };
+        // A `<li>` nested inside a matched `<tr>` yields the same link twice. That is left to
+        // the deduplication in `finish`, which keys on the download URL — and because
+        // `select` walks in document order, the outer row (the one that still has its product
+        // cell) is the copy that survives. An ancestor check here looked cheaper and was
+        // wrong: every `<tr>` has a `<table>` above it that also contains the link, so it
+        // rejected the entire table and quietly fell through to the text-only fallback.
+        let Some(download_url) = safe_download_url(anchor.value().attr("href").unwrap_or("")) else {
+            continue;
+        };
+
+        // The product cell, if the theme has one — never the cell holding the file link, whose
+        // text is the file name.
+        let product_cell = row
+            .select(&product_sel)
+            .find(|cell| cell.select(&file_sel).next().is_none());
+        let product = product_cell.map(|c| text(&c)).unwrap_or_default();
+        let link = product_cell
+            .and_then(|c| Selector::parse("a[href]").ok().and_then(|s| c.select(&s).next()))
+            .and_then(|a| safe_product_url(a.value().attr("href").unwrap_or("")))
+            .unwrap_or_default();
+
+        rows.push(Row {
+            product,
+            file_label: text(&anchor),
+            link,
+            download_url,
+        });
+    }
+    rows
+}
+
+/// Last resort: every download link on the page, wherever it sits. Loses the product/file
+/// split — the link text becomes the name — but a grid of correctly-named, installable files
+/// beats an empty one.
+fn parse_any_links(doc: &Html) -> Vec<Row> {
+    let sel = Selector::parse("a[href*=\"download_file=\"]").unwrap();
+    doc.select(&sel)
+        .filter_map(|a| {
+            let download_url = safe_download_url(a.value().attr("href").unwrap_or(""))?;
+            Some(Row {
+                product: String::new(),
+                file_label: text(&a),
+                link: String::new(),
+                download_url,
+            })
+        })
+        .collect()
+}
+
+/// Decide each row's title and identity, now that the whole page is in.
+fn finish(rows: Vec<Row>) -> Vec<HubItem> {
+    // Deduplicate first, then count. The other order says a product ships two files whenever
+    // one file was listed twice — under a second order, or by a theme that renders the table
+    // and a mobile list of the same rows — and every such title would grow a "— label" suffix
+    // it hasn't earned.
+    let mut seen: HashSet<String> = HashSet::new();
+    let rows: Vec<&Row> = rows
+        .iter()
+        .filter(|row| seen.insert(row.download_url.clone()))
+        .collect();
+
+    let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for row in &rows {
+        if !row.product.is_empty() {
+            *counts.entry(row.product.as_str()).or_default() += 1;
+        }
+    }
+
+    let mut items = Vec::new();
+    for row in rows {
+        let multi = counts.get(row.product.as_str()).copied().unwrap_or(0) > 1;
+        let product = match (row.product.trim(), row.file_label.trim()) {
+            ("", "") => "Untitled".to_string(),
+            ("", label) => label.to_string(),
+            (product, _) => product.to_string(),
+        };
+        let title = match (row.product.trim().is_empty(), multi, row.file_label.trim()) {
+            (false, true, label) if !label.is_empty() => format!("{product} — {label}"),
+            _ => product.clone(),
+        };
+
+        items.push(HubItem {
+            id: items.len() as u64 + 1,
+            slug: slug_for(&row.link, &title),
+            title,
+            product,
+            file_label: row.file_label.trim().to_string(),
+            link: row.link.clone(),
+            date: String::new(),
+            image: None,
+            download_url: row.download_url.clone(),
+        });
+    }
+    items
+}
+
+/// The product's own URL slug where the row linked to its page, else one made from the title.
+///
+/// It has to be stable and unique per row: the install queue keys its cancel token, its staging
+/// directory and its progress card on this, so two purchases sharing a slug would cancel each
+/// other. A product with several files disambiguates on the file label, which is what the
+/// title already carries.
+fn slug_for(link: &str, title: &str) -> String {
+    let from_link = reqwest::Url::parse(link)
+        .ok()
+        .and_then(|u| {
+            u.path_segments()
+                .and_then(|s| s.filter(|p| !p.is_empty()).next_back())
+                .map(str::to_string)
+        })
+        .filter(|s| !s.is_empty() && s != "product");
+
+    let base = slugify(title);
+    match from_link {
+        // Both, when the title said more than the product page can: the slug names the product
+        // and the title names the file within it.
+        Some(slug) if slugify(title) != slug => format!("{slug}-{base}"),
+        Some(slug) => slug,
+        None if base.is_empty() => "hub-download".to_string(),
+        None => base,
+    }
+}
+
+fn slugify(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut dash = false;
+    for ch in raw.trim().to_lowercase().chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch);
+            dash = false;
+        } else if !out.is_empty() && !dash {
+            out.push('-');
+            dash = true;
+        }
+    }
+    out.trim_end_matches('-').chars().take(72).collect()
+}
+
+fn text(el: &ElementRef) -> String {
+    let raw: String = el.text().collect();
+    html_escape::decode_html_entities(raw.trim())
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// A download URL we're willing to stream from: `https`, on the store, and carrying the
+/// `download_file` parameter that makes it a file rather than a page.
+///
+/// This is the one string on the page that becomes a network request with the user's session
+/// attached, so it is checked rather than trusted. A row pointing anywhere else is dropped.
+fn safe_download_url(raw: &str) -> Option<String> {
+    let url = on_the_store(raw)?;
+    url.query_pairs()
+        .any(|(k, _)| k == "download_file")
+        .then(|| url.to_string())
+}
+
+fn safe_product_url(raw: &str) -> Option<String> {
+    on_the_store(raw).map(|u| u.to_string())
+}
+
+fn on_the_store(raw: &str) -> Option<reqwest::Url> {
+    let decoded = html_escape::decode_html_entities(raw.trim()).into_owned();
+    let url = reqwest::Url::parse(&decoded).ok()?;
+    if url.scheme() != "https" {
+        return None;
+    }
+    let host = url.host_str()?.to_ascii_lowercase();
+    (host == "mxb-hub.com" || host.ends_with(".mxb-hub.com")).then_some(url)
+}
+
+/// WordPress's logout link, nonce and all, as printed in the account navigation.
+fn logout_url(html: &str) -> Option<String> {
+    let doc = Html::parse_document(html);
+    let sel = Selector::parse("a[href*=\"customer-logout\"], a[href*=\"action=logout\"]").ok()?;
+    doc.select(&sel)
+        .find_map(|a| safe_product_url(a.value().attr("href").unwrap_or("")))
+}
+
+// ───────────────────────────────── artwork ─────────────────────────────────
+
+/// The catalog entry for each purchased row, positionally.
+///
+/// The downloads page gives a name and a link and nothing else, so this is what supplies the
+/// artwork that makes the grid worth looking at. Looked up by *slug* rather than by name —
+/// the row links to the product page, and the Store API takes a comma-separated `slug` list,
+/// so the whole grid resolves in one request and an exact match. Rows whose product has since
+/// been unlisted simply come back `None`.
+pub async fn match_products(items: &[HubItem]) -> anyhow::Result<Vec<Option<super::hub::HubMod>>> {
+    let slugs: Vec<String> = items
+        .iter()
+        .filter_map(|i| product_slug(&i.link))
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    if slugs.is_empty() {
+        return Ok(vec![None; items.len()]);
+    }
+
+    let found = super::hub::by_slugs(&slugs).await?;
+    Ok(items
+        .iter()
+        .map(|item| {
+            let slug = product_slug(&item.link)?;
+            found.iter().find(|m| m.slug == slug).cloned()
+        })
+        .collect())
+}
+
+/// The `…/product/<slug>/` segment of a product permalink.
+fn product_slug(link: &str) -> Option<String> {
+    let url = reqwest::Url::parse(link).ok()?;
+    let mut segments: Vec<&str> = url.path_segments()?.filter(|s| !s.is_empty()).collect();
+    let last = segments.pop()?;
+    (!last.is_empty() && last != "product").then(|| last.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// WooCommerce's stock `myaccount/downloads.php`, as a theme renders it: a product cell
+    /// and a file cell, and a product that ships two files.
+    const TABLE: &str = r#"
+    <div class="woocommerce-MyAccount-content">
+    <table class="woocommerce-table woocommerce-table--order-downloads shop_table">
+      <thead><tr><th class="download-product">Product</th><th class="download-file">Download</th></tr></thead>
+      <tbody>
+        <tr>
+          <td class="download-product" data-title="Product">
+            <a href="https://shop.mxb-hub.com/product/bell-moto-10-fox-vue-rolloff/">BELL MOTO 10 [FOX VUE ROLLOFF]</a>
+          </td>
+          <td class="download-file" data-title="Download">
+            <a href="https://shop.mxb-hub.com/?download_file=16727&amp;order=wc_order_abc&amp;email=a%40b.c&amp;key=k1"
+               class="woocommerce-MyAccount-downloads-file button alt">BellMoto10.pkz</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="download-product" data-title="Product">
+            <a href="https://shop.mxb-hub.com/product/tld-se5-psd/">TLD SE5 [PSD]</a>
+          </td>
+          <td class="download-file" data-title="Download">
+            <a href="https://shop.mxb-hub.com/?download_file=16700&amp;order=wc_order_abc&amp;key=k2">SE5 PSD</a>
+          </td>
+        </tr>
+        <tr>
+          <td class="download-product" data-title="Product">
+            <a href="https://shop.mxb-hub.com/product/tld-se5-psd/">TLD SE5 [PSD]</a>
+          </td>
+          <td class="download-file" data-title="Download">
+            <a href="https://shop.mxb-hub.com/?download_file=16701&amp;order=wc_order_abc&amp;key=k3">SE5 PNT</a>
+          </td>
+        </tr>
+      </tbody>
+    </table></div>"#;
+
+    /// The list form, with no product cell at all — the fallback path.
+    const LIST: &str = r#"
+    <ul class="woocommerce-MyAccount-downloads">
+      <li class="woocommerce-MyAccount-downloads-file">
+        <a href="https://shop.mxb-hub.com/?download_file=99&amp;order=wc_order_z&amp;key=k9">RED BUD KXF.pkz</a>
+      </li>
+    </ul>"#;
+
+    #[test]
+    fn the_stock_table_parses_into_installable_rows() {
+        let items = parse_downloads(TABLE);
+        assert_eq!(items.len(), 3);
+
+        assert_eq!(items[0].product, "BELL MOTO 10 [FOX VUE ROLLOFF]");
+        // One file: the title is just the product, with no dangling em-dash.
+        assert_eq!(items[0].title, "BELL MOTO 10 [FOX VUE ROLLOFF]");
+        assert_eq!(items[0].slug, "bell-moto-10-fox-vue-rolloff");
+        assert!(items[0].download_url.contains("download_file=16727"));
+        // `&amp;` in the markup is one parameter separator, not part of the value.
+        assert!(items[0].download_url.contains("key=k1"), "{}", items[0].download_url);
+
+        // Two files under one product: each keeps its own label, and its own identity.
+        assert_eq!(items[1].title, "TLD SE5 [PSD] — SE5 PSD");
+        assert_eq!(items[2].title, "TLD SE5 [PSD] — SE5 PNT");
+        assert_ne!(items[1].slug, items[2].slug, "two rows must not share a slug");
+    }
+
+    #[test]
+    fn the_list_form_falls_back_to_the_link_text() {
+        let items = parse_downloads(LIST);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].title, "RED BUD KXF.pkz");
+        assert_eq!(items[0].product, "RED BUD KXF.pkz");
+        assert_eq!(items[0].slug, "red-bud-kxf-pkz");
+    }
+
+    /// The same file under two orders is one thing to install.
+    #[test]
+    fn a_repeated_file_appears_once() {
+        let html = format!("{LIST}{LIST}");
+        assert_eq!(parse_downloads(&html).len(), 1);
+    }
+
+    /// The security boundary: these URLs are fetched with the user's session attached.
+    #[test]
+    fn only_signed_store_urls_are_downloadable() {
+        assert!(safe_download_url("https://shop.mxb-hub.com/?download_file=1&key=k").is_some());
+        for bad in [
+            // Right shape, wrong host.
+            "https://evil.com/?download_file=1&key=k",
+            "https://shop.mxb-hub.com.evil.com/?download_file=1",
+            // Right host, not a file.
+            "https://shop.mxb-hub.com/my-account/",
+            // Not https.
+            "http://shop.mxb-hub.com/?download_file=1",
+            "javascript:alert(1)",
+            "",
+        ] {
+            assert!(safe_download_url(bad).is_none(), "{bad} must not be downloadable");
+        }
+    }
+
+    #[test]
+    fn a_row_pointing_off_the_store_is_dropped_not_rendered() {
+        let html = r#"<table><tr>
+            <td class="download-product">Trojan</td>
+            <td class="download-file"><a href="https://evil.com/?download_file=1">Free stuff</a></td>
+        </tr></table>"#;
+        assert!(parse_downloads(html).is_empty());
+    }
+
+    #[test]
+    fn the_login_form_is_recognised_but_an_account_page_is_not() {
+        let login = r#"<form class="woocommerce-form woocommerce-form-login login">
+            <input name="username"><input name="password" type="password"></form>"#;
+        assert!(looks_like_login(login));
+        // A signed-in account page with a search box must not read as signed out.
+        assert!(!looks_like_login(
+            r#"<div class="woocommerce-MyAccount-content"><input name="s"></div>"#
+        ));
+        assert!(!looks_like_login(TABLE));
+    }
+
+    #[test]
+    fn an_empty_account_is_not_a_parse_failure() {
+        assert!(has_empty_state(
+            r#"<div class="woocommerce-Message woocommerce-Message--info woocommerce-info no-downloads">
+               No downloads available yet.</div>"#
+        ));
+        assert!(!has_empty_state(TABLE));
+    }
+
+    #[test]
+    fn the_logout_link_is_taken_from_the_page_never_built() {
+        let html = r#"<nav><a href="https://shop.mxb-hub.com/my-account/customer-logout/?_wpnonce=abc123">Log out</a></nav>"#;
+        assert_eq!(
+            logout_url(html).as_deref(),
+            Some("https://shop.mxb-hub.com/my-account/customer-logout/?_wpnonce=abc123")
+        );
+        assert!(logout_url("<nav><a href=\"https://evil.com/customer-logout/\">x</a></nav>").is_none());
+        assert!(logout_url("<nav></nav>").is_none());
+    }
+
+    #[test]
+    fn product_slugs_come_off_the_permalink() {
+        assert_eq!(
+            product_slug("https://shop.mxb-hub.com/product/mxb-hub-fc-paint/").as_deref(),
+            Some("mxb-hub-fc-paint")
+        );
+        assert_eq!(product_slug("https://shop.mxb-hub.com/product/").as_deref(), None);
+        assert_eq!(product_slug("").as_deref(), None);
+    }
+
+    #[test]
+    fn slugify_makes_a_usable_staging_name() {
+        assert_eq!(slugify("BELL MOTO 10 [FOX VUE ROLLOFF]"), "bell-moto-10-fox-vue-rolloff");
+        assert_eq!(slugify("  ---  "), "");
+        assert_eq!(slugify("2026 HRC Honda Black BG [PAINT]"), "2026-hrc-honda-black-bg-paint");
+        assert!(slugify(&"x".repeat(200)).len() <= 72);
+    }
+}

--- a/src-tauri/src/mods/hubaccount.rs
+++ b/src-tauri/src/mods/hubaccount.rs
@@ -56,8 +56,20 @@ pub struct HubItem {
     pub category_id: u32,
     /// Likewise `None` here and filled from the catalog, which is the only side that knows.
     pub author: Option<String>,
-    /// The signed WooCommerce download URL. Only ever an `https` URL on the store itself.
+    /// Where the file comes from. Either a signed WooCommerce `?download_file=` URL on the
+    /// store, or — see [`external`] — a link to a file host.
     pub download_url: String,
+    /// True when the store hands the file off to somebody else.
+    ///
+    /// WooCommerce lets a downloadable product's "file" be any URL, and MXB Hub uses that: a
+    /// number of the free mods are MediaFire links rather than uploads. It matters for two
+    /// reasons, which is why it is recorded rather than sniffed at install time. The URL has
+    /// to be *resolved* (a MediaFire folder is a web page, not a file), and it must be fetched
+    /// **without** the user's session — a store-issued link is the only kind that has any
+    /// business carrying their cookies.
+    pub external: bool,
+    /// The file host, for the resolver and for the download history. Empty when not external.
+    pub host: String,
 }
 
 /// Fetch and parse the signed-in account's downloads.
@@ -66,6 +78,16 @@ pub async fn fetch_my_downloads(app: &AppHandle, client: &Client) -> anyhow::Res
         .get(format!("{HUB_BASE}{DOWNLOADS_PATH}"))
         .send()
         .await?;
+    // The account page is behind the same rate-based robot challenge as everything else, and
+    // it arrives as a `202` of HTML — which parses to zero rows and would otherwise read as
+    // "you own nothing". Reported as the challenge it is, so the command layer answers it.
+    if super::hub::challenged(&resp) {
+        return Err(super::Blocked::new(
+            None,
+            "MXB Hub is asking the app to prove it isn't a robot.",
+        )
+        .into());
+    }
     let status = resp.status();
     let html = resp.text().await?;
 
@@ -155,6 +177,8 @@ struct Row {
     file_label: String,
     link: String,
     download_url: String,
+    external: bool,
+    host: String,
 }
 
 /// The themed table (and the `<ul>` some themes render instead): a product cell and a file
@@ -165,7 +189,14 @@ fn parse_table(doc: &Html) -> Vec<Row> {
         Err(_) => return vec![],
     };
     let product_sel = Selector::parse(".download-product, .woocommerce-table__product-name").unwrap();
-    let file_sel = Selector::parse("a[href*=\"download_file=\"]").unwrap();
+    // Deliberately wider than `download_file=`. A product whose file is hosted elsewhere links
+    // straight out to it, so keying on that parameter alone made those rows invisible — the
+    // mod simply wasn't in the grid, with nothing to say why.
+    let file_sel = Selector::parse(
+        "a.woocommerce-MyAccount-downloads-file[href], td.download-file a[href], \
+         .download-file a[href], a[href*=\"download_file=\"]",
+    )
+    .unwrap();
 
     let mut rows = Vec::new();
     for row in doc.select(&row_sel) {
@@ -178,7 +209,7 @@ fn parse_table(doc: &Html) -> Vec<Row> {
         // cell) is the copy that survives. An ancestor check here looked cheaper and was
         // wrong: every `<tr>` has a `<table>` above it that also contains the link, so it
         // rejected the entire table and quietly fell through to the text-only fallback.
-        let Some(download_url) = safe_download_url(anchor.value().attr("href").unwrap_or("")) else {
+        let Some(file) = download_link(anchor.value().attr("href").unwrap_or("")) else {
             continue;
         };
 
@@ -197,7 +228,9 @@ fn parse_table(doc: &Html) -> Vec<Row> {
             product,
             file_label: text(&anchor),
             link,
-            download_url,
+            download_url: file.url,
+            external: file.external,
+            host: file.host,
         });
     }
     rows
@@ -207,15 +240,20 @@ fn parse_table(doc: &Html) -> Vec<Row> {
 /// split — the link text becomes the name — but a grid of correctly-named, installable files
 /// beats an empty one.
 fn parse_any_links(doc: &Html) -> Vec<Row> {
-    let sel = Selector::parse("a[href*=\"download_file=\"]").unwrap();
+    let sel = Selector::parse(
+        "a.woocommerce-MyAccount-downloads-file[href], a[href*=\"download_file=\"]",
+    )
+    .unwrap();
     doc.select(&sel)
         .filter_map(|a| {
-            let download_url = safe_download_url(a.value().attr("href").unwrap_or(""))?;
+            let file = download_link(a.value().attr("href").unwrap_or(""))?;
             Some(Row {
                 product: String::new(),
                 file_label: text(&a),
                 link: String::new(),
-                download_url,
+                download_url: file.url,
+                external: file.external,
+                host: file.host,
             })
         })
         .collect()
@@ -266,6 +304,8 @@ fn finish(rows: Vec<Row>) -> Vec<HubItem> {
             image: None,
             category_id: 0,
             author: None,
+            external: row.external,
+            host: row.host.clone(),
             download_url: row.download_url.clone(),
         });
     }
@@ -336,16 +376,55 @@ fn text(el: &ElementRef) -> String {
         .join(" ")
 }
 
-/// A download URL we're willing to stream from: `https`, on the store, and carrying the
-/// `download_file` parameter that makes it a file rather than a page.
+/// One row's file, and whether the store is serving it or handing it off.
+struct FileLink {
+    url: String,
+    external: bool,
+    host: String,
+}
+
+/// What a download button on the account page points at.
 ///
-/// This is the one string on the page that becomes a network request with the user's session
-/// attached, so it is checked rather than trusted. A row pointing anywhere else is dropped.
-fn safe_download_url(raw: &str) -> Option<String> {
-    let url = on_the_store(raw)?;
-    url.query_pairs()
-        .any(|(k, _)| k == "download_file")
-        .then(|| url.to_string())
+/// Two shapes are legitimate, and they are *not* interchangeable:
+///
+///  - The store's own signed `?download_file=…&order=…&key=…` URL. Fetched with the user's
+///    session, because that is what authorises it.
+///  - A link to a file host, which WooCommerce allows for any downloadable product and which
+///    MXB Hub uses for a number of its free mods. Fetched with the ordinary download client
+///    and resolved first — a MediaFire *folder* is a web page listing files, not a file.
+///
+/// The distinction is the security-relevant part. Sending the user's store cookies to whatever
+/// third-party URL happens to be on the page is exactly the mistake to avoid, so the answer
+/// carries which kind it is rather than leaving the caller to guess from the host.
+///
+/// Anything that isn't `https` is refused outright, as is a store URL that is plainly a page
+/// rather than a file.
+fn download_link(raw: &str) -> Option<FileLink> {
+    let decoded = html_escape::decode_html_entities(raw.trim()).into_owned();
+    let url = reqwest::Url::parse(&decoded).ok()?;
+    if url.scheme() != "https" {
+        return None;
+    }
+    let host = url.host_str()?.to_ascii_lowercase();
+
+    if host == "mxb-hub.com" || host.ends_with(".mxb-hub.com") {
+        // On the store, only a signed file link counts. Without this the "View" and product
+        // links sitting in the same table would each be offered as a download.
+        return url
+            .query_pairs()
+            .any(|(k, _)| k == "download_file")
+            .then(|| FileLink {
+                url: url.to_string(),
+                external: false,
+                host: String::new(),
+            });
+    }
+
+    Some(FileLink {
+        url: url.to_string(),
+        external: true,
+        host,
+    })
 }
 
 fn safe_product_url(raw: &str) -> Option<String> {
@@ -505,32 +584,48 @@ mod tests {
         assert_eq!(items[1].slug, "paint-pkz-2");
     }
 
-    /// The security boundary: these URLs are fetched with the user's session attached.
+    /// The security boundary. A store link is fetched with the user's session attached; an
+    /// off-store one must never be, and the flag is what keeps those two apart.
     #[test]
-    fn only_signed_store_urls_are_downloadable() {
-        assert!(safe_download_url("https://shop.mxb-hub.com/?download_file=1&key=k").is_some());
+    fn store_links_and_handed_off_links_are_told_apart() {
+        let store = download_link("https://shop.mxb-hub.com/?download_file=1&key=k").unwrap();
+        assert!(!store.external);
+        assert!(store.host.is_empty());
+
+        // WooCommerce lets a product's file live anywhere, and MXB Hub uses that for some of
+        // its free mods. Kept, but marked — never fetched with the store's cookies.
+        let away = download_link("https://www.mediafire.com/folder/abc123/paint").unwrap();
+        assert!(away.external);
+        assert_eq!(away.host, "www.mediafire.com");
+
         for bad in [
-            // Right shape, wrong host.
-            "https://evil.com/?download_file=1&key=k",
-            "https://shop.mxb-hub.com.evil.com/?download_file=1",
-            // Right host, not a file.
+            // On the store, but a page rather than a file.
             "https://shop.mxb-hub.com/my-account/",
+            "https://shop.mxb-hub.com/product/a-paint/",
             // Not https.
-            "http://shop.mxb-hub.com/?download_file=1",
+            "http://www.mediafire.com/file/x",
             "javascript:alert(1)",
             "",
         ] {
-            assert!(safe_download_url(bad).is_none(), "{bad} must not be downloadable");
+            assert!(download_link(bad).is_none(), "{bad} must not be downloadable");
         }
     }
 
+    /// A free mod whose file is a MediaFire folder has to reach the grid. Dropping it — which
+    /// is what keying on `download_file=` alone did — loses the mod with nothing said.
     #[test]
-    fn a_row_pointing_off_the_store_is_dropped_not_rendered() {
+    fn an_external_file_still_produces_a_row() {
         let html = r#"<table><tr>
-            <td class="download-product">Trojan</td>
-            <td class="download-file"><a href="https://evil.com/?download_file=1">Free stuff</a></td>
+            <td class="download-product"><a href="https://shop.mxb-hub.com/product/red-bud-kxf-paint/">RED BUD KXF [PAINT]</a></td>
+            <td class="download-file"><a class="woocommerce-MyAccount-downloads-file"
+               href="https://www.mediafire.com/folder/abc123/redbud">RED BUD KXF</a></td>
         </tr></table>"#;
-        assert!(parse_downloads(html).is_empty());
+        let items = parse_downloads(html);
+        assert_eq!(items.len(), 1);
+        assert!(items[0].external);
+        assert_eq!(items[0].host, "www.mediafire.com");
+        assert_eq!(items[0].slug, "red-bud-kxf-paint");
+        assert_eq!(items[0].product, "RED BUD KXF [PAINT]");
     }
 
     #[test]

--- a/src-tauri/src/mods/hubaccount.rs
+++ b/src-tauri/src/mods/hubaccount.rs
@@ -160,7 +160,7 @@ struct Row {
 /// The themed table (and the `<ul>` some themes render instead): a product cell and a file
 /// cell, so the product name survives even when the link text is just "Download".
 fn parse_table(doc: &Html) -> Vec<Row> {
-    let row_sel = match Selector::parse("tr, li.woocommerce-MyAccount-downloads-file, li") {
+    let row_sel = match Selector::parse("tr, li") {
         Ok(sel) => sel,
         Err(_) => return vec![],
     };
@@ -240,22 +240,24 @@ fn finish(rows: Vec<Row>) -> Vec<HubItem> {
         }
     }
 
-    let mut items = Vec::new();
+    let mut items: Vec<HubItem> = Vec::new();
+    let mut slugs: HashSet<String> = HashSet::new();
     for row in rows {
         let multi = counts.get(row.product.as_str()).copied().unwrap_or(0) > 1;
-        let product = match (row.product.trim(), row.file_label.trim()) {
+        let label = row.file_label.trim();
+        let product = match (row.product.trim(), label) {
             ("", "") => "Untitled".to_string(),
             ("", label) => label.to_string(),
             (product, _) => product.to_string(),
         };
-        let title = match (row.product.trim().is_empty(), multi, row.file_label.trim()) {
+        let title = match (row.product.trim().is_empty(), multi, label) {
             (false, true, label) if !label.is_empty() => format!("{product} — {label}"),
             _ => product.clone(),
         };
 
         items.push(HubItem {
             id: items.len() as u64 + 1,
-            slug: slug_for(&row.link, &title),
+            slug: slug_for(&row.link, &product, label, multi, &mut slugs),
             title,
             product,
             file_label: row.file_label.trim().to_string(),
@@ -270,31 +272,45 @@ fn finish(rows: Vec<Row>) -> Vec<HubItem> {
     items
 }
 
-/// The product's own URL slug where the row linked to its page, else one made from the title.
+/// The product's own URL slug where the row linked to its page, else one made from its name.
 ///
 /// It has to be stable and unique per row: the install queue keys its cancel token, its staging
 /// directory and its progress card on this, so two purchases sharing a slug would cancel each
-/// other. A product with several files disambiguates on the file label, which is what the
-/// title already carries.
-fn slug_for(link: &str, title: &str) -> String {
-    let from_link = reqwest::Url::parse(link)
-        .ok()
-        .and_then(|u| {
-            u.path_segments()
-                .and_then(|s| s.filter(|p| !p.is_empty()).next_back())
-                .map(str::to_string)
-        })
-        .filter(|s| !s.is_empty() && s != "product");
+/// other's download. Two things can collide — a product that ships several files, and (in the
+/// text-only fallback) two rows whose link text happens to match — so the file label
+/// disambiguates the first and `seen` guarantees the rest.
+fn slug_for(
+    link: &str,
+    product: &str,
+    file_label: &str,
+    multi: bool,
+    seen: &mut HashSet<String>,
+) -> String {
+    let base = product_slug(link)
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| slugify(product));
+    let base = if base.is_empty() {
+        "hub-download".to_string()
+    } else {
+        base
+    };
 
-    let base = slugify(title);
-    match from_link {
-        // Both, when the title said more than the product page can: the slug names the product
-        // and the title names the file within it.
-        Some(slug) if slugify(title) != slug => format!("{slug}-{base}"),
-        Some(slug) => slug,
-        None if base.is_empty() => "hub-download".to_string(),
-        None => base,
+    let mut slug = match (multi, slugify(file_label)) {
+        (true, label) if !label.is_empty() => format!("{base}-{label}"),
+        _ => base,
+    };
+    // Whatever is left over. A numeric suffix is ugly and never normally reached; two installs
+    // silently cancelling each other is worse.
+    if seen.contains(&slug) {
+        let stem = slug.clone();
+        let mut n = 2;
+        while seen.contains(&slug) {
+            slug = format!("{stem}-{n}");
+            n += 1;
+        }
     }
+    seen.insert(slug.clone());
+    slug
 }
 
 fn slugify(raw: &str) -> String {
@@ -455,7 +471,8 @@ mod tests {
         // Two files under one product: each keeps its own label, and its own identity.
         assert_eq!(items[1].title, "TLD SE5 [PSD] — SE5 PSD");
         assert_eq!(items[2].title, "TLD SE5 [PSD] — SE5 PNT");
-        assert_ne!(items[1].slug, items[2].slug, "two rows must not share a slug");
+        assert_eq!(items[1].slug, "tld-se5-psd-se5-psd");
+        assert_eq!(items[2].slug, "tld-se5-psd-se5-pnt");
     }
 
     #[test]
@@ -472,6 +489,20 @@ mod tests {
     fn a_repeated_file_appears_once() {
         let html = format!("{LIST}{LIST}");
         assert_eq!(parse_downloads(&html).len(), 1);
+    }
+
+    /// Two rows that name themselves identically still get their own identity — the install
+    /// queue keys its cancel token on this, so a collision means one download killing another.
+    #[test]
+    fn identical_rows_never_share_a_slug() {
+        let html = r#"<ul>
+          <li><a href="https://shop.mxb-hub.com/?download_file=1&amp;key=a">Paint.pkz</a></li>
+          <li><a href="https://shop.mxb-hub.com/?download_file=2&amp;key=b">Paint.pkz</a></li>
+        </ul>"#;
+        let items = parse_downloads(html);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].slug, "paint-pkz");
+        assert_eq!(items[1].slug, "paint-pkz-2");
     }
 
     /// The security boundary: these URLs are fetched with the user's session attached.

--- a/src-tauri/src/mods/hubaccount.rs
+++ b/src-tauri/src/mods/hubaccount.rs
@@ -50,6 +50,12 @@ pub struct HubItem {
     pub date: String,
     /// Filled in later from the catalog, by slug — see [`match_products`].
     pub image: Option<String>,
+    /// Always 0, and always from the catalog match where it matters: the downloads page files
+    /// nothing under a category. Present because the purchases grid is the shop's, and this is
+    /// the shape it reads — see [`super::mxbshop::ShopItem`].
+    pub category_id: u32,
+    /// Likewise `None` here and filled from the catalog, which is the only side that knows.
+    pub author: Option<String>,
     /// The signed WooCommerce download URL. Only ever an `https` URL on the store itself.
     pub download_url: String,
 }
@@ -256,6 +262,8 @@ fn finish(rows: Vec<Row>) -> Vec<HubItem> {
             link: row.link.clone(),
             date: String::new(),
             image: None,
+            category_id: 0,
+            author: None,
             download_url: row.download_url.clone(),
         });
     }

--- a/src-tauri/src/mods/mod.rs
+++ b/src-tauri/src/mods/mod.rs
@@ -1,3 +1,5 @@
+pub mod hub;
+pub mod hubaccount;
 pub mod mxb;
 pub mod mxbshop;
 pub mod shop_catalog;

--- a/src-tauri/src/mods/shop_catalog.rs
+++ b/src-tauri/src/mods/shop_catalog.rs
@@ -439,7 +439,7 @@ fn parse_timestamp(value: &Value) -> Option<i64> {
     }
 }
 
-fn parse_date_str(raw: &str) -> Option<i64> {
+pub(crate) fn parse_date_str(raw: &str) -> Option<i64> {
     let s = raw.trim();
     if s.is_empty() {
         return None;
@@ -542,7 +542,7 @@ fn safe_shop_url(raw: &str) -> Option<String> {
 }
 
 /// Same rule, relaxed to any https host, for images — thumbnails legitimately live on a CDN.
-fn safe_image_url(raw: &str) -> Option<String> {
+pub(crate) fn safe_image_url(raw: &str) -> Option<String> {
     let url = reqwest::Url::parse(raw.trim()).ok()?;
     (url.scheme() == "https").then(|| url.to_string())
 }
@@ -559,7 +559,7 @@ fn safe_image_url(raw: &str) -> Option<String> {
 /// ~2 KB median), so sanitising at parse time meant an html5ever parse per item on the load
 /// path that blocks the first paint, to produce markup that all but a handful of items would
 /// never show. One parse on open costs nothing and is invisible next to the click.
-fn sanitize_html(raw: &str) -> Option<String> {
+pub(crate) fn sanitize_html(raw: &str) -> Option<String> {
     use scraper::{Html, Selector};
 
     let trimmed = raw.trim();

--- a/src/Components/Dashboard/Dashboard.tsx
+++ b/src/Components/Dashboard/Dashboard.tsx
@@ -9,6 +9,7 @@ import Servers from "../Servers/Servers";
 import Studio, { type StudioTab } from "../Studio/Studio";
 import Browse from "../Browse/Browse";
 import Shop from "../Shop/Shop";
+import Hub from "../Hub/Hub";
 import ModDetail from "../ModDetail/ModDetail";
 import DropZone from "../Dropzone/DropZone";
 import Settings, { type SectionId } from "../Settings/Settings";
@@ -185,6 +186,8 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
             />
           ) : view === "shop" ? (
             <Shop refreshKey={libraryVersion} />
+          ) : view === "hub" ? (
+            <Hub refreshKey={libraryVersion} />
           ) : view === "library" ? (
             <Library
               modType={modType}
@@ -200,6 +203,7 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
               onOpenMod={openModTarget}
               onShowInLibrary={showInLibrary}
               onOpenShop={() => navigate("shop")}
+              onOpenHub={() => navigate("hub")}
             />
           ) : view === "locker" ? (
             <Locker />

--- a/src/Components/Downloads/Downloads.tsx
+++ b/src/Components/Downloads/Downloads.tsx
@@ -61,6 +61,7 @@ interface DownloadsProps {
   /** Send a failed shop purchase back to the Shop, which is the only place it can be
    *  re-downloaded from — a purchase link is signed in, so there's nothing to retry here. */
   onOpenShop: () => void;
+  onOpenHub: () => void;
 }
 
 /** Records for one calendar day, newest day first. */
@@ -83,7 +84,8 @@ function groupByDay(records: DownloadRecord[]): DayGroup[] {
 
 function sourceLabel(record: DownloadRecord, t: TFunc): string {
   if (record.source === "site") return record.host || t("downloads.sourceSite");
-  return record.source === "shop" ? t("downloads.sourceShop") : t("downloads.sourceFile");
+  if (record.source === "shop") return t("downloads.sourceShop");
+  return record.source === "hub" ? t("downloads.sourceHub") : t("downloads.sourceFile");
 }
 
 /** Where it landed, as `tracks/MX2` — the answer to "so where did that one go". */
@@ -97,6 +99,7 @@ export default function Downloads({
   onOpenMod,
   onShowInLibrary,
   onOpenShop,
+  onOpenHub,
 }: DownloadsProps) {
   const t = useT();
   const { records, loading, forget, clear, markSeen } = useDownloads();
@@ -134,7 +137,11 @@ export default function Downloads({
 
   /** Straight back through the install queue, with the same destination as last time. */
   const retry = (r: DownloadRecord) => {
+    // Neither store's download URL survives a restart — the shop's is read out of a WebView and
+    // the Hub's is signed per session — so retrying one means going back to where it can be
+    // asked for again, not replaying a link.
     if (r.source === "shop") return onOpenShop();
+    if (r.source === "hub") return onOpenHub();
     if (!r.url) return;
     startInstall({
       slug: r.slug,
@@ -148,7 +155,7 @@ export default function Downloads({
   };
 
   const canRetry = (r: DownloadRecord) =>
-    r.status === "failed" && (r.source === "shop" || !!r.url);
+    r.status === "failed" && (r.source === "shop" || r.source === "hub" || !!r.url);
 
   return (
     <div className="flex h-full flex-col">
@@ -291,7 +298,11 @@ function DownloadRow({
   const t = useT();
   const failed = record.status === "failed";
   const SourceIcon =
-    record.source === "shop" ? Store : record.source === "file" ? FileArchive : Download;
+    record.source === "shop" || record.source === "hub"
+      ? Store
+      : record.source === "file"
+        ? FileArchive
+        : Download;
   const dest = destLabel(record);
 
   return (

--- a/src/Components/Hub/Hub.tsx
+++ b/src/Components/Hub/Hub.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import HubCatalog from "./HubCatalog";
+import HubPurchases from "./HubPurchases";
+import HelpHint from "@/Components/ui/help-hint";
+import { cn } from "@/lib/utils";
+import { useT } from "../../i18n/context";
+
+type HubTab = "catalog" | "purchases";
+
+interface HubProps {
+  /** Bumped after any install, so the purchases grid re-scans its "Installed" badges. */
+  refreshKey: number;
+}
+
+/**
+ * MXB Hub: the store's public catalog, and the things this account already bought.
+ *
+ * One view with two tabs rather than two sidebar entries — they are the same store, and the
+ * natural path is browse, buy on the site, come back and install. The same shape as `Shop`,
+ * minus its conditional strip: both halves of this one work in every build, because browsing
+ * MXB Hub needs no credential.
+ */
+export default function Hub({ refreshKey }: HubProps) {
+  const t = useT();
+  const [tab, setTab] = useState<HubTab>("catalog");
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="flex flex-none items-center gap-3.5 px-7 pb-3.5 pt-5">
+        <h1 className="text-[21px] font-bold tracking-[-0.2px]">{t("nav.hub")}</h1>
+        <HelpHint title={t("nav.hub")} description={t("hub.help")} />
+
+        <div className="flex items-center gap-0.5 rounded-lg border border-input bg-card p-0.5">
+          <TabButton
+            label={t("shopTab.catalog")}
+            on={tab === "catalog"}
+            onClick={() => setTab("catalog")}
+          />
+          <TabButton
+            label={t("shopTab.purchases")}
+            on={tab === "purchases"}
+            onClick={() => setTab("purchases")}
+          />
+        </div>
+      </header>
+
+      {/* Both stay mounted: switching tabs must not re-fetch the catalog or drop a sign-in. */}
+      <div className={cn("min-h-0 flex-1 flex-col", tab === "catalog" ? "flex" : "hidden")}>
+        <HubCatalog />
+      </div>
+      <div className={cn("min-h-0 flex-1 flex-col", tab === "purchases" ? "flex" : "hidden")}>
+        <HubPurchases refreshKey={refreshKey} />
+      </div>
+    </div>
+  );
+}
+
+function TabButton({
+  label,
+  on,
+  onClick,
+}: {
+  label: string;
+  on: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "cursor-default rounded-md px-3 py-1 text-[12px] font-medium transition-colors",
+        on
+          ? "bg-foreground font-semibold text-background"
+          : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/Components/Hub/HubCatalog.tsx
+++ b/src/Components/Hub/HubCatalog.tsx
@@ -1,0 +1,266 @@
+import { useCallback, useEffect, useState } from "react";
+import { ArrowUpDown, RefreshCw, Search, Tag } from "lucide-react";
+import type { HubCategory, HubMod, HubSort } from "../../types";
+import { HUB_SORTS, hubCategories, hubDetail, hubSearch } from "../../api/hub";
+import ShopCard from "../Shop/ShopCard";
+import ShopDetail from "../Shop/ShopDetail";
+import CategoryPill from "../Shop/CategoryPill";
+import { Button } from "@/Components/ui/button";
+import { Skeleton } from "@/Components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/Components/ui/select";
+import { cn } from "@/lib/utils";
+import { useT } from "../../i18n/context";
+
+/**
+ * Browse the MXB Hub catalog.
+ *
+ * Mirrors `ShopCatalog`'s contract deliberately — 350 ms search debounce, a page-1 effect keyed
+ * on the filters, append-on-load-more, eight skeletons while loading — so all three catalogs in
+ * the app behave the same. The cards and the detail page are literally the shop's: a Hub
+ * listing is a `ShopMod` with a slug on it.
+ *
+ * Where it differs is underneath. The shop's catalog is a background-refreshed dump, so that
+ * view carries a staleness bar, a "generated" timestamp and a Refresh that re-fetches the whole
+ * thing. This one queries the store live on every filter change, so none of that exists: what
+ * is on screen is what the store said a moment ago, and Refresh just asks again.
+ */
+export default function HubCatalog() {
+  const t = useT();
+
+  const [query, setQuery] = useState("");
+  const [debounced, setDebounced] = useState("");
+  const [categoryId, setCategoryId] = useState<number | null>(null);
+  const [sort, setSort] = useState<HubSort>("newest");
+  const [onSaleOnly, setOnSaleOnly] = useState(false);
+
+  const [categories, setCategories] = useState<HubCategory[]>([]);
+  const [items, setItems] = useState<HubMod[]>([]);
+  const [currency, setCurrency] = useState("USD");
+  const [total, setTotal] = useState(0);
+
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const [openId, setOpenId] = useState<number | null>(null);
+
+  // Debounce the search box so a fast typist doesn't fire a request per keystroke — this
+  // catalog goes to the network on every change, where the shop's answers from memory.
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(query.trim()), 350);
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  // (Re)load page 1 whenever a filter changes.
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setPage(1);
+    hubSearch(debounced, categoryId, 1, sort, onSaleOnly)
+      .then((res) => {
+        if (cancelled) return;
+        setItems(res.items);
+        setHasMore(res.hasMore);
+        setCurrency(res.currency);
+        setTotal(res.total);
+      })
+      .catch((e) => !cancelled && setError(String(e)))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [debounced, categoryId, sort, onSaleOnly, reloadKey]);
+
+  // A failure here is silent: the pill row stays at "All" and the grid still works.
+  useEffect(() => {
+    let cancelled = false;
+    hubCategories()
+      .then((res) => !cancelled && setCategories(res))
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  const loadMore = useCallback(async () => {
+    const next = page + 1;
+    setLoadingMore(true);
+    try {
+      const res = await hubSearch(debounced, categoryId, next, sort, onSaleOnly);
+      setItems((prev) => [...prev, ...res.items]);
+      setHasMore(res.hasMore);
+      setPage(next);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [debounced, categoryId, sort, onSaleOnly, page]);
+
+  if (openId !== null) {
+    return (
+      <ShopDetail
+        id={openId}
+        currency={currency}
+        load={hubDetail}
+        onBack={() => setOpenId(null)}
+      />
+    );
+  }
+
+  // Only top-level categories in the first row; the children of whatever is selected go in a
+  // second row, so a 99-category tree doesn't turn into a wall of pills.
+  const roots = categories.filter((c) => c.depth === 0);
+  const selected = categories.find((c) => c.id === categoryId);
+  const branchRoot = selected ? (selected.depth === 0 ? selected.id : selected.parent) : null;
+  const children = branchRoot === null ? [] : categories.filter((c) => c.parent === branchRoot);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* No title of its own — `Hub` owns the heading and the tab strip above this. */}
+      <header className="flex flex-none flex-col gap-4 px-7 pb-3.5">
+        <div className="flex items-center gap-3.5">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setReloadKey((k) => k + 1)}
+            disabled={loading}
+            className="flex-none"
+          >
+            <RefreshCw className={cn("size-3.5", loading && "animate-spin")} />
+            {t("shopCatalog.refresh")}
+          </Button>
+          {!loading && !error && (
+            <span className="text-[12.5px] text-muted-foreground">
+              {t("hub.count", { count: total })}
+            </span>
+          )}
+          <div className="ml-auto flex w-[280px] items-center gap-2 rounded-lg border border-input bg-card px-3 py-2">
+            <Search className="size-3.5 text-faint" />
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={t("hub.searchPlaceholder")}
+              className="w-full bg-transparent text-[12.5px] placeholder:text-faint focus:outline-none"
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <CategoryPill
+            label={t("shopCatalog.allCategories")}
+            on={categoryId === null}
+            onClick={() => setCategoryId(null)}
+          />
+          {roots.map((c) => (
+            <CategoryPill
+              key={c.id}
+              label={c.name}
+              count={c.count}
+              on={categoryId === c.id || selected?.parent === c.id}
+              onClick={() => setCategoryId(c.id)}
+            />
+          ))}
+          <div className="ml-auto flex items-center gap-2 self-center">
+            <button
+              onClick={() => setOnSaleOnly((v) => !v)}
+              className={cn(
+                "flex cursor-default items-center gap-1.5 rounded-full px-3 py-[5px] text-[12px] font-medium transition-colors",
+                onSaleOnly
+                  ? "bg-emerald-500 font-semibold text-black"
+                  : "border border-input text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <Tag className="size-3" />
+              {t("shopCatalog.onSaleOnly")}
+            </button>
+            <ArrowUpDown className="size-3.5 text-faint" />
+            <Select value={sort} onValueChange={(v) => setSort(v as HubSort)}>
+              <SelectTrigger className="h-8 w-[210px] bg-card">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {HUB_SORTS.map((s) => (
+                  <SelectItem key={s.value} value={s.value}>
+                    {t(s.label)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {children.length > 0 && (
+          <div className="-mt-1 flex flex-wrap items-center gap-2">
+            {children.map((c) => (
+              <CategoryPill
+                key={c.id}
+                label={c.name}
+                count={c.count}
+                small
+                on={categoryId === c.id}
+                onClick={() => setCategoryId(c.id)}
+              />
+            ))}
+          </div>
+        )}
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-7 pb-6">
+        {error ? (
+          <div className="mx-auto flex max-w-md flex-col items-center gap-3 py-20 text-center">
+            <p className="text-[13px] font-semibold text-destructive">
+              {t("shopCatalog.loadFailed")}
+            </p>
+            <p className="select-text text-[12.5px] leading-relaxed text-muted-foreground">
+              {error.replace(/^Error:\s*/, "")}
+            </p>
+            <Button variant="outline" size="sm" onClick={() => setReloadKey((k) => k + 1)}>
+              {t("common.retry")}
+            </Button>
+          </div>
+        ) : loading ? (
+          <div className="grid grid-cols-4 gap-3.5">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <Skeleton key={i} className="aspect-square rounded-xl" />
+            ))}
+          </div>
+        ) : items.length === 0 ? (
+          <p className="py-20 text-center text-[13px] text-muted-foreground">
+            {t("shopCatalog.empty")}
+          </p>
+        ) : (
+          <>
+            <div className="grid grid-cols-4 gap-3.5">
+              {items.map((m) => (
+                <ShopCard
+                  key={m.id}
+                  mod={m}
+                  currency={currency}
+                  onOpen={() => setOpenId(m.id)}
+                />
+              ))}
+            </div>
+            {hasMore && (
+              <div className="flex justify-center pt-4">
+                <Button variant="outline" onClick={loadMore} disabled={loadingMore}>
+                  {loadingMore ? t("common.loading") : t("shopCatalog.loadMore")}
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/Components/Hub/HubPurchases.tsx
+++ b/src/Components/Hub/HubPurchases.tsx
@@ -23,6 +23,7 @@ import {
   hubMyDownloads,
   hubStatus,
   onHubAuth,
+  type HubItem,
 } from "../../api/hub";
 import {
   buildDestinations,
@@ -33,7 +34,6 @@ import {
   shopInstalledMap,
   type DestOption,
   type ModType,
-  type ShopItem,
 } from "../../api/mods";
 import { PURCHASE_SORTS, type PurchaseSort } from "../../api/shop";
 import type { HubCategory, HubMod } from "../../types";
@@ -69,6 +69,15 @@ import { cn } from "@/lib/utils";
 /** The pill for purchases the catalog no longer lists. */
 const OTHER_CATEGORY = -1;
 
+/**
+ * The shop's `Purchase`, with this store's file type.
+ *
+ * A `HubItem` is a `ShopItem` plus where its bytes live, so `PurchaseCard` takes one of these
+ * unchanged — the narrowing exists only so the install path below keeps the two fields it
+ * needs to route a MediaFire-hosted file correctly.
+ */
+type HubPurchase = Omit<Purchase, "files"> & { files: HubItem[] };
+
 interface HubPurchasesProps {
   /** Bumped after any install so the "Installed" badges re-scan. */
   refreshKey: number;
@@ -80,7 +89,7 @@ export default function HubPurchases({ refreshKey }: HubPurchasesProps) {
   const { activeFor, startHubInstall } = useInstall();
 
   const [loggedIn, setLoggedIn] = useState<boolean | null>(null);
-  const [items, setItems] = useState<ShopItem[]>([]);
+  const [items, setItems] = useState<HubItem[]>([]);
   const [listings, setListings] = useState<Record<string, HubMod | null>>({});
   const [installedNames, setInstalledNames] = useState<string[]>([]);
   /** Product → the folders its install recorded. Exact, where the fuzzy match only guesses. */
@@ -192,7 +201,7 @@ export default function HubPurchases({ refreshKey }: HubPurchasesProps) {
   }, [refreshKey, installedBump, loggedIn, game.id]);
 
   /** Purchases, one entry per product, with the catalog and library joins applied. */
-  const purchases = useMemo<Purchase[]>(() => {
+  const purchases = useMemo<HubPurchase[]>(() => {
     const fuzzy = buildInstalledIndex(installedNames);
     // Both the file name and its stem: the library lists `X.pkz` while an archive that
     // extracts lands in a folder called `X`, and a record may name either.
@@ -202,7 +211,7 @@ export default function HubPurchases({ refreshKey }: HubPurchasesProps) {
       onDisk.add(lower);
       onDisk.add(lower.replace(/\.(pkz|zip|rar|7z|pnt)$/, ""));
     }
-    const byProduct = new Map<string, ShopItem[]>();
+    const byProduct = new Map<string, HubItem[]>();
     for (const item of items) {
       const files = byProduct.get(item.product);
       if (files) files.push(item);
@@ -232,7 +241,7 @@ export default function HubPurchases({ refreshKey }: HubPurchasesProps) {
   }, [tree]);
 
   const rootsFor = useCallback(
-    (p: Purchase) =>
+    (p: HubPurchase) =>
       new Set(
         (p.listing?.categoryIds ?? [])
           .map((id) => rootOf.get(id))
@@ -260,7 +269,7 @@ export default function HubPurchases({ refreshKey }: HubPurchasesProps) {
 
   /** What the grid actually shows: the toolbar applied. */
   const shown = useMemo(() => {
-    const matches = (p: Purchase) => {
+    const matches = (p: HubPurchase) => {
       if (notInstalledOnly && p.installed) return false;
       const roots = rootsFor(p);
       if (category === OTHER_CATEGORY) {
@@ -296,7 +305,7 @@ export default function HubPurchases({ refreshKey }: HubPurchasesProps) {
 
   /** Which mod type a purchase is, from its catalog category. */
   const typeFor = useCallback(
-    (p: Purchase): ModType => {
+    (p: HubPurchase): ModType => {
       const names = (p.listing?.categoryNames ?? []).join(" ").toLowerCase();
       const types = modTypesFor(game.id);
       return (
@@ -309,7 +318,7 @@ export default function HubPurchases({ refreshKey }: HubPurchasesProps) {
   );
 
   const installOf = useCallback(
-    (files: ShopItem[]) => {
+    (files: HubItem[]) => {
       for (const f of files) {
         const it = activeFor(f.slug);
         if (it) return it;
@@ -320,7 +329,7 @@ export default function HubPurchases({ refreshKey }: HubPurchasesProps) {
   );
 
   const progressOf = useCallback(
-    (files: ShopItem[]) => {
+    (files: HubItem[]) => {
       const it = installOf(files);
       return it && it.total ? (it.received ?? 0) / it.total : null;
     },
@@ -328,8 +337,8 @@ export default function HubPurchases({ refreshKey }: HubPurchasesProps) {
   );
 
   const [pending, setPending] = useState<{
-    purchase: Purchase;
-    file: ShopItem;
+    purchase: HubPurchase;
+    file: HubItem;
     modType: ModType;
     destOptions: DestOption[];
     suggestions: string[];
@@ -337,13 +346,13 @@ export default function HubPurchases({ refreshKey }: HubPurchasesProps) {
     initialFolder: string;
   } | null>(null);
   /** Set instead of `pending` when the thing is already installed — confirm first. */
-  const [confirming, setConfirming] = useState<{ purchase: Purchase; file: ShopItem } | null>(
+  const [confirming, setConfirming] = useState<{ purchase: HubPurchase; file: HubItem } | null>(
     null,
   );
 
   /** Work out where a purchase could go, then let the user choose — Browse's flow exactly. */
   const askWhere = useCallback(
-    async (purchase: Purchase, file: ShopItem) => {
+    async (purchase: HubPurchase, file: HubItem) => {
       const modType = typeFor(purchase);
       const installedThere = await scanLibrary(modType.installSubpath).catch(() => []);
       const dest = buildDestinations(modType, purchase.product, installedThere);
@@ -364,10 +373,18 @@ export default function HubPurchases({ refreshKey }: HubPurchasesProps) {
     [game, typeFor],
   );
 
+  /**
+   * The card and the detail rail are the shop's, so they hand back a `ShopItem` — the widest
+   * thing they know about. The row is looked up again in the purchase it came from rather than
+   * asserted across, because everything below needs the two fields that says whether the file
+   * is the store's to serve, and a cast would only hide their absence until the download.
+   */
   const install = useCallback(
-    (purchase: Purchase, file: ShopItem) => {
-      if (purchase.installed) setConfirming({ purchase, file });
-      else void askWhere(purchase, file);
+    (purchase: HubPurchase, file: { id: number }) => {
+      const owned = purchase.files.find((f) => f.id === file.id) ?? purchase.files[0];
+      if (!owned) return;
+      if (purchase.installed) setConfirming({ purchase, file: owned });
+      else void askWhere(purchase, owned);
     },
     [askWhere],
   );

--- a/src/Components/Hub/HubPurchases.tsx
+++ b/src/Components/Hub/HubPurchases.tsx
@@ -1,0 +1,633 @@
+/**
+ * The signed-in half of MXB Hub: what this account owns, installable from here.
+ *
+ * The sibling of `Shop/MyDownloads` — same grid, same cards, same install flow — over a store
+ * that behaves entirely differently underneath. Three things fall away as a result:
+ *
+ *  - **No hidden WebView.** MXB Hub isn't behind Cloudflare, so the page is fetched by an HTTP
+ *    client. There is nothing holding a stale DOM, so Refresh is just another fetch and there
+ *    is no `reload` flag to thread through it.
+ *  - **One request, not two.** A Hub download row links to its product page, so Rust resolves
+ *    the catalog entries by slug on the same call — no separate match step, and no name-fold.
+ *  - **No credential gate.** Nothing here depends on a build-time secret; every build can sign
+ *    in and install.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ArrowUpDown, Check, LogOut, RefreshCw, Search, Store } from "lucide-react";
+import { toast } from "sonner";
+import {
+  hubCategories,
+  hubDetail,
+  hubLogin,
+  hubLogout,
+  hubMyDownloads,
+  hubStatus,
+  onHubAuth,
+} from "../../api/hub";
+import {
+  buildDestinations,
+  destStorageKey,
+  modTypesFor,
+  resolveInitialFolder,
+  scanLibrary,
+  shopInstalledMap,
+  type DestOption,
+  type ModType,
+  type ShopItem,
+} from "../../api/mods";
+import { PURCHASE_SORTS, type PurchaseSort } from "../../api/shop";
+import type { HubCategory, HubMod } from "../../types";
+import { buildInstalledIndex } from "../../lib/installedMatch";
+import { useInstall } from "../../Context/Install";
+import { useConfig } from "../../Context/Config";
+import { useT } from "../../i18n/context";
+import PurchaseCard, { type Purchase } from "../Shop/PurchaseCard";
+import ShopDetail from "../Shop/ShopDetail";
+import CategoryPill from "../Shop/CategoryPill";
+import InstallDialog, { type InstallChoice } from "../ModDetail/InstallDialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/Components/ui/alert-dialog";
+import { Button } from "@/Components/ui/button";
+import { Skeleton } from "@/Components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/Components/ui/select";
+import { cn } from "@/lib/utils";
+
+/** The pill for purchases the catalog no longer lists. */
+const OTHER_CATEGORY = -1;
+
+interface HubPurchasesProps {
+  /** Bumped after any install so the "Installed" badges re-scan. */
+  refreshKey: number;
+}
+
+export default function HubPurchases({ refreshKey }: HubPurchasesProps) {
+  const t = useT();
+  const { game } = useConfig();
+  const { activeFor, startHubInstall } = useInstall();
+
+  const [loggedIn, setLoggedIn] = useState<boolean | null>(null);
+  const [items, setItems] = useState<ShopItem[]>([]);
+  const [listings, setListings] = useState<Record<string, HubMod | null>>({});
+  const [installedNames, setInstalledNames] = useState<string[]>([]);
+  /** Product → the folders its install recorded. Exact, where the fuzzy match only guesses. */
+  const [installRecord, setInstallRecord] = useState<Record<string, string[]>>({});
+  /** Bumped by an install started here, which the parent's `refreshKey` never sees. */
+  const [installedBump, setInstalledBump] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Toolbar — all client-side; every purchase is already in memory.
+  const [query, setQuery] = useState("");
+  const [debounced, setDebounced] = useState("");
+  const [category, setCategory] = useState<number | null>(null);
+  const [tree, setTree] = useState<HubCategory[]>([]);
+  const [sort, setSort] = useState<PurchaseSort>("nameAsc");
+  const [notInstalledOnly, setNotInstalledOnly] = useState(false);
+  const [openProduct, setOpenProduct] = useState<string | null>(null);
+
+  const tRef = useRef(t);
+  tRef.current = t;
+
+  const loadDownloads = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { items: rows, listings: found } = await hubMyDownloads();
+      setItems(rows);
+      // Positional, so the map is built here rather than matched again by name.
+      const byProduct: Record<string, HubMod | null> = {};
+      rows.forEach((row, i) => {
+        byProduct[row.product] = found[i] ?? byProduct[row.product] ?? null;
+      });
+      setListings(byProduct);
+    } catch (e) {
+      const message = String(e);
+      setError(message);
+      // A dead cookie surfaces as an auth error — drop back to signed-out rather than
+      // leaving a grid that will fail the same way on every retry.
+      if (/sign in|session/i.test(message)) setLoggedIn(false);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Initial status probe.
+  useEffect(() => {
+    let cancelled = false;
+    hubStatus()
+      .then((ok) => {
+        if (cancelled) return;
+        setLoggedIn(ok);
+        if (ok) void loadDownloads();
+      })
+      .catch(() => !cancelled && setLoggedIn(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [loadDownloads]);
+
+  // Sign-in window completion.
+  useEffect(() => {
+    const unlisten = onHubAuth((ok) => {
+      if (ok) {
+        setLoggedIn(true);
+        toast.success(tRef.current("hub.signedIn"));
+        void loadDownloads();
+      } else {
+        toast.error(tRef.current("hub.sessionFailed"));
+      }
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [loadDownloads]);
+
+  // Same 350 ms debounce every other grid uses.
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(query.trim().toLowerCase()), 350);
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  useEffect(() => {
+    let cancelled = false;
+    hubCategories()
+      .then((cats) => !cancelled && setTree(cats))
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // "Installed" badges, across every mod folder — the Hub sells paints, gear and modelswaps,
+  // so scanning one subfolder would leave most of it unbadged.
+  useEffect(() => {
+    let cancelled = false;
+    const subpaths = modTypesFor(game.id).map((m) => m.installSubpath);
+    Promise.all(subpaths.map((s) => scanLibrary(s).catch(() => [])))
+      .then((scans) => {
+        if (cancelled) return;
+        setInstalledNames(scans.flat().map((e) => e.name));
+      })
+      .catch(() => !cancelled && setInstalledNames([]));
+    shopInstalledMap()
+      .then((m) => !cancelled && setInstallRecord(m))
+      .catch(() => !cancelled && setInstallRecord({}));
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey, installedBump, loggedIn, game.id]);
+
+  /** Purchases, one entry per product, with the catalog and library joins applied. */
+  const purchases = useMemo<Purchase[]>(() => {
+    const fuzzy = buildInstalledIndex(installedNames);
+    // Both the file name and its stem: the library lists `X.pkz` while an archive that
+    // extracts lands in a folder called `X`, and a record may name either.
+    const onDisk = new Set<string>();
+    for (const n of installedNames) {
+      const lower = n.toLowerCase();
+      onDisk.add(lower);
+      onDisk.add(lower.replace(/\.(pkz|zip|rar|7z|pnt)$/, ""));
+    }
+    const byProduct = new Map<string, ShopItem[]>();
+    for (const item of items) {
+      const files = byProduct.get(item.product);
+      if (files) files.push(item);
+      else byProduct.set(item.product, [item]);
+    }
+    return [...byProduct].map(([product, files]) => ({
+      product,
+      files,
+      listing: listings[product] ?? null,
+      installed:
+        (installRecord[product] ?? []).some((f) =>
+          onDisk.has(f.toLowerCase().replace(/\.(pkz|zip|rar|7z|pnt)$/, "")),
+        ) || fuzzy.has(product),
+    }));
+  }, [items, listings, installedNames, installRecord]);
+
+  /** Category id → its root. Only roots become pills, so the row can't grow without bound. */
+  const rootOf = useMemo(() => {
+    const byId = new Map(tree.map((c) => [c.id, c]));
+    const roots = new Map<number, number>();
+    for (const c of tree) {
+      let node = c;
+      while (node.parent !== null && byId.has(node.parent)) node = byId.get(node.parent)!;
+      roots.set(c.id, node.id);
+    }
+    return roots;
+  }, [tree]);
+
+  const rootsFor = useCallback(
+    (p: Purchase) =>
+      new Set(
+        (p.listing?.categoryIds ?? [])
+          .map((id) => rootOf.get(id))
+          .filter((r): r is number => r !== undefined),
+      ),
+    [rootOf],
+  );
+
+  const categories = useMemo(() => {
+    const names = new Map(tree.map((c) => [c.id, c.name]));
+    const counts = new Map<number, number>();
+    for (const p of purchases) {
+      for (const r of rootsFor(p)) counts.set(r, (counts.get(r) ?? 0) + 1);
+    }
+    return [...counts]
+      .map(([id, count]) => ({ id, name: names.get(id) ?? "", count }))
+      .filter((c) => c.name !== "")
+      .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+  }, [purchases, tree, rootsFor]);
+
+  const hasUncategorised = useMemo(
+    () => purchases.some((p) => rootsFor(p).size === 0),
+    [purchases, rootsFor],
+  );
+
+  /** What the grid actually shows: the toolbar applied. */
+  const shown = useMemo(() => {
+    const matches = (p: Purchase) => {
+      if (notInstalledOnly && p.installed) return false;
+      const roots = rootsFor(p);
+      if (category === OTHER_CATEGORY) {
+        if (roots.size > 0) return false;
+      } else if (category !== null && !roots.has(category)) {
+        return false;
+      }
+      if (!debounced) return true;
+      const haystack = [
+        p.product,
+        p.listing?.author ?? "",
+        ...p.files.map((f) => `${f.fileLabel} ${f.title}`),
+      ]
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(debounced);
+    };
+
+    const list = purchases.filter(matches);
+    switch (sort) {
+      case "notInstalled":
+        return list.sort(
+          (a, b) =>
+            Number(a.installed) - Number(b.installed) || a.product.localeCompare(b.product),
+        );
+      // "Recently purchased" is offered by the shared sort list and cannot be honoured here:
+      // WooCommerce's downloads table publishes no order date. It falls back to alphabetical
+      // rather than to an arbitrary order that would look like a date and not be one.
+      default:
+        return list.sort((a, b) => a.product.localeCompare(b.product));
+    }
+  }, [purchases, debounced, category, sort, notInstalledOnly, rootsFor]);
+
+  /** Which mod type a purchase is, from its catalog category. */
+  const typeFor = useCallback(
+    (p: Purchase): ModType => {
+      const names = (p.listing?.categoryNames ?? []).join(" ").toLowerCase();
+      const types = modTypesFor(game.id);
+      return (
+        types.find((mt) => names.includes(mt.id)) ??
+        types.find((mt) => mt.id === "track" && names.includes("track")) ??
+        types[0]
+      );
+    },
+    [game.id],
+  );
+
+  const installOf = useCallback(
+    (files: ShopItem[]) => {
+      for (const f of files) {
+        const it = activeFor(f.slug);
+        if (it) return it;
+      }
+      return null;
+    },
+    [activeFor],
+  );
+
+  const progressOf = useCallback(
+    (files: ShopItem[]) => {
+      const it = installOf(files);
+      return it && it.total ? (it.received ?? 0) / it.total : null;
+    },
+    [installOf],
+  );
+
+  const [pending, setPending] = useState<{
+    purchase: Purchase;
+    file: ShopItem;
+    modType: ModType;
+    destOptions: DestOption[];
+    suggestions: string[];
+    folderCounts: Map<string, number>;
+    initialFolder: string;
+  } | null>(null);
+  /** Set instead of `pending` when the thing is already installed — confirm first. */
+  const [confirming, setConfirming] = useState<{ purchase: Purchase; file: ShopItem } | null>(
+    null,
+  );
+
+  /** Work out where a purchase could go, then let the user choose — Browse's flow exactly. */
+  const askWhere = useCallback(
+    async (purchase: Purchase, file: ShopItem) => {
+      const modType = typeFor(purchase);
+      const installedThere = await scanLibrary(modType.installSubpath).catch(() => []);
+      const dest = buildDestinations(modType, purchase.product, installedThere);
+      const counts = new Map<string, number>();
+      for (const it of installedThere) counts.set(it.folder, (counts.get(it.folder) ?? 0) + 1);
+      const remembered = localStorage.getItem(destStorageKey(game, modType));
+      setPending({
+        purchase,
+        file,
+        modType,
+        destOptions: dest.options,
+        suggestions: dest.suggestions,
+        folderCounts: counts,
+        initialFolder:
+          remembered ?? resolveInitialFolder(game, modType, dest.options, dest.guess),
+      });
+    },
+    [game, typeFor],
+  );
+
+  const install = useCallback(
+    (purchase: Purchase, file: ShopItem) => {
+      if (purchase.installed) setConfirming({ purchase, file });
+      else void askWhere(purchase, file);
+    },
+    [askWhere],
+  );
+
+  /** The dialog answered: remember the folder and queue it like any other install. */
+  const confirmInstall = useCallback(
+    ({ destFolder }: InstallChoice) => {
+      if (!pending) return;
+      const { purchase, file, modType } = pending;
+      localStorage.setItem(destStorageKey(game, modType), destFolder);
+      setPending(null);
+      startHubInstall({
+        slug: file.slug,
+        title: purchase.product,
+        subpath: modType.installSubpath,
+        destFolder,
+        item: file,
+      });
+      setInstalledBump((n) => n + 1);
+    },
+    [pending, game, startHubInstall],
+  );
+
+  const logout = useCallback(async () => {
+    await hubLogout();
+    setLoggedIn(false);
+    setItems([]);
+    setListings({});
+    setError(null);
+    setOpenProduct(null);
+  }, []);
+
+  /**
+   * The purchase whose detail is open. Resolved from the live list rather than held as an
+   * object, so the page keeps up with an install finishing underneath it.
+   */
+  const open = useMemo(
+    () => purchases.find((p) => p.product === openProduct && p.listing) ?? null,
+    [purchases, openProduct],
+  );
+
+  // Signed-out gate.
+  if (loggedIn === false) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-4 px-7 pb-10 text-center">
+        <div className="grid size-14 place-items-center rounded-2xl bg-foreground/[0.06] text-foreground/50">
+          <Store className="size-7" strokeWidth={1.5} />
+        </div>
+        <div className="flex max-w-sm flex-col gap-1.5">
+          <h2 className="text-[15px] font-semibold">{t("hub.signInTitle")}</h2>
+          <p className="text-[12.5px] text-muted-foreground">{t("hub.signInBody")}</p>
+        </div>
+        <Button onClick={() => void hubLogin()}>
+          <Store className="size-4" /> {t("hub.signIn")}
+        </Button>
+      </div>
+    );
+  }
+
+  // Mounted by both the grid and the detail view, so installing from either can ask.
+  const dialogs = (
+    <>
+      {pending && (
+        <InstallDialog
+          open
+          onOpenChange={(o) => !o && setPending(null)}
+          title={pending.purchase.product}
+          image={pending.purchase.listing?.image ?? null}
+          modType={pending.modType}
+          destOptions={pending.destOptions}
+          suggestions={pending.suggestions}
+          folderCounts={pending.folderCounts}
+          initialFolder={pending.initialFolder}
+          onConfirm={confirmInstall}
+        />
+      )}
+
+      <AlertDialog open={confirming !== null} onOpenChange={(o) => !o && setConfirming(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("browse.reinstallOne", { title: confirming?.purchase.product ?? "" })}
+            </AlertDialogTitle>
+            <AlertDialogDescription>{t("browse.reinstallOneBody")}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                const next = confirming;
+                setConfirming(null);
+                if (next) void askWhere(next.purchase, next.file);
+              }}
+            >
+              {t("browse.reinstall")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+
+  // Detail takes over the whole pane, exactly as it does in the catalog.
+  if (open) {
+    return (
+      <>
+        <ShopDetail
+          id={open.listing!.id}
+          currency="USD"
+          load={hubDetail}
+          onBack={() => setOpenProduct(null)}
+          owned={{
+            files: open.files,
+            installed: open.installed,
+            busy: installOf(open.files) != null,
+            progress: progressOf(open.files),
+            disabled: false,
+            onInstall: (file) => install(open, file),
+          }}
+        />
+        {dialogs}
+      </>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex flex-none items-center gap-2 px-7 pb-3">
+        <span className="text-[12.5px] text-muted-foreground">
+          {loggedIn && !loading
+            ? t("purchases.count", { count: shown.length })
+            : t("hub.myDownloads")}
+        </span>
+        {loggedIn && (
+          <div className="ml-auto flex items-center gap-2">
+            <div className="flex w-[240px] items-center gap-2 rounded-lg border border-input bg-card px-3 py-1.5">
+              <Search className="size-3.5 text-faint" />
+              <input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder={t("purchases.searchPlaceholder")}
+                className="w-full bg-transparent text-[12.5px] placeholder:text-faint focus:outline-none"
+              />
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void loadDownloads()}
+              disabled={loading}
+            >
+              <RefreshCw className="size-3.5" /> {t("common.refresh")}
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => void logout()}>
+              <LogOut className="size-3.5" /> {t("shop.logOut")}
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {loggedIn && !loading && purchases.length > 0 && (
+        <div className="flex flex-none flex-wrap items-center gap-2 px-7 pb-3">
+          <CategoryPill
+            label={t("shopCatalog.allCategories")}
+            on={category === null}
+            onClick={() => setCategory(null)}
+          />
+          {categories.map((c) => (
+            <CategoryPill
+              key={c.id}
+              label={c.name}
+              count={c.count}
+              on={category === c.id}
+              onClick={() => setCategory(c.id)}
+            />
+          ))}
+          {hasUncategorised && (
+            <CategoryPill
+              label={t("purchases.otherCategory")}
+              on={category === OTHER_CATEGORY}
+              onClick={() => setCategory(OTHER_CATEGORY)}
+            />
+          )}
+
+          <div className="ml-auto flex items-center gap-2 self-center">
+            <button
+              onClick={() => setNotInstalledOnly((v) => !v)}
+              className={cn(
+                "flex cursor-default items-center gap-1.5 rounded-full px-3 py-[5px] text-[12px] font-medium transition-colors",
+                notInstalledOnly
+                  ? "bg-emerald-500 font-semibold text-black"
+                  : "border border-input text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <Check className="size-3" />
+              {t("purchases.notInstalledOnly")}
+            </button>
+            <ArrowUpDown className="size-3.5 text-faint" />
+            <Select value={sort} onValueChange={(v) => setSort(v as PurchaseSort)}>
+              <SelectTrigger className="h-8 w-[200px] bg-card">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {/* "Recently purchased" is dropped rather than shown and ignored: this store
+                    publishes no purchase date, and an order that pretends to be one is worse
+                    than an option that isn't there. */}
+                {PURCHASE_SORTS.filter((s) => s.value !== "recentlyPurchased").map((s) => (
+                  <SelectItem key={s.value} value={s.value}>
+                    {t(s.label)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-7 pb-6">
+        {error ? (
+          <div className="mx-auto flex max-w-md flex-col items-center gap-3 py-20 text-center">
+            <p className="select-text text-[13px] text-destructive">
+              {t("shop.loadFailed", { error: error.replace(/^Error:\s*/, "") })}
+            </p>
+            <Button variant="outline" size="sm" onClick={() => void loadDownloads()}>
+              {t("common.retry")}
+            </Button>
+          </div>
+        ) : loading || loggedIn === null ? (
+          <div className="grid grid-cols-4 gap-3.5">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <Skeleton key={i} className="aspect-square rounded-xl" />
+            ))}
+          </div>
+        ) : purchases.length === 0 ? (
+          <p className="py-20 text-center text-[13px] text-muted-foreground">
+            {t("hub.empty")}
+          </p>
+        ) : shown.length === 0 ? (
+          // Told apart from "you own nothing" on purpose: one is a filter to clear, the other
+          // is a trip to the store.
+          <p className="py-20 text-center text-[13px] text-muted-foreground">
+            {t("purchases.noMatches")}
+          </p>
+        ) : (
+          <div className="grid grid-cols-4 gap-3.5">
+            {shown.map((p) => (
+              <PurchaseCard
+                key={p.product}
+                purchase={p}
+                busy={installOf(p.files) != null}
+                progress={progressOf(p.files)}
+                disabled={false}
+                onInstall={(file) => install(p, file)}
+                onOpen={p.listing ? () => setOpenProduct(p.product) : undefined}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {dialogs}
+    </div>
+  );
+}

--- a/src/Components/Shell/Sidebar.tsx
+++ b/src/Components/Shell/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Gamepad2,
   SlidersHorizontal,
   Store,
+  ShoppingBag,
   Palette,
   PanelLeftClose,
   PanelLeftOpen,
@@ -42,6 +43,7 @@ import DownloadQueue from "./DownloadQueue";
 export type DashboardView =
   | "browse"
   | "shop"
+  | "hub"
   | "library"
   | "downloads"
   | "locker"
@@ -103,6 +105,16 @@ const NAV: NavEntry[] = [
  * hides the Catalog half in that case and opens on purchases.
  */
 const SHOP_ENTRY: NavEntry = { id: "shop", label: "nav.shop", icon: Store, cap: "shop" };
+
+/**
+ * MXB Hub — the other store, and the same reasoning as the entry above: it sells MX Bikes
+ * mods, so it has nothing to offer a player on another title.
+ *
+ * Its own entry rather than a third tab inside Shop. The two are separate storefronts with
+ * separate accounts and separate carts, and folding them into one view would mean a sign-in
+ * that silently means a different thing depending on which pill is lit.
+ */
+const HUB_ENTRY: NavEntry = { id: "hub", label: "nav.hub", icon: ShoppingBag, cap: "shop" };
 
 /** Shown only when the experimental features are on — see `settings.experimental`.
  *  Also capability-gated: it administers MX Bikes dedicated servers and keys riders by
@@ -283,7 +295,7 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
   // Two independent gates: servers needs the experimental toggle, and every entry needs the
   // active game to support it. Built here rather than inline so the JSX stays one `.map`.
   const supported = ({ cap }: NavEntry) => !cap || caps[cap];
-  const nav = [NAV[0], SHOP_ENTRY, ...NAV.slice(1), ...(experimental ? [EXPERIMENTAL_NAV] : [])]
+  const nav = [NAV[0], SHOP_ENTRY, HUB_ENTRY, ...NAV.slice(1), ...(experimental ? [EXPERIMENTAL_NAV] : [])]
     .filter(supported)
     .map((e) => (e.children ? { ...e, children: e.children.filter(supported) } : e));
 

--- a/src/Components/Shop/ShopDetail.tsx
+++ b/src/Components/Shop/ShopDetail.tsx
@@ -37,6 +37,12 @@ interface ShopDetailProps {
   onBack: () => void;
   /** Turns this into the detail page for something already bought. */
   owned?: OwnedActions;
+  /**
+   * Where the detail comes from. Defaults to the mxbikes-shop catalog; MXB Hub passes its own
+   * so both stores share this page rather than growing a second copy of it. Everything below
+   * reads a `ShopModDetail` and does not care which store produced it.
+   */
+  load?: (id: number) => Promise<ShopModDetail>;
 }
 
 /**
@@ -51,7 +57,13 @@ interface ShopDetailProps {
  * Served entirely from the catalog already in memory, so this opens instantly and works with
  * the network down.
  */
-export default function ShopDetail({ id, currency, onBack, owned }: ShopDetailProps) {
+export default function ShopDetail({
+  id,
+  currency,
+  onBack,
+  owned,
+  load = shopCatalogDetail,
+}: ShopDetailProps) {
   const t = useT();
   const [detail, setDetail] = useState<ShopModDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -63,13 +75,13 @@ export default function ShopDetail({ id, currency, onBack, owned }: ShopDetailPr
     let cancelled = false;
     setDetail(null);
     setError(null);
-    shopCatalogDetail(id)
+    load(id)
       .then((d) => !cancelled && setDetail(d))
       .catch((e) => !cancelled && setError(String(e)));
     return () => {
       cancelled = true;
     };
-  }, [id]);
+  }, [id, load]);
 
   if (error) {
     return (

--- a/src/Context/Install.tsx
+++ b/src/Context/Install.tsx
@@ -19,17 +19,24 @@ import {
   shopInstall,
   type ShopItem,
 } from "../api/mods";
+import { hubInstall } from "../api/hub";
 import type { DownloadSource, InstallStage, ReloadOutcome } from "../types";
 import { useDownloads } from "./Downloads";
 import { useDropReview } from "./DropReview";
 import { useT } from "../i18n/context";
 
-/** Where the bytes come from — a resolvable host, a file the user picked, or a shop purchase
- *  (whose download goes through a WebView, because Cloudflare refuses our HTTP client). */
+/** Where the bytes come from — a resolvable host, a file the user picked, or something already
+ *  bought on one of the two stores.
+ *
+ *  The two stores are separate kinds rather than one with a flag because they are downloaded by
+ *  entirely different means: a shop purchase goes through a WebView (Cloudflare refuses our
+ *  HTTP client on that store), while an MXB Hub purchase streams over the same client every
+ *  other download uses. Nothing above this line has to know that, but the branch below does. */
 export type InstallSource =
   | { kind: "download"; url: string; host: string }
   | { kind: "import"; path: string }
-  | { kind: "shop"; item: ShopItem };
+  | { kind: "shop"; item: ShopItem }
+  | { kind: "hub"; item: ShopItem };
 
 interface StartParams {
   slug: string;
@@ -82,6 +89,7 @@ export interface PendingInstall {
 /** How the download history names this source. */
 function historySource(source: InstallSource): DownloadSource {
   if (source.kind === "shop") return "shop";
+  if (source.kind === "hub") return "hub";
   return source.kind === "download" ? "site" : "file";
 }
 
@@ -167,6 +175,7 @@ interface InstallContextValue {
   startPendingInstall: (p: PendingInstall) => void;
   /** A purchase from the shop, queued exactly like any other install. */
   startShopInstall: (p: Omit<StartParams, "source"> & { item: ShopItem }) => void;
+  startHubInstall: (p: Omit<StartParams, "source"> & { item: ShopItem }) => void;
   /** Clear a finished (done/error) install card. */
   clear: () => void;
 }
@@ -321,6 +330,8 @@ export function InstallProvider({
         }
       } else if (source.kind === "shop") {
         await shopInstall(source.item, subpath, destFolder);
+      } else if (source.kind === "hub") {
+        await hubInstall(source.item, subpath, destFolder);
       } else {
         await importFile(source.path, subpath, destFolder);
       }
@@ -577,6 +588,11 @@ export function InstallProvider({
     [enqueue],
   );
 
+  const startHubInstall: InstallContextValue["startHubInstall"] = useCallback(
+    ({ item, ...rest }) => enqueue({ ...rest, source: { kind: "hub", item } }),
+    [enqueue],
+  );
+
   /** Retire the finished cards, leaving anything still transferring alone. */
   const clear = useCallback(
     () => setActive((cur) => cur.filter((it) => it.stage !== "done" && it.stage !== "error")),
@@ -597,6 +613,7 @@ export function InstallProvider({
       cancel,
       startInstall,
       startImport,
+      startHubInstall,
       startPendingInstall,
       startShopInstall,
       clear,
@@ -608,6 +625,7 @@ export function InstallProvider({
       cancel,
       startInstall,
       startImport,
+      startHubInstall,
       startPendingInstall,
       startShopInstall,
       clear,

--- a/src/Context/Install.tsx
+++ b/src/Context/Install.tsx
@@ -19,7 +19,7 @@ import {
   shopInstall,
   type ShopItem,
 } from "../api/mods";
-import { hubInstall } from "../api/hub";
+import { hubInstall, type HubItem } from "../api/hub";
 import type { DownloadSource, InstallStage, ReloadOutcome } from "../types";
 import { useDownloads } from "./Downloads";
 import { useDropReview } from "./DropReview";
@@ -36,7 +36,7 @@ export type InstallSource =
   | { kind: "download"; url: string; host: string }
   | { kind: "import"; path: string }
   | { kind: "shop"; item: ShopItem }
-  | { kind: "hub"; item: ShopItem };
+  | { kind: "hub"; item: HubItem };
 
 interface StartParams {
   slug: string;
@@ -175,7 +175,7 @@ interface InstallContextValue {
   startPendingInstall: (p: PendingInstall) => void;
   /** A purchase from the shop, queued exactly like any other install. */
   startShopInstall: (p: Omit<StartParams, "source"> & { item: ShopItem }) => void;
-  startHubInstall: (p: Omit<StartParams, "source"> & { item: ShopItem }) => void;
+  startHubInstall: (p: Omit<StartParams, "source"> & { item: HubItem }) => void;
   /** Clear a finished (done/error) install card. */
   clear: () => void;
 }

--- a/src/api/hub.ts
+++ b/src/api/hub.ts
@@ -1,0 +1,113 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type {
+  HubCategory,
+  HubModDetail,
+  HubPage,
+  HubSort,
+} from "../types";
+import type { ShopItem } from "./mods";
+import type { TKey } from "../i18n/core";
+
+/**
+ * MXB Hub — `shop.mxb-hub.com`, the community marketplace `mxbhub.com` redirects to.
+ *
+ * Kept out of `api/shop.ts` (mxbikes-shop) and `api/mods.ts` (mxb-mods + install + library)
+ * because it is a third store with its own session, not a variant of either. What it *does*
+ * share is the shape of its answers: a Hub listing is a `ShopMod` with a slug, and a Hub
+ * purchase is a `ShopItem`, so the grid, the price tag, the purchase card and the detail page
+ * are the shop's components used as they are.
+ *
+ * Two halves, gated differently. Browsing needs nothing — the store's WooCommerce API is
+ * public, so unlike the shop's catalog there is no build-time credential and no reason to ever
+ * hide this half. Installing needs the user's own sign-in, and nothing else.
+ */
+
+/** Matches `PER_PAGE` in `src-tauri/src/mods/hub.rs`. */
+export const HUB_PAGE_SIZE = 24;
+
+/**
+ * The orders the store honours. Checked against the live API rather than taken from the
+ * WooCommerce docs, which list a `relevance` this install rejects outright.
+ *
+ * There is no "recently updated": the Store API orders by publish date only. Rather than offer
+ * two entries that sort identically — the mistake `SHOP_SORTS` documents avoiding — there is
+ * one, and it says what it does.
+ */
+export const HUB_SORTS: { value: HubSort; label: TKey }[] = [
+  { value: "newest", label: "hubSort.newest" },
+  { value: "popular", label: "hubSort.popular" },
+  { value: "priceAsc", label: "hubSort.priceAsc" },
+  { value: "priceDesc", label: "hubSort.priceDesc" },
+  { value: "nameAsc", label: "hubSort.nameAsc" },
+];
+
+export function hubSearch(
+  query: string,
+  categoryId: number | null,
+  page: number,
+  sort: HubSort,
+  onSaleOnly: boolean,
+): Promise<HubPage> {
+  return invoke<HubPage>("hub_search", {
+    query,
+    categoryId,
+    page,
+    sort,
+    onSaleOnly,
+  });
+}
+
+export function hubCategories(): Promise<HubCategory[]> {
+  return invoke<HubCategory[]>("hub_categories");
+}
+
+export function hubDetail(id: number): Promise<HubModDetail> {
+  return invoke<HubModDetail>("hub_detail", { id });
+}
+
+/** Open the store's sign-in page in a window of its own. Resolves once the window is up — the
+ *  sign-in itself finishes later, and arrives on `onHubAuth`. */
+export function hubLogin(): Promise<void> {
+  return invoke<void>("hub_login");
+}
+
+/** Whether a Hub session is currently held. */
+export function hubStatus(): Promise<boolean> {
+  return invoke<boolean>("hub_status");
+}
+
+/** Sign out, here and on the store. Deliberately does not touch the mxbikes-shop session. */
+export function hubLogout(): Promise<void> {
+  return invoke<void>("hub_logout");
+}
+
+/** Fires when the sign-in window finishes — `true` when a session was captured. */
+export function onHubAuth(handler: (ok: boolean) => void) {
+  return listen<boolean>("hub-auth", (event) => handler(event.payload));
+}
+
+/**
+ * What this account owns, with each row's catalog entry alongside it.
+ *
+ * `listings` is positional against `items`, and `null` where the product has been unlisted.
+ * One call rather than the shop's two: a Hub download row links to its product page, so the
+ * lookup is exact and cheap enough to do on the same round trip.
+ */
+export interface HubDownloads {
+  items: ShopItem[];
+  listings: (import("../types").HubMod | null)[];
+}
+
+export function hubMyDownloads(): Promise<HubDownloads> {
+  return invoke<HubDownloads>("hub_my_downloads");
+}
+
+/** Download a file this account owns and install it where the caller chose. */
+export function hubInstall(
+  item: ShopItem,
+  subpath: string,
+  destFolder: string,
+): Promise<void> {
+  return invoke<void>("hub_install", { item, subpath, destFolder });
+}

--- a/src/api/hub.ts
+++ b/src/api/hub.ts
@@ -23,6 +23,24 @@ import type { TKey } from "../i18n/core";
  * hide this half. Installing needs the user's own sign-in, and nothing else.
  */
 
+/**
+ * One purchased file. A `ShopItem` in shape, so the shop's purchase card and detail rail read
+ * it unchanged, plus the two things only this store needs.
+ *
+ * Declared here rather than in `types/` because `ShopItem` itself lives in `api/mods.ts`.
+ */
+export interface HubItem extends ShopItem {
+  /**
+   * The store handed this file off to somebody else. WooCommerce allows any URL as a
+   * product's file and MXB Hub uses that for a number of its free mods, which are MediaFire
+   * links. Those get resolved and fetched like any Browse download, and deliberately
+   * **without** the user's store session.
+   */
+  external: boolean;
+  /** The file host, when `external`. Empty otherwise. */
+  host: string;
+}
+
 /** Matches `PER_PAGE` in `src-tauri/src/mods/hub.rs`. */
 export const HUB_PAGE_SIZE = 24;
 
@@ -95,7 +113,7 @@ export function onHubAuth(handler: (ok: boolean) => void) {
  * lookup is exact and cheap enough to do on the same round trip.
  */
 export interface HubDownloads {
-  items: ShopItem[];
+  items: HubItem[];
   listings: (import("../types").HubMod | null)[];
 }
 
@@ -105,7 +123,7 @@ export function hubMyDownloads(): Promise<HubDownloads> {
 
 /** Download a file this account owns and install it where the caller chose. */
 export function hubInstall(
-  item: ShopItem,
+  item: HubItem,
   subpath: string,
   destFolder: string,
 ): Promise<void> {

--- a/src/api/shop.ts
+++ b/src/api/shop.ts
@@ -111,19 +111,26 @@ export function shopCatalogRefresh(): Promise<ShopStatus> {
   return invoke<ShopStatus>("shop_catalog_refresh");
 }
 
+/** The stores the app browses. A URL has to be https on one of them to be openable. */
+const STORE_HOSTS = ["mxbikes-shop.com", "mxb-hub.com"];
+
 /**
  * Open a store page in the user's own browser.
  *
- * Rust already dropped any URL that wasn't https on mxbikes-shop.com, so a non-null `url`
- * has been checked once. This checks again because the cost is a line and the failure mode
- * — handing an arbitrary URL to the OS handler — is not one worth being clever about.
+ * Rust already dropped any URL that wasn't https on the store it came from, so a non-null
+ * `url` has been checked once. This checks again because the cost is a line and the failure
+ * mode — handing an arbitrary URL to the OS handler — is not one worth being clever about.
+ *
+ * Both stores go through here rather than one function each: it is the same check against a
+ * different name, and a second copy is a second place for the host list to fall out of date.
+ * Which store a URL belongs to is settled on the Rust side, per store, before it gets here.
  */
 export async function openShopUrl(url: string | null): Promise<void> {
   if (!url) return;
   try {
     const parsed = new URL(url);
     const host = parsed.hostname.toLowerCase();
-    const onStore = host === "mxbikes-shop.com" || host.endsWith(".mxbikes-shop.com");
+    const onStore = STORE_HOSTS.some((s) => host === s || host.endsWith(`.${s}`));
     if (parsed.protocol !== "https:" || !onStore) return;
     await open(url);
   } catch {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -50,6 +50,7 @@ export const de: Translation = {
   // ── Navigation ─────────────────────────────────────────────────────────────
   "nav.browse": "Entdecken",
   "nav.shop": "Shop",
+  "nav.hub": "MXB Hub",
   "nav.library": "Bibliothek",
   "nav.downloads": "Downloads",
   "nav.locker": "Spind",
@@ -502,6 +503,26 @@ export const de: Translation = {
   "shop.sessionFailed": "Sitzung des MX Bikes Shop konnte nicht übernommen werden",
   "shop.loadFailed": "Deine Käufe konnten nicht geladen werden: {{error}}",
   "shop.empty": "Für dein Konto wurden noch keine gekauften Downloads gefunden.",
+
+  // ── MXB Hub (shop.mxb-hub.com) ──
+  "hub.help":
+    "Durchsuche den MXB-Hub-Marktplatz auf shop.mxb-hub.com und installiere, was dir schon gehört. Gekauft wird weiterhin auf der Seite des Shops; melde dich unter „Meine Käufe“ an, um deine Bestellungen von hier aus zu installieren.",
+  "hub.count_one": "{{count}} Artikel",
+  "hub.count_other": "{{count}} Artikel",
+  "hub.searchPlaceholder": "MXB Hub durchsuchen…",
+  "hub.myDownloads": "Meine Käufe",
+  "hub.signInTitle": "Bei MXB Hub anmelden",
+  "hub.signInBody":
+    "Melde dich bei shop.mxb-hub.com an, um alles zu sehen und zu installieren, was dir gehört – auch kostenlose Mods. Wir öffnen die echte Seite; dein Passwort erreicht diese App nie.",
+  "hub.signIn": "Anmelden",
+  "hub.signedIn": "Bei MXB Hub angemeldet",
+  "hub.sessionFailed": "Deine MXB-Hub-Sitzung konnte nicht übernommen werden",
+  "hub.empty": "Für dein MXB-Hub-Konto wurden noch keine Downloads gefunden.",
+  "hubSort.newest": "Neueste",
+  "hubSort.popular": "Beliebteste",
+  "hubSort.priceAsc": "Preis: aufsteigend",
+  "hubSort.priceDesc": "Preis: absteigend",
+  "hubSort.nameAsc": "Name (A–Z)",
   "purchases.count_one": "{{count}} Kauf",
   "purchases.count_other": "{{count}} Käufe",
   "purchases.fileCount_one": "{{count}} Datei",
@@ -1265,6 +1286,7 @@ export const de: Translation = {
   "downloads.yesterday": "Gestern",
   "downloads.sourceSite": "Download",
   "downloads.sourceShop": "Shop",
+  "downloads.sourceHub": "MXB Hub",
   "downloads.sourceFile": "Importierte Datei",
   "downloads.showInLibrary": "In der Bibliothek zeigen",
   "downloads.openModPage": "Mod-Seite öffnen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -44,6 +44,7 @@ export const en = {
   // ── Sidebar navigation ─────────────────────────────────────────────────────
   "nav.browse": "Browse",
   "nav.shop": "Shop",
+  "nav.hub": "MXB Hub",
   "nav.library": "Library",
   "nav.downloads": "Downloads",
   "nav.locker": "Locker",
@@ -488,6 +489,26 @@ export const en = {
   "shop.sessionFailed": "Couldn't capture your MX Bikes Shop session",
   "shop.loadFailed": "Couldn't load your purchases: {{error}}",
   "shop.empty": "No purchased downloads found on your account yet.",
+
+  // ── MXB Hub (shop.mxb-hub.com — the marketplace mxbhub.com redirects to) ──
+  "hub.help":
+    "Browse the MXB Hub marketplace at shop.mxb-hub.com, and install what you already own. Buying still happens on the store's own site; sign in under My purchases to install your orders from here.",
+  "hub.count_one": "{{count}} item",
+  "hub.count_other": "{{count}} items",
+  "hub.searchPlaceholder": "Search MXB Hub…",
+  "hub.myDownloads": "My purchases",
+  "hub.signInTitle": "Sign in to MXB Hub",
+  "hub.signInBody":
+    "Log in to shop.mxb-hub.com to see and install everything you own, free mods included. We open the real site — your password never touches this app.",
+  "hub.signIn": "Sign in",
+  "hub.signedIn": "Signed in to MXB Hub",
+  "hub.sessionFailed": "Couldn't capture your MXB Hub session",
+  "hub.empty": "No downloads found on your MXB Hub account yet.",
+  "hubSort.newest": "Newest",
+  "hubSort.popular": "Most popular",
+  "hubSort.priceAsc": "Price: low to high",
+  "hubSort.priceDesc": "Price: high to low",
+  "hubSort.nameAsc": "Name (A–Z)",
   "purchases.count_one": "{{count}} purchase",
   "purchases.count_other": "{{count}} purchases",
   "purchases.fileCount_one": "{{count}} file",
@@ -1226,6 +1247,7 @@ export const en = {
   "downloads.yesterday": "Yesterday",
   "downloads.sourceSite": "Download",
   "downloads.sourceShop": "Shop",
+  "downloads.sourceHub": "MXB Hub",
   "downloads.sourceFile": "Imported file",
   "downloads.showInLibrary": "Show in library",
   "downloads.openModPage": "Open the mod's page",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -45,6 +45,7 @@ export const es: Translation = {
   // ── Navegación ─────────────────────────────────────────────────────────────
   "nav.browse": "Explorar",
   "nav.shop": "Tienda",
+  "nav.hub": "MXB Hub",
   "nav.library": "Biblioteca",
   "nav.downloads": "Descargas",
   "nav.locker": "Taquilla",
@@ -494,6 +495,26 @@ export const es: Translation = {
   "shop.sessionFailed": "No se pudo capturar tu sesión de MX Bikes Shop",
   "shop.loadFailed": "No se pudieron cargar tus compras: {{error}}",
   "shop.empty": "Aún no hay descargas compradas en tu cuenta.",
+
+  // ── MXB Hub (shop.mxb-hub.com) ──
+  "hub.help":
+    "Explora el mercado MXB Hub en shop.mxb-hub.com e instala lo que ya tienes. La compra sigue haciéndose en el sitio de la tienda; inicia sesión en Mis compras para instalar tus pedidos desde aquí.",
+  "hub.count_one": "{{count}} artículo",
+  "hub.count_other": "{{count}} artículos",
+  "hub.searchPlaceholder": "Buscar en MXB Hub…",
+  "hub.myDownloads": "Mis compras",
+  "hub.signInTitle": "Iniciar sesión en MXB Hub",
+  "hub.signInBody":
+    "Inicia sesión en shop.mxb-hub.com para ver e instalar todo lo que tienes, incluidos los mods gratuitos. Abrimos el sitio real: tu contraseña nunca pasa por esta aplicación.",
+  "hub.signIn": "Iniciar sesión",
+  "hub.signedIn": "Sesión iniciada en MXB Hub",
+  "hub.sessionFailed": "No se pudo capturar tu sesión de MXB Hub",
+  "hub.empty": "Aún no hay descargas en tu cuenta de MXB Hub.",
+  "hubSort.newest": "Más recientes",
+  "hubSort.popular": "Más populares",
+  "hubSort.priceAsc": "Precio: de menor a mayor",
+  "hubSort.priceDesc": "Precio: de mayor a menor",
+  "hubSort.nameAsc": "Nombre (A–Z)",
   "purchases.count_one": "{{count}} compra",
   "purchases.count_other": "{{count}} compras",
   "purchases.fileCount_one": "{{count}} archivo",
@@ -1252,6 +1273,7 @@ export const es: Translation = {
   "downloads.yesterday": "Ayer",
   "downloads.sourceSite": "Descarga",
   "downloads.sourceShop": "Tienda",
+  "downloads.sourceHub": "MXB Hub",
   "downloads.sourceFile": "Archivo importado",
   "downloads.showInLibrary": "Ver en la biblioteca",
   "downloads.openModPage": "Abrir la página del mod",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -47,6 +47,7 @@ export const fr: Translation = {
   // ── Navigation ─────────────────────────────────────────────────────────────
   "nav.browse": "Parcourir",
   "nav.shop": "Boutique",
+  "nav.hub": "MXB Hub",
   "nav.library": "Bibliothèque",
   "nav.downloads": "Téléchargements",
   "nav.locker": "Casier",
@@ -498,6 +499,26 @@ export const fr: Translation = {
   "shop.sessionFailed": "Impossible de récupérer votre session MX Bikes Shop",
   "shop.loadFailed": "Impossible de charger vos achats : {{error}}",
   "shop.empty": "Aucun téléchargement acheté trouvé sur votre compte.",
+
+  // ── MXB Hub (shop.mxb-hub.com) ──
+  "hub.help":
+    "Parcourez la place de marché MXB Hub sur shop.mxb-hub.com et installez ce que vous possédez déjà. L'achat se fait toujours sur le site de la boutique ; connectez-vous dans Mes achats pour installer vos commandes depuis ici.",
+  "hub.count_one": "{{count}} article",
+  "hub.count_other": "{{count}} articles",
+  "hub.searchPlaceholder": "Rechercher sur MXB Hub…",
+  "hub.myDownloads": "Mes achats",
+  "hub.signInTitle": "Se connecter à MXB Hub",
+  "hub.signInBody":
+    "Connectez-vous à shop.mxb-hub.com pour voir et installer tout ce que vous possédez, mods gratuits compris. Nous ouvrons le vrai site : votre mot de passe ne touche jamais cette application.",
+  "hub.signIn": "Se connecter",
+  "hub.signedIn": "Connecté à MXB Hub",
+  "hub.sessionFailed": "Impossible de récupérer votre session MXB Hub",
+  "hub.empty": "Aucun téléchargement trouvé sur votre compte MXB Hub.",
+  "hubSort.newest": "Plus récents",
+  "hubSort.popular": "Plus populaires",
+  "hubSort.priceAsc": "Prix : croissant",
+  "hubSort.priceDesc": "Prix : décroissant",
+  "hubSort.nameAsc": "Nom (A–Z)",
   "purchases.count_one": "{{count}} achat",
   "purchases.count_other": "{{count}} achats",
   "purchases.fileCount_one": "{{count}} fichier",
@@ -1256,6 +1277,7 @@ export const fr: Translation = {
   "downloads.yesterday": "Hier",
   "downloads.sourceSite": "Téléchargement",
   "downloads.sourceShop": "Boutique",
+  "downloads.sourceHub": "MXB Hub",
   "downloads.sourceFile": "Fichier importé",
   "downloads.showInLibrary": "Voir dans la bibliothèque",
   "downloads.openModPage": "Ouvrir la page du mod",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -45,6 +45,7 @@ export const it: Translation = {
   // ── Navigazione ────────────────────────────────────────────────────────────
   "nav.browse": "Esplora",
   "nav.shop": "Shop",
+  "nav.hub": "MXB Hub",
   "nav.library": "Libreria",
   "nav.downloads": "Download",
   "nav.locker": "Armadietto",
@@ -493,6 +494,26 @@ export const it: Translation = {
   "shop.sessionFailed": "Impossibile acquisire la tua sessione di MX Bikes Shop",
   "shop.loadFailed": "Impossibile caricare i tuoi acquisti: {{error}}",
   "shop.empty": "Nessun download acquistato trovato sul tuo account.",
+
+  // ── MXB Hub (shop.mxb-hub.com) ──
+  "hub.help":
+    "Esplora il marketplace MXB Hub su shop.mxb-hub.com e installa ciò che possiedi già. L'acquisto avviene sempre sul sito dello store; accedi in I miei acquisti per installare i tuoi ordini da qui.",
+  "hub.count_one": "{{count}} elemento",
+  "hub.count_other": "{{count}} elementi",
+  "hub.searchPlaceholder": "Cerca su MXB Hub…",
+  "hub.myDownloads": "I miei acquisti",
+  "hub.signInTitle": "Accedi a MXB Hub",
+  "hub.signInBody":
+    "Accedi a shop.mxb-hub.com per vedere e installare tutto ciò che possiedi, mod gratuite comprese. Apriamo il sito vero: la tua password non passa mai da questa app.",
+  "hub.signIn": "Accedi",
+  "hub.signedIn": "Accesso a MXB Hub effettuato",
+  "hub.sessionFailed": "Impossibile acquisire la tua sessione MXB Hub",
+  "hub.empty": "Nessun download trovato sul tuo account MXB Hub.",
+  "hubSort.newest": "Più recenti",
+  "hubSort.popular": "Più popolari",
+  "hubSort.priceAsc": "Prezzo: dal più basso",
+  "hubSort.priceDesc": "Prezzo: dal più alto",
+  "hubSort.nameAsc": "Nome (A–Z)",
   "purchases.count_one": "{{count}} acquisto",
   "purchases.count_other": "{{count}} acquisti",
   "purchases.fileCount_one": "{{count}} file",
@@ -1247,6 +1268,7 @@ export const it: Translation = {
   "downloads.yesterday": "Ieri",
   "downloads.sourceSite": "Download",
   "downloads.sourceShop": "Negozio",
+  "downloads.sourceHub": "MXB Hub",
   "downloads.sourceFile": "File importato",
   "downloads.showInLibrary": "Mostra nella libreria",
   "downloads.openModPage": "Apri la pagina della mod",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -48,6 +48,7 @@ export const ptBR: Translation = {
   // ── Navegação ──────────────────────────────────────────────────────────────
   "nav.browse": "Explorar",
   "nav.shop": "Loja",
+  "nav.hub": "MXB Hub",
   "nav.library": "Biblioteca",
   "nav.downloads": "Downloads",
   "nav.locker": "Armário",
@@ -496,6 +497,26 @@ export const ptBR: Translation = {
   "shop.sessionFailed": "Não foi possível capturar sua sessão da MX Bikes Shop",
   "shop.loadFailed": "Não foi possível carregar suas compras: {{error}}",
   "shop.empty": "Nenhum download comprado encontrado na sua conta ainda.",
+
+  // ── MXB Hub (shop.mxb-hub.com) ──
+  "hub.help":
+    "Explore o marketplace MXB Hub em shop.mxb-hub.com e instale o que você já tem. A compra continua sendo feita no site da loja; entre em Minhas compras para instalar seus pedidos daqui.",
+  "hub.count_one": "{{count}} item",
+  "hub.count_other": "{{count}} itens",
+  "hub.searchPlaceholder": "Buscar no MXB Hub…",
+  "hub.myDownloads": "Minhas compras",
+  "hub.signInTitle": "Entrar no MXB Hub",
+  "hub.signInBody":
+    "Entre em shop.mxb-hub.com para ver e instalar tudo o que você tem, incluindo mods gratuitos. Abrimos o site real: sua senha nunca passa por este app.",
+  "hub.signIn": "Entrar",
+  "hub.signedIn": "Conectado ao MXB Hub",
+  "hub.sessionFailed": "Não foi possível capturar sua sessão do MXB Hub",
+  "hub.empty": "Nenhum download encontrado na sua conta do MXB Hub ainda.",
+  "hubSort.newest": "Mais recentes",
+  "hubSort.popular": "Mais populares",
+  "hubSort.priceAsc": "Preço: do menor ao maior",
+  "hubSort.priceDesc": "Preço: do maior ao menor",
+  "hubSort.nameAsc": "Nome (A–Z)",
   "purchases.count_one": "{{count}} compra",
   "purchases.count_other": "{{count}} compras",
   "purchases.fileCount_one": "{{count}} arquivo",
@@ -1245,6 +1266,7 @@ export const ptBR: Translation = {
   "downloads.yesterday": "Ontem",
   "downloads.sourceSite": "Download",
   "downloads.sourceShop": "Loja",
+  "downloads.sourceHub": "MXB Hub",
   "downloads.sourceFile": "Arquivo importado",
   "downloads.showInLibrary": "Ver na biblioteca",
   "downloads.openModPage": "Abrir a página do mod",

--- a/src/lib/imgcache.ts
+++ b/src/lib/imgcache.ts
@@ -33,7 +33,7 @@ export const DESCRIPTION_IMAGE_WIDTH = 1200;
  * Pass `width` for a downscaled copy, or omit it for the original (what the full-size
  * gallery wants). Each width is a separate cache entry.
  *
- * Only mxb-mods.com and mxbikes-shop.com URLs are served; anything else is refused by the
+ * Only the catalogs' and the two stores' URLs are served; anything else is refused by the
  * handler, which surfaces as a normal image error and falls back to the placeholder icon.
  */
 export function cachedImage(
@@ -58,6 +58,7 @@ const CACHEABLE_HOSTS = [
   "gpb-mods.com",
   "mxbikes-shop.com",
   "mxbikes-shop.b-cdn.net",
+  "mxb-hub.com",
 ];
 
 /** Whether [`cachedImage`] would resolve to something the handler is willing to serve. */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -745,7 +745,7 @@ export interface DropOutcome {
 
 /** Where a download's bytes came from: the mod site, a shop purchase, or a local file the
  *  user imported or dragged in. */
-export type DownloadSource = "site" | "shop" | "file";
+export type DownloadSource = "site" | "shop" | "hub" | "file";
 
 export type DownloadStatus = "installed" | "failed";
 
@@ -1328,6 +1328,43 @@ export interface ShopStatus {
   veryStale: boolean;
   error: string | null;
 }
+
+/**
+ * MXB Hub — `shop.mxb-hub.com`, the marketplace `mxbhub.com` redirects to.
+ *
+ * Deliberately expressed as extensions of the shop's types rather than as a parallel set. The
+ * two stores sell the same kinds of thing to the same person, and the grid, the price tag, the
+ * purchase card and the detail page are shared between them — types that merely resembled each
+ * other would make every one of those a translation layer. What the Hub adds is a `slug` (its
+ * API is addressable by one, where the shop's dump is not) and a creator link.
+ */
+export interface HubMod extends ShopMod {
+  slug: string;
+}
+
+export interface HubModDetail extends ShopModDetail {
+  slug: string;
+  /** The store's own one-line summary — where a Hub listing says "in-game ready PKZ". */
+  summary: string | null;
+}
+
+export interface HubCategory extends ShopCategory {
+  /** The category's page on the store; also the creator's page, under `creators`. */
+  link: string | null;
+}
+
+export interface HubPage {
+  items: HubMod[];
+  total: number;
+  hasMore: boolean;
+  currency: string;
+}
+
+/**
+ * `relevance` is absent because the store rejects it — measured, not assumed. `onSale` is a
+ * filter here rather than an order, which is what the Store API actually offers.
+ */
+export type HubSort = "newest" | "popular" | "priceAsc" | "priceDesc" | "nameAsc";
 
 export type ShopSort =
   | "newest"


### PR DESCRIPTION
Adds MXB Hub — `shop.mxb-hub.com`, the marketplace `mxbhub.com` redirects to — as its own
sidebar tab, with both halves: browse the catalogue, and install what the signed-in account
already owns.

## What it is

WordPress + **WooCommerce** (the existing Shop is Easy Digital Downloads — a different
engine). 449 products across 99 categories, including 49 free mods. Browsing needs **no
build-time credential**: the store publishes WooCommerce's public Store API, which honours
`search`, `category`, `on_sale` and `orderby` for real and pages with `X-WP-Total`.

## Reuse

A Hub listing is a `ShopMod` with a slug on it, and a Hub purchase is a `ShopItem`, so the
cards, price tag, category pills, purchase card and detail page are the Shop's components used
as they are. Installing goes through the existing queue, destination dialog, progress cards and
"Installed" record. Two small seams in shipped code: `ShopDetail` took an optional `load`, and
`openShopUrl` now checks both stores' hosts from one list.

## The interesting part: this store counts requests

`shop.mxb-hub.com` is on SiteGround, whose bot protection fires on request **rate** — which is
why it is invisible to a few hand probes and entirely reproducible the moment a grid asks for
24 thumbnails at once. It then refuses everything from that address, images and API alike,
first as a `202` JavaScript proof-of-work challenge and eventually as a flat `403`.

So the tab is built not to provoke it, and to be honest when it happens anyway:

- Thumbnails fetch **two at a time** rather than eight, and the listing does not spend a
  request per page on dates only the detail page displays.
- A challenge is recognised on the response before anything is parsed, raises the existing
  `Blocked` error, and is **never written to the image cache** — otherwise a web page gets
  stored under an image's name and served long after it clears.
- `hub_clearance.rs` parks a hidden window on the store so a browser can answer the challenge,
  and hands its cookies to the HTTP clients. Deliberately much smaller than
  `mxb_fetch`/`shop_fetch`: nothing is read out of the page, only its cookie jar, so the
  window gets no IPC and needs no capability file.
- The window wears **no User-Agent override**. Forcing one was tried and was worse — it claims
  Chrome on Windows while the window is WKWebView on macOS, and the challenge fingerprints the
  browser, so the site escalated from a solvable challenge to 403. `shop_session::UA` already
  records the same lesson for Cloudflare.

## Free mods hosted elsewhere

WooCommerce lets a product's file be any URL and MXB Hub uses that — several free mods are
MediaFire links. The parser first required a store-hosted `download_file=` link, which
**silently dropped those rows**. They are kept and marked now, resolved through
`install::resolve_direct_url` (which already handles MediaFire folders, Drive and MEGA) and
fetched with the ordinary download client — never with the user's store session.

## Verification

- 1017 Rust tests, `tsc`, `eslint` (no new warnings), `vite build`.
- An ignored live test (`cargo test --bin mxb-app -- --ignored hub_live`) exercises search,
  paging, category filter, detail, by-slug lookup and creator attribution against the store.
- Driven in the running app: the tab renders, 449 items, the full category tree with counts,
  and prices correctly converted from minor units.

**Not yet proven:** the artwork rendering end-to-end and the clearance handshake against a live
challenge — the store is still rate-limiting this address from development traffic. The
signed-in downloads parser is tested against hand-written WooCommerce markup rather than a real
account page; if it ever parses nothing it dumps the page to `hub-downloads.html` in the app
cache directory.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)