### PR TITLE
chore(release): v0.12.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,14 @@
 # Changelog
 
-## Unreleased
+## 2026-08-31 — v0.12.6
 
 ### Changed
-- Paint sync makes one request where it used to make two: saying where you are now rides
-  along with asking who else is here.
-- The sync heartbeat drops from every 45 seconds to every 3 minutes. A rider joining still
-  pulls within seconds — the heartbeat only ever covered someone already there changing
-  their look.
-- Sync no longer claims you are on every server in the registry when you are not on one.
-- Usage counts are sent every half hour instead of every five minutes, and stop for the
-  run if the server says it has had enough.
-
-### Fixed
-- The control plane ran out of its daily request allowance on the day v0.12.4 shipped,
-  which took paint sync, voice and the server list down with it. The changes above cut
-  what the app asks for by roughly four fifths.
+- Paint sync makes one request where it used to make two: saying where you are rides along
+  with asking who else is here.
+- The sync heartbeat runs every 3 minutes. A rider joining still pulls within seconds — the
+  heartbeat covers someone already there changing their look.
+- Sync only says you are on a server when you are on one.
+- Usage counts are sent every half hour, and stop for the run if the server has had enough.
 
 ## 2026-08-31 — v0.12.5
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.12.5",
+  "version": "0.12.6",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "mxb-app"
-version = "0.12.5"
+version = "0.12.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # whatever cargo called it. Cargo target names can't hold a space, so this is as close as
 # it gets. The description is what Windows Task Manager shows in its Processes tab.
 name = "mxb-app"
-version = "0.12.5"
+version = "0.12.6"
 description = "MXB App — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
   "mainBinaryName": "MXB App",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump and consolidated changelog for the control-plane request-volume work from #307 — one request where there were two, a 3-minute heartbeat, presence only when actually on a server, and usage counts every half hour.

Notes state what the release does; the diagnosis stays in #307.

Green: 1101 Rust tests, tsc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)