### PR TITLE
fix(tracks): texture records the game can walk past

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 2026-09-01
 
+### Fixed
+- More of the crash at track graphics: the ground sheets in a track's graphics file were
+  written in a shape the game cannot read past.
+
+## 2026-09-01
+
 ### Added
 - Track generation reads a published track's own centreline out of its height file, so a real
   lap's corners, their radii and its straights can be measured directly rather than guessed at.

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -2091,15 +2091,38 @@ fn gfx_cfg(prog: &TrackProgram) -> String {
 /// One embedded texture, in the record shape [`crate::edf::embedded_textures`] reads.
 fn texture_record(name: &str, w: u32, h: u32, rgba: &[u8]) -> Vec<u8> {
     let payload = deflate_raw(rgba);
-    // 100 bytes of name field, dimensions, then the header the scanner keys on.
-    let mut rec = vec![0u8; 140];
+    // A **primary** record's header, measured on a published map: 104 bytes of name field,
+    // the dimensions, the payload length at +132, eight zero bytes, and the pixels at +144.
+    //
+    // Ours used the 104-byte-earlier variant, and our own scanner accepts either — it tries
+    // both. That is how this went unnoticed: the two layouts do both occur in a real map, but
+    // not interchangeably. Every *colour* sheet in Indiana is at +104 and every *secondary*
+    // — the `_n_s` normal maps hanging off them — is at +100. We write colour sheets, so
+    // ours belong at +104.
+    let mut rec = vec![0u8; 144];
     let n = name.len().min(39);
     rec[..n].copy_from_slice(&name.as_bytes()[..n]);
-    rec[100..104].copy_from_slice(&w.to_le_bytes());
-    rec[104..108].copy_from_slice(&h.to_le_bytes());
-    // The length at +128 counts the eight zero bytes that follow it, which stay zero.
-    rec[128..132].copy_from_slice(&((payload.len() + 8) as u32).to_le_bytes());
+    rec[104..108].copy_from_slice(&w.to_le_bytes());
+    rec[108..112].copy_from_slice(&h.to_le_bytes());
+    // The length at +132 counts the eight zero bytes that follow it, which stay zero.
+    rec[132..136].copy_from_slice(&((payload.len() + 8) as u32).to_le_bytes());
     rec.extend_from_slice(&payload);
+
+    // Every colour record in a published map is followed by a descriptor, and ours were
+    // followed by the next record's name. A reader that *walks* — which is what the game
+    // does, whatever our own scanner gets away with — then takes eleven bytes of "grass_c"
+    // as five words and a count, and everything after it is wherever those bytes point.
+    //
+    // Read off Indiana: `1, 1, 0, 1.0f, 1.0f, N`, where N is how many secondary maps hang
+    // off this one. `pitlane_c` says 1 and is followed inline by `pitlane_n_s`; that is how
+    // 49 materials come to ship 84 sheets. We generate colour and nothing else, so ours say
+    // none. The five leading words are the same on every sample.
+    for w in [1u32, 1, 0] {
+        rec.extend_from_slice(&w.to_le_bytes());
+    }
+    rec.extend_from_slice(&1.0f32.to_le_bytes());
+    rec.extend_from_slice(&1.0f32.to_le_bytes());
+    rec.extend_from_slice(&0u32.to_le_bytes()); // no secondary maps
     rec
 }
 
@@ -3427,6 +3450,23 @@ mod tests {
             assert_eq!(w(12), 0, "material {k} word 12");
             assert_eq!(w(13), 0, "material {k} word 13");
         }
+    }
+
+    /// A texture record ends with the descriptor a published map puts there.
+    ///
+    /// Without it a reader walking the table runs the next record's *name* through the
+    /// descriptor's fields. Ours declare no secondary maps, which is true — we generate
+    /// colour sheets and nothing else.
+    #[test]
+    fn texture_records_carry_their_descriptor() {
+        let px = vec![0u8; 64 * 64 * 4];
+        let rec = texture_record("ground_c", 64, 64, &px);
+        let tail = &rec[rec.len() - 24..];
+        let w = |i: usize| u32::from_le_bytes(tail[i * 4..i * 4 + 4].try_into().unwrap());
+        let f = |i: usize| f32::from_le_bytes(tail[i * 4..i * 4 + 4].try_into().unwrap());
+        assert_eq!((w(0), w(1), w(2)), (1, 1, 0), "the three leading words");
+        assert_eq!((f(3), f(4)), (1.0, 1.0), "the two scales");
+        assert_eq!(w(5), 0, "how many secondary maps follow");
     }
 
     #[test]


### PR DESCRIPTION
From the unpacked executable and two published maps, rather than from guesses.

## Every colour record is followed by a descriptor

24 bytes — `1, 1, 0, 1.0f, 1.0f, N` — where N is how many secondary maps hang off it.
Indiana's `pitlane_c` says 1 and is followed **inline** by `pitlane_n_s`, which is how 49
materials come to ship 84 sheets.

Ours were followed by the next record's *name*. A reader walking the table takes eleven bytes
of `grass_c` as five words and a count, and then reads from wherever those bytes point. We
generate colour and nothing else, so ours declare none.

## Primaries put their dimensions at +104, not +100

Our own scanner tries both offsets, which is exactly why this survived. Both layouts really do
occur in a real map — but not interchangeably:

| | dims offset |
|---|---|
| colour sheets (`pitlane_c`, `soil_dark_c`, …) | **+104** |
| secondary maps (`pitlane_n_s`, …) | +100 |

We write colour sheets. So the header is 144 bytes now: name, dimensions at +104, payload
length at +132, eight zero bytes, pixels at +144.

## The difference between scanning and walking is the whole bug, twice over

Our tests checked the sheets with `edf::embedded_textures`, which hunts for records anywhere in
the file and finds them however they are laid out. The game **walks** from one record to the
next. Every fault here is invisible to a scanner and fatal to a walker — which is also what
made the earlier `.map` faults survive their tests.

## Verified

Walking our own file with the same rule that walks Indiana's:

```
[0] ground_c     1024x1024 sz=1805003  inflates 4,194,304 OK desc=(1, 1, 0) n_secondary=0
[1] shoulder_c   1024x1024 sz=1776565  inflates 4,194,304 OK desc=(1, 1, 0) n_secondary=0
[2] dirt_line_c  1024x1024 sz=1520397  inflates 4,194,304 OK desc=(1, 1, 0) n_secondary=0
[3] grass_c      1024x1024 sz=1952988  inflates 4,194,304 OK desc=(1, 1, 0) n_secondary=0
ended at 29,600,369 of 29,600,369 -> CLEAN
```

## Still open

Not run in the game. A diagnostic pair is out for testing — the same track with the texture
table present and absent — which will say whether this table is the crash at all, rather than
another plausible fault on the pile.

One thing I have **not** decoded: the tail of a *secondary* record. We don't write any, so it
doesn't block us, but a walker over a real map still breaks there for me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)