### PR TITLE
perf(locker): lock several buyers at once, seal in one pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   none to copy starts flat rather than black.
 
 ### Changed
+- Protecting content is faster. A mod is locked for several buyers at once instead of one
+  after another, and each file is sealed in a single pass, so four buyers now cost barely
+  more than one and a folder of paints finishes in a fraction of the time.
 - Track diagnostics keep protected tracks protected: for a sealed track the report gives
   the layout probe's findings without listing the files inside it or their contents.
 - Paint Studio and the Designer open on the KTM 250 SX-F when it is installed, rather than on


### PR DESCRIPTION
Benchmarked the content locker and fixed the two things it was paying for. Code changes are in the gitignored writer module (merged as Frostn1/mxbapp-private#19); this PR carries the changelog entry.

## What was slow, and why
RC4 is a serial byte-at-a-time cipher — every output byte depends on the previous state, nothing vectorizes — so it runs at ~1 GB/s on one core and that is the floor for a loose file. The format is the game's, so the cipher is not a lever. What was avoidable:

- **Three full-size buffers per file**: read into one, `to_vec` into a second, then `extend_from_slice` for the 62-byte footer reallocated and memcpy'd the lot into a third. On 200 MB that alone was 5-22 ms and 3x the peak memory.
- **A serial loop** over (buyer x file), when every pair is independent — its own key, its own stream, its own output file.

## What changed
Sealing happens in the buffer the file was read into, with the trailer's bytes reserved up front, and the work list is fanned out over rayon against a 2 GB in-flight budget (each worker holds one file, so a 500 MB track runs 4 wide while a folder of paints runs on every core).

## Numbers (this Mac, optimized build)
| case | before | after |
|---|---|---|
| 200 MB loose, 1 buyer | 415-650 ms | 265 ms |
| 64 MB as 256 files | 152-199 ms | 25-29 ms |
| 16 MB as 1024 files | 118-197 ms | 61-70 ms |
| 512 MB .pkz | 1.3-2.9 s | 0.42-0.75 s |
| 64 MB to 4 buyers | 467-2329 ms | 116-150 ms |

Per-buyer cost is now nearly flat. A single big loose file is still one serial RC4 pass — 195 ms of the 200 MB case's 265 ms is the cipher itself.

## Verification
- All three shipped `model.edf` files in the `08kx special benny` test mod re-seal **byte for byte** from their plaintext with their own key, drop and GUID — the output did not move.
- The 10 existing locker tests pass, including both reader round-trips and the two-buyer run.
- Benchmarks added alongside: `cargo test --release -- --ignored --nocapture locking_speed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)