### PR TITLE
feat(studio): open on a bike worth opening on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2026-09-01
 
+### Changed
+- Paint Studio and the Designer open on the KTM 250 SX-F when it is installed, rather than on
+  whichever bike sorts first alphabetically.
+
 ### Fixed
 - Designer: the sheet list no longer offers a name that another paint misspelt — the KTM
   250 SX-F's normal map is `plastics_n`, and a paint beside it calls its own `plastics-n`,

--- a/src/Components/Studio/paintDest.tsx
+++ b/src/Components/Studio/paintDest.tsx
@@ -184,6 +184,30 @@ export interface PaintDestState {
 }
 
 /**
+ * The bike the pickers open on, when nothing has been chosen yet and it is installed.
+ *
+ * The fallback is the first name on the list, which for a real mods folder is whatever
+ * happens to sort first — `2007_H85R` on mine, out of sixty-one. That is nobody's bike; it
+ * is just the top of an alphabetical list, and it made opening the Designer to paint start
+ * with picking something else first.
+ *
+ * Matched on letters and digits alone, because a bike's folder name is whatever the pack
+ * that installed it chose. The token is narrow enough to be exact: it takes the 250 SX-F
+ * and not the two-stroke `KTM_250_SX` beside it, nor the 350.
+ */
+const PREFERRED_MODEL = "ktm250sxf";
+
+/** A model name reduced to what is stable about it — pack prefixes and punctuation vary. */
+function squash(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/** The model to open on: the preferred one if it is installed, else the first on the list. */
+function defaultModel(models: string[]): string {
+  return models.find((m) => squash(m).includes(PREFERRED_MODEL)) ?? models[0] ?? "";
+}
+
+/**
  * The destination state, with `onChange` fired whenever the answer moves.
  *
  * Callers use that to drop anything they'd computed from the old destination — Paint Studio
@@ -237,7 +261,7 @@ export function usePaintDest(onChange?: () => void): PaintDestState {
   // Keep the picked model on the list the kind offers — switching from a helmet to a bike
   // must not leave a helmet's name sitting in a bike destination.
   useEffect(() => {
-    setModelState((m) => (models.includes(m) ? m : models[0] ?? ""));
+    setModelState((m) => (models.includes(m) ? m : defaultModel(models)));
   }, [models]);
 
   const dest = useMemo<PaintDest | null>(


### PR DESCRIPTION
The model picker started on `models[0]`. On a real mods folder that is whatever sorts first — `2007_H85R` here, out of sixty-one installed bikes — which is nobody's bike, just the top of an alphabetical list. Opening the Designer to paint began with picking something else.

Now it prefers the KTM 250 SX-F when it's installed, and falls back to the first name otherwise, so an install without it behaves exactly as before.

Matched on letters and digits alone, because a bike's folder name is whatever the pack that installed it chose. The token is narrow enough to be exact — checked against all sixty-one installed bikes:

```
matches ktm250sxf:  ['MX2OEM_2023_KTM_250_SX-F']
near misses:        ['MX1OEM_2023_KTM_250_SX', 'MX2OEM_2023_KTM_250_SX-F']
```

It takes the SX-F and not the two-stroke `KTM_250_SX` sitting beside it, nor the 350.

`usePaintDest` is shared by Paint Studio and the Designer — same question, same picker — so both open there. Rider kinds are unaffected: no profile name matches, so they keep the first-on-the-list default.

One thing worth your call: this ships a named bike preference to everyone, not just to you. If you'd rather it were neutral, the alternative is to remember the last model you picked and default to that — same effect for you after one pick, no brand baked in. Say the word and I'll swap it.

### Verified

- `tsc --noEmit` and `eslint` clean.
- Match token checked against the real installed bike list (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)