### PR TITLE
feat(frostmod): keep FrostMod updated without being asked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 2026-09-04
 
+### Changed
+- The app keeps FrostMod up to date on its own. It checks for a new release while it is
+  open and installs it in the background, so you get the newest one without opening
+  Settings.
+- An update waits until you are out of the game, so nothing is pulled out from under a
+  session you are riding.
+
 ### Fixed
 - Paint sync and voice chat now know which server you are on. The app installs a small
   FrostMod plugin that reads the server name from the game, so you sync with the riders

--- a/src/Context/Frostmod.tsx
+++ b/src/Context/Frostmod.tsx
@@ -28,10 +28,22 @@ import {
 import type { Attachment, FrostmodStatus, VcRuntime } from "../types";
 import { ATTACH_PROBLEM } from "../types";
 import { displayName } from "../lib/mods";
+import { autoInstallAction } from "../lib/frostmodAuto";
+import { useGameRunning } from "../lib/useGameRunning";
 import { useT, type TFunc } from "../i18n/context";
 import { FrostmodContext } from "./FrostmodContext";
 
 const POLL_MS = 5000;
+
+/**
+ * How often to ask GitHub whether FrostMod has a newer release.
+ *
+ * The check used to run once, at mount, so an app left open never learned about a release
+ * published after it started. Half-hourly is two calls an hour against GitHub's 60/hr
+ * unauthenticated limit, and it also re-runs the sweeps `status()` carries — the stray
+ * `msvcr90.dll` and the stale game plugin — which only ever ran that one time too.
+ */
+const VERSION_CHECK_MS = 30 * 60 * 1000;
 
 /**
  * Name what the folder watcher picked up. The watcher reports mods as `<type>/<name>`;
@@ -53,6 +65,9 @@ function watchDescription(mods: string[], t: TFunc): string {
 
 export function FrostmodProvider({ children }: { children: ReactNode }) {
   const t = useT();
+  // Only ever read to decide whether an unattended update may run now — FrostMod's own
+  // process is `running` below, and the two are separate things to watch.
+  const { running: gameRunning } = useGameRunning();
   const [running, setRunning] = useState<boolean | null>(null);
   const [attachment, setAttachment] = useState<Attachment | null>(null);
   // What we last warned about, so a problem that persists across the 5s poll is reported
@@ -125,9 +140,12 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
     probe();
     void refreshStatus();
     const id = setInterval(probe, POLL_MS);
+    // Its own, much slower interval: this one hits the network, the one above doesn't.
+    const versionId = setInterval(() => void refreshStatus(), VERSION_CHECK_MS);
     return () => {
       mounted.current = false;
       clearInterval(id);
+      clearInterval(versionId);
     };
   }, [probe, refreshStatus]);
 
@@ -352,39 +370,33 @@ export function FrostmodProvider({ children }: { children: ReactNode }) {
 
   const dismissRuntimeWarning = useCallback(() => setRuntimeDismissed(true), []);
 
-  // FrostMod is core to the app, so set it up automatically on first run instead
-  // of prompting: once we learn it isn't installed, download + start it silently.
-  //
-  // `needsRepair` gets the same treatment. An install that recorded a version it never
-  // finished applying looks current to every version check, so nobody would think to
-  // press anything — and the binaries it's short of are the ones the game actually
-  // loads. Repairing it unasked is the only thing that reaches those players.
-  //
-  // So does `supportedForGame`: a build too old for the active title can't be started at
-  // all, and the player has no way to know why. Updating unasked is the fix — and if the
-  // newest release is still too old, the attempt is capped at one per session and the
-  // panel falls back to telling them.
+  // FrostMod is core to the app, so it is installed, repaired and updated without anyone
+  // being asked — `autoInstallAction` holds the whole decision table. A build that is
+  // missing, half-applied or too old for the active title does nothing at all and gives the
+  // player no way to know why; one that is merely out of date used to sit behind a button
+  // in a panel most people never open, which is the half this now covers too.
   //
   // `missingRuntimes` is deliberately NOT in here. Reinstalling FrostMod cannot put a
   // Visual C++ runtime on the machine, so auto-installing on that flag would download
   // FrostMod again to no effect — and the flag would still be set afterwards. It needs
   // the user's admin consent anyway, so it stays a banner they press.
-  //
-  // Runs at most once per session; a failed status check (`statusError`) is skipped so
-  // we only act on a confirmed snapshot, never an offline guess.
-  const autoInstallTried = useRef(false);
+  const triedRepair = useRef(false);
+  const updatedTo = useRef<string | null>(null);
   useEffect(() => {
-    if (
-      !autoInstallTried.current &&
-      status &&
-      (!status.installed || status.needsRepair || !status.supportedForGame) &&
-      !statusError &&
-      !installing
-    ) {
-      autoInstallTried.current = true;
-      void install();
-    }
-  }, [status, statusError, installing, install]);
+    const action = autoInstallAction(status, {
+      statusError,
+      installing,
+      gameRunning,
+      triedRepair: triedRepair.current,
+      updatedTo: updatedTo.current,
+    });
+    if (!action) return;
+    // Recorded before the install, not after: it must count as attempted even if it
+    // throws, or a failure would retry on every poll.
+    if (action === "repair") triedRepair.current = true;
+    else updatedTo.current = status?.latest ?? null;
+    void install();
+  }, [status, statusError, installing, gameRunning, install]);
 
   const value = useMemo(
     () => ({

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -2202,7 +2202,8 @@ export function joinServer(address: string): Promise<LaunchOutcome> {
   return invoke<LaunchOutcome>("join_server", { address });
 }
 
-/** Is MX Bikes currently running? Always false off Windows — the probe is Win32-only. */
+/** Is MX Bikes currently running? Probes for real on all three platforms — under Wine and
+ *  Proton the game is an ordinary process whose argv still names the exe. */
 export function isGameRunning(): Promise<boolean> {
   return invoke<boolean>("game_running");
 }

--- a/src/lib/frostmodAuto.ts
+++ b/src/lib/frostmodAuto.ts
@@ -1,0 +1,57 @@
+import type { FrostmodStatus } from "../types";
+
+/** Everything outside the status snapshot that can hold an unattended install back. */
+export interface AutoGates {
+  /** The last GitHub check failed — the snapshot is a guess, so act on nothing. */
+  statusError: boolean;
+  /** An install is already in flight. */
+  installing: boolean;
+  /** MX Bikes is up. Only blocks an update, never a repair. */
+  gameRunning: boolean;
+  /** A repair has already been attempted this session. */
+  triedRepair: boolean;
+  /** The release tag an update has already been attempted for, if any. */
+  updatedTo: string | null;
+}
+
+/**
+ * What, if anything, the app should install without anyone pressing a button.
+ *
+ * Pure, and in a module of its own, because it is the only thing in the app that starts a
+ * download unasked: get it wrong in one direction and a player sits on a FrostMod that
+ * can't run, in the other and it reinstalls on a loop.
+ *
+ * - `"repair"` — missing, half-applied, or too old for the active title. FrostMod does
+ *   nothing at all in these states, so this runs even mid-game, and once per session.
+ * - `"update"` — works, but there's a newer release. Waits for the game to quit, and is
+ *   tried once per tag so a bad release doesn't retry every poll while a newer one still
+ *   gets its own attempt.
+ */
+export function autoInstallAction(
+  status: FrostmodStatus | null,
+  gates: AutoGates,
+): "repair" | "update" | null {
+  if (!status || gates.statusError || gates.installing) return null;
+
+  if (
+    !gates.triedRepair &&
+    (!status.installed || status.needsRepair || !status.supportedForGame)
+  ) {
+    return "repair";
+  }
+
+  // Ordered after the repair arm and never alongside it: a FrostMod that is both
+  // unsupported and out of date must start one install, not two.
+  const { latest } = status;
+  if (
+    status.installed &&
+    latest &&
+    status.version !== latest &&
+    gates.updatedTo !== latest &&
+    !gates.gameRunning
+  ) {
+    return "update";
+  }
+
+  return null;
+}

--- a/src/lib/useGameRunning.ts
+++ b/src/lib/useGameRunning.ts
@@ -7,13 +7,13 @@ const POLL_MS = 5000;
 /**
  * Whether MX Bikes is running, polled in the background.
  *
- * Kept out of `FrostmodProvider` on purpose: that context tracks FrostMod's own process,
- * and the game is a separate thing to watch. `refresh` is exposed so a launch can check
- * straight away instead of waiting out the interval.
+ * A separate thing from FrostMod's own process, which is why this stayed out of
+ * `FrostmodProvider`'s probe — that context consumes this hook rather than folding the two
+ * answers into one call. `refresh` is exposed so a launch can check straight away instead
+ * of waiting out the interval.
  *
- * Windows and macOS both really probe (Win32 on one, `ps` on the other — under Wine the
- * game is a normal process). Linux is permanently `false`, which is harmless: the backend
- * routes through Steam, and Steam focuses the running game rather than starting a second.
+ * All three platforms really probe: Win32 on Windows, `ps` on macOS and `/proc` on Linux,
+ * where the game is an ordinary process under Wine/Proton whose argv still names the exe.
  */
 export function useGameRunning(): { running: boolean; refresh: () => void } {
   const [running, setRunning] = useState(false);


### PR DESCRIPTION
## What

The app now tracks FrostMod releases while it is open and installs a new one on its own, when it safely can.

Two gaps closed:

1. **Nothing re-checked.** `refreshStatus()` — the only thing that asks GitHub for the latest tag — ran once, at mount. An app left open all evening never learned about a release published after it started. Now on a 30-minute interval (2 calls/hr against GitHub's 60/hr unauthenticated limit). This also re-runs the sweeps `status()` quietly carries, which had the same once-per-session problem: the stray `msvcr90.dll` cleanup and the stale `frostmod.dlo` refresh.

2. **Nothing auto-updated.** The existing unattended install fired only for `!installed || needsRepair || !supportedForGame`. A FrostMod that worked but was simply old was never touched — it sat behind an "Update to vX" button in Settings → FrostMod, a panel most players never open, while the blurb directly above it already claimed *"MXB App installs it, keeps it updated, and runs it for you."* That's the promise this makes true.

## The "if it can" part

An update is held back while MX Bikes is running. `frostmod_install` stops FrostMod before swapping the binaries, which would take live reload and the overlay out of a session in progress — and the game goes on running the old DLL out of its own memory until it restarts anyway (that's what `needsGameRestart` reports), so the wait costs nothing. `gameRunning` is polled, so the gate reopens by itself once they quit.

Also gated on: a failed GitHub check (never act on an offline guess), an install already in flight, and **one attempt per release tag** — a release that fails to install must not retry every poll, but a newer one still deserves its own try.

A repair is deliberately *not* gated on the game: FrostMod does nothing at all in those states, so waiting would help nobody.

## Why a pure helper

The decision moved to `autoInstallAction` in `src/lib/frostmodAuto.ts`. It is the only thing in the app that starts a download nobody pressed a button for — wrong one way and a player sits on a FrostMod that can't run, wrong the other and it reinstalls on a loop.

It also fixes a real overlap the two-effect version would have had: a FrostMod that is **both** unsupported for the active title **and** out of date satisfies both conditions, and would have started two installs in the same render. The single ordered table can only return one action.

## Verification

- 15-case decision table exercised under `bun`, all pass — including the both-conditions overlap, the per-tag retry rule, and every gate.
- `bun run typecheck` clean, `bun run lint` clean (3 pre-existing warnings elsewhere), `bun run build` succeeds.
- Frontend-only; no Rust, no DB, no schema changes. The backend already returned everything needed (`status.latest`, `game_running`).

## Drive-by

Two doc comments claimed the game-running probe was Windows-only and permanently `false` on Linux. Both are stale — `gameproc::is_game_running` really probes on all three platforms (Win32, `ps` under Wine, `/proc` under Proton). Corrected, because the new gate rests on exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)