### PR TITLE
docs(changelog): plainer wording for v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,81 +1,27 @@
 # Changelog
 
-## 2026-08-30 — v0.12.0 — MXB Hub in the app, and a Designer that speaks Photoshop
+## 2026-08-30 — v0.12.0 — MXB Hub, and PSD support in the Designer
 
 ### Added
 
-- **Browse and install from MXB Hub.** A new sidebar tab for the shop.mxb-hub.com
-  marketplace: the whole catalogue, filterable by creator and by what a thing is, with prices
-  and artwork. Sign in and everything you already own — the free mods included — installs the
-  same way anything else does, into the folder the app suggests, with the same progress card
-  and "Installed" badge. Mods the store hosts elsewhere, on MediaFire and the like, install
-  from here too.
-
-- **Lock a mod to the people you made it for.** Studio has a new Protect tab: pick the files
-  you built — one at a time, or a whole mod folder — paste the GUIDs of the riders allowed to
-  load them, and you get a folder per rider with locked copies inside, ready to send out. A
-  `.pkz` is locked as an archive, so tracks and packaged bikes work the same as loose files.
-  Every copy is locked with its own key, so two riders can't tell they are holding the same
-  file. Your originals are only ever read — nothing is written over.
-- **Read your own GUID out of the game.** MX Bikes never writes your GUID to a file, so until
-  now the app had to wait for one of your servers to see you connect. The Protect tab reads it
-  from the running game instead, shows it, copies it, and claims it for your account — the
-  same GUID the Servers tab uses, so both places agree about who you are.
-
-- **A mod's page now says who made it.** Open a track, a bike or a set of gear and the
-  creator's name sits directly under the title, exactly as the site credits it. Click it to
-  open their page on the catalog, which is where the rest of their work is. The name is read
-  off the mod's own page rather than asked for over the catalog's API — the API stopped
-  answering who posted anything some time ago, which is why the browse cards have been
-  showing a date and nothing else.
-- **Start a paint from the bike's own plastics rather than from nothing.** The Designer could
-  already show the texture a bike ships with faintly under your sheet, to draw against — but
-  what people actually keep asking for is that picture itself, with a number on it and nothing
-  else changed. **Stock as base** paints it into the sheet at full strength, where it becomes
-  part of what gets saved instead of a guide that never is: put your number over it, save, and
-  the paint is the bike exactly as it came with your number on the shroud. A sheet nothing has
-  been done to yet also takes the texture's own size, so the bike's artwork is never resampled
-  onto a blank that happened to be a different one.
-
-- **The Designer opens and writes Photoshop files.** A livery almost always starts life as a
-  layered `.psd`, and until now the only way to bring one in was to flatten it first — which
-  threw away every layer and made this a worse editor than the file it was fed. Start from a
-  PSD and its layers arrive as layers: named, stacked in order, still at their own opacity and
-  blend mode, hidden ones still hidden, folders still grouped. Export PSD goes back the other
-  way, writing each sheet out with its layers intact, into a folder you pick. One file per
-  sheet, because sheets have their own sizes and a Photoshop document has one canvas. Both
-  directions turn the sheet the right way up, so what opens in Photoshop is the template a
-  painter draws on rather than the upside-down way the game stores it.
+- MXB Hub tab. Browse the shop.mxb-hub.com catalogue and install anything your account owns,
+  free mods included. Mods hosted on MediaFire and similar install from here too.
+- Protect tab in Studio. Lock your files to specific riders by GUID, one folder per rider.
+- The app reads your GUID from the running game, so you no longer have to wait for a server
+  to see you connect.
+- The Designer opens and exports Photoshop files with layers intact.
+- "Stock as base" paints a bike's stock texture into your sheet, so you can add a number and
+  save it as-is.
+- Mod pages show who made it, with a link to their page on the catalogue.
 
 ### Changed
 
-- **Picking a model fills in the sheets it wants.** The Designer used to open empty, with the
-  names the model binds printed underneath as a hint and a button to turn them into sheets —
-  so the first move of every session was the same move, and getting it wrong meant a paint
-  that loads and shows nothing. The sheets are simply there now, named the way the model reads
-  them, the moment a bike or a piece of gear is chosen. Change the model and they follow it. If
-  anything has been drawn, nothing is thrown away without asking: a warning names the sheets
-  the new model uses and waits for you to say switch.
+- Picking a model fills in the sheets it needs, instead of opening empty.
 
 ### Fixed
 
-- **Mirror now works on bodywork that is one piece, like a seat.** "Mirror to other side" asks
-  the model where the far side of a decal's spot actually is, and it used to ask by looking for
-  a triangle whose corners were the exact mirror image of the ones under the layer. Bikes
-  rarely oblige: a seat, a tank or a fender is modelled once as a single piece, so its left and
-  right halves are near-copies rather than vertex-exact mirrors — 2mm apart on a stock
-  CRF450R — and the mirror answered "the model has nothing at the reflection of this spot" over
-  most of the bike. On a stock YZ450F's plastics it could not mirror anything at all. It now
-  asks for the nearest bit of surface at the reflected place instead of an exact twin, which is
-  the same answer where the mesh does line up and a real one where it doesn't. Across six stock
-  bikes it went from mirroring a third of a sheet at best to nearly all of it, and every
-  placement lands on the panel the model puts there.
-
-- **A decal mirrored onto a narrow panel comes out the right size.** Working out which way the
-  far side runs means stepping a little way along the layer's own axes and seeing where those
-  land. The first step tried is a wide one, and on a strip as thin as a seat's flank it ran off
-  the panel and came back with a placement up to a third too big. A wide step is still what it
-  reaches for first, but it now keeps looking when the answer doesn't read as a reflection.
+- Mirror works on one-piece bodywork like seats and tanks. It used to fail on most of a bike.
+- A decal mirrored onto a narrow panel comes out the right size.
 
 ## Unannounced — voice chat
 


### PR DESCRIPTION
Rewrites the v0.12.0 section as short bullets. The previous wording read like marketing copy.

The published release notes are updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)