### PR TITLE
feat(tracks): the banks a venue has round it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
 - The racing line is chopped up at the scale of a wheel rather than a jump, and the field
   around it is smooth. It used to be nearly as rough out in the grass as it was on the line.
 - A track's edge is crisp against the field rather than fading out over a wide shelf.
+- A venue has banks and spoil hills around it, the way a real one does — the thing that makes
+  a plot look built rather than generated.
 - A track can be built on a hillside. The ground falls across the plot the way a real one
   does, instead of being a bumpy plain — which is most of why the land around a generated
   track never looked like the land around a real one.

--- a/control-plane/src/trackgen.ts
+++ b/control-plane/src/trackgen.ts
@@ -125,6 +125,13 @@ const TrackProgram = z.object({
           "metres the whole plot falls from one side to the other — a hillside rather than a plain. 0 for flat ground, 20-30 for a hillside national.",
         ),
       tiltAngle: z.number().describe("which way it falls, degrees, same convention as a heading"),
+      landforms: z
+        .number()
+        .int()
+        .describe(
+          "how many banks and spoil hills the venue has around the track. 0 for a bare field, 10-15 for a proper venue. These are what make a plot look built rather than generated.",
+        ),
+      landformHeight: z.number().describe("how tall the tallest of them stands, metres; 12-18 is normal"),
     }),
     surface: z
       .enum(["soil", "sand", "grass"])
@@ -259,6 +266,14 @@ explicitly asks otherwise:
                       for a hillside national (Millville, Washougal, Flanders and Sardegna
                       climb 48-66 m over a lap), 0-8 for a flat one (Lambretta Lynds climbs
                       2.2 m). Pick from the brief. tiltAngle is which way it falls.
+
+                      Then set landforms — the banks and spoil hills round the outside. 10-15
+                      of them at 12-18 m for a venue, 0 for a bare field. THIS is what makes a
+                      plot look built. Measured as height change over 25 m, Indiana reaches
+                      12.2 m at the ninety-ninth percentile and 19.8 at the worst; ground made
+                      only of noise, tuned to match its median exactly, reaches 3.6 and 6.0.
+                      Its steepest ground sits 40-120 m from the riding line — the banks people
+                      stand on, not the cut and fill beside the track.
 
                       amplitude is then the *bumps on top of it* and wants to be small — 5-8 m
                       over a 200-300 m wavelength. It used to carry the whole landform and the

--- a/src-tauri/src/trackllm.rs
+++ b/src-tauri/src/trackllm.rs
@@ -795,7 +795,7 @@ mod tests {
         for key in ["sizeX", "sizeZ", "samples", "scale", "relief"] {
             assert!(v["terrain"].get(key).is_some(), "the schema names `terrain.{key}`");
         }
-        for key in ["amplitude", "wavelength", "seed", "texture", "tilt", "tiltAngle"] {
+        for key in ["amplitude", "wavelength", "seed", "texture", "tilt", "tiltAngle", "landforms", "landformHeight"] {
             assert!(v["terrain"]["relief"].get(key).is_some(), "`relief.{key}`");
         }
         for key in ["x", "z", "angle"] {

--- a/src-tauri/src/trackprog.rs
+++ b/src-tauri/src/trackprog.rs
@@ -164,6 +164,22 @@ pub struct Relief {
     /// Which way it falls, degrees, in the same convention as a heading.
     #[serde(default)]
     pub tilt_angle: f32,
+    /// How many banks and spoil hills the venue has around the track, and how tall the
+    /// tallest of them stands.
+    ///
+    /// What separates a real plot from a plain of noise is not roughness, it is these.
+    /// Indiana's ground climbs twelve metres in twenty-five at the ninety-ninth percentile
+    /// and twenty at the worst; noise tuned to its median exactly reaches 3.6 and 6.0. The
+    /// steepest of it sits 40–120 m from the riding line — the banks people stand on, not the
+    /// cut and fill either side of the track.
+    #[serde(default)]
+    pub landforms: u32,
+    #[serde(default = "default_landform_height")]
+    pub landform_height: f32,
+}
+
+fn default_landform_height() -> f32 {
+    12.0
 }
 
 /// Measured, not chosen. The surface roughness of a published track — the mean absolute
@@ -183,6 +199,8 @@ impl Default for Relief {
             texture: default_texture(),
             tilt: 0.0,
             tilt_angle: 0.0,
+            landforms: 0,
+            landform_height: default_landform_height(),
         }
     }
 }
@@ -509,8 +527,8 @@ pub const EXAMPLE: &str = r#"{
       "location": "Generated",
       "width": 12.0,
       "terrain": {
-        "sizeX": 500.0, "sizeZ": 480.0, "samples": 2049, "scale": 62.0,
-        "relief": { "amplitude": 12.0, "wavelength": 420.0, "seed": 3, "tilt": 26.0, "tiltAngle": 35.0 }
+        "sizeX": 500.0, "sizeZ": 480.0, "samples": 2049, "scale": 86.0,
+        "relief": { "amplitude": 7.0, "wavelength": 420.0, "seed": 3, "tilt": 26.0, "tiltAngle": 35.0, "landforms": 13, "landformHeight": 17.0 }
       },
       "start": { "x": 231.10, "z": 262.90, "angle": 0.0 },
       "segments": [

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -389,6 +389,84 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
         }
     }
 
+    // 1b. The landforms — the banks and spoil hills a venue has around it.
+    //
+    // This is what separates a generated plot from a real one, and it is not roughness.
+    // Height change over twenty-five metres, Indiana against a plain of noise tuned to match
+    // its median exactly:
+    //
+    //            p50     p90     p99     max
+    //   Indiana  0.71    3.70   12.18   19.83
+    //   noise    0.71    1.84    3.64    6.05
+    //
+    // The medians agree and the tail does not. Indiana has ground that climbs twelve to
+    // twenty metres in twenty-five and noise never does, because noise is the same everywhere
+    // and a venue is not. Measured by distance from the riding line, its steepest ground is
+    // 40–120 m out — not the cut and fill either side of the track, but the banks people
+    // stand on and the hills the place was built in.
+    //
+    // So they are placed rather than shaken out: a handful of long mounds, kept clear of the
+    // track, each with its own size and bearing.
+    if r.landforms > 0 {
+        let mut placed: Vec<(f32, f32, f32, f32, f32, f32)> = Vec::new();
+        let (sx, sz) = (prog.terrain.size_x, prog.terrain.size_z);
+        for n in 0..r.landforms.min(24) {
+            // Rejection sampling on a hash, so it is deterministic in the seed.
+            for k in 0..40u32 {
+                let h1 = hash2(n as i32 * 71 + k as i32, 13, r.seed ^ 0x1A2D);
+                let h2 = hash2(n as i32 * 71 + k as i32, 29, r.seed ^ 0x1A2D);
+                let (cx, cz) = ((h1 * 0.5 + 0.5) * sx, (h2 * 0.5 + 0.5) * sz);
+                let near = stations
+                    .iter()
+                    .map(|st| (st.x - cx).powi(2) + (st.z - cz).powi(2))
+                    .fold(f32::MAX, f32::min)
+                    .sqrt();
+                let long = 55.0
+                    + 90.0 * (hash2(n as i32, 5, r.seed ^ 0x1A2D) * 0.5 + 0.5);
+                let across = long * (0.35 + 0.4 * (hash2(n as i32, 9, r.seed ^ 0x1A2D) * 0.5 + 0.5));
+                // Clear of the riding line by its own width plus the shoulder, so a bank is
+                // beside the track rather than on it.
+                if near < across + 30.0 {
+                    continue;
+                }
+                let tall = r.landform_height
+                    * (0.45 + 0.55 * (hash2(n as i32, 17, r.seed ^ 0x1A2D) * 0.5 + 0.5));
+                let bearing = hash2(n as i32, 23, r.seed ^ 0x1A2D) * std::f32::consts::PI;
+                placed.push((cx, cz, long, across, tall, bearing));
+                break;
+            }
+        }
+        for y in 0..gh {
+            for x in 0..gw {
+                let (wx, wz) = (x as f32 * mps_x, y as f32 * mps_z);
+                let mut add = 0.0f32;
+                for &(cx, cz, long, across, tall, bearing) in &placed {
+                    let (dx, dz) = (wx - cx, wz - cz);
+                    let (c, s) = (bearing.cos(), bearing.sin());
+                    let (u, v) = (dx * c + dz * s, -dx * s + dz * c);
+                    // The outline is warped, not elliptical. An ellipse with a smooth falloff
+                    // reads as a flying saucer parked on the ground however you shade it —
+                    // the eye finds the regularity instantly. Pushing the boundary about with
+                    // noise, at a wavelength near the mound's own size, makes it ragged the
+                    // way a bank of pushed-up spoil is.
+                    let warp = 0.42
+                        * fbm(
+                            wx / (long * 0.55),
+                            wz / (long * 0.55),
+                            r.seed ^ 0x1A2D ^ (long as u32),
+                        );
+                    let t = ((u / long).powi(2) + (v / across).powi(2)).sqrt() + warp;
+                    if t < 1.0 {
+                        // A mound, not a dome: flat-ish on top and steep on the flanks, which
+                        // is what a bank pushed up out of spoil looks like.
+                        add += tall * (1.0 - smoothstep(t.max(0.0))).powf(0.7);
+                    }
+                }
+                heights[y * gw + x] += add;
+            }
+        }
+    }
+
     // 2. Which station each cell belongs to, and how far off the line it is.
     let (mut dist, station) = nearest_station(&stations, gw, gh, mps_x, mps_z);
 
@@ -3230,6 +3308,8 @@ mod tests {
                     texture: 0.06,
                                     tilt: 0.0,
                     tilt_angle: 0.0,
+                                    landforms: 0,
+                    landform_height: 12.0,
                 },
                 surface: crate::trackprog::Surface::Soil,
             },


### PR DESCRIPTION
A challenge — *generate a hills track like Indiana* — and the thing that was missing turned out
not to be roughness at all.

Height change over twenty-five metres, Indiana against ground made only of noise tuned to match
its median **exactly**:

```
              p50     p90     p99     max
Indiana      0.71    3.70   12.18   19.83
noise        0.71    1.84    3.64    6.05
now          0.93    5.01   12.90   20.15
```

The medians agree and the tail does not. Indiana has ground that climbs twelve to twenty metres
in twenty-five and noise never does, because noise is the same everywhere and a venue is not.
Measured by distance from the riding line, its steepest ground sits **40–120 m out** — the banks
people stand on and the hills the place was built in, not the cut and fill beside the track.

So they are placed rather than shaken out: a handful of long mounds, kept clear of the track,
each with its own size and bearing.

## Two things the first attempt got wrong, both visible only in a render

**An ellipse reads as a flying saucer** however you shade it — the eye finds the regularity
instantly. The boundary is pushed about with noise at a wavelength near the mound's own size,
which makes it ragged the way pushed-up spoil is.

**They were too small and too far apart**, so they sat as separate objects on a plane instead of
merging into the ground. Longer, and they join up.

## The hills track

```
lap 1905 m   137 segs = 109 arcs + 28 straights   17 turns   tightest R p50 12.6 m
climbs 23.3 m (Indiana 21.3)     grade p90 15.0° (16.0)     steepest 33.6° (27–41)
23 lips/km    face p50 14.3° p90 29.8°     ruts 1.6 at 3.25 m, 0.13 m in a corner
```

## Still different, and I am not pretending otherwise

Ours is 1.5× rougher than Indiana at short distances — the mounds carry some of their own — and
Indiana's landforms come right up to the track where ours must stay 30 m clear of it. Both are
visible in the render.

The schema and prompt carry `landforms` and `landformHeight`, with the numbers above, so the
model can build a venue rather than a field.

1195 tests green, control plane typechecks, 168 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
