### PR TITLE
docs(tracks): what the ground still gets wrong, and four things that don't fix it

### DIFF
--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -426,6 +426,24 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
                 // either side of the riding line differed by 6.5 m at the ninetieth against
                 // Indiana's 3.0. A hill a track is built over is a hundred metres and more
                 // across, and then the same height buys a grade instead of a cliff.
+                // Long enough to be a hill a track is built over, small enough to leave ground
+                // between them. With 110–260 m ones covering most of the plot the map came out
+                // 27.9% flat against Indiana's 37.3, and curved everywhere at 0.29 m over
+                // fifteen metres against its 0.19 — the landforms *were* the landscape. With
+                // none at all it is 68% flat, which is flatter than Indiana. The truth is in
+                // between: they cover part of it and break harder where they do.
+                // The size is a trade, and it is worth writing down which way it runs. Small
+                // and tall gives the lap the right grade along it — 9.0° at the ninetieth
+                // against Indiana's 8.3 — and wrecks the ground across it, 7.6 m over thirty
+                // metres against its 3.0. Large and lower keeps the ground across the track
+                // sane at 5.2 and costs grade, 8.1 and 12.4 against 8.3 and 16.6.
+                //
+                // Neither is right, and no size is: ours are oriented at random, so the lap
+                // meets them however it happens to. Indiana's track was *routed* to its
+                // terrain — along the contours where it wants to be level, up the fall line
+                // where it wants to climb — which is a thing the layout would have to know
+                // about the ground, not a number here. Large is chosen because a track that
+                // is off-camber everywhere is worse than one that climbs gently.
                 let long = 110.0
                     + 150.0 * (hash2(n as i32, 5, r.seed ^ 0x1A2D) * 0.5 + 0.5);
                 let across = long * (0.45 + 0.4 * (hash2(n as i32, 9, r.seed ^ 0x1A2D) * 0.5 + 0.5));
@@ -3325,7 +3343,7 @@ mod tests {
                     tilt_angle: 0.0,
                                     landforms: 0,
                     landform_height: 12.0,
-                },
+                                },
                 surface: crate::trackprog::Surface::Soil,
             },
             start: Start {


### PR DESCRIPTION
*"The Indiana height map still looks better."* It does. This records what the difference
measures as, and what does **not** move it — I spent a long run finding out and the next person
shouldn't have to.

## The measurement

Curvature: how far the ground departs from the plane through its neighbours fifteen metres out.
Worked ground is flat in patches with hard breaks between them; noise is moderately curved
everywhere.

```
              p50    p90    p99     max    flat
Indiana      0.19   1.42   3.92    8.47   37.3%
ours         0.29   1.08   2.57    4.87   27.9%
```

Indiana is **both** flatter in more places **and** sharper where it is not.

## Four things that don't fix it

- **Terracing the ground towards levels.** Made every figure worse — 27.9% flat down to 17.4%
  at a 3.2 m bench and 25.7% at 14 m. Removed rather than shipped as a knob that hurts.
- **The field's fine detail.** 4.5 cm → 0.8 cm moved *nothing* — three runs identical to two
  decimal places.
- **The landscape's fBm amplitude.** 7 m → 1 m moved flatness by 0.2 points.
- **`BENCH_SMOOTH_M`, again.** 45 m → 20 m with real hills under the track moved the lap's
  grade at the ninetieth from 9.4° to 10.2°.

## What does set it, and why sizing can't reach it

The landforms. Without them the map is **68% flat** and curved at 0.03 — flatter than Indiana.
With six large ones, 27.9% and 0.29. Indiana's 37.3% sits between: its landforms cover *less* of
the map and break harder where they are.

But that can't be reached by sizing them, because the size is a trade running the wrong way:

```
                       land grade p90/p99      ground across the track
Indiana                    8.3° / 16.6°               3.02 m
small and tall (6×22 m)    9.0° / 15.3°  ✓            7.60 m  ✗
large and lower (6×18 m)   8.1° / 12.4°               5.21 m
```

Neither is right and no size is. Ours are oriented at random, so the lap meets them however it
happens to. **Indiana's track was routed to its terrain** — along the contours where it wants
to be level, up the fall line where it wants to climb. That is the layout knowing about the
ground, which is a structural change and not a constant.

Large is kept, because a track that is off-camber everywhere is worse than one that climbs
gently.

1195 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
