### PR TITLE
feat(diagnostics): report what a file says about itself, and read the list by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,6 @@
 
 ## 2026-09-01
 
-### Fixed
-- Two of the four values every vertex of a track's graphics file carries were left at zero.
-
-## 2026-09-01
-
-### Fixed
-- The terrain in a track's graphics file is cut into tiles, so no single piece of it is too
-  large for the game to build a buffer for.
-
-## 2026-09-01
-
-### Fixed
-- More of the crash at track graphics: the ground sheets in a track's graphics file were
-  written in a shape the game cannot read past.
-
-## 2026-09-01
-
 ### Added
 - Track generation reads a published track's own centreline out of its height file, so a real
   lap's corners, their radii and its straights can be measured directly rather than guessed at.
@@ -26,6 +9,9 @@
   published one.
 
 ### Changed
+- Diagnostics say more about each file loaded in your game: its size, when it was built,
+  whether Windows trusts its signature and who signed it, and the company and product it
+  claims to be. A file can be read the first time it is seen instead of only recognised.
 - Generated laps are laid out the way published tracks are built: corners made of several arcs
   that tighten into the apex and release out of it, far more corners than straights, and a lap
   that wanders instead of running round a rounded rectangle.
@@ -37,6 +23,9 @@
   the toggle is in Settings for anyone who wants the app waiting for them.
 
 ### Fixed
+- Two of the four values every vertex of a track's graphics file carries were left at zero.
+- The terrain in a track's graphics file is cut into tiles, so no single piece of it is too
+  large for the game to build a buffer for.
 - A corner banks the outside of the turn.
 - Ruts read as ridden ground rather than as a set of parallel lines running the whole lap.
 - The ground either side of the track no longer carries fine streaks fanning off every corner.

--- a/control-plane/migrations/0017_module_file_detail.sql
+++ b/control-plane/migrations/0017_module_file_detail.sql
@@ -1,0 +1,37 @@
+-- What a reported file says about itself.
+--
+-- The first version of client diagnostics carried a name, an origin and a hash, which
+-- between them identify a file we already know about and say nothing at all about one we
+-- don't. Every first sighting is a name nobody recognises, and the page filled up with rows
+-- there was no way to read.
+--
+-- These seven columns are what the client can read off a file cheaply, and they split into
+-- two kinds that must not be confused on the page:
+--
+--   * `trust` and `publisher` are Windows' answer, from `WinVerifyTrust` and the signing
+--     certificate. Checked, and worth something: an overlay that belongs in a game process
+--     is signed by a company whose name you know.
+--   * `company`, `product` and `description` are the version resource — text the file
+--     carries about itself, which anything can write and which nothing verifies. Useful for
+--     recognising the ordinary, worthless as evidence about the unusual.
+--
+-- `size` and `mtime` are neither: they are facts about the file on that machine, and they
+-- are what tells two builds of the same-named library apart when neither of them will hash.
+--
+-- Every column has a default, because the rows already in the table were written before any
+-- of this existed and older clients keep reporting without it. An empty `trust` would be a
+-- fourth state nobody has a name for, so absent reads as 'unchecked' — which is the same
+-- thing the client says about a file it did not look at, and deliberately not 'unsigned'.
+ALTER TABLE client_module_seen ADD COLUMN size INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE client_module_seen ADD COLUMN mtime INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE client_module_seen ADD COLUMN trust TEXT NOT NULL DEFAULT 'unchecked';
+ALTER TABLE client_module_seen ADD COLUMN publisher TEXT NOT NULL DEFAULT '';
+ALTER TABLE client_module_seen ADD COLUMN company TEXT NOT NULL DEFAULT '';
+ALTER TABLE client_module_seen ADD COLUMN product TEXT NOT NULL DEFAULT '';
+ALTER TABLE client_module_seen ADD COLUMN description TEXT NOT NULL DEFAULT '';
+
+-- The unaccounted list is read grouped by file name now — one row per file, however many
+-- people have loaded it — so the window scan is by name within the time window rather than
+-- by recency alone. The existing `(state, last_at)` index still serves the window; this one
+-- serves the grouping and the per-name signature summary that goes with it.
+CREATE INDEX client_module_seen_name_state ON client_module_seen (name, state, last_at);

--- a/control-plane/src/diagnostics.ts
+++ b/control-plane/src/diagnostics.ts
@@ -2,8 +2,17 @@
  * What is loaded inside a player's running game.
  *
  * The app walks the module list of the running game and posts it here — file name, where it
- * came from, and a hash for anything that is not a Windows system library. That is the whole
- * of the client's job: it observes and reports, and it holds no opinion about any file.
+ * came from, a hash for anything that is not a Windows system library, and what the file says
+ * about itself: size, last written, whether Windows trusts its signature and who signed it,
+ * and the company and product it claims. That is the whole of the client's job: it observes
+ * and reports, and it holds no opinion about any file.
+ *
+ * The self-description is worth having because a name and a hash only identify what is
+ * already known, and every first sighting is a name nobody recognises. `signed by NVIDIA
+ * Corporation` and `unsigned, claims nothing` are the same length on the page and mean
+ * opposite things. None of it is trusted: a version resource is text the file supplies about
+ * itself and is treated exactly like any other string off a client. Only `trust` is checked,
+ * because only Windows checked it.
  *
  * Every judgement lives here instead, against `module_rules`, and that split is the design
  * rather than an accident of layering:
@@ -56,11 +65,39 @@ export function isState(value: unknown): value is State {
   return typeof value === "string" && value in STATE_RANK;
 }
 
+/**
+ * What Windows made of a file's signature, as the client read it.
+ *
+ * `unchecked` is not `unsigned`: system libraries are never looked at, and neither is
+ * anything under Wine, where there is no trust store to ask. Folding the two together would
+ * report every Linux player's whole game as unsigned.
+ */
+export type Trust = "unchecked" | "unsigned" | "signed" | "untrusted";
+
+const TRUSTS: readonly string[] = ["unchecked", "unsigned", "signed", "untrusted"];
+
+export function isTrust(value: unknown): value is Trust {
+  return typeof value === "string" && TRUSTS.includes(value);
+}
+
 export interface ReportedModule {
   name: string;
   origin: Origin;
   /** Empty for system libraries, which the client does not hash, and for unreadable files. */
   sha256: string;
+  /** Bytes on disk; 0 when the client could not read the file. */
+  size: number;
+  /** Last written, seconds since the epoch; 0 when unknown. */
+  mtime: number;
+  trust: Trust;
+  /** The signing certificate's display name. Only ever set when `trust` is `signed`. */
+  publisher: string;
+  /** `CompanyName` off the version resource — a claim, not a checked fact. */
+  company: string;
+  /** `ProductName`. */
+  product: string;
+  /** `FileDescription`, the field Explorer shows. */
+  description: string;
 }
 
 export interface ModuleRule {
@@ -91,6 +128,16 @@ export const MAX_MODULES = 400;
 
 /** A file name. Long enough for anything real, short enough to be a column. */
 const MAX_NAME = 96;
+
+/** The same bound the client already applies to everything it reads off a file. */
+const MAX_FIELD = 96;
+
+/** Bigger than any library, and the point past which a number is a client bug or a lie. */
+const MAX_SIZE = 8 * 1024 * 1024 * 1024;
+
+/** Seconds. Anything outside this is not a timestamp — 2000-01-01 to roughly 2100. */
+const MIN_MTIME = 946_684_800;
+const MAX_MTIME = 4_102_444_800;
 
 const ORIGINS: readonly string[] = ["game", "system", "app", "other"];
 
@@ -150,9 +197,44 @@ export function parseModules(value: unknown): ReportedModule[] | null {
     const key = `${clean} ${hash}`;
     if (seen.has(key)) continue;
     seen.add(key);
-    out.push({ name: clean, origin: origin as Origin, sha256: hash });
+    const e = entry as Record<string, unknown>;
+    out.push({
+      name: clean,
+      origin: origin as Origin,
+      sha256: hash,
+      size: bounded(e.size, MAX_SIZE),
+      mtime: stamp(e.mtime),
+      // An absent or unrecognised trust reads as `unchecked` rather than rejecting the
+      // report: an older client sends no such field at all, and a report that is thrown away
+      // is worse than one that says less than it could.
+      trust: isTrust(e.trust) ? e.trust : "unchecked",
+      publisher: field(e.publisher),
+      company: field(e.company),
+      product: field(e.product),
+      description: field(e.description),
+    });
   }
   return out;
+}
+
+/** One string a file said about itself: trimmed, bounded, and stripped of control characters. */
+function field(value: unknown): string {
+  if (typeof value !== "string") return "";
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/[\u0000-\u001f\u007f]/g, "").trim().slice(0, MAX_FIELD);
+}
+
+/** A non-negative integer inside a bound, or 0. */
+function bounded(value: unknown, max: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  const n = Math.trunc(value);
+  return n > 0 && n <= max ? n : 0;
+}
+
+/** A plausible epoch-seconds timestamp, or 0. */
+function stamp(value: unknown): number {
+  const n = bounded(value, MAX_MTIME);
+  return n >= MIN_MTIME ? n : 0;
 }
 
 /**
@@ -163,7 +245,11 @@ export function parseModules(value: unknown): ReportedModule[] | null {
  *   1. **Deny first.** A named file is named wherever it loaded from — something that copies
  *      itself into the game's folder must not be trusted for being there.
  *   2. **Allow next**, so a false positive is silenced by adding one row, not by a release.
- *   3. **Loader names in the game's folder**, the one case where the location is the point.
+ *   3. **Anything in the game's own folder.** Sitting beside the executable is the cheapest
+ *      way into a process, not a credential — and this is the hole the first version left:
+ *      a file dropped next to `mxbikes.exe` under an ordinary name read as accounted for
+ *      because of where it was. The game's own libraries land here too and are cleared once,
+ *      by hash, from the admin page.
  *   4. **Anything from outside** the game, the system, and what the app installed.
  *   5. Everything else is accounted for.
  */
@@ -180,11 +266,7 @@ export function classify(modules: ReportedModule[], rules: ModuleRule[]): Classi
       continue;
     }
     if (matchRule(allow, mod)) continue;
-    if (mod.origin === "game" && LOADER_NAMES.includes(mod.name)) {
-      unknown.push(mod);
-      continue;
-    }
-    if (mod.origin === "other") unknown.push(mod);
+    if (isUnaccounted(mod)) unknown.push(mod);
   }
 
   const state: State = matched.length > 0 ? "alert" : unknown.length > 0 ? "warn" : "ok";
@@ -347,11 +429,15 @@ async function store(
     statements.push(
       env.DB.prepare(
         "INSERT INTO client_module_seen (account_id, name, sha256, origin, state, label," +
-          " rider_name, server_id, first_at, last_at, hits)" +
-          " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)" +
+          " rider_name, server_id, first_at, last_at, hits," +
+          " size, mtime, trust, publisher, company, product, description)" +
+          " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?)" +
           " ON CONFLICT(account_id, name, sha256) DO UPDATE SET origin = excluded.origin," +
           " state = excluded.state, label = excluded.label, rider_name = excluded.rider_name," +
-          " server_id = excluded.server_id, last_at = excluded.last_at, hits = hits + 1",
+          " server_id = excluded.server_id, last_at = excluded.last_at, hits = hits + 1," +
+          " size = excluded.size, mtime = excluded.mtime, trust = excluded.trust," +
+          " publisher = excluded.publisher, company = excluded.company," +
+          " product = excluded.product, description = excluded.description",
       ).bind(
         account.id,
         mod.name,
@@ -363,6 +449,13 @@ async function store(
         serverId,
         now,
         now,
+        mod.size,
+        mod.mtime,
+        mod.trust,
+        mod.publisher,
+        mod.company,
+        mod.product,
+        mod.description,
       ),
     );
   }
@@ -370,10 +463,27 @@ async function store(
   await env.DB.batch(statements);
 }
 
+/**
+ * Does this module need a rule to account for it?
+ *
+ * `system` is the only origin that accounts for itself, and it does so by where it is: a
+ * Windows system folder is not writable without administrator rights, so a file there was
+ * put there by something that already had the machine. `app` is our own install folder,
+ * which we put every file in ourselves.
+ *
+ * Everything else — the game's folder included — needs a rule. `LOADER_NAMES` no longer
+ * changes the answer for the game's folder, because the whole folder is asked about now; it
+ * stays because those names matter wherever else they turn up.
+ */
+export function isUnaccounted(mod: ReportedModule): boolean {
+  if (mod.origin === "system") return false;
+  if (mod.origin === "app") return LOADER_NAMES.includes(mod.name);
+  return true;
+}
+
 /** Was this module one of the ones nothing accounted for in the report it arrived in? */
 function unknownState(mod: ReportedModule, reportState: State): State {
-  if (mod.origin === "other") return "warn";
-  if (mod.origin === "game" && LOADER_NAMES.includes(mod.name)) return "warn";
+  if (isUnaccounted(mod)) return "warn";
   return reportState === "unknown" ? "unknown" : "ok";
 }
 
@@ -394,39 +504,88 @@ export interface LiveRow {
   updatedAt: number;
 }
 
-/** One file, as it has been seen across everyone. */
-export interface SeenRow {
-  accountId: string;
-  riderName: string;
-  serverId: string;
+/**
+ * One distinct file — one name and one hash — as it has been seen across everyone.
+ *
+ * A variant, not a sighting: the per-account rows behind it are collapsed, because the
+ * question the page asks is "what is this file" and the answer does not change with who
+ * loaded it. `riderName` is only meaningful when `accounts` is 1, and the page only shows it
+ * then; naming one of several people would read as an accusation of that one.
+ */
+export interface SeenVariant {
   name: string;
   sha256: string;
   origin: string;
   state: State;
   label: string;
-  firstAt: number;
-  lastAt: number;
-  hits: number;
+  trust: Trust;
+  publisher: string;
+  company: string;
+  product: string;
+  description: string;
+  size: number;
+  mtime: number;
+  riderName: string;
   /** How many distinct accounts have ever loaded this exact file. */
   accounts: number;
+  hits: number;
+  lastAt: number;
+}
+
+/**
+ * Every variant sharing one file name, which is how the unaccounted list is read.
+ *
+ * The name is the unit because that is what a rule is written against and what a person
+ * recognises. `variants` is where the interesting shape lives: one name with one hash on
+ * two hundred machines is a driver, and one name with two hundred hashes is something being
+ * rebuilt between sessions.
+ */
+export interface SeenGroup {
+  name: string;
+  /** The worst state any variant is in. */
+  state: State;
+  /** The first label any rule gave a variant, so a named group says what it is. */
+  label: string;
+  /** Distinct accounts across every variant of this name. */
+  accounts: number;
+  hits: number;
+  firstAt: number;
+  lastAt: number;
+  /** Distinct hashes recorded under this name in the window. */
+  variantCount: number;
+  /** The variants themselves, worst first then most recent. May be short of
+   *  `variantCount` when the detail query's cap was reached. */
+  variants: SeenVariant[];
 }
 
 export interface AdminView {
   live: LiveRow[];
-  seen: SeenRow[];
+  seen: SeenGroup[];
+  /** Distinct unaccounted file names in the window, before `MAX_SEEN_NAMES` trimmed them. */
+  seenNamesTotal: number;
   rules: ModuleRule[];
   rulesVersion: number;
   reporting: number;
 }
 
+/** The most file names the unaccounted list draws. Anything past it is counted, not drawn. */
+const MAX_SEEN_NAMES = 200;
+
+/** The most variants fetched across all of those names together. */
+const MAX_SEEN_VARIANTS = 1000;
+
 /**
  * Everything the admin page draws.
  *
  * `live` is who is reporting right now, worst first. `seen` is the evidence log — every
- * non-system file anyone's game has loaded that the rules do not account for, most recent
- * first, with the number of accounts that have ever loaded it. That last number is the one
- * that reads best: a file on one machine out of hundreds is interesting whatever any rule
- * says, and a file on all of them is a driver.
+ * non-system file anyone's game has loaded that the rules do not account for — grouped by
+ * file name, most recent first, with the number of accounts that have ever loaded it. That
+ * last number is the one that reads best: a file on one machine out of hundreds is
+ * interesting whatever any rule says, and a file on all of them is a driver.
+ *
+ * Grouped rather than listed because the list is per account and per hash, and one popular
+ * overlay was arriving as several hundred rows that said the same thing. The name is the
+ * unit a rule is written against, so it is also the unit the page is read in.
  */
 export async function collectAdminView(env: Env, days: number): Promise<AdminView> {
   const fresh = Date.now() - PRESENCE_TTL_MS;
@@ -457,30 +616,87 @@ export async function collectAdminView(env: Env, days: number): Promise<AdminVie
       server_id: string | null;
     }>();
 
-  const seen = await env.DB.prepare(
-    "SELECT s.account_id, s.rider_name, s.server_id, s.name, s.sha256, s.origin, s.state," +
-      " s.label, s.first_at, s.last_at, s.hits," +
-      " (SELECT COUNT(DISTINCT t.account_id) FROM client_module_seen t" +
-      "  WHERE t.name = s.name AND t.sha256 = s.sha256) AS accounts" +
-      " FROM client_module_seen s" +
-      " WHERE s.state IN ('warn', 'alert') AND s.last_at > ?" +
-      " ORDER BY s.last_at DESC LIMIT 500",
+  // Two queries rather than one, because the totals have to be right even where the detail
+  // is trimmed: the first counts every name in the window, the second fetches the variants
+  // to draw under them. Grouping the first in SQL is what keeps a name loaded by six hundred
+  // people from arriving as six hundred rows.
+  const names = await env.DB.prepare(
+    "SELECT name, COUNT(DISTINCT account_id) AS accounts, COUNT(DISTINCT sha256) AS variants," +
+      " SUM(hits) AS hits, MIN(first_at) AS first_at, MAX(last_at) AS last_at" +
+      " FROM client_module_seen" +
+      " WHERE state IN ('warn', 'alert') AND last_at > ?" +
+      " GROUP BY name ORDER BY MAX(last_at) DESC LIMIT ?",
+  )
+    .bind(since, MAX_SEEN_NAMES)
+    .all<{
+      name: string;
+      accounts: number;
+      variants: number;
+      hits: number;
+      first_at: number;
+      last_at: number;
+    }>();
+
+  const nameTotal = await env.DB.prepare(
+    "SELECT COUNT(DISTINCT name) AS n FROM client_module_seen" +
+      " WHERE state IN ('warn', 'alert') AND last_at > ?",
   )
     .bind(since)
+    .first<{ n: number }>();
+
+  const seen = await env.DB.prepare(
+    "SELECT name, sha256, origin, state, label, trust, publisher, company, product," +
+      " description, size, mtime, MAX(rider_name) AS rider_name," +
+      " COUNT(DISTINCT account_id) AS accounts, SUM(hits) AS hits, MAX(last_at) AS last_at" +
+      " FROM client_module_seen" +
+      " WHERE state IN ('warn', 'alert') AND last_at > ?" +
+      " GROUP BY name, sha256 ORDER BY MAX(last_at) DESC LIMIT ?",
+  )
+    .bind(since, MAX_SEEN_VARIANTS)
     .all<{
-      account_id: string;
-      rider_name: string;
-      server_id: string;
       name: string;
       sha256: string;
       origin: string;
       state: string;
       label: string;
-      first_at: number;
-      last_at: number;
-      hits: number;
+      trust: string;
+      publisher: string;
+      company: string;
+      product: string;
+      description: string;
+      size: number;
+      mtime: number;
+      rider_name: string;
       accounts: number;
+      hits: number;
+      last_at: number;
     }>();
+
+  // Variants, indexed by the name they belong to.
+  const byName = new Map<string, SeenVariant[]>();
+  for (const r of seen.results ?? []) {
+    const variant: SeenVariant = {
+      name: r.name,
+      sha256: r.sha256,
+      origin: r.origin,
+      state: isState(r.state) ? r.state : "unknown",
+      label: r.label ?? "",
+      trust: isTrust(r.trust) ? r.trust : "unchecked",
+      publisher: r.publisher ?? "",
+      company: r.company ?? "",
+      product: r.product ?? "",
+      description: r.description ?? "",
+      size: r.size ?? 0,
+      mtime: r.mtime ?? 0,
+      riderName: r.rider_name ?? "",
+      accounts: r.accounts,
+      hits: r.hits,
+      lastAt: r.last_at,
+    };
+    const list = byName.get(variant.name);
+    if (list) list.push(variant);
+    else byName.set(variant.name, [variant]);
+  }
 
   const { rules, version } = await loadRules(env);
 
@@ -508,20 +724,28 @@ export async function collectAdminView(env: Env, days: number): Promise<AdminVie
             Math.max(stateRank(a.worstState), stateRank(a.state)) ||
           b.updatedAt - a.updatedAt,
       ),
-    seen: (seen.results ?? []).map((r) => ({
-      accountId: r.account_id,
-      riderName: r.rider_name ?? "",
-      serverId: r.server_id ?? "",
-      name: r.name,
-      sha256: r.sha256,
-      origin: r.origin,
-      state: isState(r.state) ? r.state : "unknown",
-      label: r.label ?? "",
-      firstAt: r.first_at,
-      lastAt: r.last_at,
-      hits: r.hits,
-      accounts: r.accounts,
-    })),
+    seen: (names.results ?? []).map((g) => {
+      const variants = (byName.get(g.name) ?? []).sort(
+        (a, b) => stateRank(b.state) - stateRank(a.state) || b.lastAt - a.lastAt,
+      );
+      return {
+        name: g.name,
+        // Off the variants we actually have. A group whose detail was trimmed can only be
+        // as bad as what is in front of us, which is the honest answer rather than a guess.
+        state: variants.reduce<State>(
+          (worst, v) => (stateRank(v.state) > stateRank(worst) ? v.state : worst),
+          "unknown",
+        ),
+        label: variants.find((v) => v.label)?.label ?? "",
+        accounts: g.accounts,
+        hits: g.hits,
+        firstAt: g.first_at,
+        lastAt: g.last_at,
+        variantCount: g.variants,
+        variants,
+      };
+    }),
+    seenNamesTotal: nameTotal?.n ?? (names.results ?? []).length,
     rules,
     rulesVersion: version,
     reporting: (live.results ?? []).length,

--- a/control-plane/src/diagnosticspage.ts
+++ b/control-plane/src/diagnosticspage.ts
@@ -19,8 +19,10 @@ import {
   type AdminView,
   type LiveRow,
   type ModuleRule,
-  type SeenRow,
+  type SeenGroup,
+  type SeenVariant,
   type State,
+  type Trust,
 } from "./diagnostics";
 import { adminAllowed, windowDays } from "./usage";
 
@@ -129,10 +131,16 @@ function render(v: AdminView, url: URL, days: number): string {
 </section>
 
 <section class="panel">
-  <h2>Files nothing accounts for <span class="muted">— last ${days}d, most recent first</span></h2>
-  <p class="muted">Accounts is how many distinct people have ever loaded this exact file. One
-    out of many is the interesting shape; many is a driver or an overlay, and worth allowing
-    so it stops filling this list.</p>
+  <h2>Files nothing accounts for
+    <span class="muted">— last ${days}d, by file name, most recent first</span></h2>
+  <p class="muted">One row per file name. Accounts is how many distinct people have loaded
+    it — one out of many is the interesting shape; many is a driver or an overlay, and worth
+    clearing so it stops filling this list. Open a row for each distinct build of that file:
+    who signed it, what it claims to be, and its hash.</p>
+  <p class="muted"><b>Signed</b> is Windows' answer and means something. <b>Company</b> and
+    <b>product</b> are what the file says about itself, which anything can write — good for
+    recognising the ordinary, worthless as evidence about the unusual.</p>
+  ${trimmed(v)}
   ${sightings(v.seen, action)}
 </section>
 
@@ -201,42 +209,149 @@ function live(rows: LiveRow[]): string {
     .join("")}</tbody></table>`;
 }
 
-function sightings(rows: SeenRow[], action: string): string {
-  if (!rows.length) return `<p class="muted">Nothing unaccounted for in this window.</p>`;
-  return `<table>
-  <thead><tr><th>File</th><th>Where</th><th>Rider</th><th class="num">Accounts</th>
-    <th class="num">Seen</th><th>Last</th><th></th></tr></thead>
+/** Says what the page is not showing, when a cap trimmed it. Silence would read as "all". */
+function trimmed(v: AdminView): string {
+  const shown = v.seen.length;
+  if (v.seenNamesTotal <= shown) return "";
+  return `<p class="warnline">Showing ${shown} of ${v.seenNamesTotal} file names. Clear the
+    ordinary ones and the rest come into view.</p>`;
+}
+
+function sightings(groups: SeenGroup[], action: string): string {
+  if (!groups.length) return `<p class="muted">Nothing unaccounted for in this window.</p>`;
+  return `<table class="seen">
+  <thead><tr><th>File</th><th>Signed</th><th>Claims</th><th class="num">Builds</th>
+    <th class="num">Accounts</th><th class="num">Seen</th><th>Last</th><th></th></tr></thead>
+  <tbody>${groups.map((g) => group(g, action)).join("")}</tbody></table>`;
+}
+
+/**
+ * One file name, with its builds folded underneath.
+ *
+ * `<details>` rather than a script: this page has never had one and is not going to start —
+ * see the note at the top. The summary row carries the whole group's answer, so the common
+ * case is read without opening anything.
+ */
+function group(g: SeenGroup, action: string): string {
+  const label = g.label ? ` <span class="muted">${esc(g.label)}</span>` : "";
+  // Named only when one person has it. With several, naming whichever row sorted first
+  // would read as an accusation of that one.
+  const rider =
+    g.accounts === 1 && g.variants[0]?.riderName
+      ? ` <span class="muted">— ${esc(g.variants[0].riderName)}</span>`
+      : "";
+  const detail =
+    g.variants.length > 0
+      ? `<details><summary class="muted">${g.variants.length} build${
+          g.variants.length === 1 ? "" : "s"
+        }${
+          g.variantCount > g.variants.length ? ` of ${g.variantCount}` : ""
+        }</summary>${variants(g.variants, action)}</details>`
+      : "";
+  return `<tr>
+    <td><span class="pill ${esc(g.state)}"></span> <code>${esc(g.name)}</code>${label}${rider}
+      ${detail}</td>
+    <td>${trust(g.variants)}</td>
+    <td class="muted">${esc(claims(g.variants) || "—")}</td>
+    <td class="num">${g.variantCount}</td>
+    <td class="num">${g.accounts}</td>
+    <td class="num">${g.hits}</td>
+    <td class="muted">${esc(ago(g.lastAt))}</td>
+    <td class="act">${nameButtons(g, action)}</td>
+  </tr>`;
+}
+
+/**
+ * The group's signature answer, which is the worst of its builds.
+ *
+ * One unsigned build under a name whose other builds are signed is exactly the case worth
+ * seeing, so the summary must not average it away.
+ */
+function trust(variants: SeenVariant[]): string {
+  const rank: Record<Trust, number> = { signed: 0, unchecked: 1, unsigned: 2, untrusted: 3 };
+  let worst: SeenVariant | undefined;
+  for (const v of variants) {
+    if (!worst || rank[v.trust] > rank[worst.trust]) worst = v;
+  }
+  if (!worst) return `<span class="muted">—</span>`;
+  const tone = worst.trust === "signed" ? "" : worst.trust === "unchecked" ? "muted" : "warn";
+  const who = worst.trust === "signed" && worst.publisher ? esc(worst.publisher) : "";
+  return `<span class="sig ${tone}">${esc(worst.trust)}</span>${
+    who ? ` <span class="muted">${who}</span>` : ""
+  }`;
+}
+
+/** What the file says it is: the first description or company any build carries. */
+function claims(variants: SeenVariant[]): string {
+  for (const v of variants) {
+    const said = v.description || v.product || v.company;
+    if (said) return v.company && v.company !== said ? `${said} — ${v.company}` : said;
+  }
+  return "";
+}
+
+function variants(rows: SeenVariant[], action: string): string {
+  return `<table class="sub">
+  <thead><tr><th>Hash</th><th>Where</th><th>Signed</th><th>Claims</th><th class="num">Size</th>
+    <th>Built</th><th class="num">Accounts</th><th></th></tr></thead>
   <tbody>${rows
     .map((r) => {
-      const short = r.sha256 ? r.sha256.slice(0, 12) : "";
-      const label = r.label ? ` <span class="muted">${esc(r.label)}</span>` : "";
+      const said = [r.description, r.product, r.company].filter(Boolean).join(" · ");
+      const who = r.trust === "signed" && r.publisher ? ` ${esc(r.publisher)}` : "";
       return `<tr>
-      <td><span class="pill ${esc(r.state)}"></span> <code>${esc(r.name)}</code>${label}
-        ${short ? `<br><code class="muted">${esc(short)}</code>` : ""}</td>
+      <td><code class="muted">${esc(r.sha256 ? r.sha256.slice(0, 16) : "not read")}</code></td>
       <td class="muted">${esc(r.origin)}</td>
-      <td>${esc(r.riderName || "—")}</td>
+      <td class="muted">${esc(r.trust)}${who}</td>
+      <td class="muted">${esc(said || "—")}</td>
+      <td class="num muted">${esc(bytes(r.size))}</td>
+      <td class="muted">${esc(r.mtime ? ago(r.mtime * 1000) : "—")}</td>
       <td class="num">${r.accounts}</td>
-      <td class="num">${r.hits}</td>
-      <td class="muted">${esc(ago(r.lastAt))}</td>
-      <td class="act">${ruleButtons(r, action)}</td>
+      <td class="act">${hashButtons(r, action)}</td>
     </tr>`;
     })
     .join("")}</tbody></table>`;
 }
 
+/** A size a person reads, not a byte count. */
+function bytes(size: number): string {
+  if (!size) return "—";
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${Math.round(size / 1024)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 /**
- * The two buttons that turn a sighting into a rule.
+ * The two buttons that turn a whole name into a rule.
+ *
+ * By name, because that is the unit this row is: it catches every build under it, including
+ * the ones the window has not seen yet. A build that needs its own answer has its own
+ * buttons inside the row.
+ */
+function nameButtons(g: SeenGroup, action: string): string {
+  return ruleForms(
+    `<input type="hidden" name="pattern" value="${esc(g.name)}">`,
+    g.label || g.name,
+    action,
+  );
+}
+
+/**
+ * The same two buttons for one build.
  *
  * By hash when there is one, by name when there is not: a hash is what makes a rule survive
  * a rename, and a name is all a file we could not read ever gives us.
  */
-function ruleButtons(row: SeenRow, action: string): string {
+function hashButtons(row: SeenVariant, action: string): string {
   const by = row.sha256
     ? `<input type="hidden" name="sha256" value="${esc(row.sha256)}">`
     : `<input type="hidden" name="pattern" value="${esc(row.name)}">`;
+  return ruleForms(by, row.label || row.name, action);
+}
+
+function ruleForms(by: string, label: string, action: string): string {
   const one = (kind: string, text: string) => `<form method="post" action="${esc(action)}">
       ${by}<input type="hidden" name="kind" value="${kind}">
-      <input type="hidden" name="label" value="${esc(row.label || row.name)}">
+      <input type="hidden" name="label" value="${esc(label)}">
       <button type="submit" class="${kind}">${text}</button>
     </form>`;
   return `${one("deny", "Flag")}${one("allow", "Clear")}`;
@@ -342,4 +457,20 @@ button.allow{border-color:var(--ok);color:var(--ok)}
   border:1px solid var(--line);background:var(--bg);color:var(--ink);min-width:120px}
 .add input[name="sha256"]{min-width:260px}
 footer{color:var(--muted);font-size:12px;margin-top:8px;max-width:70ch}
+
+/* One file name, with its builds folded under it. */
+.warnline{color:var(--warn);font-size:12px;margin:0 0 12px}
+.sig{font-size:12px}
+.sig.warn{color:var(--warn);font-weight:600}
+details{margin-top:4px}
+summary{cursor:pointer;font-size:12px;list-style:none}
+summary::-webkit-details-marker{display:none}
+summary::before{content:"\\25b8 ";display:inline-block;transition:transform .1s}
+details[open] summary::before{content:"\\25be "}
+/* The nested table is inside a cell, so it gets its own frame to sit apart from the row. */
+table.sub{margin:8px 0 4px;background:var(--bg);border:1px solid var(--line);border-radius:8px}
+table.sub th{padding:6px 8px 6px}
+table.sub td{padding:5px 8px;font-size:12px}
+table.sub tr:last-child td{border-bottom:0}
+table.seen>tbody>tr>td{vertical-align:top}
 `;

--- a/control-plane/test/diagnostics.test.ts
+++ b/control-plane/test/diagnostics.test.ts
@@ -1,15 +1,33 @@
 import { describe, expect, it } from "vitest";
 import {
   classify,
+  isUnaccounted,
   MAX_MODULES,
   parseModules,
   stateRank,
   type ModuleRule,
   type Origin,
+  type ReportedModule,
 } from "../src/diagnostics";
 
-function mod(name: string, origin: Origin, sha256 = "") {
-  return { name, origin, sha256 };
+/** What a module with nothing read off it looks like — the shape an older client sends. */
+const BLANK = {
+  size: 0,
+  mtime: 0,
+  trust: "unchecked" as const,
+  publisher: "",
+  company: "",
+  product: "",
+  description: "",
+};
+
+function mod(
+  name: string,
+  origin: Origin,
+  sha256 = "",
+  extra: Partial<ReportedModule> = {},
+): ReportedModule {
+  return { name, origin, sha256, ...BLANK, ...extra };
 }
 
 function rule(kind: "deny" | "allow", by: { pattern?: string; sha256?: string }): ModuleRule {
@@ -26,9 +44,60 @@ describe("reading a reported module list", () => {
       { name: "kernel32.dll", origin: "system" },
     ]);
     expect(list).toEqual([
-      { name: "mxbikes.exe", origin: "game", sha256: HASH },
-      { name: "kernel32.dll", origin: "system", sha256: "" },
+      mod("mxbikes.exe", "game", HASH),
+      mod("kernel32.dll", "system"),
     ]);
+  });
+
+  it("takes what a file says about itself, and bounds every word of it", () => {
+    const list = parseModules([
+      {
+        name: "overlay.dll",
+        origin: "other",
+        sha256: HASH,
+        size: 2_400_000,
+        mtime: 1_750_000_000,
+        trust: "signed",
+        publisher: "NVIDIA Corporation",
+        company: "NVIDIA Corporation",
+        product: "NVIDIA Share",
+        description: "NVIDIA Share overlay\u0000\n",
+      },
+    ]);
+    expect(list?.[0]).toEqual(
+      mod("overlay.dll", "other", HASH, {
+        size: 2_400_000,
+        mtime: 1_750_000_000,
+        trust: "signed",
+        publisher: "NVIDIA Corporation",
+        company: "NVIDIA Corporation",
+        product: "NVIDIA Share",
+        // The control characters are gone: this is text off a file, rendered on a page.
+        description: "NVIDIA Share overlay",
+      }),
+    );
+  });
+
+  it("keeps a report a client sent nonsense detail in, and drops the nonsense", () => {
+    // A report thrown away says nothing at all, which is worse than one that says less. Only
+    // the fields that failed are dropped, and each falls back to "we do not know".
+    const list = parseModules([
+      {
+        name: "x.dll",
+        origin: "other",
+        size: -5,
+        mtime: 10,
+        trust: "definitely-fine",
+        company: 42,
+      },
+    ]);
+    expect(list?.[0]).toEqual(mod("x.dll", "other"));
+  });
+
+  it("reads an older client's report, which carries none of this", () => {
+    const list = parseModules([{ name: "x.dll", origin: "other", sha256: HASH }]);
+    expect(list?.[0]).toEqual(mod("x.dll", "other", HASH));
+    expect(list?.[0].trust).toBe("unchecked");
   });
 
   it("refuses a path where a file name belongs", () => {
@@ -71,11 +140,15 @@ describe("reading a reported module list", () => {
 });
 
 describe("what the rules make of a list", () => {
-  it("accounts for a plain machine", () => {
-    const v = classify(
-      [mod("mxbikes.exe", "game"), mod("kernel32.dll", "system"), mod("frostmod.dll", "app")],
-      [],
-    );
+  it("accounts for a plain machine once the game's own files are cleared", () => {
+    // The system's libraries and our own install folder account for themselves. The game's
+    // do not any more — they are cleared once, by hash, and then a plain machine is quiet.
+    const machine = [
+      mod("mxbikes.exe", "game", HASH),
+      mod("kernel32.dll", "system"),
+      mod("frostmod.dll", "app"),
+    ];
+    const v = classify(machine, [rule("allow", { sha256: HASH })]);
     expect(v.state).toBe("ok");
     expect(v.unknown).toHaveLength(0);
   });
@@ -122,6 +195,37 @@ describe("what the rules make of a list", () => {
     const v = classify([mod("d3d9.dll", "game", HASH)], []);
     expect(v.state).toBe("warn");
     expect(v.unknown.map((m) => m.name)).toEqual(["d3d9.dll"]);
+  });
+
+  it("asks about the game's folder whatever the file is called", () => {
+    // The hole the first version left: the loader-name list was the only thing that looked
+    // inside the game's folder, so anything injected under an ordinary name read as
+    // accounted for purely because of where it sat.
+    const v = classify([mod("physx_helper.dll", "game", HASH)], []);
+    expect(v.state).toBe("warn");
+    expect(v.unknown.map((m) => m.name)).toEqual(["physx_helper.dll"]);
+  });
+
+  it("still accounts for the system's own libraries by where they are", () => {
+    // A Windows system folder is not writable without already owning the machine, and there
+    // are hundreds of them. Asking about those would bury everything worth reading.
+    expect(classify([mod("kernel32.dll", "system")], []).state).toBe("ok");
+    expect(isUnaccounted(mod("kernel32.dll", "system"))).toBe(false);
+  });
+
+  it("accounts for what the app installed, unless it took a loader's name", () => {
+    // We put every file in that folder there ourselves — except that a loader name sitting
+    // in it is worth the same question it is worth anywhere else.
+    expect(isUnaccounted(mod("frostmod.dll", "app"))).toBe(false);
+    expect(isUnaccounted(mod("dxgi.dll", "app"))).toBe(true);
+  });
+
+  it("clears a stock game library once its hash is allowed", () => {
+    // What the change costs: the game's own libraries arrive unaccounted for on day one and
+    // are cleared once, by hash, from the page. After that they never come back.
+    const stock = [mod("mxbikes.exe", "game", HASH)];
+    expect(classify(stock, []).state).toBe("warn");
+    expect(classify(stock, [rule("allow", { sha256: HASH })]).state).toBe("ok");
   });
 
   it("clears a loader name once its exact file is allowed", () => {

--- a/src-tauri/src/fileinfo.rs
+++ b/src-tauri/src/fileinfo.rs
@@ -1,0 +1,526 @@
+//! What a file says about itself: who signed it, and who says they wrote it.
+//!
+//! Read for the modules loaded inside the running game — see [`crate::procmods`] — because a
+//! file name and a hash only ever identify something we already know about. The first
+//! sighting of anything is a name nobody recognises, and these two answers are what make it
+//! readable without recognising it: an overlay that belongs in a game process is signed by a
+//! company whose name you know, and a file that is neither is worth a look.
+//!
+//! **This module makes no judgements.** It reads two facts off a file and hands them over.
+//! What either one means is decided by the control plane, the same as everything else here.
+//!
+//! Windows-only in substance: both answers come from Windows' own APIs, and there is nothing
+//! equivalent to read under Wine (where the game's own libraries are the host's, and the
+//! trust store is empty). Everywhere else these return "not checked", which is deliberately
+//! not the same answer as "unsigned".
+
+use serde::Serialize;
+use std::path::Path;
+
+/// The most any one string off a file is worth carrying. Long enough for the longest real
+/// publisher name; short enough that a file which lies about itself can't fill a column.
+const MAX_FIELD: usize = 96;
+
+/// What Windows makes of a file's signature.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Trust {
+    /// Not looked at: a system library, a platform with nothing to ask, or a file that was
+    /// gone by the time we asked. Never folded into `unsigned` — "we didn't look" and "there
+    /// is no signature" are different facts and only one of them is interesting.
+    Unchecked,
+    /// No signature at all.
+    Unsigned,
+    /// Signed, and the chain verifies.
+    Signed,
+    /// There is a signature and it does not verify — expired, revoked, self-signed, or the
+    /// file has been modified since. Its own answer, because it is the rarest and the loudest.
+    Untrusted,
+}
+
+/// What a file says about itself. Every string is bounded and may be empty.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Details {
+    /// Who signed it, as the certificate's display name. Empty unless [`Trust::Signed`].
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub publisher: String,
+    /// `CompanyName` from the version resource — a claim the file makes, not a checked one.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub company: String,
+    /// `ProductName`.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub product: String,
+    /// `FileDescription`, which is the field Explorer shows and the one most often filled in.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub description: String,
+}
+
+/// Everything read off one file in a single pass.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileFacts {
+    pub trust: Trust,
+    #[serde(flatten)]
+    pub details: Details,
+}
+
+impl Default for FileFacts {
+    fn default() -> Self {
+        Self { trust: Trust::Unchecked, details: Details::default() }
+    }
+}
+
+/// Read a file's signature and its version resource.
+///
+/// One entry point, so the caller does not have to know which half is which — and so the
+/// platforms with no answer have one place to say so.
+pub fn read(path: &Path) -> FileFacts {
+    #[cfg(windows)]
+    {
+        let (trust, publisher) = windows::verify(path);
+        let mut details = windows::version_strings(path);
+        details.publisher = clamp(&publisher);
+        FileFacts { trust, details }
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = path;
+        FileFacts::default()
+    }
+}
+
+/// Trim a string off a file to something a column can hold, and drop anything with control
+/// characters in it — a version resource is attacker-controlled text.
+#[cfg_attr(not(windows), allow(dead_code))] // used on Windows and by the tests, which run anywhere
+pub fn clamp(value: &str) -> String {
+    let cleaned: String = value
+        .chars()
+        .filter(|c| !c.is_control())
+        .take(MAX_FIELD)
+        .collect();
+    cleaned.trim().to_string()
+}
+
+#[cfg(windows)]
+mod windows {
+    use super::{clamp, Details, Trust};
+    use std::os::raw::c_void;
+    use std::path::Path;
+
+    type Handle = *mut c_void;
+
+    #[repr(C)]
+    struct Guid {
+        data1: u32,
+        data2: u16,
+        data3: u16,
+        data4: [u8; 8],
+    }
+
+    /// `WINTRUST_ACTION_GENERIC_VERIFY_V2` — the policy that answers "is this file signed by
+    /// someone this machine trusts", which is the same question Explorer's Digital
+    /// Signatures tab asks.
+    const ACTION_GENERIC_VERIFY_V2: Guid = Guid {
+        data1: 0x00AA_C56B,
+        data2: 0xCD44,
+        data3: 0x11D0,
+        data4: [0x8C, 0xC2, 0x00, 0xC0, 0x4F, 0xC2, 0x95, 0xEE],
+    };
+
+    #[repr(C)]
+    struct WintrustFileInfo {
+        cb_struct: u32,
+        file_path: *const u16,
+        file_handle: Handle,
+        known_subject: *const Guid,
+    }
+
+    /// Only the head of `WINTRUST_DATA` is ever written by us; the tail is Windows' own
+    /// working space and is zeroed. Laid out in full because the API reads `cbStruct` and
+    /// writes into `hWVTStateData`, and a short struct would have it writing past the end.
+    #[repr(C)]
+    struct WintrustData {
+        cb_struct: u32,
+        policy_callback_data: *mut c_void,
+        sip_client_data: *mut c_void,
+        ui_choice: u32,
+        revocation_checks: u32,
+        union_choice: u32,
+        // The union: only the file-info arm is ever used.
+        file_info: *mut WintrustFileInfo,
+        state_action: u32,
+        state_data: Handle,
+        url_reference: *const u16,
+        prov_flags: u32,
+        ui_context: u32,
+        signature_settings: *mut c_void,
+    }
+
+    const WTD_UI_NONE: u32 = 2;
+    const WTD_REVOKE_NONE: u32 = 0;
+    const WTD_CHOICE_FILE: u32 = 1;
+    const WTD_STATEACTION_VERIFY: u32 = 1;
+    const WTD_STATEACTION_CLOSE: u32 = 2;
+    /// Answer from the local store only. Without it a machine with no route out sits on a
+    /// revocation lookup, and this runs beside a game.
+    const WTD_CACHE_ONLY_URL_RETRIEVAL: u32 = 0x1000;
+    const WTD_SAFER_FLAG: u32 = 0x100;
+
+    /// `TRUST_E_NOSIGNATURE`, and the two errors a file with no signature can come back as
+    /// when the subject interface package can't find one to parse.
+    const TRUST_E_NOSIGNATURE: i32 = -2146762496; // 0x800B0100
+    const TRUST_E_SUBJECT_FORM_UNKNOWN: i32 = -2146762477; // 0x800B0113
+    const TRUST_E_PROVIDER_UNKNOWN: i32 = -2146762751; // 0x800B0001
+
+    #[link(name = "wintrust")]
+    unsafe extern "system" {
+        fn WinVerifyTrust(hwnd: isize, action: *const Guid, data: *mut WintrustData) -> i32;
+    }
+
+    #[link(name = "crypt32")]
+    unsafe extern "system" {
+        fn CryptQueryObject(
+            object_type: u32,
+            object: *const c_void,
+            expected_content: u32,
+            expected_format: u32,
+            flags: u32,
+            msg_and_cert_encoding: *mut u32,
+            content_type: *mut u32,
+            format_type: *mut u32,
+            cert_store: *mut Handle,
+            msg: *mut Handle,
+            context: *mut *const c_void,
+        ) -> i32;
+        fn CryptMsgGetParam(
+            msg: Handle,
+            param_type: u32,
+            index: u32,
+            data: *mut c_void,
+            data_len: *mut u32,
+        ) -> i32;
+        fn CryptMsgClose(msg: Handle) -> i32;
+        fn CertFindCertificateInStore(
+            store: Handle,
+            encoding: u32,
+            find_flags: u32,
+            find_type: u32,
+            find_para: *const c_void,
+            prev: *const c_void,
+        ) -> *const c_void;
+        fn CertGetNameStringW(
+            cert: *const c_void,
+            name_type: u32,
+            flags: u32,
+            type_para: *mut c_void,
+            name: *mut u16,
+            name_len: u32,
+        ) -> u32;
+        fn CertFreeCertificateContext(cert: *const c_void) -> i32;
+        fn CertCloseStore(store: Handle, flags: u32) -> i32;
+    }
+
+    #[link(name = "version")]
+    unsafe extern "system" {
+        fn GetFileVersionInfoSizeW(file: *const u16, handle: *mut u32) -> u32;
+        fn GetFileVersionInfoW(
+            file: *const u16,
+            handle: u32,
+            len: u32,
+            data: *mut c_void,
+        ) -> i32;
+        fn VerQueryValueW(
+            block: *const c_void,
+            sub_block: *const u16,
+            buffer: *mut *mut c_void,
+            len: *mut u32,
+        ) -> i32;
+    }
+
+    const CERT_QUERY_OBJECT_FILE: u32 = 1;
+    const CERT_QUERY_CONTENT_FLAG_PKCS7_SIGNED_EMBED: u32 = 1 << 10;
+    const CERT_QUERY_FORMAT_FLAG_BINARY: u32 = 1 << 1;
+    const CMSG_SIGNER_CERT_INFO_PARAM: u32 = 7;
+    const CERT_FIND_SUBJECT_CERT: u32 = 0x000B_0000;
+    const CERT_NAME_SIMPLE_DISPLAY_TYPE: u32 = 4;
+    const X509_ASN_ENCODING: u32 = 1;
+    const PKCS_7_ASN_ENCODING: u32 = 0x0001_0000;
+
+    fn wide(s: &str) -> Vec<u16> {
+        s.encode_utf16().chain(std::iter::once(0)).collect()
+    }
+
+    fn wide_path(path: &Path) -> Vec<u16> {
+        wide(&path.to_string_lossy())
+    }
+
+    /// Ask Windows whether the file is signed, and by whom.
+    ///
+    /// The publisher is only read when the chain verified: an unverified signature can carry
+    /// any name at all, and reporting "signed by Microsoft" for a file that failed its own
+    /// check would be worse than reporting nothing.
+    pub fn verify(path: &Path) -> (Trust, String) {
+        let wide = wide_path(path);
+        let mut file = WintrustFileInfo {
+            cb_struct: std::mem::size_of::<WintrustFileInfo>() as u32,
+            file_path: wide.as_ptr(),
+            file_handle: std::ptr::null_mut(),
+            known_subject: std::ptr::null(),
+        };
+        let mut data = WintrustData {
+            cb_struct: std::mem::size_of::<WintrustData>() as u32,
+            policy_callback_data: std::ptr::null_mut(),
+            sip_client_data: std::ptr::null_mut(),
+            ui_choice: WTD_UI_NONE,
+            revocation_checks: WTD_REVOKE_NONE,
+            union_choice: WTD_CHOICE_FILE,
+            file_info: &mut file,
+            state_action: WTD_STATEACTION_VERIFY,
+            state_data: std::ptr::null_mut(),
+            url_reference: std::ptr::null(),
+            prov_flags: WTD_CACHE_ONLY_URL_RETRIEVAL | WTD_SAFER_FLAG,
+            ui_context: 0,
+            signature_settings: std::ptr::null_mut(),
+        };
+
+        // SAFETY: both structs outlive the call, `cbStruct` is each one's real size, and the
+        // path buffer is NUL-terminated and lives across it.
+        let rc = unsafe { WinVerifyTrust(0, &ACTION_GENERIC_VERIFY_V2, &mut data) };
+
+        // Every verify has to be closed, whatever it answered, or the state handle leaks —
+        // and this runs on a timer for the life of a session.
+        data.state_action = WTD_STATEACTION_CLOSE;
+        // SAFETY: the same struct, handed back exactly as the API requires.
+        unsafe { WinVerifyTrust(0, &ACTION_GENERIC_VERIFY_V2, &mut data) };
+
+        match rc {
+            0 => (Trust::Signed, publisher(path)),
+            TRUST_E_NOSIGNATURE | TRUST_E_SUBJECT_FORM_UNKNOWN | TRUST_E_PROVIDER_UNKNOWN => {
+                (Trust::Unsigned, String::new())
+            }
+            _ => (Trust::Untrusted, String::new()),
+        }
+    }
+
+    /// The display name on the certificate that signed the file.
+    ///
+    /// Read through the message rather than through the verify call's state data: the signer
+    /// certificate is fetched by its own issuer and serial, which needs no knowledge of
+    /// `CRYPT_PROVIDER_DATA`'s layout — a struct that has grown between Windows versions and
+    /// would be the one thing here that could be wrong on a machine we can't test on.
+    fn publisher(path: &Path) -> String {
+        let wide = wide_path(path);
+        let mut store: Handle = std::ptr::null_mut();
+        let mut msg: Handle = std::ptr::null_mut();
+        let mut encoding: u32 = 0;
+        let mut content: u32 = 0;
+        let mut format: u32 = 0;
+
+        // SAFETY: an out-parameter query against a NUL-terminated path; every handle it
+        // hands back is closed below.
+        let ok = unsafe {
+            CryptQueryObject(
+                CERT_QUERY_OBJECT_FILE,
+                wide.as_ptr() as *const c_void,
+                CERT_QUERY_CONTENT_FLAG_PKCS7_SIGNED_EMBED,
+                CERT_QUERY_FORMAT_FLAG_BINARY,
+                0,
+                &mut encoding,
+                &mut content,
+                &mut format,
+                &mut store,
+                &mut msg,
+                std::ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            return String::new();
+        }
+
+        let name = signer_name(store, msg, encoding);
+
+        // SAFETY: both handles came from the call above and are closed exactly once.
+        unsafe {
+            if !msg.is_null() {
+                CryptMsgClose(msg);
+            }
+            if !store.is_null() {
+                CertCloseStore(store, 0);
+            }
+        }
+        name
+    }
+
+    fn signer_name(store: Handle, msg: Handle, encoding: u32) -> String {
+        if msg.is_null() || store.is_null() {
+            return String::new();
+        }
+        // The signer's issuer and serial, as an opaque blob: it is handed straight back to
+        // `CertFindCertificateInStore`, which is why none of its fields need naming here.
+        let mut len: u32 = 0;
+        // SAFETY: a size query — no buffer is written when the data pointer is null.
+        let sized = unsafe {
+            CryptMsgGetParam(
+                msg,
+                CMSG_SIGNER_CERT_INFO_PARAM,
+                0,
+                std::ptr::null_mut(),
+                &mut len,
+            )
+        };
+        if sized == 0 || len == 0 || len > 64 * 1024 {
+            return String::new();
+        }
+        let mut info = vec![0u8; len as usize];
+        // SAFETY: the buffer is the size the call above asked for.
+        let got = unsafe {
+            CryptMsgGetParam(
+                msg,
+                CMSG_SIGNER_CERT_INFO_PARAM,
+                0,
+                info.as_mut_ptr() as *mut c_void,
+                &mut len,
+            )
+        };
+        if got == 0 {
+            return String::new();
+        }
+
+        let encoding = if encoding == 0 { X509_ASN_ENCODING | PKCS_7_ASN_ENCODING } else { encoding };
+        // SAFETY: `info` holds the `CERT_INFO` the message just wrote and outlives the call.
+        let cert = unsafe {
+            CertFindCertificateInStore(
+                store,
+                encoding,
+                0,
+                CERT_FIND_SUBJECT_CERT,
+                info.as_ptr() as *const c_void,
+                std::ptr::null(),
+            )
+        };
+        if cert.is_null() {
+            return String::new();
+        }
+
+        let mut buf = [0u16; 256];
+        // SAFETY: a fixed buffer whose length is passed in characters, as the API expects.
+        let written = unsafe {
+            CertGetNameStringW(
+                cert,
+                CERT_NAME_SIMPLE_DISPLAY_TYPE,
+                0,
+                std::ptr::null_mut(),
+                buf.as_mut_ptr(),
+                buf.len() as u32,
+            )
+        };
+        // SAFETY: the context came from `CertFindCertificateInStore` and is freed once.
+        unsafe { CertFreeCertificateContext(cert) };
+
+        if written <= 1 {
+            return String::new();
+        }
+        clamp(&String::from_utf16_lossy(&buf[..(written as usize) - 1]))
+    }
+
+    /// `CompanyName`, `ProductName` and `FileDescription` off the version resource.
+    ///
+    /// All three are whatever the file was built saying — a claim, not a fact — which is why
+    /// they sit beside the signature rather than instead of it.
+    pub fn version_strings(path: &Path) -> Details {
+        let wide = wide_path(path);
+        let mut handle: u32 = 0;
+        // SAFETY: a size query against a NUL-terminated path.
+        let size = unsafe { GetFileVersionInfoSizeW(wide.as_ptr(), &mut handle) };
+        // A file with no version resource answers zero, which is most of them.
+        if size == 0 || size > 1024 * 1024 {
+            return Details::default();
+        }
+        let mut block = vec![0u8; size as usize];
+        // SAFETY: the buffer is the size the call above asked for.
+        let ok = unsafe {
+            GetFileVersionInfoW(wide.as_ptr(), 0, size, block.as_mut_ptr() as *mut c_void)
+        };
+        if ok == 0 {
+            return Details::default();
+        }
+
+        // The resource is keyed by language and codepage, and a file only has to carry one.
+        // Ask which, rather than guessing at `040904b0` — the guess is right for most
+        // English-language builds and wrong for exactly the files that aren't.
+        let Some((lang, code)) = translation(&block) else { return Details::default() };
+        let prefix = format!("\\StringFileInfo\\{lang:04x}{code:04x}\\");
+        Details {
+            publisher: String::new(),
+            company: query(&block, &format!("{prefix}CompanyName")),
+            product: query(&block, &format!("{prefix}ProductName")),
+            description: query(&block, &format!("{prefix}FileDescription")),
+        }
+    }
+
+    /// The first language/codepage pair the resource declares.
+    fn translation(block: &[u8]) -> Option<(u16, u16)> {
+        let key = wide("\\VarFileInfo\\Translation");
+        let mut ptr: *mut c_void = std::ptr::null_mut();
+        let mut len: u32 = 0;
+        // SAFETY: `block` outlives the call; the pointer handed back points inside it.
+        let ok = unsafe {
+            VerQueryValueW(block.as_ptr() as *const c_void, key.as_ptr(), &mut ptr, &mut len)
+        };
+        if ok == 0 || ptr.is_null() || len < 4 {
+            return None;
+        }
+        // SAFETY: four bytes inside `block`, which is still alive — two little-endian u16s.
+        let pair = unsafe { std::slice::from_raw_parts(ptr as *const u16, 2) };
+        Some((pair[0], pair[1]))
+    }
+
+    fn query(block: &[u8], sub_block: &str) -> String {
+        let key = wide(sub_block);
+        let mut ptr: *mut c_void = std::ptr::null_mut();
+        let mut len: u32 = 0;
+        // SAFETY: as `translation` — the result points inside `block`.
+        let ok = unsafe {
+            VerQueryValueW(block.as_ptr() as *const c_void, key.as_ptr(), &mut ptr, &mut len)
+        };
+        if ok == 0 || ptr.is_null() || len == 0 || len > 4096 {
+            return String::new();
+        }
+        // `len` counts characters and includes the trailing NUL when there is one.
+        // SAFETY: `len` characters inside `block`, which is still alive.
+        let chars = unsafe { std::slice::from_raw_parts(ptr as *const u16, len as usize) };
+        let text: String = String::from_utf16_lossy(chars);
+        clamp(text.trim_end_matches('\0'))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_field_off_a_file_is_trimmed_and_bounded() {
+        assert_eq!(clamp("  NVIDIA Corporation  "), "NVIDIA Corporation");
+        assert_eq!(clamp(&"x".repeat(200)).len(), MAX_FIELD);
+    }
+
+    /// A version resource is text a file supplies about itself, so it reaches the admin page
+    /// the same way any other untrusted string does — with the characters that would break a
+    /// line or a log entry taken out first.
+    #[test]
+    fn control_characters_never_survive_a_field() {
+        assert_eq!(clamp("Over\u{0}watch\nInc\r"), "OverwatchInc");
+        assert_eq!(clamp("\u{7}"), "");
+    }
+
+    /// Nothing to ask on this platform, and "we did not look" is its own answer — folding it
+    /// into `unsigned` would report every file on a Mac as unsigned.
+    #[cfg(not(windows))]
+    #[test]
+    fn a_platform_with_nothing_to_ask_says_so() {
+        let facts = read(Path::new("/usr/lib/libSystem.B.dylib"));
+        assert_eq!(facts.trust, Trust::Unchecked);
+        assert_eq!(facts.details, Details::default());
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -18,6 +18,7 @@ mod firstpaint;
 mod frostmod;
 mod frostmod_manage;
 mod game;
+mod fileinfo;
 mod gameproc;
 mod gate;
 mod gearrepair;

--- a/src-tauri/src/procmods.rs
+++ b/src-tauri/src/procmods.rs
@@ -2,8 +2,14 @@
 //!
 //! The app already reports presence and anonymous usage. This is the same idea pointed at
 //! the game process: while MX Bikes is up, walk its module list and report what is in it —
-//! each file's name, where it was loaded from, and a hash for anything that is not a Windows
-//! system library.
+//! each file's name, where it was loaded from, a hash for anything that is not a Windows
+//! system library, and what the file says about itself: its size, when it was last written,
+//! whether Windows trusts its signature and who signed it, and the company and product it
+//! claims in its version resource (see [`crate::fileinfo`]).
+//!
+//! The extra detail is there because a name and a hash only identify what is already known.
+//! Every first sighting is a name nobody recognises, and "unsigned, no company, written last
+//! Tuesday" is what makes one of those readable without recognising it.
 //!
 //! **This module makes no judgements and holds no lists of anything.** It records where a
 //! file came from and hands that over; what any of it means is decided by the control plane
@@ -20,6 +26,7 @@
 //!   * A report is only sent when the module set has actually changed, with a heartbeat so a
 //!     settled session still says it is there.
 
+use crate::fileinfo::FileFacts;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::path::Path;
@@ -56,6 +63,19 @@ impl Origin {
     }
 }
 
+/// Everything one pass reads off a file on disk.
+///
+/// Taken in one go and cached together, because the expensive half is the same for all of
+/// it: the file has to be opened and read either way.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FileRead {
+    pub sha256: String,
+    pub size: u64,
+    /// Last written, as seconds since the epoch. Zero when it could not be read.
+    pub mtime: i64,
+    pub facts: FileFacts,
+}
+
 /// One module, as reported.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -67,6 +87,25 @@ pub struct Module {
     /// Empty for system libraries, which are not hashed, and for a file we could not read.
     #[serde(skip_serializing_if = "String::is_empty")]
     pub sha256: String,
+    /// Bytes on disk. Zero for anything not read, which is how it is left out on the wire.
+    #[serde(skip_serializing_if = "is_zero_u64")]
+    pub size: u64,
+    /// Last written, seconds since the epoch. Two builds of a file that both refuse to hash
+    /// still tell themselves apart by this.
+    #[serde(skip_serializing_if = "is_zero_i64")]
+    pub mtime: i64,
+    /// Signature and version resource. Flattened, so a module is one flat object on the wire
+    /// rather than an object with a nested one nobody reading the payload would expect.
+    #[serde(flatten)]
+    pub facts: FileFacts,
+}
+
+fn is_zero_u64(value: &u64) -> bool {
+    *value == 0
+}
+
+fn is_zero_i64(value: &i64) -> bool {
+    *value == 0
 }
 
 /// What one report says.
@@ -97,10 +136,11 @@ fn last_sent() -> &'static Mutex<Option<Sent>> {
     &LAST
 }
 
-/// Hashes already taken, keyed by path and invalidated by size or mtime. What keeps a pass
-/// from re-reading the same forty files every forty-five seconds.
-fn hash_cache() -> &'static Mutex<HashMap<String, (u64, u64, String)>> {
-    static CACHE: std::sync::OnceLock<Mutex<HashMap<String, (u64, u64, String)>>> =
+/// What has already been read off each file, keyed by path and invalidated by size or
+/// mtime. What keeps a pass from re-reading the same forty files every forty-five seconds —
+/// and it matters more now than it did: a signature check reads the whole file too.
+fn hash_cache() -> &'static Mutex<HashMap<String, FileRead>> {
+    static CACHE: std::sync::OnceLock<Mutex<HashMap<String, FileRead>>> =
         std::sync::OnceLock::new();
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
@@ -196,15 +236,15 @@ pub struct Roots {
 /// Turn a list of module paths into what gets reported.
 ///
 /// Pure, so the whole of it is testable with made-up paths on a machine with no game on it.
-/// `hash` is passed in for the same reason.
+/// `read` is passed in for the same reason.
 pub fn collect(paths: &[String], roots: &Roots) -> Vec<Module> {
-    collect_with(paths, roots, &hash_file)
+    collect_with(paths, roots, &read_file)
 }
 
 pub fn collect_with(
     paths: &[String],
     roots: &Roots,
-    hash: &dyn Fn(&Path) -> String,
+    read: &dyn Fn(&Path) -> FileRead,
 ) -> Vec<Module> {
     let mut out: Vec<Module> = Vec::new();
     for path in paths.iter().take(MAX_MODULES) {
@@ -214,11 +254,20 @@ pub fn collect_with(
             continue;
         }
         let origin = origin_of(&normalized, roots);
-        // System libraries are not hashed: there are hundreds of them, they are the same on
-        // every machine, and reading them all every session would be the expensive half of
-        // this for no answer anyone wants.
-        let sha256 = if origin.is_system() { String::new() } else { hash(Path::new(path)) };
-        out.push(Module { name, origin, sha256 });
+        // System libraries are not read at all: there are hundreds of them, they are the
+        // same on every machine, and hashing and signature-checking them every session would
+        // be the expensive half of this for no answer anyone wants. They keep the default
+        // `unchecked` trust, which is not the same claim as `unsigned`.
+        let file =
+            if origin.is_system() { FileRead::default() } else { read(Path::new(path)) };
+        out.push(Module {
+            name,
+            origin,
+            sha256: file.sha256,
+            size: file.size,
+            mtime: file.mtime,
+            facts: file.facts,
+        });
     }
     out.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.sha256.cmp(&b.sha256)));
     out.dedup_by(|a, b| a.name == b.name && a.sha256 == b.sha256);
@@ -290,41 +339,55 @@ fn file_name_of(path: &str) -> String {
     name
 }
 
-/// SHA-256 of a file, lowercase hex, cached by size and mtime.
+/// Everything read off one file: size, mtime, SHA-256, signature and version resource.
+/// Cached by path, and the cache entry is thrown away when either size or mtime moves.
 ///
-/// Empty when it cannot be read or is implausibly large. A missing hash costs a weaker
-/// report, never a wrong one — a file with no hash can still be recognised by name.
-fn hash_file(path: &Path) -> String {
-    let Ok(meta) = std::fs::metadata(path) else { return String::new() };
+/// A file that cannot be read, or is implausibly large, comes back as the default — no hash,
+/// no size, and `unchecked` rather than `unsigned`. A missing answer costs a weaker report,
+/// never a wrong one: a file with no hash can still be recognised by name.
+fn read_file(path: &Path) -> FileRead {
+    let Ok(meta) = std::fs::metadata(path) else { return FileRead::default() };
     if !meta.is_file() || meta.len() > MAX_HASH_BYTES {
-        return String::new();
+        return FileRead::default();
     }
     let mtime = meta
         .modified()
         .ok()
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_secs())
+        .map(|d| d.as_secs() as i64)
         .unwrap_or(0);
     let key = norm(path);
     if let Ok(cache) = hash_cache().lock() {
-        if let Some((size, seen, hash)) = cache.get(&key) {
-            if *size == meta.len() && *seen == mtime {
-                return hash.clone();
+        if let Some(hit) = cache.get(&key) {
+            if hit.size == meta.len() && hit.mtime == mtime {
+                return hit.clone();
             }
         }
     }
 
+    let read = FileRead {
+        sha256: sha256_of(path),
+        size: meta.len(),
+        mtime,
+        // Asked after the hash, so a file that vanished between the two costs a signature
+        // and not the whole entry.
+        facts: crate::fileinfo::read(path),
+    };
+    if let Ok(mut cache) = hash_cache().lock() {
+        cache.insert(key, read.clone());
+    }
+    read
+}
+
+/// SHA-256 of a file, lowercase hex. Empty when it cannot be opened or read through.
+fn sha256_of(path: &Path) -> String {
     use sha2::{Digest, Sha256};
     let Ok(mut file) = std::fs::File::open(path) else { return String::new() };
     let mut hasher = Sha256::new();
     if std::io::copy(&mut file, &mut hasher).is_err() {
         return String::new();
     }
-    let hash = format!("{:x}", hasher.finalize());
-    if let Ok(mut cache) = hash_cache().lock() {
-        cache.insert(key, (meta.len(), mtime, hash.clone()));
-    }
-    hash
+    format!("{:x}", hasher.finalize())
 }
 
 /// A stable fingerprint of one answer, so an unchanged session sends nothing.
@@ -388,7 +451,15 @@ mod tests {
         let owned: Vec<String> = paths.iter().map(|p| p.to_string()).collect();
         collect_with(&owned, &roots(), &|p| {
             // A stand-in for reading the file, so the classification is testable without one.
-            format!("{:0>64}", p.to_string_lossy().len())
+            FileRead {
+                sha256: format!("{:0>64}", p.to_string_lossy().len()),
+                size: p.to_string_lossy().len() as u64,
+                mtime: 1_700_000_000,
+                facts: FileFacts {
+                    trust: crate::fileinfo::Trust::Unsigned,
+                    ..Default::default()
+                },
+            }
         })
     }
 
@@ -421,12 +492,60 @@ mod tests {
     }
 
     #[test]
-    fn system_libraries_are_not_hashed() {
+    fn system_libraries_are_not_read_at_all() {
         let mods = collected(&["C:\\Windows\\System32\\kernel32.dll", "C:\\x\\other.dll"]);
         let sys = mods.iter().find(|m| m.name == "kernel32.dll").unwrap();
         let other = mods.iter().find(|m| m.name == "other.dll").unwrap();
         assert_eq!(sys.sha256, "");
+        assert_eq!(sys.size, 0);
+        assert_eq!(sys.mtime, 0);
+        // Not `unsigned`: nothing looked. There are hundreds of these and they are the same
+        // on every machine, and calling them unsigned would be a claim we never checked.
+        assert_eq!(sys.facts.trust, crate::fileinfo::Trust::Unchecked);
         assert_ne!(other.sha256, "");
+        assert_ne!(other.size, 0);
+        assert_eq!(other.facts.trust, crate::fileinfo::Trust::Unsigned);
+    }
+
+    /// The detail is flattened onto the module, so a report is a list of flat objects rather
+    /// than one with a nested `facts` nobody reading the payload would expect.
+    #[test]
+    fn what_a_file_says_about_itself_rides_alongside_it() {
+        let owned = vec!["C:\\x\\overlay.dll".to_string()];
+        let mods = collect_with(&owned, &roots(), &|_| FileRead {
+            sha256: "a".repeat(64),
+            size: 2_400_000,
+            mtime: 1_750_000_000,
+            facts: FileFacts {
+                trust: crate::fileinfo::Trust::Signed,
+                details: crate::fileinfo::Details {
+                    publisher: "NVIDIA Corporation".into(),
+                    company: "NVIDIA Corporation".into(),
+                    product: "NVIDIA Share".into(),
+                    description: "NVIDIA Share overlay".into(),
+                },
+            },
+        });
+        let json = serde_json::to_value(&mods).unwrap();
+        let one = &json[0];
+        assert_eq!(one["trust"], "signed");
+        assert_eq!(one["publisher"], "NVIDIA Corporation");
+        assert_eq!(one["product"], "NVIDIA Share");
+        assert_eq!(one["size"], 2_400_000);
+        assert_eq!(one["mtime"], 1_750_000_000);
+        assert!(one.get("facts").is_none(), "flattened, not nested: {json}");
+    }
+
+    /// Empty strings and zeros are left off the wire entirely, so a file nothing could be
+    /// read off costs three keys rather than nine on every report from every install.
+    #[test]
+    fn nothing_known_about_a_file_is_nothing_sent() {
+        let owned = vec!["C:\\x\\locked.dll".to_string()];
+        let mods = collect_with(&owned, &roots(), &|_| FileRead::default());
+        let json = serde_json::to_value(&mods).unwrap();
+        let one = json[0].as_object().unwrap();
+        assert_eq!(one.keys().len(), 3, "{json}");
+        assert_eq!(one["trust"], "unchecked");
     }
 
     #[test]
@@ -493,7 +612,12 @@ mod tests {
         assert!(json.contains(r#""origin":"game""#), "{json}");
         assert!(json.contains(r#""origin":"system""#), "{json}");
         // Absent rather than empty, which is what the parser expects of an unhashed file.
-        assert!(json.contains(r#"{"name":"a.dll","origin":"system"}"#), "{json}");
+        // `trust` is the exception and is always sent: "we did not look" is an answer, and
+        // leaving it off would have the other end infer it rather than be told.
+        assert!(
+            json.contains(r#"{"name":"a.dll","origin":"system","trust":"unchecked"}"#),
+            "{json}"
+        );
 
         // Unknown until sign-in, and then simply absent rather than an empty string.
         let anon = serde_json::to_string(&Payload {

--- a/src-tauri/src/sessionwatch.rs
+++ b/src-tauri/src/sessionwatch.rs
@@ -68,7 +68,13 @@ pub fn start(app: &AppHandle) {
             if running {
                 if reported.is_none_or(|at| at.elapsed() >= REPORT_EVERY) {
                     reported = Some(Instant::now());
-                    crate::procmods::tick(&app);
+                    // Off the runtime, not on it. The first pass of a session reads every
+                    // non-system module the game has loaded — hash, signature and version
+                    // resource — and that is disk I/O and a trust check per file, seconds of
+                    // it on a cold cache. Held here it would stall every other async task in
+                    // the app, the updater and paint sync among them, for the length of it.
+                    let handle = app.clone();
+                    tauri::async_runtime::spawn_blocking(move || crate::procmods::tick(&handle));
                 }
             } else if reported.take().is_some() {
                 // The session is over, so nothing that was true of it is true now.


### PR DESCRIPTION
## The report

> Also the anti cheat reporting — make it also bring back more info cause I don't see any weird dlls
> Also for the control plane, make it able to be grouped by dll name, as they are starting to be a lot

Two reasons nothing looked unusual, and fixing either alone leaves the other standing.

## 1. Nothing was reported that could tell an overlay from anything else

A name and a hash only identify a file we already know about, and every first sighting is a name nobody recognises. Each module now also carries two kinds of thing, kept apart on the page because only one is worth anything as evidence:

**Checked** — `WinVerifyTrust` gives `signed` / `unsigned` / `untrusted` / `unchecked`, plus the signing certificate's display name via `CryptQueryObject` → `CryptMsgGetParam` → `CertGetNameStringW`. This is the strongest single signal: what legitimately belongs in a game process — NVIDIA, Discord, Overwolf, ReShade — is signed by a company whose name you know.

**Claimed** — `CompanyName` / `ProductName` / `FileDescription` off the version resource. Anything can write these and nothing verifies them, so they are handled as untrusted text end to end: control characters stripped, bounded, escaped. Good for recognising the ordinary, worthless as evidence about the unusual.

Plus size and last-written, which tell two builds of one name apart when neither will hash.

`unchecked` is deliberately not `unsigned`. System libraries are never read, and neither is anything under Wine, where there is no trust store to ask — folding the two together would report every Linux player's whole game as unsigned.

New `src-tauri/src/fileinfo.rs`, raw FFI in the same style as `steamid.rs`, so no new dependency. The signer certificate is fetched by its own issuer and serial rather than through the verify call's state data, which avoids depending on `CRYPT_PROVIDER_DATA`'s layout — the one struct here that has grown between Windows versions.

## 2. The game's own folder was a free pass

`classify` only looked inside the game's install folder for the twelve `LOADER_NAMES`. A DLL dropped beside `mxbikes.exe` under any other name read as **accounted for, because of where it sat**. That is very likely the larger half of why the list looked clean.

The whole folder now needs a rule, as everywhere does except the system's folders (not writable without already owning the machine) and our own install folder (we put every file there).

**The cost, stated plainly:** the game's stock libraries arrive unaccounted for on day one and are cleared once, by hash, from the page. The grouping below is what makes that a handful of clicks instead of hundreds of rows.

## 3. The unaccounted list is read by file name

One row per name, with each distinct build folded underneath in a `<details>` — no scripts, that page has never had one and the reason is in its header comment. The summary row carries the group's answer so the common case needs no clicking.

The signature summary takes the **worst** build under a name: one unsigned build among signed ones is exactly the case worth seeing, so it must not be averaged away. Rule buttons work at both levels — by name on the group row (catches builds the window has not seen yet), by hash on a build (survives a rename).

Two queries rather than one, so the totals stay right where the detail is trimmed, and the page says so when it trimmed anything rather than letting silence read as "all of it".

## Also

The report pass moved off the async runtime onto a blocking thread. The first pass of a session now hashes *and* trust-checks every non-system module — seconds of disk I/O on a cold cache — and holding a Tokio worker for that would stall every other async task, the updater and paint sync among them.

## DB / deploy

Migration `0017` adds seven columns to `client_module_seen`, every one with a default, so existing rows and older clients keep working — an absent `trust` reads as `unchecked`, and a report carrying nonsense in one field loses that field rather than the report.

**Both steps are manual.** Remote D1 will not take a tracked apply, so 0017 is a by-hand run on prod; the control plane deploys by hand too, and needs to go out before or with the client.

## Verification

- `cargo test` — 1184 passed, 0 failed
- `cargo check --target x86_64-pc-windows-gnu` — clean (only the two pre-existing `sidecar_lock` warnings from the gitignored local file)
- Control plane `vitest` — 168 passed; `tsc --noEmit` clean
- New tests: the detail rides flattened on the wire, nothing known is nothing sent, system libraries stay unread and `unchecked`, the game's folder is asked about whatever the file is called, stock files clear by hash, an older client's report still parses, and a client sending nonsense loses the field rather than the report

**Not runtime-verified on Windows.** The FFI type-checks for the target, but the signature read has never run against a real trust store, and the grouped page has not been rendered. Both want one session with the game open before this is leaned on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)