### PR TITLE
feat(tracks): a base track button in the Track tab

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1186,6 +1186,18 @@ async fn generate_track(app: tauri::AppHandle, brief: String) -> Result<serde_js
     serde_json::to_value(&prog).map_err(|e| e.to_string())
 }
 
+/// A track to start from, without asking anyone for one.
+///
+/// The studio's first screen used to be a prompt and nothing else, which is a bad place to
+/// start from when the model isn't configured — and a worse one when you just want to change
+/// two jumps on something that already works.
+#[tauri::command]
+async fn base_track_program() -> Result<serde_json::Value, String> {
+    serde_json::from_str::<trackprog::TrackProgram>(trackprog::EXAMPLE)
+        .and_then(|p| serde_json::to_value(&p))
+        .map_err(|e| format!("the built-in track didn't load: {e}"))
+}
+
 /// Everything wrong with a program, without asking anyone. The studio calls this as edits are
 /// made, so a hand-edited track is held to the same corpus a generated one is.
 #[tauri::command]
@@ -8778,6 +8790,7 @@ fn main() {
             load_track_terrain,
             generate_track,
             check_track,
+            base_track_program,
             preview_track,
             install_track_preview,
             export_track_source,

--- a/src/Components/Studio/TrackStudio/TrackStudio.tsx
+++ b/src/Components/Studio/TrackStudio/TrackStudio.tsx
@@ -8,6 +8,7 @@ import { TrackViewerDialog } from "../../Viewer/TrackViewerDialog";
 import { useT } from "../../../i18n/context";
 import { cn } from "@/lib/utils";
 import {
+  baseTrackProgram,
   buildTrack,
   checkTrack,
   exportTrackSource,
@@ -82,6 +83,22 @@ export default function TrackStudio() {
       const next = await generateTrack(brief.trim());
       await settle(next);
       toast.success(t("track.generated", { name: next.name }));
+    } catch (e) {
+      toast.error(t("track.generateFailed"), { description: String(e) });
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function onBase() {
+    if (busy) return;
+    setBusy("generate");
+    setPreview(null);
+    setProblems([]);
+    try {
+      const next = await baseTrackProgram();
+      await settle(next);
+      toast.success(t("track.baseLoaded", { name: next.name }));
     } catch (e) {
       toast.error(t("track.generateFailed"), { description: String(e) });
     } finally {
@@ -201,6 +218,17 @@ export default function TrackStudio() {
           className="h-10 flex-none"
         >
           {busy === "generate" ? t("track.generating") : t("track.generate")}
+        </Button>
+        {/* Always here, not just when the model is unreachable: starting from a track that
+            already works and changing two jumps is a better first move than describing one
+            from nothing. */}
+        <Button
+          variant="outline"
+          onClick={() => void onBase()}
+          disabled={busy !== null}
+          className="h-10 flex-none"
+        >
+          {t("track.base")}
         </Button>
       </div>
 

--- a/src/api/trackgen.ts
+++ b/src/api/trackgen.ts
@@ -78,6 +78,11 @@ export function generateTrack(brief: string): Promise<TrackProgram> {
   return invoke<TrackProgram>("generate_track", { brief });
 }
 
+/** A track to start from, with no model involved. */
+export function baseTrackProgram(): Promise<TrackProgram> {
+  return invoke<TrackProgram>("base_track_program");
+}
+
 /** Everything wrong with a program, held to the same corpus a generated one is. */
 export function checkTrack(program: TrackProgram): Promise<string[]> {
   return invoke<string[]>("check_track", { program });

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -2255,4 +2255,6 @@ export const de: Translation = {
   "track.pointAtTools": "Track-Tools auswählen…",
   "track.toolsNotFound": "Kein terrained.exe in diesem Ordner",
   "track.stillNeeded": "Braucht noch eine .rdf aus TrackEd (Startgatter, Box, Kameras) und eine gate.edf aus einer anderen Strecke.",
+  "track.base": "Basis-Strecke",
+  "track.baseLoaded": "„{{name}}“ geladen",
 };

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2211,4 +2211,6 @@ export const en = {
   "track.pointAtTools": "Point at the track tools…",
   "track.toolsNotFound": "No terrained.exe in that folder",
   "track.stillNeeded": "Still needs a .rdf from TrackEd (start gate, pits, cameras) and a gate.edf copied from another track.",
+  "track.base": "Base track",
+  "track.baseLoaded": "Loaded “{{name}}”",
 } as const;

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -2241,4 +2241,6 @@ export const es: Translation = {
   "track.pointAtTools": "Indicar las herramientas…",
   "track.toolsNotFound": "No hay terrained.exe en esa carpeta",
   "track.stillNeeded": "Aún necesita un .rdf de TrackEd (parrilla, boxes, cámaras) y un gate.edf copiado de otra pista.",
+  "track.base": "Pista base",
+  "track.baseLoaded": "Se cargó «{{name}}»",
 };

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -2246,4 +2246,6 @@ export const fr: Translation = {
   "track.pointAtTools": "Indiquer les outils…",
   "track.toolsNotFound": "Aucun terrained.exe dans ce dossier",
   "track.stillNeeded": "Il manque encore un .rdf de TrackEd (grille, stands, caméras) et un gate.edf copié d'un autre circuit.",
+  "track.base": "Circuit de base",
+  "track.baseLoaded": "« {{name}} » chargé",
 };

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -2234,4 +2234,6 @@ export const it: Translation = {
   "track.pointAtTools": "Indica gli strumenti…",
   "track.toolsNotFound": "Nessun terrained.exe in quella cartella",
   "track.stillNeeded": "Servono ancora un .rdf da TrackEd (cancelletto, box, telecamere) e un gate.edf copiato da un'altra pista.",
+  "track.base": "Pista base",
+  "track.baseLoaded": "Caricata «{{name}}»",
 };

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -2231,4 +2231,6 @@ export const ptBR: Translation = {
   "track.pointAtTools": "Indicar as ferramentas…",
   "track.toolsNotFound": "Sem terrained.exe nessa pasta",
   "track.stillNeeded": "Ainda precisa de um .rdf do TrackEd (portão, boxes, câmeras) e um gate.edf copiado de outra pista.",
+  "track.base": "Pista base",
+  "track.baseLoaded": "“{{name}}” carregada",
 };


### PR DESCRIPTION
The studio's first screen was a prompt and nothing else — a bad place to start when the model isn't configured, and a worse one when you just want to change two jumps on something that already works.

`base_track_program` hands back the worked example — the same one the tests build and measure — so there is always a track to start from with nothing wired up. It goes through the same validate-and-measure path a generated one does, so editing it is the same job either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)