### PR TITLE
fix(tracks): a track edge that meets the field, not a shelf around it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
   like a car park.
 - The racing line is chopped up at the scale of a wheel rather than a jump, and the field
   around it is smooth. It used to be nearly as rough out in the grass as it was on the line.
+- A track's edge is crisp against the field rather than fading out over a wide shelf.
 - Switching MXB App off in Windows' list of startup apps sticks, and Launch at startup in
   Settings follows it.
 - More of the crash at track graphics: the ground sheets in a track's graphics file were

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -39,7 +39,14 @@ const STATION_STEP: f32 = 0.5;
 
 /// How far past the riding line the terrain is still pulled towards it, metres. This is the
 /// shoulder — the graded ground either side that a track sits in rather than on.
-const SHOULDER_M: f32 = 9.0;
+///
+/// Six, not nine. At nine the track sat in a shelf whose ground rejoined the field 19.5 m from
+/// the centreline against Indiana's 12.5, and it reads as a soft halo round every corner where
+/// a real track's edge is nearly flush with the field. The measurement is a crude one — it
+/// fits a straight line through the ground either side and asks where the profile leaves it,
+/// and it returns nonsense on the flattest sections — so the picture decided this rather than
+/// the number: side by side at 6 m the edge is crisp and at 9 m it is not.
+const SHOULDER_M: f32 = 6.0;
 
 /// Metres of lap the track's own elevation is smoothed over. Short enough to follow a hill,
 /// long enough not to follow a bush.


### PR DESCRIPTION
The graded shoulder reached nine metres past the riding line, so the ground rejoined the field
**19.5 m** from the centreline where Indiana's does at **12.5 m**. Side by side it reads as a
soft halo round every corner; a real track's edge is nearly flush with the field. Now six
metres.

## The number did not decide this, and that matters

The width estimator is crude — it fits a straight line through the ground either side of the
track and asks where the profile departs from it. It returns 0.0 m on Indiana's flattest
sections, which is nonsense, and it moved 19.5 → 17.5 where the change should have moved it
further.

So the picture decided it. Rendered side by side at matched scale and shaded in real metres,
the 6 m edge is crisp and the 9 m edge is not. Quoting 12.5 m as though the estimator supported
it would be the same mistake as the sheared sampling in #367 — a number that looks like
evidence and isn't.

## What is still different, precisely

At the same scale, Indiana's track is *finer* than ours in every respect: its hairpin here is
6.4 m radius against our median tightest corner of 18.2 m, and its ruts are a tighter comb.
The ground work is close now; the gap is the layout, and it is the one already known —
our median tightest corner sits at the very top of the published 10.6–18.5 m band.

1195 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
