### PR TITLE
feat(tracks): make the lap list an editor, and give segments elevation

### DIFF
--- a/control-plane/src/trackgen.ts
+++ b/control-plane/src/trackgen.ts
@@ -26,9 +26,14 @@ import { z } from "zod";
  * — which fails loudly, at the boundary, rather than producing a wrong track. Change one,
  * change the other.
  */
+const RISE = z
+  .number()
+  .describe("metres the ground climbs over this segment; negative drops, 0 follows the land");
+
 const Straight = z.object({
   kind: z.literal("straight"),
   length: z.number().describe("metres"),
+  rise: RISE,
 });
 
 const Arc = z.object({
@@ -37,6 +42,7 @@ const Arc = z.object({
     .number()
     .describe("metres, signed — positive turns right, negative turns left"),
   angle: z.number().describe("degrees swept, always positive"),
+  rise: RISE,
 });
 
 const Feature = z.discriminatedUnion("kind", [
@@ -149,6 +155,10 @@ already there. A rut feature is for putting one somewhere a corner would not.
 
 Set terrain.surface from the brief: sand for a sand track, grass for an early-season or
 grasstrack circuit, soil for everything else.
+
+Elevation is per segment: rise is metres gained across it, negative for a drop. A lap that
+climbs has to come back down, so the rises must sum to about zero or the finish ends up above
+the start. Leave them 0 to follow the landscape, which is what most of a track does.
 
 Berms bank the OUTSIDE of a corner, so only place one where an arc segment is — a berm on a
 straight does nothing. Jumps go on straights.

--- a/src-tauri/src/trackprog.rs
+++ b/src-tauri/src/trackprog.rs
@@ -137,20 +137,34 @@ pub struct Start {
 pub enum Segment {
     Straight {
         length: f32,
+        /// Metres the ground climbs over this segment; negative drops. Zero follows the
+        /// landscape, which is what a track does unless someone cut into it.
+        #[serde(default)]
+        rise: f32,
     },
     /// Signed radius — positive turns right, negative left — through `angle` degrees. Arc
     /// length falls out as `|radius| * angle`, which is exactly how a `.tcl` states it.
     Arc {
         radius: f32,
         angle: f32,
+        #[serde(default)]
+        rise: f32,
     },
+}
+
+impl Segment {
+    pub fn rise(&self) -> f32 {
+        match self {
+            Segment::Straight { rise, .. } | Segment::Arc { rise, .. } => *rise,
+        }
+    }
 }
 
 impl Segment {
     pub fn length(&self) -> f32 {
         match self {
-            Segment::Straight { length } => *length,
-            Segment::Arc { radius, angle } => radius.abs() * angle.abs().to_radians(),
+            Segment::Straight { length, .. } => *length,
+            Segment::Arc { radius, angle, .. } => radius.abs() * angle.abs().to_radians(),
         }
     }
 }
@@ -384,7 +398,7 @@ impl TrackProgram {
                     x += dx * len;
                     z += dz * len;
                 }
-                Segment::Arc { radius, angle } => {
+                Segment::Arc { radius, angle, .. } => {
                     let sweep = angle.abs().to_radians();
                     let turn = radius.signum();
                     let r = radius.abs().max(0.01);
@@ -528,24 +542,21 @@ mod tests {
     fn an_arc_states_its_own_length() {
         // The example track's second segment: radius 4.974413 through 179.492554°, which its
         // own file calls 15.583522 m long.
-        let seg = Segment::Arc {
-            radius: 4.974413,
-            angle: 179.492554,
-        };
+        let seg = Segment::Arc { radius: 4.974413, angle: 179.492554, rise: 0.0 };
         assert!((seg.length() - 15.583522).abs() < 1e-3, "{}", seg.length());
     }
 
     #[test]
     fn four_right_angles_close_a_square() {
         let p = prog(vec![
-            Segment::Straight { length: 50.0 },
-            Segment::Arc { radius: 20.0, angle: 90.0 },
-            Segment::Straight { length: 50.0 },
-            Segment::Arc { radius: 20.0, angle: 90.0 },
-            Segment::Straight { length: 50.0 },
-            Segment::Arc { radius: 20.0, angle: 90.0 },
-            Segment::Straight { length: 50.0 },
-            Segment::Arc { radius: 20.0, angle: 90.0 },
+            Segment::Straight { length: 50.0, rise: 0.0 },
+            Segment::Arc { radius: 20.0, angle: 90.0, rise: 0.0 },
+            Segment::Straight { length: 50.0, rise: 0.0 },
+            Segment::Arc { radius: 20.0, angle: 90.0, rise: 0.0 },
+            Segment::Straight { length: 50.0, rise: 0.0 },
+            Segment::Arc { radius: 20.0, angle: 90.0, rise: 0.0 },
+            Segment::Straight { length: 50.0, rise: 0.0 },
+            Segment::Arc { radius: 20.0, angle: 90.0, rise: 0.0 },
         ]);
         assert!(p.closure_error() < 0.05, "{} m", p.closure_error());
         assert!((p.lap_length() - (200.0 + 4.0 * 20.0 * std::f32::consts::FRAC_PI_2)).abs() < 0.01);
@@ -553,8 +564,8 @@ mod tests {
 
     #[test]
     fn a_left_turn_goes_the_other_way() {
-        let right = prog(vec![Segment::Arc { radius: 30.0, angle: 90.0 }]);
-        let left = prog(vec![Segment::Arc { radius: -30.0, angle: 90.0 }]);
+        let right = prog(vec![Segment::Arc { radius: 30.0, angle: 90.0, rise: 0.0 }]);
+        let left = prog(vec![Segment::Arc { radius: -30.0, angle: 90.0, rise: 0.0 }]);
         let (r, l) = (
             *right.stations(1.0).last().unwrap(),
             *left.stations(1.0).last().unwrap(),
@@ -566,23 +577,23 @@ mod tests {
 
     #[test]
     fn curvature_points_into_the_corner() {
-        let p = prog(vec![Segment::Arc { radius: 25.0, angle: 45.0 }]);
+        let p = prog(vec![Segment::Arc { radius: 25.0, angle: 45.0, rise: 0.0 }]);
         let st = p.stations(1.0);
         assert!((st[0].curvature - 1.0 / 25.0).abs() < 1e-4);
-        let straight = prog(vec![Segment::Straight { length: 10.0 }]);
+        let straight = prog(vec![Segment::Straight { length: 10.0, rise: 0.0 }]);
         assert_eq!(straight.stations(1.0)[0].curvature, 0.0);
     }
 
     #[test]
     fn a_lap_that_leaves_the_ground_says_so() {
-        let p = prog(vec![Segment::Straight { length: 500.0 }]);
+        let p = prog(vec![Segment::Straight { length: 500.0, rise: 0.0 }]);
         let err = p.check().unwrap_err().to_string();
         assert!(err.contains("leaves the terrain"), "{err}");
     }
 
     #[test]
     fn a_feature_past_the_finish_says_so() {
-        let mut p = prog(vec![Segment::Straight { length: 100.0 }]);
+        let mut p = prog(vec![Segment::Straight { length: 100.0, rise: 0.0 }]);
         p.features.push(Feature::Tabletop {
             at: 90.0,
             length: 20.0,
@@ -594,7 +605,7 @@ mod tests {
 
     #[test]
     fn samples_must_be_a_power_of_two_plus_one() {
-        let mut p = prog(vec![Segment::Straight { length: 50.0 }]);
+        let mut p = prog(vec![Segment::Straight { length: 50.0, rise: 0.0 }]);
         p.terrain.samples = 2048;
         assert!(p.check().is_err());
         p.terrain.samples = 2049;

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -209,6 +209,7 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
         .map(|st| sample(&heights, gw, gh, st.x / mps_x, st.z / mps_z))
         .collect();
     smooth_along(&mut along, (BENCH_SMOOTH_M / STATION_STEP) as usize);
+    apply_rise(&mut along, &stations, &prog.segments);
     apply_step_ups(&mut along, &stations, &prog.features);
 
     // Everything that varies along the lap, resampled onto one even ruler so a cell can ask
@@ -693,6 +694,36 @@ fn berm_profile(features: &[Feature], turn: &Profile, lap: f32) -> Profile {
         }
     }
     out
+}
+
+/// Climb and drop, as the segments declare it.
+///
+/// Cumulative, and eased across each segment rather than applied at its end — a straight that
+/// gains four metres gains them evenly along its length, which is what makes it a hill rather
+/// than a step. Every later station carries the total of everything before it, so a lap whose
+/// rises don't sum to zero comes back to the start higher than it left, and the height budget
+/// check is what notices.
+fn apply_rise(along: &mut [f32], st: &[Station], segments: &[Segment]) {
+    let mut at = 0.0f32;
+    let mut base = 0.0f32;
+    for seg in segments {
+        let len = seg.length();
+        let rise = seg.rise();
+        if len <= 0.0 {
+            continue;
+        }
+        for (i, s) in st.iter().enumerate() {
+            if s.s < at {
+                continue;
+            }
+            let u = ((s.s - at) / len).clamp(0.0, 1.0);
+            along[i] += base + rise * smoothstep(u);
+        }
+        // Undo the part of the loop above that ran past this segment: stations beyond it
+        // took `base + rise`, which is exactly what the next segment's base should be.
+        base += rise;
+        at += len;
+    }
 }
 
 /// A step-up doesn't sit on the ground, it *is* the ground — so it moves the elevation the
@@ -1295,7 +1326,7 @@ fn tcl(prog: &TrackProgram) -> String {
     for (i, seg) in prog.segments.iter().enumerate() {
         let (radius, angle) = match *seg {
             Segment::Straight { .. } => (0.0, 0.0),
-            Segment::Arc { radius, angle } => (radius, angle.abs()),
+            Segment::Arc { radius, angle, .. } => (radius, angle.abs()),
         };
         let kind = if matches!(seg, Segment::Straight { .. }) {
             0
@@ -1304,8 +1335,9 @@ fn tcl(prog: &TrackProgram) -> String {
         };
         s.push_str(&format!(
             "segment{i}\n{{\n\ttype = {kind}\n\tlength = {:.6}\n\tradius = {radius:.6}\n\
-             \tangle = {angle:.6}\n\theight = 0.000000\n\theightlock = 0\n}}\n",
-            seg.length()
+             \tangle = {angle:.6}\n\theight = {:.6}\n\theightlock = 0\n}}\n",
+            seg.length(),
+            seg.rise()
         ));
     }
     s
@@ -1414,10 +1446,10 @@ mod tests {
                 angle: 0.0,
             },
             segments: vec![
-                Segment::Straight { length: 160.0 },
-                Segment::Arc { radius: 60.0, angle: 180.0 },
-                Segment::Straight { length: 160.0 },
-                Segment::Arc { radius: 60.0, angle: 180.0 },
+                Segment::Straight { length: 160.0, rise: 0.0 },
+                Segment::Arc { radius: 60.0, angle: 180.0, rise: 0.0 },
+                Segment::Straight { length: 160.0, rise: 0.0 },
+                Segment::Arc { radius: 60.0, angle: 180.0, rise: 0.0 },
             ],
             width: 12.0,
             features: vec![
@@ -1474,6 +1506,25 @@ mod tests {
             "tabletop stands {:.2} m above the run-in, wanted about 2.4",
             on - before
         );
+    }
+
+    #[test]
+    fn a_segment_that_rises_takes_the_track_with_it() {
+        let mut p = oval();
+        p.features.clear();
+        // The first straight climbs six metres; the far one gives them back, so the lap
+        // still meets itself at the same height.
+        p.segments[0] = Segment::Straight { length: 160.0, rise: 6.0 };
+        p.segments[2] = Segment::Straight { length: 160.0, rise: -6.0 };
+        let s = synthesise(&p).unwrap();
+        let climb = height_at_arc(&s, 155.0) - height_at_arc(&s, 5.0);
+        assert!(
+            (climb - 6.0).abs() < 1.0,
+            "the straight climbed {climb:.2} m, not 6"
+        );
+        // And it is a hill, not a step: half way up is half way there.
+        let half = height_at_arc(&s, 80.0) - height_at_arc(&s, 5.0);
+        assert!((half - 3.0).abs() < 1.2, "half way up reads {half:.2} m");
     }
 
     #[test]

--- a/src/Components/Studio/TrackStudio/TrackStudio.tsx
+++ b/src/Components/Studio/TrackStudio/TrackStudio.tsx
@@ -1,5 +1,19 @@
 import { useCallback, useEffect, useState } from "react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
+import {
+  Activity,
+  ChevronsUp,
+  CornerUpLeft,
+  CornerUpRight,
+  Minus,
+  MoveRight,
+  Spline,
+  Square,
+  TrendingDown,
+  TrendingUp,
+  Waves,
+  type LucideIcon,
+} from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "../../ui/button";
@@ -24,6 +38,7 @@ import {
   type TrackFeature,
   type TrackPreview,
   type TrackProgram,
+  type TrackSegment,
   type TrackToolsStatus,
 } from "../../../api/trackgen";
 
@@ -154,6 +169,14 @@ export default function TrackStudio() {
       i === index ? ({ ...f, ...patch } as TrackFeature) : f,
     );
     void settle({ ...program, features });
+  }
+
+  function editSegment(index: number, patch: Partial<TrackSegment>) {
+    if (!program) return;
+    const segments = program.segments.map((seg, i) =>
+      i === index ? ({ ...seg, ...patch } as TrackSegment) : seg,
+    );
+    void settle({ ...program, segments });
   }
 
   function removeFeature(index: number) {
@@ -354,40 +377,56 @@ export default function TrackStudio() {
               that way, so here they are one sequence. */}
           <div className="min-h-0 flex-1 overflow-y-auto rounded-xl border border-input">
             <ol className="divide-y divide-input/60">
-              {lapSteps(program).map((step, row) => (
-                <li key={row} className="flex items-center gap-3 px-3.5 py-2 text-[12.5px]">
-                  <span className="w-14 flex-none tabular-nums text-right text-muted-foreground">
-                    {step.at.toFixed(0)} m
-                  </span>
-                  <span className="flex-1">{describe(step, t)}</span>
-                  {step.kind === "feature" && (
-                    <>
-                      <Num
-                        value={
-                          step.feature.kind === "rut" ? step.feature.depth : step.feature.height
-                        }
-                        step={0.1}
-                        onChange={(v) =>
-                          editFeature(
-                            step.index,
-                            (step.feature.kind === "rut"
-                              ? { depth: v }
-                              : { height: v }) as Partial<TrackFeature>,
-                          )
-                        }
-                      />
-                      <button
-                        onClick={() => removeFeature(step.index)}
-                        className="rounded px-1.5 text-muted-foreground hover:bg-foreground/[0.06] hover:text-foreground"
-                        aria-label={t("common.delete")}
-                      >
-                        ×
-                      </button>
-                    </>
-                  )}
-                  {step.kind !== "feature" && <span className="w-[92px] flex-none" />}
-                </li>
-              ))}
+              {lapSteps(program).map((step, row) => {
+                const Icon = stepIcon(step);
+                return (
+                  <li key={row} className="flex items-center gap-2.5 px-3 py-1.5 text-[12.5px]">
+                    <span className="w-12 flex-none tabular-nums text-right text-muted-foreground">
+                      {step.at.toFixed(0)}
+                    </span>
+                    <Icon
+                      className={cn(
+                        "size-4 flex-none",
+                        step.kind === "feature" ? "text-primary" : "text-muted-foreground",
+                      )}
+                    />
+                    <span className="w-[104px] flex-none truncate">{stepName(step, t)}</span>
+
+                    <div className="flex flex-1 flex-wrap items-center gap-x-3 gap-y-1">
+                      {fieldsOf(step).map((f) => (
+                        <Field
+                          key={f.label}
+                          label={f.label}
+                          value={f.value}
+                          step={f.step}
+                          onChange={(v) =>
+                            step.kind === "feature"
+                              ? editFeature(step.index, { [f.key]: v } as Partial<TrackFeature>)
+                              : editSegment(step.index, {
+                                  [f.key]:
+                                    f.key === "radius" ? (step.kind === "left" ? -v : v) : v,
+                                } as Partial<TrackSegment>)
+                          }
+                        />
+                      ))}
+                    </div>
+
+                    <button
+                      onClick={() => step.kind === "feature" && removeFeature(step.index)}
+                      disabled={step.kind !== "feature"}
+                      className={cn(
+                        "rounded px-1.5 text-muted-foreground transition-colors",
+                        step.kind === "feature"
+                          ? "hover:bg-foreground/[0.06] hover:text-foreground"
+                          : "invisible",
+                      )}
+                      aria-label={t("common.delete")}
+                    >
+                      ×
+                    </button>
+                  </li>
+                );
+              })}
             </ol>
           </div>
         </div>
@@ -405,13 +444,6 @@ export default function TrackStudio() {
   );
 }
 
-/**
- * One step of the lap, in words.
- *
- * Numbers carry their own units and need no translating, so only the noun is a key. The
- * shape is deliberately flat — "Left turn · 18 m radius, 75°" reads at a glance, and reads
- * the same way a brief is written.
- */
 const KIND_KEY = {
   tabletop: "track.kind.tabletop",
   double: "track.kind.double",
@@ -422,33 +454,101 @@ const KIND_KEY = {
   rut: "track.kind.rut",
 } as const;
 
-function describe(step: LapStep, t: ReturnType<typeof useT>): string {
-  const m = (v: number, digits = 0) => `${v.toFixed(digits)} m`;
-  switch (step.kind) {
-    case "straight":
-      return `${t("track.straight")} · ${m(step.length)}`;
-    case "left":
-    case "right":
-      return `${t(step.kind === "left" ? "track.turnLeft" : "track.turnRight")} · ${m(
-        step.radius,
-      )} ${t("track.radius")}, ${step.angle.toFixed(0)}°`;
-    case "feature": {
-      const f = step.feature;
-      const name = t(KIND_KEY[f.kind]);
-      switch (f.kind) {
-        case "double":
-          return `${name} · ${m(f.height, 1)}, ${m(f.gap)} ${t("track.gap")}`;
-        case "whoops":
-          return `${name} · ${f.count} × ${m(f.spacing, 1)}`;
-        case "rut":
-          return `${name} · ${m(f.depth, 2)} ${t("track.deep")}`;
-        case "stepUp":
-          return `${name} · ${m(f.height, 1)}`;
-        default:
-          return `${name} · ${m(f.height, 1)} ${t("track.over")} ${m(f.length)}`;
-      }
-    }
+const FEATURE_ICON: Record<TrackFeature["kind"], LucideIcon> = {
+  tabletop: Square,
+  double: ChevronsUp,
+  roller: Waves,
+  whoops: Activity,
+  stepUp: TrendingUp,
+  berm: Spline,
+  rut: Minus,
+};
+
+/** What the row is, at a glance. A list of thirty steps is scanned, not read. */
+function stepIcon(step: LapStep): LucideIcon {
+  if (step.kind === "straight") return MoveRight;
+  if (step.kind === "left") return CornerUpLeft;
+  if (step.kind === "right") return CornerUpRight;
+  // A step-down is a step-up with a negative height, and drawing both the same way hides
+  // the one thing that tells them apart.
+  if (step.feature.kind === "stepUp" && step.feature.height < 0) return TrendingDown;
+  return FEATURE_ICON[step.feature.kind];
+}
+
+function stepName(step: LapStep, t: ReturnType<typeof useT>): string {
+  if (step.kind === "straight") return t("track.straight");
+  if (step.kind === "left") return t("track.turnLeft");
+  if (step.kind === "right") return t("track.turnRight");
+  return t(KIND_KEY[step.feature.kind]);
+}
+
+/**
+ * The numbers that define a step, and which key on it each one writes.
+ *
+ * Every step is a handful of measurements and nothing else, so the row *is* the editor —
+ * there is no dialog to open and nothing to remember about which field belongs to which
+ * kind. `rise` is on every segment because "does this bit go up or down" is a question you
+ * ask of a straight as often as of a corner.
+ */
+function fieldsOf(step: LapStep): { key: string; label: string; value: number; step: number }[] {
+  const len = (v: number) => ({ key: "length", label: "m", value: v, step: 1 });
+  const rise = (v: number) => ({ key: "rise", label: "↕", value: v, step: 0.5 });
+  if (step.kind === "straight") {
+    const seg = step.segment as { length: number; rise: number };
+    return [len(seg.length), rise(seg.rise ?? 0)];
   }
+  if (step.kind === "left" || step.kind === "right") {
+    const seg = step.segment as { radius: number; angle: number; rise: number };
+    return [
+      // Signed on the wire — positive turns right — but shown as the radius you would
+      // measure, because the arrow already says which way it goes.
+      { key: "radius", label: "r", value: Math.abs(seg.radius), step: 1 },
+      { key: "angle", label: "°", value: seg.angle, step: 5 },
+      rise(seg.rise ?? 0),
+    ];
+  }
+  const f = step.feature;
+  switch (f.kind) {
+    case "double":
+      return [
+        { key: "height", label: "h", value: f.height, step: 0.1 },
+        { key: "gap", label: "gap", value: f.gap, step: 1 },
+        { key: "lip", label: "lip", value: f.lip, step: 0.5 },
+      ];
+    case "whoops":
+      return [
+        { key: "height", label: "h", value: f.height, step: 0.05 },
+        { key: "count", label: "×", value: f.count, step: 1 },
+        { key: "spacing", label: "gap", value: f.spacing, step: 0.5 },
+      ];
+    case "rut":
+      return [
+        { key: "depth", label: "deep", value: f.depth, step: 0.05 },
+        len(f.length),
+      ];
+    default:
+      return [{ key: "height", label: "h", value: f.height, step: 0.1 }, len(f.length)];
+  }
+}
+
+/** A labelled number, small enough that several fit on a row. */
+function Field({
+  label,
+  value,
+  step,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  step: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <label className="flex items-center gap-1">
+      <span className="text-[11px] text-muted-foreground">{label}</span>
+      <Num value={value} step={step} onChange={onChange} />
+    </label>
+  );
 }
 
 function Row({ label, value }: { label: string; value: string }) {
@@ -483,7 +583,7 @@ function Num({
         setDraft(null);
       }}
       className={cn(
-        "w-[68px] rounded-md border border-input bg-transparent px-1.5 py-0.5 tabular-nums",
+        "w-[58px] rounded-md border border-input bg-transparent px-1.5 py-0.5 tabular-nums",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60",
       )}
     />

--- a/src/api/trackgen.ts
+++ b/src/api/trackgen.ts
@@ -32,9 +32,10 @@ export interface TrackProgram {
 }
 
 export type TrackSegment =
-  | { kind: "straight"; length: number }
+  /** `rise` is metres climbed over the segment; negative drops, zero follows the ground. */
+  | { kind: "straight"; length: number; rise: number }
   /** Signed radius — positive turns right. */
-  | { kind: "arc"; radius: number; angle: number };
+  | { kind: "arc"; radius: number; angle: number; rise: number };
 
 export type TrackFeature =
   | { kind: "tabletop"; at: number; length: number; height: number }
@@ -112,30 +113,27 @@ export function exportTrackSource(program: TrackProgram, dir: string): Promise<s
  * written in.
  */
 export type LapStep =
-  | { at: number; kind: "straight"; length: number }
-  | { at: number; kind: "left" | "right"; radius: number; angle: number }
+  | { at: number; kind: "straight"; index: number; segment: TrackSegment }
+  // Split rather than `kind: "left" | "right"`: a discriminant that is itself a union
+  // doesn't narrow, and every reader of this then has to cast.
+  | { at: number; kind: "left"; index: number; segment: TrackSegment }
+  | { at: number; kind: "right"; index: number; segment: TrackSegment }
   | { at: number; kind: "feature"; index: number; feature: TrackFeature };
 
 export function lapSteps(program: TrackProgram): LapStep[] {
   const steps: LapStep[] = [];
   let at = 0;
-  for (const seg of program.segments) {
-    if (seg.kind === "straight") {
-      steps.push({ at, kind: "straight", length: seg.length });
-      at += seg.length;
+  program.segments.forEach((segment, index) => {
+    if (segment.kind === "straight") {
+      steps.push({ at, kind: "straight", index, segment });
+      at += segment.length;
     } else {
-      const length = (Math.abs(seg.radius) * Math.abs(seg.angle) * Math.PI) / 180;
-      steps.push({
-        at,
-        // Signed radius: positive turns right. Which way it goes is the thing a person
-        // reads, so it is the thing the row says.
-        kind: seg.radius >= 0 ? "right" : "left",
-        radius: Math.abs(seg.radius),
-        angle: Math.abs(seg.angle),
-      });
-      at += length;
+      // Signed radius: positive turns right. Which way it goes is the thing a person reads,
+      // so it is the thing the row says.
+      steps.push({ at, kind: segment.radius >= 0 ? "right" : "left", index, segment });
+      at += (Math.abs(segment.radius) * Math.abs(segment.angle) * Math.PI) / 180;
     }
-  }
+  });
   program.features.forEach((feature, index) =>
     steps.push({ at: feature.at, kind: "feature", index, feature }),
   );
@@ -148,7 +146,10 @@ export function lapSteps(program: TrackProgram): LapStep[] {
 export function lapLength(program: TrackProgram): number {
   return program.segments.reduce(
     (sum, s) =>
-      sum + (s.kind === "straight" ? s.length : Math.abs(s.radius) * (Math.abs(s.angle) * Math.PI) / 180),
+      sum +
+      (s.kind === "straight"
+        ? s.length
+        : (Math.abs(s.radius) * Math.abs(s.angle) * Math.PI) / 180),
     0,
   );
 }


### PR DESCRIPTION
The lap list was a readout. Now it's the editor.

## Icons

An arrow for a straight, a corner arrow that turns the way the corner does, and one per feature kind. A step-down draws as a step-down rather than as a step-up with a minus sign in front of it. Thirty rows get scanned, not read.

## Every number is editable in its own row

| step | fields |
|---|---|
| straight | length, rise |
| left / right turn | radius, angle, rise |
| tabletop / roller / berm | height, length |
| double | height, gap, lip |
| whoops | height, count, spacing |
| rut | depth, length |
| step-up | height, length |

No dialog, and nothing to remember about which field belongs to which kind. Each edit re-validates and re-measures, so a hand-edited track is held to the same corpus a generated one is.

The radius editor takes a magnitude and puts the sign back on from which way the corner turns, so the arrow and the number can't disagree.

## Segments have elevation now

`rise` is metres climbed across a segment, negative for a drop — the answer to "does this bit go up or down", which is a question you ask of a straight as often as of a corner. It's eased along the segment's length rather than applied at its end, so a straight that gains four metres is a hill and not a step. A test asserts both: six metres climbed, and three of them half way along.

It also fills the `.tcl`'s own `height` field, which was being written as zero the whole time.

## One TypeScript note

Split the LapStep union's turn arm into separate `left` and `right` members. A discriminant that is itself a union (`kind: "left" | "right"`) doesn't narrow, so every reader was casting around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)