### PR TITLE
feat(frostmod): expose the hide-overlay key in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## 2026-08-31
 
 ### Added
+- The replay camera's new hide-overlay key (`F7` by default) can be rebound in
+  Settings → FrostMod alongside the rest.
+
+## 2026-08-31
+
+### Added
 - Settings → FrostMod now lets you rebind the replay camera editor's keys. The game reads
   the same key at the same moment, so `S` for save also moved the camera for anyone with
   `S` bound to move-backwards; now you can put the action on a key the game doesn't use.

--- a/src-tauri/src/frostmod_manage.rs
+++ b/src-tauri/src/frostmod_manage.rs
@@ -1222,7 +1222,7 @@ pub struct Keybind {
 
 /// Mirrors `kb::Actions()` in FrostMod's `src/keybinds.h`, in the same order. The ids are
 /// the config keys (`rcam_<id>`); the UI labels them itself, translated.
-const RCAM_ACTIONS: [(&str, &str); 8] = [
+const RCAM_ACTIONS: [(&str, &str); 9] = [
     ("setkey", "K"),
     ("delete", "X"),
     ("clear", "C"),
@@ -1231,6 +1231,9 @@ const RCAM_ACTIONS: [(&str, &str); 8] = [
     ("next", "Period"),
     ("save", "S"),
     ("load", "L"),
+    // Hiding the overlay defaults to a function key, not a letter: it is pressed while
+    // recording, so a key the game might have bound would be the wrong default.
+    ("clean", "F7"),
 ];
 
 /// Key names FrostMod can parse, beyond the plain letters and digits. Mirrors the table in
@@ -1413,10 +1416,12 @@ mod rcam_tests {
     fn defaults_match_frostmods() {
         // If FrostMod's defaults move, this is the reminder to move ours with them.
         let d = default_rcam_keybinds();
-        assert_eq!(d.len(), 8);
+        assert_eq!(d.len(), 9);
         assert_eq!(d[0].id, "setkey");
         assert_eq!(d[0].key, "K");
         assert_eq!(d[6].key, "S");
+        assert_eq!(d[8].id, "clean");
+        assert_eq!(d[8].key, "F7");
         for b in &d {
             assert!(valid_bind(&b.key), "default {} is not valid", b.key);
         }

--- a/src/Components/Settings/ReplayCameraKeys.tsx
+++ b/src/Components/Settings/ReplayCameraKeys.tsx
@@ -22,6 +22,7 @@ const ACTION_LABELS: Record<string, TKey> = {
   next: "settings.rcamActionNext",
   save: "settings.rcamActionSave",
   load: "settings.rcamActionLoad",
+  clean: "settings.rcamActionClean",
 };
 
 /** `KeyboardEvent.code` -> the name FrostMod parses. Physical codes on purpose: the game

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -746,6 +746,8 @@ export const de: Translation = {
     "Nächster Punkt",
   "settings.rcamActionSave":
     "Pfad speichern",
+  "settings.rcamActionClean":
+    "Overlay ausblenden",
   "settings.rcamActionLoad":
     "Pfad laden",
   "settings.watchModsReload": "Automatisch neu laden bei Ordneränderungen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -732,6 +732,8 @@ export const en = {
     "Next key",
   "settings.rcamActionSave":
     "Save path",
+  "settings.rcamActionClean":
+    "Hide overlay",
   "settings.rcamActionLoad":
     "Load path",
   "settings.watchModsReload": "Auto-reload on folder changes",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -738,6 +738,8 @@ export const es: Translation = {
     "Punto siguiente",
   "settings.rcamActionSave":
     "Guardar trayecto",
+  "settings.rcamActionClean":
+    "Ocultar superposición",
   "settings.rcamActionLoad":
     "Cargar trayecto",
   "settings.watchModsReload": "Recarga automática al cambiar la carpeta",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -742,6 +742,8 @@ export const fr: Translation = {
     "Point suivant",
   "settings.rcamActionSave":
     "Enregistrer le trajet",
+  "settings.rcamActionClean":
+    "Masquer la surcouche",
   "settings.rcamActionLoad":
     "Charger le trajet",
   "settings.watchModsReload":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -737,6 +737,8 @@ export const it: Translation = {
     "Punto successivo",
   "settings.rcamActionSave":
     "Salva percorso",
+  "settings.rcamActionClean":
+    "Nascondi overlay",
   "settings.rcamActionLoad":
     "Carica percorso",
   "settings.watchModsReload": "Ricarica automatica alle modifiche",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -740,6 +740,8 @@ export const ptBR: Translation = {
     "Próximo ponto",
   "settings.rcamActionSave":
     "Salvar trajeto",
+  "settings.rcamActionClean":
+    "Ocultar sobreposição",
   "settings.rcamActionLoad":
     "Carregar trajeto",
   "settings.watchModsReload": "Recarregar automaticamente ao mudar a pasta",


### PR DESCRIPTION
FrostMod gained a key that hides everything it draws, for recording a replay (Frostn1/frostmod#27).

The Settings list mirrors FrostMod's action table, so it needs the ninth entry — otherwise the new key is the one thing you can't rebind. Defaults to `F7` to match FrostMod: a function key rather than a letter, since it's pressed while recording and the game binds letters.

Label translated in all six locales. `tsc` clean, Rust tests updated and passing.