### PR TITLE
fix(tracks): work the height budget out instead of asking for it

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1233,6 +1233,21 @@ async fn blank_track_program() -> Result<serde_json::Value, String> {
     Ok(json)
 }
 
+/// Give a programme a height budget that fits it.
+///
+/// The budget only exists because samples are quantised against it, and there is no reason a
+/// person should be told to guess a number the synthesiser already knows.
+#[tauri::command]
+async fn fit_track_budget(program: serde_json::Value) -> Result<serde_json::Value, String> {
+    let prog = track_program(program)?;
+    let fitted = tauri::async_runtime::spawn_blocking(move || {
+        tracksynth::with_fitted_budget(&prog).map_err(|e| format!("{e:#}"))
+    })
+    .await
+    .map_err(|e| format!("fit_track_budget task failed: {e}"))??;
+    serde_json::to_value(&fitted).map_err(|e| e.to_string())
+}
+
 /// Bring an open lap back to its start.
 #[tauri::command]
 async fn close_track_lap(program: serde_json::Value) -> Result<serde_json::Value, String> {
@@ -8926,6 +8941,7 @@ fn main() {
             base_track_program,
             blank_track_program,
             close_track_lap,
+            fit_track_budget,
             preview_track,
             install_track_preview,
             export_track_source,

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -333,6 +333,29 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
     })
 }
 
+/// How much height a programme actually needs, in metres.
+///
+/// The budget is a technical quantity — samples are quantised against it — and nobody should
+/// have to guess it. Built by synthesising against a budget large enough that the check can't
+/// fire, then reading what was used.
+pub fn required_height(prog: &TrackProgram) -> Result<f32> {
+    let mut roomy = prog.clone();
+    // Far more than any track needs, so nothing clips and `used_m` is the honest figure.
+    roomy.terrain.scale = 10_000.0;
+    Ok(synthesise(&roomy)?.used_m)
+}
+
+/// A programme with a height budget that fits it: just above what it needs, so the terrain
+/// quantises as finely as it can without clipping.
+pub fn with_fitted_budget(prog: &TrackProgram) -> Result<TrackProgram> {
+    let need = required_height(prog)?;
+    let mut out = prog.clone();
+    // Fifteen percent of headroom, rounded up to a whole metre. Room for an edit or two
+    // before this has to be worked out again, and no more.
+    out.terrain.scale = (need * 1.15).ceil().max(2.0);
+    Ok(out)
+}
+
 /// Samples across and down, both a power of two plus one, with cells as square as that allows.
 fn grid_dims(prog: &TrackProgram) -> Result<(usize, usize)> {
     let n = prog.terrain.samples as usize;
@@ -1672,6 +1695,27 @@ mod tests {
         });
         assert!(lo >= 0.0 && hi <= p.terrain.scale, "{lo}..{hi}");
         assert!(s.used_m > 1.0, "the terrain came out flat");
+    }
+
+    #[test]
+    fn a_fitted_budget_holds_the_track_and_little_else() {
+        let mut p = oval();
+        p.terrain.scale = 1.0; // far too small to build
+        let fitted = with_fitted_budget(&p).expect("fitting doesn't need a workable budget");
+        let s = synthesise(&fitted).expect("and what comes back builds");
+        assert!(
+            s.used_m < fitted.terrain.scale,
+            "used {:.1} of {:.1}",
+            s.used_m,
+            fitted.terrain.scale
+        );
+        // Snug, not generous: a budget ten times the relief quantises ten times coarser.
+        assert!(
+            fitted.terrain.scale < s.used_m * 1.5,
+            "budget {:.1} for {:.1} m of terrain",
+            fitted.terrain.scale,
+            s.used_m
+        );
     }
 
     #[test]

--- a/src/Components/Studio/TrackStudio/TrackStudio.tsx
+++ b/src/Components/Studio/TrackStudio/TrackStudio.tsx
@@ -42,6 +42,7 @@ import {
   blankTrackProgram,
   buildTrack,
   closeTrackLap,
+  fitTrackBudget,
   checkTrack,
   exportTrackSource,
   generateTrack,
@@ -122,7 +123,18 @@ export default function TrackStudio() {
       setProgram(next);
       setPreview(null);
       try {
-        const found = await checkTrack(next);
+        let found = await checkTrack(next);
+        // The height budget is arithmetic, not a decision. Work it out and carry on rather
+        // than telling someone to raise a number they have no field for.
+        if (found.problems.some((p) => p.includes("budget"))) {
+          try {
+            next = await fitTrackBudget(next);
+            setProgram(next);
+            found = await checkTrack(next);
+          } catch {
+            /* leave the original complaint standing */
+          }
+        }
         setProblems(found.problems);
         setNotes(found.notes);
         return found.problems;
@@ -358,6 +370,12 @@ export default function TrackStudio() {
     setDropAt(null);
   }
 
+  function settleTerrain(patch: Partial<TrackProgram["terrain"]>) {
+    if (!program) return;
+    setTouched(true);
+    void settle({ ...program, terrain: { ...program.terrain, ...patch } });
+  }
+
   function addFeature(kind: TrackFeatureKind) {
     if (!program) return;
     setTouched(true);
@@ -506,6 +524,52 @@ export default function TrackStudio() {
                 <Row label={t("track.features")} value={String(program.features.length)} />
                 <Row label={t("track.corners")} value={String(program.segments.filter((s) => s.kind === "arc").length)} />
               </dl>
+            </div>
+
+            <div className="rounded-xl border border-input p-3.5">
+              <h3 className="text-[12px] font-semibold uppercase tracking-wide text-muted-foreground">
+                {t("track.ground")}
+              </h3>
+              <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5">
+                <Field
+                  label={t("track.across")}
+                  value={program.terrain.sizeX}
+                  step={20}
+                  onChange={(v) =>
+                    void settleTerrain({ sizeX: Math.max(100, v), sizeZ: Math.max(100, v) })
+                  }
+                />
+                <Field
+                  label={t("track.hills")}
+                  value={program.terrain.relief.amplitude}
+                  step={1}
+                  onChange={(v) =>
+                    void settle({
+                      ...program,
+                      terrain: {
+                        ...program.terrain,
+                        relief: { ...program.terrain.relief, amplitude: Math.max(0, v) },
+                      },
+                    })
+                  }
+                />
+                <label className="flex items-center gap-1">
+                  <span className="text-[11px] text-muted-foreground">{t("track.surface")}</span>
+                  <select
+                    value={program.terrain.surface}
+                    onChange={(e) =>
+                      void settleTerrain({
+                        surface: e.target.value as TrackProgram["terrain"]["surface"],
+                      })
+                    }
+                    className="rounded-md border border-input bg-transparent px-1 py-0.5 text-[12px] outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+                  >
+                    <option value="soil">{t("track.soil")}</option>
+                    <option value="sand">{t("track.sand")}</option>
+                    <option value="grass">{t("track.grass")}</option>
+                  </select>
+                </label>
+              </div>
             </div>
 
             {/* Measured, not claimed — the same figures taken of published tracks. */}

--- a/src/api/trackgen.ts
+++ b/src/api/trackgen.ts
@@ -89,6 +89,16 @@ export function blankTrackProgram(): Promise<TrackProgram> {
   return invoke<TrackProgram>("blank_track_program");
 }
 
+/**
+ * Give the track a height budget that fits it.
+ *
+ * The budget exists only because samples are quantised against it, so nobody should be asked
+ * to guess a number the synthesiser already knows.
+ */
+export function fitTrackBudget(program: TrackProgram): Promise<TrackProgram> {
+  return invoke<TrackProgram>("fit_track_budget", { program });
+}
+
 /** Bring an open lap back to its start: a turn, a straight and a turn. */
 export function closeTrackLap(program: TrackProgram): Promise<TrackProgram> {
   return invoke<TrackProgram>("close_track_lap", { program });

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -2405,4 +2405,10 @@ export const de: Translation = {
   "track.replaceTitle": "Diese Strecke ersetzen?",
   "track.replaceBody": "Es gibt Änderungen, die weder exportiert noch installiert wurden. Eine andere Strecke zu laden verwirft sie.",
   "track.replaceConfirm": "Verwerfen und laden",
+  "track.across": "breit",
+  "track.hills": "Hügel",
+  "track.surface": "Boden",
+  "track.soil": "Erde",
+  "track.sand": "Sand",
+  "track.grass": "Gras",
 };

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2361,4 +2361,10 @@ export const en = {
   "track.replaceTitle": "Replace this track?",
   "track.replaceBody": "You've made changes that haven't been exported or installed. Loading another track discards them.",
   "track.replaceConfirm": "Discard and load",
+  "track.across": "across",
+  "track.hills": "hills",
+  "track.surface": "ground",
+  "track.soil": "Soil",
+  "track.sand": "Sand",
+  "track.grass": "Grass",
 } as const;

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -2391,4 +2391,10 @@ export const es: Translation = {
   "track.replaceTitle": "¿Reemplazar esta pista?",
   "track.replaceBody": "Has hecho cambios que no se han exportado ni instalado. Cargar otra pista los descarta.",
   "track.replaceConfirm": "Descartar y cargar",
+  "track.across": "de ancho",
+  "track.hills": "colinas",
+  "track.surface": "suelo",
+  "track.soil": "Tierra",
+  "track.sand": "Arena",
+  "track.grass": "Hierba",
 };

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -2396,4 +2396,10 @@ export const fr: Translation = {
   "track.replaceTitle": "Remplacer ce circuit ?",
   "track.replaceBody": "Tu as fait des modifications qui n'ont été ni exportées ni installées. Charger un autre circuit les supprime.",
   "track.replaceConfirm": "Supprimer et charger",
+  "track.across": "de large",
+  "track.hills": "collines",
+  "track.surface": "sol",
+  "track.soil": "Terre",
+  "track.sand": "Sable",
+  "track.grass": "Herbe",
 };

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -2384,4 +2384,10 @@ export const it: Translation = {
   "track.replaceTitle": "Sostituire questa pista?",
   "track.replaceBody": "Hai fatto modifiche che non sono state esportate né installate. Caricare un'altra pista le scarta.",
   "track.replaceConfirm": "Scarta e carica",
+  "track.across": "di lato",
+  "track.hills": "colline",
+  "track.surface": "suolo",
+  "track.soil": "Terra",
+  "track.sand": "Sabbia",
+  "track.grass": "Erba",
 };

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -2381,4 +2381,10 @@ export const ptBR: Translation = {
   "track.replaceTitle": "Substituir esta pista?",
   "track.replaceBody": "Você fez alterações que não foram exportadas nem instaladas. Carregar outra pista descarta tudo.",
   "track.replaceConfirm": "Descartar e carregar",
+  "track.across": "de largura",
+  "track.hills": "colinas",
+  "track.surface": "solo",
+  "track.soil": "Terra",
+  "track.sand": "Areia",
+  "track.grass": "Grama",
 };


### PR DESCRIPTION
> the terrain needs 34.0 m of height and the budget is 20.0 m. Raise terrain.scale to about 40.

**There is no field for `terrain.scale` anywhere in the studio.** So that was another error with no way out of it — the fourth of this shape.

## The budget is arithmetic, not a decision

It exists only because samples are quantised against it, and the synthesiser already knows what the terrain needs. So it's worked out: build against a budget nothing can clip, read what was used, set the budget just above it. Fifteen percent of headroom rounded to a metre — room for an edit or two, and no more, because a budget ten times the relief quantises ten times coarser.

It happens on its own. An edit that outgrows the budget raises it and carries on rather than stopping to complain.

## The terrain had no editors at all

Added ground size, how hilly the landscape is, and what it's made of. Their absence is why both this error *and* "the lap leaves the terrain" were dead ends rather than things you could act on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)