### PR TITLE
feat(diagnostics): search the client diagnostics log, both ways round

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## 2026-09-01
 
+### Added
+- The diagnostics dashboard searches. Riders by name, GUID, Steam id or account id; files by
+  name, hash, signer, or anything the file claims about itself.
+- Every rider has a page: their identity, last report, the servers they have been seen on,
+  and every file their game has loaded.
+- Every file has a page listing everyone who has loaded it, per build — the lookup run
+  backwards.
+- Lists are paged, with a page count and numbered links.
+
+### Changed
+- The dashboard is four views behind a nav instead of one long page, and the tables carry the
+  information the prose used to explain.
+- Rule notes show on the rules page, and a Flag or Clear button returns to the page it was
+  pressed on with its filters intact.
+
+## 2026-09-01
+
 ### Fixed
 - Generated tracks no longer crash the game at the track graphics stage: each ground layer
   now carries the material record a published map uses.

--- a/control-plane/migrations/0019_diagnostics_search.sql
+++ b/control-plane/migrations/0019_diagnostics_search.sql
@@ -1,0 +1,19 @@
+-- Indexes for searching the diagnostics log rather than only reading the top of it.
+--
+-- The dashboard used to draw one query: the unaccounted files of the last N days, most
+-- recent first. It now searches riders, searches files, and looks a file up backwards to
+-- find who has loaded it, and those reads order by time across the whole table.
+--
+-- Nothing here changes what is stored. A substring search still scans — no index helps
+-- `LIKE '%x%'` — but scanning is fine at this size and the ordering is not.
+
+-- Files by recency, unfiltered by state. The existing (state, last_at) index only serves a
+-- read that names a state, which the file search no longer does.
+CREATE INDEX client_module_seen_last ON client_module_seen (last_at);
+
+-- One rider's files, newest first. The primary key already finds the account; this is what
+-- keeps the page from sorting the whole set to draw fifty rows.
+CREATE INDEX client_module_seen_account ON client_module_seen (account_id, last_at);
+
+-- The rider list is ordered by when each last reported, over every account that ever has.
+CREATE INDEX client_modules_updated ON client_modules (updated_at);

--- a/control-plane/src/diagnostics.ts
+++ b/control-plane/src/diagnostics.ts
@@ -107,6 +107,8 @@ export interface ModuleRule {
   pattern: string;
   sha256: string;
   label: string;
+  /** Why the rule exists. Written on the add form, and only ever read on the rules page. */
+  note?: string;
 }
 
 /** One rule-matched module, as it is stored and shown. */
@@ -285,8 +287,15 @@ function matchRule(rules: ModuleRule[], mod: ReportedModule): ModuleRule | null 
 /** The rules in force, oldest first. Version is `max(id)` — see the migration. */
 export async function loadRules(env: Env): Promise<{ rules: ModuleRule[]; version: number }> {
   const rows = await env.DB.prepare(
-    "SELECT id, kind, pattern, sha256, label FROM module_rules ORDER BY id",
-  ).all<{ id: number; kind: string; pattern: string; sha256: string; label: string }>();
+    "SELECT id, kind, pattern, sha256, label, note FROM module_rules ORDER BY id",
+  ).all<{
+    id: number;
+    kind: string;
+    pattern: string;
+    sha256: string;
+    label: string;
+    note: string | null;
+  }>();
   const rules = (rows.results ?? [])
     .filter((r) => r.kind === "deny" || r.kind === "allow")
     .map((r) => ({
@@ -295,6 +304,7 @@ export async function loadRules(env: Env): Promise<{ rules: ModuleRule[]; versio
       pattern: (r.pattern ?? "").toLowerCase(),
       sha256: (r.sha256 ?? "").toLowerCase(),
       label: r.label ?? "",
+      note: r.note ?? "",
     }));
   const version = rules.reduce((max, r) => Math.max(max, r.id), 0);
   return { rules, version };
@@ -504,92 +514,21 @@ export interface LiveRow {
   updatedAt: number;
 }
 
-/**
- * One distinct file — one name and one hash — as it has been seen across everyone.
- *
- * A variant, not a sighting: the per-account rows behind it are collapsed, because the
- * question the page asks is "what is this file" and the answer does not change with who
- * loaded it. `riderName` is only meaningful when `accounts` is 1, and the page only shows it
- * then; naming one of several people would read as an accusation of that one.
- */
-export interface SeenVariant {
-  name: string;
-  sha256: string;
-  origin: string;
-  state: State;
-  label: string;
-  trust: Trust;
-  publisher: string;
-  company: string;
-  product: string;
-  description: string;
-  size: number;
-  mtime: number;
-  riderName: string;
-  /** How many distinct accounts have ever loaded this exact file. */
-  accounts: number;
-  hits: number;
-  lastAt: number;
-}
-
-/**
- * Every variant sharing one file name, which is how the unaccounted list is read.
- *
- * The name is the unit because that is what a rule is written against and what a person
- * recognises. `variants` is where the interesting shape lives: one name with one hash on
- * two hundred machines is a driver, and one name with two hundred hashes is something being
- * rebuilt between sessions.
- */
-export interface SeenGroup {
-  name: string;
-  /** The worst state any variant is in. */
-  state: State;
-  /** The first label any rule gave a variant, so a named group says what it is. */
-  label: string;
-  /** Distinct accounts across every variant of this name. */
-  accounts: number;
-  hits: number;
-  firstAt: number;
-  lastAt: number;
-  /** Distinct hashes recorded under this name in the window. */
-  variantCount: number;
-  /** The variants themselves, worst first then most recent. May be short of
-   *  `variantCount` when the detail query's cap was reached. */
-  variants: SeenVariant[];
-}
-
 export interface AdminView {
   live: LiveRow[];
-  seen: SeenGroup[];
-  /** Distinct unaccounted file names in the window, before `MAX_SEEN_NAMES` trimmed them. */
-  seenNamesTotal: number;
   rules: ModuleRule[];
   rulesVersion: number;
   reporting: number;
 }
 
-/** The most file names the unaccounted list draws. Anything past it is counted, not drawn. */
-const MAX_SEEN_NAMES = 200;
-
-/** The most variants fetched across all of those names together. */
-const MAX_SEEN_VARIANTS = 1000;
-
 /**
- * Everything the admin page draws.
+ * Who is reporting right now, worst first, and the rules that read them.
  *
- * `live` is who is reporting right now, worst first. `seen` is the evidence log — every
- * non-system file anyone's game has loaded that the rules do not account for — grouped by
- * file name, most recent first, with the number of accounts that have ever loaded it. That
- * last number is the one that reads best: a file on one machine out of hundreds is
- * interesting whatever any rule says, and a file on all of them is a driver.
- *
- * Grouped rather than listed because the list is per account and per hash, and one popular
- * overlay was arriving as several hundred rows that said the same thing. The name is the
- * unit a rule is written against, so it is also the unit the page is read in.
+ * The file side of the page lives in `diagnosticssearch.ts`: it is a search now rather than
+ * a fixed list, and the two have nothing in common but the tables.
  */
-export async function collectAdminView(env: Env, days: number): Promise<AdminView> {
+export async function collectAdminView(env: Env): Promise<AdminView> {
   const fresh = Date.now() - PRESENCE_TTL_MS;
-  const since = Date.now() - days * 24 * 60 * 60 * 1000;
 
   const live = await env.DB.prepare(
     "SELECT c.account_id, a.rider_name, a.guid, c.state, c.rules_version, c.module_count," +
@@ -615,88 +554,6 @@ export async function collectAdminView(env: Env, days: number): Promise<AdminVie
       updated_at: number;
       server_id: string | null;
     }>();
-
-  // Two queries rather than one, because the totals have to be right even where the detail
-  // is trimmed: the first counts every name in the window, the second fetches the variants
-  // to draw under them. Grouping the first in SQL is what keeps a name loaded by six hundred
-  // people from arriving as six hundred rows.
-  const names = await env.DB.prepare(
-    "SELECT name, COUNT(DISTINCT account_id) AS accounts, COUNT(DISTINCT sha256) AS variants," +
-      " SUM(hits) AS hits, MIN(first_at) AS first_at, MAX(last_at) AS last_at" +
-      " FROM client_module_seen" +
-      " WHERE state IN ('warn', 'alert') AND last_at > ?" +
-      " GROUP BY name ORDER BY MAX(last_at) DESC LIMIT ?",
-  )
-    .bind(since, MAX_SEEN_NAMES)
-    .all<{
-      name: string;
-      accounts: number;
-      variants: number;
-      hits: number;
-      first_at: number;
-      last_at: number;
-    }>();
-
-  const nameTotal = await env.DB.prepare(
-    "SELECT COUNT(DISTINCT name) AS n FROM client_module_seen" +
-      " WHERE state IN ('warn', 'alert') AND last_at > ?",
-  )
-    .bind(since)
-    .first<{ n: number }>();
-
-  const seen = await env.DB.prepare(
-    "SELECT name, sha256, origin, state, label, trust, publisher, company, product," +
-      " description, size, mtime, MAX(rider_name) AS rider_name," +
-      " COUNT(DISTINCT account_id) AS accounts, SUM(hits) AS hits, MAX(last_at) AS last_at" +
-      " FROM client_module_seen" +
-      " WHERE state IN ('warn', 'alert') AND last_at > ?" +
-      " GROUP BY name, sha256 ORDER BY MAX(last_at) DESC LIMIT ?",
-  )
-    .bind(since, MAX_SEEN_VARIANTS)
-    .all<{
-      name: string;
-      sha256: string;
-      origin: string;
-      state: string;
-      label: string;
-      trust: string;
-      publisher: string;
-      company: string;
-      product: string;
-      description: string;
-      size: number;
-      mtime: number;
-      rider_name: string;
-      accounts: number;
-      hits: number;
-      last_at: number;
-    }>();
-
-  // Variants, indexed by the name they belong to.
-  const byName = new Map<string, SeenVariant[]>();
-  for (const r of seen.results ?? []) {
-    const variant: SeenVariant = {
-      name: r.name,
-      sha256: r.sha256,
-      origin: r.origin,
-      state: isState(r.state) ? r.state : "unknown",
-      label: r.label ?? "",
-      trust: isTrust(r.trust) ? r.trust : "unchecked",
-      publisher: r.publisher ?? "",
-      company: r.company ?? "",
-      product: r.product ?? "",
-      description: r.description ?? "",
-      size: r.size ?? 0,
-      mtime: r.mtime ?? 0,
-      riderName: r.rider_name ?? "",
-      accounts: r.accounts,
-      hits: r.hits,
-      lastAt: r.last_at,
-    };
-    const list = byName.get(variant.name);
-    if (list) list.push(variant);
-    else byName.set(variant.name, [variant]);
-  }
 
   const { rules, version } = await loadRules(env);
 
@@ -724,28 +581,6 @@ export async function collectAdminView(env: Env, days: number): Promise<AdminVie
             Math.max(stateRank(a.worstState), stateRank(a.state)) ||
           b.updatedAt - a.updatedAt,
       ),
-    seen: (names.results ?? []).map((g) => {
-      const variants = (byName.get(g.name) ?? []).sort(
-        (a, b) => stateRank(b.state) - stateRank(a.state) || b.lastAt - a.lastAt,
-      );
-      return {
-        name: g.name,
-        // Off the variants we actually have. A group whose detail was trimmed can only be
-        // as bad as what is in front of us, which is the honest answer rather than a guess.
-        state: variants.reduce<State>(
-          (worst, v) => (stateRank(v.state) > stateRank(worst) ? v.state : worst),
-          "unknown",
-        ),
-        label: variants.find((v) => v.label)?.label ?? "",
-        accounts: g.accounts,
-        hits: g.hits,
-        firstAt: g.first_at,
-        lastAt: g.last_at,
-        variantCount: g.variants,
-        variants,
-      };
-    }),
-    seenNamesTotal: nameTotal?.n ?? (names.results ?? []).length,
     rules,
     rulesVersion: version,
     reporting: (live.results ?? []).length,
@@ -753,7 +588,7 @@ export async function collectAdminView(env: Env, days: number): Promise<AdminVie
 }
 
 /** A stored JSON column read back. A row that will not parse is empty, never a 500. */
-function parseMatched(text: string): Matched[] {
+export function parseMatched(text: string): Matched[] {
   try {
     const value = JSON.parse(text);
     if (!Array.isArray(value)) return [];

--- a/control-plane/src/diagnosticspage.ts
+++ b/control-plane/src/diagnosticspage.ts
@@ -5,10 +5,18 @@
  * behind an admin key that pulls anything from someone else's host stops working the day
  * that host does, and this is the only view of this data there is.
  *
- * It is a working surface rather than a report. The list of files nothing accounts for is
- * next to the buttons that account for them — see something, name it or clear it, and the
- * next report from every install reads it the new way. That loop is the feature; a page that
- * only displayed would leave the rule list permanently empty.
+ * Five views over the same two tables:
+ *
+ *   * **Overview** — who is reporting right now, and what turned up lately.
+ *   * **Riders** — search every account by name, GUID, Steam id or account id.
+ *   * **Rider** — one person: identity, last report, and every file their game has loaded.
+ *   * **Files** — search every file by name, hash, signer, or anything it claims to be.
+ *   * **File** — one file, and everybody who has it. The lookup run backwards.
+ *
+ * It is a working surface rather than a report: the rule buttons sit on the rows they are
+ * about, and a rule takes effect on the next report from every install. Every list is paged
+ * — an offset and a total, never a scroll that loads as it goes — so a link to page four is
+ * a link to page four tomorrow as well.
  */
 
 import {
@@ -18,30 +26,90 @@ import {
   stateRank,
   type AdminView,
   type LiveRow,
+  type Matched,
   type ModuleRule,
-  type SeenGroup,
-  type SeenVariant,
   type State,
   type Trust,
 } from "./diagnostics";
-import { adminAllowed, windowDays } from "./usage";
+import {
+  clampDays,
+  claimText,
+  fileDetail,
+  FILE_ORIGINS,
+  FILE_SORTS,
+  FILE_STATES,
+  FILE_TRUSTS,
+  MAX_COUNT,
+  parseFileQuery,
+  parsePage,
+  parseRiderQuery,
+  parseSightingQuery,
+  riderDetail,
+  RIDER_SORTS,
+  RIDER_STATES,
+  searchFiles,
+  searchRiders,
+  SIGHTING_STATES,
+  totals,
+  type FileDetail,
+  type FileGroup,
+  type FileQuery,
+  type FileVariant,
+  type Paged,
+  type RiderDetail,
+  type RiderQuery,
+  type RiderRow,
+  type Sighting,
+  type SightingQuery,
+} from "./diagnosticssearch";
+import { adminAllowed } from "./usage";
 
 /** Windows the header offers. Anything else still works via `?days=`. */
 const RANGES = [1, 7, 30, 90];
 
-export async function diagnosticsDashboard(
-  request: Request,
-  url: URL,
-  env: Env,
-): Promise<Response> {
+const ROOT = "/admin/diagnostics";
+
+/** Query values a link carries. `undefined` and `""` are dropped rather than sent empty. */
+type Params = Record<string, string | number | undefined | null>;
+
+/** What every view needs to draw a link back to itself: the key, and where it is. */
+interface Ctx {
+  key: string;
+  /** The path and query of the page being drawn, for a rule form to come back to. */
+  back: string;
+}
+
+function ctx(url: URL): Ctx {
+  return { key: url.searchParams.get("key") ?? "", back: `${url.pathname}${url.search}` };
+}
+
+/** Every link carries the admin key: a browser typing a URL cannot send a header. */
+function href(path: string, params: Params, key: string): string {
+  const q = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v === undefined || v === null || v === "") continue;
+    q.set(k, String(v));
+  }
+  if (key) q.set("key", key);
+  const query = q.toString();
+  return query ? `${path}?${query}` : path;
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+/** The gate every view goes through, so no handler can forget it. */
+function gate(request: Request, url: URL, env: Env): Response | null {
   const allowed = adminAllowed(request, url, env);
   if (allowed === "unset") return page(503, "No admin key is configured on this deployment.");
   if (allowed === "denied") return page(401, "Unauthorized.");
+  return null;
+}
 
-  const days = windowDays(url);
-  const view = await collectAdminView(env, days);
-  return new Response(render(view, url, days), {
-    status: 200,
+function html(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
     headers: {
       "content-type": "text/html; charset=utf-8",
       // About named people, behind a key: never cached by anything in between.
@@ -50,16 +118,92 @@ export async function diagnosticsDashboard(
   });
 }
 
+export async function diagnosticsDashboard(
+  request: Request,
+  url: URL,
+  env: Env,
+): Promise<Response> {
+  const denied = gate(request, url, env);
+  if (denied) return denied;
+
+  const c = ctx(url);
+  const days = clampDays(url.searchParams.get("days"));
+  const [view, sums, recent] = await Promise.all([
+    collectAdminView(env),
+    totals(env, days),
+    searchFiles(env, {
+      q: "",
+      state: "flagged",
+      trust: "any",
+      origin: "any",
+      sort: "state",
+      days,
+      page: 1,
+    }),
+  ]);
+  return html(overview(view, sums, recent, days, c));
+}
+
+export async function diagnosticsRiders(request: Request, url: URL, env: Env): Promise<Response> {
+  const denied = gate(request, url, env);
+  if (denied) return denied;
+  const query = parseRiderQuery(url);
+  return html(ridersView(await searchRiders(env, query), query, ctx(url)));
+}
+
+export async function diagnosticsRider(request: Request, url: URL, env: Env): Promise<Response> {
+  const denied = gate(request, url, env);
+  if (denied) return denied;
+  const who = (url.searchParams.get("id") ?? "").trim().slice(0, 128);
+  if (!who) return html(shell("Rider", "riders", empty("No rider asked for."), ctx(url)), 400);
+  const query = parseSightingQuery(url);
+  const detail = await riderDetail(env, who, query);
+  if (!detail) {
+    return html(shell("Rider", "riders", empty("No account matches that."), ctx(url)), 404);
+  }
+  return html(riderView(detail, query, ctx(url)));
+}
+
+export async function diagnosticsFiles(request: Request, url: URL, env: Env): Promise<Response> {
+  const denied = gate(request, url, env);
+  if (denied) return denied;
+  const query = parseFileQuery(url);
+  return html(filesView(await searchFiles(env, query), query, ctx(url)));
+}
+
+export async function diagnosticsFile(request: Request, url: URL, env: Env): Promise<Response> {
+  const denied = gate(request, url, env);
+  if (denied) return denied;
+  const name = (url.searchParams.get("name") ?? "").trim().slice(0, 96);
+  const sha256 = (url.searchParams.get("sha256") ?? "").trim().slice(0, 64);
+  if (!name) return html(shell("File", "files", empty("No file asked for."), ctx(url)), 400);
+  const detail = await fileDetail(env, name, sha256, parsePage(url.searchParams.get("page")));
+  if (!detail) {
+    return html(shell("File", "files", empty("Nothing has been seen under that name."), ctx(url)), 404);
+  }
+  return html(fileView(detail, ctx(url)));
+}
+
+export async function diagnosticsRulesPage(
+  request: Request,
+  url: URL,
+  env: Env,
+): Promise<Response> {
+  const denied = gate(request, url, env);
+  if (denied) return denied;
+  const view = await collectAdminView(env);
+  return html(rulesView(view, ctx(url)));
+}
+
 /**
- * The rule buttons post here and come back to the page.
+ * The rule buttons post here and come back to the page they were pressed on.
  *
  * A 303 rather than a rendered result, so a refresh does not re-submit — this is the one
  * surface where a double-click would silently add a rule twice.
  */
 export async function diagnosticsRules(request: Request, url: URL, env: Env): Promise<Response> {
-  const allowed = adminAllowed(request, url, env);
-  if (allowed === "unset") return page(503, "No admin key is configured on this deployment.");
-  if (allowed === "denied") return page(401, "Unauthorized.");
+  const denied = gate(request, url, env);
+  if (denied) return denied;
 
   let form: FormData;
   try {
@@ -67,8 +211,11 @@ export async function diagnosticsRules(request: Request, url: URL, env: Env): Pr
   } catch {
     return page(400, "That was not a form.");
   }
-  const back = `/admin/diagnostics${url.search}`;
   const field = (name: string) => String(form.get(name) ?? "");
+  // Back where the button was pressed, filters and page intact. Anything not one of our own
+  // paths is an open redirect, so it becomes the overview.
+  const asked = field("back");
+  const back = asked.startsWith(`${ROOT}`) && !asked.startsWith("//") ? asked : ROOT;
 
   if (field("action") === "delete") {
     const id = Number(field("id"));
@@ -92,62 +239,484 @@ function redirect(to: string): Response {
   return new Response(null, { status: 303, headers: { location: to, "cache-control": "no-store" } });
 }
 
-function render(v: AdminView, url: URL, days: number): string {
-  const key = url.searchParams.get("key");
-  const suffix = key ? `&key=${encodeURIComponent(key)}` : "";
-  const href = (d: number) => `?days=${d}${suffix}`;
-  const action = `/admin/diagnostics/rules?days=${days}${suffix}`;
+// ---------------------------------------------------------------------------
+// Shell
+// ---------------------------------------------------------------------------
 
-  const alerts = v.live.filter((r) => worst(r) === "alert");
-  const warns = v.live.filter((r) => worst(r) === "warn");
-  const blind = v.live.filter((r) => r.state === "unknown");
+type Tab = "overview" | "riders" | "files" | "rules";
+
+function shell(title: string, tab: Tab, body: string, c: Ctx): string {
+  const nav = (
+    [
+      ["overview", "Overview", ROOT],
+      ["riders", "Riders", `${ROOT}/riders`],
+      ["files", "Files", `${ROOT}/files`],
+      ["rules", "Rules", `${ROOT}/rules`],
+    ] as const
+  )
+    .map(
+      ([id, text, path]) =>
+        `<a class="${id === tab ? "on" : ""}" href="${esc(href(path, {}, c.key))}">${text}</a>`,
+    )
+    .join("");
 
   return `<!doctype html>
 <html lang="en"><head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="robots" content="noindex">
-<title>MXB App client diagnostics</title>
+<title>${esc(title)} — MXB App diagnostics</title>
 <style>${CSS}</style>
 </head><body>
-<header>
-  <h1>Client diagnostics</h1>
-  <nav>${RANGES.map(
-    (d) => `<a class="${d === days ? "on" : ""}" href="${esc(href(d))}">${d}d</a>`,
-  ).join("")}</nav>
-</header>
+<header><h1>${esc(title)}</h1><nav>${nav}</nav></header>
+${body}
+<footer class="muted">Only clients running the app report. A missing row means nobody told us,
+  not that nothing happened.</footer>
+</body></html>`;
+}
 
+function empty(message: string): string {
+  return `<section class="panel"><p class="muted">${esc(message)}</p></section>`;
+}
+
+// ---------------------------------------------------------------------------
+// Overview
+// ---------------------------------------------------------------------------
+
+function overview(
+  v: AdminView,
+  sums: Awaited<ReturnType<typeof totals>>,
+  recent: Paged<FileGroup>,
+  days: number,
+  c: Ctx,
+): string {
+  const alerts = v.live.filter((r) => worst(r) === "alert");
+  const warns = v.live.filter((r) => worst(r) === "warn");
+  const blind = v.live.filter((r) => r.state === "unknown");
+  const top = recent.rows.slice(0, 12);
+
+  const body = `
 <section class="tiles">
-  ${tile("Reporting now", v.reporting, "clients that reported in the last 10 minutes")}
-  ${tile("Alerts", alerts.length, "a rule named something in their game", alerts.length ? "alert" : "")}
-  ${tile("Unaccounted", warns.length, "something loaded that no rule accounts for", warns.length ? "warn" : "")}
-  ${tile("Could not look", blind.length, "the app could not read the module list")}
+  ${tile("Reporting", v.reporting, "last 10 minutes")}
+  ${tile("Alerts", alerts.length, "a rule named a file", alerts.length ? "alert" : "")}
+  ${tile("Unaccounted", warns.length, "no rule covers it", warns.length ? "warn" : "")}
+  ${tile("Blind", blind.length, "could not read the list")}
+  ${tile("Riders", sums.accounts, `${sums.reported.toLocaleString("en-GB")} have reported`)}
+  ${tile("Files", sums.files, `${sums.builds.toLocaleString("en-GB")} builds, ${days}d`)}
+  ${tile("Flagged", sums.flagged, `file names, ${days}d`, sums.flagged ? "warn" : "")}
   ${tile("Rules", v.rules.length, `version ${v.rulesVersion}`)}
 </section>
 
 <section class="panel">
-  <h2>Reporting now</h2>
-  ${live(v.live)}
+  <h2>Reporting now <span class="muted">${v.live.length} client${v.live.length === 1 ? "" : "s"}</span></h2>
+  ${liveTable(v.live, c)}
 </section>
 
 <section class="panel">
-  <h2>Files nothing accounts for
-    <span class="muted">— last ${days}d, by file name, most recent first</span></h2>
-  <p class="muted">One row per file name. Accounts is how many distinct people have loaded
-    it — one out of many is the interesting shape; many is a driver or an overlay, and worth
-    clearing so it stops filling this list. Open a row for each distinct build of that file:
-    who signed it, what it claims to be, and its hash.</p>
-  <p class="muted"><b>Signed</b> is Windows' answer and means something. <b>Company</b> and
-    <b>product</b> are what the file says about itself, which anything can write — good for
-    recognising the ordinary, worthless as evidence about the unusual.</p>
-  ${trimmed(v)}
-  ${sightings(v.seen, action)}
+  <h2>Flagged files <span class="muted">worst first, last ${days}d</span>
+    <a class="more" href="${esc(href(`${ROOT}/files`, { days }, c.key))}">Search all files →</a></h2>
+  ${top.length ? fileTable(top, c, false) : `<p class="muted">Nothing unaccounted for in this window.</p>`}
+</section>`;
+
+  return shell("Diagnostics", "overview", withRanges(body, ROOT, { days }, days, c), c);
+}
+
+/** The day-window switcher, above whichever view uses one. */
+function withRanges(body: string, path: string, params: Params, days: number, c: Ctx): string {
+  const links = RANGES.map(
+    (d) =>
+      `<a class="${d === days ? "on" : ""}" href="${esc(
+        href(path, { ...params, days: d, page: undefined }, c.key),
+      )}">${d}d</a>`,
+  ).join("");
+  return `<div class="ranges">${links}</div>${body}`;
+}
+
+function tile(label: string, value: number, hint: string, tone = ""): string {
+  return `<div class="tile ${tone}"><span class="n">${value.toLocaleString("en-GB")}</span>
+    <span class="l">${esc(label)}</span><span class="h">${esc(hint)}</span></div>`;
+}
+
+/** The worse of what a client says now and the worst it said inside the window. */
+function worst(row: LiveRow): State {
+  return stateRank(row.worstState) > stateRank(row.state) ? row.worstState : row.state;
+}
+
+function liveTable(rows: LiveRow[], c: Ctx): string {
+  if (!rows.length) return `<p class="muted">Nobody is reporting right now.</p>`;
+  return wrap(`<table>
+  <thead><tr><th>Rider</th><th>State</th><th>Server</th><th>Named</th>
+    <th class="num">Unaccounted</th><th class="num">Modules</th><th>App</th><th>Seen</th></tr></thead>
+  <tbody>${rows
+    .map((r) => {
+      const peak = worst(r);
+      const drift = peak !== r.state ? ` <span class="muted">was ${esc(peak)}</span>` : "";
+      return `<tr>
+      <td>${riderLink(r.accountId, r.riderName, c)}</td>
+      <td><span class="pill ${esc(peak)}">${esc(r.state)}</span>${drift}</td>
+      <td class="muted">${esc(r.serverId || "—")}</td>
+      <td>${named(r.matched, c)}</td>
+      <td class="num">${r.unknownCount}</td>
+      <td class="num">${r.moduleCount}</td>
+      <td class="muted">${esc(r.appVersion || "—")}</td>
+      <td class="muted">${esc(ago(r.updatedAt))}</td>
+    </tr>`;
+    })
+    .join("")}</tbody></table>`);
+}
+
+function named(matched: Matched[], c: Ctx): string {
+  if (!matched.length) return `<span class="muted">—</span>`;
+  return matched
+    .map(
+      (m) =>
+        `<a class="tag" href="${esc(
+          href(`${ROOT}/file`, { name: m.name }, c.key),
+        )}">${esc(m.label || m.name)}</a>`,
+    )
+    .join(" ");
+}
+
+// ---------------------------------------------------------------------------
+// Riders
+// ---------------------------------------------------------------------------
+
+function ridersView(found: Paged<RiderRow>, query: RiderQuery, c: Ctx): string {
+  const params: Params = {
+    q: query.q,
+    state: query.state,
+    sort: query.sort,
+    days: query.days,
+  };
+  const body = `
+<section class="panel">
+  <form class="search" method="get" action="${ROOT}/riders">
+    ${hidden("key", c.key)}
+    <input name="q" value="${esc(query.q)}" maxlength="96" autofocus
+      placeholder="rider name, GUID, Steam id, account id">
+    ${select("state", RIDER_STATES, query.state, {
+      any: "any state",
+      quiet: "not reporting",
+    })}
+    ${select("sort", RIDER_SORTS, query.sort, {
+      seen: "last report",
+      state: "worst state",
+      name: "name",
+      unaccounted: "most unaccounted",
+    })}
+    ${select("days", [1, 7, 30, 90, 365], query.days, {}, (d) => `${d}d`)}
+    <button type="submit">Search</button>
+    ${query.q || query.state !== "any" ? `<a class="clear" href="${esc(href(`${ROOT}/riders`, {}, c.key))}">Clear</a>` : ""}
+  </form>
+  ${count(found, "rider")}
+  ${riderTable(found.rows, c)}
+  ${pager(`${ROOT}/riders`, params, found, c)}
+</section>`;
+  return shell("Riders", "riders", body, c);
+}
+
+function riderTable(rows: RiderRow[], c: Ctx): string {
+  if (!rows.length) return `<p class="muted">No rider matches.</p>`;
+  return wrap(`<table>
+  <thead><tr><th>Rider</th><th>GUID</th><th>State</th><th class="num">Files</th>
+    <th class="num">Flagged</th><th>Server</th><th>App</th><th>Last report</th></tr></thead>
+  <tbody>${rows
+    .map((r) => {
+      const peak = r.worstState && stateRank(r.worstState) > stateRank(r.state) ? r.worstState : r.state;
+      const state = r.state
+        ? `<span class="pill ${esc(peak)}">${esc(r.state)}</span>${
+            peak !== r.state ? ` <span class="muted">was ${esc(peak)}</span>` : ""
+          }`
+        : `<span class="muted">never reported</span>`;
+      return `<tr>
+      <td>${riderLink(r.accountId, r.riderName, c)}</td>
+      <td><code class="muted">${esc(r.guid || "—")}</code></td>
+      <td>${state}</td>
+      <td class="num">${r.files.toLocaleString("en-GB")}</td>
+      <td class="num ${r.flagged ? "hot" : "muted"}">${r.flagged.toLocaleString("en-GB")}</td>
+      <td class="muted">${esc(r.serverId || "—")}</td>
+      <td class="muted">${esc(r.appVersion || "—")}</td>
+      <td class="muted">${esc(r.updatedAt ? ago(r.updatedAt) : "—")}</td>
+    </tr>`;
+    })
+    .join("")}</tbody></table>`);
+}
+
+function riderLink(accountId: string, name: string, c: Ctx): string {
+  const shown = name || accountId.slice(0, 8);
+  return `<a href="${esc(href(`${ROOT}/rider`, { id: accountId }, c.key))}">${esc(shown)}</a>`;
+}
+
+// ---------------------------------------------------------------------------
+// One rider
+// ---------------------------------------------------------------------------
+
+function riderView(d: RiderDetail, query: SightingQuery, c: Ctx): string {
+  const r = d.rider;
+  const peak = r.worstState && stateRank(r.worstState) > stateRank(r.state) ? r.worstState : r.state;
+  const params: Params = { id: r.accountId, f: query.q, fstate: query.state };
+
+  const body = `
+<section class="panel">
+  <div class="who">
+    <span class="name">${esc(r.riderName || "(no name)")}</span>
+    ${r.state ? `<span class="pill ${esc(peak)}">${esc(r.state)}</span>` : `<span class="muted">never reported</span>`}
+    ${peak !== r.state ? `<span class="muted">peaked at ${esc(peak)} ${esc(ago(r.worstAt))}</span>` : ""}
+  </div>
+  <dl class="facts">
+    ${fact("GUID", r.guid || "—", true)}
+    ${fact("Account", r.accountId, true)}
+    ${fact("Steam", r.steamId || "—", true)}
+    ${fact("Enrolled", r.createdAt ? stamp(r.createdAt) : "—")}
+    ${fact("Last report", r.updatedAt ? `${ago(r.updatedAt)} · ${stamp(r.updatedAt)}` : "never")}
+    ${fact("App", r.appVersion || "—")}
+    ${fact("Modules", `${r.moduleCount} loaded, ${r.unknownCount} unaccounted`)}
+    ${fact("Rules version", r.rulesVersion ? String(r.rulesVersion) : "—")}
+    ${fact("Server now", r.serverId || "—")}
+    ${fact("Files on record", `${r.files.toLocaleString("en-GB")}, ${r.flagged.toLocaleString("en-GB")} flagged`)}
+  </dl>
+  ${
+    d.matched.length
+      ? `<p class="named">Named by rules in the last report: ${named(d.matched, c)}</p>`
+      : ""
+  }
+  ${
+    d.servers.length
+      ? `<p class="muted">Seen on: ${d.servers
+          .map((s) => `<code>${esc(s.serverId)}</code> <span class="muted">${esc(ago(s.lastAt))}</span>`)
+          .join(" · ")}</p>`
+      : ""
+  }
 </section>
 
 <section class="panel">
-  <h2>Rules</h2>
-  ${rules(v.rules, action)}
-  <form class="add" method="post" action="${esc(action)}">
+  <h2>Files this game has loaded</h2>
+  <form class="search" method="get" action="${ROOT}/rider">
+    ${hidden("key", c.key)}${hidden("id", r.accountId)}
+    <input name="f" value="${esc(query.q)}" maxlength="96" placeholder="file name, hash, signer, claim">
+    ${select("fstate", SIGHTING_STATES, query.state, { any: "any state" })}
+    <button type="submit">Filter</button>
+    ${query.q || query.state !== "any" ? `<a class="clear" href="${esc(href(`${ROOT}/rider`, { id: r.accountId }, c.key))}">Clear</a>` : ""}
+  </form>
+  ${count(d.files, "file")}
+  ${sightingTable(d.files.rows, c)}
+  ${pager(`${ROOT}/rider`, params, d.files, c)}
+</section>`;
+
+  return shell(r.riderName || "Rider", "riders", body, c);
+}
+
+function fact(label: string, value: string, mono = false): string {
+  return `<div><dt>${esc(label)}</dt><dd${mono ? ' class="mono"' : ""}>${esc(value)}</dd></div>`;
+}
+
+/** One rider's files. Each row links out to who else has the same file. */
+function sightingTable(rows: Sighting[], c: Ctx): string {
+  if (!rows.length) return `<p class="muted">Nothing recorded.</p>`;
+  return wrap(`<table>
+  <thead><tr><th>File</th><th>Where</th><th>Signed</th><th>Claims</th><th class="num">Size</th>
+    <th>Built</th><th>First</th><th>Last</th><th class="num">Seen</th><th></th></tr></thead>
+  <tbody>${rows
+    .map(
+      (r) => `<tr>
+      <td><span class="dot ${esc(r.state)}"></span>
+        <a href="${esc(href(`${ROOT}/file`, { name: r.name }, c.key))}"><code>${esc(r.name)}</code></a>
+        ${r.label ? `<span class="muted">${esc(r.label)}</span>` : ""}
+        <div><code class="muted">${esc(r.sha256 ? r.sha256.slice(0, 16) : "not read")}</code></div></td>
+      <td class="muted">${esc(r.origin)}</td>
+      <td>${sig(r.trust, r.publisher)}</td>
+      <td class="muted">${esc(claimText(r.description, r.product, r.company) || "—")}</td>
+      <td class="num muted">${esc(bytes(r.size))}</td>
+      <td class="muted">${esc(r.mtime ? ago(r.mtime * 1000) : "—")}</td>
+      <td class="muted">${esc(ago(r.firstAt))}</td>
+      <td class="muted">${esc(ago(r.lastAt))}</td>
+      <td class="num">${r.hits}</td>
+      <td class="act">${ruleForms(
+        r.sha256
+          ? hidden("sha256", r.sha256)
+          : hidden("pattern", r.name),
+        r.label || r.name,
+        c,
+      )}</td>
+    </tr>`,
+    )
+    .join("")}</tbody></table>`);
+}
+
+// ---------------------------------------------------------------------------
+// Files
+// ---------------------------------------------------------------------------
+
+function filesView(found: Paged<FileGroup>, query: FileQuery, c: Ctx): string {
+  const params: Params = {
+    q: query.q,
+    state: query.state,
+    trust: query.trust,
+    origin: query.origin,
+    sort: query.sort,
+    days: query.days,
+  };
+  const filtered =
+    query.q || query.state !== "flagged" || query.trust !== "any" || query.origin !== "any";
+
+  const body = `
+<section class="panel">
+  <form class="search" method="get" action="${ROOT}/files">
+    ${hidden("key", c.key)}
+    <input name="q" value="${esc(query.q)}" maxlength="96" autofocus
+      placeholder="file name, hash, signer, company, product, description">
+    ${select("state", FILE_STATES, query.state, { flagged: "flagged", any: "any state" })}
+    ${select("trust", FILE_TRUSTS, query.trust, { any: "any signature" })}
+    ${select("origin", FILE_ORIGINS, query.origin, { any: "anywhere" })}
+    ${select("sort", FILE_SORTS, query.sort, {
+      state: "worst first",
+      last: "most recent",
+      accounts: "most accounts",
+      hits: "most sightings",
+      name: "name",
+    })}
+    ${select("days", [1, 7, 30, 90, 365], query.days, {}, (d) => `${d}d`)}
+    <button type="submit">Search</button>
+    ${filtered ? `<a class="clear" href="${esc(href(`${ROOT}/files`, {}, c.key))}">Clear</a>` : ""}
+  </form>
+  ${count(found, "file name")}
+  ${fileTable(found.rows, c, true)}
+  ${pager(`${ROOT}/files`, params, found, c)}
+</section>`;
+  return shell("Files", "files", body, c);
+}
+
+function fileTable(rows: FileGroup[], c: Ctx, actions: boolean): string {
+  if (!rows.length) return `<p class="muted">No file matches.</p>`;
+  return wrap(`<table>
+  <thead><tr><th>File</th><th>Signed</th><th>Claims</th><th class="num">Builds</th>
+    <th class="num">Accounts</th><th class="num">Seen</th><th>First</th><th>Last</th>
+    ${actions ? "<th></th>" : ""}</tr></thead>
+  <tbody>${rows
+    .map(
+      (g) => `<tr>
+      <td><span class="dot ${esc(g.state)}"></span>
+        <a href="${esc(href(`${ROOT}/file`, { name: g.name }, c.key))}"><code>${esc(g.name)}</code></a>
+        ${g.label ? `<span class="muted">${esc(g.label)}</span>` : ""}
+        ${g.riderName ? `<span class="muted">— ${esc(g.riderName)}</span>` : ""}</td>
+      <td>${sig(g.trust, g.publisher)}</td>
+      <td class="muted">${esc(g.claims || "—")}</td>
+      <td class="num">${g.variantCount}</td>
+      <td class="num">${g.accounts}</td>
+      <td class="num">${g.hits.toLocaleString("en-GB")}</td>
+      <td class="muted">${esc(ago(g.firstAt))}</td>
+      <td class="muted">${esc(ago(g.lastAt))}</td>
+      ${actions ? `<td class="act">${ruleForms(hidden("pattern", g.name), g.label || g.name, c)}</td>` : ""}
+    </tr>`,
+    )
+    .join("")}</tbody></table>`);
+}
+
+// ---------------------------------------------------------------------------
+// One file, backwards
+// ---------------------------------------------------------------------------
+
+function fileView(d: FileDetail, c: Ctx): string {
+  const params: Params = { name: d.name, sha256: d.sha256 };
+  const body = `
+<section class="panel">
+  <div class="who">
+    <span class="dot ${esc(d.state)}"></span>
+    <span class="name mono">${esc(d.name)}</span>
+    ${d.label ? `<span class="muted">${esc(d.label)}</span>` : ""}
+    ${d.sha256 ? `<span class="muted">one build only</span>
+      <a class="clear" href="${esc(href(`${ROOT}/file`, { name: d.name }, c.key))}">all builds</a>` : ""}
+  </div>
+  <dl class="facts">
+    ${fact("Accounts", d.accounts.toLocaleString("en-GB"))}
+    ${fact("Builds", String(d.variants.length))}
+    ${fact("Sightings", d.hits.toLocaleString("en-GB"))}
+    ${fact("First", `${ago(d.firstAt)} · ${stamp(d.firstAt)}`)}
+    ${fact("Last", `${ago(d.lastAt)} · ${stamp(d.lastAt)}`)}
+  </dl>
+  <div class="act left">${ruleForms(hidden("pattern", d.name), d.label || d.name, c)}
+    <span class="muted">a name rule catches every build, including ones not seen yet</span></div>
+</section>
+
+<section class="panel">
+  <h2>Builds</h2>
+  ${variantTable(d, c)}
+</section>
+
+<section class="panel">
+  <h2>Who has it</h2>
+  ${count(d.holders, "account")}
+  ${holderTable(d.holders.rows, c)}
+  ${pager(`${ROOT}/file`, params, d.holders, c)}
+</section>`;
+  return shell(d.name, "files", body, c);
+}
+
+function variantTable(d: FileDetail, c: Ctx): string {
+  if (!d.variants.length) return `<p class="muted">Nothing recorded.</p>`;
+  return wrap(`<table>
+  <thead><tr><th>Hash</th><th>Where</th><th>Signed</th><th>Claims</th><th class="num">Size</th>
+    <th>Built</th><th class="num">Accounts</th><th class="num">Seen</th><th>Last</th><th></th></tr></thead>
+  <tbody>${d.variants
+    .map((v: FileVariant) => {
+      const only = v.sha256
+        ? `<a href="${esc(href(`${ROOT}/file`, { name: d.name, sha256: v.sha256 }, c.key))}">
+            <code>${esc(v.sha256.slice(0, 16))}</code></a>`
+        : `<code class="muted">not read</code>`;
+      return `<tr>
+      <td><span class="dot ${esc(v.state)}"></span> ${only}</td>
+      <td class="muted">${esc(v.origin)}</td>
+      <td>${sig(v.trust, v.publisher)}</td>
+      <td class="muted">${esc(claimText(v.description, v.product, v.company) || "—")}</td>
+      <td class="num muted">${esc(bytes(v.size))}</td>
+      <td class="muted">${esc(v.mtime ? ago(v.mtime * 1000) : "—")}</td>
+      <td class="num">${v.accounts}</td>
+      <td class="num">${v.hits.toLocaleString("en-GB")}</td>
+      <td class="muted">${esc(ago(v.lastAt))}</td>
+      <td class="act">${ruleForms(
+        v.sha256 ? hidden("sha256", v.sha256) : hidden("pattern", v.name),
+        v.label || v.name,
+        c,
+      )}</td>
+    </tr>`;
+    })
+    .join("")}</tbody></table>`);
+}
+
+/** The reverse lookup: everyone whose game has loaded this file. */
+function holderTable(rows: Sighting[], c: Ctx): string {
+  if (!rows.length) return `<p class="muted">Nobody.</p>`;
+  return wrap(`<table>
+  <thead><tr><th>Rider</th><th>GUID</th><th>Build</th><th>State</th><th>Where</th><th>Server</th>
+    <th>First</th><th>Last</th><th class="num">Seen</th></tr></thead>
+  <tbody>${rows
+    .map(
+      (r) => `<tr>
+      <td>${riderLink(r.accountId, r.riderName, c)}</td>
+      <td><code class="muted">${esc(r.guid || "—")}</code></td>
+      <td><code class="muted">${esc(r.sha256 ? r.sha256.slice(0, 16) : "not read")}</code></td>
+      <td><span class="pill ${esc(r.state)}">${esc(r.state)}</span></td>
+      <td class="muted">${esc(r.origin)}</td>
+      <td class="muted">${esc(r.serverId || "—")}</td>
+      <td class="muted">${esc(ago(r.firstAt))}</td>
+      <td class="muted">${esc(ago(r.lastAt))}</td>
+      <td class="num">${r.hits}</td>
+    </tr>`,
+    )
+    .join("")}</tbody></table>`);
+}
+
+// ---------------------------------------------------------------------------
+// Rules
+// ---------------------------------------------------------------------------
+
+function rulesView(v: AdminView, c: Ctx): string {
+  const body = `
+<section class="panel">
+  <h2>Rules <span class="muted">version ${v.rulesVersion}</span></h2>
+  ${ruleTable(v.rules, c)}
+  <form class="search add" method="post" action="${esc(href(`${ROOT}/rules`, {}, c.key))}">
+    ${hidden("back", `${ROOT}/rules${c.key ? `?key=${encodeURIComponent(c.key)}` : ""}`)}
     <select name="kind" aria-label="kind">
       <option value="deny">deny</option>
       <option value="allow">allow</option>
@@ -158,158 +727,143 @@ function render(v: AdminView, url: URL, days: number): string {
     <input name="note" placeholder="note" maxlength="256">
     <button type="submit">Add</button>
   </form>
-  <p class="muted">A name or a hash, not both. A name matches as a substring, so
-    <code>trainer</code> catches <code>trainer_v3.dll</code>. A hash is exact and survives a
-    rename. Adding a deny rule says the person running that file is cheating — be sure.</p>
-</section>
-
-<footer class="muted">
-  Only clients running the app report, so this says what we have been told and never what is
-  true of everybody. A missing row is the ordinary case, not a suspicious one, and someone
-  who never installs the app never appears here at all.
-  Generated ${esc(new Date().toISOString().replace("T", " ").slice(0, 16))} UTC.
-</footer>
-</body></html>`;
+  <p class="muted">A name or a hash, not both. A name matches as a substring; a hash is exact
+    and survives a rename. A deny rule says the person running that file is cheating.</p>
+</section>`;
+  return shell("Rules", "rules", body, c);
 }
 
-/** The worse of what a client says now and the worst it said inside the window. */
-function worst(row: LiveRow): State {
-  return stateRank(row.worstState) > stateRank(row.state) ? row.worstState : row.state;
-}
-
-function tile(label: string, value: number, hint: string, tone = ""): string {
-  return `<div class="tile ${tone}"><span class="n">${value.toLocaleString("en-GB")}</span>
-    <span class="l">${esc(label)}</span><span class="h">${esc(hint)}</span></div>`;
-}
-
-function live(rows: LiveRow[]): string {
-  if (!rows.length) return `<p class="muted">Nobody is reporting right now.</p>`;
-  return `<table>
-  <thead><tr><th>Rider</th><th>State</th><th>Server</th><th>Found</th>
-    <th class="num">Unaccounted</th><th class="num">Modules</th><th>App</th><th>Seen</th></tr></thead>
-  <tbody>${rows
-    .map((r) => {
-      const now = r.state;
-      const peak = worst(r);
-      const drift = peak !== now ? ` <span class="muted">(was ${esc(peak)})</span>` : "";
-      const found = r.matched.length
-        ? r.matched.map((m) => `<code>${esc(m.label || m.name)}</code>`).join(" ")
-        : `<span class="muted">—</span>`;
-      return `<tr>
-      <td>${esc(r.riderName)}</td>
-      <td><span class="pill ${esc(peak)}">${esc(now)}</span>${drift}</td>
-      <td class="muted">${esc(r.serverId || "—")}</td>
-      <td>${found}</td>
-      <td class="num">${r.unknownCount}</td>
-      <td class="num">${r.moduleCount}</td>
-      <td class="muted">${esc(r.appVersion || "—")}</td>
-      <td class="muted">${esc(ago(r.updatedAt))}</td>
-    </tr>`;
-    })
-    .join("")}</tbody></table>`;
-}
-
-/** Says what the page is not showing, when a cap trimmed it. Silence would read as "all". */
-function trimmed(v: AdminView): string {
-  const shown = v.seen.length;
-  if (v.seenNamesTotal <= shown) return "";
-  return `<p class="warnline">Showing ${shown} of ${v.seenNamesTotal} file names. Clear the
-    ordinary ones and the rest come into view.</p>`;
-}
-
-function sightings(groups: SeenGroup[], action: string): string {
-  if (!groups.length) return `<p class="muted">Nothing unaccounted for in this window.</p>`;
-  return `<table class="seen">
-  <thead><tr><th>File</th><th>Signed</th><th>Claims</th><th class="num">Builds</th>
-    <th class="num">Accounts</th><th class="num">Seen</th><th>Last</th><th></th></tr></thead>
-  <tbody>${groups.map((g) => group(g, action)).join("")}</tbody></table>`;
-}
-
-/**
- * One file name, with its builds folded underneath.
- *
- * `<details>` rather than a script: this page has never had one and is not going to start —
- * see the note at the top. The summary row carries the whole group's answer, so the common
- * case is read without opening anything.
- */
-function group(g: SeenGroup, action: string): string {
-  const label = g.label ? ` <span class="muted">${esc(g.label)}</span>` : "";
-  // Named only when one person has it. With several, naming whichever row sorted first
-  // would read as an accusation of that one.
-  const rider =
-    g.accounts === 1 && g.variants[0]?.riderName
-      ? ` <span class="muted">— ${esc(g.variants[0].riderName)}</span>`
-      : "";
-  const detail =
-    g.variants.length > 0
-      ? `<details><summary class="muted">${g.variants.length} build${
-          g.variants.length === 1 ? "" : "s"
-        }${
-          g.variantCount > g.variants.length ? ` of ${g.variantCount}` : ""
-        }</summary>${variants(g.variants, action)}</details>`
-      : "";
-  return `<tr>
-    <td><span class="pill ${esc(g.state)}"></span> <code>${esc(g.name)}</code>${label}${rider}
-      ${detail}</td>
-    <td>${trust(g.variants)}</td>
-    <td class="muted">${esc(claims(g.variants) || "—")}</td>
-    <td class="num">${g.variantCount}</td>
-    <td class="num">${g.accounts}</td>
-    <td class="num">${g.hits}</td>
-    <td class="muted">${esc(ago(g.lastAt))}</td>
-    <td class="act">${nameButtons(g, action)}</td>
-  </tr>`;
-}
-
-/**
- * The group's signature answer, which is the worst of its builds.
- *
- * One unsigned build under a name whose other builds are signed is exactly the case worth
- * seeing, so the summary must not average it away.
- */
-function trust(variants: SeenVariant[]): string {
-  const rank: Record<Trust, number> = { signed: 0, unchecked: 1, unsigned: 2, untrusted: 3 };
-  let worst: SeenVariant | undefined;
-  for (const v of variants) {
-    if (!worst || rank[v.trust] > rank[worst.trust]) worst = v;
+function ruleTable(rows: ModuleRule[], c: Ctx): string {
+  if (!rows.length) {
+    return `<p class="muted">No rules yet — everything from outside the game reads as
+      unaccounted for until one says otherwise.</p>`;
   }
-  if (!worst) return `<span class="muted">—</span>`;
-  const tone = worst.trust === "signed" ? "" : worst.trust === "unchecked" ? "muted" : "warn";
-  const who = worst.trust === "signed" && worst.publisher ? esc(worst.publisher) : "";
-  return `<span class="sig ${tone}">${esc(worst.trust)}</span>${
-    who ? ` <span class="muted">${who}</span>` : ""
+  return wrap(`<table>
+  <thead><tr><th class="num">#</th><th>Kind</th><th>Matches</th><th>Label</th><th>Note</th>
+    <th></th></tr></thead>
+  <tbody>${rows
+    .map(
+      (r) => `<tr>
+      <td class="num muted">${r.id}</td>
+      <td><span class="pill ${r.kind === "deny" ? "alert" : "ok"}">${esc(r.kind)}</span></td>
+      <td><a href="${esc(
+        href(`${ROOT}/files`, { q: r.pattern || r.sha256, state: "any" }, c.key),
+      )}"><code>${esc(r.pattern || r.sha256)}</code></a></td>
+      <td>${esc(r.label)}</td>
+      <td class="muted">${esc(r.note ?? "")}</td>
+      <td class="act"><form method="post" action="${esc(href(`${ROOT}/rules`, {}, c.key))}">
+        ${hidden("back", c.back)}${hidden("action", "delete")}${hidden("id", String(r.id))}
+        <button type="submit">Remove</button>
+      </form></td>
+    </tr>`,
+    )
+    .join("")}</tbody></table>`);
+}
+
+/** The two buttons that turn a row into a rule, wherever the row is drawn. */
+function ruleForms(by: string, label: string, c: Ctx): string {
+  const one = (kind: string, text: string) => `<form method="post" action="${esc(
+    href(`${ROOT}/rules`, {}, c.key),
+  )}">${by}${hidden("back", c.back)}${hidden("kind", kind)}${hidden("label", label)}
+      <button type="submit" class="${kind}">${text}</button></form>`;
+  return `${one("deny", "Flag")}${one("allow", "Clear")}`;
+}
+
+// ---------------------------------------------------------------------------
+// Bits every view uses
+// ---------------------------------------------------------------------------
+
+function hidden(name: string, value: string): string {
+  return `<input type="hidden" name="${esc(name)}" value="${esc(value)}">`;
+}
+
+function select<T extends string | number>(
+  name: string,
+  options: readonly T[],
+  selected: T,
+  labels: Partial<Record<string, string>>,
+  format: (value: T) => string = (v) => String(v),
+): string {
+  const opts = options
+    .map(
+      (o) =>
+        `<option value="${esc(String(o))}"${o === selected ? " selected" : ""}>${esc(
+          labels[String(o)] ?? format(o),
+        )}</option>`,
+    )
+    .join("");
+  return `<select name="${esc(name)}" aria-label="${esc(name)}">${opts}</select>`;
+}
+
+/** "51–100 of 312 riders" — or "10,000+" where the count stopped counting. */
+function count(found: Paged<unknown>, noun: string): string {
+  const label = `${found.total.toLocaleString("en-GB")}${found.total >= MAX_COUNT ? "+" : ""} ${noun}${
+    found.total === 1 ? "" : "s"
   }`;
-}
-
-/** What the file says it is: the first description or company any build carries. */
-function claims(variants: SeenVariant[]): string {
-  for (const v of variants) {
-    const said = v.description || v.product || v.company;
-    if (said) return v.company && v.company !== said ? `${said} — ${v.company}` : said;
+  const shown = found.rows.length;
+  // A hand-edited `?page=` past the end. Say so, rather than showing an empty table that
+  // reads as "nothing matched".
+  if (!shown) {
+    return found.total
+      ? `<p class="count">Page ${found.page} is past the end — ${label}.</p>`
+      : "";
   }
-  return "";
+  const from = (found.page - 1) * found.size + 1;
+  return `<p class="count">${from.toLocaleString("en-GB")}–${(from + shown - 1).toLocaleString(
+    "en-GB",
+  )} of ${label}</p>`;
 }
 
-function variants(rows: SeenVariant[], action: string): string {
-  return `<table class="sub">
-  <thead><tr><th>Hash</th><th>Where</th><th>Signed</th><th>Claims</th><th class="num">Size</th>
-    <th>Built</th><th class="num">Accounts</th><th></th></tr></thead>
-  <tbody>${rows
-    .map((r) => {
-      const said = [r.description, r.product, r.company].filter(Boolean).join(" · ");
-      const who = r.trust === "signed" && r.publisher ? ` ${esc(r.publisher)}` : "";
-      return `<tr>
-      <td><code class="muted">${esc(r.sha256 ? r.sha256.slice(0, 16) : "not read")}</code></td>
-      <td class="muted">${esc(r.origin)}</td>
-      <td class="muted">${esc(r.trust)}${who}</td>
-      <td class="muted">${esc(said || "—")}</td>
-      <td class="num muted">${esc(bytes(r.size))}</td>
-      <td class="muted">${esc(r.mtime ? ago(r.mtime * 1000) : "—")}</td>
-      <td class="num">${r.accounts}</td>
-      <td class="act">${hashButtons(r, action)}</td>
-    </tr>`;
-    })
-    .join("")}</tbody></table>`;
+/**
+ * Numbered pages, not a scroll that loads as it goes.
+ *
+ * A link to page four has to still be page four tomorrow, and a page of evidence you cannot
+ * link to is not much use to anybody.
+ */
+function pager(path: string, params: Params, found: Paged<unknown>, c: Ctx): string {
+  const pages = Math.max(1, Math.ceil(Math.min(found.total, MAX_COUNT) / found.size));
+  if (pages <= 1) return "";
+
+  // Clamped for the arrows, so a `?page=` past the end still has a way back. The highlight
+  // is not clamped: nothing is marked current when the page asked for does not exist.
+  const at = Math.min(found.page, pages);
+  const here = found.page === at;
+  const first = Math.max(1, Math.min(at - 3, pages - 6));
+  const last = Math.min(pages, first + 6);
+
+  const step = (to: number, text: string, disabled: boolean) =>
+    disabled
+      ? `<span class="off">${text}</span>`
+      : `<a href="${esc(href(path, { ...params, page: to }, c.key))}">${text}</a>`;
+
+  const numbers: string[] = [];
+  for (let p = first; p <= last; p++) {
+    numbers.push(
+      p === at && here
+        ? `<span class="on">${p}</span>`
+        : `<a href="${esc(href(path, { ...params, page: p }, c.key))}">${p}</a>`,
+    );
+  }
+
+  return `<nav class="pages">
+    ${step(1, "First", at === 1 && here)}
+    ${step(at - 1, "‹ Prev", at === 1 && here)}
+    ${numbers.join("")}
+    ${step(at + 1, "Next ›", at === pages)}
+    ${step(pages, "Last", at === pages && here)}
+  </nav>`;
+}
+
+/** A signature, which is Windows' answer, and who it names. */
+function sig(trust: Trust, publisher: string): string {
+  const tone = trust === "signed" ? "" : trust === "unchecked" ? "muted" : "warn";
+  const who = trust === "signed" && publisher ? ` <span class="muted">${esc(publisher)}</span>` : "";
+  return `<span class="sig ${tone}">${esc(trust)}</span>${who}`;
+}
+
+/** Wide tables scroll inside their panel rather than pushing the page sideways. */
+function wrap(table: string): string {
+  return `<div class="scroll">${table}</div>`;
 }
 
 /** A size a person reads, not a byte count. */
@@ -320,69 +874,9 @@ function bytes(size: number): string {
   return `${(size / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-/**
- * The two buttons that turn a whole name into a rule.
- *
- * By name, because that is the unit this row is: it catches every build under it, including
- * the ones the window has not seen yet. A build that needs its own answer has its own
- * buttons inside the row.
- */
-function nameButtons(g: SeenGroup, action: string): string {
-  return ruleForms(
-    `<input type="hidden" name="pattern" value="${esc(g.name)}">`,
-    g.label || g.name,
-    action,
-  );
-}
-
-/**
- * The same two buttons for one build.
- *
- * By hash when there is one, by name when there is not: a hash is what makes a rule survive
- * a rename, and a name is all a file we could not read ever gives us.
- */
-function hashButtons(row: SeenVariant, action: string): string {
-  const by = row.sha256
-    ? `<input type="hidden" name="sha256" value="${esc(row.sha256)}">`
-    : `<input type="hidden" name="pattern" value="${esc(row.name)}">`;
-  return ruleForms(by, row.label || row.name, action);
-}
-
-function ruleForms(by: string, label: string, action: string): string {
-  const one = (kind: string, text: string) => `<form method="post" action="${esc(action)}">
-      ${by}<input type="hidden" name="kind" value="${kind}">
-      <input type="hidden" name="label" value="${esc(label)}">
-      <button type="submit" class="${kind}">${text}</button>
-    </form>`;
-  return `${one("deny", "Flag")}${one("allow", "Clear")}`;
-}
-
-function rules(rows: ModuleRule[], action: string): string {
-  if (!rows.length) {
-    return `<p class="muted">No rules yet — everything from outside the game reads as
-      unaccounted for until one says otherwise.</p>`;
-  }
-  return `<table>
-  <thead><tr><th class="num">#</th><th>Kind</th><th>Matches</th><th>Label</th><th></th></tr></thead>
-  <tbody>${rows
-    .map(
-      (r) => `<tr>
-      <td class="num muted">${r.id}</td>
-      <td><span class="pill ${r.kind === "deny" ? "alert" : "ok"}">${esc(r.kind)}</span></td>
-      <td><code>${esc(r.pattern || r.sha256)}</code></td>
-      <td>${esc(r.label)}</td>
-      <td class="act"><form method="post" action="${esc(action)}">
-        <input type="hidden" name="action" value="delete">
-        <input type="hidden" name="id" value="${r.id}">
-        <button type="submit">Remove</button>
-      </form></td>
-    </tr>`,
-    )
-    .join("")}</tbody></table>`;
-}
-
 /** How long ago, in the coarsest unit that still says something. */
 function ago(at: number): string {
+  if (!at) return "—";
   const secs = Math.max(0, Math.round((Date.now() - at) / 1000));
   if (secs < 90) return `${secs}s ago`;
   const mins = Math.round(secs / 60);
@@ -392,11 +886,17 @@ function ago(at: number): string {
   return `${Math.round(hours / 24)}d ago`;
 }
 
+/** The absolute time, where "3d ago" is not precise enough to act on. */
+function stamp(at: number): string {
+  if (!at) return "—";
+  return new Date(at).toISOString().replace("T", " ").slice(0, 16) + "Z";
+}
+
 function page(status: number, message: string): Response {
   return new Response(
     `<!doctype html><html lang="en"><head><meta charset="utf-8">
-<title>MXB App client diagnostics</title>
-<style>${CSS}</style></head><body><header><h1>Client diagnostics</h1></header>
+<title>MXB App diagnostics</title>
+<style>${CSS}</style></head><body><header><h1>Diagnostics</h1></header>
 <section class="panel"><p>${esc(message)}</p></section></body></html>`,
     { status, headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" } },
   );
@@ -418,59 +918,78 @@ const CSS = `
     --ok:#4fb872;--warn:#e0a53a;--alert:#ff5c4d}
 }
 *{box-sizing:border-box}
-body{margin:0;padding:24px;background:var(--bg);color:var(--ink);
-  font:14px/1.5 ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
-header{display:flex;align-items:baseline;justify-content:space-between;gap:16px;margin-bottom:20px}
-h1{font-size:18px;margin:0;letter-spacing:-.01em}
-h2{font-size:13px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);margin:0 0 12px}
-nav a{color:var(--muted);text-decoration:none;padding:4px 8px;border-radius:6px;margin-left:4px}
-nav a.on{background:var(--accent);color:#fff}
-.tiles{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px;margin-bottom:16px}
-.tile{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:14px;
-  display:flex;flex-direction:column;gap:2px}
+body{margin:0;padding:20px;background:var(--bg);color:var(--ink);
+  font:13px/1.5 ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+a{color:var(--accent);text-decoration:none}
+a:hover{text-decoration:underline}
+header{display:flex;align-items:baseline;justify-content:space-between;gap:16px;margin-bottom:14px}
+h1{font-size:17px;margin:0;letter-spacing:-.01em;overflow-wrap:anywhere}
+h2{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);
+  margin:0 0 10px;display:flex;align-items:baseline;gap:8px}
+h2 .more{margin-left:auto;text-transform:none;letter-spacing:0;font-size:12px}
+header nav a{color:var(--muted);padding:4px 9px;border-radius:6px;margin-left:2px}
+header nav a.on{background:var(--accent);color:#fff}
+header nav a.on:hover{text-decoration:none}
+.ranges{margin:0 0 12px}
+.ranges a{color:var(--muted);padding:3px 8px;border-radius:6px;margin-right:2px;font-size:12px}
+.ranges a.on{background:var(--accent);color:#fff}
+.tiles{display:grid;grid-template-columns:repeat(auto-fit,minmax(130px,1fr));gap:10px;margin-bottom:14px}
+.tile{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:12px;
+  display:flex;flex-direction:column;gap:1px}
 .tile.alert{border-color:var(--alert)}
 .tile.warn{border-color:var(--warn)}
-.tile .n{font-size:26px;font-weight:600;letter-spacing:-.02em}
-.tile .l{font-size:13px}
+.tile .n{font-size:24px;font-weight:600;letter-spacing:-.02em}
+.tile .l{font-size:12px}
 .tile .h,.muted{color:var(--muted);font-size:12px}
-.panel{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:16px;margin-bottom:16px}
+.panel{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:14px;
+  margin-bottom:14px}
+.scroll{overflow-x:auto}
 table{width:100%;border-collapse:collapse}
 th{text-align:left;font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);
-  font-weight:500;padding:0 8px 8px;border-bottom:1px solid var(--line)}
-td{padding:7px 8px;border-bottom:1px solid var(--line);vertical-align:top}
+  font-weight:500;padding:0 8px 7px;border-bottom:1px solid var(--line);white-space:nowrap}
+td{padding:6px 8px;border-bottom:1px solid var(--line);vertical-align:top}
 tr:last-child td{border-bottom:0}
-.num{text-align:right;font-variant-numeric:tabular-nums}
+.num{text-align:right;font-variant-numeric:tabular-nums;white-space:nowrap}
+.num.hot{color:var(--warn);font-weight:600}
 .act{text-align:right;white-space:nowrap}
+.act.left{text-align:left;margin-top:10px;display:flex;align-items:center;gap:8px}
 .act form{display:inline}
-code{font:12px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace}
-.pill{display:inline-block;min-width:10px;padding:1px 7px;border-radius:99px;font-size:11px;
+code,.mono{font:12px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;overflow-wrap:anywhere}
+.pill{display:inline-block;min-width:9px;padding:1px 7px;border-radius:99px;font-size:11px;
   color:#fff;background:var(--muted)}
 .pill.ok{background:var(--ok)}
 .pill.warn{background:var(--warn)}
 .pill.alert{background:var(--alert)}
+.dot{display:inline-block;width:8px;height:8px;border-radius:99px;background:var(--muted);
+  vertical-align:baseline}
+.dot.ok{background:var(--ok)}
+.dot.warn{background:var(--warn)}
+.dot.alert{background:var(--alert)}
+.tag{display:inline-block;padding:1px 7px;border-radius:99px;font-size:11px;
+  border:1px solid var(--line)}
+.sig{font-size:12px}
+.sig.warn{color:var(--warn);font-weight:600}
 button{font:inherit;font-size:12px;padding:3px 10px;border-radius:6px;border:1px solid var(--line);
   background:var(--panel);color:var(--ink);cursor:pointer;margin-left:4px}
 button.deny{border-color:var(--alert);color:var(--alert)}
 button.allow{border-color:var(--ok);color:var(--ok)}
-.add{display:flex;flex-wrap:wrap;gap:8px;margin-top:14px}
-.add input,.add select{font:inherit;font-size:13px;padding:4px 8px;border-radius:6px;
-  border:1px solid var(--line);background:var(--bg);color:var(--ink);min-width:120px}
-.add input[name="sha256"]{min-width:260px}
-footer{color:var(--muted);font-size:12px;margin-top:8px;max-width:70ch}
-
-/* One file name, with its builds folded under it. */
-.warnline{color:var(--warn);font-size:12px;margin:0 0 12px}
-.sig{font-size:12px}
-.sig.warn{color:var(--warn);font-weight:600}
-details{margin-top:4px}
-summary{cursor:pointer;font-size:12px;list-style:none}
-summary::-webkit-details-marker{display:none}
-summary::before{content:"\\25b8 ";display:inline-block;transition:transform .1s}
-details[open] summary::before{content:"\\25be "}
-/* The nested table is inside a cell, so it gets its own frame to sit apart from the row. */
-table.sub{margin:8px 0 4px;background:var(--bg);border:1px solid var(--line);border-radius:8px}
-table.sub th{padding:6px 8px 6px}
-table.sub td{padding:5px 8px;font-size:12px}
-table.sub tr:last-child td{border-bottom:0}
-table.seen>tbody>tr>td{vertical-align:top}
+.search{display:flex;flex-wrap:wrap;gap:8px;align-items:center;margin:0 0 12px}
+.search input,.search select{font:inherit;font-size:13px;padding:5px 8px;border-radius:6px;
+  border:1px solid var(--line);background:var(--bg);color:var(--ink)}
+.search input[name="q"],.search input[name="f"]{flex:1 1 280px;min-width:200px}
+.search .clear{font-size:12px;color:var(--muted)}
+.add input[name="sha256"]{min-width:240px}
+.count{color:var(--muted);font-size:12px;margin:0 0 8px}
+.who{display:flex;flex-wrap:wrap;align-items:center;gap:8px;margin-bottom:12px}
+.who .name{font-size:16px;font-weight:600;overflow-wrap:anywhere}
+.facts{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:10px 16px;margin:0}
+.facts dt{font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}
+.facts dd{margin:1px 0 0;overflow-wrap:anywhere}
+.named{margin:12px 0 0}
+.pages{display:flex;flex-wrap:wrap;gap:4px;align-items:center;margin-top:12px;font-size:12px}
+.pages a,.pages span{padding:3px 9px;border-radius:6px;border:1px solid var(--line);color:var(--muted)}
+.pages a{color:var(--ink)}
+.pages .on{background:var(--accent);color:#fff;border-color:var(--accent)}
+.pages .off{opacity:.4}
+footer{color:var(--muted);font-size:12px;margin-top:4px;max-width:70ch}
 `;

--- a/control-plane/src/diagnosticssearch.ts
+++ b/control-plane/src/diagnosticssearch.ts
@@ -1,0 +1,783 @@
+/**
+ * Reading the diagnostics log rather than only the top of it.
+ *
+ * `diagnostics.ts` takes reports in and decides what they mean. This takes the questions out:
+ * find a rider and everything their game has ever loaded, find a file by anything it says
+ * about itself, and take one file and list who has it. Same tables, no new facts.
+ *
+ * Every list is a page — an offset, a fixed size and a total — because the answer to "who
+ * has this" is one row or nine hundred and the page has to read the same either way.
+ */
+
+import { isState, isTrust, parseMatched, type Matched, type State, type Trust } from "./diagnostics";
+import { PRESENCE_TTL_MS } from "./validate";
+
+/** Rows per page. One screen of a dense table, and one D1 read. */
+export const PAGE_SIZE = 50;
+
+/** The most rows a count query will count exactly. Past it the page says "10,000+". */
+export const MAX_COUNT = 10_000;
+
+const DAY_MS = 86_400_000;
+
+export interface Paged<T> {
+  rows: T[];
+  /** Matching rows, counted up to `MAX_COUNT`. */
+  total: number;
+  /** 1-based. */
+  page: number;
+  size: number;
+}
+
+/** `?page=` as a 1-based page number. Anything unusable is page 1. */
+export function parsePage(value: string | null): number {
+  const asked = Number(value ?? "1");
+  if (!Number.isFinite(asked)) return 1;
+  return Math.min(10_000, Math.max(1, Math.trunc(asked)));
+}
+
+/**
+ * A search box turned into a LIKE pattern.
+ *
+ * `%` and `_` are wildcards and `\` is the escape, so someone searching `nvidia_share` gets
+ * the underscore they typed rather than any character. Empty stays empty, which every caller
+ * reads as "no filter".
+ */
+export function likeTerm(query: string): string {
+  const trimmed = query.trim().slice(0, 96);
+  if (!trimmed) return "";
+  return `%${trimmed.replace(/[\\%_]/g, (c) => `\\${c}`)}%`;
+}
+
+/** A window in days, clamped to something a page can draw. */
+export function clampDays(value: string | null, fallback = 30): number {
+  const asked = Number(value ?? String(fallback));
+  if (!Number.isFinite(asked)) return fallback;
+  return Math.min(365, Math.max(1, Math.trunc(asked)));
+}
+
+/** One of a fixed set, or the first of them. Keeps a query string out of the SQL. */
+export function oneOf<T extends string>(value: string | null, allowed: readonly T[]): T {
+  return allowed.find((a) => a === value) ?? allowed[0];
+}
+
+/** Worst-first ordering for a state column, as SQL. */
+function stateRankSql(column: string): string {
+  return `CASE ${column} WHEN 'alert' THEN 3 WHEN 'warn' THEN 2 WHEN 'ok' THEN 1 ELSE 0 END`;
+}
+
+/** The same for trust: an unsigned build under an otherwise signed name is the interesting one. */
+function trustRankSql(column: string): string {
+  return `CASE ${column} WHEN 'untrusted' THEN 3 WHEN 'unsigned' THEN 2 WHEN 'unchecked' THEN 1 ELSE 0 END`;
+}
+
+const STATE_BY_RANK: State[] = ["unknown", "ok", "warn", "alert"];
+const TRUST_BY_RANK: Trust[] = ["signed", "unchecked", "unsigned", "untrusted"];
+
+// ---------------------------------------------------------------------------
+// Riders
+// ---------------------------------------------------------------------------
+
+export const RIDER_STATES = ["any", "alert", "warn", "ok", "unknown", "quiet"] as const;
+export const RIDER_SORTS = ["seen", "state", "name", "unaccounted"] as const;
+
+export interface RiderQuery {
+  q: string;
+  state: (typeof RIDER_STATES)[number];
+  sort: (typeof RIDER_SORTS)[number];
+  days: number;
+  page: number;
+}
+
+export function parseRiderQuery(url: URL): RiderQuery {
+  return {
+    q: (url.searchParams.get("q") ?? "").trim().slice(0, 96),
+    state: oneOf(url.searchParams.get("state"), RIDER_STATES),
+    sort: oneOf(url.searchParams.get("sort"), RIDER_SORTS),
+    days: clampDays(url.searchParams.get("days")),
+    page: parsePage(url.searchParams.get("page")),
+  };
+}
+
+/** A rider as the search lists them: who they are, and what their game last looked like. */
+export interface RiderRow {
+  accountId: string;
+  riderName: string;
+  guid: string;
+  steamId: string;
+  createdAt: number;
+  /** Empty when the account has never reported — which is not the same as "ok". */
+  state: State | "";
+  worstState: State | "";
+  worstAt: number;
+  rulesVersion: number;
+  moduleCount: number;
+  unknownCount: number;
+  appVersion: string;
+  updatedAt: number;
+  /** Where they are now, while their app is still reporting presence. */
+  serverId: string;
+  /** The last server their files were recorded on, which outlives presence. */
+  lastServerId: string;
+  /** Distinct files ever recorded for this account, and how many are unaccounted for. */
+  files: number;
+  flagged: number;
+}
+
+interface RiderRecord {
+  id: string;
+  rider_name: string;
+  guid: string | null;
+  steam_id: string | null;
+  created_at: number;
+  state: string | null;
+  worst_state: string | null;
+  worst_at: number | null;
+  rules_version: number | null;
+  module_count: number | null;
+  unknown_count: number | null;
+  app_version: string | null;
+  updated_at: number | null;
+  server_id: string | null;
+}
+
+/** The columns every rider read shares. The presence subquery binds first — it is first in the text. */
+const RIDER_COLUMNS =
+  "a.id, a.rider_name, a.guid, a.steam_id, a.created_at, c.state, c.worst_state," +
+  " c.worst_at, c.rules_version, c.module_count, c.unknown_count, c.app_version," +
+  " c.updated_at," +
+  " (SELECT p.server_id FROM presence p WHERE p.account_id = a.id AND p.updated_at > ?)" +
+  "  AS server_id";
+
+/**
+ * The rider search.
+ *
+ * Driven from `accounts` rather than from the reports, so somebody who has never run the
+ * game still answers a search for their name. "No report" is an answer; a page that omitted
+ * them would read as "not enrolled".
+ */
+export async function searchRiders(env: Env, query: RiderQuery): Promise<Paged<RiderRow>> {
+  const fresh = Date.now() - PRESENCE_TTL_MS;
+  const since = Date.now() - query.days * DAY_MS;
+  const where: string[] = [];
+  const args: unknown[] = [];
+
+  const term = likeTerm(query.q);
+  if (term) {
+    // Everything that identifies a person: the name they ride under, the GUID the game
+    // publishes to every server, the Steam id, and the account id itself.
+    where.push(
+      "(a.rider_name LIKE ? ESCAPE '\\' OR a.guid LIKE ? ESCAPE '\\'" +
+        " OR a.steam_id LIKE ? ESCAPE '\\' OR a.id LIKE ? ESCAPE '\\')",
+    );
+    args.push(term, term, term, term);
+  }
+
+  if (query.state === "quiet") {
+    where.push("(c.account_id IS NULL OR c.updated_at <= ?)");
+    args.push(since);
+  } else if (query.state !== "any") {
+    // The worse of what they say now and the peak inside the live window — the same reading
+    // the live table uses, so something unloaded mid-session still answers a search.
+    where.push("(c.state = ? OR (c.worst_at > ? AND c.worst_state = ?)) AND c.updated_at > ?");
+    args.push(query.state, fresh, query.state, since);
+  }
+
+  const from = " FROM accounts a LEFT JOIN client_modules c ON c.account_id = a.id" +
+    (where.length ? ` WHERE ${where.join(" AND ")}` : "");
+
+  const order =
+    query.sort === "name"
+      ? " ORDER BY a.rider_name COLLATE NOCASE ASC"
+      : query.sort === "state"
+        ? ` ORDER BY ${stateRankSql("COALESCE(c.worst_state, c.state, '')")} DESC,` +
+          " COALESCE(c.updated_at, 0) DESC"
+        : query.sort === "unaccounted"
+          ? " ORDER BY COALESCE(c.unknown_count, 0) DESC, COALESCE(c.updated_at, 0) DESC"
+          : " ORDER BY COALESCE(c.updated_at, 0) DESC, a.created_at DESC";
+
+  const total = await env.DB.prepare(
+    `SELECT COUNT(*) AS n FROM (SELECT a.id${from} LIMIT ${MAX_COUNT})`,
+  )
+    .bind(...args)
+    .first<{ n: number }>();
+
+  const found = await env.DB.prepare(
+    `SELECT ${RIDER_COLUMNS}${from}${order} LIMIT ? OFFSET ?`,
+  )
+    // The presence subquery is the first `?` in the text, so it binds first.
+    .bind(fresh, ...args, PAGE_SIZE, (query.page - 1) * PAGE_SIZE)
+    .all<RiderRecord>();
+
+  const rows = (found.results ?? []).map(riderRow);
+  await attachFileCounts(env, rows);
+  return { rows, total: total?.n ?? rows.length, page: query.page, size: PAGE_SIZE };
+}
+
+function riderRow(r: RiderRecord): RiderRow {
+  const fresh = Date.now() - PRESENCE_TTL_MS;
+  return {
+    accountId: r.id,
+    riderName: r.rider_name,
+    guid: r.guid ?? "",
+    steamId: r.steam_id ?? "",
+    createdAt: r.created_at,
+    state: isState(r.state) ? r.state : "",
+    // Only while it is still inside the live window: past that the live row has forgotten
+    // what the peak was about.
+    worstState: (r.worst_at ?? 0) > fresh && isState(r.worst_state) ? r.worst_state : "",
+    worstAt: r.worst_at ?? 0,
+    rulesVersion: r.rules_version ?? 0,
+    moduleCount: r.module_count ?? 0,
+    unknownCount: r.unknown_count ?? 0,
+    appVersion: r.app_version ?? "",
+    updatedAt: r.updated_at ?? 0,
+    serverId: r.server_id ?? "",
+    lastServerId: "",
+    files: 0,
+    flagged: 0,
+  };
+}
+
+/**
+ * File counts for a page of riders, in one read.
+ *
+ * A correlated subquery per row would be fifty scans of the sightings table to draw one
+ * page. This is one grouped read over the accounts actually on screen.
+ */
+async function attachFileCounts(env: Env, rows: RiderRow[]): Promise<void> {
+  if (!rows.length) return;
+  const ids = rows.map((r) => r.accountId);
+  const counts = await env.DB.prepare(
+    "SELECT account_id, COUNT(*) AS files," +
+      " SUM(CASE WHEN state IN ('warn','alert') THEN 1 ELSE 0 END) AS flagged" +
+      ` FROM client_module_seen WHERE account_id IN (${ids.map(() => "?").join(",")})` +
+      " GROUP BY account_id",
+  )
+    .bind(...ids)
+    .all<{ account_id: string; files: number; flagged: number }>();
+
+  const byId = new Map((counts.results ?? []).map((c) => [c.account_id, c]));
+  for (const row of rows) {
+    row.files = byId.get(row.accountId)?.files ?? 0;
+    row.flagged = byId.get(row.accountId)?.flagged ?? 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// One rider
+// ---------------------------------------------------------------------------
+
+/** One file as it was seen on one machine — what the rider page and the reverse lookup share. */
+export interface Sighting {
+  accountId: string;
+  riderName: string;
+  guid: string;
+  name: string;
+  sha256: string;
+  origin: string;
+  state: State;
+  label: string;
+  trust: Trust;
+  publisher: string;
+  company: string;
+  product: string;
+  description: string;
+  size: number;
+  mtime: number;
+  serverId: string;
+  firstAt: number;
+  lastAt: number;
+  hits: number;
+}
+
+interface SightingRecord {
+  account_id: string;
+  rider_name: string;
+  guid?: string | null;
+  name: string;
+  sha256: string;
+  origin: string;
+  state: string;
+  label: string;
+  trust: string;
+  publisher: string;
+  company: string;
+  product: string;
+  description: string;
+  size: number;
+  mtime: number;
+  server_id: string;
+  first_at: number;
+  last_at: number;
+  hits: number;
+}
+
+function sighting(r: SightingRecord): Sighting {
+  return {
+    accountId: r.account_id,
+    riderName: r.rider_name ?? "",
+    guid: r.guid ?? "",
+    name: r.name,
+    sha256: r.sha256 ?? "",
+    origin: r.origin ?? "",
+    state: isState(r.state) ? r.state : "unknown",
+    label: r.label ?? "",
+    trust: isTrust(r.trust) ? r.trust : "unchecked",
+    publisher: r.publisher ?? "",
+    company: r.company ?? "",
+    product: r.product ?? "",
+    description: r.description ?? "",
+    size: r.size ?? 0,
+    mtime: r.mtime ?? 0,
+    serverId: r.server_id ?? "",
+    firstAt: r.first_at ?? 0,
+    lastAt: r.last_at ?? 0,
+    hits: r.hits ?? 0,
+  };
+}
+
+export interface RiderDetail {
+  rider: RiderRow;
+  /** What the rules named in their last report. */
+  matched: Matched[];
+  files: Paged<Sighting>;
+  /** Distinct servers they have been recorded on, most recent first. */
+  servers: { serverId: string; lastAt: number }[];
+}
+
+export const SIGHTING_STATES = ["any", "alert", "warn", "ok", "unknown"] as const;
+
+export interface SightingQuery {
+  q: string;
+  state: (typeof SIGHTING_STATES)[number];
+  page: number;
+}
+
+export function parseSightingQuery(url: URL): SightingQuery {
+  return {
+    q: (url.searchParams.get("f") ?? "").trim().slice(0, 96),
+    state: oneOf(url.searchParams.get("fstate"), SIGHTING_STATES),
+    page: parsePage(url.searchParams.get("page")),
+  };
+}
+
+/** Everything known about one rider, and a page of the files their game has loaded. */
+export async function riderDetail(
+  env: Env,
+  who: string,
+  query: SightingQuery,
+): Promise<RiderDetail | null> {
+  const fresh = Date.now() - PRESENCE_TTL_MS;
+  // Account id, GUID or rider name, because all three are things you have in your hand when
+  // you come to look someone up.
+  const record = await env.DB.prepare(
+    `SELECT ${RIDER_COLUMNS}, c.matched` +
+      " FROM accounts a LEFT JOIN client_modules c ON c.account_id = a.id" +
+      " WHERE a.id = ? OR a.guid = ? OR lower(a.rider_name) = lower(?) LIMIT 1",
+  )
+    .bind(fresh, who, who, who)
+    .first<RiderRecord & { matched: string | null }>();
+  if (!record) return null;
+
+  const rider = riderRow(record);
+  await attachFileCounts(env, [rider]);
+
+  const where = ["account_id = ?"];
+  const args: unknown[] = [rider.accountId];
+  const term = likeTerm(query.q);
+  if (term) {
+    where.push(
+      "(name LIKE ? ESCAPE '\\' OR sha256 LIKE ? ESCAPE '\\'" +
+        " OR publisher LIKE ? ESCAPE '\\' OR company LIKE ? ESCAPE '\\'" +
+        " OR product LIKE ? ESCAPE '\\' OR description LIKE ? ESCAPE '\\')",
+    );
+    args.push(term, term, term, term, term, term);
+  }
+  if (query.state !== "any") {
+    where.push("state = ?");
+    args.push(query.state);
+  }
+  const filter = ` WHERE ${where.join(" AND ")}`;
+
+  const [total, files, servers] = await Promise.all([
+    env.DB.prepare(`SELECT COUNT(*) AS n FROM client_module_seen${filter}`)
+      .bind(...args)
+      .first<{ n: number }>(),
+    env.DB.prepare(
+      "SELECT account_id, rider_name, name, sha256, origin, state, label, trust, publisher," +
+        " company, product, description, size, mtime, server_id, first_at, last_at, hits" +
+        ` FROM client_module_seen${filter}` +
+        ` ORDER BY ${stateRankSql("state")} DESC, last_at DESC LIMIT ? OFFSET ?`,
+    )
+      .bind(...args, PAGE_SIZE, (query.page - 1) * PAGE_SIZE)
+      .all<SightingRecord>(),
+    env.DB.prepare(
+      "SELECT server_id, MAX(last_at) AS last_at FROM client_module_seen" +
+        " WHERE account_id = ? AND server_id <> '' GROUP BY server_id" +
+        " ORDER BY MAX(last_at) DESC LIMIT 12",
+    )
+      .bind(rider.accountId)
+      .all<{ server_id: string; last_at: number }>(),
+  ]);
+
+  const seenServers = (servers.results ?? []).map((s) => ({
+    serverId: s.server_id,
+    lastAt: s.last_at,
+  }));
+  rider.lastServerId = seenServers[0]?.serverId ?? "";
+
+  return {
+    rider,
+    matched: parseMatched(record.matched ?? ""),
+    files: {
+      rows: (files.results ?? []).map(sighting),
+      total: total?.n ?? 0,
+      page: query.page,
+      size: PAGE_SIZE,
+    },
+    servers: seenServers,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Files
+// ---------------------------------------------------------------------------
+
+export const FILE_STATES = ["flagged", "any", "alert", "warn", "ok"] as const;
+export const FILE_TRUSTS = ["any", "signed", "unsigned", "untrusted", "unchecked"] as const;
+export const FILE_ORIGINS = ["any", "game", "app", "other"] as const;
+export const FILE_SORTS = ["state", "last", "accounts", "hits", "name"] as const;
+
+export interface FileQuery {
+  q: string;
+  state: (typeof FILE_STATES)[number];
+  trust: (typeof FILE_TRUSTS)[number];
+  origin: (typeof FILE_ORIGINS)[number];
+  sort: (typeof FILE_SORTS)[number];
+  days: number;
+  page: number;
+}
+
+export function parseFileQuery(url: URL): FileQuery {
+  return {
+    q: (url.searchParams.get("q") ?? "").trim().slice(0, 96),
+    state: oneOf(url.searchParams.get("state"), FILE_STATES),
+    trust: oneOf(url.searchParams.get("trust"), FILE_TRUSTS),
+    origin: oneOf(url.searchParams.get("origin"), FILE_ORIGINS),
+    sort: oneOf(url.searchParams.get("sort"), FILE_SORTS),
+    days: clampDays(url.searchParams.get("days")),
+    page: parsePage(url.searchParams.get("page")),
+  };
+}
+
+/** One distinct build of a file, folded across everyone who has it. */
+export interface FileVariant {
+  name: string;
+  sha256: string;
+  origin: string;
+  state: State;
+  label: string;
+  trust: Trust;
+  publisher: string;
+  company: string;
+  product: string;
+  description: string;
+  size: number;
+  mtime: number;
+  /** Only when exactly one account has it: naming one of several would accuse them. */
+  riderName: string;
+  accounts: number;
+  hits: number;
+  firstAt: number;
+  lastAt: number;
+}
+
+/** Every build sharing a file name — the unit a rule is written against. */
+export interface FileGroup {
+  name: string;
+  state: State;
+  label: string;
+  trust: Trust;
+  publisher: string;
+  claims: string;
+  accounts: number;
+  hits: number;
+  firstAt: number;
+  lastAt: number;
+  variantCount: number;
+  riderName: string;
+}
+
+interface GroupRecord {
+  name: string;
+  accounts: number;
+  variants: number;
+  hits: number;
+  first_at: number;
+  last_at: number;
+  state_rank: number;
+  trust_rank: number;
+  label: string | null;
+  publisher: string | null;
+  company: string | null;
+  product: string | null;
+  description: string | null;
+  rider_name: string | null;
+}
+
+/**
+ * The grouped columns, shared by the file search and one file's build list.
+ *
+ * The worst state and the worst signature come out of a ranked aggregate rather than a
+ * correlated subquery: it respects whatever filter the caller applied, and averaging would
+ * hide the odd build out, which is the one worth seeing.
+ */
+const GROUP_COLUMNS =
+  "COUNT(DISTINCT account_id) AS accounts, COUNT(DISTINCT sha256) AS variants," +
+  " SUM(hits) AS hits, MIN(first_at) AS first_at, MAX(last_at) AS last_at," +
+  ` MAX(${stateRankSql("state")}) AS state_rank, MAX(${trustRankSql("trust")}) AS trust_rank,` +
+  " MAX(label) AS label, MAX(publisher) AS publisher, MAX(company) AS company," +
+  " MAX(product) AS product, MAX(description) AS description, MAX(rider_name) AS rider_name";
+
+function fileFilter(query: FileQuery): { sql: string; args: unknown[] } {
+  const where = ["last_at > ?"];
+  const args: unknown[] = [Date.now() - query.days * DAY_MS];
+
+  const term = likeTerm(query.q);
+  if (term) {
+    // Name, hash, who signed it, and everything it claims about itself — one box, because
+    // remembering which field a half-remembered string came from is the hard part.
+    where.push(
+      "(name LIKE ? ESCAPE '\\' OR sha256 LIKE ? ESCAPE '\\'" +
+        " OR publisher LIKE ? ESCAPE '\\' OR company LIKE ? ESCAPE '\\'" +
+        " OR product LIKE ? ESCAPE '\\' OR description LIKE ? ESCAPE '\\'" +
+        " OR label LIKE ? ESCAPE '\\')",
+    );
+    args.push(term, term, term, term, term, term, term);
+  }
+  if (query.state === "flagged") where.push("state IN ('warn','alert')");
+  else if (query.state !== "any") {
+    where.push("state = ?");
+    args.push(query.state);
+  }
+  if (query.trust !== "any") {
+    where.push("trust = ?");
+    args.push(query.trust);
+  }
+  if (query.origin !== "any") {
+    where.push("origin = ?");
+    args.push(query.origin);
+  }
+  return { sql: ` WHERE ${where.join(" AND ")}`, args };
+}
+
+function fileGroup(g: GroupRecord): FileGroup {
+  return {
+    name: g.name,
+    state: STATE_BY_RANK[g.state_rank] ?? "unknown",
+    label: g.label ?? "",
+    trust: TRUST_BY_RANK[g.trust_rank] ?? "unchecked",
+    publisher: g.publisher ?? "",
+    claims: claimText(g.description ?? "", g.product ?? "", g.company ?? ""),
+    accounts: g.accounts,
+    hits: g.hits,
+    firstAt: g.first_at,
+    lastAt: g.last_at,
+    variantCount: g.variants,
+    riderName: g.accounts === 1 ? (g.rider_name ?? "") : "",
+  };
+}
+
+/**
+ * The file search: one row per file name, however many people have it.
+ *
+ * Grouped in SQL because a driver loaded by six hundred people is six hundred rows that say
+ * the same thing, and the name is what a rule is written against anyway.
+ */
+export async function searchFiles(env: Env, query: FileQuery): Promise<Paged<FileGroup>> {
+  const { sql, args } = fileFilter(query);
+
+  const order =
+    query.sort === "accounts"
+      ? " ORDER BY accounts DESC, last_at DESC"
+      : query.sort === "name"
+        ? " ORDER BY name ASC"
+        : query.sort === "hits"
+          ? " ORDER BY hits DESC, last_at DESC"
+          : query.sort === "last"
+            ? " ORDER BY last_at DESC"
+            : " ORDER BY state_rank DESC, last_at DESC";
+
+  const [total, found] = await Promise.all([
+    env.DB.prepare(
+      `SELECT COUNT(*) AS n FROM (SELECT name FROM client_module_seen${sql}` +
+        ` GROUP BY name LIMIT ${MAX_COUNT})`,
+    )
+      .bind(...args)
+      .first<{ n: number }>(),
+    env.DB.prepare(
+      `SELECT name, ${GROUP_COLUMNS} FROM client_module_seen${sql}` +
+        ` GROUP BY name${order} LIMIT ? OFFSET ?`,
+    )
+      .bind(...args, PAGE_SIZE, (query.page - 1) * PAGE_SIZE)
+      .all<GroupRecord>(),
+  ]);
+
+  const rows = (found.results ?? []).map(fileGroup);
+  return { rows, total: total?.n ?? rows.length, page: query.page, size: PAGE_SIZE };
+}
+
+/** What a file says it is, in one line. Text off a file, never evidence. */
+export function claimText(description: string, product: string, company: string): string {
+  const said = description || product || company;
+  if (!said) return "";
+  return company && company !== said ? `${said} — ${company}` : said;
+}
+
+// ---------------------------------------------------------------------------
+// One file, backwards
+// ---------------------------------------------------------------------------
+
+export interface FileDetail {
+  name: string;
+  /** Set when the page was narrowed to one build. */
+  sha256: string;
+  state: State;
+  label: string;
+  accounts: number;
+  hits: number;
+  firstAt: number;
+  lastAt: number;
+  variants: FileVariant[];
+  /** Who has loaded it. The reverse lookup this page exists for. */
+  holders: Paged<Sighting>;
+}
+
+/** The most builds drawn under one name. Past it the holders list still tells the story. */
+const MAX_VARIANTS = 100;
+
+/**
+ * One file name, and everyone whose game has loaded it.
+ *
+ * `sha256` narrows both halves to a single build, which is what a rule written by hash
+ * covers: the two questions are "what is this file" and "who has this exact file".
+ */
+export async function fileDetail(
+  env: Env,
+  name: string,
+  sha256: string,
+  page: number,
+): Promise<FileDetail | null> {
+  const narrow = sha256 ? " AND sha256 = ?" : "";
+  const key: unknown[] = sha256 ? [name, sha256] : [name];
+
+  const [summary, variants, total, holders] = await Promise.all([
+    env.DB.prepare(
+      `SELECT name, ${GROUP_COLUMNS} FROM client_module_seen WHERE name = ?${narrow}`,
+    )
+      .bind(...key)
+      .first<GroupRecord>(),
+    env.DB.prepare(
+      `SELECT name, sha256, MAX(origin) AS origin, MAX(size) AS size, MAX(mtime) AS mtime,` +
+        ` ${GROUP_COLUMNS} FROM client_module_seen WHERE name = ?${narrow}` +
+        ` GROUP BY sha256 ORDER BY state_rank DESC, last_at DESC LIMIT ${MAX_VARIANTS}`,
+    )
+      .bind(...key)
+      .all<GroupRecord & { sha256: string; origin: string; size: number; mtime: number }>(),
+    env.DB.prepare(`SELECT COUNT(*) AS n FROM client_module_seen WHERE name = ?${narrow}`)
+      .bind(...key)
+      .first<{ n: number }>(),
+    env.DB.prepare(
+      "SELECT s.account_id, s.rider_name, a.guid, s.name, s.sha256, s.origin, s.state," +
+        " s.label, s.trust, s.publisher, s.company, s.product, s.description, s.size," +
+        " s.mtime, s.server_id, s.first_at, s.last_at, s.hits" +
+        " FROM client_module_seen s LEFT JOIN accounts a ON a.id = s.account_id" +
+        ` WHERE s.name = ?${sha256 ? " AND s.sha256 = ?" : ""}` +
+        ` ORDER BY ${stateRankSql("s.state")} DESC, s.last_at DESC LIMIT ? OFFSET ?`,
+    )
+      .bind(...key, PAGE_SIZE, (page - 1) * PAGE_SIZE)
+      .all<SightingRecord>(),
+  ]);
+
+  // An aggregate over no rows still returns one row, of nulls. That is the "not found" case.
+  if (!summary || !summary.accounts) return null;
+  const group = fileGroup({ ...summary, name });
+
+  return {
+    name,
+    sha256,
+    state: group.state,
+    label: group.label,
+    accounts: group.accounts,
+    hits: group.hits,
+    firstAt: group.firstAt,
+    lastAt: group.lastAt,
+    variants: (variants.results ?? []).map<FileVariant>((v) => {
+      const folded = fileGroup({ ...v, name });
+      return {
+        name,
+        sha256: v.sha256 ?? "",
+        origin: v.origin ?? "",
+        state: folded.state,
+        label: folded.label,
+        trust: folded.trust,
+        publisher: folded.publisher,
+        company: v.company ?? "",
+        product: v.product ?? "",
+        description: v.description ?? "",
+        size: v.size ?? 0,
+        mtime: v.mtime ?? 0,
+        riderName: folded.riderName,
+        accounts: folded.accounts,
+        hits: folded.hits,
+        firstAt: folded.firstAt,
+        lastAt: folded.lastAt,
+      };
+    }),
+    holders: {
+      rows: (holders.results ?? []).map(sighting),
+      total: total?.n ?? 0,
+      page,
+      size: PAGE_SIZE,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Overview counts
+// ---------------------------------------------------------------------------
+
+export interface Totals {
+  /** Accounts on record, and how many have ever reported. */
+  accounts: number;
+  reported: number;
+  /** Distinct file names and distinct builds recorded inside the window. */
+  files: number;
+  builds: number;
+  flagged: number;
+}
+
+/** The numbers the overview tiles read. */
+export async function totals(env: Env, days: number): Promise<Totals> {
+  const [accounts, files] = await Promise.all([
+    env.DB.prepare(
+      "SELECT (SELECT COUNT(*) FROM accounts) AS accounts," +
+        " (SELECT COUNT(*) FROM client_modules) AS reported",
+    ).first<{ accounts: number; reported: number }>(),
+    env.DB.prepare(
+      "SELECT COUNT(DISTINCT name) AS files, COUNT(DISTINCT sha256) AS builds," +
+        " COUNT(DISTINCT CASE WHEN state IN ('warn','alert') THEN name END) AS flagged" +
+        " FROM client_module_seen WHERE last_at > ?",
+    )
+      .bind(Date.now() - days * DAY_MS)
+      .first<{ files: number; builds: number; flagged: number }>(),
+  ]);
+  return {
+    accounts: accounts?.accounts ?? 0,
+    reported: accounts?.reported ?? 0,
+    files: files?.files ?? 0,
+    builds: files?.builds ?? 0,
+    flagged: files?.flagged ?? 0,
+  };
+}

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -27,7 +27,15 @@ import {
 } from "./aws";
 import { bmacWebhook } from "./bmac";
 import { pruneReports, putReport } from "./diagnostics";
-import { diagnosticsDashboard, diagnosticsRules } from "./diagnosticspage";
+import {
+  diagnosticsDashboard,
+  diagnosticsFile,
+  diagnosticsFiles,
+  diagnosticsRider,
+  diagnosticsRiders,
+  diagnosticsRules,
+  diagnosticsRulesPage,
+} from "./diagnosticspage";
 import { listPlugins, myPlugins, pluginBundle, redeemKey } from "./plugins";
 import { generateTrack } from "./trackgen";
 import { bootstrapScript, imageBootstrapScript } from "./bootstrap";
@@ -195,6 +203,21 @@ async function route(request: Request, env: Env): Promise<Response> {
   // player's token should ever be enough to read this about anybody else.
   if (method === "GET" && path === "/admin/diagnostics") {
     return diagnosticsDashboard(request, url, env);
+  }
+  if (method === "GET" && path === "/admin/diagnostics/riders") {
+    return diagnosticsRiders(request, url, env);
+  }
+  if (method === "GET" && path === "/admin/diagnostics/rider") {
+    return diagnosticsRider(request, url, env);
+  }
+  if (method === "GET" && path === "/admin/diagnostics/files") {
+    return diagnosticsFiles(request, url, env);
+  }
+  if (method === "GET" && path === "/admin/diagnostics/file") {
+    return diagnosticsFile(request, url, env);
+  }
+  if (method === "GET" && path === "/admin/diagnostics/rules") {
+    return diagnosticsRulesPage(request, url, env);
   }
   if (method === "POST" && path === "/admin/diagnostics/rules") {
     return diagnosticsRules(request, url, env);

--- a/control-plane/test/diagnosticssearch.test.ts
+++ b/control-plane/test/diagnosticssearch.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampDays,
+  claimText,
+  likeTerm,
+  oneOf,
+  parseFileQuery,
+  parsePage,
+  parseRiderQuery,
+  parseSightingQuery,
+} from "../src/diagnosticssearch";
+
+const at = (query: string) => new URL(`https://example.com/admin/diagnostics${query}`);
+
+describe("turning a search box into a LIKE pattern", () => {
+  it("wraps what was typed", () => {
+    expect(likeTerm("overlay")).toBe("%overlay%");
+  });
+
+  it("escapes the wildcards, so a typed underscore is an underscore", () => {
+    expect(likeTerm("nvidia_share")).toBe("%nvidia\\_share%");
+    expect(likeTerm("50%")).toBe("%50\\%%");
+    expect(likeTerm("a\\b")).toBe("%a\\\\b%");
+  });
+
+  it("is empty for an empty box, which every caller reads as no filter", () => {
+    expect(likeTerm("")).toBe("");
+    expect(likeTerm("   ")).toBe("");
+  });
+
+  it("bounds what one box can send to the database", () => {
+    expect(likeTerm("x".repeat(400))).toBe(`%${"x".repeat(96)}%`);
+  });
+});
+
+describe("paging", () => {
+  it("starts at one", () => {
+    expect(parsePage(null)).toBe(1);
+    expect(parsePage("1")).toBe(1);
+  });
+
+  it("refuses a page nobody could have clicked to", () => {
+    expect(parsePage("0")).toBe(1);
+    expect(parsePage("-4")).toBe(1);
+    expect(parsePage("nonsense")).toBe(1);
+    expect(parsePage("1e9")).toBe(10_000);
+  });
+
+  it("takes a page in the middle", () => {
+    expect(parsePage("7")).toBe(7);
+    expect(parsePage("7.9")).toBe(7);
+  });
+});
+
+describe("the day window", () => {
+  it("defaults to a month and clamps to a year", () => {
+    expect(clampDays(null)).toBe(30);
+    expect(clampDays("400")).toBe(365);
+    expect(clampDays("0")).toBe(1);
+    expect(clampDays("rubbish")).toBe(30);
+  });
+});
+
+describe("keeping a query string out of the SQL", () => {
+  it("takes one of the set", () => {
+    expect(oneOf("warn", ["any", "warn", "alert"] as const)).toBe("warn");
+  });
+
+  it("falls back to the first for anything else", () => {
+    expect(oneOf("'; DROP TABLE accounts--", ["any", "warn"] as const)).toBe("any");
+    expect(oneOf(null, ["any", "warn"] as const)).toBe("any");
+  });
+});
+
+describe("what a file says it is", () => {
+  it("prefers the description, and names the company beside it", () => {
+    expect(claimText("Steam overlay", "Steam", "Valve Corporation")).toBe(
+      "Steam overlay — Valve Corporation",
+    );
+  });
+
+  it("does not repeat the company when it is the only thing said", () => {
+    expect(claimText("", "", "NVIDIA Corporation")).toBe("NVIDIA Corporation");
+  });
+
+  it("is empty when the file claims nothing, which is itself worth seeing", () => {
+    expect(claimText("", "", "")).toBe("");
+  });
+});
+
+describe("reading a rider search off the URL", () => {
+  it("defaults to everyone, most recently reporting first", () => {
+    expect(parseRiderQuery(at("/riders"))).toEqual({
+      q: "",
+      state: "any",
+      sort: "seen",
+      days: 30,
+      page: 1,
+    });
+  });
+
+  it("takes what was asked for", () => {
+    const q = parseRiderQuery(at("/riders?q=Frost&state=alert&sort=name&days=7&page=3"));
+    expect(q).toEqual({ q: "Frost", state: "alert", sort: "name", days: 7, page: 3 });
+  });
+
+  it("drops a state and a sort it does not have", () => {
+    const q = parseRiderQuery(at("/riders?state=banned&sort=guid"));
+    expect(q.state).toBe("any");
+    expect(q.sort).toBe("seen");
+  });
+});
+
+describe("reading a file search off the URL", () => {
+  it("opens on what nothing accounts for", () => {
+    expect(parseFileQuery(at("/files"))).toEqual({
+      q: "",
+      state: "flagged",
+      trust: "any",
+      origin: "any",
+      sort: "state",
+      days: 30,
+      page: 1,
+    });
+  });
+
+  it("takes every filter together", () => {
+    const q = parseFileQuery(
+      at("/files?q=overlay&state=any&trust=unsigned&origin=other&sort=accounts&days=90&page=2"),
+    );
+    expect(q).toEqual({
+      q: "overlay",
+      state: "any",
+      trust: "unsigned",
+      origin: "other",
+      sort: "accounts",
+      days: 90,
+      page: 2,
+    });
+  });
+
+  it("drops a trust and an origin it does not have", () => {
+    const q = parseFileQuery(at("/files?trust=probably&origin=steam"));
+    expect(q.trust).toBe("any");
+    expect(q.origin).toBe("any");
+  });
+});
+
+describe("reading a rider's own file filter off the URL", () => {
+  it("uses its own names, so it does not collide with the rider search", () => {
+    const q = parseSightingQuery(at("/rider?id=acc1&f=d3d9&fstate=warn&page=2"));
+    expect(q).toEqual({ q: "d3d9", state: "warn", page: 2 });
+  });
+
+  it("defaults to every file that rider has", () => {
+    expect(parseSightingQuery(at("/rider?id=acc1"))).toEqual({ q: "", state: "any", page: 1 });
+  });
+});


### PR DESCRIPTION
## What

The diagnostics dashboard could only draw one thing: the unaccounted files of the last N days, most recent first. You could not look a rider up, and given a file you could not find out who else had it. It is four views now, and every one of them searches.

**Riders** — every account, searchable by rider name, GUID, Steam id or account id. Filter by state (including "not reporting"), sort by last report, worst state, name or unaccounted count. Columns: rider, GUID, state, files on record, flagged, server, app, last report.

**Rider** — one person. GUID, account id, Steam id, enrolled, last report, app version, module counts, rules version, server now, servers ever seen on, what the rules named in the last report — and every file their game has loaded, with its own filter box.

**Files** — every file, not only the flagged ones. One box searches name, hash, signer, company, product, description and label together; filters for state, signature and origin; sorts by worst-first, recency, accounts, sightings or name.

**File** — the reverse lookup. One file name, its distinct builds, and every account that has loaded it: rider, GUID, which build, the server they were on, first and last seen, how many times.

Lists are paged — an offset, a total and numbered page links, so a link to page four is still page four tomorrow. No infinite scroll. A hand-edited `?page=` past the end says so instead of showing an empty table that reads as "nothing matched".

The page prose is gone; the tables carry it. Rule notes are shown on the rules page (they were written by the add form and never read back), and Flag/Clear returns to the page it was pressed on with its filters intact.

## Database

`0019_diagnostics_search.sql` — three indexes for the new orderings: `client_module_seen (last_at)`, `client_module_seen (account_id, last_at)`, `client_modules (updated_at)`. No column or table changes, and nothing new is collected — the client is untouched.

Remote D1 migrations are applied by hand on this deployment; this file needs running before the Files and Riders views are fast on production data.

## Verified

Against a local D1 seeded with 60 accounts, 40 reporters and 12 file names across ~300 sightings:

- Every route returns 200; missing/unknown rider and file give 400/404.
- Rider search matches on name, on a GUID fragment and on a Steam id fragment.
- File search matches on signer (`NVIDIA` → `nvoglv64.dll`) and on claim text (`overlay` → `discord_hook64.dll`, `gameoverlayrenderer64.dll`); `trust=unsigned` returns exactly the five unsigned names.
- Reverse lookup on `d3d9.dll`: 23 accounts, 2 builds; narrowing to one hash gives 11.
- Paging: 1–50 of 60, page 2 is 51–60, filters survive the page links, `?page=99` reports past-the-end and links back.
- Rule add and delete both work; the redirect returns to the originating view with its query string, and `back=https://evil.example/` and `back=//evil.example/x` both fall back to the overview.
- Hostile rider names, file names, publishers and labels render escaped — no raw `<script>` or event handler reaches the output.
- Search boxes are bound parameters with LIKE wildcards escaped; `'; DROP TABLE accounts--` returns 200 and the table is intact.
- `tsc --noEmit` clean; 189 tests pass, 21 of them new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)