### PR TITLE
fix(tracks): a drawn shape has points, not a height

### DIFF
--- a/src/Components/Studio/TrackStudio/ElevationCurve.tsx
+++ b/src/Components/Studio/TrackStudio/ElevationCurve.tsx
@@ -102,12 +102,24 @@ function handlesOf(s: Scoped): Handle[] {
         return [
           { at: s.at + f.length / 2, height: -f.depth, x: { key: "length", from: f.length }, y: { key: "depth", from: f.depth }, label: "rut" },
         ];
-      default: {
-        const g = f as { length: number; height: number };
+      case "custom": {
+        // A drawn shape has no height of its own — it has points, and they are dragged in
+        // shape mode. What is left to pull here is how much lap it covers.
+        const tallest = f.shape.reduce((a, p) => (Math.abs(p.h) > Math.abs(a) ? p.h : a), 0);
         return [
-          { at: s.at + g.length / 2, height: g.height, x: { key: "length", from: g.length }, y: { key: "height", from: g.height }, label: "top" },
+          { at: s.at + f.length, height: tallest, x: { key: "length", from: f.length }, label: "end" },
         ];
       }
+      // Tabletop, roller, step-up and berm: the four that really are a length and a height.
+      // Named rather than left to `default`, because the cast that arm needed is exactly
+      // what let a shape — which has neither — reach it and read `undefined`.
+      case "tabletop":
+      case "roller":
+      case "stepUp":
+      case "berm":
+        return [
+          { at: s.at + f.length / 2, height: f.height, x: { key: "length", from: f.length }, y: { key: "height", from: f.height }, label: "top" },
+        ];
     }
   }
   const seg = s.segment;
@@ -155,6 +167,11 @@ export function silhouette(s: Scoped): { at: number; height: number }[] {
       { at: at(0.65), height: -f.depth },
       { at: s.at + L, height: 0 },
     ];
+  }
+  if (f.kind === "custom") {
+    return [...f.shape]
+      .sort((a, b) => a.u - b.u)
+      .map((p) => ({ at: s.at + p.u * L, height: p.h }));
   }
   const h = (f as { height: number }).height;
   if (f.kind === "roller") {


### PR DESCRIPTION
> `undefined is not an object (evaluating 'height.toFixed')`

Selecting a hand-drawn jump crashed the tab. The handle code ended in a `default` arm that cast whatever reached it to `{ length, height }` — and a shape has neither, so it read `undefined` and threw.

- **A drawn shape gets its own case**: one handle at its end for how much lap it covers, sitting at its tallest point. Its heights *are* its points, and those are dragged in Shape mode.
- **Its silhouette comes from those points** rather than from a tabletop's up-along-down, which is what it was being handed.
- **The `default` arm is gone.** The four kinds that really are a length and a height are named now, because the cast that arm needed is exactly what let a kind with neither reach it and read nothing.

That's the second time in this feature that a `default` doing a cast has swallowed a case it shouldn't have. Worth naming the arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)