### PR TITLE
chore(release): v0.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,87 +1,46 @@
 # Changelog
 
-## 2026-09-01
+## 2026-09-01 — v0.13.4 — Ground under the track
 
 ### Added
-- The diagnostics dashboard searches. Riders by name, GUID, Steam id or account id; files by
+- Generated tracks carry their ground. An installed track has graphics instead of a black
+  surface, and no longer needs TerrainEd to be rideable.
+- The diagnostics dashboard searches: riders by name, GUID, Steam id or account id; files by
   name, hash, signer, or anything the file claims about itself.
-- Every rider has a page: their identity, last report, the servers they have been seen on,
+- Every rider has a page — their identity, last report, the servers they have been seen on,
   and every file their game has loaded.
-- Every file has a page listing everyone who has loaded it, per build — the lookup run
-  backwards.
-- Lists are paged, with a page count and numbered links.
+- Every file has a page listing everyone who has loaded it, per build.
+- Diagnostics lists are paged, with a page count and numbered links.
 
 ### Changed
-- The dashboard is four views behind a nav instead of one long page, and the tables carry the
-  information the prose used to explain.
+- Locked content is something you switch on in Settings, and applies only to games started
+  with Play.
+- Mods folders on a sync tool are read once per game session rather than every two seconds.
+- The diagnostics dashboard is four views behind a nav instead of one long page, and the
+  tables carry the information the prose used to explain.
 - Rule notes show on the rules page, and a Flag or Clear button returns to the page it was
   pressed on with its filters intact.
-
-## 2026-09-01
+- The map-loader tracer reads a whole track graphics file, and stops where it can no longer
+  be sure instead of guessing past it.
 
 ### Fixed
 - The game opens again after being closed once, without having to quit MXB App from the tray
   first.
-- Locked content is now something you switch on in Settings, and only applies to games started
-  with Play.
+- A generated track's ground lights and renders: every layer ships a normal map, writes its
+  blend mask the way the game reads it, carries a material record, and names each texture the
+  way the game caches it.
+- The starting gates sit across the track rather than off to one side, and there are forty of
+  them at the spacing every published track uses.
 - A FrostMod plugin installed into the game's own folder is kept up to date with the FrostMod
   the app manages, instead of staying on whatever version it was installed at. One that can't
   be updated is renamed so the game stops loading it, and can be renamed back.
 - A warning when your mods folder is inside OneDrive or another sync tool, which is what makes
   the game sit on a black screen while it loads.
-- Auto-reload waits for the game to finish loading when the mods folder is on OneDrive or
-  another sync tool, so a folder change during startup no longer leaves the game on a black
-  screen.
-- Mods folders on a sync tool are read once per game session rather than every two seconds.
-
-## 2026-09-01
-
-### Fixed
-- Generated tracks draw their ground. The track graphics file now carries the terrain as a
-  mesh, the way a published track does, instead of a heightfield with no surface on it.
-
-## 2026-09-01
-
-### Fixed
-- Generated tracks load and ride with their ground visible: each layer now ships the normal
-  map the renderer expects, writes its blend mask the way the game reads it, and identifies
-  each texture the way the game caches it — so the surface lights instead of dropping the game.
-
-## 2026-09-01
-
-### Fixed
-- Generated tracks no longer crash the game at the track graphics stage: each ground layer
-  now carries the material record a published map uses.
-
-## 2026-09-01
-
-### Added
-- Generated tracks carry their ground again, so an installed track has graphics instead of a
-  black surface — and no longer needs TerrainEd to be rideable.
-
-## 2026-09-01
-
-### Fixed
-- The map-loader tracer reads a whole track graphics file instead of stopping a fraction in.
-
-## 2026-09-01
-
-### Fixed
-- The starting gates sit across the track instead of off to one side of it, and there are
-  forty of them at the spacing every published track uses.
-
-## 2026-09-01
-
-### Changed
-- The map-loader tracer stops where it can no longer be sure, instead of guessing past it.
-
-### Fixed
+- Auto-reload waits for the game to finish loading when the mods folder is on a sync tool, so
+  a folder change during startup no longer leaves the game on a black screen.
 - A custom rider model no longer turns up upside down and facing backwards in the 3D preview.
-  The viewer stood a body up with one fixed turn that suits how the stock riders are built,
-  and a model built the other way round took it and landed on its head. It now checks the
-  result — skin at the top, name and number on the back — and turns the body again if the
-  first guess was wrong.
-- The map-loader tracer stops at the end of the file instead of reading zeros past it.
+  The viewer now checks the result — skin at the top, name and number on the back — and turns
+  the body again if the first guess was wrong.
 
 ## 2026-09-01 — v0.13.3 — Nothing you didn't ask for
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frost",
   "private": true,
-  "version": "0.13.3",
+  "version": "0.13.4",
   "type": "module",
   "scripts": {
     "predev": "node scripts/free-dev-port.mjs",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3532,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "mxb-app"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # whatever cargo called it. Cargo target names can't hold a space, so this is as close as
 # it gets. The description is what Windows Task Manager shows in its Processes tab.
 name = "mxb-app"
-version = "0.13.3"
+version = "0.13.4"
 description = "MXB App — MX Bikes mod manager"
 authors = ["Frost"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MXB App",
   "mainBinaryName": "MXB App",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "identifier": "com.frost.mxbikes",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Cuts MXB App v0.13.4 — a patch release off the nine unreleased CHANGELOG sections that had accumulated since v0.13.3.

## What's in it
- Generated tracks carry their ground: the `.map` ships the terrain as a mesh with normal maps, blend masks, material records and cache-correct texture names, so an installed track has graphics and no longer needs TerrainEd.
- The game opens again after being closed once; locked content moved behind a Settings switch; stale FrostMod plugins in the game folder get updated or renamed; OneDrive/sync-folder warning and startup-safe auto-reload.
- The diagnostics dashboard gains search, per-rider and per-file pages, paging and a four-view nav.
- Starting gates sit across the track, forty at published spacing; custom rider models no longer load upside down in the 3D preview.

## Consolidation notes
- Nine `## 2026-09-01` sections folded into one `## 2026-09-01 — v0.13.4 — Ground under the track`.
- Dropped "The map-loader tracer stops at the end of the file instead of reading zeros past it" — it already shipped in the v0.13.3 section.
- Collapsed the five iterations of the generated-track ground work (mesh, normal maps, blend masks, texture hashes, material records) into what the release now does, rather than the sequence it took to get there.

## Verified
- `scripts/changelog-section.sh v0.13.4 --heading` prints the heading and the body renders (39 lines), so the release notes and the Discord post will not come out empty.
- Version is 0.13.4 in `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml` and `src-tauri/Cargo.lock`. The remaining `0.13.3` in the lock is the unrelated `zstd` crate.
- No `RELEASES` entry in `src/Components/Showcase/releases.ts`: patch releases since 0.12.4 have not carried one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)