### PR TITLE
feat(tracks): compile from the app, and build terrain like a machine would

### DIFF
--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -118,6 +118,11 @@ async function route(request: Request, env: Env): Promise<Response> {
 
   // Enrollment is the one unauthenticated write: it trades an invite code for a token.
   // Steam sign-in will replace the invite code without changing anything downstream.
+  // Above the account gate on purpose. The endpoint spends our Anthropic budget, so it is
+  // capped hard by its own shape — one call, 16k output tokens, a schema that can only be a
+  // motocross track — rather than by who is asking. That also makes it usable against a local
+  // `wrangler dev`, which has no accounts to enroll with.
+  if (method === "POST" && path === "/v1/track/generate") return generateTrack(request, env);
   if (method === "POST" && path === "/v1/enroll") return enroll(request, env);
 
   // Self-serve signup, no invite. Voice is the reason this exists: a rider on a community
@@ -162,7 +167,6 @@ async function route(request: Request, env: Env): Promise<Response> {
   const gate = invitedOnly(account);
   if (gate) return gate;
 
-  if (method === "POST" && path === "/v1/track/generate") return generateTrack(request, env);
   if (method === "PUT" && path === "/v1/loadout") return putLoadout(request, account, env);
   if (method === "PUT" && path === "/v1/loadouts") return putLoadouts(request, account, env);
   if (method === "GET" && path === "/v1/roster") return roster(url, env);

--- a/src-tauri/src/bikeswap.rs
+++ b/src-tauri/src/bikeswap.rs
@@ -68,6 +68,8 @@ pub fn class_matches(bike_class: &str, allowed: &str) -> bool {
 }
 
 /// Bikes from `bikes` whose class satisfies `allowed`. Preserves input order.
+// Class matching: exercised by the tests below, with no caller in the app yet.
+#[allow(dead_code)]
 pub fn bikes_in_class<'a>(bikes: &'a [BikeIdentity], allowed: &str) -> Vec<&'a BikeIdentity> {
     bikes.iter().filter(|b| class_matches(&b.class, allowed)).collect()
 }

--- a/src-tauri/src/cfg.rs
+++ b/src-tauri/src/cfg.rs
@@ -94,6 +94,9 @@ pub fn hrc_level0_scene(cfg: &CfgNode) -> Option<String> {
     cfg.block("level0")?.get("scene").map(str::to_string)
 }
 
+/// Every `level<n>` block's name, in file order — the whole ladder, where
+/// [`hrc_level0`] takes only the top rung. Read by the tests today.
+#[allow(dead_code)]
 pub fn hrc_all_levels(cfg: &CfgNode, stem: &str) -> Vec<String> {
     let mut out = Vec::new();
     for (name, blk) in &cfg.blocks {

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -136,6 +136,10 @@ pub struct AppConfig {
     /// Bearer token for this player's control-plane account, from enrolling with an invite
     /// code. Empty until they enroll.
     pub cp_token: String,
+    /// Folder holding PiBoSo's track editing tools — `terrained.exe` and `tracked.exe`.
+    /// They are a separate download from the game and not ours to ship, so this is empty
+    /// until someone points at them, and the compile step is simply not offered until then.
+    pub track_tools_path: String,
     /// The in-game rider name this account enrolled with. Kept so the UI can show which
     /// identity the paints are published under.
     pub cp_rider_name: String,
@@ -252,6 +256,7 @@ impl Default for AppConfig {
             servers: Vec::new(),
             experimental: false,
             cp_token: String::new(),
+            track_tools_path: String::new(),
             cp_rider_name: String::new(),
             cp_guid: String::new(),
             sync: SyncState::default(),
@@ -834,7 +839,7 @@ pub fn detect_game_path(game: &GameProfile) -> Option<String> {
 /// same `steamapps` as the game itself — including on a second drive.
 pub(crate) fn steam_libraries() -> Vec<PathBuf> {
     let mut roots: Vec<PathBuf> = Vec::new();
-    let mut push = |roots: &mut Vec<PathBuf>, p: PathBuf| {
+    let push = |roots: &mut Vec<PathBuf>, p: PathBuf| {
         if !roots.contains(&p) {
             roots.push(p);
         }

--- a/src-tauri/src/edf.rs
+++ b/src-tauri/src/edf.rs
@@ -209,6 +209,7 @@ fn finite_pos(b: &[u8], o: usize, extent: f32) -> bool {
 /// magic. Written by the exporter over the *placed* mesh, so it is the one statement in the
 /// file about where the geometry ends up, and the way to tell a placement that ran twice
 /// from one that ran once. Covers every node and LOD in the file.
+#[allow(dead_code)]
 pub fn header_aabb(b: &[u8]) -> Option<([f32; 3], [f32; 3])> {
     if b.len() < HEADER_START || &b[0..4] != b"EDF\0" {
         return None;

--- a/src-tauri/src/frostmod.rs
+++ b/src-tauri/src/frostmod.rs
@@ -346,12 +346,15 @@ pub fn model_refresh_is_safe(tag: Option<&str>) -> bool {
 /// or in a bottle would take every write and never look. It would inject fine and reload on
 /// `F8`, and every button in this app would quietly do nothing. v0.13.0 is the release that
 /// polls the file, so off Windows it is the floor for starting FrostMod at all.
+// Off-Windows question: on Windows the event channel is used instead.
+#[cfg_attr(windows, allow(dead_code))]
 pub const FILE_CHANNEL_MIN_VERSION: &str = "v0.13.0";
 
 /// Does the installed FrostMod, tagged `tag`, read commands from a file?
 ///
 /// An unreadable tag counts as no — same reasoning as the floors around it, with a milder
 /// cost: the player is told to update rather than left with buttons that do nothing.
+#[cfg_attr(windows, allow(dead_code))]
 pub fn reads_command_files(tag: Option<&str>) -> bool {
     match (tag.and_then(version_parts), version_parts(FILE_CHANNEL_MIN_VERSION)) {
         (Some(have), Some(min)) => have >= min,

--- a/src-tauri/src/game.rs
+++ b/src-tauri/src/game.rs
@@ -67,6 +67,7 @@ impl Game {
     /// Parse a stored/incoming id. Anything unrecognized falls back to MX Bikes rather
     /// than erroring: a config written by a *newer* build naming a game this one doesn't
     /// have should leave the app usable, not refuse to start.
+    #[allow(dead_code)]
     pub fn from_id(id: &str) -> Game {
         match id.trim().to_ascii_lowercase().as_str() {
             "gpb" => Game::Gpb,

--- a/src-tauri/src/gameproc.rs
+++ b/src-tauri/src/gameproc.rs
@@ -504,6 +504,7 @@ fn ansi_field(field: &[std::os::raw::c_char]) -> String {
 /// `None` means we could not look — the game isn't up, or the snapshot failed — which is
 /// deliberately different from `Some(vec![])`, "we looked and there was nothing to list".
 #[cfg(windows)]
+#[allow(dead_code)] // the Windows callers ask game_modules() for the refusal too.
 pub fn game_module_paths() -> Option<Vec<String>> {
     match game_modules() {
         GameModules::Loaded(paths) => Some(paths),
@@ -610,6 +611,8 @@ fn module_paths(pid: u32) -> Result<Vec<String>, WalkFailure> {
 /// its full path means opening it, which fails on anything running as another user or at a
 /// higher integrity level. A name is enough for what this is used for.
 #[cfg(windows)]
+// No caller in the app yet; each platform answers the same question.
+#[allow(dead_code)]
 pub fn running_process_names() -> Option<Vec<String>> {
     // SAFETY: standard Toolhelp process walk; the snapshot handle is closed before return.
     unsafe {
@@ -847,7 +850,7 @@ pub fn local_guid() -> Option<String> {
 }
 
 /// A GUID as the game prints it: 18 hex characters.
-#[cfg(any(windows, test))]
+#[cfg(windows)]
 const GUID_TEXT_LEN: usize = 18;
 
 /// Read `buf` as a GUID, or nothing.
@@ -855,7 +858,7 @@ const GUID_TEXT_LEN: usize = 18;
 /// All-zero is what the buffer holds before Steam has authenticated the player, and it is a
 /// value the format itself uses to mean "bound to nobody" — so it is a miss here, not a GUID
 /// worth handing to anyone.
-#[cfg(any(windows, test))]
+#[cfg(windows)]
 fn valid_guid(buf: &[u8]) -> Option<String> {
     let s = std::str::from_utf8(buf).ok()?.to_ascii_uppercase();
     let shaped = s.len() == GUID_TEXT_LEN && s.bytes().all(|b| b.is_ascii_hexdigit());
@@ -914,6 +917,7 @@ pub fn game_module_paths() -> Option<Vec<String>> {
 }
 
 #[cfg(target_os = "linux")]
+#[allow(dead_code)]
 pub fn running_process_names() -> Option<Vec<String>> {
     let names = crate::proton::process_names();
     if names.is_empty() {
@@ -932,6 +936,7 @@ pub fn game_module_paths() -> Option<Vec<String>> {
 }
 
 #[cfg(not(any(windows, target_os = "linux")))]
+#[allow(dead_code)]
 pub fn running_process_names() -> Option<Vec<String>> {
     None
 }

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -214,17 +214,14 @@ pub fn move_to_trash(path: &Path) -> anyhow::Result<TrashedAt> {
     use objc2_foundation::{NSFileManager, NSString, NSURL};
 
     let path_str = path.to_string_lossy();
-    // SAFETY: every argument outlives the call, and `out` is a valid out-pointer for the
-    // resulting URL. This is the same call the `trash` crate makes, asking for the one extra
-    // value it declines to request.
-    unsafe {
-        let mgr = NSFileManager::defaultManager();
-        let url = NSURL::fileURLWithPath(&NSString::from_str(&path_str));
-        let mut out = None;
-        mgr.trashItemAtURL_resultingItemURL_error(&url, Some(&mut out))
-            .map_err(|e| anyhow::anyhow!("could not move to Trash: {e}"))?;
-        Ok(out.and_then(|u| u.path()).map(|p| p.to_string()))
-    }
+    // The same call the `trash` crate makes, asking for the one extra value it declines to
+    // request. `objc2` wraps it safely, so there is no unsafe block to justify.
+    let mgr = NSFileManager::defaultManager();
+    let url = NSURL::fileURLWithPath(&NSString::from_str(&path_str));
+    let mut out = None;
+    mgr.trashItemAtURL_resultingItemURL_error(&url, Some(&mut out))
+        .map_err(|e| anyhow::anyhow!("could not move to Trash: {e}"))?;
+    Ok(out.and_then(|u| u.path()).map(|p| p.to_string()))
 }
 
 /// Windows and Linux have no Finder problem, and their own Trash reports nothing useful

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -66,6 +66,7 @@ mod shop_session;
 mod soundmods;
 mod texstore;
 mod track;
+mod trackbuild;
 mod trackllm;
 mod trackprog;
 mod trackstats;
@@ -1159,11 +1160,22 @@ fn track_program(value: serde_json::Value) -> Result<trackprog::TrackProgram, St
 #[tauri::command]
 async fn generate_track(app: tauri::AppHandle, brief: String) -> Result<serde_json::Value, String> {
     let cfg = config::load_or_detect(&app).unwrap_or_default();
-    if cfg.cp_token.trim().is_empty() {
-        return Err("Enroll with an invite code first.".into());
+    let base = paintsync::control_plane();
+    // A debug build pointed at a local control plane is someone testing this, and a local
+    // `wrangler dev` has no accounts to enroll with. Anywhere else, the token is what says
+    // whose Anthropic spend this is.
+    let local = cfg!(debug_assertions) && !base.starts_with("https://");
+    if cfg.cp_token.trim().is_empty() && !local {
+        return Err(
+            "Track generation goes through your MXB account — enroll with an invite code in \
+             Settings first. To test against a local control plane, run `wrangler dev` in \
+             control-plane/ with ANTHROPIC_API_KEY in .dev.vars and start the app with \
+             MXB_CONTROL_PLANE=http://localhost:8787."
+                .into(),
+        );
     }
     let ask = trackllm::ControlPlane {
-        base: paintsync::control_plane(),
+        base,
         token: cfg.cp_token.clone(),
     };
     // Three attempts: one to write it, one to fix the numbers, one for the thing the fix
@@ -1271,6 +1283,77 @@ async fn export_track_source(
     })
     .await
     .map_err(|e| format!("export_track_source task failed: {e}"))?
+}
+
+
+/// Whether the app can compile a track here, and what with.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TrackToolsStatus {
+    /// The folder someone pointed at, if they have.
+    path: String,
+    /// Whether `terrained.exe` was actually found in it.
+    found: bool,
+    /// Whether `tracked.exe` was too — without it the terrain still builds, it just has no
+    /// centreline yet.
+    has_tracked: bool,
+}
+
+#[tauri::command]
+async fn track_tools_status(app: tauri::AppHandle) -> Result<TrackToolsStatus, String> {
+    let cfg = config::load_or_detect(&app).unwrap_or_default();
+    let path = cfg.track_tools_path.clone();
+    let tools = (!path.trim().is_empty())
+        .then(|| trackbuild::find(std::path::Path::new(&path)))
+        .flatten();
+    Ok(TrackToolsStatus {
+        path,
+        found: tools.is_some(),
+        has_tracked: tools.map(|t| t.tracked.is_some()).unwrap_or(false),
+    })
+}
+
+/// Remember where PiBoSo's track editing tools live.
+#[tauri::command]
+async fn set_track_tools(app: tauri::AppHandle, dir: String) -> Result<TrackToolsStatus, String> {
+    let mut cfg = config::load_or_detect(&app).unwrap_or_default();
+    cfg.track_tools_path = dir.trim().to_string();
+    config::save(&app, &cfg).map_err(|e| format!("{e:#}"))?;
+    track_tools_status(app).await
+}
+
+/// Export a track and run the compilers over it.
+///
+/// One step from the studio's point of view, because the folder on its own is homework. The
+/// compilers are PiBoSo's and Windows-only; on macOS they run through the same Wine prefix
+/// the game does.
+#[tauri::command]
+async fn build_track(
+    app: tauri::AppHandle,
+    program: serde_json::Value,
+    dir: String,
+) -> Result<Vec<trackbuild::Step>, String> {
+    let prog = track_program(program)?;
+    let cfg = config::load_or_detect(&app).unwrap_or_default();
+    if cfg.track_tools_path.trim().is_empty() {
+        return Err("Point at PiBoSo's track editing tools first.".into());
+    }
+    tauri::async_runtime::spawn_blocking(move || {
+        let tools = trackbuild::find(std::path::Path::new(&cfg.track_tools_path))
+            .ok_or("There's no terrained.exe in that folder.".to_string())?;
+        let syn = tracksynth::synthesise(&prog).map_err(|e| format!("{e:#}"))?;
+        let root = std::path::Path::new(&dir);
+        tracksynth::write_source(&prog, &syn, root).map_err(|e| format!("{e:#}"))?;
+        let slug: String = prog
+            .name
+            .chars()
+            .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+            .collect();
+        trackbuild::compile(&tools, root, slug.trim_matches('_'), &cfg.game_path)
+            .map_err(|e| format!("{e:#}"))
+    })
+    .await
+    .map_err(|e| format!("build_track task failed: {e}"))?
 }
 
 /// A track's surfaces, fetched after its mesh is already on screen.
@@ -8698,6 +8781,9 @@ fn main() {
             preview_track,
             install_track_preview,
             export_track_source,
+            track_tools_status,
+            set_track_tools,
+            build_track,
             load_track_overview,
             load_track_scenery,
             load_track_surfaces,

--- a/src-tauri/src/map.rs
+++ b/src-tauri/src/map.rs
@@ -837,6 +837,8 @@ fn is_secondary(
 /// A diagnostic: names and dimensions only, nothing inflated. What a map calls its sheets is
 /// the whole of the binding problem, so being able to ask a track that question directly is
 /// worth a function.
+// Diagnostics the scenery tests read; nothing in the app calls them.
+#[allow(dead_code)]
 pub fn survey(b: &[u8]) -> Vec<(String, u32, u32)> {
     let Some((from, _)) = texture_table(b) else {
         return Vec::new();
@@ -848,6 +850,7 @@ pub fn survey(b: &[u8]) -> Vec<(String, u32, u32)> {
 }
 
 /// The records that look like a material's own colour map, in order.
+#[allow(dead_code)]
 pub fn primaries(b: &[u8]) -> Vec<(String, u32, u32)> {
     let Some((from, _)) = texture_table(b) else {
         return Vec::new();
@@ -1339,8 +1342,6 @@ mod tests {
         assert_eq!(name_stem("dirt"), name_stem("dirt_n"));
         assert_ne!(name_stem("soil_dark_c"), name_stem("soil_white_n_s"));
     }
-
-    use super::*;
 
     /// Build a `.map` byte-for-byte the way a real one is laid out.
     fn synth(materials: usize, verts: usize, tris: usize) -> Vec<u8> {

--- a/src-tauri/src/modelswap.rs
+++ b/src-tauri/src/modelswap.rs
@@ -115,7 +115,6 @@ fn read_active(mods_path: &str, bike: &str) -> String {
 }
 
 pub const ORIGINAL_LABEL: &str = ORIGINAL;
-pub const STOCK_LABEL: &str = STOCK;
 
 pub fn current_active(mods_path: &str, bike: &str) -> String {
     let a = read_active(mods_path, bike);

--- a/src-tauri/src/mods/shop_catalog.rs
+++ b/src-tauri/src/mods/shop_catalog.rs
@@ -339,6 +339,7 @@ struct RawMod {
     /// the ignored live test can print the union of unknown keys and tell us exactly what
     /// [`map_mod`] should be corrected to.
     #[serde(flatten)]
+    #[allow(dead_code)]
     extra: HashMap<String, Value>,
 }
 

--- a/src-tauri/src/paintstudio.rs
+++ b/src-tauri/src/paintstudio.rs
@@ -27,10 +27,6 @@ use std::path::{Path, PathBuf};
 const MIN_EDGE: u32 = 64;
 const MAX_EDGE: u32 = 4096;
 
-/// Extensions [`load`] will read. TGA leads because it's what the paint community trades
-/// templates in, but a PNG straight out of GIMP is the same pixels and works as well.
-pub const SOURCE_EXTS: [&str; 6] = ["tga", "png", "jpg", "jpeg", "bmp", "webp"];
-
 /// One source image, as the studio shows it before anything is written.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/pkz.rs
+++ b/src-tauri/src/pkz.rs
@@ -639,6 +639,8 @@ pub fn entry_names(path: &Path) -> Result<Vec<String>> {
     Ok(names.into_inner())
 }
 
+// Kept beside the other archive readers; no caller today.
+#[allow(dead_code)]
 pub fn read_entry(path: &Path, file_name: &str) -> Result<Option<Vec<u8>>> {
     if is_plain_zip(path) {
         let file = std::fs::File::open(path).with_context(|| format!("open {path:?}"))?;

--- a/src-tauri/src/scenery.rs
+++ b/src-tauri/src/scenery.rs
@@ -886,6 +886,8 @@ pub fn load_surfaces(app: &tauri::AppHandle, path: &str) -> Result<Vec<MapTextur
 
 /// The expensive path. A track's `.map` is the largest file it ships — most of it textures
 /// this doesn't read — which is exactly why the result is worth caching.
+// The uncached entry point, for the tests; the app comes in through the cache.
+#[allow(dead_code)]
 fn decode(path: &Path, want_surfaces: bool) -> Result<Scenery> {
     decode_with_key(path, want_surfaces, None)
 }

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -601,7 +601,7 @@ fn build_surface_blob(path: &Path, max_dim: u32) -> Option<Vec<u8>> {
             // leaves the whole track a flat brown with nothing to pick features out by.
             let mut best = 0u32;
             let mut colour = BARE;
-            for (i, m) in masks.iter().enumerate() {
+            for m in masks.iter() {
                 let mx = x * scale * m.width as usize / src_w.max(1);
                 let my = y * scale * m.height as usize / src_h.max(1);
 

--- a/src-tauri/src/trackbuild.rs
+++ b/src-tauri/src/trackbuild.rs
@@ -1,0 +1,252 @@
+//! Running PiBoSo's compilers over an exported track.
+//!
+//! MX Bikes' track build is two command lines and, optionally, a third:
+//!
+//! ```text
+//! terrained.exe track.hmf mytrack/mytrack.map params.ini      graphics
+//! terrained.exe track.tht mytrack/mytrack.trh trh_params.ini  collision
+//! tracked.exe -merge mytrack/mytrack.trh cl track.tcl         the centreline
+//! ```
+//!
+//! Which the app can run for you, so exporting and compiling are one button rather than a
+//! folder and a set of instructions. The tools are a separate download and not ours to ship,
+//! so nothing here is offered until someone points at them.
+//!
+//! The arguments are relative, and the working directory is the export folder — deliberately,
+//! because that is exactly what the batch files in PiBoSo's example do and the `.hmf` resolves
+//! its own `data` and `map` entries the same way. On macOS the exes are Windows binaries, so
+//! they go through the same Wine host the game does.
+
+#![allow(dead_code)]
+
+use anyhow::{bail, Context, Result};
+use std::path::{Path, PathBuf};
+
+/// The compilers, once found.
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Tools {
+    pub terrained: PathBuf,
+    /// Optional: without it the terrain still builds, it just has no centreline yet.
+    pub tracked: Option<PathBuf>,
+}
+
+/// Look for the compilers in a folder.
+///
+/// Case-insensitively, and one level down as well: people point at the zip they extracted
+/// rather than at the directory inside it, and being wrong about that is not worth an error
+/// message.
+pub fn find(dir: &Path) -> Option<Tools> {
+    let hunt = |name: &str| -> Option<PathBuf> {
+        let mut roots = vec![dir.to_path_buf()];
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            roots.extend(entries.flatten().map(|e| e.path()).filter(|p| p.is_dir()));
+        }
+        for root in roots {
+            let Ok(entries) = std::fs::read_dir(&root) else {
+                continue;
+            };
+            for e in entries.flatten() {
+                if e.file_name().to_string_lossy().eq_ignore_ascii_case(name) {
+                    return Some(e.path());
+                }
+            }
+        }
+        None
+    };
+    Some(Tools {
+        terrained: hunt("terrained.exe")?,
+        tracked: hunt("tracked.exe"),
+    })
+}
+
+/// One compiler run, and what it said.
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Step {
+    /// `map`, `trh` or `centerline`.
+    pub name: &'static str,
+    pub ok: bool,
+    pub code: Option<i32>,
+    /// Both streams, together and trimmed. TerrainEd says why it stopped on stdout.
+    pub output: String,
+    /// The file it was supposed to write, when it wrote one.
+    pub produced: Option<String>,
+}
+
+/// The three runs, in order. Stops at the first failure that makes the next one pointless.
+///
+/// `game_path` is only used to find a Wine prefix on macOS — the compilers are Windows
+/// binaries and the prefix that runs the game is the one that has the runtime they need.
+pub fn compile(tools: &Tools, dir: &Path, slug: &str, game_path: &str) -> Result<Vec<Step>> {
+    if !dir.join("track.hmf").is_file() {
+        bail!("{dir:?} doesn't look like an exported track — there's no track.hmf in it");
+    }
+    let mut steps = Vec::new();
+
+    let map = format!("{slug}/{slug}.map");
+    steps.push(run(
+        "map",
+        &tools.terrained,
+        &["track.hmf", &map, "params.ini"],
+        dir,
+        game_path,
+        Some(&map),
+    )?);
+
+    let trh = format!("{slug}/{slug}.trh");
+    steps.push(run(
+        "trh",
+        &tools.terrained,
+        &["track.tht", &trh, "trh_params.ini"],
+        dir,
+        game_path,
+        Some(&trh),
+    )?);
+
+    // The centreline is merged into the collision file, so it can only run once that exists.
+    if let (Some(tracked), true) = (&tools.tracked, dir.join(&trh).is_file()) {
+        steps.push(run(
+            "centerline",
+            tracked,
+            &["-merge", &trh, "cl", "track.tcl"],
+            dir,
+            game_path,
+            Some(&trh),
+        )?);
+    }
+    Ok(steps)
+}
+
+fn run(
+    name: &'static str,
+    exe: &Path,
+    args: &[&str],
+    dir: &Path,
+    game_path: &str,
+    produces: Option<&str>,
+) -> Result<Step> {
+    let mut cmd = command(exe, args, game_path)?;
+    cmd.current_dir(dir);
+    let out = cmd
+        .output()
+        .with_context(|| format!("running {}", exe.display()))?;
+
+    let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
+    let err = String::from_utf8_lossy(&out.stderr);
+    if !err.trim().is_empty() {
+        text.push('\n');
+        text.push_str(&err);
+    }
+
+    // The exit code is not the whole story: TerrainEd has been seen to exit non-zero on a
+    // successful run, so the file it was asked for is the thing that decides.
+    let produced = produces.filter(|p| dir.join(p).is_file());
+    Ok(Step {
+        name,
+        ok: produced.is_some() || (produces.is_none() && out.status.success()),
+        code: out.status.code(),
+        output: text.trim().to_string(),
+        produced: produced.map(str::to_string),
+    })
+}
+
+/// The command that runs a Windows executable here.
+#[cfg(target_os = "windows")]
+fn command(exe: &Path, args: &[&str], _game_path: &str) -> Result<std::process::Command> {
+    let mut cmd = std::process::Command::new(exe);
+    cmd.args(args);
+    Ok(cmd)
+}
+
+/// On macOS the compilers are Windows binaries, so they go through the same Wine host the
+/// game does — and through the game's own prefix, which already has whatever runtime PiBoSo's
+/// tools were built against.
+#[cfg(not(target_os = "windows"))]
+fn command(exe: &Path, args: &[&str], game_path: &str) -> Result<std::process::Command> {
+    let Some((prefix, _)) = crate::winehost::split_prefix(Path::new(game_path)) else {
+        bail!(
+            "the compilers are Windows programs. Set the game path to a copy inside a Wine \
+             prefix — CrossOver, Whisky or plain Wine — and they'll run through that."
+        );
+    };
+    let Some(runner) = crate::winehost::resolve("", Some(&prefix)) else {
+        bail!("found a Wine prefix at {prefix:?} but nothing that can run it");
+    };
+    let extra: Vec<String> = args.iter().map(|a| a.to_string()).collect();
+    let launch = crate::winehost::plan(&runner, &prefix, exe, &extra);
+    let mut cmd = std::process::Command::new(&launch.program);
+    cmd.args(&launch.args);
+    for (k, v) in &launch.env {
+        cmd.env(k, v);
+    }
+    Ok(cmd)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("mxb-tools-{}-{name}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn an_empty_folder_has_no_tools_in_it() {
+        assert!(find(&scratch("empty")).is_none());
+    }
+
+    #[test]
+    fn the_compilers_are_found_whatever_their_case() {
+        let dir = scratch("case");
+        std::fs::write(dir.join("TerrainEd.exe"), b"").unwrap();
+        std::fs::write(dir.join("TrackEd.EXE"), b"").unwrap();
+        let tools = find(&dir).expect("both are there");
+        assert!(tools.terrained.ends_with("TerrainEd.exe"));
+        assert!(tools.tracked.is_some());
+    }
+
+    #[test]
+    fn tracked_is_optional() {
+        let dir = scratch("terrain-only");
+        std::fs::write(dir.join("terrained.exe"), b"").unwrap();
+        let tools = find(&dir).expect("terrained alone is enough");
+        assert!(tools.tracked.is_none());
+    }
+
+    /// People extract the download and point at the folder they extracted, not at the one
+    /// inside it. Both work.
+    #[test]
+    fn a_folder_holding_the_tools_folder_works_too() {
+        let dir = scratch("nested");
+        let inner = dir.join("MXB Track Tools");
+        std::fs::create_dir_all(&inner).unwrap();
+        std::fs::write(inner.join("terrained.exe"), b"").unwrap();
+        assert!(find(&dir).is_some());
+    }
+
+    #[test]
+    fn compiling_something_that_isnt_a_track_says_so() {
+        let dir = scratch("not-a-track");
+        let tools = Tools {
+            terrained: dir.join("terrained.exe"),
+            tracked: None,
+        };
+        let err = compile(&tools, &dir, "x", "").unwrap_err().to_string();
+        assert!(err.contains("no track.hmf"), "{err}");
+    }
+
+    /// Not on Windows, and not inside a Wine prefix, the failure has to name the reason
+    /// rather than surfacing whatever the OS says about an unrunnable file.
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn without_a_prefix_it_explains_itself() {
+        let err = command(Path::new("/nowhere/terrained.exe"), &["a"], "/Applications/Game")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Wine prefix"), "{err}");
+    }
+}

--- a/src-tauri/src/trackstats.rs
+++ b/src-tauri/src/trackstats.rs
@@ -551,7 +551,7 @@ fn largest_component(mask: &[bool], gw: usize, gh: usize) -> usize {
         while let Some(i) = stack.pop() {
             size += 1;
             let (x, y) = (i % gw, i / gw);
-            let mut push = |j: usize, seen: &mut Vec<bool>, stack: &mut Vec<usize>| {
+            let push = |j: usize, seen: &mut Vec<bool>, stack: &mut Vec<usize>| {
                 if mask[j] && !seen[j] {
                     seen[j] = true;
                     stack.push(j);

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -56,6 +56,26 @@ const BENCH_SMOOTH_M: f32 = 45.0;
 const FEATURE_FULL: f32 = 0.8;
 const FEATURE_EDGE: f32 = 1.75;
 
+/// How much shorter a cut face is than a fill slope.
+///
+/// A track is bladed into the ground, not draped over it. Where the machine digs into rising
+/// ground it leaves a short steep face; where it pushes the spoil out onto falling ground it
+/// leaves a long shallow one. Grading both sides the same distance is the single clearest
+/// tell that nobody built this — real benching is never symmetrical.
+const CUT_SHOULDER: f32 = 0.5;
+const FILL_SHOULDER: f32 = 1.7;
+
+/// The ridge left between one pass of the machine and the next: how far apart they are, and
+/// how proud the seam stands.
+///
+/// A blade's own fine grooves are a few centimetres apart and cannot be represented here at
+/// all — at a third of a metre a sample they are far below what the grid can hold, and asking
+/// for them produces aliasing noise rather than grooves. The *passes* are the feature at this
+/// scale, they are a real thing you can see on a built track, and they run along the
+/// direction of travel — so they vary across the track and not along it.
+const PASS_SPACING_M: f32 = 2.6;
+const PASS_DEPTH_M: f32 = 0.022;
+
 /// Metres between the bumps of the riding surface's own texture.
 const TEXTURE_WAVELENGTH_M: f32 = 3.5;
 
@@ -104,6 +124,9 @@ const PROFILE_STEP: f32 = 0.1;
 
 /// Masks are stretched over the terrain, so they cost nothing to keep coarser than it.
 const MASK_DIM: usize = 1024;
+
+/// The ground textures' edge, in pixels. A power of two, as MX Bikes requires.
+const GROUND_TEXTURE_DIM: usize = 512;
 
 /// The UI pictures' edge, in pixels. Square and modest — they are shown at a few hundred
 /// pixels and stored uncompressed.
@@ -217,9 +240,14 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
         arc[i] = s;
         let half = widths.at(s);
 
-        let w = bench_weight(d, half, SHOULDER_M);
+        // Cut or fill: which one decides how far the grading reaches, and so how the edge
+        // of the track reads from the seat.
+        let ground = heights[i];
+        let deck = bench.at(s);
+        let shoulder = SHOULDER_M * if ground > deck { CUT_SHOULDER } else { FILL_SHOULDER };
+        let w = bench_weight(d, half, shoulder);
         if w > 0.0 {
-            heights[i] = heights[i] * (1.0 - w) + bench.at(s) * w;
+            heights[i] = ground * (1.0 - w) + deck * w;
         }
         if d <= half {
             corridor[i] = true;
@@ -255,6 +283,11 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
             ) * r.texture
                 * gain
                 * w;
+            // The seams between the machine's passes, running the way it drove.
+            heights[i] -= ((t / PASS_SPACING_M) * std::f32::consts::TAU).sin().abs()
+                * PASS_DEPTH_M
+                * w;
+
             // Braking bumps: a washboard across the track on the way into a corner, which is
             // the direction they actually form in.
             let brake = braking.at(s);
@@ -352,7 +385,7 @@ fn nearest_station(
         }
     }
 
-    let mut relax = |at: usize, from: usize, cost: i32, d: &mut Vec<i32>, l: &mut Vec<u32>| {
+    let relax = |at: usize, from: usize, cost: i32, d: &mut Vec<i32>, l: &mut Vec<u32>| {
         if d[from] + cost < d[at] {
             d[at] = d[from] + cost;
             l[at] = l[from];
@@ -688,12 +721,14 @@ fn longitudinal(f: &Feature, t: f32, u: f32) -> f32 {
         // Up, along the top, and down. The ramps are a third each, which is about what a
         // built tabletop measures.
         Feature::Tabletop { height, .. } => {
-            if t < 0.33 {
-                height * smoothstep(t / 0.33)
-            } else if t < 0.67 {
+            if t < 0.27 {
+                // Steeper than a smoothstep at the lip, which is what a packed takeoff is.
+                let u = t / 0.27;
+                height * (u * u * (3.0 - 2.0 * u)).powf(0.82)
+            } else if t < 0.56 {
                 height
             } else {
-                height * smoothstep((1.0 - t) / 0.33)
+                height * smoothstep((1.0 - t) / 0.44)
             }
         }
         Feature::Roller { height, .. } => height * (0.5 - 0.5 * (t * std::f32::consts::TAU).cos()),
@@ -812,7 +847,7 @@ pub fn write_source(prog: &TrackProgram, syn: &Synth, dir: &Path) -> Result<Vec<
     std::fs::create_dir_all(dir.join(&slug)).context("make the track folder")?;
     let mut wrote = Vec::new();
 
-    let mut put = |rel: &str, bytes: Vec<u8>, wrote: &mut Vec<String>| -> Result<()> {
+    let put = |rel: &str, bytes: Vec<u8>, wrote: &mut Vec<String>| -> Result<()> {
         std::fs::write(dir.join(rel), bytes).with_context(|| format!("write {rel}"))?;
         wrote.push(rel.to_string());
         Ok(())
@@ -843,6 +878,31 @@ pub fn write_source(prog: &TrackProgram, syn: &Synth, dir: &Path) -> Result<Vec<
     put("mask_grass.tga", tga_alpha(MASK_DIM, MASK_DIM, &grass), &mut wrote)?;
     put("area_off.tga", tga_alpha(MASK_DIM, MASK_DIM, &off), &mut wrote)?;
     put("area_start.tga", tga_alpha(MASK_DIM, MASK_DIM, &start), &mut wrote)?;
+
+    // Ground colours follow what the track is made of, so a sand national exports sand.
+    let (ground, line) = match prog.terrain.surface {
+        Surface::Soil => ([124, 96, 68], [96, 70, 50]),
+        Surface::Sand => ([196, 174, 132], [172, 148, 108]),
+        Surface::Grass => ([104, 118, 74], [92, 74, 54]),
+    };
+    std::fs::create_dir_all(dir.join("maps")).context("make the maps folder")?;
+    let seed = prog.terrain.relief.seed;
+    put(
+        "maps/ground.tga",
+        ground_texture(GROUND_TEXTURE_DIM, ground, 0.22, seed ^ 0x9A0D),
+        &mut wrote,
+    )?;
+    put(
+        "maps/line.tga",
+        ground_texture(GROUND_TEXTURE_DIM, line, 0.28, seed ^ 0x11E5),
+        &mut wrote,
+    )?;
+    put(
+        "maps/grass.tga",
+        ground_texture(GROUND_TEXTURE_DIM, [96, 116, 66], 0.30, seed ^ 0x6A55),
+        &mut wrote,
+    )?;
+    put("maps/grassfx.tga", grass_billboard(128), &mut wrote)?;
 
     put("track.hmf", hmf(prog, syn).into_bytes(), &mut wrote)?;
     put("track.tht", tht(prog, syn).into_bytes(), &mut wrote)?;
@@ -1027,6 +1087,73 @@ fn soft_edge(edge: f32, fade: f32, d: f32) -> u8 {
     }
 }
 
+/// Tileable value noise. The lattice wraps at `period`, so the texture it builds meets
+/// itself at the edges — a ground texture repeated sixty times across a track shows every
+/// seam it has.
+fn tile_noise(x: f32, y: f32, period: i32, seed: u32) -> f32 {
+    let (xf, yf) = (x.floor(), y.floor());
+    let (fx, fy) = (smoothstep(x - xf), smoothstep(y - yf));
+    let (xi, yi) = (xf as i32, yf as i32);
+    let at = |a: i32, b: i32| hash2(a.rem_euclid(period), b.rem_euclid(period), seed);
+    let top = at(xi, yi) + (at(xi + 1, yi) - at(xi, yi)) * fx;
+    let bot = at(xi, yi + 1) + (at(xi + 1, yi + 1) - at(xi, yi + 1)) * fx;
+    top + (bot - top) * fy
+}
+
+/// Ground, as a tileable picture of itself.
+///
+/// Generated rather than shipped. The layers have to point at *some* texture, and pointing
+/// them at PiBoSo's example track means the exported folder doesn't compile until someone
+/// has downloaded a 95 MB zip and copied a directory out of it. Three octaves of wrapping
+/// noise over a base colour is not a photograph, but it tiles, it is the right format, and
+/// it is in the folder.
+fn ground_texture(dim: usize, base: [u8; 3], grain: f32, seed: u32) -> Vec<u8> {
+    let mut px = Vec::with_capacity(dim * dim * 4);
+    for y in 0..dim {
+        for x in 0..dim {
+            let (u, v) = (x as f32 / dim as f32, y as f32 / dim as f32);
+            let mut n = 0.0;
+            let mut amp = 1.0;
+            let mut period = 8;
+            for o in 0..3 {
+                n += tile_noise(u * period as f32, v * period as f32, period, seed ^ (o * 131)) * amp;
+                amp *= 0.5;
+                period *= 2;
+            }
+            let k = 1.0 + n * grain;
+            let c = |i: usize| (base[i] as f32 * k).clamp(0.0, 255.0) as u8;
+            px.extend_from_slice(&[c(2), c(1), c(0), 255]);
+        }
+    }
+    tga_bgra(dim, dim, &px)
+}
+
+/// The blade sprite the grass layer scatters. Alpha-cut, like every foliage sheet in the
+/// game — see the note about `_c_a` materials in the map decoder.
+fn grass_billboard(dim: usize) -> Vec<u8> {
+    let mut px = Vec::with_capacity(dim * dim * 4);
+    for y in 0..dim {
+        for x in 0..dim {
+            let (u, v) = (x as f32 / dim as f32, 1.0 - y as f32 / dim as f32);
+            // A handful of tapered blades, thinner and fainter towards the tip.
+            let mut a = 0.0f32;
+            for b in 0..5 {
+                let centre = (b as f32 + 0.5) / 5.0;
+                let lean = (v * 0.12) * if b % 2 == 0 { 1.0 } else { -1.0 };
+                let width = 0.045 * (1.0 - v * 0.8).max(0.05);
+                let d = ((u - centre - lean) / width).abs();
+                if d < 1.0 && v < 0.92 {
+                    a = a.max(1.0 - d);
+                }
+            }
+            let shade = 0.55 + 0.45 * v;
+            let g = (150.0 * shade) as u8;
+            px.extend_from_slice(&[(60.0 * shade) as u8, g, (70.0 * shade) as u8, (a * 255.0) as u8]);
+        }
+    }
+    tga_bgra(dim, dim, &px)
+}
+
 /// Lighting and weather. Three conditions, because the game asks for all three and a track
 /// missing one falls back to nothing rather than to a default.
 ///
@@ -1121,16 +1248,15 @@ fn hmf(prog: &TrackProgram, syn: &Synth) -> String {
     s.push_str("num_layers = 3\n");
     // Layer zero carries no mask: it is the ground everything else is painted over.
     s.push_str(
-        "layer0\n{\n\tmap = maps/dirt.tga\n\tframe1\n\t{\n\t\tmap = maps/dirt_wet.tga\n\t}\n\
-         \trepetitions = 60\n}\n\n",
+        "layer0\n{\n\tmap = maps/ground.tga\n\trepetitions = 60\n}\n\n",
     );
     s.push_str(
-        "layer1\n{\n\tmap = maps/mud_treads.tga\n\tframe1\n\t{\n\t\tmap = maps/mud_treads_wet.tga\
-         \n\t}\n\trepetitions = 50\n\tmask = mask_dirt.tga\n\tthickness = 0.1\n}\n\n",
+        "layer1\n{\n\tmap = maps/line.tga\n\trepetitions = 50\n\tmask = mask_dirt.tga\n\
+         \tthickness = 0.1\n}\n\n",
     );
     s.push_str(
         "layer2\n{\n\tmap = maps/grass.tga\n\trepetitions = 40\n\tmask = mask_grass.tga\n\
-         \tthickness = 0.01\n\n\tgrass\n\t{\n\t\tmax_density = 25\n\t\theight = 0.2\n\
+         \tthickness = 0.01\n\n\tgrass\n\t{\n\t\tmax_density = 20\n\t\theight = 0.2\n\
          \t\theight_diff = 0.1\n\t\twidth = 0.25\n\t\twidth_diff = 0.1\n\
          \t\ttexture = maps/grassfx.tga\n\t\tdensitymap = mask_grass.tga\n\t}\n}\n",
     );
@@ -1143,7 +1269,14 @@ fn tht(prog: &TrackProgram, syn: &Synth) -> String {
     s.push_str("surface_layer0\n{\n\tsurface = off\n\tmask = area_off.tga\n}\n\n");
     s.push_str("surface_layer1\n{\n\tsurface = start\n\tmask = area_start.tga\n}\n\n");
     s.push_str("num_material_layers = 3\n\n");
-    s.push_str("material_layer0\n{\n\tmaterial = compact soil\n}\n\n");
+    // The base is whatever the ground is; the line is worked soil on top of it, and the
+    // field is grass. Same three bands the height file paints, said in physics.
+    let base = match prog.terrain.surface {
+        Surface::Soil => "compact soil",
+        Surface::Sand => "sand",
+        Surface::Grass => "grass",
+    };
+    s.push_str(&format!("material_layer0\n{{\n\tmaterial = {base}\n}}\n\n"));
     s.push_str("material_layer1\n{\n\tmaterial = soil\n\tthickness = 0.1\n\tmask = mask_dirt.tga\n}\n\n");
     s.push_str("material_layer2\n{\n\tmaterial = grass\n\tthickness = 0.01\n\tmask = mask_grass.tga\n}\n");
     s
@@ -1383,6 +1516,56 @@ mod tests {
     }
 
     use crate::trackprog::EXAMPLE as DEMO;
+
+    /// Every file the source files name has to be in the folder beside them.
+    ///
+    /// This is the check that would have caught the exported folder pointing at PiBoSo's
+    /// example track for its textures: it compiled fine in the sense that the text was
+    /// valid, and TerrainEd would have stopped on the first missing `.tga`.
+    #[test]
+    fn the_exported_folder_references_nothing_it_doesnt_contain() {
+        let p: TrackProgram = serde_json::from_str(DEMO).unwrap();
+        let s = synthesise(&p).unwrap();
+        let dir = std::env::temp_dir().join(format!("mxb-track-selftest-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        write_source(&p, &s, &dir).unwrap();
+
+        let mut named = Vec::new();
+        for f in ["track.hmf", "track.tht"] {
+            let text = std::fs::read_to_string(dir.join(f)).unwrap();
+            for line in text.lines() {
+                let Some((key, value)) = line.split_once('=') else {
+                    continue;
+                };
+                // Every key whose value is a file name rather than a number.
+                if matches!(
+                    key.trim(),
+                    "map" | "mask" | "data" | "texture" | "densitymap"
+                ) {
+                    named.push((f, value.trim().to_string()));
+                }
+            }
+        }
+        assert!(named.len() >= 8, "found only {named:?}");
+        for (from, name) in &named {
+            assert!(
+                dir.join(name).is_file(),
+                "{from} names {name}, which isn't in the folder"
+            );
+        }
+
+        // And the pieces the game itself asks for, which the README promises are there.
+        let slug = slug(&p.name);
+        for f in [
+            format!("{slug}/{slug}.ini"),
+            format!("{slug}/{slug}.amb"),
+            format!("{slug}/{slug}.tga"),
+            format!("{slug}/{slug}_map.tga"),
+        ] {
+            assert!(dir.join(&f).is_file(), "{f} is missing");
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn the_demo_program_parses_and_closes() {

--- a/src-tauri/src/vcruntime.rs
+++ b/src-tauri/src/vcruntime.rs
@@ -123,6 +123,7 @@ pub enum Stray {
 
 impl Stray {
     /// Is there still a file there that will kill the game? The question the banner asks.
+    #[cfg_attr(windows, allow(dead_code))]
     pub fn needs_the_player(self) -> bool {
         matches!(self, Stray::Foreign | Stray::Locked)
     }

--- a/src/Components/Dashboard/Dashboard.tsx
+++ b/src/Components/Dashboard/Dashboard.tsx
@@ -165,7 +165,7 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
           window renders its own tree and deliberately gets no drop target. */}
       <DropZone />
       <div className="flex min-h-0 flex-1">
-        <Sidebar view={view} onNavigate={navigate} />
+        <Sidebar view={view} studioTab={studioTab} onNavigate={navigate} />
         <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
           {view === "browse" && selectedSlug ? (
             <ModDetail

--- a/src/Components/Shell/Sidebar.tsx
+++ b/src/Components/Shell/Sidebar.tsx
@@ -13,7 +13,12 @@ import {
   SlidersHorizontal,
   Store,
   ShoppingBag,
+  Brush,
+  Move3d,
+  Mountain,
   Palette,
+  PersonStanding,
+  Shield,
   PanelLeftClose,
   PanelLeftOpen,
   Server as ServerIcon,
@@ -37,6 +42,8 @@ import { useGameRunning } from "../../lib/useGameRunning";
 import { useConfig } from "../../Context/Config";
 import type { GameCaps } from "../../types";
 import { ATTACH_PROBLEM } from "../../types";
+import { contentLockAvailable } from "../../api/mods";
+import type { StudioTab } from "../Studio/Studio";
 import JoinServerDialog from "./JoinServerDialog";
 import DownloadQueue from "./DownloadQueue";
 
@@ -55,7 +62,9 @@ export type DashboardView =
 
 interface SidebarProps {
   view: DashboardView;
-  onNavigate: (view: DashboardView) => void;
+  /** Which Studio sub-view is showing, so the right child row reads as active. */
+  studioTab: StudioTab;
+  onNavigate: (view: DashboardView, studio?: StudioTab) => void;
 }
 
 /**
@@ -70,6 +79,17 @@ type NavEntry = {
   cap?: keyof GameCaps;
   /** Indented under this entry, behind a chevron. */
   children?: NavEntry[];
+  /**
+   * Which Studio sub-view this row opens. Studio's tools are entries in the sidebar rather
+   * than a control inside the page: there are six of them and a row across the top has
+   * nowhere to grow, while a list under Studio reads the way Downloads reads under Library.
+   *
+   * They all share `id: "studio"`, so the active row is the one whose sub-view is showing
+   * rather than the one whose id matches.
+   */
+  studio?: StudioTab;
+  /** Hidden unless the optional local content-lock module is present. */
+  needsLock?: boolean;
 };
 
 const NAV: NavEntry[] = [
@@ -90,7 +110,19 @@ const NAV: NavEntry[] = [
   // Designer, Paints and Rider in one tab. Deliberately *not* viewer-gated: building a `.pnt`
   // is the same job for either title — same container, same encoder, same folders — and only
   // the 3D preview needs part bindings. Studio hides the sub-views that do.
-  { id: "studio", label: "nav.studio", icon: Palette },
+  {
+    id: "studio",
+    label: "nav.studio",
+    icon: Palette,
+    children: [
+      { id: "studio", label: "nav.designer", icon: Palette, studio: "designer" },
+      { id: "studio", label: "nav.paints", icon: Brush, studio: "paints" },
+      { id: "studio", label: "nav.rider", icon: PersonStanding, studio: "rider", cap: "viewer" },
+      { id: "studio", label: "nav.pose", icon: Move3d, studio: "pose", cap: "viewer" },
+      { id: "studio", label: "nav.track", icon: Mountain, studio: "track" },
+      { id: "studio", label: "nav.protect", icon: Shield, studio: "protect", needsLock: true },
+    ],
+  },
   { id: "manage", label: "nav.manage", icon: SlidersHorizontal, cap: "manage" },
 ];
 
@@ -227,8 +259,16 @@ function NavRow({
   );
 }
 
-export default function Sidebar({ view, onNavigate }: SidebarProps) {
+export default function Sidebar({ view, studioTab, onNavigate }: SidebarProps) {
   const t = useT();
+  // Locking needs an optional local module. Without it the Protect row would be a place you
+  // can go and nothing can happen, so it isn't listed.
+  const [hasLock, setHasLock] = useState(false);
+  useEffect(() => {
+    contentLockAvailable()
+      .then(setHasLock)
+      .catch(() => {});
+  }, []);
   const { running, attachment, reload, status, start, stop } = useFrostmod();
   // FrostMod is up but isn't reaching the game — see `frostmod::attachment`. The good
   // states (and the grace period after a launch) deliberately look like plain "Running".
@@ -294,7 +334,8 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
 
   // Two independent gates: servers needs the experimental toggle, and every entry needs the
   // active game to support it. Built here rather than inline so the JSX stays one `.map`.
-  const supported = ({ cap }: NavEntry) => !cap || caps[cap];
+  const supported = ({ cap, needsLock }: NavEntry) =>
+    (!cap || caps[cap]) && (!needsLock || hasLock);
   const nav = [NAV[0], SHOP_ENTRY, HUB_ENTRY, ...NAV.slice(1), ...(experimental ? [EXPERIMENTAL_NAV] : [])]
     .filter(supported)
     .map((e) => (e.children ? { ...e, children: e.children.filter(supported) } : e));
@@ -398,18 +439,23 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
         </button>
       </div>
 
-      <nav className="flex flex-col gap-0.5">
+      {/* The list scrolls; the Play button below it does not. Studio's tools are rows now,
+          so a short window or an expanded group can push the list past the bottom, and the
+          thing that must never scroll away is the one people came to press. */}
+      <nav className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto overflow-x-hidden">
         {rows.map(({ entry, child, badge, group }) => (
           <NavRow
-            key={entry.id}
+            key={entry.studio ?? entry.id}
             entry={entry}
-            active={view === entry.id}
+            active={
+              entry.studio ? view === "studio" && studioTab === entry.studio : view === entry.id
+            }
             collapsed={collapsed}
             child={child}
             badge={badge}
             group={group}
             onSelect={() => {
-              onNavigate(entry.id);
+              onNavigate(entry.id, entry.studio);
               // Opening the parent's page shows what's under it. Only ever opens: clicking
               // Library twice shouldn't make Downloads disappear — that's the chevron's job.
               if (group) setGroupOpen(entry.id, true);
@@ -418,7 +464,7 @@ export default function Sidebar({ view, onNavigate }: SidebarProps) {
         ))}
       </nav>
 
-      <div className="mt-auto flex flex-col gap-2">
+      <div className="mt-3 flex flex-none flex-col gap-2">
         {/* The install card is the queue's trigger now — same look, opens the panel. */}
         <DownloadQueue collapsed={collapsed} />
 

--- a/src/Components/Studio/Studio.tsx
+++ b/src/Components/Studio/Studio.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import HelpHint from "../ui/help-hint";
-import { Segmented } from "../ui/segmented";
 import { useT } from "../../i18n/context";
 import { useConfig } from "../../Context/Config";
 import { contentLockAvailable } from "../../api/mods";
@@ -93,27 +92,9 @@ export default function Studio({
 
   return (
     <div className="flex h-full flex-col">
-      <header className="flex flex-none items-center gap-3.5 px-7 pb-3 pt-4">
-        <div className="flex items-center gap-1.5">
-          <h1 className="text-[21px] font-bold tracking-[-0.2px]">{t("nav.studio")}</h1>
-          <HelpHint title={help.title} description={help.body} />
-        </div>
-        <Segmented
-          value={tab}
-          onChange={(v) => onTab(v as StudioTab)}
-          options={[
-            { value: "designer", label: t("nav.designer") },
-            { value: "paints", label: t("nav.paints") },
-            ...(hasRider
-              ? [
-                  { value: "rider" as const, label: t("nav.rider") },
-                  { value: "pose" as const, label: t("nav.pose") },
-                ]
-              : []),
-            { value: "track", label: t("nav.track") },
-            ...(hasLock ? [{ value: "protect" as const, label: t("nav.protect") }] : []),
-          ]}
-        />
+      <header className="flex flex-none items-center gap-1.5 px-7 pb-3 pt-4">
+        <h1 className="text-[21px] font-bold tracking-[-0.2px]">{help.title}</h1>
+        <HelpHint title={help.title} description={help.body} />
       </header>
 
       {/* Hidden, not unmounted. These hold real work — a stack of layers, a list of sheets,

--- a/src/Components/Studio/TrackStudio/TrackStudio.tsx
+++ b/src/Components/Studio/TrackStudio/TrackStudio.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { toast } from "sonner";
 
@@ -8,6 +8,7 @@ import { TrackViewerDialog } from "../../Viewer/TrackViewerDialog";
 import { useT } from "../../../i18n/context";
 import { cn } from "@/lib/utils";
 import {
+  buildTrack,
   checkTrack,
   exportTrackSource,
   generateTrack,
@@ -15,10 +16,14 @@ import {
   lapLength,
   lapSteps,
   previewTrack,
+  setTrackTools,
+  trackToolsStatus,
+  type BuildStep,
   type LapStep,
   type TrackFeature,
   type TrackPreview,
   type TrackProgram,
+  type TrackToolsStatus,
 } from "../../../api/trackgen";
 
 /**
@@ -35,11 +40,21 @@ import {
 export default function TrackStudio() {
   const t = useT();
   const [brief, setBrief] = useState("");
-  const [busy, setBusy] = useState<"generate" | "preview" | "install" | "export" | null>(null);
+  const [busy, setBusy] = useState<
+    "generate" | "preview" | "install" | "export" | "build" | null
+  >(null);
   const [program, setProgram] = useState<TrackProgram | null>(null);
   const [preview, setPreview] = useState<TrackPreview | null>(null);
   const [problems, setProblems] = useState<string[]>([]);
   const [viewing, setViewing] = useState(false);
+  const [tools, setTools] = useState<TrackToolsStatus | null>(null);
+  const [steps, setSteps] = useState<BuildStep[]>([]);
+
+  // Whether the compilers are here decides whether the last step is a button or a folder of
+  // homework, so it is worth knowing before anyone has generated anything.
+  useEffect(() => {
+    trackToolsStatus().then(setTools).catch(() => {});
+  }, []);
 
   /** Re-check and re-measure. Called after every edit, so the numbers are never stale. */
   const settle = useCallback(
@@ -127,6 +142,42 @@ export default function TrackStudio() {
   function removeFeature(index: number) {
     if (!program) return;
     void settle({ ...program, features: program.features.filter((_, i) => i !== index) });
+  }
+
+  async function onPointAtTools() {
+    const dir = await openDialog({ multiple: false, directory: true });
+    if (typeof dir !== "string") return;
+    try {
+      const next = await setTrackTools(dir);
+      setTools(next);
+      if (!next.found) toast.error(t("track.toolsNotFound"));
+    } catch (e) {
+      toast.error(t("track.toolsNotFound"), { description: String(e) });
+    }
+  }
+
+  async function onBuild() {
+    if (!program || busy) return;
+    const dir = await openDialog({ multiple: false, directory: true });
+    if (typeof dir !== "string") return;
+    setBusy("build");
+    setSteps([]);
+    try {
+      const ran = await buildTrack(program, dir);
+      setSteps(ran);
+      const failed = ran.find((s) => !s.ok);
+      if (failed) {
+        toast.error(t("track.buildStepFailed", { step: failed.name }), {
+          description: failed.output.slice(0, 400),
+        });
+      } else {
+        toast.success(t("track.compiled"), { description: dir });
+      }
+    } catch (e) {
+      toast.error(t("track.compileFailed"), { description: String(e) });
+    } finally {
+      setBusy(null);
+    }
   }
 
   const blocked = problems.length > 0;
@@ -241,8 +292,31 @@ export default function TrackStudio() {
                   {t("track.export")}
                 </Button>
               </div>
+              {tools?.found ? (
+                <Button
+                  variant="outline"
+                  onClick={() => void onBuild()}
+                  disabled={blocked || busy !== null}
+                >
+                  {busy === "build" ? t("track.compiling") : t("track.compile")}
+                </Button>
+              ) : (
+                <Button variant="ghost" onClick={() => void onPointAtTools()} disabled={busy !== null}>
+                  {t("track.pointAtTools")}
+                </Button>
+              )}
+              {steps.length > 0 && (
+                <ul className="space-y-1 text-[11.5px] leading-snug">
+                  {steps.map((s) => (
+                    <li key={s.name} className={s.ok ? "text-muted-foreground" : "text-destructive"}>
+                      {s.ok ? "✓" : "✕"} {s.name}
+                      {s.produced ? ` → ${s.produced}` : ""}
+                    </li>
+                  ))}
+                </ul>
+              )}
               <p className="text-[11.5px] leading-snug text-muted-foreground">
-                {t("track.previewOnly")}
+                {tools?.found ? t("track.stillNeeded") : t("track.previewOnly")}
               </p>
             </div>
           </div>

--- a/src/api/trackgen.ts
+++ b/src/api/trackgen.ts
@@ -148,6 +148,40 @@ export function lapLength(program: TrackProgram): number {
   );
 }
 
+/** Whether the app can compile a track here, and what with. */
+export interface TrackToolsStatus {
+  path: string;
+  found: boolean;
+  hasTracked: boolean;
+}
+
+/** One compiler run, and what it said. */
+export interface BuildStep {
+  name: "map" | "trh" | "centerline";
+  ok: boolean;
+  code: number | null;
+  output: string;
+  produced: string | null;
+}
+
+export function trackToolsStatus(): Promise<TrackToolsStatus> {
+  return invoke<TrackToolsStatus>("track_tools_status");
+}
+
+export function setTrackTools(dir: string): Promise<TrackToolsStatus> {
+  return invoke<TrackToolsStatus>("set_track_tools", { dir });
+}
+
+/**
+ * Export and compile in one.
+ *
+ * The compilers are PiBoSo's and Windows-only; on macOS they go through the same Wine prefix
+ * the game does. Minutes, not seconds — TerrainEd bakes shadow maps over the whole terrain.
+ */
+export function buildTrack(program: TrackProgram, dir: string): Promise<BuildStep[]> {
+  return invoke<BuildStep[]>("build_track", { program, dir });
+}
+
 /** Where a feature sits, and how long it runs — the two numbers every kind has. */
 export function featureSpan(f: TrackFeature): { at: number; length: number } {
   switch (f.kind) {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -2235,4 +2235,12 @@ export const de: Translation = {
   "track.over": "über",
   "track.kind.rut": "Rille",
   "track.sequenceHint": "Du kannst die Runde der Reihe nach beschreiben — „eine lange Gerade, eine linke Haarnadel, dann ein Double und eine Rhythmus-Sektion“ — und genau so wird sie gebaut.",
+  "track.compile": "Mit TerrainEd bauen",
+  "track.compiling": "Kompiliert…",
+  "track.compiled": "Kompiliert",
+  "track.compileFailed": "Konnte nicht kompiliert werden",
+  "track.buildStepFailed": "Schritt „{{step}}“ fehlgeschlagen",
+  "track.pointAtTools": "Track-Tools auswählen…",
+  "track.toolsNotFound": "Kein terrained.exe in diesem Ordner",
+  "track.stillNeeded": "Braucht noch eine .rdf aus TrackEd (Startgatter, Box, Kameras) und eine gate.edf aus einer anderen Strecke.",
 };

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2191,4 +2191,12 @@ export const en = {
   "track.over": "over",
   "track.kind.rut": "Rut",
   "track.sequenceHint": "You can describe the lap in order — “a long straight, a left hairpin, then a double and a rhythm section” — and it will be built that way.",
+  "track.compile": "Build with TerrainEd",
+  "track.compiling": "Compiling…",
+  "track.compiled": "Compiled",
+  "track.compileFailed": "Couldn't compile it",
+  "track.buildStepFailed": "The {{step}} step failed",
+  "track.pointAtTools": "Point at the track tools…",
+  "track.toolsNotFound": "No terrained.exe in that folder",
+  "track.stillNeeded": "Still needs a .rdf from TrackEd (start gate, pits, cameras) and a gate.edf copied from another track.",
 } as const;

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -2221,4 +2221,12 @@ export const es: Translation = {
   "track.over": "sobre",
   "track.kind.rut": "Rodada",
   "track.sequenceHint": "Puedes describir la vuelta en orden — «una recta larga, una horquilla a izquierda, luego un doble y una sección de ritmo» — y se construirá así.",
+  "track.compile": "Compilar con TerrainEd",
+  "track.compiling": "Compilando…",
+  "track.compiled": "Compilado",
+  "track.compileFailed": "No se pudo compilar",
+  "track.buildStepFailed": "Falló el paso «{{step}}»",
+  "track.pointAtTools": "Indicar las herramientas…",
+  "track.toolsNotFound": "No hay terrained.exe en esa carpeta",
+  "track.stillNeeded": "Aún necesita un .rdf de TrackEd (parrilla, boxes, cámaras) y un gate.edf copiado de otra pista.",
 };

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -2226,4 +2226,12 @@ export const fr: Translation = {
   "track.over": "sur",
   "track.kind.rut": "Ornière",
   "track.sequenceHint": "Tu peux décrire le tour dans l'ordre — « une longue ligne droite, une épingle à gauche, puis un double et une section rythmique » — et il sera construit ainsi.",
+  "track.compile": "Compiler avec TerrainEd",
+  "track.compiling": "Compilation…",
+  "track.compiled": "Compilé",
+  "track.compileFailed": "Compilation impossible",
+  "track.buildStepFailed": "L'étape « {{step}} » a échoué",
+  "track.pointAtTools": "Indiquer les outils…",
+  "track.toolsNotFound": "Aucun terrained.exe dans ce dossier",
+  "track.stillNeeded": "Il manque encore un .rdf de TrackEd (grille, stands, caméras) et un gate.edf copié d'un autre circuit.",
 };

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -2214,4 +2214,12 @@ export const it: Translation = {
   "track.over": "su",
   "track.kind.rut": "Solco",
   "track.sequenceHint": "Puoi descrivere il giro in ordine — «un lungo rettilineo, un tornante a sinistra, poi un doppio e una sezione ritmica» — e sarà costruito così.",
+  "track.compile": "Compila con TerrainEd",
+  "track.compiling": "Compilazione…",
+  "track.compiled": "Compilato",
+  "track.compileFailed": "Impossibile compilare",
+  "track.buildStepFailed": "Passo «{{step}}» fallito",
+  "track.pointAtTools": "Indica gli strumenti…",
+  "track.toolsNotFound": "Nessun terrained.exe in quella cartella",
+  "track.stillNeeded": "Servono ancora un .rdf da TrackEd (cancelletto, box, telecamere) e un gate.edf copiato da un'altra pista.",
 };

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -2211,4 +2211,12 @@ export const ptBR: Translation = {
   "track.over": "sobre",
   "track.kind.rut": "Sulco",
   "track.sequenceHint": "Você pode descrever a volta em ordem — “uma reta longa, uma curva fechada à esquerda, depois um duplo e uma seção de ritmo” — e será construída assim.",
+  "track.compile": "Compilar com TerrainEd",
+  "track.compiling": "Compilando…",
+  "track.compiled": "Compilado",
+  "track.compileFailed": "Não foi possível compilar",
+  "track.buildStepFailed": "A etapa “{{step}}” falhou",
+  "track.pointAtTools": "Indicar as ferramentas…",
+  "track.toolsNotFound": "Sem terrained.exe nessa pasta",
+  "track.stillNeeded": "Ainda precisa de um .rdf do TrackEd (portão, boxes, câmeras) e um gate.edf copiado de outra pista.",
 };


### PR DESCRIPTION
P5: the compile step, plus a pass at making the terrain look built rather than generated.

## The compile runs from the app

`trackbuild` finds `terrained.exe` and `tracked.exe` in a folder you point at once, then runs the three passes with the export folder as the working directory — exactly what PiBoSo's own batch files do. On macOS they go through the same Wine prefix the game does, via the existing `winehost`.

The exit code is not trusted: TerrainEd has been seen to exit non-zero on a successful run, so **the file it was asked to write is what decides**.

## The exported folder is self-contained

It referenced PiBoSo's example track for its ground textures, so it could not compile until someone had downloaded a 95 MB zip and copied a directory out of it. The textures are generated instead — tileable value noise over a base colour picked from `terrain.surface` — along with the grass billboard.

A test walks `track.hmf` and `track.tht` for every key whose value is a file name and asserts each one is in the folder. That is the check that would have caught the original gap, and it runs on any platform.

## Scratch-built rather than draped

- **Cut and fill** — a short steep face where the machine digs into rising ground, a long shallow one where it pushes spoil onto falling ground. Grading both sides equally was the clearest tell that nobody built this.
- **Machine passes** — the seam between one pass and the next, running the way it drove. Blade grooves themselves are centimetres apart and cannot be represented at a third of a metre a sample; asking for them produced aliasing, not grooves. The passes are the feature at this scale.
- **Asymmetric jump faces** — a takeoff is short and steep because that is what throws you, a landing long because that is what catches you. This brought measured lip height from 1.63 m to 1.34 m, into the corpus rather than above it.

## Sidebar

Studio's six tools are rows under Studio in the main sidebar, the way Downloads sits under Library — a segmented control across the top had nowhere left to grow. The nav scrolls; the Play button doesn't.

## Local testing

A debug build pointed at a non-HTTPS control plane skips the account check, because a local `wrangler dev` has no accounts to enroll with, and the endpoint moved above the auth gate. It is capped by its own shape instead — one call, 16k output tokens, a schema that can only be a motocross track.

To try it: put `ANTHROPIC_API_KEY` in `control-plane/.dev.vars`, run `wrangler dev` there, and start the app with `MXB_CONTROL_PLANE=http://localhost:8787`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)