### PR TITLE
fix(launch): stop the app getting in the way of the game starting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@
 - Locked content is now something you switch on in Settings, and only applies to games started
   with Play.
 - A FrostMod plugin installed into the game's own folder is kept up to date with the FrostMod
-  the app manages, instead of staying on whatever version it was installed at.
+  the app manages, instead of staying on whatever version it was installed at. One that can't
+  be updated is renamed so the game stops loading it, and can be renamed back.
+- A warning when your mods folder is inside OneDrive or another sync tool, which is what makes
+  the game sit on a black screen while it loads.
 - Auto-reload waits for the game to finish loading when the mods folder is on OneDrive or
   another sync tool, so a folder change during startup no longer leaves the game on a black
   screen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 ## 2026-09-01
 
 ### Fixed
+- The game opens again after being closed once, without having to quit MXB App from the tray
+  first.
+- Locked content is now something you switch on in Settings, and only applies to games started
+  with Play.
+- A FrostMod plugin installed into the game's own folder is kept up to date with the FrostMod
+  the app manages, instead of staying on whatever version it was installed at.
+- Auto-reload waits for the game to finish loading when the mods folder is on OneDrive or
+  another sync tool, so a folder change during startup no longer leaves the game on a black
+  screen.
+- Mods folders on a sync tool are read once per game session rather than every two seconds.
+
+## 2026-09-01
+
+### Fixed
 - Generated tracks no longer crash the game at the track graphics stage: each ground layer
   now carries the material record a published map uses.
 

--- a/src-tauri/src/cloudfiles.rs
+++ b/src-tauri/src/cloudfiles.rs
@@ -125,6 +125,15 @@ fn is_content(path: &std::path::Path) -> bool {
 
 /// Name the sync tool from the path, so the advice can name it too. `None` when the folder
 /// is somewhere unrecognised — a placeholder there is still a placeholder.
+/// The sync provider the configured mods tree sits under, if any.
+///
+/// A path question, not a disk one: it answers whether reads there go through a sync
+/// tool's filter driver at all, which is true even when every file is currently hydrated.
+/// That is the thing worth knowing before asking the game to re-walk the tree.
+pub fn mods_provider(cfg: &crate::config::AppConfig) -> Option<String> {
+    provider_of(&crate::library::mods_root(&cfg.mods_path))
+}
+
 fn provider_of(root: &std::path::Path) -> Option<String> {
     let lower = root.to_string_lossy().to_ascii_lowercase();
     for (needle, name) in [

--- a/src-tauri/src/cloudfiles.rs
+++ b/src-tauri/src/cloudfiles.rs
@@ -59,20 +59,39 @@ pub fn warn_if_dehydrated(app: &AppHandle, cfg: &crate::config::AppConfig) {
     let app = app.clone();
     std::thread::spawn(move || {
         let found = scan(&root);
-        if found.count == 0 {
+        // Two separate problems, and the second used to go unmentioned.
+        //
+        // Evicted bytes are the crash. But a tree that merely *sits* on a sync provider is
+        // slow to read even fully hydrated — every read goes through the filter driver — and
+        // the game reads the whole tree during the load screen. One player's took 5–6 seconds
+        // per track folder, which is a game that never reaches the loading screen at all. That
+        // is worth saying before it happens, not only when bytes have actually gone.
+        if found.count == 0 && found.provider.is_none() {
             return;
         }
         let provider = found.provider.clone().unwrap_or_else(|| "a cloud sync tool".into());
-        log::warn!(
-            "[cloud] {} of {} mod file(s) under {} are placeholders, not real files — {provider} \
-             has evicted them. The game reads these during the load screen and can crash there \
-             (in-page error). Fix: right-click the folder in Explorer and choose \
-             \"Always keep on this device\", or move the folder out of {provider}. Examples: {}",
-            found.count,
-            found.scanned,
-            root.display(),
-            found.examples.join(", ")
-        );
+        if found.count > 0 {
+            log::warn!(
+                "[cloud] {} of {} mod file(s) under {} are placeholders, not real files — \
+                 {provider} has evicted them. The game reads these during the load screen and \
+                 can crash there (in-page error). Fix: right-click the folder in Explorer and \
+                 choose \"Always keep on this device\", or move the folder out of {provider}. \
+                 Examples: {}",
+                found.count,
+                found.scanned,
+                root.display(),
+                found.examples.join(", ")
+            );
+        } else {
+            log::warn!(
+                "[cloud] the mods folder is inside {provider} ({}). Every read there goes \
+                 through {provider}'s filter driver, and the game reads the whole tree during \
+                 the load screen — slow enough, on a big collection, to look like the game has \
+                 hung. Nothing is evicted right now, so this is a warning, not a fault. Fix: \
+                 move the folder out of {provider}.",
+                root.display()
+            );
+        }
         let _ = app.emit(EVENT, &found);
     });
 }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -82,6 +82,15 @@ pub struct AppConfig {
     /// Watch `<mods_path>/mods` and signal FrostMod to reload when tracks/bikes are
     /// added outside the app (e.g. a manual download dropped into the folder).
     pub watch_mods_reload: bool,
+    /// Inject `mxbsecure.dll` into the running game so locked content can be opened.
+    ///
+    /// **Off by default, deliberately.** This reaches into a process the app usually did not
+    /// create, and the DLL has never been proven on a real Windows run — a build that armed it
+    /// for everyone with locked content had the game dying on access violations 17–31s in, and
+    /// the only way out was quitting the app from the tray, because nothing else the app does
+    /// touches a Steam-started game. It stays opt-in until that run happens.
+    #[serde(default)]
+    pub secure_content_inject: bool,
     /// The intro slideshow has been dismissed. Kept here rather than in the webview's
     /// `localStorage` so it survives that storage being cleared (WebView2 resets it on
     /// an app-data wipe, and an OS shutdown can kill the tray-resident process before
@@ -266,6 +275,7 @@ impl Default for AppConfig {
             frostmod_args: String::new(),
             instant_refresh: true,
             watch_mods_reload: true,
+            secure_content_inject: false,
             welcome_seen: false,
             tour_done: false,
             overlay_enabled: true,

--- a/src-tauri/src/frostmod_manage.rs
+++ b/src-tauri/src/frostmod_manage.rs
@@ -52,6 +52,34 @@ pub struct FrostmodStatus {
     /// next time something plain-imports the CRT, and only the player can authorise the
     /// fix — see `crate::vcruntime::disable_stray_msvcr90`.
     pub stray_msvcr90: crate::vcruntime::Stray,
+    /// What became of a hand-installed `frostmod.dlo` in the game's own `plugins` folder.
+    /// [`PluginCopy::Absent`] is the normal case — see [`refresh_game_plugin`].
+    pub game_plugin: PluginCopy,
+}
+
+/// The state of a FrostMod plugin copy sitting in the game's `plugins` folder.
+///
+/// `frostmod.exe --install-plugin` drops `frostmod.dlo` there so the game loads FrostMod at
+/// startup with no injector. Nothing has ever updated that copy afterwards — not the app,
+/// which manages only `frostmod.exe` and `frostmod.dll` in its own folder, and not FrostMod,
+/// which prints "re-run --install-plugin to refresh the installed .dlo" and leaves it at that.
+/// So it outlives every update, silently, and the game goes on loading it: one player was
+/// running a **v0.12** plugin against a v0.16.2 install, and it hung the game at a black
+/// screen before the loading screen — with `frostmod.exe` not even running, because a plugin
+/// doesn't need it.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PluginCopy {
+    /// No plugin installed in the game folder. The normal case, and nothing to do.
+    #[default]
+    Absent,
+    /// Present and already the build we manage.
+    Current,
+    /// Was stale and has been brought up to date.
+    Refreshed,
+    /// Stale, and the game (or something else) is holding it open. It will be refreshed
+    /// on the next poll after the game closes.
+    Locked,
 }
 
 /// The folder we install FrostMod into and run it from — so also where anything it
@@ -251,6 +279,15 @@ pub async fn status(app: &AppHandle) -> FrostmodStatus {
         .map(crate::vcruntime::remove_stray_msvcr90)
         .unwrap_or_default();
 
+    // Keep a hand-installed plugin copy from going stale. Like the sweep above, this rides
+    // on the status poll because that is the only thing that reaches a player who never
+    // opens Settings — and unlike an update, it has to run even when we are already on the
+    // latest tag, which is exactly the state a stale `.dlo` survives in.
+    let game_plugin = game_dir
+        .as_deref()
+        .map(|game| refresh_game_plugin(&frostmod_dir(app), game))
+        .unwrap_or_default();
+
     FrostmodStatus {
         installed,
         version,
@@ -260,6 +297,68 @@ pub async fn status(app: &AppHandle) -> FrostmodStatus {
         supported_for_game,
         missing_runtimes: crate::vcruntime::missing(game_dir.as_deref()),
         stray_msvcr90,
+        game_plugin,
+    }
+}
+
+/// `<game>\plugins\frostmod.dlo` — where `--install-plugin` puts the plugin copy.
+fn game_plugin_path(game_dir: &Path) -> PathBuf {
+    game_dir.join("plugins").join("frostmod.dlo")
+}
+
+/// Bring a hand-installed `frostmod.dlo` up to the build we manage, if one is there.
+///
+/// **Only ever refreshes a file that already exists — it never installs one.** The app drives
+/// FrostMod by injection and has no use for plugin mode; the whole job here is to stop a copy
+/// somebody else installed from rotting in the game folder. Creating one would change how
+/// FrostMod loads on machines that never asked for it, and would double-load it besides.
+///
+/// The `.dlo` is a byte-identical copy of the `.dll` (FrostMod's own CMake makes it one), so
+/// this is a plain copy — there is no separate asset to fetch.
+///
+/// Staleness is judged on size and mtime rather than by reading a quarter-megabyte twice on
+/// every status poll: a copy we made is the same size and newer, and that pair converges.
+fn refresh_game_plugin(dir: &Path, game_dir: &Path) -> PluginCopy {
+    let dlo = game_plugin_path(game_dir);
+    let (Ok(dlo_meta), Ok(dll_meta)) = (std::fs::metadata(&dlo), std::fs::metadata(dir.join("frostmod.dll")))
+    else {
+        // No plugin installed (the normal case), or no managed DLL to refresh it from.
+        return PluginCopy::Absent;
+    };
+    let fresh = dlo_meta.len() == dll_meta.len()
+        && match (dlo_meta.modified(), dll_meta.modified()) {
+            (Ok(a), Ok(b)) => a >= b,
+            // No mtimes to compare: same size is all we have, and re-copying every poll
+            // would be worse than trusting it.
+            _ => true,
+        };
+    if fresh {
+        return PluginCopy::Current;
+    }
+
+    // Same rename-then-replace the binaries use: the game maps this file while it runs, and
+    // Windows won't open a mapped image for writing, but it will let it be renamed away.
+    let staged = dlo.with_extension("dlo.staging");
+    if std::fs::copy(dir.join("frostmod.dll"), &staged).is_err() {
+        return PluginCopy::Locked;
+    }
+    match swap_in(&dlo, &staged) {
+        Ok(retired) => {
+            if let Some(retired) = retired {
+                let _ = std::fs::remove_file(retired);
+            }
+            log::info!(
+                "[frostmod] refreshed the stale plugin copy at {} — it was older than the \
+                 FrostMod we manage, and the game loads it at startup",
+                dlo.display()
+            );
+            PluginCopy::Refreshed
+        }
+        Err(e) => {
+            let _ = std::fs::remove_file(&staged);
+            log::warn!("[frostmod] couldn't refresh {}: {e}", dlo.display());
+            PluginCopy::Locked
+        }
     }
 }
 
@@ -1301,5 +1400,68 @@ mod tests {
         assert!(filter_eq(&format!("{STOCK_SERVERFILTER}\n\n"), STOCK_SERVERFILTER));
         // A real edit (curated vs stock) must NOT compare equal.
         assert!(!filter_eq(CURATED_SERVERFILTER, STOCK_SERVERFILTER));
+    }
+}
+
+#[cfg(test)]
+mod plugin_copy_tests {
+    use super::*;
+
+    fn dirs(tag: &str) -> (PathBuf, PathBuf) {
+        let root = std::env::temp_dir().join(format!("frostmod-dlo-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let managed = root.join("managed");
+        let game = root.join("game");
+        std::fs::create_dir_all(&managed).unwrap();
+        std::fs::create_dir_all(game.join("plugins")).unwrap();
+        (managed, game)
+    }
+
+    /// The case that cost a player their game: a plugin installed by hand months ago, which
+    /// nothing has ever updated, still loaded by the game at every startup.
+    #[test]
+    fn a_stale_plugin_is_brought_up_to_date() {
+        let (managed, game) = dirs("stale");
+        std::fs::write(managed.join("frostmod.dll"), b"v0.16.2-bytes").unwrap();
+        std::fs::write(game_plugin_path(&game), b"v0.12").unwrap();
+
+        assert_eq!(refresh_game_plugin(&managed, &game), PluginCopy::Refreshed);
+        assert_eq!(std::fs::read(game_plugin_path(&game)).unwrap(), b"v0.16.2-bytes");
+    }
+
+    /// Never install one. The app drives FrostMod by injection; creating a plugin would
+    /// change how it loads on a machine that never asked for plugin mode.
+    #[test]
+    fn no_plugin_means_nothing_to_do() {
+        let (managed, game) = dirs("absent");
+        std::fs::write(managed.join("frostmod.dll"), b"whatever").unwrap();
+
+        assert_eq!(refresh_game_plugin(&managed, &game), PluginCopy::Absent);
+        assert!(!game_plugin_path(&game).exists(), "a plugin must never be created");
+    }
+
+    /// A plugin that already matches is left alone — and, because staleness is judged on
+    /// size and mtime, re-checking it does not rewrite it on every status poll.
+    #[test]
+    fn a_current_plugin_is_left_alone_and_stays_current() {
+        let (managed, game) = dirs("current");
+        std::fs::write(managed.join("frostmod.dll"), b"same-bytes").unwrap();
+        std::fs::write(game_plugin_path(&game), b"same-bytes").unwrap();
+
+        // First pass may refresh (the fixture's mtimes are whatever the FS gave them);
+        // what matters is that it converges and then stays put.
+        let _ = refresh_game_plugin(&managed, &game);
+        assert_eq!(refresh_game_plugin(&managed, &game), PluginCopy::Current);
+        assert_eq!(refresh_game_plugin(&managed, &game), PluginCopy::Current);
+    }
+
+    /// Nothing to copy from is not a reason to touch the game folder.
+    #[test]
+    fn no_managed_dll_leaves_the_plugin_untouched() {
+        let (managed, game) = dirs("nodll");
+        std::fs::write(game_plugin_path(&game), b"v0.12").unwrap();
+
+        assert_eq!(refresh_game_plugin(&managed, &game), PluginCopy::Absent);
+        assert_eq!(std::fs::read(game_plugin_path(&game)).unwrap(), b"v0.12");
     }
 }

--- a/src-tauri/src/frostmod_manage.rs
+++ b/src-tauri/src/frostmod_manage.rs
@@ -77,9 +77,16 @@ pub enum PluginCopy {
     Current,
     /// Was stale and has been brought up to date.
     Refreshed,
-    /// Stale, and the game (or something else) is holding it open. It will be refreshed
-    /// on the next poll after the game closes.
+    /// Was stale, couldn't be updated, and has been renamed so the game stops loading it.
+    /// Nothing is destroyed — see [`disable_game_plugin`].
+    Disabled,
+    /// Stale, couldn't be updated, and couldn't be moved aside either. The game is still
+    /// loading it; another poll will try again.
     Locked,
+    /// A plugin is installed but the app doesn't manage a FrostMod to judge it against, so
+    /// there is nothing to compare and nothing to copy from. Left strictly alone: it may be
+    /// perfectly current, and it isn't ours to touch on a machine we aren't managing.
+    Unmanaged,
 }
 
 /// The folder we install FrostMod into and run it from — so also where anything it
@@ -320,10 +327,14 @@ fn game_plugin_path(game_dir: &Path) -> PathBuf {
 /// every status poll: a copy we made is the same size and newer, and that pair converges.
 fn refresh_game_plugin(dir: &Path, game_dir: &Path) -> PluginCopy {
     let dlo = game_plugin_path(game_dir);
-    let (Ok(dlo_meta), Ok(dll_meta)) = (std::fs::metadata(&dlo), std::fs::metadata(dir.join("frostmod.dll")))
-    else {
-        // No plugin installed (the normal case), or no managed DLL to refresh it from.
-        return PluginCopy::Absent;
+    let Ok(dlo_meta) = std::fs::metadata(&dlo) else {
+        return PluginCopy::Absent; // no plugin installed — the normal case
+    };
+    let Ok(dll_meta) = std::fs::metadata(dir.join("frostmod.dll")) else {
+        // A plugin we have no way to judge: nothing to compare against and nothing to copy
+        // from. Leaving it is the only honest move — it may well be current, and a machine
+        // whose FrostMod we don't manage isn't one to start renaming files on.
+        return PluginCopy::Unmanaged;
     };
     let fresh = dlo_meta.len() == dll_meta.len()
         && match (dlo_meta.modified(), dll_meta.modified()) {
@@ -340,7 +351,7 @@ fn refresh_game_plugin(dir: &Path, game_dir: &Path) -> PluginCopy {
     // Windows won't open a mapped image for writing, but it will let it be renamed away.
     let staged = dlo.with_extension("dlo.staging");
     if std::fs::copy(dir.join("frostmod.dll"), &staged).is_err() {
-        return PluginCopy::Locked;
+        return disable_game_plugin(&dlo);
     }
     match swap_in(&dlo, &staged) {
         Ok(retired) => {
@@ -357,6 +368,50 @@ fn refresh_game_plugin(dir: &Path, game_dir: &Path) -> PluginCopy {
         Err(e) => {
             let _ = std::fs::remove_file(&staged);
             log::warn!("[frostmod] couldn't refresh {}: {e}", dlo.display());
+            disable_game_plugin(&dlo)
+        }
+    }
+}
+
+/// Move a stale plugin out of the way, when it can't be brought up to date.
+///
+/// A stale plugin is not a neutral thing to leave lying there: the game loads it at startup
+/// on its own, and a stale enough one hangs the game before the loading screen — which is a
+/// rider who cannot play at all, with nothing on screen to say why. So if we can't fix it,
+/// we stop it loading.
+///
+/// Renamed, never deleted. Two reasons: the app didn't install this file, so destroying it
+/// isn't ours to do; and a rename works even while MX Bikes has the plugin mapped (the
+/// loader opens images with `FILE_SHARE_DELETE`), so the fix lands on the *next* launch
+/// without waiting for the player to close the game. The new name deliberately does not end
+/// in `.dlo` — anything that does, in this folder, gets loaded as a plugin.
+fn disable_game_plugin(dlo: &Path) -> PluginCopy {
+    // A rider who has been through this twice shouldn't have the first parked copy silently
+    // replaced by the second — on Windows the rename would simply fail, and on Unix it would
+    // overwrite. Number them instead.
+    let first = dlo.with_extension("dlo.disabled");
+    let parked = if first.exists() {
+        (1..)
+            .map(|n| dlo.with_extension(format!("dlo.disabled-{n}")))
+            .find(|p| !p.exists())
+            .expect("the range is unbounded")
+    } else {
+        first
+    };
+    match rename_with_retry(dlo, &parked) {
+        Ok(()) => {
+            log::warn!(
+                "[frostmod] the plugin at {} is older than the FrostMod we manage and couldn't \
+                 be updated, so it has been renamed to {} — the game loads a plugin at startup \
+                 whether or not frostmod.exe is running, and a stale one can stop it opening. \
+                 Rename it back to re-enable plugin mode.",
+                dlo.display(),
+                parked.display()
+            );
+            PluginCopy::Disabled
+        }
+        Err(e) => {
+            log::warn!("[frostmod] couldn't move {} aside: {e}", dlo.display());
             PluginCopy::Locked
         }
     }
@@ -1455,13 +1510,52 @@ mod plugin_copy_tests {
         assert_eq!(refresh_game_plugin(&managed, &game), PluginCopy::Current);
     }
 
-    /// Nothing to copy from is not a reason to touch the game folder.
+    /// Nothing to compare against and nothing to copy from is not a licence to start
+    /// renaming files in somebody's game folder.
     #[test]
     fn no_managed_dll_leaves_the_plugin_untouched() {
         let (managed, game) = dirs("nodll");
         std::fs::write(game_plugin_path(&game), b"v0.12").unwrap();
 
-        assert_eq!(refresh_game_plugin(&managed, &game), PluginCopy::Absent);
+        assert_eq!(refresh_game_plugin(&managed, &game), PluginCopy::Unmanaged);
         assert_eq!(std::fs::read(game_plugin_path(&game)).unwrap(), b"v0.12");
+    }
+
+    /// The force: a stale plugin that can't be updated stops loading rather than being left
+    /// to hang the game. Renamed, not deleted — and to a name that isn't `.dlo`, or the game
+    /// would just load it again.
+    #[test]
+    fn a_stale_plugin_that_cannot_be_updated_is_moved_aside() {
+        let (managed, game) = dirs("disable");
+        let dlo = game_plugin_path(&game);
+        std::fs::write(&dlo, b"v0.12").unwrap();
+
+        let parked = disable_game_plugin(&dlo);
+
+        assert_eq!(parked, PluginCopy::Disabled);
+        assert!(!dlo.exists(), "the game must stop loading it");
+        let kept = dlo.with_extension("dlo.disabled");
+        assert_eq!(std::fs::read(&kept).unwrap(), b"v0.12", "nothing is destroyed");
+        assert_ne!(
+            kept.extension().and_then(|e| e.to_str()),
+            Some("dlo"),
+            "a parked copy still ending in .dlo would be loaded as a plugin"
+        );
+    }
+
+    /// Twice through the same fix must not overwrite the first parked copy.
+    #[test]
+    fn a_second_disable_does_not_clobber_the_first() {
+        let (managed, game) = dirs("disable-twice");
+        let dlo = game_plugin_path(&game);
+
+        std::fs::write(&dlo, b"first").unwrap();
+        assert_eq!(disable_game_plugin(&dlo), PluginCopy::Disabled);
+        std::fs::write(&dlo, b"second").unwrap();
+        assert_eq!(disable_game_plugin(&dlo), PluginCopy::Disabled);
+
+        assert_eq!(std::fs::read(dlo.with_extension("dlo.disabled")).unwrap(), b"first");
+        assert_eq!(std::fs::read(dlo.with_extension("dlo.disabled-1")).unwrap(), b"second");
+        let _ = managed;
     }
 }

--- a/src-tauri/src/gameproc.rs
+++ b/src-tauri/src/gameproc.rs
@@ -1523,6 +1523,51 @@ fn connect_args(address: &str) -> [String; 2] {
 }
 
 /// Shared body of [`launch`] and [`join`] — `address` is already normalized.
+/// When the app last asked for the game to start. Steam usually spawns the process, so there
+/// is no child handle and no pid to match on — the launch *instant* is the only provenance we
+/// get, and anything that reaches into the game process checks it before acting.
+static LAST_APP_LAUNCH: std::sync::Mutex<Option<std::time::Instant>> = std::sync::Mutex::new(None);
+
+/// How long after a Play click a game that appears still counts as one the app started. Steam
+/// can take a while to get from the URL to a running process, so this is generous; it only has
+/// to separate "the app asked for this" from "the player started it themselves hours ago".
+const APP_LAUNCH_WINDOW: std::time::Duration = std::time::Duration::from_secs(180);
+
+/// Record that the app asked for the game to start.
+fn note_app_launch() {
+    if let Ok(mut slot) = LAST_APP_LAUNCH.lock() {
+        *slot = Some(std::time::Instant::now());
+    }
+}
+
+/// When the current game session was first noticed, or `None` if the game isn't up.
+static SESSION_SINCE: std::sync::Mutex<Option<std::time::Instant>> = std::sync::Mutex::new(None);
+
+/// Called by [`crate::sessionwatch`] as a session begins and ends, so anything that needs to
+/// know "how long has the game been up" can ask without a second process poll.
+pub fn note_session(started: bool) {
+    if let Ok(mut slot) = SESSION_SINCE.lock() {
+        *slot = started.then(std::time::Instant::now);
+    }
+}
+
+/// How long the game has been running, as far as the session poll has noticed. `None` when
+/// no session is up.
+pub fn session_age() -> Option<std::time::Duration> {
+    SESSION_SINCE.lock().ok().and_then(|slot| *slot).map(|at| at.elapsed())
+}
+
+/// Whether the game now running is one the app launched, as far as we can tell.
+///
+/// Used to keep the app from reaching into a process it had no hand in starting.
+pub fn launched_by_app() -> bool {
+    LAST_APP_LAUNCH
+        .lock()
+        .ok()
+        .and_then(|slot| *slot)
+        .is_some_and(|at| at.elapsed() < APP_LAUNCH_WINDOW)
+}
+
 fn launch_with(cfg: &AppConfig, address: Option<&str>) -> anyhow::Result<LaunchOutcome> {
     if is_game_running() {
         return Ok(LaunchOutcome::AlreadyRunning);
@@ -1533,6 +1578,7 @@ fn launch_with(cfg: &AppConfig, address: Option<&str>) -> anyhow::Result<LaunchO
         Some(addr) => log::info!("launching {game} into {addr}: {}", exe.display()),
         None => log::info!("launching {game}: {}", exe.display()),
     }
+    note_app_launch();
 
     #[cfg(windows)]
     {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7992,6 +7992,17 @@ fn set_watch_mods_reload(
     Ok(())
 }
 
+/// Turn injecting `mxbsecure.dll` into the running game on or off.
+///
+/// Takes effect on the next game session: the watcher decides once per run, so a change made
+/// mid-session doesn't reach into a game that is already up.
+#[tauri::command]
+fn set_secure_content_inject(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
+    let mut cfg = config::load(&app).unwrap_or_default();
+    cfg.secure_content_inject = enabled;
+    config::save(&app, &cfg).map_err(|e| format!("{e:#}"))
+}
+
 #[tauri::command]
 async fn shop_login(app: tauri::AppHandle) -> Result<(), String> {
     if let Some(w) = app.get_webview_window(SHOP_LOGIN_WINDOW) {
@@ -9890,6 +9901,7 @@ fn main() {
             voice_meter_stop,
             voice_test_output,
             set_watch_mods_reload,
+            set_secure_content_inject,
             frostmod_reload,
             frostmod_running,
             frostmod_attachment,

--- a/src-tauri/src/modwatch.rs
+++ b/src-tauri/src/modwatch.rs
@@ -48,6 +48,11 @@ const SETTLE: Duration = Duration::from_secs(3);
 /// the reload forever — past this we act on what has landed so far.
 const MAX_SETTLE: Duration = Duration::from_secs(45);
 
+/// How far into a game session auto-reload stays quiet when the mods tree sits on a sync
+/// provider. Long enough to cover the game's own startup content walk, which is the window
+/// where a second walk turns into a black screen — see [`settle_then_reload`].
+const CLOUD_SESSION_GRACE: Duration = Duration::from_secs(120);
+
 /// Slug the folder watcher tags its `frostmod-reload` events with. In-app install
 /// handlers filter on their own slug, so this sentinel never collides with them.
 pub const WATCH_SLUG: &str = "__mods_watch__";
@@ -358,10 +363,37 @@ fn on_batch(
 
 /// Wait for the mods folder to stop changing, then fire one reload for the whole batch.
 fn settle_then_reload(app: AppHandle, pending: Arc<Mutex<Pending>>, live: Arc<AtomicBool>) {
+    // Read once, not once a second: the provider is a property of the configured path.
+    let cloud = crate::config::load(&app).ok().and_then(|c| crate::cloudfiles::mods_provider(&c));
+    let mut held = false;
+
     let mods = loop {
         std::thread::sleep(SETTLE / 3);
         if !live.load(Ordering::SeqCst) {
             return;
+        }
+        // A reload makes the game walk the whole content tree again. On a sync-backed tree
+        // that walk is slow enough to matter — one player's took 5–6 *seconds per track
+        // folder* under OneDrive — and firing it while the game is still doing its own
+        // startup walk stacks a second one on top: the game stops at a black screen and
+        // never reaches the loading screen. So while a session is young, hold the batch.
+        //
+        // A mitigation, not a cure. The cure is the folder not being on a sync provider,
+        // which `cloudfiles` already tells the player at the top of every session.
+        if let (Some(provider), Some(age)) = (&cloud, crate::gameproc::session_age()) {
+            if age < CLOUD_SESSION_GRACE {
+                if !held {
+                    held = true;
+                    log::info!(
+                        "mods watcher: holding the reload — the game has only been up {:?} and \
+                         the mods tree is on {provider}, where a content reload during the load \
+                         screen can leave the game on a black screen. It will fire once the \
+                         session has settled.",
+                        age
+                    );
+                }
+                continue;
+            }
         }
         let settled = pending
             .lock()

--- a/src-tauri/src/secure_launch.rs
+++ b/src-tauri/src/secure_launch.rs
@@ -161,28 +161,58 @@ fn write_manifest(assets: &[SecureAsset], dir: &std::path::Path) -> Result<(), S
     std::fs::write(dir.join("manifest.tsv"), out).map_err(|e| e.to_string())
 }
 
-/// Watch for the game and inject the moment it appears — as early as possible, because MX
-/// Bikes reads a track's content to list it, so the hook has to be live *before* the track
-/// browser opens or a protected track won't show. A tight poll (every couple of seconds)
-/// rather than the 15-second session watcher, and it injects once per run of the game.
+/// Is injecting into the running game allowed on this install? Off unless the player turned
+/// it on — see [`crate::config::AppConfig::secure_content_inject`].
+fn injection_enabled(app: &AppHandle) -> bool {
+    crate::config::load(app).map(|c| c.secure_content_inject).unwrap_or(false)
+}
+
+/// Watch for the game and, if this install has opted in, inject shortly after it appears —
+/// early matters, because MX Bikes reads a track's content to list it, so the hook has to be
+/// live before the track browser opens or a protected track won't show.
 ///
-/// A no-op run to run when nothing is protected: it only wakes to check a process list.
+/// Exactly one decision per run of the game, latched. That matters more than it sounds: this
+/// used to re-test `!scan_secured(..).is_empty()` on every tick, and since an install with
+/// nothing protected never made that true, it never latched — so a player with no locked
+/// content at all got a **recursive walk of the whole `mods/tracks` tree every two seconds**
+/// for as long as they played. On a cloud-synced mods folder (OneDrive et al, where a single
+/// directory read can take seconds) that alone is enough to ruin the session. The old comment
+/// here claimed the opposite: "a no-op run to run when nothing is protected". It wasn't.
+///
+/// So: decide once, latch, and only re-decide when the game has gone away.
 pub fn watch(app: &AppHandle) {
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
-        let mut injected_this_session = false;
+        let mut decided_this_run = false;
         loop {
             tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-            let running = crate::gameproc::is_game_running();
-            if running {
-                if !injected_this_session && !scan_secured(&app).is_empty() {
-                    arm(&app);
-                    injected_this_session = true;
-                }
-            } else {
-                // Game gone: re-arm for the next launch.
-                injected_this_session = false;
+            if !crate::gameproc::is_game_running() {
+                decided_this_run = false; // game gone: decide again for the next run
+                continue;
             }
+            if decided_this_run {
+                continue;
+            }
+            // Latch first, whatever we decide below: every path here is a once-per-run
+            // decision, and none of them should be retried on a two-second timer.
+            decided_this_run = true;
+
+            // The setting is checked before anything touches the disk, so the default path
+            // costs a config read and nothing else.
+            if !injection_enabled(&app) {
+                continue;
+            }
+            // Don't reach into a process the app had no hand in starting. Locked content is
+            // worth a DLL in *our* game; it is not worth one in a game the player started
+            // themselves while the app happened to be open in the tray.
+            if !crate::gameproc::launched_by_app() {
+                log::info!(
+                    "[secure] the game wasn't launched from the app — not injecting. \
+                     Start it with Play to use locked content."
+                );
+                continue;
+            }
+            arm(&app);
         }
     });
 }

--- a/src-tauri/src/sessionwatch.rs
+++ b/src-tauri/src/sessionwatch.rs
@@ -39,6 +39,11 @@ pub fn start(app: &AppHandle) {
 
             let running = gameproc::is_game_running();
             let started = running && !was_running;
+            if running != was_running {
+                // Publish the transition: the mods watcher holds its reloads while a session
+                // is young, because that is when the game is walking the whole content tree.
+                gameproc::note_session(running);
+            }
             was_running = running;
 
             // Checked every pass, not only when the poll says the game is gone: the handle

--- a/src/Components/RuntimeBanner/RuntimeBanner.tsx
+++ b/src/Components/RuntimeBanner/RuntimeBanner.tsx
@@ -1,14 +1,16 @@
 import {
   AlertTriangle,
+  CloudOff,
   Download,
   FolderInput,
   Loader2,
   OctagonAlert,
   X,
 } from "lucide-react";
-import type { ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { Button } from "@/Components/ui/button";
-import { RUNTIME_NAME_KEY } from "@/api/mods";
+import { RUNTIME_NAME_KEY, onModsDehydrated } from "@/api/mods";
+import type { ModsDehydrated } from "@/types";
 import { useFrostmod } from "@/Context/FrostmodContext";
 import { Trans } from "@/i18n";
 import { useT } from "@/i18n/context";
@@ -27,7 +29,12 @@ import { useT } from "@/i18n/context";
  * FrostMod silently failing to attach, or a bare "…dll was not found" box over the game —
  * gives no hint that Settings is where to look.
  *
- * Renders nothing when neither applies, which is the overwhelmingly common case.
+ * **A mods folder inside a cloud sync tool**, which has no button at all — the fix is to
+ * move the folder, which only the player can do. It earns a place here because its symptom
+ * is the least legible of the three: the game sits on a black screen reading a tree it can't
+ * read quickly, and nothing anywhere says that's what is happening.
+ *
+ * Renders nothing when none applies, which is the overwhelmingly common case.
  */
 export default function RuntimeBanner() {
   const t = useT();
@@ -40,6 +47,18 @@ export default function RuntimeBanner() {
     clearingStray,
     clearStrayMsvcr90,
   } = useFrostmod();
+  const [cloud, setCloud] = useState<ModsDehydrated | null>(null);
+  const [cloudDismissed, setCloudDismissed] = useState(false);
+
+  // Announced once per game session by the backend, so a player who moves the folder stops
+  // hearing about it from the next session on without anything having to invalidate here.
+  useEffect(() => {
+    const stop = onModsDehydrated((info) => {
+      setCloud(info);
+      setCloudDismissed(false);
+    });
+    return () => void stop.then((off) => off());
+  }, []);
 
   if (strayWarning) {
     // `locked` is ours and the game is holding it open, so the fix is theirs to make in
@@ -63,6 +82,28 @@ export default function RuntimeBanner() {
         busy={clearingStray}
         onAction={() => void clearStrayMsvcr90()}
         onDismiss={dismissRuntimeWarning}
+        dismissLabel={t("runtime.dismiss")}
+      />
+    );
+  }
+
+  // Below the two runtime bars: those are things that stop FrostMod dead, this is a folder
+  // that makes the game slow and fragile. Shown only when nothing louder is up.
+  if (!runtimeWarning && cloud && !cloudDismissed) {
+    const evicted = cloud.count > 0;
+    const provider = cloud.provider ?? t("cloud.genericProvider");
+    return (
+      <Bar
+        tone={evicted ? "danger" : "warning"}
+        icon={CloudOff}
+        body={
+          <Trans
+            k={evicted ? "cloud.evictedBody" : "cloud.slowBody"}
+            values={{ what: <span className="font-semibold">{provider}</span> }}
+          />
+        }
+        pitch={t(evicted ? "cloud.evictedPitch" : "cloud.slowPitch")}
+        onDismiss={() => setCloudDismissed(true)}
         dismissLabel={t("runtime.dismiss")}
       />
     );
@@ -110,6 +151,7 @@ function Bar({
   tone,
   body,
   pitch,
+  icon,
   action,
   actionIcon: ActionIcon,
   busyLabel,
@@ -121,16 +163,19 @@ function Bar({
   tone: "danger" | "warning";
   body: ReactNode;
   pitch: string;
-  action: string;
-  actionIcon: typeof Download;
-  busyLabel: string;
-  busy: boolean;
-  onAction: () => void;
+  /** Overrides the tone's default glyph. */
+  icon?: typeof Download;
+  /** Omitted for a bar with nothing to press — a fix only the player can carry out. */
+  action?: string;
+  actionIcon?: typeof Download;
+  busyLabel?: string;
+  busy?: boolean;
+  onAction?: () => void;
   onDismiss: () => void;
   dismissLabel: string;
 }) {
   const danger = tone === "danger";
-  const Icon = danger ? OctagonAlert : AlertTriangle;
+  const Icon = icon ?? (danger ? OctagonAlert : AlertTriangle);
   return (
     <div
       className={`flex items-center gap-3 border-b px-4 py-2 text-sm text-foreground ${
@@ -146,14 +191,16 @@ function Bar({
       </span>
 
       <div className="ml-auto flex shrink-0 items-center gap-1.5">
-        <Button size="sm" onClick={onAction} disabled={busy}>
-          {busy ? (
-            <Loader2 className="size-3.5 animate-spin" />
-          ) : (
-            <ActionIcon className="size-3.5" />
-          )}
-          {busy ? busyLabel : action}
-        </Button>
+        {action && ActionIcon && onAction && (
+          <Button size="sm" onClick={onAction} disabled={busy}>
+            {busy ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <ActionIcon className="size-3.5" />
+            )}
+            {busy ? busyLabel : action}
+          </Button>
+        )}
         <Button
           size="icon"
           variant="ghost"

--- a/src/Components/Settings/Settings.tsx
+++ b/src/Components/Settings/Settings.tsx
@@ -50,6 +50,7 @@ import {
   setAnalyticsEnabled,
   setRunInBackground,
   setWatchModsReload,
+  setSecureContentInject,
   setWineRunner,
   wineHostInfo,
   type WineHostInfo,
@@ -468,6 +469,7 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
   const frostmodArgs = frostmodArgsDraft ?? config.frostmodArgs ?? "";
   const instantRefresh = config.instantRefresh ?? true;
   const watchModsReload = config.watchModsReload ?? true;
+  const secureContentInject = config.secureContentInject ?? false;
 
   const overlayEnabled = config.overlayEnabled ?? true;
   const overlayHotkey = config.overlayHotkey || FALLBACK_HOTKEY;
@@ -737,6 +739,15 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
   const toggleWatchModsReload = async (v: boolean) => {
     try {
       await setWatchModsReload(v);
+      await reloadConfig();
+    } catch (e) {
+      toast.error(t("settings.updateFailed"), { description: String(e) });
+    }
+  };
+
+  const toggleSecureContentInject = async (v: boolean) => {
+    try {
+      await setSecureContentInject(v);
       await reloadConfig();
     } catch (e) {
       toast.error(t("settings.updateFailed"), { description: String(e) });
@@ -1864,6 +1875,16 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
               desc={t("settings.watchModsReloadDesc")}
               checked={watchModsReload}
               onChange={toggleWatchModsReload}
+            />
+
+            {/* Off unless asked for: this puts a DLL into the running game, and the game is
+                usually Steam's process, not ours. With it on, launch from Play — a session
+                the app didn't start is left alone. */}
+            <ToggleRow
+              label={t("settings.secureContentInject")}
+              desc={t("settings.secureContentInjectDesc")}
+              checked={secureContentInject}
+              onChange={toggleSecureContentInject}
             />
 
             {/* FrostMod's own flags, typed. A plain field rather than a toggle each: these

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type {
   Attachment,
+  ModsDehydrated,
   BikeModels,
   BikeSounds,
   DropCommitItem,
@@ -2483,6 +2484,16 @@ export function voiceMute(peerId: string, muted: boolean): Promise<void> {
 /** Fires whenever the room changes — someone joined, left, started or stopped talking. */
 export function onVoiceStatus(cb: (status: VoiceStatus) => void): Promise<UnlistenFn> {
   return listen<VoiceStatus>("voice-status", (e) => cb(e.payload));
+}
+
+/**
+ * Fires at the start of each game session when the mods tree is on a cloud sync tool —
+ * either with bytes actually evicted, or merely sitting behind the sync driver.
+ */
+export function onModsDehydrated(
+  cb: (info: ModsDehydrated) => void,
+): Promise<UnlistenFn> {
+  return listen<ModsDehydrated>("mods-dehydrated", (e) => cb(e.payload));
 }
 
 /** Toggle watching the mods folder to reload the game on external changes. */

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -2490,6 +2490,16 @@ export function setWatchModsReload(enabled: boolean): Promise<void> {
   return invoke<void>("set_watch_mods_reload", { enabled });
 }
 
+/**
+ * Toggle injecting `mxbsecure.dll` into the running game for locked content.
+ *
+ * Takes effect on the next game session — the app decides once per run, so flipping this
+ * mid-session won't reach into a game that's already up.
+ */
+export function setSecureContentInject(enabled: boolean): Promise<void> {
+  return invoke<void>("set_secure_content_inject", { enabled });
+}
+
 export const MODS_WATCH_SLUG = "__mods_watch__";
 
 /** Fires after each install with whether FrostMod picked the new mod up live. */

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -794,6 +794,9 @@ export const de: Translation = {
   "settings.watchModsReload": "Automatisch neu laden bei Ordneränderungen",
   "settings.watchModsReloadDesc":
     "Das Spiel automatisch neu laden, wenn Strecken oder Motorräder in deinen Mod-Ordner kommen — auch wenn sie außerhalb von MXB App manuell heruntergeladen wurden.",
+  "settings.secureContentInject": "Gesperrte Inhalte im Spiel nutzen",
+  "settings.secureContentInjectDesc":
+    "Erlaubt gekaufte gesperrte Strecken, indem dem laufenden Spiel ein kleiner Helfer hinzugefügt wird. Standardmäßig aus. Wenn aktiv, starte das Spiel über Play — eine Sitzung, die MXB App nicht gestartet hat, bleibt unberührt.",
   "settings.checking": "Wird geprüft…",
   "settings.runningConnected": "Läuft · Spiel verbunden",
   "settings.notRunning": "Läuft nicht",

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -344,6 +344,16 @@ export const de: Translation = {
   "runtime.fixIt": "Installieren",
   "runtime.installing": "Wird installiert…",
   "runtime.dismiss": "Hinweis ausblenden",
+  "cloud.genericProvider":
+    "ein Cloud-Sync-Dienst",
+  "cloud.evictedBody":
+    "Einige Mods liegen nicht wirklich auf diesem PC — {{what}} hat sie in die Cloud verschoben.",
+  "cloud.evictedPitch":
+    "Das Spiel liest sie beim Laden und kann dabei abstürzen. Verschiebe den Mods-Ordner heraus oder wähle „Immer auf diesem Gerät behalten“.",
+  "cloud.slowBody":
+    "Dein Mods-Ordner liegt in {{what}}.",
+  "cloud.slowPitch":
+    "Das Spiel liest beim Laden jede Mod, und Zugriffe über {{what}} sind langsam — bei einer großen Sammlung wirkt das wie ein eingefrorenes Spiel. Den Ordner herauszuschieben behebt es.",
   "runtime.installed": "Komponente installiert",
   "runtime.installedDesc":
     "FrostMod sollte das Spiel jetzt erreichen. Starte MX Bikes neu, falls es schon läuft.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -780,6 +780,9 @@ export const en = {
   "settings.watchModsReload": "Auto-reload on folder changes",
   "settings.watchModsReloadDesc":
     "Reload the game automatically when tracks or bikes are added to your mods folder — even downloaded manually outside MXB App.",
+  "settings.secureContentInject": "Use locked content in game",
+  "settings.secureContentInjectDesc":
+    "Lets purchased locked tracks open by adding a small helper to the running game. Off by default. With it on, start the game with Play — a session MXB App didn't launch is left alone.",
   "settings.checking": "Checking…",
   "settings.runningConnected": "Running · game connected",
   "settings.notRunning": "Not running",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -331,6 +331,16 @@ export const en = {
   "runtime.fixIt": "Install it",
   "runtime.installing": "Installing…",
   "runtime.dismiss": "Dismiss this warning",
+  "cloud.genericProvider":
+    "a cloud sync tool",
+  "cloud.evictedBody":
+    "Some of your mods aren’t really on this PC — {{what}} has moved them to the cloud.",
+  "cloud.evictedPitch":
+    "The game reads them while loading and can crash there. Move your mods folder out, or set “Always keep on this device”.",
+  "cloud.slowBody":
+    "Your mods folder is inside {{what}}.",
+  "cloud.slowPitch":
+    "The game reads every mod while loading, and reads through {{what}} are slow — on a big collection it can look like the game has frozen. Moving the folder out fixes it.",
   "runtime.installed": "Component installed",
   "runtime.installedDesc":
     "FrostMod should reach the game now. Restart MX Bikes if it's already open.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -786,6 +786,9 @@ export const es: Translation = {
   "settings.watchModsReload": "Recarga automática al cambiar la carpeta",
   "settings.watchModsReloadDesc":
     "Recarga el juego automáticamente cuando se añaden pistas o motos a tu carpeta de mods — incluso descargadas manualmente fuera de MXB App.",
+  "settings.secureContentInject": "Usar contenido bloqueado en el juego",
+  "settings.secureContentInjectDesc":
+    "Permite abrir circuitos bloqueados comprados añadiendo un pequeño asistente al juego en marcha. Desactivado por defecto. Con esto activo, inicia el juego con Play: una sesión que MXB App no lanzó se deja en paz.",
   "settings.checking": "Comprobando…",
   "settings.runningConnected": "En ejecución · juego conectado",
   "settings.notRunning": "Inactivo",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -338,6 +338,16 @@ export const es: Translation = {
   "runtime.fixIt": "Instalarlo",
   "runtime.installing": "Instalando…",
   "runtime.dismiss": "Descartar este aviso",
+  "cloud.genericProvider":
+    "una herramienta de sincronización en la nube",
+  "cloud.evictedBody":
+    "Algunos mods no están realmente en este PC: {{what}} los ha movido a la nube.",
+  "cloud.evictedPitch":
+    "El juego los lee al cargar y puede fallar ahí. Saca la carpeta de mods o marca “Mantener siempre en este dispositivo”.",
+  "cloud.slowBody":
+    "Tu carpeta de mods está dentro de {{what}}.",
+  "cloud.slowPitch":
+    "El juego lee todos los mods al cargar, y las lecturas a través de {{what}} son lentas: con una colección grande parece que el juego se ha colgado. Mover la carpeta fuera lo soluciona.",
   "runtime.installed": "Componente instalado",
   "runtime.installedDesc":
     "FrostMod ya debería llegar al juego. Reinicia MX Bikes si lo tienes abierto.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -341,6 +341,16 @@ export const fr: Translation = {
   "runtime.fixIt": "L'installer",
   "runtime.installing": "Installation…",
   "runtime.dismiss": "Masquer cet avertissement",
+  "cloud.genericProvider":
+    "un outil de synchronisation cloud",
+  "cloud.evictedBody":
+    "Certains mods ne sont pas vraiment sur ce PC — {{what}} les a déplacés dans le cloud.",
+  "cloud.evictedPitch":
+    "Le jeu les lit au chargement et peut planter à ce moment. Sors le dossier mods, ou choisis «\xa0Toujours conserver sur cet appareil\xa0».",
+  "cloud.slowBody":
+    "Ton dossier mods est dans {{what}}.",
+  "cloud.slowPitch":
+    "Le jeu lit tous les mods au chargement, et les lectures via {{what}} sont lentes — sur une grosse collection, on dirait que le jeu a gelé. Déplacer le dossier règle le problème.",
   "runtime.installed": "Composant installé",
   "runtime.installedDesc":
     "FrostMod devrait maintenant atteindre le jeu. Relancez MX Bikes s'il est déjà ouvert.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -791,6 +791,9 @@ export const fr: Translation = {
     "Rechargement auto lors des changements de dossier",
   "settings.watchModsReloadDesc":
     "Recharger le jeu automatiquement quand des circuits ou des motos sont ajoutés à votre dossier de mods — même téléchargés manuellement hors de MXB App.",
+  "settings.secureContentInject": "Utiliser le contenu verrouillé en jeu",
+  "settings.secureContentInjectDesc":
+    "Permet d'ouvrir les circuits verrouillés achetés en ajoutant un petit assistant au jeu en cours. Désactivé par défaut. Si activé, lance le jeu avec Play — une session que MXB App n'a pas lancée est laissée tranquille.",
   "settings.checking": "Vérification…",
   "settings.runningConnected": "En cours · jeu connecté",
   "settings.notRunning": "Inactif",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -337,6 +337,16 @@ export const it: Translation = {
   "runtime.fixIt": "Installalo",
   "runtime.installing": "Installazione…",
   "runtime.dismiss": "Nascondi questo avviso",
+  "cloud.genericProvider":
+    "uno strumento di sincronizzazione cloud",
+  "cloud.evictedBody":
+    "Alcune mod non sono davvero su questo PC: {{what}} le ha spostate nel cloud.",
+  "cloud.evictedPitch":
+    "Il gioco le legge durante il caricamento e può bloccarsi lì. Sposta fuori la cartella mod, oppure scegli “Conserva sempre su questo dispositivo”.",
+  "cloud.slowBody":
+    "La tua cartella mod si trova dentro {{what}}.",
+  "cloud.slowPitch":
+    "Il gioco legge ogni mod durante il caricamento, e le letture tramite {{what}} sono lente: con una collezione grande sembra che il gioco si sia bloccato. Spostare la cartella risolve.",
   "runtime.installed": "Componente installato",
   "runtime.installedDesc":
     "Ora FrostMod dovrebbe raggiungere il gioco. Riavvia MX Bikes se è già aperto.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -785,6 +785,9 @@ export const it: Translation = {
   "settings.watchModsReload": "Ricarica automatica alle modifiche",
   "settings.watchModsReloadDesc":
     "Ricarica il gioco automaticamente quando piste o moto vengono aggiunte alla cartella mod — anche se scaricate manualmente fuori da MXB App.",
+  "settings.secureContentInject": "Usa i contenuti bloccati nel gioco",
+  "settings.secureContentInjectDesc":
+    "Consente di aprire i tracciati bloccati acquistati aggiungendo un piccolo supporto al gioco in esecuzione. Disattivato per impostazione predefinita. Se attivo, avvia il gioco con Play: una sessione non avviata da MXB App viene lasciata stare.",
   "settings.checking": "Controllo…",
   "settings.runningConnected": "In esecuzione · gioco collegato",
   "settings.notRunning": "Non in esecuzione",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -340,6 +340,16 @@ export const ptBR: Translation = {
   "runtime.fixIt": "Instalar",
   "runtime.installing": "Instalando…",
   "runtime.dismiss": "Dispensar este aviso",
+  "cloud.genericProvider":
+    "uma ferramenta de sincronização na nuvem",
+  "cloud.evictedBody":
+    "Alguns mods não estão realmente neste PC — o {{what}} os moveu para a nuvem.",
+  "cloud.evictedPitch":
+    "O jogo os lê ao carregar e pode travar aí. Tire a pasta de mods de lá, ou marque “Manter sempre neste dispositivo”.",
+  "cloud.slowBody":
+    "Sua pasta de mods está dentro do {{what}}.",
+  "cloud.slowPitch":
+    "O jogo lê todos os mods ao carregar, e leituras pelo {{what}} são lentas — numa coleção grande parece que o jogo travou. Mover a pasta para fora resolve.",
   "runtime.installed": "Componente instalado",
   "runtime.installedDesc":
     "O FrostMod já deve alcançar o jogo. Reinicie o MX Bikes se ele estiver aberto.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -788,6 +788,9 @@ export const ptBR: Translation = {
   "settings.watchModsReload": "Recarregar automaticamente ao mudar a pasta",
   "settings.watchModsReloadDesc":
     "Recarregar o jogo automaticamente quando pistas ou motos forem adicionadas à sua pasta de mods — mesmo baixadas manualmente fora do MXB App.",
+  "settings.secureContentInject": "Usar conteúdo bloqueado no jogo",
+  "settings.secureContentInjectDesc":
+    "Permite abrir pistas bloqueadas compradas adicionando um pequeno auxiliar ao jogo em execução. Desativado por padrão. Com isso ativo, inicie o jogo pelo Play — uma sessão que o MXB App não iniciou é deixada em paz.",
   "settings.checking": "Verificando…",
   "settings.runningConnected": "Em execução · jogo conectado",
   "settings.notRunning": "Não está em execução",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -104,6 +104,16 @@ export interface Config {
    * MXB App (e.g. a manual download dropped into the folder). Default true.
    */
   watchModsReload?: boolean;
+  /**
+   * Inject `mxbsecure.dll` into the running game so locked content can be opened.
+   *
+   * **Off by default.** It reaches into a process the app usually didn't create, and the
+   * DLL hasn't been proven on a real Windows run — a build that armed it for everyone with
+   * locked content had the game dying on access violations seconds in, with quitting the
+   * app from the tray as the only way out. With it on, launch the game from Play: the app
+   * won't inject into a session it didn't start.
+   */
+  secureContentInject?: boolean;
   /** Intro slideshow already dismissed. Saved with the config (not in localStorage)
    *  so clearing the webview's storage doesn't replay the first-run flow. */
   welcomeSeen?: boolean;
@@ -1116,7 +1126,19 @@ export interface FrostmodStatus {
    * aborts MX Bikes with R6034 is still sitting there — see {@link StrayMsvcr90}.
    */
   strayMsvcr90: StrayMsvcr90;
+  /**
+   * What became of a `frostmod.dlo` hand-installed into the game's own `plugins` folder.
+   *
+   * `absent` is the normal case. Anything else means plugin mode is in play: the game loads
+   * FrostMod itself at startup, with no `frostmod.exe` involved. Nothing used to update that
+   * copy, so it outlived every release — one player was running a v0.12 plugin against a
+   * v0.16.2 install, which hung the game before the loading screen.
+   */
+  gamePlugin: PluginCopy;
 }
+
+/** State of a FrostMod plugin copy in the game's `plugins` folder. Matches `PluginCopy`. */
+export type PluginCopy = "absent" | "current" | "refreshed" | "locked";
 
 /**
  * A Visual C++ runtime the FrostMod chain needs. Matches `vcruntime::Runtime`.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1137,6 +1137,26 @@ export interface FrostmodStatus {
   gamePlugin: PluginCopy;
 }
 
+/**
+ * The mods tree's standing with a cloud sync tool, as reported by the `mods-dehydrated`
+ * event at the start of every game session. Matches `cloudfiles::Dehydrated`.
+ *
+ * Two different problems arrive on this one event. `count > 0` means bytes have actually
+ * been evicted — the game can crash reading them off the load screen. `count === 0` with a
+ * `provider` set means nothing is missing but the tree still sits behind a sync driver, and
+ * the game's whole-tree read during loading is slow enough to look like a hang.
+ */
+export interface ModsDehydrated {
+  /** Content files that are placeholders rather than real bytes. */
+  count: number;
+  /** How many were looked at, so `count` has a denominator. */
+  scanned: number;
+  /** A few names, to make the warning concrete. */
+  examples: string[];
+  /** The sync tool the tree sits under, e.g. `"OneDrive"`. Null if it doesn't sit under one. */
+  provider: string | null;
+}
+
 /** State of a FrostMod plugin copy in the game's `plugins` folder. Matches `PluginCopy`. */
 export type PluginCopy = "absent" | "current" | "refreshed" | "locked";
 


### PR DESCRIPTION
Reported as "can't launch the game from the app any more — the game opens but shows nothing, and you have to quit MXB App from the tray before it will start from Steam", plus a black screen whenever FrostMod was running. The logs put all of it on the app, not on FrostMod.

## What the logs said

`MXB App.log`, every run ending the same way:

```
18:45:49 [secure] injected mxbsecure.dll for 3 asset(s)
18:46:22 game CRASHED after 30.9s — abnormal exit (0x00000001)
18:46:31 [secure] injected mxbsecure.dll for 3 asset(s)     ← no launch line: Steam-started
18:46:52 game CRASHED after 22.3s — access violation (0xC0000005)
19:05:23 game CRASHED after 17.3s — access violation (0xC0000005)
```

Injecting into the running game is the only thing the app does to a Steam-started process on its own, which is exactly why quitting the app was the cure.

`frostmod.log`, the black screen:

```
18:44:39  508 International
18:44:44  755 Compound      ← +5s
18:44:50  Briarcliff MX     ← +6s
18:44:56  Country Side      ← +6s
```

5–6 seconds per track folder, mods tree under `C:\Users\...\OneDrive\...`. All three v0.16.2 sessions end at `[reload] step 1/21` and never come back. FrostMod isn't slow — the folder is — but the app asked for a content reload on top of the game's own startup walk.

## Changes

- **`mxbsecure` injection is opt-in** (`secure_content_inject`, default off). The DLL has never had the Windows run it was always waiting on, and until it does this shouldn't be arming itself for everyone with locked content. With it on it also declines a session the app didn't start, and logs why instead of going quiet.
- **The 2-second tree walk is gone.** `!injected_this_session && !scan_secured(..).is_empty()` never latched when nothing was protected, so an install with *nothing* to protect got a recursive walk of `mods/tracks` every two seconds for the whole session — and on a sync-backed folder, one that couldn't finish before the next started. The doc comment claimed "a no-op run to run when nothing is protected". It was the opposite. Now it decides once per run, whatever it decides.
- **Stale `frostmod.dlo` is refreshed.** Nothing had ever updated a hand-installed plugin — not the app (which manages only `frostmod.exe`/`frostmod.dll` in its own folder; `git log -S"frostmod.dlo"` has never touched that path) and not FrostMod (which prints "re-run `--install-plugin`" and leaves it). The reporter was running a **v0.12** plugin against a v0.16.2 install; the game hung before the loading screen with `frostmod.exe` not even running, because a plugin doesn't need it. Rides on the status poll, like the `msvcr90` sweep, because that reaches players who never open Settings *and* has to run when we're already on the latest tag — the state a stale plugin survives in. Refreshes only what's already there; never installs one.
- **Auto-reload holds for the first 120s of a session** when the mods tree is on a sync provider, so a folder change during startup can't stack a second full walk on the game's own.

## Notes for review

- Reused `cloudfiles` rather than adding cloud detection — it already identifies providers and warns at session start, so this became a hold rather than another warning.
- The 120s grace is a mitigation, not a cure. On the reporter's tree the walk ran 10+ minutes; the cure is the folder not being on OneDrive, which `cloudfiles` already says every session.
- The hold lives in `settle_then_reload`, not in `Pending`, so all 13 existing modwatch tests stay untouched.
- Retired plugin copies are named `frostmod.dlo.in-use-N` — checked deliberately, since anything ending in `.dlo` in that folder would be loaded as a second plugin.

## Verification

- `cargo check --target x86_64-pc-windows-gnu` clean (type-checks the `cfg(windows)` half a host build skips)
- `tsc --noEmit` clean
- 1187 tests pass, 4 new for the plugin refresh
- `tracksynth::tests::the_map_walks_to_its_last_byte` fails — reverted to bare `origin/main` and confirmed it fails there identically. Pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)