### PR TITLE
feat(tracks): set the ground height on a feature's own row

### DIFF
--- a/src/Components/Studio/TrackStudio/TrackStudio.tsx
+++ b/src/Components/Studio/TrackStudio/TrackStudio.tsx
@@ -52,12 +52,15 @@ import {
   installTrackPreview,
   lapLength,
   FEATURE_COLOUR,
+  elevationAt,
+  featureMiddle,
   featureSpan,
   fitFeatures,
   lapSteps,
   newFeature,
   pathAlong,
   positionAt,
+  setElevationAt,
   previewTrack,
   roomiestGap,
   setTrackTools,
@@ -397,6 +400,13 @@ export default function TrackStudio() {
     if (!program) return;
     setTouched(true);
     void settle({ ...program, terrain: { ...program.terrain, ...patch } });
+  }
+
+  /** Put the ground under one feature at a given height, by moving the lap's height curve. */
+  function liftFeature(f: TrackFeature, height: number) {
+    if (!program) return;
+    setTouched(true);
+    void settle(setElevationAt(program, featureMiddle(f), height));
   }
 
   function addFeature(kind: TrackFeatureKind) {
@@ -855,14 +865,21 @@ export default function TrackStudio() {
                     )}
 
                     <div className="flex flex-1 flex-wrap items-center gap-x-3 gap-y-1">
-                      {fieldsOf(step).map((f) => (
+                      {fieldsOf(
+                        step,
+                        step.kind === "feature"
+                          ? elevationAt(program, featureMiddle(step.feature))
+                          : undefined,
+                      ).map((f) => (
                         <Field
                           key={f.label}
                           label={f.label}
                           value={f.value}
                           step={f.step}
                           onChange={(v) =>
-                            step.kind === "feature"
+                            f.ground && step.kind === "feature"
+                              ? liftFeature(step.feature, v)
+                              : step.kind === "feature"
                               ? editFeature(step.index, { [f.key]: v } as Partial<TrackFeature>)
                               : editSegment(step.index, {
                                   [f.key]:
@@ -1012,7 +1029,10 @@ function stepName(step: LapStep, t: ReturnType<typeof useT>): string {
  * kind. `rise` is on every segment because "does this bit go up or down" is a question you
  * ask of a straight as often as of a corner.
  */
-function fieldsOf(step: LapStep): { key: string; label: string; value: number; step: number }[] {
+function fieldsOf(
+  step: LapStep,
+  ground?: number,
+): { key: string; label: string; value: number; step: number; ground?: boolean }[] {
   const len = (v: number) => ({ key: "length", label: "m", value: v, step: 1 });
   const rise = (v: number) => ({ key: "rise", label: "↕", value: v, step: 0.5 });
   if (step.kind === "straight") {
@@ -1030,26 +1050,33 @@ function fieldsOf(step: LapStep): { key: string; label: string; value: number; s
     ];
   }
   const f = step.feature;
+  // Where the ground is under this feature, as opposed to how tall the feature is. Every
+  // kind gets one: "this jump is three metres up" is a different question from "this jump is
+  // two metres tall", and both are worth asking of the same row.
+  const up = { key: "ground", label: "↑", value: ground ?? 0, step: 0.5, ground: true };
   switch (f.kind) {
     case "double":
       return [
         { key: "height", label: "h", value: f.height, step: 0.1 },
         { key: "gap", label: "gap", value: f.gap, step: 1 },
         { key: "lip", label: "lip", value: f.lip, step: 0.5 },
+        up,
       ];
     case "whoops":
       return [
         { key: "height", label: "h", value: f.height, step: 0.05 },
         { key: "count", label: "×", value: f.count, step: 1 },
         { key: "spacing", label: "gap", value: f.spacing, step: 0.5 },
+        up,
       ];
     case "rut":
-      return [
-        { key: "depth", label: "deep", value: f.depth, step: 0.05 },
-        len(f.length),
-      ];
+      return [{ key: "depth", label: "deep", value: f.depth, step: 0.05 }, len(f.length), up];
     default:
-      return [{ key: "height", label: "h", value: f.height, step: 0.1 }, len(f.length)];
+      return [
+        { key: "height", label: "h", value: f.height, step: 0.1 },
+        len(f.length),
+        up,
+      ];
   }
 }
 

--- a/src/api/trackgen.ts
+++ b/src/api/trackgen.ts
@@ -276,6 +276,48 @@ export function fitFeatures(program: TrackProgram): TrackProgram {
 }
 
 /**
+ * How high the track sits at a point on the lap, read off the elevation curve.
+ *
+ * The same easing the synthesiser uses — smoothstep between neighbouring points, wrapping
+ * from the last round to the first — so what a row says matches what the ground does.
+ */
+export function elevationAt(program: TrackProgram, s: number): number {
+  const k = [...(program.elevation ?? [])].sort((a, b) => a.at - b.at);
+  if (k.length === 0) return 0;
+  if (k.length === 1) return k[0].height;
+  const lap = lapLength(program);
+  let i = k.findIndex((p) => p.at > s);
+  i = i <= 0 ? k.length - 1 : i - 1;
+  const a = k[i];
+  const b = k[(i + 1) % k.length];
+  const span = b.at > a.at ? b.at - a.at : lap - a.at + b.at;
+  if (span <= 1e-3) return b.height;
+  const along = s >= a.at ? s - a.at : lap - a.at + s;
+  const u = Math.min(Math.max(along / span, 0), 1);
+  return a.height + (b.height - a.height) * (u * u * (3 - 2 * u));
+}
+
+/**
+ * Set the track's height at a point, by putting a curve point there.
+ *
+ * Within a couple of metres of an existing point it moves that one rather than crowding
+ * another in beside it — otherwise nudging a jump's height twice leaves two points fighting
+ * over the same stretch of lap.
+ */
+export function setElevationAt(program: TrackProgram, s: number, height: number): TrackProgram {
+  const knots = [...(program.elevation ?? [])];
+  const near = knots.findIndex((k) => Math.abs(k.at - s) < 2);
+  if (near >= 0) knots[near] = { at: knots[near].at, height };
+  else knots.push({ at: s, height });
+  return { ...program, elevation: knots };
+}
+
+/** The middle of a feature — where its own height point belongs. */
+export function featureMiddle(f: TrackFeature): number {
+  return f.at + featureSpan(f).length / 2;
+}
+
+/**
  * Points along a stretch of the lap, for lighting it up in the preview.
  *
  * A stretch, not a point: a straight is two hundred metres long, and marking only where it


### PR DESCRIPTION
Every feature row gets an `↑` beside its size: how far up the ground is under it.

"This jump is three metres up" is a different question from "this jump is two metres tall", and both are worth asking of the same row.

## No new field

A feature's height *is* a point on the lap's own height curve, sitting at the middle of that feature. So the row and the curve are two views of one thing and can't disagree — setting either moves the other, and both drive the same terrain.

Within a couple of metres of an existing curve point it moves that one rather than crowding another in beside it. Otherwise nudging a jump's height twice leaves two points fighting over the same stretch of lap.

## One curve, two implementations

`elevationAt` mirrors the synthesiser's own easing — smoothstep between neighbours, wrapping from the last point round to the first — so the number in the row is the height the ground actually takes there. The wrap-around branch is the one to watch if either side ever changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)