### PR TITLE
feat(control-plane): show who paint synced, and what the paints look like

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-09-02
+
+### Added
+- The control plane has a paint sync view: who has published a look, searchable by rider
+  name, GUID or Steam id, and every paint we hold with a picture of it.
+- A rider's page lists their bikes slot by slot, with the paint each one installs and where
+  it lands on disk.
+- A paint's page lists the sheets it carries and every rider wearing it, and says when the
+  file a loadout names was never uploaded.
+
 ## 2026-09-01
 
 ### Fixed

--- a/control-plane/src/adminui.ts
+++ b/control-plane/src/adminui.ts
@@ -1,0 +1,269 @@
+/**
+ * The chrome every admin page is drawn in.
+ *
+ * The diagnostics dashboard grew its own stylesheet and its own set of formatters, and the
+ * paint view needs exactly the same ones — a second copy would mean the two pages drift
+ * apart the first time either is touched. Nothing here knows what it is rendering; it is the
+ * shell, the palette and the four ways a number is written for a person.
+ */
+
+/** Query values a link carries. `undefined` and `""` are dropped rather than sent empty. */
+export type Params = Record<string, string | number | undefined | null>;
+
+/** What every view needs to draw a link back to itself: the key, and where it is. */
+export interface Ctx {
+  key: string;
+  /** The path and query of the page being drawn, for a form to come back to. */
+  back: string;
+}
+
+export function ctx(url: URL): Ctx {
+  return { key: url.searchParams.get("key") ?? "", back: `${url.pathname}${url.search}` };
+}
+
+/** Every link carries the admin key: a browser typing a URL cannot send a header. */
+export function href(path: string, params: Params, key: string): string {
+  const q = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v === undefined || v === null || v === "") continue;
+    q.set(k, String(v));
+  }
+  if (key) q.set("key", key);
+  const query = q.toString();
+  return query ? `${path}?${query}` : path;
+}
+
+export function esc(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** A size a person reads, not a byte count. */
+export function bytes(size: number): string {
+  if (!size) return "—";
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${Math.round(size / 1024)} KB`;
+  if (size < 1024 * 1024 * 1024) return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(size / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+/** How long ago, in the coarsest unit that still says something. */
+export function ago(at: number): string {
+  if (!at) return "—";
+  const secs = Math.max(0, Math.round((Date.now() - at) / 1000));
+  if (secs < 90) return `${secs}s ago`;
+  const mins = Math.round(secs / 60);
+  if (mins < 90) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 48) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+/** The absolute time, where "3d ago" is not precise enough to act on. */
+export function stamp(at: number): string {
+  if (!at) return "—";
+  return new Date(at).toISOString().replace("T", " ").slice(0, 16) + "Z";
+}
+
+/** Wide tables scroll inside their panel rather than pushing the page sideways. */
+export function wrap(table: string): string {
+  return `<div class="scroll">${table}</div>`;
+}
+
+/** The page a gate returns: no key configured, or the wrong one presented. */
+export function errorPage(title: string, status: number, message: string): Response {
+  return new Response(
+    `<!doctype html><html lang="en"><head><meta charset="utf-8">
+<title>${esc(title)}</title>
+<style>${CSS}</style></head><body><header><h1>${esc(title)}</h1></header>
+<section class="panel"><p>${esc(message)}</p></section></body></html>`,
+    { status, headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" } },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Paging
+// ---------------------------------------------------------------------------
+
+/** How many rows a listing shows at once. */
+export const PAGE_SIZE = 50;
+
+/** The most rows a count query will count exactly. Past it the page says "10,000+". */
+export const MAX_COUNT = 10_000;
+
+export interface Paged<T> {
+  rows: T[];
+  /** Matching rows, counted up to `MAX_COUNT`. */
+  total: number;
+  /** 1-based. */
+  page: number;
+  size: number;
+}
+
+/** `?page=` as a 1-based page number. Anything unusable is page 1. */
+export function parsePage(value: string | null): number {
+  const asked = Number(value ?? "1");
+  if (!Number.isFinite(asked)) return 1;
+  return Math.min(10_000, Math.max(1, Math.trunc(asked)));
+}
+
+/**
+ * What was typed in a search box, as a LIKE pattern.
+ *
+ * The wildcards are escaped, so a typed underscore matches an underscore rather than
+ * anything at all — which matters when the thing being searched for is a file name.
+ */
+export function likeTerm(query: string): string {
+  const trimmed = query.trim().slice(0, 96);
+  if (!trimmed) return "";
+  return `%${trimmed.replace(/[\\%_]/g, (c) => `\\${c}`)}%`;
+}
+
+/** The row range and total above a table. */
+export function count(found: Paged<unknown>, noun: string): string {
+  const label = `${found.total.toLocaleString("en-GB")}${found.total >= MAX_COUNT ? "+" : ""} ${noun}${
+    found.total === 1 ? "" : "s"
+  }`;
+  const shown = found.rows.length;
+  // A hand-edited `?page=` past the end. Say so, rather than showing an empty table that
+  // reads as "nothing matched".
+  if (!shown) {
+    return found.total ? `<p class="count">Page ${found.page} is past the end — ${label}.</p>` : "";
+  }
+  const from = (found.page - 1) * found.size + 1;
+  return `<p class="count">${from.toLocaleString("en-GB")}–${(from + shown - 1).toLocaleString(
+    "en-GB",
+  )} of ${label}</p>`;
+}
+
+/** The page links under a table. Nothing at all when everything fits on one. */
+export function pager(path: string, params: Params, found: Paged<unknown>, c: Ctx): string {
+  const pages = Math.max(1, Math.ceil(Math.min(found.total, MAX_COUNT) / found.size));
+  if (pages <= 1) return "";
+
+  // Clamped for the arrows, so a `?page=` past the end still has a way back. The highlight
+  // is not clamped: nothing is marked current when the page asked for does not exist.
+  const at = Math.min(found.page, pages);
+  const here = found.page === at;
+  const first = Math.max(1, Math.min(at - 3, pages - 6));
+  const last = Math.min(pages, first + 6);
+
+  const step = (to: number, text: string, disabled: boolean) =>
+    disabled
+      ? `<span class="off">${text}</span>`
+      : `<a href="${esc(href(path, { ...params, page: to }, c.key))}">${text}</a>`;
+
+  const numbers: string[] = [];
+  for (let p = first; p <= last; p++) {
+    numbers.push(
+      p === at && here
+        ? `<span class="on">${p}</span>`
+        : `<a href="${esc(href(path, { ...params, page: p }, c.key))}">${p}</a>`,
+    );
+  }
+
+  return `<nav class="pages">
+    ${step(1, "First", at === 1 && here)}
+    ${step(at - 1, "‹ Prev", at === 1 && here)}
+    ${numbers.join("")}
+    ${step(at + 1, "Next ›", at === pages)}
+    ${step(pages, "Last", at === pages && here)}
+  </nav>`;
+}
+
+export const CSS = `
+:root{--bg:#f6f7f9;--panel:#fff;--ink:#16181d;--muted:#6b7280;--line:#e3e6ea;--accent:#e2492b;
+  --ok:#3f9e5a;--warn:#c98a1b;--alert:#d33b2c;--check:#dfe3e8;--check2:#bcc3cc}
+@media (prefers-color-scheme:dark){
+  :root{--bg:#0f1114;--panel:#171a1f;--ink:#e8eaed;--muted:#9aa3ae;--line:#262b32;--accent:#ff6a42;
+    --ok:#4fb872;--warn:#e0a53a;--alert:#ff5c4d;--check:#20242a;--check2:#2b3038}
+}
+*{box-sizing:border-box}
+body{margin:0;padding:20px;background:var(--bg);color:var(--ink);
+  font:13px/1.5 ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+a{color:var(--accent);text-decoration:none}
+a:hover{text-decoration:underline}
+header{display:flex;align-items:baseline;justify-content:space-between;gap:16px;margin-bottom:14px}
+h1{font-size:17px;margin:0;letter-spacing:-.01em;overflow-wrap:anywhere}
+h2{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);
+  margin:0 0 10px;display:flex;align-items:baseline;gap:8px}
+h2 .more{margin-left:auto;text-transform:none;letter-spacing:0;font-size:12px}
+header nav a{color:var(--muted);padding:4px 9px;border-radius:6px;margin-left:2px}
+header nav a.on{background:var(--accent);color:#fff}
+header nav a.on:hover{text-decoration:none}
+header nav a.out{color:var(--muted);opacity:.75}
+.ranges{margin:0 0 12px}
+.ranges a{color:var(--muted);padding:3px 8px;border-radius:6px;margin-right:2px;font-size:12px}
+.ranges a.on{background:var(--accent);color:#fff}
+.tiles{display:grid;grid-template-columns:repeat(auto-fit,minmax(130px,1fr));gap:10px;margin-bottom:14px}
+.tile{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:12px;
+  display:flex;flex-direction:column;gap:1px}
+.tile.alert{border-color:var(--alert)}
+.tile.warn{border-color:var(--warn)}
+.tile .n{font-size:24px;font-weight:600;letter-spacing:-.02em}
+.tile .l{font-size:12px}
+.tile .h,.muted{color:var(--muted);font-size:12px}
+.panel{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:14px;
+  margin-bottom:14px}
+.scroll{overflow-x:auto}
+table{width:100%;border-collapse:collapse}
+th{text-align:left;font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);
+  font-weight:500;padding:0 8px 7px;border-bottom:1px solid var(--line);white-space:nowrap}
+td{padding:6px 8px;border-bottom:1px solid var(--line);vertical-align:top}
+tr:last-child td{border-bottom:0}
+.num{text-align:right;font-variant-numeric:tabular-nums;white-space:nowrap}
+.num.hot{color:var(--warn);font-weight:600}
+.act{text-align:right;white-space:nowrap}
+.act.left{text-align:left;margin-top:10px;display:flex;align-items:center;gap:8px}
+.act form{display:inline}
+code,.mono{font:12px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;overflow-wrap:anywhere}
+.pill{display:inline-block;min-width:9px;padding:1px 7px;border-radius:99px;font-size:11px;
+  color:#fff;background:var(--muted)}
+.pill.ok{background:var(--ok)}
+.pill.warn{background:var(--warn)}
+.pill.alert{background:var(--alert)}
+.dot{display:inline-block;width:8px;height:8px;border-radius:99px;background:var(--muted);
+  vertical-align:baseline}
+.dot.ok{background:var(--ok)}
+.dot.warn{background:var(--warn)}
+.dot.alert{background:var(--alert)}
+.tag{display:inline-block;padding:1px 7px;border-radius:99px;font-size:11px;
+  border:1px solid var(--line)}
+.sig{font-size:12px}
+.sig.warn{color:var(--warn);font-weight:600}
+button{font:inherit;font-size:12px;padding:3px 10px;border-radius:6px;border:1px solid var(--line);
+  background:var(--panel);color:var(--ink);cursor:pointer;margin-left:4px}
+button.deny{border-color:var(--alert);color:var(--alert)}
+button.allow{border-color:var(--ok);color:var(--ok)}
+.search{display:flex;flex-wrap:wrap;gap:8px;align-items:center;margin:0 0 12px}
+.search input,.search select{font:inherit;font-size:13px;padding:5px 8px;border-radius:6px;
+  border:1px solid var(--line);background:var(--bg);color:var(--ink)}
+.search input[name="q"],.search input[name="f"]{flex:1 1 280px;min-width:200px}
+.search .clear{font-size:12px;color:var(--muted)}
+.add input[name="sha256"]{min-width:240px}
+.count{color:var(--muted);font-size:12px;margin:0 0 8px}
+.who{display:flex;flex-wrap:wrap;align-items:center;gap:8px;margin-bottom:12px}
+.who .name{font-size:16px;font-weight:600;overflow-wrap:anywhere}
+.facts{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:10px 16px;margin:0}
+.facts dt{font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}
+.facts dd{margin:1px 0 0;overflow-wrap:anywhere}
+.named{margin:12px 0 0}
+.pages{display:flex;flex-wrap:wrap;gap:4px;align-items:center;margin-top:12px;font-size:12px}
+.pages a,.pages span{padding:3px 9px;border-radius:6px;border:1px solid var(--line);color:var(--muted)}
+.pages a{color:var(--ink)}
+.pages .on{background:var(--accent);color:#fff;border-color:var(--accent)}
+.pages .off{opacity:.4}
+footer{color:var(--muted);font-size:12px;margin-top:4px;max-width:70ch}
+/* Paint sheets carry alpha, so they sit on a checkerboard rather than on the panel — an
+   all-white plastics sheet and a transparent one are otherwise the same picture. */
+.thumb{display:block;width:64px;height:64px;border-radius:6px;border:1px solid var(--line);
+  object-fit:contain;background-color:var(--check);
+  background-image:linear-gradient(45deg,var(--check2) 25%,transparent 25%,transparent 75%,var(--check2) 75%),
+    linear-gradient(45deg,var(--check2) 25%,transparent 25%,transparent 75%,var(--check2) 75%);
+  background-size:12px 12px;background-position:0 0,6px 6px}
+.thumb.big{width:132px;height:132px}
+a.thumblink{display:inline-block}
+`;

--- a/control-plane/src/diagnosticspage.ts
+++ b/control-plane/src/diagnosticspage.ts
@@ -63,37 +63,29 @@ import {
   type SightingQuery,
 } from "./diagnosticssearch";
 import { adminAllowed } from "./usage";
+import {
+  ago,
+  bytes,
+  count,
+  ctx,
+  CSS,
+  errorPage,
+  esc,
+  href,
+  pager,
+  stamp,
+  wrap,
+  type Ctx,
+  type Params,
+} from "./adminui";
 
 /** Windows the header offers. Anything else still works via `?days=`. */
 const RANGES = [1, 7, 30, 90];
 
 const ROOT = "/admin/diagnostics";
 
-/** Query values a link carries. `undefined` and `""` are dropped rather than sent empty. */
-type Params = Record<string, string | number | undefined | null>;
-
-/** What every view needs to draw a link back to itself: the key, and where it is. */
-interface Ctx {
-  key: string;
-  /** The path and query of the page being drawn, for a rule form to come back to. */
-  back: string;
-}
-
-function ctx(url: URL): Ctx {
-  return { key: url.searchParams.get("key") ?? "", back: `${url.pathname}${url.search}` };
-}
-
-/** Every link carries the admin key: a browser typing a URL cannot send a header. */
-function href(path: string, params: Params, key: string): string {
-  const q = new URLSearchParams();
-  for (const [k, v] of Object.entries(params)) {
-    if (v === undefined || v === null || v === "") continue;
-    q.set(k, String(v));
-  }
-  if (key) q.set("key", key);
-  const query = q.toString();
-  return query ? `${path}?${query}` : path;
-}
+/** Named on every error page this module returns, so the title is written once. */
+const TITLE = "MXB App diagnostics";
 
 // ---------------------------------------------------------------------------
 // Routes
@@ -102,8 +94,10 @@ function href(path: string, params: Params, key: string): string {
 /** The gate every view goes through, so no handler can forget it. */
 function gate(request: Request, url: URL, env: Env): Response | null {
   const allowed = adminAllowed(request, url, env);
-  if (allowed === "unset") return page(503, "No admin key is configured on this deployment.");
-  if (allowed === "denied") return page(401, "Unauthorized.");
+  if (allowed === "unset") {
+    return errorPage(TITLE, 503, "No admin key is configured on this deployment.");
+  }
+  if (allowed === "denied") return errorPage(TITLE, 401, "Unauthorized.");
   return null;
 }
 
@@ -209,7 +203,7 @@ export async function diagnosticsRules(request: Request, url: URL, env: Env): Pr
   try {
     form = await request.formData();
   } catch {
-    return page(400, "That was not a form.");
+    return errorPage(TITLE, 400, "That was not a form.");
   }
   const field = (name: string) => String(form.get(name) ?? "");
   // Back where the button was pressed, filters and page intact. Anything not one of our own
@@ -231,7 +225,7 @@ export async function diagnosticsRules(request: Request, url: URL, env: Env): Pr
     field("label"),
     field("note"),
   );
-  if (!result.ok) return page(400, result.error ?? "That rule was not usable.");
+  if (!result.ok) return errorPage(TITLE, 400, result.error ?? "That rule was not usable.");
   return redirect(back);
 }
 
@@ -268,7 +262,8 @@ function shell(title: string, tab: Tab, body: string, c: Ctx): string {
 <title>${esc(title)} — MXB App diagnostics</title>
 <style>${CSS}</style>
 </head><body>
-<header><h1>${esc(title)}</h1><nav>${nav}</nav></header>
+<header><h1>${esc(title)}</h1><nav>${nav}
+  <a class="out" href="${esc(href("/admin/paints", {}, c.key))}">Paints</a></nav></header>
 ${body}
 <footer class="muted">Only clients running the app report. A missing row means nobody told us,
   not that nothing happened.</footer>
@@ -796,64 +791,12 @@ function select<T extends string | number>(
 }
 
 /** "51–100 of 312 riders" — or "10,000+" where the count stopped counting. */
-function count(found: Paged<unknown>, noun: string): string {
-  const label = `${found.total.toLocaleString("en-GB")}${found.total >= MAX_COUNT ? "+" : ""} ${noun}${
-    found.total === 1 ? "" : "s"
-  }`;
-  const shown = found.rows.length;
-  // A hand-edited `?page=` past the end. Say so, rather than showing an empty table that
-  // reads as "nothing matched".
-  if (!shown) {
-    return found.total
-      ? `<p class="count">Page ${found.page} is past the end — ${label}.</p>`
-      : "";
-  }
-  const from = (found.page - 1) * found.size + 1;
-  return `<p class="count">${from.toLocaleString("en-GB")}–${(from + shown - 1).toLocaleString(
-    "en-GB",
-  )} of ${label}</p>`;
-}
-
 /**
  * Numbered pages, not a scroll that loads as it goes.
  *
  * A link to page four has to still be page four tomorrow, and a page of evidence you cannot
  * link to is not much use to anybody.
  */
-function pager(path: string, params: Params, found: Paged<unknown>, c: Ctx): string {
-  const pages = Math.max(1, Math.ceil(Math.min(found.total, MAX_COUNT) / found.size));
-  if (pages <= 1) return "";
-
-  // Clamped for the arrows, so a `?page=` past the end still has a way back. The highlight
-  // is not clamped: nothing is marked current when the page asked for does not exist.
-  const at = Math.min(found.page, pages);
-  const here = found.page === at;
-  const first = Math.max(1, Math.min(at - 3, pages - 6));
-  const last = Math.min(pages, first + 6);
-
-  const step = (to: number, text: string, disabled: boolean) =>
-    disabled
-      ? `<span class="off">${text}</span>`
-      : `<a href="${esc(href(path, { ...params, page: to }, c.key))}">${text}</a>`;
-
-  const numbers: string[] = [];
-  for (let p = first; p <= last; p++) {
-    numbers.push(
-      p === at && here
-        ? `<span class="on">${p}</span>`
-        : `<a href="${esc(href(path, { ...params, page: p }, c.key))}">${p}</a>`,
-    );
-  }
-
-  return `<nav class="pages">
-    ${step(1, "First", at === 1 && here)}
-    ${step(at - 1, "‹ Prev", at === 1 && here)}
-    ${numbers.join("")}
-    ${step(at + 1, "Next ›", at === pages)}
-    ${step(pages, "Last", at === pages && here)}
-  </nav>`;
-}
-
 /** A signature, which is Windows' answer, and who it names. */
 function sig(trust: Trust, publisher: string): string {
   const tone = trust === "signed" ? "" : trust === "unchecked" ? "muted" : "warn";
@@ -861,135 +804,3 @@ function sig(trust: Trust, publisher: string): string {
   return `<span class="sig ${tone}">${esc(trust)}</span>${who}`;
 }
 
-/** Wide tables scroll inside their panel rather than pushing the page sideways. */
-function wrap(table: string): string {
-  return `<div class="scroll">${table}</div>`;
-}
-
-/** A size a person reads, not a byte count. */
-function bytes(size: number): string {
-  if (!size) return "—";
-  if (size < 1024) return `${size} B`;
-  if (size < 1024 * 1024) return `${Math.round(size / 1024)} KB`;
-  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-/** How long ago, in the coarsest unit that still says something. */
-function ago(at: number): string {
-  if (!at) return "—";
-  const secs = Math.max(0, Math.round((Date.now() - at) / 1000));
-  if (secs < 90) return `${secs}s ago`;
-  const mins = Math.round(secs / 60);
-  if (mins < 90) return `${mins}m ago`;
-  const hours = Math.round(mins / 60);
-  if (hours < 48) return `${hours}h ago`;
-  return `${Math.round(hours / 24)}d ago`;
-}
-
-/** The absolute time, where "3d ago" is not precise enough to act on. */
-function stamp(at: number): string {
-  if (!at) return "—";
-  return new Date(at).toISOString().replace("T", " ").slice(0, 16) + "Z";
-}
-
-function page(status: number, message: string): Response {
-  return new Response(
-    `<!doctype html><html lang="en"><head><meta charset="utf-8">
-<title>MXB App diagnostics</title>
-<style>${CSS}</style></head><body><header><h1>Diagnostics</h1></header>
-<section class="panel"><p>${esc(message)}</p></section></body></html>`,
-    { status, headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" } },
-  );
-}
-
-function esc(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
-
-const CSS = `
-:root{--bg:#f6f7f9;--panel:#fff;--ink:#16181d;--muted:#6b7280;--line:#e3e6ea;--accent:#e2492b;
-  --ok:#3f9e5a;--warn:#c98a1b;--alert:#d33b2c}
-@media (prefers-color-scheme:dark){
-  :root{--bg:#0f1114;--panel:#171a1f;--ink:#e8eaed;--muted:#9aa3ae;--line:#262b32;--accent:#ff6a42;
-    --ok:#4fb872;--warn:#e0a53a;--alert:#ff5c4d}
-}
-*{box-sizing:border-box}
-body{margin:0;padding:20px;background:var(--bg);color:var(--ink);
-  font:13px/1.5 ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
-a{color:var(--accent);text-decoration:none}
-a:hover{text-decoration:underline}
-header{display:flex;align-items:baseline;justify-content:space-between;gap:16px;margin-bottom:14px}
-h1{font-size:17px;margin:0;letter-spacing:-.01em;overflow-wrap:anywhere}
-h2{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);
-  margin:0 0 10px;display:flex;align-items:baseline;gap:8px}
-h2 .more{margin-left:auto;text-transform:none;letter-spacing:0;font-size:12px}
-header nav a{color:var(--muted);padding:4px 9px;border-radius:6px;margin-left:2px}
-header nav a.on{background:var(--accent);color:#fff}
-header nav a.on:hover{text-decoration:none}
-.ranges{margin:0 0 12px}
-.ranges a{color:var(--muted);padding:3px 8px;border-radius:6px;margin-right:2px;font-size:12px}
-.ranges a.on{background:var(--accent);color:#fff}
-.tiles{display:grid;grid-template-columns:repeat(auto-fit,minmax(130px,1fr));gap:10px;margin-bottom:14px}
-.tile{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:12px;
-  display:flex;flex-direction:column;gap:1px}
-.tile.alert{border-color:var(--alert)}
-.tile.warn{border-color:var(--warn)}
-.tile .n{font-size:24px;font-weight:600;letter-spacing:-.02em}
-.tile .l{font-size:12px}
-.tile .h,.muted{color:var(--muted);font-size:12px}
-.panel{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:14px;
-  margin-bottom:14px}
-.scroll{overflow-x:auto}
-table{width:100%;border-collapse:collapse}
-th{text-align:left;font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);
-  font-weight:500;padding:0 8px 7px;border-bottom:1px solid var(--line);white-space:nowrap}
-td{padding:6px 8px;border-bottom:1px solid var(--line);vertical-align:top}
-tr:last-child td{border-bottom:0}
-.num{text-align:right;font-variant-numeric:tabular-nums;white-space:nowrap}
-.num.hot{color:var(--warn);font-weight:600}
-.act{text-align:right;white-space:nowrap}
-.act.left{text-align:left;margin-top:10px;display:flex;align-items:center;gap:8px}
-.act form{display:inline}
-code,.mono{font:12px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;overflow-wrap:anywhere}
-.pill{display:inline-block;min-width:9px;padding:1px 7px;border-radius:99px;font-size:11px;
-  color:#fff;background:var(--muted)}
-.pill.ok{background:var(--ok)}
-.pill.warn{background:var(--warn)}
-.pill.alert{background:var(--alert)}
-.dot{display:inline-block;width:8px;height:8px;border-radius:99px;background:var(--muted);
-  vertical-align:baseline}
-.dot.ok{background:var(--ok)}
-.dot.warn{background:var(--warn)}
-.dot.alert{background:var(--alert)}
-.tag{display:inline-block;padding:1px 7px;border-radius:99px;font-size:11px;
-  border:1px solid var(--line)}
-.sig{font-size:12px}
-.sig.warn{color:var(--warn);font-weight:600}
-button{font:inherit;font-size:12px;padding:3px 10px;border-radius:6px;border:1px solid var(--line);
-  background:var(--panel);color:var(--ink);cursor:pointer;margin-left:4px}
-button.deny{border-color:var(--alert);color:var(--alert)}
-button.allow{border-color:var(--ok);color:var(--ok)}
-.search{display:flex;flex-wrap:wrap;gap:8px;align-items:center;margin:0 0 12px}
-.search input,.search select{font:inherit;font-size:13px;padding:5px 8px;border-radius:6px;
-  border:1px solid var(--line);background:var(--bg);color:var(--ink)}
-.search input[name="q"],.search input[name="f"]{flex:1 1 280px;min-width:200px}
-.search .clear{font-size:12px;color:var(--muted)}
-.add input[name="sha256"]{min-width:240px}
-.count{color:var(--muted);font-size:12px;margin:0 0 8px}
-.who{display:flex;flex-wrap:wrap;align-items:center;gap:8px;margin-bottom:12px}
-.who .name{font-size:16px;font-weight:600;overflow-wrap:anywhere}
-.facts{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:10px 16px;margin:0}
-.facts dt{font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}
-.facts dd{margin:1px 0 0;overflow-wrap:anywhere}
-.named{margin:12px 0 0}
-.pages{display:flex;flex-wrap:wrap;gap:4px;align-items:center;margin-top:12px;font-size:12px}
-.pages a,.pages span{padding:3px 9px;border-radius:6px;border:1px solid var(--line);color:var(--muted)}
-.pages a{color:var(--ink)}
-.pages .on{background:var(--accent);color:#fff;border-color:var(--accent)}
-.pages .off{opacity:.4}
-footer{color:var(--muted);font-size:12px;margin-top:4px;max-width:70ch}
-`;

--- a/control-plane/src/diagnosticssearch.ts
+++ b/control-plane/src/diagnosticssearch.ts
@@ -12,42 +12,13 @@
 import { isState, isTrust, parseMatched, type Matched, type State, type Trust } from "./diagnostics";
 import { PRESENCE_TTL_MS } from "./validate";
 
-/** Rows per page. One screen of a dense table, and one D1 read. */
-export const PAGE_SIZE = 50;
-
-/** The most rows a count query will count exactly. Past it the page says "10,000+". */
-export const MAX_COUNT = 10_000;
+// Paging and the search-box escaping live in `adminui.ts` — the paint views page and filter
+// the same way, and two copies of "what is page 2" is how they stop agreeing. Re-exported
+// rather than moved out of sight: every caller here has always read them from this module.
+export { likeTerm, MAX_COUNT, PAGE_SIZE, parsePage, type Paged } from "./adminui";
+import { MAX_COUNT, PAGE_SIZE, likeTerm, parsePage, type Paged } from "./adminui";
 
 const DAY_MS = 86_400_000;
-
-export interface Paged<T> {
-  rows: T[];
-  /** Matching rows, counted up to `MAX_COUNT`. */
-  total: number;
-  /** 1-based. */
-  page: number;
-  size: number;
-}
-
-/** `?page=` as a 1-based page number. Anything unusable is page 1. */
-export function parsePage(value: string | null): number {
-  const asked = Number(value ?? "1");
-  if (!Number.isFinite(asked)) return 1;
-  return Math.min(10_000, Math.max(1, Math.trunc(asked)));
-}
-
-/**
- * A search box turned into a LIKE pattern.
- *
- * `%` and `_` are wildcards and `\` is the escape, so someone searching `nvidia_share` gets
- * the underscore they typed rather than any character. Empty stays empty, which every caller
- * reads as "no filter".
- */
-export function likeTerm(query: string): string {
-  const trimmed = query.trim().slice(0, 96);
-  if (!trimmed) return "";
-  return `%${trimmed.replace(/[\\%_]/g, (c) => `\\${c}`)}%`;
-}
 
 /** A window in days, clamped to something a page can draw. */
 export function clampDays(value: string | null, fallback = 30): number {

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -36,6 +36,13 @@ import {
   diagnosticsRules,
   diagnosticsRulesPage,
 } from "./diagnosticspage";
+import {
+  paintFiles,
+  paintOne,
+  paintRider,
+  paintRiders,
+  paintThumbnail,
+} from "./paintspage";
 import { listPlugins, myPlugins, pluginBundle, redeemKey } from "./plugins";
 import { generateTrack } from "./trackgen";
 import { bootstrapScript, imageBootstrapScript } from "./bootstrap";
@@ -222,6 +229,16 @@ async function route(request: Request, env: Env): Promise<Response> {
   if (method === "POST" && path === "/admin/diagnostics/rules") {
     return diagnosticsRules(request, url, env);
   }
+
+  // Who has published a look, and what we are shipping to a grid. Behind `ADMIN_KEY` and
+  // above the account gate on exactly the same terms as the two pages before it: it names
+  // riders, their GUIDs and their Steam ids, and no player's token should be enough to read
+  // any of that about anybody else.
+  if (method === "GET" && path === "/admin/paints") return paintRiders(request, url, env);
+  if (method === "GET" && path === "/admin/paints/rider") return paintRider(request, url, env);
+  if (method === "GET" && path === "/admin/paints/files") return paintFiles(request, url, env);
+  if (method === "GET" && path === "/admin/paints/paint") return paintOne(request, url, env);
+  if (method === "GET" && path === "/admin/paints/thumb") return paintThumbnail(request, url, env);
 
   const account = await authenticate(request, env);
   if (!account) return json(401, { error: "unauthorized" });

--- a/control-plane/src/paintspage.ts
+++ b/control-plane/src/paintspage.ts
@@ -1,0 +1,718 @@
+/**
+ * What paint sync is actually holding, and who put it there.
+ *
+ * Everything else in the control plane treats a paint as a digest — which is right for
+ * moving bytes between riders and leaves nobody able to answer the two questions worth
+ * asking about it: who has published a look, and what does what we are shipping to a grid
+ * actually look like. Both are answered here, behind the same `ADMIN_KEY` as the usage and
+ * diagnostics pages and for the same reason: rider names, GUIDs and Steam ids are on it.
+ *
+ * The pictures come from `pntthumb.ts`, which reads the `.pnt` in R2. Nothing on the page
+ * depends on one appearing — a paint that is locked content, or whose blob was never
+ * uploaded, still lists with everything else and shows a tile saying which.
+ */
+
+import {
+  ago,
+  bytes,
+  count,
+  ctx,
+  errorPage,
+  esc,
+  href,
+  likeTerm,
+  MAX_COUNT,
+  PAGE_SIZE,
+  pager,
+  parsePage,
+  stamp,
+  wrap,
+  CSS,
+  type Ctx,
+  type Paged,
+  type Params,
+} from "./adminui";
+import { adminAllowed } from "./usage";
+import { imageTable, paintThumb, pickImage, type PntImage } from "./pntthumb";
+import { PRESENCE_TTL_MS } from "./validate";
+
+const ROOT = "/admin/paints";
+
+/** How many riders one paint's page lists. Past this it is a popular paint, not a list. */
+const MAX_WEARERS = 200;
+
+type Tab = "riders" | "paints";
+
+// ---------------------------------------------------------------------------
+// Rows
+// ---------------------------------------------------------------------------
+
+interface RiderRow {
+  id: string;
+  rider_name: string;
+  guid: string | null;
+  steam_id: string | null;
+  kind: string;
+  bikes: number;
+  files: number;
+  slots: number;
+  bytes: number;
+  published_at: number | null;
+  at_server: string | null;
+}
+
+interface PaintRow {
+  sha256: string;
+  file_name: string;
+  names: number;
+  riders: number;
+  size: number;
+  uses: number;
+  slots: string;
+  /** What R2 has under that digest, or null if the blob was never uploaded. */
+  stored: number | null;
+}
+
+interface SlotRow {
+  bike_id: string;
+  slot: string;
+  file_name: string;
+  sha256: string;
+  size: number;
+  rel_dest: string;
+}
+
+interface Totals {
+  riders: number;
+  paints: number;
+  slots: number;
+  today: number;
+  present: number;
+  stored: number;
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+/** The gate every view goes through, so no handler can forget it. */
+function gate(request: Request, url: URL, env: Env): Response | null {
+  const allowed = adminAllowed(request, url, env);
+  if (allowed === "unset") {
+    return errorPage("Paint sync", 503, "No admin key is configured on this deployment.");
+  }
+  if (allowed === "denied") return errorPage("Paint sync", 401, "Unauthorized.");
+  return null;
+}
+
+function html(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      // Named people, behind a key: never cached by anything in between.
+      "cache-control": "no-store",
+    },
+  });
+}
+
+/** `GET /admin/paints` — who has published a look. */
+export async function paintRiders(request: Request, url: URL, env: Env): Promise<Response> {
+  const denied = gate(request, url, env);
+  if (denied) return denied;
+
+  const c = ctx(url);
+  const q = (url.searchParams.get("q") ?? "").slice(0, 96);
+  const page = parsePage(url.searchParams.get("page"));
+  const [sums, found] = await Promise.all([totals(env), searchRiders(env, q, page)]);
+  return html(shell("Paint sync", "riders", ridersView(sums, found, q, c), c));
+}
+
+/** `GET /admin/paints/rider?id=…` — one rider's bikes, slot by slot. */
+export async function paintRider(request: Request, url: URL, env: Env): Promise<Response> {
+  const denied = gate(request, url, env);
+  if (denied) return denied;
+
+  const c = ctx(url);
+  const id = url.searchParams.get("id") ?? "";
+  const account = await env.DB.prepare(
+    "SELECT id, rider_name, guid, steam_id, kind, created_at FROM accounts WHERE id = ?",
+  )
+    .bind(id)
+    .first<{
+      id: string;
+      rider_name: string;
+      guid: string | null;
+      steam_id: string | null;
+      kind: string;
+      created_at: number;
+    }>();
+  if (!account) return html(shell("Paint sync", "riders", empty("No such account."), c), 404);
+
+  const [slots, published, presence] = await Promise.all([
+    env.DB.prepare(
+      "SELECT bike_id, slot, file_name, sha256, size, rel_dest FROM loadout_paints" +
+        " WHERE account_id = ? ORDER BY bike_id, slot",
+    )
+      .bind(id)
+      .all<SlotRow>(),
+    env.DB.prepare("SELECT bike_id, updated_at FROM loadouts WHERE account_id = ?")
+      .bind(id)
+      .all<{ bike_id: string; updated_at: number }>(),
+    env.DB.prepare("SELECT server_id, updated_at FROM presence WHERE account_id = ?")
+      .bind(id)
+      .first<{ server_id: string; updated_at: number }>(),
+  ]);
+
+  const when = new Map((published.results ?? []).map((r) => [r.bike_id, r.updated_at]));
+  return html(
+    shell(
+      account.rider_name,
+      "riders",
+      riderView(account, slots.results ?? [], when, presence, c),
+      c,
+    ),
+  );
+}
+
+/** `GET /admin/paints/files` — every paint we hold, once per digest. */
+export async function paintFiles(request: Request, url: URL, env: Env): Promise<Response> {
+  const denied = gate(request, url, env);
+  if (denied) return denied;
+
+  const c = ctx(url);
+  const q = (url.searchParams.get("q") ?? "").slice(0, 96);
+  const sort = sortOf(url.searchParams.get("sort"));
+  const page = parsePage(url.searchParams.get("page"));
+  const [sums, found] = await Promise.all([totals(env), searchPaints(env, q, sort, page)]);
+  return html(shell("Paints", "paints", paintsView(sums, found, q, sort, c), c));
+}
+
+/** `GET /admin/paints/paint?sha=…` — one paint: its sheets, and who is wearing it. */
+export async function paintOne(request: Request, url: URL, env: Env): Promise<Response> {
+  const denied = gate(request, url, env);
+  if (denied) return denied;
+
+  const c = ctx(url);
+  const sha = (url.searchParams.get("sha") ?? "").toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(sha)) {
+    return html(shell("Paints", "paints", empty("That is not a paint digest."), c), 400);
+  }
+
+  const [wearers, stored, sheets] = await Promise.all([
+    env.DB.prepare(
+      "SELECT a.id, a.rider_name, a.guid, p.bike_id, p.slot, p.file_name, p.size, p.rel_dest" +
+        " FROM loadout_paints p JOIN accounts a ON a.id = p.account_id" +
+        " WHERE p.sha256 = ? ORDER BY a.rider_name, p.bike_id, p.slot LIMIT ?",
+    )
+      .bind(sha, MAX_WEARERS)
+      .all<{
+        id: string;
+        rider_name: string;
+        guid: string | null;
+        bike_id: string;
+        slot: string;
+        file_name: string;
+        size: number;
+        rel_dest: string;
+      }>(),
+    env.PAINTS.head(sha),
+    sheetsOf(sha, env),
+  ]);
+
+  const rows = wearers.results ?? [];
+  if (rows.length === 0 && !stored) {
+    return html(shell("Paints", "paints", empty("Nothing here has that digest."), c), 404);
+  }
+  const title = rows[0]?.file_name ?? sha.slice(0, 12);
+  return html(shell(title, "paints", oneView(sha, rows, stored?.size ?? null, sheets, c), c));
+}
+
+/** `GET /admin/paints/thumb?sha=…` — the picture itself. */
+export async function paintThumbnail(request: Request, url: URL, env: Env): Promise<Response> {
+  const denied = gate(request, url, env);
+  if (denied) return denied;
+  return paintThumb((url.searchParams.get("sha") ?? "").toLowerCase(), env);
+}
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+async function totals(env: Env): Promise<Totals> {
+  const now = Date.now();
+  const row = await env.DB.prepare(
+    "SELECT" +
+      " (SELECT COUNT(DISTINCT account_id) FROM loadout_paints) AS riders," +
+      " (SELECT COUNT(DISTINCT sha256) FROM loadout_paints) AS paints," +
+      " (SELECT COUNT(*) FROM loadout_paints) AS slots," +
+      " (SELECT COUNT(DISTINCT account_id) FROM loadouts WHERE updated_at > ?) AS today," +
+      " (SELECT COUNT(*) FROM presence WHERE updated_at > ?) AS present," +
+      // Per digest, not per row: the same paint on four bikes is stored once.
+      " (SELECT COALESCE(SUM(size), 0) FROM (SELECT MAX(size) AS size FROM loadout_paints" +
+      "   GROUP BY sha256)) AS stored",
+  )
+    .bind(now - 86_400_000, now - PRESENCE_TTL_MS)
+    .first<Totals>();
+  return row ?? { riders: 0, paints: 0, slots: 0, today: 0, present: 0, stored: 0 };
+}
+
+/** The filter both the rider list and its count use, so they can never disagree. */
+const RIDER_MATCH =
+  " (? = '' OR a.rider_name LIKE ? ESCAPE '\\' OR COALESCE(a.guid, '') LIKE ? ESCAPE '\\'" +
+  " OR COALESCE(a.steam_id, '') LIKE ? ESCAPE '\\')";
+
+async function searchRiders(env: Env, q: string, page: number): Promise<Paged<RiderRow>> {
+  const like = likeTerm(q);
+  const fresh = Date.now() - PRESENCE_TTL_MS;
+
+  const rows = await env.DB.prepare(
+    "SELECT a.id, a.rider_name, a.guid, a.steam_id, a.kind," +
+      " COUNT(DISTINCT p.bike_id) AS bikes, COUNT(DISTINCT p.sha256) AS files," +
+      " COUNT(*) AS slots, SUM(p.size) AS bytes," +
+      " (SELECT MAX(l.updated_at) FROM loadouts l WHERE l.account_id = a.id) AS published_at," +
+      " (SELECT pr.server_id FROM presence pr WHERE pr.account_id = a.id AND pr.updated_at > ?)" +
+      "   AS at_server" +
+      " FROM accounts a JOIN loadout_paints p ON p.account_id = a.id" +
+      " WHERE" +
+      RIDER_MATCH +
+      " GROUP BY a.id ORDER BY published_at DESC, a.rider_name LIMIT ? OFFSET ?",
+  )
+    .bind(fresh, like, like, like, like, PAGE_SIZE, (page - 1) * PAGE_SIZE)
+    .all<RiderRow>();
+
+  const total = await env.DB.prepare(
+    "SELECT COUNT(*) AS n FROM (SELECT p.account_id FROM loadout_paints p" +
+      " JOIN accounts a ON a.id = p.account_id WHERE" +
+      RIDER_MATCH +
+      " GROUP BY p.account_id LIMIT ?)",
+  )
+    .bind(like, like, like, like, MAX_COUNT)
+    .first<{ n: number }>();
+
+  return { rows: rows.results ?? [], total: total?.n ?? 0, page, size: PAGE_SIZE };
+}
+
+const SORTS = ["riders", "size", "name"] as const;
+type Sort = (typeof SORTS)[number];
+
+function sortOf(value: string | null): Sort {
+  return (SORTS as readonly string[]).includes(value ?? "") ? (value as Sort) : "riders";
+}
+
+const PAINT_MATCH = " (? = '' OR p.file_name LIKE ? ESCAPE '\\' OR p.sha256 LIKE ? ESCAPE '\\')";
+
+async function searchPaints(
+  env: Env,
+  q: string,
+  sort: Sort,
+  page: number,
+): Promise<Paged<PaintRow>> {
+  const like = likeTerm(q);
+  const order =
+    sort === "size"
+      ? "size DESC, riders DESC"
+      : sort === "name"
+        ? "file_name COLLATE NOCASE, riders DESC"
+        : "riders DESC, uses DESC, file_name COLLATE NOCASE";
+
+  const rows = await env.DB.prepare(
+    "SELECT p.sha256, MIN(p.file_name) AS file_name, COUNT(DISTINCT p.file_name) AS names," +
+      " COUNT(DISTINCT p.account_id) AS riders, MAX(p.size) AS size, COUNT(*) AS uses," +
+      " GROUP_CONCAT(DISTINCT p.slot) AS slots" +
+      " FROM loadout_paints p WHERE" +
+      PAINT_MATCH +
+      ` GROUP BY p.sha256 ORDER BY ${order} LIMIT ? OFFSET ?`,
+  )
+    .bind(like, like, like, PAGE_SIZE, (page - 1) * PAGE_SIZE)
+    .all<Omit<PaintRow, "stored">>();
+
+  const total = await env.DB.prepare(
+    "SELECT COUNT(*) AS n FROM (SELECT p.sha256 FROM loadout_paints p WHERE" +
+      PAINT_MATCH +
+      " GROUP BY p.sha256 LIMIT ?)",
+  )
+    .bind(like, like, like, MAX_COUNT)
+    .first<{ n: number }>();
+
+  // What the database says a rider published and what the bucket holds are two different
+  // facts: a loadout row is written before the blob is uploaded, and a publish that was
+  // interrupted leaves the first without the second. The page says which rows those are.
+  const listed = rows.results ?? [];
+  const heads = await Promise.all(listed.map((r) => env.PAINTS.head(r.sha256)));
+  return {
+    rows: listed.map((r, i) => ({ ...r, stored: heads[i]?.size ?? null })),
+    total: total?.n ?? 0,
+    page,
+    size: PAGE_SIZE,
+  };
+}
+
+/**
+ * The sheets inside one paint, for its own page.
+ *
+ * Read through the same walk the thumbnail uses, so a paint that cannot be drawn says the
+ * same thing in both places rather than being blank in one of them.
+ */
+async function sheetsOf(
+  sha: string,
+  env: Env,
+): Promise<{ images: PntImage[]; chosen: number } | null> {
+  try {
+    const head = await env.PAINTS.head(sha);
+    if (!head) return null;
+    const src = {
+      size: head.size,
+      async read(offset: number, length: number) {
+        const object = await env.PAINTS.get(sha, { range: { offset, length } });
+        if (!object) throw new Error("gone");
+        return new Uint8Array(await object.arrayBuffer());
+      },
+      async stream(): Promise<ReadableStream<Uint8Array>> {
+        throw new Error("not needed");
+      },
+    };
+    const images = await imageTable(src);
+    // By index, not by name: two sheets may share a name, and only one of them is drawn.
+    return { images, chosen: images.indexOf(pickImage(images)) };
+  } catch {
+    // Sealed, absent or unreadable — the thumbnail tile already says which.
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shell
+// ---------------------------------------------------------------------------
+
+function shell(title: string, tab: Tab, body: string, c: Ctx): string {
+  const nav = (
+    [
+      ["riders", "Riders", ROOT],
+      ["paints", "Paints", `${ROOT}/files`],
+    ] as const
+  )
+    .map(
+      ([id, text, path]) =>
+        `<a class="${id === tab ? "on" : ""}" href="${esc(href(path, {}, c.key))}">${text}</a>`,
+    )
+    .join("");
+
+  return `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>${esc(title)} — MXB App paint sync</title>
+<style>${CSS}</style>
+</head><body>
+<header><h1>${esc(title)}</h1><nav>${nav}
+  <a class="out" href="${esc(href("/admin/diagnostics", {}, c.key))}">Diagnostics</a></nav></header>
+${body}
+<footer class="muted">A rider appears here once their app has published a loadout. Pictures are
+  rendered from the paint's largest sheet, which is stored upside-down and flipped for the
+  view; locked content has no readable sheets and shows as sealed.</footer>
+</body></html>`;
+}
+
+function empty(message: string): string {
+  return `<section class="panel"><p class="muted">${esc(message)}</p></section>`;
+}
+
+function tile(label: string, value: string, hint: string): string {
+  return `<div class="tile"><div class="n">${esc(value)}</div><div class="l">${esc(label)}</div>
+  <div class="h">${esc(hint)}</div></div>`;
+}
+
+function tiles(s: Totals): string {
+  return `<section class="tiles">
+  ${tile("Riders publishing", s.riders.toLocaleString("en-GB"), "accounts with a loadout")}
+  ${tile("Published today", s.today.toLocaleString("en-GB"), "in the last 24 hours")}
+  ${tile("On a server", s.present.toLocaleString("en-GB"), "reported in the last 10 minutes")}
+  ${tile("Paints", s.paints.toLocaleString("en-GB"), "distinct files, de-duplicated")}
+  ${tile("Equipped slots", s.slots.toLocaleString("en-GB"), "rider × bike × slot")}
+  ${tile("Stored", bytes(s.stored), "one copy per digest")}
+</section>`;
+}
+
+/** The picture, linking to the paint it belongs to. */
+function thumb(sha: string, name: string, c: Ctx, big = false): string {
+  return `<a class="thumblink" href="${esc(href(`${ROOT}/paint`, { sha }, c.key))}"
+  ><img class="thumb${big ? " big" : ""}" loading="lazy" decoding="async"
+    src="${esc(href(`${ROOT}/thumb`, { sha }, c.key))}" alt="${esc(name)}"></a>`;
+}
+
+function searchBox(path: string, q: string, extra: string, c: Ctx, hint: string): string {
+  return `<form class="search" method="get" action="${esc(path)}">
+  ${c.key ? `<input type="hidden" name="key" value="${esc(c.key)}">` : ""}
+  <input name="q" value="${esc(q)}" placeholder="${esc(hint)}" autocomplete="off">
+  ${extra}
+  <button type="submit">Search</button>
+  ${q ? `<a class="clear" href="${esc(href(path, {}, c.key))}">clear</a>` : ""}
+</form>`;
+}
+
+// ---------------------------------------------------------------------------
+// Riders
+// ---------------------------------------------------------------------------
+
+function ridersView(s: Totals, found: Paged<RiderRow>, q: string, c: Ctx): string {
+  const params: Params = { q };
+  return `${tiles(s)}
+<section class="panel">
+  <h2>Riders</h2>
+  ${searchBox(ROOT, q, "", c, "rider name, GUID or Steam id")}
+  ${count(found, "rider")}
+  ${found.rows.length ? wrap(riderTable(found.rows, c)) : `<p class="muted">Nobody matches.</p>`}
+  ${pager(ROOT, params, found, c)}
+</section>`;
+}
+
+function riderTable(rows: RiderRow[], c: Ctx): string {
+  return `<table><thead><tr>
+  <th>Rider</th><th>GUID</th><th>Steam</th><th class="num">Bikes</th><th class="num">Slots</th>
+  <th class="num">Paints</th><th class="num">Size</th><th>Published</th><th>Where</th>
+</tr></thead><tbody>
+${rows
+  .map(
+    (r) => `<tr>
+  <td><a href="${esc(href(`${ROOT}/rider`, { id: r.id }, c.key))}">${esc(r.rider_name)}</a>
+    ${r.kind === "device" ? ` <span class="tag">device</span>` : ""}</td>
+  <td class="mono">${r.guid ? esc(r.guid) : `<span class="muted">—</span>`}</td>
+  <td class="mono">${r.steam_id ? esc(r.steam_id) : `<span class="muted">—</span>`}</td>
+  <td class="num">${r.bikes}</td>
+  <td class="num">${r.slots}</td>
+  <td class="num">${r.files}</td>
+  <td class="num">${esc(bytes(r.bytes))}</td>
+  <td title="${esc(stamp(r.published_at ?? 0))}">${esc(ago(r.published_at ?? 0))}</td>
+  <td>${r.at_server ? `<span class="dot ok"></span> ${esc(r.at_server)}` : `<span class="muted">—</span>`}</td>
+</tr>`,
+  )
+  .join("")}
+</tbody></table>`;
+}
+
+// ---------------------------------------------------------------------------
+// One rider
+// ---------------------------------------------------------------------------
+
+function riderView(
+  account: {
+    id: string;
+    rider_name: string;
+    guid: string | null;
+    steam_id: string | null;
+    kind: string;
+    created_at: number;
+  },
+  slots: SlotRow[],
+  when: Map<string, number>,
+  presence: { server_id: string; updated_at: number } | null,
+  c: Ctx,
+): string {
+  const live = presence && presence.updated_at > Date.now() - PRESENCE_TTL_MS;
+  const facts = `<section class="panel">
+  <div class="who"><span class="name">${esc(account.rider_name)}</span>
+    <span class="tag">${esc(account.kind)}</span>
+    ${live ? `<span class="pill ok">on ${esc(presence!.server_id)}</span>` : ""}</div>
+  <dl class="facts">
+    ${fact("GUID", account.guid ?? "—", true)}
+    ${fact("Steam id", account.steam_id ?? "—", true)}
+    ${fact("Account id", account.id, true)}
+    ${fact("Enrolled", stamp(account.created_at))}
+    ${fact("Bikes published", String(when.size))}
+    ${fact("Last publish", when.size ? ago(Math.max(...when.values())) : "—")}
+    ${fact(
+      "Last seen",
+      presence ? `${ago(presence.updated_at)} on ${presence.server_id}` : "never reported",
+    )}
+  </dl>
+</section>`;
+
+  if (slots.length === 0) return `${facts}${empty("This account has no paints published.")}`;
+
+  const byBike = new Map<string, SlotRow[]>();
+  for (const row of slots) {
+    const at = byBike.get(row.bike_id);
+    if (at) at.push(row);
+    else byBike.set(row.bike_id, [row]);
+  }
+
+  const bikes = [...byBike.entries()]
+    .map(
+      ([bike, rows]) => `<section class="panel">
+  <h2>${esc(bike || "(no bike named)")}
+    <span class="more muted">${rows.length} slot${rows.length === 1 ? "" : "s"} ·
+      published ${esc(ago(when.get(bike) ?? 0))}</span></h2>
+  ${wrap(slotTable(rows, c))}
+</section>`,
+    )
+    .join("");
+
+  return `${facts}${bikes}`;
+}
+
+function fact(label: string, value: string, mono = false): string {
+  return `<dt>${esc(label)}</dt><dd${mono ? ' class="mono"' : ""}>${esc(value)}</dd>`;
+}
+
+function slotTable(rows: SlotRow[], c: Ctx): string {
+  return `<table><thead><tr>
+  <th></th><th>Slot</th><th>File</th><th class="num">Size</th><th>Installs at</th><th>Digest</th>
+</tr></thead><tbody>
+${rows
+  .map(
+    (r) => `<tr>
+  <td>${thumb(r.sha256, r.file_name, c)}</td>
+  <td>${esc(r.slot)}</td>
+  <td>${esc(r.file_name)}</td>
+  <td class="num">${esc(bytes(r.size))}</td>
+  <td class="mono">${esc(r.rel_dest)}</td>
+  <td class="mono"><a href="${esc(href(`${ROOT}/paint`, { sha: r.sha256 }, c.key))}">${esc(
+    r.sha256.slice(0, 12),
+  )}</a></td>
+</tr>`,
+  )
+  .join("")}
+</tbody></table>`;
+}
+
+// ---------------------------------------------------------------------------
+// Paints
+// ---------------------------------------------------------------------------
+
+function paintsView(
+  s: Totals,
+  found: Paged<PaintRow>,
+  q: string,
+  sort: Sort,
+  c: Ctx,
+): string {
+  const path = `${ROOT}/files`;
+  const params: Params = { q, sort };
+  const options = (
+    [
+      ["riders", "Most worn"],
+      ["size", "Largest"],
+      ["name", "By name"],
+    ] as const
+  )
+    .map(([v, text]) => `<option value="${v}"${v === sort ? " selected" : ""}>${text}</option>`)
+    .join("");
+
+  return `${tiles(s)}
+<section class="panel">
+  <h2>Paints</h2>
+  ${searchBox(path, q, `<select name="sort">${options}</select>`, c, "file name or digest")}
+  ${count(found, "paint")}
+  ${found.rows.length ? wrap(paintTable(found.rows, c)) : `<p class="muted">Nothing matches.</p>`}
+  ${pager(path, params, found, c)}
+</section>`;
+}
+
+function paintTable(rows: PaintRow[], c: Ctx): string {
+  return `<table><thead><tr>
+  <th></th><th>File</th><th>Slots</th><th class="num">Riders</th><th class="num">Uses</th>
+  <th class="num">Size</th><th>Blob</th><th>Digest</th>
+</tr></thead><tbody>
+${rows
+  .map(
+    (r) => `<tr>
+  <td>${thumb(r.sha256, r.file_name, c)}</td>
+  <td><a href="${esc(href(`${ROOT}/paint`, { sha: r.sha256 }, c.key))}">${esc(r.file_name)}</a>
+    ${r.names > 1 ? ` <span class="tag">${r.names} names</span>` : ""}</td>
+  <td class="muted">${esc((r.slots ?? "").split(",").join(", "))}</td>
+  <td class="num">${r.riders}</td>
+  <td class="num">${r.uses}</td>
+  <td class="num">${esc(bytes(r.size))}</td>
+  <td>${
+    r.stored === null
+      ? `<span class="pill alert">missing</span>`
+      : r.stored === r.size
+        ? `<span class="dot ok"></span>`
+        : `<span class="pill warn">${esc(bytes(r.stored))}</span>`
+  }</td>
+  <td class="mono">${esc(r.sha256.slice(0, 12))}</td>
+</tr>`,
+  )
+  .join("")}
+</tbody></table>`;
+}
+
+// ---------------------------------------------------------------------------
+// One paint
+// ---------------------------------------------------------------------------
+
+function oneView(
+  sha: string,
+  wearers: {
+    id: string;
+    rider_name: string;
+    guid: string | null;
+    bike_id: string;
+    slot: string;
+    file_name: string;
+    size: number;
+    rel_dest: string;
+  }[],
+  stored: number | null,
+  sheets: { images: PntImage[]; chosen: number } | null,
+  c: Ctx,
+): string {
+  const names = [...new Set(wearers.map((w) => w.file_name))];
+  const riders = new Set(wearers.map((w) => w.id)).size;
+
+  const head = `<section class="panel">
+  <div class="who">${thumb(sha, names[0] ?? sha, c, true)}
+    <div>
+      <div class="name">${esc(names[0] ?? "unknown file")}</div>
+      <div class="muted mono">${esc(sha)}</div>
+    </div></div>
+  <dl class="facts">
+    ${fact("Stored", stored === null ? "not in the bucket" : bytes(stored))}
+    ${fact("Riders", String(riders))}
+    ${fact("Equipped", `${wearers.length} slot${wearers.length === 1 ? "" : "s"}`)}
+    ${fact("Names in use", names.length > 1 ? names.join(", ") : (names[0] ?? "—"))}
+    ${fact("Sheets", sheets ? String(sheets.images.length) : "unreadable — sealed or absent")}
+  </dl>
+</section>`;
+
+  const table = sheets
+    ? `<section class="panel">
+  <h2>Sheets <span class="more muted">the largest is the one drawn</span></h2>
+  ${wrap(`<table><thead><tr><th>Texture</th><th class="num">Size</th><th></th></tr></thead><tbody>
+  ${sheets.images
+    .map(
+      (i, at) => `<tr><td class="mono">${esc(i.name)}</td>
+    <td class="num">${i.width}×${i.height}</td>
+    <td>${at === sheets.chosen ? `<span class="tag">drawn</span>` : ""}</td></tr>`,
+    )
+    .join("")}
+  </tbody></table>`)}
+</section>`
+    : "";
+
+  const worn = wearers.length
+    ? `<section class="panel">
+  <h2>Worn by${wearers.length >= MAX_WEARERS ? ` <span class="more muted">first ${MAX_WEARERS}</span>` : ""}</h2>
+  ${wrap(`<table><thead><tr>
+    <th>Rider</th><th>GUID</th><th>Bike</th><th>Slot</th><th>File</th><th>Installs at</th>
+  </tr></thead><tbody>
+  ${wearers
+    .map(
+      (w) => `<tr>
+    <td><a href="${esc(href(`${ROOT}/rider`, { id: w.id }, c.key))}">${esc(w.rider_name)}</a></td>
+    <td class="mono">${w.guid ? esc(w.guid) : `<span class="muted">—</span>`}</td>
+    <td>${esc(w.bike_id || "—")}</td>
+    <td>${esc(w.slot)}</td>
+    <td>${esc(w.file_name)}</td>
+    <td class="mono">${esc(w.rel_dest)}</td>
+  </tr>`,
+    )
+    .join("")}
+  </tbody></table>`)}
+</section>`
+    : empty("Nobody has this paint equipped — the blob is stored but unreferenced.");
+
+  return `${head}${table}${worn}`;
+}

--- a/control-plane/src/pntthumb.ts
+++ b/control-plane/src/pntthumb.ts
@@ -1,0 +1,401 @@
+/**
+ * A picture of a synced paint, rendered from the `.pnt` itself.
+ *
+ * The control plane stores paints as opaque content-addressed blobs, which is the right
+ * thing for syncing them and useless for looking at them: a page listing what we hold can
+ * only show a digest and a file name, and neither says whether the object is the paint
+ * somebody meant to publish. So the format is read here — the same walk `paint.rs` does on
+ * the client, minus everything that isn't needed to draw one small square.
+ *
+ * Three things shape the implementation, all of them the same fact: a paint is up to 192 MB
+ * and a single sheet inflates to 67 MB at 4096².
+ *
+ *   * The image table is walked with ranged reads. Every image header states its payload's
+ *     length, so the table is reachable in a few hundred bytes rather than by downloading
+ *     the file.
+ *   * Only one texture is fetched, and it is inflated as a stream: rows are sampled as they
+ *     arrive and the rest are dropped on the floor, so the isolate holds one chunk and a
+ *     thumbnail, never a sheet.
+ *   * The result is written back to R2 under its own key. The input is content-addressed, so
+ *     the output is too, and a paint is decoded exactly once however many riders wear it.
+ *
+ * There is no image library in a Worker and none is added: PNG is a length-prefixed chunk
+ * format over a zlib stream, and `CompressionStream("deflate")` is exactly that stream.
+ */
+
+const MAGIC = [0x50, 0x4e, 0x54, 0x00]; // "PNT\0"
+const HEADER_SIZE = 108;
+const NAME_SIZE = 100;
+/** name + width + height + md5 + payload length. */
+const IMAGE_HEADER_SIZE = NAME_SIZE + 4 + 4 + 16 + 4;
+const IMAGE_PADDING = 8;
+
+/** Ceilings on numbers read straight out of the file, before anything has checked them. */
+const MAX_TEXTURES = 256;
+/** Bigger than any sheet a paint carries, and small enough that one is quick to walk. */
+const MAX_PIXELS = 8192 * 8192;
+
+/** The edge of the square that comes out. Big enough to recognise a livery in a table row. */
+export const THUMB_EDGE = 256;
+
+/** Bumped when the rendering changes, so old squares are re-cut rather than served. */
+const CACHE_VERSION = "v1";
+
+export function thumbKey(sha256: string): string {
+  return `thumb/${CACHE_VERSION}/${sha256}.png`;
+}
+
+/** Why there is no picture. Each reads as a word on the page, so they are the vocabulary. */
+export type ThumbFailure = "missing" | "sealed" | "unreadable" | "empty";
+
+class Unreadable extends Error {
+  constructor(readonly reason: ThumbFailure) {
+    super(reason);
+  }
+}
+
+/**
+ * Random access to a stored paint.
+ *
+ * An interface rather than an R2 bucket so the decoder can be driven from a byte array in a
+ * test: everything below reads through this, and none of it knows what is on the other side.
+ */
+export interface PaintSource {
+  size: number;
+  read(offset: number, length: number): Promise<Uint8Array>;
+  stream(offset: number, length: number): Promise<ReadableStream<Uint8Array>>;
+}
+
+export interface PntImage {
+  name: string;
+  width: number;
+  height: number;
+  /** The deflate payload's byte range within the whole `.pnt`. */
+  start: number;
+  end: number;
+}
+
+function u32(buf: Uint8Array, off: number): number {
+  return (buf[off] | (buf[off + 1] << 8) | (buf[off + 2] << 16) | (buf[off + 3] << 24)) >>> 0;
+}
+
+function name(buf: Uint8Array, off: number): string {
+  const raw = buf.subarray(off, off + NAME_SIZE);
+  const end = raw.indexOf(0);
+  return new TextDecoder().decode(end < 0 ? raw : raw.subarray(0, end));
+}
+
+/**
+ * The images a paint carries, without inflating a pixel.
+ *
+ * A file that does not start with the magic is not corrupt: a paint from locked content is
+ * a sealed container whose header only exists once it has been decrypted, which happens on
+ * the client and never here. It reads as `sealed` rather than as an error.
+ */
+export async function imageTable(src: PaintSource): Promise<PntImage[]> {
+  const head = await src.read(0, HEADER_SIZE);
+  if (head.length < HEADER_SIZE) throw new Unreadable("unreadable");
+  if (MAGIC.some((b, i) => head[i] !== b)) throw new Unreadable("sealed");
+
+  const count = u32(head, HEADER_SIZE - 4);
+  if (count === 0) throw new Unreadable("empty");
+
+  const out: PntImage[] = [];
+  let off = HEADER_SIZE;
+  for (let i = 0; i < Math.min(count, MAX_TEXTURES); i++) {
+    const h = await src.read(off, IMAGE_HEADER_SIZE);
+    if (h.length < IMAGE_HEADER_SIZE) break;
+    const dataSize = u32(h, NAME_SIZE + 8 + 16);
+    if (dataSize < IMAGE_PADDING) break;
+
+    const width = u32(h, NAME_SIZE);
+    const height = u32(h, NAME_SIZE + 4);
+    const start = off + IMAGE_HEADER_SIZE + IMAGE_PADDING;
+    const end = off + IMAGE_HEADER_SIZE + dataSize;
+    if (end > src.size) break;
+    // Skipped rather than fatal: one header describing no real texture should cost that
+    // texture, not the paint's picture.
+    if (width > 0 && height > 0 && width * height <= MAX_PIXELS) {
+      out.push({ name: name(h, 0), width, height, start, end });
+    }
+    off = end;
+  }
+  if (out.length === 0) throw new Unreadable("empty");
+  return out;
+}
+
+/**
+ * Which sheet stands for the paint.
+ *
+ * The largest one, which on every real paint is the body: a bike's plastics sheet is 2048²
+ * or 4096² where its number plate and fonts are a quarter of that, and a helmet's shell
+ * dwarfs its trim. `w_plate` is excluded outright — it is the game's own number plate, the
+ * one surface an author never paints, so a paint whose largest sheet is that one would be
+ * represented by the only picture that says nothing about it.
+ */
+export function pickImage(images: PntImage[]): PntImage {
+  const area = (i: PntImage) => i.width * i.height;
+  const painted = images.filter((i) => !/plate/i.test(i.name));
+  const from = painted.length > 0 ? painted : images;
+  return from.reduce((best, i) => (area(i) > area(best) ? i : best));
+}
+
+/**
+ * Sample one texture down to a thumbnail, inflating it as a stream.
+ *
+ * Nearest-neighbour, because the alternative is holding rows either side of the sample and
+ * this is a 64-pixel square in a table. Rows come out of the inflate in file order and are
+ * written to their flipped destination as they pass: `.pnt` stores sheets the way the mesh
+ * samples them, which is upside-down as a flat image, uniformly for bike and rider alike.
+ */
+export async function renderThumb(
+  src: PaintSource,
+  image: PntImage,
+  edge = THUMB_EDGE,
+): Promise<{ rgba: Uint8Array; width: number; height: number }> {
+  const scale = Math.min(edge / image.width, edge / image.height, 1);
+  const tw = Math.max(1, Math.round(image.width * scale));
+  const th = Math.max(1, Math.round(image.height * scale));
+
+  // Source row -> the output rows it fills, already flipped. Built up front so the streaming
+  // pass only has to ask whether the row going past is one of them.
+  const wanted = new Map<number, number[]>();
+  for (let y = 0; y < th; y++) {
+    const sy = Math.min(image.height - 1, Math.floor(((y + 0.5) * image.height) / th));
+    const at = wanted.get(sy);
+    if (at) at.push(th - 1 - y);
+    else wanted.set(sy, [th - 1 - y]);
+  }
+  const cols = new Int32Array(tw);
+  for (let x = 0; x < tw; x++) {
+    cols[x] = Math.min(image.width - 1, Math.floor(((x + 0.5) * image.width) / tw)) * 4;
+  }
+
+  const out = new Uint8Array(tw * th * 4);
+  const rowBytes = image.width * 4;
+  const row = new Uint8Array(rowBytes);
+  const body = await src.stream(image.start, image.end - image.start);
+  // Raw deflate, no zlib wrapper — the client writes these with `flate2`'s `DeflateEncoder`.
+  const reader = body.pipeThrough(new DecompressionStream("deflate-raw")).getReader();
+
+  let sy = 0;
+  let filled = 0;
+  let left = wanted.size;
+  try {
+    while (left > 0) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      const chunk = value as Uint8Array;
+      let off = 0;
+      while (off < chunk.length && sy < image.height) {
+        const targets = wanted.get(sy);
+        const take = Math.min(rowBytes - filled, chunk.length - off);
+        // Rows nobody sampled are skipped, not copied: at 4096² that is 4000 rows of 16 KB
+        // the isolate never touches.
+        if (targets) row.set(chunk.subarray(off, off + take), filled);
+        filled += take;
+        off += take;
+        if (filled === rowBytes) {
+          if (targets) {
+            for (const y of targets) {
+              const dst = y * tw * 4;
+              for (let x = 0; x < tw; x++) {
+                const s = cols[x];
+                const d = dst + x * 4;
+                out[d] = row[s];
+                out[d + 1] = row[s + 1];
+                out[d + 2] = row[s + 2];
+                out[d + 3] = row[s + 3];
+              }
+            }
+            left--;
+          }
+          filled = 0;
+          sy++;
+        }
+      }
+    }
+  } catch (err) {
+    // A payload that is not deflate, or that stops mid-stream, fails inside the inflate with
+    // whatever the runtime calls that. It is the same fact as a short one — the file does not
+    // hold the texture its header describes — so it leaves here saying so.
+    if (err instanceof Unreadable) throw err;
+    throw new Unreadable("unreadable");
+  } finally {
+    // The last sampled row is usually well before the end of a 67 MB plane; nothing is
+    // gained by inflating the rest.
+    await reader.cancel().catch(() => {});
+  }
+  if (left > 0) throw new Unreadable("unreadable");
+  return { rgba: out, width: tw, height: th };
+}
+
+// ---------------------------------------------------------------------------
+// PNG
+// ---------------------------------------------------------------------------
+
+let crcTable: Uint32Array | null = null;
+
+function crc32(bytes: Uint8Array): number {
+  if (!crcTable) {
+    crcTable = new Uint32Array(256);
+    for (let n = 0; n < 256; n++) {
+      let c = n;
+      for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+      crcTable[n] = c >>> 0;
+    }
+  }
+  let c = 0xffffffff;
+  for (const b of bytes) c = crcTable[(c ^ b) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+function chunk(type: string, data: Uint8Array): Uint8Array {
+  const out = new Uint8Array(12 + data.length);
+  const view = new DataView(out.buffer);
+  view.setUint32(0, data.length);
+  for (let i = 0; i < 4; i++) out[4 + i] = type.charCodeAt(i);
+  out.set(data, 8);
+  view.setUint32(8 + data.length, crc32(out.subarray(4, 8 + data.length)));
+  return out;
+}
+
+async function zlib(data: Uint8Array): Promise<Uint8Array> {
+  // `deflate` rather than `deflate-raw`: PNG's IDAT is a zlib stream, header and Adler-32
+  // included, which is precisely what this produces.
+  const cs = new CompressionStream("deflate");
+  const writer = cs.writable.getWriter();
+  void writer.write(data).then(() => writer.close());
+  const parts: Uint8Array[] = [];
+  const reader = cs.readable.getReader();
+  let total = 0;
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    parts.push(value as Uint8Array);
+    total += (value as Uint8Array).length;
+  }
+  const out = new Uint8Array(total);
+  let at = 0;
+  for (const p of parts) {
+    out.set(p, at);
+    at += p.length;
+  }
+  return out;
+}
+
+/** 8-bit RGBA, no interlace, every scanline unfiltered. */
+export async function encodePng(
+  rgba: Uint8Array,
+  width: number,
+  height: number,
+): Promise<Uint8Array> {
+  const stride = width * 4;
+  const raw = new Uint8Array(height * (stride + 1));
+  for (let y = 0; y < height; y++) {
+    raw[y * (stride + 1)] = 0;
+    raw.set(rgba.subarray(y * stride, (y + 1) * stride), y * (stride + 1) + 1);
+  }
+
+  const ihdr = new Uint8Array(13);
+  const view = new DataView(ihdr.buffer);
+  view.setUint32(0, width);
+  view.setUint32(4, height);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 6; // colour type: truecolour with alpha
+  const parts = [
+    new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    chunk("IHDR", ihdr),
+    chunk("IDAT", await zlib(raw)),
+    chunk("IEND", new Uint8Array(0)),
+  ];
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let at = 0;
+  for (const p of parts) {
+    out.set(p, at);
+    at += p.length;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Serving
+// ---------------------------------------------------------------------------
+
+function r2Source(env: Env, key: string, size: number): PaintSource {
+  return {
+    size,
+    async read(offset, length) {
+      const object = await env.PAINTS.get(key, { range: { offset, length } });
+      if (!object) throw new Unreadable("missing");
+      return new Uint8Array(await object.arrayBuffer());
+    },
+    async stream(offset, length) {
+      const object = await env.PAINTS.get(key, { range: { offset, length } });
+      if (!object?.body) throw new Unreadable("missing");
+      return object.body;
+    },
+  };
+}
+
+/**
+ * `GET /admin/paints/thumb?sha=…` — the square, cut once and kept.
+ *
+ * A paint that cannot be drawn answers with a labelled tile rather than a 404, because the
+ * caller is an `<img>` in a table: a broken-image icon says the page is wrong, where the word
+ * "sealed" says the paint is locked content and everything is working.
+ */
+export async function paintThumb(sha256: string, env: Env): Promise<Response> {
+  if (!/^[0-9a-f]{64}$/.test(sha256)) return placeholder("unreadable");
+
+  const cached = await env.PAINTS.get(thumbKey(sha256));
+  if (cached) return png(cached.body);
+
+  let rendered: Uint8Array;
+  try {
+    const head = await env.PAINTS.head(sha256);
+    if (!head) return placeholder("missing");
+    const src = r2Source(env, sha256, head.size);
+    const image = pickImage(await imageTable(src));
+    const thumb = await renderThumb(src, image);
+    rendered = await encodePng(thumb.rgba, thumb.width, thumb.height);
+  } catch (err) {
+    const reason = err instanceof Unreadable ? err.reason : "unreadable";
+    if (reason === "unreadable") {
+      console.error(JSON.stringify({ msg: "thumbnail failed", sha256, error: String(err) }));
+    }
+    return placeholder(reason);
+  }
+
+  // Stored, not just returned: the decode is the expensive half and the input is immutable,
+  // so the next viewer — and every other rider wearing this paint — reads one object.
+  await env.PAINTS.put(thumbKey(sha256), rendered).catch(() => {});
+  return png(rendered);
+}
+
+function png(body: BodyInit): Response {
+  return new Response(body, {
+    headers: {
+      "content-type": "image/png",
+      // Content-addressed, so it can never mean anything else — but behind an admin key,
+      // so no shared cache is invited to keep a copy.
+      "cache-control": "private, max-age=86400, immutable",
+    },
+  });
+}
+
+/** A tile that says why, in the palette of the page it sits on. */
+function placeholder(reason: ThumbFailure): Response {
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">` +
+    `<rect width="64" height="64" fill="#9aa3ae" fill-opacity=".16"/>` +
+    `<text x="32" y="35" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif"` +
+    ` font-size="9" fill="#9aa3ae">${reason}</text></svg>`;
+  return new Response(svg, {
+    headers: {
+      "content-type": "image/svg+xml; charset=utf-8",
+      // Short: a paint that is missing today may have been uploaded by this afternoon.
+      "cache-control": "private, max-age=300",
+    },
+  });
+}

--- a/control-plane/test/pntthumb.test.ts
+++ b/control-plane/test/pntthumb.test.ts
@@ -1,0 +1,293 @@
+/**
+ * The paint decoder, driven end to end.
+ *
+ * A `.pnt` is built here rather than fixtured: the format is a header, a table and a raw
+ * deflate stream per sheet, and writing it out is the only way to assert that the reader
+ * agrees with `paint.rs` about every offset. The PNG that comes out is decoded again, so the
+ * pixels are checked rather than the byte count.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  encodePng,
+  imageTable,
+  pickImage,
+  renderThumb,
+  type PaintSource,
+  type PntImage,
+} from "../src/pntthumb";
+
+const HEADER_SIZE = 108;
+const NAME_SIZE = 100;
+const IMAGE_HEADER_SIZE = NAME_SIZE + 4 + 4 + 16 + 4;
+const IMAGE_PADDING = 8;
+
+interface Sheet {
+  name: string;
+  width: number;
+  height: number;
+  /** RGBA, row-major, in the file's own row order. */
+  rgba: Uint8Array;
+}
+
+async function deflateRaw(data: Uint8Array): Promise<Uint8Array> {
+  return collect(streamOf(data).pipeThrough(new CompressionStream("deflate-raw")));
+}
+
+async function inflate(data: Uint8Array): Promise<Uint8Array> {
+  return collect(streamOf(data).pipeThrough(new DecompressionStream("deflate")));
+}
+
+function streamOf(data: Uint8Array): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(c) {
+      c.enqueue(data);
+      c.close();
+    },
+  });
+}
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const parts: Uint8Array[] = [];
+  const reader = stream.getReader();
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    parts.push(value);
+  }
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let at = 0;
+  for (const p of parts) {
+    out.set(p, at);
+    at += p.length;
+  }
+  return out;
+}
+
+/** A `.pnt` in the layout `paint.rs` writes. */
+async function pnt(sheets: Sheet[]): Promise<Uint8Array> {
+  const parts: Uint8Array[] = [];
+  const head = new Uint8Array(HEADER_SIZE);
+  head.set([0x50, 0x4e, 0x54, 0x00]);
+  new DataView(head.buffer).setUint32(HEADER_SIZE - 4, sheets.length, true);
+  parts.push(head);
+
+  for (const sheet of sheets) {
+    const payload = await deflateRaw(sheet.rgba);
+    const header = new Uint8Array(IMAGE_HEADER_SIZE + IMAGE_PADDING);
+    const view = new DataView(header.buffer);
+    for (let i = 0; i < sheet.name.length; i++) header[i] = sheet.name.charCodeAt(i);
+    view.setUint32(NAME_SIZE, sheet.width, true);
+    view.setUint32(NAME_SIZE + 4, sheet.height, true);
+    // The md5 the format carries between the dimensions and the length is not read back.
+    view.setUint32(NAME_SIZE + 8 + 16, payload.length + IMAGE_PADDING, true);
+    parts.push(header, payload);
+  }
+  return concat(parts);
+}
+
+/** Reads a paint out of memory, in chunks small enough to cross every row boundary. */
+function sourceOf(buf: Uint8Array, chunk = 7): PaintSource {
+  return {
+    size: buf.length,
+    async read(offset, length) {
+      return buf.subarray(offset, offset + length);
+    },
+    async stream(offset, length) {
+      const slice = buf.subarray(offset, offset + length);
+      let at = 0;
+      return new ReadableStream({
+        pull(c) {
+          if (at >= slice.length) return c.close();
+          c.enqueue(slice.subarray(at, at + chunk));
+          at += chunk;
+        },
+      });
+    },
+  };
+}
+
+/** Every pixel of a sheet whose colour is a function of its position. */
+function gradient(width: number, height: number): Uint8Array {
+  const out = new Uint8Array(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const at = (y * width + x) * 4;
+      out[at] = x;
+      out[at + 1] = y;
+      out[at + 2] = 7;
+      out[at + 3] = 255;
+    }
+  }
+  return out;
+}
+
+/** The IHDR and the pixels back out of a PNG, so the encoder is checked against a reader. */
+async function readPng(png: Uint8Array): Promise<{ width: number; height: number; rgba: Uint8Array }> {
+  expect([...png.subarray(0, 8)]).toEqual([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const view = new DataView(png.buffer, png.byteOffset, png.byteLength);
+  let at = 8;
+  let width = 0;
+  let height = 0;
+  const idat: Uint8Array[] = [];
+  while (at < png.length) {
+    const length = view.getUint32(at);
+    const type = String.fromCharCode(...png.subarray(at + 4, at + 8));
+    const data = png.subarray(at + 8, at + 8 + length);
+    if (type === "IHDR") {
+      width = view.getUint32(at + 8);
+      height = view.getUint32(at + 12);
+      expect(data[8]).toBe(8);
+      expect(data[9]).toBe(6);
+    }
+    if (type === "IDAT") idat.push(data);
+    at += 12 + length;
+  }
+
+  const raw = await inflate(concat(idat));
+  const stride = width * 4;
+  const rgba = new Uint8Array(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    // Every scanline is written unfiltered, so the filter byte is all there is to skip.
+    expect(raw[y * (stride + 1)]).toBe(0);
+    rgba.set(raw.subarray(y * (stride + 1) + 1, (y + 1) * (stride + 1)), y * stride);
+  }
+  return { width, height, rgba };
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let at = 0;
+  for (const p of parts) {
+    out.set(p, at);
+    at += p.length;
+  }
+  return out;
+}
+
+const px = (img: { width: number; rgba: Uint8Array }, x: number, y: number) =>
+  [...img.rgba.subarray((y * img.width + x) * 4, (y * img.width + x) * 4 + 4)];
+
+describe("walking the image table", () => {
+  it("reads every sheet's name and size without inflating one", async () => {
+    const file = await pnt([
+      { name: "plastics", width: 4, height: 4, rgba: gradient(4, 4) },
+      { name: "w_plate", width: 2, height: 2, rgba: gradient(2, 2) },
+    ]);
+    const images = await imageTable(sourceOf(file));
+    expect(images.map((i) => i.name)).toEqual(["plastics", "w_plate"]);
+    expect(images.map((i) => [i.width, i.height])).toEqual([
+      [4, 4],
+      [2, 2],
+    ]);
+    expect(images[1].end).toBe(file.length);
+  });
+
+  it("calls a file without the magic sealed, because locked content is", async () => {
+    const sealed = new Uint8Array(HEADER_SIZE + 32).fill(0x5a);
+    await expect(imageTable(sourceOf(sealed))).rejects.toThrow("sealed");
+  });
+
+  it("refuses a file too short to hold a header", async () => {
+    await expect(imageTable(sourceOf(new Uint8Array(12)))).rejects.toThrow("unreadable");
+  });
+
+  it("stops at a truncated table rather than reading past the end", async () => {
+    const file = await pnt([{ name: "plastics", width: 4, height: 4, rgba: gradient(4, 4) }]);
+    const cut = file.subarray(0, file.length - 4);
+    await expect(imageTable(sourceOf(cut))).rejects.toThrow("empty");
+  });
+});
+
+describe("picking the sheet that stands for the paint", () => {
+  const sheet = (name: string, edge: number): PntImage => ({
+    name,
+    width: edge,
+    height: edge,
+    start: 0,
+    end: 1,
+  });
+
+  it("takes the largest", () => {
+    expect(pickImage([sheet("numbers", 128), sheet("plastics", 512)]).name).toBe("plastics");
+  });
+
+  it("never takes the number plate, which no author paints", () => {
+    expect(pickImage([sheet("w_plate", 1024), sheet("plastics", 256)]).name).toBe("plastics");
+  });
+
+  it("falls back to it when there is nothing else", () => {
+    expect(pickImage([sheet("w_plate", 64)]).name).toBe("w_plate");
+  });
+});
+
+describe("cutting the thumbnail", () => {
+  it("flips the sheet, which is stored the way the mesh samples it", async () => {
+    const file = await pnt([{ name: "plastics", width: 4, height: 4, rgba: gradient(4, 4) }]);
+    const src = sourceOf(file);
+    const thumb = await renderThumb(src, (await imageTable(src))[0], 4);
+
+    expect([thumb.width, thumb.height]).toEqual([4, 4]);
+    // Green carries the source row. The top row out is the bottom row in.
+    expect(px(thumb, 0, 0)[1]).toBe(3);
+    expect(px(thumb, 0, 3)[1]).toBe(0);
+    // Red carries the column, which is not flipped.
+    expect(px(thumb, 2, 0)[0]).toBe(2);
+  });
+
+  it("samples down without holding the sheet", async () => {
+    const file = await pnt([{ name: "plastics", width: 64, height: 64, rgba: gradient(64, 64) }]);
+    const src = sourceOf(file, 13);
+    const thumb = await renderThumb(src, (await imageTable(src))[0], 8);
+    expect([thumb.width, thumb.height]).toEqual([8, 8]);
+    // Row 4 of 8 samples source row 36, and the flip puts it three rows from the bottom.
+    expect(px(thumb, 0, 3)[1]).toBe(36);
+    expect(px(thumb, 0, 0)[2]).toBe(7);
+  });
+
+  it("leaves a sheet smaller than the target alone rather than blowing it up", async () => {
+    const file = await pnt([{ name: "plastics", width: 3, height: 2, rgba: gradient(3, 2) }]);
+    const src = sourceOf(file);
+    const thumb = await renderThumb(src, (await imageTable(src))[0], 256);
+    expect([thumb.width, thumb.height]).toEqual([3, 2]);
+  });
+
+  it("refuses a payload that stops before the last row it promised", async () => {
+    const file = await pnt([{ name: "plastics", width: 8, height: 8, rgba: gradient(8, 8) }]);
+    const src = sourceOf(file);
+    const image = (await imageTable(src))[0];
+    const truncated = { ...src, stream: (o: number, l: number) => src.stream(o, Math.max(1, l - 12)) };
+    await expect(renderThumb(truncated, image, 8)).rejects.toThrow("unreadable");
+  });
+});
+
+describe("the PNG that comes out", () => {
+  it("round-trips the pixels it was given", async () => {
+    const rgba = gradient(6, 5);
+    const decoded = await readPng(await encodePng(rgba, 6, 5));
+    expect([decoded.width, decoded.height]).toEqual([6, 5]);
+    expect([...decoded.rgba]).toEqual([...rgba]);
+  });
+
+  it("keeps alpha, so a transparent sheet is not a white one", async () => {
+    const rgba = new Uint8Array([1, 2, 3, 0, 4, 5, 6, 128]);
+    const decoded = await readPng(await encodePng(rgba, 2, 1));
+    expect(px(decoded, 0, 0)).toEqual([1, 2, 3, 0]);
+    expect(px(decoded, 1, 0)).toEqual([4, 5, 6, 128]);
+  });
+
+  it("draws a whole paint, table to picture", async () => {
+    const file = await pnt([
+      { name: "w_plate", width: 32, height: 32, rgba: gradient(32, 32) },
+      { name: "plastics", width: 16, height: 16, rgba: gradient(16, 16) },
+    ]);
+    const src = sourceOf(file, 101);
+    const image = pickImage(await imageTable(src));
+    expect(image.name).toBe("plastics");
+
+    const thumb = await renderThumb(src, image, 8);
+    const decoded = await readPng(await encodePng(thumb.rgba, thumb.width, thumb.height));
+    expect([decoded.width, decoded.height]).toEqual([8, 8]);
+    expect(px(decoded, 0, 7)[1]).toBe(1);
+  });
+});


### PR DESCRIPTION
Paint sync had no view at all. The only record that a rider had published was a row keyed on a digest, and the only thing we could say about a paint we were shipping to a grid was how many bytes it was.

## What this adds

Three pages behind the existing `ADMIN_KEY`, cross-linked from the diagnostics nav.

- **`/admin/paints`** — every rider who has published a loadout: rider name, GUID, Steam id, bikes, slots, distinct paints, total size, when they last published, and which server they are on. Searchable by name, GUID or Steam id.
- **`/admin/paints/rider?id=`** — one rider's look, per bike and per slot, with the destination each paint installs to.
- **`/admin/paints/files`** — the paints themselves, once per digest, with who wears them and whether the blob is actually in the bucket. A loadout row whose upload never finished shows as **missing** rather than as a paint we have.
- **`/admin/paints/paint?sha=`** — one paint: the sheets it carries, which one is drawn, and every rider wearing it.

## The pictures

`pntthumb.ts` reads the `.pnt` out of R2 and renders a PNG. A paint is up to 192 MB and one sheet inflates to 67 MB at 4096², so nothing is read whole:

- the image table is walked with **ranged reads** — every image header states its payload length, so the table costs a few hundred bytes rather than a download;
- only the chosen sheet is fetched, and it is inflated as a **stream**: rows are sampled as they arrive and the rest are dropped, so the isolate holds one chunk and a thumbnail;
- the result is written back to R2 under `thumb/`, so a paint is decoded once however many riders wear it.

PNG is encoded by hand — there is no image library in a Worker and none is added. IDAT is a zlib stream, which is exactly what `CompressionStream("deflate")` produces.

Two format facts are honoured: sheets are stored the way the mesh samples them (upside-down as a flat image), so the view is flipped; and `w_plate` is never the sheet drawn, being the one surface an author does not paint. Locked content has no readable header and shows a `sealed` tile rather than a broken image.

## Shared shell

The stylesheet, the paging and the formatters the diagnostics dashboard grew move to `adminui.ts` and are shared rather than copied. `diagnosticssearch.ts` re-exports the paging primitives, so nothing that imported them from there had to change.

## No schema change

Every column this reads already exists, and the two indexes it leans on (`loadout_paints_account`, `loadout_paints_sha`) came in with per-bike loadouts.

## Verification

- 203 tests pass, 14 of them new: a `.pnt` is built byte by byte in the test and taken all the way to a PNG that is decoded again and checked pixel by pixel, including the flip, the downsample, the sealed path and a truncated payload.
- Driven against a local Worker seeded with three real paints — an OEM Honda livery (36 MB, three 4096² sheets), a pair of boots, and a locked goggle paint. The bike renders in ~203 ms and serves from cache in 2 ms; the goggle correctly reads as sealed; a seeded loadout row with no blob reads as missing.
- All seven admin routes answer 200 with the key and 401 without it. The diagnostics pages render unchanged after the shell extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)