### PR TITLE
feat(tracks): drag to reorder, click to fly the camera there

### DIFF
--- a/src/Components/Studio/TrackStudio/TrackStudio.tsx
+++ b/src/Components/Studio/TrackStudio/TrackStudio.tsx
@@ -35,6 +35,7 @@ import {
   featureSpan,
   lapSteps,
   newFeature,
+  positionAt,
   previewTrack,
   roomiestGap,
   setTrackTools,
@@ -71,6 +72,8 @@ export default function TrackStudio() {
   const [problems, setProblems] = useState<string[]>([]);
   const [terrain, setTerrain] = useState<TrackTerrain | null>(null);
   const [overview, setOverview] = useState<TrackOverview | null>(null);
+  const [focus, setFocus] = useState<{ x: number; z: number } | null>(null);
+  const [dragging, setDragging] = useState<number | null>(null);
   const [tools, setTools] = useState<TrackToolsStatus | null>(null);
   const [steps, setSteps] = useState<BuildStep[]>([]);
 
@@ -201,6 +204,38 @@ export default function TrackStudio() {
   function removeSegment(index: number) {
     if (!program || program.segments.length <= 2) return;
     void settle({ ...program, segments: program.segments.filter((_, i) => i !== index) });
+  }
+
+  /**
+   * Move a row to where it was dropped.
+   *
+   * The two halves of a lap are stored differently — corners and straights are an ordered
+   * list, features are placed by how far round they are — so a drop means two different
+   * things depending on what was dragged. Reordering segments changes the shape of the lap;
+   * moving a feature only changes where on it the jump sits.
+   */
+  function reorder(steps: LapStep[], from: number, to: number) {
+    if (!program || from === to) return;
+    const moved = steps[from];
+    const target = steps[to];
+    if (moved.kind === "feature") {
+      const at = target.kind === "feature" ? target.at : target.at + (to > from ? 1 : 0);
+      const features = program.features.map((f, i) =>
+        i === moved.index ? { ...f, at: Math.max(0, at) } : f,
+      );
+      void settle({ ...program, features });
+      return;
+    }
+    // A segment lands where the row it was dropped on sits. Dropped on a feature, that is
+    // the segment the feature is on — the last one that starts at or before it.
+    const landing =
+      target.kind === "feature"
+        ? steps.filter((x) => x.kind !== "feature" && x.at <= target.at).length - 1
+        : target.index;
+    const next = [...program.segments];
+    const [seg] = next.splice(moved.index, 1);
+    next.splice(Math.min(Math.max(landing, 0), next.length), 0, seg);
+    void settle({ ...program, segments: next });
   }
 
   function addFeature(kind: TrackFeatureKind) {
@@ -434,8 +469,25 @@ export default function TrackStudio() {
             <ol className="min-h-0 flex-1 divide-y divide-input/60 overflow-y-auto">
               {lapSteps(program).map((step, row) => {
                 const Icon = stepIcon(step);
+                const steps = lapSteps(program);
                 return (
-                  <li key={row} className="flex items-center gap-2.5 px-3 py-1.5 text-[12.5px]">
+                  <li
+                    key={row}
+                    draggable
+                    onDragStart={() => setDragging(row)}
+                    onDragOver={(e) => e.preventDefault()}
+                    onDrop={() => {
+                      if (dragging !== null) reorder(steps, dragging, row);
+                      setDragging(null);
+                    }}
+                    onDragEnd={() => setDragging(null)}
+                    onClick={() => setFocus(positionAt(program, step.at))}
+                    className={cn(
+                      "flex items-center gap-2.5 px-3 py-1.5 text-[12.5px] transition-colors",
+                      terrain && "cursor-default hover:bg-foreground/[0.04]",
+                      dragging === row && "opacity-40",
+                    )}
+                  >
                     <span className="w-12 flex-none tabular-nums text-right text-muted-foreground">
                       {step.at.toFixed(0)}
                     </span>
@@ -496,6 +548,7 @@ export default function TrackStudio() {
                 ground={null}
                 placements={[]}
                 showObjects={false}
+                focus={focus}
                 className="absolute inset-0"
               />
             ) : (
@@ -611,7 +664,7 @@ function Field({
   onChange: (v: number) => void;
 }) {
   return (
-    <label className="flex items-center gap-1">
+    <label className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
       <span className="text-[11px] text-muted-foreground">{label}</span>
       <Num value={value} step={step} onChange={onChange} />
     </label>

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -278,6 +278,44 @@ function viewFrame(terrain: TrackTerrain) {
 }
 
 /**
+ * Bring the camera to a point on the track.
+ *
+ * Sets the orbit target and pulls the camera back along the direction it was already
+ * looking, so flying to a jump keeps whatever angle you had rather than snapping to a
+ * canned one. Close enough to read a single face — the point of going there at all.
+ */
+function FocusCamera({
+  terrain,
+  focus,
+}: {
+  terrain: TrackTerrain;
+  focus: { x: number; z: number } | null;
+}) {
+  const { camera, controls, invalidate } = useThree();
+  useEffect(() => {
+    if (!focus) return;
+    const frame = viewFrame(terrain);
+    const [x, , z] = toView(frame, focus.x, terrain.minHeight, focus.z);
+    // The ground's own height at that point isn't known here, so aim at the middle of the
+    // terrain's range: a jump is a metre of relief on ground that spans tens.
+    const y = 0;
+    const orbit = controls as unknown as {
+      target?: { set: (x: number, y: number, z: number) => void };
+      update?: () => void;
+    } | null;
+    const from = camera.position.clone().sub(new THREE.Vector3(x, y, z));
+    // Whatever direction the camera was at, five view-units away — about a jump and a half.
+    const back = from.lengthSq() > 1e-6 ? from.normalize() : new THREE.Vector3(0.6, 0.5, 0.6).normalize();
+    camera.position.set(x + back.x * 5, y + Math.max(back.y * 5, 1.6), z + back.z * 5);
+    orbit?.target?.set(x, y, z);
+    camera.lookAt(x, y, z);
+    orbit?.update?.();
+    invalidate();
+  }, [focus, terrain, camera, controls, invalidate]);
+  return null;
+}
+
+/**
  * Put one world-metre point where the terrain would put it.
  *
  * X is negated, the same conversion every model in the app goes through
@@ -1119,6 +1157,14 @@ interface TrackViewerProps {
   ground?: TrackGround | null;
   /** Told what a click on the scenery landed on, and when the selection clears. */
   onPick?: (piece: PickedPiece | null) => void;
+  /**
+   * A point in world metres to bring the camera to, or null to leave it alone.
+   *
+   * The identity matters as much as the value: passing a fresh object with the same
+   * coordinates moves the camera again, which is what makes clicking the same row twice
+   * bring you back to it after you have panned away.
+   */
+  focus?: { x: number; z: number } | null;
   className?: string;
 }
 
@@ -1132,6 +1178,7 @@ export function TrackViewer({
   backdrop = null,
   ground = null,
   onPick,
+  focus = null,
   className,
 }: TrackViewerProps) {
   return (
@@ -1226,6 +1273,7 @@ export function TrackViewer({
           {terrain && showObjects && placements.length > 0 && (
             <PlacementMarkers placements={placements} terrain={terrain} />
           )}
+          {terrain && <FocusCamera terrain={terrain} focus={focus} />}
           <OrbitControls
             makeDefault
             enablePan

--- a/src/api/trackgen.ts
+++ b/src/api/trackgen.ts
@@ -142,6 +142,46 @@ export function lapSteps(program: TrackProgram): LapStep[] {
   return steps.sort((a, b) => a.at - b.at || (a.kind === "feature" ? 1 : -1));
 }
 
+/**
+ * Where a point on the lap is, in world metres.
+ *
+ * The same walk the synthesiser does — heading 0 looks down +z and increases clockwise
+ * towards +x, and an arc is evaluated from its centre rather than integrated — so a point
+ * this returns is the point the terrain was built around. Keep the two in step: if one
+ * changes convention the camera flies to the wrong side of the track.
+ */
+export function positionAt(program: TrackProgram, s: number): { x: number; z: number } {
+  let { x, z } = program.start;
+  let th = (program.start.angle * Math.PI) / 180;
+  let left = s;
+  for (const seg of program.segments) {
+    const len =
+      seg.kind === "straight"
+        ? seg.length
+        : (Math.abs(seg.radius) * Math.abs(seg.angle) * Math.PI) / 180;
+    const part = Math.min(Math.max(left, 0), len);
+    if (seg.kind === "straight") {
+      x += Math.sin(th) * part;
+      z += Math.cos(th) * part;
+      if (left <= len) return { x, z };
+      th += 0;
+    } else {
+      const turn = seg.radius >= 0 ? 1 : -1;
+      const r = Math.max(Math.abs(seg.radius), 0.01);
+      const cx = x + Math.cos(th) * r * turn;
+      const cz = z - Math.sin(th) * r * turn;
+      const phi = part / r;
+      const th2 = th + turn * phi;
+      x = cx - Math.cos(th2) * r * turn;
+      z = cz + Math.sin(th2) * r * turn;
+      if (left <= len) return { x, z };
+      th = th2;
+    }
+    left -= len;
+  }
+  return { x, z };
+}
+
 /** A feature of each kind, with sizes that sit inside what published tracks measure. */
 export function newFeature(kind: TrackFeatureKind, at: number): TrackFeature {
   switch (kind) {


### PR DESCRIPTION
## Drag to reorder

Rows drag. The two halves of a lap are stored differently — corners and straights are an ordered list, features are placed by how far round the lap they are — so a drop means two different things depending on what was dragged:

- **a segment** moves in the list, which changes the shape of the lap
- **a feature** just gets a new distance-round, which changes where on the lap the jump sits

Both go through the same validate-and-measure pass, so a drag that opens the lap up says so in metres rather than silently producing a track that doesn't close.

## Click to fly there

Clicking a row brings the camera to it. `positionAt` walks the lap in TypeScript the way the synthesiser walks it in Rust — heading 0 looks down +z, arcs evaluated from their centre rather than integrated — so the point it returns is the point the terrain was actually built around. **These two have to stay in step:** if one changes convention the camera flies to the wrong side of the track.

`TrackViewer` takes a `focus` prop. It pulls the camera back along the direction it was already looking rather than snapping to a canned angle, so flying to a jump keeps whatever view you had. The prop's *identity* is what triggers the move, so clicking the same row twice brings you back to it after you've panned away.

Editing a field stops the click from propagating — otherwise changing a number would also move the camera out from under you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)