### PR TITLE
fix(tracks): stop shipping a .map the game cannot read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 2026-09-01
 
+### Fixed
+- Installing a generated track no longer crashes the game. It ships without graphics rather
+  than with graphics the game cannot read, and the Studio says so.
+
+## 2026-09-01
+
 ### Added
 - Track generation reads a published track's own centreline out of its height file, so a real
   lap's corners, their radii and its straights can be measured directly rather than guessed at.

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -1905,6 +1905,24 @@ fn rdf(prog: &TrackProgram) -> String {
 /// a 700 m plot is under three metres a quad, which reads as ground from a bike.
 const MAP_QUADS: usize = 256;
 
+/// **Incomplete. Do not ship the result as a track.**
+///
+/// What this writes is a correct *prefix* of a `.map` — magic, materials, the terrain mesh,
+/// the node tree and the ground sheets, each matching a published map field for field. It is
+/// still not a `.map`, because a real one does not end there: it continues with a large
+/// trailing block of count-prefixed sections that the loader reads immediately afterwards,
+/// and we write none of it. The game reads past the end of our file and dies at the track
+/// graphics stage.
+///
+/// The proof is PiBoSo's own OEM drag strip, which declares **materials = 0, vertices = 0,
+/// triangles = 0 and textures = 0** — every section this function fills — and is still 120 MB.
+/// All of it is in the trailing block. An empty mesh was always valid; the mesh was never what
+/// was missing.
+///
+/// Kept because the parts that are decoded are decoded correctly and were expensive to get,
+/// and because finishing this is the only route to installing a generated track without
+/// running TerrainEd. Until then nothing calls it.
+#[allow(dead_code)]
 fn map(prog: &TrackProgram, syn: &Synth) -> Vec<u8> {
     let (field, ridden, shoulder, turf) = ground_looks(prog.terrain.surface);
     let seed = prog.terrain.relief.seed;
@@ -2233,7 +2251,8 @@ pub fn write_pkz(
     // looks for them there — flat at the archive root they are not found at all.
     for (name, bytes) in [
         (format!("{slug}/{slug}.trh"), trh(prog, syn, paint_features)),
-        (format!("{slug}/{slug}.map"), map(prog, syn)),
+        // No `.map`. See `map()` — what we can write is not one the game will load, and a
+        // wrong one is worse than none: it hard-crashed at the track graphics stage.
         (format!("{slug}/{slug}.ini"), crlf(&track_ini(prog))),
         (format!("{slug}/{slug}.rdf"), crlf(&rdf(prog))),
         (format!("{slug}/{slug}.amb"), crlf(AMB)),
@@ -3455,7 +3474,6 @@ mod tests {
         let names = crate::pkz::entry_names(&path).unwrap();
         for want in [
             format!("{slug}/{slug}.trh"),
-            format!("{slug}/{slug}.map"),
             format!("{slug}/{slug}.ini"),
             format!("{slug}/{slug}.rdf"),
             format!("{slug}/{slug}.amb"),
@@ -3464,6 +3482,12 @@ mod tests {
         ] {
             assert!(names.contains(&want), "{want} is missing from {names:?}");
         }
+        // And deliberately no `.map`. We cannot write one the game will load, and a wrong one
+        // is worse than none — it hard-crashed at the track graphics stage. See `map()`.
+        assert!(
+            !names.iter().any(|n| n.ends_with(".map")),
+            "a .map we cannot write correctly must not be shipped: {names:?}"
+        );
 
         // And the `.ini` names pictures the archive actually has — it used to name two
         // files that were never written, which is a track with no artwork at all.

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -2300,7 +2300,7 @@ export const de: Translation = {
   "track.buildFailed": "Konnte nicht gebaut werden",
   "track.exported": "{{count}} Dateien geschrieben",
   "track.exportFailed": "Konnte nicht exportiert werden",
-  "track.previewOnly": "Eine installierte Strecke bringt Gelände, Oberflächen, Renndaten und den Untergrund mit — keine Kulissen. Dafür TerrainEd über den exportierten Ordner laufen lassen.",
+  "track.previewOnly": "Eine installierte Strecke enthält Gelände, Oberflächen und Renndaten — sie hat keine Grafik, das Spiel kann sie also nicht fahren. Für eine fahrbare Strecke mit TerrainEd über den exportierten Ordner bauen.",
   "track.at": "Bei",
   "track.kind": "Art",
   "track.height": "Höhe",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2256,7 +2256,7 @@ export const en = {
   "track.buildFailed": "Couldn't build it",
   "track.exported": "Wrote {{count}} files",
   "track.exportFailed": "Couldn't export it",
-  "track.previewOnly": "An installed track carries terrain, surfaces, race data and the ground it's painted with — no scenery. Run TerrainEd over the exported folder for that.",
+  "track.previewOnly": "An installed track carries terrain, surfaces and race data — it has no graphics, so the game will not ride it. Build with TerrainEd over the exported folder for a track you can ride.",
   "track.at": "At",
   "track.kind": "Kind",
   "track.height": "Height",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -2286,7 +2286,7 @@ export const es: Translation = {
   "track.buildFailed": "No se pudo construir",
   "track.exported": "Se escribieron {{count}} archivos",
   "track.exportFailed": "No se pudo exportar",
-  "track.previewOnly": "Una pista instalada lleva terreno, superficies, datos de carrera y el suelo pintado — sin decorados. Para eso, ejecuta TerrainEd sobre la carpeta exportada.",
+  "track.previewOnly": "Una pista instalada lleva terreno, superficies y datos de carrera — no tiene gráficos, así que el juego no podrá rodarla. Compila con TerrainEd sobre la carpeta exportada para una pista jugable.",
   "track.at": "En",
   "track.kind": "Tipo",
   "track.height": "Altura",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -2291,7 +2291,7 @@ export const fr: Translation = {
   "track.buildFailed": "Construction impossible",
   "track.exported": "{{count}} fichiers écrits",
   "track.exportFailed": "Export impossible",
-  "track.previewOnly": "Un circuit installé contient le terrain, les surfaces, les données de course et le sol texturé — pas les décors. Pour ça, lance TerrainEd sur le dossier exporté.",
+  "track.previewOnly": "Une piste installée contient le terrain, les surfaces et les données de course — elle n'a pas de graphismes, le jeu ne peut donc pas la rouler. Compilez avec TerrainEd sur le dossier exporté pour une piste jouable.",
   "track.at": "À",
   "track.kind": "Type",
   "track.height": "Hauteur",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -2279,7 +2279,7 @@ export const it: Translation = {
   "track.buildFailed": "Impossibile costruire",
   "track.exported": "Scritti {{count}} file",
   "track.exportFailed": "Impossibile esportare",
-  "track.previewOnly": "Una pista installata porta terreno, superfici, dati di gara e il fondo dipinto — niente scenografie. Per quelle esegui TerrainEd sulla cartella esportata.",
+  "track.previewOnly": "Una pista installata contiene terreno, superfici e dati di gara — non ha grafica, quindi il gioco non può girarci. Compila con TerrainEd sulla cartella esportata per una pista guidabile.",
   "track.at": "A",
   "track.kind": "Tipo",
   "track.height": "Altezza",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -2276,7 +2276,7 @@ export const ptBR: Translation = {
   "track.buildFailed": "Não foi possível construir",
   "track.exported": "{{count}} arquivos escritos",
   "track.exportFailed": "Não foi possível exportar",
-  "track.previewOnly": "Uma pista instalada leva terreno, superfícies, dados de corrida e o chão pintado — sem cenário. Para isso, rode o TerrainEd na pasta exportada.",
+  "track.previewOnly": "Uma pista instalada carrega terreno, superfícies e dados de corrida — não tem gráficos, então o jogo não consegue rodá-la. Compile com TerrainEd sobre a pasta exportada para uma pista jogável.",
   "track.at": "Em",
   "track.kind": "Tipo",
   "track.height": "Altura",


### PR DESCRIPTION
The crash is **none of the six faults fixed before it**.

## The reference that settles it

PiBoSo's own OEM drag strip — sitting extracted in the pkz folder the whole time — declares:

```
materials=0  vertices=0  triangles=0  textures=0
file size: 120,609,745 bytes
```

Every section this code writes is **empty** in an official track that loads fine, and the file
is still 120 MB. All of it is in a trailing block of count-prefixed sections that the loader
reads straight after the ones we write — and that we write none of. The game reads past the end
of our file.

So an empty mesh was always valid, and the mesh was never what was missing. Six rounds of
making our `.map` more like Indiana's were all fixing the prefix. I should have looked for a
*minimal* reference before starting; Indiana at 388 MB was the wrong tool for "what is the
least a map must contain".

## What ships now

Until that trailing block is decoded we cannot write a `.map`, and a wrong one is worse than
none — **none is a track the game declines; a wrong one is a hard crash.** The preview `.pkz`
ships without it, and a test asserts that so it cannot come back by accident.

`map()` stays, unused and clearly marked, because the parts that *are* decoded are decoded
correctly and were expensive to get:

- material records field for field (id at word 11, one-based)
- the vertex block's seven SoA arrays, 80 bytes a vertex
- absolute triangle indices
- leaf node words `[0, 0, tris, first tri, groups]`
- draw groups inside a 16-bit index (Indiana's largest is 8363; ours was 182512)
- texture records with their trailing descriptors, primaries at +104

Finishing it is the only route to installing a generated track without running TerrainEd.

## And the Studio stops overclaiming

It no longer says an installed track carries "the ground it's painted with". It says the track
has no graphics and points at **Build with TerrainEd** over the exported folder — which
produces something rideable, and which was always the honest answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)