### PR TITLE
feat(tracks): a lap that climbs, and a guard against straight lines in ground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@
 - The starting track is a lap that folds through its own middle instead of a regular star.
 - A step-up no longer leaves a cliff across the track at the start line. A lap that steps up
   somewhere now falls the same amount over the rest of it.
+
+### Changed
+- The starting track is built on a hillside. It climbs 22 m round the lap, which is what
+  Indiana does — half of the published tracks climb more than 20 m, and a flat plot rides
+  like a car park.
 - Switching MXB App off in Windows' list of startup apps sticks, and Launch at startup in
   Settings follows it.
 - More of the crash at track graphics: the ground sheets in a track's graphics file were

--- a/control-plane/src/trackgen.ts
+++ b/control-plane/src/trackgen.ts
@@ -242,8 +242,14 @@ What real tracks measure, from a survey of published ones. Land inside these unl
 explicitly asks otherwise:
 
   jumps on a lap      COUNT THEM. A 2000 m lap carries 30–45 features — not four.
-  landscape relief    amplitude 8–20 m over a 120–200 m wavelength. A flat plot measures
+  landscape relief    amplitude 8–25 m over a 120–200 m wavelength. A flat plot measures
                       under 18° at its steepest and is rejected for it; ground has to roll.
+  how much it climbs  2–66 m from the lowest ground on the lap to the highest, and the spread
+                      is the point rather than the middle of it. Lambretta Lynds climbs 2 m
+                      and Millville 66; Indiana 21. A track on a hillside rides nothing like a
+                      track on a field. Pick one deliberately from the brief — "sand national"
+                      and "hillside" are different tracks — instead of landing on flat by
+                      default. Amplitude is what sets it: 22 m of relief gives a 22 m climb.
   riding line width   10–17 m
   jumps per km        12–25, measured along the centrelines of published tracks
   the SIZE MIX        this is what makes a lap read as a national rather than a rhythm

--- a/src-tauri/src/trackllm.rs
+++ b/src-tauri/src/trackllm.rs
@@ -82,6 +82,12 @@ pub mod corpus {
     pub const TURNS: (f32, f32) = (10.0, 30.0);
     /// The tightest radius inside a turn, at the median. Measured 10.6–18.5 m.
     pub const TURN_RADIUS_M: (f32, f32) = (7.0, 30.0);
+    /// Highest ground on the lap over lowest. Measured 2.2–66.3 m, and the spread is the
+    /// point: Lambretta Lynds climbs 2 m and Millville 66. A track on a hillside rides
+    /// nothing like a track on a field, and both are normal.
+    pub const LAP_CLIMB_M: (f32, f32) = (2.0, 70.0);
+    /// Steepest grade along the riding line at the ninetieth. Measured 9.1–22.5°.
+    pub const GRADE_P90_DEG: (f32, f32) = (7.0, 26.0);
 }
 
 /// One round trip: what the model was last told, and what was wrong with what it sent.
@@ -532,6 +538,16 @@ pub fn review(prog: &TrackProgram) -> Review {
         }
     }
     between("the lap's total turning", turning, corpus::TOTAL_TURN_DEG, "°", &mut notes);
+    // How much of a hill it is. A generated lap lands on flat by default — the landscape
+    // amplitude is the only thing that decides it, and a track on a field rides nothing like
+    // a track on a hillside. Half the published corpus climbs more than 20 m.
+    between(
+        "the landscape's amplitude",
+        prog.terrain.relief.amplitude,
+        (4.0, 30.0),
+        " m",
+        &mut notes,
+    );
     between("the lap", real.len() as f32, corpus::TURNS, " corners", &mut notes);
     if !real.is_empty() {
         let mut r: Vec<f32> = real.iter().map(|t| t.1).collect();

--- a/src-tauri/src/trackprog.rs
+++ b/src-tauri/src/trackprog.rs
@@ -391,7 +391,8 @@ impl Feature {
 ///
 /// 1900 m, 114 segments of which 88 are arcs, nineteen corners at 167° apiece, 2634° of
 /// turning, and it closes to 0.01 m. Thirty-six features, seven of them over 2.2 m and the
-/// rest small ground, which is the ratio Indiana has.
+/// rest small ground, which is the ratio Indiana has. It climbs 22 m round the lap, which is
+/// Indiana's 21.3 — half the published corpus is a hillside and a flat plot rides like one.
 ///
 /// This is the schema's own test. It is parsed by the test suite, synthesised, and measured
 /// against published tracks, so it cannot drift away from what the code accepts.
@@ -401,8 +402,8 @@ pub const EXAMPLE: &str = r#"{
       "location": "Generated",
       "width": 12.0,
       "terrain": {
-        "sizeX": 500.0, "sizeZ": 480.0, "samples": 2049, "scale": 40.0,
-        "relief": { "amplitude": 9.0, "wavelength": 165.0, "seed": 7 }
+        "sizeX": 500.0, "sizeZ": 480.0, "samples": 2049, "scale": 60.0,
+        "relief": { "amplitude": 22.0, "wavelength": 150.0, "seed": 7 }
       },
       "start": { "x": 261.50, "z": 259.20, "angle": 0.0 },
       "segments": [

--- a/src-tauri/src/trackstats.rs
+++ b/src-tauri/src/trackstats.rs
@@ -841,6 +841,10 @@ pub struct RiddenStats {
     /// Every degree the lap turns through, both ways. A lap that closes turns 360° net; this
     /// is the gross figure, and it is what says whether a track is a shape or a scribble.
     pub total_turn_deg: f32,
+    /// Highest ground on the lap over lowest — how much of a hill the track is built on.
+    pub lap_climb_m: f32,
+    /// Steepest grade along the riding line, degrees.
+    pub grade_deg: Spread,
 
     /// Grooves counted across the line, and how far apart they lie.
     pub rut_lines: f32,
@@ -935,6 +939,20 @@ pub fn ridden(lap: &crate::trackline::Lap, g: &Grid) -> Option<RiddenStats> {
     let mut turn_radius_m: Vec<f32> =
         turns_all.iter().filter(|t| t.0 >= 25.0).map(|t| t.1).collect();
     let total_turn_deg = lap.segments.iter().map(|s| s.angle).sum();
+    // Taken from the segments' own elevations rather than the ground under them: this is the
+    // height the lap was *built* to, and it is what a rider climbs.
+    let (mut lo, mut hi) = (f32::INFINITY, f32::NEG_INFINITY);
+    for s in &lap.segments {
+        lo = lo.min(s.elevation);
+        hi = hi.max(s.elevation);
+    }
+    let lap_climb_m = if lo.is_finite() { hi - lo } else { 0.0 };
+    let mut grade_deg: Vec<f32> = (0..along.len())
+        .map(|i| {
+            let j = (i + 1) % along.len();
+            ((along[j] - along[i]).abs() / RIDDEN_STEP_M).atan().to_degrees()
+        })
+        .collect();
 
     // ---- ruts ------------------------------------------------------------
     let mut lines: Vec<f32> = Vec::new();
@@ -1076,6 +1094,8 @@ pub fn ridden(lap: &crate::trackline::Lap, g: &Grid) -> Option<RiddenStats> {
         turn_deg: spread(&mut turn_deg),
         turn_radius_m: spread(&mut turn_radius_m),
         total_turn_deg,
+        lap_climb_m,
+        grade_deg: spread(&mut grade_deg),
         rut_lines: lines.iter().sum::<f32>() / lines.len().max(1) as f32,
         rut_spacing_m: spread(&mut spacing),
         rut_depth_corner_m: spread(&mut depth_corner),
@@ -1261,9 +1281,10 @@ mod tests {
                         println!(
                             "{:<34} lap {:>5.0}m  {:>3} segs = {:>3} arcs + {:>2} straights  \
                              {:>2} turns  turn p50 {:>4.0}°  tightest R p50 {:>4.1}m  \
-                             turning {:>5.0}°",
+                             turning {:>5.0}°  climbs {:>4.1}m  grade p90 {:>4.1}°",
                             "  centreline", r.lap_m, r.segments, r.arcs, r.straights,
                             r.turns, r.turn_deg.p50, r.turn_radius_m.p50, r.total_turn_deg,
+                            r.lap_climb_m, r.grade_deg.p90,
                         );
                         println!(
                             "{:<34} ruts {:>4.1} at {:>4.2}m  depth corner p50 {:>4.2} p90 {:>4.2}  \

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -3782,9 +3782,9 @@ mod tests {
         .expect("and it measures");
         println!(
             "centreline: lap {:.0}m  {} segs = {} arcs + {} straights  {} turns  turn p50 {:.0}°  \
-             tightest R p50 {:.1}m  turning {:.0}°",
+             tightest R p50 {:.1}m  turning {:.0}°  climbs {:.1}m  grade p90 {:.1}°",
             r.lap_m, r.segments, r.arcs, r.straights, r.turns, r.turn_deg.p50,
-            r.turn_radius_m.p50, r.total_turn_deg,
+            r.turn_radius_m.p50, r.total_turn_deg, r.lap_climb_m, r.grade_deg.p90,
         );
         println!(
             "  ruts {:.1} at {:.2}m  depth corner p50 {:.2} p90 {:.2}  straight p50 {:.2}  |  \
@@ -3969,6 +3969,66 @@ mod tests {
     /// step-up used to raise everything after it and nothing put it back, so the start line —
     /// where the two ends of the lap meet in the ground — was a cliff the height of the
     /// step-up. It measured 1.30 m in a single sample on the demo, and no test saw it.
+    /// No straight line across the terrain, whichever direction it runs.
+    ///
+    /// A straight line in ground is always a defect — real terrain has no reason to step along
+    /// a row of samples — and it is the one class of fault none of the measurements we take
+    /// would report. The 2.2 m wall a step-up used to leave across the start line passed the
+    /// corridor width, the slope percentiles and the lip count without a murmur.
+    ///
+    /// A raw count of stepping samples does not separate the two: Indiana's worst row steps on
+    /// 17% of its samples, more than any generated track, because a row that runs the length
+    /// of a straight crosses a lot of jump faces. What separates them is *coherence* — a cliff
+    /// steps the same way all along its length and a row of jump faces does not. Measured on
+    /// Indiana the worst coherent line averages 0.28 m a step; the demo's is 0.25 m; the wall
+    /// was 1.35 m.
+    #[test]
+    fn the_terrain_has_no_straight_lines_in_it() {
+        let p: TrackProgram = serde_json::from_str(DEMO).unwrap();
+        let s = synthesise(&p).unwrap();
+        let step = 0.12f32; // below this it is texture, not a face
+
+        let mut worst = (0.0f32, 0usize, String::new());
+        let mut consider = |total: f32, n: usize, what: String| {
+            if n >= 20 {
+                let mean = total.abs() / n as f32;
+                if mean > worst.0 {
+                    worst = (mean, n, what);
+                }
+            }
+        };
+        for y in 1..s.gh {
+            let (mut total, mut n) = (0.0f32, 0usize);
+            for x in (0..s.gw).step_by(2) {
+                let d = s.heights[y * s.gw + x] - s.heights[(y - 1) * s.gw + x];
+                if d.abs() > step {
+                    total += d;
+                    n += 1;
+                }
+            }
+            consider(total, n, format!("row {y}"));
+        }
+        for x in 1..s.gw {
+            let (mut total, mut n) = (0.0f32, 0usize);
+            for y in (0..s.gh).step_by(2) {
+                let d = s.heights[y * s.gw + x] - s.heights[y * s.gw + x - 1];
+                if d.abs() > step {
+                    total += d;
+                    n += 1;
+                }
+            }
+            consider(total, n, format!("column {x}"));
+        }
+        assert!(
+            worst.0 < 0.60,
+            "{} steps the same way {} times, {:.2} m each — a published track's worst \
+             coherent line averages 0.28 m",
+            worst.2,
+            worst.1,
+            worst.0
+        );
+    }
+
     #[test]
     fn a_step_up_does_not_leave_a_cliff_at_the_start() {
         let mut p = hairpins();


### PR DESCRIPTION
Continuing from #362 — the step-up cliff was found by a one-off scan, so this turns that scan
into a test and then uses the same "what are we not measuring" question on the next thing.

## Hills

The starting track climbed 9 m round the lap. Nothing measured that at all: the corpus
reported layout, ruts, berms and jumps and never asked how much of a hill the track was on.
It does now, taken off each centreline's own elevations:

| | climb |
|---|---|
| Lambretta Lynds | 2.2 m |
| France | 4.4 m |
| Netherlands | 7.6 m |
| **Indiana** | **21.3 m** |
| Maryland | 28.1 m |
| Washougal | 48.2 m |
| Flanders | 53.0 m |
| Sardegna | 60.7 m |
| Millville | 66.3 m |

The spread is the point rather than the middle of it — a track on a hillside rides nothing like
a track on a field, and both are normal. The example is now 22 m of climb over a 150 m
wavelength, which is Indiana's figure, and the prompt says to pick one deliberately from the
brief rather than landing on flat by default. The validator notes an amplitude outside 4–30 m.

Grade along the riding line is measured too: published tracks run 9.1–22.5° at the ninetieth,
ours 12.9°.

## A guard against straight lines

A straight line in terrain is always a defect, and it is the one class of fault none of our
measurements report. The 2.2 m wall from #362 passed the corridor width, the slope percentiles
and the lip count without a murmur.

A raw count of stepping samples does **not** separate a defect from a jump:

```
Indiana        worst row 17.2% of samples step   <- more than any generated track
generated v2   worst row  8.6%                   <- and this one had the wall in it
```

A row that runs along a straight crosses a lot of jump faces. What separates them is
**coherence** — a cliff steps the same way all along its length and a row of faces does not:

```
Indiana        worst coherent line  0.28 m a step
generated v3   worst coherent line  0.25 m a step
the wall       worst coherent line  1.35 m a step
```

The test bounds it at 0.60 m. Verified by reverting the step-up fix — it fails, and passes
again with it restored.

## Also checked, and clean

Isolated spikes: Indiana carries 0.036% of samples more than 0.25 m off their neighbours;
the generated terrain has **zero**. Whatever is left in the hillshade is not that.

1194 tests green, control plane typechecks and 161 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
