### PR TITLE
fix(tracks): shallower ruts and braking bumps that actually form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   goes before anything is written.
 
 ### Fixed
+- Corners on a generated track wear a bundle of ruts rather than a single deep gouge. The
+  deepest groove now cuts about 0.45 m where it used to cut a metre.
+- Braking bumps appear on the approach to every corner, not just the handful that follow a
+  dead-straight section, and there is acceleration chop on the way out.
 - The cloud-storage warning names OneDrive instead of guessing at "a cloud sync tool", says
   the app itself is fine, and takes up one thin line instead of a block.
 - Sharing a track goes through. Big shares upload in smaller pieces and a piece the host

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -120,7 +120,11 @@ const RUT_RADIUS_M: (f32, f32) = (40.0, 14.0);
 /// at the median and 0.35–0.67 m at the ninetieth; and a *straight* is not smooth either —
 /// every one of those tracks wears 0.09–0.16 m of groove down its straights. Ruts everywhere,
 /// deeper through the corners, is the shape of the measurement. Ruts only in corners was ours.
-const RUT_DEPTH_M: f32 = 0.68;
+///
+/// This is the depth of the deepest groove in the tightest corner on the lap, which puts it in
+/// the middle of that ninetieth rather than at the top of it. It only means that with the gain
+/// below set to match the field; before, 0.68 here was a metre in the ground.
+const RUT_DEPTH_M: f32 = 0.45;
 const RUT_DEPTH_STRAIGHT_M: f32 = 0.17;
 
 /// Ruts do not come one at a time.
@@ -141,8 +145,15 @@ const RUT_SPACING_M: f32 = 2.05;
 /// How much of the field is cut, and how hard. A higher power leaves narrower grooves with
 /// more untouched ground between them; the gain puts the deepest of them back at full depth
 /// after the sharpening has taken the top off.
-const RUT_SHARP: f32 = 1.35;
-const RUT_GAIN: f32 = 2.9;
+///
+/// The gain has to match the field it is applied to, and it did not: the sharpened noise peaks
+/// at about 0.57, a gain of 2.9 multiplied straight through it, and the deepest ground on the
+/// lap came out 1.04 m below the bench — a ditch across the track rather than a rut. At 1.75
+/// the asked depth is what the deepest groove actually cuts. The sharpening went with it:
+/// 1.35 left the cut at zero across most of the width, so what a corner grew was two isolated
+/// gouges instead of the bundle above.
+const RUT_SHARP: f32 = 1.0;
+const RUT_GAIN: f32 = 1.75;
 
 /// How much of the half-width the bundle covers, at the loosest corner that ruts at all and
 /// at the tightest.
@@ -1299,7 +1310,15 @@ fn roughness_profile(turn: &Profile, lap: f32) -> Chop {
     let n = rough.v.len();
     let back = (BRAKING_M / PROFILE_STEP) as usize;
     let ahead = (ACCEL_M / PROFILE_STEP) as usize;
-    let in_corner = |j: usize| turn.at((j % n) as f32 * PROFILE_STEP) != 0.0;
+    // A corner, not merely curved ground. Almost every metre of a real lap is on some arc —
+    // the demo's own straights are 100 m-radius bends — so testing for curvature at all
+    // excluded the whole lap from braking bumps and left 5% of it with any. What an approach
+    // must not be is the exit of *another corner*, and that is a radius tight enough to be
+    // one.
+    let in_corner = |j: usize| {
+        let k = turn.at((j % n) as f32 * PROFILE_STEP).abs();
+        k > 0.0 && 1.0 / k < RUT_RADIUS_M.0
+    };
     for i in 0..n {
         let s = i as f32 * PROFILE_STEP;
         let k = turn.at(s).abs();


### PR DESCRIPTION
Rider feedback on Corpus National: the ruts are way too deep, and there are no braking bumps. Both reproduce as numbers.

## Ruts were a ditch, not a rut

The rut field is cut as `depth * max(fbm,0)^RUT_SHARP * fade * RUT_GAIN`. `RUT_GAIN = 2.9` was set on the reasoning that it "puts the deepest of them back at full depth after the sharpening has taken the top off" — which needs the sharpened field to peak around 0.34. It peaks near 0.57, so the gain multiplied straight through.

Measured over the demo lap, deepest cut below the graded bench per metre of lap:

```
p50 0.22   p90 0.52   p99 0.71   max 1.04
```

The worst cross-section is flat all the way across except one 2 m wide, metre-deep gouge:

```
-2.0:0.08  -1.5:0.00  -1.0:0.00  -0.5:0.00  +0.0:0.00  +0.5:0.00  +1.0:0.00  +1.5:0.57  +2.0:0.99  +2.5:0.40  +3.0:0.00
```

`RUT_SHARP = 1.35` is the second half of that: the sharpening left the cut at zero across most of the width, so a corner grew two isolated gouges instead of the bundle of parallel grooves the module's own docs describe.

- `RUT_GAIN` 2.9 → 1.75, so the asked depth is what the deepest groove actually cuts
- `RUT_DEPTH_M` 0.68 → 0.45 — the middle of the corpus ninetieth rather than the top of it
- `RUT_SHARP` 1.35 → 1.0

After: `p50 0.13  p90 0.26  p99 0.35  max 0.45`, against a published corpus of 0.15–0.30 at the median and 0.35–0.67 at the ninetieth.

### Why the acceptance test passed it

`trackstats::ridden` reports `rut_depth_corner_m` as each groove's *prominence* below the nearest local maxima in a cross-section detrended over 6 m. A single wide gouge is most of its own detrend window, so the metre came back as 0.45 and sat inside the corpus. The stats line is not a check on how deep the ground actually is; that has to be measured against the bench.

## Braking bumps were on 4.8% of the lap

`roughness_profile` refuses to put braking bumps on a cell that is already `in_corner`, so that a corner's exit isn't mistaken for the next one's approach. `in_corner` tested `curvature != 0`.

A generated lap is fitted back to arcs and straights and comes out overwhelmingly arcs — Corpus National is 109 of 137 segments, and its "straights" are 100 m+ radius bends. Curvature is non-zero over 72% of the lap, and the `turn` profile is smoothed by the blend distance on top of that. So nearly every approach was excluded:

```
before:  braking 4.8% of the lap (91 m), max 0.57   accel 6.7%
after:   braking 19.9% of the lap (379 m), max 0.98  accel 26.0%
```

The test is now a radius tight enough to be a corner (`< RUT_RADIUS_M.0`), which is what the exclusion meant.

## Verification

- 121 track tests pass, including the heightmap-orientation test from #423
- `builds_a_track` still measures the demo inside every published-track bound; slope p99 drops 36.4° → 32.2°, which is the ditch walls going away
- Merged `origin/main` in — no conflicts; this branch touches the rut constants and `roughness_profile`, #423 touches `write_source`/`heightmap_raw`. Track creation is untouched.
- Rebuilt as `Corpus National B` in the mods folder for an A/B against the lap that prompted this

🤖 Generated with [Claude Code](https://claude.com/claude-code)