### PR TITLE
feat(viewer): bikes wear their normal maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2026-08-31
 
+### Changed
+- Bikes wear their normal maps in the 3D preview, so a shroud has its curve and a seat its
+  grip instead of drawing as a flat colour. A paint can supply its own.
+
 ### Fixed
 - Designer: a sheet whose parts are tiled — the number plates, a tiled exhaust — shows those
   parts where the game reads them, instead of off the edge of the sheet.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2716,6 +2716,22 @@ fn build_bike_model(
             }
         }
     }
+    // ...and the normal map belonging to each of them, which is what gives a shroud its
+    // curve and a seat its grip in the preview. Only for sheets something actually draws:
+    // a bike embeds normals for parts it no longer uses, and each one is a megabyte of the
+    // texture store spent on pixels nothing hangs off.
+    let drawn: std::collections::HashSet<String> = nodes
+        .iter()
+        .flat_map(|n| n.texture.iter().chain(n.submeshes.iter().filter_map(|s| s.texture.as_ref())))
+        .map(|t| t.to_ascii_lowercase())
+        .collect();
+    for data in &used {
+        for tex in paint::extract_edf_normal_maps(data, |base_name| drawn.contains(base_name)) {
+            if seen.insert(tex.name.to_ascii_lowercase()) {
+                base.push(tex);
+            }
+        }
+    }
     let mut paints: Vec<(BikePaint, bool)> = pnt_jobs
         .par_iter()
         .filter_map(|(name, data, shipped, path)| {
@@ -2735,15 +2751,7 @@ fn build_bike_model(
     let base_count = base.len();
     let t_textures = t0.elapsed();
 
-    let bound: std::collections::HashSet<String> = nodes
-        .iter()
-        .flat_map(|n| {
-            n.texture
-                .iter()
-                .chain(n.submeshes.iter().filter_map(|s| s.texture.as_ref()))
-        })
-        .map(|t| t.to_ascii_lowercase())
-        .collect();
+    let bound = &drawn;
     for (p, shipped) in &mut paints {
         p.changes_preview = *shipped
             || (!bound.is_empty()

--- a/src-tauri/src/paint.rs
+++ b/src-tauri/src/paint.rs
@@ -368,6 +368,47 @@ pub fn extract_edf_textures(edf: &[u8]) -> Vec<PaintTexture> {
     extract_edf_textures_where(edf, |_| true)
 }
 
+/// The `_n` normal maps a mesh embeds, for the sheets `want` accepts.
+///
+/// Separate from [`extract_edf_textures_where`], which drops every companion map, because a
+/// normal map is not a look: it can never stand in for a colour sheet, and every caller that
+/// asks "what does this model wear" would be wrong to see one. Only the viewer wants them,
+/// and only to hang off a colour sheet it has already bound. `_r` and the exporter's own
+/// companions stay out — nothing draws those.
+///
+/// `want` is given the *colour* sheet's name, not the map's, so a caller can ask for the
+/// normals belonging to the sheets it is actually going to draw.
+pub fn extract_edf_normal_maps(edf: &[u8], want: impl Fn(&str) -> bool) -> Vec<PaintTexture> {
+    crate::edf::embedded_textures(edf)
+        .iter()
+        .filter_map(|t| {
+            let n = t.name.to_ascii_lowercase();
+            let base = n.strip_suffix("_n")?;
+            want(base).then_some(t)
+        })
+        .filter_map(|t| {
+            let rgba = crate::edf::inflate_texture(edf, t)?;
+            if rgba.len() != (t.width as usize) * (t.height as usize) * 4 {
+                return None;
+            }
+            store_capped(&t.name, t.width, t.height, rgba)
+        })
+        .collect()
+}
+
+/// Store a decoded sheet, downscaled to the edge the viewer draws at if it is bigger.
+///
+/// Shared with [`extract_edf_textures_where`] so the two can't come to different views about
+/// how much memory a sheet is allowed to occupy.
+fn store_capped(name: &str, width: u32, height: u32, rgba: Vec<u8>) -> Option<PaintTexture> {
+    if width.max(height) <= MAX_EDGE {
+        return Some(store_rgba(name, width, height, rgba));
+    }
+    let img = image::DynamicImage::ImageRgba8(image::RgbaImage::from_raw(width, height, rgba)?);
+    let scaled = img.thumbnail(MAX_EDGE, MAX_EDGE);
+    Some(store_rgba(name, scaled.width(), scaled.height(), scaled.to_rgba8().into_raw()))
+}
+
 pub fn extract_edf_textures_where(
     edf: &[u8],
     want: impl Fn(&str) -> bool,
@@ -391,19 +432,7 @@ pub fn extract_edf_textures_where(
             // this used to resample 1024² to 1024² once per sheet: 78 ms of the 120 ms a
             // bike spent on textures, for pixels that came out identical. [`into_texture`]
             // has always had this guard; this path was missing it.
-            if t.width.max(t.height) <= MAX_EDGE {
-                return Some(store_rgba(&t.name, t.width, t.height, rgba));
-            }
-            let img = image::DynamicImage::ImageRgba8(image::RgbaImage::from_raw(
-                t.width, t.height, rgba,
-            )?);
-            let scaled = img.thumbnail(MAX_EDGE, MAX_EDGE);
-            Some(store_rgba(
-                &t.name,
-                scaled.width(),
-                scaled.height(),
-                scaled.to_rgba8().into_raw(),
-            ))
+            store_capped(&t.name, t.width, t.height, rgba)
         })
         .collect()
 }

--- a/src/Components/Viewer/ModelViewer.tsx
+++ b/src/Components/Viewer/ModelViewer.tsx
@@ -56,7 +56,9 @@ async function loadTexture(t: PaintTexture): Promise<THREE.DataTexture | null> {
   const rgba = new Uint8Array(buf);
   const tex = new THREE.DataTexture(rgba, t.width, t.height, THREE.RGBAFormat);
   tex.userData.maskedAlpha = hasMaskedAlpha(rgba);
-  tex.colorSpace = THREE.SRGBColorSpace;
+  // A normal map is three numbers per texel, not a colour — decoding it as sRGB bends every
+  // one of them toward the surface and flattens the relief it exists to describe.
+  tex.colorSpace = isNormalMap(t.name) ? THREE.NoColorSpace : THREE.SRGBColorSpace;
   // MX Bikes paints use a top-left UV origin, which is `DataTexture`'s own default.
   tex.flipY = false;
   // Wrap (not clamp): some islands run outside 0–1 (plates, tiled exhaust) and need it.
@@ -68,6 +70,11 @@ async function loadTexture(t: PaintTexture): Promise<THREE.DataTexture | null> {
   tex.anisotropy = 4;
   tex.needsUpdate = true;
   return tex;
+}
+
+/** The `_n` companion of a colour sheet — `plastics_n` beside `plastics`. */
+function isNormalMap(name: string): boolean {
+  return name.toLowerCase().endsWith("_n");
 }
 
 /**
@@ -1122,13 +1129,27 @@ function RiderComposite({
   );
 }
 
-function makeEdfMaterial(name: string | null | undefined, t: THREE.Texture | null) {
+function makeEdfMaterial(
+  name: string | null | undefined,
+  t: THREE.Texture | null,
+  tex: Map<string, THREE.Texture>,
+) {
   // The number-plate planes are the game's to draw on, not ours — see `isDecalPlane`.
   if (isDecalPlane(name)) {
     return makeHiddenMaterial();
   }
+  // The sheet's own normal map, if it has one: `plastics_n` beside `plastics`. Bikes carry
+  // them the same way riders do, and until now only the rider read them — so a bike's
+  // bodywork drew as a flat colour, with the mesh weave on a seat and the vents in a shroud
+  // in the sheet nobody looked at. A paint may supply its own, which then replaces the
+  // model's by name like any other sheet.
+  const normalMap = (name && tex.get(`${name.toLowerCase()}_n`)) || null;
   return new THREE.MeshStandardMaterial({
     map: t ?? undefined,
+    normalMap,
+    // Gentle: these sheets are authored for the game's own lighting, and at full strength
+    // the relief reads as noise under the viewer's.
+    normalScale: new THREE.Vector2(0.5, 0.5),
     color: t ? 0xffffff : 0xb7bcc4,
     metalness: 0.2,
     roughness: 0.55,
@@ -1156,10 +1177,10 @@ function useEdfMeshes(
       list.map((n) =>
         n.submeshes.length
           ? n.submeshes.map((sm) =>
-              makeEdfMaterial(sm.texture, submeshTexture(sm.texture, tex)),
+              makeEdfMaterial(sm.texture, submeshTexture(sm.texture, tex), tex),
             )
           : // No submesh table → whole-node binding (the model's primary body texture).
-            [makeEdfMaterial(n.texture, submeshTexture(n.texture, tex))],
+            [makeEdfMaterial(n.texture, submeshTexture(n.texture, tex), tex)],
       ),
     [list, tex],
   );


### PR DESCRIPTION
Bikes embed a normal map beside each colour sheet — `plastics_n` next to `plastics` — and only the rider ever read one. A bike's bodywork drew as flat colour, with the weave on a seat and the vents in a shroud sitting in a sheet nobody looked at.

### What changed

- `makeEdfMaterial` binds `<sheet>_n` as the material's normal map, at half strength — these sheets are authored for the game's own lighting and read as noise under the viewer's at full.
- Normal maps upload as **linear** rather than sRGB. Decoding three numbers per texel as a colour bends every one of them toward the surface and flattens the relief. This also corrects the rider path, which bound them already and has always decoded them wrongly.
- `paint::extract_edf_normal_maps` gets them out of the mesh. The existing extractor drops every companion map and must keep doing so — a normal map can never stand in for a colour sheet, and every caller asking "what does this model wear" would be wrong to see one. Only the viewer wants them, and only to hang off a sheet it has already bound.
- Companion maps go through the same size cap as colour sheets (`MAX_EDGE`, 1024), factored into one helper so the two can't come to different views about it.

### Memory

Only sheets something actually draws get a normal map — a bike embeds normals for parts it no longer uses. On a KTM 250 SX-F that is two (`plastics_n`, `250f_metals_n`), 4 MB each after the cap, and the bike cache holds three bikes.

The set of drawn sheets was already being built a few lines later to decide which paints move the preview; it is now built once and shared rather than computed twice.

### Verified

- `cargo check` and `cargo test --bin mxb-app paint` (97 passed) clean.
- `tsc --noEmit` and `eslint` clean.

Not verified in the running app — port 1420 is held by another session's dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)