### PR TITLE
fix(designer): stop offering a sheet name the model never asks for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 2026-09-01
 
 ### Fixed
+- Designer: the sheet list no longer offers a name that another paint misspelt — the KTM
+  250 SX-F's normal map is `plastics_n`, and a paint beside it calls its own `plastics-n`,
+  which the bike asks for on no part of itself.
 - Designer: a normal or roughness sheet (`plastics_n` and the like) shows the same parts as
   the sheet it belongs to, instead of opening as a blank canvas with no layout on it.
 - More of what stopped an installed track loading: the sound config was an empty file, and the

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2140,8 +2140,29 @@ fn paint_hints(dir: &std::path::Path) -> Vec<String> {
     // the only thing that says that (see `on_goggle_side`) — and offering a helmet's shell
     // sheet to somebody painting its goggles would put the shell in the wrong file.
     let main_paints = dir.file_name().is_some_and(|s| s.eq_ignore_ascii_case("paints"));
-    if let (true, Some(model_dir)) = (main_paints, dir.parent()) {
-        add(&mut names, mesh_texture_names(model_dir));
+    let mesh = match (main_paints, dir.parent()) {
+        (true, Some(model_dir)) => mesh_texture_names(model_dir),
+        _ => Vec::new(),
+    };
+    add(&mut names, mesh.clone());
+
+    // Drop a name that is another paint's misspelling of one the model actually binds.
+    //
+    // A `.pnt` supplies textures by name, so a sheet the model never asks for changes
+    // nothing — and these names come from paints as much as from the mesh, misspellings and
+    // all. The KTM 250 SX-F binds `plastics_n`; a paint installed beside it calls its own
+    // sheet `plastics-n`, and the two sat next to each other in the list, one character
+    // apart, with the dead one first. Painting it is work that cannot reach the bike.
+    //
+    // Only a name that collides with a bound one is dropped, and only by separator or case.
+    // A paint is free to ship sheets the mesh never mentions — `tyres` and `wheel` come off
+    // the wheels rather than the bike — and those are left alone.
+    if !mesh.is_empty() {
+        let key = |s: &str| s.to_ascii_lowercase().replace('-', "_");
+        let bound: std::collections::HashSet<String> = mesh.iter().map(|n| key(n)).collect();
+        names.retain(|n| {
+            mesh.iter().any(|m| m.eq_ignore_ascii_case(n)) || !bound.contains(&key(n))
+        });
     }
     names.sort_by_key(|n| n.to_lowercase());
     names
@@ -10126,6 +10147,50 @@ mod mesh_texture_tests {
 
         std::fs::create_dir_all(root.join("Bare")).unwrap();
         assert!(mesh_texture_names(&root.join("Bare")).is_empty(), "no mesh, nothing to say");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A sheet name that only exists because another paint misspelt one the model binds is
+    /// not offered. The KTM 250 SX-F binds `plastics_n`; a paint beside it ships
+    /// `plastics-n`, which the game asks for on no part of the bike, so painting it is work
+    /// that cannot show up. Names the mesh never mentions at all are somebody else's sheet
+    /// and are left alone.
+    #[test]
+    fn a_paints_misspelling_of_a_bound_sheet_is_not_offered() {
+        let root = std::env::temp_dir().join(format!("frost-dead-sheet-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let bike = root.join("Bike");
+        std::fs::create_dir_all(bike.join("paints")).unwrap();
+        let mut mesh = mesh_naming("plastics");
+        mesh.extend_from_slice(&mesh_naming("plastics_n"));
+        std::fs::write(bike.join("model.edf"), mesh).unwrap();
+        std::fs::write(
+            bike.join("paints").join("Someone.pnt"),
+            super::paint::encode(
+                "Someone",
+                &[
+                    super::paint::PntTexture {
+                        name: "plastics-n".into(),
+                        width: 2,
+                        height: 2,
+                        rgba: vec![0; 16],
+                    },
+                    super::paint::PntTexture {
+                        name: "tyres".into(),
+                        width: 2,
+                        height: 2,
+                        rgba: vec![0; 16],
+                    },
+                ],
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        let names = paint_hints(&bike.join("paints"));
+        assert!(names.iter().any(|n| n == "plastics_n"), "the bound spelling stays: {names:?}");
+        assert!(!names.iter().any(|n| n == "plastics-n"), "the dead one goes: {names:?}");
+        assert!(names.iter().any(|n| n == "tyres"), "a sheet of its own is not ours to drop: {names:?}");
         let _ = std::fs::remove_dir_all(&root);
     }
 


### PR DESCRIPTION
A `.pnt` supplies textures **by name**, so a sheet the model doesn't bind changes nothing on the bike. The Designer's sheet list is built from installed paints as well as from the mesh, and it was passing on their misspellings.

On a KTM 250 SX-F the mesh binds `plastics_n`. A paint installed beside it ships its own normal map as `plastics-n`. Both landed in the list, sorted one character apart, **with the dead one first**:

```
before: 250F_metals, 250F_metals_N, plastics, plastics-n, plastics_n, tyres, w_plate, wheel
after:  250F_metals, 250F_metals_N, plastics,             plastics_n, tyres, w_plate, wheel
```

Pick `plastics-n` and you get a sheet you can paint all day and never see — which is exactly what happened.

- Drops a collected name that differs from a bound one only by separator or case, keeping the spelling the model actually uses.
- Only where it collides. A paint is free to ship sheets the mesh never mentions — `tyres` and `wheel` come off the wheels rather than the bike — and those are left alone.
- `mesh_texture_names` is read once and reused rather than being called for its return value alone.

### Verified

- New unit test: a mesh binding `plastics`/`plastics_n` plus a paint shipping `plastics-n` and `tyres` — the bound spelling stays, the misspelling goes, `tyres` survives.
- `paint_hints_from_env` against the real installed KTM 250 SX-F, before and after — the two lists above. Note this one needs the sidecar to read the packed mesh; run it from the main checkout, not a worktree, or `mesh_texture_names` comes back empty and the filter has nothing to work with.
- Full `cargo test --bin mxb-app` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)