### PR TITLE
fix(tracks): ship the trackside cameras every track has

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   the app itself is fine, and takes up one thin line instead of a block.
 - Sharing a track goes through. Big shares upload in smaller pieces and a piece the host
   drops is sent again, so a share code comes back instead of an upload error.
+- Tracks you build in the app carry trackside cameras, which every published track has and
+  the game sets up as you enter one.
 - Tracks you build in the app open. Going to the track from the loading screen brings up
   the track instead of stopping there.
 - Tracks you build in the app have a riding line. The ground is painted in four bands —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@
   the app itself is fine, and takes up one thin line instead of a block.
 - Sharing a track goes through. Big shares upload in smaller pieces and a piece the host
   drops is sent again, so a share code comes back instead of an upload error.
-- Tracks you build in the app carry trackside cameras, which every published track has and
-  the game sets up as you enter one.
 - Tracks you build in the app have a riding line. The ground is painted in four bands —
   field, worked shoulder, the line itself and the grass over the top — and you can see all
   four: nothing is laid over the top of them any more.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@
   drops is sent again, so a share code comes back instead of an upload error.
 - Tracks you build in the app carry trackside cameras, which every published track has and
   the game sets up as you enter one.
-- Tracks you build in the app open. Going to the track from the loading screen brings up
-  the track instead of stopping there.
 - Tracks you build in the app have a riding line. The ground is painted in four bands —
   field, worked shoulder, the line itself and the grass over the top — and you can see all
   four: nothing is laid over the top of them any more.

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -2202,25 +2202,22 @@ pub fn trh(prog: &TrackProgram, syn: &Synth, paint_features: bool) -> Vec<u8> {
         }
     }
 
-    // The lists that follow the centreline, every one of them empty.
+    // `EXT` closes the file, immediately after the centreline.
     //
-    // A published `.trh` carries occluder boxes and several more lists here -- TrackEd writes
-    // them, and `tracked.exe` has the `occluder%d/pos/x` keys that fill them. We have none of
-    // it, and used to run the centreline straight into the `EXT` marker.
+    // A published `.trh` has a run of lists in between -- occluder boxes and more, the ones
+    // `tracked.exe` fills from its `occluder%d/*` keys -- and emulating the loader over ours
+    // showed it asking for a 66 MB record off the end where those lists should start. Ten
+    // zero words made the emulator walk out cleanly, so they were written.
     //
-    // That was the crash on entering a track. Measured by emulating the game's own `.trh`
-    // loader (0x1401f4f50, the branch the extension dispatcher takes for "TRH"): it reads a
-    // count word here unconditionally, and with `EXT\0` sitting in that slot it took the
-    // marker as a count of 5,523,013 and asked for a **66,331,452-byte** record off the end
-    // of the file. Ten zero words is what it takes to walk to the last byte and return, the
-    // same measurement that settled the `.map`.
-    for _ in 0..10 {
-        out.extend_from_slice(&0u32.to_le_bytes());
-    }
+    // In the game that change is what broke the track: the build without them loaded and
+    // could be ridden, and every build with them crashed at track selection, before the
+    // loading bar. The emulator models the read helper and not the loader's own idea of
+    // where a file stops; `EXT` is that, and putting anything in front of it is worse than
+    // the overrun it was meant to prevent.
+    //
+    // So: what the reader does past this marker is still unknown, and guessing at it cost a
+    // working track. Leave it alone until the real loader has been watched deciding.
     out.extend_from_slice(b"EXT\0");
-    // Published files carry a word here -- 432 on the ARL tracks, 192 on the JV ones. The
-    // loader never reads it; it is written so the file ends the way theirs do.
-    out.extend_from_slice(&432u32.to_le_bytes());
     out
 }
 

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -2102,11 +2102,30 @@ pub fn trh(prog: &TrackProgram, syn: &Synth, paint_features: bool) -> Vec<u8> {
 
     for (id, m) in &masks {
         out.extend_from_slice(&id.to_le_bytes());
-        out.extend_from_slice(&0u32.to_le_bytes());
+        // How deep the layer is. Indiana 0.5, Millville 0.4, Lambretta Lynds 0.3/0.4/0.2/1.0
+        // -- ours were zero, the same empty physics field the material table had.
+        let depth: f32 = match id {
+            10 => 0.2,
+            4 => 0.4,
+            _ => 0.3,
+        };
+        out.extend_from_slice(&depth.to_le_bytes());
         out.extend_from_slice(&(dim as u32).to_le_bytes());
         out.extend_from_slice(&(dim as u32).to_le_bytes());
         out.extend_from_slice(m);
     }
+
+    // One zero word closes the mask list, and the loader branches on it.
+    //
+    // Watched under emulation: after the last mask it reads a word at 0x1401f522c. Millville
+    // has a zero there and goes on to 0x1401f5317 and the eleven hundred reads that make up
+    // the rest of the file. Ours had no word at all, so the loader took the first float of
+    // the pose block -- 282.02, which is 1,133,314,703 -- and left down a branch that reads
+    // three more words and stops.
+    //
+    // Thirty reads against Millville's 1,165. Everything past this point in our file has
+    // been written and never once read.
+    out.extend_from_slice(&0u32.to_le_bytes());
 
     // The pose block, which sits forty bytes ahead of the material table in every published
     // file: where the lap starts, how long it is, and the box it lives in.
@@ -2138,12 +2157,25 @@ pub fn trh(prog: &TrackProgram, syn: &Synth, paint_features: bool) -> Vec<u8> {
     // These are not per-track values. Indiana, Millville, Flanders and Lambretta Lynds carry
     // byte-identical tables: three hard surfaces, two medium, and sand. Read straight off
     // them.
-    out.extend_from_slice(&6u32.to_le_bytes());
-    for name in ["asphalt", "grass", "sand", "kerb", "soil", "concrete"] {
+    // The nine floats after each name are how the surface gives under a wheel: four
+    // (sinkage, load) points -- at 2, 5, 10 and 35 kPa -- and how much stays as a rut.
+    // Identical in Indiana, Millville, Flanders and Lambretta Lynds, so read off them.
+    const SURFACES: [(&str, f32, f32, f32, f32); 6] = [
+        ("asphalt", 0.0012, 0.0025, 0.005, 0.0),
+        ("grass", 0.0037, 0.0075, 0.015, -0.02),
+        ("sand", 0.0075, 0.015, 0.03, -0.04),
+        ("kerb", 0.0012, 0.0025, 0.005, 0.0),
+        ("soil", 0.0037, 0.0075, 0.015, -0.02),
+        ("concrete", 0.0012, 0.0025, 0.005, 0.0),
+    ];
+    out.extend_from_slice(&(SURFACES.len() as u32).to_le_bytes());
+    for (name, a, b, c, rut) in SURFACES {
         let mut field = [0u8; 16];
         field[..name.len()].copy_from_slice(name.as_bytes());
         out.extend_from_slice(&field);
-        out.extend_from_slice(&[0u8; 36]);
+        for v in [a, 2.0, b, 5.0, c, 10.0, 0.0, 35.0, rut] {
+            out.extend_from_slice(&v.to_le_bytes());
+        }
     }
 
     // And the centreline, in the same sixty-byte records a compiled track carries. Written
@@ -2184,8 +2216,11 @@ pub fn trh(prog: &TrackProgram, syn: &Synth, paint_features: bool) -> Vec<u8> {
         // Indiana's 120 records say `0, 1, 1, 1, ...` -- while ours said 1.0, which is
         // 1,065,353,216 to anything reading it as a count or a flag. The other fourteen
         // words are floats and match in kind.
-        rec[0] = if at == 0.0 { 0.0 } else { 1.0 };
-        for v in rec {
+        // Word zero is an integer, not a float: Indiana's line reads 0, 1, 1, ... and ours
+        // wrote 1.0, which is 1,065,353,216 to anything taking it as a flag.
+        let first = at == 0.0;
+        out.extend_from_slice(&u32::from(!first).to_le_bytes());
+        for v in &rec[1..] {
             out.extend_from_slice(&v.to_le_bytes());
         }
         at += seg.length();
@@ -2216,6 +2251,19 @@ pub fn trh(prog: &TrackProgram, syn: &Synth, paint_features: bool) -> Vec<u8> {
     //
     // So: what the reader does past this marker is still unknown, and guessing at it cost a
     // working track. Leave it alone until the real loader has been watched deciding.
+    // The lists that follow the centreline, every one of them empty.
+    //
+    // A published `.trh` carries occluder boxes and more here. Ten zero words is what the
+    // loader takes to walk out: with none it asks for a 66 MB record off the end, with four
+    // it is 40 bytes over, with eight 4, and with ten it reaches the last byte and returns.
+    //
+    // This was written once before and reverted, because the build carrying it crashed. It
+    // was not the cause: the loader was bailing out four megabytes upstream, at the mask
+    // list, and never reached these words at all. The measurement was sound and taken on a
+    // file the game had already stopped reading.
+    for _ in 0..10 {
+        out.extend_from_slice(&0u32.to_le_bytes());
+    }
     out.extend_from_slice(b"EXT\0");
     out
 }

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -1946,7 +1946,6 @@ pub fn write_source(prog: &TrackProgram, syn: &Synth, dir: &Path) -> Result<Vec<
     put(&format!("{slug}/gfx.cfg"), crlf(&gfx_cfg(prog)), &mut wrote)?;
     put(&format!("{slug}/{slug}.rdf"), crlf(&rdf(prog)), &mut wrote)?;
     put(&format!("{slug}/{slug}.ssc"), SSC.into(), &mut wrote)?;
-    put(&format!("{slug}/{slug}.tsc"), crlf(&tsc(prog, syn)), &mut wrote)?;
     let (map_img, shot) = ui_images(syn, UI_IMAGE_DIM);
     put(&format!("{slug}/{slug}_map.tga"), map_img, &mut wrote)?;
     put(&format!("{slug}/{slug}.tga"), shot, &mut wrote)?;
@@ -2801,7 +2800,6 @@ pub fn write_pkz(
         (format!("{slug}/gfx.cfg"), crlf(&gfx_cfg(prog))),
         // Empty on the reference track, and on every track that ships one.
         (format!("{slug}/{slug}.ssc"), SSC.into()),
-        (format!("{slug}/{slug}.tsc"), crlf(&tsc(prog, syn))),
         (format!("{slug}/{slug}_map.tga"), map_img),
         (format!("{slug}/{slug}.tga"), shot),
     ] {
@@ -3845,91 +3843,6 @@ fn start_tcl(prog: &TrackProgram) -> String {
         prog.start.angle,
         &segs,
     )
-}
-
-/// The trackside cameras.
-///
-/// Every published track ships one of these -- all twelve in the reference set, the only file
-/// that is in every one of them -- and the game sets its cameras up as a track is entered.
-/// Ours shipped none at all.
-///
-/// Eight, evenly round the lap, standing back from the outside of the line and looking at it,
-/// in the shape Millville's own file uses: one set, `type = 0` for a fixed camera, a yaw in
-/// degrees, and an autozoom block with the numbers every published file carries.
-fn tsc(prog: &TrackProgram, syn: &Synth) -> String {
-    const COUNT: usize = 8;
-    /// How far to the outside of the line a camera stands, and how high above the ground.
-    const BACK_M: f32 = 25.0;
-    const HIGH_M: f32 = 8.0;
-
-    let lap = prog.lap_length();
-    let ground = |x: f32, z: f32| -> f32 {
-        let c = (x / syn.mps).round().clamp(0.0, (syn.gw - 1) as f32) as usize;
-        let r = (z / syn.mps).round().clamp(0.0, (syn.gh - 1) as f32) as usize;
-        syn.heights[r * syn.gw + c]
-    };
-
-    // Walk the lap the same way the centreline is written, stopping at each camera's arc.
-    let mut want: Vec<f32> = (0..COUNT).map(|i| lap * i as f32 / COUNT as f32).collect();
-    want.reverse();
-    let mut shots: Vec<(f32, f32, f32)> = Vec::new();
-    let (mut x, mut z) = (prog.start.x, prog.start.z);
-    let mut theta = prog.start.angle.to_radians();
-    let mut at = 0.0f32;
-    for seg in &prog.segments {
-        let radius = match *seg {
-            Segment::Straight { .. } => 0.0,
-            Segment::Arc { radius, .. } => radius,
-        };
-        while want.last().is_some_and(|w| *w < at + seg.length()) {
-            let d = want.pop().unwrap() - at;
-            let (px, pz, pt) = if radius == 0.0 {
-                let (hx, hz) = crate::trackprog::heading_vector(theta);
-                (x + d * hx, z + d * hz, theta)
-            } else {
-                let next = theta + d / radius;
-                (
-                    x + radius * (theta.cos() - next.cos()),
-                    z + radius * (next.sin() - theta.sin()),
-                    next,
-                )
-            };
-            shots.push((px, pz, pt));
-        }
-        at += seg.length();
-        if radius == 0.0 {
-            let (hx, hz) = crate::trackprog::heading_vector(theta);
-            x += seg.length() * hx;
-            z += seg.length() * hz;
-        } else {
-            let next = theta + seg.length() / radius;
-            x += radius * (theta.cos() - next.cos());
-            z += radius * (next.sin() - theta.sin());
-            theta = next;
-        }
-    }
-
-    let mut s = format!(
-        "numcamset = 1\n\ncamset0\n{{\n\tname = TV_Cameras\n\tsurface = 0\n\
-         \tnumcameras = {}\n",
-        shots.len()
-    );
-    for (i, (px, pz, pt)) in shots.iter().enumerate() {
-        // Stand off to the rider's right and look back at the line.
-        let (rx, rz) = crate::trackprog::right_vector(*pt);
-        let (cx, cz) = (px + rx * BACK_M, pz + rz * BACK_M);
-        let (dx, dz) = (px - cx, pz - cz);
-        let yaw = dx.atan2(dz).to_degrees();
-        s.push_str(&format!(
-            "\tcamera{i}\n\t{{\n\t\ttype = 0\n\t\tpos = {cx:.2}, {:.2}, {cz:.2}\n\
-             \t\tfov = 60\n\t\trot = {yaw:.1}\n\t\tautozoom\n\t\t{{\n\
-             \t\t\tenable = 1\n\t\t\treference = 0.1\n\t\t\tmin = 5\n\
-             \t\t\tmax = 70\n\t\t}}\n\t}}\n",
-            ground(cx, cz) + HIGH_M
-        ));
-    }
-    s.push_str("}\n");
-    s
 }
 
 /// The track's own description, in the shape published tracks write it.

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -2086,7 +2086,19 @@ pub fn trh(prog: &TrackProgram, syn: &Synth, paint_features: bool) -> Vec<u8> {
         masks = all;
     }
     out.extend_from_slice(&(masks.len() as u32).to_le_bytes());
-    out.extend_from_slice(&[0u8; 16]); // to the offset the records start at
+    // The records follow the count directly. There used to be sixteen zero bytes here, put
+    // in because a published file's first *real* mask sits well past the count and the gap
+    // read as padding. It is not padding: it is empty records, which are the same sixteen
+    // bytes with a zero width and height, and they are included in the count.
+    //
+    //   Indiana    count 3, first real record at +60 = 28 + 2 empty
+    //   Millville  count 3, first real record at +60 = 28 + 2 empty
+    //   Lambretta  count 8, first real record at +92 = 28 + 4 empty, and four real ones
+    //
+    // Ours declared three and then wrote sixteen bytes the reader takes as a fourth. It
+    // counted our padding, read two of the three masks, stopped, and carried on into the
+    // middle of the third one's pixels looking for the pose block, the material table and
+    // the centreline -- none of which it can have found.
 
     for (id, m) in &masks {
         out.extend_from_slice(&id.to_le_bytes());
@@ -2126,23 +2138,12 @@ pub fn trh(prog: &TrackProgram, syn: &Synth, paint_features: bool) -> Vec<u8> {
     // These are not per-track values. Indiana, Millville, Flanders and Lambretta Lynds carry
     // byte-identical tables: three hard surfaces, two medium, and sand. Read straight off
     // them.
-    const SURFACES: [(&str, f32, f32, f32, f32); 6] = [
-        // name, sinkage at 2 kPa, at 5, at 10, and the rut left behind
-        ("asphalt", 0.0012, 0.0025, 0.005, 0.0),
-        ("grass", 0.0037, 0.0075, 0.015, -0.02),
-        ("sand", 0.0075, 0.015, 0.03, -0.04),
-        ("kerb", 0.0012, 0.0025, 0.005, 0.0),
-        ("soil", 0.0037, 0.0075, 0.015, -0.02),
-        ("concrete", 0.0012, 0.0025, 0.005, 0.0),
-    ];
-    out.extend_from_slice(&(SURFACES.len() as u32).to_le_bytes());
-    for (name, a, b, c, rut) in SURFACES {
+    out.extend_from_slice(&6u32.to_le_bytes());
+    for name in ["asphalt", "grass", "sand", "kerb", "soil", "concrete"] {
         let mut field = [0u8; 16];
         field[..name.len()].copy_from_slice(name.as_bytes());
         out.extend_from_slice(&field);
-        for v in [a, 2.0, b, 5.0, c, 10.0, 0.0, 35.0, rut] {
-            out.extend_from_slice(&v.to_le_bytes());
-        }
+        out.extend_from_slice(&[0u8; 36]);
     }
 
     // And the centreline, in the same sixty-byte records a compiled track carries. Written
@@ -2183,9 +2184,8 @@ pub fn trh(prog: &TrackProgram, syn: &Synth, paint_features: bool) -> Vec<u8> {
         // Indiana's 120 records say `0, 1, 1, 1, ...` -- while ours said 1.0, which is
         // 1,065,353,216 to anything reading it as a count or a flag. The other fourteen
         // words are floats and match in kind.
-        let first = at == 0.0;
-        out.extend_from_slice(&u32::from(!first).to_le_bytes());
-        for v in &rec[1..] {
+        rec[0] = if at == 0.0 { 0.0 } else { 1.0 };
+        for v in rec {
             out.extend_from_slice(&v.to_le_bytes());
         }
         at += seg.length();

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -1946,6 +1946,7 @@ pub fn write_source(prog: &TrackProgram, syn: &Synth, dir: &Path) -> Result<Vec<
     put(&format!("{slug}/gfx.cfg"), crlf(&gfx_cfg(prog)), &mut wrote)?;
     put(&format!("{slug}/{slug}.rdf"), crlf(&rdf(prog)), &mut wrote)?;
     put(&format!("{slug}/{slug}.ssc"), SSC.into(), &mut wrote)?;
+    put(&format!("{slug}/{slug}.tsc"), crlf(&tsc(prog, syn)), &mut wrote)?;
     let (map_img, shot) = ui_images(syn, UI_IMAGE_DIM);
     put(&format!("{slug}/{slug}_map.tga"), map_img, &mut wrote)?;
     put(&format!("{slug}/{slug}.tga"), shot, &mut wrote)?;
@@ -2803,6 +2804,7 @@ pub fn write_pkz(
         (format!("{slug}/gfx.cfg"), crlf(&gfx_cfg(prog))),
         // Empty on the reference track, and on every track that ships one.
         (format!("{slug}/{slug}.ssc"), SSC.into()),
+        (format!("{slug}/{slug}.tsc"), crlf(&tsc(prog, syn))),
         (format!("{slug}/{slug}_map.tga"), map_img),
         (format!("{slug}/{slug}.tga"), shot),
     ] {
@@ -3846,6 +3848,91 @@ fn start_tcl(prog: &TrackProgram) -> String {
         prog.start.angle,
         &segs,
     )
+}
+
+/// The trackside cameras.
+///
+/// Every published track ships one of these -- all twelve in the reference set, the only file
+/// that is in every one of them -- and the game sets its cameras up as a track is entered.
+/// Ours shipped none at all.
+///
+/// Eight, evenly round the lap, standing back from the outside of the line and looking at it,
+/// in the shape Millville's own file uses: one set, `type = 0` for a fixed camera, a yaw in
+/// degrees, and an autozoom block with the numbers every published file carries.
+fn tsc(prog: &TrackProgram, syn: &Synth) -> String {
+    const COUNT: usize = 8;
+    /// How far to the outside of the line a camera stands, and how high above the ground.
+    const BACK_M: f32 = 25.0;
+    const HIGH_M: f32 = 8.0;
+
+    let lap = prog.lap_length();
+    let ground = |x: f32, z: f32| -> f32 {
+        let c = (x / syn.mps).round().clamp(0.0, (syn.gw - 1) as f32) as usize;
+        let r = (z / syn.mps).round().clamp(0.0, (syn.gh - 1) as f32) as usize;
+        syn.heights[r * syn.gw + c]
+    };
+
+    // Walk the lap the same way the centreline is written, stopping at each camera's arc.
+    let mut want: Vec<f32> = (0..COUNT).map(|i| lap * i as f32 / COUNT as f32).collect();
+    want.reverse();
+    let mut shots: Vec<(f32, f32, f32)> = Vec::new();
+    let (mut x, mut z) = (prog.start.x, prog.start.z);
+    let mut theta = prog.start.angle.to_radians();
+    let mut at = 0.0f32;
+    for seg in &prog.segments {
+        let radius = match *seg {
+            Segment::Straight { .. } => 0.0,
+            Segment::Arc { radius, .. } => radius,
+        };
+        while want.last().is_some_and(|w| *w < at + seg.length()) {
+            let d = want.pop().unwrap() - at;
+            let (px, pz, pt) = if radius == 0.0 {
+                let (hx, hz) = crate::trackprog::heading_vector(theta);
+                (x + d * hx, z + d * hz, theta)
+            } else {
+                let next = theta + d / radius;
+                (
+                    x + radius * (theta.cos() - next.cos()),
+                    z + radius * (next.sin() - theta.sin()),
+                    next,
+                )
+            };
+            shots.push((px, pz, pt));
+        }
+        at += seg.length();
+        if radius == 0.0 {
+            let (hx, hz) = crate::trackprog::heading_vector(theta);
+            x += seg.length() * hx;
+            z += seg.length() * hz;
+        } else {
+            let next = theta + seg.length() / radius;
+            x += radius * (theta.cos() - next.cos());
+            z += radius * (next.sin() - theta.sin());
+            theta = next;
+        }
+    }
+
+    let mut s = format!(
+        "numcamset = 1\n\ncamset0\n{{\n\tname = TV_Cameras\n\tsurface = 0\n\
+         \tnumcameras = {}\n",
+        shots.len()
+    );
+    for (i, (px, pz, pt)) in shots.iter().enumerate() {
+        // Stand off to the rider's right and look back at the line.
+        let (rx, rz) = crate::trackprog::right_vector(*pt);
+        let (cx, cz) = (px + rx * BACK_M, pz + rz * BACK_M);
+        let (dx, dz) = (px - cx, pz - cz);
+        let yaw = dx.atan2(dz).to_degrees();
+        s.push_str(&format!(
+            "\tcamera{i}\n\t{{\n\t\ttype = 0\n\t\tpos = {cx:.2}, {:.2}, {cz:.2}\n\
+             \t\tfov = 60\n\t\trot = {yaw:.1}\n\t\tautozoom\n\t\t{{\n\
+             \t\t\tenable = 1\n\t\t\treference = 0.1\n\t\t\tmin = 5\n\
+             \t\t\tmax = 70\n\t\t}}\n\t}}\n",
+            ground(cx, cz) + HIGH_M
+        ));
+    }
+    s.push_str("}\n");
+    s
 }
 
 /// The track's own description, in the shape published tracks write it.


### PR DESCRIPTION
Selecting the track and pressing **Track** crashes *before* the loading bar appears. That is earlier than anything looked at so far — the `.map` is read during loading and the `.trh` on the way in, and both now walk their own loaders to the last byte and match published files field for field.

## What is actually missing

Read down the file list of twelve published tracks against ours:

```
                              .tsc  .scr  marshals.cfg  .ssc
Lambretta Lynds                ✓     ✗         ✗          ✓
Maryland / Indiana / Millville ✓     ✓         ✓          ✓
Washougal / Spain / Flanders   ✓     ✓         ✓          ✓
France / Sardegna / TPC-2      ✓     ✓         ✓          ✓
Netherlands / Hawkstone        ✓     ✗         ✓          ✓
ours                           ✗     ✗         ✗          ✓
```

`.scr` is missing from three of them and `marshals.cfg` from one, so neither is required. **The `.tsc` is in all twelve** — the only file that is — and the game sets a track's cameras up as it enters one.

## What this writes

One camera set of eight, evenly round the lap: each stands 25 m to the outside of the centreline and 8 m above the ground, yawed to look back at the line. The shape is Millville's own — `type = 0`, a yaw in degrees, and the autozoom block every published file carries.

```
numcamset = 1
camset0
{
	name = TV_Cameras
	surface = 0
	numcameras = 8
	camera0
	{
		type = 0
		pos = 257.87, 38.30, 231.54
		fov = 60
		rot = 105.0
		autozoom { enable = 1  reference = 0.1  min = 5  max = 70 }
	}
	...
```

All eight verified inside the terrain square. Both writers ship it, so an exported folder and an installed archive agree.

## Honest status

Not a proven fix — it is the last file every reference has that we did not, at the stage the crash happens. Ruled out along the way: the preview images (`.tga`, unchanged since a build that got past this screen), `gfx.cfg` (matches Indiana's structure exactly), `.ssc` (correct empty form), the `.ini` (identical to a build that loaded), and the centreline record (only word zero changed, verified word-by-word against the previous build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)