### PR TITLE
feat(secure): Protect a track in place — no original, no manual steps

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5710,6 +5710,85 @@ fn secure_steam_id() -> Option<String> {
     steamid::current_steam_id64()
 }
 
+/// What protecting a track in place produced.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SecureProtectOutcome {
+    /// The now-encrypted file, keeping its original name.
+    protected_path: String,
+    mxbkey_path: String,
+    steam_id: String,
+    plain_bytes: u64,
+}
+
+/// Protect a track file **in place**: replace it with its encrypted blob under the same name,
+/// seal the key to the buyer's Steam ID beside it, and record it for auto-injection.
+///
+/// This is the shipping shape. The file keeps its `.pkz` name, so MX Bikes' folder scan still
+/// finds it and lists the track; the injected client decrypts it on read. There is no separate
+/// `.mxbsecure` file and no plaintext left on disk — **the creator must keep their own master
+/// copy**, because this overwrites the original.
+#[tauri::command]
+async fn mxbsecure_protect(
+    app: tauri::AppHandle,
+    track_path: String,
+) -> Result<SecureProtectOutcome, String> {
+    #[cfg(mxbsecure)]
+    {
+        use std::path::Path;
+        let steam_id = steamid::current_steam_id64()
+            .ok_or("couldn't read your Steam ID — is Steam installed and signed in?")?;
+
+        let plaintext = tokio::fs::read(&track_path).await.map_err(|e| format!("read {track_path}: {e}"))?;
+        // Refuse a file that is already one of ours, so a double-protect can't seal ciphertext.
+        if plaintext.starts_with(b"MXBSEC") {
+            return Err("that file is already protected".into());
+        }
+        let name = Path::new(&track_path)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .ok_or("not a file")?;
+        let mut rnd = [0u8; 6];
+        getrandom::getrandom(&mut rnd).map_err(|e| e.to_string())?;
+        let suffix: String = rnd.iter().map(|b| format!("{b:02x}")).collect();
+        let asset_id = format!("{}-{suffix}", sanitize_asset_id(&name));
+
+        let locked = mxbsecure::lock(&plaintext, &asset_id, "k1");
+        let sealed = mxbsecure::seal_key_to_identity(&locked.content_key, &steam_id, "");
+        let mxbkey = format!("{track_path}.mxbkey");
+        tokio::fs::write(&mxbkey, &sealed).await.map_err(|e| format!("write .mxbkey: {e}"))?;
+
+        // Overwrite the original with the encrypted blob, same name. Written to a temp beside
+        // it and renamed, so a crash mid-write can't leave a half-encrypted track.
+        let tmp = format!("{track_path}.mxbsecuring");
+        tokio::fs::write(&tmp, &locked.blob).await.map_err(|e| format!("write blob: {e}"))?;
+        tokio::fs::rename(&tmp, &track_path).await.map_err(|e| format!("replace track: {e}"))?;
+
+        if let Err(e) = secure_launch::record_asset(
+            &app,
+            secure_launch::SecureAsset {
+                game_name: name,
+                blob_path: track_path.clone(),
+                mxbkey_path: mxbkey.clone(),
+            },
+        ) {
+            log::warn!("[secure] couldn't record the protected asset: {e}");
+        }
+
+        Ok(SecureProtectOutcome {
+            protected_path: track_path,
+            mxbkey_path: mxbkey,
+            steam_id,
+            plain_bytes: plaintext.len() as u64,
+        })
+    }
+    #[cfg(not(mxbsecure))]
+    {
+        let _ = (app, track_path);
+        Err("this build can't protect content".into())
+    }
+}
+
 /// What provisioning a key produced.
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -9336,6 +9415,7 @@ fn main() {
             secure_steam_id,
             mxbsecure_provision,
             mxbsecure_open_offline,
+            mxbsecure_protect,
             local_guid,
             load_bike_model,
             preview_model_swap,

--- a/src/Components/Secure/Secure.tsx
+++ b/src/Components/Secure/Secure.tsx
@@ -12,6 +12,7 @@ import {
   secureSteamId,
   mxbsecureProvision,
   mxbsecureOpenOffline,
+  mxbsecureProtect,
   type SecureLockOutcome,
 } from "../../api/mods";
 import { useT } from "../../i18n/context";
@@ -36,6 +37,23 @@ const Secure = () => {
   const [provisioned, setProvisioned] = useState(false);
   const [offlineOk, setOfflineOk] = useState<boolean | null>(null);
   const [openingOffline, setOpeningOffline] = useState(false);
+  const [protecting, setProtecting] = useState(false);
+  const [protectedPath, setProtectedPath] = useState<string | null>(null);
+
+  const protect = async () => {
+    const chosen = await openDialog({ multiple: false, directory: false });
+    if (typeof chosen !== "string") return;
+    setProtecting(true);
+    setProtectedPath(null);
+    try {
+      const out = await mxbsecureProtect(chosen);
+      setProtectedPath(out.protectedPath);
+      toast.success(t("secure.protectedOk", { id: out.steamId }));
+    } catch (e) {
+      toast.error(t("secure.protectFailed"), { description: String(e) });
+    }
+    setProtecting(false);
+  };
 
   useEffect(() => {
     secureSteamId().then(setSteamId).catch(() => setSteamId(null));
@@ -133,6 +151,41 @@ const Secure = () => {
       <div className="mx-auto w-full max-w-2xl px-7 pb-10">
         <p className="mb-5 text-[13px] leading-relaxed text-muted-foreground">
           {t("secure.intro")}
+        </p>
+
+        {/* The real action — protect a track in place. Encrypts the file under its own name,
+            binds it to the Steam account, and records it so the game auto-loads it. */}
+        <div className="mb-6 rounded-xl border border-primary/30 bg-primary/[0.04] p-4">
+          <div className="flex items-center gap-2">
+            <Lock className="size-4 text-primary" />
+            <h2 className="text-[13.5px] font-semibold">{t("secure.protectTitle")}</h2>
+          </div>
+          <p className="mt-1.5 text-[12px] leading-relaxed text-muted-foreground">
+            {t("secure.protectDesc")}
+          </p>
+          <div className="mt-3 flex flex-wrap items-center gap-3">
+            <Button size="sm" disabled={protecting || steamId === undefined} onClick={() => void protect()}>
+              {protecting ? <Loader2 className="size-3.5 animate-spin" /> : <Lock className="size-3.5" />}
+              {t("secure.protectAction")}
+            </Button>
+            {protectedPath && (
+              <span className="flex items-center gap-1.5 text-[12.5px] font-medium text-success">
+                <Check className="size-4" /> {t("secure.protectedInPlace")}
+              </span>
+            )}
+          </div>
+          {protectedPath && (
+            <p className="mt-2 break-all font-mono text-[11px] text-muted-foreground" title={protectedPath}>
+              {protectedPath}
+            </p>
+          )}
+          {steamId === null && (
+            <p className="mt-2 text-[11.5px] text-warning">{t("secure.noSteam")}</p>
+          )}
+        </div>
+
+        <p className="mb-3 text-[11.5px] font-medium uppercase tracking-wide text-muted-foreground/70">
+          {t("secure.testHeading")}
         </p>
 
         {/* Step 1 — pick and lock */}

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -364,6 +364,20 @@ export function mxbsecureOpenOffline(blobPath: string, original: string): Promis
   return invoke<boolean>("mxbsecure_open_offline", { blobPath, original });
 }
 
+/** What protecting a track in place produced. */
+export interface SecureProtectOutcome {
+  protectedPath: string;
+  mxbkeyPath: string;
+  steamId: string;
+  plainBytes: number;
+}
+
+/** Protect a track file in place: encrypt it under its own name, bound to your Steam account,
+ *  and record it for auto-injection. Overwrites the original — keep your master copy. */
+export function mxbsecureProtect(trackPath: string): Promise<SecureProtectOutcome> {
+  return invoke<SecureProtectOutcome>("mxbsecure_protect", { trackPath });
+}
+
 /** What a run would touch — folders walked, files taken as themselves, skips flagged. */
 export function contentLockPlan(paths: string[]): Promise<LockItem[]> {
   return invoke<LockItem[]>("content_lock_plan", { paths });

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -721,6 +721,14 @@ export const de: Translation = {
   "secure.experimental": "Experimentell",
   "secure.intro":
     "Datei wählen, sperren, dann das Entsperren prüfen. Beim Prüfen wird das Blob hier entschlüsselt und Byte für Byte mit dem Original verglichen — der Beleg, dass es auf diesem Rechner zurückkommt.",
+  "secure.protectTitle": "Eine Strecke schützen",
+  "secure.protectDesc":
+    "Verschlüsselt eine Streckendatei an Ort und Stelle — sie behält ihren Namen, das Spiel listet sie weiter, aber nur du kannst sie fahren, offline. Überschreibt die Datei, also behalte eine eigene Masterkopie. Dann einfach das Spiel starten.",
+  "secure.protectAction": "Strecke wählen & schützen",
+  "secure.protectedOk": "Geschützt, an {{id}} gebunden.",
+  "secure.protectedInPlace": "Geschützt — an Ort und Stelle verschlüsselt",
+  "secure.protectFailed": "Datei konnte nicht geschützt werden",
+  "secure.testHeading": "Format testen (optional)",
   "secure.step3": "An dein Steam-Konto binden & offline spielen",
   "secure.step3Desc":
     "Versiegelt den Schlüssel an dein Steam-Konto und speichert ihn lokal. Danach öffnet er ohne Server — offline, im LAN, überall — aber nur auf deinem Konto. Eine Kopie auf einem anderen Konto bekommt nichts.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -707,6 +707,14 @@ export const en = {
   "secure.experimental": "Experimental",
   "secure.intro":
     "Pick a file, lock it, then verify it unlocks. Verifying decrypts the blob right here and checks it matches the original, byte for byte — the proof it round-trips on this machine.",
+  "secure.protectTitle": "Protect a track",
+  "secure.protectDesc":
+    "Encrypts a track file in place — it keeps its name so the game still lists it, but only you can ride it, offline. Overwrites the file, so keep your own master copy. Then just start the game.",
+  "secure.protectAction": "Choose a track & protect",
+  "secure.protectedOk": "Protected, bound to {{id}}.",
+  "secure.protectedInPlace": "Protected — encrypted in place",
+  "secure.protectFailed": "Couldn't protect that file",
+  "secure.testHeading": "Test the format (optional)",
   "secure.step3": "Bind to your Steam account & play offline",
   "secure.step3Desc":
     "Seal the key to your Steam account and store it locally. From then on it opens with no server — offline, on a LAN, anywhere — but only on your account. A copy on someone else's account gets nothing.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -713,6 +713,14 @@ export const es: Translation = {
   "secure.experimental": "Experimental",
   "secure.intro":
     "Elige un archivo, bloquéalo y luego verifica que se desbloquea. Verificar descifra el blob aquí mismo y lo compara con el original, byte a byte — la prueba de que va y vuelve en esta máquina.",
+  "secure.protectTitle": "Proteger un circuito",
+  "secure.protectDesc":
+    "Cifra un archivo de circuito en el sitio — conserva su nombre, el juego lo sigue listando, pero solo tú puedes rodarlo, sin conexión. Sobrescribe el archivo, así que guarda tu propia copia maestra. Luego solo inicia el juego.",
+  "secure.protectAction": "Elegir un circuito y proteger",
+  "secure.protectedOk": "Protegido, vinculado a {{id}}.",
+  "secure.protectedInPlace": "Protegido — cifrado en el sitio",
+  "secure.protectFailed": "No se pudo proteger el archivo",
+  "secure.testHeading": "Probar el formato (opcional)",
   "secure.step3": "Vincular a tu cuenta de Steam y jugar sin conexión",
   "secure.step3Desc":
     "Sella la clave a tu cuenta de Steam y la guarda localmente. A partir de ahí se abre sin servidor — sin conexión, en LAN, donde sea — pero solo en tu cuenta. Una copia en otra cuenta no obtiene nada.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -717,6 +717,14 @@ export const fr: Translation = {
   "secure.experimental": "Expérimental",
   "secure.intro":
     "Choisissez un fichier, verrouillez-le, puis vérifiez qu'il se déverrouille. La vérification déchiffre le blob ici même et le compare à l'original, octet par octet — la preuve qu'il fait l'aller-retour sur cette machine.",
+  "secure.protectTitle": "Protéger un circuit",
+  "secure.protectDesc":
+    "Chiffre un fichier de circuit sur place — il garde son nom, le jeu le liste toujours, mais vous seul pouvez le rouler, hors ligne. Écrase le fichier, gardez donc votre propre copie maître. Ensuite, lancez simplement le jeu.",
+  "secure.protectAction": "Choisir un circuit & protéger",
+  "secure.protectedOk": "Protégé, lié à {{id}}.",
+  "secure.protectedInPlace": "Protégé — chiffré sur place",
+  "secure.protectFailed": "Impossible de protéger ce fichier",
+  "secure.testHeading": "Tester le format (facultatif)",
   "secure.step3": "Lier à votre compte Steam & jouer hors ligne",
   "secure.step3Desc":
     "Scelle la clé à votre compte Steam et la stocke localement. Ensuite elle s'ouvre sans serveur — hors ligne, en LAN, partout — mais seulement sur votre compte. Une copie sur un autre compte n'obtient rien.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -712,6 +712,14 @@ export const it: Translation = {
   "secure.experimental": "Sperimentale",
   "secure.intro":
     "Scegli un file, bloccalo, poi verifica che si sblocchi. La verifica decifra il blob qui e lo confronta con l'originale, byte per byte — la prova che fa il giro su questa macchina.",
+  "secure.protectTitle": "Proteggi una pista",
+  "secure.protectDesc":
+    "Cifra un file di pista sul posto — mantiene il nome, il gioco continua a elencarla, ma solo tu puoi guidarla, offline. Sovrascrive il file, quindi tieni una tua copia master. Poi basta avviare il gioco.",
+  "secure.protectAction": "Scegli una pista e proteggi",
+  "secure.protectedOk": "Protetta, vincolata a {{id}}.",
+  "secure.protectedInPlace": "Protetta — cifrata sul posto",
+  "secure.protectFailed": "Impossibile proteggere il file",
+  "secure.testHeading": "Prova il formato (facoltativo)",
   "secure.step3": "Vincola al tuo account Steam e gioca offline",
   "secure.step3Desc":
     "Sigilla la chiave al tuo account Steam e la salva in locale. Da quel momento si apre senza server — offline, in LAN, ovunque — ma solo sul tuo account. Una copia su un altro account non ottiene nulla.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -715,6 +715,14 @@ export const ptBR: Translation = {
   "secure.experimental": "Experimental",
   "secure.intro":
     "Escolha um arquivo, bloqueie e depois verifique que ele desbloqueia. Verificar decifra o blob aqui mesmo e compara com o original, byte a byte — a prova de que ele vai e volta nesta máquina.",
+  "secure.protectTitle": "Proteger uma pista",
+  "secure.protectDesc":
+    "Criptografa um arquivo de pista no lugar — mantém o nome, o jogo continua listando, mas só você pode andar nela, offline. Sobrescreve o arquivo, então guarde sua cópia mestra. Depois é só iniciar o jogo.",
+  "secure.protectAction": "Escolher uma pista e proteger",
+  "secure.protectedOk": "Protegida, vinculada a {{id}}.",
+  "secure.protectedInPlace": "Protegida — criptografada no lugar",
+  "secure.protectFailed": "Não foi possível proteger o arquivo",
+  "secure.testHeading": "Testar o formato (opcional)",
   "secure.step3": "Vincular à sua conta Steam e jogar offline",
   "secure.step3Desc":
     "Sela a chave à sua conta Steam e guarda localmente. A partir daí abre sem servidor — offline, em LAN, em qualquer lugar — mas só na sua conta. Uma cópia em outra conta não abre nada.",


### PR DESCRIPTION
The last piece of the in-game path. MX Bikes lists tracks by scanning for `*.pkz`, so a `.mxbsecure` blob beside the original is never discovered — you had to leave the plaintext there. Now the encrypted blob **keeps the `.pkz` name**, in place of the original: the scan finds it, the game opens it, the injected client decrypts it. No original, no separate file, no removal.

- **mxbsecure_protect**: encrypt the track, seal the key to the live Steam ID (`<track>.mxbkey`), then atomically replace the file with the blob under the same name (temp + rename). Records the asset → next game start auto-injects. Refuses an already-protected file.
- A **"Protect a track"** card leads the Secure tab; lock/verify/bind become the optional "test the format" section.
- The plaintext is gone after — the creator keeps their master; the UI says so.

Confirmed in-game already: the DLL injects, unseals, and decrypts a track that **rides**. This just makes it discoverable without the original. A test drives the whole flow on a real file. Public build compiles; tsc/eslint/vite clean; six locales.