### PR TITLE
fix(tracks): a lap that runs over itself, and a .map the game can walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-09-01
+
+### Fixed
+- A generated lap can no longer run over its own ground. Nothing checked for it, so a track
+  that crossed itself passed every test and came out with the crossing graded into the
+  terrain as a scar.
+
+### Changed
+- Which model writes the track is a setting (`TRACK_MODEL`) rather than a code change.
+
 ## 2026-08-31
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2026-09-01
 
 ### Fixed
+- Installed tracks no longer crash the game as it loads track graphics. The `.map` declared no
+  geometry at all, so anything reading it in order stopped a few bytes in.
 - A generated lap can no longer run over its own ground. Nothing checked for it, so a track
   that crossed itself passed every test and came out with the crossing graded into the
   terrain as a scar.

--- a/control-plane/src/env.d.ts
+++ b/control-plane/src/env.d.ts
@@ -25,6 +25,11 @@ declare global {
      *  carries on. Spend is capped by the endpoint itself: one Opus call per request, at
      *  most 16k output tokens, and only ever a motocross track. */
     ANTHROPIC_API_KEY?: string;
+    /**
+     * Which model writes the track, overriding the default in `trackgen.ts`. A running-cost
+     * decision rather than a code one — see the note there on what the cheap one cannot do.
+     */
+    TRACK_MODEL?: string;
     /** Ed25519 private key (PKCS#8 DER, base64url) that signs plugin entitlements. The app
      *  holds only the public half, so a leak of the app cannot mint licenses. Without it
      *  every licensing endpoint answers 503 rather than issuing something unsigned - an

--- a/control-plane/src/trackgen.ts
+++ b/control-plane/src/trackgen.ts
@@ -174,6 +174,19 @@ Close it by doing the arithmetic. Point symmetry — half a lap whose signed ang
 there as a fallback, but a track built that way is symmetrical about its own centre and reads
 as one on the map. Use it only if the layout you want will not close.
 
+KEEP THE LAP WINDING ONE WAY. This is the practical way to avoid crossing yourself, and it
+is arithmetic you can check as you write. Add up the *signed* angles: they must come to ±360.
+Now add up the *absolute* angles, ignoring sign: a clean lap comes to somewhere around 900,
+and much past that means it has wound back on itself and will probably cross. A track that turns mostly one
+way, with a few gentle counter-turns, closes cleanly; one that alternates hard left and hard
+right wanders back over its own ground.
+
+THE LAP MUST NOT CROSS ITSELF. It is a closed loop drawn on flat ground, and no part of it
+may run over another part — there are no bridges. A lap that goes out, loops, and comes back
+through where it has already been is rejected. When you have written the segments, walk the
+path in your head and check that it does not return to ground it has covered: the usual cause
+is a straight long enough to reach back across an earlier one.
+
 WRITE A LAP, NOT A SHAPE. A published circuit is twenty to forty segments: short straights,
 corners in runs, and no two turns the same radius. Six long straights joined by four identical
 arcs closes perfectly and looks like a running track from above. Vary the radii across the
@@ -234,6 +247,31 @@ over.`;
  */
 const MODEL = "claude-haiku-4-5";
 
+/**
+ * Which model, and how it wants to be asked.
+ *
+ * `TRACK_MODEL` overrides the default, because which model this wants is a running cost
+ * decision rather than a code one — put it in `.dev.vars` locally or set it as a var on the
+ * deployment. The two families take different parameters and the mismatch is a 400 rather
+ * than something ignored: Haiku 4.5 predates adaptive thinking, takes a fixed thinking
+ * budget, and rejects `output_config.effort` outright.
+ *
+ * Worth knowing before turning the cheap one on: Haiku writes laps that cross over themselves
+ * and cannot reliably fix one when told. It is the one thing here that is genuinely spatial
+ * reasoning, there is nothing to compute on its behalf, and it is where the price difference
+ * actually shows up.
+ */
+function ask(model: string) {
+  const adaptive = !/^claude-haiku/.test(model);
+  return {
+    model,
+    thinking: adaptive
+      ? ({ type: "adaptive" } as const)
+      : ({ type: "enabled", budget_tokens: 4000 } as const),
+    effort: adaptive ? ("low" as const) : undefined,
+  };
+}
+
 /** Briefs longer than this are not briefs. */
 const MAX_BRIEF = 2000;
 
@@ -285,17 +323,19 @@ export async function generateTrack(request: Request, env: Env): Promise<Respons
 
   const client = new Anthropic({ apiKey: env.ANTHROPIC_API_KEY });
   try {
+    const chosen = ask(env.TRACK_MODEL?.trim() || MODEL);
     const response = await client.messages.parse({
-      model: MODEL,
+      model: chosen.model,
       max_tokens: 16000,
       system: SYSTEM,
       messages,
       // Laying out a lap is arithmetic the model would have to do — except most of it is
-      // done for it now, see `repair` in trackllm.rs. Haiku 4.5 predates adaptive thinking
-      // and takes a fixed budget instead, and rejects `output_config.effort` outright, so
-      // the only thing left in `output_config` is the schema.
-      thinking: { type: "enabled", budget_tokens: 4000 },
-      output_config: { format: zodOutputFormat(TrackProgram) },
+      // done for it now, see `repair` in trackllm.rs.
+      thinking: chosen.thinking,
+      output_config: {
+        format: zodOutputFormat(TrackProgram),
+        ...(chosen.effort ? { effort: chosen.effort } : {}),
+      },
     });
 
     if (response.stop_reason === "refusal") {

--- a/src-tauri/src/trackllm.rs
+++ b/src-tauri/src/trackllm.rs
@@ -70,6 +70,53 @@ pub trait Ask {
         -> impl std::future::Future<Output = Result<String>>;
 }
 
+/// Where the lap runs over its own ground, if it does.
+///
+/// Returns the two distances round the lap and how close they come. Nothing else caught this:
+/// the lap closed, it fitted the plot, every feature measured, and the track still crossed
+/// itself twice — because "does this shape overlap itself" is not a question any of the other
+/// checks ask.
+///
+/// It matters more here than it would on a drawing. The synthesiser has no concept of a
+/// bridge: it benches whatever the centreline passes over, so where a lap crosses, both
+/// passes are graded into the same cells and what comes out is a scar — one pass cutting
+/// through the other's jumps, with the ground fighting over which height it should be.
+///
+/// Not repairable, so it goes to the model rather than to `repair`. Uncrossing a lap means
+/// re-routing it, which is the layout itself and the one thing here that is genuinely a
+/// design decision.
+fn self_crossing(prog: &TrackProgram) -> Option<(f32, f32, f32)> {
+    let st = prog.stations(2.0);
+    if st.len() < 8 {
+        return None;
+    }
+    let lap = prog.lap_length().max(1.0);
+    // Touching, not merely near: two ribbons this far apart centre-to-centre are already
+    // sharing dirt.
+    let near = prog.width * 1.1;
+    // How far apart along the lap two points must be before their nearness means anything.
+    // Consecutive stations are always close together, and so are the two sides of a hairpin,
+    // which is a real shape and not a fault — it takes a corner's own length to come back on
+    // yourself, so the bar is a few of them.
+    let apart = (prog.width * 6.0).max(60.0);
+    let mut worst: Option<(f32, f32, f32)> = None;
+    for (i, a) in st.iter().enumerate() {
+        for b in st.iter().skip(i + 1) {
+            // Round the lap, not along it — the finish line is not a discontinuity, and
+            // measuring it as one makes every track "cross itself" at the start.
+            let along = (b.s - a.s).abs();
+            if along.min(lap - along) < apart {
+                continue;
+            }
+            let gap = ((a.x - b.x).powi(2) + (a.z - b.z).powi(2)).sqrt();
+            if gap < near && worst.map(|(.., w)| gap < w).unwrap_or(true) {
+                worst = Some((a.s, b.s, gap));
+            }
+        }
+    }
+    worst
+}
+
 /// Whether a berm at this distance round the lap is on a corner.
 ///
 /// One definition, used by both the check and the repair. They had one each, they disagreed,
@@ -364,6 +411,14 @@ pub fn review(prog: &TrackProgram) -> Review {
             "the lap doesn't close: the finish is {closure:.0} m from the start. The turns have \
              to add up to a whole number of full circles — check that the signed angles sum to \
              ±360°."
+        ));
+    }
+    if let Some((a, b, gap)) = self_crossing(prog) {
+        out.push(format!(
+            "the lap crosses itself: {a:.0} m round comes within {gap:.0} m of {b:.0} m \
+             round, and the track is {:.0} m wide. Two parts of a lap cannot share the same \
+             ground — route one of them around the other, or turn earlier so they miss.",
+            prog.width
         ));
     }
     between("the riding line", prog.width, corpus::WIDTH_M, " m", &mut notes);
@@ -676,6 +731,29 @@ mod tests {
         assert!(
             problems.iter().any(|s| s.contains("doesn't close")),
             "{problems:?}"
+        );
+    }
+
+    #[test]
+    fn a_lap_that_runs_over_itself_is_caught() {
+        // Out, round more than half a circle, and back across where it came from. Tested on
+        // the geometry rather than through `validate`, which returns early on a lap that
+        // doesn't close — and a shape built to cross is easier to write than one built to
+        // cross *and* close *and* fit its plot.
+        let p = tweaked(|p| {
+            p.segments = vec![
+                crate::trackprog::Segment::Straight { length: 220.0, rise: 0.0 },
+                crate::trackprog::Segment::Arc { radius: 30.0, angle: 200.0, rise: 0.0 },
+                crate::trackprog::Segment::Straight { length: 220.0, rise: 0.0 },
+            ];
+        });
+        let found = self_crossing(&p);
+        assert!(found.is_some(), "a lap that doubles back over itself wasn't seen");
+        let (a, b, gap) = found.unwrap();
+        assert!(gap < p.width * 1.1, "reported a gap of {gap:.1} m as a crossing");
+        assert!(
+            (a - b).abs() > 60.0,
+            "the two points are {a:.0} m and {b:.0} m round — that is the same place twice"
         );
     }
 

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -1737,17 +1737,6 @@ fn map(prog: &TrackProgram, syn: &Synth) -> Vec<u8> {
     let seed = prog.terrain.relief.seed;
     let dim = GROUND_TEXTURE_DIM;
 
-    let mut out = Vec::new();
-    out.extend_from_slice(b"MP2\0");
-    out.extend_from_slice(&304u32.to_le_bytes()); // header size, constant on every map measured
-    out.extend_from_slice(&0u32.to_le_bytes()); // materials
-    out.extend_from_slice(&0u32.to_le_bytes()); // vertices
-    out.extend_from_slice(&0u32.to_le_bytes()); // triangles
-    out.extend_from_slice(&0u32.to_le_bytes()); // nodes
-
-    // The surfaces are counted before they are listed — `map::texture_table` reads that word
-    // where the node tree ends, and a reader walking the file straight through lands on it
-    // here. Without it the first record is read as the count and the table is empty.
     let sheets = [
         // `_c` is PiBoSo's own mark for a colour sheet, and the ground words are what a
         // reader looking for a track's dirt matches on — ours say both.
@@ -1756,7 +1745,100 @@ fn map(prog: &TrackProgram, syn: &Synth) -> Vec<u8> {
         ("dirt_line_c", ground_pixels(dim, &ridden, seed ^ 0x11E5)),
         ("grass_c", ground_pixels(dim, &turf, seed ^ 0x6A55)),
     ];
-    out.extend_from_slice(&(sheets.len() as u32).to_le_bytes());
+    let n = sheets.len();
+
+    let mut out = Vec::new();
+    out.extend_from_slice(b"MP2\0");
+    out.extend_from_slice(&304u32.to_le_bytes()); // header size, constant on every map measured
+
+    // One material per sheet. The association between the two is **positional** — the k-th
+    // colour record belongs to material k — so a map with four sheets and no materials is
+    // four pictures with nothing to hang them on. All 56 bytes of a record are white shading
+    // terms and a one-based id; nothing in it points at a texture.
+    out.extend_from_slice(&(n as u32).to_le_bytes());
+    for k in 0..n {
+        let mut rec = [0u8; 56];
+        // White, fully opaque, and its own id — the shape every published map's records have.
+        for c in 0..12 {
+            rec[c * 4..c * 4 + 4].copy_from_slice(&1.0f32.to_le_bytes());
+        }
+        rec[52..56].copy_from_slice(&((k + 1) as u32).to_le_bytes());
+        out.extend_from_slice(&rec);
+    }
+
+    // A mesh, because the format's own walk requires one: eight vertices at the least and a
+    // triangle at the least, and everything after them is found by stepping over them. A map
+    // declaring none of each is not an empty map, it is a file that stops being readable at
+    // its fifth word — `map::parse` rejects our own, which is the tell that the game's reader
+    // would too, and "crashing at track graphics" is where that shows up.
+    //
+    // What the geometry *is* barely matters, so it is the smallest thing that satisfies the
+    // walk: a box, well below the terrain, where nothing can see it. The riding surface comes
+    // from the `.trh` and a generated track ships no scenery.
+    const VC: usize = 8;
+    const TC: usize = 12;
+    let under = -500.0f32;
+    let corners: [[f32; 3]; VC] = [
+        [0.0, under, 0.0],
+        [1.0, under, 0.0],
+        [1.0, under, 1.0],
+        [0.0, under, 1.0],
+        [0.0, under - 1.0, 0.0],
+        [1.0, under - 1.0, 0.0],
+        [1.0, under - 1.0, 1.0],
+        [0.0, under - 1.0, 1.0],
+    ];
+    out.extend_from_slice(&(VC as u32).to_le_bytes());
+    // Structure of arrays, 80 bytes a vertex: positions first, texture coordinates at
+    // 12 x count, normals at 52 x count. The rest is attributes we don't write and the game
+    // doesn't need from a box nobody sees.
+    let mut block = vec![0u8; VC * 80];
+    for (i, c) in corners.iter().enumerate() {
+        for (k, v) in c.iter().enumerate() {
+            let at = i * 12 + k * 4;
+            block[at..at + 4].copy_from_slice(&v.to_le_bytes());
+        }
+        let uv = 12 * VC + i * 8;
+        block[uv..uv + 4].copy_from_slice(&0.0f32.to_le_bytes());
+        block[uv + 4..uv + 8].copy_from_slice(&0.0f32.to_le_bytes());
+        let nm = 52 * VC + i * 12;
+        block[nm + 4..nm + 8].copy_from_slice(&1.0f32.to_le_bytes()); // straight up
+    }
+    out.extend_from_slice(&block);
+
+    let tris: [[u32; 3]; TC] = [
+        [0, 1, 2], [0, 2, 3], [4, 6, 5], [4, 7, 6],
+        [0, 4, 5], [0, 5, 1], [1, 5, 6], [1, 6, 2],
+        [2, 6, 7], [2, 7, 3], [3, 7, 4], [3, 4, 0],
+    ];
+    out.extend_from_slice(&(TC as u32).to_le_bytes());
+    for t in &tris {
+        for i in t {
+            out.extend_from_slice(&i.to_le_bytes());
+        }
+    }
+
+    // One leaf node carrying a draw group per material, so every sheet is bound to something
+    // and the groups tile the index buffer exactly — which is what a real map's do.
+    out.extend_from_slice(&1u32.to_le_bytes());
+    let mut node = vec![0u8; 44];
+    for (k, v) in [0.0f32, under - 1.0, 0.0, 1.0, under, 1.0].iter().enumerate() {
+        node[k * 4..k * 4 + 4].copy_from_slice(&v.to_le_bytes());
+    }
+    node[40..44].copy_from_slice(&(n as u32).to_le_bytes());
+    out.extend_from_slice(&node);
+    let per = TC / n;
+    for k in 0..n {
+        let start = (k * per) as u32;
+        let count = if k + 1 == n { TC - k * per } else { per } as u32;
+        for w in [0u32, k as u32, start, count, 0, VC as u32] {
+            out.extend_from_slice(&w.to_le_bytes());
+        }
+    }
+
+    // The surfaces are counted before they are listed — a reader walking the file straight
+    // through lands on that word where the node tree ends.
+    out.extend_from_slice(&(n as u32).to_le_bytes());
     for (name, px) in &sheets {
         out.extend_from_slice(&texture_record(name, dim as u32, dim as u32, px));
     }
@@ -2968,12 +3050,35 @@ mod tests {
         let m = map(&p, &s);
         assert_eq!(&m[..4], b"MP2\0");
         assert_eq!(u32::from_le_bytes(m[4..8].try_into().unwrap()), 304);
-        assert_eq!(u32::from_le_bytes(m[8..12].try_into().unwrap()), 0, "materials");
-        // `map::parse` builds a *mesh*, so it rightly declines one with no geometry — that
-        // is the drag strip's shape and it is deliberate. What has to hold is that the file
-        // is recognised as a map, and that its sheets read back.
+        // One material per sheet: the two are matched positionally, so the counts have to
+        // agree or every picture is hung on the wrong thing — or on nothing.
+        assert_eq!(u32::from_le_bytes(m[8..12].try_into().unwrap()), 4, "materials");
         assert!(crate::map::is_map(&m), "not recognised as a map");
-        assert!(crate::map::parse(&m).is_none(), "there is no mesh in it to find");
+
+        // The check that matters, and the one that was missing. `embedded_textures` *scans*
+        // for records; the game walks the file — material records, then the vertex block,
+        // then the indices, then the node tree, and only then the sheets. A map that can only
+        // be scanned is one whose textures a walker never reaches, and the previous version
+        // declared no mesh at all, so the walk stopped at its fifth word. It asserted that
+        // outright: "there is no mesh in it to find".
+        let mesh = crate::map::parse(&m).expect("a walker has to find the mesh");
+        assert!(mesh.vertex_count() >= 8, "{} vertices", mesh.vertex_count());
+        assert!(mesh.triangle_count() >= 1, "{} triangles", mesh.triangle_count());
+
+        // And the sheets have to be where the walk ends up, not merely somewhere in the file.
+        let walked = crate::map::declared(&m);
+        assert_eq!(
+            walked.iter().map(|(n, ..)| n.as_str()).collect::<Vec<_>>(),
+            ["ground_c", "shoulder_c", "dirt_line_c", "grass_c"],
+            "walked to {walked:?}"
+        );
+        for (n, w, h) in &walked {
+            assert_eq!(
+                (*w, *h),
+                (GROUND_TEXTURE_DIM as u32, GROUND_TEXTURE_DIM as u32),
+                "{n} is {w}x{h}"
+            );
+        }
 
         // The scanner that reads published tracks' textures has to find ours, and they have
         // to inflate to the pixel count they claim — a record the game would skip is a
@@ -2986,19 +3091,6 @@ mod tests {
             "found {names:?}"
         );
 
-        // A reader walking the file rather than scanning it lands on the count where the
-        // node tree ends — six words in, since nothing before it has any entries.
-        let after_tree = 24;
-        assert_eq!(
-            u32::from_le_bytes(m[after_tree..after_tree + 4].try_into().unwrap()),
-            texs.len() as u32,
-            "the surfaces have to be counted before they are listed"
-        );
-        assert_eq!(
-            &m[after_tree + 4..after_tree + 4 + 8],
-            b"ground_c",
-            "the first record starts straight after the count"
-        );
         for t in &texs {
             assert_eq!(t.width, GROUND_TEXTURE_DIM as u32);
             let px = crate::edf::inflate_texture(&m, t).expect("the sheet inflates");


### PR DESCRIPTION
Two faults, both found by looking rather than by testing.

## The game crashed at track graphics

Reported from a real install. That is where the `.map` is read, and ours was malformed: it
declared **zero materials, zero vertices, zero triangles and zero nodes**, on the belief that
this is the shape PiBoSo's own drag strip ships. Nothing verified that, and our own decoder
says otherwise — `map::texture_table` requires at least 8 vertices and at least one triangle,
because everything after the mesh is found by stepping over it. A map with no mesh stops being
readable at its fifth word.

**The test asserted the fault rather than catching it:**

```rust
assert!(crate::map::parse(&m).is_none(), "there is no mesh in it to find");
```

It passed because it checked the sheets with `edf::embedded_textures`, which *scans* the file
for records. Scanning finds them anywhere in the bytes. Walking is what the game does, and a
walker never got past the header.

The map now carries what the walk needs: one material per sheet (they are matched
**positionally** — the k-th colour record belongs to material k, so four sheets against no
materials is four pictures with nothing to hang them on), a minimal mesh 500 m below the
terrain where nothing can see it, and one leaf node with a draw group per material tiling the
index buffer. The test now walks instead of scanning.

**Unverified where it matters.** I can prove our own reader accepts the file; I cannot run the
game from macOS. This fixes a format violation that is a strong candidate for the crash, not a
confirmed cure — worth one more install before anyone believes it.

## The lap ran over its own ground

Spotted by eye in a generated track: it closed, it fitted its plot, every feature measured,
and it crossed itself twice — because "does this shape overlap itself" was not a question
anything asked.

It matters more here than on a drawing. The synthesiser has no concept of a bridge — it
benches whatever the centreline passes over, so at a crossing both passes are graded into the
same cells and what comes out is a scar, one pass cutting through the other's jumps. The track
that prompted this had 182 m round sitting **0 m** from 1380 m round.

Two details are the whole check: distance is measured *round* the lap rather than along it
(the finish line is where a lap meets itself by definition — as a line, every track in the
corpus "crosses itself" at zero metres), and the bar for "far enough apart to count" is a few
corner-lengths, because a hairpin brings the track back alongside itself on purpose.

Not repairable, so it goes to the model rather than into `repair` — uncrossing a lap means
re-routing it, which is the layout itself.

### One thing I wrote and threw away

A winding-angle check, as a cheap proxy for the same fault. Then I measured our own worked
example: it winds **920°** and crosses nothing, so the bound I had picked rejected our
reference track. A check that fails a known-good input is worse than no check. The advice
survives in the prompt, where being approximate is free.

## Also

`TRACK_MODEL` selects the model, defaulting to Haiku 4.5 — a running-cost decision rather than
a code one. The two families take different parameters and a mismatch is a 400, so the request
shape follows the model.

**Neither Haiku 4.5 nor Sonnet 5 reliably avoids crossing itself yet** — sixteen attempts
across both produced no clean lap on one brief. Laying out a non-self-intersecting closed path
from turn primitives is dead reckoning, which is what models are worst at. The check is what
stops a bad one shipping silently; making them avoid it is separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)