### PR TITLE
feat(replaycam): a panel for the replay camera's saved paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Settings → FrostMod lists the nine replay camera slots. Open one to see where its keys
+  fall, drag a key to move it, change what a key does, and set how the path flies.
+- Camera paths can be exported and imported, so one can be passed to someone else.
+- Respace by distance, for a constant-speed dolly. A cut keeps the length it was given.
+- The panel says when the replay camera can't run on your game build, and why. That reason
+  only existed in a log file next to a DLL before.
+- FrostMod's eleven new replay camera actions are in the key list.
+
 ## 2026-08-31 — v0.12.1
 
 ### Added

--- a/src-tauri/src/frostmod_manage.rs
+++ b/src-tauri/src/frostmod_manage.rs
@@ -1222,7 +1222,7 @@ pub struct Keybind {
 
 /// Mirrors `kb::Actions()` in FrostMod's `src/keybinds.h`, in the same order. The ids are
 /// the config keys (`rcam_<id>`); the UI labels them itself, translated.
-const RCAM_ACTIONS: [(&str, &str); 9] = [
+const RCAM_ACTIONS: [(&str, &str); 20] = [
     ("setkey", "K"),
     ("delete", "X"),
     ("clear", "C"),
@@ -1234,6 +1234,21 @@ const RCAM_ACTIONS: [(&str, &str); 9] = [
     // Hiding the overlay defaults to a function key, not a letter: it is pressed while
     // recording, so a key the game might have bound would be the wrong default.
     ("clean", "F7"),
+    // Per-key edits, pressed while scrubbing.
+    ("ease", "E"),
+    ("target", "T"),
+    ("nudgeback", "LeftBracket"),
+    ("nudgefwd", "RightBracket"),
+    ("undo", "U"),
+    ("rig", "R"),
+    ("retime", "Ctrl+R"),
+    ("preview", "V"),
+    // Whole-path settings. Unbound on purpose: they are set once per path, this app has a
+    // panel for them, and a letter the replay screen may already use is a worse default
+    // than no key at all.
+    ("curve", "none"),
+    ("anchor", "none"),
+    ("autofov", "none"),
 ];
 
 /// Key names FrostMod can parse, beyond the plain letters and digits. Mirrors the table in
@@ -1416,12 +1431,21 @@ mod rcam_tests {
     fn defaults_match_frostmods() {
         // If FrostMod's defaults move, this is the reminder to move ours with them.
         let d = default_rcam_keybinds();
-        assert_eq!(d.len(), 9);
+        assert_eq!(d.len(), 20);
         assert_eq!(d[0].id, "setkey");
         assert_eq!(d[0].key, "K");
         assert_eq!(d[6].key, "S");
         assert_eq!(d[8].id, "clean");
         assert_eq!(d[8].key, "F7");
+        // Appended after the first release, so the ids above keep their places and a
+        // binding someone already set is not silently moved onto another action.
+        assert_eq!(d[9].id, "ease");
+        assert_eq!(d[16].id, "preview");
+        // Three ship unbound on purpose; "none" is a binding FrostMod parses, not a gap.
+        for id in ["curve", "anchor", "autofov"] {
+            let b = d.iter().find(|b| b.id == id).expect("missing action");
+            assert_eq!(b.key, "none", "{id} should ship unbound");
+        }
         for b in &d {
             assert!(valid_bind(&b.key), "default {} is not valid", b.key);
         }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -38,6 +38,7 @@ mod mods;
 mod modstate;
 mod modwatch;
 mod profilewatch;
+mod replaycam;
 mod mxb_fetch;
 mod mxb_session;
 mod overlay;
@@ -5634,6 +5635,73 @@ fn frostmod_default_keybinds() -> Vec<frostmod_manage::Keybind> {
     frostmod_manage::default_rcam_keybinds()
 }
 
+// ---- replay camera paths ---------------------------------------------------
+// FrostMod's editor is a text panel over a running game — good for setting a key while you
+// scrub, no use at all for looking at what you saved last week. These back the app's own
+// panel: nine slots you can see into, retime, re-style, and pass around.
+
+/// Every slot, and enough about each to draw the list without opening them again.
+#[tauri::command]
+fn replaycam_list(app: tauri::AppHandle) -> Vec<replaycam::Summary> {
+    let cfg = config::load(&app).unwrap_or_default();
+    replaycam::list(&app, &cfg)
+}
+
+#[tauri::command]
+fn replaycam_read(app: tauri::AppHandle, slot: u8) -> Result<replaycam::CamPath, String> {
+    let cfg = config::load(&app).unwrap_or_default();
+    replaycam::read(&app, &cfg, slot)
+}
+
+/// Save a slot back. Returns the file it landed in, which is worth showing: it may be the
+/// game's own plugins folder rather than the app's copy of FrostMod.
+#[tauri::command]
+fn replaycam_write(
+    app: tauri::AppHandle,
+    slot: u8,
+    path: replaycam::CamPath,
+) -> Result<String, String> {
+    let cfg = config::load(&app).unwrap_or_default();
+    replaycam::write(&app, &cfg, slot, &path).map(|p| p.display().to_string())
+}
+
+#[tauri::command]
+fn replaycam_delete(app: tauri::AppHandle, slot: u8) -> Result<(), String> {
+    let cfg = config::load(&app).unwrap_or_default();
+    replaycam::delete(&app, &cfg, slot)
+}
+
+/// Respace the keys by distance — the constant-speed dolly. Pure, so the UI can offer it as
+/// a preview and only write if it is kept.
+#[tauri::command]
+fn replaycam_retime(path: replaycam::CamPath) -> Result<replaycam::CamPath, String> {
+    let mut out = path;
+    replaycam::retime_by_distance(&mut out.keys)?;
+    Ok(out)
+}
+
+/// Load someone else's `.fcam` into a slot. Parsed before it is copied, so a file that
+/// FrostMod would refuse never reaches a slot.
+#[tauri::command]
+fn replaycam_import(
+    app: tauri::AppHandle,
+    slot: u8,
+    src: String,
+) -> Result<replaycam::CamPath, String> {
+    let text = std::fs::read_to_string(&src).map_err(|e| format!("{src}: {e}"))?;
+    let parsed = replaycam::parse(&text)?;
+    let cfg = config::load(&app).unwrap_or_default();
+    replaycam::write(&app, &cfg, slot, &parsed)?;
+    Ok(parsed)
+}
+
+#[tauri::command]
+fn replaycam_export(app: tauri::AppHandle, slot: u8, dst: String) -> Result<(), String> {
+    let cfg = config::load(&app).unwrap_or_default();
+    let p = replaycam::read(&app, &cfg, slot)?;
+    std::fs::write(&dst, replaycam::serialize(&p)).map_err(|e| format!("{dst}: {e}"))
+}
+
 /// Whether FrostMod actually got into the running game — and what to do when it didn't.
 ///
 /// `frostmod_running` only says the launcher is up, which is what made an elevated game so
@@ -8910,6 +8978,13 @@ fn main() {
             frostmod_keybinds,
             frostmod_set_keybinds,
             frostmod_default_keybinds,
+            replaycam_list,
+            replaycam_read,
+            replaycam_write,
+            replaycam_delete,
+            replaycam_retime,
+            replaycam_import,
+            replaycam_export,
             frostmod_running,
             frostmod_attachment,
             garage_scan_bikes,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5695,6 +5695,15 @@ fn replaycam_import(
     Ok(parsed)
 }
 
+/// What FrostMod's log says about the replay camera on the build it last attached to —
+/// including the reason it is unavailable, which until now only existed in a file next to a
+/// DLL.
+#[tauri::command]
+fn replaycam_status(app: tauri::AppHandle) -> replaycam::Status {
+    let cfg = config::load(&app).unwrap_or_default();
+    replaycam::status(&app, &cfg)
+}
+
 #[tauri::command]
 fn replaycam_export(app: tauri::AppHandle, slot: u8, dst: String) -> Result<(), String> {
     let cfg = config::load(&app).unwrap_or_default();
@@ -8985,6 +8994,7 @@ fn main() {
             replaycam_retime,
             replaycam_import,
             replaycam_export,
+            replaycam_status,
             frostmod_running,
             frostmod_attachment,
             garage_scan_bikes,

--- a/src-tauri/src/replaycam.rs
+++ b/src-tauri/src/replaycam.rs
@@ -1,0 +1,657 @@
+//! Replay camera paths — reading, editing and writing FrostMod's `.fcam` files.
+//!
+//! FrostMod's editor is a text panel drawn over a running game: fine for setting a key
+//! while you scrub, useless for looking at a path you made last week. Nine unnamed slots
+//! and no way to see what is in them is the gap this closes — the app can list them, show
+//! the keys on a timeline, retime one, change the whole-path settings, and import or export
+//! a path so it can be shared.
+//!
+//! The format is FrostMod's, and the definition lives in its `src/replaycam.h`. Plain text,
+//! one key per line, hand-editable on purpose. The enums are carried as the same words the
+//! file uses rather than numbers, so the two sides cannot disagree about what `2` meant.
+//!
+//! Writes are validated the way FrostMod would parse them, because a file it refuses to
+//! load leaves someone staring at a slot that silently does nothing.
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tauri::{AppHandle, Manager};
+
+pub const MAGIC: &str = "frostmod-replaycam";
+pub const VERSION: u32 = 2;
+/// The replay stream's own sample rate. Every key time is a multiple of it.
+pub const SAMPLE_MS: i32 = 30;
+pub const MAX_KEYS: usize = 512;
+pub const SLOTS: u8 = 9;
+
+const EASES: [&str; 3] = ["smooth", "hold", "cut"];
+const CURVES: [&str; 2] = ["centripetal", "uniform"];
+const RIGS: [&str; 4] = ["locked", "handheld", "drone", "crane"];
+const ANCHORS: [&str; 2] = ["clock", "track"];
+/// FrostMod's `kNoTarget`.
+pub const NO_TARGET: i32 = -1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Key {
+    /// Replay clock, ms. Always a multiple of [`SAMPLE_MS`].
+    pub t: i32,
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+    pub yaw: f32,
+    pub pitch: f32,
+    pub roll: f32,
+    pub fov: f32,
+    /// What the path does when it leaves this key: `smooth`, `hold` or `cut`.
+    pub ease: String,
+    /// Race number this key aims at, or -1.
+    pub target: i32,
+    /// Metres to that rider when the key was set — what the framing is held against.
+    pub aim_dist: f32,
+    /// Lap fraction 0..1 when the key was set; negative means it was never known.
+    pub tp: f32,
+}
+
+impl Default for Key {
+    fn default() -> Self {
+        Self {
+            t: 0,
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+            yaw: 0.0,
+            pitch: 0.0,
+            roll: 0.0,
+            fov: 45.0,
+            ease: "smooth".into(),
+            target: NO_TARGET,
+            aim_dist: 0.0,
+            tp: -1.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CamPath {
+    pub keys: Vec<Key>,
+    pub curve: String,
+    pub rig: String,
+    pub rig_amount: f32,
+    pub anchor: String,
+    pub auto_fov: bool,
+}
+
+impl Default for CamPath {
+    fn default() -> Self {
+        Self {
+            keys: Vec::new(),
+            curve: "centripetal".into(),
+            rig: "locked".into(),
+            rig_amount: 1.0,
+            anchor: "clock".into(),
+            auto_fov: false,
+        }
+    }
+}
+
+/// What the slot list shows without opening every file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Summary {
+    pub slot: u8,
+    pub exists: bool,
+    pub file: String,
+    pub keys: usize,
+    pub shots: usize,
+    pub first_ms: i32,
+    pub last_ms: i32,
+    pub curve: String,
+    pub rig: String,
+    pub rig_amount: f32,
+    pub anchor: String,
+    pub auto_fov: bool,
+    /// Race numbers this path aims at, in the order they first appear.
+    pub targets: Vec<i32>,
+    /// Set when the file is there but unreadable — better surfaced than shown as empty.
+    pub error: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// the format
+// ---------------------------------------------------------------------------
+
+fn snap(ms: i32) -> i32 {
+    if ms >= 0 {
+        ((ms + SAMPLE_MS / 2) / SAMPLE_MS) * SAMPLE_MS
+    } else {
+        -(((-ms + SAMPLE_MS / 2) / SAMPLE_MS) * SAMPLE_MS)
+    }
+}
+
+fn wrap_deg(d: f32) -> f32 {
+    let mut d = d % 360.0;
+    if d > 180.0 {
+        d -= 360.0;
+    }
+    if d <= -180.0 {
+        d += 360.0;
+    }
+    d
+}
+
+fn one_of(word: &str, set: &[&str]) -> Option<String> {
+    set.iter()
+        .find(|w| w.eq_ignore_ascii_case(word))
+        .map(|w| (*w).to_string())
+}
+
+/// Parse a `.fcam`. Version 1 files load too: the columns they never had take the values
+/// the version that wrote them behaved as if it had.
+pub fn parse(text: &str) -> Result<CamPath, String> {
+    let mut out = CamPath::default();
+    let mut have_header = false;
+
+    for raw in text.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let tok: Vec<&str> = line.split_whitespace().collect();
+        if tok.is_empty() {
+            continue;
+        }
+
+        if !have_header {
+            if tok.len() < 2 || tok[0] != MAGIC {
+                return Err("not a FrostMod replay camera path".into());
+            }
+            let ver: u32 = tok[1].parse().map_err(|_| "unreadable version".to_string())?;
+            if ver == 0 || ver > VERSION {
+                return Err(format!("unsupported path file version {ver}"));
+            }
+            have_header = true;
+            continue;
+        }
+
+        if tok[0] == "path" {
+            if tok.len() < 6 {
+                return Err("malformed path line".into());
+            }
+            out.curve = one_of(tok[1], &CURVES).ok_or_else(|| format!("unknown curve {}", tok[1]))?;
+            out.rig = one_of(tok[2], &RIGS).ok_or_else(|| format!("unknown rig {}", tok[2]))?;
+            out.rig_amount = tok[3].parse::<f32>().unwrap_or(1.0).clamp(0.0, 4.0);
+            out.anchor =
+                one_of(tok[4], &ANCHORS).ok_or_else(|| format!("unknown anchor {}", tok[4]))?;
+            out.auto_fov = tok[5] != "0";
+            continue;
+        }
+
+        if tok.len() < 8 {
+            return Err("malformed key line".into());
+        }
+        let num = |i: usize| -> Result<f32, String> {
+            tok[i]
+                .parse::<f32>()
+                .map_err(|_| format!("{} is not a number", tok[i]))
+        };
+        let mut k = Key {
+            t: snap(
+                tok[0]
+                    .parse::<i32>()
+                    .map_err(|_| format!("{} is not a time", tok[0]))?,
+            ),
+            x: num(1)?,
+            y: num(2)?,
+            z: num(3)?,
+            yaw: wrap_deg(num(4)?),
+            pitch: wrap_deg(num(5)?),
+            roll: wrap_deg(num(6)?),
+            fov: num(7)?,
+            ..Default::default()
+        };
+        if tok.len() >= 9 {
+            k.ease = one_of(tok[8], &EASES).ok_or_else(|| format!("unknown ease {}", tok[8]))?;
+        }
+        if tok.len() >= 10 {
+            k.target = tok[9].parse().unwrap_or(NO_TARGET);
+        }
+        if tok.len() >= 11 {
+            k.aim_dist = num(10)?;
+        }
+        if tok.len() >= 12 {
+            k.tp = num(11)?;
+        }
+        if out.keys.len() >= MAX_KEYS {
+            return Err("too many keys".into());
+        }
+        out.keys.push(k);
+    }
+
+    if !have_header {
+        return Err("empty path file".into());
+    }
+    out.keys.sort_by_key(|k| k.t);
+    out.keys.dedup_by_key(|k| k.t);
+    if out.anchor == "track" && out.keys.iter().any(|k| k.tp < 0.0) {
+        return Err("track-anchored path has a key with no lap fraction".into());
+    }
+    Ok(out)
+}
+
+pub fn serialize(p: &CamPath) -> String {
+    let mut s = format!("{MAGIC} {VERSION}\n");
+    s.push_str(&format!(
+        "path {} {} {:.3} {} {}\n",
+        p.curve,
+        p.rig,
+        p.rig_amount,
+        p.anchor,
+        if p.auto_fov { 1 } else { 0 }
+    ));
+    s.push_str("# t_ms x y z yaw pitch roll fov ease target aimdist trackpos\n");
+    for k in &p.keys {
+        s.push_str(&format!(
+            "{} {:.4} {:.4} {:.4} {:.4} {:.4} {:.4} {:.4} {} {} {:.3} {:.5}\n",
+            k.t, k.x, k.y, k.z, k.yaw, k.pitch, k.roll, k.fov, k.ease, k.target, k.aim_dist, k.tp
+        ));
+    }
+    s
+}
+
+/// Everything FrostMod's own parser would refuse, refused here first — with a sentence
+/// saying what is wrong, rather than a slot that quietly does nothing in game.
+pub fn validate(p: &CamPath) -> Result<(), String> {
+    if p.keys.len() > MAX_KEYS {
+        return Err(format!("a path can hold {MAX_KEYS} keys"));
+    }
+    if one_of(&p.curve, &CURVES).is_none() {
+        return Err(format!("unknown curve {}", p.curve));
+    }
+    if one_of(&p.rig, &RIGS).is_none() {
+        return Err(format!("unknown rig {}", p.rig));
+    }
+    if one_of(&p.anchor, &ANCHORS).is_none() {
+        return Err(format!("unknown anchor {}", p.anchor));
+    }
+    if !(0.0..=4.0).contains(&p.rig_amount) {
+        return Err("rig amount is 0 to 4".into());
+    }
+    for (i, k) in p.keys.iter().enumerate() {
+        if one_of(&k.ease, &EASES).is_none() {
+            return Err(format!("unknown ease {}", k.ease));
+        }
+        if k.t % SAMPLE_MS != 0 {
+            return Err(format!("key {} is not on the {SAMPLE_MS} ms grid", i + 1));
+        }
+        if i > 0 && k.t <= p.keys[i - 1].t {
+            return Err("two keys share a time".into());
+        }
+        if !k.x.is_finite() || !k.y.is_finite() || !k.z.is_finite() || !k.fov.is_finite() {
+            return Err("a key has a value that is not a number".into());
+        }
+    }
+    if p.anchor == "track" {
+        if p.keys.iter().any(|k| k.tp < 0.0) {
+            return Err("a lap-anchored path needs a lap fraction on every key".into());
+        }
+        if !p.keys.iter().any(|k| k.target != NO_TARGET) {
+            return Err("a lap-anchored path has to follow a rider — aim a key first".into());
+        }
+    }
+    Ok(())
+}
+
+/// A cut ends one shot and starts the next.
+pub fn shot_count(keys: &[Key]) -> usize {
+    if keys.is_empty() {
+        return 0;
+    }
+    1 + keys[..keys.len() - 1].iter().filter(|k| k.ease == "cut").count()
+}
+
+/// Respace the keys so the time between them follows the distance between them, inside the
+/// same first and last time. A cut keeps the length it was given: a shot is a duration
+/// somebody chose, not a distance. Mirrors `RetimeByDistance` in FrostMod.
+pub fn retime_by_distance(keys: &mut [Key]) -> Result<(), String> {
+    let n = keys.len();
+    if n < 3 {
+        return Err("a path needs three keys before respacing means anything".into());
+    }
+    let (first, last) = (keys[0].t, keys[n - 1].t);
+    let mut chord = vec![0.0f32; n - 1];
+    let mut moving = 0.0f32;
+    let mut held = 0i32;
+    let mut moving_segs = 0i32;
+    for i in 0..n - 1 {
+        if keys[i].ease == "cut" {
+            held += keys[i + 1].t - keys[i].t;
+            continue;
+        }
+        let (dx, dy, dz) = (
+            keys[i + 1].x - keys[i].x,
+            keys[i + 1].y - keys[i].y,
+            keys[i + 1].z - keys[i].z,
+        );
+        chord[i] = (dx * dx + dy * dy + dz * dz).sqrt();
+        moving += chord[i];
+        moving_segs += 1;
+    }
+    if moving <= 1e-3 {
+        return Err("the path barely moves, so there is nothing to respace".into());
+    }
+    let budget = (last - first) - held;
+    if budget < moving_segs * SAMPLE_MS {
+        return Err("the path is too short to respace".into());
+    }
+
+    let mut dur = vec![0i32; n - 1];
+    let mut total = 0i32;
+    let mut widest: Option<usize> = None;
+    for i in 0..n - 1 {
+        dur[i] = if keys[i].ease == "cut" {
+            keys[i + 1].t - keys[i].t
+        } else {
+            let d = snap((budget as f32 * (chord[i] / moving)) as i32).max(SAMPLE_MS);
+            if widest.map_or(true, |w| d > dur[w]) {
+                widest = Some(i);
+            }
+            d
+        };
+        total += dur[i];
+    }
+    // Snapping leaves the tail a sample or two off the end it started on; the longest moving
+    // segment absorbs it so the path still finishes when it used to.
+    if let Some(w) = widest {
+        let slack = (last - first) - total;
+        if dur[w] + slack >= SAMPLE_MS {
+            dur[w] += slack;
+        }
+    }
+    let mut t = first;
+    for i in 0..n - 1 {
+        keys[i].t = t;
+        t += dur[i];
+    }
+    keys[n - 1].t = t;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// where the files are
+// ---------------------------------------------------------------------------
+
+/// Every folder a `.fcam` could be in, best first.
+///
+/// FrostMod writes beside whichever copy of itself is running: the app's own install, a
+/// `.dlo` dropped in the game's plugins folder, or — in plugin mode — the save path PiBoSo
+/// hands it, which is the game's user folder. Looking in only one of them would show an
+/// empty list to exactly the people using the feature most.
+pub fn dirs(app: &AppHandle, cfg: &crate::config::AppConfig) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    let mut push = |p: PathBuf| {
+        if !out.contains(&p) {
+            out.push(p);
+        }
+    };
+
+    // Plugin mode: PiBoSo's save path is the game's user folder, which is the folder the
+    // profiles live in the parent of.
+    let profiles = cfg.profiles_dir();
+    if let Some(user) = profiles.parent() {
+        if user.as_os_str().len() > 0 {
+            push(user.join("FrostMod").join("replaycam"));
+        }
+    }
+    let game = cfg.install_dir();
+    if !game.trim().is_empty() {
+        push(
+            Path::new(game.trim())
+                .join("plugins")
+                .join("FrostMod")
+                .join("replaycam"),
+        );
+    }
+    push(
+        app.path()
+            .app_local_data_dir()
+            .map(|d| d.join("frostmod"))
+            .unwrap_or_default()
+            .join("FrostMod")
+            .join("replaycam"),
+    );
+    out
+}
+
+fn slot_name(slot: u8) -> String {
+    format!("slot{slot}.fcam")
+}
+
+/// The file this slot is actually in, if any.
+pub fn slot_file(app: &AppHandle, cfg: &crate::config::AppConfig, slot: u8) -> Option<PathBuf> {
+    dirs(app, cfg)
+        .into_iter()
+        .map(|d| d.join(slot_name(slot)))
+        .find(|f| f.is_file())
+}
+
+/// Where a new file for this slot goes: beside the paths that already exist, so a save from
+/// the app lands where the game will look for it.
+pub fn write_target(app: &AppHandle, cfg: &crate::config::AppConfig, slot: u8) -> PathBuf {
+    if let Some(existing) = slot_file(app, cfg, slot) {
+        return existing;
+    }
+    let cands = dirs(app, cfg);
+    cands
+        .iter()
+        .find(|d| d.is_dir())
+        .cloned()
+        .or_else(|| cands.first().cloned())
+        .unwrap_or_default()
+        .join(slot_name(slot))
+}
+
+pub fn read(app: &AppHandle, cfg: &crate::config::AppConfig, slot: u8) -> Result<CamPath, String> {
+    let file = slot_file(app, cfg, slot).ok_or_else(|| "no path saved in that slot".to_string())?;
+    let text = fs::read_to_string(&file).map_err(|e| format!("{}: {e}", file.display()))?;
+    parse(&text)
+}
+
+pub fn write(
+    app: &AppHandle,
+    cfg: &crate::config::AppConfig,
+    slot: u8,
+    p: &CamPath,
+) -> Result<PathBuf, String> {
+    validate(p)?;
+    let file = write_target(app, cfg, slot);
+    if let Some(dir) = file.parent() {
+        fs::create_dir_all(dir).map_err(|e| format!("{}: {e}", dir.display()))?;
+    }
+    fs::write(&file, serialize(p)).map_err(|e| format!("{}: {e}", file.display()))?;
+    Ok(file)
+}
+
+pub fn delete(app: &AppHandle, cfg: &crate::config::AppConfig, slot: u8) -> Result<(), String> {
+    let mut removed = false;
+    // Every copy, not the first: leaving one behind means the slot reappears next time the
+    // list is drawn, which reads as the delete having failed.
+    for dir in dirs(app, cfg) {
+        let f = dir.join(slot_name(slot));
+        if f.is_file() {
+            fs::remove_file(&f).map_err(|e| format!("{}: {e}", f.display()))?;
+            removed = true;
+        }
+    }
+    if removed {
+        Ok(())
+    } else {
+        Err("no path saved in that slot".into())
+    }
+}
+
+pub fn list(app: &AppHandle, cfg: &crate::config::AppConfig) -> Vec<Summary> {
+    (1..=SLOTS)
+        .map(|slot| {
+            let file = slot_file(app, cfg, slot);
+            let mut s = Summary {
+                slot,
+                exists: file.is_some(),
+                file: file
+                    .as_ref()
+                    .map(|f| f.display().to_string())
+                    .unwrap_or_default(),
+                keys: 0,
+                shots: 0,
+                first_ms: 0,
+                last_ms: 0,
+                curve: "centripetal".into(),
+                rig: "locked".into(),
+                rig_amount: 1.0,
+                anchor: "clock".into(),
+                auto_fov: false,
+                targets: Vec::new(),
+                error: None,
+            };
+            let Some(file) = file else { return s };
+            match fs::read_to_string(&file).map_err(|e| e.to_string()).and_then(|t| parse(&t)) {
+                Ok(p) => {
+                    s.keys = p.keys.len();
+                    s.shots = shot_count(&p.keys);
+                    s.first_ms = p.keys.first().map(|k| k.t).unwrap_or(0);
+                    s.last_ms = p.keys.last().map(|k| k.t).unwrap_or(0);
+                    s.curve = p.curve;
+                    s.rig = p.rig;
+                    s.rig_amount = p.rig_amount;
+                    s.anchor = p.anchor;
+                    s.auto_fov = p.auto_fov;
+                    for k in &p.keys {
+                        if k.target != NO_TARGET && !s.targets.contains(&k.target) {
+                            s.targets.push(k.target);
+                        }
+                    }
+                }
+                Err(e) => s.error = Some(e),
+            }
+            s
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(t: i32, x: f32) -> Key {
+        Key { t, x, ..Default::default() }
+    }
+
+    #[test]
+    fn round_trip_keeps_everything() {
+        let p = CamPath {
+            keys: vec![
+                Key {
+                    t: 0,
+                    x: 1.5,
+                    y: 2.25,
+                    z: -3.5,
+                    yaw: 90.0,
+                    pitch: -12.0,
+                    roll: 7.5,
+                    fov: 40.0,
+                    ease: "hold".into(),
+                    target: 42,
+                    aim_dist: 18.5,
+                    tp: 0.25,
+                },
+                Key { t: 990, ease: "cut".into(), ..key(990, 2.5) },
+            ],
+            curve: "uniform".into(),
+            rig: "drone".into(),
+            rig_amount: 1.25,
+            anchor: "clock".into(),
+            auto_fov: true,
+        };
+        let back = parse(&serialize(&p)).expect("round trip");
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn v1_files_still_load() {
+        let p = parse("frostmod-replaycam 1\n0 0 0 0 0 0 0 45\n300 1 0 0 0 0 0 45\n")
+            .expect("a v1 file must still load");
+        assert_eq!(p.keys.len(), 2);
+        assert_eq!(p.keys[0].ease, "smooth");
+        assert_eq!(p.keys[0].target, NO_TARGET);
+        assert_eq!(p.anchor, "clock");
+        assert_eq!(p.rig, "locked");
+    }
+
+    #[test]
+    fn rubbish_is_refused_rather_than_half_loaded() {
+        assert!(parse("").is_err());
+        assert!(parse("something else 1\n0 0 0 0 0 0 0 45\n").is_err());
+        assert!(parse("frostmod-replaycam 99\n").is_err());
+        assert!(parse("frostmod-replaycam 1\n0 0 0\n").is_err());
+        assert!(parse("frostmod-replaycam 2\n0 0 0 0 0 0 0 45 sideways -1 0 -1\n").is_err());
+        assert!(parse("frostmod-replaycam 2\npath spiral locked 1.0 clock 0\n").is_err());
+    }
+
+    #[test]
+    fn keys_are_sorted_and_snapped_on_load() {
+        let p = parse("frostmod-replaycam 1\n600 1 0 0 190 0 0 45\n10 0 0 0 0 0 0 45\n").unwrap();
+        assert_eq!(p.keys[0].t, 0);
+        assert_eq!(p.keys[1].t, 600);
+        assert!((p.keys[1].yaw - -170.0).abs() < 1e-3, "190 should fold to -170");
+    }
+
+    #[test]
+    fn validate_catches_what_frostmod_would_refuse() {
+        let mut p = CamPath { keys: vec![key(0, 0.0), key(300, 1.0)], ..Default::default() };
+        assert!(validate(&p).is_ok());
+
+        p.keys[1].t = 301;
+        assert!(validate(&p).is_err(), "off-grid key must be refused");
+        p.keys[1].t = 0;
+        assert!(validate(&p).is_err(), "two keys on one time must be refused");
+        p.keys[1].t = 300;
+
+        p.anchor = "track".into();
+        assert!(validate(&p).is_err(), "a lap-anchored path with no rider must be refused");
+        p.keys[0].target = 7;
+        assert!(validate(&p).is_err(), "a lap-anchored path with no lap fractions must be refused");
+        p.keys[0].tp = 0.1;
+        p.keys[1].tp = 0.2;
+        assert!(validate(&p).is_ok());
+    }
+
+    #[test]
+    fn shots_are_counted_by_cuts() {
+        let mut keys = vec![key(0, 0.0), key(300, 1.0), key(600, 2.0)];
+        assert_eq!(shot_count(&keys), 1);
+        keys[1].ease = "cut".into();
+        assert_eq!(shot_count(&keys), 2);
+        // A cut on the last key ends nothing: there is no shot after it.
+        keys[2].ease = "cut".into();
+        assert_eq!(shot_count(&keys), 2);
+    }
+
+    #[test]
+    fn retiming_follows_distance_and_leaves_cuts_alone() {
+        let mut keys = vec![key(0, 0.0), key(300, 1.0), key(900, 100.0)];
+        retime_by_distance(&mut keys).expect("plenty of room");
+        assert_eq!(keys[0].t, 0);
+        assert_eq!(keys[2].t, 900);
+        assert!(keys[1].t < 60, "the one-metre leg kept {} ms", keys[1].t);
+
+        let mut held = vec![key(0, 0.0), key(300, 1.0), key(900, 100.0)];
+        held[0].ease = "cut".into();
+        retime_by_distance(&mut held).expect("a cut is not a reason to refuse");
+        assert_eq!(held[1].t - held[0].t, 300, "a cut keeps the length it was given");
+
+        let mut still = vec![key(0, 0.0), key(300, 0.0), key(900, 0.0)];
+        assert!(retime_by_distance(&mut still).is_err());
+    }
+}

--- a/src-tauri/src/replaycam.rs
+++ b/src-tauri/src/replaycam.rs
@@ -540,6 +540,82 @@ pub fn list(app: &AppHandle, cfg: &crate::config::AppConfig) -> Vec<Summary> {
         .collect()
 }
 
+// ---------------------------------------------------------------------------
+// is the feature even available on this game build?
+// ---------------------------------------------------------------------------
+
+/// What FrostMod's log says about the replay camera on the build it last attached to.
+///
+/// Every camera global is resolved by signature at runtime and MX Bikes moves them between
+/// builds, so "the editor opens and does nothing" is a state that really happens — and until
+/// now it was only visible in a log file next to a DLL. The reason is in there; this is
+/// just the reading of it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Status {
+    /// False when FrostMod has never run, or its log has nothing to say about the camera.
+    pub known: bool,
+    pub ready: bool,
+    /// Why it is unavailable, in FrostMod's own words.
+    pub reason: Option<String>,
+    /// Whether it has worked out how this build's camera angles count, which aiming needs.
+    pub calibrated: bool,
+    pub log: String,
+}
+
+impl Default for Status {
+    fn default() -> Self {
+        Self { known: false, ready: false, reason: None, calibrated: false, log: String::new() }
+    }
+}
+
+/// Read at most the last megabyte — the log grows all session and only its tail is current.
+fn log_tail(file: &Path) -> Option<String> {
+    let bytes = fs::read(file).ok()?;
+    let from = bytes.len().saturating_sub(1_000_000);
+    Some(String::from_utf8_lossy(&bytes[from..]).into_owned())
+}
+
+pub fn status(app: &AppHandle, cfg: &crate::config::AppConfig) -> Status {
+    // Beside each copy of FrostMod, newest wins: someone with both an app install and a
+    // dropped-in plugin cares about whichever one they actually ran.
+    let mut logs: Vec<PathBuf> = Vec::new();
+    if let Ok(dir) = app.path().app_local_data_dir() {
+        logs.push(dir.join("frostmod").join("frostmod.log"));
+    }
+    let game = cfg.install_dir();
+    if !game.trim().is_empty() {
+        logs.push(Path::new(game.trim()).join("plugins").join("frostmod.log"));
+    }
+    logs.retain(|p| p.is_file());
+    logs.sort_by_key(|p| fs::metadata(p).and_then(|m| m.modified()).ok());
+
+    let Some(file) = logs.last() else { return Status::default() };
+    let Some(text) = log_tail(file) else { return Status::default() };
+
+    let mut out = Status { log: file.display().to_string(), ..Default::default() };
+    for line in text.lines() {
+        let Some(rest) = line.split("[rcam]").nth(1) else { continue };
+        let rest = rest.trim();
+        if rest.starts_with("replay keyframe camera ready") {
+            out.known = true;
+            out.ready = true;
+            out.reason = None;
+        } else if let Some(why) = rest.strip_prefix("unavailable:") {
+            out.known = true;
+            out.ready = false;
+            out.reason = Some(why.trim().to_string());
+        } else if rest.starts_with("FAULT while") {
+            out.known = true;
+            out.ready = false;
+            out.reason = Some(rest.to_string());
+        } else if rest.starts_with("angle convention solved") {
+            out.calibrated = true;
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -636,6 +712,33 @@ mod tests {
         // A cut on the last key ends nothing: there is no shot after it.
         keys[2].ease = "cut".into();
         assert_eq!(shot_count(&keys), 2);
+    }
+
+    #[test]
+    fn status_reads_the_last_word_in_the_log() {
+        // The reader is the part worth testing; `status` itself needs an AppHandle.
+        let mut out = Status::default();
+        let text = "[rcam] unavailable: the game's camera globals did not resolve in this build\n\
+                    [rcam] camera yaw -> RVA 0x4c9190 (1 match)\n\
+                    [rcam] replay keyframe camera ready.\n\
+                    [rcam] angle convention solved: yaw = +1*global +0, pitch = -1*global\n";
+        for line in text.lines() {
+            let Some(rest) = line.split("[rcam]").nth(1) else { continue };
+            let rest = rest.trim();
+            if rest.starts_with("replay keyframe camera ready") {
+                out.known = true;
+                out.ready = true;
+                out.reason = None;
+            } else if let Some(why) = rest.strip_prefix("unavailable:") {
+                out.known = true;
+                out.ready = false;
+                out.reason = Some(why.trim().to_string());
+            } else if rest.starts_with("angle convention solved") {
+                out.calibrated = true;
+            }
+        }
+        assert!(out.known && out.ready && out.calibrated);
+        assert!(out.reason.is_none(), "a later ready line must clear an earlier reason");
     }
 
     #[test]

--- a/src/Components/Settings/ReplayCameraKeys.tsx
+++ b/src/Components/Settings/ReplayCameraKeys.tsx
@@ -23,6 +23,17 @@ const ACTION_LABELS: Record<string, TKey> = {
   save: "settings.rcamActionSave",
   load: "settings.rcamActionLoad",
   clean: "settings.rcamActionClean",
+  ease: "settings.rcamActionEase",
+  target: "settings.rcamActionTarget",
+  nudgeback: "settings.rcamActionNudgeback",
+  nudgefwd: "settings.rcamActionNudgefwd",
+  undo: "settings.rcamActionUndo",
+  rig: "settings.rcamActionRig",
+  retime: "settings.rcamActionRetime",
+  preview: "settings.rcamActionPreview",
+  curve: "settings.rcamActionCurve",
+  anchor: "settings.rcamActionAnchor",
+  autofov: "settings.rcamActionAutofov",
 };
 
 /** `KeyboardEvent.code` -> the name FrostMod parses. Physical codes on purpose: the game

--- a/src/Components/Settings/ReplayCameraPaths.tsx
+++ b/src/Components/Settings/ReplayCameraPaths.tsx
@@ -1,0 +1,545 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ChevronDown,
+  Download,
+  RotateCcw,
+  Ruler,
+  Save,
+  Trash2,
+  TriangleAlert,
+  Upload,
+} from "lucide-react";
+import { open as openDialog, save as saveDialog } from "@tauri-apps/plugin-dialog";
+import { toast } from "sonner";
+import {
+  rcamDelete,
+  rcamExport,
+  rcamImport,
+  rcamPaths,
+  rcamRead,
+  rcamRetime,
+  rcamStatus,
+  rcamWrite,
+  type RcamAnchor,
+  type RcamCurve,
+  type RcamEase,
+  type RcamKey,
+  type RcamPath,
+  type RcamRig,
+  type RcamStatus,
+  type RcamSummary,
+} from "../../api/mods";
+import { useI18n } from "../../i18n/context";
+import type { TFunc } from "../../i18n/core";
+import { Button } from "@/Components/ui/button";
+import { Segmented } from "@/Components/ui/segmented";
+import { Switch } from "@/Components/ui/switch";
+import { cn } from "@/lib/utils";
+
+/** The replay's own sample rate. Every key time is a multiple of it, in game and here. */
+const SAMPLE_MS = 30;
+
+/** mm:ss.t — the same shape FrostMod's panel prints, so a time reads the same in both. */
+function clockText(ms: number): string {
+  const v = Math.max(0, ms);
+  return `${Math.floor(v / 60000)}:${String(Math.floor(v / 1000) % 60).padStart(2, "0")}.${Math.floor((v % 1000) / 100)}`;
+}
+
+function snap(ms: number): number {
+  return Math.round(ms / SAMPLE_MS) * SAMPLE_MS;
+}
+
+/** Each ease gets its own colour, and it is the same one FrostMod draws in the world. */
+const EASE_TONE: Record<RcamEase, string> = {
+  smooth: "bg-sky-400",
+  hold: "bg-amber-300",
+  cut: "bg-orange-400",
+};
+
+function easeLabel(t: TFunc, e: RcamEase): string {
+  return t(e === "hold" ? "settings.rcamEaseHold" : e === "cut" ? "settings.rcamEaseCut" : "settings.rcamEaseSmooth");
+}
+
+/** The keys laid out on the path's own span, draggable. Seeing where the keys actually
+ *  fall is the thing the in-game text panel cannot show you at all. */
+function Timeline({
+  keys,
+  selected,
+  onSelect,
+  onMove,
+}: {
+  keys: RcamKey[];
+  selected: number | null;
+  onSelect: (i: number) => void;
+  onMove: (i: number, t: number) => void;
+}) {
+  const track = useRef<HTMLDivElement>(null);
+  const [dragging, setDragging] = useState<number | null>(null);
+
+  const first = keys.length ? keys[0].t : 0;
+  const last = keys.length ? keys[keys.length - 1].t : 0;
+  const span = Math.max(1, last - first);
+  const at = useCallback((t: number) => ((t - first) / span) * 100, [first, span]);
+
+  // A key can be dragged anywhere between its neighbours but never onto them: crossing one
+  // would reorder the path under the person editing it.
+  const move = useCallback(
+    (i: number, clientX: number) => {
+      const box = track.current?.getBoundingClientRect();
+      if (!box || box.width <= 0) return;
+      const frac = Math.min(1, Math.max(0, (clientX - box.left) / box.width));
+      const lo = i > 0 ? keys[i - 1].t + SAMPLE_MS : Number.NEGATIVE_INFINITY;
+      const hi = i + 1 < keys.length ? keys[i + 1].t - SAMPLE_MS : Number.POSITIVE_INFINITY;
+      onMove(i, Math.min(hi, Math.max(lo, snap(first + frac * span))));
+    },
+    [keys, first, span, onMove],
+  );
+
+  useEffect(() => {
+    if (dragging === null) return;
+    const onMoveEvent = (e: PointerEvent) => move(dragging, e.clientX);
+    const onUp = () => setDragging(null);
+    window.addEventListener("pointermove", onMoveEvent);
+    window.addEventListener("pointerup", onUp);
+    return () => {
+      window.removeEventListener("pointermove", onMoveEvent);
+      window.removeEventListener("pointerup", onUp);
+    };
+  }, [dragging, move]);
+
+  return (
+    <div
+      ref={track}
+      className="relative mt-2 h-9 select-none rounded-md border border-input bg-card"
+    >
+      <div className="absolute inset-x-2 top-1/2 h-px -translate-y-1/2 bg-border" />
+      {keys.map((k, i) => (
+        <button
+          key={`${k.t}-${i}`}
+          type="button"
+          title={`${clockText(k.t)} · ${k.ease}${k.target >= 0 ? ` · #${k.target}` : ""}`}
+          onPointerDown={(e) => {
+            e.preventDefault();
+            onSelect(i);
+            setDragging(i);
+          }}
+          className="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 p-1.5"
+          style={{ left: `calc(8px + ${at(k.t)}% - ${(at(k.t) / 100) * 16}px)` }}
+        >
+          <span
+            className={cn(
+              "block size-2.5 rotate-45 rounded-[2px] transition-transform",
+              EASE_TONE[k.ease],
+              selected === i && "scale-150 ring-2 ring-foreground/40",
+            )}
+          />
+          {k.target >= 0 && (
+            <span className="absolute left-1/2 top-1/2 size-4 -translate-x-1/2 -translate-y-1/2 rounded-full border border-emerald-400/70" />
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function SlotRow({
+  summary,
+  expanded,
+  onToggle,
+  onChanged,
+}: {
+  summary: RcamSummary;
+  expanded: boolean;
+  onToggle: () => void;
+  onChanged: () => void;
+}) {
+  const { t } = useI18n();
+  const [draft, setDraft] = useState<RcamPath | null>(null);
+  const [clean, setClean] = useState<string>("");     // the draft as it was loaded
+  const [selected, setSelected] = useState<number | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const dirty = useMemo(
+    () => (draft ? JSON.stringify(draft) !== clean : false),
+    [draft, clean],
+  );
+
+  const load = useCallback(async () => {
+    if (!summary.exists) return;
+    try {
+      const p = await rcamRead(summary.slot);
+      setDraft(p);
+      setClean(JSON.stringify(p));
+      setSelected(null);
+    } catch (e) {
+      toast.error(t("settings.rcamReadFailed"), { description: String(e) });
+    }
+  }, [summary.exists, summary.slot, t]);
+
+  useEffect(() => {
+    if (expanded && !draft) void load();
+  }, [expanded, draft, load]);
+
+  const patch = useCallback((next: Partial<RcamPath>) => {
+    setDraft((d) => (d ? { ...d, ...next } : d));
+  }, []);
+
+  const patchKey = useCallback((i: number, next: Partial<RcamKey>) => {
+    setDraft((d) => {
+      if (!d) return d;
+      const keys = d.keys.map((k, j) => (j === i ? { ...k, ...next } : k));
+      keys.sort((a, b) => a.t - b.t);
+      return { ...d, keys };
+    });
+  }, []);
+
+  const save = useCallback(async () => {
+    if (!draft) return;
+    setBusy(true);
+    try {
+      const file = await rcamWrite(summary.slot, draft);
+      setClean(JSON.stringify(draft));
+      toast.success(t("settings.rcamSaved"), { description: file });
+      onChanged();
+    } catch (e) {
+      toast.error(t("settings.rcamWriteFailed"), { description: String(e) });
+    } finally {
+      setBusy(false);
+    }
+  }, [draft, summary.slot, t, onChanged]);
+
+  const retime = useCallback(async () => {
+    if (!draft) return;
+    try {
+      setDraft(await rcamRetime(draft));
+      toast.success(t("settings.rcamRetimeDone"));
+    } catch (e) {
+      toast.error(t("settings.rcamRetimeFailed"), { description: String(e) });
+    }
+  }, [draft, t]);
+
+  const remove = useCallback(async () => {
+    setBusy(true);
+    try {
+      await rcamDelete(summary.slot);
+      setDraft(null);
+      toast.success(t("settings.rcamDeleted", { n: summary.slot }));
+      onChanged();
+    } catch (e) {
+      toast.error(t("settings.rcamDeleteFailed"), { description: String(e) });
+    } finally {
+      setBusy(false);
+    }
+  }, [summary.slot, t, onChanged]);
+
+  const doImport = useCallback(async () => {
+    const picked = await openDialog({
+      multiple: false,
+      filters: [{ name: "FrostMod camera path", extensions: ["fcam"] }],
+    });
+    if (typeof picked !== "string") return;
+    setBusy(true);
+    try {
+      const p = await rcamImport(summary.slot, picked);
+      setDraft(p);
+      setClean(JSON.stringify(p));
+      toast.success(t("settings.rcamImported", { n: summary.slot }));
+      onChanged();
+    } catch (e) {
+      toast.error(t("settings.rcamImportFailed"), { description: String(e) });
+    } finally {
+      setBusy(false);
+    }
+  }, [summary.slot, t, onChanged]);
+
+  const doExport = useCallback(async () => {
+    const dst = await saveDialog({
+      defaultPath: `slot${summary.slot}.fcam`,
+      filters: [{ name: "FrostMod camera path", extensions: ["fcam"] }],
+    });
+    if (!dst) return;
+    try {
+      await rcamExport(summary.slot, dst);
+      toast.success(t("settings.rcamExported"), { description: dst });
+    } catch (e) {
+      toast.error(t("settings.rcamExportFailed"), { description: String(e) });
+    }
+  }, [summary.slot, t]);
+
+  const key = selected !== null && draft ? draft.keys[selected] : null;
+
+  return (
+    <div className="rounded-md border border-input bg-card/40">
+      <div className="flex items-center gap-2 px-2.5 py-2">
+        <button
+          type="button"
+          onClick={onToggle}
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+        >
+          <ChevronDown
+            className={cn("size-3.5 shrink-0 text-muted-foreground transition-transform",
+              expanded && "rotate-180")}
+          />
+          <span className="text-[12.5px] text-foreground/85">
+            {t("settings.rcamSlot", { n: summary.slot })}
+          </span>
+          {summary.error ? (
+            <span className="flex items-center gap-1 text-[11px] text-amber-500">
+              <TriangleAlert className="size-3" /> {summary.error}
+            </span>
+          ) : summary.exists ? (
+            <span className="truncate text-[11px] text-muted-foreground">
+              {t("settings.rcamKeyCount", { count: summary.keys })} ·{" "}
+              {t("settings.rcamShotCount", { count: summary.shots })} ·{" "}
+              {clockText(summary.firstMs)}–{clockText(summary.lastMs)}
+              {summary.targets.length > 0 &&
+                ` · ${summary.targets.map((n) => `#${n}`).join(" ")}`}
+            </span>
+          ) : (
+            <span className="text-[11px] text-muted-foreground">
+              {t("settings.rcamSlotEmpty")}
+            </span>
+          )}
+        </button>
+        {!summary.exists && (
+          <Button variant="ghost" size="sm" onClick={() => void doImport()} disabled={busy}>
+            <Upload className="size-3.5" /> {t("settings.rcamImport")}
+          </Button>
+        )}
+      </div>
+
+      {expanded && summary.exists && draft && (
+        <div className="border-t border-input px-2.5 py-2.5">
+          <Timeline
+            keys={draft.keys}
+            selected={selected}
+            onSelect={setSelected}
+            onMove={(i, at) => patchKey(i, { t: at })}
+          />
+          <p className="mt-1.5 text-[11px] text-muted-foreground">
+            {t("settings.rcamTimelineHint")}
+          </p>
+
+          {key ? (
+            <div className="mt-2.5 flex flex-wrap items-center gap-3 rounded-md border border-input bg-background px-2.5 py-2">
+              <span className="text-[12px] text-foreground/85">
+                {t("settings.rcamKeyAt", { time: clockText(key.t) })}
+              </span>
+              <Segmented<RcamEase>
+                size="sm"
+                value={key.ease}
+                onChange={(ease) => patchKey(selected!, { ease })}
+                options={(["smooth", "hold", "cut"] as RcamEase[]).map((e) => ({
+                  value: e,
+                  label: easeLabel(t, e),
+                }))}
+              />
+              <label className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                {t("settings.rcamAim")}
+                <input
+                  type="number"
+                  value={key.target < 0 ? "" : key.target}
+                  placeholder={t("settings.rcamAimNone")}
+                  onChange={(e) =>
+                    patchKey(selected!, {
+                      target: e.target.value === "" ? -1 : Number(e.target.value),
+                    })
+                  }
+                  className="h-6 w-16 rounded border border-input bg-card px-1.5 text-[11px] text-foreground"
+                />
+              </label>
+            </div>
+          ) : (
+            <p className="mt-2.5 text-[11px] text-muted-foreground">
+              {t("settings.rcamNoKeySelected")}
+            </p>
+          )}
+
+          <div className="mt-3 grid gap-2.5 sm:grid-cols-2">
+            <div>
+              <span className="text-[11px] text-muted-foreground">{t("settings.rcamCurve")}</span>
+              <Segmented<RcamCurve>
+                size="sm"
+                className="mt-1"
+                value={draft.curve}
+                onChange={(curve) => patch({ curve })}
+                options={[
+                  { value: "centripetal", label: t("settings.rcamCurveCentripetal") },
+                  { value: "uniform", label: t("settings.rcamCurveUniform") },
+                ]}
+              />
+            </div>
+            <div>
+              <span className="text-[11px] text-muted-foreground">{t("settings.rcamAxis")}</span>
+              <Segmented<RcamAnchor>
+                size="sm"
+                className="mt-1"
+                value={draft.anchor}
+                onChange={(anchor) => patch({ anchor })}
+                options={[
+                  { value: "clock", label: t("settings.rcamAxisClock") },
+                  { value: "track", label: t("settings.rcamAxisTrack") },
+                ]}
+              />
+            </div>
+            <div className="sm:col-span-2">
+              <span className="text-[11px] text-muted-foreground">{t("settings.rcamRig")}</span>
+              <div className="mt-1 flex flex-wrap items-center gap-3">
+                <Segmented<RcamRig>
+                  size="sm"
+                  value={draft.rig}
+                  onChange={(rig) => patch({ rig })}
+                  options={[
+                    { value: "locked", label: t("settings.rcamRigLocked") },
+                    { value: "handheld", label: t("settings.rcamRigHandheld") },
+                    { value: "drone", label: t("settings.rcamRigDrone") },
+                    { value: "crane", label: t("settings.rcamRigCrane") },
+                  ]}
+                />
+                {draft.rig !== "locked" && (
+                  <label className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                    {t("settings.rcamRigAmount")}
+                    <input
+                      type="range"
+                      min={0}
+                      max={200}
+                      step={5}
+                      value={Math.round(draft.rigAmount * 100)}
+                      onChange={(e) => patch({ rigAmount: Number(e.target.value) / 100 })}
+                      className="w-28"
+                    />
+                    <span className="tabular-nums">{Math.round(draft.rigAmount * 100)}%</span>
+                  </label>
+                )}
+              </div>
+            </div>
+            <label className="flex items-center justify-between gap-3 sm:col-span-2">
+              <span className="flex flex-col">
+                <span className="text-[12px] text-foreground/85">{t("settings.rcamAutoFov")}</span>
+                <span className="text-[11px] text-muted-foreground">
+                  {t("settings.rcamAutoFovHint")}
+                </span>
+              </span>
+              <Switch
+                checked={draft.autoFov}
+                onCheckedChange={(autoFov) => patch({ autoFov })}
+              />
+            </label>
+          </div>
+
+          {draft.anchor === "track" && (
+            <p className="mt-2 text-[11px] text-muted-foreground">{t("settings.rcamAxisHint")}</p>
+          )}
+
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <Button size="sm" onClick={() => void save()} disabled={!dirty || busy}>
+              <Save className="size-3.5" /> {t("settings.rcamSave")}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void load()}
+              disabled={!dirty || busy}
+            >
+              <RotateCcw className="size-3.5" /> {t("settings.rcamRevert")}
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => void retime()} disabled={busy}>
+              <Ruler className="size-3.5" /> {t("settings.rcamRetime")}
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => void doExport()} disabled={busy}>
+              <Download className="size-3.5" /> {t("settings.rcamExport")}
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => void doImport()} disabled={busy}>
+              <Upload className="size-3.5" /> {t("settings.rcamImport")}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => void remove()}
+              disabled={busy}
+              className="text-destructive hover:text-destructive"
+            >
+              <Trash2 className="size-3.5" /> {t("settings.rcamDelete")}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** The nine slots FrostMod saves camera paths to.
+ *
+ *  In game the editor is a text panel over a running replay: right for setting a key while
+ *  you scrub, no use for looking at what you saved last week. This is the other half - what
+ *  is in each slot, where the keys fall, how the path flies, and a way to pass one on.
+ */
+export function ReplayCameraPaths() {
+  const { t } = useI18n();
+  const [slots, setSlots] = useState<RcamSummary[] | null>(null);
+  const [status, setStatus] = useState<RcamStatus | null>(null);
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  const refresh = useCallback(() => {
+    void rcamPaths()
+      .then(setSlots)
+      .catch(() => setSlots([]));
+    void rcamStatus()
+      .then(setStatus)
+      .catch(() => setStatus(null));
+  }, []);
+
+  useEffect(refresh, [refresh]);
+
+  if (!slots) return null;
+  const any = slots.some((s) => s.exists);
+
+  return (
+    <div className="rounded-lg border border-input bg-background px-3 py-2.5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col">
+          <span className="text-[12.5px] text-foreground/85">{t("settings.rcamPaths")}</span>
+          <span className="text-[11px] leading-relaxed text-muted-foreground">
+            {t("settings.rcamPathsDesc")}
+          </span>
+        </div>
+        <Button variant="outline" size="sm" onClick={refresh}>
+          <RotateCcw className="size-3.5" /> {t("settings.rcamRefresh")}
+        </Button>
+      </div>
+
+      {/* The camera globals are resolved by signature and MX Bikes moves them between
+          builds, so "the editor opens and does nothing" is a real state. Its reason lived
+          in a log file next to a DLL until now. */}
+      {status?.known && !status.ready && status.reason && (
+        <p className="mt-2.5 flex items-start gap-1.5 text-[11px] text-amber-500">
+          <TriangleAlert className="mt-px size-3 shrink-0" />
+          {t("settings.rcamUnavailable", { reason: status.reason })}
+        </p>
+      )}
+      {status?.ready && !status.calibrated && (
+        <p className="mt-2.5 text-[11px] text-muted-foreground">
+          {t("settings.rcamNotCalibrated")}
+        </p>
+      )}
+
+      {!any && (
+        <p className="mt-2.5 text-[11px] text-muted-foreground">{t("settings.rcamPathsEmpty")}</p>
+      )}
+
+      <div className="mt-2.5 grid gap-1.5">
+        {slots
+          .filter((s) => s.exists || expanded === s.slot || !any)
+          .map((s) => (
+            <SlotRow
+              key={s.slot}
+              summary={s}
+              expanded={expanded === s.slot}
+              onToggle={() => setExpanded(expanded === s.slot ? null : s.slot)}
+              onChanged={refresh}
+            />
+          ))}
+      </div>
+    </div>
+  );
+}

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -76,6 +76,7 @@ import { usePlatform } from "../../lib/usePlatform";
 import { useConfig } from "../../Context/Config";
 import GameSwitcher from "../Shell/GameSwitcher";
 import { ReplayCameraKeys } from "./ReplayCameraKeys";
+import { ReplayCameraPaths } from "./ReplayCameraPaths";
 import ReshadeCard from "./ReshadeCard";
 import SupportersCard from "./SupportersCard";
 import { useTheme, type ThemeMode } from "../../Context/Theme";
@@ -1770,6 +1771,7 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
             {/* Only once FrostMod is on disk: without an install there is no config to
                 edit, and the keys would be an offer that quietly does nothing. */}
             {status?.installed && <ReplayCameraKeys />}
+            {status?.installed && <ReplayCameraPaths />}
 
             <div className="flex gap-2">
               {/* Stop is offered whenever FrostMod is running, installed by us or not —

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -2156,6 +2156,114 @@ export function frostmodDefaultKeybinds(): Promise<FrostmodKeybind[]> {
   return invoke<FrostmodKeybind[]>("frostmod_default_keybinds");
 }
 
+// ---- replay camera paths ---------------------------------------------------
+
+/** What a key does when the path leaves it. */
+export type RcamEase = "smooth" | "hold" | "cut";
+export type RcamCurve = "centripetal" | "uniform";
+export type RcamRig = "locked" | "handheld" | "drone" | "crane";
+/** `clock` = this replay's milliseconds; `track` = the aimed rider's lap fraction. */
+export type RcamAnchor = "clock" | "track";
+
+/** A camera key. Times are always on the replay's own 30 ms grid. */
+export type RcamKey = {
+  t: number;
+  x: number;
+  y: number;
+  z: number;
+  yaw: number;
+  pitch: number;
+  roll: number;
+  fov: number;
+  ease: RcamEase;
+  /** Race number this key aims at, or -1. */
+  target: number;
+  /** Metres to that rider when the key was set — what auto FOV holds the framing against. */
+  aimDist: number;
+  /** Lap fraction 0..1 when the key was set; negative means it was never known. */
+  tp: number;
+};
+
+export type RcamPath = {
+  keys: RcamKey[];
+  curve: RcamCurve;
+  rig: RcamRig;
+  rigAmount: number;
+  anchor: RcamAnchor;
+  autoFov: boolean;
+};
+
+/** Enough about a slot to draw the list without opening it again. */
+export type RcamSummary = {
+  slot: number;
+  exists: boolean;
+  file: string;
+  keys: number;
+  shots: number;
+  firstMs: number;
+  lastMs: number;
+  curve: RcamCurve;
+  rig: RcamRig;
+  rigAmount: number;
+  anchor: RcamAnchor;
+  autoFov: boolean;
+  targets: number[];
+  /** The file is there but unreadable — shown rather than passed off as an empty slot. */
+  error: string | null;
+};
+
+/** Every slot FrostMod saves camera paths to, wherever it wrote them. */
+export function rcamPaths(): Promise<RcamSummary[]> {
+  return invoke<RcamSummary[]>("replaycam_list");
+}
+
+export function rcamRead(slot: number): Promise<RcamPath> {
+  return invoke<RcamPath>("replaycam_read", { slot });
+}
+
+/** Save a slot back; resolves with the file it landed in. Rejects anything FrostMod
+ *  would refuse to load, rather than leaving a slot that silently does nothing. */
+export function rcamWrite(slot: number, path: RcamPath): Promise<string> {
+  return invoke<string>("replaycam_write", { slot, path });
+}
+
+export function rcamDelete(slot: number): Promise<void> {
+  return invoke<void>("replaycam_delete", { slot });
+}
+
+/** Respace the keys so time between them follows distance — the constant-speed dolly.
+ *  Nothing is written: the caller decides whether to keep the result. */
+export function rcamRetime(path: RcamPath): Promise<RcamPath> {
+  return invoke<RcamPath>("replaycam_retime", { path });
+}
+
+export function rcamImport(slot: number, src: string): Promise<RcamPath> {
+  return invoke<RcamPath>("replaycam_import", { slot, src });
+}
+
+export function rcamExport(slot: number, dst: string): Promise<void> {
+  return invoke<void>("replaycam_export", { slot, dst });
+}
+
+/** What FrostMod's log says about the replay camera on the build it last attached to. Every
+ *  camera global is resolved by signature and MX Bikes moves them between builds, so "the
+ *  editor opens and does nothing" is a real state — and the reason for it lived in a log
+ *  file next to a DLL. */
+export type RcamStatus = {
+  /** False when FrostMod has never run, or its log says nothing about the camera. */
+  known: boolean;
+  ready: boolean;
+  /** Why it is unavailable, in FrostMod's own words. */
+  reason: string | null;
+  /** Whether it has worked out how this build's camera angles count. Aiming needs it. */
+  calibrated: boolean;
+  log: string;
+};
+
+export function rcamStatus(): Promise<RcamStatus> {
+  return invoke<RcamStatus>("replaycam_status");
+}
+
 export function frostmodStatus(): Promise<FrostmodStatus> {
   return invoke<FrostmodStatus>("frostmod_status");
 }

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -750,6 +750,132 @@ export const de: Translation = {
     "Overlay ausblenden",
   "settings.rcamActionLoad":
     "Pfad laden",
+  "settings.rcamActionEase":
+    "Interpolation",
+  "settings.rcamActionTarget":
+    "Auf Fahrer zielen",
+  "settings.rcamActionNudgeback":
+    "Key nach hinten",
+  "settings.rcamActionNudgefwd":
+    "Key nach vorn",
+  "settings.rcamActionUndo":
+    "Ruckgangig",
+  "settings.rcamActionRig":
+    "Kamera-Rig",
+  "settings.rcamActionRetime":
+    "Nach Distanz verteilen",
+  "settings.rcamActionPreview":
+    "Pfad anzeigen",
+  "settings.rcamActionCurve":
+    "Kurvenstil",
+  "settings.rcamActionAnchor":
+    "Pfadachse",
+  "settings.rcamActionAutofov":
+    "Auto-FOV",
+  "settings.rcamPaths":
+    "Replay-Kamerapfade",
+  "settings.rcamPathsDesc":
+    "Die neun Slots, in die FrostMod Kamerapfade speichert. Offne einen, um zu sehen, wo die Keys liegen, wie der Pfad fliegt, oder um ihn weiterzugeben.",
+  "settings.rcamPathsEmpty":
+    "Noch nichts gespeichert. Setze im Spiel Keys mit dem Replay-Kamera-Editor und speichere.",
+  "settings.rcamUnavailable":
+    "Die Replay-Kamera lauft auf diesem Spiel-Build nicht: {{reason}}",
+  "settings.rcamNotCalibrated":
+    "Das Zielen ist noch nicht kalibriert. Offne den Editor im Spiel und schwenke die Kamera einmal herum.",
+  "settings.rcamRefresh":
+    "Aktualisieren",
+  "settings.rcamSlot":
+    "Slot {{n}}",
+  "settings.rcamSlotEmpty":
+    "Leer",
+  "settings.rcamKeyCount_one":
+    "{{count}} Key",
+  "settings.rcamKeyCount_other":
+    "{{count}} Keys",
+  "settings.rcamShotCount_one":
+    "{{count}} Einstellung",
+  "settings.rcamShotCount_other":
+    "{{count}} Einstellungen",
+  "settings.rcamTimelineHint":
+    "Ziehe einen Key, um ihn zu verschieben. Zeiten rasten auf dem 30-ms-Raster ein, und ein Key kommt nicht an seinem Nachbarn vorbei.",
+  "settings.rcamKeyAt":
+    "Key bei {{time}}",
+  "settings.rcamNoKeySelected":
+    "Wahle einen Key auf der Timeline, um sein Verhalten zu andern.",
+  "settings.rcamAim":
+    "Zielen auf",
+  "settings.rcamAimNone":
+    "niemanden",
+  "settings.rcamEaseSmooth":
+    "Weich",
+  "settings.rcamEaseHold":
+    "Halten",
+  "settings.rcamEaseCut":
+    "Schnitt",
+  "settings.rcamCurve":
+    "Kurve",
+  "settings.rcamCurveCentripetal":
+    "Zentripetal",
+  "settings.rcamCurveUniform":
+    "Gleichformig",
+  "settings.rcamAxis":
+    "Achse",
+  "settings.rcamAxisClock":
+    "Replay-Uhr",
+  "settings.rcamAxisTrack":
+    "Runde des Fahrers",
+  "settings.rcamAxisHint":
+    "An die Runde eines Fahrers gebunden lauft der Pfad in jeder Runde, mit jedem Fahrer, in jedem Replay. Jeder Key braucht einen Zielfahrer und eine Rundenposition.",
+  "settings.rcamRig":
+    "Rig",
+  "settings.rcamRigLocked":
+    "Fest",
+  "settings.rcamRigHandheld":
+    "Handkamera",
+  "settings.rcamRigDrone":
+    "Drohne",
+  "settings.rcamRigCrane":
+    "Kran",
+  "settings.rcamRigAmount":
+    "Starke",
+  "settings.rcamAutoFov":
+    "Grosse des Motivs halten",
+  "settings.rcamAutoFovHint":
+    "Das FOV folgt dem angezielten Fahrer, damit er gleich gross im Bild bleibt.",
+  "settings.rcamSave":
+    "Speichern",
+  "settings.rcamRevert":
+    "Zurucksetzen",
+  "settings.rcamRetime":
+    "Nach Distanz verteilen",
+  "settings.rcamExport":
+    "Exportieren",
+  "settings.rcamImport":
+    "Importieren",
+  "settings.rcamDelete":
+    "Loschen",
+  "settings.rcamSaved":
+    "Pfad gespeichert",
+  "settings.rcamWriteFailed":
+    "Pfad konnte nicht gespeichert werden",
+  "settings.rcamReadFailed":
+    "Pfad konnte nicht gelesen werden",
+  "settings.rcamRetimeDone":
+    "Keys verteilt. Zum Behalten speichern.",
+  "settings.rcamRetimeFailed":
+    "Keys konnten nicht verteilt werden",
+  "settings.rcamDeleted":
+    "Slot {{n}} geloscht",
+  "settings.rcamDeleteFailed":
+    "Pfad konnte nicht geloscht werden",
+  "settings.rcamImported":
+    "In Slot {{n}} importiert",
+  "settings.rcamImportFailed":
+    "Dieser Pfad konnte nicht importiert werden",
+  "settings.rcamExported":
+    "Pfad exportiert",
+  "settings.rcamExportFailed":
+    "Pfad konnte nicht exportiert werden",
   "settings.watchModsReload": "Automatisch neu laden bei Ordneränderungen",
   "settings.watchModsReloadDesc":
     "Das Spiel automatisch neu laden, wenn Strecken oder Motorräder in deinen Mod-Ordner kommen — auch wenn sie außerhalb von MXB App manuell heruntergeladen wurden.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -736,6 +736,132 @@ export const en = {
     "Hide overlay",
   "settings.rcamActionLoad":
     "Load path",
+  "settings.rcamActionEase":
+    "Key ease",
+  "settings.rcamActionTarget":
+    "Aim at rider",
+  "settings.rcamActionNudgeback":
+    "Nudge key back",
+  "settings.rcamActionNudgefwd":
+    "Nudge key forward",
+  "settings.rcamActionUndo":
+    "Undo",
+  "settings.rcamActionRig":
+    "Camera rig",
+  "settings.rcamActionRetime":
+    "Respace by distance",
+  "settings.rcamActionPreview":
+    "Show path",
+  "settings.rcamActionCurve":
+    "Curve style",
+  "settings.rcamActionAnchor":
+    "Path axis",
+  "settings.rcamActionAutofov":
+    "Auto FOV",
+  "settings.rcamPaths":
+    "Replay camera paths",
+  "settings.rcamPathsDesc":
+    "The nine slots FrostMod saves camera paths to. Open one to see where its keys fall, change how it flies, or pass it on.",
+  "settings.rcamPathsEmpty":
+    "Nothing saved yet. Set keys in game with the replay camera editor, then press save.",
+  "settings.rcamUnavailable":
+    "The replay camera can't run on this game build: {{reason}}",
+  "settings.rcamNotCalibrated":
+    "Aiming isn't calibrated yet. Open the editor in game and swing the camera round once.",
+  "settings.rcamRefresh":
+    "Refresh",
+  "settings.rcamSlot":
+    "Slot {{n}}",
+  "settings.rcamSlotEmpty":
+    "Empty",
+  "settings.rcamKeyCount_one":
+    "{{count}} key",
+  "settings.rcamKeyCount_other":
+    "{{count}} keys",
+  "settings.rcamShotCount_one":
+    "{{count}} shot",
+  "settings.rcamShotCount_other":
+    "{{count}} shots",
+  "settings.rcamTimelineHint":
+    "Drag a key to move it. Times snap to the replay's 30 ms grid, and a key can't cross its neighbour.",
+  "settings.rcamKeyAt":
+    "Key at {{time}}",
+  "settings.rcamNoKeySelected":
+    "Pick a key on the timeline to change what it does.",
+  "settings.rcamAim":
+    "Aim at",
+  "settings.rcamAimNone":
+    "nobody",
+  "settings.rcamEaseSmooth":
+    "Smooth",
+  "settings.rcamEaseHold":
+    "Hold",
+  "settings.rcamEaseCut":
+    "Cut",
+  "settings.rcamCurve":
+    "Curve",
+  "settings.rcamCurveCentripetal":
+    "Centripetal",
+  "settings.rcamCurveUniform":
+    "Uniform",
+  "settings.rcamAxis":
+    "Axis",
+  "settings.rcamAxisClock":
+    "Replay clock",
+  "settings.rcamAxisTrack":
+    "Rider's lap",
+  "settings.rcamAxisHint":
+    "Keyed to a rider's lap, the path plays on any lap, any rider, any replay. Every key needs an aimed rider and a lap position.",
+  "settings.rcamRig":
+    "Rig",
+  "settings.rcamRigLocked":
+    "Locked",
+  "settings.rcamRigHandheld":
+    "Handheld",
+  "settings.rcamRigDrone":
+    "Drone",
+  "settings.rcamRigCrane":
+    "Crane",
+  "settings.rcamRigAmount":
+    "Amount",
+  "settings.rcamAutoFov":
+    "Hold the subject's size",
+  "settings.rcamAutoFovHint":
+    "FOV follows the aimed rider so they stay the same size on screen.",
+  "settings.rcamSave":
+    "Save",
+  "settings.rcamRevert":
+    "Revert",
+  "settings.rcamRetime":
+    "Respace by distance",
+  "settings.rcamExport":
+    "Export",
+  "settings.rcamImport":
+    "Import",
+  "settings.rcamDelete":
+    "Delete",
+  "settings.rcamSaved":
+    "Path saved",
+  "settings.rcamWriteFailed":
+    "Could not save the path",
+  "settings.rcamReadFailed":
+    "Could not read the path",
+  "settings.rcamRetimeDone":
+    "Keys respaced. Save to keep it.",
+  "settings.rcamRetimeFailed":
+    "Could not respace the keys",
+  "settings.rcamDeleted":
+    "Slot {{n}} deleted",
+  "settings.rcamDeleteFailed":
+    "Could not delete the path",
+  "settings.rcamImported":
+    "Imported into slot {{n}}",
+  "settings.rcamImportFailed":
+    "Could not import that path",
+  "settings.rcamExported":
+    "Path exported",
+  "settings.rcamExportFailed":
+    "Could not export the path",
   "settings.watchModsReload": "Auto-reload on folder changes",
   "settings.watchModsReloadDesc":
     "Reload the game automatically when tracks or bikes are added to your mods folder — even downloaded manually outside MXB App.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -742,6 +742,132 @@ export const es: Translation = {
     "Ocultar superposición",
   "settings.rcamActionLoad":
     "Cargar trayecto",
+  "settings.rcamActionEase":
+    "Interpolacion",
+  "settings.rcamActionTarget":
+    "Apuntar al piloto",
+  "settings.rcamActionNudgeback":
+    "Mover atras",
+  "settings.rcamActionNudgefwd":
+    "Mover adelante",
+  "settings.rcamActionUndo":
+    "Deshacer",
+  "settings.rcamActionRig":
+    "Soporte de camara",
+  "settings.rcamActionRetime":
+    "Redistribuir por distancia",
+  "settings.rcamActionPreview":
+    "Mostrar la ruta",
+  "settings.rcamActionCurve":
+    "Estilo de curva",
+  "settings.rcamActionAnchor":
+    "Eje de la ruta",
+  "settings.rcamActionAutofov":
+    "FOV automatico",
+  "settings.rcamPaths":
+    "Rutas de camara de repeticion",
+  "settings.rcamPathsDesc":
+    "Las nueve ranuras donde FrostMod guarda las rutas. Abre una para ver donde caen sus claves, cambiar como vuela o compartirla.",
+  "settings.rcamPathsEmpty":
+    "Aun no hay nada guardado. Pon claves en el juego con el editor de camara y pulsa guardar.",
+  "settings.rcamUnavailable":
+    "La camara de repeticion no funciona en esta version del juego: {{reason}}",
+  "settings.rcamNotCalibrated":
+    "La punteria aun no esta calibrada. Abre el editor en el juego y gira la camara una vez.",
+  "settings.rcamRefresh":
+    "Actualizar",
+  "settings.rcamSlot":
+    "Ranura {{n}}",
+  "settings.rcamSlotEmpty":
+    "Vacia",
+  "settings.rcamKeyCount_one":
+    "{{count}} clave",
+  "settings.rcamKeyCount_other":
+    "{{count}} claves",
+  "settings.rcamShotCount_one":
+    "{{count}} plano",
+  "settings.rcamShotCount_other":
+    "{{count}} planos",
+  "settings.rcamTimelineHint":
+    "Arrastra una clave para moverla. Los tiempos se ajustan a la rejilla de 30 ms y una clave no puede pasar a su vecina.",
+  "settings.rcamKeyAt":
+    "Clave en {{time}}",
+  "settings.rcamNoKeySelected":
+    "Elige una clave en la linea de tiempo para cambiar lo que hace.",
+  "settings.rcamAim":
+    "Apuntar a",
+  "settings.rcamAimNone":
+    "nadie",
+  "settings.rcamEaseSmooth":
+    "Suave",
+  "settings.rcamEaseHold":
+    "Pausa",
+  "settings.rcamEaseCut":
+    "Corte",
+  "settings.rcamCurve":
+    "Curva",
+  "settings.rcamCurveCentripetal":
+    "Centripeta",
+  "settings.rcamCurveUniform":
+    "Uniforme",
+  "settings.rcamAxis":
+    "Eje",
+  "settings.rcamAxisClock":
+    "Reloj de la repeticion",
+  "settings.rcamAxisTrack":
+    "Vuelta del piloto",
+  "settings.rcamAxisHint":
+    "Atada a la vuelta de un piloto, la ruta sirve en cualquier vuelta, piloto y repeticion. Cada clave necesita un piloto apuntado y una posicion en la vuelta.",
+  "settings.rcamRig":
+    "Soporte",
+  "settings.rcamRigLocked":
+    "Fijo",
+  "settings.rcamRigHandheld":
+    "En mano",
+  "settings.rcamRigDrone":
+    "Dron",
+  "settings.rcamRigCrane":
+    "Grua",
+  "settings.rcamRigAmount":
+    "Intensidad",
+  "settings.rcamAutoFov":
+    "Mantener el tamano del sujeto",
+  "settings.rcamAutoFovHint":
+    "El FOV sigue al piloto apuntado para que se vea siempre del mismo tamano.",
+  "settings.rcamSave":
+    "Guardar",
+  "settings.rcamRevert":
+    "Revertir",
+  "settings.rcamRetime":
+    "Redistribuir por distancia",
+  "settings.rcamExport":
+    "Exportar",
+  "settings.rcamImport":
+    "Importar",
+  "settings.rcamDelete":
+    "Eliminar",
+  "settings.rcamSaved":
+    "Ruta guardada",
+  "settings.rcamWriteFailed":
+    "No se pudo guardar la ruta",
+  "settings.rcamReadFailed":
+    "No se pudo leer la ruta",
+  "settings.rcamRetimeDone":
+    "Claves redistribuidas. Guarda para conservarlo.",
+  "settings.rcamRetimeFailed":
+    "No se pudieron redistribuir las claves",
+  "settings.rcamDeleted":
+    "Ranura {{n}} eliminada",
+  "settings.rcamDeleteFailed":
+    "No se pudo eliminar la ruta",
+  "settings.rcamImported":
+    "Importada en la ranura {{n}}",
+  "settings.rcamImportFailed":
+    "No se pudo importar esa ruta",
+  "settings.rcamExported":
+    "Ruta exportada",
+  "settings.rcamExportFailed":
+    "No se pudo exportar la ruta",
   "settings.watchModsReload": "Recarga automática al cambiar la carpeta",
   "settings.watchModsReloadDesc":
     "Recarga el juego automáticamente cuando se añaden pistas o motos a tu carpeta de mods — incluso descargadas manualmente fuera de MXB App.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -746,6 +746,132 @@ export const fr: Translation = {
     "Masquer la surcouche",
   "settings.rcamActionLoad":
     "Charger le trajet",
+  "settings.rcamActionEase":
+    "Interpolation",
+  "settings.rcamActionTarget":
+    "Viser un pilote",
+  "settings.rcamActionNudgeback":
+    "Decaler en arriere",
+  "settings.rcamActionNudgefwd":
+    "Decaler en avant",
+  "settings.rcamActionUndo":
+    "Annuler",
+  "settings.rcamActionRig":
+    "Support camera",
+  "settings.rcamActionRetime":
+    "Repartir par distance",
+  "settings.rcamActionPreview":
+    "Afficher le trajet",
+  "settings.rcamActionCurve":
+    "Style de courbe",
+  "settings.rcamActionAnchor":
+    "Axe du trajet",
+  "settings.rcamActionAutofov":
+    "FOV automatique",
+  "settings.rcamPaths":
+    "Trajets de camera replay",
+  "settings.rcamPathsDesc":
+    "Les neuf emplacements ou FrostMod enregistre les trajets. Ouvrez-en un pour voir ou tombent ses cles, changer sa facon de voler ou le transmettre.",
+  "settings.rcamPathsEmpty":
+    "Rien d'enregistre pour l'instant. Posez des cles en jeu avec l'editeur de camera, puis enregistrez.",
+  "settings.rcamUnavailable":
+    "La camera replay ne fonctionne pas sur cette version du jeu : {{reason}}",
+  "settings.rcamNotCalibrated":
+    "La visee n'est pas encore calibree. Ouvrez l'editeur en jeu et faites pivoter la camera une fois.",
+  "settings.rcamRefresh":
+    "Actualiser",
+  "settings.rcamSlot":
+    "Emplacement {{n}}",
+  "settings.rcamSlotEmpty":
+    "Vide",
+  "settings.rcamKeyCount_one":
+    "{{count}} cle",
+  "settings.rcamKeyCount_other":
+    "{{count}} cles",
+  "settings.rcamShotCount_one":
+    "{{count}} plan",
+  "settings.rcamShotCount_other":
+    "{{count}} plans",
+  "settings.rcamTimelineHint":
+    "Faites glisser une cle pour la deplacer. Les temps s'alignent sur la grille de 30 ms et une cle ne peut pas depasser sa voisine.",
+  "settings.rcamKeyAt":
+    "Cle a {{time}}",
+  "settings.rcamNoKeySelected":
+    "Choisissez une cle sur la timeline pour changer ce qu'elle fait.",
+  "settings.rcamAim":
+    "Viser",
+  "settings.rcamAimNone":
+    "personne",
+  "settings.rcamEaseSmooth":
+    "Fluide",
+  "settings.rcamEaseHold":
+    "Pause",
+  "settings.rcamEaseCut":
+    "Coupe",
+  "settings.rcamCurve":
+    "Courbe",
+  "settings.rcamCurveCentripetal":
+    "Centripete",
+  "settings.rcamCurveUniform":
+    "Uniforme",
+  "settings.rcamAxis":
+    "Axe",
+  "settings.rcamAxisClock":
+    "Horloge du replay",
+  "settings.rcamAxisTrack":
+    "Tour du pilote",
+  "settings.rcamAxisHint":
+    "Cale sur le tour d'un pilote, le trajet fonctionne sur n'importe quel tour, pilote ou replay. Chaque cle a besoin d'un pilote vise et d'une position sur le tour.",
+  "settings.rcamRig":
+    "Support",
+  "settings.rcamRigLocked":
+    "Fixe",
+  "settings.rcamRigHandheld":
+    "A l'epaule",
+  "settings.rcamRigDrone":
+    "Drone",
+  "settings.rcamRigCrane":
+    "Grue",
+  "settings.rcamRigAmount":
+    "Intensite",
+  "settings.rcamAutoFov":
+    "Garder la taille du sujet",
+  "settings.rcamAutoFovHint":
+    "Le FOV suit le pilote vise pour qu'il garde la meme taille a l'ecran.",
+  "settings.rcamSave":
+    "Enregistrer",
+  "settings.rcamRevert":
+    "Retablir",
+  "settings.rcamRetime":
+    "Repartir par distance",
+  "settings.rcamExport":
+    "Exporter",
+  "settings.rcamImport":
+    "Importer",
+  "settings.rcamDelete":
+    "Supprimer",
+  "settings.rcamSaved":
+    "Trajet enregistre",
+  "settings.rcamWriteFailed":
+    "Impossible d'enregistrer le trajet",
+  "settings.rcamReadFailed":
+    "Impossible de lire le trajet",
+  "settings.rcamRetimeDone":
+    "Cles reparties. Enregistrez pour conserver.",
+  "settings.rcamRetimeFailed":
+    "Impossible de repartir les cles",
+  "settings.rcamDeleted":
+    "Emplacement {{n}} supprime",
+  "settings.rcamDeleteFailed":
+    "Impossible de supprimer le trajet",
+  "settings.rcamImported":
+    "Importe dans l'emplacement {{n}}",
+  "settings.rcamImportFailed":
+    "Impossible d'importer ce trajet",
+  "settings.rcamExported":
+    "Trajet exporte",
+  "settings.rcamExportFailed":
+    "Impossible d'exporter le trajet",
   "settings.watchModsReload":
     "Rechargement auto lors des changements de dossier",
   "settings.watchModsReloadDesc":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -741,6 +741,132 @@ export const it: Translation = {
     "Nascondi overlay",
   "settings.rcamActionLoad":
     "Carica percorso",
+  "settings.rcamActionEase":
+    "Interpolazione",
+  "settings.rcamActionTarget":
+    "Punta al pilota",
+  "settings.rcamActionNudgeback":
+    "Sposta indietro",
+  "settings.rcamActionNudgefwd":
+    "Sposta avanti",
+  "settings.rcamActionUndo":
+    "Annulla",
+  "settings.rcamActionRig":
+    "Supporto camera",
+  "settings.rcamActionRetime":
+    "Ridistribuisci per distanza",
+  "settings.rcamActionPreview":
+    "Mostra il percorso",
+  "settings.rcamActionCurve":
+    "Stile della curva",
+  "settings.rcamActionAnchor":
+    "Asse del percorso",
+  "settings.rcamActionAutofov":
+    "FOV automatico",
+  "settings.rcamPaths":
+    "Percorsi della camera replay",
+  "settings.rcamPathsDesc":
+    "I nove slot in cui FrostMod salva i percorsi. Aprine uno per vedere dove cadono i key, cambiare come vola o passarlo ad altri.",
+  "settings.rcamPathsEmpty":
+    "Ancora niente salvato. Imposta dei key in gioco con l'editor della camera replay, poi premi salva.",
+  "settings.rcamUnavailable":
+    "La camera replay non funziona su questa build del gioco: {{reason}}",
+  "settings.rcamNotCalibrated":
+    "La mira non e ancora calibrata. Apri l'editor in gioco e fai girare la camera una volta.",
+  "settings.rcamRefresh":
+    "Aggiorna",
+  "settings.rcamSlot":
+    "Slot {{n}}",
+  "settings.rcamSlotEmpty":
+    "Vuoto",
+  "settings.rcamKeyCount_one":
+    "{{count}} key",
+  "settings.rcamKeyCount_other":
+    "{{count}} key",
+  "settings.rcamShotCount_one":
+    "{{count}} inquadratura",
+  "settings.rcamShotCount_other":
+    "{{count}} inquadrature",
+  "settings.rcamTimelineHint":
+    "Trascina un key per spostarlo. I tempi si allineano alla griglia da 30 ms del replay e un key non puo superare il vicino.",
+  "settings.rcamKeyAt":
+    "Key a {{time}}",
+  "settings.rcamNoKeySelected":
+    "Scegli un key sulla timeline per cambiarne il comportamento.",
+  "settings.rcamAim":
+    "Punta a",
+  "settings.rcamAimNone":
+    "nessuno",
+  "settings.rcamEaseSmooth":
+    "Morbida",
+  "settings.rcamEaseHold":
+    "Pausa",
+  "settings.rcamEaseCut":
+    "Stacco",
+  "settings.rcamCurve":
+    "Curva",
+  "settings.rcamCurveCentripetal":
+    "Centripeta",
+  "settings.rcamCurveUniform":
+    "Uniforme",
+  "settings.rcamAxis":
+    "Asse",
+  "settings.rcamAxisClock":
+    "Tempo del replay",
+  "settings.rcamAxisTrack":
+    "Giro del pilota",
+  "settings.rcamAxisHint":
+    "Legato al giro di un pilota, il percorso funziona su qualsiasi giro, pilota e replay. Ogni key deve avere un pilota puntato e una posizione sul giro.",
+  "settings.rcamRig":
+    "Supporto",
+  "settings.rcamRigLocked":
+    "Fisso",
+  "settings.rcamRigHandheld":
+    "A mano",
+  "settings.rcamRigDrone":
+    "Drone",
+  "settings.rcamRigCrane":
+    "Gru",
+  "settings.rcamRigAmount":
+    "Intensita",
+  "settings.rcamAutoFov":
+    "Mantieni la dimensione del soggetto",
+  "settings.rcamAutoFovHint":
+    "Il FOV segue il pilota puntato per tenerlo sempre della stessa dimensione.",
+  "settings.rcamSave":
+    "Salva",
+  "settings.rcamRevert":
+    "Ripristina",
+  "settings.rcamRetime":
+    "Ridistribuisci per distanza",
+  "settings.rcamExport":
+    "Esporta",
+  "settings.rcamImport":
+    "Importa",
+  "settings.rcamDelete":
+    "Elimina",
+  "settings.rcamSaved":
+    "Percorso salvato",
+  "settings.rcamWriteFailed":
+    "Impossibile salvare il percorso",
+  "settings.rcamReadFailed":
+    "Impossibile leggere il percorso",
+  "settings.rcamRetimeDone":
+    "Key ridistribuiti. Salva per mantenerli.",
+  "settings.rcamRetimeFailed":
+    "Impossibile ridistribuire i key",
+  "settings.rcamDeleted":
+    "Slot {{n}} eliminato",
+  "settings.rcamDeleteFailed":
+    "Impossibile eliminare il percorso",
+  "settings.rcamImported":
+    "Importato nello slot {{n}}",
+  "settings.rcamImportFailed":
+    "Impossibile importare quel percorso",
+  "settings.rcamExported":
+    "Percorso esportato",
+  "settings.rcamExportFailed":
+    "Impossibile esportare il percorso",
   "settings.watchModsReload": "Ricarica automatica alle modifiche",
   "settings.watchModsReloadDesc":
     "Ricarica il gioco automaticamente quando piste o moto vengono aggiunte alla cartella mod — anche se scaricate manualmente fuori da MXB App.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -744,6 +744,132 @@ export const ptBR: Translation = {
     "Ocultar sobreposição",
   "settings.rcamActionLoad":
     "Carregar trajeto",
+  "settings.rcamActionEase":
+    "Interpolacao",
+  "settings.rcamActionTarget":
+    "Mirar no piloto",
+  "settings.rcamActionNudgeback":
+    "Mover para tras",
+  "settings.rcamActionNudgefwd":
+    "Mover para frente",
+  "settings.rcamActionUndo":
+    "Desfazer",
+  "settings.rcamActionRig":
+    "Suporte de camera",
+  "settings.rcamActionRetime":
+    "Redistribuir por distancia",
+  "settings.rcamActionPreview":
+    "Mostrar o caminho",
+  "settings.rcamActionCurve":
+    "Estilo da curva",
+  "settings.rcamActionAnchor":
+    "Eixo do caminho",
+  "settings.rcamActionAutofov":
+    "FOV automatico",
+  "settings.rcamPaths":
+    "Caminhos da camera de replay",
+  "settings.rcamPathsDesc":
+    "Os nove slots em que o FrostMod salva os caminhos. Abra um para ver onde caem as chaves, mudar como ele voa ou passar adiante.",
+  "settings.rcamPathsEmpty":
+    "Nada salvo ainda. Marque chaves no jogo com o editor de camera e salve.",
+  "settings.rcamUnavailable":
+    "A camera de replay nao funciona nesta versao do jogo: {{reason}}",
+  "settings.rcamNotCalibrated":
+    "A mira ainda nao esta calibrada. Abra o editor no jogo e gire a camera uma vez.",
+  "settings.rcamRefresh":
+    "Atualizar",
+  "settings.rcamSlot":
+    "Slot {{n}}",
+  "settings.rcamSlotEmpty":
+    "Vazio",
+  "settings.rcamKeyCount_one":
+    "{{count}} chave",
+  "settings.rcamKeyCount_other":
+    "{{count}} chaves",
+  "settings.rcamShotCount_one":
+    "{{count}} plano",
+  "settings.rcamShotCount_other":
+    "{{count}} planos",
+  "settings.rcamTimelineHint":
+    "Arraste uma chave para move-la. Os tempos se alinham a grade de 30 ms e uma chave nao passa da vizinha.",
+  "settings.rcamKeyAt":
+    "Chave em {{time}}",
+  "settings.rcamNoKeySelected":
+    "Escolha uma chave na linha do tempo para mudar o que ela faz.",
+  "settings.rcamAim":
+    "Mirar em",
+  "settings.rcamAimNone":
+    "ninguem",
+  "settings.rcamEaseSmooth":
+    "Suave",
+  "settings.rcamEaseHold":
+    "Pausa",
+  "settings.rcamEaseCut":
+    "Corte",
+  "settings.rcamCurve":
+    "Curva",
+  "settings.rcamCurveCentripetal":
+    "Centripeta",
+  "settings.rcamCurveUniform":
+    "Uniforme",
+  "settings.rcamAxis":
+    "Eixo",
+  "settings.rcamAxisClock":
+    "Relogio do replay",
+  "settings.rcamAxisTrack":
+    "Volta do piloto",
+  "settings.rcamAxisHint":
+    "Preso a volta de um piloto, o caminho funciona em qualquer volta, piloto e replay. Cada chave precisa de um piloto mirado e de uma posicao na volta.",
+  "settings.rcamRig":
+    "Suporte",
+  "settings.rcamRigLocked":
+    "Fixo",
+  "settings.rcamRigHandheld":
+    "Na mao",
+  "settings.rcamRigDrone":
+    "Drone",
+  "settings.rcamRigCrane":
+    "Grua",
+  "settings.rcamRigAmount":
+    "Intensidade",
+  "settings.rcamAutoFov":
+    "Manter o tamanho do sujeito",
+  "settings.rcamAutoFovHint":
+    "O FOV segue o piloto mirado para ele ficar sempre do mesmo tamanho na tela.",
+  "settings.rcamSave":
+    "Salvar",
+  "settings.rcamRevert":
+    "Reverter",
+  "settings.rcamRetime":
+    "Redistribuir por distancia",
+  "settings.rcamExport":
+    "Exportar",
+  "settings.rcamImport":
+    "Importar",
+  "settings.rcamDelete":
+    "Excluir",
+  "settings.rcamSaved":
+    "Caminho salvo",
+  "settings.rcamWriteFailed":
+    "Nao foi possivel salvar o caminho",
+  "settings.rcamReadFailed":
+    "Nao foi possivel ler o caminho",
+  "settings.rcamRetimeDone":
+    "Chaves redistribuidas. Salve para manter.",
+  "settings.rcamRetimeFailed":
+    "Nao foi possivel redistribuir as chaves",
+  "settings.rcamDeleted":
+    "Slot {{n}} excluido",
+  "settings.rcamDeleteFailed":
+    "Nao foi possivel excluir o caminho",
+  "settings.rcamImported":
+    "Importado no slot {{n}}",
+  "settings.rcamImportFailed":
+    "Nao foi possivel importar esse caminho",
+  "settings.rcamExported":
+    "Caminho exportado",
+  "settings.rcamExportFailed":
+    "Nao foi possivel exportar o caminho",
   "settings.watchModsReload": "Recarregar automaticamente ao mudar a pasta",
   "settings.watchModsReloadDesc":
     "Recarregar o jogo automaticamente quando pistas ou motos forem adicionadas à sua pasta de mods — mesmo baixadas manualmente fora do MXB App.",


### PR DESCRIPTION
The app half of the replay camera work. Pairs with frostmod#29, but stands on its own:
everything here reads and writes files FrostMod already writes today.

## Why

FrostMod's editor is a text panel drawn over a running replay. That is the right shape for
setting a key while you scrub, and the wrong one for everything else - nine unnamed slots,
no way to see what is in one, and no way to hand a path to anyone.

## What it does

- Each slot shows its key count, shots, span and the riders it aims at. Opening one lays the
  keys on a timeline you can drag them along. A key snaps to the replay's own 30 ms grid and
  cannot cross its neighbour - crossing one would reorder the path under the person editing
  it.
- A selected key's ease and aimed rider are editable here. A cut you meant to be a hold no
  longer means going back into the game to fix it.
- Curve, rig, rig amount, axis and auto FOV are per-path settings. They are exactly the
  three actions FrostMod ships unbound, because they are set once - and this is where.
- Respace by distance runs in the backend and comes back as a preview; nothing is written
  until you save.
- Export and import, so a path is something you can pass on.
- The card says when the replay camera cannot run on your game build, and why, read out of
  FrostMod's own log. Every camera global is resolved by signature and MX Bikes moves them
  between builds, so "the editor opens and does nothing" really happens - and until now its
  reason existed only in a file next to a DLL.

## Notes

`src-tauri/src/replaycam.rs` implements FrostMod's `.fcam` format. The enums travel as the
same words the file uses rather than as numbers, so the two programs cannot disagree about
what a `2` meant. v1 files load. Every write is validated the way FrostMod's own parser
would, because a file it refuses leaves someone staring at a slot that silently does nothing.

Paths are looked for in all three places FrostMod might have written them - the game's user
folder in plugin mode, a `.dlo` dropped in the game's plugins folder, and the app's own
install. Checking one would show an empty list to exactly the people using the feature most.
A delete removes every copy, or the slot reappears next time the list is drawn.

## Testing

Eight unit tests over the format, validation, shot counting and retiming; `cargo check`,
`tsc --noEmit`, `eslint` and `vite build` all clean. The card only renders where FrostMod is
installed, so it has not been driven on screen from this Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)