### PR TITLE
feat(secure): release the content key to an entitled session

### DIFF
--- a/control-plane/migrations/0014_asset_keys.sql
+++ b/control-plane/migrations/0014_asset_keys.sql
@@ -1,0 +1,12 @@
+-- Where a secured asset's content key lives, wrapped.
+--
+-- The packer seals a blob under a content key (a CEK) and hands that key to us; the DLL
+-- needs exactly that key to open the blob. So the server has to hold it — but never in the
+-- clear. It is stored wrapped under a master key that lives only in a Worker secret
+-- (`MXB_ASSET_MASTER_KEY`), so a database leak yields wrapped keys that are useless without
+-- the secret, and the secret never touches the database.
+--
+-- On the `assets` row rather than a new table: one asset has one current content key, the
+-- same way it has one title. `key_id` (already on `assets`) names which master-key version
+-- wrapped it, so the master key can rotate without re-packing every asset.
+ALTER TABLE assets ADD COLUMN wrapped_key TEXT;

--- a/control-plane/scripts/entitlements-e2e.sh
+++ b/control-plane/scripts/entitlements-e2e.sh
@@ -20,6 +20,9 @@ BASE="http://127.0.0.1:${PORT}"
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LOG="$(mktemp -t mxb-ent-e2e)"
 STEAM_ID="76561198000000042"
+# A fixed master key and content key so the grant can be checked byte-for-byte.
+MASTER="AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="   # base64 of 0x00..0x1f
+CEK_HEX="1111111111111111111111111111111111111111111111111111111111111111"
 FAIL=0
 
 cd "$HERE"
@@ -44,7 +47,7 @@ for m in migrations/*.sql; do
 done
 
 say "start the control plane on :${PORT}"
-npx wrangler dev --port "$PORT" --local >"$LOG" 2>&1 &
+npx wrangler dev --port "$PORT" --local --var "MXB_ASSET_MASTER_KEY:${MASTER}" >"$LOG" 2>&1 &
 trap 'kill %1 2>/dev/null || true' EXIT
 for _ in $(seq 1 60); do curl -fsS "${BASE}/v1/servers" >/dev/null 2>&1 && break; sleep 1; done
 curl -fsS "${BASE}/v1/servers" >/dev/null || { echo "worker never came up:"; cat "$LOG"; exit 1; }
@@ -100,6 +103,44 @@ DENIES=$(npx wrangler d1 execute mxb-control-plane --local --json \
 # browsed.
 want "every decision is recorded"              "7" "$GRANTS"
 want "including the refusals"                  "6" "$DENIES"
+
+say "releasing the content key to an entitled session"
+# Relink the entitled identity (the earlier tests moved it away), and give trk_pinehill a
+# real wrapped key. A second asset is entitled but never packed, to prove the keyless case.
+d1 "UPDATE accounts SET steam_id = '${STEAM_ID}' WHERE id = '${ACCOUNT}'"
+d1 "UPDATE entitlements SET revoked_at = NULL WHERE steam_id = '${STEAM_ID}' AND asset_id = 'trk_pinehill'"
+d1 "INSERT INTO assets (id, creator_id, title, created_at) VALUES ('trk_nokey', '${ACCOUNT}', 'Never packed', 1)"
+d1 "INSERT INTO entitlements (steam_id, asset_id, source, granted_at) VALUES ('${STEAM_ID}', 'trk_nokey', 'purchase', 1)"
+
+WRAP="$(mktemp -t mxb-wrap).js"
+cat > "$WRAP" <<'JS'
+const { webcrypto } = require("crypto");
+const { subtle } = webcrypto;
+(async () => {
+  const master = Buffer.from(process.argv[2], "base64");
+  const cek = Buffer.from(process.argv[3], "hex");
+  const key = await subtle.importKey("raw", master, { name: "AES-GCM" }, false, ["encrypt"]);
+  const iv = webcrypto.getRandomValues(new Uint8Array(12));
+  const ct = Buffer.from(await subtle.encrypt({ name: "AES-GCM", iv }, key, cek));
+  process.stdout.write(Buffer.concat([Buffer.from(iv), ct]).toString("base64"));
+})();
+JS
+WRAPPED="$(node "$WRAP" "$MASTER" "$CEK_HEX")"
+d1 "UPDATE assets SET wrapped_key = '${WRAPPED}', key_id = 'k1' WHERE id = 'trk_pinehill'"
+
+grant() { curl -s -X POST "${BASE}/v1/keys/grant" -H "authorization: Bearer ${TOKEN}"   -H 'content-type: application/json' -d "{\"assetId\":\"$1\",\"sessionId\":\"s2\"}"; }
+grant_code() { curl -s -o /dev/null -w '%{http_code}' -X POST "${BASE}/v1/keys/grant"   -H "authorization: Bearer ${TOKEN}" -H 'content-type: application/json'   -d "{\"assetId\":\"$1\",\"sessionId\":\"s2\"}"; }
+
+want "an entitled session is granted the key" "200" "$(grant_code trk_pinehill)"
+GOT_HEX="$(grant trk_pinehill | python3 -c 'import json,sys,base64; print(base64.b64decode(json.load(sys.stdin)["contentKey"]).hex())')"
+want "and it is the real content key"          "$CEK_HEX" "$GOT_HEX"
+
+want "an entitled asset with no key is a 409"  "409" "$(grant_code trk_nokey)"
+
+d1 "UPDATE entitlements SET revoked_at = 99 WHERE steam_id = '${STEAM_ID}' AND asset_id = 'trk_pinehill'"
+want "a revoked entitlement is denied the key" "403" "$(grant_code trk_pinehill)"
+
+rm -f "$WRAP"
 
 printf '\n'
 [ "$FAIL" = 0 ] && echo "PASS" || { echo "FAILURES ABOVE"; exit 1; }

--- a/control-plane/src/assetkey.ts
+++ b/control-plane/src/assetkey.ts
@@ -1,0 +1,95 @@
+/**
+ * Wrapping and unwrapping a content key under the master key.
+ *
+ * The packer seals each asset under a content key; the DLL needs that exact key to open the
+ * blob. We hold it so it can be released to an entitled session and withheld from everyone
+ * else — but holding a decryption key in a database is only safe if the database never has
+ * the usable form. So the content key is stored **wrapped**: AES-GCM-encrypted under a
+ * master key that exists only as a Worker secret. A leaked database is a pile of wrapped
+ * keys and no way to unwrap them.
+ *
+ * AES-GCM via WebCrypto, which is present in the Workers runtime — no dependency, and the
+ * primitive rather than a scheme of our own. The wrapped form is `iv(12) ‖ ciphertext+tag`,
+ * base64, so it is one self-contained string on the row.
+ */
+
+const IV_LEN = 12;
+
+/** Base64 of raw bytes. */
+function b64(bytes: Uint8Array): string {
+  let s = "";
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s);
+}
+
+/** Raw bytes of base64, or null if it isn't valid base64. */
+function unb64(text: string): Uint8Array | null {
+  try {
+    const s = atob(text);
+    const out = new Uint8Array(s.length);
+    for (let i = 0; i < s.length; i++) out[i] = s.charCodeAt(i);
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Import the master key from the secret.
+ *
+ * The secret is base64 of 32 raw bytes. Absent or malformed means the feature is off, not
+ * that a request should be served with a key derived from nothing — the caller turns `null`
+ * into a 503, the same way the rest of the control plane treats a missing credential.
+ */
+async function masterKey(secret: string | undefined): Promise<CryptoKey | null> {
+  if (!secret) return null;
+  const raw = unb64(secret.trim());
+  if (!raw || raw.length !== 32) return null;
+  return crypto.subtle.importKey("raw", raw, { name: "AES-GCM" }, false, ["encrypt", "decrypt"]);
+}
+
+/**
+ * Wrap a content key for storage. Used at pack/register time.
+ *
+ * `contentKey` is the raw 32-byte CEK. Returns the base64 string to put on the row, or null
+ * if there is no usable master key — in which case the asset cannot be registered as
+ * secured, which is the correct refusal rather than storing the key in the clear.
+ */
+export async function wrapContentKey(
+  contentKey: Uint8Array,
+  secret: string | undefined,
+): Promise<string | null> {
+  const key = await masterKey(secret);
+  if (!key || contentKey.length !== 32) return null;
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LEN));
+  const ct = new Uint8Array(await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, contentKey));
+  const out = new Uint8Array(IV_LEN + ct.length);
+  out.set(iv, 0);
+  out.set(ct, IV_LEN);
+  return b64(out);
+}
+
+/**
+ * Unwrap a stored content key for release to an entitled session.
+ *
+ * Returns the raw 32-byte CEK, or null if the master key is missing or the wrapped value
+ * doesn't authenticate — a tampered or wrongly-keyed row must yield nothing, never a
+ * plausible-looking key.
+ */
+export async function unwrapContentKey(
+  wrapped: string,
+  secret: string | undefined,
+): Promise<Uint8Array | null> {
+  const key = await masterKey(secret);
+  if (!key) return null;
+  const raw = unb64(wrapped);
+  if (!raw || raw.length <= IV_LEN) return null;
+  const iv = raw.slice(0, IV_LEN);
+  const ct = raw.slice(IV_LEN);
+  try {
+    const pt = new Uint8Array(await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ct));
+    return pt.length === 32 ? pt : null;
+  } catch {
+    return null;
+  }
+}

--- a/control-plane/src/env.d.ts
+++ b/control-plane/src/env.d.ts
@@ -32,6 +32,10 @@ declare global {
     /** Keys the daily digest of a signup's IP address. Without it the digest is a plain
      *  hash, which is reversible for IPv4 — set it before open signup carries real load. */
     IP_HASH_SECRET?: string;
+    /** Base64 of 32 random bytes. Wraps every secured asset's content key, so a database
+     *  leak yields wrapped keys and no way to unwrap them. Absent means secured content is
+     *  off: `/v1/keys/grant` answers 503 rather than serving a key from nothing. */
+    MXB_ASSET_MASTER_KEY?: string;
   }
 }
 

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -8,6 +8,7 @@
  * else), so the app reports it here and every other app on the server reads it back.
  */
 
+import { unwrapContentKey } from "./assetkey";
 import {
   isVerified,
   loginUrl,
@@ -197,6 +198,7 @@ async function route(request: Request, env: Env): Promise<Response> {
   if (method === "POST" && path === "/v1/entitlements/check") {
     return checkEntitlement(request, account, env);
   }
+  if (method === "POST" && path === "/v1/keys/grant") return grantKey(request, account, env);
   if (method === "GET" && path === "/v1/voice/room") return voiceRoom(request, url, account, env);
 
   // Paint sync, open on the same terms as voice, and for the same reason: a rider only sees
@@ -433,15 +435,23 @@ async function listEntitlements(account: Account, env: Env): Promise<Response> {
  * Every call is written to the audit log, refusals included: one identity walking the
  * catalogue is only visible if the "no"s are recorded too.
  */
-async function checkEntitlement(request: Request, account: Account, env: Env): Promise<Response> {
-  const body = await readJson(request);
-  if (!body) return json(400, { error: "expected a JSON body" });
-  const { assetId, sessionId } = body as { assetId?: unknown; sessionId?: unknown };
-  if (typeof assetId !== "string" || !assetId.trim()) {
-    return json(400, { error: "an asset id is required" });
-  }
-  const session = typeof sessionId === "string" && sessionId.trim() ? sessionId.trim() : "none";
-
+/**
+ * The single entitlement decision, and the single audit write.
+ *
+ * Extracted so the check and the key grant cannot drift: a key is released on exactly the
+ * condition the check reports, because they are the same function. Both the withdrawn-asset
+ * and the revoked-entitlement branches matter to the grant especially — a key must stop
+ * being issued the instant either flips, which is what makes revocation real.
+ *
+ * Every call is logged, refusals included: one identity walking the catalogue is only
+ * visible if the "no"s are written down too.
+ */
+async function decideEntitlement(
+  account: Account,
+  assetId: string,
+  session: string,
+  env: Env,
+): Promise<{ allowed: boolean; reason: string }> {
   const decide = async (): Promise<{ allowed: boolean; reason: string }> => {
     if (!account.steam_id) return { allowed: false, reason: "no Steam account linked" };
     const asset = await env.DB.prepare("SELECT withdrawn_at FROM assets WHERE id = ?")
@@ -460,15 +470,99 @@ async function checkEntitlement(request: Request, account: Account, env: Env): P
     return { allowed: true, reason: "entitled" };
   };
 
-  const { allowed, reason } = await decide();
+  const result = await decide();
   await env.DB.prepare(
     "INSERT INTO entitlement_grants (steam_id, asset_id, session_id, decision, reason, issued_at)" +
       " VALUES (?, ?, ?, ?, ?, ?)",
   )
-    .bind(account.steam_id ?? "unlinked", assetId, session, allowed ? "allow" : "deny", reason, Date.now())
+    .bind(
+      account.steam_id ?? "unlinked",
+      assetId,
+      session,
+      result.allowed ? "allow" : "deny",
+      result.reason,
+      Date.now(),
+    )
     .run();
+  return result;
+}
 
+/** Pull and validate `{ assetId, sessionId }` from a request body. */
+async function assetRequest(
+  request: Request,
+): Promise<{ assetId: string; session: string } | Response> {
+  const body = await readJson(request);
+  if (!body) return json(400, { error: "expected a JSON body" });
+  const { assetId, sessionId } = body as { assetId?: unknown; sessionId?: unknown };
+  if (typeof assetId !== "string" || !assetId.trim()) {
+    return json(400, { error: "an asset id is required" });
+  }
+  const session = typeof sessionId === "string" && sessionId.trim() ? sessionId.trim() : "none";
+  return { assetId: assetId.trim(), session };
+}
+
+async function checkEntitlement(request: Request, account: Account, env: Env): Promise<Response> {
+  const parsed = await assetRequest(request);
+  if (parsed instanceof Response) return parsed;
+  const { allowed, reason } = await decideEntitlement(account, parsed.assetId, parsed.session, env);
   return json(allowed ? 200 : 403, { allowed, reason });
+}
+
+/**
+ * Release the content key for a secured asset to an entitled session.
+ *
+ * The step the DLL cannot proceed without: it has the ciphertext blob and needs the key to
+ * open it. The key is released on exactly the entitlement check above — same function, so a
+ * withdrawal or revocation stops key issuance immediately — and only after the master-key
+ * secret unwraps the stored key. The raw content key leaves the server only here, only to a
+ * caller Valve's identity and our entitlement both vouch for, and the grant is audited like
+ * any other.
+ *
+ * `ttlSeconds` tells the DLL how briefly to hold it before asking again, which is what keeps
+ * revocation to one TTL rather than one session.
+ */
+async function grantKey(request: Request, account: Account, env: Env): Promise<Response> {
+  const parsed = await assetRequest(request);
+  if (parsed instanceof Response) return parsed;
+  const { assetId, session } = parsed;
+
+  const { allowed, reason } = await decideEntitlement(account, assetId, session, env);
+  if (!allowed) return json(403, { error: reason });
+
+  const asset = await env.DB.prepare("SELECT wrapped_key, key_id FROM assets WHERE id = ?")
+    .bind(assetId)
+    .first<{ wrapped_key: string | null; key_id: string | null }>();
+  if (!asset?.wrapped_key) {
+    // Entitled, but the asset has no stored key — it was never packed, or was registered
+    // before key custody existed. Not the caller's fault and not a 403: there is simply
+    // nothing to hand back.
+    return json(409, { error: "asset has no content key" });
+  }
+
+  const key = await unwrapContentKey(asset.wrapped_key, env.MXB_ASSET_MASTER_KEY);
+  if (!key) {
+    // No master key configured, or the stored key doesn't unwrap. Either way this
+    // deployment cannot serve secured content right now; say so rather than 200 with
+    // nothing usable.
+    return json(503, { error: "content keys are unavailable" });
+  }
+
+  return json(200, {
+    assetId,
+    keyId: asset.key_id ?? null,
+    contentKey: b64(key),
+    ttlSeconds: KEY_GRANT_TTL_SECONDS,
+  });
+}
+
+/** How briefly the DLL should cache a released key before re-checking entitlement. */
+const KEY_GRANT_TTL_SECONDS = 300;
+
+/** Base64 of raw bytes, for handing the key back over JSON. */
+function b64(bytes: Uint8Array): string {
+  let s = "";
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s);
 }
 
 /**

--- a/control-plane/test/assetkey.test.ts
+++ b/control-plane/test/assetkey.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { unwrapContentKey, wrapContentKey } from "../src/assetkey";
+
+/** A master key secret: base64 of 32 bytes. */
+const MASTER = btoa(String.fromCharCode(...Array.from({ length: 32 }, (_, i) => i + 1)));
+const OTHER = btoa(String.fromCharCode(...Array.from({ length: 32 }, (_, i) => 200 - i)));
+
+/** A content key: 32 bytes. */
+const CEK = new Uint8Array(Array.from({ length: 32 }, (_, i) => (i * 7) & 0xff));
+
+describe("wrap/unwrap", () => {
+  it("round-trips a content key under the master key", async () => {
+    const wrapped = await wrapContentKey(CEK, MASTER);
+    expect(wrapped).not.toBeNull();
+    const back = await unwrapContentKey(wrapped!, MASTER);
+    expect(back).not.toBeNull();
+    expect(Array.from(back!)).toEqual(Array.from(CEK));
+  });
+
+  it("does not put the content key in the wrapped form", async () => {
+    // The point of wrapping: the stored string must not contain the key it protects.
+    const wrapped = await wrapContentKey(CEK, MASTER);
+    const raw = atob(wrapped!);
+    const bytes = Uint8Array.from(raw, (c) => c.charCodeAt(0));
+    // Slide the CEK across the wrapped bytes; it must not appear.
+    let found = false;
+    for (let i = 0; i + CEK.length <= bytes.length; i++) {
+      if (CEK.every((b, j) => bytes[i + j] === b)) found = true;
+    }
+    expect(found).toBe(false);
+  });
+
+  it("wraps the same key to different bytes each time", async () => {
+    // A fresh IV per wrap, so two assets sharing a key — or one re-registered — don't
+    // produce an identical stored value that leaks the fact.
+    expect(await wrapContentKey(CEK, MASTER)).not.toEqual(await wrapContentKey(CEK, MASTER));
+  });
+
+  it("will not unwrap under a different master key", async () => {
+    const wrapped = await wrapContentKey(CEK, MASTER);
+    expect(await unwrapContentKey(wrapped!, OTHER)).toBeNull();
+  });
+
+  it("refuses a tampered wrapped value", async () => {
+    const wrapped = await wrapContentKey(CEK, MASTER);
+    const raw = atob(wrapped!);
+    const bytes = Uint8Array.from(raw, (c) => c.charCodeAt(0));
+    bytes[bytes.length - 1] ^= 0x01; // flip a tag byte
+    const tampered = btoa(String.fromCharCode(...bytes));
+    expect(await unwrapContentKey(tampered, MASTER)).toBeNull();
+  });
+
+  it("is off when there is no master key", async () => {
+    // A deployment with no secret cannot secure content, and must not fall back to some
+    // fixed key — it produces nothing, and the caller turns that into a 503.
+    expect(await wrapContentKey(CEK, undefined)).toBeNull();
+    expect(await unwrapContentKey("anything", undefined)).toBeNull();
+    expect(await wrapContentKey(CEK, "not-32-bytes")).toBeNull();
+  });
+
+  it("refuses a content key that is not 32 bytes", async () => {
+    expect(await wrapContentKey(new Uint8Array(16), MASTER)).toBeNull();
+  });
+});


### PR DESCRIPTION
The step the injected DLL (step 4) cannot proceed without: it holds the ciphertext blob and needs the key to open it. This is where the content key leaves the server — only to a caller Valve's identity and our entitlement both vouch for.

- **0014** stores each asset's content key on its row, **wrapped**. `assetkey.ts` wraps it under a master key that lives only in a Worker secret (`MXB_ASSET_MASTER_KEY`), AES-GCM via WebCrypto. A database leak yields wrapped keys and no way to unwrap them; the secret never touches the database.
- **POST /v1/keys/grant** releases the raw key, gated on the **same** entitlement decision as `/v1/entitlements/check` — the check was extracted into one function so the two can't drift, and a withdrawal or revocation stops key issuance immediately. Audited like every other decision, and TTL-bound so revocation is one cache lifetime, not one session.
- No master key → 503; entitled but never-packed asset → 409. Never a 200 with nothing usable.

## Testing
- 7 unit tests on wrap/unwrap: round trip, wrong master key, tampered value, off-without-secret, fresh IV each time, and that the wrapped form does not contain the key it protects.
- The e2e now seeds a real wrapped key and proves an **entitled session gets the exact CEK back**, a keyless asset is a **409**, and a revoked entitlement a **403**. **PASS.**
- 125 worker tests green, tsc clean.

**Deploy note:** set the `MXB_ASSET_MASTER_KEY` secret (base64 of 32 random bytes) before this serves secured content; without it `/v1/keys/grant` answers 503 and everything else carries on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)