### PR TITLE
feat(tracks): shape the height of one corner or straight at a time

### DIFF
--- a/src/Components/Studio/TrackStudio/ElevationCurve.tsx
+++ b/src/Components/Studio/TrackStudio/ElevationCurve.tsx
@@ -11,6 +11,15 @@ export interface Knot {
 interface Props {
   /** Metres round the lap. */
   lap: number;
+  /**
+   * The stretch of lap on screen, in metres. Defaults to all of it.
+   *
+   * Scoping this to one corner or one straight is the difference between a curve you can
+   * shape and a curve you can only wave at: on a 1500 m lap, a 40 m berm is three pixels
+   * wide and every point you place lands on top of the last.
+   */
+  from?: number;
+  to?: number;
   knots: Knot[];
   /**
    * Drawn along the bottom, and draggable there: a feature's position is the one thing about
@@ -31,6 +40,27 @@ const EDGE_PX = 7;
 /** The bar row's share of the strip. */
 const BAR_TOP = 88;
 
+/**
+ * The curve's height at a point, easing between neighbours and wrapping round the lap.
+ *
+ * The same shape `apply_elevation` builds in the synthesiser and `elevationAt` reads in the
+ * api — three copies of one curve, which is two more than anybody wants, but drawing it here
+ * from the same rule is what stops the picture disagreeing with the ground.
+ */
+function heightAt(sorted: Knot[], s: number, lap: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0].height;
+  let i = sorted.findIndex((p) => p.at > s);
+  i = i <= 0 ? sorted.length - 1 : i - 1;
+  const a = sorted[i];
+  const b = sorted[(i + 1) % sorted.length];
+  const span = b.at > a.at ? b.at - a.at : lap - a.at + b.at;
+  if (span <= 1e-3) return b.height;
+  const along = s >= a.at ? s - a.at : lap - a.at + s;
+  const u = Math.min(Math.max(along / span, 0), 1);
+  return a.height + (b.height - a.height) * (u * u * (3 - 2 * u));
+}
+
 /** Metres shown above and below zero when the curve is flat or nearly so. */
 const MIN_RANGE = 6;
 
@@ -49,6 +79,8 @@ const GRAB_PX = 14;
  */
 export default function ElevationCurve({
   lap,
+  from = 0,
+  to,
   knots,
   features,
   onChange,
@@ -61,6 +93,8 @@ export default function ElevationCurve({
   // a hundred events, each of which would otherwise rebuild and re-measure the whole track.
   // The line follows the pointer from this; the program hears about it once, on release.
   const [drag, setDrag] = useState<{ index: number; knot: Knot } | null>(null);
+  const end = to ?? lap;
+  const width = Math.max(end - from, 1);
   // A feature being moved or stretched. Held here for the same reason the curve point is:
   // a drag is a hundred events and only the last is worth building.
   const [bar, setBar] = useState<{
@@ -79,7 +113,7 @@ export default function ElevationCurve({
   // neighbour doesn't renumber the thing under the pointer and swap which one you are moving.
   const sorted = [...live].sort((a, b) => a.at - b.at);
 
-  const toX = (at: number) => (lap > 0 ? (at / lap) * 100 : 0);
+  const toX = (at: number) => ((at - from) / width) * 100;
   const toY = (h: number) => 50 - (h / span) * 45;
 
   /** Where in the lap, and at what height, a pointer is. */
@@ -88,7 +122,7 @@ export default function ElevationCurve({
     if (!r) return null;
     const fx = Math.min(Math.max((e.clientX - r.left) / r.width, 0), 1);
     const fy = Math.min(Math.max((e.clientY - r.top) / r.height, 0), 1);
-    return { at: fx * lap, height: ((0.5 - fy) / 0.45) * span };
+    return { at: from + fx * width, height: ((0.5 - fy) / 0.45) * span };
   }
 
   /** The size a bar's right edge controls, which is not `length` for every kind. */
@@ -107,8 +141,8 @@ export default function ElevationCurve({
     // is far more likely to be aimed at a jump than at the line.
     if ((e.clientY - r.top) / r.height > BAR_TOP / 100) {
       const hit = features.findIndex((f) => {
-        const x0 = (f.at / lap) * r.width;
-        const x1 = ((f.at + featureSpan(f).length) / lap) * r.width;
+        const x0 = ((f.at - from) / width) * r.width;
+        const x1 = ((f.at + featureSpan(f).length - from) / width) * r.width;
         const x = e.clientX - r.left;
         return x >= x0 - 2 && x <= x1 + 2;
       });
@@ -226,11 +260,13 @@ export default function ElevationCurve({
         {sorted.length > 0 && (
           <polyline
             points={[
-              // Closed round the lap, because that is how it is read: the last point eases
-              // into the first.
-              `0,${toY(sorted[sorted.length - 1].height)}`,
-              ...sorted.map((k) => `${toX(k.at)},${toY(k.height)}`),
-              `100,${toY(sorted[0].height)}`,
+              // Sampled across the view rather than drawn point to point, so the line shows
+              // the easing the terrain actually takes — and so a view holding no points at
+              // all still shows the height it inherits from its neighbours.
+              ...Array.from({ length: 65 }, (_, i) => {
+                const at = from + (width * i) / 64;
+                return `${(i / 64) * 100},${toY(heightAt(sorted, at, lap))}`;
+              }),
             ].join(" ")}
             fill="none"
             className="stroke-primary"
@@ -243,6 +279,7 @@ export default function ElevationCurve({
       {/* Handles as real elements rather than SVG circles: the viewBox is stretched, which
           would make them ovals. */}
       {live.map((k, i) => (
+        k.at < from - 0.5 || k.at > end + 0.5 ? null : (
         <button
           key={i}
           onDoubleClick={(e) => {
@@ -256,6 +293,7 @@ export default function ElevationCurve({
           )}
           title={`${k.at.toFixed(0)} m · ${k.height.toFixed(1)} m`}
         />
+        )
       ))}
     </div>
   );

--- a/src/Components/Studio/TrackStudio/TrackStudio.tsx
+++ b/src/Components/Studio/TrackStudio/TrackStudio.tsx
@@ -118,6 +118,9 @@ export default function TrackStudio() {
   // have in their heads.
   const [shut, setShut] = useState<Set<number>>(new Set());
   const [flash, setFlash] = useState<number | null>(null);
+  // Which row the height strip is showing. A corner or a straight at a time, because on a
+  // 1500 m lap a 40 m berm is three pixels wide and every point lands on the last one.
+  const [scope, setScope] = useState<number | null>(null);
   // Rebuilding a two-thousand-square terrain on every drag is real work, so this is a choice
   // rather than the default. With it on, an edit settles and then the view catches up.
   const [live, setLive] = useState(false);
@@ -780,7 +783,10 @@ export default function TrackStudio() {
                     key={row}
                     data-step={row}
                     data-at={step.at}
-                    onClick={() => setFocus(positionAt(program, step.at))}
+                    onClick={() => {
+                      setScope(row);
+                      setFocus(positionAt(program, step.at));
+                    }}
                     onPointerEnter={() =>
                       setHover({
                         // The whole of it, not where it starts: a straight is two hundred
@@ -802,6 +808,7 @@ export default function TrackStudio() {
                       dragging === row && "opacity-40",
                       // The line lands above this row when it is the drop target, and below
                       // the last one when the drop is past the end.
+                      scope === row && "bg-foreground/[0.06]",
                       dropAt === row && "before:absolute before:inset-x-2 before:top-0 before:h-0.5 before:bg-primary",
                       dropAt === steps.length &&
                         row === steps.length - 1 &&
@@ -908,11 +915,36 @@ export default function TrackStudio() {
             {/* The lap's own height, as a line you can pull about — the same shape the
                 segment rises describe, in the form you can take hold of. */}
             <div className="flex-none border-t border-input px-2 pb-1 pt-1.5">
-              <div className="px-1 text-[10.5px] uppercase tracking-wide text-muted-foreground">
-                {t("track.height")}
+              <div className="flex items-center gap-2 px-1 text-[10.5px] uppercase tracking-wide text-muted-foreground">
+                <span>{t("track.height")}</span>
+                {(() => {
+                  const steps = lapSteps(program);
+                  const on = scope !== null ? steps[scope] : undefined;
+                  return on ? (
+                    <button
+                      onClick={() => setScope(null)}
+                      className="cursor-default rounded px-1 normal-case tracking-normal text-foreground hover:bg-foreground/[0.06]"
+                      title={t("track.wholeLap")}
+                    >
+                      {stepName(on, t)} · {on.at.toFixed(0)}–
+                      {(on.at + stepLength(on)).toFixed(0)} m ×
+                    </button>
+                  ) : (
+                    <span className="normal-case tracking-normal">{t("track.wholeLap")}</span>
+                  );
+                })()}
               </div>
               <ElevationCurve
                 lap={lapLength(program)}
+                {...(() => {
+                  const steps = lapSteps(program);
+                  const on = scope !== null ? steps[scope] : undefined;
+                  if (!on) return {};
+                  // A little either side, so the ends of the stretch can be shaped against
+                  // what they run into rather than against the edge of the picture.
+                  const pad = Math.max(stepLength(on) * 0.15, 5);
+                  return { from: Math.max(0, on.at - pad), to: on.at + stepLength(on) + pad };
+                })()}
                 knots={program.elevation ?? []}
                 features={program.features}
                 onChange={(elevation) => {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -2420,4 +2420,5 @@ export const de: Translation = {
   "track.smoothing": "Übergang",
   "track.live": "Live",
   "track.rebuild": "Vorschau neu bauen",
+  "track.wholeLap": "ganze Runde",
 };

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2376,4 +2376,5 @@ export const en = {
   "track.smoothing": "blend",
   "track.live": "Live",
   "track.rebuild": "Rebuild the preview",
+  "track.wholeLap": "whole lap",
 } as const;

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -2406,4 +2406,5 @@ export const es: Translation = {
   "track.smoothing": "fundido",
   "track.live": "En vivo",
   "track.rebuild": "Reconstruir la vista",
+  "track.wholeLap": "vuelta entera",
 };

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -2411,4 +2411,5 @@ export const fr: Translation = {
   "track.smoothing": "fondu",
   "track.live": "Direct",
   "track.rebuild": "Reconstruire l'aperçu",
+  "track.wholeLap": "tour entier",
 };

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -2399,4 +2399,5 @@ export const it: Translation = {
   "track.smoothing": "raccordo",
   "track.live": "Dal vivo",
   "track.rebuild": "Ricostruisci l'anteprima",
+  "track.wholeLap": "giro intero",
 };

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -2396,4 +2396,5 @@ export const ptBR: Translation = {
   "track.smoothing": "suavização",
   "track.live": "Ao vivo",
   "track.rebuild": "Reconstruir a prévia",
+  "track.wholeLap": "volta inteira",
 };


### PR DESCRIPTION
The strip was the whole lap, always. On a 1500 m track a 40 m berm is **three pixels wide** and every point you place lands on top of the last, so it could only ever be waved at.

Clicking a row scopes it to that step — the corner, the straight, the jump — with a little either side, so the ends of a stretch can be shaped against what they run into rather than against the edge of the picture. The header says which one you're in and clears back to the whole lap.

## The line is sampled, not joined

It's drawn by sampling the curve across the view rather than by joining the points. Two reasons: it shows the easing the terrain actually takes, and **a stretch holding no points of its own still shows the height it inherits from its neighbours** — which is the thing you're shaping against.

## One thing I'm not happy about

That easing now exists three times: in the synthesiser, in the api for the per-feature field, and here for the drawing. Two more than anyone wants. I kept them identical deliberately — a picture drawn from a different rule than the ground is worse than a duplicated function — but it's the obvious place for these to drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)