### PR TITLE
tools(tracks): trace the .map loader by emulating it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 2026-09-01
 
+### Added
+- A tool that traces exactly which bytes MX Bikes reads out of a track's graphics file, by
+  emulating the game's own loader. Groundwork for generating tracks the game can ride without
+  running TerrainEd.
+
+## 2026-09-01
+
 ### Fixed
 - Installing a generated track no longer crashes the game. It ships without graphics rather
   than with graphics the game cannot read, and the Studio says so.

--- a/scripts/map-loader-trace.py
+++ b/scripts/map-loader-trace.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Trace exactly which bytes MX Bikes reads out of a `.map`, by emulating its loader.
+
+The `.map` format is not documented and static reading of the loader kept producing
+plausible-but-wrong answers — the sections are flag-gated and irregular, so a wrong guess
+looks right for one record and drifts on the next. This runs the real loader instead.
+
+It maps the unpacked `mxbikes.exe` into a Unicorn x86-64 emulator, starts at the function that
+reads everything after the mesh (`0x14025f180`), and hooks the game's own read helper so every
+call is serviced from a real `.map` on disk and logged as `(offset, size)`. Whatever comes out
+*is* the format, for that file, with no inference.
+
+Everything that cannot touch the file is stubbed: a function is skipped if neither it nor
+anything it calls reaches the read helper, so imports, string handling and the rest never need
+to work. Calls through pointers we never filled in are unwound with a shadow return stack.
+
+    pip3 install unicorn pefile capstone
+    python3 scripts/map-loader-trace.py [start-offset]
+
+Needs `~/Downloads/mxbikes.exe.unpacked.exe` (see the notes on the unpacked binaries) and a
+`.map` to read. The OEM drag strip is the reference worth using: its mesh, materials and
+textures are all declared empty, so everything it contains is in the part still being decoded.
+
+Known limit: the texture payload's decompressor is stubbed, so a length after the first
+payload comes out negative and the trace drifts from there. Letting that function run for
+real is what would produce the whole file's layout in one pass.
+"""
+
+import struct, os, sys
+import pefile
+from unicorn import *
+from unicorn.x86_const import *
+
+EXE = os.path.expanduser("~/Downloads/mxbikes.exe.unpacked.exe")
+MAP = os.path.expanduser("~/Projects/pkz/L21-DragStrip_OEM/L21-DragStrip_OEM.map")
+
+pe = pefile.PE(EXE, fast_load=True)
+pe.parse_data_directories(directories=[pefile.DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_EXCEPTION']])
+_pdata = [(e.struct.BeginAddress, e.struct.EndAddress) for e in pe.DIRECTORY_ENTRY_EXCEPTION]
+BASE = pe.OPTIONAL_HEADER.ImageBase
+img  = pe.get_memory_mapped_image(ImageBase=BASE)
+IMGSZ = (len(img) + 0xFFF) & ~0xFFF
+
+READ  = 0x140158a90     # read(handle, size, dest)
+ALLOC = 0x14015b4f0     # alloc(size)
+FREE  = 0x14015b540
+MEMSET= 0x1402ab340
+ENTRY = 0x14025f180
+
+HEAP  = 0x200000000
+STACK = 0x300000000
+FILE  = 0x100000000     # not mapped; we service reads from python
+
+mu = Uc(UC_ARCH_X86, UC_MODE_64)
+mu.mem_map(BASE, IMGSZ + 0x1000)
+mu.mem_write(BASE, bytes(img))
+mu.mem_map(HEAP, 0x40000000)          # 1 GB scratch
+mu.mem_map(STACK, 0x100000)
+mu.mem_map(0, 0x100000)          # scratch for writes through null pointers
+
+data = open(MAP,'rb').read()
+state = {"cursor": int(sys.argv[1]) if len(sys.argv)>1 else 312,
+         "heap": HEAP + 0x1000, "log": [], "depth": 0}
+
+_stub_targets = set()
+_trail = []
+def _unwind(uc):
+    # Execution has left the image — a call through a pointer we never filled in. Find the
+    # nearest return address on the stack and carry on as if that call returned 0.
+    rsp = uc.reg_read(UC_X86_REG_RSP)
+    for slot in range(0, 96):
+        try:
+            ret = struct.unpack('<Q', uc.mem_read(rsp + slot*8, 8))[0]
+        except Exception:
+            return False
+        if BASE <= ret < BASE + IMGSZ:
+            uc.reg_write(UC_X86_REG_RAX, 0)
+            uc.reg_write(UC_X86_REG_RSP, rsp + (slot+1)*8)
+            uc.reg_write(UC_X86_REG_RIP, ret)
+            return True
+    return False
+
+_shadow = []
+def hook_code(uc, addr, size, _):
+    _trail.append(addr)
+    if len(_trail) > 24: _trail.pop(0)
+    # A shadow return stack. Tail calls through pointers we never filled in leave nothing on
+    # the real stack to unwind to, so remember where each call came from ourselves.
+    if BASE <= addr < BASE + IMGSZ:
+        try:
+            b0 = img[addr-BASE]
+            if b0 == 0xE8 or (b0 == 0xFF and (img[addr-BASE+1] >> 3) & 7 == 2):
+                _shadow.append(addr + size)
+                if len(_shadow) > 256: _shadow.pop(0)
+        except Exception:
+            pass
+    if not (BASE <= addr < BASE + IMGSZ):
+        if not _unwind(uc):
+            if _shadow:
+                uc.reg_write(UC_X86_REG_RAX, 0)
+                uc.reg_write(UC_X86_REG_RIP, _shadow.pop())
+                return
+            rsp = uc.reg_read(UC_X86_REG_RSP)
+            try:
+                sl = struct.unpack('<8Q', uc.mem_read(rsp, 64))
+            except Exception:
+                sl = ()
+            print(f"  [cannot unwind from {addr:#x}; rsp={rsp:#x} slots={[hex(x) for x in sl]}]")
+            uc.emu_stop()
+        return
+    # First instruction of a function that never touches the file: skip the whole thing.
+    if addr not in (READ, ALLOC, FREE, MEMSET, ENTRY):
+        fn = _fn_of(addr)
+        if fn and fn[0] == addr and not reads_file(addr):
+            _stub_targets.add(addr)
+    if addr == READ:
+        h  = uc.reg_read(UC_X86_REG_ECX)
+        n  = uc.reg_read(UC_X86_REG_EDX) & 0xFFFFFFFF
+        dst= uc.reg_read(UC_X86_REG_R8)
+        off= state["cursor"]
+        chunk = data[off:off+n]
+        if len(chunk) < n: chunk = chunk + b'\0'*(n-len(chunk))
+        try: uc.mem_write(dst, chunk)
+        except Exception: pass
+        state["log"].append((off, n, dst))
+        state["cursor"] += n
+        # return 0 and emulate `ret`
+        uc.reg_write(UC_X86_REG_RAX, 0)
+        rsp = uc.reg_read(UC_X86_REG_RSP)
+        uc.reg_write(UC_X86_REG_RIP, struct.unpack('<Q', uc.mem_read(rsp,8))[0])
+        uc.reg_write(UC_X86_REG_RSP, rsp+8)
+    elif addr in (ALLOC,):
+        n = uc.reg_read(UC_X86_REG_ECX) & 0xFFFFFFFF
+        p = state["heap"]
+        state["heap"] = (p + max(n,16) + 0xFFF) & ~0xFFF
+        uc.reg_write(UC_X86_REG_RAX, p)
+        rsp = uc.reg_read(UC_X86_REG_RSP)
+        uc.reg_write(UC_X86_REG_RIP, struct.unpack('<Q', uc.mem_read(rsp,8))[0])
+        uc.reg_write(UC_X86_REG_RSP, rsp+8)
+    elif addr not in (ENTRY,) and addr in _stub_targets:
+        uc.reg_write(UC_X86_REG_RAX, 0)
+        rsp = uc.reg_read(UC_X86_REG_RSP)
+        uc.reg_write(UC_X86_REG_RIP, struct.unpack('<Q', uc.mem_read(rsp,8))[0])
+        uc.reg_write(UC_X86_REG_RSP, rsp+8)
+    elif addr in (FREE, MEMSET):
+        if addr == MEMSET:
+            d = uc.reg_read(UC_X86_REG_RCX); v = uc.reg_read(UC_X86_REG_EDX)&0xFF
+            n = uc.reg_read(UC_X86_REG_R8) & 0xFFFFFF
+            try: uc.mem_write(d, bytes([v])*n)
+            except Exception: pass
+        uc.reg_write(UC_X86_REG_RAX, 0)
+        rsp = uc.reg_read(UC_X86_REG_RSP)
+        uc.reg_write(UC_X86_REG_RIP, struct.unpack('<Q', uc.mem_read(rsp,8))[0])
+        uc.reg_write(UC_X86_REG_RSP, rsp+8)
+
+# Which functions actually read from the file, directly or through another that does.
+# Everything else can be stubbed to "returned 0" without changing the byte layout, which is
+# the only thing being measured here.
+import capstone
+_ranges = [(BASE+a, BASE+b) for a,b in _pdata]
+_md = capstone.Cs(capstone.CS_ARCH_X86, capstone.CS_MODE_64)
+_calls = {}
+def _fn_of(va):
+    for a,b in _ranges:
+        if a <= va < b: return (a,b)
+    return None
+def _direct_calls(fn):
+    if fn in _calls: return _calls[fn]
+    a,b = fn
+    out=set()
+    try:
+        code = bytes(img[a-BASE:b-BASE])
+        for ins in _md.disasm(code, a):
+            if ins.mnemonic=="call" and ins.op_str.startswith("0x"):
+                out.add(int(ins.op_str,16))
+    except Exception:
+        pass
+    _calls[fn]=out
+    return out
+_reads_file = {}
+def reads_file(va, depth=0):
+    fn=_fn_of(va)
+    if fn is None: return False
+    if fn in _reads_file: return _reads_file[fn]
+    if depth > 6:
+        return False
+    _reads_file[fn]=False           # break cycles
+    r = READ in _direct_calls(fn) or any(reads_file(t, depth+1) for t in _direct_calls(fn))
+    _reads_file[fn]=r
+    return r
+
+mu.hook_add(UC_HOOK_CODE, hook_code)
+
+# Anything we haven't implemented — imports, vtable calls into unmapped memory — is treated as
+# a function that returned 0. That keeps the walk going through the parts we don't care about;
+# what we are after is the sequence of file reads, and those are hooked above.
+def on_bad_fetch(uc, access, addr, size, value, _):
+    # Landed somewhere that isn't code — an unresolved import, a vtable slot we never filled.
+    # Walk up the stack for the nearest plausible return address and carry on from there as
+    # if the call had returned 0.
+    rsp = uc.reg_read(UC_X86_REG_RSP)
+    for slot in range(0, 64):
+        try:
+            ret = struct.unpack('<Q', uc.mem_read(rsp + slot*8, 8))[0]
+        except Exception:
+            break
+        if BASE <= ret < BASE + IMGSZ:
+            uc.reg_write(UC_X86_REG_RAX, 0)
+            uc.reg_write(UC_X86_REG_RSP, rsp + (slot+1)*8)
+            uc.reg_write(UC_X86_REG_RIP, ret)
+            return True
+    return False
+mu.hook_add(UC_HOOK_MEM_FETCH_UNMAPPED, on_bad_fetch)
+
+_mapped = set()
+def on_bad_mem(uc, access, addr, size, value, _):
+
+    # Map, zero filled, whatever the code touches that we didn't plan for. One page at a
+    # time and remembered, because mapping over an existing region is itself an error.
+    # The null page is mapped too: a stray write through a pointer we never filled in should
+    # land somewhere harmless rather than stop the run. Execution down there is still caught,
+    # in hook_code, which is the case that actually matters.
+    # Map a generous slab, skipping anything already mapped — the decompressor writes
+    # megabytes and a page at a time just faults again on the next byte.
+    SLAB = 0x400000
+    start = addr & ~(SLAB-1)
+    existing = [(r[0], r[1]) for r in uc.mem_regions()]
+    for off in range(0, SLAB, 0x1000):
+        pg = start + off
+        if pg in _mapped: continue
+        if any(a <= pg <= b for a,b in existing): 
+            _mapped.add(pg); continue
+        try:
+            uc.mem_map(pg, 0x1000)
+        except Exception:
+            pass
+        _mapped.add(pg)
+    return True
+mu.hook_add(UC_HOOK_MEM_READ_UNMAPPED | UC_HOOK_MEM_WRITE_UNMAPPED, on_bad_mem)
+
+obj = HEAP           # the "rbx" object the loader fills in
+mu.reg_write(UC_X86_REG_RCX, obj)
+mu.reg_write(UC_X86_REG_RDX, 1)        # file handle
+mu.reg_write(UC_X86_REG_R8, 304)       # version
+sp = STACK + 0x80000
+mu.reg_write(UC_X86_REG_RSP, sp)
+mu.mem_write(sp, struct.pack('<Q', 0xdeadf00d))   # fake return address
+
+try:
+    mu.emu_start(ENTRY, 0xdeadf00d, timeout=0, count=80_000_000)
+except UcError as e:
+    print(f"stopped: {e} at rip={mu.reg_read(UC_X86_REG_RIP):x}")
+except Exception as e:
+    print("stopped:", e)
+
+print("last addresses before stopping:", " -> ".join(hex(a) for a in _trail[-12:]))
+log = state["log"]
+print(f"{len(log)} reads, cursor ended at {state['cursor']:,} of {len(data):,}")
+SZ = len(data)
+for i,(o,n,d) in enumerate(log):
+    if o > SZ:
+        print(f"  ... ran past the end of the file after {i} reads")
+        break
+    print(f"  {i:3}  off={o:>12,}  size={n:>10,}")


### PR DESCRIPTION
You want tracks rideable without TerrainEd. That means writing a real `.map`, which means
finishing the format — and static reading of the loader is what has been failing.

## Why emulate

The sections are flag-gated and irregular, so a wrong guess **looks right for one record and
drifts on the next**. That is precisely how six rounds of `.map` fixes shipped without touching
the real fault.

`scripts/map-loader-trace.py` maps the unpacked `mxbikes.exe` into a Unicorn x86-64 emulator,
starts at the function that reads everything after the mesh (`0x14025f180`), and hooks the
game's own read helper so every call is serviced from a real `.map` on disk and logged as
`(offset, size)`. Whatever comes out **is** the format for that file, with no inference.

Anything that cannot touch the file is stubbed: a function is skipped when neither it nor
anything it calls reaches the read helper, so imports, string handling and the rest never have
to work. Calls through pointers we never filled in are unwound with a shadow return stack —
tail calls leave nothing on the real stack to return to.

## What it has already settled

Traced against the OEM drag strip (the right reference: its mesh, materials and textures are
all declared empty, so everything it contains is the part still being decoded):

```
312    u32 A, u32 B, then A*B*2 bytes     the terrain heightfield, 2049x1025
       f32 1000.0  size in metres
       f32 200.0   height scale
       f32 5.0, u32 0, u32 0, u32 0
       u32 C = 12                         record count
then   C x { 56-byte name blob, u32 k, k x texture record, tail }

texture record:
  +0    100 bytes  name
  +100  u32        a flag, not a width
  +104  u32        width
  +108  u32        height
  +112  16 bytes
  +128  u32 N
  +132  u32 size   counts the 8 pad bytes
  +136  8 zero bytes
  +144  payload    raw DEFLATE -> RGBA8, length size-8
```

Every offset came out of the trace rather than a guess, and the first record's 3,879,730-byte
payload lands exactly where the file has it.

## Known limit

Written at the top of the script: the payload decompressor is stubbed, so a length after the
first payload comes out negative (`0xFFFFFFF9`) and the trace drifts from there. Letting that
function run for real is what produces the whole file's layout in one pass — that is the next
step, and it is a focused one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)