### PR TITLE
chore(release): fold the paint-sync cleanup into v0.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,12 @@
 # Changelog
 
-## 2026-09-01
-
-### Added
-- Settings shows how many paints other riders' syncs have put in your mods folder, with a
-  button that takes them back out. Paints you have edited since are kept.
-
 ## 2026-09-01 — v0.13.4 — Ground under the track
 
 ### Added
 - Generated tracks carry their ground. An installed track has graphics instead of a black
   surface, and no longer needs TerrainEd to be rideable.
+- Settings shows how many paints other riders' syncs have put in your mods folder, with a
+  button that takes them back out. Paints you have edited since are kept.
 - The diagnostics dashboard searches: riders by name, GUID, Steam id or account id; files by
   name, hash, signer, or anything the file claims about itself.
 - Every rider has a page — their identity, last report, the servers they have been seen on,


### PR DESCRIPTION
PR #389 merged after the v0.13.4 section was consolidated, so it added its own dated section above it. That section would have shipped as an orphan — `changelog-section.sh` only reads the section carrying the `v0.13.4` marker, so the paint-sync cleanup would have been missing from the release notes and the Discord post.

Folds its entry into v0.13.4's `### Added` list.

## Verified
- `scripts/changelog-section.sh v0.13.4 --heading` prints the heading; body renders at 41 lines.
- Only one unversioned `## 2026-09-01` heading remains — none.
- Version files are already at 0.13.4 from #388; untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)