### PR TITLE
feat(control-plane): sort the paint sync tables by any column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026-09-02
 
 ### Added
+- Every column of the paint sync tables sorts, either way, by clicking its header.
 - The control plane has a paint sync view: who has published a look, searchable by rider
   name, GUID or Steam id, and every paint we hold with a picture of it.
 - A rider's page lists their bikes slot by slot, with the paint each one installs and where

--- a/control-plane/src/adminui.ts
+++ b/control-plane/src/adminui.ts
@@ -215,6 +215,11 @@ th{text-align:left;font-size:11px;text-transform:uppercase;letter-spacing:.05em;
 td{padding:6px 8px;border-bottom:1px solid var(--line);vertical-align:top}
 tr:last-child td{border-bottom:0}
 .num{text-align:right;font-variant-numeric:tabular-nums;white-space:nowrap}
+/* A sortable header is a link that still reads as a header until it is the one in use. */
+th a{color:inherit;display:inline-block}
+th a:hover{color:var(--accent);text-decoration:none}
+th.on a{color:var(--accent)}
+th .dir{margin-left:3px;font-size:10px;vertical-align:1px}
 .num.hot{color:var(--warn);font-weight:600}
 .act{text-align:right;white-space:nowrap}
 .act.left{text-align:left;margin-top:10px;display:flex;align-items:center;gap:8px}

--- a/control-plane/src/paintspage.ts
+++ b/control-plane/src/paintspage.ts
@@ -92,6 +92,107 @@ interface Totals {
 }
 
 // ---------------------------------------------------------------------------
+// Sorting
+// ---------------------------------------------------------------------------
+
+/** Which way a column reads. Two words, and the query string may name no others. */
+export type Dir = "asc" | "desc";
+
+export function parseDir(value: string | null, fallback: Dir): Dir {
+  return value === "asc" || value === "desc" ? value : fallback;
+}
+
+interface Column {
+  label: string;
+  /** Right-aligned, as every number in these tables is. */
+  num?: boolean;
+  /** Which way this column is worth reading first — names up, quantities and dates down. */
+  first: Dir;
+  /** The ORDER BY fragment. A fixed expression and one of the two words above; nothing a
+   *  caller typed ever reaches it. */
+  order(dir: Dir): string;
+}
+
+/** Text, with the empties at the bottom whichever way the column is read. */
+function byText(expr: string): Column["order"] {
+  return (dir) => `(${expr} IS NULL OR ${expr} = ''), ${expr} COLLATE NOCASE ${dir.toUpperCase()}`;
+}
+
+/** A count, a size or a timestamp, with the absent ones at the bottom either way. */
+function byNumber(expr: string): Column["order"] {
+  return (dir) => `${expr} IS NULL, ${expr} ${dir.toUpperCase()}`;
+}
+
+/**
+ * The columns of the rider table.
+ *
+ * Aggregates are named by their expression rather than by the alias they are selected under:
+ * `size` is also a column of `loadout_paints`, and a bare alias in ORDER BY is one rename
+ * away from quietly sorting by the wrong thing. The two correlated subqueries are the
+ * exception — nothing else is called `published_at` or `at_server`, and repeating a subquery
+ * would mean re-binding its parameter.
+ */
+export const RIDER_COLUMNS: Record<string, Column> = {
+  name: { label: "Rider", first: "asc", order: byText("a.rider_name") },
+  guid: { label: "GUID", first: "asc", order: byText("a.guid") },
+  steam: { label: "Steam", first: "asc", order: byText("a.steam_id") },
+  bikes: { label: "Bikes", num: true, first: "desc", order: byNumber("COUNT(DISTINCT p.bike_id)") },
+  slots: { label: "Slots", num: true, first: "desc", order: byNumber("COUNT(*)") },
+  paints: {
+    label: "Paints",
+    num: true,
+    first: "desc",
+    order: byNumber("COUNT(DISTINCT p.sha256)"),
+  },
+  size: { label: "Size", num: true, first: "desc", order: byNumber("SUM(p.size)") },
+  published: { label: "Published", first: "desc", order: byNumber("published_at") },
+  where: { label: "Where", first: "asc", order: byText("at_server") },
+};
+
+export const PAINT_COLUMNS: Record<string, Column> = {
+  file: { label: "File", first: "asc", order: byText("MIN(p.file_name)") },
+  slots: { label: "Slots", first: "asc", order: byText("GROUP_CONCAT(DISTINCT p.slot)") },
+  riders: {
+    label: "Riders",
+    num: true,
+    first: "desc",
+    order: byNumber("COUNT(DISTINCT p.account_id)"),
+  },
+  uses: { label: "Uses", num: true, first: "desc", order: byNumber("COUNT(*)") },
+  size: { label: "Size", num: true, first: "desc", order: byNumber("MAX(p.size)") },
+  digest: { label: "Digest", first: "asc", order: byText("p.sha256") },
+};
+
+/** How a table is being read: a column that exists, and a direction. */
+export interface Order {
+  sort: string;
+  dir: Dir;
+}
+
+/**
+ * The column asked for, or the one the table opens on.
+ *
+ * The name is looked up in the map rather than trusted — an unknown one is a hand-edited URL
+ * or a stale link, and either way the answer is the default rather than an error.
+ */
+export function parseOrder(url: URL, columns: Record<string, Column>, fallback: string): Order {
+  const asked = url.searchParams.get("sort") ?? "";
+  const sort = asked in columns ? asked : fallback;
+  return { sort, dir: parseDir(url.searchParams.get("dir"), columns[sort].first) };
+}
+
+/**
+ * The ORDER BY for a table, with a tie-break that never changes.
+ *
+ * Without the tie-break, rows that match on the sorted column come back in whatever order
+ * the query planner felt like — which is invisible on one page and duplicates or drops rows
+ * across two.
+ */
+export function orderBy(columns: Record<string, Column>, order: Order, tiebreak: string): string {
+  return `${columns[order.sort].order(order.dir)}, ${tiebreak}`;
+}
+
+// ---------------------------------------------------------------------------
 // Routes
 // ---------------------------------------------------------------------------
 
@@ -123,9 +224,10 @@ export async function paintRiders(request: Request, url: URL, env: Env): Promise
 
   const c = ctx(url);
   const q = (url.searchParams.get("q") ?? "").slice(0, 96);
+  const order = parseOrder(url, RIDER_COLUMNS, "published");
   const page = parsePage(url.searchParams.get("page"));
-  const [sums, found] = await Promise.all([totals(env), searchRiders(env, q, page)]);
-  return html(shell("Paint sync", "riders", ridersView(sums, found, q, c), c));
+  const [sums, found] = await Promise.all([totals(env), searchRiders(env, q, order, page)]);
+  return html(shell("Paint sync", "riders", ridersView(sums, found, q, order, c), c));
 }
 
 /** `GET /admin/paints/rider?id=…` — one rider's bikes, slot by slot. */
@@ -182,10 +284,10 @@ export async function paintFiles(request: Request, url: URL, env: Env): Promise<
 
   const c = ctx(url);
   const q = (url.searchParams.get("q") ?? "").slice(0, 96);
-  const sort = sortOf(url.searchParams.get("sort"));
+  const order = parseOrder(url, PAINT_COLUMNS, "riders");
   const page = parsePage(url.searchParams.get("page"));
-  const [sums, found] = await Promise.all([totals(env), searchPaints(env, q, sort, page)]);
-  return html(shell("Paints", "paints", paintsView(sums, found, q, sort, c), c));
+  const [sums, found] = await Promise.all([totals(env), searchPaints(env, q, order, page)]);
+  return html(shell("Paints", "paints", paintsView(sums, found, q, order, c), c));
 }
 
 /** `GET /admin/paints/paint?sha=…` — one paint: its sheets, and who is wearing it. */
@@ -262,7 +364,12 @@ const RIDER_MATCH =
   " (? = '' OR a.rider_name LIKE ? ESCAPE '\\' OR COALESCE(a.guid, '') LIKE ? ESCAPE '\\'" +
   " OR COALESCE(a.steam_id, '') LIKE ? ESCAPE '\\')";
 
-async function searchRiders(env: Env, q: string, page: number): Promise<Paged<RiderRow>> {
+async function searchRiders(
+  env: Env,
+  q: string,
+  order: Order,
+  page: number,
+): Promise<Paged<RiderRow>> {
   const like = likeTerm(q);
   const fresh = Date.now() - PRESENCE_TTL_MS;
 
@@ -276,7 +383,8 @@ async function searchRiders(env: Env, q: string, page: number): Promise<Paged<Ri
       " FROM accounts a JOIN loadout_paints p ON p.account_id = a.id" +
       " WHERE" +
       RIDER_MATCH +
-      " GROUP BY a.id ORDER BY published_at DESC, a.rider_name LIMIT ? OFFSET ?",
+      ` GROUP BY a.id ORDER BY ${orderBy(RIDER_COLUMNS, order, "a.rider_name COLLATE NOCASE")}` +
+      " LIMIT ? OFFSET ?",
   )
     .bind(fresh, like, like, like, like, PAGE_SIZE, (page - 1) * PAGE_SIZE)
     .all<RiderRow>();
@@ -293,28 +401,15 @@ async function searchRiders(env: Env, q: string, page: number): Promise<Paged<Ri
   return { rows: rows.results ?? [], total: total?.n ?? 0, page, size: PAGE_SIZE };
 }
 
-const SORTS = ["riders", "size", "name"] as const;
-type Sort = (typeof SORTS)[number];
-
-function sortOf(value: string | null): Sort {
-  return (SORTS as readonly string[]).includes(value ?? "") ? (value as Sort) : "riders";
-}
-
 const PAINT_MATCH = " (? = '' OR p.file_name LIKE ? ESCAPE '\\' OR p.sha256 LIKE ? ESCAPE '\\')";
 
 async function searchPaints(
   env: Env,
   q: string,
-  sort: Sort,
+  order: Order,
   page: number,
 ): Promise<Paged<PaintRow>> {
   const like = likeTerm(q);
-  const order =
-    sort === "size"
-      ? "size DESC, riders DESC"
-      : sort === "name"
-        ? "file_name COLLATE NOCASE, riders DESC"
-        : "riders DESC, uses DESC, file_name COLLATE NOCASE";
 
   const rows = await env.DB.prepare(
     "SELECT p.sha256, MIN(p.file_name) AS file_name, COUNT(DISTINCT p.file_name) AS names," +
@@ -322,7 +417,8 @@ async function searchPaints(
       " GROUP_CONCAT(DISTINCT p.slot) AS slots" +
       " FROM loadout_paints p WHERE" +
       PAINT_MATCH +
-      ` GROUP BY p.sha256 ORDER BY ${order} LIMIT ? OFFSET ?`,
+      ` GROUP BY p.sha256 ORDER BY ${orderBy(PAINT_COLUMNS, order, "MIN(p.file_name) COLLATE NOCASE")}` +
+      " LIMIT ? OFFSET ?",
   )
     .bind(like, like, like, PAGE_SIZE, (page - 1) * PAGE_SIZE)
     .all<Omit<PaintRow, "stored">>();
@@ -442,6 +538,41 @@ function thumb(sha: string, name: string, c: Ctx, big = false): string {
     src="${esc(href(`${ROOT}/thumb`, { sha }, c.key))}" alt="${esc(name)}"></a>`;
 }
 
+/**
+ * A header row whose columns are links.
+ *
+ * Clicking the column already being read turns it around; clicking a new one starts it the
+ * way that column is worth reading. `page` is dropped rather than carried: page 7 of a
+ * different ordering is a different set of rows, and landing there reads as a bug.
+ */
+function sortable(
+  path: string,
+  params: Params,
+  columns: Record<string, Column>,
+  order: Order,
+  c: Ctx,
+  lead = "",
+  trail = "",
+): string {
+  const heads = Object.entries(columns)
+    .map(([key, col]) => {
+      const on = key === order.sort;
+      const dir: Dir = on ? (order.dir === "asc" ? "desc" : "asc") : col.first;
+      const arrow = on ? `<span class="dir">${order.dir === "asc" ? "\u2191" : "\u2193"}</span>` : "";
+      const to = href(path, { ...params, sort: key, dir, page: undefined }, c.key);
+      return `<th class="${col.num ? "num" : ""}${on ? " on" : ""}"><a href="${esc(to)}"
+    title="Sort by ${esc(col.label)}">${esc(col.label)}${arrow}</a></th>`;
+    })
+    .join("");
+  return `<thead><tr>${lead}${heads}${trail}</tr></thead>`;
+}
+
+/** The current ordering, as hidden fields, so searching does not reset the table. */
+function keep(order: Order): string {
+  return `<input type="hidden" name="sort" value="${esc(order.sort)}">
+  <input type="hidden" name="dir" value="${esc(order.dir)}">`;
+}
+
 function searchBox(path: string, q: string, extra: string, c: Ctx, hint: string): string {
   return `<form class="search" method="get" action="${esc(path)}">
   ${c.key ? `<input type="hidden" name="key" value="${esc(c.key)}">` : ""}
@@ -456,23 +587,32 @@ function searchBox(path: string, q: string, extra: string, c: Ctx, hint: string)
 // Riders
 // ---------------------------------------------------------------------------
 
-function ridersView(s: Totals, found: Paged<RiderRow>, q: string, c: Ctx): string {
-  const params: Params = { q };
+function ridersView(
+  s: Totals,
+  found: Paged<RiderRow>,
+  q: string,
+  order: Order,
+  c: Ctx,
+): string {
+  const params: Params = { q, sort: order.sort, dir: order.dir };
   return `${tiles(s)}
 <section class="panel">
   <h2>Riders</h2>
-  ${searchBox(ROOT, q, "", c, "rider name, GUID or Steam id")}
+  ${searchBox(ROOT, q, keep(order), c, "rider name, GUID or Steam id")}
   ${count(found, "rider")}
-  ${found.rows.length ? wrap(riderTable(found.rows, c)) : `<p class="muted">Nobody matches.</p>`}
+  ${
+    found.rows.length
+      ? wrap(riderTable(found.rows, params, order, c))
+      : `<p class="muted">Nobody matches.</p>`
+  }
   ${pager(ROOT, params, found, c)}
 </section>`;
 }
 
-function riderTable(rows: RiderRow[], c: Ctx): string {
-  return `<table><thead><tr>
-  <th>Rider</th><th>GUID</th><th>Steam</th><th class="num">Bikes</th><th class="num">Slots</th>
-  <th class="num">Paints</th><th class="num">Size</th><th>Published</th><th>Where</th>
-</tr></thead><tbody>
+function riderTable(rows: RiderRow[], params: Params, order: Order, c: Ctx): string {
+  return `<table>
+${sortable(ROOT, params, RIDER_COLUMNS, order, c)}
+<tbody>
 ${rows
   .map(
     (r) => `<tr>
@@ -585,36 +725,33 @@ function paintsView(
   s: Totals,
   found: Paged<PaintRow>,
   q: string,
-  sort: Sort,
+  order: Order,
   c: Ctx,
 ): string {
   const path = `${ROOT}/files`;
-  const params: Params = { q, sort };
-  const options = (
-    [
-      ["riders", "Most worn"],
-      ["size", "Largest"],
-      ["name", "By name"],
-    ] as const
-  )
-    .map(([v, text]) => `<option value="${v}"${v === sort ? " selected" : ""}>${text}</option>`)
-    .join("");
+  const params: Params = { q, sort: order.sort, dir: order.dir };
 
   return `${tiles(s)}
 <section class="panel">
   <h2>Paints</h2>
-  ${searchBox(path, q, `<select name="sort">${options}</select>`, c, "file name or digest")}
+  ${searchBox(path, q, keep(order), c, "file name or digest")}
   ${count(found, "paint")}
-  ${found.rows.length ? wrap(paintTable(found.rows, c)) : `<p class="muted">Nothing matches.</p>`}
+  ${
+    found.rows.length
+      ? wrap(paintTable(found.rows, params, order, c))
+      : `<p class="muted">Nothing matches.</p>`
+  }
   ${pager(path, params, found, c)}
 </section>`;
 }
 
-function paintTable(rows: PaintRow[], c: Ctx): string {
-  return `<table><thead><tr>
-  <th></th><th>File</th><th>Slots</th><th class="num">Riders</th><th class="num">Uses</th>
-  <th class="num">Size</th><th>Blob</th><th>Digest</th>
-</tr></thead><tbody>
+function paintTable(rows: PaintRow[], params: Params, order: Order, c: Ctx): string {
+  // The picture leads and `Blob` trails, neither of them a column the database can order by:
+  // one is the paint itself, and the other is what the bucket answered about this page's
+  // rows after the query had already run.
+  return `<table>
+${sortable(`${ROOT}/files`, params, PAINT_COLUMNS, order, c, "<th></th>", "<th>Blob</th>")}
+<tbody>
 ${rows
   .map(
     (r) => `<tr>
@@ -625,6 +762,7 @@ ${rows
   <td class="num">${r.riders}</td>
   <td class="num">${r.uses}</td>
   <td class="num">${esc(bytes(r.size))}</td>
+  <td class="mono">${esc(r.sha256.slice(0, 12))}</td>
   <td>${
     r.stored === null
       ? `<span class="pill alert">missing</span>`
@@ -632,7 +770,6 @@ ${rows
         ? `<span class="dot ok"></span>`
         : `<span class="pill warn">${esc(bytes(r.stored))}</span>`
   }</td>
-  <td class="mono">${esc(r.sha256.slice(0, 12))}</td>
 </tr>`,
   )
   .join("")}

--- a/control-plane/test/paintsort.test.ts
+++ b/control-plane/test/paintsort.test.ts
@@ -1,0 +1,107 @@
+/**
+ * How a paint table is ordered.
+ *
+ * Two things are being pinned here. The first is that a column name arriving in a query
+ * string can only ever select one of the fixed expressions in the map — this is the only
+ * place in the module where anything typed by a caller decides part of a SQL statement, and
+ * it must decide it by lookup rather than by interpolation. The second is that every listing
+ * has a tie-break, without which two pages of the same query can show the same row twice.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  orderBy,
+  PAINT_COLUMNS,
+  parseDir,
+  parseOrder,
+  RIDER_COLUMNS,
+  type Order,
+} from "../src/paintspage";
+
+const at = (query: string) => new URL(`https://example.com/admin/paints${query}`);
+
+describe("which column was asked for", () => {
+  it("takes one the table has", () => {
+    expect(parseOrder(at("?sort=size"), RIDER_COLUMNS, "published").sort).toBe("size");
+  });
+
+  it("falls back to the column the table opens on", () => {
+    expect(parseOrder(at(""), RIDER_COLUMNS, "published").sort).toBe("published");
+    expect(parseOrder(at("?sort=nonsense"), RIDER_COLUMNS, "published").sort).toBe("published");
+  });
+
+  it("does not take a column from the other table", () => {
+    expect(parseOrder(at("?sort=uses"), RIDER_COLUMNS, "published").sort).toBe("published");
+    expect(parseOrder(at("?sort=steam"), PAINT_COLUMNS, "riders").sort).toBe("riders");
+  });
+
+  it("refuses anything that is not one of the two directions", () => {
+    expect(parseDir("asc", "desc")).toBe("asc");
+    expect(parseDir("DESC; DROP TABLE accounts", "asc")).toBe("asc");
+    expect(parseDir(null, "desc")).toBe("desc");
+  });
+
+  it("opens each column the way that column is worth reading", () => {
+    // A name is read from the top, a quantity or a date from the largest or the newest.
+    expect(parseOrder(at("?sort=name"), RIDER_COLUMNS, "published").dir).toBe("asc");
+    expect(parseOrder(at("?sort=size"), RIDER_COLUMNS, "published").dir).toBe("desc");
+    expect(parseOrder(at("?sort=file"), PAINT_COLUMNS, "riders").dir).toBe("asc");
+    expect(parseOrder(at("?sort=riders"), PAINT_COLUMNS, "riders").dir).toBe("desc");
+  });
+
+  it("still takes the direction that was asked for", () => {
+    expect(parseOrder(at("?sort=name&dir=desc"), RIDER_COLUMNS, "published").dir).toBe("desc");
+  });
+});
+
+describe("the ORDER BY it builds", () => {
+  const order = (sort: string, dir: "asc" | "desc"): Order => ({ sort, dir });
+
+  it("names the expression the column stands for, not the alias it is selected under", () => {
+    // `size` is also a column of `loadout_paints`; ordering by the bare alias is one rename
+    // away from sorting by a single row's size rather than the group's.
+    expect(orderBy(PAINT_COLUMNS, order("size", "desc"), "x")).toContain("MAX(p.size) DESC");
+    expect(orderBy(RIDER_COLUMNS, order("size", "desc"), "x")).toContain("SUM(p.size) DESC");
+  });
+
+  it("keeps the empties at the bottom whichever way a text column is read", () => {
+    const up = orderBy(RIDER_COLUMNS, order("guid", "asc"), "x");
+    const down = orderBy(RIDER_COLUMNS, order("guid", "desc"), "x");
+    expect(up).toContain("(a.guid IS NULL OR a.guid = '')");
+    expect(down).toContain("(a.guid IS NULL OR a.guid = '')");
+    expect(up).toContain("COLLATE NOCASE ASC");
+    expect(down).toContain("COLLATE NOCASE DESC");
+  });
+
+  it("keeps a rider who has never published under one who has", () => {
+    expect(orderBy(RIDER_COLUMNS, order("published", "desc"), "x")).toBe(
+      "published_at IS NULL, published_at DESC, x",
+    );
+  });
+
+  it("always ends in the tie-break, so paging cannot repeat a row", () => {
+    for (const [columns, fallback] of [
+      [RIDER_COLUMNS, "published"],
+      [PAINT_COLUMNS, "riders"],
+    ] as const) {
+      for (const key of Object.keys(columns)) {
+        for (const dir of ["asc", "desc"] as const) {
+          expect(orderBy(columns, order(key, dir), "tie")).toMatch(/, tie$/);
+        }
+      }
+      expect(orderBy(columns, order(fallback, "desc"), "tie")).toMatch(/, tie$/);
+    }
+  });
+
+  it("emits nothing but the two words for a direction", () => {
+    for (const columns of [RIDER_COLUMNS, PAINT_COLUMNS]) {
+      for (const key of Object.keys(columns)) {
+        for (const dir of ["asc", "desc"] as const) {
+          const sql = orderBy(columns, order(key, dir), "tie");
+          expect(sql).toContain(dir.toUpperCase());
+          expect(sql).not.toMatch(/;|--/);
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
The rider table had no sort at all — it opened on last-published and stayed there — and the paint table had three canned orders behind a select. Both now sort on every column they show, either way, by clicking the header.

## What sorts

- **Riders** — name, GUID, Steam id, bikes, slots, paints, size, last published, and which server they are on.
- **Paints** — file name, slots, riders, uses, size, digest.

`Blob` is the one column that does not sort. It is not a column at all: it is what the bucket answered about this page's rows *after* the query had already run, so there is nothing for the database to order by. It moves to the end of the row, where its header now is.

## Behaviour

- Clicking the column already in use turns it around; clicking a new one opens it the way that column is worth reading — names up, quantities and dates down.
- Empties sort to the bottom whichever way a column is read, so a rider with no GUID never displaces one who has published something.
- Every listing ends in a fixed tie-break. Without it, rows that match on the sorted column come back in whatever order the planner felt like, which is invisible on one page and repeats or drops rows across two.
- Searching keeps the ordering (hidden fields), and re-sorting drops the page number rather than landing on page 7 of a different set of rows.

## The SQL

A column name arriving in a query string selects one of a fixed set of expressions **by lookup** — it is never interpolated — and a direction can only ever become one of two words. Unknown values fall back to the column the table opens on.

Aggregates are ordered by their expression rather than by the alias they are selected under: `size` is also a column of `loadout_paints`, and a bare alias in `ORDER BY` is one rename away from quietly sorting a group by a single row's value.

## Verification

- 214 tests pass, 11 of them new over the sort parsing and the `ORDER BY` it builds: the whitelist, the fallbacks, the per-column opening direction, empties-last in both directions, and that every column in both tables ends in the tie-break.
- Driven against a local Worker: all **nine** rider columns and all **six** paint columns were requested in both directions and the row order checked by hand each time. Nulls stayed at the bottom both ways; junk in `?sort=` and `?dir=` answered 200 on the default ordering rather than 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)