### PR TITLE
fix(track): install into the mods folder the game reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2026-08-31
 
 ### Changed
+- Track Studio installs a track into your MX Bikes mods folder, where the game reads its
+  tracks from. If no folder is set yet, it says so instead of installing.
 - A track installed from Track Studio is packed the way the game reads tracks, so it turns up
   in the in-game list.
 - The track file names the artwork it ships and states its lap length in metres.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1384,6 +1384,22 @@ async fn preview_track(
     .map_err(|e| format!("preview_track task failed: {e}"))?
 }
 
+/// Where an installed track goes: the mods tree's `tracks` folder.
+///
+/// Not `game_path` — that is the folder with the executable in it, which the game never
+/// reads content from, and which is empty on a machine that only has the mods folder
+/// configured. And `mods` is resolved rather than joined on: a player who relocated the
+/// tree with `mxbikes.ini` has `mods_path` already pointing at it.
+fn track_install_dir(cfg: &AppConfig) -> Result<std::path::PathBuf, String> {
+    if cfg.mods_path.trim().is_empty() {
+        return Err(format!(
+            "No {} folder is configured yet — set it in Settings.",
+            cfg.game().display
+        ));
+    }
+    Ok(library::mods_subdir(&cfg.mods_path, "mods/tracks"))
+}
+
 /// Install the preview into the game's tracks folder.
 ///
 /// Terrain only, so the game will list it and fail to load it — the studio says so. It is
@@ -1396,18 +1412,12 @@ async fn install_track_preview(
 ) -> Result<String, String> {
     let prog = track_program(program)?;
     let cfg = config::load_or_detect(&app).unwrap_or_default();
+    let dir = track_install_dir(&cfg)?;
     tauri::async_runtime::spawn_blocking(move || {
         let syn = tracksynth::synthesise(&prog).map_err(|e| format!("{e:#}"))?;
-        let dir = std::path::Path::new(&cfg.game_path)
-            .join("mods")
-            .join("tracks");
-        std::fs::create_dir_all(&dir).map_err(|e| format!("{e}"))?;
-        let name: String = prog
-            .name
-            .chars()
-            .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-            .collect();
-        let path = dir.join(format!("{}.pkz", name.trim_matches('_')));
+        std::fs::create_dir_all(&dir).map_err(|e| format!("{}: {e}", dir.display()))?;
+        // The archive's own name, so the `.pkz` and the folder inside it agree.
+        let path = dir.join(format!("{}.pkz", tracksynth::slug(&prog.name)));
         tracksynth::write_pkz(&prog, &syn, &path, false).map_err(|e| format!("{e:#}"))?;
         usage::track("track.install");
         Ok(path.to_string_lossy().into_owned())
@@ -12502,5 +12512,58 @@ mod live_look_tests {
         for _ in 0..5 {
             assert!(!live_look_cooldown_passed(), "the rest fold into it");
         }
+    }
+}
+
+#[cfg(test)]
+mod track_install_tests {
+    use super::*;
+
+    fn tmp(name: &str) -> std::path::PathBuf {
+        let d = std::env::temp_dir().join(format!("frost-trackdest-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        d
+    }
+
+    #[test]
+    fn a_track_installs_into_the_mods_tree_not_the_install_dir() {
+        let user = tmp("user");
+        std::fs::create_dir_all(user.join("mods").join("tracks")).unwrap();
+        let cfg = AppConfig {
+            mods_path: user.to_string_lossy().into_owned(),
+            // Deliberately set, and deliberately not where the track goes.
+            game_path: "/somewhere/else/MX Bikes".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            track_install_dir(&cfg).unwrap(),
+            user.join("mods").join("tracks")
+        );
+        let _ = std::fs::remove_dir_all(&user);
+    }
+
+    /// `mxbikes.ini` lets a player point the game at `C:\mods`, and then `mods_path` *is*
+    /// the tree — joining `mods` on by hand would write to `C:\mods\mods\tracks`.
+    #[test]
+    fn a_relocated_tree_is_the_mods_folder_itself() {
+        let tree = tmp("tree");
+        for d in ["bikes", "tracks", "rider"] {
+            std::fs::create_dir_all(tree.join(d)).unwrap();
+        }
+        let cfg = AppConfig {
+            mods_path: tree.to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+        assert_eq!(track_install_dir(&cfg).unwrap(), tree.join("tracks"));
+        let _ = std::fs::remove_dir_all(&tree);
+    }
+
+    /// With no folder configured the old code joined onto an empty `game_path` and wrote
+    /// `mods/tracks` relative to the working directory — a track installed into thin air.
+    #[test]
+    fn no_configured_folder_is_an_error_not_a_relative_path() {
+        let cfg = AppConfig { mods_path: String::new(), ..Default::default() };
+        let err = track_install_dir(&cfg).unwrap_err();
+        assert!(err.contains("configured"), "{err}");
     }
 }

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -1064,22 +1064,12 @@ pub fn write_source(prog: &TrackProgram, syn: &Synth, dir: &Path) -> Result<Vec<
     put("params.ini", PARAMS_INI.into(), &mut wrote)?;
     put("trh_params.ini", TRH_PARAMS_INI.into(), &mut wrote)?;
     put("track.tcl", tcl(prog).into_bytes(), &mut wrote)?;
-    put(
-        &format!("{slug}/{slug}.ini"),
-        track_ini(prog).into_bytes(),
-        &mut wrote,
-    )?;
-    put(&format!("{slug}/{slug}.amb"), AMB.into(), &mut wrote)?;
-    put(
-        &format!("{slug}/gfx.cfg"),
-        gfx_cfg(prog).into_bytes(),
-        &mut wrote,
-    )?;
-    put(
-        &format!("{slug}/{slug}.rdf"),
-        rdf(prog).into_bytes(),
-        &mut wrote,
-    )?;
+    // The game-facing files, byte for byte what the `.pkz` carries.
+    put(&format!("{slug}/{slug}.ini"), crlf(&track_ini(prog)), &mut wrote)?;
+    put(&format!("{slug}/{slug}.amb"), crlf(AMB), &mut wrote)?;
+    put(&format!("{slug}/gfx.cfg"), crlf(&gfx_cfg(prog)), &mut wrote)?;
+    put(&format!("{slug}/{slug}.rdf"), crlf(&rdf(prog)), &mut wrote)?;
+    put(&format!("{slug}/{slug}.ssc"), Vec::new(), &mut wrote)?;
     let (map_img, shot) = ui_images(syn, UI_IMAGE_DIM);
     put(&format!("{slug}/{slug}_map.tga"), map_img, &mut wrote)?;
     put(&format!("{slug}/{slug}.tga"), shot, &mut wrote)?;
@@ -1479,10 +1469,12 @@ pub fn write_pkz(
     for (name, bytes) in [
         (format!("{slug}/{slug}.trh"), trh(prog, syn, paint_features)),
         (format!("{slug}/{slug}.map"), map(prog, syn)),
-        (format!("{slug}/{slug}.ini"), track_ini(prog).into_bytes()),
-        (format!("{slug}/{slug}.rdf"), rdf(prog).into_bytes()),
-        (format!("{slug}/{slug}.amb"), AMB.as_bytes().to_vec()),
-        (format!("{slug}/gfx.cfg"), gfx_cfg(prog).into_bytes()),
+        (format!("{slug}/{slug}.ini"), crlf(&track_ini(prog))),
+        (format!("{slug}/{slug}.rdf"), crlf(&rdf(prog))),
+        (format!("{slug}/{slug}.amb"), crlf(AMB)),
+        (format!("{slug}/gfx.cfg"), crlf(&gfx_cfg(prog))),
+        // Empty on the reference track, and on every track that ships one.
+        (format!("{slug}/{slug}.ssc"), Vec::new()),
         (format!("{slug}/{slug}_map.tga"), map_img),
         (format!("{slug}/{slug}.tga"), shot),
     ] {
@@ -1491,6 +1483,11 @@ pub fn write_pkz(
     }
     zip.finish()?;
     Ok(std::fs::metadata(path).map(|m| m.len()).unwrap_or(0))
+}
+
+/// PiBoSo's own config files are CRLF throughout, so ours are too.
+fn crlf(text: &str) -> Vec<u8> {
+    text.replace("\r\n", "\n").replace('\n', "\r\n").into_bytes()
 }
 
 /// The heightmap: little-endian u16, quantised against the height budget.
@@ -1849,7 +1846,7 @@ fn readme(prog: &TrackProgram, syn: &Synth, slug: &str) -> String {
     )
 }
 
-fn slug(name: &str) -> String {
+pub fn slug(name: &str) -> String {
     let s: String = name
         .chars()
         .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
@@ -2245,6 +2242,7 @@ mod tests {
             format!("{slug}/{slug}.ini"),
             format!("{slug}/{slug}.rdf"),
             format!("{slug}/{slug}.amb"),
+            format!("{slug}/{slug}.ssc"),
             format!("{slug}/gfx.cfg"),
         ] {
             assert!(names.contains(&want), "{want} is missing from {names:?}");
@@ -2255,6 +2253,11 @@ mod tests {
         let ini =
             String::from_utf8(crate::pkz::read_entry(&path, &format!("{slug}.ini")).unwrap().unwrap())
                 .unwrap();
+        // PiBoSo writes these CRLF, so a line of ours is never bare LF.
+        assert!(
+            ini.contains("\r\n") && !ini.replace("\r\n", "").contains('\n'),
+            "the ini is not CRLF throughout"
+        );
         for line in ini.lines() {
             let Some((key, value)) = line.split_once('=') else {
                 continue;


### PR DESCRIPTION
Track Studio's Install button wrote the `.pkz` to `<game_path>/mods/tracks` — the folder with `mxbikes.exe` in it, which the game never reads content from. `game_path` is also blank on any install that only has the mods folder configured, and then the path was relative: the archives landed in `src-tauri/mods/tracks/` beside the running binary. Either way nothing reached the game.

- Resolve the destination with `library::mods_subdir(&cfg.mods_path, "mods/tracks")` — the resolver that also keeps a relocated `C:\mods` tree from becoming `C:\mods\mods\tracks`. No configured folder is now an error the studio shows, not a silent write to nowhere.
- The archive is named with `tracksynth::slug`, the same name the folder inside it uses, so the two can't drift.
- Ship the empty `.ssc` SFDR and every other published track carries, and write the `.ini`, `.rdf`, `.amb` and `gfx.cfg` CRLF like PiBoSo's own. The exported source folder gets the same bytes.

## Verify

`cargo test` — 1140 passed, 0 failed. Three new tests cover the destination: an ordinary user folder, a relocated tree, and no folder configured.

A generated archive now matches SFDR's shape:

```
Corpus_National/Corpus_National.trh
Corpus_National/Corpus_National.map
Corpus_National/Corpus_National.ini
Corpus_National/Corpus_National.rdf
Corpus_National/Corpus_National.amb
Corpus_National/gfx.cfg
Corpus_National/Corpus_National.ssc   (0 bytes)
Corpus_National/Corpus_National_map.tga
Corpus_National/Corpus_National.tga
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)