### PR TITLE
feat(tracks): one blend control for how things join

### DIFF
--- a/control-plane/src/trackgen.ts
+++ b/control-plane/src/trackgen.ts
@@ -121,6 +121,11 @@ const TrackProgram = z.object({
     z: z.number(),
     angle: z.number().describe("degrees; 0 looks down +z and increases clockwise towards +x"),
   }),
+  blend: z
+    .number()
+    .describe(
+      "metres things ease into each other over: where two jumps meet, where a straight becomes a corner, and how long a jump's own ramps are. 1.2 is normal; 0 is every edge sharp",
+    ),
   segments: z.array(z.discriminatedUnion("kind", [Straight, Arc])),
   features: z.array(Feature),
 });

--- a/src-tauri/src/trackprog.rs
+++ b/src-tauri/src/trackprog.rs
@@ -58,6 +58,20 @@ pub struct TrackProgram {
     pub width: f32,
     #[serde(default)]
     pub features: Vec<Feature>,
+    /// How far things ease into each other, in metres.
+    ///
+    /// One number for the whole track, because the three places it matters are the same
+    /// question asked three times: where two jumps meet, where a straight becomes a corner,
+    /// and how long a jump's own ramps are. Zero is every edge as sharp as the grid allows;
+    /// a few metres is a track a machine shaped.
+    #[serde(default = "default_blend")]
+    pub blend: f32,
+}
+
+pub(crate) fn default_blend() -> f32 {
+    // Enough to join two jumps that touch, little enough to leave a takeoff face crisp:
+    // at 2.5 the demo track lost four degrees off its steepest ground.
+    1.2
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Debug)]
@@ -637,6 +651,7 @@ mod tests {
             segments,
             width: 12.0,
             features: Vec::new(),
+            blend: default_blend(),
         }
     }
 

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -215,12 +215,19 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
     // Everything that varies along the lap, resampled onto one even ruler so a cell can ask
     // for the value at *its* distance round rather than at the nearest station's.
     let bench = resample(&stations, &along, lap);
-    let turn = resample(
+    let mut turn = resample(
         &stations,
         &stations.iter().map(|s| s.curvature).collect::<Vec<_>>(),
         lap,
     );
-    let feat = feature_profile(&prog.features, lap);
+    // Curvature steps from nothing to 1/r the instant a corner starts, and everything that
+    // reads it — the ruts, the roughness, which side a berm stands on — stepped with it. Eased
+    // over the blend distance, a corner arrives instead of appearing.
+    smooth_along(
+        &mut turn.v,
+        (prog.blend.max(0.0) / PROFILE_STEP).round() as usize,
+    );
+    let feat = feature_profile(&prog.features, lap, prog.blend.max(0.0));
     let berms = berm_profile(&prog.features, &turn, lap);
     let ruts = rut_profile(&prog.features, &turn, lap, r.seed);
     let widths = width_profile(prog.width * 0.5, lap, r.seed);
@@ -671,7 +678,7 @@ fn resample(st: &[Station], vals: &[f32], lap: f32) -> Profile {
 }
 
 /// Height added by everything built on the line, along the lap.
-fn feature_profile(features: &[Feature], lap: f32) -> Profile {
+fn feature_profile(features: &[Feature], lap: f32, blend: f32) -> Profile {
     let mut out = Profile::blank(lap);
     for f in features {
         if matches!(f, Feature::StepUp { .. } | Feature::Berm { .. }) {
@@ -685,9 +692,16 @@ fn feature_profile(features: &[Feature], lap: f32) -> Profile {
             if u < 0.0 || u > len {
                 continue;
             }
-            out.v[i] += longitudinal(f, u / len, u);
+            // The larger of the two, not the sum. Two jumps a metre apart used to add, so
+            // the ground between them rose to their combined height and a rhythm section came
+            // out as one tall lump with notches in it.
+            out.v[i] = out.v[i].max(longitudinal(f, u / len, u));
         }
     }
+    // Then round the whole thing off over the blend distance. That is what turns two jumps
+    // that merely touch into one shape, and it is the same control that decides how long a
+    // single jump's ramps are — they are the same question asked twice.
+    smooth_along(&mut out.v, (blend / PROFILE_STEP).round() as usize);
     out
 }
 
@@ -1694,6 +1708,7 @@ mod tests {
                 Segment::Arc { radius: 60.0, angle: 180.0, rise: 0.0 },
             ],
             width: 12.0,
+            blend: crate::trackprog::default_blend(),
             features: vec![
                 Feature::Tabletop { at: 30.0, length: 22.0, height: 2.4 },
                 Feature::Double { at: 70.0, height: 2.0, gap: 9.0, lip: 6.0 },
@@ -1755,6 +1770,34 @@ mod tests {
         // Area over length is the width, give or take the ends of the lap.
         let width = area / p.lap_length();
         assert!((width - p.width).abs() < 1.0, "measured {width:.2} m");
+    }
+
+    /// Two jumps close together must not add up. Before, the ground between a pair of
+    /// tabletops rose to their combined height and a rhythm section came out as one tall
+    /// lump; each should keep its own height and the pair should read as one shape.
+    #[test]
+    fn jumps_that_touch_keep_their_own_height() {
+        let mut p = oval();
+        // Overlapping where both are at full height, which is the only place summing shows
+        // itself — two jumps that meet ramp-to-ramp barely overlap at all.
+        // Flat ground, so the only thing in the measurement is the jumps.
+        p.terrain.relief.amplitude = 0.0;
+        // Overlapping where both are at full height, which is the only place summing shows
+        // itself — two jumps that meet ramp-to-ramp barely overlap at all.
+        p.features = vec![
+            Feature::Tabletop { at: 30.0, length: 24.0, height: 2.0 },
+            Feature::Tabletop { at: 33.0, length: 24.0, height: 2.0 },
+        ];
+        let s = synthesise(&p).unwrap();
+        let base = height_at_arc(&s, 10.0);
+        let peak = (300..=700)
+            .map(|i| height_at_arc(&s, i as f32 / 10.0) - base)
+            .fold(f32::MIN, f32::max);
+        assert!(
+            peak < 2.4,
+            "two 2 m jumps a hair apart came out {peak:.2} m tall"
+        );
+        assert!(peak > 1.4, "and they should still be jumps: {peak:.2} m");
     }
 
     #[test]

--- a/src/Components/Studio/TrackStudio/TrackStudio.tsx
+++ b/src/Components/Studio/TrackStudio/TrackStudio.tsx
@@ -553,6 +553,15 @@ export default function TrackStudio() {
                     })
                   }
                 />
+                <Field
+                  label={t("track.smoothing")}
+                  value={program.blend}
+                  step={0.5}
+                  onChange={(v) => {
+                    setTouched(true);
+                    void settle({ ...program, blend: Math.max(0, v) });
+                  }}
+                />
                 <label className="flex items-center gap-1">
                   <span className="text-[11px] text-muted-foreground">{t("track.surface")}</span>
                   <select

--- a/src/api/trackgen.ts
+++ b/src/api/trackgen.ts
@@ -29,6 +29,12 @@ export interface TrackProgram {
   start: { x: number; z: number; angle: number };
   segments: TrackSegment[];
   features: TrackFeature[];
+  /**
+   * Metres things ease into each other over: where two jumps meet, where a straight becomes
+   * a corner, and how long a jump's own ramps are. One control, because those are the same
+   * question asked three times.
+   */
+  blend: number;
 }
 
 export type TrackSegment =

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -2411,4 +2411,5 @@ export const de: Translation = {
   "track.soil": "Erde",
   "track.sand": "Sand",
   "track.grass": "Gras",
+  "track.smoothing": "Übergang",
 };

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2367,4 +2367,5 @@ export const en = {
   "track.soil": "Soil",
   "track.sand": "Sand",
   "track.grass": "Grass",
+  "track.smoothing": "blend",
 } as const;

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -2397,4 +2397,5 @@ export const es: Translation = {
   "track.soil": "Tierra",
   "track.sand": "Arena",
   "track.grass": "Hierba",
+  "track.smoothing": "fundido",
 };

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -2402,4 +2402,5 @@ export const fr: Translation = {
   "track.soil": "Terre",
   "track.sand": "Sable",
   "track.grass": "Herbe",
+  "track.smoothing": "fondu",
 };

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -2390,4 +2390,5 @@ export const it: Translation = {
   "track.soil": "Terra",
   "track.sand": "Sabbia",
   "track.grass": "Erba",
+  "track.smoothing": "raccordo",
 };

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -2387,4 +2387,5 @@ export const ptBR: Translation = {
   "track.soil": "Terra",
   "track.sand": "Areia",
   "track.grass": "Grama",
+  "track.smoothing": "suavização",
 };


### PR DESCRIPTION
Three asks that turn out to be the same question — where two jumps meet, where a straight becomes a corner, and how long a jump's own ramps are. So one number, in metres, answers all three.

## Features stop adding up

They combined by **summing**. Two jumps a metre apart raised the ground between them to their combined height: 2 m and 2 m came out **4 m tall**, and a rhythm section read as one lump with notches in it. They take the larger of the two now.

## Then the profile is rounded off

Smoothing the whole feature profile over the blend distance is what turns two jumps that merely touch into one shape — and it's the same pass that decides how long a single jump's ramps are.

## Corners arrive instead of appearing

Curvature stepped from nothing to `1/r` the instant a corner began, and everything reading it — the ruts, the roughness, which side a berm stands on — stepped with it. It's eased over the blend distance now.

## The version I threw away

My first attempt used the blend as a height-domain constant inside a smooth maximum. That's dimensionally wrong — it's metres of *arc*, not metres of *height* — and it inflated every overlap by a quarter of itself. Plain maximum plus smoothing along the lap is the same idea with the units the right way round.

## The default

1.2 m. At 2.5 the demo track lost four degrees off its steepest ground, which is a real jump face going soft. Editable per track in the Ground card.

The test for this passed twice while proving nothing before it bit — first because the two jumps only overlapped where both were near zero, then because the oval's landscape was drowning the measurement. It now flattens the ground and overlaps the flat tops, and reports 4.01 m against the old code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)