### PR TITLE
fix(images): fall back to the origin URL when the cache can't serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-09-05
+
+### Fixed
+- Pictures load on machines where the app's image cache can't be reached. Browse, Shop and
+  MXB Hub fall back to loading a thumbnail straight from the site, so the grids show what
+  you are downloading instead of placeholder icons.
+
 ## 2026-09-04 — v0.13.6 — Paint sync, in beta
 
 ### Added

--- a/src/Components/Browse/ModCard.tsx
+++ b/src/Components/Browse/ModCard.tsx
@@ -20,7 +20,8 @@ import {
 } from "@/Components/ui/context-menu";
 import { cn } from "@/lib/utils";
 import { formatDateShort } from "../../lib/mods";
-import { cachedImage, GRID_THUMB_WIDTH } from "../../lib/imgcache";
+import { GRID_THUMB_WIDTH } from "../../lib/imgcache";
+import CachedImg from "@/Components/ui/cached-img";
 import { useT } from "../../i18n/context";
 
 interface ModCardProps {
@@ -66,14 +67,15 @@ export default function ModCard({
         >
           <div className="relative aspect-video overflow-hidden bg-gradient-to-br from-[#3a3f45] to-[#20242a]">
             {mod.image && !broken ? (
-              <img
+              <CachedImg
                 // Through the on-disk cache, so scrolling the grid twice doesn't re-fetch
-                // every thumbnail. A cache miss 404s, which lands on `onError` below exactly
-                // as a dead remote URL would.
-                src={cachedImage(mod.image, GRID_THUMB_WIDTH)}
+                // every thumbnail; a miss falls back to the origin URL, and only then to the
+                // placeholder below.
+                src={mod.image}
+                width={GRID_THUMB_WIDTH}
                 alt={mod.title}
                 loading="lazy"
-                onError={() => setBroken(true)}
+                onUnavailable={() => setBroken(true)}
                 className="size-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
               />
             ) : (

--- a/src/Components/ModDetail/Gallery.tsx
+++ b/src/Components/ModDetail/Gallery.tsx
@@ -6,7 +6,8 @@ import "swiper/css";
 import "swiper/css/navigation";
 import "swiper/css/pagination";
 import { cn } from "@/lib/utils";
-import { cachedImage, STRIP_THUMB_WIDTH } from "../../lib/imgcache";
+import { STRIP_THUMB_WIDTH } from "../../lib/imgcache";
+import CachedImg from "@/Components/ui/cached-img";
 
 interface GalleryProps {
   images: string[];
@@ -83,8 +84,8 @@ export default function Gallery({
                 is 16:9, and cropping to fill sliced the top and bottom off every one of them.
                 A 16:9 screenshot still fills the frame exactly, so mxb-mods is unaffected —
                 only images whose shape differs get letterboxed, which is the honest result. */}
-            <img
-              src={cachedImage(src)}
+            <CachedImg
+              src={src}
               alt={title}
               className="size-full bg-[#15181c] object-contain"
             />
@@ -105,8 +106,9 @@ export default function Gallery({
                   : "border-transparent opacity-60 hover:opacity-100",
               )}
             >
-              <img
-                src={cachedImage(src, STRIP_THUMB_WIDTH)}
+              <CachedImg
+                src={src}
+                width={STRIP_THUMB_WIDTH}
                 alt=""
                 className="size-full bg-[#15181c] object-contain"
               />

--- a/src/Components/ModDetail/RichDescription.tsx
+++ b/src/Components/ModDetail/RichDescription.tsx
@@ -4,6 +4,7 @@ import {
   cachedImage,
   DESCRIPTION_IMAGE_WIDTH,
   isCacheableImage,
+  schemeIsBroken,
 } from "../../lib/imgcache";
 
 interface RichDescriptionProps {
@@ -73,6 +74,10 @@ export default function RichDescription({ html }: RichDescriptionProps) {
  */
 function proxyImages(html: string): string {
   if (typeof DOMParser === "undefined") return html;
+  // Rewriting into a scheme that has already proved unusable on this machine would turn
+  // images that load today into ones that cannot. `CachedImg` recovers per image; this is
+  // markup, so the whole rewrite steps aside instead.
+  if (schemeIsBroken()) return html;
 
   const doc = new DOMParser().parseFromString(html, "text/html");
   for (const img of doc.querySelectorAll("img[src]")) {

--- a/src/Components/Shop/PurchaseCard.tsx
+++ b/src/Components/Shop/PurchaseCard.tsx
@@ -3,7 +3,8 @@ import { Check, Download, ExternalLink, Loader2, Store } from "lucide-react";
 import type { ShopMod } from "../../types";
 import type { ShopItem } from "../../api/mods";
 import { openShopUrl } from "../../api/shop";
-import { cachedImage, GRID_THUMB_WIDTH } from "../../lib/imgcache";
+import { GRID_THUMB_WIDTH } from "../../lib/imgcache";
+import CachedImg from "@/Components/ui/cached-img";
 import { useT } from "../../i18n/context";
 import { Button } from "@/Components/ui/button";
 import {
@@ -89,11 +90,12 @@ export default function PurchaseCard({
             className="relative aspect-square cursor-default overflow-hidden bg-gradient-to-br from-[#3a3f45] to-[#20242a] disabled:cursor-not-allowed"
           >
             {listing?.image && !broken ? (
-              <img
-                src={cachedImage(listing.image, GRID_THUMB_WIDTH)}
+              <CachedImg
+                src={listing.image}
+                width={GRID_THUMB_WIDTH}
                 alt={product}
                 loading="lazy"
-                onError={() => setBroken(true)}
+                onUnavailable={() => setBroken(true)}
                 className="size-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
               />
             ) : (

--- a/src/Components/Shop/ShopCard.tsx
+++ b/src/Components/Shop/ShopCard.tsx
@@ -3,7 +3,8 @@ import { ExternalLink, ShoppingBag, Store } from "lucide-react";
 import type { ShopMod } from "../../types";
 import PriceTag from "./PriceTag";
 import { openShopUrl } from "../../api/shop";
-import { cachedImage, GRID_THUMB_WIDTH } from "../../lib/imgcache";
+import { GRID_THUMB_WIDTH } from "../../lib/imgcache";
+import CachedImg from "@/Components/ui/cached-img";
 import { useT } from "../../i18n/context";
 import {
   ContextMenu,
@@ -47,11 +48,12 @@ export default function ShopCard({ mod, currency, onOpen }: ShopCardProps) {
               // it edge to edge without cropping anything off the ~93% that are square. Only
               // the rare widescreen one loses a sliver at the sides, which beats letterboxing
               // every card to accommodate the exception.
-              <img
-                src={cachedImage(mod.image, GRID_THUMB_WIDTH)}
+              <CachedImg
+                src={mod.image}
+                width={GRID_THUMB_WIDTH}
                 alt={mod.title}
                 loading="lazy"
-                onError={() => setBroken(true)}
+                onUnavailable={() => setBroken(true)}
                 className="size-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
               />
             ) : (

--- a/src/Components/ui/cached-img.tsx
+++ b/src/Components/ui/cached-img.tsx
@@ -1,0 +1,66 @@
+import { useState, type ImgHTMLAttributes } from "react";
+import {
+  cachedImage,
+  noteDirectRecovery,
+  schemeIsBroken,
+} from "../../lib/imgcache";
+
+interface CachedImgProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, "src" | "width"> {
+  /** The origin URL. Routed through the cache; see `cachedImage`. */
+  src: string;
+  /** Width to ask the cache for, or omit for the original. */
+  width?: number;
+  /** Called when the origin URL fails too — there is no picture to show. */
+  onUnavailable?: () => void;
+}
+
+/**
+ * A thumbnail, through the on-disk cache, falling back to the origin URL.
+ *
+ * The cache is worth having — a grid scrolled twice shouldn't refetch every image across the
+ * internet — but it sits between the picture and the screen, and a user turned up for whom
+ * that middle step never worked at all: every image in the app blank, `thumbnails 0 served`,
+ * every catalog's text loading normally around them. Nothing in the app could recover from
+ * that, because a cache miss went straight to the placeholder icon.
+ *
+ * So a miss now tries the origin URL before giving up. That request is the webview's own —
+ * real browser, real fingerprint, the site's cookies — which is also the one thing that gets
+ * a Cloudflare-challenged user their mxb-mods.com pictures, since a `cf_clearance` cannot be
+ * replayed into our HTTP client (see `mxb_session.rs`). One fallback, two failures answered.
+ */
+export default function CachedImg({
+  src,
+  width,
+  onUnavailable,
+  ...rest
+}: CachedImgProps) {
+  // `direct` from the start once the scheme has been written off, so the rest of a session
+  // doesn't pay a doomed request per image.
+  const [direct, setDirect] = useState(() => schemeIsBroken());
+  // Set when this image is showing *because* of the fallback, so its load can be reported.
+  const [recovered, setRecovered] = useState(false);
+
+  return (
+    <img
+      {...rest}
+      // Keyed so React swaps the element rather than reusing one the browser has already
+      // marked as errored, which can leave the new `src` unrequested.
+      key={direct ? "direct" : "cached"}
+      src={direct ? src : cachedImage(src, width)}
+      onError={() => {
+        if (direct) {
+          onUnavailable?.();
+          return;
+        }
+        setDirect(true);
+        setRecovered(true);
+      }}
+      onLoad={() => {
+        if (recovered) {
+          setRecovered(false);
+          noteDirectRecovery();
+        }
+      }}
+    />
+  );
+}

--- a/src/lib/imgcache.ts
+++ b/src/lib/imgcache.ts
@@ -73,3 +73,42 @@ export function isCacheableImage(url: string): boolean {
     return false;
   }
 }
+
+/**
+ * Whether the `imgcache` scheme has proved unusable this session.
+ *
+ * A user's report: every picture in the app blank — Browse, Shop and Hub alike — while all
+ * the text around them loaded fine. Their log read `thumbnails 0 served (0 MB)` for the whole
+ * session, so nothing had reached the handler at all; three different origins failing at once
+ * is the scheme, not any one site. Whatever intercepts `http://imgcache.localhost` on that
+ * machine, the origin URL still loads in the same webview, so falling back to it is the
+ * difference between a grid of pictures and a grid of placeholders.
+ *
+ * Session-local and one-way. Losing the cache for a session costs re-fetching thumbnails;
+ * getting it wrong the other way costs the user every image, which is what they reported.
+ */
+let directRecoveries = 0;
+let schemeBroken = false;
+
+/**
+ * How many images must load direct after failing through the cache before the scheme itself
+ * is written off. More than one, because a single image can fail through the cache on its own
+ * merits — an origin that 404s only for us, a body past the fetch cap, a format the sniffer
+ * won't have — and one of those must not cost everyone else their cache.
+ */
+const RECOVERIES_BEFORE_GIVING_UP = 3;
+
+/** Whether [`cachedImage`] should be skipped in favour of the origin URL. */
+export function schemeIsBroken(): boolean {
+  return schemeBroken;
+}
+
+/**
+ * Report that `url` failed through the cache and then loaded directly.
+ *
+ * Only affects images mounted afterwards; the one that recovered is already showing.
+ */
+export function noteDirectRecovery(): void {
+  directRecoveries += 1;
+  if (directRecoveries >= RECOVERIES_BEFORE_GIVING_UP) schemeBroken = true;
+}


### PR DESCRIPTION
## The report

A user: *"the app not loading any picture, i'm on the latest version, i have good internet and it's in all the folders in the app."* Their screenshots show Browse and Shop with every card's **title, date, price and creator** present and every **picture** a placeholder, and a Shop detail page rendering a broken-image glyph with its alt text.

## What the log says

`thumbnails 0 served (0 MB)` — every sample, for a 17-hour session. Nothing ever reached the `imgcache` scheme handler.

That rules out the per-site explanations. Browse (mxb-mods.com), Shop (mxbikes-shop.com / Bunny) and MXB Hub (mxb-hub.com) are three unrelated origins with three separate reqwest clients, and the catalog *text* from all of them loaded fine. The one thing they share is that every `<img src>` goes through `imgcache://` — `http://imgcache.localhost/…` on Windows.

Their log also carries a genuine Cloudflare challenge on mxb-mods.com (`403`, `cf-mitigated=challenge`, `jar: none`) and a hidden-window clearance that never cleared. That is a real second problem, and it has the same symptom for images: `mxb_fetch` moves *text* into the WebView for challenged users, never images, so `imgcache` keeps using the client Cloudflare refuses. See mxb_session.rs:11-16 — a `cf_clearance` is bound to the TLS/HTTP2 fingerprint that earned it and can't be replayed into rustls.

Either way, an image had no way back: a cache miss went straight to the placeholder.

## The change

`CachedImg` tries the cache, then the origin URL, then the placeholder. The second request is issued by the webview itself — real Chrome fingerprint, the site's own cookies — which is exactly what works on the reporter's machine (they confirmed mxb-mods.com loads fine in a browser there).

- Browse grid, Shop grid, purchases, detail gallery and thumbnail strip.
- After three images recover that way the scheme is written off for the session, so a long grid doesn't pay a doomed request per card. Three rather than one: a single image can fail through the cache on its own merits — an origin that 404s only for us, a body past the fetch cap, a format the sniffer won't have — and one of those must not cost everyone else their disk cache.
- `RichDescription` rewrites HTML rather than rendering components, so it steps aside wholesale once the scheme is written off.

The fallback only adds an attempt where the placeholder was already showing, so a host that refuses a hotlink lands exactly where it does today.

## Verified

Ran the UI against the debug binary with `cachedImage` pointed at a deliberately dead scheme, standing in for the reporter's machine:

- **scheme broken** — Browse grid painted full of real thumbnails via the fallback
- **scheme restored** — identical grid, no fallback triggered, no regression

`tsc --noEmit` and `eslint` clean. The store's own host wasn't exercised — this build has no shop credentials, so the catalog won't render — but it is the same component and the same props.

## Not covered here

The hidden mxb-mods.com clearance window failing for this user (`the hidden mxb-mods.com window never became ready`) still breaks their **mod detail pages**. Separate issue, separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)