### PR TITLE
fix(tracks): write the vertex's own slot, not halfway into the block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## 2026-09-01
 
 ### Fixed
+- Two of the four values every vertex of a track's graphics file carries were left at zero.
+
+## 2026-09-01
+
+### Fixed
 - The terrain in a track's graphics file is cut into tiles, so no single piece of it is too
   large for the game to build a buffer for.
 

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -2044,9 +2044,19 @@ fn map(prog: &TrackProgram, syn: &Synth) -> Vec<u8> {
                     let uv = 12 * vc + v * 8;
                     block[uv..uv + 4].copy_from_slice(&(x / tile).to_le_bytes());
                     block[uv + 4..uv + 8].copy_from_slice(&(z / tile).to_le_bytes());
-                    let pair = 44 * vc + v * 8;
-                    block[pair..pair + 4].copy_from_slice(&1.0f32.to_le_bytes());
-                    block[pair + 4..pair + 8].copy_from_slice(&1.0f32.to_le_bytes());
+                    // Sixteen bytes a vertex starting at 36 x count, and every one of the
+                    // four floats is 1.0 on every vertex of a published map.
+                    //
+                    // This used to write two floats at `44 * vc + v * 8`, which is not this
+                    // vertex's slot — it is halfway into the block and eight bytes a vertex,
+                    // so it landed in some other vertex's. It read back correct because
+                    // *every* value in the region is 1.0 on the map I measured against, so
+                    // any offset into it looks right. Ours came out with two of four zeroed.
+                    let quad = 36 * vc + v * 16;
+                    for c in 0..4 {
+                        block[quad + c * 4..quad + c * 4 + 4]
+                            .copy_from_slice(&1.0f32.to_le_bytes());
+                    }
                     let gx = ((i + dx) * (syn.gw - 1) / q).min(syn.gw - 1);
                     let gy = ((j + dz) * (syn.gh - 1) / q).min(syn.gh - 1);
                     let dhx = (at(gx + 1, gy) - at(gx.saturating_sub(1), gy)) / (2.0 * syn.mps);
@@ -3578,6 +3588,41 @@ mod tests {
         }
         assert_eq!((tri as usize, vert as usize), (tc, vc), "every triangle in a group");
         assert!(groups > 1, "one group over the whole terrain is what this test exists for");
+    }
+
+    /// Every vertex attribute has to be what a published map puts there.
+    ///
+    /// Three of these were wrong at some point and each was invisible: a zero-length tangent
+    /// (a divide by zero in anything that shades it), a zero-length normal, and four floats
+    /// written into the wrong vertex's slot. That last one read back correct against the
+    /// reference because *every* value in that region is 1.0 on a real map, so any offset
+    /// into it looks right — only checking our own file, per vertex, catches it.
+    #[test]
+    fn every_vertex_carries_what_the_format_expects() {
+        let p = oval();
+        let s = synthesise(&p).unwrap();
+        let m = map(&p, &s);
+        let n = u32::from_le_bytes(m[8..12].try_into().unwrap()) as usize;
+        let at = 12 + n * 56;
+        let vc = u32::from_le_bytes(m[at..at + 4].try_into().unwrap()) as usize;
+        let block = &m[at + 4..at + 4 + vc * 80];
+        let f = |o: usize| f32::from_le_bytes(block[o..o + 4].try_into().unwrap());
+        for v in 0..vc {
+            let nm = 52 * vc + v * 12;
+            let len = (f(nm).powi(2) + f(nm + 4).powi(2) + f(nm + 8).powi(2)).sqrt();
+            assert!((len - 1.0).abs() < 1e-3, "vertex {v}: normal is {len}, not a unit vector");
+
+            let tg = 64 * vc + v * 16;
+            let tl = (f(tg).powi(2) + f(tg + 4).powi(2) + f(tg + 8).powi(2)).sqrt();
+            assert!((tl - 1.0).abs() < 1e-3, "vertex {v}: tangent is {tl}, not a unit vector");
+            assert_eq!(f(tg + 12).abs(), 1.0, "vertex {v}: handedness is {}", f(tg + 12));
+
+            // Sixteen bytes a vertex at 36 x count, all four floats 1.0 on a published map.
+            let q = 36 * vc + v * 16;
+            for c in 0..4 {
+                assert_eq!(f(q + c * 4), 1.0, "vertex {v}: float {c} of its own slot");
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Found by comparing attribute **ranges** rather than structure:

```
=== Indiana ===
   @36      [1,1] [1,1] [1,1] [1,1]
=== ours ===
   @36      [0,1] [0,1] [0,1] [0,1]
```

Across a published map every vertex's sixteen-byte slot at `36 * count` is 1.0 in all four
floats. Ours had two of the four at zero.

## The trap

I wrote the pair at `44 * vc + v * 8` — right region, wrong arithmetic. The block is **sixteen
bytes a vertex** from `36 * vc`, so `44 * vc` is halfway into it and a stride of eight lands in
some *other* vertex's slot.

It verified fine against the reference because **every value in that region is 1.0 on a real
map** — read any offset into it and it says 1.0. The only way to see the zeros is to read our
own file, per vertex.

## Now

All four floats at `36 * vc + v * 16`, and a test walks every vertex of a built map asserting
the four floats, a unit normal, a unit tangent, and a handedness of exactly ±1. Three separate
faults have hidden in this block — a zero tangent, a zero normal, and now this — so it has a
guard.

## Noted and deliberately left

Our texture coordinates run to 189 where Indiana's reach about 24, because our sheets tile
every few metres rather than every twenty. That is a look decision, not a fault — flagging it
so it isn't "fixed" later by someone reading the same comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)