### PR TITLE
fix(tracks): keep a sealed track's contents out of the diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2026-09-01
 
 ### Changed
+- Track diagnostics keep protected tracks protected: for a sealed track the report gives
+  the layout probe's findings without listing the files inside it or their contents.
 - Paint Studio and the Designer open on the KTM 250 SX-F when it is installed, rather than on
   whichever bike sorts first alphabetically.
 

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -732,15 +732,25 @@ pub fn diagnose(path: &Path) -> String {
     use std::fmt::Write;
     let mut out = String::new();
 
+    // A sealed archive's contents are the author's, and this report is text a player copies
+    // out of the app. Everything below is read through the unlock, so for a sealed track the
+    // report stays at the level of derived facts — how many entries, what shape the grid is —
+    // and never reproduces a name or a byte of what's inside.
+    let sealed = !is_dir(path) && !crate::pkz::is_plain_zip(path);
+
     let names = match entry_names(path) {
         Ok(n) => n,
         Err(e) => return format!("couldn't list {path:?}: {e:#}"),
     };
     let _ = writeln!(out, "{}\n{} entries", path.display(), names.len());
-    for n in &names {
-        let role = role_of(n);
-        if !matches!(role, "other" | "image") {
-            let _ = writeln!(out, "  [{role:<11}] {n}");
+    if sealed {
+        out.push_str("  (sealed archive — entries not listed)\n");
+    } else {
+        for n in &names {
+            let role = role_of(n);
+            if !matches!(role, "other" | "image") {
+                let _ = writeln!(out, "  [{role:<11}] {n}");
+            }
         }
     }
 
@@ -752,13 +762,21 @@ pub fn diagnose(path: &Path) -> String {
     if heightfields.is_empty() {
         out.push_str("no heightfield-looking entries — nothing for the probe to read\n");
     }
-    for entry in heightfields {
-        let _ = writeln!(out, "\n--- {entry} ---");
-        match read_entry(path, &entry) {
+    for (i, entry) in heightfields.iter().enumerate() {
+        let label = if sealed {
+            format!("heightfield {}", i + 1)
+        } else {
+            entry.clone()
+        };
+        let _ = writeln!(out, "\n--- {label} ---");
+        match read_entry(path, entry) {
             // The first bytes are worth having verbatim: if the probe found nothing, a magic
-            // string or a dimension pair in here is what tells us how to widen it.
+            // string or a dimension pair in here is what tells us how to widen it. Sealed
+            // tracks give up the probe's verdict only — that's derived, the bytes aren't.
             Ok(bytes) => {
-                let _ = writeln!(out, "first bytes: {}", hex_preview(&bytes, 64));
+                if !sealed {
+                    let _ = writeln!(out, "first bytes: {}", hex_preview(&bytes, 64));
+                }
                 let _ = writeln!(out, "{}", heightfield::report(&bytes, hint));
             }
             Err(e) => {


### PR DESCRIPTION
## What

`track::diagnose` — surfaced in the viewer when a track's terrain won't load, and reachable from the UI via `diagnose_track` — reads every entry through the unlock. For a **sealed** track that meant the report reproduced, in text a player copies out of the app:

- the archive's full file manifest
- `first bytes:` — 64 verbatim bytes of each heightfield entry, straight out of the decrypted stream

Spotted on `L21-DragStrip_OEM.pkz`, whose header is `61 df 53 dc` (not `PK`) and which `unzip` cannot open — yet the report listed all 13 entries and dumped its `.trh` header.

## Fix

Gate the two content-reproducing lines on `pkz::is_plain_zip`. The layout probe is untouched in both cases: it prints only derived facts — file size, candidate dimensions, sample type, offset, roughness, confidence — so a format we've never seen is still diagnosable from the report alone.

## Verified

Sealed (`L21-DragStrip_OEM.pkz`):

```
13 entries
  (sealed archive — entries not listed)
ini dimensions None, spacing None

--- heightfield 1 ---
23076114 bytes, hint None
3 candidate layouts (threshold 0.12):
  --    2049x1025  F32 @12     [header] samples aren't finite numbers
  --    2049x1025  U16 @12     [header] no relief at all
  --    2049x1025  I16 @12     [header] no relief at all
chose nothing — no layout read as terrain.
```

Unsealed (`Corpus_National.pkz`) — unchanged, full manifest and hex preview, still `reads as a self-describing .trh: 2049x2049 i16 at 12, confidence 0.99`.

`cargo check` clean.

## Note, not in scope

The DragStrip's `.trh` header is genuine (`TRH\0`, 2049x1025) and its samples really are a constant `0x0685` — the probe rejects it under its "no relief" heuristic, not because the entry failed to decrypt. That's why that track won't render, and it's a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)