### PR TITLE
fix(secure): unsafe extern blocks in the app Windows FFI

### DIFF
--- a/src-tauri/src/secure_launch.rs
+++ b/src-tauri/src/secure_launch.rs
@@ -165,7 +165,7 @@ mod win {
     const MEM_COMMIT_RESERVE: u32 = 0x1000 | 0x2000;
     const PAGE_READWRITE: u32 = 0x04;
 
-    extern "system" {
+    unsafe extern "system" {
         fn OpenProcess(access: u32, inherit: i32, pid: u32) -> *mut c_void;
         fn GetModuleHandleW(name: *const u16) -> *mut c_void;
         fn GetProcAddress(module: *mut c_void, name: *const i8) -> *mut c_void;

--- a/src-tauri/src/steamid.rs
+++ b/src-tauri/src/steamid.rs
@@ -73,7 +73,7 @@ fn windows_steam_path() -> Option<PathBuf> {
     const RRF_RT_REG_SZ: u32 = 0x0000_0002;
 
     #[link(name = "advapi32")]
-    extern "system" {
+    unsafe extern "system" {
         fn RegGetValueW(
             hkey: isize,
             subkey: *const u16,


### PR DESCRIPTION
Match the private crate — secure_launch and steamid use `unsafe extern` blocks, required by newer rustc even on edition 2021 and accepted by older. Forward-compatible with edition 2024. Windows target clean.