### PR TITLE
feat(tracks): a Height/Shape pill, and jumps you can draw point by point

### DIFF
--- a/control-plane/src/trackgen.ts
+++ b/control-plane/src/trackgen.ts
@@ -85,6 +85,14 @@ const Feature = z.discriminatedUnion("kind", [
     height: z.number(),
   }),
   z.object({
+    kind: z.literal("custom"),
+    at: z.number(),
+    length: z.number(),
+    shape: z
+      .array(z.object({ u: z.number(), h: z.number() }))
+      .describe('heights along the feature; u runs 0 at its start to 1 at its end'),
+  }),
+  z.object({
     kind: z.literal("rut"),
     at: z.number(),
     length: z.number(),

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -449,6 +449,7 @@ fn surface_colour(id: u32) -> [u8; 3] {
         204 => [110, 180, 130], // step-up
         205 => [150, 110, 200], // berm
         206 => [90, 90, 110],   // rut
+        207 => [200, 200, 210], // a shape drawn by hand
         12 => [124, 126, 102], // olive, so it parts from both grass and soil
         _ => [138, 126, 106],
     }
@@ -1197,7 +1198,7 @@ mod tests {
         // The whole point of them is telling one lump from another in the preview, so two
         // sharing a colour is the one thing that must not happen.
         let mut seen = std::collections::HashSet::new();
-        for id in 200..=206 {
+        for id in 200..=207 {
             assert!(seen.insert(surface_colour(id)), "id {id} repeats a colour");
         }
         // And none of them collides with a surface a real track paints.

--- a/src-tauri/src/trackprog.rs
+++ b/src-tauri/src/trackprog.rs
@@ -211,7 +211,7 @@ impl Segment {
 }
 
 /// Something built on the riding line, placed by how far round the lap it is.
-#[derive(serde::Deserialize, serde::Serialize, Clone, Copy, Debug)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, Debug)]
 #[serde(tag = "kind", rename_all = "camelCase")]
 pub enum Feature {
     /// Up, along, down. The safe jump, and the commonest thing on a track.
@@ -241,6 +241,25 @@ pub enum Feature {
     /// A groove worn into the line by everyone riding it. Corners grow their own — this is
     /// for putting one somewhere a corner wouldn't.
     Rut { at: f32, length: f32, depth: f32 },
+    /// A shape drawn by hand: heights along the feature, from its start to its end.
+    ///
+    /// Its own kind rather than a field on the others, because once a jump has been shaped
+    /// point by point it is no longer a tabletop with a taller top — it is a shape, and the
+    /// parameters a tabletop has stop meaning anything about it.
+    Custom {
+        at: f32,
+        length: f32,
+        shape: Vec<ShapePoint>,
+    },
+}
+
+/// One point of a hand-drawn feature: how far along it, and how high.
+#[derive(serde::Deserialize, serde::Serialize, Clone, Copy, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ShapePoint {
+    /// 0 at the feature's start, 1 at its end.
+    pub u: f32,
+    pub h: f32,
 }
 
 fn default_lip() -> f32 {
@@ -256,7 +275,8 @@ impl Feature {
             | Feature::Whoops { at, .. }
             | Feature::StepUp { at, .. }
             | Feature::Berm { at, .. }
-            | Feature::Rut { at, .. } => *at,
+            | Feature::Rut { at, .. }
+            | Feature::Custom { at, .. } => *at,
         }
     }
 
@@ -267,7 +287,8 @@ impl Feature {
             | Feature::Roller { length, .. }
             | Feature::StepUp { length, .. }
             | Feature::Berm { length, .. }
-            | Feature::Rut { length, .. } => *length,
+            | Feature::Rut { length, .. }
+            | Feature::Custom { length, .. } => *length,
             // Two faces up and two back down, with the gap between them.
             Feature::Double { gap, lip, .. } => (lip + lip.min(5.0)) * 2.0 + gap,
             Feature::Whoops {
@@ -286,6 +307,7 @@ impl Feature {
             Feature::StepUp { .. } => "step-up",
             Feature::Berm { .. } => "berm",
             Feature::Rut { .. } => "rut",
+            Feature::Custom { .. } => "shape",
         }
     }
 
@@ -299,6 +321,11 @@ impl Feature {
             | Feature::Berm { height, .. } => *height,
             // A rut goes down rather than up, and its depth is the figure that matters.
             Feature::Rut { depth, .. } => -*depth,
+            // The tallest point it was drawn with.
+            Feature::Custom { shape, .. } => shape
+                .iter()
+                .map(|p| p.h)
+                .fold(0.0f32, |a, b| if b.abs() > a.abs() { b } else { a }),
         }
     }
 }
@@ -796,7 +823,7 @@ mod tests {
         let last = p.features.len() - 1;
         let length = p.features[last].length() as f64;
         let at = (lap64 - length) as f32;
-        p.features[last] = match p.features[last] {
+        p.features[last] = match p.features[last].clone() {
             Feature::Berm { length, height, .. } => Feature::Berm { at, length, height },
             other => other,
         };

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -835,6 +835,11 @@ fn apply_step_ups(along: &mut [f32], st: &[Station], features: &[Feature]) {
 
 /// A feature's shape along the track. `t` runs 0–1 across it, `u` is metres from its start.
 fn longitudinal(f: &Feature, t: f32, u: f32) -> f32 {
+    // Drawn by hand: eased between the points it was given, which is the same easing the lap's
+    // own height curve uses. Nothing else here has a shape someone chose point by point.
+    if let Feature::Custom { shape, .. } = f {
+        return along_points(shape, t);
+    }
     match *f {
         // Up, along the top, and down. The ramps are a third each, which is about what a
         // built tabletop measures.
@@ -882,7 +887,31 @@ fn longitudinal(f: &Feature, t: f32, u: f32) -> f32 {
         // Both are applied elsewhere: a step-up moves the elevation profile, and a berm
         // and a rut are shaped across the track rather than along it.
         Feature::StepUp { .. } | Feature::Berm { .. } | Feature::Rut { .. } => 0.0,
+        Feature::Custom { .. } => unreachable!("handled above"),
     }
+}
+
+/// A hand-drawn shape's height at `t`, which runs 0 to 1 across the feature.
+///
+/// Eased rather than joined straight, so points placed roughly still make a shape a bike can
+/// ride. Outside the points it reads as the nearest one, so a shape that does not start at
+/// zero simply begins at the height it was drawn at.
+fn along_points(points: &[crate::trackprog::ShapePoint], t: f32) -> f32 {
+    if points.is_empty() {
+        return 0.0;
+    }
+    let mut p: Vec<_> = points.to_vec();
+    p.sort_by(|a, b| a.u.total_cmp(&b.u));
+    if t <= p[0].u {
+        return p[0].h;
+    }
+    if t >= p[p.len() - 1].u {
+        return p[p.len() - 1].h;
+    }
+    let i = p.iter().rposition(|q| q.u <= t).unwrap_or(0);
+    let (a, b) = (p[i], p[(i + 1).min(p.len() - 1)]);
+    let span = (b.u - a.u).max(1e-6);
+    a.h + (b.h - a.h) * smoothstep((t - a.u) / span)
 }
 
 fn smoothstep(t: f32) -> f32 {
@@ -1095,6 +1124,7 @@ fn feature_id(f: &Feature) -> u32 {
         Feature::StepUp { .. } => 204,
         Feature::Berm { .. } => 205,
         Feature::Rut { .. } => 206,
+        Feature::Custom { .. } => 207,
     }
 }
 
@@ -1832,6 +1862,31 @@ mod tests {
     /// Two jumps close together must not add up. Before, the ground between a pair of
     /// tabletops rose to their combined height and a rhythm section came out as one tall
     /// lump; each should keep its own height and the pair should read as one shape.
+    /// A shape drawn point by point is built as it was drawn.
+    #[test]
+    fn a_hand_drawn_shape_is_built_where_its_points_are() {
+        use crate::trackprog::ShapePoint;
+        let mut p = oval();
+        p.terrain.relief.amplitude = 0.0;
+        p.features = vec![Feature::Custom {
+            at: 40.0,
+            length: 40.0,
+            shape: vec![
+                ShapePoint { u: 0.0, h: 0.0 },
+                ShapePoint { u: 0.3, h: 2.5 },
+                ShapePoint { u: 0.6, h: 0.4 },
+                ShapePoint { u: 1.0, h: 0.0 },
+            ],
+        }];
+        let s = synthesise(&p).unwrap();
+        let ground = height_at_arc(&s, 20.0);
+        let crest = height_at_arc(&s, 40.0 + 40.0 * 0.3) - ground;
+        let dip = height_at_arc(&s, 40.0 + 40.0 * 0.6) - ground;
+        assert!((crest - 2.5).abs() < 0.6, "the crest reads {crest:.2} m, drawn at 2.5");
+        assert!(dip < 1.2, "the dip reads {dip:.2} m, drawn at 0.4");
+        assert!(crest - dip > 1.2, "the two are {:.2} m apart", crest - dip);
+    }
+
     #[test]
     fn jumps_that_touch_keep_their_own_height() {
         let mut p = oval();

--- a/src/Components/Studio/TrackStudio/ElevationCurve.tsx
+++ b/src/Components/Studio/TrackStudio/ElevationCurve.tsx
@@ -62,6 +62,13 @@ interface Props {
   scoped?: Scoped | null;
   /** One of the scoped step's numbers, changed. Called once, on release. */
   onScoped?: (patch: Record<string, number>) => void;
+  /**
+   * `height` shapes the ground the track runs on; `shape` shapes the thing built on it.
+   * They share a strip because they share an axis — both are metres above the same line.
+   */
+  mode?: "height" | "shape";
+  /** The scoped feature's points, replaced. Only meaningful in shape mode. */
+  onShape?: (shape: { u: number; h: number }[]) => void;
   className?: string;
 }
 
@@ -117,7 +124,7 @@ function handlesOf(s: Scoped): Handle[] {
 }
 
 /** The shape a feature cuts, roughly — a picture of its numbers, not of the terrain. */
-function silhouette(s: Scoped): { at: number; height: number }[] {
+export function silhouette(s: Scoped): { at: number; height: number }[] {
   const f = s.feature;
   if (!f) return [];
   const L = featureSpan(f).length;
@@ -213,6 +220,8 @@ export default function ElevationCurve({
   onHover,
   scoped = null,
   onScoped,
+  mode = "height",
+  onShape,
   className,
 }: Props) {
   const box = useRef<HTMLDivElement>(null);
@@ -265,6 +274,36 @@ export default function ElevationCurve({
     const r = box.current?.getBoundingClientRect();
     const here = fromPointer(e);
     if (!r || !here) return;
+
+    // In shape mode the points are the feature's own, and a click on empty space adds one.
+    if (mode === "shape" && scoped?.feature) {
+      const f = scoped.feature;
+      const L = featureSpan(f).length;
+      const pts = f.kind === "custom" ? f.shape : [];
+      let near = -1;
+      let best = GRAB_PX;
+      pts.forEach((q, i) => {
+        const d = Math.hypot(
+          ((scoped.at + q.u * L - from) / width) * r.width - (e.clientX - r.left),
+          (toY(q.h) / 100) * r.height - (e.clientY - r.top),
+        );
+        if (d < best) {
+          best = d;
+          near = i;
+        }
+      });
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+      const u = Math.min(Math.max((here.at - scoped.at) / Math.max(L, 1e-6), 0), 1);
+      if (near >= 0) {
+        setGrip({ index: near, at: here.at, height: pts[near].h });
+      } else {
+        // A new point where the line was clicked, and the drag continues from it.
+        const next = [...pts, { u, h: here.height }];
+        onShape?.(next);
+        setGrip({ index: next.length - 1, at: here.at, height: here.height });
+      }
+      return;
+    }
 
     // The scoped step's own numbers come first: they are what the strip is showing.
     const hs = scoped ? handlesOf(scoped) : [];
@@ -365,6 +404,22 @@ export default function ElevationCurve({
   }
 
   function onUp() {
+    if (grip && mode === "shape" && scoped?.feature && onShape) {
+      const f = scoped.feature;
+      const L = featureSpan(f).length;
+      const pts = f.kind === "custom" ? [...f.shape] : [];
+      if (pts[grip.index]) {
+        pts[grip.index] = {
+          u: Math.min(Math.max((grip.at - scoped.at) / Math.max(L, 1e-6), 0), 1),
+          h: grip.height,
+        };
+        onShape(pts);
+      }
+      setGrip(null);
+      setBar(null);
+      setDrag(null);
+      return;
+    }
     if (grip && scoped && onScoped) {
       const h = handlesOf(scoped)[grip.index];
       const patch: Record<string, number> = {};
@@ -460,7 +515,32 @@ export default function ElevationCurve({
 
       {/* Handles as real elements rather than SVG circles: the viewBox is stretched, which
           would make them ovals. */}
-      {scoped &&
+      {mode === "shape" && scoped?.feature?.kind === "custom" &&
+        scoped.feature.shape.map((q, i) => {
+          const L = featureSpan(scoped.feature!).length;
+          const at = grip?.index === i ? grip.at : scoped.at + q.u * L;
+          const height = grip?.index === i ? grip.height : q.h;
+          if (at < from - 0.5 || at > end + 0.5) return null;
+          return (
+            <button
+              key={`s${i}`}
+              onDoubleClick={(ev) => {
+                ev.stopPropagation();
+                onShape?.(scoped.feature!.kind === "custom"
+                  ? scoped.feature!.shape.filter((_, j) => j !== i)
+                  : []);
+              }}
+              style={{ left: `${toX(at)}%`, top: `${toY(height)}%` }}
+              className={cn(
+                "absolute size-2.5 -translate-x-1/2 -translate-y-1/2 cursor-default rounded-full border border-background",
+                grip?.index === i ? "bg-foreground ring-2 ring-primary/50" : "bg-foreground/80",
+              )}
+              title={`${(q.u * 100).toFixed(0)}% · ${height.toFixed(2)} m`}
+            />
+          );
+        })}
+
+      {mode === "height" && scoped &&
         handlesOf(scoped).map((h, i) => {
           const at = grip?.index === i ? grip.at : h.at;
           const height = grip?.index === i ? grip.height : h.height;
@@ -478,7 +558,7 @@ export default function ElevationCurve({
           );
         })}
 
-      {live.map((k, i) => (
+      {mode === "height" && live.map((k, i) => (
         k.at < from - 0.5 || k.at > end + 0.5 ? null : (
         <button
           key={i}

--- a/src/Components/Studio/TrackStudio/TrackStudio.tsx
+++ b/src/Components/Studio/TrackStudio/TrackStudio.tsx
@@ -14,6 +14,7 @@ import {
   ChevronDown,
   ChevronRight,
   GripVertical,
+  PenLine,
   Plus,
   RefreshCw,
   Waves,
@@ -34,8 +35,9 @@ import {
 import { Button } from "../../ui/button";
 import { Input } from "../../ui/input";
 import { TrackViewer } from "../../Viewer/TrackViewer";
-import ElevationCurve from "./ElevationCurve";
+import ElevationCurve, { silhouette } from "./ElevationCurve";
 import { Switch } from "../../ui/switch";
+import { Segmented } from "../../ui/segmented";
 import { loadTrackOverview, loadTrackTerrain } from "../../../api/tracks";
 import type { TrackOverview, TrackTerrain } from "../../../types";
 import { useT } from "../../../i18n/context";
@@ -61,6 +63,7 @@ import {
   pathAlong,
   positionAt,
   setElevationAt,
+  toCustom,
   previewTrack,
   roomiestGap,
   setTrackTools,
@@ -121,6 +124,7 @@ export default function TrackStudio() {
   // Which row the height strip is showing. A corner or a straight at a time, because on a
   // 1500 m lap a 40 m berm is three pixels wide and every point lands on the last one.
   const [scope, setScope] = useState<number | null>(null);
+  const [stripMode, setStripMode] = useState<"height" | "shape">("height");
   // Rebuilding a two-thousand-square terrain on every drag is real work, so this is a choice
   // rather than the default. With it on, an edit settles and then the view catches up.
   const [live, setLive] = useState(false);
@@ -933,6 +937,19 @@ export default function TrackStudio() {
                     <span className="normal-case tracking-normal">{t("track.wholeLap")}</span>
                   );
                 })()}
+                {/* Only where there is a shape to edit: a straight has ground, not a shape. */}
+                {scope !== null && lapSteps(program)[scope]?.kind === "feature" && (
+                  <div className="ml-auto">
+                    <Segmented
+                      value={stripMode}
+                      onChange={(v) => setStripMode(v as "height" | "shape")}
+                      options={[
+                        { value: "height", label: t("track.mode.height") },
+                        { value: "shape", label: t("track.mode.shape") },
+                      ]}
+                    />
+                  </div>
+                )}
               </div>
               <ElevationCurve
                 lap={lapLength(program)}
@@ -965,6 +982,25 @@ export default function TrackStudio() {
                       on.kind === "feature"
                         ? editFeature(on.index, patch as Partial<TrackFeature>)
                         : editSegment(on.index, patch as Partial<TrackSegment>),
+                    mode: on.kind === "feature" ? stripMode : "height",
+                    onShape: (shape: { u: number; h: number }[]) => {
+                      if (on.kind !== "feature") return;
+                      setTouched(true);
+                      // The first point drawn on a jump turns it into a shape, keeping the
+                      // shape it already had as its starting points.
+                      const base =
+                        on.feature.kind === "custom"
+                          ? on.feature
+                          : toCustom(on.feature, silhouette({ at: on.feature.at, feature: on.feature }));
+                      void settle({
+                        ...program,
+                        features: program.features.map((f, i) =>
+                          i === on.index
+                            ? ({ ...base, shape } as TrackFeature)
+                            : f,
+                        ),
+                      });
+                    },
                   };
                 })()}
                 onHover={(i) =>
@@ -1044,6 +1080,7 @@ const KIND_KEY = {
   stepUp: "track.kind.stepUp",
   berm: "track.kind.berm",
   rut: "track.kind.rut",
+  custom: "track.kind.custom",
 } as const;
 
 const FEATURE_ICON: Record<TrackFeature["kind"], LucideIcon> = {
@@ -1054,6 +1091,7 @@ const FEATURE_ICON: Record<TrackFeature["kind"], LucideIcon> = {
   stepUp: TrendingUp,
   berm: Spline,
   rut: Minus,
+  custom: PenLine,
 };
 
 /** What the row is, at a glance. A list of thirty steps is scanned, not read. */
@@ -1133,6 +1171,9 @@ function fieldsOf(
       ];
     case "rut":
       return [{ key: "depth", label: "deep", value: f.depth, step: 0.05 }, len(f.length), up];
+    case "custom":
+      // A shape has no height or length to type at — it has points, and they are dragged.
+      return [len(f.length), up];
     default:
       return [
         { key: "height", label: "h", value: f.height, step: 0.1 },

--- a/src/api/trackgen.ts
+++ b/src/api/trackgen.ts
@@ -55,7 +55,9 @@ export type TrackFeature =
   | { kind: "whoops"; at: number; count: number; spacing: number; height: number }
   | { kind: "stepUp"; at: number; length: number; height: number }
   | { kind: "berm"; at: number; length: number; height: number }
-  | { kind: "rut"; at: number; length: number; depth: number };
+  | { kind: "rut"; at: number; length: number; depth: number }
+  /** A shape drawn point by point. `u` runs 0 at the feature's start to 1 at its end. */
+  | { kind: "custom"; at: number; length: number; shape: { u: number; h: number }[] };
 
 export type TrackFeatureKind = TrackFeature["kind"];
 
@@ -312,6 +314,22 @@ export function setElevationAt(program: TrackProgram, s: number, height: number)
   return { ...program, elevation: knots };
 }
 
+/**
+ * Turn a feature into a hand-drawn shape, keeping the shape it already had.
+ *
+ * Once a jump has been shaped point by point it is no longer a tabletop with a taller top —
+ * it is a shape, and a tabletop's parameters stop meaning anything about it. So the kind
+ * changes, and the silhouette it had becomes the points you start from.
+ */
+export function toCustom(f: TrackFeature, silhouette: { at: number; height: number }[]): TrackFeature {
+  const length = featureSpan(f).length;
+  const shape = silhouette.map((p) => ({
+    u: Math.min(Math.max((p.at - f.at) / Math.max(length, 1e-6), 0), 1),
+    h: p.height,
+  }));
+  return { kind: "custom", at: f.at, length, shape };
+}
+
 /** The middle of a feature — where its own height point belongs. */
 export function featureMiddle(f: TrackFeature): number {
   return f.at + featureSpan(f).length / 2;
@@ -347,6 +365,12 @@ export function newFeature(kind: TrackFeatureKind, at: number): TrackFeature {
       return { kind, at, length: 20, height: 1.6 };
     case "rut":
       return { kind, at, length: 20, depth: 0.15 };
+    case "custom":
+      return { kind, at, length: 24, shape: [
+        { u: 0, h: 0 },
+        { u: 0.35, h: 1.6 },
+        { u: 1, h: 0 },
+      ] };
   }
 }
 
@@ -432,6 +456,7 @@ export const FEATURE_COLOUR: Record<TrackFeatureKind, string> = {
   stepUp: "rgb(110, 180, 130)",
   berm: "rgb(150, 110, 200)",
   rut: "rgb(90, 90, 110)",
+  custom: "rgb(200, 200, 210)",
 };
 
 /** Where a feature sits, and how long it runs — the two numbers every kind has. */
@@ -441,6 +466,8 @@ export function featureSpan(f: TrackFeature): { at: number; length: number } {
       return { at: f.at, length: (f.lip + Math.min(f.lip, 5)) * 2 + f.gap };
     case "whoops":
       return { at: f.at, length: f.count * f.spacing };
+    case "custom":
+      return { at: f.at, length: f.length };
     default:
       return { at: f.at, length: f.length };
   }

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -2433,4 +2433,7 @@ export const de: Translation = {
   "track.live": "Live",
   "track.rebuild": "Vorschau neu bauen",
   "track.wholeLap": "ganze Runde",
+  "track.kind.custom": "Form",
+  "track.mode.height": "Höhe",
+  "track.mode.shape": "Form",
 };

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2389,4 +2389,7 @@ export const en = {
   "track.live": "Live",
   "track.rebuild": "Rebuild the preview",
   "track.wholeLap": "whole lap",
+  "track.kind.custom": "Shape",
+  "track.mode.height": "Height",
+  "track.mode.shape": "Shape",
 } as const;

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -2419,4 +2419,7 @@ export const es: Translation = {
   "track.live": "En vivo",
   "track.rebuild": "Reconstruir la vista",
   "track.wholeLap": "vuelta entera",
+  "track.kind.custom": "Forma",
+  "track.mode.height": "Altura",
+  "track.mode.shape": "Forma",
 };

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -2424,4 +2424,7 @@ export const fr: Translation = {
   "track.live": "Direct",
   "track.rebuild": "Reconstruire l'aperçu",
   "track.wholeLap": "tour entier",
+  "track.kind.custom": "Forme",
+  "track.mode.height": "Hauteur",
+  "track.mode.shape": "Forme",
 };

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -2412,4 +2412,7 @@ export const it: Translation = {
   "track.live": "Dal vivo",
   "track.rebuild": "Ricostruisci l'anteprima",
   "track.wholeLap": "giro intero",
+  "track.kind.custom": "Forma",
+  "track.mode.height": "Altezza",
+  "track.mode.shape": "Forma",
 };

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -2409,4 +2409,7 @@ export const ptBR: Translation = {
   "track.live": "Ao vivo",
   "track.rebuild": "Reconstruir a prévia",
   "track.wholeLap": "volta inteira",
+  "track.kind.custom": "Forma",
+  "track.mode.height": "Altura",
+  "track.mode.shape": "Forma",
 };


### PR DESCRIPTION
## The pill

The strip carries one when a feature is scoped. **Height** shapes the ground the track runs on; **Shape** shapes the thing built on it. They share a strip because they share an axis — both are metres above the same line. A straight only gets Height: it has ground, not a shape.

## Drawing a jump

In Shape mode, clicking adds a point, dragging moves it, double-click takes one away.

That needed somewhere to put them, so there's a new `custom` feature: heights along a jump, from its start to its end. **Its own kind rather than a field on the others** — once a jump has been shaped point by point it's no longer a tabletop with a taller top, it's a shape, and a tabletop's parameters stop meaning anything about it.

The first point drawn on a tabletop converts it, **keeping the silhouette it already had** as the points you start from. Nobody wants to redraw a jump from nothing to move one corner of it.

## How the points read

Eased rather than joined straight — the same easing the lap's height curve uses — so points placed roughly still make a shape a bike can ride. Outside them the shape reads as the nearest one, so a jump that starts above zero simply begins at the height it was drawn at.

`Feature` stops being `Copy`, since a shape is a `Vec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)