### PR TITLE
fix(tracks): a blank lap is empty, not broken

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1258,9 +1258,9 @@ async fn close_track_lap(program: serde_json::Value) -> Result<serde_json::Value
 /// Everything wrong with a program, without asking anyone. The studio calls this as edits are
 /// made, so a hand-edited track is held to the same corpus a generated one is.
 #[tauri::command]
-async fn check_track(program: serde_json::Value) -> Result<Vec<String>, String> {
+async fn check_track(program: serde_json::Value) -> Result<trackllm::Review, String> {
     let prog = track_program(program)?;
-    tauri::async_runtime::spawn_blocking(move || trackllm::validate(&prog))
+    tauri::async_runtime::spawn_blocking(move || trackllm::review(&prog))
         .await
         .map_err(|e| format!("check_track task failed: {e}"))
 }

--- a/src-tauri/src/trackllm.rs
+++ b/src-tauri/src/trackllm.rs
@@ -113,13 +113,33 @@ pub async fn generate(brief: &str, ask: &impl Ask, tries: usize) -> Result<Track
     )
 }
 
+/// What is wrong with a program, and what is merely unlike a published one.
+///
+/// The difference matters: a blank lap with nothing built on it is not broken, it is empty,
+/// and telling someone their brand new track has "0.0 features per km" as though it were a
+/// fault is how a starting point stops being one. Problems block; notes do not.
+#[derive(serde::Serialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Review {
+    /// Structural: it won't build, or it isn't a lap, or a feature does nothing where it is.
+    pub problems: Vec<String>,
+    /// It builds and it is a lap — it just doesn't measure like the tracks people ride.
+    pub notes: Vec<String>,
+}
+
 /// Everything wrong with a program, said the way the model needs to hear it.
 ///
 /// Each problem names the measurement, the value, and what published tracks do. That last
 /// part is what makes it fixable: "too wide" is an opinion, "31 m against a corpus of 10–17"
 /// is an instruction.
 pub fn validate(prog: &TrackProgram) -> Vec<String> {
+    let r = review(prog);
+    r.problems.into_iter().chain(r.notes).collect()
+}
+
+pub fn review(prog: &TrackProgram) -> Review {
     let mut out = Vec::new();
+    let mut notes = Vec::new();
     let between = |what: &str, v: f32, (lo, hi): (f32, f32), unit: &str, out: &mut Vec<String>| {
         if v < lo || v > hi {
             out.push(format!(
@@ -132,7 +152,7 @@ pub fn validate(prog: &TrackProgram) -> Vec<String> {
     // can't be synthesised, so there would be nothing to measure.
     if let Err(e) = prog.check() {
         out.push(e.to_string());
-        return out;
+        return Review { problems: out, notes };
     }
 
     let closure = prog.closure_error();
@@ -143,11 +163,15 @@ pub fn validate(prog: &TrackProgram) -> Vec<String> {
              ±360°."
         ));
     }
-    between("the riding line", prog.width, corpus::WIDTH_M, " m", &mut out);
-    between("the lap", prog.lap_length(), corpus::LAP_M, " m", &mut out);
+    between("the riding line", prog.width, corpus::WIDTH_M, " m", &mut notes);
+    between("the lap", prog.lap_length(), corpus::LAP_M, " m", &mut notes);
 
-    let per_km = prog.features.len() as f32 * 1000.0 / prog.lap_length().max(1.0);
-    between("feature density", per_km, corpus::LIPS_PER_KM, " per km", &mut out);
+    // Only worth saying once there is something to count. A lap with nothing built on it is
+    // a starting point, and "0 features per km" is not news to whoever just asked for one.
+    if !prog.features.is_empty() {
+        let per_km = prog.features.len() as f32 * 1000.0 / prog.lap_length().max(1.0);
+        between("feature density", per_km, corpus::LIPS_PER_KM, " per km", &mut notes);
+    }
 
     // Per-feature, where the complaint can name the thing that's wrong.
     let turn = prog.stations(1.0);
@@ -203,20 +227,24 @@ pub fn validate(prog: &TrackProgram) -> Vec<String> {
         Ok(s) => s,
         Err(e) => {
             out.push(e.to_string());
-            return out;
+            return Review { problems: out, notes };
         }
     };
     let c = crate::trackstats::measure("synth", &syn.corridor, &syn.heights, syn.gw, syn.gh, syn.mps);
 
-    between("the built relief", c.feature_relief_m.p90, corpus::RELIEF_M, " m", &mut out);
-    between("the steepest ground", c.slope_deg.p99, corpus::SLOPE_P99_DEG, "°", &mut out);
+    // Both of these measure what was *built* on the ground, so an empty lap has nothing to
+    // say about them either.
+    if !prog.features.is_empty() {
+        between("the built relief", c.feature_relief_m.p90, corpus::RELIEF_M, " m", &mut notes);
+        between("the steepest ground", c.slope_deg.p99, corpus::SLOPE_P99_DEG, "°", &mut notes);
+    }
     if c.largest_component_fraction < 0.95 {
         out.push(format!(
             "the riding line comes out in {:.0}% pieces — the lap probably crosses itself",
             (1.0 - c.largest_component_fraction) * 100.0
         ));
     }
-    out
+    Review { problems: out, notes }
 }
 
 /// The brief, as the app sends it. Kept small on purpose: everything that shapes the output
@@ -326,6 +354,21 @@ mod tests {
         let mut p: TrackProgram = serde_json::from_str(EXAMPLE).unwrap();
         f(&mut p);
         p
+    }
+
+    /// A lap with nothing built on it is a starting point, not a broken track. It must not
+    /// come back with problems, or the Blank button hands you an error.
+    #[test]
+    fn a_blank_lap_is_empty_rather_than_broken() {
+        let blank = tweaked(|p| p.features.clear());
+        let r = review(&blank);
+        assert_eq!(r.problems, Vec::<String>::new(), "a blank lap should build");
+        // And nothing about what was built on it, because nothing was.
+        assert!(
+            !r.notes.iter().any(|n| n.contains("density") || n.contains("built relief")),
+            "{:?}",
+            r.notes
+        );
     }
 
     #[test]

--- a/src/Components/Studio/TrackStudio/TrackStudio.tsx
+++ b/src/Components/Studio/TrackStudio/TrackStudio.tsx
@@ -19,6 +19,16 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { toast } from "sonner";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "../../ui/alert-dialog";
 
 import { Button } from "../../ui/button";
 import { Input } from "../../ui/input";
@@ -77,6 +87,11 @@ export default function TrackStudio() {
   const [program, setProgram] = useState<TrackProgram | null>(null);
   const [preview, setPreview] = useState<TrackPreview | null>(null);
   const [problems, setProblems] = useState<string[]>([]);
+  const [notes, setNotes] = useState<string[]>([]);
+  // Whether anything has been changed since it was loaded, so a starting point can't be
+  // dropped on top of an afternoon's work by accident.
+  const [touched, setTouched] = useState(false);
+  const [confirming, setConfirming] = useState<(() => Promise<void>) | null>(null);
   const [terrain, setTerrain] = useState<TrackTerrain | null>(null);
   const [overview, setOverview] = useState<TrackOverview | null>(null);
   const [focus, setFocus] = useState<{ x: number; z: number } | null>(null);
@@ -108,10 +123,12 @@ export default function TrackStudio() {
       setPreview(null);
       try {
         const found = await checkTrack(next);
-        setProblems(found);
-        return found;
+        setProblems(found.problems);
+        setNotes(found.notes);
+        return found.problems;
       } catch (e) {
         setProblems([String(e)]);
+        setNotes([]);
         return [String(e)];
       }
     },
@@ -137,12 +154,24 @@ export default function TrackStudio() {
   /** Load a starting point and put it on screen — a track you can't see isn't a start. */
   async function onLoad(load: () => Promise<TrackProgram>) {
     if (busy) return;
+    // Replacing a track you have been working on is the one action here that throws work
+    // away, so it asks first — and only when there is work to throw away.
+    if (touched) {
+      setConfirming(() => () => reallyLoad(load));
+      return;
+    }
+    await reallyLoad(load);
+  }
+
+  async function reallyLoad(load: () => Promise<TrackProgram>) {
+    if (busy) return;
     setBusy("generate");
     setPreview(null);
     setProblems([]);
     try {
       const next = await load();
       const found = await settle(next);
+      setTouched(false);
       toast.success(t("track.baseLoaded", { name: next.name }));
       if (found.length === 0) await showIn3d(next);
     } catch (e) {
@@ -219,6 +248,7 @@ export default function TrackStudio() {
 
   function editFeature(index: number, patch: Partial<TrackFeature>) {
     if (!program) return;
+    setTouched(true);
     const features = program.features.map((f, i) =>
       i === index ? ({ ...f, ...patch } as TrackFeature) : f,
     );
@@ -227,6 +257,7 @@ export default function TrackStudio() {
 
   function editSegment(index: number, patch: Partial<TrackSegment>) {
     if (!program) return;
+    setTouched(true);
     const segments = program.segments.map((seg, i) =>
       i === index ? ({ ...seg, ...patch } as TrackSegment) : seg,
     );
@@ -236,6 +267,7 @@ export default function TrackStudio() {
 
   function removeFeature(index: number) {
     if (!program) return;
+    setTouched(true);
     void settle({ ...program, features: program.features.filter((_, i) => i !== index) });
   }
 
@@ -243,6 +275,7 @@ export default function TrackStudio() {
   /// in metres, which is a better teacher than a disabled button.
   function removeSegment(index: number) {
     if (!program || program.segments.length <= 2) return;
+    setTouched(true);
     void settle(
       fitFeatures({ ...program, segments: program.segments.filter((_, i) => i !== index) }),
     );
@@ -258,6 +291,7 @@ export default function TrackStudio() {
    */
   function reorder(steps: LapStep[], from: number, to: number) {
     if (!program || from === to) return;
+    setTouched(true);
     const moved = steps[from];
     const target = steps[to];
     if (moved.kind === "feature") {
@@ -326,6 +360,7 @@ export default function TrackStudio() {
 
   function addFeature(kind: TrackFeatureKind) {
     if (!program) return;
+    setTouched(true);
     const probe = newFeature(kind, 0);
     const at = roomiestGap(program, featureSpan(probe).length);
     void settle({ ...program, features: [...program.features, newFeature(kind, at)] });
@@ -513,6 +548,19 @@ export default function TrackStudio() {
                     {t("track.closeLap")}
                   </Button>
                 )}
+              </div>
+            )}
+
+            {notes.length > 0 && problems.length === 0 && (
+              <div className="rounded-xl border border-input p-3.5">
+                <h3 className="text-[12px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  {t("track.notes")}
+                </h3>
+                <ul className="mt-2 space-y-1.5 text-[12.5px] leading-snug text-muted-foreground">
+                  {notes.map((n, i) => (
+                    <li key={i}>{n}</li>
+                  ))}
+                </ul>
               </div>
             )}
 
@@ -761,6 +809,26 @@ export default function TrackStudio() {
         </div>
       )}
 
+      <AlertDialog open={confirming !== null} onOpenChange={(o) => !o && setConfirming(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("track.replaceTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>{t("track.replaceBody")}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                const go = confirming;
+                setConfirming(null);
+                void go?.();
+              }}
+            >
+              {t("track.replaceConfirm")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/api/trackgen.ts
+++ b/src/api/trackgen.ts
@@ -94,9 +94,19 @@ export function closeTrackLap(program: TrackProgram): Promise<TrackProgram> {
   return invoke<TrackProgram>("close_track_lap", { program });
 }
 
-/** Everything wrong with a program, held to the same corpus a generated one is. */
-export function checkTrack(program: TrackProgram): Promise<string[]> {
-  return invoke<string[]>("check_track", { program });
+/**
+ * What is wrong with a program, and what is merely unlike a published one.
+ *
+ * `problems` block: it won't build, or it isn't a lap, or a feature does nothing where it
+ * sits. `notes` don't: a blank lap is empty, not broken.
+ */
+export interface TrackReview {
+  problems: string[];
+  notes: string[];
+}
+
+export function checkTrack(program: TrackProgram): Promise<TrackReview> {
+  return invoke<TrackReview>("check_track", { program });
 }
 
 /** Build it, and write it where the track viewer can open it. */

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -2401,4 +2401,8 @@ export const de: Translation = {
   "track.closeLap": "Runde schließen",
   "track.lapClosed": "Die Runde schließt sich jetzt",
   "track.closeFailed": "Konnte nicht geschlossen werden",
+  "track.notes": "Anders als veröffentlichte Strecken",
+  "track.replaceTitle": "Diese Strecke ersetzen?",
+  "track.replaceBody": "Es gibt Änderungen, die weder exportiert noch installiert wurden. Eine andere Strecke zu laden verwirft sie.",
+  "track.replaceConfirm": "Verwerfen und laden",
 };

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2357,4 +2357,8 @@ export const en = {
   "track.closeLap": "Close the lap",
   "track.lapClosed": "The lap meets itself now",
   "track.closeFailed": "Couldn't close it",
+  "track.notes": "Unlike a published track",
+  "track.replaceTitle": "Replace this track?",
+  "track.replaceBody": "You've made changes that haven't been exported or installed. Loading another track discards them.",
+  "track.replaceConfirm": "Discard and load",
 } as const;

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -2387,4 +2387,8 @@ export const es: Translation = {
   "track.closeLap": "Cerrar la vuelta",
   "track.lapClosed": "La vuelta ya cierra",
   "track.closeFailed": "No se pudo cerrar",
+  "track.notes": "Distinto de una pista publicada",
+  "track.replaceTitle": "¿Reemplazar esta pista?",
+  "track.replaceBody": "Has hecho cambios que no se han exportado ni instalado. Cargar otra pista los descarta.",
+  "track.replaceConfirm": "Descartar y cargar",
 };

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -2392,4 +2392,8 @@ export const fr: Translation = {
   "track.closeLap": "Fermer le tour",
   "track.lapClosed": "Le tour se referme",
   "track.closeFailed": "Fermeture impossible",
+  "track.notes": "Différent d'un circuit publié",
+  "track.replaceTitle": "Remplacer ce circuit ?",
+  "track.replaceBody": "Tu as fait des modifications qui n'ont été ni exportées ni installées. Charger un autre circuit les supprime.",
+  "track.replaceConfirm": "Supprimer et charger",
 };

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -2380,4 +2380,8 @@ export const it: Translation = {
   "track.closeLap": "Chiudi il giro",
   "track.lapClosed": "Il giro ora si chiude",
   "track.closeFailed": "Impossibile chiudere",
+  "track.notes": "Diverso da una pista pubblicata",
+  "track.replaceTitle": "Sostituire questa pista?",
+  "track.replaceBody": "Hai fatto modifiche che non sono state esportate né installate. Caricare un'altra pista le scarta.",
+  "track.replaceConfirm": "Scarta e carica",
 };

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -2377,4 +2377,8 @@ export const ptBR: Translation = {
   "track.closeLap": "Fechar a volta",
   "track.lapClosed": "A volta agora fecha",
   "track.closeFailed": "Não foi possível fechar",
+  "track.notes": "Diferente de uma pista publicada",
+  "track.replaceTitle": "Substituir esta pista?",
+  "track.replaceBody": "Você fez alterações que não foram exportadas nem instaladas. Carregar outra pista descarta tudo.",
+  "track.replaceConfirm": "Descartar e carregar",
 };


### PR DESCRIPTION
Clicking **Blank** produced three errors:

```
feature density is 0.0 per km; published tracks run 12–80 per km
the built relief is 0.2 m; published tracks run 0–2 m
the steepest ground is 4.1°; published tracks run 18–50°
```

All true, none of them faults. Nothing built on a lap has no feature density, no built relief and no steep ground. Handing someone an error the moment they ask for a starting point is how a starting point stops being one.

## Problems and notes are now separate

- **Problems** are structural — it won't build, it isn't a lap, or a feature does nothing where it sits. They block Preview, Install and Export.
- **Notes** are the corpus comparisons. They don't block, and they read as observations rather than faults.
- The three that measure what was *built* are skipped entirely when nothing has been. "0 features per km" is not news to whoever just pressed Blank.

`validate` still returns both, because the model being asked for a track should fix a note as readily as a fault — it was asked for a finished track, not a canvas.

## Loading no longer discards work

Loading Base or Blank over a track you've been editing asks first, and only when there's something to lose. Every edit marks the track as touched; loading a starting point clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)