### PR TITLE
fix(trackgen): a stray backtick broke the control plane, and generation never said why it failed

### DIFF
--- a/control-plane/src/trackgen.ts
+++ b/control-plane/src/trackgen.ts
@@ -151,7 +151,7 @@ const TrackProgram = z.object({
  * ones. Quoted rather than described: a model given "13 m wide" writes a track, a model given
  * "realistic" writes a guess.
  */
-const SYSTEM = `You design motocross tracks for MX Bikes as a "track program" — a document the
+export const SYSTEM = `You design motocross tracks for MX Bikes as a "track program" — a document the
 game's own terrain compiler is built from. You never write a heightmap.
 
 A lap is a start pose plus a list of segments, each either a straight of some length or an arc
@@ -193,7 +193,8 @@ a part of the lap you drew earlier. Long straights are good, but a straight that
 you past the middle of the infield is too long.
 
 WRITE A LAP, NOT A SHAPE. This is the thing generated tracks get most wrong, and it is not a
-matter of taste — a `.trh` carries the centreline its builder typed, so we can read exactly
+matter of taste — a track's height file carries the centreline its builder typed, so we can
+read exactly
 what ten published circuits are made of:
 
   segments in a lap   52-150. Not twenty.

--- a/control-plane/test/trackgen.test.ts
+++ b/control-plane/test/trackgen.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { generateTrack } from "../src/trackgen";
+import { SYSTEM, generateTrack } from "../src/trackgen";
 
 /** A request the endpoint would accept, so each test can spoil one thing about it. */
 function post(body: unknown): Request {
@@ -55,5 +55,17 @@ describe("the no-key check comes first", () => {
       withoutKey,
     );
     expect(res.status).toBe(503);
+  });
+});
+
+describe("the system prompt", () => {
+  it("is one string, not a tagged template", () => {
+    // It is a backtick literal, so a stray backtick in the prose ends it and turns the next
+    // line into a tag call — `a \`.trh\` carries` parses fine and throws `.trh is not a
+    // function` the moment the module is evaluated. It shipped that way once: `tsc` catches
+    // it, and `esbuild` and a bundle check both do not.
+    expect(typeof SYSTEM).toBe("string");
+    expect(SYSTEM.length).toBeGreaterThan(1000);
+    expect(SYSTEM).not.toContain("`");
   });
 });

--- a/src-tauri/src/trackllm.rs
+++ b/src-tauri/src/trackllm.rs
@@ -377,11 +377,18 @@ pub async fn generate(brief: &str, ask: &impl Ask, tries: usize) -> Result<Track
                 if problems.is_empty() {
                     return Ok(prog);
                 }
+                // Each one, not just how many. A run that ends "gave up after 4 attempts"
+                // with four lines saying `came back with 1 problems` records nothing about
+                // why — and the one line that does carry the reason goes to the caller, so
+                // it is gone as soon as the dialog is dismissed.
                 log::info!(
-                    "[trackllm] attempt {} came back with {} problems",
+                    "[trackllm] attempt {} came back with {} problem(s):",
                     round + 1,
                     problems.len()
                 );
+                for p in &problems {
+                    log::info!("[trackllm]   - {p}");
+                }
                 attempt = Attempt {
                     previous: Some(raw.clone()),
                     problems,
@@ -390,6 +397,7 @@ pub async fn generate(brief: &str, ask: &impl Ask, tries: usize) -> Result<Track
             Err(e) => {
                 // A schema violation is the model's to fix too, and saying which field
                 // beats saying "invalid JSON".
+                log::info!("[trackllm] attempt {} didn't parse: {e}", round + 1);
                 attempt = Attempt {
                     previous: Some(raw.clone()),
                     problems: vec![format!("that didn't parse as a track program: {e}")],
@@ -399,6 +407,11 @@ pub async fn generate(brief: &str, ask: &impl Ask, tries: usize) -> Result<Track
         last = Some(attempt.problems.join("; "));
     }
 
+    log::warn!(
+        "[trackllm] gave up after {} attempts; last: {}",
+        tries.max(1),
+        last.clone().unwrap_or_else(|| "no answer".into())
+    );
     bail!(
         "gave up after {} attempts — last time: {}",
         tries.max(1),


### PR DESCRIPTION
Main has been red since #352 and the control plane could not deploy, so the prompt half of
that work was never live.

## The backtick

`SYSTEM` is a template literal. The new layout section wrote the height file's extension in
backticks in the prose:

```
matter of taste — a `.trh` carries the centreline its builder typed, so we can read exactly
```

The first backtick ends the string, `.trh` becomes a property access on it, and the second
starts a new literal — a tagged template. It parses, so `esbuild` bundles it happily; it
throws `.trh is not a function` when the module is evaluated, which is why `wrangler deploy`
refused with a validation error rather than anything that mentions strings.

CI reported it exactly:

```
src/trackgen.ts(196,23): error TS2339: Property 'trh' does not exist on type
'"You design motocross tracks for MX Bikes as a \"track program\" …'
```

I missed it because my local `tsc` was failing on a missing `worker-configuration.d.ts` and I
took the real error for that noise. CI runs `npx wrangler types` first, so it sees past it.

`SYSTEM` is now exported and a test asserts it is a string over a thousand characters with no
backtick in it.

## Generation never said what was wrong

The log records a count and nothing else:

```
[trackllm] attempt 1 came back with 3 problems
[trackllm] attempt 2 came back with 1 problems
[trackllm] attempt 3 came back with 1 problems
[trackllm] attempt 4 came back with 1 problems
```

Four attempts, no record of what any of them was. The one message that does carry the reason
is the error returned to the caller, so it is gone as soon as the dialog is dismissed. Now
each problem is logged on its own line, a parse failure says so, and giving up is a warning
that repeats the last reason.

Those four attempts above are from 02:47 local, against `06ca1cc` — before #352 landed in this
checkout at 02:49. Whatever they were, they were not that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
