### PR TITLE
refactor(plugins): call it a license, because entitlement means mods

### DIFF
--- a/control-plane/migrations/0015_plugins.sql
+++ b/control-plane/migrations/0015_plugins.sql
@@ -1,8 +1,8 @@
 -- Paid plugins, the keys that grant them, and who currently holds one.
 --
 -- A plugin is a bundle the app downloads and runs. The bundle is not the secret — it is
--- handed to anyone with a live licence, and a determined person keeps their copy. What the
--- licence actually buys is the right to keep receiving working, current ones, which is why
+-- handed to anyone with a live license, and a determined person keeps their copy. What the
+-- license actually buys is the right to keep receiving working, current ones, which is why
 -- the interesting column here is an expiry rather than a boolean.
 
 CREATE TABLE plugins (
@@ -10,7 +10,7 @@ CREATE TABLE plugins (
   id            TEXT PRIMARY KEY,
   name          TEXT NOT NULL,
   summary       TEXT,
-  -- The bundle currently on offer. The hash is served in the entitlement as well, so the
+  -- The bundle currently on offer. The hash is served in the license as well, so the
   -- app can tell whether the copy it already has is the one being offered without
   -- downloading it to find out — and so a bundle swapped in R2 without going through here
   -- fails verification instead of running.
@@ -25,12 +25,12 @@ CREATE TABLE plugins (
 CREATE TABLE plugin_keys (
   code        TEXT PRIMARY KEY,
   plugin_id   TEXT NOT NULL REFERENCES plugins(id),
-  -- Whole months. A key is bought in months, and the licence it grants is measured the same
+  -- Whole months. A key is bought in months, and the license it grants is measured the same
   -- way, so a renewal is arithmetic on this rather than a date someone typed.
   months      INTEGER NOT NULL,
   note        TEXT,
   created_at  INTEGER NOT NULL,
-  -- Set on redemption, and the reason a key is one-shot: the renewable thing is the licence
+  -- Set on redemption, and the reason a key is one-shot: the renewable thing is the license
   -- it created, not the code. Redeeming twice must extend nothing.
   redeemed_by TEXT REFERENCES accounts(id),
   redeemed_at INTEGER
@@ -39,14 +39,14 @@ CREATE INDEX plugin_keys_plugin ON plugin_keys (plugin_id);
 
 -- One row per (account, plugin). A renewal moves `expires_at` rather than adding a row, so
 -- "may they run it" is one lookup and never a max() over a history table.
-CREATE TABLE plugin_licences (
+CREATE TABLE plugin_licenses (
   account_id  TEXT NOT NULL REFERENCES accounts(id),
   plugin_id   TEXT NOT NULL REFERENCES plugins(id),
   expires_at  INTEGER NOT NULL,
   granted_at  INTEGER NOT NULL,
   PRIMARY KEY (account_id, plugin_id)
 );
-CREATE INDEX plugin_licences_account ON plugin_licences (account_id);
+CREATE INDEX plugin_licenses_account ON plugin_licenses (account_id);
 
 -- The one plugin there is. Bundle columns stay null until a build is published: a plugin
 -- with no bundle is listed and can be licensed, it simply has nothing to install yet.

--- a/control-plane/scripts/mint-plugin-key.ts
+++ b/control-plane/scripts/mint-plugin-key.ts
@@ -9,7 +9,7 @@
  *
  *   wrangler d1 execute mxb-control-plane --remote --file=/tmp/keys.sql
  *
- * A key is one-shot and grants months on a licence. Renewing is another key — until there
+ * A key is one-shot and grants months on a license. Renewing is another key — until there
  * is a billing webhook, at which point it inserts these same rows and nothing downstream
  * has to know the difference.
  */

--- a/control-plane/scripts/plugin-keypair.ts
+++ b/control-plane/scripts/plugin-keypair.ts
@@ -1,16 +1,16 @@
 /**
- * Generate the Ed25519 pair that signs plugin entitlements. Run once, ever.
+ * Generate the Ed25519 pair that signs plugin licenses. Run once, ever.
  *
  *   bun scripts/plugin-keypair.ts
  *
  * The private half goes into the worker as a secret; the public half is compiled into the
  * app. Rotating means shipping a new app build, so this is not a thing to do casually —
  * every installed copy verifies against the key it was built with, and one that has not
- * updated will reject every entitlement signed by the new pair.
+ * updated will reject every license signed by the new pair.
  *
  * The private key is printed once and not stored. If it is lost, mint a new pair and ship
  * an app update; if it leaks, do the same immediately, because anyone holding it can grant
- * themselves and everyone else a permanent licence.
+ * themselves and everyone else a permanent license.
  */
 
 function b64url(bytes: Uint8Array): string {
@@ -35,7 +35,7 @@ Set it and then close this terminal:
   ${b64url(privatePkcs8)}
 
 Public key (raw, 32 bytes, base64url) — compile into the app.
-Put it in src-tauri/src/plugins.rs as ENTITLEMENT_PUBLIC_KEY:
+Put it in src-tauri/src/plugins.rs as LICENSE_PUBLIC_KEY:
 
   ${b64url(publicRaw)}
 `);

--- a/control-plane/src/env.d.ts
+++ b/control-plane/src/env.d.ts
@@ -26,9 +26,9 @@ declare global {
      *  most 16k output tokens, and only ever a motocross track. */
     ANTHROPIC_API_KEY?: string;
     /** Ed25519 private key (PKCS#8 DER, base64url) that signs plugin entitlements. The app
-     *  holds only the public half, so a leak of the app cannot mint licences. Without it
+     *  holds only the public half, so a leak of the app cannot mint licenses. Without it
      *  every licensing endpoint answers 503 rather than issuing something unsigned - an
-     *  unsigned entitlement is not a degraded one, it is a forgery with our name on it.
+     *  unsigned license is not a degraded one, it is a forgery with our name on it.
      *  Generate with `bun scripts/plugin-keypair.ts`. */
     PLUGIN_SIGNING_KEY?: string;
     /** Reads the usage dashboard and the stats JSON. Without it both answer 503, which is

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -197,7 +197,7 @@ async function route(request: Request, env: Env): Promise<Response> {
   if (method === "GET" && path === "/v1/voice/ice") return iceServers();
 
   // Paid plugins. Open to every account on the same terms as voice and paint sync: holding
-  // a licence is what gates the bundle, not holding an invite.
+  // a license is what gates the bundle, not holding an invite.
   if (method === "GET" && path === "/v1/me/plugins") return myPlugins(account, env);
   if (method === "POST" && path === "/v1/plugins/redeem") return redeemKey(request, account, env);
   const bundle = /^\/v1\/plugins\/([a-z0-9-]{1,32})\/bundle$/.exec(path);

--- a/control-plane/src/plugins.ts
+++ b/control-plane/src/plugins.ts
@@ -1,15 +1,15 @@
 /**
- * Paid plugins: licences, redeemable keys, and the signed entitlement the app runs on.
+ * Paid plugins: licenses, redeemable keys, and the signed license the app runs on.
  *
  * The shape of the problem is that the app has to keep working on a plane. So the plane is
  * not asked "may this person run the plugin" at the moment they run it — it is asked
- * periodically, and answers with a short-lived **entitlement**: a small signed statement the
+ * periodically, and answers with a short-lived **license**: a small signed statement the
  * app can check by itself, with no network and no shared secret.
  *
  * Signed with Ed25519, not an HMAC. An HMAC would need the same key at both ends, and the
  * app's end ships to the people paying for the plugin — one `strings` away from being able
  * to mint their own. With a signature the app only ever holds the public half, and forging
- * an entitlement means breaking the curve rather than reading a binary.
+ * an license means breaking the curve rather than reading a binary.
  *
  * Two clocks matter and they are deliberately different:
  *   * `expires`      — when the subscription runs out. Months away.
@@ -18,22 +18,22 @@
  * the end of the month, without the app needing to be online to find out.
  */
 
-/** How long an entitlement is honoured with no contact. */
+/** How long an license is honoured with no contact. */
 export const GRACE_DAYS = 7;
 
 /** Format version, so a future field can be added without old apps mis-reading a token. */
-export const ENTITLEMENT_VERSION = 1;
+export const LICENSE_VERSION = 1;
 
-export interface Entitlement {
+export interface License {
   v: number;
-  /** Account the entitlement was issued to. Bound so a token cannot be passed around. */
+  /** Account the license was issued to. Bound so a token cannot be passed around. */
   account: string;
   plugin: string;
   /** Seconds since epoch. When the subscription ends. */
   expires: number;
   /** Seconds since epoch. When the app must re-check. Always <= expires. */
   refreshAfter: number;
-  /** The bundle this entitlement is good for, so a swapped bundle fails to verify. */
+  /** The bundle this license is good for, so a swapped bundle fails to verify. */
   bundleSha256: string | null;
   issued: number;
 }
@@ -58,8 +58,8 @@ function unb64url(s: string): Uint8Array {
  * Import the signing key from its PKCS#8 DER, base64'd, in `PLUGIN_SIGNING_KEY`.
  *
  * Generate one with `scripts/plugin-keypair.ts`. Absent, every endpoint here answers 503
- * rather than issuing something unsigned — an unsigned entitlement is not a degraded
- * entitlement, it is a forged one that happens to be ours.
+ * rather than issuing something unsigned — an unsigned license is not a degraded
+ * license, it is a forged one that happens to be ours.
  */
 async function signingKey(env: Env): Promise<CryptoKey | null> {
   if (!env.PLUGIN_SIGNING_KEY) return null;
@@ -77,17 +77,17 @@ async function signingKey(env: Env): Promise<CryptoKey | null> {
 }
 
 /** `<b64url(json)>.<b64url(sig)>` — a JWS in spirit, without the header nobody reads. */
-export async function signEntitlement(e: Entitlement, key: CryptoKey): Promise<string> {
+export async function signLicense(e: License, key: CryptoKey): Promise<string> {
   const payload = new TextEncoder().encode(JSON.stringify(e));
   const sig = await crypto.subtle.sign({ name: "Ed25519" }, key, payload);
   return `${b64url(payload)}.${b64url(new Uint8Array(sig))}`;
 }
 
 /** The app's side of the same check, kept here so the two can be tested against each other. */
-export async function verifyEntitlement(
+export async function verifyLicense(
   token: string,
   publicKey: CryptoKey,
-): Promise<Entitlement | null> {
+): Promise<License | null> {
   const dot = token.indexOf(".");
   if (dot < 0) return null;
   const payload = unb64url(token.slice(0, dot));
@@ -95,21 +95,21 @@ export async function verifyEntitlement(
   const ok = await crypto.subtle.verify({ name: "Ed25519" }, publicKey, sig, payload);
   if (!ok) return null;
   try {
-    return JSON.parse(new TextDecoder().decode(payload)) as Entitlement;
+    return JSON.parse(new TextDecoder().decode(payload)) as License;
   } catch {
     return null;
   }
 }
 
 // ---------------------------------------------------------------------------
-// licences
+// licenses
 // ---------------------------------------------------------------------------
 
 export interface Account {
   id: string;
 }
 
-interface LicenceRow {
+interface LicenseRow {
   plugin_id: string;
   expires_at: number;
   bundle_sha256: string | null;
@@ -144,13 +144,13 @@ async function issue(
   row: { plugin_id: string; expires_at: number; bundle_sha256: string | null },
 ): Promise<string> {
   const now = nowSec();
-  return signEntitlement(
+  return signLicense(
     {
-      v: ENTITLEMENT_VERSION,
+      v: LICENSE_VERSION,
       account: accountId,
       plugin: row.plugin_id,
       expires: row.expires_at,
-      // Never past the subscription itself: a licence with three days left must not hand out
+      // Never past the subscription itself: a license with three days left must not hand out
       // a seven-day grace.
       refreshAfter: Math.min(now + GRACE_DAYS * DAY, row.expires_at),
       bundleSha256: row.bundle_sha256,
@@ -183,38 +183,38 @@ export async function listPlugins(env: Env): Promise<Response> {
   });
 }
 
-/** What this account holds, each with a freshly signed entitlement. */
+/** What this account holds, each with a freshly signed license. */
 export async function myPlugins(account: Account, env: Env): Promise<Response> {
   const key = await signingKey(env);
   if (!key) return json(503, { error: "plugin licensing is not configured" });
 
   const { results } = await env.DB.prepare(
     `SELECT l.plugin_id, l.expires_at, p.bundle_sha256, p.version, p.name
-       FROM plugin_licences l JOIN plugins p ON p.id = l.plugin_id
+       FROM plugin_licenses l JOIN plugins p ON p.id = l.plugin_id
       WHERE l.account_id = ?`,
   )
     .bind(account.id)
-    .all<LicenceRow>();
+    .all<LicenseRow>();
 
   const now = nowSec();
-  const licences = [];
+  const licenses = [];
   for (const row of results ?? []) {
-    licences.push({
+    licenses.push({
       plugin: row.plugin_id,
       name: row.name,
       version: row.version,
       expires: row.expires_at,
       active: row.expires_at > now,
-      // An expired licence gets no entitlement at all. Handing one out and letting the app
+      // An expired license gets no license at all. Handing one out and letting the app
       // notice it is stale would make every consumer responsible for a check that belongs
       // in exactly one place.
-      entitlement: row.expires_at > now ? await issue(env, key, account.id, row) : null,
+      license: row.expires_at > now ? await issue(env, key, account.id, row) : null,
     });
   }
-  return json(200, { licences });
+  return json(200, { licenses });
 }
 
-/** Trade a key for months on a licence. */
+/** Trade a key for months on a license. */
 export async function redeemKey(
   request: Request,
   account: Account,
@@ -236,7 +236,7 @@ export async function redeemKey(
   // Claim the key first, and only if it is still unclaimed. Doing this as the WHERE of the
   // UPDATE is what makes two simultaneous redemptions of one code resolve to one winner:
   // the second matches no row and gets the "already used" answer, rather than both reading
-  // "unredeemed" and both extending the licence.
+  // "unredeemed" and both extending the license.
   const claimed = await env.DB.prepare(
     `UPDATE plugin_keys SET redeemed_by = ?, redeemed_at = ?
       WHERE code = ? AND redeemed_by IS NULL
@@ -256,14 +256,14 @@ export async function redeemKey(
   }
 
   const current = await env.DB.prepare(
-    `SELECT expires_at FROM plugin_licences WHERE account_id = ? AND plugin_id = ?`,
+    `SELECT expires_at FROM plugin_licenses WHERE account_id = ? AND plugin_id = ?`,
   )
     .bind(account.id, claimed.plugin_id)
     .first<{ expires_at: number }>();
 
   const expires = extendBy(current?.expires_at ?? null, claimed.months, now);
   await env.DB.prepare(
-    `INSERT INTO plugin_licences (account_id, plugin_id, expires_at, granted_at)
+    `INSERT INTO plugin_licenses (account_id, plugin_id, expires_at, granted_at)
      VALUES (?, ?, ?, ?)
      ON CONFLICT (account_id, plugin_id) DO UPDATE SET expires_at = excluded.expires_at`,
   )
@@ -281,7 +281,7 @@ export async function redeemKey(
     name: meta?.name ?? claimed.plugin_id,
     version: meta?.version ?? null,
     expires,
-    entitlement: await issue(env, key, account.id, {
+    license: await issue(env, key, account.id, {
       plugin_id: claimed.plugin_id,
       expires_at: expires,
       bundle_sha256: meta?.bundle_sha256 ?? null,
@@ -290,7 +290,7 @@ export async function redeemKey(
 }
 
 /**
- * The bundle itself, for an account whose licence is live right now.
+ * The bundle itself, for an account whose license is live right now.
  *
  * Streamed from R2 rather than redirected to it: a redirect would be a URL that works for
  * whoever holds it, and the whole point of this route is that it does not.
@@ -303,7 +303,7 @@ export async function pluginBundle(
   const row = await env.DB.prepare(
     `SELECT p.bundle_key, p.bundle_sha256, l.expires_at
        FROM plugins p
-       LEFT JOIN plugin_licences l ON l.plugin_id = p.id AND l.account_id = ?
+       LEFT JOIN plugin_licenses l ON l.plugin_id = p.id AND l.account_id = ?
       WHERE p.id = ?`,
   )
     .bind(account.id, pluginId)
@@ -311,7 +311,7 @@ export async function pluginBundle(
 
   if (!row) return json(404, { error: "no such plugin" });
   if (!row.expires_at || row.expires_at <= nowSec()) {
-    return json(403, { error: "no live licence for that plugin" });
+    return json(403, { error: "no live license for that plugin" });
   }
   if (!row.bundle_key) return json(404, { error: "that plugin has no build published yet" });
 
@@ -320,7 +320,7 @@ export async function pluginBundle(
   return new Response(object.body, {
     headers: {
       "content-type": "application/octet-stream",
-      // Private and uncached: this response is only correct for the licence that fetched it.
+      // Private and uncached: this response is only correct for the license that fetched it.
       "cache-control": "private, no-store",
       ...(row.bundle_sha256 ? { etag: row.bundle_sha256 } : {}),
     },

--- a/control-plane/test/plugins.test.ts
+++ b/control-plane/test/plugins.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
-  ENTITLEMENT_VERSION,
+  LICENSE_VERSION,
   GRACE_DAYS,
   extendBy,
   myPlugins,
   normaliseCode,
   pluginBundle,
   redeemKey,
-  signEntitlement,
-  verifyEntitlement,
-  type Entitlement,
+  signLicense,
+  verifyLicense,
+  type License,
 } from "../src/plugins";
 
 const DAY = 86400;
@@ -38,22 +38,22 @@ async function keypair() {
 
 /**
  * A D1 stand-in that behaves like the real thing on the two points this code leans on:
- * `RETURNING` yields a row only when the UPDATE matched, and the licence upsert replaces.
+ * `RETURNING` yields a row only when the UPDATE matched, and the license upsert replaces.
  */
 function stubDb(opts: {
   keys?: Record<string, { plugin_id: string; months: number; redeemed_by: string | null }>;
-  licences?: Record<string, number>; // `${account}:${plugin}` -> expires_at
+  licenses?: Record<string, number>; // `${account}:${plugin}` -> expires_at
   plugins?: Record<string, { name: string; version: string | null; bundle_sha256: string | null; bundle_key: string | null }>;
 } = {}) {
   const keys = opts.keys ?? {};
-  const licences = opts.licences ?? {};
+  const licenses = opts.licenses ?? {};
   const plugins = opts.plugins ?? {
     replaycam: { name: "Frost's Replay Mod", version: "1.0.0", bundle_sha256: "abc123", bundle_key: "plugins/replaycam-1.0.0.zip" },
   };
 
   return {
     keys,
-    licences,
+    licenses,
     prepare(sql: string) {
       return {
         bind(...args: unknown[]) {
@@ -73,7 +73,7 @@ function stubDb(opts: {
               }
               if (sql.startsWith("SELECT expires_at")) {
                 const [account, plugin] = args as [string, string];
-                const e = licences[`${account}:${plugin}`];
+                const e = licenses[`${account}:${plugin}`];
                 return e ? { expires_at: e } : null;
               }
               if (sql.startsWith("SELECT bundle_sha256")) {
@@ -87,15 +87,15 @@ function stubDb(opts: {
                 return {
                   bundle_key: p.bundle_key,
                   bundle_sha256: p.bundle_sha256,
-                  expires_at: licences[`${account}:${plugin}`] ?? null,
+                  expires_at: licenses[`${account}:${plugin}`] ?? null,
                 };
               }
               return null;
             },
             async all() {
-              if (sql.includes("FROM plugin_licences l JOIN plugins p")) {
+              if (sql.includes("FROM plugin_licenses l JOIN plugins p")) {
                 const account = String(args[0]);
-                const results = Object.entries(licences)
+                const results = Object.entries(licenses)
                   .filter(([k]) => k.startsWith(`${account}:`))
                   .map(([k, expires]) => {
                     const plugin = k.split(":")[1];
@@ -113,9 +113,9 @@ function stubDb(opts: {
               return { results: [] };
             },
             async run() {
-              if (sql.startsWith("INSERT INTO plugin_licences")) {
+              if (sql.startsWith("INSERT INTO plugin_licenses")) {
                 const [account, plugin, expires] = args as [string, string, number];
-                licences[`${account}:${plugin}`] = expires;
+                licenses[`${account}:${plugin}`] = expires;
               }
               return { success: true };
             },
@@ -141,11 +141,11 @@ function post(body: unknown): Request {
 
 // ---------------------------------------------------------------------------
 
-describe("entitlement signing", () => {
+describe("license signing", () => {
   it("round-trips through a real Ed25519 signature", async () => {
     const { pair } = await keypair();
-    const e: Entitlement = {
-      v: ENTITLEMENT_VERSION,
+    const e: License = {
+      v: LICENSE_VERSION,
       account: "acc_1",
       plugin: "replaycam",
       expires: 1_800_000_000,
@@ -153,13 +153,13 @@ describe("entitlement signing", () => {
       bundleSha256: "abc123",
       issued: 1_699_000_000,
     };
-    const token = await signEntitlement(e, pair.privateKey);
-    expect(await verifyEntitlement(token, pair.publicKey)).toEqual(e);
+    const token = await signLicense(e, pair.privateKey);
+    expect(await verifyLicense(token, pair.publicKey)).toEqual(e);
   });
 
   it("refuses a payload that was edited after signing", async () => {
     const { pair } = await keypair();
-    const token = await signEntitlement(
+    const token = await signLicense(
       {
         v: 1,
         account: "acc_1",
@@ -177,29 +177,29 @@ describe("entitlement signing", () => {
     const decoded = JSON.parse(new TextDecoder().decode(unb64url(payload)));
     decoded.expires = 9_999_999_999;
     const forged = `${b64url(new TextEncoder().encode(JSON.stringify(decoded)))}.${sig}`;
-    expect(await verifyEntitlement(forged, pair.publicKey)).toBeNull();
+    expect(await verifyLicense(forged, pair.publicKey)).toBeNull();
   });
 
   it("refuses a signature from a different key", async () => {
     const a = await keypair();
     const b = await keypair();
-    const token = await signEntitlement(
+    const token = await signLicense(
       { v: 1, account: "x", plugin: "replaycam", expires: 1, refreshAfter: 1, bundleSha256: null, issued: 0 },
       b.pair.privateKey,
     );
-    expect(await verifyEntitlement(token, a.pair.publicKey)).toBeNull();
+    expect(await verifyLicense(token, a.pair.publicKey)).toBeNull();
   });
 
   it("refuses a token that is not a token", async () => {
     const { pair } = await keypair();
-    expect(await verifyEntitlement("nonsense", pair.publicKey)).toBeNull();
+    expect(await verifyLicense("nonsense", pair.publicKey)).toBeNull();
   });
 });
 
 describe("extendBy", () => {
   const now = Math.floor(Date.UTC(2026, 0, 15) / 1000); // 15 Jan 2026
 
-  it("runs from today when there is no licence", () => {
+  it("runs from today when there is no license", () => {
     const out = extendBy(null, 1, now);
     expect(new Date(out * 1000).toISOString().slice(0, 10)).toBe("2026-02-15");
   });
@@ -226,16 +226,16 @@ describe("extendBy", () => {
 });
 
 describe("redeemKey", () => {
-  it("grants a month and returns a verifiable entitlement", async () => {
+  it("grants a month and returns a verifiable license", async () => {
     const { pair, pkcs8B64 } = await keypair();
     const db = stubDb({ keys: { "FRST-AAAA": { plugin_id: "replaycam", months: 1, redeemed_by: null } } });
     const res = await redeemKey(post({ code: "frst-aaaa" }), ACCOUNT, envWith(db, pkcs8B64));
     expect(res.status).toBe(200);
 
-    const body = (await res.json()) as { plugin: string; expires: number; entitlement: string };
+    const body = (await res.json()) as { plugin: string; expires: number; license: string };
     expect(body.plugin).toBe("replaycam");
 
-    const e = await verifyEntitlement(body.entitlement, pair.publicKey);
+    const e = await verifyLicense(body.license, pair.publicKey);
     expect(e).not.toBeNull();
     expect(e!.account).toBe("acc_1");
     expect(e!.plugin).toBe("replaycam");
@@ -248,12 +248,12 @@ describe("redeemKey", () => {
 
   it("never lets refreshAfter outlive the subscription", async () => {
     const { pair, pkcs8B64 } = await keypair();
-    // A licence with a day left must not hand out a seven-day grace.
+    // A license with a day left must not hand out a seven-day grace.
     const nearly = Math.floor(Date.now() / 1000) + DAY;
-    const db = stubDb({ licences: { "acc_1:replaycam": nearly } });
+    const db = stubDb({ licenses: { "acc_1:replaycam": nearly } });
     const res = await myPlugins(ACCOUNT, envWith(db, pkcs8B64));
-    const body = (await res.json()) as { licences: { entitlement: string }[] };
-    const e = await verifyEntitlement(body.licences[0].entitlement, pair.publicKey);
+    const body = (await res.json()) as { licenses: { license: string }[] };
+    const e = await verifyLicense(body.licenses[0].license, pair.publicKey);
     expect(e!.refreshAfter).toBeLessThanOrEqual(e!.expires);
   });
 
@@ -264,12 +264,12 @@ describe("redeemKey", () => {
 
     const first = await redeemKey(post({ code: "FRST-AAAA" }), ACCOUNT, env);
     expect(first.status).toBe(200);
-    const granted = db.licences["acc_1:replaycam"];
+    const granted = db.licenses["acc_1:replaycam"];
 
     const second = await redeemKey(post({ code: "FRST-AAAA" }), ACCOUNT, env);
     expect(second.status).toBe(409);
-    // And crucially the licence did not move.
-    expect(db.licences["acc_1:replaycam"]).toBe(granted);
+    // And crucially the license did not move.
+    expect(db.licenses["acc_1:replaycam"]).toBe(granted);
   });
 
   it("tells an unknown code apart from a used one", async () => {
@@ -284,7 +284,7 @@ describe("redeemKey", () => {
     const db = stubDb({ keys: { "FRST-AAAA": { plugin_id: "replaycam", months: 1, redeemed_by: null } } });
     const res = await redeemKey(post({ code: "FRST-AAAA" }), ACCOUNT, envWith(db, undefined));
     expect(res.status).toBe(503);
-    // An unsigned entitlement is not a degraded one, so nothing may be granted either.
+    // An unsigned license is not a degraded one, so nothing may be granted either.
     expect(db.keys["FRST-AAAA"].redeemed_by).toBeNull();
   });
 
@@ -298,40 +298,40 @@ describe("redeemKey", () => {
 });
 
 describe("myPlugins", () => {
-  it("gives an expired licence no entitlement at all", async () => {
+  it("gives an expired license no license at all", async () => {
     const { pkcs8B64 } = await keypair();
     const past = Math.floor(Date.now() / 1000) - DAY;
-    const db = stubDb({ licences: { "acc_1:replaycam": past } });
+    const db = stubDb({ licenses: { "acc_1:replaycam": past } });
     const res = await myPlugins(ACCOUNT, envWith(db, pkcs8B64));
-    const body = (await res.json()) as { licences: { active: boolean; entitlement: string | null }[] };
-    expect(body.licences[0].active).toBe(false);
-    expect(body.licences[0].entitlement).toBeNull();
+    const body = (await res.json()) as { licenses: { active: boolean; license: string | null }[] };
+    expect(body.licenses[0].active).toBe(false);
+    expect(body.licenses[0].license).toBeNull();
   });
 });
 
 describe("pluginBundle", () => {
   const r2 = { async get(key: string) { return key ? { body: "BUNDLE" } : null; } };
 
-  it("serves the bundle to a live licence", async () => {
-    const db = stubDb({ licences: { "acc_1:replaycam": Math.floor(Date.now() / 1000) + DAY } });
+  it("serves the bundle to a live license", async () => {
+    const db = stubDb({ licenses: { "acc_1:replaycam": Math.floor(Date.now() / 1000) + DAY } });
     const res = await pluginBundle("replaycam", ACCOUNT, envWith(db, undefined, r2));
     expect(res.status).toBe(200);
     expect(res.headers.get("cache-control")).toContain("no-store");
   });
 
-  it("refuses an expired licence", async () => {
-    const db = stubDb({ licences: { "acc_1:replaycam": Math.floor(Date.now() / 1000) - DAY } });
+  it("refuses an expired license", async () => {
+    const db = stubDb({ licenses: { "acc_1:replaycam": Math.floor(Date.now() / 1000) - DAY } });
     expect((await pluginBundle("replaycam", ACCOUNT, envWith(db, undefined, r2))).status).toBe(403);
   });
 
-  it("refuses an account with no licence", async () => {
+  it("refuses an account with no license", async () => {
     const db = stubDb();
     expect((await pluginBundle("replaycam", ACCOUNT, envWith(db, undefined, r2))).status).toBe(403);
   });
 
   it("404s a plugin that has no build published", async () => {
     const db = stubDb({
-      licences: { "acc_1:replaycam": Math.floor(Date.now() / 1000) + DAY },
+      licenses: { "acc_1:replaycam": Math.floor(Date.now() / 1000) + DAY },
       plugins: { replaycam: { name: "x", version: null, bundle_sha256: null, bundle_key: null } },
     });
     expect((await pluginBundle("replaycam", ACCOUNT, envWith(db, undefined, r2))).status).toBe(404);

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -1,19 +1,19 @@
 //! Paid plugins: what this install is allowed to run, and how it proves it offline.
 //!
-//! The control plane hands out a short-lived **entitlement** — a small Ed25519-signed
+//! The control plane hands out a short-lived **license** — a small Ed25519-signed
 //! statement that a named account holds a named plugin until a named date. The app checks
 //! it locally, so the plugin keeps working on a plane and through an outage; and because
-//! the entitlement carries a second, much nearer deadline (`refresh_after`), a cancelled
+//! the license carries a second, much nearer deadline (`refresh_after`), a cancelled
 //! subscription stops working within the grace window rather than at the end of the month.
 //!
 //! We hold only the public half of the signing key. That is the whole reason it is a
 //! signature and not a MAC: a MAC key shipped in this binary is one `strings` away from
-//! letting anyone mint themselves a permanent licence.
+//! letting anyone mint themselves a permanent license.
 //!
 //! Three things are checked before a bundle is allowed to run, and all three matter:
 //!   1. the signature, or the payload is just JSON somebody typed;
 //!   2. the two clocks, against a time that cannot be wound backwards (see `Clock`);
-//!   3. the bundle's SHA-256 against the one the entitlement names, so a bundle swapped
+//!   3. the bundle's SHA-256 against the one the license names, so a bundle swapped
 //!      anywhere between R2 and this disk fails to load instead of running.
 
 use std::collections::BTreeMap;
@@ -31,22 +31,22 @@ use sha2::{Digest, Sha256};
 /// **This is a placeholder from a throwaway pair.** Before shipping, run
 /// `control-plane/scripts/plugin-keypair.ts`, put the private half in the worker
 /// (`wrangler secret put PLUGIN_SIGNING_KEY`) and the public half here. Until both sides
-/// hold halves of the same pair, every entitlement fails verification — which is the safe
+/// hold halves of the same pair, every license fails verification — which is the safe
 /// direction to fail in, but it does mean nothing works.
 ///
 /// Rotating it later means shipping an app update: an install that has not updated rejects
-/// every entitlement signed by the new pair.
-pub const ENTITLEMENT_PUBLIC_KEY: &str = "3RVzr7dGG2rcorozGze9rR7NUTj61bwxS2IL0t40kk0";
+/// every license signed by the new pair.
+pub const LICENSE_PUBLIC_KEY: &str = "3RVzr7dGG2rcorozGze9rR7NUTj61bwxS2IL0t40kk0";
 
-/// Entitlement format we understand. A newer one is refused rather than half-read.
-pub const ENTITLEMENT_VERSION: u32 = 1;
+/// License format we understand. A newer one is refused rather than half-read.
+pub const LICENSE_VERSION: u32 = 1;
 
 // ---------------------------------------------------------------------------
-// the entitlement
+// the license
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct Entitlement {
+pub struct License {
     pub v: u32,
     /// Account it was issued to. Bound so a token cannot simply be passed around.
     pub account: String,
@@ -56,7 +56,7 @@ pub struct Entitlement {
     /// When we must have talked to the control plane again. Always <= `expires`.
     #[serde(rename = "refreshAfter")]
     pub refresh_after: i64,
-    /// The bundle this entitlement is good for, lowercase hex. None before a build exists.
+    /// The bundle this license is good for, lowercase hex. None before a build exists.
     #[serde(rename = "bundleSha256")]
     pub bundle_sha256: Option<String>,
     pub issued: i64,
@@ -64,26 +64,26 @@ pub struct Entitlement {
 
 /// Verify a `<b64url(payload)>.<b64url(sig)>` token and return what it says.
 ///
-/// Every failure is the same answer to the caller — no licence — but they are distinguished
+/// Every failure is the same answer to the caller — no license — but they are distinguished
 /// in the error text because "your clock is wrong" and "that signature is not ours" send a
 /// person to very different places.
-pub fn verify_entitlement(token: &str) -> Result<Entitlement> {
-    verify_with(token, ENTITLEMENT_PUBLIC_KEY)
+pub fn verify_license(token: &str) -> Result<License> {
+    verify_with(token, LICENSE_PUBLIC_KEY)
 }
 
 /// The same check against a named key. Split out so a test can pin the wire format against
 /// a token the control plane's own TypeScript actually produced — the encoding is agreed
 /// across two languages and nothing in either would notice if they drifted apart.
-pub fn verify_with(token: &str, public_key_b64: &str) -> Result<Entitlement> {
+pub fn verify_with(token: &str, public_key_b64: &str) -> Result<License> {
     let (payload_b64, sig_b64) = token
         .split_once('.')
-        .ok_or_else(|| anyhow!("not an entitlement token"))?;
+        .ok_or_else(|| anyhow!("not an license token"))?;
     let payload = URL_SAFE_NO_PAD
         .decode(payload_b64)
-        .context("entitlement payload is not base64url")?;
+        .context("license payload is not base64url")?;
     let sig_bytes = URL_SAFE_NO_PAD
         .decode(sig_b64)
-        .context("entitlement signature is not base64url")?;
+        .context("license signature is not base64url")?;
 
     let key_bytes: [u8; 32] = URL_SAFE_NO_PAD
         .decode(public_key_b64)
@@ -95,14 +95,14 @@ pub fn verify_with(token: &str, public_key_b64: &str) -> Result<Entitlement> {
     let sig_arr: [u8; 64] = sig_bytes
         .as_slice()
         .try_into()
-        .map_err(|_| anyhow!("entitlement signature is the wrong length"))?;
+        .map_err(|_| anyhow!("license signature is the wrong length"))?;
     key.verify_strict(&payload, &Signature::from_bytes(&sig_arr))
-        .map_err(|_| anyhow!("that entitlement was not signed by us"))?;
+        .map_err(|_| anyhow!("that license was not signed by us"))?;
 
-    let e: Entitlement =
-        serde_json::from_slice(&payload).context("entitlement payload is not one of ours")?;
-    if e.v != ENTITLEMENT_VERSION {
-        bail!("that entitlement is version {}; this build understands {ENTITLEMENT_VERSION}. Update MXB App.", e.v);
+    let e: License =
+        serde_json::from_slice(&payload).context("license payload is not one of ours")?;
+    if e.v != LICENSE_VERSION {
+        bail!("that license is version {}; this build understands {LICENSE_VERSION}. Update MXB App.", e.v);
     }
     Ok(e)
 }
@@ -123,7 +123,7 @@ pub enum Status {
     Expired,
 }
 
-pub fn status(e: &Entitlement, now: i64) -> Status {
+pub fn status(e: &License, now: i64) -> Status {
     if now >= e.expires {
         Status::Expired
     } else if now >= e.refresh_after {
@@ -140,9 +140,9 @@ pub fn status(e: &Entitlement, now: i64) -> Status {
 /// A wall clock that cannot be wound backwards.
 ///
 /// Every expiry check on a machine the user controls has the same hole: set the clock to
-/// last year and a lapsed licence is live again. It cannot be closed offline — there is no
+/// last year and a lapsed license is live again. It cannot be closed offline — there is no
 /// trusted time source — but it can be made a one-way door. We remember the latest instant
-/// we have ever been sure of (the `issued` of an entitlement the control plane signed, or
+/// we have ever been sure of (the `issued` of an license the control plane signed, or
 /// simply the highest wall-clock reading we have seen) and never accept a reading below it.
 ///
 /// So winding the clock back does not extend anything; it freezes it, which is the failure
@@ -156,7 +156,7 @@ pub struct Clock {
 }
 
 impl Clock {
-    /// The time to judge an entitlement by, and the updated mark to persist.
+    /// The time to judge an license by, and the updated mark to persist.
     pub fn observe(&mut self, wall: i64) -> i64 {
         if wall > self.high_water {
             self.high_water = wall;
@@ -164,9 +164,9 @@ impl Clock {
         self.high_water
     }
 
-    /// A signed entitlement is evidence of a real instant: the control plane stamped it, so
+    /// A signed license is evidence of a real instant: the control plane stamped it, so
     /// time is at least that. Fold it in when one arrives.
-    pub fn witness(&mut self, e: &Entitlement) {
+    pub fn witness(&mut self, e: &License) {
         if e.issued > self.high_water {
             self.high_water = e.issued;
         }
@@ -180,70 +180,70 @@ impl Clock {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Installed {
     pub version: Option<String>,
-    /// SHA-256 of the bundle that was unpacked, so a mismatch against the entitlement is
+    /// SHA-256 of the bundle that was unpacked, so a mismatch against the license is
     /// noticed without hashing the unpacked tree.
     pub sha256: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PluginState {
-    /// The account these entitlements belong to. Learnt from the first one verified; a later
-    /// entitlement naming a different account is refused, which is what stops one being
+    /// The account these licenses belong to. Learnt from the first one verified; a later
+    /// license naming a different account is refused, which is what stops one being
     /// copied between machines.
     #[serde(default)]
     pub account: Option<String>,
     #[serde(default)]
     pub clock: Clock,
-    /// plugin id -> the entitlement token as issued.
+    /// plugin id -> the license token as issued.
     #[serde(default)]
-    pub entitlements: BTreeMap<String, String>,
+    pub licenses: BTreeMap<String, String>,
     #[serde(default)]
     pub installed: BTreeMap<String, Installed>,
 }
 
 impl PluginState {
-    /// Take an entitlement the control plane just issued.
+    /// Take an license the control plane just issued.
     ///
     /// Refuses one for another account, which is the casual-sharing case: the token is a
     /// file, and a file gets pasted into someone else's install.
-    pub fn accept(&mut self, token: &str) -> Result<Entitlement> {
-        let e = verify_entitlement(token)?;
+    pub fn accept(&mut self, token: &str) -> Result<License> {
+        let e = verify_license(token)?;
         match &self.account {
             Some(existing) if existing != &e.account => {
-                bail!("that entitlement belongs to a different account")
+                bail!("that license belongs to a different account")
             }
             _ => {}
         }
         self.account = Some(e.account.clone());
         self.clock.witness(&e);
-        self.entitlements.insert(e.plugin.clone(), token.to_string());
+        self.licenses.insert(e.plugin.clone(), token.to_string());
         Ok(e)
     }
 
     /// Test-only twin of `accept`, against a named key.
     #[cfg(test)]
-    pub fn accept_with(&mut self, token: &str, key: &str) -> Result<Entitlement> {
+    pub fn accept_with(&mut self, token: &str, key: &str) -> Result<License> {
         let e = verify_with(token, key)?;
         match &self.account {
             Some(existing) if existing != &e.account => {
-                bail!("that entitlement belongs to a different account")
+                bail!("that license belongs to a different account")
             }
             _ => {}
         }
         self.account = Some(e.account.clone());
         self.clock.witness(&e);
-        self.entitlements.insert(e.plugin.clone(), token.to_string());
+        self.licenses.insert(e.plugin.clone(), token.to_string());
         Ok(e)
     }
 
     /// What this install may run right now, judged against the un-windable clock.
     pub fn status_of(&mut self, plugin: &str, wall: i64) -> Status {
         let now = self.clock.observe(wall);
-        match self.entitlements.get(plugin) {
+        match self.licenses.get(plugin) {
             None => Status::Expired,
-            Some(token) => match verify_entitlement(token) {
+            Some(token) => match verify_license(token) {
                 Ok(e) if e.plugin == plugin => status(&e, now),
-                // A token that no longer verifies is not a licence, whatever it used to be.
+                // A token that no longer verifies is not a license, whatever it used to be.
                 _ => Status::Expired,
             },
         }
@@ -316,7 +316,7 @@ pub fn version_at_least(have: &str, need: &str) -> bool {
     !(a_pre && !b_pre)
 }
 
-/// Verify a downloaded bundle against the entitlement, then unpack it.
+/// Verify a downloaded bundle against the license, then unpack it.
 ///
 /// The hash check is the load-bearing one and it happens **before** a single byte is
 /// written: this is code that is about to run inside the app, and "unpack then check" would
@@ -331,9 +331,9 @@ pub fn install_bundle(
     let got = sha256_hex(bytes);
     match expected_sha256 {
         Some(want) if !want.eq_ignore_ascii_case(&got) => {
-            bail!("the downloaded plugin does not match what your licence names ({want} vs {got}) - it was not installed")
+            bail!("the downloaded plugin does not match what your license names ({want} vs {got}) - it was not installed")
         }
-        None => bail!("your licence doesn't name a build for that plugin yet"),
+        None => bail!("your license doesn't name a build for that plugin yet"),
         _ => {}
     }
 
@@ -429,7 +429,7 @@ mod tests {
         )
     }
 
-    /// A token produced by the control plane's own `signEntitlement`, in TypeScript, in a
+    /// A token produced by the control plane's own `signLicense`, in TypeScript, in a
     /// Worker runtime — pasted here verbatim.
     ///
     /// This is the one seam neither side can check alone. The payload is JSON with a field
@@ -437,7 +437,7 @@ mod tests {
     /// every one of those is a place the two languages could quietly disagree: a `+` for a
     /// `-`, a padded string, a re-serialised payload with the keys in another order. Each of
     /// those produces a token that looks perfectly well-formed and fails to verify, and the
-    /// symptom in production is "nobody's licence works".
+    /// symptom in production is "nobody's license works".
     const TS_PUBLIC_KEY: &str = "Sp8dtEFQK86a9AKfQg-2wwRxFBGgZX4Wc6qHN2UHLJg";
     const TS_TOKEN: &str = "eyJ2IjoxLCJhY2NvdW50IjoiYWNjX3Rlc3QiLCJwbHVnaW4iOiJyZXBsYXljYW0iLCJleHBpcmVzIjoyMDAwMDAwMDAwLCJyZWZyZXNoQWZ0ZXIiOjE5MDAwMDAwMDAsImJ1bmRsZVNoYTI1NiI6Ijc3OTZkNDdlYzBkZTg0OGYzYjQxOWY0M2ZmMjExMTQ5ZGI0Y2MzYzQ0MDA3Yzk3ZjhkYTIxYTc2OWUzZTYwZGYiLCJpc3N1ZWQiOjE4MDAwMDAwMDB9.fljHCXVRtstMp1ZvUbPP54Vw1N1vwJAezyDkrgXwN-5at1M4P5LJtZ90UMqdWV1pRkpH5ccnILW1ffhkJ_fIAA";
 
@@ -460,14 +460,14 @@ mod tests {
 
     #[test]
     fn rejects_the_worker_token_under_a_different_key() {
-        // Same token, the app's own key: this is what a licence signed by someone else's
+        // Same token, the app's own key: this is what a license signed by someone else's
         // control plane looks like.
-        assert!(verify_with(TS_TOKEN, ENTITLEMENT_PUBLIC_KEY).is_err());
+        assert!(verify_with(TS_TOKEN, LICENSE_PUBLIC_KEY).is_err());
     }
 
     #[test]
     fn status_has_three_states_and_the_middle_one_matters() {
-        let e = Entitlement {
+        let e = License {
             v: 1,
             account: "acc".into(),
             plugin: "replaycam".into(),
@@ -488,7 +488,7 @@ mod tests {
     fn the_clock_does_not_run_backwards() {
         let mut c = Clock::default();
         assert_eq!(c.observe(1_000), 1_000);
-        // Winding the machine's clock back a year must not resurrect a lapsed licence.
+        // Winding the machine's clock back a year must not resurrect a lapsed license.
         assert_eq!(c.observe(10), 1_000);
         // Forward is believed, and becomes the new floor.
         assert_eq!(c.observe(2_000), 2_000);
@@ -496,9 +496,9 @@ mod tests {
     }
 
     #[test]
-    fn a_signed_entitlement_is_evidence_of_the_time() {
+    fn a_signed_license_is_evidence_of_the_time() {
         let mut c = Clock::default();
-        let e = Entitlement {
+        let e = License {
             v: 1,
             account: "acc".into(),
             plugin: "p".into(),
@@ -515,7 +515,7 @@ mod tests {
     #[test]
     fn verify_rejects_junk_without_panicking() {
         for bad in ["", "nodot", "a.b", "....", "!!!.???"] {
-            assert!(verify_entitlement(bad).is_err(), "accepted {bad:?}");
+            assert!(verify_license(bad).is_err(), "accepted {bad:?}");
         }
     }
 
@@ -530,7 +530,7 @@ mod tests {
             }),
             &other,
         );
-        let err = verify_entitlement(&token).unwrap_err().to_string();
+        let err = verify_license(&token).unwrap_err().to_string();
         assert!(err.contains("not signed by us"), "{err}");
     }
 
@@ -539,13 +539,13 @@ mod tests {
         let mut st = PluginState::default();
         let e = st.accept_with(TS_TOKEN, TS_PUBLIC_KEY).unwrap();
         assert_eq!(st.account.as_deref(), Some("acc_test"));
-        assert_eq!(st.entitlements.get("replaycam").map(String::as_str), Some(TS_TOKEN));
+        assert_eq!(st.licenses.get("replaycam").map(String::as_str), Some(TS_TOKEN));
         // The signed `issued` is evidence of a real instant, so the clock now floors there.
         assert_eq!(st.clock.high_water, e.issued);
     }
 
     #[test]
-    fn state_refuses_an_entitlement_for_another_account() {
+    fn state_refuses_an_license_for_another_account() {
         // The casual-sharing case: the token is a file, and a file gets pasted into
         // somebody else's install. The signature is perfectly valid — the account is not.
         let mut st = PluginState {
@@ -555,19 +555,19 @@ mod tests {
         let err = st.accept_with(TS_TOKEN, TS_PUBLIC_KEY).unwrap_err().to_string();
         assert!(err.contains("different account"), "{err}");
         assert_eq!(st.account.as_deref(), Some("someone_else"));
-        assert!(st.entitlements.is_empty());
+        assert!(st.licenses.is_empty());
     }
 
     #[test]
-    fn no_entitlement_means_expired_not_live() {
+    fn no_license_means_expired_not_live() {
         let mut s = PluginState::default();
         assert_eq!(s.status_of("replaycam", 100), Status::Expired);
     }
 
     #[test]
-    fn a_token_that_stops_verifying_stops_being_a_licence() {
+    fn a_token_that_stops_verifying_stops_being_a_license() {
         let mut s = PluginState::default();
-        s.entitlements
+        s.licenses
             .insert("replaycam".into(), "not-a-token".into());
         assert_eq!(s.status_of("replaycam", 100), Status::Expired);
     }
@@ -618,7 +618,7 @@ mod tests {
     }
 
     #[test]
-    fn install_refuses_when_the_licence_names_no_build() {
+    fn install_refuses_when_the_license_names_no_build() {
         let dir = tempdir();
         let err = install_bundle(&dir, "replaycam", b"x", None, "0.12.4")
             .unwrap_err()
@@ -795,10 +795,10 @@ pub struct PluginView {
     /// Whether there is a build to install at all.
     pub published: bool,
     pub status: Status,
-    /// Seconds since epoch, when the licence runs out. None if never held.
+    /// Seconds since epoch, when the license runs out. None if never held.
     pub expires: Option<i64>,
     pub installed_version: Option<String>,
-    /// True when a licence is live and the installed build is the one on offer.
+    /// True when a license is live and the installed build is the one on offer.
     pub ready: bool,
 }
 
@@ -816,20 +816,20 @@ struct CataloguePlugin {
 }
 
 #[derive(Deserialize)]
-struct LicencesResp {
-    licences: Vec<LicenceRow>,
+struct LicensesResp {
+    licenses: Vec<LicenseRow>,
 }
 #[derive(Deserialize)]
-struct LicenceRow {
+struct LicenseRow {
     plugin: String,
     expires: i64,
-    entitlement: Option<String>,
+    license: Option<String>,
 }
 
-/// The catalogue plus this account's licences, refreshed from the control plane.
+/// The catalogue plus this account's licenses, refreshed from the control plane.
 ///
 /// Best-effort by design: with no network we still answer from what is on disk, because the
-/// whole point of a signed entitlement is that being offline is not a licensing failure.
+/// whole point of a signed license is that being offline is not a licensing failure.
 #[tauri::command]
 pub async fn plugin_list(app: tauri::AppHandle) -> Result<Vec<PluginView>, String> {
     let base = crate::paintsync::control_plane();
@@ -857,13 +857,13 @@ pub async fn plugin_list(app: tauri::AppHandle) -> Result<Vec<PluginView>, Strin
             .await
         {
             if resp.status().is_success() {
-                if let Ok(body) = resp.json::<LicencesResp>().await {
-                    for row in body.licences {
+                if let Ok(body) = resp.json::<LicensesResp>().await {
+                    for row in body.licenses {
                         expiries.insert(row.plugin.clone(), row.expires);
-                        if let Some(t) = row.entitlement {
-                            // A refused entitlement (wrong account, bad signature) leaves the
+                        if let Some(t) = row.license {
+                            // A refused license (wrong account, bad signature) leaves the
                             // previous one in place rather than clearing it: a bad answer from
-                            // the network must not revoke a licence we already verified.
+                            // the network must not revoke a license we already verified.
                             let _ = state.accept(&t);
                         }
                     }
@@ -898,7 +898,7 @@ pub async fn plugin_list(app: tauri::AppHandle) -> Result<Vec<PluginView>, Strin
     Ok(out)
 }
 
-/// Trade a key for months on a licence.
+/// Trade a key for months on a license.
 #[tauri::command]
 pub async fn plugin_redeem(app: tauri::AppHandle, code: String) -> Result<String, String> {
     let tok = token(&app).map_err(|e| e.to_string())?;
@@ -920,38 +920,38 @@ pub async fn plugin_redeem(app: tauri::AppHandle, code: String) -> Result<String
     struct Redeemed {
         plugin: String,
         name: String,
-        entitlement: String,
+        license: String,
     }
     let body: Redeemed = resp.json().await.map_err(|e| e.to_string())?;
 
     let mut state = load_state(&app);
-    state.accept(&body.entitlement).map_err(|e| e.to_string())?;
+    state.accept(&body.license).map_err(|e| e.to_string())?;
     save_state(&app, &state).map_err(|e| e.to_string())?;
     let _ = body.plugin;
     Ok(body.name)
 }
 
-/// Download, verify and unpack a plugin this account holds a live licence for.
+/// Download, verify and unpack a plugin this account holds a live license for.
 #[tauri::command]
 pub async fn plugin_install(app: tauri::AppHandle, id: String) -> Result<String, String> {
     let tok = token(&app).map_err(|e| e.to_string())?;
 
-    // Check what we already hold before asking for bytes: a lapsed licence should say so
+    // Check what we already hold before asking for bytes: a lapsed license should say so
     // rather than downloading a bundle it is not allowed to run.
     let mut state = load_state(&app);
     let wall = now_secs();
     match state.status_of(&id, wall) {
         Status::Live => {}
         Status::Stale => {
-            return Err("Your licence needs re-checking and the control plane isn't answering. Try again when you're online.".into())
+            return Err("Your license needs re-checking and the control plane isn't answering. Try again when you're online.".into())
         }
-        Status::Expired => return Err("You don't have a live licence for that plugin.".into()),
+        Status::Expired => return Err("You don't have a live license for that plugin.".into()),
     }
-    let entitlement = state
-        .entitlements
+    let license = state
+        .licenses
         .get(&id)
-        .and_then(|t| verify_entitlement(t).ok())
-        .ok_or_else(|| "You don't have a live licence for that plugin.".to_string())?;
+        .and_then(|t| verify_license(t).ok())
+        .ok_or_else(|| "You don't have a live license for that plugin.".to_string())?;
 
     let resp = reqwest::Client::new()
         .get(format!(
@@ -973,7 +973,7 @@ pub async fn plugin_install(app: tauri::AppHandle, id: String) -> Result<String,
         &dir,
         &id,
         &bytes,
-        entitlement.bundle_sha256.as_deref(),
+        license.bundle_sha256.as_deref(),
         &app_version,
     )
     .map_err(|e| e.to_string())?;
@@ -982,7 +982,7 @@ pub async fn plugin_install(app: tauri::AppHandle, id: String) -> Result<String,
         id.clone(),
         Installed {
             version: Some(manifest.version.clone()),
-            sha256: entitlement.bundle_sha256.clone(),
+            sha256: license.bundle_sha256.clone(),
         },
     );
     save_state(&app, &state).map_err(|e| e.to_string())?;
@@ -994,7 +994,7 @@ pub async fn plugin_remove(app: tauri::AppHandle, id: String) -> Result<(), Stri
     let dir = plugins_dir(&app).map_err(|e| e.to_string())?;
     std::fs::remove_dir_all(dir.join(&id)).ok();
     let mut state = load_state(&app);
-    // The licence survives an uninstall — it is a subscription, not an install token, and
+    // The license survives an uninstall — it is a subscription, not an install token, and
     // someone removing the plugin for a week must not have to buy it again.
     state.installed.remove(&id);
     save_state(&app, &state).map_err(|e| e.to_string())?;
@@ -1004,7 +1004,7 @@ pub async fn plugin_remove(app: tauri::AppHandle, id: String) -> Result<(), Stri
 /// What the webview needs to mount a plugin: its manifest, and its entry module's source.
 ///
 /// The source is handed over as text rather than a path so the webview never loads code off
-/// the filesystem by URL. It is only ever produced for a plugin whose licence is live *at
+/// the filesystem by URL. It is only ever produced for a plugin whose license is live *at
 /// this moment* — the check is here, at the last point before the code runs, and not only
 /// on the page that lists them.
 #[derive(Debug, Serialize)]
@@ -1036,7 +1036,7 @@ pub fn plugin_runtime(app: tauri::AppHandle, id: String) -> Result<PluginRuntime
 }
 
 /// Where a plugin's non-code payload was unpacked, for the Rust side to install into the
-/// game. Returns None unless the licence is live right now.
+/// game. Returns None unless the license is live right now.
 pub fn payload_dir(app: &tauri::AppHandle, id: &str) -> Option<PathBuf> {
     let mut state = load_state(app);
     if state.status_of(id, now_secs()) != Status::Live {
@@ -1091,7 +1091,7 @@ pub fn resolve_in(root: &Path, rel: &str) -> Result<PathBuf> {
     Ok(full)
 }
 
-/// Every file call is licence-gated at the moment it happens. Checking only when the panel
+/// Every file call is license-gated at the moment it happens. Checking only when the panel
 /// mounted would leave a plugin able to write for as long as the window stayed open.
 fn licensed(app: &tauri::AppHandle, id: &str) -> Result<(), String> {
     let mut state = load_state(app);

--- a/src/Components/Settings/Plugins.tsx
+++ b/src/Components/Settings/Plugins.tsx
@@ -28,7 +28,7 @@ function until(at: number | null): string | null {
  * What this row is, in one sentence, plus the one button that changes it.
  *
  * A paid thing that isn't working has to say which of the four reasons it is: not bought,
- * bought but not installed, installed but the licence needs re-checking, or working. Every
+ * bought but not installed, installed but the license needs re-checking, or working. Every
  * one of those sends the person somewhere different, and a single "unavailable" state would
  * send them all to the same place — support.
  */
@@ -146,7 +146,7 @@ const PluginRow = ({
 /**
  * The Plugins page.
  *
- * Everything here works offline except redeeming a key: the licence is a signed statement
+ * Everything here works offline except redeeming a key: the license is a signed statement
  * the app already holds, so a list that showed nothing without a network would be lying
  * about a plugin that is, right now, running.
  */

--- a/src/api/plugins.ts
+++ b/src/api/plugins.ts
@@ -3,7 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 /**
  * Why a plugin is or is not runnable.
  *
- * `stale` is the one worth understanding: the licence has not expired, but we have not been
+ * `stale` is the one worth understanding: the license has not expired, but we have not been
  * able to re-check it inside the grace window. It reads to the user as "needs to go online",
  * not as "you have been cut off" — and it is what makes a cancellation take effect on a
  * machine that stops asking.
@@ -19,7 +19,7 @@ export interface PluginView {
   /** Whether there is a build to install at all. */
   published: boolean;
   status: PluginStatus;
-  /** Seconds since epoch. Null if this account has never held a licence. */
+  /** Seconds since epoch. Null if this account has never held a license. */
   expires: number | null;
   installedVersion: string | null;
   /** Licensed, installed, and on the current build — the only state that runs. */
@@ -41,12 +41,12 @@ export interface PluginRuntime {
   source: string;
 }
 
-/** The catalogue plus this account's licences. Works offline, from what is on disk. */
+/** The catalogue plus this account's licenses. Works offline, from what is on disk. */
 export function listPlugins(): Promise<PluginView[]> {
   return invoke("plugin_list");
 }
 
-/** Trade a key for months on a licence. Resolves with the plugin's name. */
+/** Trade a key for months on a license. Resolves with the plugin's name. */
 export function redeemPluginKey(code: string): Promise<string> {
   return invoke("plugin_redeem", { code });
 }
@@ -63,8 +63,8 @@ export function removePlugin(id: string): Promise<void> {
 /**
  * Fetch a plugin's manifest and entry source.
  *
- * The licence is checked again on this call, at the last point before the code runs — not
- * only on the page that listed it. A plugin whose licence lapsed between the list and the
+ * The license is checked again on this call, at the last point before the code runs — not
+ * only on the page that listed it. A plugin whose license lapsed between the list and the
  * mount must not start.
  */
 export function pluginRuntime(id: string): Promise<PluginRuntime> {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2240,14 +2240,14 @@ export const en = {
 
   // --- paid plugins ---
   "plugins.section": "Plugins",
-  "plugins.sectionDesc": "Paid add-ons for MXB App. A licence is a monthly subscription tied to your account, and it keeps working offline for a week between checks.",
+  "plugins.sectionDesc": "Paid add-ons for MXB App. A license is a monthly subscription tied to your account, and it keeps working offline for a week between checks.",
   "plugins.keyLabel": "Redeem a key",
   "plugins.keyHelp": "Paste the key you were sent. Renewing is another key — it adds to whatever time you have left.",
   "plugins.redeem": "Redeem",
   "plugins.redeemed": "{{name}} is licensed on this account.",
   "plugins.available": "Available",
   "plugins.refresh": "Refresh",
-  "plugins.loading": "Checking your licences…",
+  "plugins.loading": "Checking your licenses…",
   "plugins.none": "Nothing on offer yet.",
   "plugins.install": "Install",
   "plugins.update": "Update",
@@ -2262,7 +2262,7 @@ export const en = {
   "plugins.needsCheck": "Needs a check-in",
   "plugins.needsCheckDetail": "it's been a week since we could reach the control plane. Go online and refresh.",
   "plugins.lapsed": "Lapsed",
-  "plugins.lapsedDetail": "your licence ran out on {{date}}. Redeem a key to carry on.",
+  "plugins.lapsedDetail": "your license ran out on {{date}}. Redeem a key to carry on.",
   "plugins.notLicensed": "Not licensed",
   "plugins.notLicensedDetail": "redeem a key above to unlock it.",
 } as const;

--- a/src/lib/pluginHost.ts
+++ b/src/lib/pluginHost.ts
@@ -8,14 +8,14 @@ import { pluginRuntime, type PluginManifest } from "@/api/plugins";
  * Loading and mounting a paid plugin's UI.
  *
  * A plugin ships its panels as one ES module. The Rust side has already verified the
- * licence and the bundle's signature-named hash before handing us a line of it, so what is
+ * license and the bundle's signature-named hash before handing us a line of it, so what is
  * left here is the mechanics: turn the source text into a module, hand it a small stable
  * API, and take back the components it registers.
  *
  * **Source text, not a file URL.** The module arrives as a string and is turned into a blob
  * URL right before `import()`. That is deliberate: nothing on disk is ever loaded by path,
  * so a file dropped into the plugins folder by hand is not a way to get code into the app —
- * the only route in goes through the licence check that produced this string.
+ * the only route in goes through the license check that produced this string.
  *
  * The API handed to a plugin is deliberately small. Every method here is one the app is
  * promising to keep working across versions, so the bar for adding one is that a plugin
@@ -34,7 +34,7 @@ export interface PluginPanel {
  *
  * Paths are relative to `Documents\PiBoSo\<game>` and cannot leave it — including through
  * a symlink already on disk, which the backend checks by resolving the path rather than
- * only inspecting it. Every call re-checks the licence, so a plugin whose subscription
+ * only inspecting it. Every call re-checks the license, so a plugin whose subscription
  * lapses stops being able to write mid-session.
  */
 export interface PluginFiles {
@@ -53,7 +53,7 @@ export interface PluginApi {
    * Call a backend command the plugin's own payload installed, or one of the app's.
    *
    * Not a general escape hatch by intent, but it is one in effect — a plugin runs with the
-   * app's privileges, which is why a bundle only ever arrives over a verified licence.
+   * app's privileges, which is why a bundle only ever arrives over a verified license.
    */
   invoke<T>(command: string, args?: Record<string, unknown>): Promise<T>;
   /** Read and write inside the game's user folder. */
@@ -96,7 +96,7 @@ export function isMounted(id: string): boolean {
 /**
  * Verify, fetch and run a plugin's entry module.
  *
- * Throws with something a person can act on: the licence checks in the backend answer in
+ * Throws with something a person can act on: the license checks in the backend answer in
  * sentences, and a plugin that fails to mount is a thing the user paid for, so "it didn't
  * work" is not an acceptable message.
  */
@@ -156,7 +156,7 @@ export async function mountPlugin(id: string): Promise<LoadedPlugin> {
  * Drop a plugin from this session.
  *
  * The module itself cannot be unloaded — nothing in a browser can — so this only stops the
- * app rendering its panels. A licence that lapses mid-session therefore takes its UI away
+ * app rendering its panels. A license that lapses mid-session therefore takes its UI away
  * without pretending the code has gone; the code that matters is the game-side payload, and
  * that is gated where it is installed.
  */


### PR DESCRIPTION
The control plane has two paid-access systems, and until this change both called their signed thing an *entitlement*.

|  | `entitlements` | `plugin_licenses` |
|---|---|---|
| Gates | creator-sold **mod content** — sealed blobs the DLL opens | **app plugin** code bundles |
| Identity | SteamID, from Valve | control-plane account |
| Time | perpetual (`granted_at` / `revoked_at`) | **monthly** (`expires_at`) |
| Decision | server-side, per use, audited | **offline**, signed token, 7-day grace |

One word for two tables is how someone ends up joining the wrong one. It already caused a real confusion in the conversation that produced this — which is the cheap version, because nothing has shipped and the rename is still free.

## What moved

`Entitlement` → `License`, `verify_entitlement` → `verify_license`, `ENTITLEMENT_PUBLIC_KEY` → `LICENSE_PUBLIC_KEY`, the `entitlement` wire field → `license`, the `entitlements` map in `state.json` → `licenses`, and `plugin_licences` → `plugin_licenses` in migration `0015`.

The mods system is untouched — `/v1/entitlements`, `listEntitlements`, `checkEntitlement` and the `entitlements` table all stay exactly as they are. **"Entitlement" in this control plane now means mods, and only mods.**

Spelling is American to match the app's own UI strings (`Enroll`, not `Enrol`). The French locale keeps `licence`, which is the French word.

## Not behavioural

The wire field, the on-disk state key and the table name move together, and none has ever been written in production — the migration isn't applied and no key has been minted.

## Verification

145 control-plane tests · 22 Rust plugin tests · `tsc`, `eslint` (0 errors), `cargo check` (0 warnings) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)