### PR TITLE
fix(tracks): a double's lip was a 65° wall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,8 @@
   around it is smooth. It used to be nearly as rough out in the grass as it was on the line.
 - A track's edge is crisp against the field rather than fading out over a wide shelf.
 - Jumps are built rather than dropped on. A takeoff ramps up over ten metres instead of five,
-  its faces are half as steep, and the ground either side dips where the dirt for it came
-  from.
+  the ground either side dips where the dirt for it came from, and no face is steeper than
+  dirt will stand — a big double's lip was a 65° wall and is now a 30° face.
 - Switching MXB App off in Windows' list of startup apps sticks, and Launch at startup in
   Settings follows it.
 - More of the crash at track graphics: the ground sheets in a track's graphics file were

--- a/src-tauri/src/trackprog.rs
+++ b/src-tauri/src/trackprog.rs
@@ -205,6 +205,37 @@ impl Segment {
     }
 }
 
+/// The steepest face a jump is allowed, degrees.
+///
+/// Thirty because that is the ceiling across every published track measured, not a judgement:
+/// their steepest faces run 19.2–29.6° at the ninetieth percentile and Millville, the steepest
+/// of the ten, does not reach 30. A dirt lip pushed up by a machine cannot stand steeper than
+/// the material holds.
+pub const JUMP_FACE_DEG: f32 = 30.0;
+
+/// The shortest a face may be however small the jump.
+///
+/// The angle alone makes a small jump *worse*: at 30° a 1.2 m double would get a two-metre
+/// face where a flat four gives it twenty-four degrees. The angle is a ceiling on the tall
+/// ones, not a target for all of them.
+pub const JUMP_FACE_MIN_M: f32 = 4.0;
+
+/// How long a double's ramp and its lip's back face are, in metres, for a given height.
+///
+/// One definition, used by both the shape and by [`Feature::length`], because they have to
+/// agree about where the feature ends.
+///
+/// The 1.5 is not a fudge, and leaving it out is why this was still a wall after being fixed
+/// once: a smoothstep's steepest point is half again as steep as its average, so a face sized
+/// to *average* 30° peaks at 45. A 3.6 m double dropped at 53.5° at a flat four metres, 40.9°
+/// sized by the average, and 30.0° sized by the peak.
+pub fn double_faces(height: f32, lip: f32) -> (f32, f32) {
+    let face = 1.5 * height.abs() / JUMP_FACE_DEG.to_radians().tan();
+    let back = face.max(JUMP_FACE_MIN_M);
+    // A short lip on a tall jump is a wall whichever side of it you are on.
+    (lip.max(back), back)
+}
+
 /// Under this many degrees an arc is a drift, not a corner — a builder nudging a straight
 /// back onto line.
 pub const CORNER_DEG: f32 = 1.0;
@@ -347,8 +378,17 @@ impl Feature {
             | Feature::Berm { length, .. }
             | Feature::Rut { length, .. }
             | Feature::Custom { length, .. } => *length,
-            // Two faces up and two back down, with the gap between them.
-            Feature::Double { gap, lip, .. } => (lip + lip.min(5.0)) * 2.0 + gap,
+            // Two faces up and two back down, with the gap between them. The two lengths
+            // come from `double_faces` rather than being written out again here: they used
+            // to be, and when the faces were lengthened this went on reporting the old
+            // figure, so the profile was written up to a point eight metres short of where
+            // the shape actually ended and the last ramp was cut off into a step.
+            Feature::Double {
+                height, gap, lip, ..
+            } => {
+                let (lip, back) = double_faces(*height, *lip);
+                (lip + back) * 2.0 + gap
+            }
             Feature::Whoops {
                 count, spacing, ..
             } => *count as f32 * spacing,

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -256,22 +256,13 @@ const BERM_REACH_M: f32 = 4.5;
 const FIELD_DETAIL_M: f32 = 4.5;
 const FIELD_DETAIL_HEIGHT_M: f32 = 0.045;
 
-/// The short back face of a double's takeoff, and the short front face of its landing. This
-/// is the lip itself — steep, but a face rather than a step.
-///
-/// Four metres, not two and a half. At 2.5 m a two-metre jump drops at 39°, and measured
-/// against Indiana that is what "abrupt" is: its landing faces run 12.7° at the median and
-/// 19° at the ninetieth, against ours at 21.3° and 36.3°.
-const DOUBLE_BACK_M: f32 = 4.0;
-
 /// The hollow a jump is dug out of, as a fraction of its height, and how far past its ends
 /// that hollow reaches.
 ///
 /// Every cubic metre standing in a jump came out of the ground beside it, and on a real track
 /// you can see where. Indiana's average jump profile, normalised against its own height, sits
 /// at −0.26 twenty metres before the crest and −0.32 twenty metres after, with the lip itself
-/// at +0.97: the jump is a hump between two scoops. Ours had flat ground either side and
-/// nothing to say where the dirt came from.
+/// at +0.97: the jump is a hump between two scoops.
 const JUMP_HOLLOW: f32 = 0.30;
 const JUMP_HOLLOW_M: f32 = 22.0;
 
@@ -1396,7 +1387,9 @@ fn longitudinal(f: &Feature, t: f32, u: f32) -> f32 {
         Feature::Double {
             height, gap, lip, ..
         } => {
-            let back = DOUBLE_BACK_M.min(lip * 0.6);
+            // Both faces from one definition, shared with `Feature::length` so the two
+            // cannot disagree about where the shape ends.
+            let (lip, back) = crate::trackprog::double_faces(height, lip);
             let takeoff = lip + back;
             if u <= lip {
                 height * smoothstep(u / lip)


### PR DESCRIPTION
Still too abrupt after #370, and this is why: a face was sized by a **length** instead of by an
**angle**, so how steep it came out depended only on how tall the jump was asked to be.

```
before   lip 6.0 m, back 2.5 m    33.4 m long, steepest face 64.9°
    ···░░░▓▓▓█████▓░░··································░▓▓█████▓▓▓░░░··

now      lip and back 9.35 m      57.1 m long, steepest face 30.0°
    ····░░░░░░▓▓▓▓▓██████████████▓▓▓▓░░░░░·······································░░░░░▓▓▓▓▓█████████████▓▓▓▓▓░░░░░░····
```

Thirty degrees is not a judgement. Across the ten published tracks the steepest faces run
19.2–29.6° at the ninetieth percentile, and Millville — the steepest of them — does not reach
30. Dirt pushed up by a machine will not stand steeper.

## Two things I got wrong first time

**A smoothstep's steepest point is half again as steep as its average.** Sizing a face to
*average* 30° peaks at 45, which is why my first attempt moved a 3.6 m lip from 53.5° only as
far as 40.9° and the jump still read as a wall.

**An angle alone makes small jumps worse.** At 30° a 1.2 m double gets a two-metre face where a
flat four gives it 24°. The angle is a ceiling on the tall ones, not a target for all of them,
so the four-metre floor stays.

## And a latent bug it exposed

`Feature::length` wrote the double's geometry out a second time and went on reporting the old
figure when the faces were lengthened — so the profile was written up to a point **eight metres
short** of where the shape actually ends, cutting the last ramp off into a step. `double_faces`
is now the one definition, used by both.

## Where it lands

```
                takeoff p50/p90    landing p50/p90
before             22.1 / 36.6        21.3 / 36.3
now                15.1 / 24.1        13.5 / 26.8
Indiana            13.3 / 27.0        12.7 / 19.0
```

Steepest ground on the lap falls from 39.5° to 32.5°.

## Still short

Tabletops lag the doubles: their ramps are a fixed 27% of the feature's length, so a short
tabletop keeps a short ramp whatever else changes. The averaged profile still reads +0.19 five
metres before the crest against Indiana's +0.50, and that is where the remainder is.

1195 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
