### PR TITLE
chore(release): v0.12.5 — paint sync off by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-08-31 — v0.12.5
+
+### Changed
+- Paint sync is off by default. Turn it on in Settings → General.
+- A sync only reaches into the running game when it has actually installed something.
+
 ## 2026-08-31 — v0.12.4 — Paint sync, on every server
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.12.4",
+  "version": "0.12.5",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "mxb-app"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # whatever cargo called it. Cargo target names can't hold a space, so this is as close as
 # it gets. The description is what Windows Task Manager shows in its Processes tab.
 name = "mxb-app"
-version = "0.12.4"
+version = "0.12.5"
 description = "MXB App — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -95,14 +95,25 @@ pub struct AppConfig {
     /// Voice chat is off until the player turns it on. A feature that opens a microphone
     /// is not something anyone should discover by accident.
     pub voice_enabled: bool,
-    /// Paint sync is on unless the player turns it off. Unlike voice, it opens nothing and
-    /// costs nothing to be wrong about: the app publishes the look this rider is already
-    /// showing to everyone on the grid, and installs what the grid published back. Off by
-    /// default would mean a rider only sees the paints of whoever else went looking for a
-    /// setting, which is the same empty grid the feature exists to fix.
+    /// Which paint-sync default this config has been through.
     ///
-    /// A config written before this field deserializes to the struct default, which is on —
-    /// see the `default` on `AppConfig` itself.
+    /// v0.12.4 shipped paint sync on, and any config it saved carries
+    /// `paintSyncEnabled: true` written out explicitly — so simply changing the default
+    /// would not reach a single person who already has it. This is the one-shot: below
+    /// [`PAINT_SYNC_REV`], the setting is forced off once and the counter is caught up.
+    /// Anyone who then turns it back on keeps it, because the counter no longer moves.
+    #[serde(default)]
+    pub paint_sync_rev: u32,
+    /// Paint sync, off until the player turns it on.
+    ///
+    /// It shipped on by default and was turned off again the same day: keeping a running
+    /// session in step means reaching into the game — re-reading the mods folder, re-running
+    /// its customization loader — and that was freezing MX Bikes. Neither of those is a
+    /// thing to do to someone's race uninvited, however good the feature is when it works.
+    ///
+    /// The cost of off is real and understood: sync only pays off when the riders beside you
+    /// have it on too, so a default of off is a slower start. That is the right trade until
+    /// the freeze is understood on Windows — see `tasks/`.
     pub paint_sync_enabled: bool,
     /// Microphone to listen to. **Blank means "follow the system default"** — storing the
     /// resolved name instead would pin the player to whichever headset was plugged in the
@@ -244,7 +255,8 @@ impl Default for AppConfig {
             overlay_hotkey: DEFAULT_OVERLAY_HOTKEY.to_string(),
             preview_tyres: String::new(),
             voice_enabled: false,
-            paint_sync_enabled: true,
+            paint_sync_rev: PAINT_SYNC_REV,
+            paint_sync_enabled: false,
             voice_input_device: String::new(),
             voice_output_device: String::new(),
             voice_ptt_hotkey: DEFAULT_PTT_HOTKEY.to_string(),
@@ -269,7 +281,22 @@ impl Default for AppConfig {
 /// Applied on every read rather than in a one-shot upgrade step: the config is also
 /// written by hand and by older builds still on disk, so "has this already been
 /// migrated?" is only ever answerable from the values themselves.
+/// Bumped to turn paint sync off for everyone once.
+///
+/// v1: v0.12.4 shipped it on and it froze the game.
+pub const PAINT_SYNC_REV: u32 = 1;
+
 pub fn migrate(mut cfg: AppConfig) -> AppConfig {
+    // The one-shot described on `paint_sync_rev`. A config that never had the field is at
+    // rev 0 too, and forcing an already-off setting off is a no-op, so this needs no way to
+    // tell those two apart.
+    if cfg.paint_sync_rev < PAINT_SYNC_REV {
+        if cfg.paint_sync_enabled {
+            log::info!("turning paint sync off: it is off by default while the freeze is understood");
+        }
+        cfg.paint_sync_enabled = false;
+        cfg.paint_sync_rev = PAINT_SYNC_REV;
+    }
     if LEGACY_OVERLAY_HOTKEYS.contains(&cfg.overlay_hotkey.trim()) {
         log::info!(
             "moving the overlay hotkey off the retired default {} → {DEFAULT_OVERLAY_HOTKEY}",
@@ -945,18 +972,42 @@ mod tests {
         );
     }
 
-    /// Paint sync is on for every install that predates the setting.
+    /// Paint sync is off for every install that predates the setting.
     ///
-    /// It reaches players as an upgrade, not as an install, so the field is absent from every
-    /// config that exists today. Off would mean the feature shipped switched off for
-    /// everyone who already has the app — which is everyone it is for.
+    /// It briefly shipped on by default and was turned off again the same day, because
+    /// keeping a live session in step was freezing the game. An absent field must therefore
+    /// read as off: a config written by the build that defaulted it on carries the field
+    /// explicitly, so nothing that has it on loses it, and nothing that never had it gains it.
     #[test]
-    fn paint_sync_is_on_for_a_config_written_before_it_existed() {
+    fn paint_sync_is_off_for_a_config_written_before_it_existed() {
         let json = r#"{ "modsPath": "/games/MX Bikes", "voiceEnabled": false }"#;
         let cfg = serde_json::from_str::<AppConfig>(json).unwrap();
 
-        assert!(cfg.paint_sync_enabled, "an absent field means on");
+        assert!(!cfg.paint_sync_enabled, "an absent field means off");
         assert!(!cfg.voice_enabled, "and a field that is there still means what it says");
+    }
+
+    /// The hotfix's whole job: a v0.12.4 config says `paintSyncEnabled: true` in so many
+    /// words, so changing the default alone would reach nobody who already has the freeze.
+    #[test]
+    fn a_v0124_config_gets_paint_sync_turned_off_once() {
+        let json = r#"{ "modsPath": "/games/MX Bikes", "paintSyncEnabled": true }"#;
+        let cfg = migrate(serde_json::from_str::<AppConfig>(json).unwrap());
+
+        assert!(!cfg.paint_sync_enabled, "the explicit true is overridden once");
+        assert_eq!(cfg.paint_sync_rev, PAINT_SYNC_REV, "and the config is caught up");
+    }
+
+    /// Once. Someone who turns it back on afterwards keeps it — otherwise the setting is
+    /// not a setting, it is a switch that resets every launch.
+    #[test]
+    fn turning_paint_sync_back_on_survives_the_next_launch() {
+        let mut cfg = migrate(AppConfig::default());
+        cfg.paint_sync_enabled = true;
+
+        let saved = serde_json::to_string(&cfg).unwrap();
+        let reloaded = migrate(serde_json::from_str::<AppConfig>(&saved).unwrap());
+        assert!(reloaded.paint_sync_enabled, "their choice stands");
     }
 
     /// Turning it off has to survive a round trip, or the switch springs back on restart.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6535,8 +6535,14 @@ async fn pull_rosters(
         log::warn!("[sync] couldn't record the pull: {e:#}");
     }
     // Anything newly on disk is invisible to a running game until the loader re-reads the
-    // mods folder.
-    let _ = frostmod::signal_reload();
+    // mods folder — but only *newly*. This used to fire on every pull, and a pull that
+    // installed nothing is the overwhelmingly common one: the grid is unchanged, everyone's
+    // paints are already here, and there is nothing for the game to re-read. Asking it to
+    // rescan the mods folder anyway, every time a rider joined, is work done to a process
+    // that is mid-race.
+    if outcome.installed > 0 {
+        let _ = frostmod::signal_reload();
+    }
     Ok(outcome)
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
   "mainBinaryName": "MXB App",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -466,9 +466,8 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
   // Same shape as the overlay pair above: the config's fields are optional (an install
   // predating voice has none), so every read is defaulted here rather than at each use.
   const voiceEnabled = config.voiceEnabled ?? false;
-  // On unless it was turned off — an older config has no field and means "on", same as the
-  // backend's default.
-  const paintSyncEnabled = config.paintSyncEnabled ?? true;
+  // Off unless it was turned on, matching the backend's default.
+  const paintSyncEnabled = config.paintSyncEnabled ?? false;
   const voiceInput = config.voiceInputDevice ?? "";
   const voiceOutput = config.voiceOutputDevice ?? "";
   const voicePtt = config.voicePttHotkey || FALLBACK_PTT_HOTKEY;

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1603,7 +1603,7 @@ export const de: Translation = {
   "showcase.v0124.anyserver":
     "Jeder Server, nicht nur unsere. Die App liest den Server aus dem laufenden Spiel, also funktioniert eine öffentliche Lobby genau wie eine private.",
   "showcase.v0124.nosetup":
-    "Nichts einzurichten. Kein Einladungscode, keine Anmeldung, keine Server-Installation — Spiel starten, fertig.",
+    "Nichts einzurichten. Kein Einladungscode, keine Anmeldung, keine Server-Installation — in den Einstellungen einschalten, den Rest macht sie selbst.",
   "showcase.v0124.everyone":
     "Du siehst jeden Fahrer, der ebenfalls MXB App hat. Je mehr in deiner Lobby, desto mehr vom Feld sieht richtig aus.",
   "showcase.v0124.settings":

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1564,7 +1564,7 @@ export const en = {
   "showcase.v0124.anyserver":
     "Any server, not just ours. The app reads the server from the running game, so a public lobby works exactly like a private one.",
   "showcase.v0124.nosetup":
-    "Nothing to set up. No invite code, no sign-up, no server-side install — start the game and it goes.",
+    "Nothing to set up. No invite code, no sign-up, no server-side install — switch it on in Settings and it runs by itself.",
   "showcase.v0124.everyone":
     "You'll see any rider who also has MXB App. The more of your lobby that does, the more of the grid looks right.",
   "showcase.v0124.settings":

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1590,7 +1590,7 @@ export const es: Translation = {
   "showcase.v0124.anyserver":
     "Cualquier servidor, no solo los nuestros. La app lee el servidor del juego en marcha, así que una sala pública funciona igual que una privada.",
   "showcase.v0124.nosetup":
-    "Nada que configurar. Sin código de invitación, sin registro, sin instalar nada en el servidor — abre el juego y ya está.",
+    "Nada que configurar. Sin código de invitación, sin registro, sin instalar nada en el servidor — actívala en Ajustes y funciona sola.",
   "showcase.v0124.everyone":
     "Verás a cualquier piloto que también tenga MXB App. Cuantos más haya en tu sala, más parrilla se ve como debe.",
   "showcase.v0124.settings":

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1594,7 +1594,7 @@ export const fr: Translation = {
   "showcase.v0124.anyserver":
     "N'importe quel serveur, pas seulement les nôtres. L'app lit le serveur depuis le jeu en cours, donc un lobby public fonctionne comme un lobby privé.",
   "showcase.v0124.nosetup":
-    "Rien à configurer. Pas de code d'invitation, pas d'inscription, rien à installer côté serveur — lancez le jeu et c'est parti.",
+    "Rien à configurer. Pas de code d'invitation, pas d'inscription, rien à installer côté serveur — activez-la dans les Paramètres, elle fait le reste toute seule.",
   "showcase.v0124.everyone":
     "Vous verrez tout pilote qui a aussi MXB App. Plus votre lobby en compte, plus la grille est correcte.",
   "showcase.v0124.settings":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1585,7 +1585,7 @@ export const it: Translation = {
   "showcase.v0124.anyserver":
     "Qualsiasi server, non solo i nostri. L'app legge il server dal gioco in esecuzione, così una lobby pubblica funziona come una privata.",
   "showcase.v0124.nosetup":
-    "Niente da configurare. Nessun codice d'invito, nessuna registrazione, niente da installare sul server — avvia il gioco e parte.",
+    "Niente da configurare. Nessun codice d'invito, nessuna registrazione, niente da installare sul server — attivala nelle Impostazioni e fa tutto da sé.",
   "showcase.v0124.everyone":
     "Vedrai ogni pilota che ha anch'esso MXB App. Più ce ne sono nella tua lobby, più la griglia appare giusta.",
   "showcase.v0124.settings":

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1583,7 +1583,7 @@ export const ptBR: Translation = {
   "showcase.v0124.anyserver":
     "Qualquer servidor, não só os nossos. O app lê o servidor do jogo em execução, então uma sala pública funciona igual a uma privada.",
   "showcase.v0124.nosetup":
-    "Nada para configurar. Sem código de convite, sem cadastro, sem instalar nada no servidor — abra o jogo e pronto.",
+    "Nada para configurar. Sem código de convite, sem cadastro, sem instalar nada no servidor — ative nas Configurações e ela roda sozinha.",
   "showcase.v0124.everyone":
     "Você verá qualquer piloto que também tenha o MXB App. Quanto mais gente na sua sala tiver, mais o grid fica certo.",
   "showcase.v0124.settings":


### PR DESCRIPTION
Keeping a live session in step means reaching into the running game: signalling FrostMod to re-read the mods folder, and re-running the customization loader in the process. That is enough to freeze MX Bikes mid-session, so paint sync waits behind a switch until the freeze is understood on Windows.

- `paint_sync_enabled` defaults to false.
- **A one-shot migration turns it off for configs that already have it on.** v0.12.4 shipped it on and wrote `paintSyncEnabled: true` out explicitly, so moving the default alone would have reached nobody who actually has the problem. `paint_sync_rev` makes it happen exactly once — someone who turns it back on afterwards keeps it, which is the difference between a setting and a switch that resets every launch. Both directions are tested.
- **A pull that installed nothing no longer signals a mods reload.** That fired on every pull, and with the grid-arrival trigger from #302 it meant asking a mid-race game to rescan its mods folder every time somebody joined. The overwhelmingly common pull installs nothing at all.

Release notes stay plain — off by default, and where the switch is.

Green: 1101 Rust tests, cargo check on macOS and `x86_64-pc-windows-gnu`, tsc, eslint, vite build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)