### PR TITLE
feat(frostmod): rebind the replay camera keys from Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-08-31
+
+### Added
+- Settings → FrostMod now lets you rebind the replay camera editor's keys. The game reads
+  the same key at the same moment, so `S` for save also moved the camera for anyone with
+  `S` bound to move-backwards; now you can put the action on a key the game doesn't use.
+- Keys are written into FrostMod's own config, including a plugin-folder install, and take
+  effect the next time the editor opens.
+
 ## 2026-08-30 — v0.12.0 — MXB Hub, and PSD support in the Designer
 
 ### Added

--- a/src-tauri/src/frostmod_manage.rs
+++ b/src-tauri/src/frostmod_manage.rs
@@ -1197,3 +1197,228 @@ mod tests {
         assert!(!filter_eq(CURATED_SERVERFILTER, STOCK_SERVERFILTER));
     }
 }
+
+// ---------------------------------------------------------------------------
+// Replay camera key bindings
+//
+// FrostMod's replay camera editor polls the keyboard, so the game sees the same key on
+// the same frame: a player with `S` bound to move-backwards could not save a path without
+// moving the camera. FrostMod made the keys configurable; this is the half that edits
+// them, because a config file next to a DLL is not somewhere anyone should have to go.
+//
+// They live in FrostMod's existing `frostmod_radar.cfg` as `rcam_save=F9` lines, which
+// also carries radar/overlay settings — so every write here is a merge, never a rewrite.
+// ---------------------------------------------------------------------------
+
+/// One editor action, and the key it is on. `key` is FrostMod's own text form
+/// (`F9`, `Ctrl+Numpad1`, `none`) — kept as a string so the two sides agree on one
+/// spelling rather than each inventing an encoding.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Keybind {
+    pub id: String,
+    pub key: String,
+}
+
+/// Mirrors `kb::Actions()` in FrostMod's `src/keybinds.h`, in the same order. The ids are
+/// the config keys (`rcam_<id>`); the UI labels them itself, translated.
+const RCAM_ACTIONS: [(&str, &str); 8] = [
+    ("setkey", "K"),
+    ("delete", "X"),
+    ("clear", "C"),
+    ("play", "P"),
+    ("prev", "Comma"),
+    ("next", "Period"),
+    ("save", "S"),
+    ("load", "L"),
+];
+
+/// Key names FrostMod can parse, beyond the plain letters and digits. Mirrors the table in
+/// `keybinds.h`. We validate against it rather than trusting the front end: a name FrostMod
+/// cannot read back leaves someone with a key that does nothing and no error to explain it.
+const NAMED_KEYS: [&str; 57] = [
+    "Space", "Tab", "Enter", "Backspace", "Insert", "Delete", "Home", "End",
+    "PageUp", "PageDown", "Left", "Up", "Right", "Down",
+    "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12",
+    "F13", "F14", "F15", "F16",
+    "Numpad0", "Numpad1", "Numpad2", "Numpad3", "Numpad4", "Numpad5", "Numpad6",
+    "Numpad7", "Numpad8", "Numpad9",
+    "NumpadMultiply", "NumpadAdd", "NumpadSubtract", "NumpadDecimal", "NumpadDivide",
+    "Comma", "Period", "Semicolon", "Slash", "Backtick", "Minus", "Equals",
+    "LeftBracket", "Backslash", "RightBracket", "Quote", "Escape",
+];
+
+const RCAM_CFG: &str = "frostmod_radar.cfg";
+
+/// Every config FrostMod might be reading. There are two installs to think about: the one
+/// this app manages, and a `.dlo` the player dropped in the game's own plugins folder —
+/// which keeps its config there, next to the DLL. Editing only ours would look like the
+/// setting did nothing for anyone running in plugin mode.
+fn rcam_cfg_paths(app: &AppHandle, game_path: &str) -> Vec<PathBuf> {
+    let mut out = vec![frostmod_dir(app).join(RCAM_CFG)];
+    if !game_path.is_empty() {
+        let plugins = Path::new(game_path).join("plugins");
+        if plugins.join("frostmod.dlo").exists() || plugins.join(RCAM_CFG).exists() {
+            out.push(plugins.join(RCAM_CFG));
+        }
+    }
+    out
+}
+
+/// Is this something FrostMod's `ParseBind` will accept? Same rules: optional `Ctrl+`,
+/// `Alt+`, `Shift+` prefixes, then a single letter or digit, or one of the named keys.
+fn valid_bind(text: &str) -> bool {
+    let text = text.trim();
+    if text.is_empty() {
+        return false;
+    }
+    if text.eq_ignore_ascii_case("none") {
+        return true;
+    }
+    let mut rest = text;
+    loop {
+        let Some(plus) = rest.find('+') else { break };
+        // a trailing '+' is the key itself, which we do not accept as a name
+        if plus == 0 || plus + 1 >= rest.len() {
+            return false;
+        }
+        let (modifier, tail) = rest.split_at(plus);
+        if !["ctrl", "control", "alt", "shift"]
+            .iter()
+            .any(|m| modifier.eq_ignore_ascii_case(m))
+        {
+            return false;
+        }
+        rest = tail[1..].trim_start();
+    }
+    if rest.len() == 1 {
+        let c = rest.as_bytes()[0];
+        if c.is_ascii_alphanumeric() {
+            return true;
+        }
+    }
+    NAMED_KEYS.iter().any(|k| k.eq_ignore_ascii_case(rest))
+}
+
+/// The bindings in force: FrostMod's defaults, with whatever the config overrides. Reading
+/// the app's own copy first and letting a plugin-folder config win matches what the game
+/// would actually load if both exist.
+pub fn rcam_keybinds(app: &AppHandle, game_path: &str) -> Vec<Keybind> {
+    let mut binds: Vec<Keybind> = RCAM_ACTIONS
+        .iter()
+        .map(|(id, def)| Keybind { id: (*id).to_string(), key: (*def).to_string() })
+        .collect();
+
+    for path in rcam_cfg_paths(app, game_path) {
+        let Ok(text) = std::fs::read_to_string(&path) else { continue };
+        for line in text.lines() {
+            let Some((name, value)) = line.split_once('=') else { continue };
+            let Some(id) = name.trim().strip_prefix("rcam_") else { continue };
+            let value = value.trim();
+            if !valid_bind(value) {
+                continue;
+            }
+            if let Some(b) = binds.iter_mut().find(|b| b.id == id) {
+                b.key = value.to_string();
+            }
+        }
+    }
+    binds
+}
+
+/// Write the bindings into every config FrostMod might read, keeping every other line.
+/// FrostMod re-reads the file each time the editor opens, so this lands without a restart.
+pub fn set_rcam_keybinds(
+    app: &AppHandle,
+    game_path: &str,
+    binds: &[Keybind],
+) -> Result<(), String> {
+    for b in binds {
+        if !RCAM_ACTIONS.iter().any(|(id, _)| *id == b.id) {
+            return Err(format!("unknown replay camera action '{}'", b.id));
+        }
+        if !valid_bind(&b.key) {
+            return Err(format!("'{}' is not a key FrostMod can read", b.key));
+        }
+    }
+
+    let mut wrote = 0usize;
+    let mut last_err = None;
+    for path in rcam_cfg_paths(app, game_path) {
+        let existing = std::fs::read_to_string(&path).unwrap_or_default();
+        let mut out: Vec<String> = Vec::new();
+        for line in existing.lines() {
+            let is_ours = line
+                .split_once('=')
+                .map(|(name, _)| name.trim().starts_with("rcam_"))
+                .unwrap_or(false);
+            if !is_ours {
+                out.push(line.to_string());
+            }
+        }
+        for b in binds {
+            out.push(format!("rcam_{}={}", b.id, b.key.trim()));
+        }
+        let body = out.join("\n") + "\n";
+
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        match std::fs::write(&path, body) {
+            Ok(()) => {
+                wrote += 1;
+                log::info!("wrote replay camera key bindings to {}", path.display());
+            }
+            Err(e) => {
+                log::warn!("could not write {}: {e}", path.display());
+                last_err = Some(e.to_string());
+            }
+        }
+    }
+
+    if wrote == 0 {
+        return Err(last_err.unwrap_or_else(|| "no FrostMod config folder to write to".into()));
+    }
+    Ok(())
+}
+
+/// FrostMod's shipped defaults, for the reset button.
+pub fn default_rcam_keybinds() -> Vec<Keybind> {
+    RCAM_ACTIONS
+        .iter()
+        .map(|(id, def)| Keybind { id: (*id).to_string(), key: (*def).to_string() })
+        .collect()
+}
+
+#[cfg(test)]
+mod rcam_tests {
+    use super::*;
+
+    #[test]
+    fn accepts_what_frostmod_can_parse() {
+        for good in ["K", "k", "9", "F9", "Numpad1", "Comma", "none", "NONE",
+                     "Ctrl+S", "ctrl+shift+Numpad0", "Alt+F4"] {
+            assert!(valid_bind(good), "{good} should be accepted");
+        }
+    }
+
+    #[test]
+    fn refuses_what_it_cannot() {
+        for bad in ["", "  ", "Meta+K", "Ctrl+", "NotAKey", "F99", "KK", "+"] {
+            assert!(!valid_bind(bad), "{bad} should be refused");
+        }
+    }
+
+    #[test]
+    fn defaults_match_frostmods() {
+        // If FrostMod's defaults move, this is the reminder to move ours with them.
+        let d = default_rcam_keybinds();
+        assert_eq!(d.len(), 8);
+        assert_eq!(d[0].id, "setkey");
+        assert_eq!(d[0].key, "K");
+        assert_eq!(d[6].key, "S");
+        for b in &d {
+            assert!(valid_bind(&b.key), "default {} is not valid", b.key);
+        }
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5359,6 +5359,30 @@ fn frostmod_running() -> bool {
     frostmod::is_running()
 }
 
+/// The replay camera editor's key bindings, as FrostMod would read them.
+#[tauri::command]
+fn frostmod_keybinds(app: tauri::AppHandle) -> Vec<frostmod_manage::Keybind> {
+    let cfg = config::load(&app).unwrap_or_default();
+    frostmod_manage::rcam_keybinds(&app, &cfg.game_path)
+}
+
+/// Rebind the replay camera editor. Written into FrostMod's own config, which it re-reads
+/// each time the editor opens — so this applies without restarting the game.
+#[tauri::command]
+fn frostmod_set_keybinds(
+    app: tauri::AppHandle,
+    binds: Vec<frostmod_manage::Keybind>,
+) -> Result<(), String> {
+    let cfg = config::load(&app).unwrap_or_default();
+    frostmod_manage::set_rcam_keybinds(&app, &cfg.game_path, &binds)
+}
+
+/// What FrostMod ships with, for the reset button.
+#[tauri::command]
+fn frostmod_default_keybinds() -> Vec<frostmod_manage::Keybind> {
+    frostmod_manage::default_rcam_keybinds()
+}
+
 /// Whether FrostMod actually got into the running game — and what to do when it didn't.
 ///
 /// `frostmod_running` only says the launcher is up, which is what made an elevated game so
@@ -8623,6 +8647,9 @@ fn main() {
             voice_test_output,
             set_watch_mods_reload,
             frostmod_reload,
+            frostmod_keybinds,
+            frostmod_set_keybinds,
+            frostmod_default_keybinds,
             frostmod_running,
             frostmod_attachment,
             garage_scan_bikes,

--- a/src/Components/Settings/ReplayCameraKeys.tsx
+++ b/src/Components/Settings/ReplayCameraKeys.tsx
@@ -1,0 +1,235 @@
+import { useCallback, useEffect, useState } from "react";
+import { RotateCcw, TriangleAlert } from "lucide-react";
+import { toast } from "sonner";
+import {
+  frostmodDefaultKeybinds,
+  frostmodKeybinds,
+  setFrostmodKeybinds,
+  type FrostmodKeybind,
+} from "../../api/mods";
+import { useI18n } from "../../i18n/context";
+import type { TKey } from "../../i18n/core";
+import { Button } from "@/Components/ui/button";
+import { cn } from "@/lib/utils";
+
+/** Order and ids mirror FrostMod's `kb::Actions()`; the labels are ours to translate. */
+const ACTION_LABELS: Record<string, TKey> = {
+  setkey: "settings.rcamActionSetkey",
+  delete: "settings.rcamActionDelete",
+  clear: "settings.rcamActionClear",
+  play: "settings.rcamActionPlay",
+  prev: "settings.rcamActionPrev",
+  next: "settings.rcamActionNext",
+  save: "settings.rcamActionSave",
+  load: "settings.rcamActionLoad",
+};
+
+/** `KeyboardEvent.code` -> the name FrostMod parses. Physical codes on purpose: the game
+ *  reads scancodes too, so what matters is the key you actually pressed, not what the
+ *  current layout prints on it. Anything not here has no FrostMod name and is refused. */
+const CODE_NAMES: Record<string, string> = {
+  NumpadMultiply: "NumpadMultiply",
+  NumpadAdd: "NumpadAdd",
+  NumpadSubtract: "NumpadSubtract",
+  NumpadDecimal: "NumpadDecimal",
+  NumpadDivide: "NumpadDivide",
+  Comma: "Comma",
+  Period: "Period",
+  Semicolon: "Semicolon",
+  Slash: "Slash",
+  Backquote: "Backtick",
+  Minus: "Minus",
+  Equal: "Equals",
+  BracketLeft: "LeftBracket",
+  Backslash: "Backslash",
+  BracketRight: "RightBracket",
+  Quote: "Quote",
+  Space: "Space",
+  Tab: "Tab",
+  Enter: "Enter",
+  Insert: "Insert",
+  Delete: "Delete",
+  Home: "Home",
+  End: "End",
+  PageUp: "PageUp",
+  PageDown: "PageDown",
+  ArrowLeft: "Left",
+  ArrowUp: "Up",
+  ArrowRight: "Right",
+  ArrowDown: "Down",
+};
+
+function keyNameFor(e: KeyboardEvent): string | null {
+  const c = e.code;
+  if (/^Key[A-Z]$/.test(c)) return c.slice(3);
+  if (/^Digit[0-9]$/.test(c)) return c.slice(5);
+  if (/^Numpad[0-9]$/.test(c)) return c;
+  if (/^F([1-9]|1[0-6])$/.test(c)) return c;
+  return CODE_NAMES[c] ?? null;
+}
+
+function bindTextFor(e: KeyboardEvent): string | null {
+  const key = keyNameFor(e);
+  if (!key) return null;
+  return (
+    (e.ctrlKey ? "Ctrl+" : "") +
+    (e.altKey ? "Alt+" : "") +
+    (e.shiftKey ? "Shift+" : "") +
+    key
+  );
+}
+
+/** The replay camera editor's keys.
+ *
+ *  This exists because of one collision: the editor polls the keyboard, and the game reads
+ *  the same key on the same frame — so a player with `S` bound to move-backwards could not
+ *  press `S` to save without also moving the camera. A modifier does not help, because the
+ *  game does not care whether Ctrl was held. The only fix is moving the action onto a key
+ *  the game does not use, which is what this panel is for, and why the hint below says so
+ *  rather than leaving people to work it out.
+ */
+export function ReplayCameraKeys() {
+  const { t } = useI18n();
+  const [binds, setBinds] = useState<FrostmodKeybind[] | null>(null);
+  const [capturing, setCapturing] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    void frostmodKeybinds()
+      .then((b) => alive && setBinds(b))
+      .catch(() => alive && setBinds([]));
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const persist = useCallback(
+    async (next: FrostmodKeybind[]) => {
+      const prev = binds;
+      setBinds(next); // optimistic: the press should feel like it landed
+      setSaving(true);
+      try {
+        await setFrostmodKeybinds(next);
+      } catch (e) {
+        setBinds(prev); // put the old key back rather than showing one FrostMod rejected
+        toast.error(t("settings.rcamSaveFailed"), { description: String(e) });
+      } finally {
+        setSaving(false);
+      }
+    },
+    [binds, t],
+  );
+
+  // While capturing, the next key press becomes the binding. Escape backs out, Backspace
+  // unbinds. Captured on the window in the capture phase so the key never reaches whatever
+  // else is listening — including the button that started the capture.
+  useEffect(() => {
+    if (!capturing) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (["Control", "Alt", "Shift", "Meta", "OS"].includes(e.key)) return; // a modifier alone is not a binding
+      e.preventDefault();
+      e.stopPropagation();
+      if (e.code === "Escape") {
+        setCapturing(null);
+        return;
+      }
+      const next =
+        e.code === "Backspace" ? "none" : bindTextFor(e);
+      if (!next) {
+        toast.error(t("settings.rcamUnsupportedKey"));
+        return;
+      }
+      const id = capturing;
+      setCapturing(null);
+      void persist((binds ?? []).map((b) => (b.id === id ? { ...b, key: next } : b)));
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [capturing, binds, persist, t]);
+
+  const reset = useCallback(async () => {
+    try {
+      await persist(await frostmodDefaultKeybinds());
+    } catch (e) {
+      toast.error(t("settings.rcamSaveFailed"), { description: String(e) });
+    }
+  }, [persist, t]);
+
+  if (!binds || binds.length === 0) return null;
+
+  const duplicated = new Set(
+    binds
+      .filter((b) => b.key !== "none")
+      .map((b) => b.key)
+      .filter((k, i, all) => all.indexOf(k) !== i),
+  );
+
+  return (
+    <div className="rounded-lg border border-input bg-background px-3 py-2.5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col">
+          <span className="text-[12.5px] text-foreground/85">
+            {t("settings.rcamKeys")}
+          </span>
+          <span className="text-[11px] leading-relaxed text-muted-foreground">
+            {t("settings.rcamKeysDesc")}
+          </span>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => void reset()}
+          disabled={saving}
+          title={t("settings.rcamReset")}
+        >
+          <RotateCcw className="size-3.5" /> {t("settings.rcamReset")}
+        </Button>
+      </div>
+
+      <div className="mt-3 grid gap-1 sm:grid-cols-2">
+        {binds.map((b) => {
+          const isCapturing = capturing === b.id;
+          const clashes = b.key !== "none" && duplicated.has(b.key);
+          return (
+            <div
+              key={b.id}
+              className="flex items-center justify-between gap-2 rounded-md px-1.5 py-1"
+            >
+              <span className="text-[12px] text-foreground/75">
+                {ACTION_LABELS[b.id] ? t(ACTION_LABELS[b.id]) : b.id}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                className={cn(
+                  "h-7 min-w-[104px] font-mono text-[11.5px]",
+                  isCapturing && "border-primary text-primary",
+                  clashes && !isCapturing && "border-destructive text-destructive",
+                )}
+                onClick={() => setCapturing(isCapturing ? null : b.id)}
+                title={clashes ? t("settings.rcamDuplicate") : undefined}
+              >
+                {isCapturing
+                  ? t("settings.rcamPressKey")
+                  : b.key === "none"
+                    ? t("settings.rcamUnbound")
+                    : b.key}
+              </Button>
+            </div>
+          );
+        })}
+      </div>
+
+      <p className="mt-2 text-[11px] text-muted-foreground">
+        {capturing ? t("settings.rcamCaptureHint") : t("settings.rcamAppliesHint")}
+      </p>
+
+      {duplicated.size > 0 && (
+        <p className="mt-1 flex items-center gap-1.5 text-[11px] text-destructive">
+          <TriangleAlert className="size-3.5" /> {t("settings.rcamDuplicate")}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -75,6 +75,7 @@ import { useUpdate } from "../../Context/Update";
 import { usePlatform } from "../../lib/usePlatform";
 import { useConfig } from "../../Context/Config";
 import GameSwitcher from "../Shell/GameSwitcher";
+import { ReplayCameraKeys } from "./ReplayCameraKeys";
 import ReshadeCard from "./ReshadeCard";
 import SupportersCard from "./SupportersCard";
 import { useTheme, type ThemeMode } from "../../Context/Theme";
@@ -1765,6 +1766,10 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
               checked={watchModsReload}
               onChange={toggleWatchModsReload}
             />
+
+            {/* Only once FrostMod is on disk: without an install there is no config to
+                edit, and the keys would be an offer that quietly does nothing. */}
+            {status?.installed && <ReplayCameraKeys />}
 
             <div className="flex gap-2">
               {/* Stop is offered whenever FrostMod is running, installed by us or not —

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -2136,6 +2136,26 @@ export function isGameRunning(): Promise<boolean> {
 }
 
 /** Install/version/running snapshot (hits GitHub for the latest tag). */
+/** One replay camera editor action and the key it is on, in FrostMod's own text form
+ *  (`F9`, `Ctrl+Numpad1`, `none`) — one spelling shared by both programs. */
+export type FrostmodKeybind = { id: string; key: string };
+
+/** The bindings FrostMod would read right now: its defaults, plus whatever its config says. */
+export function frostmodKeybinds(): Promise<FrostmodKeybind[]> {
+  return invoke<FrostmodKeybind[]>("frostmod_keybinds");
+}
+
+/** Rebind the editor. FrostMod re-reads its config each time the editor opens, so this
+ *  lands without restarting the game. Rejects a key FrostMod could not read back. */
+export function setFrostmodKeybinds(binds: FrostmodKeybind[]): Promise<void> {
+  return invoke<void>("frostmod_set_keybinds", { binds });
+}
+
+/** What FrostMod ships with, for the reset button. */
+export function frostmodDefaultKeybinds(): Promise<FrostmodKeybind[]> {
+  return invoke<FrostmodKeybind[]>("frostmod_default_keybinds");
+}
+
 export function frostmodStatus(): Promise<FrostmodStatus> {
   return invoke<FrostmodStatus>("frostmod_status");
 }

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -712,6 +712,42 @@ export const de: Translation = {
   "settings.autoRunFrostmod": "FrostMod automatisch starten",
   "settings.autoRunFrostmodDesc":
     "FrostMod im Hintergrund starten, sobald MXB App geöffnet wird.",
+  "settings.rcamKeys":
+    "Tasten der Replay-Kamera",
+  "settings.rcamKeysDesc":
+    "Das Spiel liest dieselbe Taste im selben Moment. Wähle daher Tasten, die deine Kamerasteuerung nicht belegt — Funktionstasten und der Ziffernblock sind meist frei.",
+  "settings.rcamReset":
+    "Zurücksetzen",
+  "settings.rcamPressKey":
+    "Taste drücken",
+  "settings.rcamUnbound":
+    "Nicht belegt",
+  "settings.rcamCaptureHint":
+    "Drücke die gewünschte Taste. Esc bricht ab, Rücktaste löscht die Belegung.",
+  "settings.rcamAppliesHint":
+    "Gilt beim nächsten Öffnen des Editors im Spiel — kein Neustart nötig.",
+  "settings.rcamDuplicate":
+    "Zwei Aktionen teilen sich eine Taste.",
+  "settings.rcamUnsupportedKey":
+    "FrostMod kann diese Taste nicht verwenden.",
+  "settings.rcamSaveFailed":
+    "Tasten konnten nicht gespeichert werden",
+  "settings.rcamActionSetkey":
+    "Punkt setzen",
+  "settings.rcamActionDelete":
+    "Punkt löschen",
+  "settings.rcamActionClear":
+    "Pfad leeren",
+  "settings.rcamActionPlay":
+    "Start / Stopp",
+  "settings.rcamActionPrev":
+    "Vorheriger Punkt",
+  "settings.rcamActionNext":
+    "Nächster Punkt",
+  "settings.rcamActionSave":
+    "Pfad speichern",
+  "settings.rcamActionLoad":
+    "Pfad laden",
   "settings.watchModsReload": "Automatisch neu laden bei Ordneränderungen",
   "settings.watchModsReloadDesc":
     "Das Spiel automatisch neu laden, wenn Strecken oder Motorräder in deinen Mod-Ordner kommen — auch wenn sie außerhalb von MXB App manuell heruntergeladen wurden.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -698,6 +698,42 @@ export const en = {
   "settings.autoRunFrostmod": "Run FrostMod automatically",
   "settings.autoRunFrostmodDesc":
     "Start FrostMod in the background whenever MXB App opens.",
+  "settings.rcamKeys":
+    "Replay camera keys",
+  "settings.rcamKeysDesc":
+    "The game reads the same key at the same moment, so pick keys your camera controls don't use — function keys and the numpad are usually free.",
+  "settings.rcamReset":
+    "Reset",
+  "settings.rcamPressKey":
+    "Press a key",
+  "settings.rcamUnbound":
+    "Not set",
+  "settings.rcamCaptureHint":
+    "Press the key you want. Esc cancels, Backspace clears the binding.",
+  "settings.rcamAppliesHint":
+    "Applies the next time you open the editor in game — no restart needed.",
+  "settings.rcamDuplicate":
+    "Two actions share a key.",
+  "settings.rcamUnsupportedKey":
+    "FrostMod can't use that key.",
+  "settings.rcamSaveFailed":
+    "Could not save the keys",
+  "settings.rcamActionSetkey":
+    "Set key",
+  "settings.rcamActionDelete":
+    "Delete key",
+  "settings.rcamActionClear":
+    "Clear path",
+  "settings.rcamActionPlay":
+    "Play / stop",
+  "settings.rcamActionPrev":
+    "Previous key",
+  "settings.rcamActionNext":
+    "Next key",
+  "settings.rcamActionSave":
+    "Save path",
+  "settings.rcamActionLoad":
+    "Load path",
   "settings.watchModsReload": "Auto-reload on folder changes",
   "settings.watchModsReloadDesc":
     "Reload the game automatically when tracks or bikes are added to your mods folder — even downloaded manually outside MXB App.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -704,6 +704,42 @@ export const es: Translation = {
   "settings.autoRunFrostmod": "Ejecutar FrostMod automáticamente",
   "settings.autoRunFrostmodDesc":
     "Inicia FrostMod en segundo plano cada vez que abres MXB App.",
+  "settings.rcamKeys":
+    "Teclas de la cámara de repetición",
+  "settings.rcamKeysDesc":
+    "El juego lee la misma tecla en el mismo momento, así que elige teclas que tus controles de cámara no usen — las teclas de función y el teclado numérico suelen estar libres.",
+  "settings.rcamReset":
+    "Restablecer",
+  "settings.rcamPressKey":
+    "Pulsa una tecla",
+  "settings.rcamUnbound":
+    "Sin asignar",
+  "settings.rcamCaptureHint":
+    "Pulsa la tecla que quieras. Esc cancela, Retroceso borra la asignación.",
+  "settings.rcamAppliesHint":
+    "Se aplica la próxima vez que abras el editor en el juego — sin reiniciar.",
+  "settings.rcamDuplicate":
+    "Dos acciones comparten una tecla.",
+  "settings.rcamUnsupportedKey":
+    "FrostMod no puede usar esa tecla.",
+  "settings.rcamSaveFailed":
+    "No se pudieron guardar las teclas",
+  "settings.rcamActionSetkey":
+    "Fijar punto",
+  "settings.rcamActionDelete":
+    "Borrar punto",
+  "settings.rcamActionClear":
+    "Vaciar trayecto",
+  "settings.rcamActionPlay":
+    "Reproducir / parar",
+  "settings.rcamActionPrev":
+    "Punto anterior",
+  "settings.rcamActionNext":
+    "Punto siguiente",
+  "settings.rcamActionSave":
+    "Guardar trayecto",
+  "settings.rcamActionLoad":
+    "Cargar trayecto",
   "settings.watchModsReload": "Recarga automática al cambiar la carpeta",
   "settings.watchModsReloadDesc":
     "Recarga el juego automáticamente cuando se añaden pistas o motos a tu carpeta de mods — incluso descargadas manualmente fuera de MXB App.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -708,6 +708,42 @@ export const fr: Translation = {
   "settings.autoRunFrostmod": "Lancer FrostMod automatiquement",
   "settings.autoRunFrostmodDesc":
     "Démarrer FrostMod en arrière-plan à chaque ouverture de MXB App.",
+  "settings.rcamKeys":
+    "Touches de la caméra de replay",
+  "settings.rcamKeysDesc":
+    "Le jeu lit la même touche au même moment : choisis des touches que tes commandes de caméra n'utilisent pas — les touches de fonction et le pavé numérique sont souvent libres.",
+  "settings.rcamReset":
+    "Réinitialiser",
+  "settings.rcamPressKey":
+    "Appuie sur une touche",
+  "settings.rcamUnbound":
+    "Non attribuée",
+  "settings.rcamCaptureHint":
+    "Appuie sur la touche voulue. Échap annule, Retour arrière efface l'attribution.",
+  "settings.rcamAppliesHint":
+    "Prise en compte à la prochaine ouverture de l'éditeur en jeu — sans redémarrer.",
+  "settings.rcamDuplicate":
+    "Deux actions partagent une touche.",
+  "settings.rcamUnsupportedKey":
+    "FrostMod ne peut pas utiliser cette touche.",
+  "settings.rcamSaveFailed":
+    "Impossible d'enregistrer les touches",
+  "settings.rcamActionSetkey":
+    "Placer un point",
+  "settings.rcamActionDelete":
+    "Supprimer le point",
+  "settings.rcamActionClear":
+    "Effacer le trajet",
+  "settings.rcamActionPlay":
+    "Lecture / arrêt",
+  "settings.rcamActionPrev":
+    "Point précédent",
+  "settings.rcamActionNext":
+    "Point suivant",
+  "settings.rcamActionSave":
+    "Enregistrer le trajet",
+  "settings.rcamActionLoad":
+    "Charger le trajet",
   "settings.watchModsReload":
     "Rechargement auto lors des changements de dossier",
   "settings.watchModsReloadDesc":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -703,6 +703,42 @@ export const it: Translation = {
   "settings.autoRunFrostmod": "Avvia FrostMod automaticamente",
   "settings.autoRunFrostmodDesc":
     "Avvia FrostMod in background ogni volta che apri MXB App.",
+  "settings.rcamKeys":
+    "Tasti della telecamera replay",
+  "settings.rcamKeysDesc":
+    "Il gioco legge lo stesso tasto nello stesso momento, quindi scegli tasti che i tuoi comandi telecamera non usano — i tasti funzione e il tastierino numerico di solito sono liberi.",
+  "settings.rcamReset":
+    "Ripristina",
+  "settings.rcamPressKey":
+    "Premi un tasto",
+  "settings.rcamUnbound":
+    "Non assegnato",
+  "settings.rcamCaptureHint":
+    "Premi il tasto che vuoi. Esc annulla, Backspace cancella l'assegnazione.",
+  "settings.rcamAppliesHint":
+    "Si applica alla prossima apertura dell'editor in gioco — senza riavviare.",
+  "settings.rcamDuplicate":
+    "Due azioni condividono un tasto.",
+  "settings.rcamUnsupportedKey":
+    "FrostMod non può usare quel tasto.",
+  "settings.rcamSaveFailed":
+    "Impossibile salvare i tasti",
+  "settings.rcamActionSetkey":
+    "Imposta punto",
+  "settings.rcamActionDelete":
+    "Elimina punto",
+  "settings.rcamActionClear":
+    "Svuota percorso",
+  "settings.rcamActionPlay":
+    "Riproduci / ferma",
+  "settings.rcamActionPrev":
+    "Punto precedente",
+  "settings.rcamActionNext":
+    "Punto successivo",
+  "settings.rcamActionSave":
+    "Salva percorso",
+  "settings.rcamActionLoad":
+    "Carica percorso",
   "settings.watchModsReload": "Ricarica automatica alle modifiche",
   "settings.watchModsReloadDesc":
     "Ricarica il gioco automaticamente quando piste o moto vengono aggiunte alla cartella mod — anche se scaricate manualmente fuori da MXB App.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -706,6 +706,42 @@ export const ptBR: Translation = {
   "settings.autoRunFrostmod": "Iniciar o FrostMod automaticamente",
   "settings.autoRunFrostmodDesc":
     "Iniciar o FrostMod em segundo plano sempre que o MXB App abrir.",
+  "settings.rcamKeys":
+    "Teclas da câmera de replay",
+  "settings.rcamKeysDesc":
+    "O jogo lê a mesma tecla no mesmo instante, então escolha teclas que seus controles de câmera não usem — teclas de função e o teclado numérico costumam estar livres.",
+  "settings.rcamReset":
+    "Redefinir",
+  "settings.rcamPressKey":
+    "Pressione uma tecla",
+  "settings.rcamUnbound":
+    "Sem atalho",
+  "settings.rcamCaptureHint":
+    "Pressione a tecla desejada. Esc cancela, Backspace limpa o atalho.",
+  "settings.rcamAppliesHint":
+    "Vale na próxima vez que abrir o editor no jogo — sem reiniciar.",
+  "settings.rcamDuplicate":
+    "Duas ações usam a mesma tecla.",
+  "settings.rcamUnsupportedKey":
+    "O FrostMod não consegue usar essa tecla.",
+  "settings.rcamSaveFailed":
+    "Não foi possível salvar as teclas",
+  "settings.rcamActionSetkey":
+    "Marcar ponto",
+  "settings.rcamActionDelete":
+    "Excluir ponto",
+  "settings.rcamActionClear":
+    "Limpar trajeto",
+  "settings.rcamActionPlay":
+    "Reproduzir / parar",
+  "settings.rcamActionPrev":
+    "Ponto anterior",
+  "settings.rcamActionNext":
+    "Próximo ponto",
+  "settings.rcamActionSave":
+    "Salvar trajeto",
+  "settings.rcamActionLoad":
+    "Carregar trajeto",
   "settings.watchModsReload": "Recarregar automaticamente ao mudar a pasta",
   "settings.watchModsReloadDesc":
     "Recarregar o jogo automaticamente quando pistas ou motos forem adicionadas à sua pasta de mods — mesmo baixadas manualmente fora do MXB App.",


### PR DESCRIPTION
Reported in use: `S` is a camera-movement binding for some players, so pressing `S` to save a replay camera path also moved the camera.

FrostMod polls the keyboard and the game reads the same key on the same frame — nothing can swallow it, and a modifier doesn't help either, since the game ignores whether Ctrl was held. The fix is moving the action onto a key the game doesn't use, which needs somewhere to do it.

- **Settings → FrostMod** gains a keys panel: click an action, press the key. Esc cancels, Backspace unbinds, and a duplicate is called out rather than silently making one action unreachable.
- Read and written in FrostMod's own `frostmod_radar.cfg`, **merged** rather than rewritten, so the radar/overlay lines in the same file survive. A `.dlo` in the game's plugins folder keeps its config there, so that copy is written too — editing only ours would look like the setting did nothing in plugin mode.
- Key names are validated against FrostMod's table before writing; one it can't parse would leave a key that does nothing with no error to explain it. Capture reads `KeyboardEvent.code` (the physical key), because that's what the game reads.
- Shown only once FrostMod is installed.

Pairs with Frostn1/frostmod#25. Against an older FrostMod the panel still writes the config; it's ignored until FrostMod updates.

`cargo check` clean, 3 new Rust unit tests, `tsc` and eslint clean.