### PR TITLE
feat(tracks): write the race data, and close an open lap

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1202,6 +1202,59 @@ async fn base_track_program() -> Result<serde_json::Value, String> {
         .map_err(|e| format!("the built-in track didn't load: {e}"))
 }
 
+/// A lap with nothing on it: somewhere to start from scratch.
+///
+/// Deliberately the plainest thing that is still a track — an oval on a small plot, 12 m
+/// wide, no jumps at all. It validates, it builds, and everything on it is yours.
+#[tauri::command]
+async fn blank_track_program() -> Result<serde_json::Value, String> {
+    let json = serde_json::json!({
+        "name": "New Track",
+        "author": "",
+        "location": "",
+        "width": 12.0,
+        "terrain": {
+            "sizeX": 400.0, "sizeZ": 400.0, "samples": 2049, "scale": 20.0,
+            "relief": { "amplitude": 4.0, "wavelength": 130.0, "seed": 1, "texture": 0.06 },
+            "surface": "soil"
+        },
+        "start": { "x": 120.0, "z": 260.0, "angle": 90.0 },
+        "segments": [
+            { "kind": "straight", "length": 120.0, "rise": 0.0 },
+            { "kind": "arc", "radius": 45.0, "angle": 180.0, "rise": 0.0 },
+            { "kind": "straight", "length": 120.0, "rise": 0.0 },
+            { "kind": "arc", "radius": 45.0, "angle": 180.0, "rise": 0.0 }
+        ],
+        "features": []
+    });
+    // Through the type, so a blank track can never be one the rest of this refuses.
+    serde_json::from_value::<trackprog::TrackProgram>(json.clone())
+        .map_err(|e| format!("the blank track didn't load: {e}"))?;
+    Ok(json)
+}
+
+/// Bring an open lap back to its start.
+#[tauri::command]
+async fn close_track_lap(program: serde_json::Value) -> Result<serde_json::Value, String> {
+    let mut prog = track_program(program)?;
+    // A turn no tighter than the lap's own tightest, so the join doesn't need a corner
+    // sharper than anything already on the track.
+    let radius = prog
+        .segments
+        .iter()
+        .filter_map(|s| match s {
+            trackprog::Segment::Arc { radius, .. } => Some(radius.abs()),
+            _ => None,
+        })
+        .fold(f32::MAX, f32::min);
+    let radius = if radius.is_finite() { radius } else { 25.0 };
+    match prog.closing_segments(radius) {
+        Some(add) => prog.segments.extend(add),
+        None => return Err("The lap already meets itself.".into()),
+    }
+    serde_json::to_value(&prog).map_err(|e| e.to_string())
+}
+
 /// Everything wrong with a program, without asking anyone. The studio calls this as edits are
 /// made, so a hand-edited track is held to the same corpus a generated one is.
 #[tauri::command]
@@ -8871,6 +8924,8 @@ fn main() {
             generate_track,
             check_track,
             base_track_program,
+            blank_track_program,
+            close_track_lap,
             preview_track,
             install_track_preview,
             export_track_source,

--- a/src-tauri/src/trackprog.rs
+++ b/src-tauri/src/trackprog.rs
@@ -366,6 +366,16 @@ pub const EXAMPLE: &str = r#"{
 // Walking the centreline
 // ---------------------------------------------------------------------------
 
+/// An angle brought into (-pi, pi].
+fn wrap(a: f32) -> f32 {
+    let tau = std::f32::consts::TAU;
+    let mut x = (a + std::f32::consts::PI).rem_euclid(tau) - std::f32::consts::PI;
+    if x <= -std::f32::consts::PI {
+        x += tau;
+    }
+    x
+}
+
 /// One point on the riding line, and which way it faces there.
 #[derive(Clone, Copy, Debug)]
 pub struct Station {
@@ -529,6 +539,68 @@ impl TrackProgram {
         Ok(())
     }
 
+    /// Segments that bring the finish back to the start, or `None` if it is already there.
+    ///
+    /// A turn, a straight, and a turn — the shortest of the two same-direction Dubins paths
+    /// between two poses. Both are tried and the shorter kept, which is enough for a lap that
+    /// has drifted open under an edit; the mixed-direction paths matter only when the two
+    /// poses are closer together than the turning circles, and a lap that has come apart
+    /// never is.
+    ///
+    /// Closing the *pose* is what closes the lap. Position alone leaves a kink at the line;
+    /// heading alone leaves it parallel and somewhere else.
+    pub fn closing_segments(&self, radius: f32) -> Option<Vec<Segment>> {
+        let st = self.stations(1.0);
+        let last = *st.last()?;
+        let r = radius.abs().max(1.0);
+        let goal = (self.start.x, self.start.z, self.start.angle.to_radians());
+
+        let gap = ((last.x - goal.0).powi(2) + (last.z - goal.1).powi(2)).sqrt();
+        let turned = wrap(goal.2 - last.heading).abs();
+        if gap < 0.5 && turned < 0.02 {
+            return None;
+        }
+
+        // `turn` is +1 for a pair of right-hand circles, -1 for left.
+        let solve = |turn: f32| -> Option<(f32, f32, f32)> {
+            let centre = |x: f32, z: f32, th: f32| {
+                let (rx, rz) = right_vector(th);
+                (x + rx * r * turn, z + rz * r * turn)
+            };
+            let c1 = centre(last.x, last.z, last.heading);
+            let c2 = centre(goal.0, goal.1, goal.2);
+            let (dx, dz) = (c2.0 - c1.0, c2.1 - c1.1);
+            let run = (dx * dx + dz * dz).sqrt();
+            if run < 1e-3 {
+                return None;
+            }
+            // The straight's heading, in the same convention the walk uses.
+            let th_s = dx.atan2(dz);
+            let sweep = |from: f32, to: f32| {
+                let d = wrap(to - from) * turn;
+                if d < 0.0 { d + std::f32::consts::TAU } else { d }
+            };
+            Some((sweep(last.heading, th_s), run, sweep(th_s, goal.2)))
+        };
+
+        let mut best: Option<(f32, f32, Vec<Segment>)> = None;
+        for turn in [1.0f32, -1.0] {
+            let Some((a1, run, a2)) = solve(turn) else {
+                continue;
+            };
+            let cost = (a1 + a2) * r + run;
+            let segs = vec![
+                Segment::Arc { radius: r * turn, angle: a1.to_degrees(), rise: 0.0 },
+                Segment::Straight { length: run, rise: 0.0 },
+                Segment::Arc { radius: r * turn, angle: a2.to_degrees(), rise: 0.0 },
+            ];
+            if best.as_ref().map(|b| cost < b.0).unwrap_or(true) {
+                best = Some((cost, run, segs));
+            }
+        }
+        best.map(|(_, _, segs)| segs)
+    }
+
     /// How far the finish is from the start. A lap that doesn't close is a dead end, and the
     /// error is easier to read as a distance than as a drawing.
     pub fn closure_error(&self) -> f32 {
@@ -612,6 +684,49 @@ mod tests {
         assert!((st[0].curvature - 1.0 / 25.0).abs() < 1e-4);
         let straight = prog(vec![Segment::Straight { length: 10.0, rise: 0.0 }]);
         assert_eq!(straight.stations(1.0)[0].curvature, 0.0);
+    }
+
+    #[test]
+    fn an_open_lap_can_be_closed() {
+        // Three quarters of a rounded square: it ends facing the wrong way, a long way off.
+        let mut p = prog(vec![
+            Segment::Straight { length: 60.0, rise: 0.0 },
+            Segment::Arc { radius: 20.0, angle: 90.0, rise: 0.0 },
+            Segment::Straight { length: 60.0, rise: 0.0 },
+            Segment::Arc { radius: 20.0, angle: 90.0, rise: 0.0 },
+            Segment::Straight { length: 60.0, rise: 0.0 },
+        ]);
+        assert!(p.closure_error() > 50.0, "the fixture should be open");
+
+        let add = p.closing_segments(20.0).expect("it has somewhere to go");
+        p.segments.extend(add);
+        assert!(
+            p.closure_error() < 1.0,
+            "still {:.1} m from home",
+            p.closure_error()
+        );
+        // And facing the way it started, or the line has a kink in it.
+        let end = *p.stations(1.0).last().unwrap();
+        assert!(
+            wrap(end.heading - p.start.angle.to_radians()).abs() < 0.05,
+            "ends {:.1} degrees off",
+            wrap(end.heading - p.start.angle.to_radians()).to_degrees()
+        );
+    }
+
+    #[test]
+    fn a_closed_lap_needs_nothing_added() {
+        let p = prog(vec![
+            Segment::Straight { length: 50.0, rise: 0.0 },
+            Segment::Arc { radius: 20.0, angle: 90.0, rise: 0.0 },
+            Segment::Straight { length: 50.0, rise: 0.0 },
+            Segment::Arc { radius: 20.0, angle: 90.0, rise: 0.0 },
+            Segment::Straight { length: 50.0, rise: 0.0 },
+            Segment::Arc { radius: 20.0, angle: 90.0, rise: 0.0 },
+            Segment::Straight { length: 50.0, rise: 0.0 },
+            Segment::Arc { radius: 20.0, angle: 90.0, rise: 0.0 },
+        ]);
+        assert!(p.closing_segments(20.0).is_none());
     }
 
     #[test]

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -946,6 +946,11 @@ pub fn write_source(prog: &TrackProgram, syn: &Synth, dir: &Path) -> Result<Vec<
         &mut wrote,
     )?;
     put(&format!("{slug}/{slug}.amb"), AMB.into(), &mut wrote)?;
+    put(
+        &format!("{slug}/{slug}.rdf"),
+        rdf(prog).into_bytes(),
+        &mut wrote,
+    )?;
     let (map_img, shot) = ui_images(syn, UI_IMAGE_DIM);
     put(&format!("{slug}/{slug}_map.tga"), map_img, &mut wrote)?;
     put(&format!("{slug}/{slug}.tga"), shot, &mut wrote)?;
@@ -1113,6 +1118,115 @@ fn ground(s: Surface) -> (u32, f32) {
     }
 }
 
+/// Race data: the start gate, the pit lane, the finish line and the checkpoints.
+///
+/// TrackEd writes this, and TrackEd is Windows-only — but the file is plain text, and its
+/// positions are stated as `long` and `lat` along the centreline, which is the one coordinate
+/// system this whole module already thinks in. So it can be written here.
+///
+/// Laid out from the lap rather than copied: the finish line a little into the first
+/// straight, the gate behind it, the pit lane alongside, and the splits and checkpoints
+/// spread evenly round. The example track's own file is the shape this follows, down to the
+/// keys and the order.
+///
+/// Untested against the game — nothing here has been loaded by MX Bikes. The structure is
+/// right; whether every field means what it looks like is not something a macOS box can say.
+fn rdf(prog: &TrackProgram) -> String {
+    let lap = prog.lap_length();
+    let half = prog.width * 0.5;
+    // Far enough in that the gate behind it is still on the opening straight.
+    let line = (lap * 0.06).clamp(10.0, 40.0);
+    let gate_at = (line - 12.0).max(1.0);
+
+    let mut s = String::new();
+    let mark = |s: &mut String, name: &str, at: f32, w: f32| {
+        s.push_str(&format!(
+            "{name}\n{{\n\tline = 0\n\tlong = {at:.6}\n\tleft = {:.6}\n\tright = {:.6}\n}}\n",
+            -w, w
+        ));
+    };
+    mark(&mut s, "finish_line", line, half);
+    mark(&mut s, "split1", (line + lap / 3.0) % lap, half);
+    mark(&mut s, "split2", (line + lap * 2.0 / 3.0) % lap, half);
+
+    // The pit lane runs alongside the opening straight, a track's width off the racing line.
+    let stalls = 16;
+    let lane_lat = -(half + 6.0);
+    s.push_str(&format!(
+        "pit_lane\n{{\n\tnumstalls = {stalls}\n\tstarttype = 1\n\tstartstartlong = 0.000000\n\
+         \tstartdifflong = 0.000000\n\tstartstartlat = 0.000000\n\tstartendlat = 0.000000\n\
+         \tstartanglerel = 0.000000\n\tstartposx = {:.6}\n\tstartposz = {:.6}\n\
+         \tstartspacingx = -4.000000\n\tstartspacingz = 6.000000\n\tstartangleabs = {:.6}\n\
+         \tstartcolumns = 8\n",
+        prog.start.x, prog.start.z, prog.start.angle
+    ));
+    for i in 0..stalls {
+        s.push_str(&format!(
+            "\tstart_stall{i}\n\t{{\n\t\tlong = {:.6}\n\t\tlat = {lane_lat:.6}\n\
+             \t\tangle = 0.000000\n\t}}\n",
+            gate_at + i as f32 * 5.0
+        ));
+    }
+    s.push_str("}\n");
+
+    s.push_str(
+        "pit_board\n{\n\theight = 1.500000\n\tstartlong = 18.000000\n\tdifflong = 1.400000\n\
+         \tstartlat = -5.000000\n\tendlat = -5.000000\n",
+    );
+    for i in 0..stalls {
+        s.push_str(&format!(
+            "\tstall{i}\n\t{{\n\t\tlong = {:.6}\n\t\tlat = {:.6}\n\t\tangle = 0.000000\n\t}}\n",
+            18.0 + i as f32 * 1.4,
+            lane_lat
+        ));
+    }
+    s.push_str("}\n");
+
+    // One row of gates across the track, which is what a motocross start is.
+    let grid = 24;
+    s.push_str(&format!(
+        "starting_grid\n{{\n\tnumstalls = {grid}\n\ttype = 1\n\tposx = {:.6}\n\
+         \tposz = {:.6}\n\tangle = {:.6}\n\tnumstallsperrow = {grid}\n\
+         \tdistfromstartline = 0.000000\n\tlanespacing = 0.000000\n\trowspacing = 0.000000\n\
+         \tdifflat = 0.000000\n\tlanewidth = 1.500000\n\tlatshift = 0.000000\n\tside = 1\n",
+        prog.start.x, prog.start.z, prog.start.angle
+    ));
+    for i in 0..grid {
+        // Spread across the track and a little beyond it: a gate is wider than the line.
+        let lat = -half * 1.4 + (i as f32 + 0.5) * (half * 2.8 / grid as f32);
+        s.push_str(&format!(
+            "\tstall{i}\n\t{{\n\t\tlong = {gate_at:.6}\n\t\tlat = {lat:.6}\n\
+             \t\tangle = 0.000000\n\t}}\n"
+        ));
+    }
+    s.push_str("}\n");
+
+    // Three, evenly round, so a lap can't be cut. The first carries the start flag.
+    s.push_str("num_checkpoints = 3\n");
+    for i in 0..3 {
+        let at = (line + lap * (i as f32 + 1.0) / 4.0) % lap;
+        s.push_str(&format!(
+            "checkpoint{i}\n{{\n\tlong = {at:.6}\n\tleft = {:.6}\n\tright = {:.6}\n\
+             \tpenalty = {:.6}\n\tline = 0\n\tstart = {}\n}}\n",
+            -half * 1.3,
+            half * 1.3,
+            if i == 0 { 15.0 } else { 5.0 },
+            if i == 0 { 1 } else { 0 }
+        ));
+    }
+
+    s.push_str(&format!(
+        "30secondsboard_posx = {:.6}\n30secondsboard_posz = {:.6}\n30secondsboard_angle = {:.6}\n\
+         30seconds_board\n{{\n\tlong = {:.6}\n\tlat = {:.6}\n\tangle = 0.000000\n}}\n",
+        prog.start.x,
+        prog.start.z,
+        prog.start.angle - 90.0,
+        gate_at - 4.0,
+        -(half + 3.0)
+    ));
+    s
+}
+
 /// The smallest `.map` the format allows: no materials, no geometry, no nodes.
 ///
 /// TerrainEd is what really makes these, and it is Windows-only. This is not a substitute —
@@ -1157,6 +1271,7 @@ pub fn write_pkz(
         (format!("{slug}.trh"), trh(prog, syn, paint_features)),
         (format!("{slug}.map"), empty_map()),
         (format!("{slug}.ini"), track_ini(prog).into_bytes()),
+        (format!("{slug}.rdf"), rdf(prog).into_bytes()),
         (format!("{slug}.amb"), AMB.as_bytes().to_vec()),
         (format!("{slug}_map.tga"), map_img),
         (format!("{slug}.tga"), shot),
@@ -1632,6 +1747,44 @@ mod tests {
 
     /// The empty `.map` has to be one our own parser accepts, or it is not the format's
     /// degenerate case — it is a broken file.
+    /// The race data has to parse as the same shape the example track's does, because that
+    /// file is the only description of the format there is.
+    #[test]
+    fn the_race_data_has_the_blocks_the_game_looks_for() {
+        let p: TrackProgram = serde_json::from_str(DEMO).unwrap();
+        let text = rdf(&p);
+        for block in [
+            "finish_line",
+            "split1",
+            "split2",
+            "pit_lane",
+            "pit_board",
+            "starting_grid",
+            "num_checkpoints = 3",
+            "checkpoint0",
+            "30seconds_board",
+        ] {
+            assert!(text.contains(block), "no {block}");
+        }
+        // Braces balance, or the game's parser walks off the end of the file.
+        assert_eq!(
+            text.matches('{').count(),
+            text.matches('}').count(),
+            "unbalanced braces"
+        );
+        // Every marker sits somewhere on the lap.
+        for line in text.lines() {
+            if let Some(v) = line.trim().strip_prefix("long = ") {
+                let at: f32 = v.parse().unwrap();
+                assert!(
+                    (0.0..=p.lap_length()).contains(&at),
+                    "a marker at {at} m is off a {} m lap",
+                    p.lap_length()
+                );
+            }
+        }
+    }
+
     #[test]
     fn the_empty_map_is_a_map() {
         let m = empty_map();

--- a/src/Components/Studio/TrackStudio/TrackStudio.tsx
+++ b/src/Components/Studio/TrackStudio/TrackStudio.tsx
@@ -29,7 +29,9 @@ import { useT } from "../../../i18n/context";
 import { cn } from "@/lib/utils";
 import {
   baseTrackProgram,
+  blankTrackProgram,
   buildTrack,
+  closeTrackLap,
   checkTrack,
   exportTrackSource,
   generateTrack,
@@ -132,20 +134,41 @@ export default function TrackStudio() {
     }
   }
 
-  async function onBase() {
+  /** Load a starting point and put it on screen — a track you can't see isn't a start. */
+  async function onLoad(load: () => Promise<TrackProgram>) {
     if (busy) return;
     setBusy("generate");
     setPreview(null);
     setProblems([]);
     try {
-      const next = await baseTrackProgram();
-      await settle(next);
+      const next = await load();
+      const found = await settle(next);
       toast.success(t("track.baseLoaded", { name: next.name }));
+      if (found.length === 0) await showIn3d(next);
     } catch (e) {
       toast.error(t("track.generateFailed"), { description: String(e) });
     } finally {
       setBusy(null);
     }
+  }
+
+  async function onClose() {
+    if (!program || busy) return;
+    try {
+      const next = await closeTrackLap(program);
+      await settle(next);
+      toast.success(t("track.lapClosed"));
+    } catch (e) {
+      toast.error(t("track.closeFailed"), { description: String(e) });
+    }
+  }
+
+  async function showIn3d(prog: TrackProgram) {
+    const p = await previewTrack(prog);
+    setPreview(p);
+    const t3 = await loadTrackTerrain(p.path, 1024);
+    setTerrain(t3);
+    setOverview(await loadTrackOverview(p.path, 2048).catch(() => null));
   }
 
   async function onPreview() {
@@ -375,11 +398,19 @@ export default function TrackStudio() {
             from nothing. */}
         <Button
           variant="outline"
-          onClick={() => void onBase()}
+          onClick={() => void onLoad(baseTrackProgram)}
           disabled={busy !== null}
           className="h-10 flex-none"
         >
           {t("track.base")}
+        </Button>
+        <Button
+          variant="ghost"
+          onClick={() => void onLoad(blankTrackProgram)}
+          disabled={busy !== null}
+          className="h-10 flex-none"
+        >
+          {t("track.blank")}
         </Button>
       </div>
 
@@ -472,6 +503,16 @@ export default function TrackStudio() {
                     <li key={i}>{p}</li>
                   ))}
                 </ul>
+                {problems.some((p) => p.includes("doesn't close")) && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="mt-2.5 w-full"
+                    onClick={() => void onClose()}
+                  >
+                    {t("track.closeLap")}
+                  </Button>
+                )}
               </div>
             )}
 
@@ -520,9 +561,11 @@ export default function TrackStudio() {
                   ))}
                 </ul>
               )}
-              <p className="text-[11.5px] leading-snug text-muted-foreground">
-                {tools?.found ? t("track.stillNeeded") : t("track.previewOnly")}
-              </p>
+              {tools?.found && (
+                <p className="text-[11.5px] leading-snug text-muted-foreground">
+                  {t("track.stillNeeded")}
+                </p>
+              )}
             </div>
           </div>
 

--- a/src/api/trackgen.ts
+++ b/src/api/trackgen.ts
@@ -84,6 +84,16 @@ export function baseTrackProgram(): Promise<TrackProgram> {
   return invoke<TrackProgram>("base_track_program");
 }
 
+/** A lap with nothing on it, to start from scratch. */
+export function blankTrackProgram(): Promise<TrackProgram> {
+  return invoke<TrackProgram>("blank_track_program");
+}
+
+/** Bring an open lap back to its start: a turn, a straight and a turn. */
+export function closeTrackLap(program: TrackProgram): Promise<TrackProgram> {
+  return invoke<TrackProgram>("close_track_lap", { program });
+}
+
 /** Everything wrong with a program, held to the same corpus a generated one is. */
 export function checkTrack(program: TrackProgram): Promise<string[]> {
   return invoke<string[]>("check_track", { program });

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -2397,4 +2397,8 @@ export const de: Translation = {
   "track.author": "Autor",
   "track.previewHint": "Auf Vorschau drücken, um sie zu bauen und hier anzusehen.",
   "track.location": "Ort",
+  "track.blank": "Leer",
+  "track.closeLap": "Runde schließen",
+  "track.lapClosed": "Die Runde schließt sich jetzt",
+  "track.closeFailed": "Konnte nicht geschlossen werden",
 };

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2353,4 +2353,8 @@ export const en = {
   "track.author": "Author",
   "track.previewHint": "Press Preview to build it and look at it here.",
   "track.location": "Location",
+  "track.blank": "Blank",
+  "track.closeLap": "Close the lap",
+  "track.lapClosed": "The lap meets itself now",
+  "track.closeFailed": "Couldn't close it",
 } as const;

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -2383,4 +2383,8 @@ export const es: Translation = {
   "track.author": "Autor",
   "track.previewHint": "Pulsa Previsualizar para construirla y verla aquí.",
   "track.location": "Ubicación",
+  "track.blank": "En blanco",
+  "track.closeLap": "Cerrar la vuelta",
+  "track.lapClosed": "La vuelta ya cierra",
+  "track.closeFailed": "No se pudo cerrar",
 };

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -2388,4 +2388,8 @@ export const fr: Translation = {
   "track.author": "Auteur",
   "track.previewHint": "Appuie sur Aperçu pour le construire et le voir ici.",
   "track.location": "Lieu",
+  "track.blank": "Vierge",
+  "track.closeLap": "Fermer le tour",
+  "track.lapClosed": "Le tour se referme",
+  "track.closeFailed": "Fermeture impossible",
 };

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -2376,4 +2376,8 @@ export const it: Translation = {
   "track.author": "Autore",
   "track.previewHint": "Premi Anteprima per costruirla e vederla qui.",
   "track.location": "Località",
+  "track.blank": "Vuota",
+  "track.closeLap": "Chiudi il giro",
+  "track.lapClosed": "Il giro ora si chiude",
+  "track.closeFailed": "Impossibile chiudere",
 };

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -2373,4 +2373,8 @@ export const ptBR: Translation = {
   "track.author": "Autor",
   "track.previewHint": "Toque em Prévia para construir e ver aqui.",
   "track.location": "Local",
+  "track.blank": "Em branco",
+  "track.closeLap": "Fechar a volta",
+  "track.lapClosed": "A volta agora fecha",
+  "track.closeFailed": "Não foi possível fechar",
 };


### PR DESCRIPTION
## The `.rdf` — the file TrackEd writes

It turns out to be **plain text**, and its positions are stated as `long` and `lat` along the centreline, which is the coordinate system this module already thinks in. So it can be written here.

Finish line, two splits, pit lane and boards, a starting grid, three checkpoints and the thirty-second board — laid out from the lap rather than copied from anywhere. The structure follows the example track's own file, key for key and block for block.

That leaves `gate.edf` as the only file a playable track needs that we don't produce, and that one is a model rather than a description.

**Untested against the game.** Nothing here has been loaded by MX Bikes. Whether every field means what it looks like is not something a macOS box can answer.

## Close the lap

Offered right next to the complaint that says it's open. A turn, a straight and a turn — the shorter of the two same-direction Dubins paths from the finish pose back to the start pose.

Closing the **pose** is what closes a lap: position alone leaves a kink at the line, heading alone leaves it parallel and somewhere else. The turn radius used is the tightest the lap already has, so the join never needs a sharper corner than the track already asks for.

## Blank, and showing what you loaded

- **Blank** — an oval, 12 m wide, nothing on it.
- Base and Blank now build and show the track rather than leaving an empty canvas. A track you can't see isn't a starting point.
- Dropped the line about the preview being terrain only. Install writes the whole set now, so it was no longer true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)