### PR TITLE
feat(tracks): give a generated lap a start straight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## 2026-09-05
 
 ### Changed
+- Tracks you build now start where a start belongs. The lap begins on its longest straight,
+  with the gate row a few metres onto it, the finish line past that and the run at turn one
+  beyond — instead of the gates landing wherever the lap happened to be forty metres in.
+- The start opens out to hold the whole row. Forty gates are 48 m across, so the track fans
+  out to 54 m where they stand, graded flat as far as the ground beside it allows, and
+  funnels back down to riding width by turn one. The pit lane, the thirty-second board and
+  the timing line move out with it.
+
+### Changed
 - Tracks you build now read as tracks. The riding surface was one flat brown from edge to
   edge, with nothing to tell you where the line went or where the track stopped. It is now
   painted in five: a bright graded verge either side, dry loose dirt at the edges and round

--- a/control-plane/src/trackgen.ts
+++ b/control-plane/src/trackgen.ts
@@ -230,6 +230,12 @@ what ten published circuits are made of:
 So: build each corner as a run of arcs, keep the straights short, and let the lap wander.
 Count the arcs before you send it — if straights outnumber corners you have written a shape.
 
+START THE LAP ON A STRAIGHT. A motocross start is forty gates in a line 48 m across, and the
+gate row, the finish line and the run at turn one all sit on the lap's opening straight — a lap
+that begins on a corner has its gates laid round a bend. So the FIRST segment is a straight of
+60-100 m, and the lap has to come back to it. That is the one long straight; the rest stay
+short. Leave it clear — no jumps in the first 40 m, riders are forty abreast there.
+
 THE LAP MUST STILL CLOSE, and a lap like this closes the same way: the signed angles sum to
 ±360° and the straights bring it home. A serpentine that turns 2400° in total and 360° net is
 exactly what the published tracks do — they alternate a big turn one way with a slightly

--- a/src-tauri/src/trackllm.rs
+++ b/src-tauri/src/trackllm.rs
@@ -232,20 +232,26 @@ fn repair(prog: &mut TrackProgram) -> Vec<String> {
     //    After the closing, because rotating a lap that doesn't meet itself moves the part
     //    that comes after the seam by however far the gap is.
     if prog.opening_straight() < crate::trackprog::START_STRAIGHT_M {
+        let need = crate::trackprog::START_STRAIGHT_M;
         let features = prog.features.clone();
-        let on_a_feature = |at: f32| {
-            features
+        // Nothing built on the stretch a start needs. Forty riders leave the gate abreast and
+        // reach the first jump in a pack, so a start straight is bare ground — and a jump that
+        // began before the new start line would be left straddling the finish.
+        let clear_from = |at: f32| {
+            !features
                 .iter()
-                .any(|f| at > f.at() + 0.01 && at < f.at() + f.length() - 0.01)
+                .any(|f| f.at() + f.length() > at + 0.01 && f.at() < at + need - 0.01)
         };
         let runs = prog.straight_runs();
-        // The longest straight the lap has, preferring one whose beginning isn't under a jump
-        // — starting there would leave the jump straddling the finish.
         let longest = |it: &mut dyn Iterator<Item = &(usize, f32, f32)>| {
             it.max_by(|a, b| a.2.total_cmp(&b.2)).copied()
         };
-        let best = longest(&mut runs.iter().filter(|(_, at, _)| !on_a_feature(*at)))
-            .or_else(|| longest(&mut runs.iter()));
+        // Long enough and clear first; failing that, the longest the lap has — a start on a
+        // short straight still beats one laid round a bend.
+        let best = longest(
+            &mut runs.iter().filter(|(_, at, len)| *len >= need && clear_from(*at)),
+        )
+        .or_else(|| longest(&mut runs.iter()));
         if let Some((index, at, len)) = best {
             if len > prog.opening_straight() + 5.0 {
                 prog.rotate_start(index);

--- a/src-tauri/src/trackllm.rs
+++ b/src-tauri/src/trackllm.rs
@@ -195,7 +195,69 @@ fn berm_on_a_corner(turn: &[crate::trackprog::Station], at: f32) -> bool {
 fn repair(prog: &mut TrackProgram) -> Vec<String> {
     let mut done = Vec::new();
 
-    // 1. Put the lap on the ground, and make the cells square, which is one problem and
+    // 1. Close the lap, with a turn no tighter than the tightest already on it — the same
+    //    rule the studio's own "Close the lap" button uses.
+    let closure = prog.closure_error();
+    if closure > corpus::CLOSURE_M {
+        let radius = prog
+            .segments
+            .iter()
+            .filter_map(|s| match s {
+                crate::trackprog::Segment::Arc { radius, .. } => Some(radius.abs()),
+                _ => None,
+            })
+            .fold(f32::MAX, f32::min);
+        let radius = if radius.is_finite() { radius } else { 25.0 };
+        if let Some(add) = prog.closing_segments(radius) {
+            let n = add.len();
+            prog.segments.extend(add);
+            done.push(format!(
+                "closed the lap: {closure:.0} m gap shut with {n} segment(s), now {:.2} m",
+                prog.closure_error()
+            ));
+        }
+    }
+
+    // 2. Start the lap on a straight, because that is where a start goes.
+    //
+    //    A closed lap has no natural beginning — the model picks one, and it picks the point
+    //    it started drawing from. That left the gate row wherever the lap happened to be a
+    //    few dozen metres in, which on a lap that opens on a corner is forty gates laid round
+    //    a bend, and the pit lane and the thirty-second board out in a field with them.
+    //
+    //    Nothing about the track changes: the same ground, ridden from a different point on
+    //    it. So this is repaired rather than sent back — where a lap starts is not a design
+    //    decision, it is bookkeeping, and the model has better things to spend an attempt on.
+    //
+    //    After the closing, because rotating a lap that doesn't meet itself moves the part
+    //    that comes after the seam by however far the gap is.
+    if prog.opening_straight() < crate::trackprog::START_STRAIGHT_M {
+        let features = prog.features.clone();
+        let on_a_feature = |at: f32| {
+            features
+                .iter()
+                .any(|f| at > f.at() + 0.01 && at < f.at() + f.length() - 0.01)
+        };
+        let runs = prog.straight_runs();
+        // The longest straight the lap has, preferring one whose beginning isn't under a jump
+        // — starting there would leave the jump straddling the finish.
+        let longest = |it: &mut dyn Iterator<Item = &(usize, f32, f32)>| {
+            it.max_by(|a, b| a.2.total_cmp(&b.2)).copied()
+        };
+        let best = longest(&mut runs.iter().filter(|(_, at, _)| !on_a_feature(*at)))
+            .or_else(|| longest(&mut runs.iter()));
+        if let Some((index, at, len)) = best {
+            if len > prog.opening_straight() + 5.0 {
+                prog.rotate_start(index);
+                done.push(format!(
+                    "the lap now starts on its longest straight — {len:.0} m, {at:.0} m round \
+                     from where it began — so the gate row stands on one"
+                ));
+            }
+        }
+    }
+
+    // 3. Put the lap on the ground, and make the cells square, which is one problem and
     //    not two.
     //
     //    They were two steps and they fought: fitting the plot to the lap and then squaring
@@ -213,7 +275,9 @@ fn repair(prog: &mut TrackProgram) -> Vec<String> {
     {
         let st = prog.stations(2.0);
         if !st.is_empty() {
-            let margin = prog.width.max(1.0) * 1.5;
+            // Enough for the start fan, not just the riding line: the opening straight
+            // widens out to hold a 48 m gate row, and it needs to be on the plot.
+            let margin = (prog.width.max(1.0) * 1.5).max(tracksynth::START_FAN_HALF_M + 8.0);
             let (mut lo_x, mut hi_x) = (f32::MAX, f32::MIN);
             let (mut lo_z, mut hi_z) = (f32::MAX, f32::MIN);
             for s in &st {
@@ -280,21 +344,7 @@ fn repair(prog: &mut TrackProgram) -> Vec<String> {
             // lies and which way round it faces.
             if let Some(p) = tracksynth::place_on_ground(prog) {
                 if p.was_cross_m - p.cross_m > 0.25 {
-                    let (c, s) = (p.turn_deg.to_radians().cos(), p.turn_deg.to_radians().sin());
-                    let st = prog.stations(4.0);
-                    let (mut lo_x, mut hi_x, mut lo_z, mut hi_z) =
-                        (f32::MAX, f32::MIN, f32::MAX, f32::MIN);
-                    for q in &st {
-                        lo_x = lo_x.min(q.x);
-                        hi_x = hi_x.max(q.x);
-                        lo_z = lo_z.min(q.z);
-                        hi_z = hi_z.max(q.z);
-                    }
-                    let (cx, cz) = ((lo_x + hi_x) * 0.5, (lo_z + hi_z) * 0.5);
-                    let (rx, rz) = (prog.start.x - cx, prog.start.z - cz);
-                    prog.start.x = cx + rx * c - rz * s + p.dx;
-                    prog.start.z = cz + rx * s + rz * c + p.dz;
-                    prog.start.angle += p.turn_deg;
+                    tracksynth::place(prog, &p);
                     done.push(format!(
                         "lap turned {:.0}° to lie along the ground — the fall across it drops \
                          from {:.1} m to {:.1} m over thirty metres, climbing at {:.1}°",
@@ -305,30 +355,7 @@ fn repair(prog: &mut TrackProgram) -> Vec<String> {
         }
     }
 
-    // 2. Close the lap, with a turn no tighter than the tightest already on it — the same
-    //    rule the studio's own "Close the lap" button uses.
-    let closure = prog.closure_error();
-    if closure > corpus::CLOSURE_M {
-        let radius = prog
-            .segments
-            .iter()
-            .filter_map(|s| match s {
-                crate::trackprog::Segment::Arc { radius, .. } => Some(radius.abs()),
-                _ => None,
-            })
-            .fold(f32::MAX, f32::min);
-        let radius = if radius.is_finite() { radius } else { 25.0 };
-        if let Some(add) = prog.closing_segments(radius) {
-            let n = add.len();
-            prog.segments.extend(add);
-            done.push(format!(
-                "closed the lap: {closure:.0} m gap shut with {n} segment(s), now {:.2} m",
-                prog.closure_error()
-            ));
-        }
-    }
-
-    // 3. Put berms on corners. A berm on a straight silently does nothing, and it is never
+    // 4. Put berms on corners. A berm on a straight silently does nothing, and it is never
     //    what was meant — a model that asks for one has decided the corner wants banking and
     //    then got the distance round the lap wrong. Where the corners are is not a matter of
     //    opinion, so slide it to the nearest one rather than sending the whole program back.
@@ -357,7 +384,7 @@ fn repair(prog: &mut TrackProgram) -> Vec<String> {
         }
     }
 
-    // 4. Fit the height budget. It exists only because samples are quantised against it, and
+    // 5. Fit the height budget. It exists only because samples are quantised against it, and
     //    it is a number the synthesiser already knows — there was never a reason to make the
     //    model guess it and then be told off for guessing wrong.
     if let Ok(fitted) = crate::tracksynth::with_fitted_budget(prog) {
@@ -371,6 +398,12 @@ fn repair(prog: &mut TrackProgram) -> Vec<String> {
     }
 
     done
+}
+
+/// `repair`, for tests in other modules.
+#[cfg(test)]
+pub fn repair_for_tests(prog: &mut TrackProgram) -> Vec<String> {
+    repair(prog)
 }
 
 /// Ask for a track, and keep asking until it measures like one.
@@ -503,6 +536,33 @@ pub fn review(prog: &TrackProgram) -> Review {
              to add up to a whole number of full circles — check that the signed angles sum to \
              ±360°."
         ));
+    }
+    // Where the race starts. Not structural — a lap with no straight on it builds and rides
+    // — but everything the `.rdf` puts at the start goes on the opening straight, and a gate
+    // row is forty gates in a line 48 m across. Round a bend it is forty gates in a hedge.
+    let opening = prog.opening_straight();
+    if opening < crate::trackprog::START_STRAIGHT_M {
+        let longest = prog
+            .straight_runs()
+            .into_iter()
+            .max_by(|a, b| a.2.total_cmp(&b.2));
+        let need = crate::trackprog::START_STRAIGHT_M;
+        notes.push(match longest {
+            Some((_, at, len)) if len >= need => format!(
+                "the lap opens with {opening:.0} m of straight and the start needs {need:.0} — \
+                 the gate row, the finish line and a run at turn one. There is a {len:.0} m \
+                 straight {at:.0} m round; start the lap from there."
+            ),
+            Some((_, _, len)) => format!(
+                "the lap's longest straight is {len:.0} m and a start needs {need:.0} — a gate \
+                 row is 48 m across and it has to stand in a line. Give the lap one straight \
+                 that long and begin it there."
+            ),
+            None => format!(
+                "the lap is all corners, and a start needs {need:.0} m of straight to put the \
+                 gate row, the finish line and the run at turn one on."
+            ),
+        });
     }
     if let Some((a, b, gap)) = self_crossing(prog) {
         // Named in the model's own terms. It wrote a list of segments, not a distance round
@@ -845,6 +905,24 @@ mod tests {
         // camelCase on the wire, so a step-up is `stepUp` and not `step_up`.
         assert!(kinds.contains(&"stepUp"), "{kinds:?}");
         assert!(kinds.contains(&"tabletop") && kinds.contains(&"berm"));
+    }
+
+    /// The example is what the model is shown, and `generate` puts every answer through
+    /// `repair` before it measures it. If repairing the example breaks it, every generated
+    /// track starts from a shape that has already been mangled.
+    #[test]
+    fn the_worked_example_survives_being_repaired() {
+        let mut p: TrackProgram = serde_json::from_str(crate::trackprog::EXAMPLE).unwrap();
+        let done = repair(&mut p);
+        let problems = validate(&p);
+        assert!(problems.is_empty(), "repaired {done:#?}\nbut {problems:#?}");
+        // It is drawn starting halfway round a corner, which is where the gate row used to
+        // end up. Repairing it has to have moved the start onto a straight.
+        assert!(
+            p.opening_straight() >= crate::trackprog::START_STRAIGHT_M,
+            "the lap opens with {:.0} m of straight",
+            p.opening_straight()
+        );
     }
 
     #[test]

--- a/src-tauri/src/trackprog.rs
+++ b/src-tauri/src/trackprog.rs
@@ -537,7 +537,7 @@ impl Feature {
 /// not star-shaped: Indiana folds back across its own infield four times. A loop grown on a
 /// lattice folds as often as it likes and is still simple, so it cannot cross either.
 ///
-/// It begins on a 90 m straight, because that is where a start goes: the gate row, the finish
+/// It begins on its longest straight, all 145 m of it, because that is where a start goes: the gate row, the finish
 /// line and the run at turn one all sit on the lap's opening straight, and a lap that opens on
 /// a corner puts forty gates round a bend. Turned round to start there rather than redrawn —
 /// see [`TrackProgram::rotate_start`], and the printer beside its tests.
@@ -558,28 +558,8 @@ pub const EXAMPLE: &str = r#"{
         "sizeX": 500.0, "sizeZ": 500.0, "samples": 2049, "scale": 63.0,
         "relief": { "amplitude": 7.0, "wavelength": 420.0, "seed": 3, "tilt": 26.0, "tiltAngle": 35.0, "landforms": 6, "landformHeight": 18.0 }
       },
-      "start": { "x": 280.64, "z": 204.04, "angle": 181.98 },
+      "start": { "x": 336.20, "z": 61.04, "angle": 272.27 },
       "segments": [
-        { "kind": "straight", "length": 90.3427 },
-        { "kind": "arc", "radius": -29.7662, "angle": 15.3989 },
-        { "kind": "arc", "radius": -12.1796, "angle": 32.9296 },
-        { "kind": "arc", "radius": -14.3360, "angle": 35.9696 },
-        { "kind": "arc", "radius": -26.7612, "angle": 17.1280 },
-        { "kind": "arc", "radius": -62.8691, "angle": 10.0249 },
-        { "kind": "straight", "length": 14.8925 },
-        { "kind": "arc", "radius": 85.2827, "angle": 2.0155 },
-        { "kind": "straight", "length": 8.0000 },
-        { "kind": "arc", "radius": 58.4038, "angle": 6.6786 },
-        { "kind": "arc", "radius": 30.0985, "angle": 17.1325 },
-        { "kind": "arc", "radius": 20.2107, "angle": 34.8569 },
-        { "kind": "arc", "radius": 58.4731, "angle": 11.9787 },
-        { "kind": "arc", "radius": 81.8716, "angle": 8.8265 },
-        { "kind": "arc", "radius": 48.2785, "angle": 9.4942 },
-        { "kind": "arc", "radius": 16.6843, "angle": 24.0389 },
-        { "kind": "arc", "radius": 11.4412, "angle": 75.1175 },
-        { "kind": "arc", "radius": 36.3257, "angle": 12.0854 },
-        { "kind": "straight", "length": 24.1297 },
-        { "kind": "arc", "radius": -118.9746, "angle": 0.4816 },
         { "kind": "straight", "length": 145.1504 },
         { "kind": "arc", "radius": 63.4878, "angle": 8.1222 },
         { "kind": "arc", "radius": 24.3538, "angle": 16.4685 },
@@ -696,49 +676,69 @@ pub const EXAMPLE: &str = r#"{
         { "kind": "arc", "radius": -12.8808, "angle": 31.1370 },
         { "kind": "arc", "radius": -32.8954, "angle": 13.9340 },
         { "kind": "straight", "length": 11.1325 },
-        { "kind": "arc", "radius": 125.4045, "angle": 0.9138 }
+        { "kind": "arc", "radius": 125.4045, "angle": 0.9138 },
+        { "kind": "straight", "length": 90.3427 },
+        { "kind": "arc", "radius": -29.7662, "angle": 15.3989 },
+        { "kind": "arc", "radius": -12.1796, "angle": 32.9296 },
+        { "kind": "arc", "radius": -14.3360, "angle": 35.9696 },
+        { "kind": "arc", "radius": -26.7612, "angle": 17.1280 },
+        { "kind": "arc", "radius": -62.8691, "angle": 10.0249 },
+        { "kind": "straight", "length": 14.8925 },
+        { "kind": "arc", "radius": 85.2827, "angle": 2.0155 },
+        { "kind": "straight", "length": 8.0000 },
+        { "kind": "arc", "radius": 58.4038, "angle": 6.6786 },
+        { "kind": "arc", "radius": 30.0985, "angle": 17.1325 },
+        { "kind": "arc", "radius": 20.2107, "angle": 34.8569 },
+        { "kind": "arc", "radius": 58.4731, "angle": 11.9787 },
+        { "kind": "arc", "radius": 81.8716, "angle": 8.8265 },
+        { "kind": "arc", "radius": 48.2785, "angle": 9.4942 },
+        { "kind": "arc", "radius": 16.6843, "angle": 24.0389 },
+        { "kind": "arc", "radius": 11.4412, "angle": 75.1175 },
+        { "kind": "arc", "radius": 36.3257, "angle": 12.0854 },
+        { "kind": "straight", "length": 24.1297 },
+        { "kind": "arc", "radius": -118.9746, "angle": 0.4816 }
       ],
       "features": [
-        { "kind": "tabletop", "at": 4.6674767, "length": 28.7, "height": 2.5 },
-        { "kind": "double", "at": 27.267479, "height": 1.7, "gap": 10.2, "lip": 5.5 },
-        { "kind": "double", "at": 49.867477, "height": 1.3, "gap": 8.9, "lip": 5.5 },
-        { "kind": "roller", "at": 72.567474, "length": 15.9, "height": 0.54 },
-        { "kind": "roller", "at": 136.56747, "length": 14.3, "height": 0.79 },
-        { "kind": "tabletop", "at": 151.86748, "length": 19.0, "height": 1.1 },
-        { "kind": "tabletop", "at": 203.76747, "length": 18.4, "height": 1.1 },
-        { "kind": "berm", "at": 227.16748, "length": 15.0, "height": 1.7 },
-        { "kind": "tabletop", "at": 272.96747, "length": 31.3, "height": 3.1 },
-        { "kind": "roller", "at": 306.26746, "length": 11.3, "height": 0.8 },
-        { "kind": "tabletop", "at": 339.46747, "length": 22.6, "height": 1.5 },
-        { "kind": "stepUp", "at": 372.76746, "length": 20.9, "height": 2.0 },
-        { "kind": "roller", "at": 405.96747, "length": 14.4, "height": 0.75 },
-        { "kind": "berm", "at": 540.46747, "length": 8.0, "height": 1.7 },
-        { "kind": "double", "at": 570.6675, "height": 1.5, "gap": 8.8, "lip": 5.5 },
-        { "kind": "roller", "at": 683.6675, "length": 11.1, "height": 0.79 },
-        { "kind": "tabletop", "at": 756.5675, "length": 29.5, "height": 3.4 },
-        { "kind": "roller", "at": 776.8675, "length": 11.6, "height": 0.8 },
-        { "kind": "double", "at": 797.1675, "height": 1.9, "gap": 9.2, "lip": 5.5 },
-        { "kind": "double", "at": 858.1675, "height": 3.6, "gap": 14.6, "lip": 6.0 },
-        { "kind": "stepUp", "at": 875.7675, "length": 19.3, "height": 2.2 },
-        { "kind": "roller", "at": 893.3675, "length": 13.5, "height": 0.46 },
-        { "kind": "whoops", "at": 955.46747, "count": 7, "spacing": 4.2, "height": 0.57 },
-        { "kind": "double", "at": 973.96747, "height": 1.2, "gap": 12.7, "lip": 5.5 },
-        { "kind": "tabletop", "at": 1023.3675, "length": 20.3, "height": 1.2 },
-        { "kind": "tabletop", "at": 1116.8674, "length": 16.9, "height": 1.0 },
-        { "kind": "double", "at": 1134.2675, "height": 1.6, "gap": 8.2, "lip": 5.5 },
-        { "kind": "stepUp", "at": 1200.6675, "length": 25.2, "height": 1.9 },
-        { "kind": "roller", "at": 1265.5674, "length": 14.8, "height": 0.6 },
-        { "kind": "tabletop", "at": 1339.8674, "length": 24.4, "height": 2.5 },
-        { "kind": "roller", "at": 1365.7675, "length": 14.4, "height": 0.82 },
-        { "kind": "roller", "at": 1391.6675, "length": 13.2, "height": 0.58 },
-        { "kind": "tabletop", "at": 1458.1675, "length": 24.1, "height": 1.1 },
-        { "kind": "double", "at": 1528.8674, "height": 3.6, "gap": 16.4, "lip": 6.0 },
-        { "kind": "roller", "at": 1572.0674, "length": 14.6, "height": 0.64 },
-        { "kind": "tabletop", "at": 1615.2675, "length": 17.3, "height": 1.2 },
-        { "kind": "tabletop", "at": 1658.4674, "length": 18.2, "height": 1.4 },
-        { "kind": "roller", "at": 1701.6675, "length": 11.5, "height": 0.77 },
-        { "kind": "whoops", "at": 1799.4674, "count": 7, "spacing": 5.0, "height": 0.75 },
-        { "kind": "tabletop", "at": 1841.4674, "length": 22.5, "height": 1.6 }
+        { "kind": "roller", "at": 31.299774, "length": 11.3, "height": 0.8 },
+        { "kind": "tabletop", "at": 64.49979, "length": 22.6, "height": 1.5 },
+        { "kind": "stepUp", "at": 97.799774, "length": 20.9, "height": 2.0 },
+        { "kind": "roller", "at": 130.99979, "length": 14.4, "height": 0.75 },
+        { "kind": "berm", "at": 265.4998, "length": 8.0, "height": 1.7 },
+        { "kind": "double", "at": 295.6998, "height": 1.5, "gap": 8.8, "lip": 5.5 },
+        { "kind": "roller", "at": 408.6998, "length": 11.1, "height": 0.79 },
+        { "kind": "tabletop", "at": 481.59982, "length": 29.5, "height": 3.4 },
+        { "kind": "roller", "at": 501.8998, "length": 11.6, "height": 0.8 },
+        { "kind": "double", "at": 522.1998, "height": 1.9, "gap": 9.2, "lip": 5.5 },
+        { "kind": "double", "at": 583.1998, "height": 3.6, "gap": 14.6, "lip": 6.0 },
+        { "kind": "stepUp", "at": 600.7998, "length": 19.3, "height": 2.2 },
+        { "kind": "roller", "at": 618.3998, "length": 13.5, "height": 0.46 },
+        { "kind": "whoops", "at": 680.49976, "count": 7, "spacing": 4.2, "height": 0.57 },
+        { "kind": "double", "at": 698.99976, "height": 1.2, "gap": 12.7, "lip": 5.5 },
+        { "kind": "tabletop", "at": 748.3998, "length": 20.3, "height": 1.2 },
+        { "kind": "tabletop", "at": 841.8998, "length": 16.9, "height": 1.0 },
+        { "kind": "double", "at": 859.2998, "height": 1.6, "gap": 8.2, "lip": 5.5 },
+        { "kind": "stepUp", "at": 925.6998, "length": 25.2, "height": 1.9 },
+        { "kind": "roller", "at": 990.59973, "length": 14.8, "height": 0.6 },
+        { "kind": "tabletop", "at": 1064.8998, "length": 24.4, "height": 2.5 },
+        { "kind": "roller", "at": 1090.7998, "length": 14.4, "height": 0.82 },
+        { "kind": "roller", "at": 1116.6998, "length": 13.2, "height": 0.58 },
+        { "kind": "tabletop", "at": 1183.1998, "length": 24.1, "height": 1.1 },
+        { "kind": "double", "at": 1253.8998, "height": 3.6, "gap": 16.4, "lip": 6.0 },
+        { "kind": "roller", "at": 1297.0997, "length": 14.6, "height": 0.64 },
+        { "kind": "tabletop", "at": 1340.2998, "length": 17.3, "height": 1.2 },
+        { "kind": "tabletop", "at": 1383.4998, "length": 18.2, "height": 1.4 },
+        { "kind": "roller", "at": 1426.6998, "length": 11.5, "height": 0.77 },
+        { "kind": "whoops", "at": 1524.4998, "count": 7, "spacing": 5.0, "height": 0.75 },
+        { "kind": "tabletop", "at": 1566.4998, "length": 22.5, "height": 1.6 },
+        { "kind": "tabletop", "at": 1634.8657, "length": 28.7, "height": 2.5 },
+        { "kind": "double", "at": 1657.4657, "height": 1.7, "gap": 10.2, "lip": 5.5 },
+        { "kind": "double", "at": 1680.0657, "height": 1.3, "gap": 8.9, "lip": 5.5 },
+        { "kind": "roller", "at": 1702.7656, "length": 15.9, "height": 0.54 },
+        { "kind": "roller", "at": 1766.7656, "length": 14.3, "height": 0.79 },
+        { "kind": "tabletop", "at": 1782.0657, "length": 19.0, "height": 1.1 },
+        { "kind": "tabletop", "at": 1833.9657, "length": 18.4, "height": 1.1 },
+        { "kind": "berm", "at": 1857.3657, "length": 15.0, "height": 1.7 },
+        { "kind": "tabletop", "at": 1873.8658, "length": 31.3, "height": 3.1 }
       ]
     }"#;
 
@@ -880,6 +880,9 @@ impl TrackProgram {
         let lap = self.lap_length();
         let shift: f32 = self.segments[..index].iter().map(|s| s.length()).sum();
         self.start = end_pose(self.start, &self.segments[..index]);
+        // Back into a circle: the walk adds every turn to the heading, so starting partway
+        // round a lap that turns 2651° leaves the pose facing 541 degrees.
+        self.start.angle = self.start.angle.rem_euclid(360.0);
         self.segments.rotate_left(index);
 
         for f in &mut self.features {
@@ -1239,18 +1242,20 @@ mod tests {
     fn print_the_example_started_on_its_straight() {
         let mut p: TrackProgram = serde_json::from_str(EXAMPLE).unwrap();
         let features = p.features.clone();
-        let on_a_feature = |at: f32| {
-            features
-                .iter()
-                .any(|f| at > f.at() + 0.01 && at < f.at() + f.length() - 0.01)
+        let clear_from = |at: f32| {
+            !features.iter().any(|f| {
+                f.at() + f.length() > at + 0.01 && f.at() < at + START_STRAIGHT_M - 0.01
+            })
         };
         let runs = p.straight_runs();
         let longest = |it: &mut dyn Iterator<Item = &(usize, f32, f32)>| {
             it.max_by(|a, b| a.2.total_cmp(&b.2)).copied()
         };
-        let (index, _, len) = longest(&mut runs.iter().filter(|(_, at, _)| !on_a_feature(*at)))
-            .or_else(|| longest(&mut runs.iter()))
-            .expect("a straight to start on");
+        let (index, _, len) = longest(
+            &mut runs.iter().filter(|(_, at, len)| *len >= START_STRAIGHT_M && clear_from(*at)),
+        )
+        .or_else(|| longest(&mut runs.iter()))
+        .expect("a straight to start on");
         p.rotate_start(index);
         println!("// {len:.0} m opening straight, closes to {:.2} m", p.closure_error());
         println!(

--- a/src-tauri/src/trackprog.rs
+++ b/src-tauri/src/trackprog.rs
@@ -307,6 +307,14 @@ pub fn tabletop_faces(height: f32, length: f32) -> (f32, f32, f32) {
     (up, top, down)
 }
 
+/// The shortest straight a start will fit on, metres.
+///
+/// A motocross start is a gate row, the finish line a dozen metres past it, and a run at the
+/// first turn — all of it in a line, because forty gates cannot be laid round a bend.
+/// Published start straights are longer than this; it is the floor below which the layout
+/// stops fitting on the track.
+pub const START_STRAIGHT_M: f32 = 60.0;
+
 /// Under this many degrees an arc is a drift, not a corner — a builder nudging a straight
 /// back onto line.
 pub const CORNER_DEG: f32 = 1.0;
@@ -440,6 +448,21 @@ impl Feature {
         }
     }
 
+    /// Where it sits, to move it. Rotating the lap's start moves everything placed by
+    /// distance round it, and a feature is placed by distance round it.
+    pub fn at_mut(&mut self) -> &mut f32 {
+        match self {
+            Feature::Tabletop { at, .. }
+            | Feature::Double { at, .. }
+            | Feature::Roller { at, .. }
+            | Feature::Whoops { at, .. }
+            | Feature::StepUp { at, .. }
+            | Feature::Berm { at, .. }
+            | Feature::Rut { at, .. }
+            | Feature::Custom { at, .. } => at,
+        }
+    }
+
     /// How much of the lap it occupies.
     pub fn length(&self) -> f32 {
         match self {
@@ -514,6 +537,11 @@ impl Feature {
 /// not star-shaped: Indiana folds back across its own infield four times. A loop grown on a
 /// lattice folds as often as it likes and is still simple, so it cannot cross either.
 ///
+/// It begins on a 90 m straight, because that is where a start goes: the gate row, the finish
+/// line and the run at turn one all sit on the lap's opening straight, and a lap that opens on
+/// a corner puts forty gates round a bend. Turned round to start there rather than redrawn —
+/// see [`TrackProgram::rotate_start`], and the printer beside its tests.
+///
 /// 1905 m, 137 segments of which 109 are arcs, seventeen corners at a median 12.6 m through
 /// their tightest point — Indiana's is 10.6 — and 2651° of turning. Forty features, seven of them over 2.2 m and the
 /// rest small ground, which is the ratio Indiana has. It climbs 22 m round the lap, which is
@@ -530,11 +558,8 @@ pub const EXAMPLE: &str = r#"{
         "sizeX": 500.0, "sizeZ": 500.0, "samples": 2049, "scale": 63.0,
         "relief": { "amplitude": 7.0, "wavelength": 420.0, "seed": 3, "tilt": 26.0, "tiltAngle": 35.0, "landforms": 6, "landformHeight": 18.0 }
       },
-      "start": { "x": 282.02, "z": 225.07, "angle": 195.0 },
+      "start": { "x": 280.64, "z": 204.04, "angle": 181.98 },
       "segments": [
-        { "kind": "arc", "radius": -32.8954, "angle": 13.9340 },
-        { "kind": "straight", "length": 11.1325 },
-        { "kind": "arc", "radius": 125.4045, "angle": 0.9138 },
         { "kind": "straight", "length": 90.3427 },
         { "kind": "arc", "radius": -29.7662, "angle": 15.3989 },
         { "kind": "arc", "radius": -12.1796, "angle": 32.9296 },
@@ -668,49 +693,52 @@ pub const EXAMPLE: &str = r#"{
         { "kind": "arc", "radius": -54.6225, "angle": 12.4011 },
         { "kind": "arc", "radius": -52.9898, "angle": 32.2688 },
         { "kind": "arc", "radius": -12.0022, "angle": 36.2527 },
-        { "kind": "arc", "radius": -12.8808, "angle": 31.1370 }
+        { "kind": "arc", "radius": -12.8808, "angle": 31.1370 },
+        { "kind": "arc", "radius": -32.8954, "angle": 13.9340 },
+        { "kind": "straight", "length": 11.1325 },
+        { "kind": "arc", "radius": 125.4045, "angle": 0.9138 }
       ],
       "features": [
-        { "kind": "tabletop", "at": 25.8, "length": 28.7, "height": 2.50 },
-        { "kind": "double", "at": 48.4, "height": 1.70, "gap": 10.2, "lip": 5.5 },
-        { "kind": "double", "at": 71.0, "height": 1.30, "gap": 8.9, "lip": 5.5 },
-        { "kind": "roller", "at": 93.7, "length": 15.9, "height": 0.54 },
-        { "kind": "roller", "at": 157.7, "length": 14.3, "height": 0.79 },
-        { "kind": "tabletop", "at": 173.0, "length": 19.0, "height": 1.10 },
-        { "kind": "tabletop", "at": 224.9, "length": 18.4, "height": 1.10 },
-        { "kind": "berm", "at": 248.3, "length": 15.0, "height": 1.70 },
-        { "kind": "tabletop", "at": 294.1, "length": 31.3, "height": 3.10 },
-        { "kind": "roller", "at": 327.4, "length": 11.3, "height": 0.80 },
-        { "kind": "tabletop", "at": 360.6, "length": 22.6, "height": 1.50 },
-        { "kind": "stepUp", "at": 393.9, "length": 20.9, "height": 2.00 },
-        { "kind": "roller", "at": 427.1, "length": 14.4, "height": 0.75 },
-        { "kind": "berm", "at": 561.6, "length": 8.0, "height": 1.70 },
-        { "kind": "double", "at": 591.8, "height": 1.50, "gap": 8.8, "lip": 5.5 },
-        { "kind": "roller", "at": 704.8, "length": 11.1, "height": 0.79 },
-        { "kind": "tabletop", "at": 777.7, "length": 29.5, "height": 3.40 },
-        { "kind": "roller", "at": 798.0, "length": 11.6, "height": 0.80 },
-        { "kind": "double", "at": 818.3, "height": 1.90, "gap": 9.2, "lip": 5.5 },
-        { "kind": "double", "at": 879.3, "height": 3.60, "gap": 14.6, "lip": 6.0 },
-        { "kind": "stepUp", "at": 896.9, "length": 19.3, "height": 2.20 },
-        { "kind": "roller", "at": 914.5, "length": 13.5, "height": 0.46 },
-        { "kind": "whoops", "at": 976.6, "count": 7, "spacing": 4.2, "height": 0.57 },
-        { "kind": "double", "at": 995.1, "height": 1.20, "gap": 12.7, "lip": 5.5 },
-        { "kind": "tabletop", "at": 1044.5, "length": 20.3, "height": 1.20 },
-        { "kind": "tabletop", "at": 1138.0, "length": 16.9, "height": 1.00 },
-        { "kind": "double", "at": 1155.4, "height": 1.60, "gap": 8.2, "lip": 5.5 },
-        { "kind": "stepUp", "at": 1221.8, "length": 25.2, "height": 1.90 },
-        { "kind": "roller", "at": 1286.7, "length": 14.8, "height": 0.60 },
-        { "kind": "tabletop", "at": 1361.0, "length": 24.4, "height": 2.50 },
-        { "kind": "roller", "at": 1386.9, "length": 14.4, "height": 0.82 },
-        { "kind": "roller", "at": 1412.8, "length": 13.2, "height": 0.58 },
-        { "kind": "tabletop", "at": 1479.3, "length": 24.1, "height": 1.10 },
-        { "kind": "double", "at": 1550.0, "height": 3.60, "gap": 16.4, "lip": 6.0 },
-        { "kind": "roller", "at": 1593.2, "length": 14.6, "height": 0.64 },
-        { "kind": "tabletop", "at": 1636.4, "length": 17.3, "height": 1.20 },
-        { "kind": "tabletop", "at": 1679.6, "length": 18.2, "height": 1.40 },
-        { "kind": "roller", "at": 1722.8, "length": 11.5, "height": 0.77 },
-        { "kind": "whoops", "at": 1820.6, "count": 7, "spacing": 5.0, "height": 0.75 },
-        { "kind": "tabletop", "at": 1862.6, "length": 22.5, "height": 1.60 }
+        { "kind": "tabletop", "at": 4.6674767, "length": 28.7, "height": 2.5 },
+        { "kind": "double", "at": 27.267479, "height": 1.7, "gap": 10.2, "lip": 5.5 },
+        { "kind": "double", "at": 49.867477, "height": 1.3, "gap": 8.9, "lip": 5.5 },
+        { "kind": "roller", "at": 72.567474, "length": 15.9, "height": 0.54 },
+        { "kind": "roller", "at": 136.56747, "length": 14.3, "height": 0.79 },
+        { "kind": "tabletop", "at": 151.86748, "length": 19.0, "height": 1.1 },
+        { "kind": "tabletop", "at": 203.76747, "length": 18.4, "height": 1.1 },
+        { "kind": "berm", "at": 227.16748, "length": 15.0, "height": 1.7 },
+        { "kind": "tabletop", "at": 272.96747, "length": 31.3, "height": 3.1 },
+        { "kind": "roller", "at": 306.26746, "length": 11.3, "height": 0.8 },
+        { "kind": "tabletop", "at": 339.46747, "length": 22.6, "height": 1.5 },
+        { "kind": "stepUp", "at": 372.76746, "length": 20.9, "height": 2.0 },
+        { "kind": "roller", "at": 405.96747, "length": 14.4, "height": 0.75 },
+        { "kind": "berm", "at": 540.46747, "length": 8.0, "height": 1.7 },
+        { "kind": "double", "at": 570.6675, "height": 1.5, "gap": 8.8, "lip": 5.5 },
+        { "kind": "roller", "at": 683.6675, "length": 11.1, "height": 0.79 },
+        { "kind": "tabletop", "at": 756.5675, "length": 29.5, "height": 3.4 },
+        { "kind": "roller", "at": 776.8675, "length": 11.6, "height": 0.8 },
+        { "kind": "double", "at": 797.1675, "height": 1.9, "gap": 9.2, "lip": 5.5 },
+        { "kind": "double", "at": 858.1675, "height": 3.6, "gap": 14.6, "lip": 6.0 },
+        { "kind": "stepUp", "at": 875.7675, "length": 19.3, "height": 2.2 },
+        { "kind": "roller", "at": 893.3675, "length": 13.5, "height": 0.46 },
+        { "kind": "whoops", "at": 955.46747, "count": 7, "spacing": 4.2, "height": 0.57 },
+        { "kind": "double", "at": 973.96747, "height": 1.2, "gap": 12.7, "lip": 5.5 },
+        { "kind": "tabletop", "at": 1023.3675, "length": 20.3, "height": 1.2 },
+        { "kind": "tabletop", "at": 1116.8674, "length": 16.9, "height": 1.0 },
+        { "kind": "double", "at": 1134.2675, "height": 1.6, "gap": 8.2, "lip": 5.5 },
+        { "kind": "stepUp", "at": 1200.6675, "length": 25.2, "height": 1.9 },
+        { "kind": "roller", "at": 1265.5674, "length": 14.8, "height": 0.6 },
+        { "kind": "tabletop", "at": 1339.8674, "length": 24.4, "height": 2.5 },
+        { "kind": "roller", "at": 1365.7675, "length": 14.4, "height": 0.82 },
+        { "kind": "roller", "at": 1391.6675, "length": 13.2, "height": 0.58 },
+        { "kind": "tabletop", "at": 1458.1675, "length": 24.1, "height": 1.1 },
+        { "kind": "double", "at": 1528.8674, "height": 3.6, "gap": 16.4, "lip": 6.0 },
+        { "kind": "roller", "at": 1572.0674, "length": 14.6, "height": 0.64 },
+        { "kind": "tabletop", "at": 1615.2675, "length": 17.3, "height": 1.2 },
+        { "kind": "tabletop", "at": 1658.4674, "length": 18.2, "height": 1.4 },
+        { "kind": "roller", "at": 1701.6675, "length": 11.5, "height": 0.77 },
+        { "kind": "whoops", "at": 1799.4674, "count": 7, "spacing": 5.0, "height": 0.75 },
+        { "kind": "tabletop", "at": 1841.4674, "length": 22.5, "height": 1.6 }
       ]
     }"#;
 
@@ -726,6 +754,35 @@ fn wrap(a: f32) -> f32 {
         x += tau;
     }
     x
+}
+
+/// Where a run of segments leaves you, ridden from `from`.
+///
+/// The same walk [`TrackProgram::stations`] does, without the sampling: arcs are stepped from
+/// their centre, so a hundred segments end exactly where their radii and angles say.
+fn end_pose(from: Start, segs: &[Segment]) -> Start {
+    let (mut x, mut z) = (from.x, from.z);
+    let mut theta = from.angle.to_radians();
+    for seg in segs {
+        match *seg {
+            Segment::Straight { .. } => {
+                let (dx, dz) = heading_vector(theta);
+                x += dx * seg.length();
+                z += dz * seg.length();
+            }
+            Segment::Arc { radius, angle, .. } => {
+                let turn = radius.signum();
+                let r = radius.abs().max(0.01);
+                let (rx, rz) = right_vector(theta);
+                let (cx, cz) = (x + rx * r * turn, z + rz * r * turn);
+                theta += turn * angle.abs().to_radians();
+                let (rx, rz) = right_vector(theta);
+                x = cx - rx * r * turn;
+                z = cz - rz * r * turn;
+            }
+        }
+    }
+    Start { x, z, angle: theta.to_degrees() }
 }
 
 /// One point on the riding line, and which way it faces there.
@@ -745,6 +802,97 @@ pub struct Station {
 impl TrackProgram {
     pub fn lap_length(&self) -> f32 {
         self.segments.iter().map(|s| s.length()).sum()
+    }
+
+    /// How much straight the lap opens with, metres.
+    ///
+    /// The leading run, not the first segment: consecutive straights are colinear, so three
+    /// of them in a row are one straight to everything that rides it. This is what the start
+    /// gets laid out on — the gate row, the finish line and the run at turn one all sit on
+    /// it, and every file that mentions the start measures from where it begins.
+    pub fn opening_straight(&self) -> f32 {
+        self.segments
+            .iter()
+            .take_while(|s| matches!(s, Segment::Straight { .. }))
+            .map(|s| s.length())
+            .sum()
+    }
+
+    /// Every straight on the lap: `(segment index, metres round the lap, length)`.
+    ///
+    /// Runs of consecutive straights are merged for the same reason as above, and so is the
+    /// pair either side of the finish — a lap that ends on a straight and begins on one has
+    /// a single straight through the line, and it is usually the longest thing on the track.
+    pub fn straight_runs(&self) -> Vec<(usize, f32, f32)> {
+        let mut out: Vec<(usize, f32, f32)> = Vec::new();
+        let mut at = 0.0f32;
+        for (i, seg) in self.segments.iter().enumerate() {
+            let len = seg.length();
+            if matches!(seg, Segment::Straight { .. }) {
+                match out.last_mut() {
+                    // Carrying on the run the segment before it started.
+                    Some(run) if (run.1 + run.2 - at).abs() < 1e-3 => run.2 += len,
+                    _ => out.push((i, at, len)),
+                }
+            }
+            at += len;
+        }
+        // Across the finish, when the lap both ends and begins on one — and only when it
+        // closes, because two straights either side of a lap that doesn't meet itself are two
+        // straights pointing different ways in different places.
+        if out.len() > 1 && self.closes() {
+            let first = out[0];
+            let last = *out.last().expect("more than one run");
+            if first.0 == 0 && (last.1 + last.2 - at).abs() < 1e-3 {
+                out.pop();
+                out.remove(0);
+                out.push((last.0, last.1, last.2 + first.2));
+            }
+        }
+        out
+    }
+
+    /// Whether the finish meets the start, pose and all — near enough that the two ends are
+    /// the same piece of track.
+    pub fn closes(&self) -> bool {
+        let end = end_pose(self.start, &self.segments);
+        let gap = ((end.x - self.start.x).powi(2) + (end.z - self.start.z).powi(2)).sqrt();
+        gap < 1.0 && wrap((end.angle - self.start.angle).to_radians()).abs() < 0.02
+    }
+
+    /// Begin the lap at segment `index`: the same track, ridden from a different point on it.
+    ///
+    /// Where a lap starts is not part of its shape — it decides where the gate row stands and
+    /// what `long = 0` means in every file that states a distance round the lap, and nothing
+    /// else. So a lap drawn starting halfway round a corner can be given a proper start
+    /// straight without redrawing it: turn the list of segments round and walk the start pose
+    /// to where the new first segment begins.
+    ///
+    /// Everything placed by distance moves with it — the features and the elevation knots —
+    /// and a feature left straddling the new finish is pulled back to end on it, which is
+    /// what the studio does to a stranded jump.
+    ///
+    /// Returns how far round the old lap the new start is.
+    pub fn rotate_start(&mut self, index: usize) -> f32 {
+        if self.segments.is_empty() || index == 0 || index >= self.segments.len() {
+            return 0.0;
+        }
+        let lap = self.lap_length();
+        let shift: f32 = self.segments[..index].iter().map(|s| s.length()).sum();
+        self.start = end_pose(self.start, &self.segments[..index]);
+        self.segments.rotate_left(index);
+
+        for f in &mut self.features {
+            let len = f.length();
+            let at = (f.at() - shift).rem_euclid(lap.max(1.0));
+            *f.at_mut() = if at + len > lap { (lap - len).max(0.0) } else { at };
+        }
+        self.features.sort_by(|a, b| a.at().total_cmp(&b.at()));
+        for k in &mut self.elevation {
+            k.at = (k.at - shift).rem_euclid(lap.max(1.0));
+        }
+        self.elevation.sort_by(|a, b| a.at.total_cmp(&b.at));
+        shift
     }
 
     /// The centreline, sampled every `step` metres.
@@ -992,6 +1140,151 @@ mod tests {
             blend: default_blend(),
             elevation: Vec::new(),
         }
+    }
+
+    /// An oval: two straights of different lengths, so which one the start lands on is
+    /// visible in the numbers.
+    fn oval() -> TrackProgram {
+        prog(vec![
+            Segment::Arc { radius: 40.0, angle: 180.0, rise: 0.0 },
+            Segment::Straight { length: 30.0, rise: 0.0 },
+            Segment::Arc { radius: 40.0, angle: 180.0, rise: 0.0 },
+            Segment::Straight { length: 30.0, rise: 0.0 },
+        ])
+    }
+
+    #[test]
+    fn straight_runs_merge_what_rides_as_one_straight() {
+        let p = prog(vec![
+            Segment::Straight { length: 20.0, rise: 0.0 },
+            Segment::Straight { length: 25.0, rise: 0.0 },
+            Segment::Arc { radius: 30.0, angle: 90.0, rise: 0.0 },
+            Segment::Straight { length: 10.0, rise: 0.0 },
+        ]);
+        let runs = p.straight_runs();
+        assert_eq!(runs.len(), 2, "{runs:?}");
+        assert_eq!(runs[0].0, 0);
+        assert!((runs[0].2 - 45.0).abs() < 0.01, "{runs:?}");
+    }
+
+    #[test]
+    fn a_straight_through_the_finish_is_one_straight() {
+        // An oval whose finish sits in the middle of a straight: 20 m of it before the line
+        // and 30 m after, which is one 50 m straight and not two.
+        let p = prog(vec![
+            Segment::Straight { length: 30.0, rise: 0.0 },
+            Segment::Arc { radius: 40.0, angle: 180.0, rise: 0.0 },
+            Segment::Straight { length: 50.0, rise: 0.0 },
+            Segment::Arc { radius: 40.0, angle: 180.0, rise: 0.0 },
+            Segment::Straight { length: 20.0, rise: 0.0 },
+        ]);
+        let runs = p.straight_runs();
+        assert_eq!(runs.len(), 2, "{runs:?}");
+        let through = runs.iter().find(|r| r.0 == 4).expect("the run through the finish");
+        assert!((through.2 - 50.0).abs() < 0.01, "{runs:?}");
+    }
+
+    #[test]
+    fn a_rotated_lap_is_the_same_lap() {
+        let before = oval();
+        let mut after = before.clone();
+        let shift = after.rotate_start(1);
+        assert!((shift - 40.0 * std::f32::consts::PI).abs() < 0.01, "{shift}");
+        assert!((after.lap_length() - before.lap_length()).abs() < 0.01);
+        assert!(after.closure_error() < 0.05, "{}", after.closure_error());
+
+        // Every point of the rotated lap is a point of the original, at the shifted distance.
+        let lap = before.lap_length();
+        let was = before.stations(1.0);
+        for st in after.stations(1.0) {
+            let s = (st.s + shift).rem_euclid(lap);
+            let near = was
+                .iter()
+                .map(|q| ((q.x - st.x).powi(2) + (q.z - st.z).powi(2)).sqrt())
+                .fold(f32::MAX, f32::min);
+            assert!(near < 0.6, "{:.1} m off the old lap at {s:.0} m", near);
+        }
+    }
+
+    #[test]
+    fn rotating_carries_the_features_round() {
+        let mut p = oval();
+        p.features = vec![Feature::Tabletop { at: 150.0, length: 20.0, height: 1.5 }];
+        p.elevation = vec![Knot { at: 150.0, height: 2.0 }];
+        let shift = p.rotate_start(1);
+        assert!((p.features[0].at() - (150.0 - shift)).abs() < 0.01, "{:?}", p.features[0]);
+        assert!((p.elevation[0].at - (150.0 - shift)).abs() < 0.01, "{:?}", p.elevation[0]);
+        p.check().expect("and the lap is still one the synthesiser will take");
+    }
+
+    #[test]
+    fn a_feature_left_straddling_the_finish_is_pulled_back_onto_it() {
+        let mut p = oval();
+        // Sits over the point the lap is about to start at, which after the rotation would
+        // put it half before the start and half past the finish.
+        let at = 40.0 * std::f32::consts::PI - 5.0;
+        p.features = vec![Feature::Tabletop { at, length: 20.0, height: 1.5 }];
+        p.rotate_start(1);
+        p.check().expect("nothing hangs off the end of the lap");
+    }
+
+    /// Prints [`EXAMPLE`] turned round to begin on a straight, in the layout the constant is
+    /// written in. Run when the example changes:
+    ///
+    /// ```text
+    /// cargo test -- --ignored --nocapture print_the_example
+    /// ```
+    #[test]
+    #[ignore = "prints a program"]
+    fn print_the_example_started_on_its_straight() {
+        let mut p: TrackProgram = serde_json::from_str(EXAMPLE).unwrap();
+        let features = p.features.clone();
+        let on_a_feature = |at: f32| {
+            features
+                .iter()
+                .any(|f| at > f.at() + 0.01 && at < f.at() + f.length() - 0.01)
+        };
+        let runs = p.straight_runs();
+        let longest = |it: &mut dyn Iterator<Item = &(usize, f32, f32)>| {
+            it.max_by(|a, b| a.2.total_cmp(&b.2)).copied()
+        };
+        let (index, _, len) = longest(&mut runs.iter().filter(|(_, at, _)| !on_a_feature(*at)))
+            .or_else(|| longest(&mut runs.iter()))
+            .expect("a straight to start on");
+        p.rotate_start(index);
+        println!("// {len:.0} m opening straight, closes to {:.2} m", p.closure_error());
+        println!(
+            "      \"start\": {{ \"x\": {:.2}, \"z\": {:.2}, \"angle\": {:.2} }},",
+            p.start.x, p.start.z, p.start.angle
+        );
+        println!("      \"segments\": [");
+        for seg in &p.segments {
+            match seg {
+                Segment::Straight { length, .. } => {
+                    println!("        {{ \"kind\": \"straight\", \"length\": {length:.4} }},")
+                }
+                Segment::Arc { radius, angle, .. } => println!(
+                    "        {{ \"kind\": \"arc\", \"radius\": {radius:.4}, \"angle\": {angle:.4} }},"
+                ),
+            }
+        }
+        println!("      ],");
+        println!("      \"features\": [");
+        for f in &p.features {
+            println!("        {},", serde_json::to_string(f).unwrap());
+        }
+        println!("      ]");
+    }
+
+    #[test]
+    fn the_example_starts_on_a_straight_long_enough_for_a_start() {
+        let p: TrackProgram = serde_json::from_str(EXAMPLE).unwrap();
+        assert!(
+            p.opening_straight() >= START_STRAIGHT_M,
+            "the example opens with {:.0} m of straight",
+            p.opening_straight()
+        );
+        assert!(p.closes(), "and it still meets itself");
     }
 
     #[test]

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -395,6 +395,8 @@ pub struct Synth {
     /// to the rider's right. Smoothed along the lap, so it leans into a corner before the
     /// corner and drifts back out after it rather than stepping across at the seams.
     pub line_lat: Vec<f32>,
+    /// How wide the start fans out, which every file that draws the track has to agree on.
+    pub fan: StartFan,
     /// What the terrain actually used of its budget, and what the budget was.
     pub used_m: f32,
     pub budget_m: f32,
@@ -532,6 +534,39 @@ pub struct Placement {
     pub grade_p90_deg: f32,
 }
 
+/// Turning a point about the origin by the same angle a heading is turned by.
+///
+/// Not the textbook rotation matrix. A heading of `theta` points along `(sin, cos)`, so it
+/// grows *clockwise* in the x/z plane and the usual `(xc - zs, xs + zc)` turns positions the
+/// other way. The search rotated positions with one and headings with the other, so what it
+/// scored and what a caller then built were mirror images of each other — the lap came out
+/// turned the wrong way round, and on a plot with no room to spare it came out off the edge.
+fn turn_point(x: f32, z: f32, c: f32, s: f32) -> (f32, f32) {
+    (x * c + z * s, -x * s + z * c)
+}
+
+/// Turn and shift a lap the way a [`Placement`] says.
+///
+/// Here rather than in the caller because it has to be the same arithmetic the search scored
+/// with: a placement applied differently from how it was measured is a number about a track
+/// nobody built.
+pub fn place(prog: &mut TrackProgram, p: &Placement) {
+    let (c, s) = (p.turn_deg.to_radians().cos(), p.turn_deg.to_radians().sin());
+    let st = prog.stations(SEARCH_STATION_M);
+    let (mut lo_x, mut hi_x, mut lo_z, mut hi_z) = (f32::MAX, f32::MIN, f32::MAX, f32::MIN);
+    for q in &st {
+        lo_x = lo_x.min(q.x);
+        hi_x = hi_x.max(q.x);
+        lo_z = lo_z.min(q.z);
+        hi_z = hi_z.max(q.z);
+    }
+    let (cx, cz) = ((lo_x + hi_x) * 0.5, (lo_z + hi_z) * 0.5);
+    let (rx, rz) = turn_point(prog.start.x - cx, prog.start.z - cz, c, s);
+    prog.start.x = cx + rx + p.dx;
+    prog.start.z = cz + rz + p.dz;
+    prog.start.angle += p.turn_deg;
+}
+
 /// How much fall across the track the search will trade a degree of grade for.
 ///
 /// Both matter and they pull against each other. Cross-slope is weighted the harder of the
@@ -540,12 +575,16 @@ pub struct Placement {
 const ROUTE_GRADE_TARGET_DEG: f32 = 8.3;
 const ROUTE_GRADE_WEIGHT: f32 = 0.35;
 
+/// How often the placement search samples the lap. Shared with [`place`], which turns the lap
+/// about the box these points make.
+const SEARCH_STATION_M: f32 = 2.0;
+
 /// Route a lap over its ground: pick the rotation and offset whose line has the least fall
 /// across it, at about the grade a published track climbs at.
 pub fn place_on_ground(prog: &TrackProgram) -> Option<Placement> {
     let land = Landscape::of(prog);
     let (sx, sz) = (prog.terrain.size_x, prog.terrain.size_z);
-    let base = prog.stations(2.0);
+    let base = prog.stations(SEARCH_STATION_M);
     if base.len() < 16 {
         return None;
     }
@@ -564,6 +603,10 @@ pub fn place_on_ground(prog: &TrackProgram) -> Option<Placement> {
     // centreline — and a little over, because the placement is scored on stations two metres
     // apart and the lap between two of them can bulge past both.
     let margin = prog.width * 2.0 + SHOULDER_M;
+    // The start needs more of it than the rest of the lap: the opening straight fans out to
+    // hold a 48 m gate row, and a fan hanging off the edge of the plot is gates in the void.
+    let run = prog.opening_straight();
+    let fan_margin = margin.max(START_FAN_HALF_M + SHOULDER_M);
 
     let score = |turn: f32, dx: f32, dz: f32| -> Option<(f32, f32, f32)> {
         let (c, s) = (turn.cos(), turn.sin());
@@ -571,12 +614,12 @@ pub fn place_on_ground(prog: &TrackProgram) -> Option<Placement> {
         let mut grade: Vec<f32> = Vec::with_capacity(base.len());
         let mut placed: Vec<(f32, f32, f32)> = Vec::with_capacity(base.len());
         for st in &base {
-            let (rx, rz) = (st.x - cx, st.z - cz);
-            let x = cx + rx * c - rz * s + dx;
-            let z = cz + rx * s + rz * c + dz;
+            let (rx, rz) = turn_point(st.x - cx, st.z - cz, c, s);
+            let (x, z) = (cx + rx + dx, cz + rz + dz);
             // Anything off the plot disqualifies the whole placement — a lap that leaves its
             // ground is not a candidate however well the rest of it lies.
-            if x < margin || z < margin || x > sx - margin || z > sz - margin {
+            let m = if st.s <= run { fan_margin } else { margin };
+            if x < m || z < m || x > sx - m || z > sz - m {
                 return None;
             }
             placed.push((x, z, st.heading + turn));
@@ -694,7 +737,10 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
     let feat = feature_profile(&prog.features, lap, prog.blend.max(0.0));
     let berms = berm_profile(&prog.features, &turn, lap);
     let ruts = rut_profile(&prog.features, &turn, lap, r.seed);
-    let widths = width_profile(prog.width * 0.5, lap, r.seed);
+    // The start fan, against the deck the lap is benched to: all of it is track, and as much
+    // of it as the ground beside the straight has room for is cut flat.
+    let fan = StartFan::of(prog, &stations, &along);
+    let (widths, flats) = width_profile(&fan, lap, r.seed);
     let chop = roughness_profile(&turn, lap);
 
     // 3. Bench the corridor in, then build on it.
@@ -717,8 +763,11 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
         // covers, how far the features reach, where the windrow sits. The plain one is what
         // the grading works from, because the shoulder reaches twenty metres into the field
         // and out there the two sides' wobbles meet along a line the eye reads as a crease.
-        let plain_half = widths.at(s);
-        let half = (plain_half
+        //
+        // They are the same number everywhere except across the start, where the fan is track
+        // for its whole width and flat for as much of it as there was room to cut.
+        let plain_half = flats.at(s);
+        let half = (widths.at(s)
             + EDGE_WOBBLE_M * fbm(s / EDGE_WOBBLE_WAVELENGTH_M, lane, r.seed ^ 0xE39E))
         .max(1.0);
 
@@ -736,7 +785,9 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
         }
         let f = feat.at(s);
         if f != 0.0 {
-            heights[i] += f * lateral(d, half);
+            // Against the graded width: a jump is an earthwork, and it reaches as far as the
+            // machine did rather than as far as the paint does.
+            heights[i] += f * lateral(d, plain_half.min(half));
         }
         // A berm stands on the outside of the corner, which is the side away from the turn.
         // Whatever the program asked for, plus what the corner would have grown on its own:
@@ -925,6 +976,7 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
         station,
         line_lat,
         stations,
+        fan,
         used_m: used,
         budget_m: budget,
     })
@@ -1185,13 +1237,15 @@ fn lateral(d: f32, half: f32) -> f32 {
 /// Not a constant. A track of exactly one width for its whole length reads as machine-made
 /// before you have looked at anything else — real ones pinch into corners and open onto the
 /// straights, and a tenth of the width is enough to break the tell.
-fn width_profile(half: f32, lap: f32, seed: u32) -> Profile {
-    let mut out = Profile::blank(lap);
-    for i in 0..out.v.len() {
+fn width_profile(fan: &StartFan, lap: f32, seed: u32) -> (Profile, Profile) {
+    let (mut track, mut flat) = (Profile::blank(lap), Profile::blank(lap));
+    for i in 0..track.v.len() {
         let s = i as f32 * PROFILE_STEP;
-        out.v[i] = half * (1.0 + WIDTH_WANDER * fbm(s / WIDTH_WAVELENGTH_M, 0.5, seed ^ 0x1D77));
+        let wander = 1.0 + WIDTH_WANDER * fbm(s / WIDTH_WAVELENGTH_M, 0.5, seed ^ 0x1D77);
+        track.v[i] = fan.at(s) * wander;
+        flat.v[i] = fan.bench_at(s) * wander;
     }
-    out
+    (track, flat)
 }
 
 /// The ruts, along the lap: how deep they are, how far across the track the bundle reaches,
@@ -1868,23 +1922,29 @@ pub fn write_source(prog: &TrackProgram, syn: &Synth, dir: &Path) -> Result<Vec<
 
     // The riding line, and everything that isn't it. Every boundary is torn rather than
     // drawn — see `edge_noise`.
-    let half = prog.width * 0.5;
     let seed = prog.terrain.relief.seed;
-    let dirt = mask_from(syn, MASK_DIM, |d, _, x, z| {
-        soft_edge(half + 1.5 + edge_noise(x, z, seed ^ 0xD127, 1.6, 0.7), 2.0, d)
+    let fan = &syn.fan;
+    // Every band is measured out from the width the track has *there*, so the start fan is
+    // painted, graded and surfaced as track rather than as a flat patch of field.
+    let dirt = mask_from(syn, MASK_DIM, |d, s, x, z| {
+        soft_edge(
+            fan.at(s) + 1.5 + edge_noise(x, z, seed ^ 0xD127, 1.6, 0.7),
+            2.0,
+            d,
+        )
     });
     // The shoulder: worked ground either side of the line, painted from the edge of the
     // riding surface out to where the field starts. It is most of what a rider sees.
-    let shoulder = mask_from(syn, MASK_DIM, |d, _, x, z| {
+    let shoulder = mask_from(syn, MASK_DIM, |d, s, x, z| {
         255 - soft_edge(
-            half + SHOULDER_M * 0.75 + edge_noise(x, z, seed ^ 0x5A1D, 2.4, 1.0),
+            fan.at(s) + SHOULDER_M * 0.75 + edge_noise(x, z, seed ^ 0x5A1D, 2.4, 1.0),
             5.0,
             d,
         )
     });
-    let grass = mask_from(syn, MASK_DIM, |d, _, x, z| {
+    let grass = mask_from(syn, MASK_DIM, |d, s, x, z| {
         255 - soft_edge(
-            half + SHOULDER_M + edge_noise(x, z, seed ^ 0x6EE2, 3.2, 1.2),
+            fan.at(s) + SHOULDER_M + edge_noise(x, z, seed ^ 0x6EE2, 3.2, 1.2),
             6.0,
             d,
         )
@@ -1892,17 +1952,22 @@ pub fn write_source(prog: &TrackProgram, syn: &Synth, dir: &Path) -> Result<Vec<
     // Off-track starts where the graded shoulder ends: the rider is on the track, or in the
     // field, with the shoulder belonging to neither. This one decides where the game says a
     // rider has gone off, so it is the one boundary that stays smooth.
-    let off = mask_from(syn, MASK_DIM, |d, _, _, _| {
-        255 - soft_edge(half + SHOULDER_M * 0.6, 3.0, d)
+    let off = mask_from(syn, MASK_DIM, |d, s, _, _| {
+        255 - soft_edge(fan.at(s) + SHOULDER_M * 0.6, 3.0, d)
     });
-    let start_len = 45.0f32.min(prog.lap_length() * 0.2);
+    // The start area is the fan itself: the whole of the opening straight, out to the width
+    // the gate row needs. It used to be a fixed forty-five metres of a track-and-a-bit wide
+    // strip, which covered neither the row nor the run at turn one.
+    let start_len = match prog.opening_straight() {
+        run if run > 20.0 => run,
+        _ => 45.0f32.min(prog.lap_length() * 0.2),
+    };
     let start = mask_from(syn, MASK_DIM, |d, s, _, _| {
-        if d <= half * 1.4 && s <= start_len {
-            255
-        } else {
-            0
-        }
+        u8::from(s <= start_len && d <= fan.at(s) * 1.05) * 255
     });
+    // These two keep the plain width: a rut is worn by everyone taking the same line and the
+    // loose stuff piles up beside it, and neither of those happens out on the start fan.
+    let half = prog.width * 0.5;
     let rut = rut_mask(syn, half, seed, MASK_DIM);
     let loose = loose_mask(syn, half, seed, MASK_DIM);
     put("mask_dirt.tga", tga_alpha(MASK_DIM, MASK_DIM, &dirt), &mut wrote)?;
@@ -1916,7 +1981,7 @@ pub fn write_source(prog: &TrackProgram, syn: &Synth, dir: &Path) -> Result<Vec<
     // The pit lane, in the same place the race data puts its stalls. It runs along the
     // opening straight, so the straight's own frame gives the side the lane is on — the
     // distance the other masks read is unsigned and would paint a lane on both sides.
-    let pits = pit_lane(prog);
+    let pits = pit_lane(prog, fan);
     let (fx, fz) = crate::trackprog::heading_vector(prog.start.angle.to_radians());
     let (rx, rz) = crate::trackprog::right_vector(prog.start.angle.to_radians());
     let pit_area = mask_from(syn, MASK_DIM, |_, _, x, z| {
@@ -2014,7 +2079,7 @@ pub fn write_source(prog: &TrackProgram, syn: &Synth, dir: &Path) -> Result<Vec<
     put(&format!("{slug}/{slug}.ini"), crlf(&track_ini(prog)), &mut wrote)?;
     put(&format!("{slug}/{slug}.amb"), crlf(AMB), &mut wrote)?;
     put(&format!("{slug}/gfx.cfg"), crlf(&gfx_cfg(prog)), &mut wrote)?;
-    put(&format!("{slug}/{slug}.rdf"), crlf(&rdf(prog)), &mut wrote)?;
+    put(&format!("{slug}/{slug}.rdf"), crlf(&rdf(prog, &syn.fan)), &mut wrote)?;
     put(&format!("{slug}/{slug}.ssc"), SSC.into(), &mut wrote)?;
     let (map_img, shot) = ui_images(syn, UI_IMAGE_DIM);
     put(&format!("{slug}/{slug}_map.tga"), map_img, &mut wrote)?;
@@ -2071,7 +2136,7 @@ fn feature_id(f: &Feature) -> u32 {
 /// Grouped by kind rather than one per feature: thirty masks would be thirty megabytes and
 /// the question being answered is "which of these is the double", not "which double".
 fn feature_masks(prog: &TrackProgram, syn: &Synth, dim: usize) -> Vec<(u32, Vec<u8>)> {
-    let half = prog.width * 0.5;
+    let fan = &syn.fan;
     let mut out: Vec<(u32, Vec<u8>)> = Vec::new();
     for f in &prog.features {
         let id = feature_id(f);
@@ -2087,7 +2152,8 @@ fn feature_masks(prog: &TrackProgram, syn: &Synth, dim: usize) -> Vec<(u32, Vec<
         out.push((
             id,
             mask_from(syn, dim, |d, s, _, _| {
-                let on = d <= half && spans.iter().any(|(lo, hi)| s >= *lo && s <= *hi);
+                let on = d <= fan.at(s)
+                    && spans.iter().any(|(lo, hi)| s >= *lo && s <= *hi);
                 u8::from(on) * 255
             }),
         ));
@@ -2114,7 +2180,6 @@ pub fn trh(prog: &TrackProgram, syn: &Synth, paint_features: bool) -> Vec<u8> {
     out.extend_from_slice(&prog.terrain.size_z.to_le_bytes());
     out.extend_from_slice(&[0u8; 12]);
 
-    let half = prog.width * 0.5;
     // Hard edges, unlike the `.tga` masks: those are blended into a texture, while these say
     // which surface a cell *is*. A soft edge here reads as a wider track — a metre of fade
     // each side put the riding line two metres over what it was built as.
@@ -2128,24 +2193,29 @@ pub fn trh(prog: &TrackProgram, syn: &Synth, paint_features: bool) -> Vec<u8> {
     // The bands wander the same way the painted ones do, so a preview and a compiled track
     // are the same track. Hard-edged still — soft is what made the line measure wide.
     let seed = prog.terrain.relief.seed;
-    let line_at = move |x: f32, z: f32| half + edge_noise(x, z, seed ^ 0xD127, 1.6, 0.7);
+    // Off the local width rather than off one number, so the start fan is surfaced as track.
+    // This file is what the game reads to decide whether a wheel is on the track at all: with
+    // a fixed width the outer thirty-six metres of the gate row stood on grass.
+    let fan = &syn.fan;
+    let line_at =
+        |s: f32, x: f32, z: f32| fan.at(s) + edge_noise(x, z, seed ^ 0xD127, 1.6, 0.7);
     let field_at =
-        move |x: f32, z: f32| half + shoulder + edge_noise(x, z, seed ^ 0x6EE2, 3.2, 1.2);
+        |s: f32, x: f32, z: f32| fan.at(s) + shoulder + edge_noise(x, z, seed ^ 0x6EE2, 3.2, 1.2);
     let mut masks: Vec<(u32, Vec<u8>)> = vec![
         // 10 is the riding line — the id published tracks paint their ribbon with.
         (
             10,
-            mask_from(syn, dim, |d, _, x, z| u8::from(d <= line_at(x, z)) * 255),
+            mask_from(syn, dim, |d, s, x, z| u8::from(d <= line_at(s, x, z)) * 255),
         ),
         (
             shoulder_id,
-            mask_from(syn, dim, |d, _, x, z| {
-                u8::from(d > line_at(x, z) && d <= field_at(x, z)) * 255
+            mask_from(syn, dim, |d, s, x, z| {
+                u8::from(d > line_at(s, x, z) && d <= field_at(s, x, z)) * 255
             }),
         ),
         (
             1,
-            mask_from(syn, dim, |d, _, x, z| u8::from(d > field_at(x, z)) * 255),
+            mask_from(syn, dim, |d, s, x, z| u8::from(d > field_at(s, x, z)) * 255),
         ),
     ];
     if paint_features {
@@ -2322,15 +2392,225 @@ fn ground(s: Surface) -> (u32, f32) {
 ///
 /// Untested against the game — nothing here has been loaded by MX Bikes. The structure is
 /// right; whether every field means what it looks like is not something a macOS box can say.
+/// How many gates the row holds, and how wide a lane each one gets.
+///
+/// Forty at 1.2 m, because that is what every modern track ships: Indiana, Millville,
+/// Washougal, Maryland and the GP tracks all say 40, and their lane widths run 1.1 to 1.3.
+const GRID_STALLS: usize = 40;
+const GRID_LANE_M: f32 = 1.2;
+
+/// How far into the opening straight the gate row stands, and how far past it the line is.
+///
+/// The row is a few metres in so the gates and the thirty-second board have dirt under them,
+/// and the finish line sits ahead of it: riders cross the line the moment the gate drops, and
+/// everything else round the lap is measured from there.
+const GATE_INSET_M: f32 = 5.0;
+const GATE_TO_LINE_M: f32 = 12.0;
+
 /// Where the finish line and the gate row sit, in metres round the lap.
+///
+/// On the opening straight, at its beginning, because that is what a start straight is for.
+/// It used to be a fraction of the lap — six per cent, up to forty metres — which put the row
+/// wherever the lap happened to be forty metres in, and on a lap that opens on a corner that
+/// is a gate row laid round a bend. `trackllm::repair` turns a generated lap round so it
+/// begins on its longest straight; this is what then sits on it.
 ///
 /// Shared, because the race data places them, the start `.tcl` begins at the gate, and the
 /// collision file paints the start area around it. Three files disagreeing about where a
 /// race starts is a race that starts in the wrong place.
 fn start_marks(prog: &TrackProgram) -> (f32, f32) {
-    // Far enough in that the gate behind it is still on the opening straight.
-    let line = (prog.lap_length() * 0.06).clamp(10.0, 40.0);
-    (line, (line - 12.0).max(1.0))
+    let run = prog.opening_straight();
+    // A lap with no straight at its start has nowhere to lay this out. Rather than put the
+    // row on a corner at a made-up distance, it goes where it always went — and the studio
+    // says so, so the fix is a straight rather than a mystery.
+    if run < GATE_INSET_M + GATE_TO_LINE_M {
+        let line = (prog.lap_length() * 0.06).clamp(10.0, 40.0);
+        return (line, (line - 12.0).max(1.0));
+    }
+    let gate = GATE_INSET_M.min(run * 0.1);
+    (gate + GATE_TO_LINE_M, gate)
+}
+
+/// How wide the start fans out, as a half-width in metres.
+///
+/// The gate row is 48 m across and it stands *on the track*, so the track has to be that wide
+/// where it stands. This is not the riding line being too wide: a start straight is a fan
+/// that funnels into turn one, and the published tracks measure 13 to 15 m at the finish line
+/// with a 45 to 53 m row of gates on the start.
+pub const START_FAN_HALF_M: f32 = GRID_STALLS as f32 * GRID_LANE_M * 0.5 + 3.0;
+
+/// How far back from the gate row the fan reaches, metres. The lap's last corner feeds onto
+/// the start straight, so the width has somewhere to come from.
+const START_FAN_BEHIND_M: f32 = 25.0;
+
+/// The start fan: how far the opening straight opens out, and over what stretch of the lap.
+///
+/// The riding line is one width all the way round except here. A start is a fan that holds
+/// forty gates in a line and funnels into turn one, and everything that reads a width has to
+/// agree about it — the corridor, the ground it is benched into, the surfaces the collision
+/// file paints, the sheets the graphics map is drawn with. A fan that only one of them knows
+/// about is a gate row in the grass, so it is measured once and carried on the [`Synth`].
+///
+/// Two widths, not one. The gate row needs 27 m of *track* either side of the line whatever
+/// else is true — forty gates have to stand on dirt — but only some of that can be cut flat.
+/// A published start is a graded pad because a published start straight has a field beside it;
+/// a generated lap folds back on itself every eighty metres, and grading a 54 m pad across a
+/// pass of the track sitting three metres higher benches the same cells to two heights and
+/// leaves a wall down the edge of it. So the whole fan is surfaced, and the flat part takes
+/// the room the ground actually has — see [`StartFan::of`].
+#[derive(Clone, Debug)]
+pub struct StartFan {
+    /// Half-width at the gate row: what is surfaced and painted as track.
+    half: f32,
+    /// How much of it can be graded flat, half-width in metres every [`PROFILE_STEP`] round
+    /// the lap. As much as the ground beside the straight has room for, which varies along it
+    /// — a fan is usually widest where the straight is furthest from the rest of the lap.
+    /// Empty until the ground has been measured, which means "as much as it likes".
+    flat: Vec<f32>,
+    /// The riding line's own half-width, which is what it narrows back to.
+    line_half: f32,
+    /// The opening straight, and where the gate row stands on it.
+    run: f32,
+    gate: f32,
+    lap: f32,
+}
+
+/// How far the decks either side of a boundary may differ before grading across it is a step
+/// rather than a slope.
+const FAN_DECK_STEP_M: f32 = 0.6;
+
+impl StartFan {
+    /// The fan the start would like, before the ground has a say: what the race data lays a
+    /// gate row out against, and what a placement leaves room for.
+    pub fn intended(prog: &TrackProgram) -> StartFan {
+        let line_half = prog.width * 0.5;
+        let run = prog.opening_straight();
+        let (_, gate) = start_marks(prog);
+        let wanted = if run < gate + 10.0 { line_half } else { START_FAN_HALF_M.max(line_half) };
+        StartFan {
+            half: wanted,
+            flat: Vec::new(),
+            line_half,
+            run,
+            gate,
+            lap: prog.lap_length().max(1.0),
+        }
+    }
+
+    /// And how much of it the ground will let us grade flat. `deck` is the height the lap is
+    /// benched to at each station, which is what says whether a neighbouring pass is in the
+    /// way.
+    ///
+    /// The whole fan is surfaced as track whatever this returns — the gate row has to have
+    /// dirt under it — but only this much of it is cut flat. A published start is a graded
+    /// pad because a published start straight has a field beside it; a generated lap folds
+    /// back on itself every eighty metres, and grading a 54 m pad across a pass of the track
+    /// sitting three metres higher benches the same cells to two different heights and leaves
+    /// a wall down the edge of it. So the flat part stops short of any ground the lap has
+    /// already claimed at a different height, and the rest of the fan follows the landscape.
+    ///
+    /// What matters is the ground *abeam* the straight, not the ground near it. A station a
+    /// hundred metres further up the same straight is close by and no obstacle at all — the
+    /// bench runs smoothly into it — while a pass of the lap crossing thirty metres to the
+    /// side at a different height is a wall waiting to happen. So each point on the straight
+    /// looks sideways, and only at ground whose deck it could not blend into.
+    pub fn of(prog: &TrackProgram, stations: &[Station], deck: &[f32]) -> StartFan {
+        let mut fan = StartFan::intended(prog);
+        if fan.half <= fan.line_half || stations.len() != deck.len() {
+            return fan;
+        }
+        // Every station, not only the ones on the straight: the fan reaches back over the end
+        // of the lap as well, and the taper says how wide it is at each of them.
+        //
+        // How far past the fan's edge its own bench reaches, and how far ahead or behind a
+        // station still counts as beside us rather than in front of us.
+        let reach = SHOULDER_M * FILL_SHOULDER;
+        const ABEAM_M: f32 = 10.0;
+
+        let mut flat: Vec<f32> = (0..((fan.lap / PROFILE_STEP).ceil() as usize + 2))
+            .map(|i| fan.at(i as f32 * PROFILE_STEP))
+            .collect();
+        for (i, a) in stations.iter().enumerate() {
+            if fan.taper(a.s) > 0.99 {
+                continue;
+            }
+            let (fx, fz) = crate::trackprog::heading_vector(a.heading);
+            let (rx, rz) = crate::trackprog::right_vector(a.heading);
+            let mut room = f32::MAX;
+            for (j, b) in stations.iter().enumerate() {
+                if (deck[i] - deck[j]).abs() < FAN_DECK_STEP_M {
+                    continue;
+                }
+                let (dx, dz) = (b.x - a.x, b.z - a.z);
+                if (dx * fx + dz * fz).abs() > ABEAM_M {
+                    continue;
+                }
+                // Halfway is where the cells stop being ours and start being that pass's, and
+                // the bench has to have faded by then.
+                room = room.min((dx * rx + dz * rz).abs() * 0.5 - reach);
+            }
+            // Never below the track's own width: where the lap is already that tight, the
+            // plain riding line lives there and the fan is not what put it there.
+            let room = room.max(fan.line_half);
+            // Over the station's own stretch, so the samples between two stations are held to
+            // the tighter of them.
+            let lo = ((a.s - STATION_STEP) / PROFILE_STEP).floor().max(0.0) as usize;
+            let hi = (((a.s + STATION_STEP) / PROFILE_STEP).ceil() as usize).min(flat.len() - 1);
+            for f in &mut flat[lo..=hi] {
+                *f = f.min(room);
+            }
+        }
+        fan.flat = flat;
+        fan
+    }
+
+    /// The riding line's half-width this far round the lap.
+    ///
+    /// Widest at the gate row, easing down to the track's own width by the end of the opening
+    /// straight, and easing back up over the last few metres of the lap — the last corner
+    /// feeds onto the start straight, so the width has somewhere to come from.
+    pub fn at(&self, s: f32) -> f32 {
+        self.widen(self.half, s)
+    }
+
+    /// And how wide the flat ground under it is, which is never wider than the fan.
+    pub fn bench_at(&self, s: f32) -> f32 {
+        if self.flat.is_empty() {
+            return self.at(s);
+        }
+        let x = (s / PROFILE_STEP).clamp(0.0, (self.flat.len() - 1) as f32);
+        let i = x.floor() as usize;
+        let (a, b) = (self.flat[i], self.flat[(i + 1).min(self.flat.len() - 1)]);
+        (a + (b - a) * (x - i as f32)).min(self.at(s))
+    }
+
+    fn widen(&self, to: f32, s: f32) -> f32 {
+        if to <= self.line_half {
+            return self.line_half;
+        }
+        to + (self.line_half - to) * self.taper(s)
+    }
+
+    /// How far through the funnel a point is: 0 across the gate row, 1 where the start is
+    /// over and the track is its own width again.
+    fn taper(&self, s: f32) -> f32 {
+        let u = if s >= self.gate && s <= self.run {
+            (s - self.gate) / (self.run - self.gate)
+        } else {
+            let behind = if s < self.gate { self.gate - s } else { self.lap - s + self.gate };
+            behind / START_FAN_BEHIND_M
+        };
+        smoothstep(u.clamp(0.0, 1.0))
+    }
+
+    /// How wide the start comes out, across the whole row, and how much of it is flat.
+    pub fn width_m(&self) -> f32 {
+        self.half * 2.0
+    }
+
+    pub fn bench_width_m(&self) -> f32 {
+        self.bench_at(self.gate) * 2.0
+    }
 }
 
 /// The pit lane: alongside the opening straight, a track's width off the racing line.
@@ -2349,19 +2629,25 @@ struct PitLane {
     half_width: f32,
 }
 
-fn pit_lane(prog: &TrackProgram) -> PitLane {
+fn pit_lane(prog: &TrackProgram, fan: &StartFan) -> PitLane {
     let (_, gate_at) = start_marks(prog);
-    let stalls = 16;
+    // Beside the straight, not across it: the lane clears whatever the track is at the gates,
+    // which on a start is the fan and not the riding line.
+    let lat = -(fan.at(gate_at) + 6.0);
+    // As many as fit alongside the straight. The lane used to run a fixed eighty metres from
+    // the gates, which on a short start straight carried it out into the field past turn one.
+    let run = prog.opening_straight().max(prog.lap_length() * 0.1);
+    let stalls = (((run - gate_at) / 5.0).floor() as usize).clamp(4, 16);
     PitLane {
         stalls,
-        lat: -(prog.width * 0.5 + 6.0),
+        lat,
         from: gate_at,
         to: gate_at + (stalls - 1) as f32 * 5.0,
         half_width: 4.0,
     }
 }
 
-fn rdf(prog: &TrackProgram) -> String {
+fn rdf(prog: &TrackProgram, fan: &StartFan) -> String {
     let lap = prog.lap_length();
     let half = prog.width * 0.5;
     let (line, gate_at) = start_marks(prog);
@@ -2373,11 +2659,14 @@ fn rdf(prog: &TrackProgram) -> String {
             -w, w
         ));
     };
-    mark(&mut s, "finish_line", line, half);
+    // The finish line spans the start straight, not the riding line: forty riders leave the
+    // gate abreast across the whole fan, and a timing plane six metres either side of the
+    // centre is one most of them cross outside of.
+    mark(&mut s, "finish_line", line, fan.at(line).max(half));
     mark(&mut s, "split1", (line + lap / 3.0) % lap, half);
     mark(&mut s, "split2", (line + lap * 2.0 / 3.0) % lap, half);
 
-    let pits = pit_lane(prog);
+    let pits = pit_lane(prog, fan);
     let (stalls, lane_lat) = (pits.stalls, pits.lat);
     s.push_str(&format!(
         "pit_lane\n{{\n\tnumstalls = {stalls}\n\tstarttype = 1\n\tstartstartlong = 0.000000\n\
@@ -2411,24 +2700,22 @@ fn rdf(prog: &TrackProgram) -> String {
 
     // One row of gates across the start, which is what a motocross start is.
     //
-    // Forty of them, at 1.2 m apart, because that is what every modern track ships: Indiana,
-    // Millville, Washougal, Maryland and the GP tracks all say 40, and their lane widths run
-    // 1.1 to 1.3. Twenty-four at 1.5 was a guess.
-    //
     // The row is far wider than the riding line — 48 m against 14 — and that is correct. A
-    // start straight is a wide fan that funnels into the track; the published tracks measure
-    // 13 to 15 m at the finish line and still put a 45 to 53 m gate row on the start.
+    // start straight is a wide fan that funnels into the track, and `StartFan` is what
+    // builds the dirt the row stands on.
     //
-    // What was wrong is where the row was anchored. `posx`/`posz` is one *end* of it, not the
-    // middle, so anchoring at the centreline laid all forty gates out to one side and left
-    // every one of them off the track. The anchor now sits half a row-width to the side so
-    // the gates come out centred on the line.
-    let grid = 40;
-    let lane = 1.2f32;
+    // Two things about where it goes were wrong. `posx`/`posz` is one *end* of the row, not
+    // the middle, so anchoring at the centreline laid all forty gates out to one side; the
+    // anchor sits half a row-width across to fix that. And it was anchored at the lap's start
+    // while every stall below said `long = gate_at`, so the row the game drew stood metres
+    // behind the stalls the riders were put in. Both now measure from the same point.
+    let grid = GRID_STALLS;
+    let lane = GRID_LANE_M;
     let span = grid as f32 * lane;
+    let (fx, fz) = crate::trackprog::heading_vector(prog.start.angle.to_radians());
     let (rx, rz) = crate::trackprog::right_vector(prog.start.angle.to_radians());
-    let anchor_x = prog.start.x + rx * span * 0.5;
-    let anchor_z = prog.start.z + rz * span * 0.5;
+    let anchor_x = prog.start.x + fx * gate_at + rx * span * 0.5;
+    let anchor_z = prog.start.z + fz * gate_at + rz * span * 0.5;
     s.push_str(&format!(
         "starting_grid\n{{\n\tnumstalls = {grid}\n\ttype = 1\n\tposx = {anchor_x:.6}\n\
          \tposz = {anchor_z:.6}\n\tangle = {:.6}\n\tnumstallsperrow = {grid}\n\
@@ -2461,14 +2748,17 @@ fn rdf(prog: &TrackProgram) -> String {
         ));
     }
 
+    // The thirty-second board stands beside the gates, so it clears the fan rather than the
+    // riding line — and never behind the start of the lap, which is where `gate_at - 4` put
+    // it once the row moved to the top of the straight.
+    let board_at = (gate_at - 4.0).max(0.5);
     s.push_str(&format!(
         "30secondsboard_posx = {:.6}\n30secondsboard_posz = {:.6}\n30secondsboard_angle = {:.6}\n\
-         30seconds_board\n{{\n\tlong = {:.6}\n\tlat = {:.6}\n\tangle = 0.000000\n}}\n",
+         30seconds_board\n{{\n\tlong = {board_at:.6}\n\tlat = {:.6}\n\tangle = 0.000000\n}}\n",
         prog.start.x,
         prog.start.z,
         prog.start.angle - 90.0,
-        gate_at - 4.0,
-        -(half + 3.0)
+        -(fan.at(gate_at) + 3.0)
     ));
     s
 }
@@ -2630,13 +2920,14 @@ fn map(prog: &TrackProgram, syn: &Synth) -> Vec<u8> {
     let dim = GROUND_TEXTURE_DIM;
     let half = prog.width * 0.5;
     let (_, shoulder_scale) = ground(prog.terrain.surface);
+    let fan = &syn.fan;
     // The same bands the exported track is painted with, so what the studio draws is what
     // gets ridden. Anything keyed off the racing line comes from the shared mask functions.
     let bands: [(&str, &GroundLook, u32, f32, BandMask); 6] = [
         ("ground_c", &field, 0x9A0D, TILE_FIELD_M, BandMask::Everywhere),
         ("shoulder_c", &shoulder, 0x30D2, TILE_SHOULDER_M,
-         BandMask::Within(half + SHOULDER_M * shoulder_scale)),
-        ("dirt_line_c", &ridden, 0x11E5, TILE_LINE_M, BandMask::Within(half)),
+         BandMask::Out(SHOULDER_M * shoulder_scale)),
+        ("dirt_line_c", &ridden, 0x11E5, TILE_LINE_M, BandMask::Out(0.0)),
         ("loose_c", &loose, 0x7C41, TILE_LOOSE_M, BandMask::Loose),
         ("rut_c", &rut, 0x5B93, TILE_RUT_M, BandMask::Rut),
         ("grass_c", &turf, 0x6A55, TILE_GRASS_M, BandMask::Beyond),
@@ -2719,13 +3010,12 @@ fn map(prog: &TrackProgram, syn: &Synth) -> Vec<u8> {
                     BandMask::Everywhere => unreachable!(),
                     BandMask::Rut => rut_mask(syn, half, seed, mw),
                     BandMask::Loose => loose_mask(syn, half, seed, mw),
-                    BandMask::Beyond => {
-                        let to = half + SHOULDER_M;
-                        mask_rect(syn, mw, mh, |d, _, _, _| u8::from(d > to) * 255)
-                    }
-                    BandMask::Within(to) => {
-                        mask_rect(syn, mw, mh, |d, _, _, _| u8::from(d <= to) * 255)
-                    }
+                    BandMask::Beyond => mask_rect(syn, mw, mh, |d, s, _, _| {
+                        u8::from(d > fan.at(s) + SHOULDER_M) * 255
+                    }),
+                    BandMask::Out(extra) => mask_rect(syn, mw, mh, |d, s, _, _| {
+                        u8::from(d <= fan.at(s) + extra) * 255
+                    }),
                 };
                 let packed = deflate_raw(&m);
                 out.extend_from_slice(&u(1));
@@ -2879,7 +3169,7 @@ pub fn write_pkz(
         (format!("{slug}/{slug}.trh"), trh(prog, syn, paint_features)),
         (format!("{slug}/{slug}.map"), map(prog, syn)),
         (format!("{slug}/{slug}.ini"), crlf(&track_ini(prog))),
-        (format!("{slug}/{slug}.rdf"), crlf(&rdf(prog))),
+        (format!("{slug}/{slug}.rdf"), crlf(&rdf(prog, &syn.fan))),
         (format!("{slug}/{slug}.amb"), crlf(AMB)),
         (format!("{slug}/gfx.cfg"), crlf(&gfx_cfg(prog))),
         // Empty on the reference track, and on every track that ships one.
@@ -3017,8 +3307,9 @@ fn mask_across(syn: &Synth, dim: usize, f: impl Fn(f32, f32, f32, f32, f32, f32)
 enum BandMask {
     /// The base band: everything, and so no mask at all.
     Everywhere,
-    /// Within this many metres of the centreline.
-    Within(f32),
+    /// Out to the riding line's own width, plus this many metres. Not a fixed distance: the
+    /// start fans out to hold the gate row, and dirt painted at one width leaves it green.
+    Out(f32),
     /// Past the shoulder — the field and the turf on it.
     Beyond,
     /// The packed racing line.
@@ -4309,10 +4600,53 @@ mod tests {
     fn the_corridor_is_the_width_it_was_asked_for() {
         let p = oval();
         let s = synthesise(&p).unwrap();
-        let area = s.corridor.iter().filter(|c| **c).count() as f32 * s.mps * s.mps;
-        // Area over length is the width, give or take the ends of the lap.
-        let width = area / p.lap_length();
+        // Away from the start. The opening straight fans out to hold the gate row, and that
+        // is the one stretch of a track that is deliberately not the width it was asked for.
+        let (from, to) = (p.opening_straight(), p.lap_length() - START_FAN_BEHIND_M);
+        let cells = s
+            .corridor
+            .iter()
+            .enumerate()
+            .filter(|(i, c)| **c && s.arc[*i] > from && s.arc[*i] < to)
+            .count();
+        // Area over length is the width, give or take the ends of the stretch.
+        let width = cells as f32 * s.mps * s.mps / (to - from);
         assert!((width - p.width).abs() < 1.0, "measured {width:.2} m");
+    }
+
+    /// The gate row is 48 m across. Forty gates on a 12 m track is thirty-six metres of them
+    /// standing in the field, which is what a start straight that isn't one looks like.
+    #[test]
+    fn the_start_fans_out_far_enough_to_hold_the_gate_row() {
+        let p = oval();
+        let s = synthesise(&p).unwrap();
+        let (_, gate) = start_marks(&p);
+        let span = GRID_STALLS as f32 * GRID_LANE_M;
+        // The widest cell on the row, measured off the line the way the game measures a
+        // stall's `lat`.
+        let reach = s
+            .corridor
+            .iter()
+            .enumerate()
+            .filter(|(i, c)| **c && (s.arc[*i] - gate).abs() < 2.0)
+            .map(|(i, _)| s.dist[i])
+            .fold(0.0f32, f32::max);
+        assert!(
+            reach >= span * 0.5,
+            "the row is {span:.0} m across and the track reaches {reach:.1} m off the line"
+        );
+        // And back to the track's own width by the end of the straight.
+        let narrowed = s
+            .corridor
+            .iter()
+            .enumerate()
+            .filter(|(i, c)| **c && (s.arc[*i] - p.opening_straight()).abs() < 2.0)
+            .map(|(i, _)| s.dist[i])
+            .fold(0.0f32, f32::max);
+        assert!(
+            narrowed < p.width,
+            "it is still {narrowed:.1} m wide where it meets turn one"
+        );
     }
 
     /// Two jumps close together must not add up. Before, the ground between a pair of
@@ -4527,7 +4861,7 @@ mod tests {
     #[test]
     fn the_race_data_has_the_blocks_the_game_looks_for() {
         let p: TrackProgram = serde_json::from_str(DEMO).unwrap();
-        let text = rdf(&p);
+        let text = rdf(&p, &StartFan::intended(&p));
         for block in [
             "finish_line",
             "split1",
@@ -4937,7 +5271,7 @@ mod tests {
 
         let tga = std::fs::read(dir.join("area_pits.tga")).unwrap();
         let px = &tga[18..18 + MASK_DIM * MASK_DIM * 4];
-        let pits = pit_lane(&p);
+        let pits = pit_lane(&p, &StartFan::intended(&p));
         let (fx, fz) = crate::trackprog::heading_vector(p.start.angle.to_radians());
         let (rx, rz) = crate::trackprog::right_vector(p.start.angle.to_radians());
 
@@ -5460,6 +5794,50 @@ mod tests {
             placed.cross_m,
             placed.was_cross_m
         );
+    }
+
+    #[test]
+    #[ignore = "prints numbers"]
+    fn print_the_fan() {
+        for (name, json) in [("demo", DEMO), ("example", crate::trackprog::EXAMPLE)] {
+            let mut p: TrackProgram = serde_json::from_str(json).unwrap();
+            let _ = crate::trackllm::repair_for_tests(&mut p);
+            let s = synthesise(&p).unwrap();
+            let (_, gate) = start_marks(&p);
+            println!(
+                "{name}: opening straight {:.0} m, fan {:.1} m wide at the gates ({:.1} m of \
+                 it flat) against a {:.0} m track, row {:.0} m",
+                p.opening_straight(),
+                s.fan.width_m(),
+                s.fan.bench_width_m(),
+                p.width,
+                GRID_STALLS as f32 * GRID_LANE_M,
+            );
+            let _ = gate;
+        }
+    }
+
+    /// The lap that gets placed has to be the lap that was scored. Positions were turned one
+    /// way and headings the other, so applying a placement built the mirror of what the search
+    /// had measured — a lap routed to lie along the hill came out lying across it, and on a
+    /// plot with no room to spare it came out over the edge.
+    #[test]
+    fn the_lap_that_gets_placed_is_the_lap_that_was_scored() {
+        let mut p: TrackProgram = serde_json::from_str(DEMO).unwrap();
+        p.terrain.relief.landforms = 8;
+        p.terrain.relief.landform_height = 18.0;
+        let placed = place_on_ground(&p).expect("a lap that fits has a placement");
+        place(&mut p, &placed);
+        // Scored again where it now lies: the untouched figure this time is the one the
+        // search promised last time.
+        let after = place_on_ground(&p).expect("and it can be scored where it landed");
+        assert!(
+            (after.was_cross_m - placed.cross_m).abs() < 0.15,
+            "placed a lap measuring {:.2} m where {:.2} m was scored",
+            after.was_cross_m,
+            placed.cross_m
+        );
+        p.check().expect("and it is still on its ground");
     }
 
     #[test]


### PR DESCRIPTION
The gate row landed wherever the lap happened to be forty metres in — on a corner, as often as not, with forty gates laid round a bend and the pit lane and the thirty-second board out in a field beside it.

## What it does

- **`TrackProgram::rotate_start`** turns a lap round to begin at any segment: the same ground, ridden from a different point on it. Features and elevation knots travel with it; one left straddling the new finish is pulled back onto it.
- **`repair`** uses it — after closing the lap, before fitting the plot — to start a generated lap on its longest straight that is clear of everything built for the first 60 m. `review` says so when there isn't one, and the control plane's prompt asks for a 60–100 m opener with nothing on it.
- **The race data is laid out from that straight** rather than from a fraction of the lap: gate row five metres on, finish line twelve past it, the rest as the run at turn one. The pit lane fits itself alongside, and the finish line spans the start rather than the riding line.
- **`StartFan`** fans the track out to 54 m across the gate row — forty gates at 1.2 m — and funnels it back to riding width by turn one. Every file that draws the track reads it: corridor, bench, `.trh` surfaces, `.map` sheets, the exported masks and the preview painter, so the gates stand on dirt in the game as well as in the picture.
- **Only as much of the fan as the ground has room for is graded flat.** A pass of the lap running abeam at a different height would otherwise be benched twice and leave a wall down the edge of the pad — the "no straight lines in the terrain" test caught a 3.5 m one. Measured against the deck the lap is benched to, so the corner feeding onto the straight is no obstacle and the pass climbing back past it four metres up is.
- The built-in example lap now begins on its own 145 m straight.

## Two things that were wrong underneath

- `starting_grid`'s `posx`/`posz` sat at `long = 0` while every stall said `long = gate_at`, so the row the game drew stood metres behind the riders it put in it.
- The placement search turned positions one way and headings the other: a lap routed to lie along the ground was built as the mirror of what was measured, and on a full plot it came out over the edge. One convention now, and `tracksynth::place` applies exactly what `place_on_ground` scored — with a test that fails on the old maths.

## Checks

Full suite 1306 passed / 0 failed. `builds_a_track` measures a 16.5 m corridor against the corpus's 8–20, and the terrain carries no coherent step over 0.6 m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)