### PR TITLE
fix(tracks): jumps that were built, not dropped on the ground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@
 - The racing line is chopped up at the scale of a wheel rather than a jump, and the field
   around it is smooth. It used to be nearly as rough out in the grass as it was on the line.
 - A track's edge is crisp against the field rather than fading out over a wide shelf.
+- Jumps are built rather than dropped on. A takeoff ramps up over ten metres instead of five,
+  its faces are half as steep, and the ground either side dips where the dirt for it came
+  from.
 - Switching MXB App off in Windows' list of startup apps sticks, and Launch at startup in
   Settings follows it.
 - More of the crash at track graphics: the ground sheets in a track's graphics file were

--- a/src-tauri/src/trackprog.rs
+++ b/src-tauri/src/trackprog.rs
@@ -316,8 +316,12 @@ pub struct ShapePoint {
     pub h: f32,
 }
 
+/// Measured against Indiana rather than chosen: its jumps reach half their height five
+/// metres before the crest and full height at it, so the ramp is about ten metres long. At
+/// six the takeoff is still at a tenth of its height five metres out — a spike rather than a
+/// ramp, and it rides like one.
 fn default_lip() -> f32 {
-    6.0
+    10.0
 }
 
 impl Feature {
@@ -527,42 +531,42 @@ pub const EXAMPLE: &str = r#"{
         { "kind": "straight", "length": 8.0000 }
       ],
       "features": [
-        { "kind": "tabletop", "at": 18.7, "length": 19.0, "height": 1.10 },
+        { "kind": "tabletop", "at": 18.7, "length": 25.7, "height": 1.10 },
         { "kind": "berm", "at": 47.4, "length": 10.1, "height": 1.70 },
-        { "kind": "double", "at": 120.5, "height": 3.60, "gap": 16.4, "lip": 6.0 },
+        { "kind": "double", "at": 120.5, "height": 3.60, "gap": 16.4, "lip": 11.0 },
         { "kind": "roller", "at": 153.1, "length": 14.6, "height": 0.64 },
-        { "kind": "tabletop", "at": 185.7, "length": 17.3, "height": 1.20 },
-        { "kind": "tabletop", "at": 218.2, "length": 18.2, "height": 1.40 },
+        { "kind": "tabletop", "at": 185.7, "length": 23.4, "height": 1.20 },
+        { "kind": "tabletop", "at": 218.2, "length": 24.6, "height": 1.40 },
         { "kind": "roller", "at": 250.8, "length": 11.5, "height": 0.77 },
         { "kind": "roller", "at": 316.1, "length": 11.6, "height": 0.80 },
-        { "kind": "double", "at": 335.8, "height": 1.90, "gap": 9.2, "lip": 5.5 },
-        { "kind": "tabletop", "at": 390.5, "length": 22.5, "height": 1.60 },
-        { "kind": "tabletop", "at": 449.0, "length": 25.2, "height": 1.50 },
+        { "kind": "double", "at": 335.8, "height": 1.90, "gap": 9.2, "lip": 9.5 },
+        { "kind": "tabletop", "at": 390.5, "length": 30.4, "height": 1.60 },
+        { "kind": "tabletop", "at": 449.0, "length": 34.0, "height": 1.50 },
         { "kind": "stepUp", "at": 466.7, "length": 19.3, "height": 2.20 },
-        { "kind": "tabletop", "at": 566.9, "length": 26.9, "height": 2.90 },
+        { "kind": "tabletop", "at": 566.9, "length": 29.6, "height": 2.90 },
         { "kind": "roller", "at": 589.5, "length": 15.7, "height": 0.70 },
         { "kind": "roller", "at": 687.9, "length": 13.5, "height": 0.46 },
         { "kind": "whoops", "at": 702.6, "count": 7, "spacing": 4.2, "height": 0.57 },
         { "kind": "berm", "at": 754.5, "length": 17.8, "height": 1.70 },
-        { "kind": "double", "at": 789.5, "height": 3.20, "gap": 13.7, "lip": 6.0 },
-        { "kind": "double", "at": 811.0, "height": 1.30, "gap": 8.9, "lip": 5.5 },
+        { "kind": "double", "at": 789.5, "height": 3.20, "gap": 13.7, "lip": 11.0 },
+        { "kind": "double", "at": 811.0, "height": 1.30, "gap": 8.9, "lip": 9.5 },
         { "kind": "roller", "at": 832.4, "length": 15.9, "height": 0.54 },
-        { "kind": "tabletop", "at": 888.9, "length": 24.4, "height": 2.50 },
+        { "kind": "tabletop", "at": 888.9, "length": 32.9, "height": 2.50 },
         { "kind": "roller", "at": 913.4, "length": 14.4, "height": 0.82 },
-        { "kind": "double", "at": 1002.4, "height": 1.50, "gap": 8.8, "lip": 5.5 },
-        { "kind": "tabletop", "at": 1112.5, "length": 18.4, "height": 1.10 },
+        { "kind": "double", "at": 1002.4, "height": 1.50, "gap": 8.8, "lip": 9.5 },
+        { "kind": "tabletop", "at": 1112.5, "length": 24.8, "height": 1.10 },
         { "kind": "roller", "at": 1197.0, "length": 11.1, "height": 0.79 },
-        { "kind": "tabletop", "at": 1260.0, "length": 24.1, "height": 1.10 },
-        { "kind": "tabletop", "at": 1353.4, "length": 31.3, "height": 3.10 },
+        { "kind": "tabletop", "at": 1260.0, "length": 32.5, "height": 1.10 },
+        { "kind": "tabletop", "at": 1353.4, "length": 34.4, "height": 3.10 },
         { "kind": "roller", "at": 1377.8, "length": 11.3, "height": 0.80 },
-        { "kind": "tabletop", "at": 1402.2, "length": 22.6, "height": 1.50 },
-        { "kind": "double", "at": 1495.8, "height": 2.90, "gap": 15.6, "lip": 6.0 },
+        { "kind": "tabletop", "at": 1402.2, "length": 30.5, "height": 1.50 },
+        { "kind": "double", "at": 1495.8, "height": 2.90, "gap": 15.6, "lip": 11.0 },
         { "kind": "roller", "at": 1518.3, "length": 14.4, "height": 0.75 },
         { "kind": "roller", "at": 1540.8, "length": 11.5, "height": 0.66 },
-        { "kind": "double", "at": 1607.3, "height": 1.60, "gap": 8.2, "lip": 5.5 },
+        { "kind": "double", "at": 1607.3, "height": 1.60, "gap": 8.2, "lip": 9.5 },
         { "kind": "roller", "at": 1620.8, "length": 14.3, "height": 0.79 },
-        { "kind": "double", "at": 1667.4, "height": 1.20, "gap": 12.7, "lip": 5.5 },
-        { "kind": "tabletop", "at": 1681.0, "length": 16.9, "height": 1.00 }
+        { "kind": "double", "at": 1667.4, "height": 1.20, "gap": 12.7, "lip": 9.5 },
+        { "kind": "tabletop", "at": 1681.0, "length": 22.8, "height": 1.00 }
       ]
     }"#;
 

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -258,7 +258,22 @@ const FIELD_DETAIL_HEIGHT_M: f32 = 0.045;
 
 /// The short back face of a double's takeoff, and the short front face of its landing. This
 /// is the lip itself — steep, but a face rather than a step.
-const DOUBLE_BACK_M: f32 = 2.5;
+///
+/// Four metres, not two and a half. At 2.5 m a two-metre jump drops at 39°, and measured
+/// against Indiana that is what "abrupt" is: its landing faces run 12.7° at the median and
+/// 19° at the ninetieth, against ours at 21.3° and 36.3°.
+const DOUBLE_BACK_M: f32 = 4.0;
+
+/// The hollow a jump is dug out of, as a fraction of its height, and how far past its ends
+/// that hollow reaches.
+///
+/// Every cubic metre standing in a jump came out of the ground beside it, and on a real track
+/// you can see where. Indiana's average jump profile, normalised against its own height, sits
+/// at −0.26 twenty metres before the crest and −0.32 twenty metres after, with the lip itself
+/// at +0.97: the jump is a hump between two scoops. Ours had flat ground either side and
+/// nothing to say where the dirt came from.
+const JUMP_HOLLOW: f32 = 0.30;
+const JUMP_HOLLOW_M: f32 = 22.0;
 
 /// Metres between samples of the profiles that run along the lap.
 ///
@@ -1155,6 +1170,47 @@ fn feature_profile(features: &[Feature], lap: f32, blend: f32) -> Profile {
             out.v[i] = out.v[i].max(longitudinal(f, u / len, u));
         }
     }
+    // And the hollow each one was dug out of.
+    //
+    // Every cubic metre standing in a jump came out of the ground beside it, and on a real
+    // track you can see where. Subtracted rather than maxed, and applied after the humps are
+    // in, so a jump sitting inside another feature's hollow still stands its full height —
+    // what the hollow lowers is the ground between jumps, not the jumps.
+    let mut dig = vec![0.0f32; out.v.len()];
+    for f in features {
+        if matches!(f, Feature::StepUp { .. } | Feature::Berm { .. } | Feature::Rut { .. }) {
+            continue;
+        }
+        let h = f.height().abs();
+        if h <= 0.0 {
+            continue;
+        }
+        let (at, len) = (f.at(), f.length());
+        for (side, edge) in [(-1.0f32, at), (1.0f32, at + len)] {
+            let span = JUMP_HOLLOW_M;
+            let steps = (span / PROFILE_STEP).ceil() as usize;
+            for k in 0..=steps {
+                let d = k as f32 * PROFILE_STEP;
+                let s_at = edge + side * d;
+                if s_at < 0.0 || s_at >= lap {
+                    continue;
+                }
+                let i = (s_at / PROFILE_STEP).round() as usize;
+                if i >= dig.len() {
+                    continue;
+                }
+                // Deepest a third of the way out and back to grade by the end, so the ground
+                // dips away from the jump's foot rather than stepping down at it.
+                let x = d / span;
+                let bowl = (x * std::f32::consts::PI).sin().powf(0.8);
+                dig[i] = dig[i].max(h * JUMP_HOLLOW * bowl);
+            }
+        }
+    }
+    for i in 0..out.v.len() {
+        out.v[i] -= dig[i];
+    }
+
     // Then round the whole thing off over the blend distance. That is what turns two jumps
     // that merely touch into one shape, and it is the same control that decides how long a
     // single jump's ramps are — they are the same question asked twice.
@@ -1340,7 +1396,7 @@ fn longitudinal(f: &Feature, t: f32, u: f32) -> f32 {
         Feature::Double {
             height, gap, lip, ..
         } => {
-            let back = DOUBLE_BACK_M.min(lip * 0.5);
+            let back = DOUBLE_BACK_M.min(lip * 0.6);
             let takeoff = lip + back;
             if u <= lip {
                 height * smoothstep(u / lip)


### PR DESCRIPTION
Reported as *"the double is very abrupt"*. The measurement says the same thing.

The average jump profile against Indiana's, normalised against its own height, in metres from
the crest:

```
              -10 m   -5 m   crest   +5 m   +10 m
Indiana       +0.09  +0.50   +0.97  +0.63   +0.05      a 20 m ramp
ours          -0.21  -0.18   +0.83  -0.14   -0.18      a 5 m spike
```

Ours went from *below the surrounding ground* five metres out to full height at the crest.

## Three changes

**A takeoff ramps over ten metres, not six.** Indiana reaches half its height five metres
before the crest; at a 6 m lip ours was at a tenth of it there. Note the default alone changed
nothing — the example's own doubles are written `"lip": 6.0`, so they never used it.

**The lip's back face is 4 m, not 2.5.** At 2.5 m a two-metre jump drops at 39°, which is what
"abrupt" is.

**A jump sits in the hollow it was dug out of.** Every cubic metre standing in one came out of
the ground beside it, and on a real track you can see where: Indiana reads −0.26 twenty metres
before the crest and −0.32 after. Ours had flat ground either side and nothing to say where the
dirt came from. This is the one that makes a jump read as built.

## Where it lands

```
                takeoff p50/p90    landing p50/p90
before             22.1 / 36.6        21.3 / 36.3
after              14.9 / 25.7        13.5 / 24.2
Indiana            13.3 / 27.0        12.7 / 19.0
```

The hollow lands where Indiana's does: −0.22 twenty metres out against its −0.26. Steepest
ground falls from 39.9° to 36.9°, still inside the published 27–41.

## Still short

The ramp is broader but not yet Indiana's: we read +0.15 five metres before the crest where it
reads +0.50. Tabletops are the ones lagging — their ramps are a fixed 27% of the feature's
length, so a short tabletop still has a short ramp regardless of the lip setting. That wants
the ramp stated in metres rather than as a fraction, which is a bigger change than this one.

1195 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
