### PR TITLE
fix(cloud): name OneDrive, say the app is fine, and shrink the bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   into any of them.
 
 ### Fixed
+- The cloud-storage warning names OneDrive instead of guessing at "a cloud sync tool", says
+  the app itself is fine, and takes up one thin line instead of a block.
 - Sharing a track goes through. Big shares upload in smaller pieces and a piece the host
   drops is sent again, so a share code comes back instead of an upload error.
 - Tracks you build in the app have a riding line. The ground is painted in four bands —

--- a/src-tauri/src/cloudfiles.rs
+++ b/src-tauri/src/cloudfiles.rs
@@ -58,7 +58,7 @@ pub fn warn_if_dehydrated(app: &AppHandle, cfg: &crate::config::AppConfig) {
     let root = crate::library::mods_root(&cfg.mods_path);
     let app = app.clone();
     std::thread::spawn(move || {
-        let found = scan(&root);
+        let mut found = scan(&root);
         // Two separate problems, and the second used to go unmentioned.
         //
         // Evicted bytes are the crash. But a tree that merely *sits* on a sync provider is
@@ -69,6 +69,11 @@ pub fn warn_if_dehydrated(app: &AppHandle, cfg: &crate::config::AppConfig) {
         if found.count == 0 && found.provider.is_none() {
             return;
         }
+        // The gate above uses the *detected* provider; the name below is what the player is
+        // told. When the path doesn't say, don't hedge — on Windows this is OneDrive far more
+        // often than not (it ships on, and syncs Documents by default), and "a cloud sync
+        // tool" only gets players insisting they don't have one.
+        found.provider = found.provider.or_else(fallback_provider);
         let provider = found.provider.clone().unwrap_or_else(|| "a cloud sync tool".into());
         if found.count > 0 {
             log::warn!(
@@ -151,6 +156,18 @@ fn is_content(path: &std::path::Path) -> bool {
 /// That is the thing worth knowing before asking the game to re-walk the tree.
 pub fn mods_provider(cfg: &crate::config::AppConfig) -> Option<String> {
     provider_of(&crate::library::mods_root(&cfg.mods_path))
+}
+
+/// What to call the sync tool when the path doesn't name one. `None` where the platform has
+/// no obvious default, and the UI falls back to a generic phrase.
+fn fallback_provider() -> Option<String> {
+    if cfg!(windows) {
+        Some("OneDrive".into())
+    } else if cfg!(target_os = "macos") {
+        Some("iCloud Drive".into())
+    } else {
+        None
+    }
 }
 
 fn provider_of(root: &std::path::Path) -> Option<String> {

--- a/src/Components/RuntimeBanner/RuntimeBanner.tsx
+++ b/src/Components/RuntimeBanner/RuntimeBanner.tsx
@@ -102,7 +102,9 @@ export default function RuntimeBanner() {
             values={{ what: <span className="font-semibold">{provider}</span> }}
           />
         }
-        pitch={t(evicted ? "cloud.evictedPitch" : "cloud.slowPitch")}
+        pitch={t(evicted ? "cloud.evictedPitch" : "cloud.slowPitch", {
+          what: provider,
+        })}
         onDismiss={() => setCloudDismissed(true)}
         dismissLabel={t("runtime.dismiss")}
       />
@@ -178,25 +180,25 @@ function Bar({
   const Icon = icon ?? (danger ? OctagonAlert : AlertTriangle);
   return (
     <div
-      className={`flex items-center gap-3 border-b px-4 py-2 text-sm text-foreground ${
+      className={`flex items-center gap-2 border-b px-3 py-1 text-xs text-foreground ${
         danger
           ? "border-red-500/25 bg-red-500/10"
           : "border-amber-500/25 bg-amber-500/10"
       }`}
     >
-      <Icon className={`size-4 shrink-0 ${danger ? "text-red-500" : "text-amber-500"}`} />
+      <Icon className={`size-3.5 shrink-0 ${danger ? "text-red-500" : "text-amber-500"}`} />
       <span className="min-w-0 truncate">
         {body}
         <span className="ml-1 text-muted-foreground">{pitch}</span>
       </span>
 
-      <div className="ml-auto flex shrink-0 items-center gap-1.5">
+      <div className="ml-auto flex shrink-0 items-center gap-1">
         {action && ActionIcon && onAction && (
-          <Button size="sm" onClick={onAction} disabled={busy}>
+          <Button size="sm" className="h-6 px-2 text-xs" onClick={onAction} disabled={busy}>
             {busy ? (
-              <Loader2 className="size-3.5 animate-spin" />
+              <Loader2 className="size-3 animate-spin" />
             ) : (
-              <ActionIcon className="size-3.5" />
+              <ActionIcon className="size-3" />
             )}
             {busy ? busyLabel : action}
           </Button>
@@ -204,12 +206,12 @@ function Bar({
         <Button
           size="icon"
           variant="ghost"
-          className="size-8"
+          className="size-6"
           onClick={onDismiss}
           disabled={busy}
           aria-label={dismissLabel}
         >
-          <X className="size-4" />
+          <X className="size-3.5" />
         </Button>
       </div>
     </div>

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -349,11 +349,11 @@ export const de: Translation = {
   "cloud.evictedBody":
     "Einige Mods liegen nicht wirklich auf diesem PC — {{what}} hat sie in die Cloud verschoben.",
   "cloud.evictedPitch":
-    "Das Spiel liest sie beim Laden und kann dabei abstürzen. Verschiebe den Mods-Ordner heraus oder wähle „Immer auf diesem Gerät behalten“.",
+    "Mit der App ist alles in Ordnung — abstürzen kann das Spiel beim Lesen. Rechtsklick auf den Mods-Ordner und „Immer auf diesem Gerät behalten“ wählen.",
   "cloud.slowBody":
     "Dein Mods-Ordner liegt in {{what}}.",
   "cloud.slowPitch":
-    "Das Spiel liest beim Laden jede Mod, und Zugriffe über {{what}} sind langsam — bei einer großen Sammlung wirkt das wie ein eingefrorenes Spiel. Den Ordner herauszuschieben behebt es.",
+    "Mit der App ist alles in Ordnung — das Spiel lädt nur langsam, weil es über {{what}} liest. Den Ordner herauszuschieben behebt es.",
   "runtime.installed": "Komponente installiert",
   "runtime.installedDesc":
     "FrostMod sollte das Spiel jetzt erreichen. Starte MX Bikes neu, falls es schon läuft.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -336,11 +336,11 @@ export const en = {
   "cloud.evictedBody":
     "Some of your mods aren’t really on this PC — {{what}} has moved them to the cloud.",
   "cloud.evictedPitch":
-    "The game reads them while loading and can crash there. Move your mods folder out, or set “Always keep on this device”.",
+    "Nothing is wrong with the app — it's the game that can crash reading them. Right-click your mods folder and pick “Always keep on this device”.",
   "cloud.slowBody":
     "Your mods folder is inside {{what}}.",
   "cloud.slowPitch":
-    "The game reads every mod while loading, and reads through {{what}} are slow — on a big collection it can look like the game has frozen. Moving the folder out fixes it.",
+    "Nothing is wrong with the app — the game just loads slowly reading through {{what}}. Moving the folder out fixes it.",
   "runtime.installed": "Component installed",
   "runtime.installedDesc":
     "FrostMod should reach the game now. Restart MX Bikes if it's already open.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -343,11 +343,11 @@ export const es: Translation = {
   "cloud.evictedBody":
     "Algunos mods no están realmente en este PC: {{what}} los ha movido a la nube.",
   "cloud.evictedPitch":
-    "El juego los lee al cargar y puede fallar ahí. Saca la carpeta de mods o marca “Mantener siempre en este dispositivo”.",
+    "La app está bien: es el juego el que puede fallar al leerlos. Haz clic derecho en tu carpeta de mods y marca “Mantener siempre en este dispositivo”.",
   "cloud.slowBody":
     "Tu carpeta de mods está dentro de {{what}}.",
   "cloud.slowPitch":
-    "El juego lee todos los mods al cargar, y las lecturas a través de {{what}} son lentas: con una colección grande parece que el juego se ha colgado. Mover la carpeta fuera lo soluciona.",
+    "La app está bien: el juego solo carga lento porque lee a través de {{what}}. Mover la carpeta fuera lo soluciona.",
   "runtime.installed": "Componente instalado",
   "runtime.installedDesc":
     "FrostMod ya debería llegar al juego. Reinicia MX Bikes si lo tienes abierto.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -346,11 +346,11 @@ export const fr: Translation = {
   "cloud.evictedBody":
     "Certains mods ne sont pas vraiment sur ce PC — {{what}} les a déplacés dans le cloud.",
   "cloud.evictedPitch":
-    "Le jeu les lit au chargement et peut planter à ce moment. Sors le dossier mods, ou choisis «\xa0Toujours conserver sur cet appareil\xa0».",
+    "L'app n'a rien\xa0: c'est le jeu qui peut planter en les lisant. Clic droit sur ton dossier mods, puis «\xa0Toujours conserver sur cet appareil\xa0».",
   "cloud.slowBody":
     "Ton dossier mods est dans {{what}}.",
   "cloud.slowPitch":
-    "Le jeu lit tous les mods au chargement, et les lectures via {{what}} sont lentes — sur une grosse collection, on dirait que le jeu a gelé. Déplacer le dossier règle le problème.",
+    "L'app n'a rien\xa0: le jeu charge simplement lentement en lisant via {{what}}. Déplacer le dossier règle le problème.",
   "runtime.installed": "Composant installé",
   "runtime.installedDesc":
     "FrostMod devrait maintenant atteindre le jeu. Relancez MX Bikes s'il est déjà ouvert.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -342,11 +342,11 @@ export const it: Translation = {
   "cloud.evictedBody":
     "Alcune mod non sono davvero su questo PC: {{what}} le ha spostate nel cloud.",
   "cloud.evictedPitch":
-    "Il gioco le legge durante il caricamento e può bloccarsi lì. Sposta fuori la cartella mod, oppure scegli “Conserva sempre su questo dispositivo”.",
+    "L'app sta bene: è il gioco che può bloccarsi leggendole. Fai clic destro sulla cartella mod e scegli “Conserva sempre su questo dispositivo”.",
   "cloud.slowBody":
     "La tua cartella mod si trova dentro {{what}}.",
   "cloud.slowPitch":
-    "Il gioco legge ogni mod durante il caricamento, e le letture tramite {{what}} sono lente: con una collezione grande sembra che il gioco si sia bloccato. Spostare la cartella risolve.",
+    "L'app sta bene: il gioco carica solo lentamente perché legge tramite {{what}}. Spostare la cartella fuori risolve.",
   "runtime.installed": "Componente installato",
   "runtime.installedDesc":
     "Ora FrostMod dovrebbe raggiungere il gioco. Riavvia MX Bikes se è già aperto.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -345,11 +345,11 @@ export const ptBR: Translation = {
   "cloud.evictedBody":
     "Alguns mods não estão realmente neste PC — o {{what}} os moveu para a nuvem.",
   "cloud.evictedPitch":
-    "O jogo os lê ao carregar e pode travar aí. Tire a pasta de mods de lá, ou marque “Manter sempre neste dispositivo”.",
+    "O app está bem: quem pode travar ao lê-los é o jogo. Clique com o botão direito na pasta de mods e marque “Manter sempre neste dispositivo”.",
   "cloud.slowBody":
     "Sua pasta de mods está dentro do {{what}}.",
   "cloud.slowPitch":
-    "O jogo lê todos os mods ao carregar, e leituras pelo {{what}} são lentas — numa coleção grande parece que o jogo travou. Mover a pasta para fora resolve.",
+    "O app está bem: o jogo só carrega devagar porque lê pelo {{what}}. Mover a pasta para fora resolve.",
   "runtime.installed": "Componente instalado",
   "runtime.installedDesc":
     "O FrostMod já deve alcançar o jogo. Reinicie o MX Bikes se ele estiver aberto.",


### PR DESCRIPTION
## What

The mods-on-cloud-storage warning was hedging, oversized, and left the one question every report came with unanswered.

**It names the provider now.** When the mods path doesn't spell out a sync tool, the warning said "a cloud sync tool" — and players reliably answered that they don't have one. They do: OneDrive ships on by default on Windows and syncs Documents out of the box. Detection from the path still wins (a Dropbox user still sees Dropbox); the fallback is OneDrive on Windows, iCloud Drive on macOS, generic elsewhere.

**It says the app is fine.** Both pitches now lead with that. The app is only the messenger — it's the game that reads the tree during the load screen and crashes or stalls there.

> Some of your mods aren't really on this PC — **OneDrive** has moved them to the cloud. *Nothing is wrong with the app — it's the game that can crash reading them. Right-click your mods folder and pick "Always keep on this device".*

**It's half the height.** `py-2` → `py-1`, `text-sm` → `text-xs`, and the 32px dismiss/action buttons down to 24px. ~48px → ~26px, one thin line instead of a block across the top of the window.

## Also fixed

`cloud.slowPitch` names the provider twice but `t()` was called with no vars, so it rendered a literal `{{what}}` to the player.

## Test

- `cargo test cloudfiles::` — 3 passed
- `npx tsc --noEmit` — clean (all six locales are typed against `en`)
- The banner itself can't be rendered on macOS; the copy and the classnames are the whole change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)