### PR TITLE
chore(release): v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,13 @@
 # Changelog
 
-## 2026-08-31
-
-### Added
-- The replay camera's new hide-overlay key (`F7` by default) can be rebound in
-  Settings → FrostMod alongside the rest.
-
-## 2026-08-31
+## 2026-08-31 — v0.12.1
 
 ### Added
 - Settings → FrostMod now lets you rebind the replay camera editor's keys. The game reads
   the same key at the same moment, so `S` for save also moved the camera for anyone with
   `S` bound to move-backwards; now you can put the action on a key the game doesn't use.
+- The hide-overlay key (`F7` by default), which hides everything FrostMod draws for
+  recording a replay, is rebindable there too.
 - Keys are written into FrostMod's own config, including a plugin-folder install, and take
   effect the next time the editor opens.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.12.1",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "mxb-app"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # whatever cargo called it. Cargo target names can't hold a space, so this is as close as
 # it gets. The description is what Windows Task Manager shows in its Processes tab.
 name = "mxb-app"
-version = "0.12.0"
+version = "0.12.1"
 description = "MXB App — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
   "mainBinaryName": "MXB App",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/Components/Showcase/releases.ts
+++ b/src/Components/Showcase/releases.ts
@@ -9,6 +9,7 @@
  * else knows about versions.
  */
 import {
+  EyeOff,
   Mountain,
   Sun,
   Ruler,
@@ -70,6 +71,19 @@ export interface Release {
 }
 
 export const RELEASES: Release[] = [
+  {
+    version: "0.12.1",
+    hero: {
+      icon: Keyboard,
+      title: "showcase.v0121.hero.title",
+      body: "showcase.v0121.hero.body",
+    },
+    highlights: [
+      { icon: Keyboard, text: "showcase.v0121.rebind" },
+      { icon: Gamepad2, text: "showcase.v0121.clash" },
+      { icon: EyeOff, text: "showcase.v0121.clean" },
+    ],
+  },
   {
     version: "0.11.3",
     hero: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1461,6 +1461,16 @@ export const de: Translation = {
   "showcase.supporters.title_one": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.title_other": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.more": "+{{count}} weitere",
+  "showcase.v0121.hero.title":
+    "Deine Replay-Kamera-Tasten, deine Tastatur",
+  "showcase.v0121.hero.body":
+    "FrostMods Replay-Kamera liest die Tastatur direkt — und das Spiel im selben Moment ebenso. Wenn S deine Kamera rückwärts bewegt, hat S zum Speichern eines Pfads auch die Kamera bewegt. Jede Taste des Editors lässt sich jetzt dorthin legen, wo das Spiel nicht hinfasst.",
+  "showcase.v0121.rebind":
+    "Belege jede Editor-Taste neu unter Einstellungen → FrostMod: Aktion anklicken, Taste drücken.",
+  "showcase.v0121.clash":
+    "Wähle eine Taste, die deine Kamerasteuerung nicht nutzt. Funktionstasten und der Ziffernblock sind meist frei; ein Modifier hilft nicht, das Spiel sieht die Taste darunter trotzdem.",
+  "showcase.v0121.clean":
+    "F7 blendet alles aus, was FrostMod zeichnet — Panel, Radar, Umrisse — für saubere Aufnahmen.",
   "showcase.v0113.hero.title":
     "Jede Strecke \u00f6ffnet sich als der Ort, der sie ist",
   "showcase.v0113.hero.body":

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1422,6 +1422,16 @@ export const en = {
   "showcase.supporters.title_one": "Made possible by {{count}} supporter",
   "showcase.supporters.title_other": "Made possible by {{count}} supporters",
   "showcase.supporters.more": "+{{count}} more",
+  "showcase.v0121.hero.title":
+    "Your replay camera keys, your keyboard",
+  "showcase.v0121.hero.body":
+    "FrostMod's replay camera reads the keyboard directly, and so does the game — at the same moment. If S moves your camera backwards, pressing S to save a path moved the camera too. Every key the editor uses can now be moved somewhere the game leaves alone.",
+  "showcase.v0121.rebind":
+    "Rebind any of the editor's keys in Settings → FrostMod: click an action, press the key.",
+  "showcase.v0121.clash":
+    "Pick a key your camera controls don't use. Function keys and the numpad are usually free; a modifier won't help, because the game still sees the key underneath.",
+  "showcase.v0121.clean":
+    "F7 hides everything FrostMod draws — panel, radar, outlines — so a recorded pass is clean.",
   "showcase.v0113.hero.title":
     "Every track opens as the place it is",
   "showcase.v0113.hero.body":

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1448,6 +1448,16 @@ export const es: Translation = {
   "showcase.supporters.title_one": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.title_other": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.more": "+{{count}} más",
+  "showcase.v0121.hero.title":
+    "Tus teclas de la cámara de repetición, tu teclado",
+  "showcase.v0121.hero.body":
+    "La cámara de repetición de FrostMod lee el teclado directamente, y el juego hace lo mismo en el mismo instante. Si S mueve tu cámara hacia atrás, pulsar S para guardar un trayecto también movía la cámara. Ahora cada tecla del editor puede ir a donde el juego no llega.",
+  "showcase.v0121.rebind":
+    "Reasigna cualquier tecla del editor en Ajustes → FrostMod: pulsa una acción y luego la tecla.",
+  "showcase.v0121.clash":
+    "Elige una tecla que tus controles de cámara no usen. Las teclas de función y el teclado numérico suelen estar libres; un modificador no sirve, porque el juego sigue viendo la tecla de debajo.",
+  "showcase.v0121.clean":
+    "F7 oculta todo lo que dibuja FrostMod — panel, radar, contornos — para grabar limpio.",
   "showcase.v0113.hero.title":
     "Cada pista se abre como el lugar que es",
   "showcase.v0113.hero.body":

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1452,6 +1452,16 @@ export const fr: Translation = {
   "showcase.supporters.title_one": "Rendu possible par {{count}} soutien",
   "showcase.supporters.title_other": "Rendu possible par {{count}} soutiens",
   "showcase.supporters.more": "+{{count}} autres",
+  "showcase.v0121.hero.title":
+    "Tes touches de caméra replay, ton clavier",
+  "showcase.v0121.hero.body":
+    "La caméra replay de FrostMod lit le clavier directement, et le jeu aussi, au même instant. Si S recule ta caméra, appuyer sur S pour enregistrer un trajet la faisait reculer aussi. Chaque touche de l'éditeur peut désormais aller là où le jeu ne va pas.",
+  "showcase.v0121.rebind":
+    "Réattribue n'importe quelle touche de l'éditeur dans Paramètres → FrostMod : clique une action, appuie sur la touche.",
+  "showcase.v0121.clash":
+    "Choisis une touche que tes commandes de caméra n'utilisent pas. Les touches de fonction et le pavé numérique sont souvent libres ; un modificateur n'y change rien, le jeu voit toujours la touche en dessous.",
+  "showcase.v0121.clean":
+    "F7 masque tout ce que FrostMod dessine — panneau, radar, contours — pour un enregistrement propre.",
   "showcase.v0113.hero.title":
     "Chaque piste s\u2019ouvre comme le lieu qu\u2019elle est",
   "showcase.v0113.hero.body":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1443,6 +1443,16 @@ export const it: Translation = {
   "showcase.supporters.title_one": "Reso possibile da {{count}} sostenitore",
   "showcase.supporters.title_other": "Reso possibile da {{count}} sostenitori",
   "showcase.supporters.more": "+{{count}} altri",
+  "showcase.v0121.hero.title":
+    "I tasti della telecamera replay, sulla tua tastiera",
+  "showcase.v0121.hero.body":
+    "La telecamera replay di FrostMod legge la tastiera direttamente, e il gioco fa lo stesso nello stesso istante. Se S sposta la telecamera indietro, premere S per salvare un percorso la spostava comunque. Ora ogni tasto dell'editor può stare dove il gioco non arriva.",
+  "showcase.v0121.rebind":
+    "Riassegna qualsiasi tasto dell'editor in Impostazioni → FrostMod: clicca un'azione, premi il tasto.",
+  "showcase.v0121.clash":
+    "Scegli un tasto che i tuoi comandi telecamera non usano. I tasti funzione e il tastierino numerico di solito sono liberi; un modificatore non aiuta, perché il gioco vede comunque il tasto sotto.",
+  "showcase.v0121.clean":
+    "F7 nasconde tutto ciò che FrostMod disegna — pannello, radar, contorni — per registrare pulito.",
   "showcase.v0113.hero.title":
     "Ogni pista si apre come il luogo che \u00e8",
   "showcase.v0113.hero.body":

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1441,6 +1441,16 @@ export const ptBR: Translation = {
   "showcase.supporters.title_one": "Possível graças a {{count}} apoiador",
   "showcase.supporters.title_other": "Possível graças a {{count}} apoiadores",
   "showcase.supporters.more": "+{{count}} outros",
+  "showcase.v0121.hero.title":
+    "As teclas da câmera de replay são suas",
+  "showcase.v0121.hero.body":
+    "A câmera de replay do FrostMod lê o teclado direto, e o jogo lê a mesma tecla no mesmo instante. Se S move sua câmera para trás, apertar S para salvar um trajeto movia a câmera também. Agora cada tecla do editor pode ir para onde o jogo não mexe.",
+  "showcase.v0121.rebind":
+    "Reconfigure qualquer tecla do editor em Configurações → FrostMod: clique numa ação e pressione a tecla.",
+  "showcase.v0121.clash":
+    "Escolha uma tecla que seus controles de câmera não usem. Teclas de função e o teclado numérico costumam estar livres; um modificador não resolve, porque o jogo continua vendo a tecla embaixo.",
+  "showcase.v0121.clean":
+    "F7 esconde tudo o que o FrostMod desenha — painel, radar, contornos — para gravar limpo.",
   "showcase.v0113.hero.title":
     "Cada pista abre como o lugar que ela \u00e9",
   "showcase.v0113.hero.body":


### PR DESCRIPTION
Patch release: the replay camera keys are rebindable from Settings, including the new hide-overlay key.

- Version bumped in `package.json`, `tauri.conf.json` and `Cargo.toml`.
- The two unreleased `## 2026-08-31` sections consolidated into one `v0.12.1` section — parallel branches had each added their own heading. `release-notes.sh v0.12.1` renders.
- What's new entry added with strings in all six locales. Worth noting v0.12.0 shipped without one.