### PR TITLE
fix(ci): ask for the secure DLL only where one exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,19 @@ jobs:
         shell: bash
         run: bash .sidecar-src/sync.sh "$GITHUB_WORKSPACE"
 
+      # Ask the bundler for the DLL only on the leg that has one. Tauri's `resources` glob
+      # is a hard error when it matches nothing, so keeping it in the committed config
+      # broke every build without the private module — CI on both platforms, and the
+      # macOS and Linux release legs. The file must be there by now: sync.sh put it in
+      # src/, build.rs copies it into resources/ before the bundler looks.
+      - name: Bundle the secure-content DLL
+        if: ${{ github.repository == 'Frostn1/mxb-app' && startsWith(matrix.platform, 'windows') }}
+        shell: bash
+        run: |
+          test -f src-tauri/src/mxbsecure.dll || { echo "::error::mxbsecure.dll missing after sync.sh"; exit 1; }
+          jq '.bundle.resources = ["resources/*.dll"]' src-tauri/tauri.conf.json > tauri.conf.patched
+          mv tauri.conf.patched src-tauri/tauri.conf.json
+
       # The release page should say what shipped, not only which file to download — so
       # the body is composed from this tag's CHANGELOG section. Same section the Discord
       # announcement reads, so the two can't drift apart.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -43,7 +43,6 @@
   },
   "bundle": {
     "active": true,
-    "resources": ["resources/*.dll"],
     "targets": ["nsis", "app", "dmg", "appimage", "deb", "rpm"],
     "category": "Game",
     "createUpdaterArtifacts": true,


### PR DESCRIPTION
## What broke

`68b1543` added `"resources": ["resources/*.dll"]` to `src-tauri/tauri.conf.json` so the Windows installer would carry the injected secure-content DLL. Tauri validates that glob inside the build script, and treats *matching nothing* as a hard error:

```
error: failed to run custom build command for `mxb-app v0.13.0`
  glob pattern resources/*.dll path not found or didn't match any files.
```

The DLL is gitignored and only built on the Windows release leg from the private crate, so on every other checkout the glob matches nothing and the crate fails before compiling a line. That took down:

- **CI on `main`** — both `cargo test` legs, Linux and Windows ([run 33469953007](https://github.com/Frostn1/mxb-app/actions/runs/33469953007))
- **the `v0.13.0-beta.1` release** — the macOS and Linux bundles ([run 33469978285](https://github.com/Frostn1/mxb-app/actions/runs/33469978285))
- any fork or clean clone, at `cargo check`

The `resources/.gitkeep` that shipped alongside doesn't help — the glob wants a `.dll`.

## The fix

Keep the committed config free of the glob and set it at release time, on the one leg that has a DLL:

```yaml
- name: Bundle the secure-content DLL
  if: ${{ github.repository == 'Frostn1/mxb-app' && startsWith(matrix.platform, 'windows') }}
  run: |
    test -f src-tauri/src/mxbsecure.dll || { echo "::error::mxbsecure.dll missing after sync.sh"; exit 1; }
    jq '.bundle.resources = ["resources/*.dll"]' ...
```

It runs after `Apply sidecar module` (which puts the DLL in `src/`) and before the build, where `build.rs` copies it into `resources/` — so the glob matches by the time the build script validates it. The `test -f` guard means a missing DLL fails the release rather than quietly shipping an installer without it.

A `tauri.windows.conf.json` overlay was the other option, but it would leave the Windows `cargo test` job just as red — the merged config is what the build script sees.

## What ships is unchanged

Windows installer still carries `mxbsecure.dll`; no other platform ever bundled it.

## Verified

- `release.yml` parses, and the new step lands between `Apply sidecar module` and `Build and publish release`
- the `jq` expression produces a valid config with the glob restored
- the committed config has no `bundle.resources` key — the state `main` was in at #321, when CI was last green

No `CHANGELOG.md` entry: this is build plumbing for the v0.13.0 section that's already written, and nothing about it is visible to a player.