### PR TITLE
feat(tracks): edit a step's numbers by dragging its shape

### DIFF
--- a/src/Components/Studio/TrackStudio/ElevationCurve.tsx
+++ b/src/Components/Studio/TrackStudio/ElevationCurve.tsx
@@ -1,12 +1,36 @@
 import { useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
-import { FEATURE_COLOUR, featureSpan, type TrackFeature } from "../../../api/trackgen";
+import {
+  FEATURE_COLOUR,
+  featureSpan,
+  type TrackFeature,
+  type TrackSegment,
+} from "../../../api/trackgen";
 
 export interface Knot {
   at: number;
   height: number;
 }
+
+export interface Scoped {
+  at: number;
+  feature?: TrackFeature;
+  segment?: TrackSegment;
+}
+
+/** A draggable number on the strip: where it sits, and what moving it changes. */
+interface Handle {
+  at: number;
+  height: number;
+  /** Metres of lap per metre dragged sideways, and which key that writes. */
+  x?: { key: string; from: number };
+  y?: { key: string; from: number };
+  label: string;
+}
+
+/** Within this many metres of the ground line, a drag lands on it exactly. */
+const SNAP_M = 0.35;
 
 interface Props {
   /** Metres round the lap. */
@@ -31,6 +55,13 @@ interface Props {
   onFeature: (index: number, patch: Partial<TrackFeature>) => void;
   /** Told which feature the pointer is over, for lighting it up in the 3D view. */
   onHover?: (index: number | null) => void;
+  /**
+   * The step the strip is scoped to, drawn as its own shape with handles on its numbers —
+   * a double's takeoff and gap, a tabletop's height and length, a straight's climb.
+   */
+  scoped?: Scoped | null;
+  /** One of the scoped step's numbers, changed. Called once, on release. */
+  onScoped?: (patch: Record<string, number>) => void;
   className?: string;
 }
 
@@ -39,6 +70,100 @@ const EDGE_PX = 7;
 
 /** The bar row's share of the strip. */
 const BAR_TOP = 88;
+
+/**
+ * The numbers of a step, as points you can pull.
+ *
+ * Deliberately a handful rather than the whole shape: a double is a takeoff, a gap and a
+ * landing, and those are the three things worth taking hold of. Dragging sideways changes the
+ * length of something, dragging up changes a height — the same gesture the curve points use.
+ */
+function handlesOf(s: Scoped): Handle[] {
+  const f = s.feature;
+  if (f) {
+    switch (f.kind) {
+      case "double":
+        return [
+          { at: s.at + f.lip, height: f.height, x: { key: "lip", from: f.lip }, y: { key: "height", from: f.height }, label: "lip" },
+          { at: s.at + f.lip * 2 + f.gap, height: 0, x: { key: "gap", from: f.gap }, label: "gap" },
+        ];
+      case "whoops":
+        return [
+          { at: s.at + f.spacing, height: f.height, x: { key: "spacing", from: f.spacing }, y: { key: "height", from: f.height }, label: "×" },
+        ];
+      case "rut":
+        return [
+          { at: s.at + f.length / 2, height: -f.depth, x: { key: "length", from: f.length }, y: { key: "depth", from: f.depth }, label: "rut" },
+        ];
+      default: {
+        const g = f as { length: number; height: number };
+        return [
+          { at: s.at + g.length / 2, height: g.height, x: { key: "length", from: g.length }, y: { key: "height", from: g.height }, label: "top" },
+        ];
+      }
+    }
+  }
+  const seg = s.segment;
+  if (!seg) return [];
+  if (seg.kind === "straight") {
+    return [
+      { at: s.at + seg.length, height: seg.rise ?? 0, x: { key: "length", from: seg.length }, y: { key: "rise", from: seg.rise ?? 0 }, label: "end" },
+    ];
+  }
+  const len = (Math.abs(seg.radius) * Math.abs(seg.angle) * Math.PI) / 180;
+  return [
+    { at: s.at + len, height: seg.rise ?? 0, x: { key: "angle", from: seg.angle }, y: { key: "rise", from: seg.rise ?? 0 }, label: "end" },
+  ];
+}
+
+/** The shape a feature cuts, roughly — a picture of its numbers, not of the terrain. */
+function silhouette(s: Scoped): { at: number; height: number }[] {
+  const f = s.feature;
+  if (!f) return [];
+  const L = featureSpan(f).length;
+  const at = (u: number) => s.at + u * L;
+  if (f.kind === "double") {
+    const back = Math.min(2.5, f.lip * 0.5);
+    const total = (f.lip + back) * 2 + f.gap;
+    const p = (m: number) => s.at + m;
+    return [
+      { at: s.at, height: 0 },
+      { at: p(f.lip), height: f.height },
+      { at: p(f.lip + back), height: 0 },
+      { at: p(f.lip + back + f.gap), height: 0 },
+      { at: p(f.lip + back * 2 + f.gap), height: f.height },
+      { at: s.at + total, height: 0 },
+    ];
+  }
+  if (f.kind === "whoops") {
+    return Array.from({ length: f.count * 4 + 1 }, (_, i) => ({
+      at: s.at + (i * f.spacing) / 4,
+      height: (f.height / 2) * (1 - Math.cos((i / 4) * Math.PI * 2)),
+    }));
+  }
+  if (f.kind === "rut") {
+    return [
+      { at: s.at, height: 0 },
+      { at: at(0.35), height: -f.depth },
+      { at: at(0.65), height: -f.depth },
+      { at: s.at + L, height: 0 },
+    ];
+  }
+  const h = (f as { height: number }).height;
+  if (f.kind === "roller") {
+    return Array.from({ length: 17 }, (_, i) => ({
+      at: at(i / 16),
+      height: (h / 2) * (1 - Math.cos((i / 16) * Math.PI * 2)),
+    }));
+  }
+  // Tabletop, berm and step-up all read as up, along, down.
+  return [
+    { at: s.at, height: 0 },
+    { at: at(0.27), height: h },
+    { at: at(0.56), height: h },
+    { at: s.at + L, height: f.kind === "stepUp" ? h : 0 },
+  ];
+}
 
 /**
  * The curve's height at a point, easing between neighbours and wrapping round the lap.
@@ -86,6 +211,8 @@ export default function ElevationCurve({
   onChange,
   onFeature,
   onHover,
+  scoped = null,
+  onScoped,
   className,
 }: Props) {
   const box = useRef<HTMLDivElement>(null);
@@ -104,6 +231,8 @@ export default function ElevationCurve({
     size: number;
     grabbed: number;
   } | null>(null);
+  // A number of the scoped step being pulled. Same rule as the rest: held here, told once.
+  const [grip, setGrip] = useState<{ index: number; at: number; height: number } | null>(null);
 
   const live = drag
     ? knots.map((k, i) => (i === drag.index ? drag.knot : k))
@@ -136,6 +265,26 @@ export default function ElevationCurve({
     const r = box.current?.getBoundingClientRect();
     const here = fromPointer(e);
     if (!r || !here) return;
+
+    // The scoped step's own numbers come first: they are what the strip is showing.
+    const hs = scoped ? handlesOf(scoped) : [];
+    let hit = -1;
+    let closest = GRAB_PX;
+    hs.forEach((h, i) => {
+      const d = Math.hypot(
+        ((h.at - from) / width) * r.width - (e.clientX - r.left),
+        (toY(h.height) / 100) * r.height - (e.clientY - r.top),
+      );
+      if (d < closest) {
+        closest = d;
+        hit = i;
+      }
+    });
+    if (hit >= 0) {
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+      setGrip({ index: hit, at: hs[hit].at, height: hs[hit].height });
+      return;
+    }
 
     // The bar row first: it sits over the bottom of the curve's area, and a click down there
     // is far more likely to be aimed at a jump than at the line.
@@ -187,6 +336,13 @@ export default function ElevationCurve({
   function onMove(e: React.PointerEvent) {
     const here = fromPointer(e);
     if (!here) return;
+    if (grip) {
+      // Snapped to the ground line, because "level with everything else" is a thing you
+      // aim at constantly and can never hit by hand.
+      const h = Math.abs(here.height) < SNAP_M ? 0 : here.height;
+      setGrip({ ...grip, at: here.at, height: h });
+      return;
+    }
     if (bar) {
       const moved = here.at - bar.grabbed;
       setBar(
@@ -209,6 +365,17 @@ export default function ElevationCurve({
   }
 
   function onUp() {
+    if (grip && scoped && onScoped) {
+      const h = handlesOf(scoped)[grip.index];
+      const patch: Record<string, number> = {};
+      // Sideways moves whatever length that handle governs; up and down moves its height.
+      if (h.x) patch[h.x.key] = Math.max(0.5, h.x.from + (grip.at - h.at));
+      if (h.y) {
+        const raw = h.y.from + (grip.height - h.height);
+        patch[h.y.key] = h.y.key === "depth" ? Math.max(0, -grip.height) : raw;
+      }
+      onScoped(patch);
+    }
     if (bar) {
       const f = features[bar.index];
       onFeature(
@@ -221,6 +388,7 @@ export default function ElevationCurve({
     if (drag) onChange(knots.map((k, i) => (i === drag.index ? drag.knot : k)));
     setBar(null);
     setDrag(null);
+    setGrip(null);
   }
 
   return (
@@ -257,6 +425,20 @@ export default function ElevationCurve({
           );
         })}
 
+        {scoped && (
+          <polyline
+            points={silhouette(scoped)
+              .map((p) => `${toX(p.at)},${toY(p.height + heightAt(sorted, p.at, lap))}`)
+              .join(" ")}
+            fill="none"
+            stroke={scoped.feature ? FEATURE_COLOUR[scoped.feature.kind] : "currentColor"}
+            className={scoped.feature ? undefined : "stroke-muted-foreground"}
+            strokeWidth="1"
+            vectorEffect="non-scaling-stroke"
+            opacity={0.9}
+          />
+        )}
+
         {sorted.length > 0 && (
           <polyline
             points={[
@@ -278,6 +460,24 @@ export default function ElevationCurve({
 
       {/* Handles as real elements rather than SVG circles: the viewBox is stretched, which
           would make them ovals. */}
+      {scoped &&
+        handlesOf(scoped).map((h, i) => {
+          const at = grip?.index === i ? grip.at : h.at;
+          const height = grip?.index === i ? grip.height : h.height;
+          if (at < from - 0.5 || at > end + 0.5) return null;
+          return (
+            <button
+              key={`h${i}`}
+              style={{ left: `${toX(at)}%`, top: `${toY(height)}%` }}
+              className={cn(
+                "absolute size-3 -translate-x-1/2 -translate-y-1/2 cursor-default rounded-sm border-2 border-background",
+                grip?.index === i ? "bg-foreground ring-2 ring-primary/50" : "bg-foreground/70",
+              )}
+              title={`${h.label} · ${height.toFixed(2)} m`}
+            />
+          );
+        })}
+
       {live.map((k, i) => (
         k.at < from - 0.5 || k.at > end + 0.5 ? null : (
         <button

--- a/src/Components/Studio/TrackStudio/TrackStudio.tsx
+++ b/src/Components/Studio/TrackStudio/TrackStudio.tsx
@@ -952,6 +952,21 @@ export default function TrackStudio() {
                   void settle({ ...program, elevation });
                 }}
                 onFeature={editFeature}
+                {...(() => {
+                  const steps = lapSteps(program);
+                  const on = scope !== null ? steps[scope] : undefined;
+                  if (!on) return {};
+                  return {
+                    scoped:
+                      on.kind === "feature"
+                        ? { at: on.at, feature: on.feature }
+                        : { at: on.at, segment: on.segment },
+                    onScoped: (patch: Record<string, number>) =>
+                      on.kind === "feature"
+                        ? editFeature(on.index, patch as Partial<TrackFeature>)
+                        : editSegment(on.index, patch as Partial<TrackSegment>),
+                  };
+                })()}
                 onHover={(i) =>
                   setHover(
                     i === null


### PR DESCRIPTION
Scope the strip to something and it draws **that thing** — a double's takeoff, gap and landing; a tabletop's up, along and down; a straight's climb — with handles on the numbers that make it. Drag sideways to change a length, up or down to change a height. Same gesture the curve points already use.

| step | handles |
|---|---|
| double | the takeoff lip (lip + height), and where the gap ends (gap) |
| whoops | one on the first crest — spacing and height at once |
| tabletop / roller / berm / step-up | one on the top — length and height |
| rut | one in the middle — length and depth |
| straight | one at the far end — length and climb |
| corner | one at the far end — angle and climb |

**Handles snap to the ground line.** "Level with everything else" is a thing you aim at constantly and can never hit by hand.

The silhouette sits on the height curve rather than on zero, so a jump on a hill is drawn on the hill.

## What the shape is and isn't

It's a picture of the numbers, not of the terrain. The synthesiser's own profiles are steeper at a takeoff and longer at a landing than these straight runs suggest. Drawing the real ones would mean a fourth copy of that maths in TypeScript — and a diagram that's right about *what you can change* is worth more than one that's right about every centimetre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)