### PR TITLE
perf(sync): stop asking every server on the platform for its roster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2026-09-01
 
+### Changed
+- Paint sync only asks about the server you are actually on. Starting the game no longer
+  fetches every rider's paints from every server on the registry — the paints for your grid
+  arrive when you join it. The Sync button still checks everywhere if you ask it to.
+
 ### Added
 - Track generation reads a published track's own centreline out of its height file, so a real
   lap's corners, their radii and its straights can be measured directly rather than guessed at.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## 2026-09-01
 
-### Changed
-- Paint sync only asks about the server you are actually on. Starting the game no longer
-  fetches every rider's paints from every server on the registry — the paints for your grid
-  arrive when you join it. The Sync button still checks everywhere if you ask it to.
-
 ### Added
 - Track generation reads a published track's own centreline out of its height file, so a real
   lap's corners, their radii and its straights can be measured directly rather than guessed at.
@@ -14,6 +9,9 @@
   published one.
 
 ### Changed
+- Paint sync only asks about the server you are actually on. Starting the game no longer
+  fetches every rider's paints from every server on the registry — the paints for your grid
+  arrive when you join it. The Sync button still checks everywhere if you ask it to.
 - Diagnostics say more about each file loaded in your game: its size, when it was built,
   whether Windows trusts its signature and who signed it, and the company and product it
   claims to be. A file can be read the first time it is seen instead of only recognised.

--- a/control-plane/migrations/0018_roster_read_cost.sql
+++ b/control-plane/migrations/0018_roster_read_cost.sql
@@ -1,0 +1,32 @@
+-- Two indexes, for the two queries that were reading the database dry.
+--
+-- On 2026-09-01 the account passed D1's free-tier ceiling of 5,000,000 rows read in a day,
+-- with hours of the day left. Everything that touches the database answered 500 from then
+-- until midnight UTC. `wrangler d1 insights` named the cost precisely, and it was not spread
+-- around: one query was 11.77M of the ~12.2M rows read, and a second was most of the rest.
+
+-- ── The roster ───────────────────────────────────────────────────────────────────────────
+--
+-- `/v1/roster` reads 1,022 rows to return about 215 of them — 21% efficiency, 11,514 times a
+-- day. The waste is the join's fan-out: loadouts are per bike, and a rider's gear repeats
+-- for every bike they own, so a rider with ~94 stored paint rows has only ~20 distinct
+-- destinations. The `GROUP BY a.id, p.rel_dest, p.sha256` throws the other three quarters
+-- away *after* reading them.
+--
+-- `loadout_paints_account` is on `(account_id)` alone, so every one of those 94 rows costs an
+-- index seek and then the table row behind it. This index carries every column the roster
+-- selects, in the order it groups by: the join, the dedup and the projection are all
+-- satisfied from the index, and the table is never touched.
+--
+-- Deliberately not a replacement for `loadout_paints_account` — that one still serves the
+-- plain `WHERE account_id = ?` reads and deletes, and is much narrower to maintain on write.
+CREATE INDEX loadout_paints_roster
+  ON loadout_paints (account_id, rel_dest, sha256, slot, file_name, size);
+
+-- ── The daily claims sweep ───────────────────────────────────────────────────────────────
+--
+-- `DELETE FROM device_claims WHERE day < ?` read 1,327 rows every time it ran and 469,845
+-- across the day — 4% of the whole ceiling to delete a handful of rows. The primary key is
+-- `(ip_digest, day, kind)`, so `day` on its own is not a prefix of it and the sweep had no
+-- way to find its rows but to read all of them.
+CREATE INDEX device_claims_day ON device_claims (day);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6637,7 +6637,9 @@ fn sync_paints_soon(app: &tauri::AppHandle, address: Option<String>) {
             return;
         }
         emit_sync(&app, SyncEvent::phase("pulling"));
-        match pull_rosters(&app, address).await {
+        // Nobody asked for this one — it fires when the game starts, before the rider has
+        // joined anything. With no server to aim at there is nothing worth reading.
+        match pull_rosters(&app, address, Sweep::Never).await {
             Ok(o) => {
                 log::info!(
                     "[sync] {} riders, {} paints installed, {} already held, {} kept as yours, \
@@ -6772,7 +6774,7 @@ fn live_sync_session(app: &tauri::AppHandle, address: Option<String>) {
             }
             last_pull = std::time::Instant::now();
 
-            match pull_rosters(&app, address.clone()).await {
+            match pull_rosters(&app, address.clone(), Sweep::Never).await {
                 // Only say so when something actually arrived: an unchanged grid is the
                 // common case and does not need announcing every 45 seconds.
                 Ok(o) if o.installed > 0 => {
@@ -6862,9 +6864,43 @@ impl GridWatch {
 /// [`live_server_key`]. Before then there is nothing to read, so `address` narrows this to
 /// where they're headed when we launched them at one, and to the whole registry when they
 /// pressed Play and will pick from the game's own browser.
+/// Whether a pull with nowhere to aim may fall back to every server on the registry.
+///
+/// It is a whole-platform sweep — one roster read per registered server, each one returning
+/// the paints of everybody on it — so it is only ever right when a person asked for it. On
+/// 2026-09-01 the automatic paths doing this took the account past D1's daily row ceiling and
+/// every endpoint that reads the database answered 500 for the rest of the day.
+///
+/// The same reasoning already applies to the write half: reporting presence for every key was
+/// removed from this function for being untrue. Reading every roster is the other half of the
+/// same mistake, and it is the expensive half.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Sweep {
+    /// A person pressed something. One sweep, now.
+    Allowed,
+    /// Nobody asked. With no server and no address there is nothing to sync *for* — the
+    /// grid this feature exists to render does not exist yet.
+    Never,
+}
+
+/// Which servers to ask about, once it is settled that the rider is not on one.
+///
+/// An address is a server, whoever gave it to us. Without one, the registry is every server
+/// there is, and asking all of them is a thing only a person may set off.
+fn sync_targets(address_key: Option<String>, registry_ids: &[String], sweep: Sweep) -> Vec<String> {
+    match address_key {
+        Some(key) => vec![key],
+        None => match sweep {
+            Sweep::Allowed => registry_ids.to_vec(),
+            Sweep::Never => Vec::new(),
+        },
+    }
+}
+
 async fn pull_rosters(
     app: &tauri::AppHandle,
     address: Option<String>,
+    sweep: Sweep,
 ) -> Result<paintsync::PullOutcome, String> {
     let cfg = config::load_or_detect(app).unwrap_or_default();
     let token = voice::signal::account(app, &cfg).await?;
@@ -6873,7 +6909,14 @@ async fn pull_rosters(
     // reads out of the running game is the one key every rider on that server can compute,
     // so it is the only one that works on a server we have nothing to do with — which is
     // most of them.
-    let keys: Vec<String> = if let Some(key) = live_server_key() {
+    let live = live_server_key();
+    // Nothing to aim at and no sweep allowed: stop before the registry is even fetched. That
+    // read is not free either — it was 20,869 calls the day the database hit its ceiling, and
+    // every one of them was a prelude to reading a roster we had no business reading.
+    if live.is_none() && address.is_none() && sweep == Sweep::Never {
+        return Err("No servers to sync with yet.".into());
+    }
+    let keys: Vec<String> = if let Some(key) = live {
         vec![key]
     } else {
         // Not on a server yet. An unreachable registry doesn't have to sink a targeted sync
@@ -6886,10 +6929,8 @@ async fn pull_rosters(
                 Vec::new()
             }
         };
-        match &address {
-            Some(addr) => vec![paintsync::server_key_for(&registry, addr)],
-            None => registry.iter().map(|s| s.id.clone()).collect(),
-        }
+        let ids: Vec<String> = registry.iter().map(|s| s.id.clone()).collect();
+        sync_targets(address.as_deref().map(|a| paintsync::server_key_for(&registry, a)), &ids, sweep)
     };
     if keys.is_empty() {
         return Err("No servers to sync with yet.".into());
@@ -6934,7 +6975,9 @@ async fn pull_rosters(
 #[tauri::command]
 async fn sync_paints(app: tauri::AppHandle) -> Result<paintsync::PullOutcome, String> {
     emit_sync(&app, SyncEvent::phase("pulling"));
-    match pull_rosters(&app, None).await {
+    // The one place a sweep is right: a person pressed Sync, and if they are not on a server
+    // the whole registry is the only answer to "whose paints do you mean".
+    match pull_rosters(&app, None, Sweep::Allowed).await {
         Ok(o) => {
             emit_sync(&app, SyncEvent::pulled(&o));
             Ok(o)
@@ -9958,6 +10001,46 @@ mod release_version_tests {
     fn the_tags_v_prefix_is_optional() {
         assert_eq!(pick_release_version(Some("0.9.0"), "0.8.0".into()), "0.9.0");
         assert_eq!(pick_release_version(Some("v0.9.0"), "0.8.0".into()), "0.9.0");
+    }
+}
+
+#[cfg(test)]
+mod sync_target_tests {
+    use super::*;
+
+    fn registry() -> Vec<String> {
+        vec!["alpha".to_string(), "bravo".to_string(), "charlie".to_string()]
+    }
+
+    /// The bug that emptied the database: every automatic pull that ran before the rider had
+    /// joined anything asked every server on the platform for its full roster — and each of
+    /// those answers is the paints of everyone on that server.
+    #[test]
+    fn an_automatic_pull_with_nowhere_to_aim_asks_nobody() {
+        assert!(sync_targets(None, &registry(), Sweep::Never).is_empty());
+    }
+
+    /// The manual button still works the way it reads: a person asked whose paints they are
+    /// missing, and with no server of their own the registry is the only answer there is.
+    #[test]
+    fn a_person_pressing_sync_may_still_ask_everyone() {
+        assert_eq!(sync_targets(None, &registry(), Sweep::Allowed), registry());
+    }
+
+    /// An address is a server. Whoever supplied it, and whatever the sweep rule says, that is
+    /// the one to ask — a targeted sync is never the expensive case.
+    #[test]
+    fn an_address_is_asked_about_whatever_the_sweep_rule_says() {
+        let one = vec!["bravo".to_string()];
+        assert_eq!(sync_targets(Some("bravo".into()), &registry(), Sweep::Never), one);
+        assert_eq!(sync_targets(Some("bravo".into()), &registry(), Sweep::Allowed), one);
+    }
+
+    /// An empty registry is not a reason to sweep something else — it is simply nothing.
+    #[test]
+    fn an_empty_registry_asks_nobody_either_way() {
+        assert!(sync_targets(None, &[], Sweep::Allowed).is_empty());
+        assert!(sync_targets(None, &[], Sweep::Never).is_empty());
     }
 }
 


### PR DESCRIPTION
## What happened

On 2026-09-01 the account passed D1's free-tier ceiling of **5,000,000 rows read per day**, with hours of the UTC day left. Every endpoint that touches the database answered 500 until midnight. The worker itself stayed up and `/health` kept returning 200, which is why it did not look like an outage.

`wrangler d1 insights` put the cost in one place:

| query | rows read | runs | efficiency |
|---|---|---|---|
| `/v1/roster` join | **11,771,506** | 11,514 | 21% |
| `DELETE FROM device_claims WHERE day < ?` | 469,845 | 354 | 0% |
| everything else | ~150,000 | — | — |

Two independent causes behind the first one.

## 1. The roster was being swept platform-wide

With no live server and no address, `pull_rosters` asked **every server on the registry** for its full roster — and each of those answers is every present rider's entire paint list. `sync_on_game_started` takes exactly that path on every launch, because at that moment the rider has not joined anything yet.

The write half of this mistake was already found and fixed once: reporting presence for every key was removed for being untrue, and for costing a write per server. This is the read half of the same mistake, and it is the expensive half — the comment describing the write fix is directly above the code still doing the read.

A `Sweep` argument now makes the choice explicit. Automatic pulls (`Sweep::Never`) ask only about the server the rider is actually on. The manual Sync button keeps `Sweep::Allowed`, because there a person asked and the registry is the only sensible answer to "whose paints do you mean". The automatic path also returns *before* fetching the registry at all, which drops a slice of the 20,869 `/v1/servers` calls that were only ever its prelude.

## 2. The join fanned out 4.7×

Loadouts are per bike and gear repeats for every bike a rider owns, so ~94 stored paint rows carry only ~20 distinct destinations. The `GROUP BY a.id, p.rel_dest, p.sha256` threw three quarters of them away *after* reading them, through `loadout_paints_account` — an index on `account_id` alone, so every row cost an index seek and then the table row behind it.

`loadout_paints_roster` carries every column the roster selects, in the order it groups by. Confirmed against production:

```
SEARCH pr USING INDEX presence_server (server_id=? AND updated_at>?)
SEARCH a USING INDEX sqlite_autoindex_accounts_1 (id=?)
SEARCH p USING COVERING INDEX loadout_paints_roster (account_id=?)
```

The table is never touched now.

## 3. `device_claims`

`DELETE FROM device_claims WHERE day < ?` against a `(ip_digest, day, kind)` primary key — `day` is not a prefix of it, so the sweep had no way to find its rows but to read all of them. 469,845 rows, 4% of the entire daily ceiling, to delete a handful. One index.

## Known cost

`live_server_key()` comes from FrostMod reading the running game. A rider running **without FrostMod**, who starts from Steam and joins from the in-game browser, no longer gets an automatic pull — before, they got their grid's paints incidentally, as a side effect of fetching everyone's on the platform. Joining through the app still syncs, and the Sync button still sweeps.

That trade is deliberate: the alternative is the database going down for everybody. It is also easy to reverse on its own if you would rather keep the sweep and lean on the indexes.

## Considered and dropped

A per-server response cache via the Cache API. `caches.default` is bypassed on `workers.dev`, so it would have been dead code that looked like a fix. If the indexes and the sweep removal are not enough, the real version of that is a Durable Object cache — `VOICE_ROOMS` already proves DOs work on this account.

## DB / deploy

Migration `0018` is two indexes, **already applied to production by hand and verified** (`PRAGMA index_list`, `EXPLAIN QUERY PLAN` above). No control-plane code changed, so no worker deploy is needed for it — the relief is live now and does not wait on an app release.

## Verification

- `cargo test` — 1189 passed, 0 failed
- `cargo check --target x86_64-pc-windows-gnu` — clean
- 4 new tests covering the sweep decision: an automatic pull with nowhere to aim asks nobody, a person pressing Sync may still ask everyone, an address is asked about either way, an empty registry asks nobody

Worth re-running `wrangler d1 insights mxb-control-plane --sort-by reads` after a full day on this to confirm the numbers moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)