### PR TITLE
perf(sync): cut what the app asks the control plane for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- Paint sync makes one request where it used to make two: saying where you are now rides
+  along with asking who else is here.
+- The sync heartbeat drops from every 45 seconds to every 3 minutes. A rider joining still
+  pulls within seconds — the heartbeat only ever covered someone already there changing
+  their look.
+- Sync no longer claims you are on every server in the registry when you are not on one.
+- Usage counts are sent every half hour instead of every five minutes, and stop for the
+  run if the server says it has had enough.
+
+### Fixed
+- The control plane ran out of its daily request allowance on the day v0.12.4 shipped,
+  which took paint sync, voice and the server list down with it. The changes above cut
+  what the app asks for by roughly four fifths.
+
 ## 2026-08-31 — v0.12.4 — Paint sync, on every server
 
 ### Added

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -189,7 +189,7 @@ async function route(request: Request, env: Env): Promise<Response> {
   // than the paints they actually wear.
   if (method === "PUT" && path === "/v1/loadout") return putLoadout(request, account, env);
   if (method === "PUT" && path === "/v1/loadouts") return putLoadouts(request, account, env);
-  if (method === "GET" && path === "/v1/roster") return roster(url, env);
+  if (method === "GET" && path === "/v1/roster") return roster(url, account, env);
 
   const openPaint = /^\/v1\/paints\/([0-9a-f]{64})$/.exec(path);
   if (openPaint) {
@@ -1393,14 +1393,19 @@ async function putPresence(request: Request, account: Account, env: Env): Promis
   const { serverId } = body as { serverId?: unknown };
   if (!isServerKey(serverId)) return json(400, { error: "that isn't a server" });
 
+  await markPresent(account.id, (serverId as string).trim(), env);
+  return json(200, { ok: true });
+}
+
+/** Record that an account is on a server. One writer, so the two callers cannot drift. */
+async function markPresent(accountId: string, serverId: string, env: Env): Promise<void> {
   await env.DB.prepare(
     "INSERT INTO presence (account_id, server_id, updated_at) VALUES (?, ?, ?)" +
       " ON CONFLICT(account_id) DO UPDATE SET server_id = excluded.server_id," +
       " updated_at = excluded.updated_at",
   )
-    .bind(account.id, (serverId as string).trim(), Date.now())
+    .bind(accountId, serverId, Date.now())
     .run();
-  return json(200, { ok: true });
 }
 
 /**
@@ -1415,9 +1420,32 @@ async function putPresence(request: Request, account: Account, env: Env): Promis
  * who is genuinely there — the next heartbeat brings them back within a minute — than to
  * accumulate a grid of people who left hours ago.
  */
-async function roster(url: URL, env: Env): Promise<Response> {
+/**
+ * Who is on a server, and what they are wearing.
+ *
+ * `?here=1` also records that the caller is on that server, which is what lets a client in a
+ * session do the whole loop in one request instead of a presence write followed by this
+ * read. That halving is not a micro-optimisation: every app in a session ran both every 45
+ * seconds, and on 2026-08-31 the pair took the worker past its daily request ceiling within
+ * hours of paint sync being turned on for everyone.
+ *
+ * Absent, nothing is written — a client sweeping the registry is asking about servers it is
+ * *not* on, and claiming presence on all of them would be both untrue and the thing that
+ * made every rider download every other rider's paints.
+ */
+async function roster(url: URL, account: Account, env: Env): Promise<Response> {
   const serverId = url.searchParams.get("server");
   if (!serverId) return json(400, { error: "a server id is required" });
+
+  if (url.searchParams.get("here") === "1") {
+    // Held to the same rule as the standalone report: this one writes a row other clients
+    // read, so it cannot be looser about what a server key is just because it arrived in a
+    // query string.
+    if (!isServerKey(serverId)) return json(400, { error: "that isn't a server" });
+    // Before the read, not after: the roster is scoped by presence, and a rider should
+    // appear in the same answer they are asking for.
+    await markPresent(account.id, serverId.trim(), env);
+  }
 
   // DISTINCT on the destination: loadouts are per bike, and gear repeats across every bike a
   // rider owns, so the raw join returns the same helmet paint many times over. The receiver

--- a/control-plane/src/usage.ts
+++ b/control-plane/src/usage.ts
@@ -136,9 +136,10 @@ export async function reportUsage(request: Request, env: Env): Promise<Response>
     .bind(digest, day)
     .first<{ claims: number }>();
   if (seen && seen.claims >= MAX_REPORTS_PER_DAY) {
-    // Answered as accepted-and-ignored rather than 429: the client has nothing useful to do
-    // with a retry, and a rejection it would keep retrying is worse for both sides.
-    return json(202, { ok: true });
+    // A real 429, not the 202-and-ignore this first shipped with. The client reads it as
+    // "stop reporting for this run" rather than as something to retry, which is the only
+    // answer that actually reduces load — and load is the entire reason the cap exists.
+    return json(429, { error: "too many reports from here today" });
   }
 
   const statements = [

--- a/control-plane/test/usage.test.ts
+++ b/control-plane/test/usage.test.ts
@@ -181,20 +181,26 @@ describe("the endpoint", () => {
     expect(db.statements).toHaveLength(0);
   });
 
-  it("drops reports once an address is past its daily cap, without asking it to retry", async () => {
-    const db = stubDb(MAX_REPORTS_PER_DAY);
-    const res = await reportUsage(post(body()), { DB: db } as unknown as Env);
-
-    expect(res.status).toBe(202);
-    expect(db.statements).toHaveLength(0);
-  });
-
   it("counts a signup and a usage report separately", async () => {
     const db = stubDb();
     await reportUsage(post(body()), { DB: db } as unknown as Env);
 
     const claims = db.statements.find((s) => s.sql.includes("INTO device_claims"))!;
     expect(claims.sql).toContain("'usage'");
+  });
+});
+
+describe("what a rate-limited caller is told", () => {
+  it("answers 429 once an address is past its cap, so the client stops asking", async () => {
+    // The client treats 429 as "stop reporting this run" — see `usage.rs`. It must therefore
+    // actually see one, rather than the 202-and-ignore this used to answer with: a few
+    // hundred installs each knocking every half hour is exactly how a daily ceiling is
+    // reached, and a counter is not worth being part of that.
+    const db = stubDb(MAX_REPORTS_PER_DAY);
+    const res = await reportUsage(post(body()), { DB: db } as unknown as Env);
+
+    expect(res.status).toBe(429);
+    expect(db.statements).toHaveLength(0);
   });
 });
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6287,12 +6287,20 @@ fn sync_paints_soon(app: &tauri::AppHandle, address: Option<String>) {
     });
 }
 
-/// How often to re-check the grid while a session is running.
+/// The fallback heartbeat while a session is running.
 ///
-/// A rider who joins after you did is invisible until the next pull, so this is the gap
-/// between someone arriving and their paint appearing. Short enough not to matter in a race,
-/// long enough that an unchanged roster — the overwhelmingly common answer — costs nothing.
-const LIVE_SYNC_EVERY: std::time::Duration = std::time::Duration::from_secs(45);
+/// Not the gap between a rider arriving and their paint appearing — `GRID_POLL` below
+/// watches the entry list and pulls within seconds of a new name, which is the case that
+/// matters in a race. This only covers what the grid cannot announce: a rider who was
+/// already there and has since changed their look, and keeping our own presence inside the
+/// endpoint's ten-minute window.
+///
+/// Three minutes rather than the 45 seconds it ran at. At 45s every player in a session was
+/// a request a minute and a half, and with paint sync on by default that was most of what
+/// took the worker past its daily ceiling on 2026-08-31. Nothing was bought for it: an
+/// unchanged roster is the overwhelmingly common answer, and the arrival path already
+/// covers the change anyone would notice.
+const LIVE_SYNC_EVERY: std::time::Duration = std::time::Duration::from_secs(180);
 
 /// How often to read the grid out of FrostMod.
 ///
@@ -6515,15 +6523,16 @@ async fn pull_rosters(
         return Err("No servers to sync with yet.".into());
     }
 
-    // Say where we are before asking who else is here: the roster is scoped by presence, so
-    // reporting first is what puts this rider into everyone else's grid too.
-    for key in &keys {
-        if let Err(e) = paintsync::report_presence(&token, key).await {
-            log::debug!("[sync] couldn't report presence on {key}: {e:#}");
-        }
-    }
-
-    let outcome = paintsync::pull(&cfg, &token, &keys).await.map_err(|e| format!("{e:#}"))?;
+    // Where we are rides along with the request that asks who else is here — the roster
+    // records it and then scopes itself by it, so this is one request rather than two.
+    //
+    // Only the server the rider is actually on. Reporting presence for every key used to
+    // happen here, which on a registry sweep meant claiming to be on every server at once:
+    // untrue, and one write per server for the privilege.
+    let here = live_server_key();
+    let outcome = paintsync::pull(&cfg, &token, &keys, here.as_deref())
+        .await
+        .map_err(|e| format!("{e:#}"))?;
     // Re-read immediately before writing: the pull took a round trip, and `config::save`
     // rewrites the whole file.
     let mut cfg = config::load_or_detect(app).unwrap_or_default();

--- a/src-tauri/src/paintsync.rs
+++ b/src-tauri/src/paintsync.rs
@@ -551,7 +551,18 @@ fn rider_key(rider: &RosterRider) -> String {
 /// Rosters overlap heavily — the same rider is on more than one, and riders share paints —
 /// so everything is de-duplicated *before* any work happens. Without that, two servers means
 /// hashing every local file twice and a report that double-counts what it did.
-pub async fn pull(cfg: &AppConfig, token: &str, server_ids: &[String]) -> anyhow::Result<PullOutcome> {
+/// Pull every rider's paints for the given servers.
+///
+/// `here` names the server this rider is actually on, if any. That key's roster request also
+/// reports the presence the roster is scoped by, so a rider in a session does the whole loop
+/// in one request rather than a write followed by a read — see the endpoint's own note. The
+/// other keys get no presence at all, which is the truth: the rider is not on them.
+pub async fn pull(
+    cfg: &AppConfig,
+    token: &str,
+    server_ids: &[String],
+    here: Option<&str>,
+) -> anyhow::Result<PullOutcome> {
     let http = client()?;
 
     let mut seen_riders: std::collections::HashSet<String> = std::collections::HashSet::new();
@@ -563,9 +574,13 @@ pub async fn pull(cfg: &AppConfig, token: &str, server_ids: &[String]) -> anyhow
     let mut reached = 0usize;
 
     for server_id in server_ids {
+        let mut query: Vec<(&str, &str)> = vec![("server", server_id.as_str())];
+        if here == Some(server_id.as_str()) {
+            query.push(("here", "1"));
+        }
         let roster: Roster = match http
             .get(format!("{}/v1/roster", control_plane()))
-            .query(&[("server", server_id.as_str())])
+            .query(&query)
             .bearer_auth(token)
             .send()
             .await
@@ -1191,7 +1206,7 @@ mod live_sync {
 
         // Bob rides onto the server and pulls.
         let (bob_root, bob_cfg) = rider_machine("bob");
-        let out = pull(&bob_cfg, &bob.token, &[server.clone()]).await.unwrap();
+        let out = pull(&bob_cfg, &bob.token, &[server.clone()], Some(server.as_str())).await.unwrap();
         println!("bob: {out:?}");
 
         let landed = bob_root.join("mods/bikes/YZ450F/paints/Alice.pnt");
@@ -1207,7 +1222,7 @@ mod live_sync {
 
         // And the other direction, which is the half a one-sided test would miss.
         let (alice_root, alice_cfg) = rider_machine("alice");
-        let out = pull(&alice_cfg, &alice.token, &[server.clone()]).await.unwrap();
+        let out = pull(&alice_cfg, &alice.token, &[server.clone()], Some(server.as_str())).await.unwrap();
         assert_eq!(
             std::fs::read(alice_root.join("mods/bikes/YZ450F/paints/Bob.pnt")).ok(),
             Some(bob_paint),
@@ -1215,7 +1230,7 @@ mod live_sync {
         );
 
         // A second pass installs nothing: the manifest recognises what it wrote.
-        let again = pull(&bob_cfg, &bob.token, &[server.clone()]).await.unwrap();
+        let again = pull(&bob_cfg, &bob.token, &[server.clone()], Some(server.as_str())).await.unwrap();
         assert_eq!(again.installed, 0, "a repeat sync installs nothing: {again:?}");
         assert!(again.already_had >= 1, "and recognises what it already has: {again:?}");
 
@@ -1223,9 +1238,10 @@ mod live_sync {
         // different server sees an empty grid, not Alice and Bob.
         let carol = sign_up("Carol", &fresh_guid(3)).await;
         let elsewhere = crate::voice::session::room_key("Someone Else's Server");
-        report_presence(&carol.token, &elsewhere).await.unwrap();
+        // No separate presence call: the pull below reports it, which is the whole point of
+        // `here` — one request where there used to be two.
         let (carol_root, carol_cfg) = rider_machine("carol");
-        let out = pull(&carol_cfg, &carol.token, &[elsewhere]).await.unwrap();
+        let out = pull(&carol_cfg, &carol.token, &[elsewhere.clone()], Some(elsewhere.as_str())).await.unwrap();
         assert_eq!(out.installed, 0, "another server is another grid: {out:?}");
         assert!(
             !carol_root.join("mods/bikes/YZ450F/paints/Alice.pnt").exists(),
@@ -1266,7 +1282,7 @@ mod live_sync {
         report_presence(&second.token, &server).await.unwrap();
 
         let (root, cfg) = rider_machine("clash");
-        let out = pull(&cfg, &first.token, &[server]).await.unwrap();
+        let out = pull(&cfg, &first.token, &[server.clone()], Some(server.as_str())).await.unwrap();
         println!("name clash: {out:?}");
 
         assert_eq!(
@@ -1294,7 +1310,7 @@ mod live_sync {
         let before = std::fs::read(&mine).unwrap();
 
         let cfg = AppConfig { mods_path: root.to_string_lossy().into_owned(), ..Default::default() };
-        let out = pull(&cfg, &token(), &["local".to_string()]).await.unwrap();
+        let out = pull(&cfg, &token(), &["local".to_string()], None).await.unwrap();
         println!("{out:?}");
 
         assert_eq!(std::fs::read(&mine).unwrap(), before, "our own paint must be untouched");
@@ -1310,7 +1326,7 @@ mod live_sync {
         );
 
         // Second run: nothing new, and still no damage.
-        let again = pull(&cfg, &token(), &["local".to_string()]).await.unwrap();
+        let again = pull(&cfg, &token(), &["local".to_string()], None).await.unwrap();
         assert_eq!(again.installed, 0, "a repeat sync installs nothing: {again:?}");
         assert!(again.already_had >= 1, "what we installed is recognised: {again:?}");
         assert_eq!(std::fs::read(&mine).unwrap(), before);

--- a/src-tauri/src/usage.rs
+++ b/src-tauri/src/usage.rs
@@ -36,20 +36,41 @@ pub const DISABLE_ENV: &str = "MXB_NO_ANALYTICS";
 /// times a day would otherwise be the most active user it has.
 pub const DEV_ENV: &str = "MXB_ANALYTICS_DEV";
 
-/// How often the buffer is emptied. Long enough that a session is a handful of requests,
-/// short enough that a crash loses minutes rather than an evening.
-const FLUSH_EVERY: Duration = Duration::from_secs(5 * 60);
+/// How often the buffer is emptied.
+///
+/// Half-hourly, not the five minutes this shipped with. The app defaults to launching at
+/// login and living in the tray, so the interval is not "per session" — it is per waking
+/// hour of every machine that has the app. At five minutes that is ~288 requests a day from
+/// an install nobody is even using, and on 2026-08-31 the control plane hit its daily
+/// ceiling with a few hundred installs on it. Counters are counters: nothing here is worth
+/// a request every five minutes, and a report that is late is worth exactly as much as one
+/// that is prompt.
+const FLUSH_EVERY: Duration = Duration::from_secs(30 * 60);
 
 /// ...but the first report goes out a minute in.
 ///
 /// Otherwise the app would only ever count sessions that lasted longer than a flush, and
 /// "opened it, looked at one thing, closed it" — which is a great many of them — would be
-/// invisible. The daily active number is exactly the number that bias would ruin.
+/// invisible. The daily active number is exactly the number that bias would ruin. This is
+/// what makes the long interval above affordable: the day's active install is recorded a
+/// minute in, and everything after it is detail.
 const FIRST_FLUSH: Duration = Duration::from_secs(60);
 
 /// How long a quit waits for the last report. Short: nobody's shutdown should be held up by
 /// a counter, and the next launch would carry the loss anyway.
 const EXIT_GRACE: Duration = Duration::from_secs(3);
+
+/// What a report got back, so the loop knows whether to keep trying.
+#[derive(Debug, PartialEq)]
+enum Outcome {
+    /// Sent, or there was nothing to send.
+    Done,
+    /// Kept, and worth trying again on the next tick.
+    Retry,
+    /// The endpoint is turning callers away. Every install would be hearing this at once,
+    /// so the answer is to stop for the run rather than to knock again in half an hour.
+    RateLimited,
+}
 
 /// Distinct names held at once — the same cap the endpoint enforces. Reaching it means a
 /// call site is generating names rather than naming things, which is a bug on this side.
@@ -243,43 +264,62 @@ pub fn set_enabled(app: &AppHandle, on: bool, cfg: &AppConfig) {
 /// low number for one day, and a spool file would be a record of somebody's activity sitting
 /// on their machine for the sake of that.
 pub async fn flush(app: &AppHandle) {
+    if report(app).await == Outcome::RateLimited {
+        // Not a pause: reporting is done for this run. A counter is not worth being part of
+        // the reason a service stays over its limit, and tomorrow's launch counts this
+        // install again anyway.
+        log::warn!("[usage] the endpoint is rate limiting — not reporting again this run");
+        ENABLED.store(false, Ordering::Relaxed);
+        BUFFER.lock().unwrap().events.clear();
+    }
+}
+
+async fn report(app: &AppHandle) -> Outcome {
     if !ENABLED.load(Ordering::Relaxed) {
-        return;
+        return Outcome::Done;
     }
     let cfg = config::load(app).unwrap_or_default();
     // Re-read rather than trust the flag: the config can be edited by hand, and this is the
     // last point before anything leaves.
     if !allowed(&cfg) || cfg.install_id.trim().is_empty() {
         ENABLED.store(false, Ordering::Relaxed);
-        return;
+        return Outcome::Done;
     }
 
-    let Some(report) = take(&cfg, &app.package_info().version.to_string()) else {
-        return;
+    let Some(payload) = take(&cfg, &app.package_info().version.to_string()) else {
+        return Outcome::Done;
     };
     let url = format!("{}/v1/usage", control_plane());
     let sent = match client() {
-        Ok(client) => client.post(&url).json(&report).send().await,
+        Ok(client) => client.post(&url).json(&payload).send().await,
         Err(e) => {
             log::debug!("[usage] no HTTP client: {e}");
-            restore(report);
-            return;
+            restore(payload);
+            return Outcome::Retry;
         }
     };
     match sent {
-        Ok(res) if res.status().is_success() => {}
+        Ok(res) if res.status().is_success() => Outcome::Done,
+        Ok(res) if res.status() == reqwest::StatusCode::TOO_MANY_REQUESTS => {
+            // Either the endpoint's own per-address cap or the platform's daily one. Both
+            // mean the same thing to a client: stop asking.
+            Outcome::RateLimited
+        }
         Ok(res) => {
-            // A 4xx means this build is sending something the endpoint won't take; retrying
-            // it forever would never work, so drop it and leave the reason in the log.
+            // Any other 4xx means this build is sending something the endpoint won't take;
+            // retrying it forever would never work, so drop it and leave the reason.
             if res.status().is_client_error() {
                 log::warn!("[usage] report refused ({}) — dropped", res.status());
+                Outcome::Done
             } else {
-                restore(report);
+                restore(payload);
+                Outcome::Retry
             }
         }
         Err(e) => {
             log::debug!("[usage] report didn't send ({e}) — keeping it for the next try");
-            restore(report);
+            restore(payload);
+            Outcome::Retry
         }
     }
 }


### PR DESCRIPTION
## What happened

The control plane hit Cloudflare's free-plan ceiling — **100,000 Worker requests/day** — about eight hours after v0.12.4 shipped, returning error 1027 on every endpoint until the UTC reset. Paint sync, voice rooms, the server registry and track generation all went down together.

v0.12.4 turned paint sync on by default with no invite code, so the whole user base started polling at once. From the usage counters (which is what let this be measured rather than guessed):

| | |
|---|---|
| Installs on v0.12.4 | **414** |
| Device accounts signed up | **432** |
| Installs publishing paints | **367** |
| Usage-endpoint requests | **9,032** (~9% of the cap) |

So analytics was a minor contributor; the sync loop was the bulk. But analytics scaled worse than anything: the app launches at login and lives in the tray, so its 5-minute flush is per waking hour of every machine that has it — ~288 requests/day from an install nobody is using. At a few hundred installs that alone approaches the cap.

## Changes

**One request instead of two per tick.** `GET /v1/roster?server=…&here=1` now records the caller's presence as well as reading the roster. The client used to `PUT /v1/presence` and then `GET /v1/roster` every tick. `markPresent` is the single writer, shared with `PUT /v1/presence`, which stays for voice and for clients older than this.

`here=1` is validated with the same `isServerKey` as the standalone report — it writes a row other clients read, so it can't be looser just because the value arrived in a query string. Without the flag nothing is written, which is correct for a client sweeping servers it is *not* on.

**Heartbeat 45s → 3 minutes.** This was never the gap between a rider arriving and their paint landing — `GRID_POLL` watches the entry list and pulls within seconds of a new name. The heartbeat only covers a rider already present changing their look, and 3 minutes stays well inside the 10-minute presence TTL.

**No presence for servers you're not on.** The registry sweep used to report presence on *every* registered server — untrue, and a write per server.

**Usage flush 5 min → 30 min**, first report still at 60s so short sessions stay counted.

**429 means stop.** The usage endpoint's own cap now answers 429 rather than 202-and-ignore, and the client treats a 429 as "done reporting for this run" instead of retrying every interval. Hundreds of installs each retrying politely is how a ceiling gets held.

Together: roughly a fifth of the request volume for the same behaviour.

## Verification

- 1099 Rust tests, 101 worker tests, `tsc` clean both sides.
- Against a local `wrangler dev` with a real account token: a roster request without `here` writes no presence row; with `here=1` it writes exactly one for the right server; a junk server key with `here=1` is refused 400 with nothing written; two riders on two servers produce one row each, so presence scoping is intact.
- The paint-sync e2e test now exercises the folded path — Carol's presence rides along with her own pull rather than a separate call.

## Deploy order

Worker **first** — `here=1` is additive and clients that don't send it behave exactly as now, so deploying ahead of the app release is safe and necessary.

Note this does not raise the ceiling; it moves the app further from it. The plan upgrade is still the thing that ends the daily cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)