### PR TITLE
fix(modwatch): a file the cloud took back is not a mod change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
   published one.
 
 ### Changed
+- Instant refresh looks before it leaps. Applying a look to a running game re-runs one of the
+  game's own routines, at an address that is only right for the build it was read from. The
+  app now asks the game what is actually mapped there and does nothing if it isn't the game's
+  own executable code — and writes the running game's build to the log either way, so a game
+  update that moves the address can be noticed rather than crashed into.
 - Diagnostics say more about each file loaded in your game: its size, when it was built,
   whether Windows trusts its signature and who signed it, and the company and product it
   claims to be. A file can be read the first time it is seen instead of only recognised.
@@ -23,6 +28,11 @@
   the toggle is in Settings for anyone who wants the app waiting for them.
 
 ### Fixed
+- Cloud sync tidying up behind you no longer asks the game to reload its mods. OneDrive,
+  Dropbox and iCloud all take back the contents of files they think you have stopped using,
+  and to the folder watcher that looked exactly like a mod being installed — so the game was
+  sent to re-read a track that had left the machine, at a moment nobody chose. Those changes
+  are now ignored, and the log says which files and how to keep them on the device.
 - Two of the four values every vertex of a track's graphics file carries were left at zero.
 - The terrain in a track's graphics file is cut into tiles, so no single piece of it is too
   large for the game to build a buffer for.

--- a/src-tauri/src/gameproc.rs
+++ b/src-tauri/src/gameproc.rs
@@ -6,6 +6,8 @@ use crate::config::AppConfig;
 ///
 /// An `mxbikes.exe` offset, so it is only ever used when MX Bikes is the active game —
 /// see [`crate::game::Caps::instant_refresh`], which gates every path that reaches here.
+/// It is an address in *one build* of that exe; [`KNOWN_GOOD_BUILDS`] and
+/// [`loader_looks_runnable`] are what keep it from being run in a different one.
 #[cfg(windows)]
 const LOADER_OFFSET: usize = 0x000e_cd00;
 
@@ -22,6 +24,25 @@ const LOADER_OFFSET: usize = 0x000e_cd00;
 /// found", never as a GUID.
 #[cfg(windows)]
 const GUID_OFFSET: usize = 0x000e_5522c;
+
+/// Builds of `mxbikes.exe` the offsets above are known to be right for, as the PE
+/// `TimeDateStamp` the linker wrote into the image.
+///
+/// The offsets are addresses in one particular build. PiBoSo ships new ones, code moves,
+/// and nothing about `base + 0xecd00` announces that it is no longer the customization
+/// loader — it is simply whatever now lives at that address. [`local_guid`] survives that
+/// by checking what it reads back; [`refresh_look`] cannot, because it does not read
+/// anything. It starts a thread there. On the wrong build that is a jump into the middle of
+/// an unrelated function, on the game's own process, with the player's session behind it.
+///
+/// So the offsets are qualified by the build they came from. **Empty means unqualified**,
+/// and unqualified is what shipped before this list existed: the structural checks in
+/// [`loader_looks_runnable`] still apply, but a build match is not required, because
+/// requiring a match against an empty list would take the feature away from everyone.
+/// Filling this in is what turns the guard on, and `refresh_look` logs the running build's
+/// stamp every time so any player's log yields the value to put here.
+#[cfg(windows)]
+const KNOWN_GOOD_BUILDS: &[u32] = &[];
 
 /// The flag that makes a fresh game process connect straight to a server.
 ///
@@ -52,6 +73,11 @@ pub enum LiveRefresh {
     GameNotRunning,
     /// The instant-refresh setting was off — we didn't try.
     Disabled,
+    /// The running game isn't a build the loader offset is known good for, so nothing was
+    /// run in it. The look stays as it is until the game is restarted, which is the
+    /// outcome the offset was buying us anyway — and a great deal better than a thread
+    /// started at whatever that address holds now.
+    UnknownBuild,
     /// This platform can't do it (non-Windows dev builds).
     Unsupported,
 }
@@ -111,6 +137,38 @@ mod ffi {
     /// We aren't pumping messages on this thread; without it the shell can return before
     /// it has finished with the string buffers we lent it.
     pub const SEE_MASK_NOASYNC: u32 = 0x0000_0100;
+
+    /// `MEM_COMMIT` — the page is backed, not merely reserved.
+    pub const MEM_COMMIT: u32 = 0x0000_1000;
+
+    /// The four page protections that permit execution. A start address whose page is not
+    /// one of these is not code, whatever the offset says it should be.
+    pub const PAGE_EXECUTE: u32 = 0x10;
+    pub const PAGE_EXECUTE_READ: u32 = 0x20;
+    pub const PAGE_EXECUTE_READWRITE: u32 = 0x40;
+    pub const PAGE_EXECUTE_WRITECOPY: u32 = 0x80;
+
+    /// `MEMORY_BASIC_INFORMATION`. The two padding slots are the x64 layout's own
+    /// `__alignment` members; without them `region_size` lands four bytes early and every
+    /// field after it is read from the wrong place.
+    // No `Default`: raw pointers have none. Every caller zeroes it, as the rest of this
+    // module does for the toolhelp structs. Most of it is never read — the fields are here
+    // to put `state` and `protect` at the offsets the kernel writes them to.
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    #[allow(dead_code)]
+    pub struct MemoryBasicInformation {
+        pub base_address: *mut c_void,
+        pub allocation_base: *mut c_void,
+        pub allocation_protect: u32,
+        pub partition_id: u16,
+        pub _alignment1: u16,
+        pub region_size: usize,
+        pub state: u32,
+        pub protect: u32,
+        pub kind: u32,
+        pub _alignment2: u32,
+    }
 
     /// `TOKEN_ELEVATION` — one `BOOL`, non-zero when the token is an elevated one.
     #[repr(C)]
@@ -196,6 +254,14 @@ mod ffi {
             size: usize,
             read: *mut usize,
         ) -> i32;
+        /// What the process has mapped at an address: enough to say whether a start
+        /// address is committed, executable, and part of the exe's own image.
+        pub fn VirtualQueryEx(
+            process: Handle,
+            address: *const c_void,
+            buffer: *mut MemoryBasicInformation,
+            length: usize,
+        ) -> usize;
         pub fn CreateRemoteThread(
             process: Handle,
             attrs: *mut c_void,
@@ -769,6 +835,104 @@ pub fn is_exclusive_fullscreen() -> bool {
     hr == 0 && state == ffi::QUNS_RUNNING_D3D_FULL_SCREEN
 }
 
+/// The PE `TimeDateStamp` of the image mapped at `base`, read out of the live process.
+///
+/// The linker writes it once per build, so it is the cheapest exact answer to "is this the
+/// game the offsets were read from?" — cheaper and far more specific than a file version,
+/// which PiBoSo leaves at `0.0.0.0`. Read from the process rather than off disk on purpose:
+/// the question is about the image that is actually running.
+///
+/// `None` when the headers can't be read or don't look like a PE, which is treated the same
+/// as a build that doesn't match.
+#[cfg(windows)]
+unsafe fn image_build_stamp(proc: ffi::Handle, base: *mut u8) -> Option<u32> {
+    /// `e_magic` — "MZ".
+    const DOS_MAGIC: u16 = 0x5A4D;
+    /// `Signature` — "PE\0\0".
+    const PE_MAGIC: u32 = 0x0000_4550;
+    /// `e_lfanew`, the offset of the NT headers, at a fixed place in the DOS header.
+    const E_LFANEW: usize = 0x3C;
+    /// `TimeDateStamp` sits two `WORD`s into `IMAGE_FILE_HEADER`, itself just past the
+    /// four-byte signature.
+    const STAMP_FROM_NT: usize = 4 + 4;
+
+    // SAFETY: every read is a fixed-size read into a local, at an address inside the image
+    // the caller resolved; a short or failed read yields `None` rather than a value.
+    unsafe fn read<T: Copy>(proc: ffi::Handle, at: *const u8) -> Option<T> {
+        let mut out = std::mem::zeroed::<T>();
+        let mut got = 0usize;
+        let ok = ffi::ReadProcessMemory(
+            proc,
+            at as *const std::os::raw::c_void,
+            &mut out as *mut T as *mut std::os::raw::c_void,
+            std::mem::size_of::<T>(),
+            &mut got,
+        ) != 0
+            && got == std::mem::size_of::<T>();
+        ok.then_some(out)
+    }
+
+    if read::<u16>(proc, base)? != DOS_MAGIC {
+        return None;
+    }
+    let nt = base.add(read::<u32>(proc, base.add(E_LFANEW))? as usize);
+    if read::<u32>(proc, nt)? != PE_MAGIC {
+        return None;
+    }
+    read::<u32>(proc, nt.add(STAMP_FROM_NT))
+}
+
+/// Why [`LOADER_OFFSET`] must not be run in this process, or `Ok(())` if it may be.
+///
+/// Two layers, because they fail differently. The structural one asks the kernel what is
+/// mapped at the address — a start address that isn't committed, executable code belonging
+/// to the exe's own image is disqualifying whatever build this is, and it needs no
+/// knowledge of any build to say so. The build match is the sharper check and the one that
+/// catches the case that actually happens: the address is still perfectly good code, just
+/// not the function we meant. It only applies once [`KNOWN_GOOD_BUILDS`] has entries.
+#[cfg(windows)]
+unsafe fn loader_looks_runnable(proc: ffi::Handle, base: *mut u8) -> Result<(), String> {
+    let start = base.add(LOADER_OFFSET);
+
+    let mut info = std::mem::zeroed::<ffi::MemoryBasicInformation>();
+    let wrote = ffi::VirtualQueryEx(
+        proc,
+        start as *const std::os::raw::c_void,
+        &mut info,
+        std::mem::size_of::<ffi::MemoryBasicInformation>(),
+    );
+    if wrote == 0 {
+        return Err(format!("VirtualQueryEx failed (error {})", ffi::GetLastError()));
+    }
+    if info.state != ffi::MEM_COMMIT {
+        return Err("the loader address isn't committed memory".into());
+    }
+    let executable = ffi::PAGE_EXECUTE
+        | ffi::PAGE_EXECUTE_READ
+        | ffi::PAGE_EXECUTE_READWRITE
+        | ffi::PAGE_EXECUTE_WRITECOPY;
+    if info.protect & executable == 0 {
+        return Err(format!("the loader address isn't executable (protect {:#x})", info.protect));
+    }
+    if info.allocation_base != base as *mut std::os::raw::c_void {
+        return Err("the loader address isn't inside the game's own image".into());
+    }
+
+    let stamp = image_build_stamp(proc, base);
+    match stamp {
+        Some(s) => log::info!("[look] running game build: TimeDateStamp {s:#010x}"),
+        None => log::warn!("[look] could not read the running game's build stamp"),
+    }
+    if KNOWN_GOOD_BUILDS.is_empty() {
+        return Ok(());
+    }
+    match stamp {
+        Some(s) if KNOWN_GOOD_BUILDS.contains(&s) => Ok(()),
+        Some(s) => Err(format!("build {s:#010x} is not one the loader offset is known good for")),
+        None => Err("the running game's build stamp is unreadable".into()),
+    }
+}
+
 /// Experimental: re-run the game's profile-load routine in the live process. Best-effort.
 #[cfg(windows)]
 pub fn refresh_look() -> LiveRefresh {
@@ -785,13 +949,21 @@ pub fn refresh_look() -> LiveRefresh {
         | ffi::PROCESS_VM_WRITE
         | ffi::PROCESS_VM_READ;
 
-    // SAFETY: we open the process for thread creation, spawn a thread at the
-    // resolved loader address, wait briefly, and close every handle we open. The
-    // start address is the module base plus a fixed code offset within the exe.
+    // SAFETY: we open the process for thread creation, check what is actually mapped at
+    // the resolved loader address, and only then spawn a thread there, wait briefly, and
+    // close every handle we open — on the refusing path too. The start address is the
+    // module base plus a fixed code offset within the exe.
     unsafe {
         let proc = ffi::OpenProcess(access, 0, pid);
         if proc.is_null() {
             return LiveRefresh::Failed;
+        }
+        // Nothing below this point can be undone, so everything that could say "not this
+        // process" has to have said it by here.
+        if let Err(why) = loader_looks_runnable(proc, base) {
+            log::warn!("[look] not running the loader in the live game: {why}");
+            ffi::CloseHandle(proc);
+            return LiveRefresh::UnknownBuild;
         }
         let start = base.add(LOADER_OFFSET) as *mut std::os::raw::c_void;
         let thread = ffi::CreateRemoteThread(

--- a/src-tauri/src/modwatch.rs
+++ b/src-tauri/src/modwatch.rs
@@ -9,7 +9,7 @@
 //! the sibling `profiles/` folder, which churns constantly during gameplay (replays,
 //! telemetry, settings) and would otherwise fire reloads mid-race.
 //!
-//! Two things keep the reload from being a blunt instrument:
+//! Three things keep the reload from being a blunt instrument:
 //!
 //! * **Settling.** Copying a folder of tracks writes files for as long as the copy
 //!   takes, and the debouncer keeps handing us batches throughout. Reloading on each
@@ -20,6 +20,9 @@
 //!   scoped to the new mods rather than the whole collection. The plain reload event is
 //!   still pulsed afterwards, so a FrostMod that doesn't know the verb behaves exactly
 //!   as it does today.
+//! * **Only what's really there.** A cloud sync tool evicting a file's bytes is a change
+//!   to the folder like any other, and reloading for it hands the game a content list it
+//!   then has to read off a disk the bytes have left. See [`split_evicted`].
 
 use std::collections::BTreeSet;
 use std::path::{Component, Path, PathBuf};
@@ -225,6 +228,34 @@ fn is_partial(path: &Path) -> bool {
     lower.starts_with('~') || PARTIAL_SUFFIXES.iter().any(|s| lower.ends_with(s))
 }
 
+/// Split a batch into the paths worth reloading for and the ones whose bytes aren't here.
+///
+/// Half-written files were already dropped by [`is_partial`]; this drops the other kind of
+/// path that is present in name only. OneDrive, Dropbox and iCloud all evict a file's
+/// content and leave its entry behind, and evicting one *is a change to the folder* — so a
+/// sync tool tidying up behind the player looks exactly like a mod being installed, and the
+/// watcher would pulse FrostMod for it. FrostMod's reload then rebuilds the game's content
+/// lists, which means reading files that are no longer on the disk, on the game's own
+/// thread. That is the crash `cloudfiles` documents, reached by a route the player never
+/// asked for: they touched nothing.
+///
+/// So a placeholder is not a mod change. A *hydration* still is — once the bytes land the
+/// file stops being a placeholder and the next event carries it through — and so is a
+/// deletion, whose attributes read as unavailable rather than as a placeholder.
+///
+/// The predicate is a parameter so the split is testable without a sync tool to hand; in
+/// production it is always [`crate::cloudfiles::is_placeholder`], which reads attributes
+/// only and so cannot itself trigger the download it is looking for.
+fn split_evicted<'a>(
+    changed: &'a [PathBuf],
+    evicted: impl Fn(&Path) -> bool,
+) -> (Vec<&'a PathBuf>, Vec<&'a PathBuf>) {
+    changed
+        .iter()
+        .filter(|p| !is_partial(p))
+        .partition(|p| !evicted(p))
+}
+
 /// Reduce a changed path to the mod it belongs to: `<type>/<name>` relative to the
 /// watched root, e.g. `.../mods/tracks/Red Bud/Red Bud.pkz` -> `tracks/Red Bud`.
 ///
@@ -287,13 +318,28 @@ fn on_batch(
     if !live.load(Ordering::SeqCst) {
         return;
     }
-    let keys: Vec<String> = changed
-        .iter()
-        .filter(|p| !is_partial(p))
+    let (present, evicted) = split_evicted(&changed, crate::cloudfiles::is_placeholder);
+    if !evicted.is_empty() {
+        // Not silent: a player whose auto-reload has gone quiet deserves the reason in the
+        // log, and it is the same reason — and the same fix — `cloudfiles` already warns
+        // about when a session starts.
+        log::warn!(
+            "mods watcher: {} of {} changed path(s) are cloud placeholders, not real files — \
+             not treating them as mod changes, because a reload would send the game reading \
+             them. Fix: \"Always keep on this device\" on the mods folder, or move it off the \
+             sync tool. e.g. {}",
+            evicted.len(),
+            changed.len(),
+            evicted[0].display(),
+        );
+    }
+    let keys: Vec<String> = present
+        .into_iter()
         .flat_map(|p| mod_keys(root, links, p))
         .collect();
     if keys.is_empty() {
-        // Everything in the batch was scratch files, or churn directly in the root.
+        // Everything in the batch was scratch files, churn directly in the root, or bytes
+        // that aren't on this machine.
         return;
     }
 
@@ -358,6 +404,45 @@ fn reload(app: &AppHandle, mods: Vec<String>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A sync tool evicting a file's bytes is a folder change like any other. Reloading
+    /// for it is what sends the game reading content that has left the disk.
+    #[test]
+    fn evicted_files_are_split_out_of_a_batch() {
+        let batch = vec![
+            PathBuf::from("/games/mxb/mods/tracks/Red Bud/Red Bud.pkz"),
+            PathBuf::from("/games/mxb/mods/tracks/Gone/Gone.pkz"),
+        ];
+        let (present, evicted) = split_evicted(&batch, |p| p.ends_with("Gone/Gone.pkz"));
+        assert_eq!(present, vec![&batch[0]]);
+        assert_eq!(evicted, vec![&batch[1]]);
+    }
+
+    /// The two filters compose, and neither swallows the other: a half-written file is
+    /// dropped whether or not it is a placeholder, and it is never reported as one.
+    #[test]
+    fn half_written_files_are_dropped_before_the_eviction_split() {
+        let batch = vec![
+            PathBuf::from("/games/mxb/mods/tracks/Red Bud/Red Bud.pkz.crdownload"),
+            PathBuf::from("/games/mxb/mods/tracks/Red Bud/Red Bud.pkz"),
+        ];
+        let (present, evicted) = split_evicted(&batch, |_| false);
+        assert_eq!(present, vec![&batch[1]]);
+        assert!(evicted.is_empty(), "a scratch file is not an evicted one");
+    }
+
+    /// Nothing is skipped on a folder no sync tool has touched — which is every folder,
+    /// off Windows and macOS, where `is_placeholder` is always false.
+    #[test]
+    fn an_ordinary_batch_passes_through_whole() {
+        let batch = vec![
+            PathBuf::from("/games/mxb/mods/tracks/Red Bud/Red Bud.pkz"),
+            PathBuf::from("/games/mxb/mods/bikes/KTM 450/paints/Frost.pnt"),
+        ];
+        let (present, evicted) = split_evicted(&batch, crate::cloudfiles::is_placeholder);
+        assert_eq!(present.len(), 2);
+        assert!(evicted.is_empty());
+    }
 
     #[test]
     fn watch_root_is_the_content_subfolder_not_the_root() {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -997,7 +997,11 @@ export type LiveRefresh =
   | "failed"
   | "game_not_running"
   | "disabled"
-  | "unsupported";
+  | "unsupported"
+  /** The running `mxbikes.exe` isn't a build the loader offset is known good for, so
+   *  nothing was run in it. Reads to the player exactly like `failed` — the look didn't
+   *  change — and both fall to the same "reselect your profile" note. */
+  | "unknown_build";
 
 /** Result of a payload-carrying command sent to FrostMod (see `frostmod.rs`). */
 export type CommandOutcome =


### PR DESCRIPTION
OneDrive, Dropbox and iCloud all evict the contents of files they think
you have stopped using, leaving the entry behind. To a folder watcher
that is a change like any other, so the sync tool tidying up looked
exactly like a mod being installed — and the reload we pulsed for it sent
the game to rebuild its content lists by reading files whose bytes had
left the machine, on the game's own thread, at a moment the player never
chose. That read is the crash `cloudfiles` already documents, reached by
a route nobody asked for.

Each batch is now split: paths that are really here become mod keys,
placeholders don't. Hydration still counts, because the file stops being
a placeholder once the bytes land; so does deletion, whose attributes
read as unavailable rather than as a placeholder. The predicate is a
parameter so the split is testable without a sync tool to hand.

Not silent — a batch that loses paths says so in the log, with the same
fix `cloudfiles` names, so auto-reload going quiet has a reason.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018n1HXYSExXxTAuJUd4HS8h