### PR TITLE
feat(tracks): draw the lap's height by hand, live preview, whole-step highlight

### DIFF
--- a/control-plane/src/trackgen.ts
+++ b/control-plane/src/trackgen.ts
@@ -126,6 +126,14 @@ const TrackProgram = z.object({
     .describe(
       "metres things ease into each other over: where two jumps meet, where a straight becomes a corner, and how long a jump's own ramps are. 1.2 is normal; 0 is every edge sharp",
     ),
+  elevation: z
+    .array(
+      z.object({
+        at: z.number().describe('metres round the lap'),
+        height: z.number().describe('metres above the ground the track would otherwise follow'),
+      }),
+    )
+    .describe('the lap height as a curve; leave empty to follow the landscape'),
   segments: z.array(z.discriminatedUnion("kind", [Straight, Arc])),
   features: z.array(Feature),
 });

--- a/src-tauri/src/trackprog.rs
+++ b/src-tauri/src/trackprog.rs
@@ -66,6 +66,24 @@ pub struct TrackProgram {
     /// a few metres is a track a machine shaped.
     #[serde(default = "default_blend")]
     pub blend: f32,
+    /// Height the track is lifted or dropped by, at points round the lap.
+    ///
+    /// Empty means the track simply follows the ground it crosses, which is what it did
+    /// before this existed. A `rise` on a segment says "climb four metres across this
+    /// corner"; these say "be four metres up *here*" — the same shape stated as a curve
+    /// rather than as a run of instructions, which is the form you can take hold of.
+    #[serde(default)]
+    pub elevation: Vec<Knot>,
+}
+
+/// One point on the lap's height curve.
+#[derive(serde::Deserialize, serde::Serialize, Clone, Copy, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Knot {
+    /// Metres round the lap.
+    pub at: f32,
+    /// Metres above the ground the track would otherwise have followed.
+    pub height: f32,
 }
 
 pub(crate) fn default_blend() -> f32 {
@@ -652,6 +670,7 @@ mod tests {
             width: 12.0,
             features: Vec::new(),
             blend: default_blend(),
+            elevation: Vec::new(),
         }
     }
 

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -31,7 +31,7 @@
 use anyhow::{bail, Context, Result};
 use std::path::Path;
 
-use crate::trackprog::{Feature, Segment, Station, Surface, TrackProgram};
+use crate::trackprog::{Feature, Knot, Segment, Station, Surface, TrackProgram};
 
 /// Metres of centreline between stations. Finer than the grid, so every cell finds a station
 /// nearer than its own width.
@@ -210,6 +210,7 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
         .collect();
     smooth_along(&mut along, (BENCH_SMOOTH_M / STATION_STEP) as usize);
     apply_rise(&mut along, &stations, &prog.segments);
+    apply_elevation(&mut along, &stations, &prog.elevation, lap);
     apply_step_ups(&mut along, &stations, &prog.features);
 
     // Everything that varies along the lap, resampled onto one even ruler so a cell can ask
@@ -766,6 +767,45 @@ fn apply_rise(along: &mut [f32], st: &[Station], segments: &[Segment]) {
             }
         }
         at += len;
+    }
+}
+
+/// The hand-drawn height curve, added to whatever the ground was already doing.
+///
+/// Eased between neighbouring points rather than run straight between them, so a curve drawn
+/// with four points is four hills and not four ramps with corners on them. It **wraps**: the
+/// last point eases into the first, because a lap is a loop and a step across the finish line
+/// is the one place a rider would notice one.
+fn apply_elevation(along: &mut [f32], st: &[Station], knots: &[Knot], lap: f32) {
+    if knots.is_empty() || lap <= 0.0 {
+        return;
+    }
+    let mut k: Vec<Knot> = knots.to_vec();
+    k.sort_by(|a, b| a.at.total_cmp(&b.at));
+
+    let at = |s: f32| -> f32 {
+        // Which pair of points this station falls between, treating the list as a ring.
+        let n = k.len();
+        if n == 1 {
+            return k[0].height;
+        }
+        let i = match k.iter().position(|p| p.at > s) {
+            Some(0) | None => n - 1, // before the first or after the last: the wrap-around pair
+            Some(j) => j - 1,
+        };
+        let a = k[i];
+        let b = k[(i + 1) % n];
+        // The gap, measured the way round that actually connects them.
+        let span = if b.at > a.at { b.at - a.at } else { lap - a.at + b.at };
+        if span <= 1e-3 {
+            return b.height;
+        }
+        let along = if s >= a.at { s - a.at } else { lap - a.at + s };
+        a.height + (b.height - a.height) * smoothstep((along / span).clamp(0.0, 1.0))
+    };
+
+    for (i, s) in st.iter().enumerate() {
+        along[i] += at(s.s);
     }
 }
 
@@ -1709,6 +1749,7 @@ mod tests {
             ],
             width: 12.0,
             blend: crate::trackprog::default_blend(),
+            elevation: Vec::new(),
             features: vec![
                 Feature::Tabletop { at: 30.0, length: 22.0, height: 2.4 },
                 Feature::Double { at: 70.0, height: 2.0, gap: 9.0, lip: 6.0 },
@@ -1848,6 +1889,31 @@ mod tests {
 
     /// Rises are cumulative, and nothing should count twice. Two climbs and two drops of the
     /// same size, spread round a lap, has to come out level however many segments carry it.
+    /// A curve drawn by hand lifts the track where its points say, and comes back round to
+    /// meet itself — a lap is a loop, so the last point has to ease into the first.
+    #[test]
+    fn a_drawn_curve_lifts_the_track_where_it_says() {
+        let mut p = oval();
+        p.features.clear();
+        p.terrain.relief.amplitude = 0.0;
+        let lap = p.lap_length();
+        p.elevation = vec![
+            Knot { at: 0.0, height: 0.0 },
+            Knot { at: lap * 0.25, height: 8.0 },
+            Knot { at: lap * 0.5, height: 0.0 },
+            Knot { at: lap * 0.75, height: -4.0 },
+        ];
+        let s = synthesise(&p).unwrap();
+        let ground = height_at_arc(&s, 1.0);
+        let top = height_at_arc(&s, lap * 0.25) - ground;
+        let dip = height_at_arc(&s, lap * 0.75) - ground;
+        assert!((top - 8.0).abs() < 1.2, "the peak reads {top:.2} m, wanted 8");
+        assert!((dip + 4.0).abs() < 1.2, "the dip reads {dip:.2} m, wanted -4");
+        // And across the line, where the wrap has to hold.
+        let before = height_at_arc(&s, lap - 2.0) - ground;
+        assert!(before.abs() < 1.2, "it comes back {before:.2} m off");
+    }
+
     #[test]
     fn climbs_and_drops_cancel_however_many_there_are() {
         let mut p = oval();

--- a/src/Components/Studio/TrackStudio/ElevationCurve.tsx
+++ b/src/Components/Studio/TrackStudio/ElevationCurve.tsx
@@ -1,0 +1,159 @@
+import { useRef, useState } from "react";
+
+import { cn } from "@/lib/utils";
+import { FEATURE_COLOUR, featureSpan, type TrackFeature } from "../../../api/trackgen";
+
+export interface Knot {
+  at: number;
+  height: number;
+}
+
+interface Props {
+  /** Metres round the lap. */
+  lap: number;
+  knots: Knot[];
+  /** Drawn along the bottom, so a hill can be put under a particular jump. */
+  features: TrackFeature[];
+  onChange: (knots: Knot[]) => void;
+  className?: string;
+}
+
+/** Metres shown above and below zero when the curve is flat or nearly so. */
+const MIN_RANGE = 6;
+
+/** How far from a point a click counts as grabbing it rather than adding one. */
+const GRAB_PX = 14;
+
+/**
+ * The track's height along the lap, as a line you can pull about.
+ *
+ * The same shape a run of `rise` values describes, said as a curve instead of as a list of
+ * instructions — which is the form you can take hold of. Drag a point to move it, click the
+ * line to add one, double-click a point to take it away.
+ *
+ * The jumps are drawn along the bottom in their own colours, because "put a hill under the
+ * rhythm section" is the thing this is for, and it can't be done against an empty axis.
+ */
+export default function ElevationCurve({ lap, knots, features, onChange, className }: Props) {
+  const box = useRef<HTMLDivElement>(null);
+  const [dragging, setDragging] = useState<number | null>(null);
+
+  const span = Math.max(
+    MIN_RANGE,
+    ...knots.map((k) => Math.abs(k.height) + 1),
+  );
+  const sorted = [...knots].sort((a, b) => a.at - b.at);
+
+  const toX = (at: number) => (lap > 0 ? (at / lap) * 100 : 0);
+  const toY = (h: number) => 50 - (h / span) * 45;
+
+  /** Where in the lap, and at what height, a pointer is. */
+  function fromPointer(e: React.PointerEvent) {
+    const r = box.current?.getBoundingClientRect();
+    if (!r) return null;
+    const fx = Math.min(Math.max((e.clientX - r.left) / r.width, 0), 1);
+    const fy = Math.min(Math.max((e.clientY - r.top) / r.height, 0), 1);
+    return { at: fx * lap, height: ((0.5 - fy) / 0.45) * span };
+  }
+
+  function onDown(e: React.PointerEvent) {
+    const r = box.current?.getBoundingClientRect();
+    const here = fromPointer(e);
+    if (!r || !here) return;
+    // Nearest point, in pixels — the two axes are on wildly different scales, so metres
+    // would make a point at the far end of a long lap easier to grab than one underfoot.
+    let near = -1;
+    let best = GRAB_PX;
+    sorted.forEach((k, i) => {
+      const dx = (toX(k.at) / 100) * r.width - (e.clientX - r.left);
+      const dy = (toY(k.height) / 100) * r.height - (e.clientY - r.top);
+      const d = Math.hypot(dx, dy);
+      if (d < best) {
+        best = d;
+        near = i;
+      }
+    });
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    if (near >= 0) {
+      setDragging(near);
+      return;
+    }
+    const next = [...sorted, here].sort((a, b) => a.at - b.at);
+    setDragging(next.findIndex((k) => k === here));
+    onChange(next);
+  }
+
+  function onMove(e: React.PointerEvent) {
+    if (dragging === null) return;
+    const here = fromPointer(e);
+    if (!here) return;
+    const next = sorted.map((k, i) => (i === dragging ? here : k));
+    onChange(next);
+  }
+
+  return (
+    <div
+      ref={box}
+      className={cn("relative select-none", className)}
+      onPointerDown={onDown}
+      onPointerMove={onMove}
+      onPointerUp={() => setDragging(null)}
+      onPointerCancel={() => setDragging(null)}
+    >
+      <svg viewBox="0 0 100 100" preserveAspectRatio="none" className="h-full w-full">
+        {/* Ground level, which is what the numbers are relative to. */}
+        <line x1="0" y1="50" x2="100" y2="50" className="stroke-input" strokeWidth="0.4" />
+
+        {/* Where the jumps are, so a hill can be put under one on purpose. */}
+        {features.map((f, i) => {
+          const { length } = featureSpan(f);
+          return (
+            <rect
+              key={i}
+              x={toX(f.at)}
+              y={94}
+              width={Math.max(toX(length), 0.4)}
+              height={5}
+              fill={FEATURE_COLOUR[f.kind]}
+              opacity={0.75}
+            />
+          );
+        })}
+
+        {sorted.length > 0 && (
+          <polyline
+            points={[
+              // Closed round the lap, because that is how it is read: the last point eases
+              // into the first.
+              `0,${toY(sorted[sorted.length - 1].height)}`,
+              ...sorted.map((k) => `${toX(k.at)},${toY(k.height)}`),
+              `100,${toY(sorted[0].height)}`,
+            ].join(" ")}
+            fill="none"
+            className="stroke-primary"
+            strokeWidth="0.8"
+            vectorEffect="non-scaling-stroke"
+          />
+        )}
+      </svg>
+
+      {/* Handles as real elements rather than SVG circles: the viewBox is stretched, which
+          would make them ovals. */}
+      {sorted.map((k, i) => (
+        <button
+          key={i}
+          onDoubleClick={(e) => {
+            e.stopPropagation();
+            onChange(sorted.filter((_, j) => j !== i));
+          }}
+          style={{ left: `${toX(k.at)}%`, top: `${toY(k.height)}%` }}
+          className={cn(
+            "absolute size-2.5 -translate-x-1/2 -translate-y-1/2 cursor-default rounded-full border border-background bg-primary",
+            dragging === i && "ring-2 ring-primary/50",
+          )}
+          title={`${k.at.toFixed(0)} m · ${k.height.toFixed(1)} m`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/Components/Studio/TrackStudio/TrackStudio.tsx
+++ b/src/Components/Studio/TrackStudio/TrackStudio.tsx
@@ -15,6 +15,7 @@ import {
   ChevronRight,
   GripVertical,
   Plus,
+  RefreshCw,
   Waves,
   type LucideIcon,
 } from "lucide-react";
@@ -33,6 +34,8 @@ import {
 import { Button } from "../../ui/button";
 import { Input } from "../../ui/input";
 import { TrackViewer } from "../../Viewer/TrackViewer";
+import ElevationCurve from "./ElevationCurve";
+import { Switch } from "../../ui/switch";
 import { loadTrackOverview, loadTrackTerrain } from "../../../api/tracks";
 import type { TrackOverview, TrackTerrain } from "../../../types";
 import { useT } from "../../../i18n/context";
@@ -53,6 +56,7 @@ import {
   fitFeatures,
   lapSteps,
   newFeature,
+  pathAlong,
   positionAt,
   previewTrack,
   roomiestGap,
@@ -96,7 +100,10 @@ export default function TrackStudio() {
   const [terrain, setTerrain] = useState<TrackTerrain | null>(null);
   const [overview, setOverview] = useState<TrackOverview | null>(null);
   const [focus, setFocus] = useState<{ x: number; z: number } | null>(null);
-  const [hover, setHover] = useState<{ x: number; z: number; width: number } | null>(null);
+  const [hover, setHover] = useState<{
+    path: { x: number; z: number }[];
+    width: number;
+  } | null>(null);
   // Reordering is done with pointer events, not HTML5 drag-and-drop. Tauri's
   // `dragDropEnabled` hands drags to the OS so the webview never sees a dragstart — which is
   // also why the whole-window file dropzone was catching every attempt.
@@ -108,6 +115,10 @@ export default function TrackStudio() {
   // have in their heads.
   const [shut, setShut] = useState<Set<number>>(new Set());
   const [flash, setFlash] = useState<number | null>(null);
+  // Rebuilding a two-thousand-square terrain on every drag is real work, so this is a choice
+  // rather than the default. With it on, an edit settles and then the view catches up.
+  const [live, setLive] = useState(false);
+  const rebuild = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [tools, setTools] = useState<TrackToolsStatus | null>(null);
   const [steps, setSteps] = useState<BuildStep[]>([]);
 
@@ -137,6 +148,12 @@ export default function TrackStudio() {
         }
         setProblems(found.problems);
         setNotes(found.notes);
+        if (live && found.problems.length === 0) {
+          // Debounced: a drag is a hundred edits, and only the last one is worth building.
+          if (rebuild.current) clearTimeout(rebuild.current);
+          const settled = next;
+          rebuild.current = setTimeout(() => void showIn3d(settled).catch(() => {}), 500);
+        }
         return found.problems;
       } catch (e) {
         setProblems([String(e)]);
@@ -144,7 +161,7 @@ export default function TrackStudio() {
         return [String(e)];
       }
     },
-    [],
+    [live],
   );
 
   async function onGenerate() {
@@ -446,6 +463,19 @@ export default function TrackStudio() {
         >
           {busy === "generate" ? t("track.generating") : t("track.generate")}
         </Button>
+        <label className="flex flex-none cursor-default items-center gap-2 pl-1 text-[12.5px] text-muted-foreground">
+          <Switch checked={live} onCheckedChange={setLive} />
+          {t("track.live")}
+          <button
+            onClick={() => void onPreview()}
+            disabled={blocked || busy !== null}
+            title={t("track.rebuild")}
+            aria-label={t("track.rebuild")}
+            className="cursor-default rounded p-1 transition-colors hover:bg-foreground/[0.06] hover:text-foreground disabled:opacity-40"
+          >
+            <RefreshCw className={cn("size-3.5", busy === "preview" && "animate-spin")} />
+          </button>
+        </label>
         {/* Always here, not just when the model is unreachable: starting from a track that
             already works and changing two jumps is a better first move than describing one
             from nothing. */}
@@ -638,9 +668,6 @@ export default function TrackStudio() {
             )}
 
             <div className="mt-auto flex flex-col gap-2">
-              <Button onClick={() => void onPreview()} disabled={blocked || busy !== null}>
-                {busy === "preview" ? t("track.building") : t("track.preview")}
-              </Button>
               <div className="flex gap-2">
                 <Button
                   variant="outline"
@@ -740,13 +767,14 @@ export default function TrackStudio() {
                     onClick={() => setFocus(positionAt(program, step.at))}
                     onPointerEnter={() =>
                       setHover({
-                        // The middle of the feature, not its start — a 40 m berm marked at
-                        // its entry looks like it belongs to the corner before it.
-                        ...positionAt(
+                        // The whole of it, not where it starts: a straight is two hundred
+                        // metres long and its first metre says nothing about which one it is.
+                        path: pathAlong(
                           program,
+                          step.at,
                           step.kind === "feature"
-                            ? step.at + featureSpan(step.feature).length / 2
-                            : step.at,
+                            ? featureSpan(step.feature).length
+                            : stepLength(step),
                         ),
                         width: program.width * 1.6,
                       })
@@ -854,6 +882,23 @@ export default function TrackStudio() {
                 );
               })}
             </ol>
+            {/* The lap's own height, as a line you can pull about — the same shape the
+                segment rises describe, in the form you can take hold of. */}
+            <div className="flex-none border-t border-input px-2 pb-1 pt-1.5">
+              <div className="px-1 text-[10.5px] uppercase tracking-wide text-muted-foreground">
+                {t("track.height")}
+              </div>
+              <ElevationCurve
+                lap={lapLength(program)}
+                knots={program.elevation ?? []}
+                features={program.features}
+                onChange={(elevation) => {
+                  setTouched(true);
+                  void settle({ ...program, elevation });
+                }}
+                className="h-[92px]"
+              />
+            </div>
           </div>
 
           {/* Right: the track itself. Features are painted with a colour each, so a row in
@@ -935,6 +980,15 @@ function stepIcon(step: LapStep): LucideIcon {
   // the one thing that tells them apart.
   if (step.feature.kind === "stepUp" && step.feature.height < 0) return TrendingDown;
   return FEATURE_ICON[step.feature.kind];
+}
+
+/** How much lap a step covers. */
+function stepLength(step: LapStep): number {
+  if (step.kind === "feature") return featureSpan(step.feature).length;
+  const seg = step.segment;
+  return seg.kind === "straight"
+    ? seg.length
+    : (Math.abs(seg.radius) * Math.abs(seg.angle) * Math.PI) / 180;
 }
 
 function stepName(step: LapStep, t: ReturnType<typeof useT>): string {

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -277,27 +277,42 @@ function viewFrame(terrain: TrackTerrain) {
   };
 }
 
-/** A soft column of light over one feature, for pointing at it from a list. */
+/** A standing ribbon over a stretch of track, for pointing at it from a list. */
 function Highlight({
   terrain,
   at,
 }: {
   terrain: TrackTerrain;
-  at: { x: number; z: number; width: number };
+  at: { path: { x: number; z: number }[]; width: number };
 }) {
-  const frame = viewFrame(terrain);
-  const [x, , z] = toView(frame, at.x, terrain.minHeight, at.z);
-  const radius = Math.max((at.width / 2) * frame.unitsPerMetre, 0.05);
-  // Tall enough to clear any relief the terrain has, and centred on the middle of its range
-  // so it reaches both above and below the ground it marks.
-  const tall = (terrain.maxHeight - terrain.minHeight) * frame.heightScale + 4;
+  const geometry = useMemo(() => {
+    const frame = viewFrame(terrain);
+    // Tall enough to clear any relief the terrain has, and reaching below it too, so the
+    // ribbon is visible whether the ground there is high or low.
+    const tall = (terrain.maxHeight - terrain.minHeight) * frame.heightScale + 4;
+    const verts: number[] = [];
+    for (const p of at.path) {
+      const [x, , z] = toView(frame, p.x, terrain.minHeight, p.z);
+      verts.push(x, -tall / 2, z, x, tall / 2, z);
+    }
+    const index: number[] = [];
+    for (let i = 0; i + 1 < at.path.length; i++) {
+      const a = i * 2;
+      index.push(a, a + 1, a + 2, a + 1, a + 3, a + 2);
+    }
+    const g = new THREE.BufferGeometry();
+    g.setAttribute("position", new THREE.Float32BufferAttribute(verts, 3));
+    g.setIndex(index);
+    return g;
+  }, [terrain, at]);
+
+  if (at.path.length < 2) return null;
   return (
-    <mesh position={[x, 0, z]} renderOrder={2}>
-      <cylinderGeometry args={[radius, radius, tall, 24, 1, true]} />
+    <mesh geometry={geometry} renderOrder={2}>
       <meshBasicMaterial
         color="#ffffff"
         transparent
-        opacity={0.16}
+        opacity={0.14}
         depthWrite={false}
         side={THREE.DoubleSide}
       />
@@ -1194,11 +1209,14 @@ interface TrackViewerProps {
    */
   focus?: { x: number; z: number } | null;
   /**
-   * A point to light up, in world metres, and how wide it is. Drawn as a soft column so it
-   * reads from any angle and at any zoom — a highlight painted flat on the ground disappears
-   * the moment the camera is low, which is exactly when you are looking at a jump.
+   * A stretch of track to light up: world-metre points along it, and how wide it is.
+   *
+   * A path rather than a point, because a straight is two hundred metres long and marking
+   * only where it begins says almost nothing about which one it is. Drawn as a standing
+   * ribbon — a highlight painted flat on the ground disappears the moment the camera is low,
+   * which is exactly when you are looking at a jump.
    */
-  highlight?: { x: number; z: number; width: number } | null;
+  highlight?: { path: { x: number; z: number }[]; width: number } | null;
   className?: string;
 }
 

--- a/src/api/trackgen.ts
+++ b/src/api/trackgen.ts
@@ -35,6 +35,11 @@ export interface TrackProgram {
    * question asked three times.
    */
   blend: number;
+  /**
+   * Height the track is lifted or dropped by, at points round the lap. Empty means it simply
+   * follows the ground it crosses.
+   */
+  elevation: { at: number; height: number }[];
 }
 
 export type TrackSegment =
@@ -268,6 +273,19 @@ export function fitFeatures(program: TrackProgram): TrackProgram {
       return { ...f, at: Math.max(0, Math.min(f.at, lap - featureSpan(f).length)) };
     }),
   };
+}
+
+/**
+ * Points along a stretch of the lap, for lighting it up in the preview.
+ *
+ * A stretch, not a point: a straight is two hundred metres long, and marking only where it
+ * starts says almost nothing about which one it is.
+ */
+export function pathAlong(program: TrackProgram, from: number, length: number): { x: number; z: number }[] {
+  const steps = Math.max(2, Math.min(48, Math.ceil(length / 4)));
+  return Array.from({ length: steps + 1 }, (_, i) =>
+    positionAt(program, from + (length * i) / steps),
+  );
 }
 
 /** A feature of each kind, with sizes that sit inside what published tracks measure. */

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -2412,4 +2412,6 @@ export const de: Translation = {
   "track.sand": "Sand",
   "track.grass": "Gras",
   "track.smoothing": "Übergang",
+  "track.live": "Live",
+  "track.rebuild": "Vorschau neu bauen",
 };

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2368,4 +2368,6 @@ export const en = {
   "track.sand": "Sand",
   "track.grass": "Grass",
   "track.smoothing": "blend",
+  "track.live": "Live",
+  "track.rebuild": "Rebuild the preview",
 } as const;

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -2398,4 +2398,6 @@ export const es: Translation = {
   "track.sand": "Arena",
   "track.grass": "Hierba",
   "track.smoothing": "fundido",
+  "track.live": "En vivo",
+  "track.rebuild": "Reconstruir la vista",
 };

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -2403,4 +2403,6 @@ export const fr: Translation = {
   "track.sand": "Sable",
   "track.grass": "Herbe",
   "track.smoothing": "fondu",
+  "track.live": "Direct",
+  "track.rebuild": "Reconstruire l'aperçu",
 };

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -2391,4 +2391,6 @@ export const it: Translation = {
   "track.sand": "Sabbia",
   "track.grass": "Erba",
   "track.smoothing": "raccordo",
+  "track.live": "Dal vivo",
+  "track.rebuild": "Ricostruisci l'anteprima",
 };

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -2388,4 +2388,6 @@ export const ptBR: Translation = {
   "track.sand": "Areia",
   "track.grass": "Grama",
   "track.smoothing": "suavização",
+  "track.live": "Ao vivo",
+  "track.rebuild": "Reconstruir a prévia",
 };


### PR DESCRIPTION
## The shape, as a curve

The track's height was a run of instructions — four metres across this corner, three down that straight. This adds the same shape stated as a **curve**, which is the form you can take hold of.

`elevation` is a list of points round the lap saying how far above the ground the track sits there. Eased between neighbours rather than run straight, so four points are four hills and not four ramps with corners on them — and it **wraps**, because a step across the finish line is the one place a rider would find one.

It's drawn under the lap with the jumps along the bottom in their own colours: "put a hill under the rhythm section" is what this is for, and it can't be done against an empty axis. Drag a point, click the line to add one, double-click to take it away.

## Live, and a rebuild button

Off by default — rebuilding a two-thousand-square terrain on every drag is real work — and debounced, so a drag builds once at the end rather than a hundred times. The **Preview in 3D** button is gone; the toggle and the refresh beside it replace it.

## Hovering lights up the whole step

It marked a single point. A straight is two hundred metres long, and where it begins says almost nothing about which one it is. It's a ribbon following the track now, standing rather than flat — a highlight painted on the ground disappears the moment the camera is low, which is exactly when you're looking at a jump.

## One small thing

The curve's handles are real elements rather than SVG circles: the viewBox is stretched to the strip's shape, which would have drawn them as ovals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)