### PR TITLE
chore(changelog): move the number-plate fix out of the v0.13.1 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## 2026-08-31 — v0.13.1 — Tracks that look ridden
+## 2026-08-31
 
 ### Fixed
 - The 3D preview shows the livery on a bike's side and front number plates, instead of the
   blank plate the model carries there.
+
+## 2026-08-31 — v0.13.1 — Tracks that look ridden
 
 ### Added
 - A FrostMod flags box in Settings. What you type there is handed to FrostMod the next time


### PR DESCRIPTION
#331 and the v0.13.1 release PR merged 33 seconds apart. The release renamed the open dated section to `## 2026-08-31 — v0.13.1 — Tracks that look ridden`, and git merged the fix's entry into it — but the `v0.13.1` tag points at the release merge, which does not contain the fix. Left alone, the release notes would claim it.

Moves the entry to an unreleased `## 2026-08-31` section above v0.13.1. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)