### PR TITLE
fix(track): the track creator's left column scrolls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-09-01
+
+### Fixed
+- The track creator's left column scrolls, so the install and export buttons stay reachable
+  on a short window.
+
 ## 2026-09-01 — v0.13.4 — Ground under the track
 
 ### Added

--- a/src/Components/Studio/TrackStudio/TrackStudio.tsx
+++ b/src/Components/Studio/TrackStudio/TrackStudio.tsx
@@ -563,7 +563,7 @@ export default function TrackStudio() {
       {program && (
         <div className="flex min-h-0 flex-1 gap-4">
           {/* Left: what the lap is, and what it measures. */}
-          <div className="flex w-[300px] flex-none flex-col gap-3">
+          <div className="flex min-h-0 w-[300px] flex-none flex-col gap-3 overflow-y-auto">
             <div className="rounded-xl border border-input p-3.5">
               {/* The name is the folder, the .pkz and what the game lists it as, so it is
                   worth being able to change before any of those are written. */}


### PR DESCRIPTION
The left panel column in the track creator was a flex child with no `min-h-0` and no overflow, so once the name/measurements/problems/notes cards plus the action block outgrew the row height, everything below the fold was clipped — including install/export/compile.

Adds `min-h-0 overflow-y-auto`, the same pattern the Designer rail already uses. The `mt-auto` on the action block still pins it to the bottom when content is short.

🤖 Generated with [Claude Code](https://claude.com/claude-code)