### PR TITLE
fix(secure): bundle the DLL via a Windows-only config overlay

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,16 @@ jobs:
         shell: bash
         run: bash .sidecar-src/sync.sh "$GITHUB_WORKSPACE"
 
+      # Bundle the secure DLL, Windows only. tauri auto-merges tauri.windows.conf.json on the
+      # Windows target and ignores it everywhere else, so the resources glob (which errors if it
+      # matches nothing) is never seen by the macOS/Linux legs. Written only on the Frostn1 repo,
+      # where the sync step above placed the DLL — a fork's Windows build has no overlay and no
+      # glob to satisfy, so it builds the DLL-less variant instead of failing.
+      - name: Enable secure DLL bundling (Windows)
+        if: ${{ github.repository == 'Frostn1/mxb-app' && startsWith(matrix.platform, 'windows') }}
+        shell: bash
+        run: echo '{"bundle":{"resources":["resources/*.dll"]}}' > "$GITHUB_WORKSPACE/src-tauri/tauri.windows.conf.json"
+
       # The release page should say what shipped, not only which file to download — so
       # the body is composed from this tag's CHANGELOG section. Same section the Discord
       # announcement reads, so the two can't drift apart.

--- a/src-tauri/.gitignore
+++ b/src-tauri/.gitignore
@@ -13,3 +13,4 @@
 /src/mxbsecure.rs
 /src/mxbsecure.dll
 /resources/*.dll
+/tauri.windows.conf.json

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -43,7 +43,6 @@
   },
   "bundle": {
     "active": true,
-    "resources": ["resources/*.dll"],
     "targets": ["nsis", "app", "dmg", "appimage", "deb", "rpm"],
     "category": "Game",
     "createUpdaterArtifacts": true,


### PR DESCRIPTION
The `resources` glob failed the macOS/Linux release legs — tauri validates `bundle.resources` at build-script time and errors when a glob matches no files, and those legs have no DLL. Moves the glob out of base config into a Windows-only overlay written by CI on the Frostn1 Windows leg (where the DLL exists). tauri auto-merges `tauri.windows.conf.json` on Windows only; mac/Linux and forks never see it. Verified on macOS: base builds clean, overlay ignored on mac, and with the glob+DLL in effect the installer carries it at `resources/mxbsecure.dll`.