### PR TITLE
fix(tools): the tracer must stop at the end of the file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2026-09-01
 
+### Fixed
+- The map-loader tracer stops at the end of the file instead of reading zeros past it.
+
+## 2026-09-01
+
 ### Added
 - A tool that traces exactly which bytes MX Bikes reads out of a track's graphics file, by
   emulating the game's own loader. Groundwork for generating tracks the game can ride without

--- a/scripts/map-loader-trace.py
+++ b/scripts/map-loader-trace.py
@@ -60,7 +60,7 @@ mu.mem_map(0, 0x100000)          # scratch for writes through null pointers
 
 data = open(MAP,'rb').read()
 state = {"cursor": int(sys.argv[1]) if len(sys.argv)>1 else 312,
-         "heap": HEAP + 0x1000, "log": [], "depth": 0}
+         "heap": HEAP + 0x1000, "log": [], "depth": 0, "overran": None}
 
 _stub_targets = set()
 _trail = []
@@ -118,8 +118,16 @@ def hook_code(uc, addr, size, _):
         n  = uc.reg_read(UC_X86_REG_EDX) & 0xFFFFFFFF
         dst= uc.reg_read(UC_X86_REG_R8)
         off= state["cursor"]
+        # Stop dead at the end of the file. This used to zero-fill, and zero-filling is how
+        # you get a confident, detailed, entirely fictional trace: once the cursor runs off,
+        # every count reads back as 0, every loop "terminates cleanly", and the log looks like
+        # a decode. It cost me a wrong finding — "records 1 to 11 have no textures" — that was
+        # nothing but zeros past the end.
+        if off >= len(data) or off + n > len(data):
+            state["overran"] = (off, n)
+            uc.emu_stop()
+            return
         chunk = data[off:off+n]
-        if len(chunk) < n: chunk = chunk + b'\0'*(n-len(chunk))
         try: uc.mem_write(dst, chunk)
         except Exception: pass
         state["log"].append((off, n, dst))
@@ -256,6 +264,10 @@ except Exception as e:
 print("last addresses before stopping:", " -> ".join(hex(a) for a in _trail[-12:]))
 log = state["log"]
 print(f"{len(log)} reads, cursor ended at {state['cursor']:,} of {len(data):,}")
+if state["overran"]:
+    off, n = state["overran"]
+    print(f"stopped at the end of the file: a read of {n:,} bytes at {off:,} "
+          f"(file is {len(data):,}). Everything up to here is real; nothing past it would be.")
 SZ = len(data)
 for i,(o,n,d) in enumerate(log):
     if o > SZ:


### PR DESCRIPTION
The tracer zero-filled reads past EOF. Zero-filling is how you get a confident, detailed,
**entirely fictional** trace: once the cursor runs off the end, every count reads back as 0,
every loop "terminates cleanly", and the log looks exactly like a decode.

It cost me a wrong finding, which I had already reported as fact:

> record 0 has one texture and records 1 to 11 have none, so the remaining 112 MB must be in
> the per-record blobs

Records 1 to 11 were **zeros past the end of the file**. The `k=0` I was reading was my own
padding. The "12 terrain layers" reading built on top of it goes with it.

The tracer now stops at the first read that would cross the end, and says so:

```
stopped at the end of the file: a read of 4,294,967,289 bytes at 8,080,732
(file is 120,609,745). Everything up to here is real; nothing past it would be.
```

## What actually survives

Verified, and unchanged:

```
312    u32 A=2049, u32 B=1025, then A*B*2 bytes   the terrain heightfield
       f32 1000.0, f32 200.0, f32 5.0, u32 x3
       u32 C = 12                                 record count
rec 0: 56-byte name blob, k=1, one texture `_Silica1WetD` 2048x2048,
       payload 3,879,730 bytes landing byte-exactly where the file has it
```

**Record 1 onwards is undecoded**, and the notes now say that plainly instead of describing a
layer model inferred from padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)