### PR TITLE
feat(tracks): berms follow their corner, and the list wears the track's colours

### DIFF
--- a/src-tauri/src/frostmod.rs
+++ b/src-tauri/src/frostmod.rs
@@ -130,9 +130,11 @@ pub fn is_running() -> bool {
 // Must match `HandleFrostModCommand` in frostmod.cpp, verb names included.
 //
 // Verbs:
-//   `refresh_bike_model` — re-apply the named bike so a just-swapped model shows
-//       in the garage without the class-switch away-and-back. FrostMod no-ops
-//       unless that bike is the one currently selected.
+//   `refresh_bike_model` — the named bike's model changed on disk. FrostMod logs it and
+//       puts a notice on screen; it does NOT re-apply the bike (v0.9.11 removed that —
+//       the replay crashed the game). The player has to switch bike category away and
+//       back. NOTE: FrostMod's own notice still says "re-select the bike", which isn't
+//       enough — fix it there.
 //   `swap_bike` — switch the active bike outright. NOT implemented in FrostMod
 //       yet (Stage B); it logs and ignores.
 //
@@ -283,8 +285,9 @@ pub fn signal_swap_bike(bike_id: &str) -> CommandOutcome {
     send_command(command_json("swap_bike", bike_id))
 }
 
-/// Ask FrostMod to re-apply `bike_id` so a just-swapped model shows in the garage
-/// straight away. A no-op inside FrostMod unless that bike is the selected one.
+/// Tell FrostMod that `bike_id`'s model changed on disk. It answers with an in-game
+/// notice; the mesh does not reload on its own, and only a bike-category switch away
+/// and back re-reads it (see the verb table above).
 ///
 /// NOT safe to fire at every FrostMod — see `model_refresh_is_safe`, which every
 /// caller must clear first.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -491,9 +491,9 @@ struct SwapApplyOutcome {
     content_reload: ReloadOutcome,
     game_running: bool,
     live_refresh: gameproc::LiveRefresh,
-    /// Model swaps only (`None` for sound). `live_refresh` re-runs the *customization*
-    /// loader, which reloads paints/gear but never the mesh — the model needs FrostMod
-    /// to re-apply the bike. See `frostmod::signal_refresh_model`.
+    /// Model swaps only (`None` for sound). Nothing here makes the mesh appear live —
+    /// `live_refresh` re-runs the *customization* loader (paints/gear, never the mesh)
+    /// and the verb below is only a notice. See `frostmod::signal_refresh_model`.
     model_refresh: Option<frostmod::CommandOutcome>,
     /// Liveries the swap couldn't move into or out of `paints/`, because MX Bikes holds
     /// bike files open while it runs. Zero on every other path. See
@@ -638,9 +638,14 @@ fn watch_worn_paints(app: &tauri::AppHandle) {
     );
 }
 
-/// Ask FrostMod to re-apply `bike` so a just-swapped model shows live. `None` when
+/// Tell FrostMod that `bike`'s model changed, so it can say so in-game. `None` when
 /// instant refresh is off — the same switch that gates `live_refresh`, since both
 /// reach into the running game.
+///
+/// It does not make the model appear: FrostMod v0.9.11 removed the live re-apply (it
+/// crashed the game), so the player still switches bike category away and back — that
+/// is what re-reads the model; reselecting the same bike does not. All this buys is
+/// the in-game notice.
 ///
 /// The tag our installer recorded decides whether the command goes out at all. It used
 /// to be sent unconditionally and only the *wording* adjusted afterwards, because the
@@ -750,9 +755,7 @@ fn apply_model_swap_blocking(
         eprintln!("sound reconcile after model swap failed: {e:#}");
     }
     let content_reload = frostmod::signal_reload();
-    // Ask FrostMod to re-apply the bike so the new model shows in the garage without a
-    // class switch away-and-back. Only acts if `bike` is the selected one (decided
-    // inside FrostMod, which is the only side that knows). Gated on the same
+    // Tell FrostMod the model changed so it prompts the player in-game. Gated on the same
     // instant-refresh setting as the look refresh — both poke the live game.
     let model_refresh = model_refresh_cmd(&app, cfg.instant_refresh, &bike);
     // A different model can resolve a slot to a different file, so the look watcher has to

--- a/src-tauri/src/trackllm.rs
+++ b/src-tauri/src/trackllm.rs
@@ -179,9 +179,20 @@ pub fn validate(prog: &TrackProgram) -> Vec<String> {
                 .map(|s| s.curvature == 0.0)
                 .unwrap_or(true);
             if straight {
+                // Say which corner, not just "a corner". This turns up after an edit moves
+                // the corners out from under a berm that was on one, and the way out is a
+                // number.
+                let nearest = turn
+                    .iter()
+                    .filter(|s| s.curvature != 0.0)
+                    .min_by(|a, b| {
+                        (a.s - at).abs().total_cmp(&(b.s - at).abs())
+                    })
+                    .map(|s| format!(" The nearest corner starts around {:.0} m.", s.s))
+                    .unwrap_or_else(|| " This lap has no corners at all.".into());
                 out.push(format!(
-                    "the berm at {at:.0} m is on a straight. Berms bank the outside of a \
-                     corner — put it where an arc segment is."
+                    "the berm at {at:.0} m is on a straight, where it does nothing — a berm \
+                     banks the outside of a corner.{nearest}"
                 ));
             }
         }

--- a/src/Components/Locker/Locker.tsx
+++ b/src/Components/Locker/Locker.tsx
@@ -94,9 +94,10 @@ function pruneHiddenOrphans(live: OrphanedSetup[]): Set<string> {
  *
  * Models and sounds get different notes because they refresh by different routes.
  * `live_refresh` re-runs the game's *customization* loader — that reloads paints and
- * gear but never the bike mesh, so it says nothing about whether a swapped model is
- * visible. A model only appears live if FrostMod re-applies the bike (`model_refresh`),
- * which it does solely for the bike you currently have selected.
+ * gear but never the bike mesh. Nothing reloads the mesh: FrostMod v0.9.11 removed the
+ * live re-apply because it crashed the game, so every model outcome ends in the same
+ * instruction — switch bike category away and back, which is what actually re-reads
+ * the model. Reselecting the same bike does not. `model_refresh` only decides who says it.
  */
 function swapNote(
   kind: "model" | "sound",
@@ -108,11 +109,10 @@ function swapNote(
   if (kind === "model") {
     switch (outcome.model_refresh) {
       case "signaled":
-        return t("locker.modelRefreshing");
+      case "withheld":
+        return t("locker.modelSwitchCategory");
       case "not_running":
         return t("locker.modelFrostmodNotRunning");
-      case "withheld":
-        return t("locker.modelReselectBike");
       case "write_failed":
         return t("locker.modelFrostmodUnreachable");
       case "unsupported":

--- a/src/Components/Studio/TrackStudio/TrackStudio.tsx
+++ b/src/Components/Studio/TrackStudio/TrackStudio.tsx
@@ -33,6 +33,7 @@ import {
   generateTrack,
   installTrackPreview,
   lapLength,
+  FEATURE_COLOUR,
   featureSpan,
   fitFeatures,
   lapSteps,
@@ -75,6 +76,7 @@ export default function TrackStudio() {
   const [terrain, setTerrain] = useState<TrackTerrain | null>(null);
   const [overview, setOverview] = useState<TrackOverview | null>(null);
   const [focus, setFocus] = useState<{ x: number; z: number } | null>(null);
+  const [hover, setHover] = useState<{ x: number; z: number; width: number } | null>(null);
   // Reordering is done with pointer events, not HTML5 drag-and-drop. Tauri's
   // `dragDropEnabled` hands drags to the OS so the webview never sees a dragstart — which is
   // also why the whole-window file dropzone was catching every attempt.
@@ -517,6 +519,20 @@ export default function TrackStudio() {
                   <li
                     key={row}
                     onClick={() => setFocus(positionAt(program, step.at))}
+                    onPointerEnter={() =>
+                      setHover({
+                        // The middle of the feature, not its start — a 40 m berm marked at
+                        // its entry looks like it belongs to the corner before it.
+                        ...positionAt(
+                          program,
+                          step.kind === "feature"
+                            ? step.at + featureSpan(step.feature).length / 2
+                            : step.at,
+                        ),
+                        width: program.width * 1.6,
+                      })
+                    }
+                    onPointerLeave={() => setHover(null)}
                     className={cn(
                       "relative flex items-center gap-1.5 px-2 py-1.5 text-[12.5px] transition-colors",
                       terrain && "cursor-default hover:bg-foreground/[0.04]",
@@ -528,6 +544,11 @@ export default function TrackStudio() {
                         row === steps.length - 1 &&
                         "after:absolute after:inset-x-2 after:bottom-0 after:h-0.5 after:bg-primary",
                     )}
+                    style={
+                      step.kind === "feature"
+                        ? { boxShadow: `inset 3px 0 0 ${FEATURE_COLOUR[step.feature.kind]}` }
+                        : undefined
+                    }
                   >
                     <GripVertical
                       onPointerDown={(e) => onGripDown(e, row)}
@@ -541,8 +562,13 @@ export default function TrackStudio() {
                     <Icon
                       className={cn(
                         "size-4 flex-none",
-                        step.kind === "feature" ? "text-primary" : "text-muted-foreground",
+                        step.kind !== "feature" && "text-muted-foreground",
                       )}
+                      style={
+                        step.kind === "feature"
+                          ? { color: FEATURE_COLOUR[step.feature.kind] }
+                          : undefined
+                      }
                     />
                     <span className="w-[104px] flex-none truncate">{stepName(step, t)}</span>
 
@@ -596,6 +622,7 @@ export default function TrackStudio() {
                 placements={[]}
                 showObjects={false}
                 focus={focus}
+                highlight={hover}
                 className="absolute inset-0"
               />
             ) : (

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -277,6 +277,34 @@ function viewFrame(terrain: TrackTerrain) {
   };
 }
 
+/** A soft column of light over one feature, for pointing at it from a list. */
+function Highlight({
+  terrain,
+  at,
+}: {
+  terrain: TrackTerrain;
+  at: { x: number; z: number; width: number };
+}) {
+  const frame = viewFrame(terrain);
+  const [x, , z] = toView(frame, at.x, terrain.minHeight, at.z);
+  const radius = Math.max((at.width / 2) * frame.unitsPerMetre, 0.05);
+  // Tall enough to clear any relief the terrain has, and centred on the middle of its range
+  // so it reaches both above and below the ground it marks.
+  const tall = (terrain.maxHeight - terrain.minHeight) * frame.heightScale + 4;
+  return (
+    <mesh position={[x, 0, z]} renderOrder={2}>
+      <cylinderGeometry args={[radius, radius, tall, 24, 1, true]} />
+      <meshBasicMaterial
+        color="#ffffff"
+        transparent
+        opacity={0.16}
+        depthWrite={false}
+        side={THREE.DoubleSide}
+      />
+    </mesh>
+  );
+}
+
 /**
  * Bring the camera to a point on the track.
  *
@@ -1165,6 +1193,12 @@ interface TrackViewerProps {
    * bring you back to it after you have panned away.
    */
   focus?: { x: number; z: number } | null;
+  /**
+   * A point to light up, in world metres, and how wide it is. Drawn as a soft column so it
+   * reads from any angle and at any zoom — a highlight painted flat on the ground disappears
+   * the moment the camera is low, which is exactly when you are looking at a jump.
+   */
+  highlight?: { x: number; z: number; width: number } | null;
   className?: string;
 }
 
@@ -1179,6 +1213,7 @@ export function TrackViewer({
   ground = null,
   onPick,
   focus = null,
+  highlight = null,
   className,
 }: TrackViewerProps) {
   return (
@@ -1274,6 +1309,7 @@ export function TrackViewer({
             <PlacementMarkers placements={placements} terrain={terrain} />
           )}
           {terrain && <FocusCamera terrain={terrain} focus={focus} />}
+          {terrain && highlight && <Highlight terrain={terrain} at={highlight} />}
           <OrbitControls
             makeDefault
             enablePan

--- a/src/api/trackgen.ts
+++ b/src/api/trackgen.ts
@@ -189,14 +189,44 @@ export function positionAt(program: TrackProgram, s: number): { x: number; z: nu
  * and the row editor has no field for where a feature sits — so without this, removing one
  * segment produces an error the person has no way to clear except by deleting their jumps.
  */
+/**
+ * Where each corner starts and ends, in metres round the lap.
+ */
+export function corners(program: TrackProgram): { at: number; length: number }[] {
+  const out: { at: number; length: number }[] = [];
+  let at = 0;
+  for (const seg of program.segments) {
+    if (seg.kind === "straight") {
+      at += seg.length;
+    } else {
+      const length = (Math.abs(seg.radius) * Math.abs(seg.angle) * Math.PI) / 180;
+      out.push({ at, length });
+      at += length;
+    }
+  }
+  return out;
+}
+
 export function fitFeatures(program: TrackProgram): TrackProgram {
   // A metre short of the line, not exactly on it. The lap is summed here in double precision
   // and in the synthesiser in single, so "exactly on the line" is a different number in each
   // — and clamping to the boundary produced a jump the validator then rejected.
   const lap = lapLength(program) - 1;
+  const turns = corners(program);
   return {
     ...program,
     features: program.features.map((f) => {
+      // A berm's whole meaning is "on this corner". Move the corners and the berm has to
+      // follow, or it lands on a straight where the synthesiser silently drops it.
+      if (f.kind === "berm" && turns.length) {
+        const on = turns.find((c) => f.at >= c.at && f.at < c.at + c.length);
+        if (!on) {
+          const near = turns.reduce((best, c) =>
+            Math.abs(c.at - f.at) < Math.abs(best.at - f.at) ? c : best,
+          );
+          return { ...f, at: near.at + 1, length: Math.max(4, near.length - 2) };
+        }
+      }
       const end = f.at + featureSpan(f).length;
       if (end <= lap && f.at >= 0) return f;
       return { ...f, at: Math.max(0, Math.min(f.at, lap - featureSpan(f).length)) };
@@ -290,6 +320,23 @@ export function setTrackTools(dir: string): Promise<TrackToolsStatus> {
 export function buildTrack(program: TrackProgram, dir: string): Promise<BuildStep[]> {
   return invoke<BuildStep[]>("build_track", { program, dir });
 }
+
+/**
+ * The colours the preview paints each feature kind with.
+ *
+ * The same values as `surface_colour` in `src-tauri/src/track.rs`, ids 200–206. They have to
+ * match: the point of both is that a row in the list and a lump on the ground are obviously
+ * the same thing.
+ */
+export const FEATURE_COLOUR: Record<TrackFeatureKind, string> = {
+  tabletop: "rgb(214, 120, 60)",
+  double: "rgb(206, 74, 96)",
+  roller: "rgb(120, 150, 200)",
+  whoops: "rgb(190, 170, 70)",
+  stepUp: "rgb(110, 180, 130)",
+  berm: "rgb(150, 110, 200)",
+  rut: "rgb(90, 90, 110)",
+};
 
 /** Where a feature sits, and how long it runs — the two numbers every kind has. */
 export function featureSpan(f: TrackFeature): { at: number; length: number } {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1369,18 +1369,16 @@ export const de: Translation = {
     "Wähle dein Profil in MX Bikes neu aus, um den Tausch zu laden.",
   "locker.loadsNextTime":
     "Wird beim nächsten Start des Spiels geladen.",
-  "locker.modelRefreshing":
-    "Wird im Spiel aktualisiert — wenn es dein ausgewähltes Motorrad ist, ändert es sich jetzt.",
   "locker.modelFrostmodNotRunning":
-    "Starte FrostMod, um Modellwechsel live zu sehen — wähle das Motorrad vorerst im Spiel neu aus.",
-  "locker.modelReselectBike":
-    "Modell gewechselt — wähle das Motorrad in MX Bikes neu aus, um es zu sehen.",
+    "FrostMod läuft nicht — wechsle in MX Bikes die Motorradkategorie weg und zurück, um das Modell zu sehen.",
+  "locker.modelSwitchCategory":
+    "Modell gewechselt — wechsle in MX Bikes die Motorradkategorie weg und zurück, um es zu sehen.",
   "locker.modelFrostmodUnreachable":
-    "FrostMod war nicht erreichbar — wähle das Motorrad im Spiel neu aus, um es zu laden.",
+    "FrostMod nicht erreichbar — wechsle im Spiel die Motorradkategorie weg und zurück, um das Modell zu laden.",
   "locker.modelRefreshWindowsOnly":
-    "Die Live-Modellaktualisierung gibt es nur unter Windows — wähle das Motorrad im Spiel neu aus.",
+    "Modell gewechselt — wechsle im Spiel die Motorradkategorie weg und zurück, um es zu sehen.",
   "locker.modelInstantRefreshOff":
-    "Wähle das Motorrad in MX Bikes neu aus, um es zu laden (die sofortige Aktualisierung ist aus).",
+    "Wechsle in MX Bikes die Motorradkategorie weg und zurück, um das Modell zu laden.",
 
   // ── Registrierung loser Sets ───────────────────────────────────────────────
   "swaps.model": "Modell",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1334,18 +1334,16 @@ export const en = {
     "Instant refresh failed — reselect your profile in-game to load it.",
   "locker.reselectProfile": "Reselect your profile in MX Bikes to load the swap.",
   "locker.loadsNextTime": "Loads next time the game opens.",
-  "locker.modelRefreshing":
-    "Refreshing in-game — if it's your selected bike, it changes now.",
   "locker.modelFrostmodNotRunning":
-    "Run FrostMod to see model swaps live — for now, reselect the bike in-game.",
-  "locker.modelReselectBike":
-    "Model swapped — reselect the bike in MX Bikes to see it.",
+    "FrostMod isn't running — switch bike category away and back in MX Bikes to see the model.",
+  "locker.modelSwitchCategory":
+    "Model swapped — switch bike category away and back in MX Bikes to see it.",
   "locker.modelFrostmodUnreachable":
-    "Couldn't reach FrostMod — reselect the bike in-game to load it.",
+    "Couldn't reach FrostMod — switch bike category away and back in-game to load the model.",
   "locker.modelRefreshWindowsOnly":
-    "Live model refresh is Windows-only — reselect the bike in-game.",
+    "Model swapped — switch bike category away and back in-game to see it.",
   "locker.modelInstantRefreshOff":
-    "Reselect the bike in MX Bikes to load it (instant refresh is off).",
+    "Switch bike category away and back in MX Bikes to load the model.",
 
   // ── Loose model/sound swap registration ────────────────────────────────────
   "swaps.model": "model",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1358,18 +1358,16 @@ export const es: Translation = {
     "Vuelve a seleccionar tu perfil en MX Bikes para cargar el cambio.",
   "locker.loadsNextTime":
     "Se cargará la próxima vez que abras el juego.",
-  "locker.modelRefreshing":
-    "Actualizando en el juego — si es la moto que tienes seleccionada, cambia ahora.",
   "locker.modelFrostmodNotRunning":
-    "Ejecuta FrostMod para ver los cambios de modelo en directo — por ahora, vuelve a seleccionar la moto en el juego.",
-  "locker.modelReselectBike":
-    "Modelo cambiado — vuelve a seleccionar la moto en MX Bikes para verlo.",
+    "FrostMod no está en ejecución — en MX Bikes cambia de categoría de moto y vuelve para ver el modelo.",
+  "locker.modelSwitchCategory":
+    "Modelo cambiado — en MX Bikes cambia de categoría de moto y vuelve para verlo.",
   "locker.modelFrostmodUnreachable":
-    "No se pudo contactar con FrostMod — vuelve a seleccionar la moto en el juego para cargarla.",
+    "No se pudo contactar con FrostMod — en el juego cambia de categoría de moto y vuelve para cargar el modelo.",
   "locker.modelRefreshWindowsOnly":
-    "La actualización del modelo en directo es solo para Windows — vuelve a seleccionar la moto en el juego.",
+    "Modelo cambiado — en el juego cambia de categoría de moto y vuelve para verlo.",
   "locker.modelInstantRefreshOff":
-    "Vuelve a seleccionar la moto en MX Bikes para cargarla (la actualización instantánea está desactivada).",
+    "En MX Bikes cambia de categoría de moto y vuelve para cargar el modelo.",
 
   // ── Registro de sets sueltos ───────────────────────────────────────────────
   "swaps.model": "modelo",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1361,18 +1361,16 @@ export const fr: Translation = {
     "Resélectionnez votre profil dans MX Bikes pour charger l'échange.",
   "locker.loadsNextTime":
     "Sera chargé à la prochaine ouverture du jeu.",
-  "locker.modelRefreshing":
-    "Actualisation en jeu — si c'est la moto que vous avez sélectionnée, elle change maintenant.",
   "locker.modelFrostmodNotRunning":
-    "Lancez FrostMod pour voir les changements de modèle en direct — pour l'instant, resélectionnez la moto en jeu.",
-  "locker.modelReselectBike":
-    "Modèle changé — resélectionnez la moto dans MX Bikes pour le voir.",
+    "FrostMod n'est pas lancé — dans MX Bikes, changez de catégorie de moto puis revenez pour voir le modèle.",
+  "locker.modelSwitchCategory":
+    "Modèle changé — dans MX Bikes, changez de catégorie de moto puis revenez pour le voir.",
   "locker.modelFrostmodUnreachable":
-    "Impossible de joindre FrostMod — resélectionnez la moto en jeu pour la charger.",
+    "Impossible de joindre FrostMod — en jeu, changez de catégorie de moto puis revenez pour charger le modèle.",
   "locker.modelRefreshWindowsOnly":
-    "L'actualisation du modèle en direct est réservée à Windows — resélectionnez la moto en jeu.",
+    "Modèle changé — en jeu, changez de catégorie de moto puis revenez pour le voir.",
   "locker.modelInstantRefreshOff":
-    "Resélectionnez la moto dans MX Bikes pour la charger (l'actualisation instantanée est désactivée).",
+    "Dans MX Bikes, changez de catégorie de moto puis revenez pour charger le modèle.",
 
   // ── Enregistrement des sets en vrac ────────────────────────────────────────
   "swaps.model": "modèle",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1353,18 +1353,16 @@ export const it: Translation = {
     "Riseleziona il tuo profilo in MX Bikes per caricare lo scambio.",
   "locker.loadsNextTime":
     "Verrà caricato alla prossima apertura del gioco.",
-  "locker.modelRefreshing":
-    "Aggiornamento in gioco — se è la moto che hai selezionata, cambia adesso.",
   "locker.modelFrostmodNotRunning":
-    "Avvia FrostMod per vedere i cambi modello in tempo reale — per ora riseleziona la moto in gioco.",
-  "locker.modelReselectBike":
-    "Modello cambiato — riseleziona la moto in MX Bikes per vederlo.",
+    "FrostMod non è in esecuzione — in MX Bikes cambia categoria moto e torna indietro per vedere il modello.",
+  "locker.modelSwitchCategory":
+    "Modello cambiato — in MX Bikes cambia categoria moto e torna indietro per vederlo.",
   "locker.modelFrostmodUnreachable":
-    "Impossibile raggiungere FrostMod — riseleziona la moto in gioco per caricarla.",
+    "Impossibile raggiungere FrostMod — in gioco cambia categoria moto e torna indietro per caricare il modello.",
   "locker.modelRefreshWindowsOnly":
-    "L'aggiornamento del modello in tempo reale è solo per Windows — riseleziona la moto in gioco.",
+    "Modello cambiato — in gioco cambia categoria moto e torna indietro per vederlo.",
   "locker.modelInstantRefreshOff":
-    "Riseleziona la moto in MX Bikes per caricarla (l'aggiornamento istantaneo è disattivato).",
+    "In MX Bikes cambia categoria moto e torna indietro per caricare il modello.",
 
   // ── Registrazione set sparsi ───────────────────────────────────────────────
   "swaps.model": "modello",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1352,18 +1352,16 @@ export const ptBR: Translation = {
   "locker.reselectProfile":
     "Selecione seu perfil de novo no MX Bikes para carregar a troca.",
   "locker.loadsNextTime": "Carrega na próxima vez que o jogo abrir.",
-  "locker.modelRefreshing":
-    "Atualizando no jogo — se for a moto que você tem selecionada, ela muda agora.",
   "locker.modelFrostmodNotRunning":
-    "Rode o FrostMod para ver as trocas de modelo ao vivo — por enquanto, selecione a moto de novo no jogo.",
-  "locker.modelReselectBike":
-    "Modelo trocado — selecione a moto de novo no MX Bikes para vê-lo.",
+    "O FrostMod não está rodando — no MX Bikes, troque a categoria de moto e volte para ver o modelo.",
+  "locker.modelSwitchCategory":
+    "Modelo trocado — no MX Bikes, troque a categoria de moto e volte para ver.",
   "locker.modelFrostmodUnreachable":
-    "Não deu pra falar com o FrostMod — selecione a moto de novo no jogo para carregar.",
+    "Não foi possível falar com o FrostMod — no jogo, troque a categoria de moto e volte para carregar o modelo.",
   "locker.modelRefreshWindowsOnly":
-    "A atualização de modelo ao vivo é só no Windows — selecione a moto de novo no jogo.",
+    "Modelo trocado — no jogo, troque a categoria de moto e volte para ver.",
   "locker.modelInstantRefreshOff":
-    "Selecione a moto de novo no MX Bikes para carregar (a atualização instantânea está desligada).",
+    "No MX Bikes, troque a categoria de moto e volte para carregar o modelo.",
 
   // ── Registro de sets soltos ────────────────────────────────────────────────
   "swaps.model": "modelo",


### PR DESCRIPTION
## The berms weren't misplaced

An edit moved the corner boundaries out from under them. A berm's whole meaning is "on this corner", so when the corners move it has to follow — the same way a jump past the finish gets pulled back. Left alone it lands on a straight, where the synthesiser silently drops it, and the row editor has **no field for where a feature sits**, so there was no way to put it right.

- Segment edits re-home a stranded berm onto the nearest corner and fit it to that corner's length.
- If the message does still appear, it names the corner to use rather than the idea of one.

## Colour

Each feature row carries its kind's colour — a bar down its left edge and a tinted icon — using the same seven colours the preview paints the ground with, so a row and a lump can be matched without reading either. The palette is defined in both `track.rs` (ids 200–206) and `trackgen.ts`, and each says so.

## Hover to light it up

Hovering a row lights that feature in the 3D view. A soft column rather than a patch on the ground: a flat highlight disappears the moment the camera is low, which is exactly when you're looking at a jump. It marks the *middle* of a feature, not its start — a 40 m berm marked at its entry looks like it belongs to the corner before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)