### PR TITLE
feat(tracks): render the track picture instead of diagramming it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 2026-09-05
 
 ### Changed
+- The picture the game lists a built track by is now a view of the place rather than a
+  diagram of it: the ground rendered from above and off to one side, lit by the track's own
+  sun, with the lap cut into it and the country running out to the haze.
 - Tracks you build now start where a start belongs. The lap begins on its longest straight,
   with the gate row a few metres onto it, the finish line past that and the run at turn one
   beyond — instead of the gates landing wherever the lap happened to be forty metres in.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -141,6 +141,7 @@ mod trackbuild;
 mod trackline;
 mod trackllm;
 mod trackprog;
+mod trackshot;
 mod trackstats;
 mod tracksynth;
 mod upload;

--- a/src-tauri/src/trackshot.rs
+++ b/src-tauri/src/trackshot.rs
@@ -1,0 +1,616 @@
+//! The picture the game shows beside a track's name.
+//!
+//! Not a map. `<track>_map.tga` is the plan view the game draws the route over and it has to
+//! stay one; this is the photograph. A flat false-colour relief with the lap tinted over it
+//! tells a player nothing they can't read off the map, so this renders the terrain properly:
+//! a camera above and off to one side, the grid rasterised through a depth buffer, lit by the
+//! same sun the track's own `.amb` declares, and hazed with distance.
+//!
+//! Nothing here knows what a track is. It takes a heightfield, a sheet of ground colour and a
+//! set of points the frame has to hold, which is all a picture of one needs.
+
+/// What to render, and what to light it with.
+pub struct Scene<'a> {
+    pub gw: usize,
+    pub gh: usize,
+    /// Metres between samples, both axes — the grid's cells are square.
+    pub mps: f32,
+    /// Metres, `gw * gh`, row-major, row zero at `z = 0`.
+    pub heights: &'a [f32],
+    /// The ground's colour, `adim * adim`, sampled by where a point is across the terrain
+    /// rather than by grid index — it is a sheet, not a per-vertex attribute, so it can be
+    /// finer or coarser than the heightfield without either one caring.
+    pub albedo: &'a [[f32; 3]],
+    pub adim: usize,
+    /// World `(x, z)` the frame must hold. The camera is placed and pulled back to fit these
+    /// and nothing else, so a lap on a corner of a big terrain still fills the picture.
+    pub focus: &'a [(f32, f32)],
+    /// Direction *to* the sun, and the light either side of it. Straight off the `.amb`, so
+    /// the picture is lit the way the track is.
+    pub sun: [f32; 3],
+    pub sun_colour: [f32; 3],
+    pub ambient: [f32; 3],
+    /// The sky overhead, at the horizon, and the haze the distance goes to.
+    pub zenith: [f32; 3],
+    pub horizon: [f32; 3],
+    pub haze: [f32; 3],
+    /// How far above the ground the camera sits, degrees. Low reads as a photograph and hides
+    /// the lap behind its own hills; straight down reads as the map again. See [`TILT_DEG`].
+    pub tilt_deg: f32,
+}
+
+/// Bird's eye, tilted: high enough that the whole lap reads as a shape, shallow enough that
+/// the hills under it have a near side and a far side.
+pub const TILT_DEG: f32 = 36.0;
+
+/// Fairly long, because a wide lens bends a lap into a bowl and puts the near corner of the
+/// terrain in your face.
+const FOV_DEG: f32 = 36.0;
+
+/// How much of the frame the focus points fill.
+const FIT: f32 = 0.88;
+
+/// Rendered at twice the picture's size and averaged down. A heightfield's silhouette against
+/// the sky is one long near-horizontal edge, which is the worst case for aliasing.
+const SS: usize = 2;
+
+/// The grid is sampled down to at most this many vertices across before it is drawn. A quad
+/// smaller than a pixel costs the same as one that fills the screen and shows less; the relief
+/// it carries is kept, because normals are still taken from the full-resolution neighbours.
+const MESH_MAX: usize = 400;
+
+/// Nothing closer than this is drawn — it is behind the lens.
+const NEAR_M: f32 = 1.0;
+
+/// How many rings of ground are carried on past the terrain's edge before the haze has them.
+const APRON: usize = 28;
+
+/// Over how many metres the apron's ground levels off to the country's own height.
+const APRON_LEVEL_M: f32 = 90.0;
+
+/// And how quickly it stops being the terrain's colour. Much shorter than the levelling: a
+/// smeared colour shows as streaks radiating out of the picture, where a smeared height only
+/// shows as a gentle shelf.
+const APRON_TINT_M: f32 = 25.0;
+
+/// The picture, `dim * dim` RGB, row zero at the top.
+pub fn render(scene: &Scene, dim: usize) -> Vec<[u8; 3]> {
+    let sdim = dim * SS;
+    let cam = fit(scene);
+
+    // The mesh: the heightfield sampled down, with each vertex already projected and shaded.
+    //
+    // And an apron of ground carried on past the terrain's own edge. A terrain is a few
+    // hundred metres square and the horizon is not, so without one the picture is a slab of
+    // land floating in the sky with a cut edge — the apron holds the border height and colour
+    // and runs out until the haze has it, which is what standing on a track looks like.
+    // What the country past the terrain is made of: the average of the sheet's own border, so
+    // the join is invisible whatever the ground is painted with. Guessing it — the field's
+    // base colour, say — puts a square of terrain in a plain of a different colour, because
+    // the outermost band a track paints is the turf and not the soil under it.
+    let country = border(scene);
+    let flat = level(scene);
+    let stride = scene.gw.max(scene.gh).div_ceil(MESH_MAX).max(1);
+    let span_x = (scene.gw - 1) as f32 * scene.mps;
+    let span_z = (scene.gh - 1) as f32 * scene.mps;
+    let reach = cam.reach * 2.5;
+    // Spaced so they bunch up against the terrain, where the join has to be invisible, and
+    // stretch out towards the horizon, where nothing is in focus anyway.
+    let out = |k: usize| reach * (k as f32 / APRON as f32).powi(2);
+    let axis = |span: f32| -> Vec<f32> {
+        let mut v: Vec<f32> = (1..=APRON).rev().map(|k| -out(k)).collect();
+        let step = stride as f32 * scene.mps;
+        let n = (span / step).floor() as usize;
+        v.extend((0..=n).map(|i| i as f32 * step));
+        // The terrain's own far edge, so the apron starts exactly where the ground stops.
+        if v.last().is_some_and(|&x| x < span - 1e-3) {
+            v.push(span);
+        }
+        v.extend((1..=APRON).map(|k| span + out(k)));
+        v
+    };
+    let xs = axis(span_x);
+    let zs = axis(span_z);
+    let (rw, rh) = (xs.len(), zs.len());
+    let mut sx = vec![0.0f32; rw * rh];
+    let mut sy = vec![0.0f32; rw * rh];
+    let mut depth = vec![0.0f32; rw * rh];
+    let mut lit = vec![[0.0f32; 3]; rw * rh];
+    for (j, &z) in zs.iter().enumerate() {
+        for (i, &x) in xs.iter().enumerate() {
+            let y = height(scene, flat, x, z);
+            let (ndc, d) = cam.project([x, y, z]);
+            let at = j * rw + i;
+            sx[at] = (ndc[0] * 0.5 + 0.5) * sdim as f32;
+            sy[at] = (0.5 - ndc[1] * 0.5) * sdim as f32;
+            depth[at] = d;
+            lit[at] = shade(scene, country, flat, x, z);
+        }
+    }
+
+    // The sky, and the ground drawn over it.
+    let mut px = vec![[0.0f32; 3]; sdim * sdim];
+    for y in 0..sdim {
+        for x in 0..sdim {
+            px[y * sdim + x] = cam.sky(scene, x, y, sdim);
+        }
+    }
+    let mut zbuf = vec![f32::INFINITY; sdim * sdim];
+    for j in 0..rh.saturating_sub(1) {
+        for i in 0..rw.saturating_sub(1) {
+            let (a, b, c, d) = (j * rw + i, j * rw + i + 1, (j + 1) * rw + i + 1, (j + 1) * rw + i);
+            for tri in [[a, b, c], [a, c, d]] {
+                raster(&tri, &sx, &sy, &depth, &lit, scene, &cam, &mut px, &mut zbuf, sdim);
+            }
+        }
+    }
+
+    // Down to the picture's own size.
+    let mut out = vec![[0u8; 3]; dim * dim];
+    for y in 0..dim {
+        for x in 0..dim {
+            let mut acc = [0.0f32; 3];
+            for sy in 0..SS {
+                for sxo in 0..SS {
+                    let p = px[(y * SS + sy) * sdim + x * SS + sxo];
+                    for k in 0..3 {
+                        acc[k] += p[k];
+                    }
+                }
+            }
+            let n = (SS * SS) as f32;
+            out[y * dim + x] = [
+                (acc[0] / n).clamp(0.0, 255.0) as u8,
+                (acc[1] / n).clamp(0.0, 255.0) as u8,
+                (acc[2] / n).clamp(0.0, 255.0) as u8,
+            ];
+        }
+    }
+    out
+}
+
+/// One vertex's colour before the distance is put back in: the ground's own sheet, under the
+/// track's sun and its sky.
+fn shade(scene: &Scene, country: [f32; 3], flat: f32, x: f32, z: f32) -> [f32; 3] {
+    let n = normal(scene, flat, x, z);
+    let d = (n[0] * scene.sun[0] + n[1] * scene.sun[1] + n[2] * scene.sun[2]).max(0.0);
+    // The sky is not a constant: ground facing up gets the whole of it, a slope facing away
+    // from it gets less. Without this every flat piece of shadow is the same flat grey.
+    let sky = 0.55 + 0.45 * n[1].max(0.0);
+    let a = sample(scene, country, x, z);
+    let mut c = [0.0f32; 3];
+    for k in 0..3 {
+        c[k] = a[k] * (scene.ambient[k] * sky + scene.sun_colour[k] * d);
+    }
+    c
+}
+
+/// The height at a place, with the apron past the terrain's edge levelling off to the border's
+/// mean.
+///
+/// Clamping instead — every edge sample keeping its own height all the way out — extrudes the
+/// terrain's border into a fan of ridges reaching the horizon, and they shade as bright streaks
+/// radiating out of the picture.
+fn height(scene: &Scene, flat: f32, x: f32, z: f32) -> f32 {
+    let (gx, gy) = cell(scene, x, z);
+    let h = scene.heights[gy * scene.gw + gx];
+    let past = outside(scene, x, z);
+    if past <= 0.0 {
+        return h;
+    }
+    h + (flat - h) * smoothstep(past / APRON_LEVEL_M)
+}
+
+/// How far past the terrain's edge a place is, metres, and zero on it.
+fn outside(scene: &Scene, x: f32, z: f32) -> f32 {
+    let span_x = (scene.gw - 1) as f32 * scene.mps;
+    let span_z = (scene.gh - 1) as f32 * scene.mps;
+    (-x).max(x - span_x).max((-z).max(z - span_z))
+}
+
+/// Which sample a place on the ground belongs to, clamped inside the grid.
+fn cell(scene: &Scene, x: f32, z: f32) -> (usize, usize) {
+    (
+        (x / scene.mps).round().clamp(0.0, (scene.gw - 1) as f32) as usize,
+        (z / scene.mps).round().clamp(0.0, (scene.gh - 1) as f32) as usize,
+    )
+}
+
+/// The heightfield's normal, from the ground either side at full resolution — the relief
+/// between two drawn vertices is what tells a rut from a berm, and a mesh sampled down to fit
+/// the picture would lose all of it. Taken through [`height`], so the apron flattens out.
+fn normal(scene: &Scene, flat: f32, x: f32, z: f32) -> [f32; 3] {
+    let e = scene.mps;
+    let h = |x: f32, z: f32| height(scene, flat, x, z);
+    let n = [
+        -(h(x + e, z) - h(x - e, z)) / (2.0 * e),
+        1.0,
+        -(h(x, z + e) - h(x, z - e)) / (2.0 * e),
+    ];
+    let l = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+    [n[0] / l, n[1] / l, n[2] / l]
+}
+
+/// The height the country settles to: the mean round the terrain's edge.
+fn level(scene: &Scene) -> f32 {
+    let (w, h) = (scene.gw, scene.gh);
+    let mut sum = 0.0f64;
+    let mut n = 0.0f64;
+    for i in 0..w {
+        sum += (scene.heights[i] + scene.heights[(h - 1) * w + i]) as f64;
+        n += 2.0;
+    }
+    for j in 0..h {
+        sum += (scene.heights[j * w] + scene.heights[j * w + w - 1]) as f64;
+        n += 2.0;
+    }
+    (sum / n) as f32
+}
+
+/// The average colour round the edge of the ground sheet.
+fn border(scene: &Scene) -> [f32; 3] {
+    let d = scene.adim;
+    let mut sum = [0.0f64; 3];
+    let mut n = 0.0f64;
+    for i in 0..d {
+        for at in [i, (d - 1) * d + i, i * d, i * d + d - 1] {
+            for k in 0..3 {
+                sum[k] += scene.albedo[at][k] as f64;
+            }
+            n += 1.0;
+        }
+    }
+    [(sum[0] / n) as f32, (sum[1] / n) as f32, (sum[2] / n) as f32]
+}
+
+/// The ground sheet at a place on the terrain, bilinear so the picture doesn't show the
+/// sheet's own pixels where the camera is close.
+fn sample(scene: &Scene, country: [f32; 3], x: f32, z: f32) -> [f32; 3] {
+    let d = scene.adim as f32;
+    let (span_x, span_z) = ((scene.gw - 1) as f32 * scene.mps, (scene.gh - 1) as f32 * scene.mps);
+    let u = (x / span_x * d - 0.5).clamp(0.0, d - 1.001);
+    let v = (z / span_z * d - 0.5).clamp(0.0, d - 1.001);
+    let (x0, y0) = (u as usize, v as usize);
+    let (fx, fy) = (u - x0 as f32, v - y0 as f32);
+    let at = |x: usize, y: usize| scene.albedo[y.min(scene.adim - 1) * scene.adim + x.min(scene.adim - 1)];
+    let (a, b, c, d) = (at(x0, y0), at(x0 + 1, y0), at(x0, y0 + 1), at(x0 + 1, y0 + 1));
+    let mut out = [0.0f32; 3];
+    for k in 0..3 {
+        let top = a[k] + (b[k] - a[k]) * fx;
+        let bot = c[k] + (d[k] - c[k]) * fx;
+        out[k] = top + (bot - top) * fy;
+    }
+    // Past the terrain the sheet has nothing left to say, and clamping it paints the border
+    // pixel all the way to the horizon — which shows as stripes radiating out of the picture.
+    // So the apron settles to open country over the first few tens of metres instead.
+    let past = outside(scene, x, z);
+    if past > 0.0 {
+        let t = smoothstep(past / APRON_TINT_M);
+        for k in 0..3 {
+            out[k] += (country[k] - out[k]) * t;
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// The camera
+// ---------------------------------------------------------------------------
+
+struct Camera {
+    pos: [f32; 3],
+    right: [f32; 3],
+    up: [f32; 3],
+    fwd: [f32; 3],
+    tan_half: f32,
+    /// How far the frame's own subject is, which is what the haze is measured against — an
+    /// absolute fog density would swallow a big track and leave a small one crisp.
+    reach: f32,
+}
+
+impl Camera {
+    /// Where a world point lands: the frame in `-1..1` both ways, and how far in front of the
+    /// lens it is.
+    fn project(&self, w: [f32; 3]) -> ([f32; 2], f32) {
+        let v = [w[0] - self.pos[0], w[1] - self.pos[1], w[2] - self.pos[2]];
+        let dot = |a: [f32; 3]| v[0] * a[0] + v[1] * a[1] + v[2] * a[2];
+        let d = dot(self.fwd);
+        if d <= NEAR_M {
+            return ([0.0, 0.0], d);
+        }
+        ([dot(self.right) / d / self.tan_half, dot(self.up) / d / self.tan_half], d)
+    }
+
+    /// The sky behind everything, as the ray through a pixel sees it.
+    fn sky(&self, scene: &Scene, x: usize, y: usize, sdim: usize) -> [f32; 3] {
+        let nx = ((x as f32 + 0.5) / sdim as f32 * 2.0 - 1.0) * self.tan_half;
+        let ny = (1.0 - (y as f32 + 0.5) / sdim as f32 * 2.0) * self.tan_half;
+        let mut d = [0.0f32; 3];
+        for k in 0..3 {
+            d[k] = self.fwd[k] + self.right[k] * nx + self.up[k] * ny;
+        }
+        let l = (d[0] * d[0] + d[1] * d[1] + d[2] * d[2]).sqrt();
+        let e = d[1] / l;
+        let mut out = [0.0f32; 3];
+        for k in 0..3 {
+            // Above the horizon the sky climbs to its zenith; below it, where the terrain has
+            // run out, the haze the ground fades into — so an edge of terrain against the
+            // background has nothing to be an edge against.
+            out[k] = if e >= 0.0 {
+                let t = smoothstep((e / 0.42).min(1.0));
+                scene.horizon[k] + (scene.zenith[k] - scene.horizon[k]) * t
+            } else {
+                let t = smoothstep((-e / 0.30).min(1.0));
+                scene.horizon[k] + (scene.haze[k] - scene.horizon[k]) * t
+            };
+        }
+        out
+    }
+}
+
+/// Place the camera: above and off to one side, looking along the lap's short axis so its long
+/// one runs across the frame, and pulled back until the whole of it fits.
+fn fit(scene: &Scene) -> Camera {
+    let flat = level(scene);
+    let h = |x: f32, z: f32| height(scene, flat, x, z);
+    // The subject: where the focus points are, and how far they spread.
+    let n = scene.focus.len().max(1) as f32;
+    let (mut cx, mut cz, mut cy) = (0.0f32, 0.0f32, 0.0f32);
+    for &(x, z) in scene.focus {
+        cx += x;
+        cz += z;
+        cy += h(x, z);
+    }
+    let (cx, cz, cy) = (cx / n, cz / n, cy / n);
+    let (mut sxx, mut sxz, mut szz, mut extent) = (0.0f32, 0.0f32, 0.0f32, 1.0f32);
+    for &(x, z) in scene.focus {
+        let (dx, dz) = (x - cx, z - cz);
+        sxx += dx * dx;
+        sxz += dx * dz;
+        szz += dz * dz;
+        extent = extent.max((dx * dx + dz * dz).sqrt());
+    }
+    // The long way through the focus points, and the way across it — which is where the camera
+    // goes, so the lap is seen along its narrow side and fills the width of the picture.
+    let theta = 0.5 * (2.0 * sxz).atan2(sxx - szz);
+    let across = (-theta.sin(), theta.cos());
+    // Of the two sides, the one the sun is on: a subject lit from behind the camera shows its
+    // relief, and one lit from behind itself is a silhouette.
+    let sun_h = (scene.sun[0], scene.sun[2]);
+    let sign = if across.0 * sun_h.0 + across.1 * sun_h.1 >= 0.0 { 1.0 } else { -1.0 };
+    let dir = (across.0 * sign, across.1 * sign);
+
+    let el = scene.tilt_deg.to_radians();
+    let tan_half = (FOV_DEG.to_radians() * 0.5).tan();
+    let target = [cx, cy, cz];
+    let mut dist = extent * 2.6 + 60.0;
+    let mut cam = at(target, dir, el, dist, tan_half);
+    // Pull back until nothing wanted is outside the frame. The frame's size goes as one over
+    // the distance, so scaling by how far over it is converges in a handful of passes.
+    for _ in 0..40 {
+        let mut m: f32 = 0.0;
+        for &(x, z) in scene.focus {
+            let (ndc, d) = cam.project([x, h(x, z), z]);
+            if d <= NEAR_M {
+                m = m.max(4.0);
+                continue;
+            }
+            m = m.max(ndc[0].abs()).max(ndc[1].abs());
+        }
+        if m <= 1e-4 {
+            break;
+        }
+        let k = m / FIT;
+        dist *= k.clamp(0.4, 2.5);
+        cam = at(target, dir, el, dist, tan_half);
+        if (k - 1.0).abs() < 0.002 {
+            break;
+        }
+    }
+    cam
+}
+
+/// A camera an azimuth, an elevation and a distance from what it is looking at.
+fn at(target: [f32; 3], dir: (f32, f32), el: f32, dist: f32, tan_half: f32) -> Camera {
+    let (ce, se) = (el.cos(), el.sin());
+    let pos = [
+        target[0] + dir.0 * ce * dist,
+        target[1] + se * dist,
+        target[2] + dir.1 * ce * dist,
+    ];
+    let mut fwd = [target[0] - pos[0], target[1] - pos[1], target[2] - pos[2]];
+    let l = (fwd[0] * fwd[0] + fwd[1] * fwd[1] + fwd[2] * fwd[2]).sqrt().max(1e-6);
+    for k in 0..3 {
+        fwd[k] /= l;
+    }
+    // Right is forward crossed with world up, so the horizon in the picture is level.
+    let mut right = [fwd[2], 0.0, -fwd[0]];
+    let rl = (right[0] * right[0] + right[2] * right[2]).sqrt().max(1e-6);
+    right[0] /= rl;
+    right[2] /= rl;
+    // The world is left-handed — x across, y up, z down the grid — so right is up crossed
+    // with forward, and up is forward crossed with right. The other way round turns the
+    // picture upside down, which reads as a camera underground.
+    let up = [
+        fwd[1] * right[2] - fwd[2] * right[1],
+        fwd[2] * right[0] - fwd[0] * right[2],
+        fwd[0] * right[1] - fwd[1] * right[0],
+    ];
+    Camera { pos, right, up, fwd, tan_half, reach: dist }
+}
+
+// ---------------------------------------------------------------------------
+// Drawing
+// ---------------------------------------------------------------------------
+
+/// One triangle into the depth buffer, perspective-correct, with the haze put back in per
+/// pixel — across a quad in the foreground it changes fast enough that doing it per vertex
+/// bands the ground.
+#[allow(clippy::too_many_arguments)]
+fn raster(
+    tri: &[usize; 3],
+    sx: &[f32],
+    sy: &[f32],
+    depth: &[f32],
+    lit: &[[f32; 3]],
+    scene: &Scene,
+    cam: &Camera,
+    px: &mut [[f32; 3]],
+    zbuf: &mut [f32],
+    sdim: usize,
+) {
+    let z = [depth[tri[0]], depth[tri[1]], depth[tri[2]]];
+    if z.iter().any(|&d| d <= NEAR_M) {
+        return;
+    }
+    let p = [
+        [sx[tri[0]], sy[tri[0]]],
+        [sx[tri[1]], sy[tri[1]]],
+        [sx[tri[2]], sy[tri[2]]],
+    ];
+    let area = (p[1][0] - p[0][0]) * (p[2][1] - p[0][1]) - (p[2][0] - p[0][0]) * (p[1][1] - p[0][1]);
+    if area.abs() < 1e-9 {
+        return;
+    }
+    let x0 = p.iter().map(|q| q[0]).fold(f32::INFINITY, f32::min).floor().max(0.0) as usize;
+    let x1 = (p.iter().map(|q| q[0]).fold(f32::NEG_INFINITY, f32::max).ceil()).clamp(0.0, sdim as f32) as usize;
+    let y0 = p.iter().map(|q| q[1]).fold(f32::INFINITY, f32::min).floor().max(0.0) as usize;
+    let y1 = (p.iter().map(|q| q[1]).fold(f32::NEG_INFINITY, f32::max).ceil()).clamp(0.0, sdim as f32) as usize;
+    if x0 >= x1 || y0 >= y1 {
+        return;
+    }
+    let c = [lit[tri[0]], lit[tri[1]], lit[tri[2]]];
+    let inv = 1.0 / area;
+    for y in y0..y1 {
+        let py = y as f32 + 0.5;
+        for x in x0..x1 {
+            let pxc = x as f32 + 0.5;
+            let e = |a: [f32; 2], b: [f32; 2]| (b[0] - a[0]) * (py - a[1]) - (b[1] - a[1]) * (pxc - a[0]);
+            let w = [e(p[1], p[2]) * inv, e(p[2], p[0]) * inv, e(p[0], p[1]) * inv];
+            if w.iter().any(|&v| v < 0.0) {
+                continue;
+            }
+            let iz = w[0] / z[0] + w[1] / z[1] + w[2] / z[2];
+            if iz <= 0.0 {
+                continue;
+            }
+            let d = 1.0 / iz;
+            let at = y * sdim + x;
+            if d >= zbuf[at] {
+                continue;
+            }
+            zbuf[at] = d;
+            let mut col = [0.0f32; 3];
+            for k in 0..3 {
+                col[k] = (w[0] * c[0][k] / z[0] + w[1] * c[1][k] / z[1] + w[2] * c[2][k] / z[2]) * d;
+            }
+            // Air. Measured against the camera's own reach rather than in absolute metres, so
+            // a 400 m track and a 900 m one come out with the same amount of it.
+            let t = smoothstep(((d - cam.reach) / (cam.reach * 2.0)).clamp(0.0, 1.0)) * 0.94;
+            for k in 0..3 {
+                px[at][k] = col[k] + (scene.haze[k] - col[k]) * t;
+            }
+        }
+    }
+}
+
+fn smoothstep(t: f32) -> f32 {
+    let t = t.clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A square of ground with a jagged border, so the apron has something to smear if it is
+    /// going to.
+    fn scene(n: usize) -> (Vec<f32>, Vec<[f32; 3]>) {
+        let heights = (0..n * n)
+            .map(|i| {
+                let (x, y) = (i % n, i / n);
+                if x == 0 || y == 0 || x == n - 1 || y == n - 1 {
+                    // The edge alternates hard, which is what used to be extruded to the
+                    // horizon as a fan of ridges.
+                    ((x + y) % 2) as f32 * 8.0
+                } else {
+                    0.0
+                }
+            })
+            .collect();
+        let albedo = (0..n * n)
+            .map(|i| if i % 3 == 0 { [200.0, 60.0, 60.0] } else { [40.0, 40.0, 40.0] })
+            .collect();
+        (heights, albedo)
+    }
+
+    fn of<'a>(heights: &'a [f32], albedo: &'a [[f32; 3]], n: usize) -> Scene<'a> {
+        Scene {
+            gw: n,
+            gh: n,
+            mps: 1.0,
+            heights,
+            albedo,
+            adim: n,
+            focus: &[],
+            sun: [0.0, 1.0, 0.0],
+            sun_colour: [1.0, 1.0, 1.0],
+            ambient: [0.0, 0.0, 0.0],
+            zenith: [0.0, 0.0, 0.0],
+            horizon: [0.0, 0.0, 0.0],
+            haze: [0.0, 0.0, 0.0],
+            tilt_deg: TILT_DEG,
+        }
+    }
+
+    /// Up is up.
+    ///
+    /// It was not: the up vector was the cross product taken the wrong way round for a
+    /// left-handed world, and every picture came out upside down — the near ground along the
+    /// top and the sky underneath it.
+    #[test]
+    fn a_point_higher_up_lands_higher_in_the_frame() {
+        let cam = at([0.0, 0.0, 0.0], (1.0, 0.0), TILT_DEG.to_radians(), 100.0, 0.3);
+        let (low, _) = cam.project([0.0, 0.0, 0.0]);
+        let (high, _) = cam.project([0.0, 10.0, 0.0]);
+        assert!(high[1] > low[1], "{high:?} should be above {low:?}");
+    }
+
+    /// And right is right. The world is left-handed — looking along `+z` with `+y` up puts
+    /// `+x` to the right — so a camera facing that way has to put it on the right of the
+    /// picture. Cross it the other way and every track ships mirrored.
+    #[test]
+    fn a_point_to_the_right_lands_on_the_right() {
+        let cam = at([0.0, 0.0, 100.0], (0.0, -1.0), 0.0, 100.0, 0.3);
+        let (right, _) = cam.project([10.0, 0.0, 100.0]);
+        assert!(right[0] > 0.0, "+x should be screen right, not {right:?}");
+    }
+
+    /// Past the terrain's edge the ground becomes country: level, and its own colour.
+    ///
+    /// Carrying the edge samples outwards instead — which is what clamping does — extrudes the
+    /// border into ridges reaching the horizon, and they shade as bright streaks radiating out
+    /// of the picture.
+    #[test]
+    fn the_apron_settles_to_open_country() {
+        let n = 32;
+        let (heights, albedo) = scene(n);
+        let s = of(&heights, &albedo, n);
+        let flat = level(&s);
+        let country = border(&s);
+        let span = (n - 1) as f32;
+        // Two places well outside, nearest to two edge samples that disagree by the whole of
+        // the border's swing. Out there they have to agree with each other.
+        for z in [0.0, 1.0] {
+            let h = height(&s, flat, span + APRON_LEVEL_M * 3.0, z);
+            assert!((h - flat).abs() < 0.01, "apron at z={z} sits at {h}, not {flat}");
+            let c = sample(&s, country, span + APRON_TINT_M * 3.0, z);
+            assert!(
+                (0..3).all(|k| (c[k] - country[k]).abs() < 0.01),
+                "apron at z={z} is {c:?}, not {country:?}"
+            );
+        }
+        // And on the terrain itself nothing has been touched.
+        assert_eq!(height(&s, flat, 8.0, 8.0), heights[8 * n + 8]);
+    }
+}

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -2197,7 +2197,7 @@ pub fn write_source(prog: &TrackProgram, syn: &Synth, dir: &Path) -> Result<Vec<
     put(&format!("{slug}/gfx.cfg"), crlf(&gfx_cfg(prog)), &mut wrote)?;
     put(&format!("{slug}/{slug}.rdf"), crlf(&rdf(prog, &syn.fan)), &mut wrote)?;
     put(&format!("{slug}/{slug}.ssc"), SSC.into(), &mut wrote)?;
-    let (map_img, shot) = ui_images(syn, UI_IMAGE_DIM);
+    let (map_img, shot) = ui_images(prog, syn, UI_IMAGE_DIM);
     put(&format!("{slug}/{slug}_map.tga"), map_img, &mut wrote)?;
     put(&format!("{slug}/{slug}.tga"), shot, &mut wrote)?;
 
@@ -3323,7 +3323,7 @@ pub fn write_pkz(
         zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
 
     use std::io::Write;
-    let (map_img, shot) = ui_images(syn, UI_IMAGE_DIM);
+    let (map_img, shot) = ui_images(prog, syn, UI_IMAGE_DIM);
     // Every published track puts its files in a folder named after itself, and the game
     // looks for them there — flat at the archive root they are not found at all.
     for (name, bytes) in [
@@ -3807,9 +3807,13 @@ fn shd(normal: &str, repetitions: u32, shininess: u32, reflect: Option<Reflect>)
 /// are — and they are never seen in focus.
 ///
 /// The sky matches the `.amb`'s own fog, because the two are looked at together.
+///
+/// The two colours are up here rather than inside `env_faces` because the track's picture is
+/// rendered under the same sky the game puts over it, and a picture with its own weather in it
+/// is a picture of a different track.
+const ZENITH: [f32; 3] = [96.0, 140.0, 196.0];
+const HORIZON: [f32; 3] = [179.0, 179.0, 217.0];
 fn env_faces(dim: usize) -> Vec<(&'static str, Vec<u8>)> {
-    const ZENITH: [f32; 3] = [96.0, 140.0, 196.0];
-    const HORIZON: [f32; 3] = [179.0, 179.0, 217.0];
     const GROUND: [f32; 3] = [86.0, 74.0, 60.0];
 
     let mix = |a: [f32; 3], b: [f32; 3], t: f32| -> [u8; 3] {
@@ -4304,50 +4308,154 @@ rainy\n{\n\tambient\n\t{\n\t\tred = 0.6\n\t\tgreen = 0.6\n\t\tblue = 0.85\n\t}\n
 
 /// The two pictures the game's UI wants: an overhead of the lap, and something to show
 /// beside the track's name. Neither is optional — a track without them lists as a blank.
-fn ui_images(syn: &Synth, dim: usize) -> (Vec<u8>, Vec<u8>) {
+///
+/// They are not the same kind of picture and never were. The map is a diagram: the game draws
+/// the route and the riders over it, so it stays flat, north-up and unshaded. The other one is
+/// a photograph of the place, and it is rendered as one — see [`ui_shot`].
+fn ui_images(prog: &TrackProgram, syn: &Synth, dim: usize) -> (Vec<u8>, Vec<u8>) {
     let mut map = vec![0u8; dim * dim * 4];
-    let mut shot = vec![0u8; dim * dim * 4];
-    // Sampled down to the picture's own size *before* blurring. Blurring the full grid to
-    // shade a postage stamp costs two copies of the terrain and changes nothing you can see.
-    let small: Vec<f32> = (0..dim * dim)
-        .map(|i| {
-            let gy = ((i / dim) * syn.gh / dim).min(syn.gh - 1);
-            let gx = ((i % dim) * syn.gw / dim).min(syn.gw - 1);
-            syn.heights[gy * syn.gw + gx]
-        })
-        .collect();
-    let base_small = crate::trackstats::box_blur(&small, dim, dim, 3);
     for y in 0..dim {
-        // One orientation for the whole picture. The corridor used to be read from the far
-        // edge back while the relief was read straight through, so the shading and the line
-        // it was shading disagreed by a flip — and the lap came out mirrored against the
-        // route the game draws over it.
+        // Row zero of a TGA is the bottom of the picture, and row zero of the grid is `z = 0`,
+        // so the read runs from the far edge back. Get this wrong and the lap comes out
+        // mirrored against the route the game draws over it.
         let row = dim - 1 - y;
         let gy = (row * syn.gh / dim).min(syn.gh - 1);
         for x in 0..dim {
             let gx = (x * syn.gw / dim).min(syn.gw - 1);
-            let i = gy * syn.gw + gx;
-            let at = (y * dim + x) * 4;
-
-            // The map: the lap as a shape, on paper.
-            let on = syn.corridor[i];
-            let c: [u8; 3] = if on { [60, 70, 150] } else { [232, 232, 236] };
-            map[at..at + 4].copy_from_slice(&[c[2], c[1], c[0], 255]);
-
-            // The picture: the terrain's own relief, with the line picked out.
-            let here = row * dim + x;
-            let relief =
-                ((small[here] - base_small[here]) * 90.0 + 128.0).clamp(0.0, 255.0) as u8;
-            let s: [u8; 3] = if on {
-                [relief.saturating_add(40), relief / 2, relief / 3]
+            let c: [u8; 3] = if syn.corridor[gy * syn.gw + gx] {
+                [60, 70, 150]
             } else {
-                [relief / 2, (relief as f32 * 0.62) as u8, relief / 3]
+                [232, 232, 236]
             };
-            shot[at..at + 4].copy_from_slice(&[s[2], s[1], s[0], 255]);
+            let at = (y * dim + x) * 4;
+            map[at..at + 4].copy_from_slice(&[c[2], c[1], c[0], 255]);
         }
     }
-    (tga_bgra(dim, dim, &map), tga_bgra(dim, dim, &shot))
+    (tga_bgra(dim, dim, &map), ui_shot(prog, syn, dim))
 }
+
+/// The picture beside the track's name: the terrain rendered from above and off to one side.
+///
+/// It used to be a false-colour relief of the heightfield with the corridor tinted orange over
+/// it — the same plan view as the map, in worse colours, and it told a player nothing about
+/// the place they were about to ride. This is the ground as it will actually look: the six
+/// painted bands the `.map` ships, lit by the sun the `.amb` declares, seen from a camera that
+/// places itself to fit the lap and to keep the sun behind it.
+fn ui_shot(prog: &TrackProgram, syn: &Synth, dim: usize) -> Vec<u8> {
+    // The camera has to frame the lap, not the terrain — a track in one corner of a big
+    // landscape would otherwise be a smudge in the middle of a field. Every eighth corridor
+    // cell is plenty to bound a shape with.
+    let mut focus = Vec::new();
+    for gy in (0..syn.gh).step_by(8) {
+        for gx in (0..syn.gw).step_by(8) {
+            if syn.corridor[gy * syn.gw + gx] {
+                focus.push((gx as f32 * syn.mps, gy as f32 * syn.mps));
+            }
+        }
+    }
+    // A track with no corridor at all is not one anybody asked for, but the camera still has
+    // to go somewhere: the terrain itself.
+    if focus.is_empty() {
+        focus = vec![
+            (0.0, 0.0),
+            (prog.terrain.size_x, 0.0),
+            (0.0, prog.terrain.size_z),
+            (prog.terrain.size_x, prog.terrain.size_z),
+        ];
+    }
+
+    let albedo = ground_sheet(prog, syn, dim);
+    // Straight off the `.amb`: `sun_position`, and the `clear` condition's light. The picture
+    // is of the track in the weather the game opens it in.
+    let sun = {
+        let v = [2.0f32, 10.0, -7.0];
+        let l = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt();
+        [v[0] / l, v[1] / l, v[2] / l]
+    };
+    let scene = crate::trackshot::Scene {
+        gw: syn.gw,
+        gh: syn.gh,
+        mps: syn.mps,
+        heights: &syn.heights,
+        albedo: &albedo,
+        adim: dim,
+        focus: &focus,
+        sun,
+        sun_colour: [1.10, 0.95, 0.70],
+        ambient: [0.40, 0.45, 0.55],
+        zenith: ZENITH,
+        horizon: HORIZON,
+        // The `.amb`'s own fog colour, which is what the distance goes to in the game too.
+        haze: [179.0, 179.0, 217.0],
+        tilt_deg: crate::trackshot::TILT_DEG,
+    };
+    let rgb = crate::trackshot::render(&scene, dim);
+    // The renderer hands back rows from the top; a TGA's row zero is the bottom.
+    let mut px = Vec::with_capacity(dim * dim * 4);
+    for y in (0..dim).rev() {
+        for x in 0..dim {
+            let c = rgb[y * dim + x];
+            px.extend_from_slice(&[c[2], c[1], c[0], 255]);
+        }
+    }
+    tga_bgra(dim, dim, &px)
+}
+
+/// The ground's colour across the terrain: the same bands the `.map` paints, composited in
+/// the same order they are painted in.
+///
+/// It walks `layers` rather than listing the bands again, so the picture cannot show a track
+/// painted differently from the one shipped beside it. What it does not do is tile the sheets
+/// — at a couple of metres to the pixel a 4.5 m tile of soil is below the picture's own
+/// resolution — so each band contributes its base colour with the broad mottle that survives
+/// at this scale and nothing finer.
+fn ground_sheet(prog: &TrackProgram, syn: &Synth, dim: usize) -> Vec<[f32; 3]> {
+    let seed = prog.terrain.relief.seed;
+    let half = prog.width * 0.5;
+    let fan = &syn.fan;
+    let mut px = vec![[0.0f32; 3]; dim * dim];
+    for l in layers(prog) {
+        let cover = match l.band {
+            BandMask::Everywhere => vec![255u8; dim * dim],
+            BandMask::Rut => rut_mask(syn, half, seed, dim, dim),
+            BandMask::Loose => loose_mask(syn, half, seed, dim, dim),
+            BandMask::Beyond => mask_rect(syn, dim, dim, |d, s, _, _| {
+                u8::from(d > fan.at(s) + SHOULDER_M) * 255
+            }),
+            BandMask::Out(extra) => mask_rect(syn, dim, dim, |d, s, _, _| {
+                u8::from(d <= fan.at(s) + extra) * 255
+            }),
+        };
+        for y in 0..dim {
+            let gy = (y * syn.gh / dim).min(syn.gh - 1);
+            for x in 0..dim {
+                let a = cover[y * dim + x] as f32 / 255.0;
+                if a <= 0.0 {
+                    continue;
+                }
+                let gx = (x * syn.gw / dim).min(syn.gw - 1);
+                let (wx, wz) = (gx as f32 * syn.mps, gy as f32 * syn.mps);
+                // The same patching `ground_pixels` gives the sheets, at the only scale a
+                // picture this size can hold it: without it the ground is flat colour and the
+                // track reads as a drawing again.
+                let k = SHEET_SHADE * (1.0 + l.look.mottle * fbm(wx * 0.06, wz * 0.06, seed ^ l.salt));
+                let at = y * dim + x;
+                for c in 0..3 {
+                    px[at][c] += (l.look.base[c] * k - px[at][c]) * a;
+                }
+            }
+        }
+    }
+    px
+}
+
+/// How much of its base colour a painted sheet keeps once it is shaded.
+///
+/// `ground_pixels` draws each band as clods and crevice rather than as flat colour, and what
+/// comes out lands around three quarters of the colour that went in. The picture composites
+/// the base colours directly, so it has to take the same cut or every band in it is brighter
+/// than the ground it is a picture of.
+const SHEET_SHADE: f32 = 0.78;
 
 /// Uncompressed 32-bit BGRA, the mask in the alpha channel — the shape the official example's
 /// own masks are in, down to the descriptor byte and the file footer.
@@ -6683,6 +6791,137 @@ mod tests {
             }
             let _ = std::fs::write(out, ppm);
         }
+    }
+
+    /// The picture the game lists a track by, as rows from the top.
+    fn shot_rows(p: &TrackProgram, dim: usize) -> Vec<[u8; 3]> {
+        let s = synthesise(p).unwrap();
+        let tga = ui_shot(p, &s, dim);
+        let px = &tga[18..18 + dim * dim * 4];
+        // A TGA's row zero is the bottom of the picture, and it is stored BGRA.
+        let mut out = Vec::with_capacity(dim * dim);
+        for y in (0..dim).rev() {
+            for x in 0..dim {
+                let at = (y * dim + x) * 4;
+                out.push([px[at + 2], px[at + 1], px[at]]);
+            }
+        }
+        out
+    }
+
+    /// The distance is at the top of the picture, which is the only place a camera looking
+    /// down at the ground can put it.
+    ///
+    /// Air is the tell: the far ground is hazed towards the sky's own colour and the near
+    /// ground is not, so the top of the picture has to be the paler half. This is the whole
+    /// chain — the camera, the render and the flip into a bottom-up TGA — and every one of
+    /// them has turned it over at some point.
+    #[test]
+    fn the_track_picture_is_the_right_way_up() {
+        let dim = 160;
+        let rows = shot_rows(&oval(), dim);
+        let haze = [179.0f32, 179.0, 217.0];
+        let off = |from: usize, to: usize| -> f32 {
+            let mut d = 0.0;
+            for y in from..to {
+                for x in 0..dim {
+                    let c = rows[y * dim + x];
+                    d += (0..3).map(|k| (c[k] as f32 - haze[k]).abs()).sum::<f32>();
+                }
+            }
+            d / ((to - from) * dim) as f32
+        };
+        // The oval measures about three quarters. Upside down it would measure about four
+        // thirds, so anything under one separates the two — this leaves room for a track that
+        // hazes less without letting a flipped one through.
+        let (top, bottom) = (off(0, dim / 8), off(dim - dim / 8, dim));
+        assert!(
+            top < bottom * 0.85,
+            "the top of the picture should be the hazy distance: {top:.0} against {bottom:.0} \
+             at the bottom"
+        );
+    }
+
+    /// And the lap is in it, across most of it.
+    ///
+    /// The camera places itself to fit the corridor rather than the terrain, so a track built
+    /// on one corner of a big landscape is still the subject. If the fit gives up, the lap
+    /// ends up a smudge in the middle of a field — which is what a picture framed on the
+    /// terrain looks like, and it is not obviously wrong until you measure it.
+    #[test]
+    fn the_lap_fills_the_track_picture() {
+        let dim = 160;
+        let rows = shot_rows(&oval(), dim);
+        // The ridden line is far darker than the ground it is cut into — Indiana's own soil
+        // measures a mean of 39 against its field's 142 — so the darkest of the picture is
+        // the track and nothing else.
+        let luma = |c: [u8; 3]| 0.3 * c[0] as f32 + 0.6 * c[1] as f32 + 0.1 * c[2] as f32;
+        let mut sorted: Vec<f32> = rows.iter().map(|&c| luma(c)).collect();
+        sorted.sort_by(f32::total_cmp);
+        let dark = sorted[rows.len() / 25];
+        let (mut x0, mut x1, mut y0, mut y1) = (dim, 0usize, dim, 0usize);
+        for (i, &c) in rows.iter().enumerate() {
+            if luma(c) <= dark {
+                let (x, y) = (i % dim, i / dim);
+                x0 = x0.min(x);
+                x1 = x1.max(x);
+                y0 = y0.min(y);
+                y1 = y1.max(y);
+            }
+        }
+        let (w, h) = (x1 + 1 - x0, y1 + 1 - y0);
+        assert!(
+            w * 10 >= dim * 7,
+            "the lap spans {w} of {dim} across the picture"
+        );
+        assert!(h * 10 >= dim * 2, "the lap spans {h} of {dim} down the picture");
+    }
+
+    /// Look at the pictures the game lists a track by.
+    ///
+    /// The shot is a render, and a render is judged by looking at it — so this writes both of
+    /// them out as `.ppm` beside each other, for a couple of laps.
+    ///
+    /// ```text
+    /// FROST_SHOT=/tmp/shots cargo test -- --ignored --nocapture the_track_pictures
+    /// ```
+    #[test]
+    #[ignore = "writes pictures to look at — set FROST_SHOT"]
+    fn the_track_pictures() {
+        let dir = std::env::var("FROST_SHOT").expect("set FROST_SHOT");
+        let dir = Path::new(&dir);
+        std::fs::create_dir_all(dir).unwrap();
+        // A flat stadium, a tight one, and one cut into real ground — the last is the only
+        // one that says whether the picture shows relief at all.
+        let rolling = {
+            let mut p = oval();
+            p.name = "Test Rolling".into();
+            p.terrain.relief.landforms = 8;
+            p.terrain.relief.landform_height = 14.0;
+            p.terrain.scale = 50.0;
+            p
+        };
+        for p in [oval(), hairpins(), rolling] {
+            let s = synthesise(&p).unwrap();
+            let (map, shot) = ui_images(&p, &s, UI_IMAGE_DIM);
+            let name = slug(&p.name);
+            tga_to_ppm(&map, UI_IMAGE_DIM, &dir.join(format!("{name}_map.ppm")));
+            tga_to_ppm(&shot, UI_IMAGE_DIM, &dir.join(format!("{name}.ppm")));
+            println!("wrote {name}.ppm and {name}_map.ppm to {}", dir.display());
+        }
+    }
+
+    /// Our own 32-bit BGRA TGA, bottom-up, back into something a viewer opens.
+    fn tga_to_ppm(tga: &[u8], dim: usize, out: &Path) {
+        let px = &tga[18..18 + dim * dim * 4];
+        let mut ppm = format!("P6\n{dim} {dim}\n255\n").into_bytes();
+        for y in (0..dim).rev() {
+            for x in 0..dim {
+                let at = (y * dim + x) * 4;
+                ppm.extend_from_slice(&[px[at + 2], px[at + 1], px[at]]);
+            }
+        }
+        std::fs::write(out, ppm).unwrap();
     }
 
     /// The terrain, slope-shaded, with the riding line tinted.


### PR DESCRIPTION
The picture the game lists a built track by — `<track>.tga` — was a false-colour relief of the heightfield with the corridor tinted orange over it. That is the same plan view as the map beside it, in worse colours, and it told a player nothing about the place they were about to ride. It is now a render.

## What it does

`src-tauri/src/trackshot.rs` is a heightfield rasteriser: project the grid, draw it through a depth buffer at twice size, average down. It knows nothing about tracks — it takes a heightfield, a sheet of ground colour and the points the frame has to hold.

The camera places itself. PCA over the corridor gives the lap's long axis, and the camera goes off the short one so the lap runs across the frame; of the two sides it takes whichever keeps the sun behind the lens, because a subject lit from behind itself is a silhouette. Tilt is 36° — high enough that the lap reads as a shape, shallow enough that the hills under it have a near side and a far side. Then it pulls back until the corridor fills 88% of the frame, so a track built on one corner of a big terrain is still the subject.

The ground is composited from `layers` — the same bands the `.map` paints, in the same order — so the picture cannot show a track painted differently from the one shipped beside it. Lit by the `.amb`'s own `sun_position` and its `clear` ambient: it is the track in the weather the game opens it in.

`<track>_map.tga` is untouched. The game draws the route and the riders over that one, so it stays flat, unshaded and north-up.

## Two things that had to be got right

**The apron.** A terrain is a few hundred metres square and the horizon is not, so the ground has to carry on past the terrain's edge or the picture is a slab of land floating in the sky with a cut edge. Clamping the edge samples outward turned out to be worse: it extrudes the border into a fan of ridges reaching the horizon, and they shade as bright streaks radiating out of the picture. The apron now levels off to the border's mean height over 90 m and settles to its mean colour over 25 m — the colour has to settle much faster, because a smeared colour streaks where a smeared height only makes a gentle shelf.

**Handedness.** The world is left-handed — x across, y up, z down the grid — so right is up crossed with forward and up is forward crossed with right. Taken the other way round the whole picture comes out upside down, with the near ground along the top and the sky underneath it. That is now a test, as is the mirror case.

## Tests

- `trackshot`: a point higher up lands higher in the frame; `+x` lands on the right; the apron settles to open country in both height and colour, and the terrain itself is untouched.
- `tracksynth`: the shipped TGA is the right way up (the far ground is hazed, so the top of the picture has to be the paler half — this covers the camera, the render *and* the flip into a bottom-up TGA), and the lap spans at least 70% of the picture's width.
- `the_track_pictures` (ignored) writes the pictures out as `.ppm` to look at — `FROST_SHOT=/tmp/shots cargo test -- --ignored the_track_pictures`.

Suite green: 1311 pass, 0 fail.