### PR TITLE
fix(viewer): show the bodywork under a bike's number plates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2026-08-31
 
+### Fixed
+- The 3D preview shows the livery on a bike's side and front number plates, instead of the
+  blank plate the model carries there.
+
 ### Added
 - Installed tracks carry the ground they are painted with, and a gfx.cfg so roost is the
   colour of the dirt.

--- a/src/Components/Viewer/ModelViewer.tsx
+++ b/src/Components/Viewer/ModelViewer.tsx
@@ -75,9 +75,11 @@ async function loadTexture(t: PaintTexture): Promise<THREE.DataTexture | null> {
  *
  * A wheel's brake discs and its sprocket are flat quads wearing a masked square — two thirds
  * of `fdisc` is fully transparent — so drawn without a mask each one is a square sitting on
- * the wheel. A naive "does it have alpha" test can't be used, though: a bike's `w_plate` is
- * alpha-0 on *every* pixel, an unused channel, and masking on that erases the number plates
- * outright. So the channel only counts as a mask when it varies.
+ * the wheel. A naive "does it have alpha" test can't be used, though: plenty of sheets are
+ * alpha-0 on *every* pixel simply because nobody filled the channel in — a mod's `airbox` or
+ * `lens`, and most `_n`/`_r`/`_s` maps — and cutting those out erases the part. So the
+ * channel only counts as a mask when it varies. The decal planes, which are alpha-0 for a
+ * reason rather than by neglect, are hidden by name instead — see {@link isDecalPlane}.
  *
  * Sampled, not scanned: a 4096² sheet is 16M pixels and this runs per texture per load,
  * while a real mask covers a third of the image or more and turns up in the first few
@@ -656,11 +658,36 @@ function useNodeGeometries(nodes: EdfNode[], skin?: Skin | null) {
   return geoms;
 }
 
+/**
+ * Whether a texture name belongs to one of the planes the game writes on itself.
+ *
+ * `w_plate`, `w_number` and `w_name` are flat quads the game composites the rider's number
+ * and name onto at run time — on a bike they are the side and front number plates, declared
+ * by its `gfx.cfg` as `plate { texture = w_plate }`. Nothing is meant to be visible there
+ * until the game draws on it, and the sheet behind them says so: every bike ships it alpha-0
+ * on every pixel, with whatever RGB the modeller happened to leave — half white and half
+ * black, or all white, or all black, or 512x256. That is only consistent if the plane is
+ * meant to be invisible, and drawn it puts that placeholder over the number plates instead
+ * of the livery.
+ *
+ * By name rather than by alpha, because the alpha channel can't tell this apart from a sheet
+ * nobody filled in (see {@link hasMaskedAlpha}). The rider's side has always read these by
+ * name too — `body_slot` maps any `w_` texture to the `hide` slot.
+ */
+function isDecalPlane(name: string | null | undefined): boolean {
+  return !!name && name.toLowerCase().startsWith("w_");
+}
+
+/** Renders nothing and occludes nothing — for a plane that is not ours to draw. */
+function makeHiddenMaterial() {
+  return new THREE.MeshBasicMaterial({ colorWrite: false, depthWrite: false });
+}
+
 function makeBodyMaterial(name: string | null | undefined, tex: Map<string, THREE.Texture>) {
   const key = name?.toLowerCase();
   // Decal planes: render nothing rather than smear the suit over a flat quad.
   if (key === "hide") {
-    return new THREE.MeshBasicMaterial({ colorWrite: false, depthWrite: false });
+    return makeHiddenMaterial();
   }
   // Head/neck: bare skin so the kit doesn't wrap onto it.
   if (key === "face") {
@@ -1095,7 +1122,11 @@ function RiderComposite({
   );
 }
 
-function makeEdfMaterial(t: THREE.Texture | null) {
+function makeEdfMaterial(name: string | null | undefined, t: THREE.Texture | null) {
+  // The number-plate planes are the game's to draw on, not ours — see `isDecalPlane`.
+  if (isDecalPlane(name)) {
+    return makeHiddenMaterial();
+  }
   return new THREE.MeshStandardMaterial({
     map: t ?? undefined,
     color: t ? 0xffffff : 0xb7bcc4,
@@ -1124,9 +1155,11 @@ function useEdfMeshes(
     () =>
       list.map((n) =>
         n.submeshes.length
-          ? n.submeshes.map((sm) => makeEdfMaterial(submeshTexture(sm.texture, tex)))
+          ? n.submeshes.map((sm) =>
+              makeEdfMaterial(sm.texture, submeshTexture(sm.texture, tex)),
+            )
           : // No submesh table → whole-node binding (the model's primary body texture).
-            [makeEdfMaterial(submeshTexture(n.texture, tex))],
+            [makeEdfMaterial(n.texture, submeshTexture(n.texture, tex))],
       ),
     [list, tex],
   );


### PR DESCRIPTION
The side and front number plates are separate planes the game composites the rider's number and name onto at run time — a bike's `gfx.cfg` declares them as `plate { texture = w_plate }` on the chassis and the steer. The viewer was drawing them, so every bike in the 3D preview wore its own placeholder over both plates instead of its livery.

### Why not by alpha

`hasMaskedAlpha` only treats alpha as a cut-out when it *varies*, and `w_plate` is alpha-0 on every pixel — so it fell through to `alphaTest: 0` and drew opaque. The obvious fix is to widen the predicate to "any clear texel", but that is wrong: scanning every mesh and paint under `mods/` turns up plenty of sheets that are alpha-0 by neglect rather than by intent — a mod's `airbox`, `lens`, `rim` and `fatbar`, and most `_n`/`_r`/`_s` maps. Cutting those out erases the part.

So the planes are hidden **by name** instead, which is what the rider's side has always done: `body_slot` maps any `w_` texture to the `hide` slot. Bikes now use the same no-draw material, so the planes neither paint nor occlude. `hasMaskedAlpha` is unchanged; only its comment moves off the `w_plate` example onto the sheets that actually depend on it.

### Evidence

- All 113 installed bikes ship `w_plate` with alpha 0 on **every** pixel, and the RGB behind it varies freely — half white and half black, all white, all black, even 512x256. Nothing that arbitrary is meant to be seen.
- Exactly one paint in the whole mods tree ships a `w_plate` of its own, and it is flat purple. A paint that supplies one is hidden too, which is right: the plane is the game's to draw on.

### Verified

- `tsc --noEmit` and `eslint` clean.
- The render difference reproduced offline against the real KTM 250 SX-F mesh, using the same material rule the viewer applies — the plane covers the side plate exactly.
- Checked the bound texture names on that bike: `w_plate` is the only one the `w_` rule catches.

Not verified in the running app — port 1420 was held by another session's dev server, and I did not want to take it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)