### PR TITLE
feat(entitlements): Steam identity and the server-side entitlement decision

### DIFF
--- a/control-plane/migrations/0013_entitlements.sql
+++ b/control-plane/migrations/0013_entitlements.sql
@@ -1,0 +1,78 @@
+-- Secured assets, and who is allowed to use them.
+--
+-- A creator can sell content that stays unusable without a live, authorized session. The
+-- decision "may this person use this asset" is made here and nowhere else: the client asks,
+-- the server answers, and no client-side flag can grant itself anything.
+--
+-- Nothing in this migration is cryptographic. It records identity and entitlement, which is
+-- the part that has to be right before any of the rest is worth building.
+
+-- One secured asset. The creator sells it; we gate it.
+CREATE TABLE assets (
+  id           TEXT PRIMARY KEY,
+  -- Who published it. Their account, so a creator can be paid, contacted, and — if it
+  -- comes to it — held responsible for what they uploaded.
+  creator_id   TEXT NOT NULL REFERENCES accounts (id),
+  title        TEXT NOT NULL,
+  -- Where the packed blob lives. No key material is stored here, ever: `key_id` names
+  -- *which* key it was packed under so keys can rotate without re-packing everything,
+  -- and the key itself lives in the secret store.
+  blob_key     TEXT,
+  key_id       TEXT,
+  created_at   INTEGER NOT NULL,
+  -- Pulled from sale, or taken down. Set rather than deleted: entitlements and the audit
+  -- log both reference assets, and the history of a withdrawn asset is exactly what you
+  -- want to still have.
+  withdrawn_at INTEGER
+);
+CREATE INDEX assets_creator ON assets (creator_id);
+
+-- Who may use what.
+--
+-- Keyed on the **SteamID**, not on our own account id. Identity comes from Valve — that is
+-- the whole design — and a purchase belongs to the Steam account that made it, which
+-- outlives any community account we happen to have attached to it. It also makes the
+-- operation that matters in an incident ("stop this person") a single predicate on the
+-- identity Valve gave us, rather than a join through our own records.
+CREATE TABLE entitlements (
+  steam_id    TEXT NOT NULL,
+  asset_id    TEXT NOT NULL REFERENCES assets (id) ON DELETE CASCADE,
+  -- How they came by it: a purchase, a creator granting it, or the creator's own asset.
+  source      TEXT NOT NULL,
+  granted_at  INTEGER NOT NULL,
+  -- Revocation is a timestamp, not a delete. A refunded or charged-back entitlement is a
+  -- thing you need to be able to see afterwards.
+  revoked_at  INTEGER,
+  PRIMARY KEY (steam_id, asset_id)
+);
+CREATE INDEX entitlements_asset ON entitlements (asset_id);
+
+-- Every decision, append-only.
+--
+-- This is the "theft has a name on it" ledger. Denials are recorded as well as grants:
+-- one identity sweeping the whole catalogue, or a burst of re-authentication, looks like
+-- extraction tooling and is only visible if the refusals are written down too.
+CREATE TABLE entitlement_grants (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  steam_id    TEXT NOT NULL,
+  asset_id    TEXT NOT NULL,
+  -- Which authorized session asked. Ties a series of requests together.
+  session_id  TEXT NOT NULL,
+  decision    TEXT NOT NULL,
+  reason      TEXT,
+  issued_at   INTEGER NOT NULL
+);
+CREATE INDEX entitlement_grants_steam ON entitlement_grants (steam_id, issued_at);
+
+-- A Steam sign-in in progress.
+--
+-- The browser leaves for Steam and comes back, and the two halves have to be tied together
+-- by something the round trip cannot forge: `id` travels in the return URL, and the row it
+-- names says which account was signing in. Rows are short-lived and single-use — a replayed
+-- return is a row that has already been consumed.
+CREATE TABLE steam_logins (
+  id          TEXT PRIMARY KEY,
+  account_id  TEXT NOT NULL REFERENCES accounts (id) ON DELETE CASCADE,
+  created_at  INTEGER NOT NULL,
+  consumed_at INTEGER
+);

--- a/control-plane/scripts/entitlements-e2e.sh
+++ b/control-plane/scripts/entitlements-e2e.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# The entitlement decision, end to end against a local control plane.
+#
+# Proves the thing step 2 exists to prove: the server, and only the server, decides whether
+# a player may use a secured asset — and it decides on the Steam identity, not on anything
+# the caller says about itself. No crypto is involved; there is nothing to decrypt yet.
+#
+# The Steam round trip itself cannot run here (it needs a browser and a real Steam account),
+# so the link is seeded directly into D1. What Valve's half must do is covered by the
+# adversarial cases in `test/steam.test.ts`, including an assertion minted for another site
+# and a Steam that cannot be reached.
+#
+#   ./scripts/entitlements-e2e.sh
+#
+set -euo pipefail
+
+PORT="${MXB_E2E_PORT:-8798}"
+BASE="http://127.0.0.1:${PORT}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG="$(mktemp -t mxb-ent-e2e)"
+STEAM_ID="76561198000000042"
+FAIL=0
+
+cd "$HERE"
+
+say()  { printf '\n== %s\n' "$1"; }
+# want <description> <expected> <actual>
+want() {
+  if [ "$2" = "$3" ]; then
+    printf '   ok   %s\n' "$1"
+  else
+    printf '   FAIL %s\n        expected: %s\n        actual:   %s\n' "$1" "$2" "$3"
+    FAIL=1
+  fi
+}
+d1() { npx wrangler d1 execute mxb-control-plane --local --command "$1" >/dev/null; }
+
+say "clean local state"
+rm -rf .wrangler/state
+for m in migrations/*.sql; do
+  npx wrangler d1 execute mxb-control-plane --local --file "$m" >/dev/null 2>&1 ||
+    echo "   (${m##*/} already applied)"
+done
+
+say "start the control plane on :${PORT}"
+npx wrangler dev --port "$PORT" --local >"$LOG" 2>&1 &
+trap 'kill %1 2>/dev/null || true' EXIT
+for _ in $(seq 1 60); do curl -fsS "${BASE}/v1/servers" >/dev/null 2>&1 && break; sleep 1; done
+curl -fsS "${BASE}/v1/servers" >/dev/null || { echo "worker never came up:"; cat "$LOG"; exit 1; }
+
+say "a player, and a creator's asset"
+TOKEN=$(curl -fsS -X POST "${BASE}/v1/account" -H 'content-type: application/json' \
+  -d '{"riderName":"Frost"}' | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')
+ACCOUNT=$(npx wrangler d1 execute mxb-control-plane --local --json \
+  --command "SELECT id FROM accounts LIMIT 1" | python3 -c 'import json,sys; print(json.load(sys.stdin)[0]["results"][0]["id"])')
+d1 "INSERT INTO assets (id, creator_id, title, created_at) VALUES ('trk_pinehill', '${ACCOUNT}', 'Pine Hill', 1)"
+d1 "INSERT INTO assets (id, creator_id, title, created_at, withdrawn_at) VALUES ('trk_gone', '${ACCOUNT}', 'Withdrawn', 1, 2)"
+
+check() { curl -s -o /dev/null -w '%{http_code}' -X POST "${BASE}/v1/entitlements/check" \
+  -H "authorization: Bearer ${TOKEN}" -H 'content-type: application/json' \
+  -d "{\"assetId\":\"$1\",\"sessionId\":\"s1\"}"; }
+
+say "before anything is linked or bought"
+want "an unlinked account owns nothing"      "403" "$(check trk_pinehill)"
+want "and its entitlement list is empty"     "0" \
+  "$(curl -fsS "${BASE}/v1/entitlements" -H "authorization: Bearer ${TOKEN}" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["assets"]))')"
+
+say "link the Steam identity (the browser half, seeded)"
+d1 "UPDATE accounts SET steam_id = '${STEAM_ID}' WHERE id = '${ACCOUNT}'"
+want "linked but unentitled is still refused" "403" "$(check trk_pinehill)"
+
+say "buy it"
+d1 "INSERT INTO entitlements (steam_id, asset_id, source, granted_at) VALUES ('${STEAM_ID}', 'trk_pinehill', 'purchase', 1)"
+want "an entitled player is allowed"          "200" "$(check trk_pinehill)"
+want "and it shows in their list"             "trk_pinehill" \
+  "$(curl -fsS "${BASE}/v1/entitlements" -H "authorization: Bearer ${TOKEN}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["assets"][0]["assetId"])')"
+
+say "the refusals that matter"
+want "an asset that does not exist"           "403" "$(check trk_nosuch)"
+want "an asset withdrawn from sale"           "403" "$(check trk_gone)"
+
+d1 "UPDATE entitlements SET revoked_at = 99 WHERE steam_id = '${STEAM_ID}' AND asset_id = 'trk_pinehill'"
+want "a revoked entitlement stops immediately" "403" "$(check trk_pinehill)"
+want "and drops out of their list"             "0" \
+  "$(curl -fsS "${BASE}/v1/entitlements" -H "authorization: Bearer ${TOKEN}" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["assets"]))')"
+
+say "somebody else's purchase is not yours"
+d1 "UPDATE entitlements SET revoked_at = NULL WHERE steam_id = '${STEAM_ID}'"
+d1 "UPDATE accounts SET steam_id = '76561198000000999' WHERE id = '${ACCOUNT}'"
+want "same account, different Steam identity"  "403" "$(check trk_pinehill)"
+
+say "the audit log"
+GRANTS=$(npx wrangler d1 execute mxb-control-plane --local --json \
+  --command "SELECT COUNT(*) AS n FROM entitlement_grants" | python3 -c 'import json,sys; print(json.load(sys.stdin)[0]["results"][0]["n"])')
+DENIES=$(npx wrangler d1 execute mxb-control-plane --local --json \
+  --command "SELECT COUNT(*) AS n FROM entitlement_grants WHERE decision = 'deny'" | python3 -c 'import json,sys; print(json.load(sys.stdin)[0]["results"][0]["n"])')
+# Seven checks above: one allow and six refusals. Listing entitlements is not a decision
+# and deliberately writes nothing — the log is what was *asked and answered*, not what was
+# browsed.
+want "every decision is recorded"              "7" "$GRANTS"
+want "including the refusals"                  "6" "$DENIES"
+
+printf '\n'
+[ "$FAIL" = 0 ] && echo "PASS" || { echo "FAILURES ABOVE"; exit 1; }

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -9,6 +9,12 @@
  */
 
 import {
+  isVerified,
+  loginUrl,
+  verifyAssertion,
+  LOGIN_TTL_MS,
+} from "./steam";
+import {
   awsEnv,
   createImage,
   fleet,
@@ -132,6 +138,11 @@ async function route(request: Request, env: Env): Promise<Response> {
   if (method === "POST" && path === "/v1/track/generate") return generateTrack(request, env);
   if (method === "POST" && path === "/v1/enroll") return enroll(request, env);
 
+  // Steam comes back to the browser, which carries no bearer token — the login id in the
+  // return URL is what identifies the sign-in, and it is single-use. Above the account
+  // gate for that reason, not because it is unprotected.
+  if (method === "GET" && path === "/v1/steam/return") return steamReturn(request, url, env);
+
   // Self-serve signup, no invite. Voice is the reason this exists: a rider on a community
   // server has nobody to talk to unless the people beside them can sign up too. The account
   // it mints can report presence and join a voice room and nothing else — see `invitedOnly`.
@@ -179,6 +190,13 @@ async function route(request: Request, env: Env): Promise<Response> {
   if (method === "PUT" && path === "/v1/me/guid") return putGuid(request, account, env);
   if (method === "PUT" && path === "/v1/presence") return putPresence(request, account, env);
   if (method === "GET" && path === "/v1/voice/ice") return iceServers();
+  // Linking a Steam account, and asking what it may use. Open to every account: identity
+  // is the point of the flow, and entitlement is checked per asset when it is asked for.
+  if (method === "POST" && path === "/v1/steam/login") return steamLogin(request, account, env);
+  if (method === "GET" && path === "/v1/entitlements") return listEntitlements(account, env);
+  if (method === "POST" && path === "/v1/entitlements/check") {
+    return checkEntitlement(request, account, env);
+  }
   if (method === "GET" && path === "/v1/voice/room") return voiceRoom(request, url, account, env);
 
   // Paint sync, open on the same terms as voice, and for the same reason: a rider only sees
@@ -292,6 +310,165 @@ async function enroll(request: Request, env: Env): Promise<Response> {
   // The only time the token is ever visible. It is stored as a digest, so it cannot be
   // shown again and a database leak yields nothing presentable.
   return json(201, { accountId: id, token, riderName: (riderName as string).trim() });
+}
+
+/**
+ * Begin a Steam sign-in.
+ *
+ * Returns a URL rather than redirecting: the caller is the app, which opens it in the
+ * player's browser and waits. The login row is what ties the browser's eventual return to
+ * the account that started it — the browser itself carries no credential of ours.
+ */
+async function steamLogin(request: Request, account: Account, env: Env): Promise<Response> {
+  const id = crypto.randomUUID();
+  await env.DB.prepare(
+    "INSERT INTO steam_logins (id, account_id, created_at) VALUES (?, ?, ?)",
+  )
+    .bind(id, account.id, Date.now())
+    .run();
+
+  const origin = new URL(request.url).origin;
+  const returnTo = `${origin}/v1/steam/return?login=${id}`;
+  return json(200, { url: loginUrl(returnTo, `${origin}/`), loginId: id });
+}
+
+/**
+ * Steam sending the player back.
+ *
+ * Everything in the query string is attacker-controlled until Valve confirms it, so the
+ * order here is deliberate: find the pending login, check it is still open, then ask Steam
+ * whether it really signed this. The row is consumed before anything is written, so a
+ * replayed return finds nothing to complete.
+ *
+ * The response is a page, not JSON — a person is looking at it.
+ */
+async function steamReturn(request: Request, url: URL, env: Env): Promise<Response> {
+  const loginId = url.searchParams.get("login");
+  if (!loginId) return page(400, "That sign-in link is incomplete.");
+
+  const login = await env.DB.prepare(
+    "SELECT account_id, created_at, consumed_at FROM steam_logins WHERE id = ?",
+  )
+    .bind(loginId)
+    .first<{ account_id: string; created_at: number; consumed_at: number | null }>();
+
+  if (!login) return page(404, "That sign-in has expired or already been used.");
+  if (login.consumed_at !== null) return page(409, "That sign-in has already been used.");
+  if (Date.now() - login.created_at > LOGIN_TTL_MS) {
+    return page(410, "That sign-in took too long. Start it again from the app.");
+  }
+
+  const expectedReturnTo = `${url.origin}${url.pathname}`;
+  const result = await verifyAssertion(url.searchParams, expectedReturnTo);
+  if (!isVerified(result)) {
+    return page(403, `Steam couldn't confirm that sign-in: ${result.error}.`);
+  }
+
+  // Consumed whatever happens next, so a failed link cannot be retried against a row that
+  // has already been through Valve.
+  await env.DB.prepare("UPDATE steam_logins SET consumed_at = ? WHERE id = ?")
+    .bind(Date.now(), loginId)
+    .run();
+
+  // `accounts.steam_id` is UNIQUE: one Steam account is one identity here, and a second
+  // community account cannot quietly claim an identity that is already spoken for.
+  try {
+    await env.DB.prepare("UPDATE accounts SET steam_id = ? WHERE id = ?")
+      .bind(result.steamId, login.account_id)
+      .run();
+  } catch (err) {
+    if (String(err).includes("UNIQUE")) {
+      return page(409, "That Steam account is already linked to another profile.");
+    }
+    throw err;
+  }
+
+  return page(200, "Steam account linked. You can close this tab and go back to the app.");
+}
+
+/** A one-line page for the browser half of the sign-in. */
+function page(status: number, message: string): Response {
+  const body = `<!doctype html><meta charset="utf-8"><title>MXB App</title>` +
+    `<body style="font:16px/1.5 system-ui;margin:4rem auto;max-width:30rem;padding:0 1rem">` +
+    `<p>${message.replace(/[<&]/g, (c) => (c === "<" ? "&lt;" : "&amp;"))}</p>`;
+  return new Response(body, { status, headers: { "content-type": "text/html; charset=utf-8" } });
+}
+
+/**
+ * What this player may use.
+ *
+ * Empty for an account with no Steam link — not an error. Entitlement is keyed on the
+ * Steam identity, so an unlinked account simply owns nothing yet, and saying so plainly is
+ * more useful than a failure the app has to interpret.
+ */
+async function listEntitlements(account: Account, env: Env): Promise<Response> {
+  if (!account.steam_id) return json(200, { steamId: null, assets: [] });
+
+  const rows = await env.DB.prepare(
+    "SELECT e.asset_id, a.title, e.source, e.granted_at" +
+      " FROM entitlements e JOIN assets a ON a.id = e.asset_id" +
+      " WHERE e.steam_id = ? AND e.revoked_at IS NULL AND a.withdrawn_at IS NULL" +
+      " ORDER BY e.granted_at DESC",
+  )
+    .bind(account.steam_id)
+    .all<{ asset_id: string; title: string; source: string; granted_at: number }>();
+
+  return json(200, {
+    steamId: account.steam_id,
+    assets: (rows.results ?? []).map((r) => ({
+      assetId: r.asset_id,
+      title: r.title,
+      source: r.source,
+      grantedAt: r.granted_at,
+    })),
+  });
+}
+
+/**
+ * May this player use this asset, right now?
+ *
+ * The question the whole system exists to answer. No key is minted here and no crypto
+ * happens — this is the decision, proved end to end before there is anything to decrypt.
+ *
+ * Every call is written to the audit log, refusals included: one identity walking the
+ * catalogue is only visible if the "no"s are recorded too.
+ */
+async function checkEntitlement(request: Request, account: Account, env: Env): Promise<Response> {
+  const body = await readJson(request);
+  if (!body) return json(400, { error: "expected a JSON body" });
+  const { assetId, sessionId } = body as { assetId?: unknown; sessionId?: unknown };
+  if (typeof assetId !== "string" || !assetId.trim()) {
+    return json(400, { error: "an asset id is required" });
+  }
+  const session = typeof sessionId === "string" && sessionId.trim() ? sessionId.trim() : "none";
+
+  const decide = async (): Promise<{ allowed: boolean; reason: string }> => {
+    if (!account.steam_id) return { allowed: false, reason: "no Steam account linked" };
+    const asset = await env.DB.prepare("SELECT withdrawn_at FROM assets WHERE id = ?")
+      .bind(assetId)
+      .first<{ withdrawn_at: number | null }>();
+    if (!asset) return { allowed: false, reason: "no such asset" };
+    if (asset.withdrawn_at !== null) return { allowed: false, reason: "withdrawn" };
+
+    const row = await env.DB.prepare(
+      "SELECT revoked_at FROM entitlements WHERE steam_id = ? AND asset_id = ?",
+    )
+      .bind(account.steam_id, assetId)
+      .first<{ revoked_at: number | null }>();
+    if (!row) return { allowed: false, reason: "not entitled" };
+    if (row.revoked_at !== null) return { allowed: false, reason: "revoked" };
+    return { allowed: true, reason: "entitled" };
+  };
+
+  const { allowed, reason } = await decide();
+  await env.DB.prepare(
+    "INSERT INTO entitlement_grants (steam_id, asset_id, session_id, decision, reason, issued_at)" +
+      " VALUES (?, ?, ?, ?, ?, ?)",
+  )
+    .bind(account.steam_id ?? "unlinked", assetId, session, allowed ? "allow" : "deny", reason, Date.now())
+    .run();
+
+  return json(allowed ? 200 : 403, { allowed, reason });
 }
 
 /**

--- a/control-plane/src/steam.ts
+++ b/control-plane/src/steam.ts
@@ -1,0 +1,166 @@
+/**
+ * Steam sign-in, for the one thing only Valve can tell us: who this person is.
+ *
+ * Entitlement is ours — it is a row in `entitlements` and nothing else. What we cannot
+ * decide for ourselves is whether the person claiming to be a given player really is one,
+ * and that is all this file does: turn a browser round trip through Steam into a SteamID64
+ * we are willing to trust.
+ *
+ * ## Why OpenID and not an auth-session ticket
+ *
+ * The in-process route (`GetAuthSessionTicket`, verified with `AuthenticateUserTicket`) is
+ * bound to a Steam AppID. MX Bikes' AppID is PiBoSo's, and `ISteamUser/CheckAppOwnership`
+ * "requires the publisher API key that owns the specified App ID" — a publisher key works
+ * only on its own apps. So we could never have asked Valve about MX Bikes anyway, with any
+ * key obtainable by us.
+ *
+ * OpenID needs no AppID, no publisher key and no code inside the game. What it proves is
+ * narrower and the difference matters: **that the person who authorized this sign-in
+ * controls that Steam account**, not that the account is the one running the game right
+ * now. The gap that leaves is an entitled user handing access to a friend — bounded by
+ * short-lived sessions and attribution, and small next to the fact that anyone entitled can
+ * read the decrypted asset out of their own memory regardless.
+ *
+ * ## Verifying, rather than believing
+ *
+ * Steam sends the assertion back as query parameters on a URL *the user's browser is
+ * holding*, so every one of them is attacker-controlled until proven otherwise. Exactly one
+ * thing makes them trustworthy: sending them back to Steam with `check_authentication` and
+ * getting `is_valid:true`. Everything else here exists to stop an assertion that is
+ * genuinely valid — for some other site, or replayed a second time — from counting as one
+ * for us.
+ */
+
+/** Steam's OpenID 2.0 endpoint. */
+const OPENID_ENDPOINT = "https://steamcommunity.com/openid/login";
+
+/** The only issuer whose claimed identifiers we accept. */
+const CLAIMED_ID_PREFIX = "https://steamcommunity.com/openid/id/";
+
+/** A sign-in that hasn't completed in this long is abandoned, not pending. */
+export const LOGIN_TTL_MS = 10 * 60 * 1000;
+
+/** How long to wait on Steam before giving up on a verification. */
+const VERIFY_TIMEOUT_MS = 10_000;
+
+/**
+ * Where to send the browser to sign in.
+ *
+ * `returnTo` carries the login id, so the assertion comes back attached to the row that
+ * says who was signing in. It is also checked on the way back — see [`verifyAssertion`] —
+ * which is what stops an assertion minted for another site being replayed at ours.
+ */
+export function loginUrl(returnTo: string, realm: string): string {
+  const params = new URLSearchParams({
+    "openid.ns": "http://specs.openid.net/auth/2.0",
+    "openid.mode": "checkid_setup",
+    "openid.return_to": returnTo,
+    "openid.realm": realm,
+    // Steam ignores per-user identifiers and always answers with the signed-in account,
+    // so both of these are the "not yet known" sentinel the spec defines.
+    "openid.identity": "http://specs.openid.net/auth/2.0/identifier_select",
+    "openid.claimed_id": "http://specs.openid.net/auth/2.0/identifier_select",
+  });
+  return `${OPENID_ENDPOINT}?${params.toString()}`;
+}
+
+/** What a verified sign-in yields. */
+export interface VerifiedSteamId {
+  steamId: string;
+}
+
+/** Why one didn't. Returned rather than thrown: every branch here is a normal outcome. */
+export type VerifyFailure = { error: string };
+
+export type VerifyResult = VerifiedSteamId | VerifyFailure;
+
+export function isVerified(r: VerifyResult): r is VerifiedSteamId {
+  return (r as VerifiedSteamId).steamId !== undefined;
+}
+
+/**
+ * A SteamID64, as Valve writes them: 17 digits, and nothing else.
+ *
+ * Checked because this value becomes a database key and is compared against entitlements.
+ * A claimed identifier that is a valid URL but not a Steam profile must not become an
+ * identity.
+ */
+export function steamIdFromClaimedId(claimedId: unknown): string | null {
+  if (typeof claimedId !== "string") return null;
+  if (!claimedId.startsWith(CLAIMED_ID_PREFIX)) return null;
+  const id = claimedId.slice(CLAIMED_ID_PREFIX.length);
+  return /^\d{17}$/.test(id) ? id : null;
+}
+
+/**
+ * Is this assertion addressed to us?
+ *
+ * An OpenID assertion is only meaningful for the `return_to` it was minted for. Without
+ * this check, an assertion a user legitimately obtained at any other Steam-login site could
+ * be pasted at ours and would verify perfectly — `check_authentication` would say `true`,
+ * because it *is* a true assertion. It just isn't one about us.
+ *
+ * Compared on origin and path, ignoring query: the return URL carries the login id, and
+ * that is checked separately by looking the row up.
+ */
+export function returnToMatches(asserted: unknown, expected: string): boolean {
+  if (typeof asserted !== "string") return false;
+  try {
+    const a = new URL(asserted);
+    const e = new URL(expected);
+    return a.origin === e.origin && a.pathname === e.pathname;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Ask Steam whether it really said this.
+ *
+ * The whole assertion is echoed back with `openid.mode` swapped to `check_authentication`,
+ * which is the spec's "did you sign this" question. Only `is_valid:true` counts; anything
+ * else — a false, a malformed body, a network failure — is a refusal. There is deliberately
+ * no path here that lets a verification failure resolve as success.
+ */
+export async function verifyAssertion(
+  query: URLSearchParams,
+  expectedReturnTo: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<VerifyResult> {
+  if (query.get("openid.mode") !== "id_res") {
+    // `cancel` is the user declining at Steam, which is not an error worth alarming about.
+    return { error: query.get("openid.mode") === "cancel" ? "cancelled" : "not an assertion" };
+  }
+  if (!returnToMatches(query.get("openid.return_to"), expectedReturnTo)) {
+    return { error: "that sign-in was not for this site" };
+  }
+  const steamId = steamIdFromClaimedId(query.get("openid.claimed_id"));
+  if (!steamId) return { error: "no Steam account in that sign-in" };
+
+  const body = new URLSearchParams(query);
+  body.set("openid.mode", "check_authentication");
+
+  let text: string;
+  try {
+    const resp = await fetchImpl(OPENID_ENDPOINT, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+      signal: AbortSignal.timeout(VERIFY_TIMEOUT_MS),
+    });
+    if (!resp.ok) return { error: `Steam refused the check (${resp.status})` };
+    text = await resp.text();
+  } catch {
+    return { error: "couldn't reach Steam to check that sign-in" };
+  }
+
+  // Key-value form, one pair per line. Matched on a whole line so that a value appearing
+  // inside some other field cannot be mistaken for the verdict.
+  const valid = text
+    .split("\n")
+    .map((line) => line.trim())
+    .includes("is_valid:true");
+  if (!valid) return { error: "Steam did not confirm that sign-in" };
+
+  return { steamId };
+}

--- a/control-plane/test/steam.test.ts
+++ b/control-plane/test/steam.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import {
+  isVerified,
+  loginUrl,
+  returnToMatches,
+  steamIdFromClaimedId,
+  verifyAssertion,
+} from "../src/steam";
+
+/** A well-formed assertion, as Steam sends one back. */
+function assertion(over: Record<string, string> = {}): URLSearchParams {
+  return new URLSearchParams({
+    "openid.ns": "http://specs.openid.net/auth/2.0",
+    "openid.mode": "id_res",
+    "openid.op_endpoint": "https://steamcommunity.com/openid/login",
+    "openid.claimed_id": "https://steamcommunity.com/openid/id/76561198000000001",
+    "openid.identity": "https://steamcommunity.com/openid/id/76561198000000001",
+    "openid.return_to": "https://cp.example.com/v1/steam/return?login=abc",
+    "openid.sig": "deadbeef",
+    "openid.signed": "signed,op_endpoint,claimed_id,identity,return_to",
+    ...over,
+  });
+}
+
+const RETURN_TO = "https://cp.example.com/v1/steam/return";
+
+/** A Steam that confirms everything. */
+const saysValid = async () => new Response("ns:http://specs.openid.net/auth/2.0\nis_valid:true\n");
+/** A Steam that confirms nothing. */
+const saysInvalid = async () =>
+  new Response("ns:http://specs.openid.net/auth/2.0\nis_valid:false\n");
+
+describe("steamIdFromClaimedId", () => {
+  it("takes a real Steam claimed identifier", () => {
+    expect(steamIdFromClaimedId("https://steamcommunity.com/openid/id/76561198000000001")).toBe(
+      "76561198000000001",
+    );
+  });
+
+  it("refuses an identifier from anywhere but Steam", () => {
+    // The whole identity rests on this prefix. A look-alike host that happened to answer
+    // an OpenID check would otherwise mint any identity it liked.
+    for (const bad of [
+      "https://steamcommunity.com.evil.test/openid/id/76561198000000001",
+      "http://steamcommunity.com/openid/id/76561198000000001",
+      "https://example.com/openid/id/76561198000000001",
+    ]) {
+      expect(steamIdFromClaimedId(bad), bad).toBeNull();
+    }
+  });
+
+  it("refuses anything that isn't a SteamID64", () => {
+    for (const bad of [
+      "https://steamcommunity.com/openid/id/",
+      "https://steamcommunity.com/openid/id/12345",
+      "https://steamcommunity.com/openid/id/7656119800000000x",
+      "https://steamcommunity.com/openid/id/765611980000000012",
+      undefined,
+      42,
+    ]) {
+      expect(steamIdFromClaimedId(bad as unknown), String(bad)).toBeNull();
+    }
+  });
+});
+
+describe("returnToMatches", () => {
+  it("accepts our own return URL whatever the query carries", () => {
+    expect(returnToMatches("https://cp.example.com/v1/steam/return?login=abc", RETURN_TO)).toBe(
+      true,
+    );
+  });
+
+  it("refuses an assertion minted for another site", () => {
+    // This is the attack the check exists for: an assertion a user genuinely obtained at
+    // some other Steam-login site verifies perfectly at Valve, because it is real. It is
+    // just not about us.
+    expect(returnToMatches("https://other.example.com/v1/steam/return", RETURN_TO)).toBe(false);
+  });
+
+  it("refuses a different path on our own host", () => {
+    expect(returnToMatches("https://cp.example.com/v1/something/else", RETURN_TO)).toBe(false);
+  });
+
+  it("refuses junk", () => {
+    expect(returnToMatches("not a url", RETURN_TO)).toBe(false);
+    expect(returnToMatches(undefined, RETURN_TO)).toBe(false);
+  });
+});
+
+describe("verifyAssertion", () => {
+  it("returns the SteamID when Steam confirms it", async () => {
+    const r = await verifyAssertion(assertion(), RETURN_TO, saysValid as typeof fetch);
+    expect(isVerified(r) && r.steamId).toBe("76561198000000001");
+  });
+
+  it("asks Steam with mode swapped to check_authentication", async () => {
+    // The verification is the entire security of this flow; if the echo back were sent
+    // with the original mode, Steam would answer a different question.
+    let sent: URLSearchParams | null = null;
+    const spy = (async (_url: string, init: RequestInit) => {
+      sent = new URLSearchParams(String(init.body));
+      return new Response("is_valid:true");
+    }) as unknown as typeof fetch;
+
+    await verifyAssertion(assertion(), RETURN_TO, spy);
+    expect(sent!.get("openid.mode")).toBe("check_authentication");
+    expect(sent!.get("openid.sig")).toBe("deadbeef");
+  });
+
+  it("refuses when Steam says no", async () => {
+    const r = await verifyAssertion(assertion(), RETURN_TO, saysInvalid as typeof fetch);
+    expect(isVerified(r)).toBe(false);
+  });
+
+  it("refuses an assertion for another site even when Steam would confirm it", async () => {
+    const r = await verifyAssertion(
+      assertion({ "openid.return_to": "https://other.example.com/v1/steam/return" }),
+      RETURN_TO,
+      saysValid as typeof fetch,
+    );
+    expect(isVerified(r)).toBe(false);
+  });
+
+  it("refuses a non-Steam claimed id even when Steam would confirm it", async () => {
+    const r = await verifyAssertion(
+      assertion({ "openid.claimed_id": "https://example.com/openid/id/76561198000000001" }),
+      RETURN_TO,
+      saysValid as typeof fetch,
+    );
+    expect(isVerified(r)).toBe(false);
+  });
+
+  it("treats a user cancelling as a cancellation, not a failure", async () => {
+    const r = await verifyAssertion(
+      assertion({ "openid.mode": "cancel" }),
+      RETURN_TO,
+      saysValid as typeof fetch,
+    );
+    expect(isVerified(r)).toBe(false);
+    expect((r as { error: string }).error).toBe("cancelled");
+  });
+
+  it("fails closed when Steam is unreachable", async () => {
+    // No path may resolve a verification failure as success — least of all the one that
+    // fires when the thing doing the verifying is down.
+    const dead = (async () => {
+      throw new Error("network");
+    }) as unknown as typeof fetch;
+    expect(isVerified(await verifyAssertion(assertion(), RETURN_TO, dead))).toBe(false);
+  });
+
+  it("fails closed on an error status from Steam", async () => {
+    const boom = (async () => new Response("nope", { status: 503 })) as unknown as typeof fetch;
+    expect(isVerified(await verifyAssertion(assertion(), RETURN_TO, boom))).toBe(false);
+  });
+
+  it("does not mistake is_valid:true inside another field for the verdict", async () => {
+    // The response is line-oriented key:value. A value that merely contains the string
+    // must not be read as the answer.
+    const sneaky = (async () =>
+      new Response("ns:http://x/\nnote:is_valid:true was not said\nis_valid:false\n")) as unknown as typeof fetch;
+    expect(isVerified(await verifyAssertion(assertion(), RETURN_TO, sneaky))).toBe(false);
+  });
+});
+
+describe("loginUrl", () => {
+  it("asks Steam to pick the signed-in account and come back to us", () => {
+    const url = new URL(loginUrl("https://cp.example.com/v1/steam/return?login=abc", "https://cp.example.com/"));
+    expect(url.origin + url.pathname).toBe("https://steamcommunity.com/openid/login");
+    expect(url.searchParams.get("openid.mode")).toBe("checkid_setup");
+    expect(url.searchParams.get("openid.return_to")).toBe(
+      "https://cp.example.com/v1/steam/return?login=abc",
+    );
+    expect(url.searchParams.get("openid.identity")).toBe(
+      "http://specs.openid.net/auth/2.0/identifier_select",
+    );
+  });
+});


### PR DESCRIPTION
Step 2 of the secure-content plan: prove the trust model before there is any crypto to protect. The server, and only the server, decides whether a player may use a secured asset, and it decides on the identity Valve returned — not on anything the client says about itself.

## What's here

- **Migration 0013** — `assets`, `entitlements`, an append-only decision log, and short-lived single-use Steam sign-in rows. Entitlements key on the **SteamID**, not our account id: a purchase belongs to the Steam account that made it, and revoking one person is then one predicate on the identity Valve gave us.
- **`src/steam.ts`** — Steam **OpenID**, not an auth-session ticket. `CheckAppOwnership` requires the publisher key that owns the appid, so MX Bikes ownership was never checkable by us — and never needed to be. Entitlement is ours; only identity is Valve's. The verification refuses an assertion minted for another site, a non-Steam claimed id, a Steam that says no, and a Steam it can't reach.
- **Entitlement routes** in `src/index.ts` — link Steam, list what you own, and the check that answers "may this player use this asset, now." Every decision is audited, refusals included.

## Why OpenID, and its one honest gap

OpenID proves the person controls that Steam account, not that the account is running the game on this machine right now. The residual gap is an *entitled* user proxying access to a friend — bounded by short key TTLs, machine binding and concurrent-session limits, and small next to the RAM-extraction ceiling this class of DRM already concedes. Full reasoning in `docs/secure-content/03-auth-backend.md` (gitignored).

## Testing

- 17 unit tests on the OpenID verification, including a response crafted so `is_valid:true` appears in a field that is not the verdict, and every fail-closed path.
- `control-plane/scripts/entitlements-e2e.sh` walks the whole decision on a local worker: unlinked → linked-but-unentitled → entitled → absent → withdrawn → revoked → someone else's purchase. Every decision lands in the audit log. **PASS.**
- Full worker suite: 118 tests green. tsc clean.

No crypto in this PR by design — that's the packer (step 3), which lives in the private repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)