### PR TITLE
feat(designer): a companion sheet starts from the model's own map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2026-09-01
 
+### Added
+- Designer: naming a sheet as a normal or roughness map starts it from the model's own — the
+  vents and the seat weave already in it — instead of from a blank canvas. A normal map with
+  none to copy starts flat rather than black.
+
 ### Changed
 - Track diagnostics keep protected tracks protected: for a sealed track the report gives
   the layout probe's findings without listing the files inside it or their contents.

--- a/src/Components/Studio/Designer/Designer.tsx
+++ b/src/Components/Studio/Designer/Designer.tsx
@@ -66,6 +66,8 @@ import {
   groupOf,
   imageLayer,
   isCompanionMap,
+  isNormalMap,
+  FLAT_NORMAL,
   layerExtent,
   newId,
   paintLayer,
@@ -130,6 +132,22 @@ function stockBitmap(tex: PaintTexture): Promise<ImageBitmap | null> {
   return textureBytes(tex.token)
     .then((buf) => bitmapFromRgba(buf, tex.width, tex.height))
     .catch(() => null);
+}
+
+/** A sheet of flat normal — the value that says "no relief of my own", drawn once. */
+async function flatNormalBitmap(size: number): Promise<ImageBitmap | null> {
+  try {
+    const c = document.createElement("canvas");
+    c.width = size;
+    c.height = size;
+    const ctx = c.getContext("2d");
+    if (!ctx) return null;
+    ctx.fillStyle = FLAT_NORMAL;
+    ctx.fillRect(0, 0, size, size);
+    return await createImageBitmap(c);
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -1678,6 +1696,60 @@ export default function Designer({ incoming, onIncomingLoaded }: DesignerProps) 
     },
     [stockTextures],
   );
+
+  /**
+   * Give a companion sheet something correct to start from.
+   *
+   * A colour sheet starts blank because blank is where a livery starts. A companion map is the
+   * opposite: a paint replaces the model's textures *by name*, so saving an empty `plastics_n`
+   * does not add a normal map — it throws the bike's real one away and puts black in its
+   * place, which decodes to a surface pointing back into itself. That is why these are kept
+   * off the suggestion list, and it left anyone who did want to author one starting from the
+   * worst possible sheet.
+   *
+   * So: the model's own map if it has one — the actual base, the vents and the seat weave
+   * already in it, ready to be drawn over. Failing that, and only for a normal map, flat
+   * (128, 128, 255), which is the one companion with an honest neutral value. Other companions
+   * are left alone rather than given a constant that would be a claim about the material.
+   *
+   * Only ever onto a pristine sheet, and once per name, so this cannot land on someone's work
+   * or fight a template they loaded themselves.
+   */
+  const seeded = useRef(new Set<string>());
+  useEffect(() => {
+    const sheet = sheets.find(
+      (s) =>
+        !s.base &&
+        !s.layers.length &&
+        isCompanionMap(s.name) &&
+        !seeded.current.has(`${s.id}:${s.name.trim().toLowerCase()}`),
+    );
+    if (!sheet) return;
+    const key = `${sheet.id}:${sheet.name.trim().toLowerCase()}`;
+    seeded.current.add(key);
+    let alive = true;
+    void (async () => {
+      const stock = stockFor(sheet.name);
+      const base = stock
+        ? await stockBitmap(stock)
+        : isNormalMap(sheet.name)
+          ? await flatNormalBitmap(sheet.width)
+          : null;
+      if (!alive || !base) return;
+      patchSheet(
+        sheet.id,
+        (sh) =>
+          sh.base || sh.layers.length
+            ? sh
+            : { ...sh, base, width: base.width, height: base.height },
+        false,
+      );
+      bump();
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [bump, patchSheet, sheets, stockFor]);
 
   /**
    * Fetch the model's own texture for the active sheet, the same way and for the same reasons.

--- a/src/Components/Studio/Designer/layers.ts
+++ b/src/Components/Studio/Designer/layers.ts
@@ -517,3 +517,23 @@ export function isCompanionMap(name: string): boolean {
   const n = name.trim().toLowerCase();
   return COMPANION_SUFFIXES.some((s) => n.endsWith(s));
 }
+
+/** The companion suffixes that mean a tangent-space normal map specifically. */
+const NORMAL_SUFFIXES = ["_n", "_normal", "_nrm"];
+
+/**
+ * Whether a texture name is a normal map, as opposed to some other companion.
+ *
+ * Worth separating from {@link isCompanionMap} because a normal map is the one companion with
+ * a *neutral* value: (128, 128, 255) is "this surface is exactly as flat as the mesh says",
+ * which is a correct sheet rather than a missing one. There is no such value for a roughness
+ * or an occlusion map — whatever constant you pick is a claim about the material, and the
+ * model's own sheet is the only honest starting point.
+ */
+export function isNormalMap(name: string): boolean {
+  const n = name.trim().toLowerCase();
+  return NORMAL_SUFFIXES.some((s) => n.endsWith(s));
+}
+
+/** The flat value of a tangent-space normal map: straight out of the surface. */
+export const FLAT_NORMAL = "#8080ff";


### PR DESCRIPTION
A colour sheet starts blank because blank is where a livery starts. A companion map is the opposite.

A paint replaces the model's textures **by name**, so saving an empty `plastics_n` doesn't *add* a normal map — it throws the bike's real one away and puts black in its place, which decodes to a surface pointing back into itself. `isCompanionMap` already existed to keep these off the suggestion list for exactly that reason, and the effect was that anyone who did want to author one started from the worst possible sheet.

### What it does

- Name a sheet as a companion map, and it seeds from the model's texture of that name — the actual base, with the vents and the seat weave already in it, ready to draw over.
- With none to copy, a **normal** map seeds flat: `#8080ff`, the one companion with an honest neutral value, meaning "exactly as flat as the mesh says".
- Other companions are left alone. Any constant for a roughness or occlusion map would be a claim about the material, and the model's own sheet is the only truthful starting point.
- Only onto a pristine sheet, and once per name — it can't land on work in progress or fight a template loaded by hand.

### What it deliberately doesn't do

Companion names stay out of the bulk "add every sheet this model wants". Seeding one with an unchanged copy of the model's map would put another 2048² sheet into every paint for no gain — that alone is most of why my own test paint is 12.5 MB. They're still discoverable: the hint line has always listed them, so `plastics_n` is visible, and typing it now gets you something correct instead of something destructive.

Depends on the viewer having the model's `_n` sheets at all, which it has since #334.

### Verified

- `tsc --noEmit` and `eslint` clean.
- The two predicates exercised under bun against the real texture names on this bike and a few plausible others:

```
plastics_n         companion=true  normal=true
250f_metals_n      companion=true  normal=true
tyres_normal       companion=true  normal=true
body_nrm           companion=true  normal=true
livery_roughness   companion=true  normal=false     <- gets the model's map or nothing
shell_ao           companion=true  normal=false     <- never a made-up constant
plastics           companion=false normal=false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)