### PR TITLE
fix(startup): don't start at login unless it's asked for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,13 @@
   repeated down the lap.
 - Ruts, berms and banking are built to numbers measured off ten published tracks.
 - Straights carry worn ground rather than being smooth between the corners.
+- MXB App stays off at login unless you ask for it. Launch at startup is off by default, and
+  the toggle is in Settings for anyone who wants the app waiting for them.
 
 ### Fixed
 - A corner banks the outside of the turn.
+- Switching MXB App off in Windows' list of startup apps sticks, and Launch at startup in
+  Settings follows it.
 
 ## 2026-09-01 — v0.13.2 — Tracks that load
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 ## 2026-09-01
 
-### Fixed
-- More of the crash at track graphics: the ground sheets in a track's graphics file were
-  written in a shape the game cannot read past.
-
-## 2026-09-01
-
 ### Added
 - Track generation reads a published track's own centreline out of its height file, so a real
   lap's corners, their radii and its straights can be measured directly rather than guessed at.
@@ -29,6 +23,8 @@
 - A corner banks the outside of the turn.
 - Switching MXB App off in Windows' list of startup apps sticks, and Launch at startup in
   Settings follows it.
+- More of the crash at track graphics: the ground sheets in a track's graphics file were
+  written in a shape the game cannot read past.
 
 ## 2026-09-01 — v0.13.2 — Tracks that load
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -61,10 +61,15 @@ pub struct AppConfig {
     pub wine_runner: String,
     /// Hide to the tray on window close and keep running.
     pub run_in_background: bool,
-    /// Start MXB App automatically on login.
+    /// Start MXB App automatically on login. Off until the player asks for it: it is a mod
+    /// manager, not something that needs to be running before the game is.
     pub launch_at_startup: bool,
     /// Which [`AUTOSTART_BINDING_REV`] the login item was last written for.
     pub autostart_binding_rev: u32,
+    /// Which [`LAUNCH_AT_STARTUP_REV`] this config has been through — the one-shot that
+    /// turns the setting off once, described on [`LAUNCH_AT_STARTUP_REV`].
+    #[serde(default)]
+    pub launch_at_startup_rev: u32,
     /// Launch FrostMod automatically when the app opens.
     pub auto_run_frostmod: bool,
     /// Extra command-line flags for `frostmod.exe`, exactly as they would be typed. Empty
@@ -251,10 +256,12 @@ impl Default for AppConfig {
             reshade_path: String::new(),
             wine_runner: String::new(),
             run_in_background: true,
-            launch_at_startup: true,
+            launch_at_startup: false,
             // Zero, not the current rev: a config without the field predates the rename and
             // its login item still names the old binary.
             autostart_binding_rev: 0,
+            // The current rev, so a config created now is not immediately "migrated".
+            launch_at_startup_rev: LAUNCH_AT_STARTUP_REV,
             auto_run_frostmod: true,
             frostmod_args: String::new(),
             instant_refresh: true,
@@ -292,6 +299,18 @@ impl Default for AppConfig {
 /// v1: v0.12.4 shipped it on and it froze the game.
 pub const PAINT_SYNC_REV: u32 = 1;
 
+/// Bumped to turn launch-at-startup off for everyone once.
+///
+/// Changing the default alone would reach nobody: it shipped on, so every config already
+/// written carries `launchAtStartup: true` spelled out. Nobody picked that — it is what the
+/// app chose for them — and turning it back off by hand didn't stick, which is what the
+/// reports were about. So it is switched off once here, the same one-shot as
+/// [`PAINT_SYNC_REV`]. Anyone who then turns it on keeps it, because the counter no longer
+/// moves.
+///
+/// v1: it shipped on by default and shouldn't have.
+pub const LAUNCH_AT_STARTUP_REV: u32 = 1;
+
 /// Bring a config written by an older build up to date.
 ///
 /// Applied on every read rather than in a one-shot upgrade step: the config is also
@@ -311,6 +330,16 @@ pub fn migrate(cfg: &mut AppConfig) -> bool {
         }
         cfg.paint_sync_enabled = false;
         cfg.paint_sync_rev = PAINT_SYNC_REV;
+        changed = true;
+    }
+    // The one-shot described on `LAUNCH_AT_STARTUP_REV`. The login item itself is left to
+    // the reconcile at startup, which takes the setting off a config this has already fixed.
+    if cfg.launch_at_startup_rev < LAUNCH_AT_STARTUP_REV {
+        if cfg.launch_at_startup {
+            log::info!("turning launch-at-startup off: it is off by default until it is asked for");
+        }
+        cfg.launch_at_startup = false;
+        cfg.launch_at_startup_rev = LAUNCH_AT_STARTUP_REV;
         changed = true;
     }
     if LEGACY_OVERLAY_HOTKEYS.contains(&cfg.overlay_hotkey.trim()) {
@@ -1039,6 +1068,33 @@ mod tests {
         assert!(!migrate(&mut next), "and the read after it has none");
     }
 
+    /// The same one-shot for launch-at-startup, and the same reason it is needed: every
+    /// config already out there says `launchAtStartup: true` in so many words, because that
+    /// is what the app chose, so moving the default alone would reach nobody.
+    #[test]
+    fn an_existing_config_gets_launch_at_startup_turned_off_once() {
+        let json = r#"{ "modsPath": "/games/MX Bikes", "launchAtStartup": true }"#;
+        let mut cfg = serde_json::from_str::<AppConfig>(json).unwrap();
+
+        assert!(migrate(&mut cfg), "and the caller is told to write it down");
+        assert!(!cfg.launch_at_startup, "the explicit true is overridden once");
+        assert_eq!(cfg.launch_at_startup_rev, LAUNCH_AT_STARTUP_REV, "and it is caught up");
+
+        // Read back the way the next poll reads it: the flip lands once, not forever.
+        let saved = serde_json::to_string(&cfg).unwrap();
+        let mut next = serde_json::from_str::<AppConfig>(&saved).unwrap();
+        assert!(!migrate(&mut next), "the read after it has none");
+    }
+
+    /// Once. Whoever wants the app waiting for them at login says so and keeps it.
+    #[test]
+    fn turning_launch_at_startup_back_on_survives_the_next_launch() {
+        let mut cfg = AppConfig::default();
+        cfg.launch_at_startup = true;
+        assert!(!migrate(&mut cfg), "a caught-up config has nothing to migrate");
+        assert!(cfg.launch_at_startup, "and the setting is left where it was put");
+    }
+
     /// Once. Someone who turns it back on afterwards keeps it — otherwise the setting is
     /// not a setting, it is a switch that resets every launch.
     #[test]
@@ -1517,7 +1573,7 @@ mod tests {
         assert_eq!(cfg.mods_path, "C:\\MXB");
         assert_eq!(cfg.game_path, "C:\\Steam\\MX Bikes");
         assert!(!cfg.run_in_background);
-        assert!(cfg.launch_at_startup, "unset fields fall back to the defaults");
+        assert!(!cfg.launch_at_startup, "unset fields fall back to the defaults");
         assert!(!cfg.welcome_seen);
         assert!(!cfg.tour_done);
         assert!(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6061,6 +6061,9 @@ enum Autostart {
     /// It is there, but it was written for a binary this build no longer has.
     Rebind,
     Disable,
+    /// Windows' own Startup list has the app switched off. Take that as the answer and
+    /// turn the setting off to match, instead of writing over it.
+    Adopt,
 }
 
 /// Reconcile the login item with the setting.
@@ -6069,13 +6072,88 @@ enum Autostart {
 /// renaming the binary leaves every existing one pointing at a file that is gone — while
 /// `is_enabled` still answers yes, because all it looks for is the entry. Left alone, the app
 /// simply stops starting at login and nothing ever says why.
-fn autostart_action(wanted: bool, enabled: bool, stale: bool) -> Autostart {
+///
+/// `vetoed` is the other one, and it outranks everything: see [`startup_vetoed`].
+fn autostart_action(wanted: bool, enabled: bool, vetoed: bool, stale: bool) -> Autostart {
     match (wanted, enabled) {
+        (true, _) if vetoed => Autostart::Adopt,
         (true, false) => Autostart::Enable,
         (true, true) if stale => Autostart::Rebind,
         (false, true) => Autostart::Disable,
         _ => Autostart::Leave,
     }
+}
+
+/// Has the player switched the app off in Windows' own list of startup apps?
+///
+/// Task Manager → Startup apps (and Settings → Apps → Startup) does not remove the `Run`
+/// entry. It leaves it where it is and stamps a flag beside it under `StartupApproved\Run`:
+/// twelve bytes whose tail is all zeros for on, and carries the time it was switched off for
+/// off. `auto-launch` folds that flag into `is_enabled()`, so a veto there reads back exactly
+/// like "there is no entry" — and the reconcile above answered that by calling `enable()`,
+/// which rewrites both the entry *and* the flag. Every launch quietly undid the choice, and
+/// an update, which restarts the app, is where people noticed.
+///
+/// The value name is the app's own name, which is what `tauri-plugin-autostart` passes
+/// `auto-launch` as the entry name.
+#[cfg(windows)]
+fn startup_vetoed(app_name: &str) -> bool {
+    use std::os::raw::c_void;
+
+    const HKEY_CURRENT_USER: isize = -2147483647; // 0x80000001
+    const RRF_RT_REG_BINARY: u32 = 0x0000_0008;
+
+    #[link(name = "advapi32")]
+    unsafe extern "system" {
+        fn RegGetValueW(
+            hkey: isize,
+            subkey: *const u16,
+            value: *const u16,
+            flags: u32,
+            typ: *mut u32,
+            data: *mut c_void,
+            data_len: *mut u32,
+        ) -> i32;
+    }
+
+    fn wide(s: &str) -> Vec<u16> {
+        s.encode_utf16().chain(std::iter::once(0)).collect()
+    }
+
+    let subkey =
+        wide("Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run");
+    let value = wide(app_name);
+    let mut buf = [0u8; 32];
+    let mut len = buf.len() as u32;
+    // SAFETY: a read-only registry query into a fixed stack buffer, length passed in bytes.
+    let rc = unsafe {
+        RegGetValueW(
+            HKEY_CURRENT_USER,
+            subkey.as_ptr(),
+            value.as_ptr(),
+            RRF_RT_REG_BINARY,
+            std::ptr::null_mut(),
+            buf.as_mut_ptr() as *mut c_void,
+            &mut len,
+        )
+    };
+    // No flag at all is the normal case — nobody has been through that screen.
+    if rc != 0 {
+        return false;
+    }
+    startup_flag_is_veto(&buf[..(len as usize).min(buf.len())])
+}
+
+#[cfg(not(windows))]
+fn startup_vetoed(_app_name: &str) -> bool {
+    false
+}
+
+/// Read one `StartupApproved\Run` flag: enabled carries a zero tail, disabled carries the
+/// FILETIME it was switched off. Anything too short to hold one is not a veto.
+#[cfg_attr(not(windows), allow(dead_code))] // read only on Windows; the tests run anywhere
+fn startup_flag_is_veto(bytes: &[u8]) -> bool {
+    bytes.len() >= 8 && !bytes.iter().rev().take(8).all(|b| *b == 0)
 }
 
 /// The frontend has drawn its first frame — see [`firstpaint`].
@@ -9289,9 +9367,11 @@ fn main() {
                 }
                 let manager = handle.autolaunch();
                 let stale = cfg.autostart_binding_rev < config::AUTOSTART_BINDING_REV;
+                let mut cfg_dirty = false;
                 match autostart_action(
                     cfg.launch_at_startup,
                     manager.is_enabled().unwrap_or(false),
+                    startup_vetoed(&handle.package_info().name),
                     stale,
                 ) {
                     Autostart::Enable => {
@@ -9305,10 +9385,21 @@ fn main() {
                     Autostart::Disable => {
                         let _ = manager.disable();
                     }
+                    Autostart::Adopt => {
+                        log::info!(
+                            "Windows' startup list has the app switched off — turning \
+                             Launch at startup off to match"
+                        );
+                        cfg.launch_at_startup = false;
+                        cfg_dirty = true;
+                    }
                     Autostart::Leave => {}
                 }
                 if stale {
                     cfg.autostart_binding_rev = config::AUTOSTART_BINDING_REV;
+                    cfg_dirty = true;
+                }
+                if cfg_dirty {
                     let _ = config::save(handle, &cfg);
                 }
                 if cfg.auto_run_frostmod && frostmod_manage::is_installed(handle) {
@@ -9875,25 +9966,55 @@ mod autostart_tests {
 
     #[test]
     fn the_setting_is_honoured_when_the_binding_is_current() {
-        assert_eq!(autostart_action(true, false, false), Autostart::Enable);
-        assert_eq!(autostart_action(true, true, false), Autostart::Leave);
-        assert_eq!(autostart_action(false, true, false), Autostart::Disable);
-        assert_eq!(autostart_action(false, false, false), Autostart::Leave);
+        assert_eq!(autostart_action(true, false, false, false), Autostart::Enable);
+        assert_eq!(autostart_action(true, true, false, false), Autostart::Leave);
+        assert_eq!(autostart_action(false, true, false, false), Autostart::Disable);
+        assert_eq!(autostart_action(false, false, false, false), Autostart::Leave);
     }
 
     /// The rename bug: the entry exists, so nothing looks wrong, but it names a binary that
     /// is gone. Without this the app quietly stops starting at login for everyone upgrading.
     #[test]
     fn an_entry_written_for_the_old_binary_is_rewritten() {
-        assert_eq!(autostart_action(true, true, true), Autostart::Rebind);
+        assert_eq!(autostart_action(true, true, false, true), Autostart::Rebind);
     }
 
     /// Whoever turned it off gets it off, however old their entry is — a stale binding is a
     /// reason to rewrite the entry, never to bring one back.
     #[test]
     fn a_stale_binding_never_revives_a_disabled_login_item() {
-        assert_eq!(autostart_action(false, true, true), Autostart::Disable);
-        assert_eq!(autostart_action(false, false, true), Autostart::Leave);
+        assert_eq!(autostart_action(false, true, false, true), Autostart::Disable);
+        assert_eq!(autostart_action(false, false, false, true), Autostart::Leave);
+    }
+
+    /// The report: turned off in Task Manager, back on after the next update. A veto there
+    /// reads as "not enabled", so every one of these used to come out `Enable` — and
+    /// `enable()` rewrites the very flag that was the player saying no.
+    #[test]
+    fn windows_own_startup_list_wins_over_the_setting() {
+        assert_eq!(autostart_action(true, false, true, false), Autostart::Adopt);
+        assert_eq!(autostart_action(true, false, true, true), Autostart::Adopt);
+        // Belt and braces: a veto standing next to an entry that still reads as enabled.
+        assert_eq!(autostart_action(true, true, true, false), Autostart::Adopt);
+    }
+
+    /// A veto is a reason to stop turning it on, never a reason to turn it on. With the
+    /// setting already off there is nothing left to reconcile.
+    #[test]
+    fn a_veto_leaves_an_already_off_setting_alone() {
+        assert_eq!(autostart_action(false, false, true, false), Autostart::Leave);
+        assert_eq!(autostart_action(false, false, true, true), Autostart::Leave);
+    }
+
+    /// The twelve bytes Windows writes: `02 00…` while the app is allowed to start, `03 00`
+    /// plus the FILETIME it was switched off once it isn't.
+    #[test]
+    fn the_startup_flag_is_read_off_its_tail() {
+        assert!(!startup_flag_is_veto(&[2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]));
+        assert!(startup_flag_is_veto(&[3, 0, 0, 0, 0x1e, 0x2b, 0x9c, 0x5f, 0x7a, 0x0d, 0xdc, 0x01]));
+        // Too short to carry a timestamp, so there is nothing there that says "off".
+        assert!(!startup_flag_is_veto(&[]));
+        assert!(!startup_flag_is_veto(&[3, 0, 0, 0]));
     }
 }
 

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -460,7 +460,7 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
 
   const runInBackground = config.runInBackground ?? true;
   const analyticsEnabled = config.analyticsEnabled ?? true;
-  const launchAtStartup = config.launchAtStartup ?? true;
+  const launchAtStartup = config.launchAtStartup ?? false;
   const autoRunFrostmod = config.autoRunFrostmod ?? true;
   // Typed flags are edited freely and saved on blur, so the field holds a draft until then —
   // saving per keystroke would write the config on every letter and fight the cursor.


### PR DESCRIPTION
## The report

> Can you turn off the "auto start"? I have to turn it off every single time there is a new update. And the updates keep coming.

Two separate things were making that true, and fixing either one alone leaves the other standing.

## 1. The setting shipped on

`launch_at_startup` defaulted to `true`. It's a mod manager — nothing needs it running before the game is — so it now defaults to off, with the toggle in Settings for anyone who wants the app waiting for them.

Moving the default alone reaches **nobody**, though: it shipped on, so every config already written carries `launchAtStartup: true` spelled out. Nobody picked that; the app picked it for them. So there's a one-shot, `LAUNCH_AT_STARTUP_REV`, modelled exactly on the `PAINT_SYNC_REV` one already in that file — switched off once, and anyone who turns it back on keeps it because the counter no longer moves.

## 2. Windows' own startup list was being overwritten

Task Manager → Startup apps (and Settings → Apps → Startup) does **not** remove the `Run` entry. It leaves it where it is and stamps a flag beside it under `StartupApproved\Run`: twelve bytes whose tail is all zeros for on, and carries the FILETIME it was switched off for off.

[`auto-launch` 0.5.0](https://docs.rs/crate/auto-launch/0.5.0/source/src/windows.rs) folds that flag into `is_enabled()` (`al_enabled && task_manager_enabled`), so a veto there reads back **identically to "there is no entry"**. The startup reconcile answered that with `enable()` — which rewrites the entry *and* resets the flag to approved (`TASK_MANAGER_OVERRIDE_ENABLED_VALUE`). Every launch silently undid the choice, and an update, which restarts the app, is where people noticed.

A new `Autostart::Adopt` arm outranks everything else: read the flag directly and take it as the answer, carrying it into the config so Settings agrees with Windows, and touch nothing in the registry. Turning it back on in Settings still clears the veto — an explicit instruction should.

The probe is raw `RegGetValueW` in the same style as `steamid.rs`, so no new dependency.

### Ruled out along the way

The NSIS installer is innocent — Tauri's template preserves both the `HKCU\...\Run` value and `%LOCALAPPDATA%\<bundleid>` on updates (`$UpdateMode <> 1` guards both), so neither the config nor the entry is lost across a version bump.

## Verification

- `cargo test` — 1177 passed, 0 failed
- `cargo check --target x86_64-pc-windows-gnu` — clean, which is the only thing that type-checks the `cfg(windows)` half from macOS
- `tsc --noEmit` — clean
- 8 new tests: the veto beats the setting, a veto never revives an off setting, the flag's byte layout, the one-shot fires once and doesn't re-fire, and turning it back on survives the next launch

Not runtime-verified on Windows — the registry read and the login-item write both need a real machine.

## DB / schema

None. `launchAtStartupRev` is a new config field; absent reads as rev 0, which is what makes the one-shot fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)