### PR TITLE
feat(secure): auto-inject the client on game start — no manual steps

### DIFF
--- a/src-tauri/src/gameproc.rs
+++ b/src-tauri/src/gameproc.rs
@@ -313,6 +313,12 @@ fn find_game_pid() -> Option<u32> {
     find_pid(crate::game::active().exe)
 }
 
+/// The running game's PID, for another module (e.g. secure-content injection) to act on it.
+#[cfg(windows)]
+pub fn game_pid() -> Option<u32> {
+    find_game_pid()
+}
+
 /// Runtime base address of `mxbikes.exe` in `pid` (retries transient snapshot failures).
 #[cfg(windows)]
 fn module_base(pid: u32) -> Option<*mut u8> {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -57,6 +57,7 @@ mod sidecar_lock;
 #[cfg(mxbsecure)]
 mod mxbsecure;
 mod steamid;
+mod secure_launch;
 
 #[cfg(all(test, mxbsecure))]
 mod offline_flow_test {
@@ -5722,6 +5723,7 @@ struct SecureProvisionOutcome {
 /// Lock tab supplies it). From then on the key opens offline for this account only.
 #[tauri::command]
 async fn mxbsecure_provision(
+    app: tauri::AppHandle,
     blob_path: String,
     key: String,
 ) -> Result<SecureProvisionOutcome, String> {
@@ -5733,6 +5735,26 @@ async fn mxbsecure_provision(
         let sealed = mxbsecure::seal_key_to_identity(&content_key, &steam_id, "");
         let out = std::path::PathBuf::from(format!("{blob_path}.mxbkey"));
         tokio::fs::write(&out, &sealed).await.map_err(|e| format!("write .mxbkey: {e}"))?;
+
+        // Remember the mapping so the app can arm this asset — write the manifest and inject
+        // the DLL — the next time the game starts. The game name is the blob's own name with
+        // the `.mxbsecure` suffix removed: the file the engine will ask for.
+        let game_name = std::path::Path::new(&blob_path)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .map(|n| n.strip_suffix(".mxbsecure").unwrap_or(&n).to_string())
+            .unwrap_or_default();
+        if let Err(e) = secure_launch::record_asset(
+            &app,
+            secure_launch::SecureAsset {
+                game_name,
+                blob_path: blob_path.clone(),
+                mxbkey_path: out.to_string_lossy().to_string(),
+            },
+        ) {
+            log::warn!("[secure] couldn't record the provisioned asset: {e}");
+        }
+
         Ok(SecureProvisionOutcome {
             mxbkey_path: out.to_string_lossy().to_string(),
             steam_id,
@@ -5740,7 +5762,7 @@ async fn mxbsecure_provision(
     }
     #[cfg(not(mxbsecure))]
     {
-        let _ = (blob_path, key);
+        let _ = (app, blob_path, key);
         Err("this build can't provision mxbsecure content".into())
     }
 }

--- a/src-tauri/src/secure_launch.rs
+++ b/src-tauri/src/secure_launch.rs
@@ -1,0 +1,179 @@
+//! Arming secure content in the running game — the app half of the injected client, so a
+//! player does none of it by hand.
+//!
+//! When you lock a file and bind it to your account, the app remembers the mapping (below).
+//! When the game starts, this writes the manifest next to `mxbsecure.dll` and injects the DLL
+//! into the running process. No environment to set, no manifest to write, no `inject.exe`.
+//!
+//! Injection is into the **running** game rather than at launch, because MX Bikes is usually
+//! started by Steam and we don't create that process. The DLL goes in shortly after the game
+//! appears — at the menu, before a track is loaded — which is in time for the reads that
+//! matter. The DLL reads its manifest from its own directory (no inherited environment), which
+//! is why the manifest is written there.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+
+/// One secured asset the app knows how to serve: the name the game opens, the blob, and the
+/// key sealed to the buyer (`.mxbkey`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SecureAsset {
+    /// The file name the game opens (e.g. `pinehill.pkz`).
+    pub game_name: String,
+    pub blob_path: String,
+    pub mxbkey_path: String,
+}
+
+/// Where the registry of secured assets lives.
+fn registry_path(app: &AppHandle) -> Option<PathBuf> {
+    Some(app.path().app_local_data_dir().ok()?.join("secure_assets.json"))
+}
+
+/// The assets provisioned on this machine, or an empty list.
+pub fn load_assets(app: &AppHandle) -> Vec<SecureAsset> {
+    registry_path(app)
+        .and_then(|p| std::fs::read(p).ok())
+        .and_then(|b| serde_json::from_slice(&b).ok())
+        .unwrap_or_default()
+}
+
+/// Record a newly provisioned asset, replacing any earlier entry for the same game name so a
+/// re-lock doesn't leave two. Only the full (mxbsecure) build provisions, so it is otherwise
+/// unused.
+#[cfg_attr(not(mxbsecure), allow(dead_code))]
+pub fn record_asset(app: &AppHandle, asset: SecureAsset) -> Result<(), String> {
+    let path = registry_path(app).ok_or("no app data dir")?;
+    let mut assets = load_assets(app);
+    assets.retain(|a| !a.game_name.eq_ignore_ascii_case(&asset.game_name));
+    assets.push(asset);
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    let json = serde_json::to_vec_pretty(&assets).map_err(|e| e.to_string())?;
+    std::fs::write(&path, json).map_err(|e| e.to_string())
+}
+
+/// Where `mxbsecure.dll` is. Beside the app's own executable, unless `MXB_SECURE_DLL` points
+/// elsewhere — the build places it next to the binary, so there is nothing to configure.
+pub fn dll_path() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("MXB_SECURE_DLL") {
+        let p = PathBuf::from(p);
+        return p.exists().then_some(p);
+    }
+    let exe = std::env::current_exe().ok()?;
+    let p = exe.parent()?.join("mxbsecure.dll");
+    p.exists().then_some(p)
+}
+
+/// Write the manifest the DLL reads — `manifest.tsv` beside the DLL, one tab-separated line
+/// per asset: game name, blob, `.mxbkey`.
+fn write_manifest(assets: &[SecureAsset], dll: &std::path::Path) -> Result<(), String> {
+    let dir = dll.parent().ok_or("dll has no directory")?;
+    let mut out = String::new();
+    for a in assets {
+        out.push_str(&format!("{}\t{}\t{}\n", a.game_name, a.blob_path, a.mxbkey_path));
+    }
+    std::fs::write(dir.join("manifest.tsv"), out).map_err(|e| e.to_string())
+}
+
+/// Arm secure content for the session that just started: write the manifest and inject the
+/// DLL into the running game. Best-effort and quiet on the common "nothing to secure" — a
+/// player with no locked content should see no trace of this.
+pub fn arm(app: &AppHandle) {
+    let assets = load_assets(app);
+    if assets.is_empty() {
+        return;
+    }
+    let Some(dll) = dll_path() else {
+        log::warn!("[secure] have {} secured asset(s) but no mxbsecure.dll to inject", assets.len());
+        return;
+    };
+    if let Err(e) = write_manifest(&assets, &dll) {
+        log::warn!("[secure] couldn't write the manifest: {e}");
+        return;
+    }
+    match inject(&dll) {
+        Ok(()) => log::info!("[secure] injected mxbsecure.dll for {} asset(s)", assets.len()),
+        Err(e) => log::warn!("[secure] injection failed: {e}"),
+    }
+}
+
+/// Inject `dll` into the running game.
+#[cfg(windows)]
+fn inject(dll: &std::path::Path) -> Result<(), String> {
+    let pid = crate::gameproc::game_pid().ok_or("the game isn't running")?;
+    win::inject_into(pid, dll)
+}
+
+#[cfg(not(windows))]
+fn inject(_dll: &std::path::Path) -> Result<(), String> {
+    Err("injection is Windows-only".into())
+}
+
+#[cfg(windows)]
+mod win {
+    use std::ffi::{c_void, OsStr};
+    use std::os::windows::ffi::OsStrExt;
+    use std::ptr::null_mut;
+
+    const PROCESS_ACCESS: u32 = 0x0002 | 0x0008 | 0x0010 | 0x0020 | 0x0400; // VM ops + create thread + query
+    const MEM_COMMIT_RESERVE: u32 = 0x1000 | 0x2000;
+    const PAGE_READWRITE: u32 = 0x04;
+
+    extern "system" {
+        fn OpenProcess(access: u32, inherit: i32, pid: u32) -> *mut c_void;
+        fn GetModuleHandleW(name: *const u16) -> *mut c_void;
+        fn GetProcAddress(module: *mut c_void, name: *const i8) -> *mut c_void;
+        fn VirtualAllocEx(p: *mut c_void, addr: *mut c_void, size: usize, typ: u32, prot: u32) -> *mut c_void;
+        fn WriteProcessMemory(p: *mut c_void, addr: *mut c_void, buf: *const c_void, size: usize, wrote: *mut usize) -> i32;
+        fn CreateRemoteThread(p: *mut c_void, attr: *mut c_void, stack: usize, start: *mut c_void, param: *mut c_void, flags: u32, tid: *mut u32) -> *mut c_void;
+        fn WaitForSingleObject(h: *mut c_void, ms: u32) -> u32;
+        fn CloseHandle(h: *mut c_void) -> i32;
+        fn GetLastError() -> u32;
+    }
+
+    fn wide(s: &str) -> Vec<u16> {
+        OsStr::new(s).encode_wide().chain(std::iter::once(0)).collect()
+    }
+
+    /// Load `dll` into process `pid` via the standard `LoadLibraryW` remote thread.
+    pub fn inject_into(pid: u32, dll: &std::path::Path) -> Result<(), String> {
+        let dll_w: Vec<u16> = wide(&dll.to_string_lossy());
+        // SAFETY: a textbook remote-thread injection into a process we opened for it; every
+        // handle is closed, and the one remote allocation holds only the DLL path string.
+        unsafe {
+            let proc = OpenProcess(PROCESS_ACCESS, 0, pid);
+            if proc.is_null() {
+                return Err(format!("OpenProcess({pid}) failed: {}", GetLastError()));
+            }
+            let bytes = dll_w.len() * 2;
+            let remote = VirtualAllocEx(proc, null_mut(), bytes, MEM_COMMIT_RESERVE, PAGE_READWRITE);
+            if remote.is_null() {
+                CloseHandle(proc);
+                return Err(format!("VirtualAllocEx failed: {}", GetLastError()));
+            }
+            if WriteProcessMemory(proc, remote, dll_w.as_ptr() as *const c_void, bytes, null_mut()) == 0 {
+                CloseHandle(proc);
+                return Err(format!("WriteProcessMemory failed: {}", GetLastError()));
+            }
+            let k32 = GetModuleHandleW(wide("kernel32.dll").as_ptr());
+            let load = GetProcAddress(k32, c"LoadLibraryW".as_ptr());
+            if load.is_null() {
+                CloseHandle(proc);
+                return Err("LoadLibraryW not found".into());
+            }
+            let thread = CreateRemoteThread(proc, null_mut(), 0, load, remote, 0, null_mut());
+            if thread.is_null() {
+                CloseHandle(proc);
+                return Err(format!("CreateRemoteThread failed: {}", GetLastError()));
+            }
+            WaitForSingleObject(thread, 10_000);
+            CloseHandle(thread);
+            CloseHandle(proc);
+        }
+        Ok(())
+    }
+}

--- a/src-tauri/src/sessionwatch.rs
+++ b/src-tauri/src/sessionwatch.rs
@@ -42,6 +42,9 @@ pub fn start(app: &AppHandle) {
                 // game from Steam or a shortcut, and until this was here those sessions
                 // synced with nobody — the Play button was the only way in.
                 crate::sync_on_game_started(&app, &cfg);
+                // Arm any secured content: write the manifest and inject the client DLL into
+                // the game we just saw start. No-op when nothing is locked.
+                crate::secure_launch::arm(&app);
                 session = gameproc::GameSession::open();
                 // The mods folder is read during the load screen, so a placeholder that
                 // isn't really on disk becomes a crash there. Ask now, while there is still


### PR DESCRIPTION
The app does all the manual work now: lock + bind a file → the app remembers it → the game starts → the app writes the manifest and injects `mxbsecure.dll` into the running game. **No env vars, no hand-written manifest, no inject.exe.**

- **secure_launch.rs** — a registry of provisioned assets (`secure_assets.json`), written on provision; `arm()` on game start writes `manifest.tsv` beside the DLL and injects it into the **running** process (OpenProcess + LoadLibraryW remote thread). Injection is into the running game because MX Bikes is usually Steam-launched — we don't create that process — and the DLL reads its manifest from its own directory, so nothing is set on the game.
- **mxbsecure_provision** records the asset (game name from the blob name).
- **sessionwatch** arms it once per game-start transition.
- DLL resolved beside the app's exe (or `MXB_SECURE_DLL`). Bundling it into the release next to the binary is the remaining packaging step.

Pairs with mxbapp-private #14 (DLL reads its manifest beside itself).

Public build (feature off) compiles clean; Windows target compiles; native + windows clippy clean on the new code; 1127 tests, tsc clean. Injection is Windows-only and not yet run in a real process — this removes the manual work so that run is one click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)