### PR TITLE
feat(tracks): the 3D view beside the list, coloured features, add and remove

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1226,7 +1226,7 @@ async fn preview_track(
         // One file, overwritten. A studio session generates many tracks and none of them are
         // worth keeping until someone installs one.
         let path = dir.join("preview.pkz");
-        tracksynth::write_pkz(&prog, &syn, &path).map_err(|e| format!("{e:#}"))?;
+        tracksynth::write_pkz(&prog, &syn, &path, true).map_err(|e| format!("{e:#}"))?;
 
         let c = trackstats::measure("synth", &syn.corridor, &syn.heights, syn.gw, syn.gh, syn.mps);
         Ok(TrackPreview {
@@ -1274,7 +1274,7 @@ async fn install_track_preview(
             .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
             .collect();
         let path = dir.join(format!("{}.pkz", name.trim_matches('_')));
-        tracksynth::write_pkz(&prog, &syn, &path).map_err(|e| format!("{e:#}"))?;
+        tracksynth::write_pkz(&prog, &syn, &path, false).map_err(|e| format!("{e:#}"))?;
         Ok(path.to_string_lossy().into_owned())
     })
     .await

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -439,6 +439,16 @@ fn surface_colour(id: u32) -> [u8; 3] {
         4 => [150, 118, 84],   // soil — mid brown
         5 => [158, 156, 150],  // concrete — light, neutral
         10 => [128, 84, 58],   // the riding line — darkest, reddest
+        // Generated tracks paint their features with ids of their own, so the studio's 3D
+        // preview can show you which lump is which. Nothing published uses these — real
+        // tracks' surface ids are all under about 16 — so they cost real tracks nothing.
+        200 => [214, 120, 60],  // tabletop
+        201 => [206, 74, 96],   // double
+        202 => [120, 150, 200], // roller
+        203 => [190, 170, 70],  // whoops
+        204 => [110, 180, 130], // step-up
+        205 => [150, 110, 200], // berm
+        206 => [90, 90, 110],   // rut
         12 => [124, 126, 102], // olive, so it parts from both grass and soil
         _ => [138, 126, 106],
     }
@@ -1175,9 +1185,25 @@ mod tests {
     #[test]
     fn a_surface_the_file_does_not_name_still_gets_a_colour() {
         // Ids past the table turn up on real tracks, and one that panicked or came back
-        // black would be worse than one that is merely approximate.
-        assert_ne!(surface_colour(200), [0, 0, 0]);
-        assert_eq!(surface_colour(200), surface_colour(201));
+        // black would be worse than one that is merely approximate. 200-206 are spoken for
+        // now — the studio paints generated features with them — so this asks about ids
+        // nothing has claimed.
+        assert_ne!(surface_colour(300), [0, 0, 0]);
+        assert_eq!(surface_colour(300), surface_colour(301));
+    }
+
+    #[test]
+    fn every_generated_feature_kind_gets_its_own_colour() {
+        // The whole point of them is telling one lump from another in the preview, so two
+        // sharing a colour is the one thing that must not happen.
+        let mut seen = std::collections::HashSet::new();
+        for id in 200..=206 {
+            assert!(seen.insert(surface_colour(id)), "id {id} repeats a colour");
+        }
+        // And none of them collides with a surface a real track paints.
+        for real in [0, 1, 2, 3, 4, 5, 10, 12] {
+            assert!(!seen.contains(&surface_colour(real)), "id {real} collides");
+        }
     }
 
     #[test]

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -981,7 +981,49 @@ pub fn write_source(prog: &TrackProgram, syn: &Synth, dir: &Path) -> Result<Vec<
 ///
 /// This is a *preview*, not a build. It carries terrain and surfaces and nothing else — no
 /// graphics, no scenery, no race data — so the game has no use for it. The app does.
-pub fn trh(prog: &TrackProgram, syn: &Synth) -> Vec<u8> {
+/// The surface id a feature kind is painted with in a preview. See `track::surface_colour`.
+fn feature_id(f: &Feature) -> u32 {
+    match f {
+        Feature::Tabletop { .. } => 200,
+        Feature::Double { .. } => 201,
+        Feature::Roller { .. } => 202,
+        Feature::Whoops { .. } => 203,
+        Feature::StepUp { .. } => 204,
+        Feature::Berm { .. } => 205,
+        Feature::Rut { .. } => 206,
+    }
+}
+
+/// One coverage mask per kind of feature on the track, so a preview can colour them.
+///
+/// Grouped by kind rather than one per feature: thirty masks would be thirty megabytes and
+/// the question being answered is "which of these is the double", not "which double".
+fn feature_masks(prog: &TrackProgram, syn: &Synth, dim: usize) -> Vec<(u32, Vec<u8>)> {
+    let half = prog.width * 0.5;
+    let mut out: Vec<(u32, Vec<u8>)> = Vec::new();
+    for f in &prog.features {
+        let id = feature_id(f);
+        if out.iter().any(|(k, _)| *k == id) {
+            continue;
+        }
+        let spans: Vec<(f32, f32)> = prog
+            .features
+            .iter()
+            .filter(|g| feature_id(g) == id)
+            .map(|g| (g.at(), g.at() + g.length()))
+            .collect();
+        out.push((
+            id,
+            mask_from(syn, dim, |d, s| {
+                let on = d <= half && spans.iter().any(|(lo, hi)| s >= *lo && s <= *hi);
+                u8::from(on) * 255
+            }),
+        ));
+    }
+    out
+}
+
+pub fn trh(prog: &TrackProgram, syn: &Synth, paint_features: bool) -> Vec<u8> {
     let scale = prog.terrain.scale;
     let mut out = Vec::with_capacity(12 + syn.heights.len() * 2 + 1024);
     out.extend_from_slice(b"TRH\0");
@@ -1010,7 +1052,7 @@ pub fn trh(prog: &TrackProgram, syn: &Synth) -> Vec<u8> {
     // different material from both, and it is most of what you see from the seat.
     let (shoulder_id, shoulder_scale) = ground(prog.terrain.surface);
     let shoulder = SHOULDER_M * shoulder_scale;
-    let masks: [(u32, Vec<u8>); 3] = [
+    let mut masks: Vec<(u32, Vec<u8>)> = vec![
         // 10 is the riding line — the id published tracks paint their ribbon with.
         (10, mask_from(syn, TRH_MASK_DIM, |d, _| u8::from(d <= half) * 255)),
         (
@@ -1023,6 +1065,13 @@ pub fn trh(prog: &TrackProgram, syn: &Synth) -> Vec<u8> {
             u8::from(d > half + shoulder) * 255
         })),
     ];
+    if paint_features {
+        // First in the list, because a reader compositing these takes the first mask that
+        // covers a cell — and on a feature that is the answer wanted.
+        let mut all = feature_masks(prog, syn, TRH_MASK_DIM);
+        all.extend(masks);
+        masks = all;
+    }
     out.extend_from_slice(&(masks.len() as u32).to_le_bytes());
     out.extend_from_slice(&[0u8; 16]); // to the offset the records start at
 
@@ -1066,7 +1115,12 @@ fn ground(s: Surface) -> (u32, f32) {
 
 /// The preview as a `.pkz` the app can open: a plain zip, which is what the reader falls back
 /// to when a file isn't one of PiBoSo's encrypted ones.
-pub fn write_pkz(prog: &TrackProgram, syn: &Synth, path: &Path) -> Result<u64> {
+pub fn write_pkz(
+    prog: &TrackProgram,
+    syn: &Synth,
+    path: &Path,
+    paint_features: bool,
+) -> Result<u64> {
     let slug = slug(&prog.name);
     let file = std::fs::File::create(path).with_context(|| format!("create {path:?}"))?;
     let mut zip = zip::ZipWriter::new(file);
@@ -1075,7 +1129,7 @@ pub fn write_pkz(prog: &TrackProgram, syn: &Synth, path: &Path) -> Result<u64> {
 
     use std::io::Write;
     zip.start_file(format!("{slug}.trh"), opts)?;
-    zip.write_all(&trh(prog, syn))?;
+    zip.write_all(&trh(prog, syn, paint_features))?;
     zip.start_file(format!("{slug}.ini"), opts)?;
     zip.write_all(track_ini(prog).as_bytes())?;
     zip.finish()?;
@@ -1711,7 +1765,7 @@ mod tests {
             // the same code that reads published tracks. Anything the viewer would get wrong
             // shows up here as a track that measures like nothing.
             let pkz = dir.join(format!("{}.pkz", slug(&p.name)));
-            let size = write_pkz(&p, &s, &pkz).unwrap();
+            let size = write_pkz(&p, &s, &pkz, false).unwrap();
             let back = crate::trackstats::analyse(&pkz).expect("the .pkz reads back as a track");
             let bc = back.corridor.as_ref().expect("the .pkz carries a riding line");
             println!(
@@ -1791,7 +1845,7 @@ mod tests {
         if let Ok(dir) = std::env::var("FROST_BUILD") {
             let dir = Path::new(&dir);
             let wrote = write_source(&p, &s, dir).unwrap();
-            write_pkz(&p, &s, &dir.join(format!("{}.pkz", slug(&p.name)))).unwrap();
+            write_pkz(&p, &s, &dir.join(format!("{}.pkz", slug(&p.name))), true).unwrap();
             preview(&s, &dir.join("preview.ppm"));
             println!("wrote {} files to {}", wrote.len() + 2, dir.display());
         }

--- a/src/Components/Studio/TrackStudio/TrackStudio.tsx
+++ b/src/Components/Studio/TrackStudio/TrackStudio.tsx
@@ -11,6 +11,7 @@ import {
   Square,
   TrendingDown,
   TrendingUp,
+  Plus,
   Waves,
   type LucideIcon,
 } from "lucide-react";
@@ -18,7 +19,9 @@ import { toast } from "sonner";
 
 import { Button } from "../../ui/button";
 import { Input } from "../../ui/input";
-import { TrackViewerDialog } from "../../Viewer/TrackViewerDialog";
+import { TrackViewer } from "../../Viewer/TrackViewer";
+import { loadTrackOverview, loadTrackTerrain } from "../../../api/tracks";
+import type { TrackOverview, TrackTerrain } from "../../../types";
 import { useT } from "../../../i18n/context";
 import { cn } from "@/lib/utils";
 import {
@@ -29,13 +32,17 @@ import {
   generateTrack,
   installTrackPreview,
   lapLength,
+  featureSpan,
   lapSteps,
+  newFeature,
   previewTrack,
+  roomiestGap,
   setTrackTools,
   trackToolsStatus,
   type BuildStep,
   type LapStep,
   type TrackFeature,
+  type TrackFeatureKind,
   type TrackPreview,
   type TrackProgram,
   type TrackSegment,
@@ -62,7 +69,8 @@ export default function TrackStudio() {
   const [program, setProgram] = useState<TrackProgram | null>(null);
   const [preview, setPreview] = useState<TrackPreview | null>(null);
   const [problems, setProblems] = useState<string[]>([]);
-  const [viewing, setViewing] = useState(false);
+  const [terrain, setTerrain] = useState<TrackTerrain | null>(null);
+  const [overview, setOverview] = useState<TrackOverview | null>(null);
   const [tools, setTools] = useState<TrackToolsStatus | null>(null);
   const [steps, setSteps] = useState<BuildStep[]>([]);
 
@@ -127,7 +135,11 @@ export default function TrackStudio() {
     try {
       const p = await previewTrack(program);
       setPreview(p);
-      setViewing(true);
+      // Terrain first so something is on screen, then the surfaces that colour the features
+      // — the second is the slower half and the view is useful before it lands.
+      const t3 = await loadTrackTerrain(p.path, 1024);
+      setTerrain(t3);
+      setOverview(await loadTrackOverview(p.path, 2048).catch(() => null));
     } catch (e) {
       toast.error(t("track.buildFailed"), { description: String(e) });
     } finally {
@@ -182,6 +194,20 @@ export default function TrackStudio() {
   function removeFeature(index: number) {
     if (!program) return;
     void settle({ ...program, features: program.features.filter((_, i) => i !== index) });
+  }
+
+  /// A corner or a straight can go too — the lap stops closing, and the validator says so
+  /// in metres, which is a better teacher than a disabled button.
+  function removeSegment(index: number) {
+    if (!program || program.segments.length <= 2) return;
+    void settle({ ...program, segments: program.segments.filter((_, i) => i !== index) });
+  }
+
+  function addFeature(kind: TrackFeatureKind) {
+    if (!program) return;
+    const probe = newFeature(kind, 0);
+    const at = roomiestGap(program, featureSpan(probe).length);
+    void settle({ ...program, features: [...program.features, newFeature(kind, at)] });
   }
 
   async function onPointAtTools() {
@@ -278,7 +304,21 @@ export default function TrackStudio() {
           {/* Left: what the lap is, and what it measures. */}
           <div className="flex w-[300px] flex-none flex-col gap-3">
             <div className="rounded-xl border border-input p-3.5">
-              <h2 className="text-[15px] font-bold tracking-[-0.2px]">{program.name}</h2>
+              {/* The name is the folder, the .pkz and what the game lists it as, so it is
+                  worth being able to change before any of those are written. */}
+              <input
+                value={program.name}
+                onChange={(e) => void settle({ ...program, name: e.target.value })}
+                className="w-full rounded-md bg-transparent text-[15px] font-bold tracking-[-0.2px] outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+                aria-label={t("track.name")}
+              />
+              <input
+                value={program.author}
+                onChange={(e) => void settle({ ...program, author: e.target.value })}
+                placeholder={t("track.author")}
+                className="mt-0.5 w-full rounded-md bg-transparent text-[12px] text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+                aria-label={t("track.author")}
+              />
               <dl className="mt-2.5 grid grid-cols-2 gap-x-3 gap-y-1.5 text-[12.5px]">
                 <Row label={t("track.lap")} value={`${lapLength(program).toFixed(0)} m`} />
                 <Row label={t("track.width")} value={`${program.width.toFixed(1)} m`} />
@@ -372,11 +412,26 @@ export default function TrackStudio() {
             </div>
           </div>
 
-          {/* Right: the lap in the order you ride it — a straight, a left turn, a double.
+          {/* Middle: the lap in the order you ride it — a straight, a left turn, a double.
               Corners and jumps live in different lists in the program, but nobody rides them
               that way, so here they are one sequence. */}
-          <div className="min-h-0 flex-1 overflow-y-auto rounded-xl border border-input">
-            <ol className="divide-y divide-input/60">
+          <div className="flex min-h-0 w-[420px] flex-none flex-col rounded-xl border border-input">
+            {/* Adding one is picking what it is; where it goes is the emptiest stretch of
+                lap, because dropping it at the finish usually lands it on something. */}
+            <div className="flex flex-none flex-wrap items-center gap-1 border-b border-input px-2 py-1.5">
+              <Plus className="size-3.5 flex-none text-muted-foreground" />
+              {(Object.keys(FEATURE_ICON) as TrackFeatureKind[]).map((kind) => (
+                <button
+                  key={kind}
+                  onClick={() => addFeature(kind)}
+                  disabled={busy !== null}
+                  className="cursor-default rounded px-1.5 py-1 text-[11.5px] text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground disabled:opacity-40"
+                >
+                  {t(KIND_KEY[kind])}
+                </button>
+              ))}
+            </div>
+            <ol className="min-h-0 flex-1 divide-y divide-input/60 overflow-y-auto">
               {lapSteps(program).map((step, row) => {
                 const Icon = stepIcon(step);
                 return (
@@ -412,14 +467,12 @@ export default function TrackStudio() {
                     </div>
 
                     <button
-                      onClick={() => step.kind === "feature" && removeFeature(step.index)}
-                      disabled={step.kind !== "feature"}
-                      className={cn(
-                        "rounded px-1.5 text-muted-foreground transition-colors",
+                      onClick={() =>
                         step.kind === "feature"
-                          ? "hover:bg-foreground/[0.06] hover:text-foreground"
-                          : "invisible",
-                      )}
+                          ? removeFeature(step.index)
+                          : removeSegment(step.index)
+                      }
+                      className="rounded px-1.5 text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
                       aria-label={t("common.delete")}
                     >
                       ×
@@ -429,17 +482,31 @@ export default function TrackStudio() {
               })}
             </ol>
           </div>
+
+          {/* Right: the track itself. Features are painted with a colour each, so a row in
+              the list and a lump on the ground can be matched up by eye. */}
+          <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden rounded-xl border border-input bg-black/20">
+            {terrain ? (
+              <TrackViewer
+                terrain={terrain}
+                overview={overview}
+                scenery={null}
+                surfaces={[]}
+                backdrop={null}
+                ground={null}
+                placements={[]}
+                showObjects={false}
+                className="absolute inset-0"
+              />
+            ) : (
+              <div className="absolute inset-0 grid place-items-center px-6 text-center text-[12.5px] text-muted-foreground">
+                {busy === "preview" ? t("track.building") : t("track.previewHint")}
+              </div>
+            )}
+          </div>
         </div>
       )}
 
-      {preview && (
-        <TrackViewerDialog
-          open={viewing}
-          onOpenChange={setViewing}
-          path={preview.path}
-          title={preview.name}
-        />
-      )}
     </div>
   );
 }

--- a/src/api/trackgen.ts
+++ b/src/api/trackgen.ts
@@ -142,6 +142,47 @@ export function lapSteps(program: TrackProgram): LapStep[] {
   return steps.sort((a, b) => a.at - b.at || (a.kind === "feature" ? 1 : -1));
 }
 
+/** A feature of each kind, with sizes that sit inside what published tracks measure. */
+export function newFeature(kind: TrackFeatureKind, at: number): TrackFeature {
+  switch (kind) {
+    case "tabletop":
+      return { kind, at, length: 20, height: 1.6 };
+    case "double":
+      return { kind, at, height: 1.6, gap: 10, lip: 6 };
+    case "roller":
+      return { kind, at, length: 14, height: 0.9 };
+    case "whoops":
+      return { kind, at, count: 5, spacing: 5, height: 0.7 };
+    case "stepUp":
+      return { kind, at, length: 25, height: 2.5 };
+    case "berm":
+      return { kind, at, length: 20, height: 1.6 };
+    case "rut":
+      return { kind, at, length: 20, depth: 0.15 };
+  }
+}
+
+/**
+ * The emptiest stretch of the lap, which is where a new feature should go.
+ *
+ * Dropping one at the finish line means it usually lands on top of something, and the
+ * validator then complains about a track the person didn't ask for.
+ */
+export function roomiestGap(program: TrackProgram, want: number): number {
+  const lap = lapLength(program);
+  const taken = program.features
+    .map((f) => ({ lo: f.at, hi: f.at + featureSpan(f).length }))
+    .sort((a, b) => a.lo - b.lo);
+  let best = { at: lap / 2, size: -1 };
+  let cursor = 0;
+  for (const span of [...taken, { lo: lap, hi: lap }]) {
+    const size = span.lo - cursor;
+    if (size > best.size) best = { at: cursor + (size - want) / 2, size };
+    cursor = Math.max(cursor, span.hi);
+  }
+  return Math.max(0, Math.min(best.at, Math.max(0, lap - want)));
+}
+
 /** How long the lap is. An arc states its radius and angle, so its length falls out. */
 export function lapLength(program: TrackProgram): number {
   return program.segments.reduce(

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -2257,4 +2257,7 @@ export const de: Translation = {
   "track.stillNeeded": "Braucht noch eine .rdf aus TrackEd (Startgatter, Box, Kameras) und eine gate.edf aus einer anderen Strecke.",
   "track.base": "Basis-Strecke",
   "track.baseLoaded": "„{{name}}“ geladen",
+  "track.name": "Streckenname",
+  "track.author": "Autor",
+  "track.previewHint": "Auf Vorschau drücken, um sie zu bauen und hier anzusehen.",
 };

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2213,4 +2213,7 @@ export const en = {
   "track.stillNeeded": "Still needs a .rdf from TrackEd (start gate, pits, cameras) and a gate.edf copied from another track.",
   "track.base": "Base track",
   "track.baseLoaded": "Loaded “{{name}}”",
+  "track.name": "Track name",
+  "track.author": "Author",
+  "track.previewHint": "Press Preview to build it and look at it here.",
 } as const;

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -2243,4 +2243,7 @@ export const es: Translation = {
   "track.stillNeeded": "Aún necesita un .rdf de TrackEd (parrilla, boxes, cámaras) y un gate.edf copiado de otra pista.",
   "track.base": "Pista base",
   "track.baseLoaded": "Se cargó «{{name}}»",
+  "track.name": "Nombre de la pista",
+  "track.author": "Autor",
+  "track.previewHint": "Pulsa Previsualizar para construirla y verla aquí.",
 };

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -2248,4 +2248,7 @@ export const fr: Translation = {
   "track.stillNeeded": "Il manque encore un .rdf de TrackEd (grille, stands, caméras) et un gate.edf copié d'un autre circuit.",
   "track.base": "Circuit de base",
   "track.baseLoaded": "« {{name}} » chargé",
+  "track.name": "Nom du circuit",
+  "track.author": "Auteur",
+  "track.previewHint": "Appuie sur Aperçu pour le construire et le voir ici.",
 };

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -2236,4 +2236,7 @@ export const it: Translation = {
   "track.stillNeeded": "Servono ancora un .rdf da TrackEd (cancelletto, box, telecamere) e un gate.edf copiato da un'altra pista.",
   "track.base": "Pista base",
   "track.baseLoaded": "Caricata «{{name}}»",
+  "track.name": "Nome pista",
+  "track.author": "Autore",
+  "track.previewHint": "Premi Anteprima per costruirla e vederla qui.",
 };

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -2233,4 +2233,7 @@ export const ptBR: Translation = {
   "track.stillNeeded": "Ainda precisa de um .rdf do TrackEd (portão, boxes, câmeras) e um gate.edf copiado de outra pista.",
   "track.base": "Pista base",
   "track.baseLoaded": "“{{name}}” carregada",
+  "track.name": "Nome da pista",
+  "track.author": "Autor",
+  "track.previewHint": "Toque em Prévia para construir e ver aqui.",
 };


### PR DESCRIPTION
## Side by side

The preview is a panel next to the lap rather than a dialog over it, so changing a jump and seeing it are the same glance. It loads **terrain and surfaces only** — a generated track carries no scenery, so the dialog's other six loaders would all return nothing, and reusing it would have meant refactoring 400 lines of state for no gain.

## Features have colours

Every feature kind is painted with its own surface id in the preview, and `surface_colour` gives each one a colour, so a row in the list and a lump on the ground can be matched up by eye. Ids 200–206 — nothing published uses them; real tracks' surface ids are all under about 16 — and **only in the preview**: the `.pkz` written for the game keeps the three real surfaces.

## Adding

Adding a feature is picking what it is. Where it goes is worked out: the emptiest stretch of lap, because dropping one at the finish line usually lands it on top of something and the validator then complains about a track nobody asked for.

## Removing

Straights and corners can go too, not just features. The lap stops closing and the validator says so in metres — which teaches more than a disabled button does.

## Renaming

The name and author are editable in place. The name is the folder, the `.pkz`, and what the game lists it as, so it's worth being able to set before any of those get written.

## One test needed moving

`a_surface_the_file_does_not_name_still_gets_a_colour` used 200 and 201 as its example of unclaimed ids, which they no longer are. It moved to 300/301, and there's a new test that the seven feature colours are distinct from each other *and* from every surface a real track paints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)