### PR TITLE
chore(release): v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2026-08-31
+## 2026-08-31 — v0.13.1 — Tracks that look ridden
 
 ### Added
 - A FrostMod flags box in Settings. What you type there is handed to FrostMod the next time

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3532,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "mxb-app"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # whatever cargo called it. Cargo target names can't hold a space, so this is as close as
 # it gets. The description is what Windows Task Manager shows in its Processes tab.
 name = "mxb-app"
-version = "0.13.0"
+version = "0.13.1"
 description = "MXB App — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
   "mainBinaryName": "MXB App",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Cuts v0.13.1. The last release players actually got is **v0.12.6** — v0.13.0 only ever shipped as betas — so this one carries the Secure-tracks work too.

- Version bumped in `package.json`, `tauri.conf.json`, `Cargo.toml` and `Cargo.lock`.
- The unreleased CHANGELOG section is stamped `v0.13.1 — Tracks that look ridden`. `scripts/changelog-section.sh v0.13.1 --heading` prints it, and `release-notes.sh` renders the body, so the GitHub release and the Discord post both have their text.
- No What's-new modal entry — same as v0.12.5, v0.12.6 and v0.13.0. This is generated-track polish plus a diagnostics field; say the word if you'd rather it announced itself.

Contents: Track Studio's ground, ruts and packing work, and the FrostMod flags box (#329).

🤖 Generated with [Claude Code](https://claude.com/claude-code)