### PR TITLE
feat(tracks): ground that falls across the plot — and what that still misses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@
 - The racing line is chopped up at the scale of a wheel rather than a jump, and the field
   around it is smooth. It used to be nearly as rough out in the grass as it was on the line.
 - A track's edge is crisp against the field rather than fading out over a wide shelf.
+- A track can be built on a hillside. The ground falls across the plot the way a real one
+  does, instead of being a bumpy plain — which is most of why the land around a generated
+  track never looked like the land around a real one.
 - The starting track's corners are as tight as a published track's: a median 12.6 m through
   their tightest point, where Indiana's is 10.6 and ours used to be 18.2.
 - Jumps are built rather than dropped on. A takeoff ramps up over ten metres instead of five,

--- a/control-plane/src/trackgen.ts
+++ b/control-plane/src/trackgen.ts
@@ -118,7 +118,13 @@ const TrackProgram = z.object({
       amplitude: z.number().describe("the landscape's own hills, peak to trough, metres"),
       wavelength: z.number().describe("metres between those hills"),
       seed: z.number().int(),
-      texture: z.number().describe("ridden-surface roughness, metres; 0.06 is normal"),
+      texture: z.number().describe("ridden-surface roughness, metres; 0.085 is normal"),
+      tilt: z
+        .number()
+        .describe(
+          "metres the whole plot falls from one side to the other — a hillside rather than a plain. 0 for flat ground, 20-30 for a hillside national.",
+        ),
+      tiltAngle: z.number().describe("which way it falls, degrees, same convention as a heading"),
     }),
     surface: z
       .enum(["soil", "sand", "grass"])
@@ -242,8 +248,22 @@ What real tracks measure, from a survey of published ones. Land inside these unl
 explicitly asks otherwise:
 
   jumps on a lap      COUNT THEM. A 2000 m lap carries 30–45 features — not four.
-  landscape relief    amplitude 8–25 m over a 120–200 m wavelength. A flat plot measures
-                      under 18° at its steepest and is rejected for it; ground has to roll.
+  the ground it sits on  A published track is usually a HILLSIDE, not a bumpy plain, and this
+                      is the single biggest thing about how the land reads. Measured as how
+                      much the ground rises and falls over a given distance, Indiana runs
+                      0.15 m over 5 m and 9.36 m over 200 — a ratio of 62, where noise of any
+                      wavelength saturates around 25 because noise flattens out past half its
+                      wavelength and a slope does not.
+
+                      So set tilt — metres the plot falls from one side to the other. 20-30
+                      for a hillside national (Millville, Washougal, Flanders and Sardegna
+                      climb 48-66 m over a lap), 0-8 for a flat one (Lambretta Lynds climbs
+                      2.2 m). Pick from the brief. tiltAngle is which way it falls.
+
+                      amplitude is then the *bumps on top of it* and wants to be small — 5-8 m
+                      over a 200-300 m wavelength. It used to carry the whole landform and the
+                      result measured two to four times rougher than a real track at every
+                      scale, worst at the short distances a rider sees.
   how much it climbs  2–66 m from the lowest ground on the lap to the highest, and the spread
                       is the point rather than the middle of it. Lambretta Lynds climbs 2 m
                       and Millville 66; Indiana 21. A track on a hillside rides nothing like a

--- a/src-tauri/src/trackllm.rs
+++ b/src-tauri/src/trackllm.rs
@@ -795,7 +795,7 @@ mod tests {
         for key in ["sizeX", "sizeZ", "samples", "scale", "relief"] {
             assert!(v["terrain"].get(key).is_some(), "the schema names `terrain.{key}`");
         }
-        for key in ["amplitude", "wavelength", "seed", "texture"] {
+        for key in ["amplitude", "wavelength", "seed", "texture", "tilt", "tiltAngle"] {
             assert!(v["terrain"]["relief"].get(key).is_some(), "`relief.{key}`");
         }
         for key in ["x", "z", "angle"] {

--- a/src-tauri/src/trackprog.rs
+++ b/src-tauri/src/trackprog.rs
@@ -147,6 +147,23 @@ pub struct Relief {
     /// else in the corpus.
     #[serde(default = "default_texture")]
     pub texture: f32,
+    /// Metres the ground falls across the plot, and which way — a hillside rather than a
+    /// plain.
+    ///
+    /// Not a refinement. Measured as how much the ground rises and falls over a given
+    /// distance, Indiana runs 0.15 m over 5 m and 9.36 m over 200 — a ratio of 62 where a
+    /// noise field of any wavelength saturates around 25, because noise flattens out past
+    /// half its wavelength and a slope does not. It is 0.030 m per metre at five and 0.047 at
+    /// two hundred: near enough a constant grade. Indiana is not a bumpy plain with a track
+    /// on it, it is a hillside, and so are Millville, Washougal, Flanders and Sardegna —
+    /// their laps climb 48 to 66 m.
+    ///
+    /// Zero is a flat plot, which is also real: Lambretta Lynds climbs 2.2 m.
+    #[serde(default)]
+    pub tilt: f32,
+    /// Which way it falls, degrees, in the same convention as a heading.
+    #[serde(default)]
+    pub tilt_angle: f32,
 }
 
 /// Measured, not chosen. The surface roughness of a published track — the mean absolute
@@ -164,6 +181,8 @@ impl Default for Relief {
             wavelength: 180.0,
             seed: 1,
             texture: default_texture(),
+            tilt: 0.0,
+            tilt_angle: 0.0,
         }
     }
 }
@@ -490,8 +509,8 @@ pub const EXAMPLE: &str = r#"{
       "location": "Generated",
       "width": 12.0,
       "terrain": {
-        "sizeX": 500.0, "sizeZ": 480.0, "samples": 2049, "scale": 40.0,
-        "relief": { "amplitude": 22.0, "wavelength": 150.0, "seed": 3 }
+        "sizeX": 500.0, "sizeZ": 480.0, "samples": 2049, "scale": 62.0,
+        "relief": { "amplitude": 6.0, "wavelength": 260.0, "seed": 3, "tilt": 26.0, "tiltAngle": 35.0 }
       },
       "start": { "x": 231.10, "z": 262.90, "angle": 0.0 },
       "segments": [

--- a/src-tauri/src/trackprog.rs
+++ b/src-tauri/src/trackprog.rs
@@ -510,7 +510,7 @@ pub const EXAMPLE: &str = r#"{
       "width": 12.0,
       "terrain": {
         "sizeX": 500.0, "sizeZ": 480.0, "samples": 2049, "scale": 62.0,
-        "relief": { "amplitude": 6.0, "wavelength": 260.0, "seed": 3, "tilt": 26.0, "tiltAngle": 35.0 }
+        "relief": { "amplitude": 12.0, "wavelength": 420.0, "seed": 3, "tilt": 26.0, "tiltAngle": 35.0 }
       },
       "start": { "x": 231.10, "z": 262.90, "angle": 0.0 },
       "segments": [

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -253,6 +253,10 @@ const BERM_REACH_M: f32 = 4.5;
 /// And the field is not ridden. Seven and a half centimetres of detail everywhere left the
 /// field nearly as rough as the racing line — 1.07 cm against 1.26 — where a published track's
 /// field is a quarter of its line.
+/// How many octaves the landscape carries and how fast they fall away. See [`fbm_of`].
+const LANDSCAPE_OCTAVES: u32 = 3;
+const LANDSCAPE_GAIN: f32 = 0.30;
+
 const FIELD_DETAIL_M: f32 = 4.5;
 const FIELD_DETAIL_HEIGHT_M: f32 = 0.045;
 
@@ -369,7 +373,17 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
             // Plus a metre-scale octave everywhere. Four octaves over a hundred metres put
             // the smallest hummock twelve metres across, and a field of those is a blur, not
             // ground — this is what the eye reads as land when it is nowhere near the track.
-            heights[y * gw + x] = fbm(wx / r.wavelength, wz / r.wavelength, r.seed) * r.amplitude
+            // The hillside the whole thing sits on, before anything else.
+            let (tx, tz) = crate::trackprog::heading_vector(r.tilt_angle.to_radians());
+            let along = (wx * tx + wz * tz) / (prog.terrain.size_x.max(prog.terrain.size_z)).max(1.0);
+            heights[y * gw + x] = -r.tilt * along
+                + fbm_of(
+                wx / r.wavelength,
+                wz / r.wavelength,
+                r.seed,
+                LANDSCAPE_OCTAVES,
+                LANDSCAPE_GAIN,
+            ) * r.amplitude
                 + fbm(wx / FIELD_DETAIL_M, wz / FIELD_DETAIL_M, r.seed ^ 0xF1E1D)
                     * FIELD_DETAIL_HEIGHT_M;
         }
@@ -1510,14 +1524,27 @@ fn value_noise(x: f32, y: f32, seed: u32) -> f32 {
 /// Four octaves, each half the amplitude and twice the frequency. Normalised so the result
 /// stays inside ±1 and `amplitude` means what it says.
 fn fbm(x: f32, y: f32, seed: u32) -> f32 {
+    fbm_of(x, y, seed, 4, 0.5)
+}
+
+/// Value noise summed over `octaves`, each half the wavelength of the last and `gain` times
+/// its amplitude.
+///
+/// The two are exposed because the *landscape* wants a far steeper roll-off than anything
+/// else here. Measured as how much ground rises and falls over a given distance, Indiana runs
+/// 0.15 m over 5 m and 9.36 m over 200 — one big smooth landform with almost nothing on it at
+/// small scales. Four octaves at a half gain spread the energy across every scale instead, and
+/// the terrain came out two to four times rougher than a real one everywhere, worst at the
+/// short distances a rider actually sees.
+fn fbm_of(x: f32, y: f32, seed: u32, octaves: u32, gain: f32) -> f32 {
     let mut sum = 0.0;
     let mut amp = 1.0;
     let mut norm = 0.0;
     let mut f = 1.0;
-    for o in 0..4 {
+    for o in 0..octaves {
         sum += value_noise(x * f, y * f, seed.wrapping_add(o * 7919)) * amp;
         norm += amp;
-        amp *= 0.5;
+        amp *= gain;
         f *= 2.0;
     }
     sum / norm
@@ -3201,6 +3228,8 @@ mod tests {
                     wavelength: 150.0,
                     seed: 3,
                     texture: 0.06,
+                                    tilt: 0.0,
+                    tilt_angle: 0.0,
                 },
                 surface: crate::trackprog::Surface::Soil,
             },


### PR DESCRIPTION
*"The Indiana height map still looks different"* — it does. Measuring how much the ground rises
and falls over a given distance:

```
              5 m    10 m    25 m    50 m   100 m   200 m
Indiana      0.15    0.29    0.69    1.44    3.35    9.36
before       0.38    0.75    1.67    2.86    5.01   13.31
now          0.19    0.38    0.94    1.92    3.98    9.48
```

Two to four times too rough at every scale, worst at the distances a rider sees.

The **shape** of Indiana's curve is the finding. It rises by a factor of 62 from five metres to
two hundred, where a noise field of any wavelength saturates around 25 — because noise flattens
out past half its wavelength and a slope does not. Indiana is not a bumpy plain with a track on
it. It is a **hillside**, as are Millville, Washougal, Flanders and Sardegna, whose laps climb
48 to 66 m.

`Relief` grows `tilt` (metres the plot falls across itself) and `tiltAngle`. Amplitude becomes
what it should always have been: the bumps on top. The landscape also gets its own octave count
and roll-off — four octaves at half gain spread energy across every scale; three at 0.30 leave
the landform carrying it.

## And that still is not what makes Indiana look different

Rendered side by side under one camera the match is poor, and the reason is a distribution the
median hides. Height change over 25 m:

```
              p50     p90     p99     max
Indiana      0.71    3.70   12.18   19.83
ours         0.71    1.84    3.64    6.05
```

**The medians are identical. The tail is not.** Indiana has places where the ground climbs
twelve to twenty metres in twenty-five, and we have none — its ground is mostly as smooth as
ours with a handful of dramatic landforms in it (embankments, spectator banks, cut faces),
where ours is uniform noise everywhere.

Distinct landforms are a thing we don't generate at all. That is the next piece of work rather
than more noise, and I am recording it because the structure function alone said we had matched
and it was measuring the wrong statistic.

The prompt asks the model to pick a tilt from the brief — 20–30 m for a hillside national, 0–8
for a flat one — and the schema carries both fields. I put the file extension in backticks in
the prompt again; the test from #353 caught it before it could ship.

1195 tests green, control plane typechecks, 168 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
