### PR TITLE
feat(diagnostics): report and read what the running game has loaded

### DIFF
--- a/control-plane/migrations/0016_client_diagnostics.sql
+++ b/control-plane/migrations/0016_client_diagnostics.sql
@@ -1,0 +1,105 @@
+-- What is loaded inside a player's running game, so a session can be explained after it ends.
+--
+-- The app already reports presence and usage; this is the same idea applied to the game
+-- process itself. The client walks the module list of the running game and sends what it
+-- finds — file name, where it was loaded from, and a hash for anything that is not a Windows
+-- system library. It sends observations and nothing else: every judgement about what an
+-- observation *means* is made here, against `module_rules`, so the shipped binary carries no
+-- opinion about any file and there is nothing in it to read.
+--
+-- Three tables, because they answer three different questions:
+--
+--   * `client_modules`   — what is true right now. One row per account, rewritten on every
+--                          report, exactly like `presence`. Live state, not history.
+--   * `client_module_seen` — what has ever been seen, per account and per file. Append-only
+--                          in spirit (an upsert that bumps `last_at` and `hits`), because
+--                          the live row forgets and the interesting observation is usually
+--                          the one that was true ten minutes ago.
+--   * `module_rules`     — how to read all of it. Editable at runtime from the admin page,
+--                          so a new entry takes effect on the next report from every client
+--                          without a release, a deploy, or a commit.
+--
+-- A client that is not running the app has no row. So a read answers "what have we been
+-- told", never "what is true of everyone" — a missing row is the ordinary case.
+
+-- Live state, one row per account.
+CREATE TABLE client_modules (
+  account_id    TEXT PRIMARY KEY REFERENCES accounts (id) ON DELETE CASCADE,
+  -- 'ok' | 'warn' | 'alert' | 'unknown'. Text rather than an integer so a row read straight
+  -- out of the database says what it means. 'unknown' is its own state and never means
+  -- 'ok': it is what a client reports when it could not read the module list at all.
+  state         TEXT NOT NULL,
+  -- Highest `module_rules.id` in force when this was classified. A row read as 'ok' against
+  -- an empty rule list means much less than one read against the current list, and the two
+  -- are only distinguishable if the version travels with the verdict.
+  rules_version INTEGER NOT NULL,
+  -- How many modules were in the list, and how many of those came from outside the game,
+  -- the system, and anything the app installed. The second number is the one worth reading.
+  module_count  INTEGER NOT NULL,
+  unknown_count INTEGER NOT NULL,
+  -- JSON array of {name,sha256,label} for rule-matched modules only.
+  matched       TEXT NOT NULL,
+  -- The worst state reported inside the freshness window, and when.
+  --
+  -- Without it the whole thing is defeated by unloading: load something for one lap, unload
+  -- it, and the next report overwrites 'alert' with 'ok' as if nothing happened. The live
+  -- read only surfaces this while `worst_at` is inside the same window presence uses, so it
+  -- describes the current session. `client_module_seen` is what remembers past that.
+  worst_state   TEXT NOT NULL,
+  worst_at      INTEGER NOT NULL,
+  -- Which build reported. A state that only ever appears on one app version is a bug in the
+  -- app before it is anything about the player.
+  app_version   TEXT NOT NULL DEFAULT '',
+  updated_at    INTEGER NOT NULL
+);
+
+-- Everything that has been seen loaded in anyone's game, per account and per file.
+--
+-- Keyed by account + name + hash, so a file that loads on every launch is one row with a
+-- rising `hits` rather than a thousand rows. System libraries are deliberately not recorded
+-- here: there are hundreds of them, they are the same on every machine, and they would bury
+-- the handful of rows that are worth looking at.
+CREATE TABLE client_module_seen (
+  account_id  TEXT NOT NULL REFERENCES accounts (id) ON DELETE CASCADE,
+  name        TEXT NOT NULL,
+  -- Empty when the client could not read the file (deleted mid-session, or locked).
+  sha256      TEXT NOT NULL,
+  -- 'game' | 'app' | 'other' — where it was loaded from, as the client saw it.
+  origin      TEXT NOT NULL,
+  -- What the rules made of it the last time it was seen.
+  state       TEXT NOT NULL,
+  label       TEXT NOT NULL DEFAULT '',
+  -- Snapshots, so a row still reads as something after the session and the presence row are
+  -- both gone. Not a join: who they were and where they were at the time is the fact.
+  rider_name  TEXT NOT NULL DEFAULT '',
+  server_id   TEXT NOT NULL DEFAULT '',
+  first_at    INTEGER NOT NULL,
+  last_at     INTEGER NOT NULL,
+  hits        INTEGER NOT NULL DEFAULT 1,
+  PRIMARY KEY (account_id, name, sha256)
+);
+
+-- The admin view opens on "what is not ok, most recent first", and the prevalence column
+-- asks "how many other accounts have ever loaded this file" — a file seen on one machine out
+-- of hundreds is the interesting one, whatever any rule says about it.
+CREATE INDEX client_module_seen_state ON client_module_seen (state, last_at);
+CREATE INDEX client_module_seen_name ON client_module_seen (name, sha256);
+
+-- How to read an observation.
+--
+-- `deny` names something that should not be in a game process; `allow` says a file is fine
+-- wherever it loads from, which is how a false positive is silenced. A rule matches by hash
+-- or by lowercase name substring, never both — an entry needing each is two rules sharing a
+-- label. `id` is monotone and its maximum is the rules version reported beside every state,
+-- which is why this table is never rewritten in place.
+CREATE TABLE module_rules (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  kind       TEXT NOT NULL,
+  pattern    TEXT NOT NULL DEFAULT '',
+  sha256     TEXT NOT NULL DEFAULT '',
+  label      TEXT NOT NULL DEFAULT '',
+  note       TEXT NOT NULL DEFAULT '',
+  created_at INTEGER NOT NULL
+);
+
+CREATE UNIQUE INDEX module_rules_unique ON module_rules (kind, pattern, sha256);

--- a/control-plane/src/diagnostics.ts
+++ b/control-plane/src/diagnostics.ts
@@ -1,0 +1,604 @@
+/**
+ * What is loaded inside a player's running game.
+ *
+ * The app walks the module list of the running game and posts it here — file name, where it
+ * came from, and a hash for anything that is not a Windows system library. That is the whole
+ * of the client's job: it observes and reports, and it holds no opinion about any file.
+ *
+ * Every judgement lives here instead, against `module_rules`, and that split is the design
+ * rather than an accident of layering:
+ *
+ *   * **The client cannot be read.** A shipped binary is one `strings` away from telling
+ *     anyone what it looks for. Nothing in it looks for anything.
+ *   * **A rule takes effect immediately**, on the next report from every install, without a
+ *     release or a deploy — which matters because the thing being described changes weekly.
+ *   * **The client is never told what we made of it.** `putReport` answers `{ ok: true }`
+ *     whatever it decided. A client that could read its own state could be made to stop
+ *     reporting exactly when the answer got interesting.
+ *
+ * Three states above "we could not look", and the middle one is doing the real work:
+ *
+ *   * `ok`      — everything in the list is accounted for.
+ *   * `warn`    — something is loaded that nothing accounts for. Not a conclusion. An
+ *                 overlay nobody has listed yet lands here, and so does the first sighting
+ *                 of something that matters.
+ *   * `alert`   — a rule named it.
+ *   * `unknown` — the list could not be read. Never folded into `ok`: a report that says a
+ *                 machine is fine when it was never looked at is worse than no report.
+ *
+ * The honest limit, stated once: this describes clients that run the app and report. Someone
+ * who does not is not described, and someone who patches the app reports what they like. It
+ * raises the cost of the ordinary case; it is not a wall.
+ */
+
+import { isAppVersion, isSha256, PRESENCE_TTL_MS } from "./validate";
+
+export interface Account {
+  id: string;
+  rider_name: string;
+}
+
+/** Where the client loaded a module from. Its judgement of location, not of character. */
+export type Origin = "game" | "system" | "app" | "other";
+
+export type State = "unknown" | "ok" | "warn" | "alert";
+
+/** Worst-last, so a report's state is the maximum over its modules. */
+const STATE_RANK: Record<State, number> = { unknown: 0, ok: 1, warn: 2, alert: 3 };
+
+export function stateRank(value: string): number {
+  return STATE_RANK[value as State] ?? 0;
+}
+
+export function isState(value: unknown): value is State {
+  return typeof value === "string" && value in STATE_RANK;
+}
+
+export interface ReportedModule {
+  name: string;
+  origin: Origin;
+  /** Empty for system libraries, which the client does not hash, and for unreadable files. */
+  sha256: string;
+}
+
+export interface ModuleRule {
+  id: number;
+  kind: "deny" | "allow";
+  /** Lowercase substring of a file name. Empty when the rule matches by hash. */
+  pattern: string;
+  sha256: string;
+  label: string;
+}
+
+/** One rule-matched module, as it is stored and shown. */
+export interface Matched {
+  name: string;
+  sha256: string;
+  label: string;
+}
+
+export interface Classification {
+  state: State;
+  matched: Matched[];
+  /** Loaded from somewhere nothing accounts for. */
+  unknown: ReportedModule[];
+}
+
+/** A module list longer than this is not a game, it is a client bug or an attempt at one. */
+export const MAX_MODULES = 400;
+
+/** A file name. Long enough for anything real, short enough to be a column. */
+const MAX_NAME = 96;
+
+const ORIGINS: readonly string[] = ["game", "system", "app", "other"];
+
+/** Anything but a plain file name: a path would carry the player's user folder with it. */
+const NAME_SHAPE = /^[a-z0-9._+()-]+$/;
+
+/**
+ * Names the Windows loader will pull out of the executable's own folder before it looks
+ * anywhere else.
+ *
+ * A file with one of these names beside the game's exe is loaded into it without anything
+ * having to inject it, which makes it the cheapest way into a process — and the one case
+ * where sitting in the game's own folder is the observation rather than the defence. Kept
+ * here rather than in the client for the reason everything else is: it is a thing we look
+ * for, and the client looks for nothing.
+ *
+ * `opengl32.dll` is on the list and is also how ReShade legitimately installs into an OpenGL
+ * title, which MX Bikes is. That is what `allow` rules are for: allow the hash once, and
+ * every install carrying that exact file reads as accounted for.
+ */
+const LOADER_NAMES: readonly string[] = [
+  "opengl32.dll",
+  "dxgi.dll",
+  "d3d9.dll",
+  "d3d10.dll",
+  "d3d11.dll",
+  "d3d12.dll",
+  "dinput8.dll",
+  "dsound.dll",
+  "winmm.dll",
+  "version.dll",
+  "wininet.dll",
+  "xinput1_3.dll",
+];
+
+/**
+ * Read a reported module list, or `null` if it is not one.
+ *
+ * Bounded on every axis before anything is stored: this is a list of strings from a client,
+ * and it becomes rows in a table and text on an admin's page.
+ */
+export function parseModules(value: unknown): ReportedModule[] | null {
+  if (!Array.isArray(value)) return null;
+  if (value.length > MAX_MODULES) return null;
+  const out: ReportedModule[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") return null;
+    const { name, origin, sha256 } = entry as Record<string, unknown>;
+    if (typeof name !== "string" || typeof origin !== "string") return null;
+    const clean = name.trim().toLowerCase();
+    if (!clean || clean.length > MAX_NAME) return null;
+    if (!NAME_SHAPE.test(clean)) return null;
+    if (!ORIGINS.includes(origin)) return null;
+    const hash = typeof sha256 === "string" ? sha256.trim().toLowerCase() : "";
+    if (hash && !isSha256(hash)) return null;
+    const key = `${clean} ${hash}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ name: clean, origin: origin as Origin, sha256: hash });
+  }
+  return out;
+}
+
+/**
+ * What the rules make of one module list.
+ *
+ * The order is the policy, and it is deliberate:
+ *
+ *   1. **Deny first.** A named file is named wherever it loaded from — something that copies
+ *      itself into the game's folder must not be trusted for being there.
+ *   2. **Allow next**, so a false positive is silenced by adding one row, not by a release.
+ *   3. **Loader names in the game's folder**, the one case where the location is the point.
+ *   4. **Anything from outside** the game, the system, and what the app installed.
+ *   5. Everything else is accounted for.
+ */
+export function classify(modules: ReportedModule[], rules: ModuleRule[]): Classification {
+  const deny = rules.filter((r) => r.kind === "deny");
+  const allow = rules.filter((r) => r.kind === "allow");
+  const matched: Matched[] = [];
+  const unknown: ReportedModule[] = [];
+
+  for (const mod of modules) {
+    const hit = matchRule(deny, mod);
+    if (hit) {
+      matched.push({ name: mod.name, sha256: mod.sha256, label: hit.label });
+      continue;
+    }
+    if (matchRule(allow, mod)) continue;
+    if (mod.origin === "game" && LOADER_NAMES.includes(mod.name)) {
+      unknown.push(mod);
+      continue;
+    }
+    if (mod.origin === "other") unknown.push(mod);
+  }
+
+  const state: State = matched.length > 0 ? "alert" : unknown.length > 0 ? "warn" : "ok";
+  return { state, matched, unknown };
+}
+
+/** The first rule that names this module, by hash or by name. */
+function matchRule(rules: ModuleRule[], mod: ReportedModule): ModuleRule | null {
+  for (const rule of rules) {
+    if (rule.sha256 && mod.sha256 && rule.sha256 === mod.sha256) return rule;
+    if (rule.pattern && mod.name.includes(rule.pattern)) return rule;
+  }
+  return null;
+}
+
+/** The rules in force, oldest first. Version is `max(id)` — see the migration. */
+export async function loadRules(env: Env): Promise<{ rules: ModuleRule[]; version: number }> {
+  const rows = await env.DB.prepare(
+    "SELECT id, kind, pattern, sha256, label FROM module_rules ORDER BY id",
+  ).all<{ id: number; kind: string; pattern: string; sha256: string; label: string }>();
+  const rules = (rows.results ?? [])
+    .filter((r) => r.kind === "deny" || r.kind === "allow")
+    .map((r) => ({
+      id: r.id,
+      kind: r.kind as "deny" | "allow",
+      pattern: (r.pattern ?? "").toLowerCase(),
+      sha256: (r.sha256 ?? "").toLowerCase(),
+      label: r.label ?? "",
+    }));
+  const version = rules.reduce((max, r) => Math.max(max, r.id), 0);
+  return { rules, version };
+}
+
+/**
+ * A client posting what its game has loaded.
+ *
+ * Answers `{ ok: true }` for everything it accepts, including the reports it finds most
+ * interesting. Nothing about the classification travels back down the wire.
+ */
+export async function putReport(request: Request, account: Account, env: Env): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return json(400, { error: "expected a JSON body" });
+  }
+  if (!body || typeof body !== "object") return json(400, { error: "expected a JSON body" });
+  const { modules, appVersion, available } = body as Record<string, unknown>;
+
+  const now = Date.now();
+  const version = isAppVersion(appVersion) ? appVersion : "";
+
+  // The client saying it could not read the list. A real answer, stored as one: it is the
+  // difference between "nothing was loaded" and "we were not allowed to look", and an app
+  // running below the game's integrity level reports it every pass.
+  if (available === false) {
+    await store(env, account, "unknown", 0, 0, 0, [], [], version, now);
+    return json(200, { ok: true });
+  }
+
+  const list = parseModules(modules);
+  if (!list) return json(400, { error: "that is not a module list" });
+
+  const { rules, version: rulesVersion } = await loadRules(env);
+  const verdict = classify(list, rules);
+  await store(
+    env,
+    account,
+    verdict.state,
+    rulesVersion,
+    list.length,
+    verdict.unknown.length,
+    verdict.matched,
+    // System libraries are not recorded per-file: hundreds of them, identical everywhere,
+    // and they would bury the rows worth reading.
+    list.filter((m) => m.origin !== "system"),
+    version,
+    now,
+  );
+  return json(200, { ok: true });
+}
+
+/**
+ * Write one report: the live row, and a row per non-system module seen.
+ *
+ * The live row keeps the worst state of the recent past alongside the current one, for the
+ * reason the migration gives — otherwise the feature is defeated by unloading. The `seen`
+ * rows are what survive the session.
+ */
+async function store(
+  env: Env,
+  account: Account,
+  state: State,
+  rulesVersion: number,
+  moduleCount: number,
+  unknownCount: number,
+  matched: Matched[],
+  seen: ReportedModule[],
+  appVersion: string,
+  now: number,
+): Promise<void> {
+  const prev = await env.DB.prepare(
+    "SELECT worst_state, worst_at FROM client_modules WHERE account_id = ?",
+  )
+    .bind(account.id)
+    .first<{ worst_state: string; worst_at: number }>();
+  const stillCurrent = prev !== null && prev.worst_at > now - PRESENCE_TTL_MS;
+  const keepWorst = stillCurrent && stateRank(prev!.worst_state) > stateRank(state);
+
+  const where = await env.DB.prepare(
+    "SELECT server_id FROM presence WHERE account_id = ? AND updated_at > ?",
+  )
+    .bind(account.id, now - PRESENCE_TTL_MS)
+    .first<{ server_id: string }>();
+  const serverId = where?.server_id ?? "";
+
+  const byName = new Map<string, Matched>();
+  for (const hit of matched) byName.set(`${hit.name} ${hit.sha256}`, hit);
+
+  const statements = [
+    env.DB.prepare(
+      "INSERT INTO client_modules (account_id, state, rules_version, module_count," +
+        " unknown_count, matched, worst_state, worst_at, app_version, updated_at)" +
+        " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)" +
+        " ON CONFLICT(account_id) DO UPDATE SET state = excluded.state," +
+        " rules_version = excluded.rules_version, module_count = excluded.module_count," +
+        " unknown_count = excluded.unknown_count, matched = excluded.matched," +
+        " worst_state = excluded.worst_state, worst_at = excluded.worst_at," +
+        " app_version = excluded.app_version, updated_at = excluded.updated_at",
+    ).bind(
+      account.id,
+      state,
+      rulesVersion,
+      moduleCount,
+      unknownCount,
+      JSON.stringify(matched),
+      keepWorst ? prev!.worst_state : state,
+      keepWorst ? prev!.worst_at : now,
+      appVersion,
+      now,
+    ),
+  ];
+
+  for (const mod of seen) {
+    const hit = byName.get(`${mod.name} ${mod.sha256}`);
+    // Per module rather than per report: this row is about the file, so it carries what the
+    // rules made of that file and not the state of the machine it was on.
+    const modState: State = hit ? "alert" : unknownState(mod, state);
+    statements.push(
+      env.DB.prepare(
+        "INSERT INTO client_module_seen (account_id, name, sha256, origin, state, label," +
+          " rider_name, server_id, first_at, last_at, hits)" +
+          " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)" +
+          " ON CONFLICT(account_id, name, sha256) DO UPDATE SET origin = excluded.origin," +
+          " state = excluded.state, label = excluded.label, rider_name = excluded.rider_name," +
+          " server_id = excluded.server_id, last_at = excluded.last_at, hits = hits + 1",
+      ).bind(
+        account.id,
+        mod.name,
+        mod.sha256,
+        mod.origin,
+        modState,
+        hit?.label ?? "",
+        account.rider_name,
+        serverId,
+        now,
+        now,
+      ),
+    );
+  }
+
+  await env.DB.batch(statements);
+}
+
+/** Was this module one of the ones nothing accounted for in the report it arrived in? */
+function unknownState(mod: ReportedModule, reportState: State): State {
+  if (mod.origin === "other") return "warn";
+  if (mod.origin === "game" && LOADER_NAMES.includes(mod.name)) return "warn";
+  return reportState === "unknown" ? "unknown" : "ok";
+}
+
+/** One account's current answer, for the admin page. */
+export interface LiveRow {
+  accountId: string;
+  riderName: string;
+  guid: string;
+  serverId: string;
+  state: State;
+  worstState: State;
+  worstAt: number;
+  rulesVersion: number;
+  moduleCount: number;
+  unknownCount: number;
+  matched: Matched[];
+  appVersion: string;
+  updatedAt: number;
+}
+
+/** One file, as it has been seen across everyone. */
+export interface SeenRow {
+  accountId: string;
+  riderName: string;
+  serverId: string;
+  name: string;
+  sha256: string;
+  origin: string;
+  state: State;
+  label: string;
+  firstAt: number;
+  lastAt: number;
+  hits: number;
+  /** How many distinct accounts have ever loaded this exact file. */
+  accounts: number;
+}
+
+export interface AdminView {
+  live: LiveRow[];
+  seen: SeenRow[];
+  rules: ModuleRule[];
+  rulesVersion: number;
+  reporting: number;
+}
+
+/**
+ * Everything the admin page draws.
+ *
+ * `live` is who is reporting right now, worst first. `seen` is the evidence log — every
+ * non-system file anyone's game has loaded that the rules do not account for, most recent
+ * first, with the number of accounts that have ever loaded it. That last number is the one
+ * that reads best: a file on one machine out of hundreds is interesting whatever any rule
+ * says, and a file on all of them is a driver.
+ */
+export async function collectAdminView(env: Env, days: number): Promise<AdminView> {
+  const fresh = Date.now() - PRESENCE_TTL_MS;
+  const since = Date.now() - days * 24 * 60 * 60 * 1000;
+
+  const live = await env.DB.prepare(
+    "SELECT c.account_id, a.rider_name, a.guid, c.state, c.rules_version, c.module_count," +
+      " c.unknown_count, c.matched, c.worst_state, c.worst_at, c.app_version, c.updated_at," +
+      " (SELECT p.server_id FROM presence p WHERE p.account_id = c.account_id" +
+      "  AND p.updated_at > ?) AS server_id" +
+      " FROM client_modules c JOIN accounts a ON a.id = c.account_id" +
+      " WHERE c.updated_at > ?",
+  )
+    .bind(fresh, fresh)
+    .all<{
+      account_id: string;
+      rider_name: string;
+      guid: string | null;
+      state: string;
+      rules_version: number;
+      module_count: number;
+      unknown_count: number;
+      matched: string;
+      worst_state: string;
+      worst_at: number;
+      app_version: string;
+      updated_at: number;
+      server_id: string | null;
+    }>();
+
+  const seen = await env.DB.prepare(
+    "SELECT s.account_id, s.rider_name, s.server_id, s.name, s.sha256, s.origin, s.state," +
+      " s.label, s.first_at, s.last_at, s.hits," +
+      " (SELECT COUNT(DISTINCT t.account_id) FROM client_module_seen t" +
+      "  WHERE t.name = s.name AND t.sha256 = s.sha256) AS accounts" +
+      " FROM client_module_seen s" +
+      " WHERE s.state IN ('warn', 'alert') AND s.last_at > ?" +
+      " ORDER BY s.last_at DESC LIMIT 500",
+  )
+    .bind(since)
+    .all<{
+      account_id: string;
+      rider_name: string;
+      server_id: string;
+      name: string;
+      sha256: string;
+      origin: string;
+      state: string;
+      label: string;
+      first_at: number;
+      last_at: number;
+      hits: number;
+      accounts: number;
+    }>();
+
+  const { rules, version } = await loadRules(env);
+
+  return {
+    live: (live.results ?? [])
+      .map((r) => ({
+        accountId: r.account_id,
+        riderName: r.rider_name,
+        guid: r.guid ?? "",
+        serverId: r.server_id ?? "",
+        state: isState(r.state) ? r.state : "unknown",
+        worstState:
+          r.worst_at > fresh && isState(r.worst_state) ? r.worst_state : "unknown",
+        worstAt: r.worst_at,
+        rulesVersion: r.rules_version,
+        moduleCount: r.module_count,
+        unknownCount: r.unknown_count,
+        matched: parseMatched(r.matched),
+        appVersion: r.app_version ?? "",
+        updatedAt: r.updated_at,
+      }))
+      .sort(
+        (a, b) =>
+          Math.max(stateRank(b.worstState), stateRank(b.state)) -
+            Math.max(stateRank(a.worstState), stateRank(a.state)) ||
+          b.updatedAt - a.updatedAt,
+      ),
+    seen: (seen.results ?? []).map((r) => ({
+      accountId: r.account_id,
+      riderName: r.rider_name ?? "",
+      serverId: r.server_id ?? "",
+      name: r.name,
+      sha256: r.sha256,
+      origin: r.origin,
+      state: isState(r.state) ? r.state : "unknown",
+      label: r.label ?? "",
+      firstAt: r.first_at,
+      lastAt: r.last_at,
+      hits: r.hits,
+      accounts: r.accounts,
+    })),
+    rules,
+    rulesVersion: version,
+    reporting: (live.results ?? []).length,
+  };
+}
+
+/** A stored JSON column read back. A row that will not parse is empty, never a 500. */
+function parseMatched(text: string): Matched[] {
+  try {
+    const value = JSON.parse(text);
+    if (!Array.isArray(value)) return [];
+    return value
+      .filter((v) => v && typeof v === "object")
+      .map((v) => ({
+        name: String((v as Matched).name ?? ""),
+        sha256: String((v as Matched).sha256 ?? ""),
+        label: String((v as Matched).label ?? ""),
+      }))
+      .filter((v) => v.name);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Add a rule.
+ *
+ * Takes effect on the next report from every install. Nothing re-reads the past: a rule
+ * added now says what the next sighting means, and the row that prompted it keeps whatever
+ * it was recorded as — which is the honest record of what was known at the time.
+ */
+export async function addRule(
+  env: Env,
+  kind: string,
+  pattern: string,
+  sha256: string,
+  label: string,
+  note: string,
+): Promise<{ ok: boolean; error?: string }> {
+  if (kind !== "deny" && kind !== "allow") return { ok: false, error: "kind must be deny or allow" };
+  const cleanPattern = pattern.trim().toLowerCase().slice(0, 96);
+  const cleanHash = sha256.trim().toLowerCase();
+  if (cleanHash && !isSha256(cleanHash)) return { ok: false, error: "that is not a sha256" };
+  if (!cleanPattern && !cleanHash) return { ok: false, error: "a name or a hash is required" };
+  // One or the other. A rule carrying both reads as "this name with this hash" to whoever
+  // writes it and as "this name, or this hash" to the matcher, and the gap between those is
+  // where a wrong accusation comes from.
+  if (cleanPattern && cleanHash) return { ok: false, error: "a name or a hash, not both" };
+  await env.DB.prepare(
+    "INSERT INTO module_rules (kind, pattern, sha256, label, note, created_at)" +
+      " VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(kind, pattern, sha256) DO UPDATE SET" +
+      " label = excluded.label, note = excluded.note",
+  )
+    .bind(kind, cleanPattern, cleanHash, label.trim().slice(0, 96), note.trim().slice(0, 256), Date.now())
+    .run();
+  return { ok: true };
+}
+
+/** Drop a rule by id. The version does not go backwards: `max(id)` is over what remains. */
+export async function deleteRule(env: Env, id: number): Promise<void> {
+  await env.DB.prepare("DELETE FROM module_rules WHERE id = ?").bind(id).run();
+}
+
+/** How long a sighting is kept. Long enough to describe a season, not a career. */
+const RETENTION_DAYS = 90;
+
+/**
+ * Drop sightings nobody will read again.
+ *
+ * Runs on the same cron sweep as the other prunes. A failed sweep is the next sweep's
+ * problem: it must never be able to take out a scheduled run that also does real work.
+ */
+export async function pruneReports(env: Env): Promise<void> {
+  try {
+    await env.DB.batch([
+      env.DB.prepare("DELETE FROM client_module_seen WHERE last_at < ?").bind(
+        Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000,
+      ),
+      env.DB.prepare("DELETE FROM client_modules WHERE updated_at < ?").bind(
+        Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000,
+      ),
+    ]);
+  } catch (err) {
+    console.error(JSON.stringify({ msg: "report sweep failed", error: String(err) }));
+  }
+}
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}

--- a/control-plane/src/diagnosticspage.ts
+++ b/control-plane/src/diagnosticspage.ts
@@ -1,0 +1,345 @@
+/**
+ * The client diagnostics dashboard, rendered on the server.
+ *
+ * Plain HTML with its CSS inline and no scripts, for the reason the usage page gives: a page
+ * behind an admin key that pulls anything from someone else's host stops working the day
+ * that host does, and this is the only view of this data there is.
+ *
+ * It is a working surface rather than a report. The list of files nothing accounts for is
+ * next to the buttons that account for them — see something, name it or clear it, and the
+ * next report from every install reads it the new way. That loop is the feature; a page that
+ * only displayed would leave the rule list permanently empty.
+ */
+
+import {
+  addRule,
+  collectAdminView,
+  deleteRule,
+  stateRank,
+  type AdminView,
+  type LiveRow,
+  type ModuleRule,
+  type SeenRow,
+  type State,
+} from "./diagnostics";
+import { adminAllowed, windowDays } from "./usage";
+
+/** Windows the header offers. Anything else still works via `?days=`. */
+const RANGES = [1, 7, 30, 90];
+
+export async function diagnosticsDashboard(
+  request: Request,
+  url: URL,
+  env: Env,
+): Promise<Response> {
+  const allowed = adminAllowed(request, url, env);
+  if (allowed === "unset") return page(503, "No admin key is configured on this deployment.");
+  if (allowed === "denied") return page(401, "Unauthorized.");
+
+  const days = windowDays(url);
+  const view = await collectAdminView(env, days);
+  return new Response(render(view, url, days), {
+    status: 200,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      // About named people, behind a key: never cached by anything in between.
+      "cache-control": "no-store",
+    },
+  });
+}
+
+/**
+ * The rule buttons post here and come back to the page.
+ *
+ * A 303 rather than a rendered result, so a refresh does not re-submit — this is the one
+ * surface where a double-click would silently add a rule twice.
+ */
+export async function diagnosticsRules(request: Request, url: URL, env: Env): Promise<Response> {
+  const allowed = adminAllowed(request, url, env);
+  if (allowed === "unset") return page(503, "No admin key is configured on this deployment.");
+  if (allowed === "denied") return page(401, "Unauthorized.");
+
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return page(400, "That was not a form.");
+  }
+  const back = `/admin/diagnostics${url.search}`;
+  const field = (name: string) => String(form.get(name) ?? "");
+
+  if (field("action") === "delete") {
+    const id = Number(field("id"));
+    if (Number.isInteger(id) && id > 0) await deleteRule(env, id);
+    return redirect(back);
+  }
+
+  const result = await addRule(
+    env,
+    field("kind"),
+    field("pattern"),
+    field("sha256"),
+    field("label"),
+    field("note"),
+  );
+  if (!result.ok) return page(400, result.error ?? "That rule was not usable.");
+  return redirect(back);
+}
+
+function redirect(to: string): Response {
+  return new Response(null, { status: 303, headers: { location: to, "cache-control": "no-store" } });
+}
+
+function render(v: AdminView, url: URL, days: number): string {
+  const key = url.searchParams.get("key");
+  const suffix = key ? `&key=${encodeURIComponent(key)}` : "";
+  const href = (d: number) => `?days=${d}${suffix}`;
+  const action = `/admin/diagnostics/rules?days=${days}${suffix}`;
+
+  const alerts = v.live.filter((r) => worst(r) === "alert");
+  const warns = v.live.filter((r) => worst(r) === "warn");
+  const blind = v.live.filter((r) => r.state === "unknown");
+
+  return `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>MXB App client diagnostics</title>
+<style>${CSS}</style>
+</head><body>
+<header>
+  <h1>Client diagnostics</h1>
+  <nav>${RANGES.map(
+    (d) => `<a class="${d === days ? "on" : ""}" href="${esc(href(d))}">${d}d</a>`,
+  ).join("")}</nav>
+</header>
+
+<section class="tiles">
+  ${tile("Reporting now", v.reporting, "clients that reported in the last 10 minutes")}
+  ${tile("Alerts", alerts.length, "a rule named something in their game", alerts.length ? "alert" : "")}
+  ${tile("Unaccounted", warns.length, "something loaded that no rule accounts for", warns.length ? "warn" : "")}
+  ${tile("Could not look", blind.length, "the app could not read the module list")}
+  ${tile("Rules", v.rules.length, `version ${v.rulesVersion}`)}
+</section>
+
+<section class="panel">
+  <h2>Reporting now</h2>
+  ${live(v.live)}
+</section>
+
+<section class="panel">
+  <h2>Files nothing accounts for <span class="muted">— last ${days}d, most recent first</span></h2>
+  <p class="muted">Accounts is how many distinct people have ever loaded this exact file. One
+    out of many is the interesting shape; many is a driver or an overlay, and worth allowing
+    so it stops filling this list.</p>
+  ${sightings(v.seen, action)}
+</section>
+
+<section class="panel">
+  <h2>Rules</h2>
+  ${rules(v.rules, action)}
+  <form class="add" method="post" action="${esc(action)}">
+    <select name="kind" aria-label="kind">
+      <option value="deny">deny</option>
+      <option value="allow">allow</option>
+    </select>
+    <input name="pattern" placeholder="name contains" maxlength="96">
+    <input name="sha256" placeholder="or sha256" maxlength="64">
+    <input name="label" placeholder="label" maxlength="96">
+    <input name="note" placeholder="note" maxlength="256">
+    <button type="submit">Add</button>
+  </form>
+  <p class="muted">A name or a hash, not both. A name matches as a substring, so
+    <code>trainer</code> catches <code>trainer_v3.dll</code>. A hash is exact and survives a
+    rename. Adding a deny rule says the person running that file is cheating — be sure.</p>
+</section>
+
+<footer class="muted">
+  Only clients running the app report, so this says what we have been told and never what is
+  true of everybody. A missing row is the ordinary case, not a suspicious one, and someone
+  who never installs the app never appears here at all.
+  Generated ${esc(new Date().toISOString().replace("T", " ").slice(0, 16))} UTC.
+</footer>
+</body></html>`;
+}
+
+/** The worse of what a client says now and the worst it said inside the window. */
+function worst(row: LiveRow): State {
+  return stateRank(row.worstState) > stateRank(row.state) ? row.worstState : row.state;
+}
+
+function tile(label: string, value: number, hint: string, tone = ""): string {
+  return `<div class="tile ${tone}"><span class="n">${value.toLocaleString("en-GB")}</span>
+    <span class="l">${esc(label)}</span><span class="h">${esc(hint)}</span></div>`;
+}
+
+function live(rows: LiveRow[]): string {
+  if (!rows.length) return `<p class="muted">Nobody is reporting right now.</p>`;
+  return `<table>
+  <thead><tr><th>Rider</th><th>State</th><th>Server</th><th>Found</th>
+    <th class="num">Unaccounted</th><th class="num">Modules</th><th>App</th><th>Seen</th></tr></thead>
+  <tbody>${rows
+    .map((r) => {
+      const now = r.state;
+      const peak = worst(r);
+      const drift = peak !== now ? ` <span class="muted">(was ${esc(peak)})</span>` : "";
+      const found = r.matched.length
+        ? r.matched.map((m) => `<code>${esc(m.label || m.name)}</code>`).join(" ")
+        : `<span class="muted">—</span>`;
+      return `<tr>
+      <td>${esc(r.riderName)}</td>
+      <td><span class="pill ${esc(peak)}">${esc(now)}</span>${drift}</td>
+      <td class="muted">${esc(r.serverId || "—")}</td>
+      <td>${found}</td>
+      <td class="num">${r.unknownCount}</td>
+      <td class="num">${r.moduleCount}</td>
+      <td class="muted">${esc(r.appVersion || "—")}</td>
+      <td class="muted">${esc(ago(r.updatedAt))}</td>
+    </tr>`;
+    })
+    .join("")}</tbody></table>`;
+}
+
+function sightings(rows: SeenRow[], action: string): string {
+  if (!rows.length) return `<p class="muted">Nothing unaccounted for in this window.</p>`;
+  return `<table>
+  <thead><tr><th>File</th><th>Where</th><th>Rider</th><th class="num">Accounts</th>
+    <th class="num">Seen</th><th>Last</th><th></th></tr></thead>
+  <tbody>${rows
+    .map((r) => {
+      const short = r.sha256 ? r.sha256.slice(0, 12) : "";
+      const label = r.label ? ` <span class="muted">${esc(r.label)}</span>` : "";
+      return `<tr>
+      <td><span class="pill ${esc(r.state)}"></span> <code>${esc(r.name)}</code>${label}
+        ${short ? `<br><code class="muted">${esc(short)}</code>` : ""}</td>
+      <td class="muted">${esc(r.origin)}</td>
+      <td>${esc(r.riderName || "—")}</td>
+      <td class="num">${r.accounts}</td>
+      <td class="num">${r.hits}</td>
+      <td class="muted">${esc(ago(r.lastAt))}</td>
+      <td class="act">${ruleButtons(r, action)}</td>
+    </tr>`;
+    })
+    .join("")}</tbody></table>`;
+}
+
+/**
+ * The two buttons that turn a sighting into a rule.
+ *
+ * By hash when there is one, by name when there is not: a hash is what makes a rule survive
+ * a rename, and a name is all a file we could not read ever gives us.
+ */
+function ruleButtons(row: SeenRow, action: string): string {
+  const by = row.sha256
+    ? `<input type="hidden" name="sha256" value="${esc(row.sha256)}">`
+    : `<input type="hidden" name="pattern" value="${esc(row.name)}">`;
+  const one = (kind: string, text: string) => `<form method="post" action="${esc(action)}">
+      ${by}<input type="hidden" name="kind" value="${kind}">
+      <input type="hidden" name="label" value="${esc(row.label || row.name)}">
+      <button type="submit" class="${kind}">${text}</button>
+    </form>`;
+  return `${one("deny", "Flag")}${one("allow", "Clear")}`;
+}
+
+function rules(rows: ModuleRule[], action: string): string {
+  if (!rows.length) {
+    return `<p class="muted">No rules yet — everything from outside the game reads as
+      unaccounted for until one says otherwise.</p>`;
+  }
+  return `<table>
+  <thead><tr><th class="num">#</th><th>Kind</th><th>Matches</th><th>Label</th><th></th></tr></thead>
+  <tbody>${rows
+    .map(
+      (r) => `<tr>
+      <td class="num muted">${r.id}</td>
+      <td><span class="pill ${r.kind === "deny" ? "alert" : "ok"}">${esc(r.kind)}</span></td>
+      <td><code>${esc(r.pattern || r.sha256)}</code></td>
+      <td>${esc(r.label)}</td>
+      <td class="act"><form method="post" action="${esc(action)}">
+        <input type="hidden" name="action" value="delete">
+        <input type="hidden" name="id" value="${r.id}">
+        <button type="submit">Remove</button>
+      </form></td>
+    </tr>`,
+    )
+    .join("")}</tbody></table>`;
+}
+
+/** How long ago, in the coarsest unit that still says something. */
+function ago(at: number): string {
+  const secs = Math.max(0, Math.round((Date.now() - at) / 1000));
+  if (secs < 90) return `${secs}s ago`;
+  const mins = Math.round(secs / 60);
+  if (mins < 90) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 48) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+function page(status: number, message: string): Response {
+  return new Response(
+    `<!doctype html><html lang="en"><head><meta charset="utf-8">
+<title>MXB App client diagnostics</title>
+<style>${CSS}</style></head><body><header><h1>Client diagnostics</h1></header>
+<section class="panel"><p>${esc(message)}</p></section></body></html>`,
+    { status, headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" } },
+  );
+}
+
+function esc(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+const CSS = `
+:root{--bg:#f6f7f9;--panel:#fff;--ink:#16181d;--muted:#6b7280;--line:#e3e6ea;--accent:#e2492b;
+  --ok:#3f9e5a;--warn:#c98a1b;--alert:#d33b2c}
+@media (prefers-color-scheme:dark){
+  :root{--bg:#0f1114;--panel:#171a1f;--ink:#e8eaed;--muted:#9aa3ae;--line:#262b32;--accent:#ff6a42;
+    --ok:#4fb872;--warn:#e0a53a;--alert:#ff5c4d}
+}
+*{box-sizing:border-box}
+body{margin:0;padding:24px;background:var(--bg);color:var(--ink);
+  font:14px/1.5 ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+header{display:flex;align-items:baseline;justify-content:space-between;gap:16px;margin-bottom:20px}
+h1{font-size:18px;margin:0;letter-spacing:-.01em}
+h2{font-size:13px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);margin:0 0 12px}
+nav a{color:var(--muted);text-decoration:none;padding:4px 8px;border-radius:6px;margin-left:4px}
+nav a.on{background:var(--accent);color:#fff}
+.tiles{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px;margin-bottom:16px}
+.tile{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:14px;
+  display:flex;flex-direction:column;gap:2px}
+.tile.alert{border-color:var(--alert)}
+.tile.warn{border-color:var(--warn)}
+.tile .n{font-size:26px;font-weight:600;letter-spacing:-.02em}
+.tile .l{font-size:13px}
+.tile .h,.muted{color:var(--muted);font-size:12px}
+.panel{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:16px;margin-bottom:16px}
+table{width:100%;border-collapse:collapse}
+th{text-align:left;font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);
+  font-weight:500;padding:0 8px 8px;border-bottom:1px solid var(--line)}
+td{padding:7px 8px;border-bottom:1px solid var(--line);vertical-align:top}
+tr:last-child td{border-bottom:0}
+.num{text-align:right;font-variant-numeric:tabular-nums}
+.act{text-align:right;white-space:nowrap}
+.act form{display:inline}
+code{font:12px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace}
+.pill{display:inline-block;min-width:10px;padding:1px 7px;border-radius:99px;font-size:11px;
+  color:#fff;background:var(--muted)}
+.pill.ok{background:var(--ok)}
+.pill.warn{background:var(--warn)}
+.pill.alert{background:var(--alert)}
+button{font:inherit;font-size:12px;padding:3px 10px;border-radius:6px;border:1px solid var(--line);
+  background:var(--panel);color:var(--ink);cursor:pointer;margin-left:4px}
+button.deny{border-color:var(--alert);color:var(--alert)}
+button.allow{border-color:var(--ok);color:var(--ok)}
+.add{display:flex;flex-wrap:wrap;gap:8px;margin-top:14px}
+.add input,.add select{font:inherit;font-size:13px;padding:4px 8px;border-radius:6px;
+  border:1px solid var(--line);background:var(--bg);color:var(--ink);min-width:120px}
+.add input[name="sha256"]{min-width:260px}
+footer{color:var(--muted);font-size:12px;margin-top:8px;max-width:70ch}
+`;

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -26,6 +26,8 @@ import {
   terminateInstance,
 } from "./aws";
 import { bmacWebhook } from "./bmac";
+import { pruneReports, putReport } from "./diagnostics";
+import { diagnosticsDashboard, diagnosticsRules } from "./diagnosticspage";
 import { listPlugins, myPlugins, pluginBundle, redeemKey } from "./plugins";
 import { generateTrack } from "./trackgen";
 import { bootstrapScript, imageBootstrapScript } from "./bootstrap";
@@ -96,6 +98,7 @@ export default {
         advanceImageBuild(env),
         pruneDeviceClaims(env),
         pruneUsage(env),
+        pruneReports(env),
       ]).then(
         () => undefined,
       ),
@@ -186,6 +189,17 @@ async function route(request: Request, env: Env): Promise<Response> {
   if (method === "GET" && path === "/v1/usage/stats") return usageStats(request, url, env);
   if (method === "GET" && path === "/admin/usage") return usageDashboard(request, url, env);
 
+  // What the app sees loaded inside people's running games, and the rules that say how to
+  // read it. Behind `ADMIN_KEY` on the same terms as the usage page, and above the account
+  // gate for the same reason: the key belongs to whoever runs the deployment, and no
+  // player's token should ever be enough to read this about anybody else.
+  if (method === "GET" && path === "/admin/diagnostics") {
+    return diagnosticsDashboard(request, url, env);
+  }
+  if (method === "POST" && path === "/admin/diagnostics/rules") {
+    return diagnosticsRules(request, url, env);
+  }
+
   const account = await authenticate(request, env);
   if (!account) return json(401, { error: "unauthorized" });
 
@@ -194,6 +208,7 @@ async function route(request: Request, env: Env): Promise<Response> {
   if (method === "GET" && path === "/v1/me") return me(account, env);
   if (method === "PUT" && path === "/v1/me/guid") return putGuid(request, account, env);
   if (method === "PUT" && path === "/v1/presence") return putPresence(request, account, env);
+  if (method === "PUT" && path === "/v1/diagnostics") return putReport(request, account, env);
   if (method === "GET" && path === "/v1/voice/ice") return iceServers();
 
   // Paid plugins. Open to every account on the same terms as voice and paint sync: holding

--- a/control-plane/test/diagnostics.test.ts
+++ b/control-plane/test/diagnostics.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  classify,
+  MAX_MODULES,
+  parseModules,
+  stateRank,
+  type ModuleRule,
+  type Origin,
+} from "../src/diagnostics";
+
+function mod(name: string, origin: Origin, sha256 = "") {
+  return { name, origin, sha256 };
+}
+
+function rule(kind: "deny" | "allow", by: { pattern?: string; sha256?: string }): ModuleRule {
+  return { id: 1, kind, pattern: by.pattern ?? "", sha256: by.sha256 ?? "", label: "named" };
+}
+
+const HASH = "a".repeat(64);
+const OTHER_HASH = "b".repeat(64);
+
+describe("reading a reported module list", () => {
+  it("takes an ordinary one", () => {
+    const list = parseModules([
+      { name: "MXBikes.exe", origin: "game", sha256: HASH },
+      { name: "kernel32.dll", origin: "system" },
+    ]);
+    expect(list).toEqual([
+      { name: "mxbikes.exe", origin: "game", sha256: HASH },
+      { name: "kernel32.dll", origin: "system", sha256: "" },
+    ]);
+  });
+
+  it("refuses a path where a file name belongs", () => {
+    // The name is rendered on the admin page and stored as a column. A path would carry the
+    // player's user folder into both, which is exactly what this must never collect.
+    for (const bad of [
+      "c:/users/rider/cheats/x.dll",
+      "..\\x.dll",
+      "sub/dir.dll",
+      "my file.dll",
+    ]) {
+      expect(parseModules([{ name: bad, origin: "other" }]), bad).toBeNull();
+    }
+  });
+
+  it("refuses anything that is not a module list", () => {
+    expect(parseModules("nope")).toBeNull();
+    expect(parseModules([{ name: "x.dll" }])).toBeNull();
+    expect(parseModules([{ name: "x.dll", origin: "everywhere" }])).toBeNull();
+    expect(parseModules([{ name: "x.dll", origin: "other", sha256: "short" }])).toBeNull();
+    expect(parseModules([{ name: "x".repeat(200), origin: "other" }])).toBeNull();
+  });
+
+  it("caps the list, so one client cannot write a thousand rows", () => {
+    const many = Array.from({ length: MAX_MODULES + 1 }, (_, i) => ({
+      name: `m${i}.dll`,
+      origin: "system" as const,
+    }));
+    expect(parseModules(many)).toBeNull();
+    expect(parseModules(many.slice(0, MAX_MODULES))).toHaveLength(MAX_MODULES);
+  });
+
+  it("drops a repeat of the same file rather than storing it twice", () => {
+    const list = parseModules([
+      { name: "x.dll", origin: "other", sha256: HASH },
+      { name: "X.DLL", origin: "other", sha256: HASH.toUpperCase() },
+    ]);
+    expect(list).toHaveLength(1);
+  });
+});
+
+describe("what the rules make of a list", () => {
+  it("accounts for a plain machine", () => {
+    const v = classify(
+      [mod("mxbikes.exe", "game"), mod("kernel32.dll", "system"), mod("frostmod.dll", "app")],
+      [],
+    );
+    expect(v.state).toBe("ok");
+    expect(v.unknown).toHaveLength(0);
+  });
+
+  it("does not need a rule to notice something loaded from outside", () => {
+    // The heuristic is what works on day one, before anything has been named. A deployment
+    // with an empty rule list still sees the shape.
+    const v = classify([mod("something.dll", "other", HASH)], []);
+    expect(v.state).toBe("warn");
+    expect(v.unknown.map((m) => m.name)).toEqual(["something.dll"]);
+    expect(v.matched).toHaveLength(0);
+  });
+
+  it("names a file by hash wherever it loaded from", () => {
+    // The point of hashing: copying itself into the game's own folder must not buy trust.
+    const v = classify([mod("innocent.dll", "game", HASH)], [rule("deny", { sha256: HASH })]);
+    expect(v.state).toBe("alert");
+    expect(v.matched).toEqual([{ name: "innocent.dll", sha256: HASH, label: "named" }]);
+  });
+
+  it("names a file by a substring of its name", () => {
+    const v = classify([mod("trainer_v3.dll", "other")], [rule("deny", { pattern: "trainer" })]);
+    expect(v.state).toBe("alert");
+  });
+
+  it("lets an allow rule silence a false positive", () => {
+    const overlay = [mod("someoverlay.dll", "other", HASH)];
+    expect(classify(overlay, []).state).toBe("warn");
+    expect(classify(overlay, [rule("allow", { sha256: HASH })]).state).toBe("ok");
+  });
+
+  it("will not let an allow rule clear something a deny rule named", () => {
+    // Order is the policy: allow exists to quiet a heuristic, never to un-name a match.
+    const v = classify(
+      [mod("x.dll", "other", HASH)],
+      [rule("deny", { sha256: HASH }), rule("allow", { pattern: "x.dll" })],
+    );
+    expect(v.state).toBe("alert");
+  });
+
+  it("treats a loader name in the game's own folder as unaccounted for", () => {
+    // Nothing has to inject a d3d9.dll sitting beside the exe — the loader does it. Being in
+    // the game folder is the observation here, not the defence.
+    const v = classify([mod("d3d9.dll", "game", HASH)], []);
+    expect(v.state).toBe("warn");
+    expect(v.unknown.map((m) => m.name)).toEqual(["d3d9.dll"]);
+  });
+
+  it("clears a loader name once its exact file is allowed", () => {
+    // ReShade installs as opengl32.dll in an OpenGL title, which MX Bikes is. Allowing the
+    // hash clears that build everywhere without clearing the name for anyone else.
+    const reshade = [mod("opengl32.dll", "game", HASH)];
+    expect(classify(reshade, []).state).toBe("warn");
+    expect(classify(reshade, [rule("allow", { sha256: HASH })]).state).toBe("ok");
+    expect(classify([mod("opengl32.dll", "game", OTHER_HASH)], [rule("allow", { sha256: HASH })]).state)
+      .toBe("warn");
+  });
+
+  it("reports the worst thing it found, not the last", () => {
+    const v = classify(
+      [mod("unknown.dll", "other"), mod("bad.dll", "other", HASH), mod("kernel32.dll", "system")],
+      [rule("deny", { sha256: HASH })],
+    );
+    expect(v.state).toBe("alert");
+    expect(v.matched).toHaveLength(1);
+    expect(v.unknown).toHaveLength(1);
+  });
+});
+
+describe("state ordering", () => {
+  it("puts 'could not look' below 'looked and it was fine'", () => {
+    // The one that matters: a client that could not read the module list must never sort or
+    // carry forward as though it had, and must never overwrite a worse answer.
+    expect(stateRank("unknown")).toBeLessThan(stateRank("ok"));
+    expect(stateRank("ok")).toBeLessThan(stateRank("warn"));
+    expect(stateRank("warn")).toBeLessThan(stateRank("alert"));
+    expect(stateRank("nonsense")).toBe(0);
+  });
+});

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -47,6 +47,8 @@ mod paintwatch;
 mod pkz;
 /// Paid plugins: what this install may run, and how it proves it offline.
 mod plugins;
+/// What the running game has loaded, reported for diagnostics.
+mod procmods;
 /// Linux only: the Proton prefix the game runs in, and how to put a Windows program in it.
 #[cfg(target_os = "linux")]
 mod proton;

--- a/src-tauri/src/procmods.rs
+++ b/src-tauri/src/procmods.rs
@@ -456,6 +456,22 @@ mod tests {
         assert_ne!(digest(true, &[]), digest(false, &[]));
     }
 
+    /// The wire shape the control plane parses. Its validator refuses anything else outright,
+    /// so a rename on either side is a silent stop rather than an error anybody sees.
+    #[test]
+    fn the_payload_is_the_shape_the_other_end_reads() {
+        let mods = collected(&["C:\\Games\\MX Bikes\\mxbikes.exe", "C:\\Windows\\System32\\a.dll"]);
+        let json =
+            serde_json::to_string(&Payload { app_version: "0.13.1", available: true, modules: &mods })
+                .unwrap();
+        assert!(json.contains(r#""appVersion":"0.13.1""#), "{json}");
+        assert!(json.contains(r#""available":true"#), "{json}");
+        assert!(json.contains(r#""origin":"game""#), "{json}");
+        assert!(json.contains(r#""origin":"system""#), "{json}");
+        // Absent rather than empty, which is what the parser expects of an unhashed file.
+        assert!(json.contains(r#"{"name":"a.dll","origin":"system"}"#), "{json}");
+    }
+
     #[test]
     fn a_mapping_that_is_not_a_file_name_is_dropped() {
         // Linux hands back mappings that are not always plain files; the control plane takes

--- a/src-tauri/src/procmods.rs
+++ b/src-tauri/src/procmods.rs
@@ -1,0 +1,466 @@
+//! What is loaded inside the running game.
+//!
+//! The app already reports presence and anonymous usage. This is the same idea pointed at
+//! the game process: while MX Bikes is up, walk its module list and report what is in it —
+//! each file's name, where it was loaded from, and a hash for anything that is not a Windows
+//! system library.
+//!
+//! **This module makes no judgements and holds no lists of anything.** It records where a
+//! file came from and hands that over; what any of it means is decided by the control plane
+//! against rules it holds, which is what lets those rules change in a minute rather than in
+//! a release, and what keeps them out of a binary anyone can read. Nothing comes back down:
+//! the endpoint answers `{ ok: true }` and the app is never told what was made of a report.
+//!
+//! Cheap by construction, because it runs beside a game:
+//!
+//!   * A module list walk is a Toolhelp snapshot, which is what [`crate::gameproc`] already
+//!     does to find FrostMod.
+//!   * Hashes are cached by path, size and mtime, so a file is read once per session rather
+//!     than once per pass.
+//!   * A report is only sent when the module set has actually changed, with a heartbeat so a
+//!     settled session still says it is there.
+
+use serde::Serialize;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// Refuse to hash anything larger than this. A library is a few megabytes; a hundred-megabyte
+/// one would only be a way to make every pass stall on disk I/O.
+const MAX_HASH_BYTES: u64 = 96 * 1024 * 1024;
+
+/// The most modules one report carries. The control plane caps the same number.
+const MAX_MODULES: usize = 400;
+
+/// How often an unchanged session says it is still there.
+const HEARTBEAT: Duration = Duration::from_secs(300);
+
+/// Where a module was loaded from. A statement about location, and only that.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Origin {
+    /// Inside the game's own install folder.
+    Game,
+    /// One of Windows' own library folders — or, under Wine, the prefix's equivalent.
+    System,
+    /// Inside something this app installed.
+    App,
+    /// Anywhere else.
+    Other,
+}
+
+impl Origin {
+    fn is_system(self) -> bool {
+        matches!(self, Origin::System)
+    }
+}
+
+/// One module, as reported.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Module {
+    /// File name, lowercased. Never a path: a path carries the player's user folder, and
+    /// nothing on the other end needs one.
+    pub name: String,
+    pub origin: Origin,
+    /// Empty for system libraries, which are not hashed, and for a file we could not read.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub sha256: String,
+}
+
+/// What one report says.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Payload<'a> {
+    app_version: &'a str,
+    /// False when the module list could not be read — the game is above us, or the platform
+    /// has nothing to read. Sent rather than skipped: "we could not look" is a real answer,
+    /// and the alternative is silence that reads exactly like a clean machine.
+    available: bool,
+    modules: &'a [Module],
+}
+
+/// What the last report said, so an unchanged session stays quiet.
+struct Sent {
+    digest: u64,
+    at: Instant,
+}
+
+fn last_sent() -> &'static Mutex<Option<Sent>> {
+    static LAST: Mutex<Option<Sent>> = Mutex::new(None);
+    &LAST
+}
+
+/// Hashes already taken, keyed by path and invalidated by size or mtime. What keeps a pass
+/// from re-reading the same forty files every forty-five seconds.
+fn hash_cache() -> &'static Mutex<HashMap<String, (u64, u64, String)>> {
+    static CACHE: std::sync::OnceLock<Mutex<HashMap<String, (u64, u64, String)>>> =
+        std::sync::OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Forget what was sent and what was hashed. Called when the game goes away, so the next
+/// session reports in full rather than inheriting the last one's answer.
+pub fn reset() {
+    if let Ok(mut slot) = last_sent().lock() {
+        *slot = None;
+    }
+    if let Ok(mut cache) = hash_cache().lock() {
+        cache.clear();
+    }
+}
+
+/// Look at the running game and report, if there is anything new to say.
+///
+/// Called from [`crate::sessionwatch`] on its poll rather than from a watcher of its own:
+/// the question only has an answer while the game is up, and that loop already knows.
+pub fn tick(app: &tauri::AppHandle) {
+    let cfg = crate::config::load_or_detect(app).unwrap_or_default();
+    let token = cfg.cp_token.trim().to_string();
+    // Nothing to report to. Enrolment is what gives a report somewhere to go.
+    if token.is_empty() {
+        return;
+    }
+
+    let (available, modules) = match crate::gameproc::game_modules() {
+        crate::gameproc::GameModules::Loaded(paths) => {
+            (true, collect(&paths, &roots(app, &cfg)))
+        }
+        // Refused, or a platform that cannot read a mapping list. Both are "we could not
+        // look", which is deliberately not the same as an empty list.
+        crate::gameproc::GameModules::Denied | crate::gameproc::GameModules::Unavailable => {
+            (false, Vec::new())
+        }
+        crate::gameproc::GameModules::NotRunning => return,
+    };
+
+    let digest = digest(available, &modules);
+    let due = match last_sent().lock() {
+        Ok(slot) => match slot.as_ref() {
+            Some(prev) => prev.digest != digest || prev.at.elapsed() >= HEARTBEAT,
+            None => true,
+        },
+        Err(_) => true,
+    };
+    if !due {
+        return;
+    }
+    if let Ok(mut slot) = last_sent().lock() {
+        *slot = Some(Sent { digest, at: Instant::now() });
+    }
+
+    let version = app.package_info().version.to_string();
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = send(&token, &version, available, &modules).await {
+            log::debug!("[diag] report not sent: {e:#}");
+        }
+    });
+}
+
+/// The folders whose contents are this app's own doing.
+fn roots(app: &tauri::AppHandle, cfg: &crate::config::AppConfig) -> Roots {
+    Roots {
+        game: norm_str(&cfg.install_dir()),
+        app: vec![norm(&crate::frostmod_manage::frostmod_dir(app))],
+    }
+}
+
+/// The folders one pass is compared against.
+#[derive(Debug, Clone, Default)]
+pub struct Roots {
+    /// The game's install folder.
+    pub game: String,
+    /// Folders this app installed into.
+    pub app: Vec<String>,
+}
+
+/// Turn a list of module paths into what gets reported.
+///
+/// Pure, so the whole of it is testable with made-up paths on a machine with no game on it.
+/// `hash` is passed in for the same reason.
+pub fn collect(paths: &[String], roots: &Roots) -> Vec<Module> {
+    collect_with(paths, roots, &hash_file)
+}
+
+pub fn collect_with(
+    paths: &[String],
+    roots: &Roots,
+    hash: &dyn Fn(&Path) -> String,
+) -> Vec<Module> {
+    let mut out: Vec<Module> = Vec::new();
+    for path in paths.iter().take(MAX_MODULES) {
+        let normalized = norm_str(path);
+        let name = file_name_of(&normalized);
+        if name.is_empty() {
+            continue;
+        }
+        let origin = origin_of(&normalized, roots);
+        // System libraries are not hashed: there are hundreds of them, they are the same on
+        // every machine, and reading them all every session would be the expensive half of
+        // this for no answer anyone wants.
+        let sha256 = if origin.is_system() { String::new() } else { hash(Path::new(path)) };
+        out.push(Module { name, origin, sha256 });
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.sha256.cmp(&b.sha256)));
+    out.dedup_by(|a, b| a.name == b.name && a.sha256 == b.sha256);
+    out
+}
+
+/// Where did this come from?
+///
+/// The order matters in one place: the system test runs before the game test, so a Wine
+/// prefix's `system32` inside the game's own folder still reads as the system folder.
+fn origin_of(path: &str, roots: &Roots) -> Origin {
+    if is_system_path(path) {
+        return Origin::System;
+    }
+    if !roots.game.is_empty() && is_inside(path, &roots.game) {
+        return Origin::Game;
+    }
+    if roots.app.iter().any(|root| !root.is_empty() && is_inside(path, root)) {
+        return Origin::App;
+    }
+    Origin::Other
+}
+
+/// Is this one of the platform's own libraries, by where it lives?
+///
+/// Matched on the shape of the path rather than on a substring, so nothing buys a free pass
+/// by putting itself in `C:\somewhere\windows\system32\`. Three spellings are real: a drive
+/// root, the same folder inside a Wine prefix, and the builtin libraries a Wine or Proton
+/// runtime maps in place of them.
+fn is_system_path(path: &str) -> bool {
+    const SYSTEM_DIRS: [&str; 4] = ["system32/", "syswow64/", "winsxs/", "globalization/"];
+    const RUNTIME_DIRS: [&str; 4] = ["/wine/", "/proton", "/dist/lib/", "/files/lib/"];
+    if RUNTIME_DIRS.iter().any(|d| path.contains(d)) {
+        return true;
+    }
+    let Some((root, rest)) = path.split_once("/windows/") else { return false };
+    let rooted = (root.len() == 2 && root.ends_with(':')) || root.ends_with("/drive_c");
+    rooted && SYSTEM_DIRS.iter().any(|d| rest.starts_with(d))
+}
+
+/// Is `path` inside `root`? Compared on path boundaries, so `c:/games/mx` does not swallow
+/// `c:/games/mxsomething`.
+fn is_inside(path: &str, root: &str) -> bool {
+    path.strip_prefix(root).is_some_and(|rest| rest.starts_with('/'))
+}
+
+/// A path lowercased with forward slashes, so Windows and Wine spellings compare equal.
+fn norm(path: &Path) -> String {
+    norm_str(&path.to_string_lossy())
+}
+
+fn norm_str(path: &str) -> String {
+    path.replace('\\', "/").trim_end_matches('/').to_ascii_lowercase()
+}
+
+/// The file name from a path, lowercased.
+fn file_name_of(path: &str) -> String {
+    let name = path.rsplit('/').next().unwrap_or(path).to_ascii_lowercase();
+    // The control plane takes file names and refuses anything else, so a mapping whose name
+    // is not one is dropped here rather than rejected there. An extension is part of that:
+    // every mapped module has one, and requiring it drops the directories and the anonymous
+    // mappings Linux hands back alongside them.
+    let shaped = name
+        .bytes()
+        .all(|b| matches!(b, b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b'+' | b'(' | b')' | b'-'));
+    if !shaped || !name.contains('.') || name.starts_with('.') || name.ends_with('.') {
+        return String::new();
+    }
+    name
+}
+
+/// SHA-256 of a file, lowercase hex, cached by size and mtime.
+///
+/// Empty when it cannot be read or is implausibly large. A missing hash costs a weaker
+/// report, never a wrong one — a file with no hash can still be recognised by name.
+fn hash_file(path: &Path) -> String {
+    let Ok(meta) = std::fs::metadata(path) else { return String::new() };
+    if !meta.is_file() || meta.len() > MAX_HASH_BYTES {
+        return String::new();
+    }
+    let mtime = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let key = norm(path);
+    if let Ok(cache) = hash_cache().lock() {
+        if let Some((size, seen, hash)) = cache.get(&key) {
+            if *size == meta.len() && *seen == mtime {
+                return hash.clone();
+            }
+        }
+    }
+
+    use sha2::{Digest, Sha256};
+    let Ok(mut file) = std::fs::File::open(path) else { return String::new() };
+    let mut hasher = Sha256::new();
+    if std::io::copy(&mut file, &mut hasher).is_err() {
+        return String::new();
+    }
+    let hash = format!("{:x}", hasher.finalize());
+    if let Ok(mut cache) = hash_cache().lock() {
+        cache.insert(key, (meta.len(), mtime, hash.clone()));
+    }
+    hash
+}
+
+/// A stable fingerprint of one answer, so an unchanged session sends nothing.
+///
+/// FNV-1a over the sorted list. Not a cryptographic question: the only thing asked of it is
+/// whether this pass differs from the last one.
+fn digest(available: bool, modules: &[Module]) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    let mut eat = |bytes: &[u8]| {
+        for b in bytes {
+            hash ^= *b as u64;
+            hash = hash.wrapping_mul(0x1000_0000_01b3);
+        }
+    };
+    eat(if available { b"1" } else { b"0" });
+    for module in modules {
+        eat(module.name.as_bytes());
+        eat(module.sha256.as_bytes());
+        eat(match module.origin {
+            Origin::Game => b"g",
+            Origin::System => b"s",
+            Origin::App => b"a",
+            Origin::Other => b"o",
+        });
+    }
+    hash
+}
+
+async fn send(
+    token: &str,
+    app_version: &str,
+    available: bool,
+    modules: &[Module],
+) -> anyhow::Result<()> {
+    let res = reqwest::Client::new()
+        .put(format!("{}/v1/diagnostics", crate::paintsync::control_plane()))
+        .bearer_auth(token)
+        .json(&Payload { app_version, available, modules })
+        .timeout(Duration::from_secs(10))
+        .send()
+        .await?;
+    if !res.status().is_success() {
+        anyhow::bail!("control plane said {}", res.status());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roots() -> Roots {
+        Roots {
+            game: "c:/games/mx bikes".into(),
+            app: vec!["c:/users/rider/appdata/local/mxbapp/frostmod".into()],
+        }
+    }
+
+    fn collected(paths: &[&str]) -> Vec<Module> {
+        let owned: Vec<String> = paths.iter().map(|p| p.to_string()).collect();
+        collect_with(&owned, &roots(), &|p| {
+            // A stand-in for reading the file, so the classification is testable without one.
+            format!("{:0>64}", p.to_string_lossy().len())
+        })
+    }
+
+    #[test]
+    fn a_module_is_placed_by_where_it_loaded_from() {
+        let mods = collected(&[
+            "C:\\Games\\MX Bikes\\mxbikes.exe",
+            "C:\\Windows\\System32\\kernel32.dll",
+            "C:\\Users\\rider\\AppData\\Local\\mxbapp\\frostmod\\frostmod.dll",
+            "C:\\Users\\rider\\Downloads\\something.dll",
+        ]);
+        let by_name = |n: &str| mods.iter().find(|m| m.name == n).unwrap().origin;
+        assert_eq!(by_name("mxbikes.exe"), Origin::Game);
+        assert_eq!(by_name("kernel32.dll"), Origin::System);
+        assert_eq!(by_name("frostmod.dll"), Origin::App);
+        assert_eq!(by_name("something.dll"), Origin::Other);
+    }
+
+    /// The privacy line the whole feature stands on: what leaves is a file name, a location
+    /// word and a hash. Anything that changes this test is changing what the app says about
+    /// the person running it.
+    #[test]
+    fn a_report_carries_no_paths() {
+        let mods = collected(&["C:\\Users\\rider\\Secret Work Tools\\vpnhook.dll"]);
+        let json = serde_json::to_string(&mods).unwrap();
+        assert!(!json.to_lowercase().contains("secret"), "{json}");
+        assert!(!json.to_lowercase().contains("rider"), "{json}");
+        assert!(!json.contains("users"), "{json}");
+        assert!(json.contains("vpnhook.dll"), "{json}");
+    }
+
+    #[test]
+    fn system_libraries_are_not_hashed() {
+        let mods = collected(&["C:\\Windows\\System32\\kernel32.dll", "C:\\x\\other.dll"]);
+        let sys = mods.iter().find(|m| m.name == "kernel32.dll").unwrap();
+        let other = mods.iter().find(|m| m.name == "other.dll").unwrap();
+        assert_eq!(sys.sha256, "");
+        assert_ne!(other.sha256, "");
+    }
+
+    #[test]
+    fn a_folder_that_merely_starts_the_same_is_not_the_game() {
+        let mods = collected(&["C:\\Games\\MX Bikes Cheats\\loader.dll"]);
+        assert_eq!(mods[0].origin, Origin::Other);
+    }
+
+    #[test]
+    fn a_windows_folder_somebody_made_up_is_not_the_system_folder() {
+        let mods = collected(&["C:\\loader\\windows\\system32\\hook.dll"]);
+        assert_eq!(mods[0].origin, Origin::Other);
+        // And a real one still is, including inside a Wine prefix.
+        let real = collected(&[
+            "C:\\Windows\\SysWOW64\\user32.dll",
+            "/home/rider/.steam/pfx/drive_c/windows/system32/ntdll.dll",
+        ]);
+        assert!(real.iter().all(|m| m.origin == Origin::System), "{real:?}");
+    }
+
+    #[test]
+    fn a_proton_runtime_library_reads_as_the_system_one() {
+        // Under Proton the game's own kernel32 genuinely comes out of the runtime, which is
+        // neither the system folder nor the game folder. Without this every Linux session
+        // would report a hundred unaccounted-for files.
+        let mods = collected(&[
+            "/home/rider/.steam/steam/steamapps/common/Proton - Experimental/files/lib/wine/x86_64-windows/kernel32.dll",
+        ]);
+        assert_eq!(mods[0].origin, Origin::System);
+    }
+
+    #[test]
+    fn the_same_file_twice_is_reported_once() {
+        let mods = collected(&["C:\\x\\a.dll", "C:\\x\\a.dll"]);
+        assert_eq!(mods.len(), 1);
+    }
+
+    #[test]
+    fn the_digest_only_changes_when_the_answer_does() {
+        let a = collected(&["C:\\x\\a.dll", "C:\\x\\b.dll"]);
+        let b = collected(&["C:\\x\\b.dll", "C:\\x\\a.dll"]);
+        assert_eq!(digest(true, &a), digest(true, &b), "order must not matter");
+        let c = collected(&["C:\\x\\a.dll"]);
+        assert_ne!(digest(true, &a), digest(true, &c));
+        // "Could not look" is a different answer from "looked and found nothing".
+        assert_ne!(digest(true, &[]), digest(false, &[]));
+    }
+
+    #[test]
+    fn a_mapping_that_is_not_a_file_name_is_dropped() {
+        // Linux hands back mappings that are not always plain files; the control plane takes
+        // file names and nothing else, so anything odd is dropped here.
+        assert!(collected(&["/memfd:wayland-shm (deleted)"]).is_empty());
+        assert!(collected(&["C:\\x\\"]).is_empty());
+    }
+}

--- a/src-tauri/src/sessionwatch.rs
+++ b/src-tauri/src/sessionwatch.rs
@@ -5,13 +5,23 @@
 //! the mods folder is really on disk before the load screen reads it. It also holds a handle
 //! on the running session, so how it ended is still readable once the process is gone (see
 //! [`crate::gameproc::GameSession`]).
+//!
+//! While a session is up it is also where [`crate::procmods`] reports what the game has
+//! loaded. That is a second job for one poll rather than a second poll: this loop is already
+//! the one thing that knows a game is running, and it knows it whether the game came from
+//! the Play button or from Steam.
 
 use crate::gameproc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tauri::AppHandle;
 
 /// How often to ask whether the game has started. A process-table walk, and nothing else.
 const POLL: Duration = Duration::from_secs(15);
+
+/// How often to look at what the running game has loaded. Slower than the poll above: the
+/// answer barely moves within a session, and the report is only sent when it does. Matched
+/// to the live paint sync, which is the other thing running through a race.
+const REPORT_EVERY: Duration = Duration::from_secs(45);
 
 /// Start the standing watcher. Call once, from `setup`.
 pub fn start(app: &AppHandle) {
@@ -21,6 +31,9 @@ pub fn start(app: &AppHandle) {
         // A handle on the current session, held so how it ended is still readable once the
         // process is gone.
         let mut session: Option<gameproc::GameSession> = None;
+        // When the game's module list was last looked at. `None` until a session starts, so
+        // the first pass of every session reports rather than waiting out the interval.
+        let mut reported: Option<Instant> = None;
         loop {
             let cfg = crate::config::load_or_detect(&app).unwrap_or_default();
 
@@ -47,6 +60,19 @@ pub fn start(app: &AppHandle) {
                 // isn't really on disk becomes a crash there. Ask now, while there is still
                 // a log line to attach the answer to.
                 crate::cloudfiles::warn_if_dehydrated(&app, &cfg);
+                // A new session is a new answer, whatever the last one said.
+                crate::procmods::reset();
+                reported = None;
+            }
+
+            if running {
+                if reported.is_none_or(|at| at.elapsed() >= REPORT_EVERY) {
+                    reported = Some(Instant::now());
+                    crate::procmods::tick(&app);
+                }
+            } else if reported.take().is_some() {
+                // The session is over, so nothing that was true of it is true now.
+                crate::procmods::reset();
             }
 
             tokio::time::sleep(POLL).await;


### PR DESCRIPTION
Reports which modules are loaded inside the running game, so a session can be explained after it ends, and gives the deployment an admin view of what came back.

## The app

`procmods` walks the running game's module list and reports, per file: its name, where it loaded from (`game` / `system` / `app` / `other`), and a SHA-256 for anything that is not a Windows system library. **No paths ever leave** — a path carries the player's user folder and nothing on the other end needs one.

It holds no lists and makes no judgements. Everything about what an observation *means* lives in the worker, which is what lets that change without a release.

Driven from `sessionwatch`, which already knows when a session starts, so this is a second job for one poll rather than a second poll. 45s cadence, a report only when the module set actually changed, and a 5-minute heartbeat so a settled session still says it is there. Hashes are cached by path, size and mtime, so a file is read once per session; system libraries are never hashed at all.

"Could not look" is reported as itself. An app running below the game's integrity level says so rather than going silent, which would otherwise read exactly like a machine with nothing on it.

## The control plane

`PUT /v1/diagnostics` stores a report and answers `{ ok: true }` for everything it accepts, so nothing about the classification travels back down the wire.

Three tables:
- `client_modules` — live state, one row per account, rewritten on every report like `presence`. Keeps the worst state of the recent past alongside the current one, so a file that is loaded and then unloaded inside the window does not erase itself.
- `client_module_seen` — per-file sightings that outlive the session. System libraries excluded: hundreds of them, identical on every machine, and they would bury the rows worth reading.
- `module_rules` — how to read an observation. Editable at runtime, so a new entry applies to the next report from every install.

`/admin/diagnostics` behind `ADMIN_KEY`, mirroring `/admin/usage`. Live table worst first, then the sightings log with a prevalence count — how many distinct accounts have ever loaded that exact file, which is what separates a driver from something one person has. Buttons on each row write a rule from the row that prompted it.

Sightings prune at 90 days on the existing cron sweep.

## Verified

25 tests (15 worker, 10 app), full worker suite green, `cargo check` green on macOS and `x86_64-pc-windows-gnu`. Exercised end to end against a local worker and then against production: report → rule added → next report reads it the new way with no deploy → the observation survives the file being unloaded. The production check ran on a throwaway account that has been deleted.

Migration `0016_client_diagnostics.sql` is already applied to the production D1.