### PR TITLE
chore: release v0.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,19 @@
 # Changelog
 
-## 2026-09-01
-
-### Fixed
-- The map-loader tracer stops at the end of the file instead of reading zeros past it.
-
-## 2026-09-01
+## 2026-09-01 — v0.13.3 — Nothing you didn't ask for
 
 ### Added
 - A tool that traces exactly which bytes MX Bikes reads out of a track's graphics file, by
   emulating the game's own loader. Groundwork for generating tracks the game can ride without
   running TerrainEd.
-
-## 2026-09-01
-
-### Fixed
-- Installing a generated track no longer crashes the game. It ships without graphics rather
-  than with graphics the game cannot read, and the Studio says so.
-
-## 2026-09-01
-
-### Added
 - Track generation reads a published track's own centreline out of its height file, so a real
   lap's corners, their radii and its straights can be measured directly rather than guessed at.
 - A generated track carries its centreline too, and is measured by the same code as a
   published one.
 
 ### Changed
+- MXB App stays off at login unless you ask for it. Launch at startup is off by default, and
+  the toggle is in Settings for anyone who wants the app waiting for them.
 - Paint sync only asks about the server you are actually on. Starting the game no longer
   fetches every rider's paints from every server on the registry — the paints for your grid
   arrive when you join it. The Sync button still checks everywhere if you ask it to.
@@ -45,26 +32,6 @@
   repeated down the lap.
 - Ruts, berms and banking are built to numbers measured off ten published tracks.
 - Straights carry worn ground rather than being smooth between the corners.
-- MXB App stays off at login unless you ask for it. Launch at startup is off by default, and
-  the toggle is in Settings for anyone who wants the app waiting for them.
-
-### Fixed
-- Cloud sync tidying up behind you no longer asks the game to reload its mods. OneDrive,
-  Dropbox and iCloud all take back the contents of files they think you have stopped using,
-  and to the folder watcher that looked exactly like a mod being installed — so the game was
-  sent to re-read a track that had left the machine, at a moment nobody chose. Those changes
-  are now ignored, and the log says which files and how to keep them on the device.
-- Two of the four values every vertex of a track's graphics file carries were left at zero.
-- The terrain in a track's graphics file is cut into tiles, so no single piece of it is too
-  large for the game to build a buffer for.
-- A corner banks the outside of the turn.
-- Ruts read as ridden ground rather than as a set of parallel lines running the whole lap.
-- The ground either side of the track no longer carries fine streaks fanning off every corner.
-- The starting track is a lap that folds through its own middle instead of a regular star.
-- A step-up no longer leaves a cliff across the track at the start line. A lap that steps up
-  somewhere now falls the same amount over the rest of it.
-
-### Changed
 - The starting track is built on a hillside. It climbs 22 m round the lap, which is what
   Indiana does — half of the published tracks climb more than 20 m, and a flat plot rides
   like a car park.
@@ -74,10 +41,29 @@
 - Jumps are built rather than dropped on. A takeoff ramps up over ten metres instead of five,
   its faces are half as steep, and the ground either side dips where the dirt for it came
   from.
+
+### Fixed
+- Cloud sync tidying up behind you no longer asks the game to reload its mods. OneDrive,
+  Dropbox and iCloud all take back the contents of files they think you have stopped using,
+  and to the folder watcher that looked exactly like a mod being installed — so the game was
+  sent to re-read a track that had left the machine, at a moment nobody chose. Those changes
+  are now ignored, and the log says which files and how to keep them on the device.
 - Switching MXB App off in Windows' list of startup apps sticks, and Launch at startup in
   Settings follows it.
+- Installing a generated track no longer crashes the game. It ships without graphics rather
+  than with graphics the game cannot read, and the Studio says so.
 - More of the crash at track graphics: the ground sheets in a track's graphics file were
   written in a shape the game cannot read past.
+- The map-loader tracer stops at the end of the file instead of reading zeros past it.
+- Two of the four values every vertex of a track's graphics file carries were left at zero.
+- The terrain in a track's graphics file is cut into tiles, so no single piece of it is too
+  large for the game to build a buffer for.
+- A corner banks the outside of the turn.
+- Ruts read as ridden ground rather than as a set of parallel lines running the whole lap.
+- The ground either side of the track no longer carries fine streaks fanning off every corner.
+- The starting track is a lap that folds through its own middle instead of a regular star.
+- A step-up no longer leaves a cliff across the track at the start line. A lap that steps up
+  somewhere now falls the same amount over the rest of it.
 
 ## 2026-09-01 — v0.13.2 — Tracks that load
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.13.2",
+  "version": "0.13.3",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/scripts/changelog-section.sh
+++ b/scripts/changelog-section.sh
@@ -93,6 +93,18 @@ if [ "$SUMMARY" -eq 1 ]; then
     /^[[:space:]]+/                     { next }
     # Keep the bold headline the bullet opens with; drop the explanation after it.
     match($0, /^- \*\*[^*]+\*\*/)       { print substr($0, 1, RLENGTH); next }
+    # No bold headline. The changelog is written as plain bullets now, so there is no
+    # headline to cut to and this used to print the item whole — which made a summary the
+    # same length as the thing it was summarising, and left the caller nothing to do but
+    # trim the lot mid-sentence. The first sentence is the headline in that style.
+    #
+    # Cut at a full stop followed by a space and a capital: a decimal ("0.13.3") has no
+    # space, and "22 m round the lap" has no full stop, so neither is mistaken for the end
+    # of a sentence.
+    /^- / {
+      if (match($0, /\. [A-Z]/)) { print substr($0, 1, RSTART - 1) "…"; next }
+      print; next
+    }
                                         { print }
   ')"
 fi

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3532,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "mxb-app"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # whatever cargo called it. Cargo target names can't hold a space, so this is as close as
 # it gets. The description is what Windows Task Manager shows in its Processes tab.
 name = "mxb-app"
-version = "0.13.2"
+version = "0.13.3"
 description = "MXB App — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
   "mainBinaryName": "MXB App",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Cuts **v0.13.3 — Nothing you didn't ask for**.

## Version

0.13.2 → 0.13.3 across `package.json`, `tauri.conf.json`, `Cargo.toml` and `Cargo.lock`.

## Changelog consolidation

The unreleased section arrived in the state the release process warns about, from parallel sessions merging around each other:

- **four** `## 2026-09-01` headings
- **two** `### Changed` and **two** `### Fixed` blocks between them
- one entry (`More of the crash at track graphics…`) duplicated across two merges
- the Windows startup-list fix filed under Changed rather than Fixed

Now one section, `## 2026-09-01 — v0.13.3 — Nothing you didn't ask for`, with 3 Added / 13 Changed / 11 Fixed, ordered so what a player notices comes first. Every bullet from the old headings is accounted for — nothing dropped but the duplicate.

## A defect this release would have hit

`scripts/changelog-section.sh --summary` cuts each bullet to its **bold headline** and printed the bullet whole when there wasn't one. The changelog is written as plain bullets now, so nothing was summarised: the summary came out 4,465 chars against `notify-discord.sh`'s 3,500 cap, and the script fell through to its last-resort hard trim — a Discord post cut mid-sentence with the last items missing.

That is the one outcome `notify-discord.sh` says it will never produce ("every item still gets named, which a hard cut can't promise").

A bullet with no bold headline now cuts to its first sentence, at a full stop followed by a space and a capital — so `0.13.3` and `22 m round the lap` aren't mistaken for sentence ends.

| | before | after |
|---|---|---|
| `--summary` length | 4,465 | **2,712** |
| vs Discord's 3,500 cap | over → hard trim | under → every item named |

Bold-headline entries are unaffected; that rule matches first. Checked against v0.12.4's section.

## Checked before tagging

- `changelog-section.sh v0.13.3 --heading` prints — the check that catches a section silently orphaned from its heading, which publishes a release with no notes and nothing in CI to catch it
- `release-notes.sh v0.13.3` renders the full body, 5,872 chars
- `cargo metadata --offline` clean against the bumped lock

## Not included

No `RELEASES` entry for the showcase. `releases.ts` has nothing newer than 0.12.4, so v0.13.0, v0.13.1 and v0.13.2 all shipped without one — this follows that precedent rather than setting new policy. It is a curated hero plus ~5 lines in six locales, and which features are worth interrupting someone for is your call. Say the word and I'll add one before the tag.

Tag `v0.13.3` (no suffix) goes out after merge: three-platform build, `releases/latest`, offered by the in-app updater, and announced to the release Discord channel rather than the beta one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)