### PR TITLE
feat(tracks): sections, editable identity, and everything Install can write

### DIFF
--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -1113,6 +1113,27 @@ fn ground(s: Surface) -> (u32, f32) {
     }
 }
 
+/// The smallest `.map` the format allows: no materials, no geometry, no nodes.
+///
+/// TerrainEd is what really makes these, and it is Windows-only. This is not a substitute —
+/// it is the degenerate case the format already has, which the OEM L21-DragStrip ships (its
+/// material count is zero and it carries no geometry at all). Whether the game will draw the
+/// terrain from the `.trh` when the `.map` is empty is the one thing about this pipeline that
+/// cannot be answered without running it, and shipping the empty file is how the question
+/// gets asked.
+///
+/// The layout is `map.rs`'s, which is the parser that reads real ones.
+fn empty_map() -> Vec<u8> {
+    let mut out = Vec::with_capacity(24);
+    out.extend_from_slice(b"MP2\0");
+    out.extend_from_slice(&304u32.to_le_bytes()); // header size, constant on every map measured
+    out.extend_from_slice(&0u32.to_le_bytes()); // materials
+    out.extend_from_slice(&0u32.to_le_bytes()); // vertices
+    out.extend_from_slice(&0u32.to_le_bytes()); // triangles
+    out.extend_from_slice(&0u32.to_le_bytes()); // nodes
+    out
+}
+
 /// The preview as a `.pkz` the app can open: a plain zip, which is what the reader falls back
 /// to when a file isn't one of PiBoSo's encrypted ones.
 pub fn write_pkz(
@@ -1128,10 +1149,21 @@ pub fn write_pkz(
         zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
 
     use std::io::Write;
-    zip.start_file(format!("{slug}.trh"), opts)?;
-    zip.write_all(&trh(prog, syn, paint_features))?;
-    zip.start_file(format!("{slug}.ini"), opts)?;
-    zip.write_all(track_ini(prog).as_bytes())?;
+    let (map_img, shot) = ui_images(syn, UI_IMAGE_DIM);
+    // Everything a track needs that we can actually produce. What is still missing is the
+    // `.rdf` — start gate, pit lane, cameras, which only TrackEd writes — and a `gate.edf`
+    // copied from another track. Neither is ours to make at any effort.
+    for (name, bytes) in [
+        (format!("{slug}.trh"), trh(prog, syn, paint_features)),
+        (format!("{slug}.map"), empty_map()),
+        (format!("{slug}.ini"), track_ini(prog).into_bytes()),
+        (format!("{slug}.amb"), AMB.as_bytes().to_vec()),
+        (format!("{slug}_map.tga"), map_img),
+        (format!("{slug}.tga"), shot),
+    ] {
+        zip.start_file(name, opts)?;
+        zip.write_all(&bytes)?;
+    }
     zip.finish()?;
     Ok(std::fs::metadata(path).map(|m| m.len()).unwrap_or(0))
 }
@@ -1596,6 +1628,21 @@ mod tests {
             worst = worst.max((v as f32 * step - h).abs());
         }
         assert!(worst <= step, "worst {worst} against a step of {step}");
+    }
+
+    /// The empty `.map` has to be one our own parser accepts, or it is not the format's
+    /// degenerate case — it is a broken file.
+    #[test]
+    fn the_empty_map_is_a_map() {
+        let m = empty_map();
+        assert_eq!(&m[..4], b"MP2\0");
+        assert_eq!(u32::from_le_bytes(m[4..8].try_into().unwrap()), 304);
+        assert_eq!(u32::from_le_bytes(m[8..12].try_into().unwrap()), 0, "materials");
+        // `map::parse` builds a *mesh*, so it rightly declines one with no geometry — that
+        // is the whole point of the degenerate case. What has to hold is that the file is
+        // recognised as a map at all, and that reading it doesn't panic.
+        assert!(crate::map::is_map(&m), "not recognised as a map");
+        assert!(crate::map::parse(&m).is_none(), "there is no mesh in it to find");
     }
 
     #[test]

--- a/src/Components/Studio/TrackStudio/TrackStudio.tsx
+++ b/src/Components/Studio/TrackStudio/TrackStudio.tsx
@@ -11,6 +11,8 @@ import {
   Square,
   TrendingDown,
   TrendingUp,
+  ChevronDown,
+  ChevronRight,
   GripVertical,
   Plus,
   Waves,
@@ -83,6 +85,11 @@ export default function TrackStudio() {
   const listRef = useRef<HTMLOListElement>(null);
   const [dragging, setDragging] = useState<number | null>(null);
   const [dropAt, setDropAt] = useState<number | null>(null);
+  // Collapsed by segment index. A lap is a run of corners and straights with jumps on them,
+  // so the segment is the section — no new field, and it is the grouping people already
+  // have in their heads.
+  const [shut, setShut] = useState<Set<number>>(new Set());
+  const [flash, setFlash] = useState<number | null>(null);
   const [tools, setTools] = useState<TrackToolsStatus | null>(null);
   const [steps, setSteps] = useState<BuildStep[]>([]);
 
@@ -251,13 +258,24 @@ export default function TrackStudio() {
   }
 
   /** Which gap between rows the pointer is over. */
-  function gapUnder(clientY: number): number {
-    const rows = Array.from(listRef.current?.children ?? []) as HTMLElement[];
-    for (let i = 0; i < rows.length; i++) {
-      const box = rows[i].getBoundingClientRect();
-      if (clientY < box.top + box.height / 2) return i;
+  // Bring a newly added feature into view once the list has it.
+  useEffect(() => {
+    if (flash === null || !listRef.current) return;
+    const row = listRef.current.querySelector<HTMLElement>(`[data-at="${flash}"]`);
+    row?.scrollIntoView({ block: "center", behavior: "smooth" });
+    const id = setTimeout(() => setFlash(null), 1400);
+    return () => clearTimeout(id);
+  }, [flash, program]);
+
+  function gapUnder(clientY: number, total: number): number {
+    const rows = Array.from(
+      listRef.current?.querySelectorAll<HTMLElement>("[data-step]") ?? [],
+    );
+    for (const row of rows) {
+      const box = row.getBoundingClientRect();
+      if (clientY < box.top + box.height / 2) return Number(row.dataset.step);
     }
-    return rows.length;
+    return total;
   }
 
   function onGripDown(e: React.PointerEvent, row: number) {
@@ -268,9 +286,9 @@ export default function TrackStudio() {
     setDropAt(row);
   }
 
-  function onGripMove(e: React.PointerEvent) {
+  function onGripMove(e: React.PointerEvent, total: number) {
     if (dragging === null) return;
-    setDropAt(gapUnder(e.clientY));
+    setDropAt(gapUnder(e.clientY, total));
   }
 
   function onGripUp(steps: LapStep[]) {
@@ -288,6 +306,10 @@ export default function TrackStudio() {
     const probe = newFeature(kind, 0);
     const at = roomiestGap(program, featureSpan(probe).length);
     void settle({ ...program, features: [...program.features, newFeature(kind, at)] });
+    // Put it on screen. It lands in the emptiest stretch of lap, which is rarely the part
+    // you are looking at — a new row appearing somewhere off-screen reads as nothing
+    // happening at all.
+    setFlash(at);
   }
 
   async function onPointAtTools() {
@@ -386,19 +408,31 @@ export default function TrackStudio() {
             <div className="rounded-xl border border-input p-3.5">
               {/* The name is the folder, the .pkz and what the game lists it as, so it is
                   worth being able to change before any of those are written. */}
+              {/* Bordered, because a field that looks like a heading doesn't get typed in.
+                  All three end up in the track's `.ini` and in what the game lists. */}
               <input
                 value={program.name}
                 onChange={(e) => void settle({ ...program, name: e.target.value })}
-                className="w-full rounded-md bg-transparent text-[15px] font-bold tracking-[-0.2px] outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+                className="w-full rounded-md border border-input bg-transparent px-2 py-1 text-[14px] font-bold tracking-[-0.2px] outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
                 aria-label={t("track.name")}
+                placeholder={t("track.name")}
               />
-              <input
-                value={program.author}
-                onChange={(e) => void settle({ ...program, author: e.target.value })}
-                placeholder={t("track.author")}
-                className="mt-0.5 w-full rounded-md bg-transparent text-[12px] text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
-                aria-label={t("track.author")}
-              />
+              <div className="mt-1.5 flex gap-1.5">
+                <input
+                  value={program.author}
+                  onChange={(e) => void settle({ ...program, author: e.target.value })}
+                  placeholder={t("track.author")}
+                  className="min-w-0 flex-1 rounded-md border border-input bg-transparent px-2 py-1 text-[12px] text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+                  aria-label={t("track.author")}
+                />
+                <input
+                  value={program.location}
+                  onChange={(e) => void settle({ ...program, location: e.target.value })}
+                  placeholder={t("track.location")}
+                  className="min-w-0 flex-1 rounded-md border border-input bg-transparent px-2 py-1 text-[12px] text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+                  aria-label={t("track.location")}
+                />
+              </div>
               <dl className="mt-2.5 grid grid-cols-2 gap-x-3 gap-y-1.5 text-[12.5px]">
                 <Row label={t("track.lap")} value={`${lapLength(program).toFixed(0)} m`} />
                 <Row label={t("track.width")} value={`${program.width.toFixed(1)} m`} />
@@ -515,9 +549,30 @@ export default function TrackStudio() {
               {lapSteps(program).map((step, row) => {
                 const Icon = stepIcon(step);
                 const steps = lapSteps(program);
+                // Which section this row belongs to: the last segment at or before it.
+                let section = -1;
+                for (let i = row; i >= 0; i--) {
+                  if (steps[i].kind !== "feature") {
+                    section = steps[i].index;
+                    break;
+                  }
+                }
+                const collapsed = shut.has(section);
+                if (step.kind === "feature" && collapsed) return null;
+                const inSection =
+                  step.kind !== "feature"
+                    ? steps.filter((x, i) => {
+                        if (x.kind !== "feature") return false;
+                        for (let j = i; j >= 0; j--)
+                          if (steps[j].kind !== "feature") return steps[j].index === step.index;
+                        return false;
+                      }).length
+                    : 0;
                 return (
                   <li
                     key={row}
+                    data-step={row}
+                    data-at={step.at}
                     onClick={() => setFocus(positionAt(program, step.at))}
                     onPointerEnter={() =>
                       setHover({
@@ -543,6 +598,7 @@ export default function TrackStudio() {
                       dropAt === steps.length &&
                         row === steps.length - 1 &&
                         "after:absolute after:inset-x-2 after:bottom-0 after:h-0.5 after:bg-primary",
+                      flash !== null && step.at === flash && "bg-primary/15",
                     )}
                     style={
                       step.kind === "feature"
@@ -550,9 +606,32 @@ export default function TrackStudio() {
                         : undefined
                     }
                   >
+                    {step.kind !== "feature" ? (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setShut((prev) => {
+                            const next = new Set(prev);
+                            if (!next.delete(step.index)) next.add(step.index);
+                            return next;
+                          });
+                        }}
+                        className="flex-none rounded text-muted-foreground hover:text-foreground"
+                        aria-expanded={!collapsed}
+                        aria-label={stepName(step, t)}
+                      >
+                        {collapsed ? (
+                          <ChevronRight className="size-3.5" />
+                        ) : (
+                          <ChevronDown className="size-3.5" />
+                        )}
+                      </button>
+                    ) : (
+                      <span className="w-3.5 flex-none" />
+                    )}
                     <GripVertical
                       onPointerDown={(e) => onGripDown(e, row)}
-                      onPointerMove={onGripMove}
+                      onPointerMove={(e) => onGripMove(e, steps.length)}
                       onPointerUp={() => onGripUp(steps)}
                       className="size-3.5 flex-none cursor-default text-faint hover:text-foreground"
                     />
@@ -570,7 +649,12 @@ export default function TrackStudio() {
                           : undefined
                       }
                     />
-                    <span className="w-[104px] flex-none truncate">{stepName(step, t)}</span>
+                    <span className="w-[96px] flex-none truncate">{stepName(step, t)}</span>
+                    {step.kind !== "feature" && collapsed && inSection > 0 && (
+                      <span className="flex-none rounded bg-foreground/[0.08] px-1.5 text-[11px] text-muted-foreground">
+                        {inSection}
+                      </span>
+                    )}
 
                     <div className="flex flex-1 flex-wrap items-center gap-x-3 gap-y-1">
                       {fieldsOf(step).map((f) => (

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -2396,4 +2396,5 @@ export const de: Translation = {
   "track.name": "Streckenname",
   "track.author": "Autor",
   "track.previewHint": "Auf Vorschau drücken, um sie zu bauen und hier anzusehen.",
+  "track.location": "Ort",
 };

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2352,4 +2352,5 @@ export const en = {
   "track.name": "Track name",
   "track.author": "Author",
   "track.previewHint": "Press Preview to build it and look at it here.",
+  "track.location": "Location",
 } as const;

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -2382,4 +2382,5 @@ export const es: Translation = {
   "track.name": "Nombre de la pista",
   "track.author": "Autor",
   "track.previewHint": "Pulsa Previsualizar para construirla y verla aquí.",
+  "track.location": "Ubicación",
 };

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -2387,4 +2387,5 @@ export const fr: Translation = {
   "track.name": "Nom du circuit",
   "track.author": "Auteur",
   "track.previewHint": "Appuie sur Aperçu pour le construire et le voir ici.",
+  "track.location": "Lieu",
 };

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -2375,4 +2375,5 @@ export const it: Translation = {
   "track.name": "Nome pista",
   "track.author": "Autore",
   "track.previewHint": "Premi Anteprima per costruirla e vederla qui.",
+  "track.location": "Località",
 };

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -2372,4 +2372,5 @@ export const ptBR: Translation = {
   "track.name": "Nome da pista",
   "track.author": "Autor",
   "track.previewHint": "Toque em Prévia para construir e ver aqui.",
+  "track.location": "Local",
 };


### PR DESCRIPTION
## Does Install make a usable `.pkz`?

It did not — it wrote **two files**, a `.trh` and an `.ini`. The game would list it and fail.

It now writes everything a track needs that we can actually produce: the `.trh`, a `.map`, the `.ini`, the `.amb`, and both UI images. What is still missing is the `.rdf` — start gate, pit lane, cameras, which only TrackEd writes — and a `gate.edf` copied from another track. Neither is ours to make at any effort.

The `.map` is the format's own degenerate case: no materials, no geometry, no nodes, which is exactly what the OEM L21-DragStrip ships. **Whether the game draws terrain from the `.trh` when the `.map` is empty is the one thing about this pipeline that can't be answered without running it**, and shipping the empty file is how the question gets asked.

My first test for it asserted `map::parse` accepts the empty map. That was wrong — `parse` builds a *mesh*, so declining one with no geometry is correct behaviour. It now checks the file is recognised as a map and that reading it doesn't panic.

## Sections

The lap groups by segment: each corner and straight heads a section holding the jumps on it, collapsible, with a count when shut. No new field — the segment is the grouping people already have in their heads, and it's the order the list was already in.

The drop index is a step index now rather than a DOM child index, because a shut section renders fewer rows than the lap has steps.

## Adding scrolls to it

A new feature lands in the emptiest stretch of lap, which is rarely the part you were looking at — so without scrolling to it and flashing the row, adding one reads as nothing happening.

## Identity

Name, author and location are proper bordered fields. They looked like headings before, and a field that looks like a heading doesn't get typed in. All three end up in the track's `.ini`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)