### PR TITLE
fix(tracks): the track runs over the hills, not past them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
 - The racing line is chopped up at the scale of a wheel rather than a jump, and the field
   around it is smooth. It used to be nearly as rough out in the grass as it was on the line.
 - A track's edge is crisp against the field rather than fading out over a wide shelf.
+- The track runs over the hills instead of past them — it climbs and drops the way a hillside
+  track does, rather than sitting flat with scenery in the distance.
 - A venue has banks and spoil hills around it, the way a real one does — the thing that makes
   a plot look built rather than generated.
 - A track can be built on a hillside. The ground falls across the plot the way a real one

--- a/src-tauri/src/trackprog.rs
+++ b/src-tauri/src/trackprog.rs
@@ -528,7 +528,7 @@ pub const EXAMPLE: &str = r#"{
       "width": 12.0,
       "terrain": {
         "sizeX": 500.0, "sizeZ": 480.0, "samples": 2049, "scale": 86.0,
-        "relief": { "amplitude": 7.0, "wavelength": 420.0, "seed": 3, "tilt": 26.0, "tiltAngle": 35.0, "landforms": 13, "landformHeight": 17.0 }
+        "relief": { "amplitude": 7.0, "wavelength": 420.0, "seed": 3, "tilt": 26.0, "tiltAngle": 35.0, "landforms": 6, "landformHeight": 18.0 }
       },
       "start": { "x": 231.10, "z": 262.90, "angle": 0.0 },
       "segments": [

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -421,14 +421,29 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
                     .map(|st| (st.x - cx).powi(2) + (st.z - cz).powi(2))
                     .fold(f32::MAX, f32::min)
                     .sqrt();
-                let long = 55.0
-                    + 90.0 * (hash2(n as i32, 5, r.seed ^ 0x1A2D) * 0.5 + 0.5);
-                let across = long * (0.35 + 0.4 * (hash2(n as i32, 9, r.seed ^ 0x1A2D) * 0.5 + 0.5));
-                // Clear of the riding line by its own width plus the shoulder, so a bank is
-                // beside the track rather than on it.
-                if near < across + 30.0 {
+                // Big enough that their flanks are gentle. A tall mound on a small footprint
+                // is a wall beside the track: with 55–145 m ones the ground fifteen metres
+                // either side of the riding line differed by 6.5 m at the ninetieth against
+                // Indiana's 3.0. A hill a track is built over is a hundred metres and more
+                // across, and then the same height buys a grade instead of a cliff.
+                let long = 110.0
+                    + 150.0 * (hash2(n as i32, 5, r.seed ^ 0x1A2D) * 0.5 + 0.5);
+                let across = long * (0.45 + 0.4 * (hash2(n as i32, 9, r.seed ^ 0x1A2D) * 0.5 + 0.5));
+                // Not clear of the track. A bank the rider never touches is scenery, and
+                // scenery is not what makes a hills track: Indiana's lap climbs and drops at
+                // 12.6° at the ninetieth and 29.4° at the ninety-ninth over twenty metres,
+                // and it does that by running over the ground, not past it. Keeping every
+                // mound 30 m clear left ours at 5.2° and 12.5° — a flat track with hills in
+                // the distance.
+                //
+                // What is required instead is that the mound be big enough for a track to be
+                // built over: the lap's own elevation is smoothed over 45 m, so anything
+                // shorter than that becomes a bump under the riding line rather than a hill
+                // the track climbs.
+                if long < BENCH_SMOOTH_M * 1.6 {
                     continue;
                 }
+                let _ = near;
                 let tall = r.landform_height
                     * (0.45 + 0.55 * (hash2(n as i32, 17, r.seed ^ 0x1A2D) * 0.5 + 0.5));
                 let bearing = hash2(n as i32, 23, r.seed ^ 0x1A2D) * std::f32::consts::PI;


### PR DESCRIPTION
The last round placed hills and kept every one of them **thirty metres clear of the riding
line**. That is scenery — the rider never touches it, and a track with hills in the distance is
not a hills track. Fairly called out.

What the lap actually does over twenty metres of it, separating the land from what is built on
it (the raw figure counts jump faces):

```
                      p50    p90     p99
Indiana, land        1.9°   8.2°   16.6°
before               2.8°   6.5°    9.8°
now                  3.5°   8.1°   12.4°
```

The clearance rule is gone. What replaces it is a **size** rule: a mound has to be longer than
the distance the lap's own elevation is smoothed over, or it becomes a bump under the riding
line instead of a hill the track climbs.

They are also much larger — 110–260 m rather than 55–145. A tall mound on a small footprint is a
wall beside the track: at the smaller size the ground fifteen metres either side of the line
differed by 6.5 m at the ninetieth against Indiana's 3.0.

## Three things this does not fix

- **The land is still not steep enough at the tail** — 12.4° at the ninety-ninth against 16.6.
- **The ground beside the track is still too steep**: 5.2 m across thirty metres against 3.0.
  Ours are randomly oriented; Indiana's track was *routed* to its terrain — along the contours
  where it wants to be level, up the fall line where it wants to climb. That needs the layout
  to know about the ground, which is a structural change rather than a number.
- **Total lap relief is 35 m against 22.** More hill than the place needs.

Also worth recording: `BENCH_SMOOTH_M` is still not the lever it looks like. With real hills
under the track, 45 m → 20 m moved the lap's grade at the ninetieth from 9.4° to 10.2°.

1195 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
