### PR TITLE
fix(designer): put a tiled sheet's uv islands where the game samples them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2026-08-31
 
 ### Fixed
+- Designer: a sheet whose parts are tiled — the number plates, a tiled exhaust — shows those
+  parts where the game reads them, instead of off the edge of the sheet.
 - The 3D preview shows the livery on a bike's side and front number plates, instead of the
   blank plate the model carries there.
 

--- a/src/Components/Studio/Designer/uv.ts
+++ b/src/Components/Studio/Designer/uv.ts
@@ -198,6 +198,37 @@ export function faceAt(parts: UvPart[], u: number, v: number): Face | null {
   return codes.length ? summariseFaces(codes) : null;
 }
 
+/**
+ * Move one triangle into the tile the sheet is actually sampled in, in place.
+ *
+ * Most bodywork is unwrapped inside the unit square and this does nothing to it. The number
+ * plates are not: a side plate runs u -0.44..0.87 and every plate runs v 0.55..1.20, because
+ * the sheet is a decal each plate tiles rather than a place on the model. Left raw, those
+ * islands are drawn off the edge of the sheet and over the top of each other, so a plate sheet
+ * is painted at coordinates the game never reads.
+ *
+ * The triangle is moved whole. Wrapping each corner on its own would tear any triangle that
+ * crosses the seam into a band across the entire sheet — one corner at 0.98 and the next at
+ * 0.02 describe a hair's breadth on the model and the full width of the square here. So each
+ * corner is first pulled to the tile nearest the triangle's own centre, and only then is the
+ * whole thing shifted down to the tile around the origin. A triangle that genuinely straddles
+ * the seam still pokes out one side, which is correct — that is what it does on the bike.
+ */
+function untile(tri: Float32Array): void {
+  for (let axis = 0; axis < 2; axis += 1) {
+    const mid = (tri[axis] + tri[2 + axis] + tri[4 + axis]) / 3;
+    for (let c = 0; c < 3; c += 1) {
+      tri[c * 2 + axis] -= Math.round(tri[c * 2 + axis] - mid);
+    }
+    const shift = Math.floor(mid);
+    if (shift) {
+      tri[axis] -= shift;
+      tri[2 + axis] -= shift;
+      tri[4 + axis] -= shift;
+    }
+  }
+}
+
 /** A stable hue per mesh-group name. */
 function hueOf(label: string): number {
   let h = 0;
@@ -248,6 +279,9 @@ export function uvParts(
   const lateralByLabel = new Map<string, number[]>();
   const facesByLabel = new Map<string, number[]>();
   const nodesByLabel = new Map<string, Set<string>>();
+  // One triangle's corners, reused: a bike is a few hundred thousand of them and a fresh
+  // array each would be the only allocation in the loop.
+  const tri = new Float32Array(6);
   for (let nodeIndex = 0; nodeIndex < nodes.length; nodeIndex += 1) {
     const node = nodes[nodeIndex];
     if (!node.uvs.length || !node.indices.length) continue;
@@ -298,10 +332,13 @@ export function uvParts(
         let ny = 0;
         for (let c = 0; c < 3; c += 1) {
           const v = node.indices[t * 3 + c];
-          flat.push(node.uvs[v * 2], node.uvs[v * 2 + 1]);
+          tri[c * 2] = node.uvs[v * 2];
+          tri[c * 2 + 1] = node.uvs[v * 2 + 1];
           if (sides) x += node.positions[v * 3];
           if (faces && hasNormals) ny += node.normals[v * 3 + 1];
         }
+        untile(tri);
+        flat.push(tri[0], tri[1], tri[2], tri[3], tri[4], tri[5]);
         // The centroid, not every corner: a triangle with one vertex over the line is still on
         // the side the rest of it is, and a panel's inner edge is full of them.
         if (sides) sides.push(x / 3);


### PR DESCRIPTION
`uvParts` took uv0 raw. Most bodywork is unwrapped inside the unit square so that was fine, but a sheet whose parts *tile* it is not — the app's own comment in `ModelViewer` already names them: "some islands run outside 0–1 (plates, tiled exhaust)".

Measured on a real KTM 250 SX-F, running the Designer's own `uvParts` over the mesh:

| sheet / part | before | after |
|---|---|---|
| `w_plate` / side plate | u[-0.441, 0.873] v[0.557, 1.203] — 41% of corners outside | u[-0.166, 1.138] v[-0.154, 1.093] — 22% |
| `w_plate` / front plate | u[-0.057, 0.559] v[0.549, 1.152] — 18% | u[-0.057, 1.083] v[-0.100, 0.949] — 15% |
| `plastics` / all four parts | 0% outside | **identical bounds, 0% outside** |

Before, those islands were drawn off the edge of the sheet, so a plate sheet was painted at coordinates the game never reads.

Each triangle is now moved into the tile the sheet is actually sampled in, and moved **whole**: corners pulled to the tile nearest the triangle's own centre, then the triangle shifted to the tile around the origin. Wrapping each corner independently would tear any triangle crossing the seam into a band across the entire sheet — one corner at 0.98 and the next at 0.02 are a hair apart on the model and the full width of the square here. (I hit exactly this writing the offline rasterizer for the livery work.)

The residual outside-corners are triangles that genuinely straddle the seam, which is correct — that is what they do on the bike.

### What this does not fix

A side plate spans 1.31 tiles of u, so it overlaps itself and the other plates however it is laid out. The plates share one decal by design — the game composites the rider's number onto it once and every plate samples the whole sheet. That is the model's layout, not something the Designer can undo.

### Verified

- `tsc --noEmit` and `eslint` clean.
- `uvParts` run under bun against a real assembled bike, before and after — the table above. `plastics` is unchanged, which is the property that matters for every sheet anyone actually paints today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)