### PR TITLE
feat(frostmod): let FrostMod's flags be typed in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2026-08-31
 
 ### Added
+- A FrostMod flags box in Settings. What you type there is handed to FrostMod the next time
+  it starts, after the flags the app already sends.
 - Installed tracks carry the ground they are painted with, and a gfx.cfg so roost is the
   colour of the dirt.
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -67,6 +67,11 @@ pub struct AppConfig {
     pub autostart_binding_rev: u32,
     /// Launch FrostMod automatically when the app opens.
     pub auto_run_frostmod: bool,
+    /// Extra command-line flags for `frostmod.exe`, exactly as they would be typed. Empty
+    /// for everyone who hasn't been asked for one: these are FrostMod's diagnostics, and
+    /// they carry their own warnings (`--force-overjump-off` is offline-only). Appended
+    /// after the flags we always send, so a flag typed here wins a repeat.
+    pub frostmod_args: String,
     /// Re-run the game's profile loader in place after applying a preset (Windows-only).
     pub instant_refresh: bool,
     /// Watch `<mods_path>/mods` and signal FrostMod to reload when tracks/bikes are
@@ -251,6 +256,7 @@ impl Default for AppConfig {
             // its login item still names the old binary.
             autostart_binding_rev: 0,
             auto_run_frostmod: true,
+            frostmod_args: String::new(),
             instant_refresh: true,
             watch_mods_reload: true,
             welcome_seen: false,

--- a/src-tauri/src/frostmod_manage.rs
+++ b/src-tauri/src/frostmod_manage.rs
@@ -484,6 +484,34 @@ struct StartPlan {
     /// The mods *tree*, when the player has a folder set. Still a host path: anything
     /// running inside a prefix has to rewrite it as the prefix sees it before handing over.
     mods_root: Option<PathBuf>,
+    /// Whatever the player typed into the FrostMod flags box, split into arguments. Passed
+    /// through untouched and unvalidated: FrostMod ignores a flag it doesn't know, which is
+    /// what lets a diagnostic ship in a FrostMod build before the app knows about it.
+    extra: Vec<String>,
+}
+
+/// Split a typed flag line into arguments, keeping double-quoted runs together so a path
+/// with spaces survives (`--mods "C:\My Mods"`). Everything else is whitespace-separated.
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
+fn split_args(line: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    let mut quoted = false;
+    for c in line.chars() {
+        match c {
+            '"' => quoted = !quoted,
+            c if c.is_whitespace() && !quoted => {
+                if !cur.is_empty() {
+                    out.push(std::mem::take(&mut cur));
+                }
+            }
+            c => cur.push(c),
+        }
+    }
+    if !cur.is_empty() {
+        out.push(cur);
+    }
+    out
 }
 
 /// Check what has to be true before starting, and work out what to tell FrostMod.
@@ -534,7 +562,8 @@ fn plan_start(app: &AppHandle) -> anyhow::Result<Option<StartPlan>> {
     // exist — silently, since neither reports an empty root as an error.
     let mods_root = (!cfg.mods_path.trim().is_empty())
         .then(|| crate::library::mods_root(&cfg.mods_path));
-    Ok(Some(StartPlan { exe, game: cfg.active_game.id(), mods_root }))
+    let extra = split_args(&cfg.frostmod_args);
+    Ok(Some(StartPlan { exe, game: cfg.active_game.id(), mods_root, extra }))
 }
 
 /// Launch `frostmod.exe` hidden as a managed child.
@@ -549,6 +578,7 @@ pub fn start(app: &AppHandle, state: &FrostmodProcess) -> anyhow::Result<bool> {
     if let Some(mods) = &plan.mods_root {
         args.extend(["--mods".into(), mods.to_string_lossy().into_owned()]);
     }
+    args.extend(plan.extra.iter().cloned());
     // Logged on both sides, as Linux and macOS already are. FrostMod not working is the
     // single most reported thing about this app, and until now the Windows path — the one
     // nearly every report comes from — said nothing at all in the log, whether it worked
@@ -634,6 +664,7 @@ pub fn start(app: &AppHandle, state: &FrostmodProcess) -> anyhow::Result<bool> {
         // side of the wall calls the same folder.
         args.extend(["--mods".into(), crate::proton::windows_path(&runner.prefix(), mods)]);
     }
+    args.extend(plan.extra.iter().cloned());
 
     log::info!(
         "starting FrostMod via {}: {} run {} {:?} (prefix {})",
@@ -691,6 +722,9 @@ fn mac_launch(
     exe: &Path,
     game: &str,
     mods_root: Option<&Path>,
+    // The player's own flags, already split. Appended last, so one of them can override a
+    // flag we sent — which is the point of being able to type them.
+    extra: &[String],
 ) -> anyhow::Result<(crate::winehost::Launch, String)> {
     let (prefix, runner) = crate::gameproc::game_prefix_and_runner(cfg)?;
     // Without a Z: drive nothing inside the bottle can see FrostMod's folder — not the
@@ -709,6 +743,7 @@ fn mac_launch(
         // the mods folder — inside the bottle — is `C:\users\…`.
         args.extend(["--mods".into(), crate::winehost::windows_path(&prefix, mods)]);
     }
+    args.extend(extra.iter().cloned());
     Ok((
         crate::winehost::plan(&runner, &prefix, exe, &args),
         runner.via().to_string(),
@@ -732,7 +767,7 @@ pub fn start(app: &AppHandle, state: &FrostmodProcess) -> anyhow::Result<bool> {
     needs_the_file_channel(app, "macOS", "Inside a Wine bottle")?;
 
     let cfg = crate::config::load(app).unwrap_or_default();
-    let (launch, via) = mac_launch(&cfg, &plan.exe, plan.game, plan.mods_root.as_deref())?;
+    let (launch, via) = mac_launch(&cfg, &plan.exe, plan.game, plan.mods_root.as_deref(), &plan.extra)?;
     log::info!(
         "starting FrostMod via {via}: {} {:?}",
         launch.program.display(),
@@ -920,7 +955,7 @@ mod tests {
         cfg.wine_runner = runner.to_string_lossy().into_owned();
 
         let (launch, _) =
-            mac_launch(&cfg, &exe, "mxb", Some(&mods)).expect("a stub runner is enough");
+            mac_launch(&cfg, &exe, "mxb", Some(&mods), &[]).expect("a stub runner is enough");
         let mut cmd = std::process::Command::new(&launch.program);
         cmd.args(&launch.args).current_dir(&frostmod);
         for (key, value) in &launch.env {
@@ -955,6 +990,77 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
+    /// The flags box is a line of text, and a path in it has spaces. Quoted runs stay one
+    /// argument; everything else splits on whitespace.
+    #[test]
+    fn typed_flags_split_the_way_a_shell_would() {
+        assert_eq!(split_args(""), Vec::<String>::new());
+        assert_eq!(split_args("   "), Vec::<String>::new());
+        assert_eq!(
+            split_args("--probe-overjump  --force-overjump-off"),
+            ["--probe-overjump", "--force-overjump-off"]
+        );
+        assert_eq!(
+            split_args("--mods \"C:\\My Mods\" --wait 2000"),
+            ["--mods", "C:\\My Mods", "--wait", "2000"]
+        );
+    }
+
+    /// What the box is for: a flag typed there reaches FrostMod's argv, after the ones we
+    /// always send. Same stub-runner spawn as the start test, so it is the real argv.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn typed_flags_reach_frostmods_argv() {
+        let root = temp_dir("mac-extra-args");
+        let prefix = root.join("Bottles/MXB");
+        let game_dir = prefix.join("drive_c/Program Files/MX Bikes");
+        std::fs::create_dir_all(&game_dir).unwrap();
+        std::fs::create_dir_all(prefix.join("dosdevices")).unwrap();
+        std::os::unix::fs::symlink("/", prefix.join("dosdevices/z:")).unwrap();
+        std::fs::write(game_dir.join(crate::game::MXB.exe), b"stub").unwrap();
+
+        let frostmod = root.join("data/frostmod");
+        std::fs::create_dir_all(&frostmod).unwrap();
+        let exe = frostmod.join("frostmod.exe");
+        std::fs::write(&exe, b"stub").unwrap();
+
+        let record = root.join("argv.txt");
+        let runner = root.join("fake-wine");
+        std::fs::write(
+            &runner,
+            format!(
+                "#!/bin/sh\n{{ for a in \"$@\"; do printf '%s\\n' \"$a\"; done; }} > {}\n",
+                record.display()
+            ),
+        )
+        .unwrap();
+        std::process::Command::new("chmod").arg("+x").arg(&runner).status().unwrap();
+
+        let mut cfg = crate::config::AppConfig::default();
+        cfg.game_path = game_dir.to_string_lossy().into_owned();
+        cfg.wine_runner = runner.to_string_lossy().into_owned();
+        cfg.frostmod_args = "--probe-overjump --wait 2000".into();
+
+        let (launch, _) = mac_launch(&cfg, &exe, "mxb", None, &split_args(&cfg.frostmod_args))
+            .expect("a stub runner is enough");
+        let mut cmd = std::process::Command::new(&launch.program);
+        cmd.args(&launch.args).current_dir(&frostmod);
+        for (key, value) in &launch.env {
+            cmd.env(key, value);
+        }
+        cmd.spawn().unwrap().wait().unwrap();
+
+        let written = std::fs::read_to_string(&record).unwrap();
+        let lines: Vec<&str> = written.lines().collect();
+        assert_eq!(
+            &lines[..],
+            [exe.to_string_lossy().as_ref(), "--game", "mxb", "--probe-overjump", "--wait", "2000"],
+            "typed flags follow the ones we always send: {written:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     /// A bottle with no `Z:` can't see FrostMod's folder, and every button in the app would
     /// write a command file nothing ever reads. Refused, with the fix named.
     #[cfg(target_os = "macos")]
@@ -972,7 +1078,7 @@ mod tests {
         cfg.game_path = game_dir.to_string_lossy().into_owned();
         cfg.wine_runner = runner.to_string_lossy().into_owned();
 
-        let err = mac_launch(&cfg, &root.join("frostmod.exe"), "mxb", None)
+        let err = mac_launch(&cfg, &root.join("frostmod.exe"), "mxb", None, &[])
             .expect_err("no Z: drive, no way in");
         let msg = format!("{err:#}");
         assert!(msg.contains("Z:"), "names what's missing: {msg}");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7407,6 +7407,16 @@ fn set_auto_run_frostmod(app: tauri::AppHandle, enabled: bool) -> Result<(), Str
     config::save(&app, &cfg).map_err(|e| format!("{e:#}"))
 }
 
+/// Extra flags for `frostmod.exe`, stored as typed. Not validated here: FrostMod ignores a
+/// flag it doesn't know, so an unknown one costs nothing, while checking against a list this
+/// app carries would reject flags a newer FrostMod does understand.
+#[tauri::command]
+fn set_frostmod_args(app: tauri::AppHandle, args: String) -> Result<(), String> {
+    let mut cfg = config::load(&app).unwrap_or_default();
+    cfg.frostmod_args = args.trim().to_string();
+    config::save(&app, &cfg).map_err(|e| format!("{e:#}"))
+}
+
 #[tauri::command]
 fn set_instant_refresh(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
     let mut cfg = config::load(&app).unwrap_or_default();
@@ -9505,6 +9515,7 @@ fn main() {
             track_event,
             set_launch_at_startup,
             set_auto_run_frostmod,
+            set_frostmod_args,
             set_instant_refresh,
             overlay_toggle,
             overlay_hide,

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -39,6 +39,7 @@ import {
   overlayToggle,
   presetsListProfiles,
   setAutoRunFrostmod,
+  setFrostmodArgs,
   setGamePath,
   setInstantRefresh,
   setLaunchAtStartup,
@@ -461,6 +462,10 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
   const analyticsEnabled = config.analyticsEnabled ?? true;
   const launchAtStartup = config.launchAtStartup ?? true;
   const autoRunFrostmod = config.autoRunFrostmod ?? true;
+  // Typed flags are edited freely and saved on blur, so the field holds a draft until then —
+  // saving per keystroke would write the config on every letter and fight the cursor.
+  const [frostmodArgsDraft, setFrostmodArgsDraft] = useState<string | null>(null);
+  const frostmodArgs = frostmodArgsDraft ?? config.frostmodArgs ?? "";
   const instantRefresh = config.instantRefresh ?? true;
   const watchModsReload = config.watchModsReload ?? true;
 
@@ -742,6 +747,19 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
     try {
       await setAutoRunFrostmod(v);
       await reloadConfig();
+    } catch (e) {
+      toast.error(t("settings.updateFailed"), { description: String(e) });
+    }
+  };
+
+  const saveFrostmodArgs = async () => {
+    if (frostmodArgsDraft === null) return;
+    try {
+      await setFrostmodArgs(frostmodArgsDraft);
+      await reloadConfig();
+      // Back to reading the config: it is the one that survives a restart, and it has the
+      // trimmed form of what was typed.
+      setFrostmodArgsDraft(null);
     } catch (e) {
       toast.error(t("settings.updateFailed"), { description: String(e) });
     }
@@ -1847,6 +1865,30 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
               checked={watchModsReload}
               onChange={toggleWatchModsReload}
             />
+
+            {/* FrostMod's own flags, typed. A plain field rather than a toggle each: these
+                are diagnostics that come and go with FrostMod's releases, and the app would
+                otherwise have to ship a new build to offer one. `--game` and `--mods` are
+                still sent by the app; anything typed here follows them. */}
+            <div className="flex flex-col gap-1.5">
+              <span className="text-[12.5px] text-foreground/85">
+                {t("settings.frostmodArgs")}
+              </span>
+              <input
+                value={frostmodArgs}
+                spellCheck={false}
+                placeholder="--probe-overjump"
+                onChange={(e) => setFrostmodArgsDraft(e.currentTarget.value)}
+                onBlur={saveFrostmodArgs}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") e.currentTarget.blur();
+                }}
+                className="min-w-0 flex-1 rounded-lg border border-input bg-background px-3 py-2 font-mono text-[12px] text-muted-foreground"
+              />
+              <span className="text-[11.5px] text-muted-foreground">
+                {t("settings.frostmodArgsDesc")}
+              </span>
+            </div>
 
             {/* Only once FrostMod is on disk: without an install there is no config to
                 edit, and the keys would be an offer that quietly does nothing. */}

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -2311,6 +2311,11 @@ export function setAutoRunFrostmod(enabled: boolean): Promise<void> {
   return invoke<void>("set_auto_run_frostmod", { enabled });
 }
 
+/** Extra command-line flags handed to `frostmod.exe`, exactly as typed. */
+export function setFrostmodArgs(args: string): Promise<void> {
+  return invoke<void>("set_frostmod_args", { args });
+}
+
 export function setInstantRefresh(enabled: boolean): Promise<void> {
   return invoke<void>("set_instant_refresh", { enabled });
 }

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -788,6 +788,9 @@ export const de: Translation = {
   "settings.autoRunFrostmod": "FrostMod automatisch starten",
   "settings.autoRunFrostmodDesc":
     "FrostMod im Hintergrund starten, sobald MXB App geöffnet wird.",
+  "settings.frostmodArgs": "FrostMod-Flags",
+  "settings.frostmodArgsDesc":
+    "Zusätzliche Kommandozeile für FrostMod, so getippt wie im Terminal. Gilt ab dem nächsten Start von FrostMod. Lass das Feld leer, außer du hast ein Flag zum Ausprobieren bekommen.",
   "settings.watchModsReload": "Automatisch neu laden bei Ordneränderungen",
   "settings.watchModsReloadDesc":
     "Das Spiel automatisch neu laden, wenn Strecken oder Motorräder in deinen Mod-Ordner kommen — auch wenn sie außerhalb von MXB App manuell heruntergeladen wurden.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -774,6 +774,9 @@ export const en = {
   "settings.autoRunFrostmod": "Run FrostMod automatically",
   "settings.autoRunFrostmodDesc":
     "Start FrostMod in the background whenever MXB App opens.",
+  "settings.frostmodArgs": "FrostMod flags",
+  "settings.frostmodArgsDesc":
+    "Extra command line for FrostMod, typed as you would in a terminal. Applies the next time FrostMod starts. Leave it empty unless you've been given a flag to try.",
   "settings.watchModsReload": "Auto-reload on folder changes",
   "settings.watchModsReloadDesc":
     "Reload the game automatically when tracks or bikes are added to your mods folder — even downloaded manually outside MXB App.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -780,6 +780,9 @@ export const es: Translation = {
   "settings.autoRunFrostmod": "Ejecutar FrostMod automáticamente",
   "settings.autoRunFrostmodDesc":
     "Inicia FrostMod en segundo plano cada vez que abres MXB App.",
+  "settings.frostmodArgs": "Flags de FrostMod",
+  "settings.frostmodArgsDesc":
+    "Línea de comandos extra para FrostMod, escrita como en una terminal. Se aplica la próxima vez que FrostMod arranque. Déjalo vacío salvo que te hayan dado un flag para probar.",
   "settings.watchModsReload": "Recarga automática al cambiar la carpeta",
   "settings.watchModsReloadDesc":
     "Recarga el juego automáticamente cuando se añaden pistas o motos a tu carpeta de mods — incluso descargadas manualmente fuera de MXB App.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -784,6 +784,9 @@ export const fr: Translation = {
   "settings.autoRunFrostmod": "Lancer FrostMod automatiquement",
   "settings.autoRunFrostmodDesc":
     "Démarrer FrostMod en arrière-plan à chaque ouverture de MXB App.",
+  "settings.frostmodArgs": "Options FrostMod",
+  "settings.frostmodArgsDesc":
+    "Ligne de commande supplémentaire pour FrostMod, saisie comme dans un terminal. Prise en compte au prochain démarrage de FrostMod. Laisse vide, sauf si on t'a donné une option à tester.",
   "settings.watchModsReload":
     "Rechargement auto lors des changements de dossier",
   "settings.watchModsReloadDesc":

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -779,6 +779,9 @@ export const it: Translation = {
   "settings.autoRunFrostmod": "Avvia FrostMod automaticamente",
   "settings.autoRunFrostmodDesc":
     "Avvia FrostMod in background ogni volta che apri MXB App.",
+  "settings.frostmodArgs": "Flag di FrostMod",
+  "settings.frostmodArgsDesc":
+    "Riga di comando extra per FrostMod, scritta come in un terminale. Vale dal prossimo avvio di FrostMod. Lascia vuoto, a meno che non ti abbiano dato un flag da provare.",
   "settings.watchModsReload": "Ricarica automatica alle modifiche",
   "settings.watchModsReloadDesc":
     "Ricarica il gioco automaticamente quando piste o moto vengono aggiunte alla cartella mod — anche se scaricate manualmente fuori da MXB App.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -782,6 +782,9 @@ export const ptBR: Translation = {
   "settings.autoRunFrostmod": "Iniciar o FrostMod automaticamente",
   "settings.autoRunFrostmodDesc":
     "Iniciar o FrostMod em segundo plano sempre que o MXB App abrir.",
+  "settings.frostmodArgs": "Flags do FrostMod",
+  "settings.frostmodArgsDesc":
+    "Linha de comando extra para o FrostMod, digitada como num terminal. Vale a partir da próxima vez que o FrostMod iniciar. Deixe vazio, a não ser que tenham te passado uma flag para testar.",
   "settings.watchModsReload": "Recarregar automaticamente ao mudar a pasta",
   "settings.watchModsReloadDesc":
     "Recarregar o jogo automaticamente quando pistas ou motos forem adicionadas à sua pasta de mods — mesmo baixadas manualmente fora do MXB App.",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -96,6 +96,8 @@ export interface Config {
   launchAtStartup?: boolean;
   /** Auto-run FrostMod when the app opens (default true). */
   autoRunFrostmod?: boolean;
+  /** Extra command-line flags for `frostmod.exe`, exactly as typed. Empty by default. */
+  frostmodArgs?: string;
   instantRefresh?: boolean;
   /**
    * Watch `<modsPath>/mods` and reload the game when tracks/bikes are added outside


### PR DESCRIPTION
## Why

FrostMod's diagnostics live behind its own flags, and getting one run meant asking a player to open a terminal — the wrong ask for the people whose logs we most need. It is why `--probe-overjump` (frostmod #34 / #35, the overjump-crash investigation) had no route to anyone.

## What

A **FrostMod flags** field in Settings. What is typed there is split and appended to FrostMod's argv after the `--game` / `--mods` the app already sends, so a flag typed there wins a repeat.

- Nothing is checked against a list the app carries: FrostMod ignores a flag it doesn't know, while validating here would reject flags a *newer* FrostMod understands. That is what lets a diagnostic ship in a FrostMod release without an app build.
- Split once in `plan_start` and used by all three launch paths (Windows child, Proton, Wine bottle), so they can't drift apart.
- Saved on blur or Enter, not per keystroke.

## Verification

- `cargo test --bin mxb-app frostmod_manage` — 15 passed, including the two new ones: the splitter keeps a quoted path in one piece, and the macOS path is asserted on a **real spawn** against the stub runner, so the assertion is on FrostMod's actual argv and its order.
- `cargo check --bin mxb-app --target x86_64-pc-windows-gnu` clean, which is the half a macOS build skips.
- `tsc --noEmit` clean; all six locales carry the two new keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)