### PR TITLE
chore(release): consolidate v0.12.4 and announce it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Added
-- Anonymous usage counts, so which pages and features actually get used is knowable. The
-  app sends a random install id, its version, the OS, the title, a session count and
-  counters for named pages and features — never your name, your files or your address.
-- A switch in Settings → General turns it off, and the welcome slideshow says it is there.
-- The control plane serves the numbers at `/admin/usage` behind an admin key: active
-  installs by day, week and month, version and OS spread, and every page and feature
-  ranked by how many installs touched it — including the ones nothing touched.
-
 ## 2026-08-31 — v0.12.4 — Paint sync, on every server
 
 ### Added
@@ -20,8 +9,24 @@
 - No invite code. The app signs itself up the first time sync runs, the same way voice does.
 - Paint sync is on by default, with a switch in Settings → General to turn it off.
 - Starting the game from Steam or a shortcut now syncs too. Only the Play button did before.
-- A feature's ground height is set on its own row in the track editor.
-- Features can be dragged along the height strip.
+- A feature's ground height is set on its own row in the track editor, and features can be
+  dragged along the height strip.
+- A Height/Shape pill on that strip. Height shapes the ground the track runs on; Shape
+  shapes the thing built on it. A straight only gets Height — it has ground, not a shape.
+- In Shape mode a jump's outline is the jump: drag the top of a tabletop to set its height,
+  its far end to set its length, the far side of a double's gap to set the gap, a whoop's
+  first crest for spacing and height, its far corner for how many crests. Corners with
+  nothing behind them sit there as anchors rather than pretending to be adjustable.
+- Handles ride the height curve, so a jump on a hill is grabbed on the hill rather than at
+  zero.
+- Jumps can be drawn point by point: click to add a point, drag to move it, double-click to
+  take it away. A jump drawn this way keeps its points; nothing turns a tabletop into one
+  behind your back.
+- Anonymous usage counts, so which pages and features actually get used is knowable. The
+  app sends a random install id, its version, the OS, the title, a session count and
+  counters for named pages and features — never your name, your files or your address.
+- A switch in Settings → General turns those off, and the welcome slideshow says it is
+  there.
 
 ### Changed
 - The sync line in the sidebar is no longer behind the experimental toggle.

--- a/src/Components/Showcase/releases.ts
+++ b/src/Components/Showcase/releases.ts
@@ -54,6 +54,7 @@ import {
   Zap,
   Users,
   SlidersHorizontal,
+  BarChart3,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { TKey } from "../../i18n/context";
@@ -92,6 +93,10 @@ export const RELEASES: Release[] = [
       { icon: Zap, text: "showcase.v0124.nosetup" },
       { icon: Users, text: "showcase.v0124.everyone" },
       { icon: SlidersHorizontal, text: "showcase.v0124.settings" },
+      { icon: Mountain, text: "showcase.v0124.shape" },
+      // Said here because it is the kind of change people would rather be told about than
+      // find: the switch is one click from this modal.
+      { icon: BarChart3, text: "showcase.v0124.stats" },
     ],
   },
   {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1608,6 +1608,10 @@ export const de: Translation = {
     "Du siehst jeden Fahrer, der ebenfalls MXB App hat. Je mehr in deiner Lobby, desto mehr vom Feld sieht richtig aus.",
   "showcase.v0124.settings":
     "Einstellungen → Lackierungs-Sync zeigt, was rausging, was ankam und welche Lackierung nicht überschrieben wurde. Der Schalter zum Abschalten sitzt unter Allgemein.",
+  "showcase.v0124.shape":
+    "Sprünge werden über ihre Kontur geformt. Zieh die Oberkante eines Tabletops für die Höhe, das hintere Ende für die Länge, die Gegenseite eines Doubles für die Lücke — oder zeichne einen Punkt für Punkt.",
+  "showcase.v0124.stats":
+    "MXB App zählt jetzt anonym, welche Seiten und Funktionen genutzt werden — eine zufällige ID und nichts über dich. Einstellungen → Allgemein schaltet es ab.",
   "showcase.v0122.hero.title":
     "Die Replay-Kamera kann dem Fahrer folgen",
   "showcase.v0122.hero.body":

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1569,6 +1569,10 @@ export const en = {
     "You'll see any rider who also has MXB App. The more of your lobby that does, the more of the grid looks right.",
   "showcase.v0124.settings":
     "Settings → Paint sync shows what went out, what came back, and any paint it refused to overwrite. The switch to turn it off is in General.",
+  "showcase.v0124.shape":
+    "Jumps are shaped by dragging their outline. Grab the top of a tabletop for its height, the far end for its length, the far side of a double for its gap — or draw one point by point.",
+  "showcase.v0124.stats":
+    "MXB App now counts which pages and features get used, anonymously — a random ID and nothing about you. Settings → General turns it off.",
   "showcase.v0122.hero.title":
     "The replay camera can follow the rider",
   "showcase.v0122.hero.body":

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1595,6 +1595,10 @@ export const es: Translation = {
     "Verás a cualquier piloto que también tenga MXB App. Cuantos más haya en tu sala, más parrilla se ve como debe.",
   "showcase.v0124.settings":
     "Ajustes → Sincronización de pinturas muestra qué salió, qué llegó y cualquier pintura que se negó a sobrescribir. El interruptor está en General.",
+  "showcase.v0124.shape":
+    "Los saltos se moldean arrastrando su contorno. Agarra la parte alta de un tabletop para su altura, el extremo para su longitud, el lado opuesto de un doble para su hueco — o dibuja uno punto a punto.",
+  "showcase.v0124.stats":
+    "MXB App ahora cuenta de forma anónima qué páginas y funciones se usan — un ID aleatorio y nada sobre ti. Ajustes → General lo desactiva.",
   "showcase.v0122.hero.title":
     "La cámara de repetición puede seguir al piloto",
   "showcase.v0122.hero.body":

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1599,6 +1599,10 @@ export const fr: Translation = {
     "Vous verrez tout pilote qui a aussi MXB App. Plus votre lobby en compte, plus la grille est correcte.",
   "showcase.v0124.settings":
     "Paramètres → Synchro des peintures montre ce qui est parti, ce qui est arrivé, et toute peinture qu'elle a refusé d'écraser. L'interrupteur est dans Général.",
+  "showcase.v0124.shape":
+    "Les sauts se façonnent en tirant leur contour. Attrapez le haut d'un tabletop pour sa hauteur, l'extrémité pour sa longueur, l'autre côté d'un double pour son écart — ou dessinez-en un point par point.",
+  "showcase.v0124.stats":
+    "MXB App compte désormais anonymement quelles pages et fonctions sont utilisées — un identifiant aléatoire et rien sur vous. Paramètres → Général le désactive.",
   "showcase.v0122.hero.title":
     "La caméra replay peut suivre le pilote",
   "showcase.v0122.hero.body":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1590,6 +1590,10 @@ export const it: Translation = {
     "Vedrai ogni pilota che ha anch'esso MXB App. Più ce ne sono nella tua lobby, più la griglia appare giusta.",
   "showcase.v0124.settings":
     "Impostazioni → Sincronizzazione livree mostra cosa è uscito, cosa è arrivato e ogni livrea che ha rifiutato di sovrascrivere. L'interruttore è in Generali.",
+  "showcase.v0124.shape":
+    "I salti si modellano trascinando il loro profilo. Prendi la cima di un tabletop per l'altezza, l'estremità per la lunghezza, il lato opposto di un doppio per il vuoto — o disegnane uno punto per punto.",
+  "showcase.v0124.stats":
+    "MXB App ora conta in modo anonimo quali pagine e funzioni vengono usate — un ID casuale e nulla su di te. Impostazioni → Generali lo disattiva.",
   "showcase.v0122.hero.title":
     "La telecamera replay può seguire il pilota",
   "showcase.v0122.hero.body":

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1588,6 +1588,10 @@ export const ptBR: Translation = {
     "Você verá qualquer piloto que também tenha o MXB App. Quanto mais gente na sua sala tiver, mais o grid fica certo.",
   "showcase.v0124.settings":
     "Configurações → Sincronização de pinturas mostra o que saiu, o que chegou e qualquer pintura que ela recusou sobrescrever. O interruptor fica em Geral.",
+  "showcase.v0124.shape":
+    "Os saltos são moldados arrastando o contorno. Pegue o topo de um tabletop para a altura, a ponta para o comprimento, o lado oposto de um double para o vão — ou desenhe um ponto a ponto.",
+  "showcase.v0124.stats":
+    "O MXB App agora conta anonimamente quais páginas e recursos são usados — um ID aleatório e nada sobre você. Configurações → Geral desliga isso.",
   "showcase.v0122.hero.title":
     "A câmera de replay pode seguir o piloto",
   "showcase.v0122.hero.body":


### PR DESCRIPTION
## Why

**v0.12.4 was prepared but never tagged** — the version bump and its changelog section landed in #298, but no tag was pushed, so `v0.12.3` is still the newest release. Four PRs have merged on top of it since.

So this consolidates everything since v0.12.3 into the existing v0.12.4 section and releases *that*, rather than opening a v0.12.5 and leaving v0.12.4's notes — paint sync on every server, the biggest thing in the batch — permanently unpublished.

## What changed in the notes

- **The two height-strip entries are replaced by what the tab actually does now.** They were written before the shape work landed on top of them; #303 explicitly undid part of #300 (`toCustom` is gone, nothing converts a tabletop behind your back). Shipping the earlier wording would have described behaviour that no longer exists — the exact trap that nearly put `Ctrl+Shift+M` in the v0.7.0 notes.
- **The track work merged since #298 had no entries at all.** Added: the Height/Shape pill, dragging a jump's outline to change the jump itself, handles that ride the height curve, and jumps drawn point by point.
- **The crash on selecting a hand-drawn jump is deliberately not listed.** It was never in a release, so there is nothing for a player to recognise.
- The `/admin/usage` dashboard is left out too — it is an operator surface, not something a player can act on.
- Merged `main` in and carried across #302's sync-on-join entry.

## Showcase

`RELEASES` already had a 0.12.4 entry built around paint sync. Two highlights added: the shape work, and the anonymous usage counts — the second because it is the kind of change people would rather be told about than discover, and the switch is one click from that modal. Strings in all six locales.

## Verification

- `scripts/changelog-section.sh v0.12.4 --heading` prints its heading (exit 0), and `release-notes.sh v0.12.4` renders the full body — the check that catches a section silently orphaned from its heading.
- `tsc` and `eslint` clean.

No version bump: `package.json`, `Cargo.toml` and `tauri.conf.json` already read 0.12.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)