### PR TITLE
fix(overlay): mount the review sheet above the overlay's installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 - A Servers tab that lists every live MX Bikes server the way the in-game browser does —
   who's on each one, the track it's running, and its address. Press Join to launch straight
   into any of them.
+- The overlay reviews an install the way the main window does. A pack you download without
+  leaving the game comes up in the same sheet, listing what it found and where each piece
+  goes before anything is written.
 
 ### Fixed
 - The cloud-storage warning names OneDrive instead of guessing at "a cloud sync tool", says

--- a/src/Components/Overlay/Overlay.tsx
+++ b/src/Components/Overlay/Overlay.tsx
@@ -15,6 +15,7 @@ import { FrostmodProvider } from "../../Context/Frostmod";
 import { ConfigContext, MXB_FALLBACK } from "../../Context/Config";
 import { InstallProvider } from "../../Context/Install";
 import { DownloadsProvider } from "../../Context/Downloads";
+import { DropReviewProvider } from "../../Context/DropReview";
 import { useModBrowsing } from "../../lib/useModBrowsing";
 import {
   bikePreviewAvailable,
@@ -256,6 +257,10 @@ export default function Overlay() {
                       {/* No Downloads page in here, but installs made mid-session still
                           belong in the history the main window shows. */}
                       <DownloadsProvider>
+                      {/* Above the installer, as in the Dashboard: a download that turns
+                          out to be a pack is handed to this sheet, so `InstallProvider`
+                          has to be able to reach it here too. */}
+                      <DropReviewProvider onInstalled={onInstalled}>
                       <InstallProvider onInstalled={onInstalled} onOpenMod={openModTarget}>
                         <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
                           {tab === "presets" ? (
@@ -284,6 +289,7 @@ export default function Overlay() {
                           )}
                         </div>
                       </InstallProvider>
+                      </DropReviewProvider>
                       </DownloadsProvider>
                     </ConfigContext.Provider>
                   ) : (


### PR DESCRIPTION
## What

Opening the in-game overlay threw `useDropReview must be used inside a DropReviewProvider` into the overlay's ErrorBoundary — the window rendered nothing but "Something went wrong".

## Why

`InstallProvider` picked up a `useDropReview()` dependency ([Install.tsx:213](src/Context/Install.tsx#L213)) when the staged-install review sheet was hoisted out of `DropZone` into its own provider — a download that turns out to be a pack is handed to the sheet instead of being installed.

Only the Dashboard tree was given a `DropReviewProvider`. The overlay window loads the same bundle with `?overlay=1` and builds its own provider tree, which went straight from `DownloadsProvider` to `InstallProvider`, so mounting the installer threw.

## Fix

Wrap the overlay's `InstallProvider` in `DropReviewProvider`, nested in the same order as the Dashboard (`Downloads` > `DropReview` > `Install`). Side effect worth having: a pack downloaded from inside the overlay now gets the same review sheet, the same collision warnings and the same destination override as one downloaded in the main window, rather than having nowhere to go.

These are the only two places that mount `InstallProvider`.

## Verification

- `npx tsc --noEmit` clean.
- Manual: open the overlay (Settings → show overlay) — it renders instead of the error screen; start a download from the overlay's Browse tab and confirm it lands.

No DB or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)