### PR TITLE
feat(secure): inject the DLL the instant the game appears

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9296,6 +9296,7 @@ fn main() {
             // Notice the game starting (Steam or Play button) to re-arm FrostMod for the
             // session and check the mods folder is really on disk.
             sessionwatch::start(handle);
+            secure_launch::watch(handle);
             // Voice follows the rider onto whatever server they join, and off it again.
             // There is nothing to press: the supervisor is the whole of "joining a room".
             voice::session::start(handle);

--- a/src-tauri/src/secure_launch.rs
+++ b/src-tauri/src/secure_launch.rs
@@ -114,6 +114,32 @@ fn write_manifest(assets: &[SecureAsset], dir: &std::path::Path) -> Result<(), S
     std::fs::write(dir.join("manifest.tsv"), out).map_err(|e| e.to_string())
 }
 
+/// Watch for the game and inject the moment it appears — as early as possible, because MX
+/// Bikes reads a track's content to list it, so the hook has to be live *before* the track
+/// browser opens or a protected track won't show. A tight poll (every couple of seconds)
+/// rather than the 15-second session watcher, and it injects once per run of the game.
+///
+/// A no-op run to run when nothing is protected: it only wakes to check a process list.
+pub fn watch(app: &AppHandle) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let mut injected_this_session = false;
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            let running = crate::gameproc::is_game_running();
+            if running {
+                if !injected_this_session && !load_assets(&app).is_empty() {
+                    arm(&app);
+                    injected_this_session = true;
+                }
+            } else {
+                // Game gone: re-arm for the next launch.
+                injected_this_session = false;
+            }
+        }
+    });
+}
+
 /// Arm secure content for the session that just started: stage the DLL, write the manifest
 /// beside it, and inject. Best-effort and quiet on the common "nothing to secure" — a player
 /// with no locked content should see no trace of this.

--- a/src-tauri/src/sessionwatch.rs
+++ b/src-tauri/src/sessionwatch.rs
@@ -42,9 +42,6 @@ pub fn start(app: &AppHandle) {
                 // game from Steam or a shortcut, and until this was here those sessions
                 // synced with nobody — the Play button was the only way in.
                 crate::sync_on_game_started(&app, &cfg);
-                // Arm any secured content: write the manifest and inject the client DLL into
-                // the game we just saw start. No-op when nothing is locked.
-                crate::secure_launch::arm(&app);
                 session = gameproc::GameSession::open();
                 // The mods folder is read during the load screen, so a placeholder that
                 // isn't really on disk becomes a crash there. Ask now, while there is still


### PR DESCRIPTION
MX Bikes reads a track's content to list it, so the hook must be live **before** the track browser opens or a protected .pkz shows as ciphertext and isn't listed. The old path armed on the 15s session watcher — often too late.

`secure_launch::watch` polls every 2s and injects the moment the game appears, once per run, re-arming on exit. A no-op when nothing is protected. Public build + Windows + clippy clean.