### PR TITLE
feat(servers): a Servers tab listing the live world server list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2026-09-05
 
+### Added
+- A Servers tab that lists every live MX Bikes server the way the in-game browser does —
+  who's on each one, the track it's running, and its address. Press Join to launch straight
+  into any of them.
+
 ### Fixed
 - Tracks you build in the app have a riding line again. The ground is painted in four bands
   — field, worked shoulder, the line itself and the grass over the top — where before every

--- a/src-tauri/.gitignore
+++ b/src-tauri/.gitignore
@@ -9,6 +9,7 @@
 # Local-only module (not part of the public tree)
 /src/sidecar.rs
 /src/sidecar_lock.rs
+/src/worldnet.rs
 /src/fixtures/test_sidecar.pkz
 /src/mxbsecure.rs
 /src/mxbsecure.dll

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -549,6 +549,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3536,7 +3546,9 @@ version = "0.13.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "blowfish",
  "chacha20poly1305",
+ "cipher",
  "cpal",
  "dirs-next",
  "ed25519-dalek",
@@ -3546,6 +3558,7 @@ dependencies = [
  "html-escape",
  "http",
  "image",
+ "libloading 0.8.9",
  "log",
  "md-5",
  "mega",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -148,6 +148,15 @@ tungstenite = { version = "0.24", default-features = false, features = [
     "rustls-tls-webpki-roots",
 ] }
 
+# Used only by the local-only `worldnet` module (the server browser). Pure-Rust and tiny, so
+# they cost the public build a few unused crates rather than a native link: `blowfish`+`cipher`
+# are the master protocol's cipher, and `libloading` reaches Steam's flat C API at runtime the
+# same way the app reads Steam identity from files — no build-time `steam_api` linkage (see
+# `steamid.rs`).
+blowfish = "0.9"
+cipher = "0.4"
+libloading = "0.8"
+
 # Only for putting a mod back after an uninstall. `trash` calls `trashItemAtURL` but throws
 # away the destination it reports, and the Trash folder can't simply be read back — macOS
 # refuses `~/.Trash` to an app without Full Disk Access. Asking the API where it put the file

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -14,6 +14,14 @@ fn main() {
     println!("cargo::rerun-if-changed=src/sidecar.rs");
     println!("cargo::rerun-if-changed=src/sidecar_lock.rs");
 
+    // The world-server browser client, gated the same way: present locally, absent from the
+    // public tree. Holds the master-server protocol, so it never ships in the open source.
+    println!("cargo::rustc-check-cfg=cfg(worldnet)");
+    if Path::new("src/worldnet.rs").exists() {
+        println!("cargo::rustc-cfg=worldnet");
+    }
+    println!("cargo::rerun-if-changed=src/worldnet.rs");
+
     // The secure-content packer, gated independently of the sidecar modules above.
     println!("cargo::rustc-check-cfg=cfg(mxbsecure)");
     if Path::new("src/mxbsecure.rs").exists() {

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -857,6 +857,65 @@ fn parse_ini_mods_folder(bytes: &[u8]) -> Option<String> {
     fallback
 }
 
+/// The master server the client talks to when the `.ini` names none. Community-documented,
+/// not shipped in the binary (which reads the address from the `.ini` — see `parse_master_servers`).
+pub const DEFAULT_MASTER: &str = "master.mx-bikes.com:54200";
+
+/// Pull the `[master]` server addresses out of a PiBoSo `.ini`.
+///
+/// The game reads up to ten — `server`, `server2` … `server10` — and tries each in turn, so
+/// this returns them in that order. Same forgiving Windows-1252 `[section]`/`key = value`
+/// parse as [`parse_ini_mods_folder`]; empty when the file has no `[master]` section.
+pub fn parse_master_servers(bytes: &[u8]) -> Vec<String> {
+    let text: String = bytes.iter().map(|&b| b as char).collect();
+    let mut section = String::new();
+    // Keyed by index so `server`, `server2`, … come back in the order the game reads them,
+    // regardless of the order they appear in the file.
+    let mut found: Vec<(u32, String)> = Vec::new();
+    for line in text.lines() {
+        let line = line.split(';').next().unwrap_or("").trim();
+        if let Some(name) = line.strip_prefix('[').and_then(|l| l.strip_suffix(']')) {
+            section = name.trim().to_ascii_lowercase();
+            continue;
+        }
+        if section != "master" {
+            continue;
+        }
+        let Some((k, v)) = line.split_once('=') else { continue };
+        let (k, v) = (k.trim().to_ascii_lowercase(), v.trim().trim_matches('"').trim());
+        if v.is_empty() {
+            continue;
+        }
+        // `server` is index 1; `serverN` is index N. Anything else in the section is ignored.
+        let idx = match k.strip_prefix("server") {
+            Some("") => Some(1),
+            Some(n) => n.parse::<u32>().ok(),
+            None => None,
+        };
+        if let Some(idx) = idx {
+            found.push((idx, v.to_string()));
+        }
+    }
+    found.sort_by_key(|(idx, _)| *idx);
+    found.into_iter().map(|(_, addr)| addr).collect()
+}
+
+/// The master addresses to query for this install: the `.ini`'s if it names any, else the
+/// documented default so a fresh install still reaches the public list.
+pub fn master_servers(cfg: &AppConfig) -> Vec<String> {
+    let name = game_ini_name(cfg.game());
+    let from_ini = [cfg.game_path.trim(), cfg.mods_path.trim()]
+        .into_iter()
+        .filter(|d| !d.is_empty())
+        .map(|d| crate::library::resolve_child(Path::new(d), &name))
+        .filter(|p| p.is_file())
+        .find_map(|ini| {
+            let servers = parse_master_servers(&std::fs::read(&ini).ok()?);
+            (!servers.is_empty()).then_some(servers)
+        });
+    from_ini.unwrap_or_else(|| vec![DEFAULT_MASTER.to_string()])
+}
+
 /// The game's user folder inside a Wine prefix.
 ///
 /// Wherever the game runs as a Windows process — Proton on Linux, CrossOver/Whisky on
@@ -1511,6 +1570,30 @@ mod tests {
             Some("C:\\modsé".to_string()),
             "Windows-1252, like every other file these games write",
         );
+    }
+
+    /// The master list drives the server browser, so its order and its bounds matter: the
+    /// game reads `server`, `server2` … `server10` in that order and tries each in turn.
+    #[test]
+    fn parses_the_master_servers_out_of_a_piboso_ini() {
+        // One server, the stock file.
+        assert_eq!(
+            parse_master_servers(b"[master]\nserver = master.mx-bikes.com:54200\n\n[mods]\nfolder = C:\\mods\n"),
+            vec!["master.mx-bikes.com:54200".to_string()],
+        );
+
+        // Several, returned in game order even when the file lists them out of order.
+        assert_eq!(
+            parse_master_servers(b"[master]\nserver2 = b:2\nserver = a:1\nserver10 = j:10\n"),
+            vec!["a:1".to_string(), "b:2".to_string(), "j:10".to_string()],
+        );
+
+        // A `server` key outside `[master]`, an empty value, and a non-numbered stray are all
+        // ignored; nothing to read yields nothing (the caller falls back to the default).
+        assert_eq!(parse_master_servers(b"[net]\nserver = elsewhere:1\n"), Vec::<String>::new());
+        assert_eq!(parse_master_servers(b"[master]\nserver =\n"), Vec::<String>::new());
+        assert_eq!(parse_master_servers(b"[master]\nserverfoo = x:1\n"), Vec::<String>::new());
+        assert_eq!(parse_master_servers(b""), Vec::<String>::new());
     }
 
     /// A value that doesn't resolve to a real mods tree is thrown away rather than

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -60,6 +60,10 @@ mod proton;
 mod sidecar;
 #[cfg(sidecar)]
 mod sidecar_lock;
+/// The world-server browser: speaks the master-server protocol to list live servers.
+/// Local-only, like [`sidecar`] — the public tree neither has the file nor the feature.
+#[cfg(worldnet)]
+mod worldnet;
 #[cfg(mxbsecure)]
 mod mxbsecure;
 mod steamid;
@@ -7688,6 +7692,49 @@ fn join_server(app: tauri::AppHandle, address: String) -> Result<gameproc::Launc
     Ok(outcome)
 }
 
+/// One live server as the Servers tab shows it. Filled by the local-only `worldnet` module
+/// from the master-server list; a superset of [`paintsync::RegisteredServer`] so the tab's
+/// Join button reuses [`join_server`]. The struct carries no protocol detail — that all lives
+/// behind `cfg(worldnet)` — so it stays in the public tree and the command compiles either way.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorldServer {
+    /// Display name the operator gave the server.
+    pub name: String,
+    /// `ip:port`, the form the game's connect flag and [`join_server`] take.
+    pub address: String,
+    /// Riders currently connected, and the seat cap.
+    pub players: u32,
+    pub max_players: u32,
+    /// Round-trip to the server in milliseconds, or `None` if it wasn't measured.
+    pub ping_ms: Option<u32>,
+    /// The track the server is running, when the master reports it.
+    pub track: String,
+    /// Whether a password is required to join.
+    pub passworded: bool,
+    /// Free-text region/label, empty when unknown.
+    pub region: String,
+}
+
+/// The live MX Bikes server list, as the game's WORLD browser sees it.
+///
+/// All the work — the master-server protocol, the Steam auth ticket, the parsing — lives in
+/// the local-only `worldnet` module. Without it (the public tree, or a build that never had
+/// the file) the tab still exists but says the browser isn't included, rather than failing
+/// opaquely.
+#[tauri::command]
+async fn list_master_servers(app: tauri::AppHandle) -> Result<Vec<WorldServer>, String> {
+    #[cfg(worldnet)]
+    {
+        worldnet::list_servers(app).await
+    }
+    #[cfg(not(worldnet))]
+    {
+        let _ = app;
+        Err("The server browser isn't included in this build.".into())
+    }
+}
+
 /// Is MX Bikes running? Polled by the sidebar so Play can show the live state.
 #[tauri::command]
 fn game_running() -> bool {
@@ -10083,6 +10130,7 @@ fn main() {
             frostmod_stop,
             launch_game,
             join_server,
+            list_master_servers,
             experimental_state,
             enroll_account,
             // Paid plugins: the catalogue, redeeming a key, and getting a bundle on disk.

--- a/src/Components/Dashboard/Dashboard.tsx
+++ b/src/Components/Dashboard/Dashboard.tsx
@@ -10,6 +10,7 @@ import Manage from "../Manage/Manage";
 import Secure from "../Secure/Secure";
 import Studio, { type StudioTab } from "../Studio/Studio";
 import Browse from "../Browse/Browse";
+import Servers from "../Servers/Servers";
 import Shop from "../Shop/Shop";
 import Hub from "../Hub/Hub";
 import ModDetail from "../ModDetail/ModDetail";
@@ -228,6 +229,8 @@ const Dashboard = ({ welcomeActive = false }: DashboardProps) => {
               onOpenMod={openMod}
               onChangeType={changeType}
             />
+          ) : view === "servers" ? (
+            <Servers />
           ) : view === "shop" ? (
             <Shop refreshKey={libraryVersion} />
           ) : view === "hub" ? (

--- a/src/Components/Servers/Servers.tsx
+++ b/src/Components/Servers/Servers.tsx
@@ -1,0 +1,260 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Search,
+  RefreshCw,
+  Loader2,
+  Lock,
+  Users,
+  Signal,
+  Copy,
+  Plug,
+  ServerOff,
+} from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { Button } from "@/Components/ui/button";
+import HelpHint from "@/Components/ui/help-hint";
+import {
+  listMasterServers,
+  joinServer,
+  type MasterServer,
+} from "../../api/mods";
+import { useT } from "../../i18n/context";
+
+/**
+ * The live MX Bikes server list, read straight from PiBoSo's master server — the same
+ * population the in-game WORLD browser shows, with the IP the game never surfaces. Joining a
+ * row reuses the existing `-directconnect` launch, so this is the one-click path the address
+ * dialog only hinted at.
+ *
+ * The fetch is one Rust command; everything the master needs (auth, the protocol) lives
+ * behind it. A build without the browser, or a master that won't answer, comes back as a
+ * plain error string this renders rather than a blank tab.
+ */
+const Servers = () => {
+  const t = useT();
+  const [servers, setServers] = useState<MasterServer[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [query, setQuery] = useState("");
+  const [joining, setJoining] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    listMasterServers()
+      .then((list) => {
+        // Busiest first — an empty server is the last thing anyone's looking for.
+        list.sort((a, b) => b.players - a.players);
+        setServers(list);
+      })
+      .catch((e: unknown) => {
+        setServers([]);
+        setError(typeof e === "string" ? e : String(e));
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const shown = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q || !servers) return servers ?? [];
+    return servers.filter(
+      (s) =>
+        s.name.toLowerCase().includes(q) ||
+        s.track.toLowerCase().includes(q) ||
+        s.address.toLowerCase().includes(q),
+    );
+  }, [servers, query]);
+
+  const join = useCallback(
+    async (address: string) => {
+      if (joining) return;
+      setJoining(address);
+      try {
+        const outcome = await joinServer(address);
+        if (outcome === "already_running") {
+          toast.info(t("join.alreadyRunning"));
+        } else {
+          toast.success(t("join.launching", { address }));
+        }
+      } catch (e) {
+        toast.error(typeof e === "string" ? e : t("serverBrowser.joinFailed"));
+      } finally {
+        setJoining(null);
+      }
+    },
+    [joining, t],
+  );
+
+  const copy = useCallback(
+    (address: string) => {
+      navigator.clipboard
+        .writeText(address)
+        .then(() => toast.success(t("serverBrowser.copied")))
+        .catch(() => {});
+    },
+    [t],
+  );
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="flex flex-none flex-col gap-3 px-7 pb-3.5 pt-5">
+        <div className="flex items-center gap-3.5">
+          <h1 className="text-[21px] font-bold tracking-[-0.2px]">
+            {t("servers.title")}
+          </h1>
+          <HelpHint
+            title={t("servers.title")}
+            description={t("serverBrowser.help")}
+          />
+          {servers && servers.length > 0 && (
+            <span className="text-[12.5px] text-faint">
+              {t("serverBrowser.count", { count: servers.length })}
+            </span>
+          )}
+          <div className="ml-auto flex items-center gap-2">
+            <div className="flex w-[240px] items-center gap-2 rounded-lg border border-input bg-card px-3 py-2">
+              <Search className="size-3.5 text-faint" />
+              <input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder={t("serverBrowser.searchPlaceholder")}
+                className="w-full bg-transparent text-[12.5px] placeholder:text-faint focus:outline-none"
+              />
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={load}
+              disabled={loading}
+              title={t("serverBrowser.refresh")}
+            >
+              <RefreshCw className={cn("size-3.5", loading && "animate-spin")} />
+              {t("serverBrowser.refresh")}
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-7 pb-6">
+        {servers === null ? (
+          <Centered>
+            <Loader2 className="size-5 animate-spin text-faint" />
+            <p className="text-[13px] text-faint">{t("serverBrowser.loading")}</p>
+          </Centered>
+        ) : error ? (
+          <Centered>
+            <ServerOff className="size-6 text-faint" />
+            <p className="max-w-[420px] text-center text-[13px] text-muted-foreground">
+              {error}
+            </p>
+            <Button variant="outline" size="sm" onClick={load}>
+              <RefreshCw className="size-3.5" />
+              {t("serverBrowser.retry")}
+            </Button>
+          </Centered>
+        ) : shown.length === 0 ? (
+          <Centered>
+            <ServerOff className="size-6 text-faint" />
+            <p className="text-[13px] text-faint">{t("serverBrowser.empty")}</p>
+          </Centered>
+        ) : (
+          <div className="overflow-hidden rounded-xl border border-input">
+            <table className="w-full border-collapse text-[13px]">
+              <thead>
+                <tr className="border-b border-input bg-card text-left text-[11.5px] uppercase tracking-wide text-faint">
+                  <th className="px-3.5 py-2.5 font-semibold">{t("serverBrowser.name")}</th>
+                  <th className="w-[92px] px-2 py-2.5 font-semibold">{t("serverBrowser.players")}</th>
+                  <th className="px-2 py-2.5 font-semibold">{t("servers.track")}</th>
+                  <th className="w-[72px] px-2 py-2.5 font-semibold">{t("serverBrowser.ping")}</th>
+                  <th className="px-2 py-2.5 font-semibold">{t("serverBrowser.address")}</th>
+                  <th className="w-[110px] px-3.5 py-2.5" />
+                </tr>
+              </thead>
+              <tbody>
+                {shown.map((s, i) => (
+                  <tr
+                    key={`${s.address}-${i}`}
+                    className="border-b border-input/60 last:border-0 hover:bg-foreground/[0.03]"
+                  >
+                    <td className="px-3.5 py-2.5">
+                      <div className="flex items-center gap-2">
+                        {s.passworded && (
+                          <Lock
+                            className="size-3.5 shrink-0 text-faint"
+                            aria-label={t("serverBrowser.passworded")}
+                          />
+                        )}
+                        <span className="truncate font-medium" title={s.name}>
+                          {s.name}
+                        </span>
+                      </div>
+                    </td>
+                    <td className="px-2 py-2.5 tabular-nums text-muted-foreground">
+                      <span className="inline-flex items-center gap-1.5">
+                        <Users className="size-3.5 text-faint" />
+                        {s.players}/{s.maxPlayers}
+                      </span>
+                    </td>
+                    <td className="px-2 py-2.5 text-muted-foreground">
+                      <span className="block max-w-[220px] truncate" title={s.track}>
+                        {s.track || "—"}
+                      </span>
+                    </td>
+                    <td className="px-2 py-2.5 tabular-nums text-muted-foreground">
+                      {s.pingMs === null ? (
+                        "—"
+                      ) : (
+                        <span className="inline-flex items-center gap-1.5">
+                          <Signal className="size-3.5 text-faint" />
+                          {s.pingMs}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-2 py-2.5">
+                      <button
+                        onClick={() => copy(s.address)}
+                        title={t("serverBrowser.copyAddress")}
+                        className="inline-flex items-center gap-1.5 rounded-md px-1.5 py-0.5 font-mono text-[12px] text-muted-foreground hover:bg-foreground/[0.06] hover:text-foreground"
+                      >
+                        {s.address}
+                        <Copy className="size-3 text-faint" />
+                      </button>
+                    </td>
+                    <td className="px-3.5 py-2.5 text-right">
+                      <Button
+                        size="sm"
+                        onClick={() => join(s.address)}
+                        disabled={joining !== null}
+                      >
+                        {joining === s.address ? (
+                          <Loader2 className="size-3.5 animate-spin" />
+                        ) : (
+                          <Plug className="size-3.5" />
+                        )}
+                        {t("serverBrowser.join")}
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+/** The three non-list states (loading, error, empty) share this centered column. */
+const Centered = ({ children }: { children: React.ReactNode }) => (
+  <div className="flex h-full flex-col items-center justify-center gap-3 py-16">
+    {children}
+  </div>
+);
+
+export default Servers;

--- a/src/Components/Shell/Sidebar.tsx
+++ b/src/Components/Shell/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Loader2,
   Gamepad2,
   SlidersHorizontal,
+  Server,
   Store,
   ShoppingBag,
   Brush,
@@ -58,6 +59,7 @@ import DownloadQueue from "./DownloadQueue";
 export type DashboardView =
   | `plugin:${string}`
   | "browse"
+  | "servers"
   | "shop"
   | "hub"
   | "library"
@@ -113,6 +115,9 @@ const entryLabel = (t: TFunc, e: NavEntry) => e.rawLabel ?? t(e.label);
 
 const NAV: NavEntry[] = [
   { id: "browse", label: "nav.browse", icon: Home },
+  // The live server list from the game's master server — a second catalog, of servers
+  // rather than mods, so it sits right under Browse.
+  { id: "servers", label: "nav.servers", icon: Server },
   {
     id: "library",
     label: "nav.library",

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -2971,6 +2971,29 @@ export function cpServers(): Promise<RegisteredServer[]> {
   return invoke<RegisteredServer[]>("cp_servers");
 }
 
+/** One live server from the game's master list — what the Servers tab shows per row. */
+export interface MasterServer {
+  name: string;
+  /** `ip:port`, ready for {@link joinServer}. */
+  address: string;
+  players: number;
+  maxPlayers: number;
+  /** Round-trip in ms, or `null` when it wasn't measured. */
+  pingMs: number | null;
+  track: string;
+  passworded: boolean;
+  region: string;
+}
+
+/**
+ * Every live MX Bikes server, as the in-game WORLD browser sees it, read straight from
+ * PiBoSo's master server. Rejects with a human-readable message when the list can't be
+ * fetched (this build lacks the browser, or the master didn't answer) — the tab shows it.
+ */
+export function listMasterServers(): Promise<MasterServer[]> {
+  return invoke<MasterServer[]>("list_master_servers");
+}
+
 export type ServerAction = "start" | "stop" | "restart";
 
 export function listServers(): Promise<ServerRef[]> {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1060,6 +1060,24 @@ export const de: Translation = {
   "servers.atCap": "Es laufen bereits {{cap}} Server, das ist das Limit. Schalte einen ab, um einen neuen zu starten.",
   "servers.help": "Teile deine Designs mit allen auf einem Server und betreibe einen eigenen Dedicated Server.",
 
+  "serverBrowser.help":
+    "Alle laufenden MX-Bikes-Server, direkt vom Master-Server des Spiels – mit der Adresse zum Beitreten. Wähle einen aus und klicke auf Beitreten, um direkt zu starten.",
+  "serverBrowser.searchPlaceholder": "Server suchen…",
+  "serverBrowser.count": "{{count}} online",
+  "serverBrowser.refresh": "Aktualisieren",
+  "serverBrowser.retry": "Erneut versuchen",
+  "serverBrowser.loading": "Serverliste wird geladen…",
+  "serverBrowser.empty": "Gerade sind keine Server online.",
+  "serverBrowser.name": "Server",
+  "serverBrowser.players": "Fahrer",
+  "serverBrowser.ping": "Ping",
+  "serverBrowser.address": "Adresse",
+  "serverBrowser.passworded": "Passwort erforderlich",
+  "serverBrowser.join": "Beitreten",
+  "serverBrowser.joinFailed": "Konnte diesem Server nicht beitreten",
+  "serverBrowser.copyAddress": "Adresse kopieren",
+  "serverBrowser.copied": "Adresse kopiert",
+
   "sync.autoNote":
     "Dein Look veröffentlicht sich selbst — jedes Bike, sobald du ihn in der App oder in der Garage des Spiels änderst. Der der anderen kommt, wenn du auf Spielen drückst.",
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1037,6 +1037,25 @@ export const en = {
   "servers.atCap": "{{cap}} servers are already running, which is the limit. Shut one down to start another.",
   "servers.help": "Share your liveries with everyone else on a server, and run a dedicated server of your own.",
 
+  // ── Server browser (the live world list) ───────────────────────────────────
+  "serverBrowser.help":
+    "Every live MX Bikes server, straight from the game's master server — with the address you need to join. Pick one and press Join to launch straight into it.",
+  "serverBrowser.searchPlaceholder": "Search servers…",
+  "serverBrowser.count": "{{count}} online",
+  "serverBrowser.refresh": "Refresh",
+  "serverBrowser.retry": "Try again",
+  "serverBrowser.loading": "Reading the server list…",
+  "serverBrowser.empty": "No servers are online right now.",
+  "serverBrowser.name": "Server",
+  "serverBrowser.players": "Players",
+  "serverBrowser.ping": "Ping",
+  "serverBrowser.address": "Address",
+  "serverBrowser.passworded": "Password required",
+  "serverBrowser.join": "Join",
+  "serverBrowser.joinFailed": "Couldn't join that server",
+  "serverBrowser.copyAddress": "Copy the address",
+  "serverBrowser.copied": "Address copied",
+
   "sync.autoNote":
     "Your look publishes itself — every bike, whenever you change it in the app or in the game's own garage. Everyone else's arrives when you press Play.",
 

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1053,6 +1053,24 @@ export const es: Translation = {
   "servers.atCap": "Ya hay {{cap}} servidores activos, que es el límite. Apaga uno para arrancar otro.",
   "servers.help": "Comparte tus libreas con todos en un servidor y gestiona un servidor dedicado propio.",
 
+  "serverBrowser.help":
+    "Todos los servidores de MX Bikes en directo, desde el servidor maestro del juego, con la dirección para unirte. Elige uno y pulsa Unirse para entrar directamente.",
+  "serverBrowser.searchPlaceholder": "Buscar servidores…",
+  "serverBrowser.count": "{{count}} en línea",
+  "serverBrowser.refresh": "Actualizar",
+  "serverBrowser.retry": "Reintentar",
+  "serverBrowser.loading": "Cargando la lista de servidores…",
+  "serverBrowser.empty": "Ahora mismo no hay servidores en línea.",
+  "serverBrowser.name": "Servidor",
+  "serverBrowser.players": "Pilotos",
+  "serverBrowser.ping": "Ping",
+  "serverBrowser.address": "Dirección",
+  "serverBrowser.passworded": "Requiere contraseña",
+  "serverBrowser.join": "Unirse",
+  "serverBrowser.joinFailed": "No se pudo unir a ese servidor",
+  "serverBrowser.copyAddress": "Copiar la dirección",
+  "serverBrowser.copied": "Dirección copiada",
+
   "sync.autoNote":
     "Tu look se publica solo — cada moto, cada vez que lo cambias en la app o en el garaje del juego. El de los demás llega cuando pulsas Jugar.",
 

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1058,6 +1058,24 @@ export const fr: Translation = {
   "servers.atCap": "{{cap}} serveurs tournent déjà, c'est la limite. Éteignez-en un pour en démarrer un autre.",
   "servers.help": "Partagez vos livrées avec tout le monde sur un serveur, et gérez votre propre serveur dédié.",
 
+  "serverBrowser.help":
+    "Tous les serveurs MX Bikes en ligne, directement depuis le serveur maître du jeu, avec l'adresse pour les rejoindre. Choisis-en un et clique sur Rejoindre pour y entrer directement.",
+  "serverBrowser.searchPlaceholder": "Rechercher des serveurs…",
+  "serverBrowser.count": "{{count}} en ligne",
+  "serverBrowser.refresh": "Actualiser",
+  "serverBrowser.retry": "Réessayer",
+  "serverBrowser.loading": "Chargement de la liste des serveurs…",
+  "serverBrowser.empty": "Aucun serveur en ligne pour le moment.",
+  "serverBrowser.name": "Serveur",
+  "serverBrowser.players": "Pilotes",
+  "serverBrowser.ping": "Ping",
+  "serverBrowser.address": "Adresse",
+  "serverBrowser.passworded": "Mot de passe requis",
+  "serverBrowser.join": "Rejoindre",
+  "serverBrowser.joinFailed": "Impossible de rejoindre ce serveur",
+  "serverBrowser.copyAddress": "Copier l'adresse",
+  "serverBrowser.copied": "Adresse copiée",
+
   "sync.autoNote":
     "Votre look se publie tout seul — chaque moto, dès que vous le changez dans l'app ou dans le garage du jeu. Celui des autres arrive quand vous appuyez sur Jouer.",
 

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1051,6 +1051,24 @@ export const it: Translation = {
   "servers.atCap": "Ci sono già {{cap}} server attivi, che è il limite. Spegnine uno per avviarne un altro.",
   "servers.help": "Condividi le tue livree con tutti gli altri su un server e gestisci un server dedicato tuo.",
 
+  "serverBrowser.help":
+    "Tutti i server MX Bikes online, direttamente dal server master del gioco, con l'indirizzo per entrare. Scegline uno e premi Entra per avviare direttamente.",
+  "serverBrowser.searchPlaceholder": "Cerca server…",
+  "serverBrowser.count": "{{count}} online",
+  "serverBrowser.refresh": "Aggiorna",
+  "serverBrowser.retry": "Riprova",
+  "serverBrowser.loading": "Caricamento della lista server…",
+  "serverBrowser.empty": "Nessun server online al momento.",
+  "serverBrowser.name": "Server",
+  "serverBrowser.players": "Piloti",
+  "serverBrowser.ping": "Ping",
+  "serverBrowser.address": "Indirizzo",
+  "serverBrowser.passworded": "Password richiesta",
+  "serverBrowser.join": "Entra",
+  "serverBrowser.joinFailed": "Impossibile entrare in quel server",
+  "serverBrowser.copyAddress": "Copia l'indirizzo",
+  "serverBrowser.copied": "Indirizzo copiato",
+
   "sync.autoNote":
     "Il tuo look si pubblica da solo — ogni moto, ogni volta che lo cambi nell'app o nel garage del gioco. Quello degli altri arriva quando premi Gioca.",
 

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1053,6 +1053,24 @@ export const ptBR: Translation = {
   "servers.atCap": "Já há {{cap}} servidores rodando, que é o limite. Desligue um para iniciar outro.",
   "servers.help": "Compartilhe suas pinturas com todo mundo num servidor e administre um servidor dedicado seu.",
 
+  "serverBrowser.help":
+    "Todos os servidores de MX Bikes online, direto do servidor mestre do jogo, com o endereço para entrar. Escolha um e clique em Entrar para iniciar direto nele.",
+  "serverBrowser.searchPlaceholder": "Buscar servidores…",
+  "serverBrowser.count": "{{count}} online",
+  "serverBrowser.refresh": "Atualizar",
+  "serverBrowser.retry": "Tentar de novo",
+  "serverBrowser.loading": "Lendo a lista de servidores…",
+  "serverBrowser.empty": "Nenhum servidor online no momento.",
+  "serverBrowser.name": "Servidor",
+  "serverBrowser.players": "Pilotos",
+  "serverBrowser.ping": "Ping",
+  "serverBrowser.address": "Endereço",
+  "serverBrowser.passworded": "Senha obrigatória",
+  "serverBrowser.join": "Entrar",
+  "serverBrowser.joinFailed": "Não foi possível entrar nesse servidor",
+  "serverBrowser.copyAddress": "Copiar o endereço",
+  "serverBrowser.copied": "Endereço copiado",
+
   "sync.autoNote":
     "Seu visual se publica sozinho — cada moto, sempre que você muda no app ou na garagem do jogo. O dos outros chega quando você aperta Jogar.",
 


### PR DESCRIPTION
## What

Adds a **Servers** tab (sidebar, under Browse) that shows the live MX Bikes server population the way the in-game WORLD browser does — server name, players, track, ping, a lock for passworded servers, and the `ip:port` address the game never surfaces. Busiest servers first; search filters by name/track/address; **Join** launches straight into a server via the existing `-directconnect` path; the address is one-click copyable.

## How

The server list comes from PiBoSo's master server (UDP + Blowfish), reverse-engineered from `mxbikes.exe`. All protocol detail lives in a **local-only, gitignored `worldnet.rs`** module gated behind `cfg(worldnet)` — wired exactly like `sidecar`, so the public tree has neither the file nor the feature and compiles unchanged (the command returns a clean "not included" error). It tries the game's no-auth browse mode first and falls back to a Steam-ticket `LOGIN` only if the master doesn't answer.

Committed (public) surface carries no protocol detail:
- `list_master_servers` command + `WorldServer` DTO (`main.rs`)
- `config::parse_master_servers` / `master_servers` — the `[master]` addresses from `mxbikes.ini`, with the documented default as fallback
- The `Servers` tab, `api/mods.ts` binding, the `DashboardView` union + sidebar nav entry, and `serverBrowser.*` strings in all six locales
- Tiny pure-Rust deps for the local module: `blowfish`, `cipher`, `libloading`

## Verification

- `cargo check` (native) and `cargo check --target x86_64-pc-windows-gnu` (the Windows-only Steam path) both clean
- Unit tests pass: Blowfish standard test vectors, encrypt/decrypt round-trip, 19-byte address codec, synthetic `LIST` parse, and the `[master]` ini parser
- `tsc --noEmit` clean

## Notes

- The live master handshake is verifiable only on Windows with Steam running; `MXB_WORLDNET_DEBUG=1` logs each decrypted reply as hex so the inferred per-record byte meanings (players/max/passworded) can be confirmed against a real reply. Per-server ping is not yet measured.
- `worldnet.rs` is gitignored (not in this PR) — it needs to reach CI/other machines via the private module sync, like the other local-only modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)