### PR TITLE
chore(release): v0.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2026-08-31 — v0.12.4 — Paint sync, on every server
 
 ### Added
 - Paint sync works on any server, not just ours. The app reads the server name out of the
@@ -9,9 +9,14 @@
 - No invite code. The app signs itself up the first time sync runs, the same way voice does.
 - Paint sync is on by default, with a switch in Settings → General to turn it off.
 - Starting the game from Steam or a shortcut now syncs too. Only the Play button did before.
+- A feature's ground height is set on its own row in the track editor.
+- Features can be dragged along the height strip.
 
 ### Changed
 - The sync line in the sidebar is no longer behind the experimental toggle.
+- The Manage tab is called Race mode, which is what its own help text has always called it.
+- Join server only appears when there are servers to list. Until the app can read the
+  game's own browser, an empty list behind a button is worse than no button.
 - Paint sync has its own Settings page — what it published, what it pulled, your GUID, and
   any paint it declined to overwrite. It used to live on the Servers tab.
 
@@ -19,6 +24,7 @@
 - The Servers tab, and the experimental toggle that revealed it. Creating and hosting
   servers is out of the app for now. Joining one by address is unaffected and no longer
   hidden.
+
 ## 2026-08-31 — v0.12.3
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.12.3",
+  "version": "0.12.4",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "mxb-app"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # whatever cargo called it. Cargo target names can't hold a space, so this is as close as
 # it gets. The description is what Windows Task Manager shows in its Processes tab.
 name = "mxb-app"
-version = "0.12.3"
+version = "0.12.4"
 description = "MXB App — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
   "mainBinaryName": "MXB App",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/Components/Shell/Sidebar.tsx
+++ b/src/Components/Shell/Sidebar.tsx
@@ -32,6 +32,7 @@ import { useDownloads } from "../../Context/Downloads";
 import { useT, type TKey } from "../../i18n/context";
 import {
   experimentalState,
+  cpServers,
   launchGame,
   onSyncEvent,
   type ExperimentalState,
@@ -299,6 +300,19 @@ export default function Sidebar({ view, studioTab, onNavigate }: SidebarProps) {
   }, []);
   useEffect(readExperimental, [readExperimental, view]);
 
+  // Whether there is anywhere to join. The dialog can only offer servers the control plane
+  // knows about, and the real list — the one the game's own browser shows — comes from
+  // PiBoSo's master server, which we cannot read yet (see `tasks/mxb-server-browser.md`).
+  // A button that opens onto an empty list and an IP box is worse than no button, so it
+  // waits until there is something behind it. When the public browser lands, this gate is
+  // what brings the button back on its own.
+  const [joinable, setJoinable] = useState(false);
+  useEffect(() => {
+    cpServers()
+      .then((list) => setJoinable(list.length > 0))
+      .catch(() => setJoinable(false));
+  }, [view]);
+
   // Follow the background work as it happens, and re-read the record it leaves behind.
   useEffect(() => {
     const pending = onSyncEvent((e) => {
@@ -478,10 +492,11 @@ export default function Sidebar({ view, studioTab, onNavigate }: SidebarProps) {
         </button>
 
         {/* Join-by-address launches the game with `-directconnect`. Joining a server is not
-            hosting one, so it is not hidden with the server-creation surface. Capability-
-            gated — both the argv parser offset it was found at and the default port it
-            assumes are MX Bikes', so it waits until GP's are confirmed. */}
-        {!collapsed && caps.joinByAddress && (
+            hosting one, so it is not hidden with the server-creation surface — but it only
+            appears when there is a real list to show. Capability-gated too: both the argv
+            parser offset it was found at and the default port it assumes are MX Bikes', so
+            it waits until GP's are confirmed. */}
+        {!collapsed && joinable && caps.joinByAddress && (
         <>
         <button
           onClick={() => setJoinOpen(true)}

--- a/src/Components/Showcase/releases.ts
+++ b/src/Components/Showcase/releases.ts
@@ -49,6 +49,11 @@ import {
   Undo2,
   ShieldAlert,
   SwatchBook,
+  Shirt,
+  Globe,
+  Zap,
+  Users,
+  SlidersHorizontal,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { TKey } from "../../i18n/context";
@@ -75,6 +80,20 @@ export interface Release {
 }
 
 export const RELEASES: Release[] = [
+  {
+    version: "0.12.4",
+    hero: {
+      icon: Shirt,
+      title: "showcase.v0124.hero.title",
+      body: "showcase.v0124.hero.body",
+    },
+    highlights: [
+      { icon: Globe, text: "showcase.v0124.anyserver" },
+      { icon: Zap, text: "showcase.v0124.nosetup" },
+      { icon: Users, text: "showcase.v0124.everyone" },
+      { icon: SlidersHorizontal, text: "showcase.v0124.settings" },
+    ],
+  },
   {
     version: "0.12.2",
     hero: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -61,7 +61,7 @@ export const de: Translation = {
   "nav.paints": "Designs",
   "nav.studio": "Studio",
   "nav.servers": "Server",
-  "nav.manage": "Verwalten",
+  "nav.manage": "Rennmodus",
   "nav.settings": "Einstellungen",
 
   "sidebar.installing": "„{{name}}“ wird installiert",
@@ -1591,6 +1591,18 @@ export const de: Translation = {
   "showcase.supporters.title_one": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.title_other": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.more": "+{{count}} weitere",
+  "showcase.v0124.hero.title":
+    "Jeder im Starterfeld in der Lackierung, die er wirklich gewählt hat",
+  "showcase.v0124.hero.body":
+    "MX Bikes überträgt keine eigenen Inhalte, also war ein Lobby voller Fremder immer ein Lobby voller Standard-Lackierungen. MXB App teilt jetzt, was du trägst, mit den Fahrern um dich herum und installiert deren Lackierungen — auf jedem Server, ohne Zutun des Hosts und ohne Code.",
+  "showcase.v0124.anyserver":
+    "Jeder Server, nicht nur unsere. Die App liest den Server aus dem laufenden Spiel, also funktioniert eine öffentliche Lobby genau wie eine private.",
+  "showcase.v0124.nosetup":
+    "Nichts einzurichten. Kein Einladungscode, keine Anmeldung, keine Server-Installation — Spiel starten, fertig.",
+  "showcase.v0124.everyone":
+    "Du siehst jeden Fahrer, der ebenfalls MXB App hat. Je mehr in deiner Lobby, desto mehr vom Feld sieht richtig aus.",
+  "showcase.v0124.settings":
+    "Einstellungen → Lackierungs-Sync zeigt, was rausging, was ankam und welche Lackierung nicht überschrieben wurde. Der Schalter zum Abschalten sitzt unter Allgemein.",
   "showcase.v0122.hero.title":
     "Die Replay-Kamera kann dem Fahrer folgen",
   "showcase.v0122.hero.body":

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -55,7 +55,7 @@ export const en = {
   "nav.paints": "Paints",
   "nav.studio": "Studio",
   "nav.servers": "Servers",
-  "nav.manage": "Manage",
+  "nav.manage": "Race mode",
   "nav.settings": "Settings",
 
   "sidebar.installing": "Installing “{{name}}”",
@@ -1552,6 +1552,18 @@ export const en = {
   "showcase.supporters.title_one": "Made possible by {{count}} supporter",
   "showcase.supporters.title_other": "Made possible by {{count}} supporters",
   "showcase.supporters.more": "+{{count}} more",
+  "showcase.v0124.hero.title":
+    "Everyone on the grid, in the paint they actually chose",
+  "showcase.v0124.hero.body":
+    "MX Bikes sends no custom content, so a lobby of strangers has always been a lobby of default liveries. MXB App now shares what you're wearing with the riders around you and installs theirs — on any server, with nothing for the host to do and no code to enter.",
+  "showcase.v0124.anyserver":
+    "Any server, not just ours. The app reads the server from the running game, so a public lobby works exactly like a private one.",
+  "showcase.v0124.nosetup":
+    "Nothing to set up. No invite code, no sign-up, no server-side install — start the game and it goes.",
+  "showcase.v0124.everyone":
+    "You'll see any rider who also has MXB App. The more of your lobby that does, the more of the grid looks right.",
+  "showcase.v0124.settings":
+    "Settings → Paint sync shows what went out, what came back, and any paint it refused to overwrite. The switch to turn it off is in General.",
   "showcase.v0122.hero.title":
     "The replay camera can follow the rider",
   "showcase.v0122.hero.body":

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -56,7 +56,7 @@ export const es: Translation = {
   "nav.paints": "Pinturas",
   "nav.studio": "Studio",
   "nav.servers": "Servidores",
-  "nav.manage": "Gestionar",
+  "nav.manage": "Modo carrera",
   "nav.settings": "Ajustes",
 
   "sidebar.installing": "Instalando «{{name}}»",
@@ -1578,6 +1578,18 @@ export const es: Translation = {
   "showcase.supporters.title_one": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.title_other": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.more": "+{{count}} más",
+  "showcase.v0124.hero.title":
+    "Toda la parrilla con la pintura que de verdad eligió",
+  "showcase.v0124.hero.body":
+    "MX Bikes no envía contenido personalizado, así que una sala de desconocidos siempre ha sido una sala de libreas por defecto. MXB App ahora comparte lo que llevas con los pilotos que te rodean e instala las suyas — en cualquier servidor, sin que el anfitrión haga nada y sin códigos.",
+  "showcase.v0124.anyserver":
+    "Cualquier servidor, no solo los nuestros. La app lee el servidor del juego en marcha, así que una sala pública funciona igual que una privada.",
+  "showcase.v0124.nosetup":
+    "Nada que configurar. Sin código de invitación, sin registro, sin instalar nada en el servidor — abre el juego y ya está.",
+  "showcase.v0124.everyone":
+    "Verás a cualquier piloto que también tenga MXB App. Cuantos más haya en tu sala, más parrilla se ve como debe.",
+  "showcase.v0124.settings":
+    "Ajustes → Sincronización de pinturas muestra qué salió, qué llegó y cualquier pintura que se negó a sobrescribir. El interruptor está en General.",
   "showcase.v0122.hero.title":
     "La cámara de repetición puede seguir al piloto",
   "showcase.v0122.hero.body":

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -58,7 +58,7 @@ export const fr: Translation = {
   "nav.paints": "Décos",
   "nav.studio": "Studio",
   "nav.servers": "Serveurs",
-  "nav.manage": "Gérer",
+  "nav.manage": "Mode course",
   "nav.settings": "Réglages",
 
   "sidebar.installing": "Installation de « {{name}} »",
@@ -1582,6 +1582,18 @@ export const fr: Translation = {
   "showcase.supporters.title_one": "Rendu possible par {{count}} soutien",
   "showcase.supporters.title_other": "Rendu possible par {{count}} soutiens",
   "showcase.supporters.more": "+{{count}} autres",
+  "showcase.v0124.hero.title":
+    "Toute la grille dans la peinture qu'elle a vraiment choisie",
+  "showcase.v0124.hero.body":
+    "MX Bikes ne transmet aucun contenu personnalisé : un lobby d'inconnus a toujours été un lobby de livrées par défaut. MXB App partage désormais ce que vous portez avec les pilotes autour de vous et installe les leurs — sur n'importe quel serveur, sans rien à faire côté hébergeur et sans code à saisir.",
+  "showcase.v0124.anyserver":
+    "N'importe quel serveur, pas seulement les nôtres. L'app lit le serveur depuis le jeu en cours, donc un lobby public fonctionne comme un lobby privé.",
+  "showcase.v0124.nosetup":
+    "Rien à configurer. Pas de code d'invitation, pas d'inscription, rien à installer côté serveur — lancez le jeu et c'est parti.",
+  "showcase.v0124.everyone":
+    "Vous verrez tout pilote qui a aussi MXB App. Plus votre lobby en compte, plus la grille est correcte.",
+  "showcase.v0124.settings":
+    "Paramètres → Synchro des peintures montre ce qui est parti, ce qui est arrivé, et toute peinture qu'elle a refusé d'écraser. L'interrupteur est dans Général.",
   "showcase.v0122.hero.title":
     "La caméra replay peut suivre le pilote",
   "showcase.v0122.hero.body":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -56,7 +56,7 @@ export const it: Translation = {
   "nav.paints": "Livree",
   "nav.studio": "Studio",
   "nav.servers": "Server",
-  "nav.manage": "Gestisci",
+  "nav.manage": "Modalità gara",
   "nav.settings": "Impostazioni",
 
   "sidebar.installing": "Installazione di “{{name}}”",
@@ -1573,6 +1573,18 @@ export const it: Translation = {
   "showcase.supporters.title_one": "Reso possibile da {{count}} sostenitore",
   "showcase.supporters.title_other": "Reso possibile da {{count}} sostenitori",
   "showcase.supporters.more": "+{{count}} altri",
+  "showcase.v0124.hero.title":
+    "Tutta la griglia con la livrea che ha davvero scelto",
+  "showcase.v0124.hero.body":
+    "MX Bikes non trasmette contenuti personalizzati, quindi una lobby di sconosciuti è sempre stata una lobby di livree predefinite. MXB App ora condivide quello che indossi con i piloti attorno a te e installa le loro — su qualsiasi server, senza nulla da fare per l'host e senza codici.",
+  "showcase.v0124.anyserver":
+    "Qualsiasi server, non solo i nostri. L'app legge il server dal gioco in esecuzione, così una lobby pubblica funziona come una privata.",
+  "showcase.v0124.nosetup":
+    "Niente da configurare. Nessun codice d'invito, nessuna registrazione, niente da installare sul server — avvia il gioco e parte.",
+  "showcase.v0124.everyone":
+    "Vedrai ogni pilota che ha anch'esso MXB App. Più ce ne sono nella tua lobby, più la griglia appare giusta.",
+  "showcase.v0124.settings":
+    "Impostazioni → Sincronizzazione livree mostra cosa è uscito, cosa è arrivato e ogni livrea che ha rifiutato di sovrascrivere. L'interruttore è in Generali.",
   "showcase.v0122.hero.title":
     "La telecamera replay può seguire il pilota",
   "showcase.v0122.hero.body":

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -59,7 +59,7 @@ export const ptBR: Translation = {
   "nav.paints": "Pinturas",
   "nav.studio": "Studio",
   "nav.servers": "Servidores",
-  "nav.manage": "Gerenciar",
+  "nav.manage": "Modo corrida",
   "nav.settings": "Configurações",
 
   "sidebar.installing": "Instalando “{{name}}”",
@@ -1571,6 +1571,18 @@ export const ptBR: Translation = {
   "showcase.supporters.title_one": "Possível graças a {{count}} apoiador",
   "showcase.supporters.title_other": "Possível graças a {{count}} apoiadores",
   "showcase.supporters.more": "+{{count}} outros",
+  "showcase.v0124.hero.title":
+    "Todo o grid com a pintura que realmente escolheu",
+  "showcase.v0124.hero.body":
+    "O MX Bikes não envia conteúdo personalizado, então uma sala de desconhecidos sempre foi uma sala de pinturas padrão. O MXB App agora compartilha o que você está usando com os pilotos ao seu redor e instala as deles — em qualquer servidor, sem nada a fazer para o host e sem código.",
+  "showcase.v0124.anyserver":
+    "Qualquer servidor, não só os nossos. O app lê o servidor do jogo em execução, então uma sala pública funciona igual a uma privada.",
+  "showcase.v0124.nosetup":
+    "Nada para configurar. Sem código de convite, sem cadastro, sem instalar nada no servidor — abra o jogo e pronto.",
+  "showcase.v0124.everyone":
+    "Você verá qualquer piloto que também tenha o MXB App. Quanto mais gente na sua sala tiver, mais o grid fica certo.",
+  "showcase.v0124.settings":
+    "Configurações → Sincronização de pinturas mostra o que saiu, o que chegou e qualquer pintura que ela recusou sobrescrever. O interruptor fica em Geral.",
   "showcase.v0122.hero.title":
     "A câmera de replay pode seguir o piloto",
   "showcase.v0122.hero.body":


### PR DESCRIPTION
Version bump, consolidated changelog, and the What's new entry for 0.12.4.

Also folds in two small UI changes asked for alongside the release:

- **Join server** only appears when there is a list to show. It offers the control plane's registry, which is empty now that server creation is out of the app; the real list is PiBoSo's master server, which needs a login we do not have. The gate is on the list rather than a flag, so the button returns by itself the day that browser works.
- **Manage → Race mode.** The page's own help text already said "hit Race mode".

Two track-editor changes from #294 and #295 had landed with no changelog entry and are now written up — they would have shipped silently.

Release notes render: `scripts/changelog-section.sh v0.12.4 --heading` prints.

**Do not tag until the control plane is deployed** — the invite gate is server-side, and an app that ships ahead of it gets 403 on publish and roster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)