### PR TITLE
fix(designer): a companion sheet shows its base sheet's parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2026-09-01
 
 ### Fixed
+- Designer: a normal or roughness sheet (`plastics_n` and the like) shows the same parts as
+  the sheet it belongs to, instead of opening as a blank canvas with no layout on it.
 - More of what stopped an installed track loading: the sound config was an empty file, and the
   track file claimed a lap length in a field no published track uses that way.
 

--- a/src/Components/Studio/Designer/uv.ts
+++ b/src/Components/Studio/Designer/uv.ts
@@ -199,6 +199,33 @@ export function faceAt(parts: UvPart[], u: number, v: number): Face | null {
 }
 
 /**
+ * Which sheet's uv layout to read for `sheetName`.
+ *
+ * Normally itself. But a companion map — `plastics_n` beside `plastics`, and the `_r`/`_s`
+ * maps with it — is never bound to any geometry: the material names the colour sheet, and the
+ * companion rides along on the *same* uv, which is the whole reason it can be a separate
+ * image at all. Asked for one by name, nothing matched and the editor put up a blank sheet
+ * with no parts on it — every island, every clip and every hover gone, for a sheet whose
+ * layout is the one already on screen next to it.
+ *
+ * The literal name is tried first, so a model that really does bind a texture called
+ * `something_n` still wins. Only when nothing is bound does it fall back to the base.
+ */
+function sheetFor(nodes: EdfNode[], sheetName: string): string {
+  const want = sheetName.trim().toLowerCase();
+  if (!want) return "";
+  const binds = (name: string) =>
+    nodes.some(
+      (n) =>
+        n.texture?.toLowerCase() === name ||
+        n.submeshes.some((sm) => sm.texture?.toLowerCase() === name),
+    );
+  if (binds(want)) return want;
+  const base = want.replace(/_(n|r|s)$/, "");
+  return base !== want && binds(base) ? base : want;
+}
+
+/**
  * Move one triangle into the tile the sheet is actually sampled in, in place.
  *
  * Most bodywork is unwrapped inside the unit square and this does nothing to it. The number
@@ -264,7 +291,7 @@ export function uvParts(
   sheetName: string,
   opts?: { assembled?: boolean },
 ): UvPart[] {
-  const want = sheetName.trim().toLowerCase();
+  const want = sheetFor(nodes, sheetName);
   if (!want) return [];
 
   // A fraction of the model's width, so the dead band around the mirror plane scales with the


### PR DESCRIPTION
Picking `plastics_n` in the Designer opened a blank canvas — no islands, no clip paths, no hover — for a sheet whose layout is the one already open beside it.

`uvParts` matched the sheet name against what each submesh binds. A companion map is never bound to anything: the material names the colour sheet, and `plastics_n` rides along on the **same** uv, which is the whole reason it can be a separate image at all. So nothing matched and no parts came back.

Measured on a real KTM 250 SX-F, running the Designer's own `uvParts` over the mesh:

| sheet | before | after |
|---|---|---|
| `plastics_n` | **0 parts** | 4 — the same parts `plastics` has, identical bounds |
| `250f_metals_n` | **0 parts** | 13 |
| `plastics` | 4 parts | 4, unchanged |

The literal name is tried first, so a model that really does bind a texture called `something_n` still wins; the fallback only fires when nothing binds the name at all.

Worth noting this was reachable from the sheet list rather than only by typing a name in — `paint_studio_hints` includes `mesh_texture_names`, which reads every texture record off the mesh, companions included.

### Verified

- `tsc --noEmit` and `eslint` clean.
- `uvParts` run under bun against a real assembled bike, before and after — the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)