### PR TITLE
feat(tracks): drag features along the height strip

### DIFF
--- a/src/Components/Studio/TrackStudio/ElevationCurve.tsx
+++ b/src/Components/Studio/TrackStudio/ElevationCurve.tsx
@@ -12,11 +12,24 @@ interface Props {
   /** Metres round the lap. */
   lap: number;
   knots: Knot[];
-  /** Drawn along the bottom, so a hill can be put under a particular jump. */
+  /**
+   * Drawn along the bottom, and draggable there: a feature's position is the one thing about
+   * it that no row can edit, and this is the natural place to say where a jump goes.
+   */
   features: TrackFeature[];
   onChange: (knots: Knot[]) => void;
+  /** Move or resize one feature. Called once, when the drag ends. */
+  onFeature: (index: number, patch: Partial<TrackFeature>) => void;
+  /** Told which feature the pointer is over, for lighting it up in the 3D view. */
+  onHover?: (index: number | null) => void;
   className?: string;
 }
+
+/** How close to a bar's right edge counts as grabbing the edge rather than the bar. */
+const EDGE_PX = 7;
+
+/** The bar row's share of the strip. */
+const BAR_TOP = 88;
 
 /** Metres shown above and below zero when the curve is flat or nearly so. */
 const MIN_RANGE = 6;
@@ -34,12 +47,29 @@ const GRAB_PX = 14;
  * The jumps are drawn along the bottom in their own colours, because "put a hill under the
  * rhythm section" is the thing this is for, and it can't be done against an empty axis.
  */
-export default function ElevationCurve({ lap, knots, features, onChange, className }: Props) {
+export default function ElevationCurve({
+  lap,
+  knots,
+  features,
+  onChange,
+  onFeature,
+  onHover,
+  className,
+}: Props) {
   const box = useRef<HTMLDivElement>(null);
   // The point being dragged, held here rather than pushed upstream on every move: a drag is
   // a hundred events, each of which would otherwise rebuild and re-measure the whole track.
   // The line follows the pointer from this; the program hears about it once, on release.
   const [drag, setDrag] = useState<{ index: number; knot: Knot } | null>(null);
+  // A feature being moved or stretched. Held here for the same reason the curve point is:
+  // a drag is a hundred events and only the last is worth building.
+  const [bar, setBar] = useState<{
+    index: number;
+    edge: boolean;
+    at: number;
+    size: number;
+    grabbed: number;
+  } | null>(null);
 
   const live = drag
     ? knots.map((k, i) => (i === drag.index ? drag.knot : k))
@@ -61,10 +91,41 @@ export default function ElevationCurve({ lap, knots, features, onChange, classNa
     return { at: fx * lap, height: ((0.5 - fy) / 0.45) * span };
   }
 
+  /** The size a bar's right edge controls, which is not `length` for every kind. */
+  function sizeOf(f: TrackFeature): { key: string; value: number } {
+    if (f.kind === "double") return { key: "gap", value: f.gap };
+    if (f.kind === "whoops") return { key: "spacing", value: f.spacing };
+    return { key: "length", value: (f as { length: number }).length };
+  }
+
   function onDown(e: React.PointerEvent) {
     const r = box.current?.getBoundingClientRect();
     const here = fromPointer(e);
     if (!r || !here) return;
+
+    // The bar row first: it sits over the bottom of the curve's area, and a click down there
+    // is far more likely to be aimed at a jump than at the line.
+    if ((e.clientY - r.top) / r.height > BAR_TOP / 100) {
+      const hit = features.findIndex((f) => {
+        const x0 = (f.at / lap) * r.width;
+        const x1 = ((f.at + featureSpan(f).length) / lap) * r.width;
+        const x = e.clientX - r.left;
+        return x >= x0 - 2 && x <= x1 + 2;
+      });
+      if (hit >= 0) {
+        const f = features[hit];
+        const x1 = ((f.at + featureSpan(f).length) / lap) * r.width;
+        (e.target as HTMLElement).setPointerCapture(e.pointerId);
+        setBar({
+          index: hit,
+          edge: Math.abs(e.clientX - r.left - x1) < EDGE_PX,
+          at: f.at,
+          size: sizeOf(f).value,
+          grabbed: here.at,
+        });
+        return;
+      }
+    }
     // Nearest point, in pixels — the two axes are on wildly different scales, so metres
     // would make a point at the far end of a long lap easier to grab than one underfoot.
     let near = -1;
@@ -90,13 +151,41 @@ export default function ElevationCurve({ lap, knots, features, onChange, classNa
   }
 
   function onMove(e: React.PointerEvent) {
-    if (!drag) return;
     const here = fromPointer(e);
-    if (here) setDrag({ ...drag, knot: here });
+    if (!here) return;
+    if (bar) {
+      const moved = here.at - bar.grabbed;
+      setBar(
+        bar.edge
+          ? { ...bar, size: Math.max(2, bar.size + moved), grabbed: here.at }
+          : {
+              ...bar,
+              // Kept inside the lap while dragging rather than clamped afterwards, so the
+              // bar goes where the pointer does right up to the line and then stops.
+              at: Math.min(
+                Math.max(0, bar.at + moved),
+                Math.max(0, lap - featureSpan(features[bar.index]).length),
+              ),
+              grabbed: here.at,
+            },
+      );
+      return;
+    }
+    if (drag) setDrag({ ...drag, knot: here });
   }
 
   function onUp() {
+    if (bar) {
+      const f = features[bar.index];
+      onFeature(
+        bar.index,
+        (bar.edge
+          ? { [sizeOf(f).key]: bar.size }
+          : { at: bar.at }) as Partial<TrackFeature>,
+      );
+    }
     if (drag) onChange(knots.map((k, i) => (i === drag.index ? drag.knot : k)));
+    setBar(null);
     setDrag(null);
   }
 
@@ -115,16 +204,21 @@ export default function ElevationCurve({ lap, knots, features, onChange, classNa
 
         {/* Where the jumps are, so a hill can be put under one on purpose. */}
         {features.map((f, i) => {
-          const { length } = featureSpan(f);
+          const live = bar?.index === i ? bar : null;
+          const at = live ? live.at : f.at;
+          const length = live && live.edge ? featureSpan({ ...f, [sizeOf(f).key]: live.size } as TrackFeature).length : featureSpan(f).length;
           return (
             <rect
               key={i}
-              x={toX(f.at)}
-              y={94}
+              x={toX(at)}
+              y={BAR_TOP + 6}
               width={Math.max(toX(length), 0.4)}
               height={5}
               fill={FEATURE_COLOUR[f.kind]}
-              opacity={0.75}
+              opacity={bar?.index === i ? 1 : 0.75}
+              onPointerEnter={() => onHover?.(i)}
+              onPointerLeave={() => onHover?.(null)}
+              style={{ cursor: "ew-resize" }}
             />
           );
         })}

--- a/src/Components/Studio/TrackStudio/TrackStudio.tsx
+++ b/src/Components/Studio/TrackStudio/TrackStudio.tsx
@@ -919,7 +919,22 @@ export default function TrackStudio() {
                   setTouched(true);
                   void settle({ ...program, elevation });
                 }}
-                className="h-[92px]"
+                onFeature={editFeature}
+                onHover={(i) =>
+                  setHover(
+                    i === null
+                      ? null
+                      : {
+                          path: pathAlong(
+                            program,
+                            program.features[i].at,
+                            featureSpan(program.features[i]).length,
+                          ),
+                          width: program.width * 1.6,
+                        },
+                  )
+                }
+                className="h-[104px]"
               />
             </div>
           </div>


### PR DESCRIPTION
The strip under the lap was a picture with the jumps drawn on it. It's a **timeline** now: drag a bar to move a jump along the lap, drag its right edge to stretch it, hover it to light that feature up in the 3D view.

## This closes the gap behind a run of dead-end errors

A feature's *position* was the one thing about it no editor could change — not the row, not the list. So "the berm at 603 m is on a straight" and "it ends past the finish" could both be true with nothing to do about them but delete the jump. Every one of those clamps I added was papering over the missing control.

## Details

- **The edge drags whatever size that kind actually has**: `length` for most, `gap` for a double, `spacing` for a whoop section. Dragging a double's edge and getting a longer takeoff would be a lie about what the bar shows.
- **Kept inside the lap while dragging** rather than clamped after, so the bar follows the pointer right up to the line and then stops.
- Like the curve points, a drag is held locally and the track hears about it once, on release — a drag is a hundred events and only the last is worth building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)