### PR TITLE
feat(tracks): make track generation actually work, on the cheapest model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@
 - Ground sheets tile at a fixed size on the ground, so a long track and a short one get soil of
   the same grain.
 - Generated laps have more corners, and more variety in them.
+- Track generation works. It had never actually run against the model — the schema compiled
+  to a grammar the API rejects, on every model — and the lap, the plot and the height budget
+  are now worked out rather than asked for.
+- Generating a track costs about a fifth of what it was going to.
+- The 3D preview has a full-screen button.
 
 ## 2026-08-31 — v0.13.0 — Secure tracks
 

--- a/control-plane/src/trackgen.ts
+++ b/control-plane/src/trackgen.ts
@@ -45,13 +45,31 @@ const Arc = z.object({
   rise: RISE,
 });
 
+/**
+ * The four features that are the same shape as each other, carried as one variant.
+ *
+ * Not a simplification of the track program — the wire format is byte-for-byte what eight
+ * separate variants produced, because each object still names its own `kind`. It is a
+ * constrained-decoding limit: the API compiles this schema into a grammar, and a union of
+ * eight object alternatives inside an array compiles to one too large to accept. Measured
+ * rather than guessed — eight is rejected and six is accepted, on every model from Haiku 4.5
+ * up to Opus 5, so this was never a question of paying for a bigger model.
+ *
+ * Collapsing the four that share `at`/`length`/`height` into a single variant tagged by an
+ * enum takes the union to five and costs nothing. If a fifth same-shaped feature is ever
+ * added, it belongs in this enum rather than beside it.
+ */
+const SimpleFeature = z.object({
+  kind: z.enum(["tabletop", "roller", "stepUp", "berm"]),
+  at: z.number().describe("metres round the lap from the start"),
+  length: z.number(),
+  height: z
+    .number()
+    .describe("metres; for stepUp, the ground gained — negative for a step down"),
+});
+
 const Feature = z.discriminatedUnion("kind", [
-  z.object({
-    kind: z.literal("tabletop"),
-    at: z.number().describe("metres round the lap from the start"),
-    length: z.number(),
-    height: z.number(),
-  }),
+  SimpleFeature,
   z.object({
     kind: z.literal("double"),
     at: z.number(),
@@ -60,28 +78,10 @@ const Feature = z.discriminatedUnion("kind", [
     lip: z.number().describe("metres of takeoff face"),
   }),
   z.object({
-    kind: z.literal("roller"),
-    at: z.number(),
-    length: z.number(),
-    height: z.number(),
-  }),
-  z.object({
     kind: z.literal("whoops"),
     at: z.number(),
     count: z.number().int(),
     spacing: z.number().describe("metres crest to crest"),
-    height: z.number(),
-  }),
-  z.object({
-    kind: z.literal("stepUp"),
-    at: z.number(),
-    length: z.number(),
-    height: z.number().describe("metres the ground gains; negative for a step down"),
-  }),
-  z.object({
-    kind: z.literal("berm"),
-    at: z.number(),
-    length: z.number(),
     height: z.number(),
   }),
   z.object({
@@ -196,6 +196,11 @@ straight does nothing. Jumps go on straights.
 What real tracks measure, from a survey of published ones. Land inside these unless the brief
 explicitly asks otherwise:
 
+  jumps on a lap      COUNT THEM. A 1500 m lap needs 30–60 features in the list — not four.
+                      A track with eight jumps on it is a field with a path across it, and it
+                      is the single most common thing to get wrong here.
+  landscape relief    amplitude 8–20 m over a 120–200 m wavelength. A flat plot measures
+                      under 18° at its steepest and is rejected for it; ground has to roll.
   riding line width   10–17 m
   lap length          1300–1800 m
   jumps per km        29–61
@@ -212,6 +217,22 @@ jump — too small and the build is rejected, far too large and the terrain quan
 The app builds and measures whatever you send. If it comes back with problems, they carry the
 measured number and what published tracks do; edit the program you sent rather than starting
 over.`;
+
+/**
+ * The model that writes the lap.
+ *
+ * The cheapest one that can do the job, on purpose: $1/$5 per MTok against Opus 5's $5/$25.
+ * A lap is a few thousand output tokens, so an attempt costs well under a cent, and the app
+ * validates every answer by synthesising the terrain and measuring it — a weaker model that
+ * needs a second attempt is still far cheaper than a stronger one that gets it first time.
+ *
+ * The thing to watch is lap closure: the signed turn angles have to sum to ±360°, which is
+ * arithmetic rather than judgement, and it is the one part of this a small model is likely to
+ * get wrong repeatedly. The validator catches it and says so with the number, but if repairs
+ * start costing more than they save, `claude-sonnet-5` ($2/$10) is the next rung up and takes
+ * the same request shape as this one.
+ */
+const MODEL = "claude-haiku-4-5";
 
 /** Briefs longer than this are not briefs. */
 const MAX_BRIEF = 2000;
@@ -265,26 +286,36 @@ export async function generateTrack(request: Request, env: Env): Promise<Respons
   const client = new Anthropic({ apiKey: env.ANTHROPIC_API_KEY });
   try {
     const response = await client.messages.parse({
-      model: "claude-opus-5",
+      model: MODEL,
       max_tokens: 16000,
       system: SYSTEM,
       messages,
-      // Laying out a lap that closes is arithmetic the model has to actually do.
-      thinking: { type: "adaptive" },
-      output_config: {
-        effort: "high",
-        format: zodOutputFormat(TrackProgram),
-      },
+      // Laying out a lap is arithmetic the model would have to do — except most of it is
+      // done for it now, see `repair` in trackllm.rs. Haiku 4.5 predates adaptive thinking
+      // and takes a fixed budget instead, and rejects `output_config.effort` outright, so
+      // the only thing left in `output_config` is the schema.
+      thinking: { type: "enabled", budget_tokens: 4000 },
+      output_config: { format: zodOutputFormat(TrackProgram) },
     });
 
     if (response.stop_reason === "refusal") {
       return json(422, { error: "the model declined that brief" });
     }
     if (!response.parsed_output) {
-      return json(502, { error: "the model's answer didn't fit the track schema" });
+      return json(422, { error: "the model's answer didn't fit the track schema" });
     }
     return json(200, { program: response.parsed_output });
   } catch (err) {
+    // An answer that doesn't fit the schema is the model's mistake, not the service's, and
+    // it is the single most common thing a small model gets wrong here — it invents a
+    // feature kind. Reported as a 422 so the app's loop treats it as something to send back
+    // and fix; a 500 aborts the whole loop on the first stumble, which threw away two
+    // perfectly good remaining attempts.
+    if (err instanceof Error && /structured output|parse/i.test(err.message)) {
+      return json(422, {
+        error: `that didn't fit the track schema: ${err.message.slice(0, 400)}`,
+      });
+    }
     if (err instanceof Anthropic.RateLimitError) {
       return json(429, { error: "the track service is busy — try again in a minute" });
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1243,9 +1243,11 @@ async fn generate_track(app: tauri::AppHandle, brief: String) -> Result<serde_js
         base,
         token: cfg.cp_token.clone(),
     };
-    // Three attempts: one to write it, one to fix the numbers, one for the thing the fix
-    // broke. Past that it isn't converging and the cost is real.
-    let prog = trackllm::generate(brief.trim(), &ask, 3)
+    // Four attempts: one to write it, one to fix the numbers, one for the thing the fix
+    // broke, and one more because they are cheap now. Three was set when this called Opus at
+    // $5/$25 per MTok; it calls Haiku at $1/$5, most of what used to come back wrong is
+    // repaired without asking, and an attempt costs a fraction of a cent and twenty seconds.
+    let prog = trackllm::generate(brief.trim(), &ask, 4)
         .await
         .map_err(|e| format!("{e:#}"))?;
     usage::track("track.generate");

--- a/src-tauri/src/trackllm.rs
+++ b/src-tauri/src/trackllm.rs
@@ -70,11 +70,187 @@ pub trait Ask {
         -> impl std::future::Future<Output = Result<String>>;
 }
 
+/// Whether a berm at this distance round the lap is on a corner.
+///
+/// One definition, used by both the check and the repair. They had one each, they disagreed,
+/// and the disagreement was invisible until a berm sat in the gap between them.
+fn berm_on_a_corner(turn: &[crate::trackprog::Station], at: f32) -> bool {
+    turn.iter()
+        .find(|s| s.s >= at)
+        .map(|s| s.curvature != 0.0)
+        .unwrap_or(false)
+}
+
+/// Everything wrong with a program that we can simply work out, worked out.
+///
+/// Three of the complaints the validator used to send back were not judgement at all — they
+/// were arithmetic, and we have exact code for each of them. Handing them to a language model
+/// and asking it to try again is both the slowest way to fix them and the least reliable:
+/// closing a lap means making the signed turn angles sum to a whole number of circles *and*
+/// the straights bring it home, which a small model gets wrong over and over. Pointed at
+/// Haiku 4.5, three rounds of that failed every time on lap closure alone.
+///
+/// So the loop repairs first and complains second. What reaches the model afterwards is the
+/// part it can actually act on — the track is too flat, there are not enough jumps, the
+/// corners are too tight — rather than a sum it cannot do.
+///
+/// Returns a line per repair, for the log. Nothing here can fail: each fix either applies or
+/// is not needed, and anything left over is the validator's business.
+fn repair(prog: &mut TrackProgram) -> Vec<String> {
+    let mut done = Vec::new();
+
+    // 1. Put the lap on the ground. Where the lap's corners fall is the model's business;
+    //    how big a rectangle it needs and where to sit it is not — it is the lap's own
+    //    bounding box plus a track's width of margin, which is exactly what the check
+    //    measures. The plot only ever grows, and the start pose slides so the lap is
+    //    centred on it, which leaves the shape of the track untouched.
+    {
+        let st = prog.stations(2.0);
+        if !st.is_empty() {
+            let margin = prog.width.max(1.0);
+            let (mut lo_x, mut hi_x) = (f32::MAX, f32::MIN);
+            let (mut lo_z, mut hi_z) = (f32::MAX, f32::MIN);
+            for s in &st {
+                lo_x = lo_x.min(s.x);
+                hi_x = hi_x.max(s.x);
+                lo_z = lo_z.min(s.z);
+                hi_z = hi_z.max(s.z);
+            }
+            let need_x = (hi_x - lo_x) + margin * 2.0;
+            let need_z = (hi_z - lo_z) + margin * 2.0;
+            let grow_x = prog.terrain.size_x.max(need_x * 1.05);
+            let grow_z = prog.terrain.size_z.max(need_z * 1.05);
+            // Centre it: the offset that puts the lap's own middle at the plot's middle.
+            let dx = grow_x * 0.5 - (lo_x + hi_x) * 0.5;
+            let dz = grow_z * 0.5 - (lo_z + hi_z) * 0.5;
+            let grew = grow_x > prog.terrain.size_x + 0.5 || grow_z > prog.terrain.size_z + 0.5;
+            let moved = dx.abs() > 0.5 || dz.abs() > 0.5;
+            if grew || moved {
+                let mut what = Vec::new();
+                if grew {
+                    what.push(format!(
+                        "plot {:.0}x{:.0} m grows to {grow_x:.0}x{grow_z:.0}",
+                        prog.terrain.size_x, prog.terrain.size_z
+                    ));
+                }
+                if moved {
+                    what.push(format!("start moves by ({dx:.0}, {dz:.0}) m to centre the lap"));
+                }
+                done.push(what.join("; "));
+                prog.terrain.size_x = grow_x;
+                prog.terrain.size_z = grow_z;
+                prog.start.x += dx;
+                prog.start.z += dz;
+            }
+        }
+    }
+
+    // 2. Square the cells. The synthesiser snaps the short side of the grid to a power of two
+    //    plus one, so a plot whose sides aren't near that ratio gets cells wider one way than
+    //    the other — and it refuses to build one, because a berm would come out wider across
+    //    than along. The plot is ours to nudge; the lap is not.
+    if let Some((sx, sz)) = squared_plot(prog) {
+        if (sx - prog.terrain.size_x).abs() > 0.5 || (sz - prog.terrain.size_z).abs() > 0.5 {
+            done.push(format!(
+                "squared the cells: plot {:.0}x{:.0} m becomes {sx:.0}x{sz:.0}",
+                prog.terrain.size_x, prog.terrain.size_z
+            ));
+            prog.terrain.size_x = sx;
+            prog.terrain.size_z = sz;
+        }
+    }
+
+    // 3. Close the lap, with a turn no tighter than the tightest already on it — the same
+    //    rule the studio's own "Close the lap" button uses.
+    let closure = prog.closure_error();
+    if closure > corpus::CLOSURE_M {
+        let radius = prog
+            .segments
+            .iter()
+            .filter_map(|s| match s {
+                crate::trackprog::Segment::Arc { radius, .. } => Some(radius.abs()),
+                _ => None,
+            })
+            .fold(f32::MAX, f32::min);
+        let radius = if radius.is_finite() { radius } else { 25.0 };
+        if let Some(add) = prog.closing_segments(radius) {
+            let n = add.len();
+            prog.segments.extend(add);
+            done.push(format!(
+                "closed the lap: {closure:.0} m gap shut with {n} segment(s), now {:.2} m",
+                prog.closure_error()
+            ));
+        }
+    }
+
+    // 4. Put berms on corners. A berm on a straight silently does nothing, and it is never
+    //    what was meant — a model that asks for one has decided the corner wants banking and
+    //    then got the distance round the lap wrong. Where the corners are is not a matter of
+    //    opinion, so slide it to the nearest one rather than sending the whole program back.
+    let turn = prog.stations(1.0);
+    let corner_at = |at: f32| -> Option<f32> {
+        turn.iter()
+            .filter(|st| st.curvature != 0.0)
+            .min_by(|a, b| (a.s - at).abs().total_cmp(&(b.s - at).abs()))
+            .map(|st| st.s)
+    };
+    for f in &mut prog.features {
+        let crate::trackprog::Feature::Berm { at, .. } = f else {
+            continue;
+        };
+        // `berm_on_a_corner` and nothing else. The first version of this asked whether the
+        // berm *reached* a corner anywhere along its length, which is a laxer question than
+        // the one the validator asks — so a berm starting 19 m short of a turn passed the
+        // repair and was then rejected, and the loop spent every remaining attempt on a
+        // fault it had already decided was fine.
+        if berm_on_a_corner(&turn, *at) {
+            continue;
+        }
+        if let Some(to) = corner_at(*at) {
+            done.push(format!("moved the berm at {at:.0} m onto the corner at {to:.0} m"));
+            *at = to;
+        }
+    }
+
+    // 5. Fit the height budget. It exists only because samples are quantised against it, and
+    //    it is a number the synthesiser already knows — there was never a reason to make the
+    //    model guess it and then be told off for guessing wrong.
+    if let Ok(fitted) = crate::tracksynth::with_fitted_budget(prog) {
+        if (fitted.terrain.scale - prog.terrain.scale).abs() > 0.5 {
+            done.push(format!(
+                "fitted the height budget: {:.0} m becomes {:.0}",
+                prog.terrain.scale, fitted.terrain.scale
+            ));
+            prog.terrain.scale = fitted.terrain.scale;
+        }
+    }
+
+    done
+}
+
+/// The plot the synthesiser would actually build, in metres, once it has snapped the short
+/// side of the grid to a power of two. `None` if it would not build one at all.
+fn squared_plot(prog: &TrackProgram) -> Option<(f32, f32)> {
+    let (gw, gh) = crate::tracksynth::grid_for(prog).ok()?;
+    let (sx, sz) = (prog.terrain.size_x, prog.terrain.size_z);
+    if sx >= sz {
+        let mps = sx / (gw.max(2) - 1) as f32;
+        Some((sx, mps * (gh.max(2) - 1) as f32))
+    } else {
+        let mps = sz / (gh.max(2) - 1) as f32;
+        Some((mps * (gw.max(2) - 1) as f32, sz))
+    }
+}
+
 /// Ask for a track, and keep asking until it measures like one.
 ///
 /// `tries` counts total attempts, not retries. Two is the useful minimum: models get the
 /// shape right and the *numbers* wrong, and the numbers are exactly what a measured
 /// complaint fixes.
+/// What an answer starts with when the service is reporting the model's mistake rather than
+/// its own. Not a track, and not a failure either — a thing to send back and have fixed.
+const REJECTED: &str = "\u{0}rejected\u{0}";
+
 pub async fn generate(brief: &str, ask: &impl Ask, tries: usize) -> Result<TrackProgram> {
     let mut attempt = Attempt::default();
     let mut last: Option<String> = None;
@@ -85,8 +261,22 @@ pub async fn generate(brief: &str, ask: &impl Ask, tries: usize) -> Result<Track
             .await
             .with_context(|| format!("asking for a track (attempt {})", round + 1))?;
 
+        if let Some(why) = raw.strip_prefix(REJECTED) {
+            log::info!("[trackllm] attempt {} was rejected: {why}", round + 1);
+            attempt = Attempt {
+                previous: attempt.previous.clone(),
+                problems: vec![why.to_string()],
+            };
+            last = Some(why.to_string());
+            continue;
+        }
+
         match serde_json::from_str::<TrackProgram>(&raw) {
-            Ok(prog) => {
+            Ok(mut prog) => {
+                // Fix what arithmetic can fix before complaining about it. See `repair`.
+                for fixed in repair(&mut prog) {
+                    log::info!("[trackllm] {fixed}");
+                }
                 let problems = validate(&prog);
                 if problems.is_empty() {
                     return Ok(prog);
@@ -204,12 +394,7 @@ pub fn review(prog: &TrackProgram) -> Review {
         // A berm is a banked wall on the outside of a corner. On a straight there is no
         // outside, so it silently does nothing — which reads as the synthesiser dropping it.
         if let Feature::Berm { at, .. } = f {
-            let straight = turn
-                .iter()
-                .find(|s| s.s >= *at)
-                .map(|s| s.curvature == 0.0)
-                .unwrap_or(true);
-            if straight {
+            if !berm_on_a_corner(&turn, *at) {
                 // Say which corner, not just "a corner". This turns up after an edit moves
                 // the corners out from under a berm that was on one, and the way out is a
                 // number.
@@ -312,6 +497,14 @@ impl Ask for ControlPlane {
                 .ok()
                 .and_then(|g| g.error)
                 .unwrap_or(text);
+            // 422 means the model answered and the answer was wrong — a made-up feature
+            // kind, a refused brief. That is a thing to send back and have fixed, so it
+            // comes back as an unparseable answer and the loop spends another attempt on
+            // it. Everything else — no key, rate limited, service down — is fatal, because
+            // asking again would only fail the same way.
+            if status.as_u16() == 422 {
+                return Ok(format!("{REJECTED}{why}"));
+            }
             bail!("the track service answered {}: {why}", status.as_u16());
         }
 
@@ -529,5 +722,65 @@ mod tests {
         let problems = validate(&p);
         assert_eq!(problems.len(), 1, "structural faults stop everything else");
         assert!(problems[0].contains("leaves the terrain"), "{problems:?}");
+    }
+
+    /// The whole loop, against a real control plane and a real model.
+    ///
+    /// Every other test here runs against a stub, which is what let the request shape be
+    /// wrong for months without anyone noticing — the schema compiled to a grammar the API
+    /// rejects, and a stub cannot tell you that. This is the one that would have caught it.
+    ///
+    /// ```text
+    /// cd control-plane && npx wrangler dev --port 8787 --local     # ANTHROPIC_API_KEY in .dev.vars
+    /// FROST_CP=http://localhost:8787 cargo test -- --ignored --nocapture asks_a_real_model
+    /// ```
+    ///
+    /// Costs real money — a few tenths of a cent per attempt on the model this is pointed at.
+    #[test]
+    #[ignore = "spends money against a live control plane — set FROST_CP"]
+    fn asks_a_real_model() {
+        let base = std::env::var("FROST_CP").expect("set FROST_CP to a control plane's base URL");
+        let brief = std::env::var("FROST_BRIEF").unwrap_or_else(|_| {
+            "A long start straight into a right hairpin, then a rhythm section of three \
+             doubles, a sweeping left, and a set of whoops before the finish."
+                .into()
+        });
+        let tries: usize = std::env::var("FROST_TRIES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(3);
+
+        let ask = ControlPlane {
+            base,
+            // A local `wrangler dev` has no accounts to enroll with, and the endpoint sits
+            // above the auth gate for exactly that reason.
+            token: String::new(),
+        };
+        let started = std::time::Instant::now();
+        let out = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(generate(&brief, &ask, tries));
+
+        match out {
+            Ok(prog) => {
+                println!(
+                    "{} — {:.0} m lap over {} segments, {} features, closes to {:.2} m, in {:.0}s",
+                    prog.name,
+                    prog.lap_length(),
+                    prog.segments.len(),
+                    prog.features.len(),
+                    prog.closure_error(),
+                    started.elapsed().as_secs_f32()
+                );
+                assert!(validate(&prog).is_empty(), "a returned track has no problems");
+            }
+            Err(e) => {
+                // Not an assertion failure dressed up: a small model that cannot close a lap
+                // in three goes is a real result and the numbers are the useful part.
+                panic!("gave up after {tries} attempts in {:.0}s: {e:#}", started.elapsed().as_secs_f32());
+            }
+        }
     }
 }

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -575,6 +575,12 @@ pub fn with_fitted_budget(prog: &TrackProgram) -> Result<TrackProgram> {
 }
 
 /// Samples across and down, both a power of two plus one, with cells as square as that allows.
+/// The grid the synthesiser would build for this program, so the repair pass can work out
+/// what plot would make its cells square.
+pub fn grid_for(prog: &TrackProgram) -> Result<(usize, usize)> {
+    grid_dims(prog)
+}
+
 fn grid_dims(prog: &TrackProgram) -> Result<(usize, usize)> {
     let n = prog.terrain.samples as usize;
     let (sx, sz) = (prog.terrain.size_x, prog.terrain.size_z);

--- a/src/Components/Studio/TrackStudio/TrackStudio.tsx
+++ b/src/Components/Studio/TrackStudio/TrackStudio.tsx
@@ -14,6 +14,8 @@ import {
   ChevronDown,
   ChevronRight,
   GripVertical,
+  Maximize2,
+  Minimize2,
   PenLine,
   Plus,
   RefreshCw,
@@ -105,6 +107,10 @@ export default function TrackStudio() {
   const [terrain, setTerrain] = useState<TrackTerrain | null>(null);
   const [overview, setOverview] = useState<TrackOverview | null>(null);
   const [focus, setFocus] = useState<{ x: number; z: number } | null>(null);
+  // The viewer, filling the window. It is the same element either way — only the wrapper's
+  // classes change — because remounting it would throw away the scene and rebuild the
+  // terrain from scratch every time you toggled.
+  const [full, setFull] = useState(false);
   const [hover, setHover] = useState<{
     path: { x: number; z: number }[];
     width: number;
@@ -218,6 +224,23 @@ export default function TrackStudio() {
       setBusy(null);
     }
   }
+
+  // Escape leaves full screen. Anything that covers the whole window has to have a way out
+  // that does not involve finding a button on top of a 3D scene.
+  useEffect(() => {
+    if (!full) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setFull(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [full]);
+
+  // A track that goes away while you are looking at it full screen would leave you staring
+  // at an empty black window with no obvious way back.
+  useEffect(() => {
+    if (!terrain) setFull(false);
+  }, [terrain]);
 
   async function onClose() {
     if (!program || busy) return;
@@ -1017,7 +1040,14 @@ export default function TrackStudio() {
 
           {/* Right: the track itself. Features are painted with a colour each, so a row in
               the list and a lump on the ground can be matched up by eye. */}
-          <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden rounded-xl border border-input bg-black/20">
+          <div
+            className={cn(
+              "relative overflow-hidden",
+              full
+                ? "fixed inset-0 z-50 bg-black"
+                : "min-h-0 min-w-0 flex-1 rounded-xl border border-input bg-black/20",
+            )}
+          >
             {terrain ? (
               <TrackViewer
                 terrain={terrain}
@@ -1036,6 +1066,18 @@ export default function TrackStudio() {
               <div className="absolute inset-0 grid place-items-center px-6 text-center text-[12.5px] text-muted-foreground">
                 {busy === "preview" ? t("track.building") : t("track.previewHint")}
               </div>
+            )}
+            {terrain && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setFull((v) => !v)}
+                title={t(full ? "track.exitFullscreen" : "track.fullscreen")}
+                aria-label={t(full ? "track.exitFullscreen" : "track.fullscreen")}
+                className="absolute right-2 top-2 size-8 bg-black/45 text-white/90 backdrop-blur hover:bg-black/65"
+              >
+                {full ? <Minimize2 className="size-4" /> : <Maximize2 className="size-4" />}
+              </Button>
             )}
           </div>
         </div>

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -2286,6 +2286,8 @@ export const de: Translation = {
   "track.budget": "Höhe genutzt",
   "track.problems": "Zu beheben",
   "track.preview": "In 3D ansehen",
+  "track.fullscreen": "Vollbild",
+  "track.exitFullscreen": "Vollbild verlassen",
   "track.building": "Baut…",
   "track.install": "Installieren",
   "track.export": "Quelle exportieren",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2242,6 +2242,8 @@ export const en = {
   "track.budget": "Height used",
   "track.problems": "Needs fixing",
   "track.preview": "Preview in 3D",
+  "track.fullscreen": "Full screen",
+  "track.exitFullscreen": "Exit full screen",
   "track.building": "Building…",
   "track.install": "Install",
   "track.export": "Export source",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -2272,6 +2272,8 @@ export const es: Translation = {
   "track.budget": "Altura usada",
   "track.problems": "Por corregir",
   "track.preview": "Ver en 3D",
+  "track.fullscreen": "Pantalla completa",
+  "track.exitFullscreen": "Salir de pantalla completa",
   "track.building": "Construyendo…",
   "track.install": "Instalar",
   "track.export": "Exportar fuente",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -2277,6 +2277,8 @@ export const fr: Translation = {
   "track.budget": "Hauteur utilisée",
   "track.problems": "À corriger",
   "track.preview": "Aperçu en 3D",
+  "track.fullscreen": "Plein écran",
+  "track.exitFullscreen": "Quitter le plein écran",
   "track.building": "Construction…",
   "track.install": "Installer",
   "track.export": "Exporter la source",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -2265,6 +2265,8 @@ export const it: Translation = {
   "track.budget": "Altezza usata",
   "track.problems": "Da correggere",
   "track.preview": "Anteprima in 3D",
+  "track.fullscreen": "Schermo intero",
+  "track.exitFullscreen": "Esci da schermo intero",
   "track.building": "Costruzione…",
   "track.install": "Installa",
   "track.export": "Esporta sorgente",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -2262,6 +2262,8 @@ export const ptBR: Translation = {
   "track.budget": "Altura usada",
   "track.problems": "A corrigir",
   "track.preview": "Ver em 3D",
+  "track.fullscreen": "Tela cheia",
+  "track.exitFullscreen": "Sair da tela cheia",
   "track.building": "Construindo…",
   "track.install": "Instalar",
   "track.export": "Exportar fonte",


### PR DESCRIPTION
Track generation had never run against a real model. Every test used a stub, and the first
live call failed before generating a single token:

```
400 invalid_request_error: The compiled grammar is too large
```

The structured-output schema compiles to a constrained-decoding grammar with a hard size cap,
and ours was over it — on **Haiku 4.5, Sonnet 5 and Opus 5 alike**, so this was never a
question of paying for a bigger model.

A grammar rejection happens before any token is generated, so it costs nothing and the limit
is free to bisect. Measured against the live API: **8 feature variants refused, 6 accepted.**
Four of the eight — tabletop, roller, stepUp, berm — have identical fields, so they collapse
into one variant tagged by an enum. The union goes to five and the wire format doesn't change
a byte, so the Rust side is untouched.

`z.union` was not enough on its own: it compiles to a grammar that does not constrain the tag,
and the model returned feature kinds absent from the schema. `z.discriminatedUnion` over the
same five options is both smaller and actually constraining.

## Repair the arithmetic; ask only about judgement

Most of what came back wrong was not judgement, and we had exact code for all of it. The loop
now fixes it before it complains:

- the plot grows to the lap's bounding box, and the start slides to centre it
- the cells are squared against the grid the synthesiser would really build
- the lap is closed with `closing_segments` — the same call the studio's own button uses
- a berm on a straight slides to the nearest corner
- the height budget is fitted

What reaches the model afterwards is what it can act on: too flat, too few jumps, corners too
tight, lap too long.

This is what makes the cheap model viable:

| | before | after |
|---|---|---|
| Haiku 4.5 | failed 3/3, always on lap closure | 1375 m lap, 32 features, closes to 0.00 m, 33 s |
| Sonnet 5 | failed | passes, ~120 s, 2x the cost |

## A bug worth naming

The berm rule was written twice and the two disagreed. `validate` asks whether the station at
`at` is curving; the repair asked whether the berm *reached* a corner anywhere along its
length. A berm 19 m short of a turn passed the repair and was rejected by the check — so the
loop spent every remaining attempt on a fault it had already decided was fine. There is now
one `berm_on_a_corner` used by both.

Any repair whose rule paraphrases a check's rule will drift, and the symptom is a loop that
never converges on a complaint that never changes.

## Also

- **Haiku 4.5** ($1/$5 per MTok against Opus 5's $5/$25). It predates adaptive thinking and
  rejects `output_config.effort`, so both change with it.
- A schema-rejected answer is a **422, not a 500** — it is the model's mistake, not the
  service's, and a 500 aborted the loop on the first stumble and threw away the rest.
- Four attempts rather than three, since an attempt is now a fraction of a cent.
- The prompt states jump *counts*, not only a density range — a lap with eight jumps on it was
  the most common miss.
- `asks_a_real_model` (ignored by default) runs the whole loop against a live control plane.
  It is the test that would have caught the grammar fault, and the reason it existed nowhere
  is that a stub cannot fail this way.
- **The 3D preview has a full-screen button**, Escape to leave. Same DOM element either way,
  so toggling doesn't rebuild the scene.

## Not covered

Reliability on Haiku at four tries is roughly 2-3 briefs in 3; the misses are corpus bounds
(lap length, feature density) rather than structural faults. `claude-sonnet-5` is one line
away if that proves annoying.

The deployed worker still has **no** `ANTHROPIC_API_KEY`, deliberately — `/v1/track/generate`
sits above the account gate, so a key there is spendable by anyone with the URL. Worth a rate
limit or a move below the gate before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)