### PR TITLE
chore(release): v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2026-08-31 — v0.12.2
 
 ### Added
 - Settings → FrostMod lists the nine replay camera slots. Open one to see where its keys
@@ -10,6 +10,8 @@
 - The panel says when the replay camera can't run on your game build, and why. That reason
   only existed in a log file next to a DLL before.
 - FrostMod's eleven new replay camera actions are in the key list.
+- The camera itself learned to aim at a rider, cut between shots and fly with a handheld or
+  drone rig, in FrostMod 0.15.3 — which the app installs and updates for you.
 
 ## 2026-08-31 — v0.12.1
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.12.1",
+  "version": "0.12.2",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "mxb-app"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # whatever cargo called it. Cargo target names can't hold a space, so this is as close as
 # it gets. The description is what Windows Task Manager shows in its Processes tab.
 name = "mxb-app"
-version = "0.12.1"
+version = "0.12.2"
 description = "MXB App — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
   "mainBinaryName": "MXB App",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/Components/Showcase/releases.ts
+++ b/src/Components/Showcase/releases.ts
@@ -9,6 +9,10 @@
  * else knows about versions.
  */
 import {
+  Crosshair,
+  Scissors,
+  Route,
+  ListVideo,
   EyeOff,
   Mountain,
   Sun,
@@ -71,6 +75,20 @@ export interface Release {
 }
 
 export const RELEASES: Release[] = [
+  {
+    version: "0.12.2",
+    hero: {
+      icon: Crosshair,
+      title: "showcase.v0122.hero.title",
+      body: "showcase.v0122.hero.body",
+    },
+    highlights: [
+      { icon: Crosshair, text: "showcase.v0122.aim" },
+      { icon: Scissors, text: "showcase.v0122.shots" },
+      { icon: Route, text: "showcase.v0122.preview" },
+      { icon: ListVideo, text: "showcase.v0122.paths" },
+    ],
+  },
   {
     version: "0.12.1",
     hero: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1587,6 +1587,18 @@ export const de: Translation = {
   "showcase.supporters.title_one": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.title_other": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.more": "+{{count}} weitere",
+  "showcase.v0122.hero.title":
+    "Die Replay-Kamera kann dem Fahrer folgen",
+  "showcase.v0122.hero.body":
+    "Ziele mit einem Key auf einen Fahrer, und FrostMods Replay-Kamera hält Bild für Bild auf ihn statt auf die Winkel, die du geflogen hast. Schneide zwischen Einstellungen, halte auf einer, und sieh den ganzen Pfad in der Welt, während du ihn baust.",
+  "showcase.v0122.aim":
+    "Drücke T auf einem Key, um auf einen Fahrer zu zielen. Die Kamera folgt ihm, und bei zwei Fahrern auf einem Abschnitt gleitet sie weich von einem zum anderen.",
+  "showcase.v0122.shots":
+    "E entscheidet, was ein Key tut: durchlaufen, darauf halten oder hart auf die nächste Einstellung schneiden. Ein Pfad kann ein ganzer Schnitt sein.",
+  "showcase.v0122.preview":
+    "V zeichnet den Pfad in der Welt, während du ihn baust, und U macht die letzte Änderung rückgängig — vierundzwanzig Schritte weit.",
+  "showcase.v0122.paths":
+    "Einstellungen → FrostMod listet jeden gespeicherten Pfad: wo seine Keys liegen, wie er fliegt, und wie du ihn weitergibst.",
   "showcase.v0121.hero.title":
     "Deine Replay-Kamera-Tasten, deine Tastatur",
   "showcase.v0121.hero.body":

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1548,6 +1548,18 @@ export const en = {
   "showcase.supporters.title_one": "Made possible by {{count}} supporter",
   "showcase.supporters.title_other": "Made possible by {{count}} supporters",
   "showcase.supporters.more": "+{{count}} more",
+  "showcase.v0122.hero.title":
+    "The replay camera can follow the rider",
+  "showcase.v0122.hero.body":
+    "Aim a key at a rider and FrostMod's replay camera points at them frame by frame, instead of at the angles you flew. Cut between shots, hold on one, and watch the whole path in the world while you build it.",
+  "showcase.v0122.aim":
+    "Press T on a key to aim it at a rider. The camera tracks them, and two riders across one stretch eases from one to the other.",
+  "showcase.v0122.shots":
+    "E decides what a key does: run through it, settle on it, or cut hard to the next shot. One path can be a whole edit.",
+  "showcase.v0122.preview":
+    "V draws the path in the world while you build it, and U undoes the last edit — twenty-four deep.",
+  "showcase.v0122.paths":
+    "Settings → FrostMod lists every saved path: where its keys fall, how it flies, and a way to hand one to someone.",
   "showcase.v0121.hero.title":
     "Your replay camera keys, your keyboard",
   "showcase.v0121.hero.body":

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1574,6 +1574,18 @@ export const es: Translation = {
   "showcase.supporters.title_one": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.title_other": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.more": "+{{count}} más",
+  "showcase.v0122.hero.title":
+    "La cámara de repetición puede seguir al piloto",
+  "showcase.v0122.hero.body":
+    "Apunta una clave a un piloto y la cámara de repetición de FrostMod lo enfoca fotograma a fotograma, en vez de los ángulos que volaste. Corta entre planos, mantente en uno y mira todo el recorrido en el mundo mientras lo construyes.",
+  "showcase.v0122.aim":
+    "Pulsa T sobre una clave para apuntarla a un piloto. La cámara lo sigue, y con dos pilotos en un mismo tramo pasa suavemente de uno a otro.",
+  "showcase.v0122.shots":
+    "E decide qué hace una clave: pasar por ella, detenerse en ella o cortar en seco al siguiente plano. Un recorrido puede ser un montaje entero.",
+  "showcase.v0122.preview":
+    "V dibuja el recorrido en el mundo mientras lo haces, y U deshace el último cambio — hasta veinticuatro atrás.",
+  "showcase.v0122.paths":
+    "Ajustes → FrostMod lista cada recorrido guardado: dónde caen sus claves, cómo vuela y cómo pasárselo a alguien.",
   "showcase.v0121.hero.title":
     "Tus teclas de la cámara de repetición, tu teclado",
   "showcase.v0121.hero.body":

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1578,6 +1578,18 @@ export const fr: Translation = {
   "showcase.supporters.title_one": "Rendu possible par {{count}} soutien",
   "showcase.supporters.title_other": "Rendu possible par {{count}} soutiens",
   "showcase.supporters.more": "+{{count}} autres",
+  "showcase.v0122.hero.title":
+    "La caméra replay peut suivre le pilote",
+  "showcase.v0122.hero.body":
+    "Visez un pilote avec une clé et la caméra replay de FrostMod le cadre image par image, au lieu des angles que vous avez posés. Coupez entre les plans, tenez-en un, et voyez tout le trajet dans le monde pendant que vous le construisez.",
+  "showcase.v0122.aim":
+    "Appuyez sur T sur une clé pour viser un pilote. La caméra le suit, et avec deux pilotes sur un même segment elle glisse doucement de l'un à l'autre.",
+  "showcase.v0122.shots":
+    "E décide de ce que fait une clé : la traverser, s'y poser, ou couper net vers le plan suivant. Un trajet peut être un montage entier.",
+  "showcase.v0122.preview":
+    "V dessine le trajet dans le monde pendant que vous le faites, et U annule la dernière modification — jusqu'à vingt-quatre en arrière.",
+  "showcase.v0122.paths":
+    "Paramètres → FrostMod liste chaque trajet enregistré : où tombent ses clés, comment il vole, et comment le transmettre.",
   "showcase.v0121.hero.title":
     "Tes touches de caméra replay, ton clavier",
   "showcase.v0121.hero.body":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1569,6 +1569,18 @@ export const it: Translation = {
   "showcase.supporters.title_one": "Reso possibile da {{count}} sostenitore",
   "showcase.supporters.title_other": "Reso possibile da {{count}} sostenitori",
   "showcase.supporters.more": "+{{count}} altri",
+  "showcase.v0122.hero.title":
+    "La telecamera replay può seguire il pilota",
+  "showcase.v0122.hero.body":
+    "Punta un key su un pilota e la telecamera replay di FrostMod lo inquadra fotogramma per fotogramma, invece degli angoli che hai impostato. Stacca tra le inquadrature, fermati su una, e guarda tutto il percorso nel mondo mentre lo costruisci.",
+  "showcase.v0122.aim":
+    "Premi T su un key per puntarlo su un pilota. La telecamera lo segue, e con due piloti sullo stesso tratto passa dolcemente dall'uno all'altro.",
+  "showcase.v0122.shots":
+    "E decide cosa fa un key: passarci attraverso, fermarsi, o staccare di netto sull'inquadratura successiva. Un percorso può essere un montaggio intero.",
+  "showcase.v0122.preview":
+    "V disegna il percorso nel mondo mentre lo costruisci, e U annulla l'ultima modifica — fino a ventiquattro indietro.",
+  "showcase.v0122.paths":
+    "Impostazioni → FrostMod elenca ogni percorso salvato: dove cadono i suoi key, come vola, e come passarlo a qualcuno.",
   "showcase.v0121.hero.title":
     "I tasti della telecamera replay, sulla tua tastiera",
   "showcase.v0121.hero.body":

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1567,6 +1567,18 @@ export const ptBR: Translation = {
   "showcase.supporters.title_one": "Possível graças a {{count}} apoiador",
   "showcase.supporters.title_other": "Possível graças a {{count}} apoiadores",
   "showcase.supporters.more": "+{{count}} outros",
+  "showcase.v0122.hero.title":
+    "A câmera de replay pode seguir o piloto",
+  "showcase.v0122.hero.body":
+    "Mire uma chave em um piloto e a câmera de replay do FrostMod aponta para ele quadro a quadro, em vez dos ângulos que você voou. Corte entre planos, segure em um, e veja todo o caminho no mundo enquanto o monta.",
+  "showcase.v0122.aim":
+    "Pressione T em uma chave para mirar em um piloto. A câmera o segue, e com dois pilotos no mesmo trecho ela passa suavemente de um para o outro.",
+  "showcase.v0122.shots":
+    "E decide o que uma chave faz: passar por ela, parar nela, ou cortar seco para o próximo plano. Um caminho pode ser uma edição inteira.",
+  "showcase.v0122.preview":
+    "V desenha o caminho no mundo enquanto você o monta, e U desfaz a última alteração — até vinte e quatro atrás.",
+  "showcase.v0122.paths":
+    "Configurações → FrostMod lista cada caminho salvo: onde caem suas chaves, como ele voa, e como passá-lo adiante.",
   "showcase.v0121.hero.title":
     "As teclas da câmera de replay são suas",
   "showcase.v0121.hero.body":


### PR DESCRIPTION
Version bump in `package.json`, `tauri.conf.json`, `Cargo.toml` and `Cargo.lock`; the unreleased changelog section dated as v0.12.2; and the What's new entry with its strings in all six locales.

Ships the replay camera path panel from #276, alongside frostmod v0.15.3 which is what the panel is a front end for.

`scripts/changelog-section.sh v0.12.2 --heading` renders, so the release notes will not publish empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)