### PR TITLE
fix(control-plane): drop the paint page footer, link the two rider views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@
 
 ### Added
 - Every column of the paint sync tables sorts, either way, by clicking its header.
+- A rider's paint page and their diagnostics page link to each other.
 - The control plane has a paint sync view: who has published a look, searchable by rider
   name, GUID or Steam id, and every paint we hold with a picture of it.
 - A rider's page lists their bikes slot by slot, with the paint each one installs and where
   it lands on disk.
 - A paint's page lists the sheets it carries and every rider wearing it, and says when the
   file a loadout names was never uploaded.
+
+### Removed
+- The explanatory footer under the paint sync pages.
 
 ## 2026-09-01
 

--- a/control-plane/src/adminui.ts
+++ b/control-plane/src/adminui.ts
@@ -252,6 +252,9 @@ button.allow{border-color:var(--ok);color:var(--ok)}
 .count{color:var(--muted);font-size:12px;margin:0 0 8px}
 .who{display:flex;flex-wrap:wrap;align-items:center;gap:8px;margin-bottom:12px}
 .who .name{font-size:16px;font-weight:600;overflow-wrap:anywhere}
+/* The same rider on the other dashboard. Pushed right, so it reads as a way out of this
+   page rather than as another fact about them. */
+.who .aside{margin-left:auto;font-size:12px}
 .facts{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:10px 16px;margin:0}
 .facts dt{font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}
 .facts dd{margin:1px 0 0;overflow-wrap:anywhere}

--- a/control-plane/src/diagnosticspage.ts
+++ b/control-plane/src/diagnosticspage.ts
@@ -457,6 +457,8 @@ function riderView(d: RiderDetail, query: SightingQuery, c: Ctx): string {
     <span class="name">${esc(r.riderName || "(no name)")}</span>
     ${r.state ? `<span class="pill ${esc(peak)}">${esc(r.state)}</span>` : `<span class="muted">never reported</span>`}
     ${peak !== r.state ? `<span class="muted">peaked at ${esc(peak)} ${esc(ago(r.worstAt))}</span>` : ""}
+    <a class="aside" href="${esc(href("/admin/paints/rider", { id: r.accountId }, c.key))}"
+      >Paints for this rider →</a>
   </div>
   <dl class="facts">
     ${fact("GUID", r.guid || "—", true)}

--- a/control-plane/src/paintspage.ts
+++ b/control-plane/src/paintspage.ts
@@ -505,9 +505,6 @@ function shell(title: string, tab: Tab, body: string, c: Ctx): string {
 <header><h1>${esc(title)}</h1><nav>${nav}
   <a class="out" href="${esc(href("/admin/diagnostics", {}, c.key))}">Diagnostics</a></nav></header>
 ${body}
-<footer class="muted">A rider appears here once their app has published a loadout. Pictures are
-  rendered from the paint's largest sheet, which is stored upside-down and flipped for the
-  view; locked content has no readable sheets and shows as sealed.</footer>
 </body></html>`;
 }
 
@@ -651,10 +648,14 @@ function riderView(
   c: Ctx,
 ): string {
   const live = presence && presence.updated_at > Date.now() - PRESENCE_TTL_MS;
+  // Both dashboards key on the same account id, so one rider is one link away from what
+  // their game has loaded — the two halves of the same person, previously unconnected.
+  const diagnostics = href("/admin/diagnostics/rider", { id: account.id }, c.key);
   const facts = `<section class="panel">
   <div class="who"><span class="name">${esc(account.rider_name)}</span>
     <span class="tag">${esc(account.kind)}</span>
-    ${live ? `<span class="pill ok">on ${esc(presence!.server_id)}</span>` : ""}</div>
+    ${live ? `<span class="pill ok">on ${esc(presence!.server_id)}</span>` : ""}
+    <a class="aside" href="${esc(diagnostics)}">Diagnostics for this rider →</a></div>
   <dl class="facts">
     ${fact("GUID", account.guid ?? "—", true)}
     ${fact("Steam id", account.steam_id ?? "—", true)}


### PR DESCRIPTION
Two small things, one of which came out of asking whether the dashboards know about each other.

- The explanatory footer under every paint sync page is gone.
- A rider's paint page and their diagnostics page now link to each other.

## Why the link

Both dashboards have always keyed on the same `account_id`, and nothing joined them. In prod that is **159 accounts appearing in both** — 177 have reported diagnostics, 484 have published paints — so what someone is wearing and what their game has loaded were two searches rather than one click.

Usage stays unjoined, and deliberately: its key is an install id tied to no account and no rider name, which is the whole point of it.

## Verification

Driven against a local Worker: no `<footer>` in any of the four paint views, the diagnostics footer untouched, and both links resolve to the same account id in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)