### PR TITLE
feat(tracks): stand objects beside a generated track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-09-06
+
+### Added
+- A track you build now has things standing beside it. Marker boards line both sides of the
+  riding line the whole way round, fencing runs behind them, hay bales guard the outside of
+  the corners, trees stand back in the field and a gantry crosses the start.
+- Bales and the start gantry stop a bike. Marker boards and trees do not, so clipping one
+  costs you nothing.
+
 ## 2026-09-05
 
 ### Changed

--- a/scripts/track-render.py
+++ b/scripts/track-render.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Draw a compiled track: the ground from its heightfield, the objects from its .map.
+
+The picture is the check. Numbers say a fence is 19 m from the centreline and say nothing
+about whether it is standing in a jump face — and the corpus work found two placement faults
+that every measurement passed. So `trackscenery::built::builds_a_track_with_objects` writes a
+`scene.bin` beside the compiled track and this draws it:
+
+    FROST_BUILD=/tmp/objtrack ... cargo test -- --ignored --nocapture builds_a_track_with_objects
+    python3 scripts/track-render.py /tmp/objtrack/scene.bin /tmp/shot.png
+
+Three views come out: what a rider sees, the same corner from beside the track, and the lap
+from above. Terrain is ray-marched over the heightfield; the scenery is rasterised from the
+`.map`'s own triangles through its own sheets, with the alpha test that makes a foliage card
+a tree rather than a green slab. Needs numpy and pillow, nothing else."""
+import struct, sys, math
+import numpy as np
+from PIL import Image
+
+def load(path):
+    b = open(path, 'rb').read()
+    o = 0
+    assert b[:4] == b'SDMP', b[:4]
+    o = 4
+    gw, gh = struct.unpack_from('<II', b, o); o += 8
+    mps, size_x = struct.unpack_from('<ff', b, o); o += 8
+    n = gw * gh
+    H = np.frombuffer(b, '<f4', n, o).reshape(gh, gw).copy(); o += 4 * n
+    C = np.frombuffer(b, 'u1', n, o).reshape(gh, gw).copy(); o += n
+    nm, = struct.unpack_from('<I', b, o); o += 4
+    mats = []
+    for _ in range(nm):
+        dim, = struct.unpack_from('<I', b, o); o += 4
+        t = np.frombuffer(b, 'u1', dim*dim*4, o).reshape(dim, dim, 4).copy(); o += dim*dim*4
+        mats.append(t)
+    vc, = struct.unpack_from('<I', b, o); o += 4
+    P = np.frombuffer(b, '<f4', vc*3, o).reshape(vc, 3).copy(); o += 12*vc
+    UV = np.frombuffer(b, '<f4', vc*2, o).reshape(vc, 2).copy(); o += 8*vc
+    tc, = struct.unpack_from('<I', b, o); o += 4
+    I = np.frombuffer(b, '<u4', tc*3, o).reshape(tc, 3).copy(); o += 12*tc
+    M = np.frombuffer(b, '<u4', tc, o).copy(); o += 4*tc
+    return dict(gw=gw, gh=gh, mps=mps, size_x=size_x, H=H, C=C, mats=mats, P=P, UV=UV, I=I, M=M)
+
+def sample_h(H, mps, x, z):
+    gh, gw = H.shape
+    fx = np.clip(x / mps, 0, gw - 1.001)
+    fz = np.clip(z / mps, 0, gh - 1.001)
+    x0 = fx.astype(np.int32); z0 = fz.astype(np.int32)
+    tx = fx - x0; tz = fz - z0
+    a = H[z0, x0]; bb = H[z0, x0+1]; c = H[z0+1, x0]; d = H[z0+1, x0+1]
+    return (a*(1-tx)+bb*tx)*(1-tz) + (c*(1-tx)+d*tx)*tz
+
+def look_at(eye, target, up=(0,1,0)):
+    f = np.array(target, np.float64) - np.array(eye, np.float64)
+    f /= np.linalg.norm(f)
+    u = np.array(up, np.float64)
+    s = np.cross(f, u); s /= np.linalg.norm(s)
+    u = np.cross(s, f)
+    return np.stack([s, u, f])           # rows: right, up, forward
+
+def render(d, eye, target, W=1100, Hh=680, fov=58.0, sky=(150,178,205)):
+    H, mps = d['H'], d['mps']
+    R = look_at(eye, target)
+    eye = np.array(eye, np.float64)
+    ar = W / Hh
+    th = math.tan(math.radians(fov) * 0.5)
+    px = (np.arange(W) + 0.5) / W * 2 - 1
+    py = 1 - (np.arange(Hh) + 0.5) / Hh * 2
+    PX, PY = np.meshgrid(px, py)
+    dirs = (R[0] * (PX * th * ar)[..., None] + R[1] * (PY * th)[..., None] + R[2])
+    dirs /= np.linalg.norm(dirs, axis=-1, keepdims=True)
+
+    # --- terrain, by marching the heightfield ---
+    far = float(max(d['size_x'], 400.0)) * 1.6
+    t = np.full((Hh, W), 1.0)
+    hit = np.zeros((Hh, W), bool)
+    step0 = 0.35
+    tt = t.copy()
+    prev = np.zeros((Hh, W))
+    for i in range(900):
+        step = step0 * (1.0 + tt * 0.02)
+        cand = tt + step
+        p = eye + dirs * cand[..., None]
+        h = sample_h(H, mps, p[..., 0], p[..., 2])
+        under = (p[..., 1] < h) & ~hit & (cand < far)
+        prev = np.where(~hit, tt, prev)
+        hit |= under
+        tt = np.where(hit, tt, cand)
+        if hit.all() or tt.min() > far:
+            break
+    # refine
+    lo, hi = prev, tt
+    for _ in range(24):
+        mid = 0.5 * (lo + hi)
+        p = eye + dirs * mid[..., None]
+        h = sample_h(H, mps, p[..., 0], p[..., 2])
+        below = p[..., 1] < h
+        hi = np.where(below, mid, hi)
+        lo = np.where(below, lo, mid)
+    tdepth = np.where(hit, hi, np.inf)
+    ph = eye + dirs * np.where(hit, hi, 0)[..., None]
+
+    # ground shading: slope + the corridor tint
+    gx = np.clip(ph[..., 0] / mps, 1, H.shape[1]-2).astype(np.int32)
+    gz = np.clip(ph[..., 2] / mps, 1, H.shape[0]-2).astype(np.int32)
+    dzdx = (H[gz, gx+1] - H[gz, gx-1]) / (2*mps)
+    dzdz = (H[gz+1, gx] - H[gz-1, gx]) / (2*mps)
+    n = np.stack([-dzdx, np.ones_like(dzdx), -dzdz], -1)
+    n /= np.linalg.norm(n, axis=-1, keepdims=True)
+    L = np.array([0.35, 0.86, -0.37]); L /= np.linalg.norm(L)
+    lam = np.clip((n * L).sum(-1), 0, 1)
+    on = d['C'][gz, gx] > 0
+    base = np.where(on[..., None], np.array([0.42, 0.30, 0.22]), np.array([0.34, 0.40, 0.22]))
+    col = base * (0.42 + 0.72 * lam)[..., None]
+    img = np.where(hit[..., None], col, np.array(sky)/255.0)
+
+    # --- scenery, rasterised over the same depth buffer ---
+    P, UV, I, M, mats = d['P'], d['UV'], d['I'], d['M'], d['mats']
+    if len(I):
+        rel = P.astype(np.float64) - eye
+        cam = rel @ R.T                                # x right, y up, z forward
+        zc = cam[:, 2]
+        sx = (cam[:, 0] / (zc * th * ar) * 0.5 + 0.5) * W
+        sy = (0.5 - cam[:, 1] / (zc * th) * 0.5) * Hh
+        order = np.argsort(-zc[I].mean(1))             # far to near; the z-buffer settles ties
+        for tri in order:
+            a, bq, c = I[tri]
+            if zc[a] <= 0.2 or zc[bq] <= 0.2 or zc[c] <= 0.2:
+                continue
+            xs = np.array([sx[a], sx[bq], sx[c]]); ys = np.array([sy[a], sy[bq], sy[c]])
+            x0 = max(int(np.floor(xs.min())), 0); x1 = min(int(np.ceil(xs.max())) + 1, W)
+            y0 = max(int(np.floor(ys.min())), 0); y1 = min(int(np.ceil(ys.max())) + 1, Hh)
+            if x0 >= x1 or y0 >= y1 or (x1-x0)*(y1-y0) > 400000:
+                continue
+            X, Y = np.meshgrid(np.arange(x0, x1) + 0.5, np.arange(y0, y1) + 0.5)
+            d0 = (xs[1]-xs[0])*(ys[2]-ys[0]) - (xs[2]-xs[0])*(ys[1]-ys[0])
+            if abs(d0) < 1e-9:
+                continue
+            w1 = ((X-xs[0])*(ys[2]-ys[0]) - (Y-ys[0])*(xs[2]-xs[0])) / d0
+            w2 = ((Y-ys[0])*(xs[1]-xs[0]) - (X-xs[0])*(ys[1]-ys[0])) / d0
+            w0 = 1 - w1 - w2
+            inside = (w0 >= 0) & (w1 >= 0) & (w2 >= 0)
+            if not inside.any():
+                continue
+            # perspective-correct interpolation
+            iz = w0/zc[a] + w1/zc[bq] + w2/zc[c]
+            depth = 1.0 / np.maximum(iz, 1e-9)
+            vis = inside & (depth < tdepth[y0:y1, x0:x1])
+            if not vis.any():
+                continue
+            u = (w0*UV[a,0]/zc[a] + w1*UV[bq,0]/zc[bq] + w2*UV[c,0]/zc[c]) * depth
+            v = (w0*UV[a,1]/zc[a] + w1*UV[bq,1]/zc[bq] + w2*UV[c,1]/zc[c]) * depth
+            tex = mats[M[tri] % len(mats)]
+            dim = tex.shape[0]
+            ti = np.clip((np.mod(u, 1.0) * dim).astype(np.int32), 0, dim-1)
+            tj = np.clip((np.mod(v, 1.0) * dim).astype(np.int32), 0, dim-1)
+            texel = tex[tj, ti]
+            vis &= texel[..., 3] > 110
+            if not vis.any():
+                continue
+            # flat shade from the triangle's own normal
+            e1 = P[bq] - P[a]; e2 = P[c] - P[a]
+            nn = np.cross(e1, e2); ln = np.linalg.norm(nn)
+            lam2 = 0.55 if ln < 1e-9 else 0.45 + 0.55*abs(float(np.dot(nn/ln, L)))
+            rgb = texel[..., :3].astype(np.float64) / 255.0 * lam2
+            sub = img[y0:y1, x0:x1]
+            sub[vis] = rgb[vis]
+            img[y0:y1, x0:x1] = sub
+            sd = tdepth[y0:y1, x0:x1]
+            sd[vis] = depth[vis]
+            tdepth[y0:y1, x0:x1] = sd
+
+    # distance haze
+    fog = np.clip((tdepth - 90.0) / 700.0, 0, 0.72)[..., None]
+    img = img * (1 - fog) + np.array(sky)/255.0 * fog
+    return (np.clip(img, 0, 1) * 255).astype(np.uint8)
+
+if __name__ == '__main__':
+    d = load(sys.argv[1])
+    print('grid', d['gw'], d['gh'], 'mps %.3f' % d['mps'],
+          'scenery', len(d['P']), 'verts', len(d['I']), 'tris', len(d['mats']), 'sheets')
+    # A point on the riding line, and which way it runs there.
+    zs, xs = np.nonzero(d['C'])
+    k = len(zs) // 3
+    cx, cz = xs[k] * d['mps'], zs[k] * d['mps']
+    near = (np.abs(xs*d['mps'] - cx) < 30) & (np.abs(zs*d['mps'] - cz) < 30)
+    pts = np.stack([xs[near]*d['mps'] - cx, zs[near]*d['mps'] - cz], 1)
+    u, s, vt = np.linalg.svd(pts - pts.mean(0), full_matrices=False)
+    dirv = vt[0]
+    gy = float(sample_h(d['H'], d['mps'], np.array([cx]), np.array([cz]))[0])
+
+    views = {
+      'rider': (( cx - dirv[0]*22, gy + 2.4, cz - dirv[1]*22),
+                ( cx + dirv[0]*60, gy + 1.0, cz + dirv[1]*60), 62.0),
+      'trackside': (( cx - dirv[1]*34, gy + 9.0, cz + dirv[0]*34),
+                    ( cx + dirv[0]*25, gy + 1.0, cz + dirv[1]*25), 55.0),
+      'aerial': ((d['size_x']*0.5 - 210, gy + 210, d['size_x']*0.5 - 250),
+                 (d['size_x']*0.5, gy + 2, d['size_x']*0.5), 60.0),
+    }
+    for name, (eye, tgt, fov) in views.items():
+        print('rendering', name, '...', flush=True)
+        im = render(d, eye, tgt, fov=fov)
+        out = sys.argv[2].replace('.png', f'-{name}.png')
+        Image.fromarray(im).save(out)
+        print('  wrote', out)

--- a/src-tauri/src/edf.rs
+++ b/src-tauri/src/edf.rs
@@ -891,9 +891,19 @@ pub fn embedded_textures(b: &[u8]) -> Vec<EmbeddedTexture> {
     const SIZES: [u32; 7] = [64, 128, 256, 512, 1024, 2048, 4096];
     let mut out = Vec::new();
     let mut o = 0usize;
+    // Where the last accepted record ended. The next one starts exactly there, and at that
+    // one offset the boundary rule below does not apply — see the comment on it.
+    let mut resume = usize::MAX;
     'scan: while o + TEX_W_FROM_NAME[1] + TEX_DATA_FROM_W <= b.len() {
-        // A name starts a record only at a word boundary (else `2021crf` also matches at `crf`).
-        if !b[o].is_ascii_alphanumeric() || (o > 0 && b[o - 1].is_ascii_alphanumeric()) {
+        // A name starts a record only at a word boundary (else `2021crf` also matches at
+        // `crf`) — except immediately after a record we have already accepted, where the
+        // preceding byte is the tail of a DEFLATE stream and says nothing. It is ASCII
+        // alphanumeric about a quarter of the time, and the record after it was being
+        // dropped: a two-sheet model came back with one sheet, and which one depended on
+        // how its pixels happened to compress.
+        if !b[o].is_ascii_alphanumeric()
+            || (o > 0 && o != resume && b[o - 1].is_ascii_alphanumeric())
+        {
             o += 1;
             continue;
         }
@@ -927,6 +937,7 @@ pub fn embedded_textures(b: &[u8]) -> Vec<EmbeddedTexture> {
                 data_len,
             });
             o = data_off + data_len; // records don't overlap — skip the payload
+            resume = o;
             continue 'scan;
         }
         o += 1;

--- a/src-tauri/src/edfwrite.rs
+++ b/src-tauri/src/edfwrite.rs
@@ -1,0 +1,660 @@
+//! Writing an `.edf`, which is the only mesh format PiBoSo's compilers load.
+//!
+//! `terrained.exe` places objects from `scene<N>` blocks in a `.hmf`, and `.edf` is the one
+//! extension it will open — its own string table says so. So a generated track can only stand
+//! anything beside its riding line if we can write one, and nothing here could: [`crate::edf`]
+//! is a reader that scans and resynchronises rather than walking a known structure.
+//!
+//! Reading `flagpoles.edf` from PiBoSo's example track against that reader's own constants
+//! accounts for every byte of it, and the container turns out to be small:
+//!
+//! ```text
+//! "EDF\0"
+//! f32[6]                  bounding box over the placed geometry, min then max
+//! u32                     material count
+//!   per material, 56 B:   0 | six 1.0f | 0 | 0,0,0 | colour texture, 1-based | 0 | companion
+//! u32                     vertex count, and the node starts here
+//!   f32[vc*3] position | f32[vc*2] uv0 | f32[vc*2] uv1 | f32[vc*2] ones | f32[vc*2] ones
+//!   f32[vc*3] normal   | f32[vc*4] tangent and its handedness            72 B a vertex
+//! u32                     triangle count
+//!   u32[tc*3]             a plain triangle list
+//! u32                     submesh count
+//! char[104]               the node's name
+//! f32[16]                 the node's placement matrix, row-major
+//! …                       zeros, then one 24 B group record per submesh and its own bounds
+//! u32                     texture count
+//!   per texture:          char[104] name | u32 w | u32 h | 16 B | 0 | u32 size | 8 B zeros
+//!                         | raw-DEFLATE RGBA, `size - 8` bytes
+//! ```
+//!
+//! Written this way a file reads back through [`crate::edf::parse`] with its positions, UVs
+//! and normals intact. That is the first of three checks; the other two are that
+//! `terrained.exe` bakes it and that [`crate::map`] finds the geometry in the `.map` it wrote.
+
+#![allow(dead_code)]
+
+use std::io::Write;
+
+/// Bytes a name field occupies, in a node and in a texture record alike.
+const NAME_LEN: usize = 104;
+/// Bytes per material record.
+const MAT_STRIDE: usize = 56;
+/// Where the node's placement matrix sits, from the start of its name.
+const NODE_MAT_OFF: usize = 104;
+/// Zero words between the placement matrix and the group block.
+const GROUP_GAP: usize = 72;
+
+/// A mesh in the frame it will be placed in: metres, Y up, as the game holds them.
+#[derive(Clone, Debug, Default)]
+pub struct Mesh {
+    /// `3 * vertex_count`.
+    pub positions: Vec<f32>,
+    /// `2 * vertex_count`.
+    pub uvs: Vec<f32>,
+    /// `3 * vertex_count`, unit length.
+    pub normals: Vec<f32>,
+    /// `3 * triangle_count`.
+    pub indices: Vec<u32>,
+}
+
+impl Mesh {
+    pub fn vertex_count(&self) -> usize {
+        self.positions.len() / 3
+    }
+    pub fn triangle_count(&self) -> usize {
+        self.indices.len() / 3
+    }
+
+    /// Append another mesh, shifting its indices.
+    pub fn append(&mut self, other: &Mesh) {
+        let base = self.vertex_count() as u32;
+        self.positions.extend_from_slice(&other.positions);
+        self.uvs.extend_from_slice(&other.uvs);
+        self.normals.extend_from_slice(&other.normals);
+        self.indices.extend(other.indices.iter().map(|i| i + base));
+    }
+
+    /// The box the geometry sits in, as `(min, max)`.
+    pub fn bounds(&self) -> ([f32; 3], [f32; 3]) {
+        let mut lo = [f32::INFINITY; 3];
+        let mut hi = [f32::NEG_INFINITY; 3];
+        for v in self.positions.chunks_exact(3) {
+            for k in 0..3 {
+                lo[k] = lo[k].min(v[k]);
+                hi[k] = hi[k].max(v[k]);
+            }
+        }
+        if !lo[0].is_finite() {
+            return ([0.0; 3], [0.0; 3]);
+        }
+        (lo, hi)
+    }
+}
+
+/// A texture to embed, RGBA8.
+#[derive(Clone, Debug)]
+pub struct Texture {
+    /// The name the material binds by. A `_c_a` suffix marks it an alpha cut-out, which is
+    /// what makes a foliage card a tree rather than a standing sheet of paper.
+    pub name: String,
+    pub width: u32,
+    pub height: u32,
+    /// `width * height * 4`.
+    pub rgba: Vec<u8>,
+}
+
+/// One drawn part: a mesh and the texture it wears.
+#[derive(Clone, Debug)]
+pub struct Part {
+    pub name: String,
+    pub mesh: Mesh,
+    /// Index into the model's textures.
+    pub texture: usize,
+}
+
+fn put_u32(out: &mut Vec<u8>, v: u32) {
+    out.extend_from_slice(&v.to_le_bytes());
+}
+fn put_f32(out: &mut Vec<u8>, v: f32) {
+    out.extend_from_slice(&v.to_le_bytes());
+}
+fn put_name(out: &mut Vec<u8>, name: &str) {
+    let mut field = [0u8; NAME_LEN];
+    for (i, b) in name.bytes().take(NAME_LEN - 1).enumerate() {
+        field[i] = b;
+    }
+    out.extend_from_slice(&field);
+}
+
+/// Per-vertex tangents, from the UVs where they say anything and from the normal where they
+/// don't. The fourth component is handedness, which every vertex of the example model writes
+/// as 1.
+fn tangents(mesh: &Mesh) -> Vec<[f32; 4]> {
+    let vc = mesh.vertex_count();
+    let mut acc = vec![[0.0f32; 3]; vc];
+    for t in mesh.indices.chunks_exact(3) {
+        let (i0, i1, i2) = (t[0] as usize, t[1] as usize, t[2] as usize);
+        if i0 >= vc || i1 >= vc || i2 >= vc {
+            continue;
+        }
+        let p = |i: usize| {
+            [
+                mesh.positions[i * 3],
+                mesh.positions[i * 3 + 1],
+                mesh.positions[i * 3 + 2],
+            ]
+        };
+        let uv = |i: usize| [mesh.uvs[i * 2], mesh.uvs[i * 2 + 1]];
+        let (p0, p1, p2) = (p(i0), p(i1), p(i2));
+        let (t0, t1, t2) = (uv(i0), uv(i1), uv(i2));
+        let e1 = [p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2]];
+        let e2 = [p2[0] - p0[0], p2[1] - p0[1], p2[2] - p0[2]];
+        let (du1, dv1) = (t1[0] - t0[0], t1[1] - t0[1]);
+        let (du2, dv2) = (t2[0] - t0[0], t2[1] - t0[1]);
+        let det = du1 * dv2 - du2 * dv1;
+        if det.abs() < 1e-12 {
+            continue;
+        }
+        let r = 1.0 / det;
+        let tan = [
+            (e1[0] * dv2 - e2[0] * dv1) * r,
+            (e1[1] * dv2 - e2[1] * dv1) * r,
+            (e1[2] * dv2 - e2[2] * dv1) * r,
+        ];
+        for &i in &[i0, i1, i2] {
+            for k in 0..3 {
+                acc[i][k] += tan[k];
+            }
+        }
+    }
+    (0..vc)
+        .map(|i| {
+            let n = [
+                mesh.normals[i * 3],
+                mesh.normals[i * 3 + 1],
+                mesh.normals[i * 3 + 2],
+            ];
+            let mut t = acc[i];
+            // Gram-Schmidt against the normal, so the frame is orthogonal.
+            let d = t[0] * n[0] + t[1] * n[1] + t[2] * n[2];
+            for k in 0..3 {
+                t[k] -= n[k] * d;
+            }
+            let len = (t[0] * t[0] + t[1] * t[1] + t[2] * t[2]).sqrt();
+            if len > 1e-6 {
+                [t[0] / len, t[1] / len, t[2] / len, 1.0]
+            } else {
+                // A degenerate UV frame still needs a tangent: any vector across the normal.
+                let a = if n[1].abs() < 0.9 { [0.0, 1.0, 0.0] } else { [1.0, 0.0, 0.0] };
+                let c = [
+                    a[1] * n[2] - a[2] * n[1],
+                    a[2] * n[0] - a[0] * n[2],
+                    a[0] * n[1] - a[1] * n[0],
+                ];
+                let l = (c[0] * c[0] + c[1] * c[1] + c[2] * c[2]).sqrt().max(1e-6);
+                [c[0] / l, c[1] / l, c[2] / l, 1.0]
+            }
+        })
+        .collect()
+}
+
+/// Write a model: its parts, and the textures they wear.
+///
+/// One node per part, in the order given, then every texture once at the end. A material is
+/// emitted per part and binds the texture that part names.
+pub fn write(parts: &[Part], textures: &[Texture]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(b"EDF\0");
+
+    // The bounds are written over the *placed* geometry, and these are placed where they were
+    // authored — the node matrix below is identity — so the union of the parts is it.
+    let (mut lo, mut hi) = ([f32::INFINITY; 3], [f32::NEG_INFINITY; 3]);
+    for p in parts {
+        let (a, b) = p.mesh.bounds();
+        for k in 0..3 {
+            lo[k] = lo[k].min(a[k]);
+            hi[k] = hi[k].max(b[k]);
+        }
+    }
+    if !lo[0].is_finite() {
+        (lo, hi) = ([0.0; 3], [0.0; 3]);
+    }
+    for v in lo.iter().chain(hi.iter()) {
+        put_f32(&mut out, *v);
+    }
+
+    // One material per part. `texture` is 1-based in the file, zero meaning none.
+    put_u32(&mut out, parts.len() as u32);
+    for p in parts {
+        let start = out.len();
+        put_u32(&mut out, 0);
+        for _ in 0..6 {
+            put_f32(&mut out, 1.0);
+        }
+        for _ in 0..4 {
+            put_u32(&mut out, 0);
+        }
+        put_u32(&mut out, p.texture as u32 + 1);
+        put_u32(&mut out, 0);
+        put_u32(&mut out, 0);
+        debug_assert_eq!(out.len() - start, MAT_STRIDE);
+    }
+
+    for p in parts {
+        write_node(&mut out, p);
+    }
+    // One count for the whole model, then the records back to back. `finish_gate.edf` is
+    // what says this is a count rather than a per-node word: it writes 4 here and carries
+    // four sheets, where the one-sheet models write 1.
+    put_u32(&mut out, textures.len() as u32);
+    for t in textures {
+        write_texture(&mut out, t);
+    }
+    out
+}
+
+fn write_node(out: &mut Vec<u8>, part: &Part) {
+    let mesh = &part.mesh;
+    let vc = mesh.vertex_count();
+    let tc = mesh.triangle_count();
+    let tans = tangents(mesh);
+
+    put_u32(out, vc as u32);
+    for v in &mesh.positions {
+        put_f32(out, *v);
+    }
+    for v in &mesh.uvs {
+        put_f32(out, *v);
+    }
+    // uv1 is zero on every node measured, and the two lanes after it are a constant (1, 1).
+    for _ in 0..vc * 2 {
+        put_f32(out, 0.0);
+    }
+    for _ in 0..vc * 4 {
+        put_f32(out, 1.0);
+    }
+    for v in &mesh.normals {
+        put_f32(out, *v);
+    }
+    for t in &tans {
+        for v in t {
+            put_f32(out, *v);
+        }
+    }
+
+    put_u32(out, tc as u32);
+    for i in &mesh.indices {
+        put_u32(out, *i);
+    }
+    put_u32(out, 1); // one submesh: the node is one piece
+
+    let name_at = out.len();
+    put_name(out, &part.name);
+    debug_assert_eq!(out.len() - name_at, NODE_MAT_OFF);
+
+    // Placed where it was authored.
+    for row in 0..4 {
+        for col in 0..4 {
+            put_f32(out, if row == col { 1.0 } else { 0.0 });
+        }
+    }
+    for _ in 0..GROUP_GAP / 4 {
+        put_u32(out, 0);
+    }
+    // The group block: one group covering the whole node, and the bounds it covers.
+    put_u32(out, 1);
+    for _ in 0..3 {
+        put_u32(out, 0);
+    }
+    put_u32(out, tc as u32);
+    put_u32(out, 0);
+    put_u32(out, vc as u32);
+    put_u32(out, vc as u32);
+    put_u32(out, 0);
+    let (lo, hi) = mesh.bounds();
+    for v in lo.iter().chain(hi.iter()) {
+        put_f32(out, *v);
+    }
+}
+
+fn write_texture(out: &mut Vec<u8>, t: &Texture) {
+    put_name(out, &t.name);
+    put_u32(out, t.width);
+    put_u32(out, t.height);
+    // Four words the exporter fills with something of its own and nothing reads, then a zero.
+    for _ in 0..5 {
+        put_u32(out, 0);
+    }
+    let mut enc = flate2::write::DeflateEncoder::new(Vec::new(), flate2::Compression::default());
+    let _ = enc.write_all(&t.rgba);
+    let data = enc.finish().unwrap_or_default();
+    put_u32(out, data.len() as u32 + 8);
+    put_u32(out, 0);
+    put_u32(out, 0);
+    out.extend_from_slice(&data);
+}
+
+/// A flat card standing upright, `w` across and `h` tall, centred on the origin and facing
+/// +z. The primitive nearly everything on a track is made of.
+pub fn card(w: f32, h: f32) -> Mesh {
+    let (hw, y) = (w * 0.5, h);
+    Mesh {
+        positions: vec![-hw, 0.0, 0.0, hw, 0.0, 0.0, hw, y, 0.0, -hw, y, 0.0],
+        uvs: vec![0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0],
+        normals: vec![0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0],
+        indices: vec![0, 1, 2, 0, 2, 3],
+    }
+}
+
+/// `n` cards through the same upright axis, evenly spread — the shape a tree, a bush or a
+/// crowd line is in every published track: flat quads whose sheet cuts the silhouette out.
+///
+/// Two is the usual answer and three reads better from a low camera, which is where a rider
+/// is. Also the smallest honest node: a lone card is four vertices, and
+/// [`crate::edf::parse`] cannot see a node that small.
+pub fn crossed(w: f32, h: f32, n: usize) -> Mesh {
+    let mut mesh = Mesh::default();
+    for i in 0..n.max(2) {
+        let deg = 180.0 * i as f32 / n.max(2) as f32;
+        mesh.append(&turned(&card(w, h), deg));
+    }
+    mesh
+}
+
+/// Rotate a mesh about Y, degrees.
+pub fn turned(mesh: &Mesh, deg: f32) -> Mesh {
+    let (s, c) = deg.to_radians().sin_cos();
+    let spin = |v: &[f32]| vec![v[0] * c + v[2] * s, v[1], -v[0] * s + v[2] * c];
+    Mesh {
+        positions: mesh.positions.chunks_exact(3).flat_map(spin).collect(),
+        normals: mesh.normals.chunks_exact(3).flat_map(spin).collect(),
+        uvs: mesh.uvs.clone(),
+        indices: mesh.indices.clone(),
+    }
+}
+
+/// Move a mesh.
+pub fn moved(mesh: &Mesh, by: [f32; 3]) -> Mesh {
+    Mesh {
+        positions: mesh
+            .positions
+            .chunks_exact(3)
+            .flat_map(|v| vec![v[0] + by[0], v[1] + by[1], v[2] + by[2]])
+            .collect(),
+        ..mesh.clone()
+    }
+}
+
+/// A box with its base on y = 0, `w` by `d` and `h` tall, centred on the origin in x and z.
+pub fn cuboid(w: f32, h: f32, d: f32) -> Mesh {
+    let (hw, hd) = (w * 0.5, d * 0.5);
+    let mut mesh = Mesh::default();
+    // Six faces, each its own four vertices so every one carries its own normal.
+    let faces: [([f32; 3], [f32; 3], [f32; 3]); 6] = [
+        ([0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]),
+        ([0.0, 0.0, -1.0], [-1.0, 0.0, 0.0], [0.0, 1.0, 0.0]),
+        ([1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]),
+        ([-1.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 1.0, 0.0]),
+        ([0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, -1.0]),
+        ([0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]),
+    ];
+    let half = [hw, h * 0.5, hd];
+    for (n, u, v) in faces {
+        let centre = [n[0] * half[0], h * 0.5 + n[1] * half[1], n[2] * half[2]];
+        let eu = [u[0] * half[0], u[1] * half[1], u[2] * half[2]];
+        let ev = [v[0] * half[0], v[1] * half[1], v[2] * half[2]];
+        let base = mesh.vertex_count() as u32;
+        for (su, sv) in [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)] {
+            for k in 0..3 {
+                mesh.positions
+                    .push(centre[k] + eu[k] * su as f32 + ev[k] * sv as f32);
+            }
+            mesh.normals.extend_from_slice(&n);
+        }
+        mesh.uvs
+            .extend_from_slice(&[0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0]);
+        mesh.indices
+            .extend_from_slice(&[base, base + 1, base + 2, base, base + 2, base + 3]);
+    }
+    mesh
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A flat sheet, so the check is on the container rather than on the picture.
+    fn sheet(name: &str, dim: u32, rgba: [u8; 4]) -> Texture {
+        Texture {
+            name: name.to_string(),
+            width: dim,
+            height: dim,
+            rgba: rgba
+                .iter()
+                .copied()
+                .cycle()
+                .take((dim * dim * 4) as usize)
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn a_written_edf_reads_back_through_our_own_parser() {
+        let mesh = cuboid(2.0, 3.0, 1.0);
+        let (vc, tc) = (mesh.vertex_count(), mesh.triangle_count());
+        let bytes = write(
+            &[Part { name: "post".into(), mesh: mesh.clone(), texture: 0 }],
+            &[sheet("post_c", 64, [200, 180, 60, 255])],
+        );
+
+        assert!(crate::edf::is_edf(&bytes));
+        let nodes = crate::edf::parse_world(&bytes);
+        assert_eq!(nodes.len(), 1, "one part, one node");
+        let n = &nodes[0];
+        assert_eq!(n.name, "post");
+        assert_eq!(n.positions.len(), vc * 3);
+        assert_eq!(n.normals.len(), vc * 3);
+        assert_eq!(n.uvs.len(), vc * 2);
+        assert_eq!(n.indices.len() / 3, tc);
+
+        // The geometry has to come back where it was written, not merely in the right shape.
+        for (a, b) in n.positions.iter().zip(mesh.positions.iter()) {
+            assert!((a - b).abs() < 1e-4, "{a} != {b}");
+        }
+    }
+
+    #[test]
+    fn the_header_states_the_bounds_the_geometry_actually_has() {
+        // The one statement the file makes about where the model sits, and the reader
+        // checks placed geometry against it — see `edf::header_aabb`.
+        let mesh = moved(&cuboid(2.0, 3.0, 1.0), [5.0, 0.0, -4.0]);
+        let bytes = write(
+            &[Part { name: "post".into(), mesh: mesh.clone(), texture: 0 }],
+            &[sheet("post_c", 64, [1, 2, 3, 255])],
+        );
+        let (lo, hi) = crate::edf::header_aabb(&bytes).expect("header states bounds");
+        let (mlo, mhi) = mesh.bounds();
+        for k in 0..3 {
+            assert!((lo[k] - mlo[k]).abs() < 1e-4, "min {k}: {} != {}", lo[k], mlo[k]);
+            assert!((hi[k] - mhi[k]).abs() < 1e-4, "max {k}: {} != {}", hi[k], mhi[k]);
+        }
+    }
+
+    #[test]
+    fn the_texture_comes_back_out_of_the_file() {
+        let tex = sheet("bark_c_a", 64, [10, 120, 30, 255]);
+        let bytes = write(
+            &[Part { name: "trunk".into(), mesh: card(1.0, 4.0), texture: 0 }],
+            &[tex.clone()],
+        );
+        let found = crate::edf::embedded_textures(&bytes);
+        assert_eq!(found.len(), 1, "one texture in, one out");
+        assert_eq!(found[0].name, "bark_c_a");
+        assert_eq!((found[0].width, found[0].height), (64, 64));
+        let rgba = crate::edf::inflate_texture(&bytes, &found[0]).expect("inflates");
+        assert_eq!(rgba, tex.rgba, "the pixels survive the round trip");
+    }
+
+    #[test]
+    fn several_parts_each_bind_their_own_sheet() {
+        let bytes = write(
+            &[
+                Part { name: "trunk".into(), mesh: cuboid(0.4, 4.0, 0.4), texture: 0 },
+                Part { name: "canopy".into(), mesh: crossed(5.0, 5.0, 2), texture: 1 },
+            ],
+            &[sheet("bark_c", 64, [90, 60, 40, 255]), sheet("leaf_c_a", 64, [40, 110, 40, 128])],
+        );
+        let nodes = crate::edf::parse_world(&bytes);
+        let names: Vec<&str> = nodes.iter().map(|n| n.name.as_str()).collect();
+        assert!(names.contains(&"trunk") && names.contains(&"canopy"), "{names:?}");
+        assert_eq!(crate::edf::embedded_textures(&bytes).len(), 2);
+        // Which material each node names — the binding a compiler will read.
+        let textures = crate::edf::embedded_textures(&bytes).len();
+        let table = crate::edf::node_material_table(&bytes, 0x1c + 4 + MAT_STRIDE * 2, textures);
+        assert_eq!(table, vec![Some(0), Some(1)], "two materials, two sheets, in order");
+    }
+
+    #[test]
+    fn a_node_under_eight_vertices_is_invisible_to_the_reader() {
+        // Not a fault in what is written — it is [`crate::edf::parse`]'s own floor, and it
+        // exists because that parser finds nodes by scanning for a plausible vertex count in
+        // a file it cannot walk. A lone card is four vertices and lands under it. Everything
+        // this module builds crosses cards or boxes them, so nothing real sits below eight,
+        // but a bare `card` node would vanish and it is better to have said so.
+        let bytes = write(
+            &[Part { name: "lone".into(), mesh: card(1.0, 1.0), texture: 0 }],
+            &[sheet("x_c", 64, [1, 1, 1, 255])],
+        );
+        assert!(crate::edf::parse_world(&bytes).is_empty());
+        assert_eq!(crate::edf::embedded_textures(&bytes).len(), 1, "the sheet is still there");
+    }
+
+    #[test]
+    fn a_card_stands_up_and_faces_the_way_it_was_turned() {
+        let m = turned(&card(2.0, 2.0), 90.0);
+        // Facing +z turned a quarter is facing +x, and it still stands from y = 0 to y = 2.
+        assert!((m.normals[0] - 1.0).abs() < 1e-5, "{:?}", &m.normals[..3]);
+        let (lo, hi) = m.bounds();
+        assert!((lo[1] - 0.0).abs() < 1e-5 && (hi[1] - 2.0).abs() < 1e-5);
+    }
+}
+
+#[cfg(test)]
+mod compiles {
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    /// A sheet with something to look at, so a compiled map can be told apart from a blank.
+    fn checks(name: &str, dim: u32, a: [u8; 4], b: [u8; 4]) -> Texture {
+        let mut rgba = Vec::with_capacity((dim * dim * 4) as usize);
+        for y in 0..dim {
+            for x in 0..dim {
+                let c = if (x / 8 + y / 8) % 2 == 0 { a } else { b };
+                rgba.extend_from_slice(&c);
+            }
+        }
+        Texture { name: name.into(), width: dim, height: dim, rgba }
+    }
+
+    /// The one check that matters: `terrained.exe` opens what we wrote, and the geometry
+    /// comes back out of the `.map` it compiled, where the `scene` block asked for it.
+    ///
+    /// ```text
+    /// FROST_TOOLS=~/Downloads/mxb-trackbuild/tools \
+    /// FROST_PREFIX=~/Downloads/mxb-trackbuild/prefix \
+    /// FROST_WINE="~/Downloads/mxb-trackbuild/Wine Devel.app/Contents/Resources/wine/bin/wine" \
+    /// FROST_SCENE=/tmp/edftest \
+    ///   cargo test -- --ignored --nocapture terrained_bakes_what_we_wrote
+    /// ```
+    ///
+    /// `FROST_SCENE` is a folder holding a `track.hmf` whose `scene0` names `probe.edf`, a
+    /// flat `heightmap.raw` and one layer sheet — the smallest thing TerrainEd will compile.
+    #[test]
+    #[ignore = "needs PiBoSo's compilers and a Wine prefix"]
+    fn terrained_bakes_what_we_wrote() {
+        let dir = PathBuf::from(std::env::var("FROST_SCENE").expect("set FROST_SCENE"));
+        let tools = PathBuf::from(std::env::var("FROST_TOOLS").expect("set FROST_TOOLS"));
+        let terrained = crate::trackbuild::find(&tools)
+            .expect("terrained.exe under FROST_TOOLS")
+            .terrained;
+
+        // A post you could not mistake for terrain: two metres square, four tall, standing
+        // where the scene block says and nowhere else.
+        let (w, h) = (2.0f32, 4.0f32);
+        let bytes = write(
+            &[Part { name: "probe".into(), mesh: cuboid(w, h, w), texture: 0 }],
+            &[checks("probe_c", 64, [220, 40, 40, 255], [250, 250, 250, 255])],
+        );
+        std::fs::write(dir.join("probe.edf"), &bytes).unwrap();
+        println!("probe.edf: {} bytes", bytes.len());
+
+        let map = "out/probe.map";
+        let _ = std::fs::remove_file(dir.join(map));
+        let out = run(&terrained, &["track.hmf", map, "params.ini"], &dir);
+        println!("--- terrained ---\n{out}\n---");
+
+        let produced = dir.join(map);
+        assert!(produced.is_file(), "terrained wrote no {map}");
+        let mb = std::fs::read(&produced).unwrap();
+        let mesh = crate::map::parse(&mb).expect("the .map parses");
+        println!(
+            "{} materials, {} vertices, {} triangles, {} islands",
+            mesh.materials,
+            mesh.vertex_count(),
+            mesh.triangle_count(),
+            mesh.objects.len()
+        );
+
+        // The scene block put it at (40, 3, 50). Terrain in this scene is flat at y = 0 and
+        // covers 128 m square, so anything standing between 3 and 7 metres up is ours.
+        let ours: Vec<[f32; 3]> = mesh
+            .positions
+            .chunks_exact(3)
+            .filter(|v| v[1] > 2.5)
+            .map(|v| [v[0], v[1], v[2]])
+            .collect();
+        assert!(!ours.is_empty(), "nothing in the map stands above the ground");
+        let mut lo = [f32::INFINITY; 3];
+        let mut hi = [f32::NEG_INFINITY; 3];
+        for v in &ours {
+            for k in 0..3 {
+                lo[k] = lo[k].min(v[k]);
+                hi[k] = hi[k].max(v[k]);
+            }
+        }
+        println!("what stands above the ground: {lo:?} .. {hi:?}");
+        assert!((hi[1] - (3.0 + h)).abs() < 0.5, "top should be at {}, is {}", 3.0 + h, hi[1]);
+        assert!((hi[0] - lo[0] - w).abs() < 0.5, "should be {w} m across, is {}", hi[0] - lo[0]);
+        // And the texture travelled with it.
+        let names: Vec<String> = crate::map::survey(&mb).into_iter().map(|(n, ..)| n).collect();
+        println!("sheets in the map: {names:?}");
+        assert!(
+            names.iter().any(|n| n.eq_ignore_ascii_case("probe_c")),
+            "the sheet the model embedded is not in the map: {names:?}"
+        );
+    }
+
+    fn run(exe: &Path, args: &[&str], dir: &Path) -> String {
+        let mut cmd = if cfg!(target_os = "windows") {
+            std::process::Command::new(exe)
+        } else {
+            let wine = std::env::var("FROST_WINE").expect("set FROST_WINE");
+            let mut c = std::process::Command::new(wine);
+            c.env(
+                "WINEPREFIX",
+                std::env::var("FROST_PREFIX").expect("set FROST_PREFIX"),
+            );
+            c.env("WINEDEBUG", "-all");
+            c.arg(exe);
+            c
+        };
+        cmd.args(args).current_dir(dir);
+        let out = cmd.output().expect("running terrained");
+        format!(
+            "exit {:?}\n{}{}",
+            out.status.code(),
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        )
+    }
+}

--- a/src-tauri/src/edfwrite.rs
+++ b/src-tauri/src/edfwrite.rs
@@ -18,14 +18,33 @@
 //!   f32[vc*3] normal   | f32[vc*4] tangent and its handedness            72 B a vertex
 //! u32                     triangle count
 //!   u32[tc*3]             a plain triangle list
-//! u32                     submesh count
+//! u32                     submesh count, which is 1 whatever the group count is
 //! char[104]               the node's name
 //! f32[16]                 the node's placement matrix, row-major
-//! …                       zeros, then one 24 B group record per submesh and its own bounds
+//! 72 B                    zeros
+//! u32 group count, u32 0
+//!   per group, 24 B:      material | tri start | tri count | vert start | vert count | end
+//! u32 0, f32[6]           the node's own bounds
 //! u32                     texture count
 //!   per texture:          char[104] name | u32 w | u32 h | 16 B | 0 | u32 size | 8 B zeros
 //!                         | raw-DEFLATE RGBA, `size - 8` bytes
 //! ```
+//!
+//! **A model of several materials is one node of several groups, not several nodes.**
+//! `finish_gate.edf` settles it: four materials, four groups, one node called
+//! `finishgate_proxy`, and its groups' triangle counts sum to the node's exactly. Written as
+//! several nodes instead, TerrainEd faults on a null write and produces nothing — which is
+//! how this was found, because a one-part model happens to be byte-identical either way.
+//!
+//! **One sheet per model.** TerrainEd accepts everything here with a single material —
+//! boxes, cut-out cards, two groups sharing one sheet, two hundred copies in one node — and
+//! faults on the *second material*, however the geometry is arranged. See
+//! `which_ingredient_terrained_refuses`, which is the test that says so, case by case. The
+//! reason is in the texture block: real files put a trailer between records whose length
+//! varies with the record (8, 24 and 40 bytes in the two example models), and nothing here
+//! knows what it says yet. So a model written here carries one sheet, and a thing with
+//! several materials is several models — which is exactly what PiBoSo's own example track
+//! does, shipping `finish_gate`, `flagpoles` and `standings_tower` as three `scene` blocks.
 //!
 //! Written this way a file reads back through [`crate::edf::parse`] with its positions, UVs
 //! and normals intact. That is the first of three checks; the other two are that
@@ -200,25 +219,31 @@ fn tangents(mesh: &Mesh) -> Vec<[f32; 4]> {
 
 /// Write a model: its parts, and the textures they wear.
 ///
-/// One node per part, in the order given, then every texture once at the end. A material is
-/// emitted per part and binds the texture that part names.
-pub fn write(parts: &[Part], textures: &[Texture]) -> Vec<u8> {
+/// The parts become **groups of one node**, in the order given, each binding the texture it
+/// names. A part's `name` is for our own bookkeeping — a group has no name field in the file;
+/// only the node does, and it takes `name`.
+pub fn write(name: &str, parts: &[Part], textures: &[Texture]) -> Vec<u8> {
     let mut out = Vec::new();
     out.extend_from_slice(b"EDF\0");
 
-    // The bounds are written over the *placed* geometry, and these are placed where they were
-    // authored — the node matrix below is identity — so the union of the parts is it.
-    let (mut lo, mut hi) = ([f32::INFINITY; 3], [f32::NEG_INFINITY; 3]);
+    // One combined mesh, and where each part landed in it.
+    let mut mesh = Mesh::default();
+    let mut ranges: Vec<Range> = Vec::with_capacity(parts.len());
     for p in parts {
-        let (a, b) = p.mesh.bounds();
-        for k in 0..3 {
-            lo[k] = lo[k].min(a[k]);
-            hi[k] = hi[k].max(b[k]);
-        }
+        let r = Range {
+            material: ranges.len() as u32,
+            tri_start: mesh.triangle_count() as u32,
+            tri_count: p.mesh.triangle_count() as u32,
+            vert_start: mesh.vertex_count() as u32,
+            vert_count: p.mesh.vertex_count() as u32,
+        };
+        mesh.append(&p.mesh);
+        ranges.push(r);
     }
-    if !lo[0].is_finite() {
-        (lo, hi) = ([0.0; 3], [0.0; 3]);
-    }
+
+    // The bounds are written over the placed geometry, and the node matrix below is identity,
+    // so the combined mesh is it.
+    let (lo, hi) = mesh.bounds();
     for v in lo.iter().chain(hi.iter()) {
         put_f32(&mut out, *v);
     }
@@ -240,9 +265,8 @@ pub fn write(parts: &[Part], textures: &[Texture]) -> Vec<u8> {
         debug_assert_eq!(out.len() - start, MAT_STRIDE);
     }
 
-    for p in parts {
-        write_node(&mut out, p);
-    }
+    write_node(&mut out, name, &mesh, &ranges);
+
     // One count for the whole model, then the records back to back. `finish_gate.edf` is
     // what says this is a count rather than a per-node word: it writes 4 here and carries
     // four sheets, where the one-sheet models write 1.
@@ -253,8 +277,17 @@ pub fn write(parts: &[Part], textures: &[Texture]) -> Vec<u8> {
     out
 }
 
-fn write_node(out: &mut Vec<u8>, part: &Part) {
-    let mesh = &part.mesh;
+/// One group of a node: which material paints which run of triangles.
+#[derive(Clone, Copy, Debug)]
+struct Range {
+    material: u32,
+    tri_start: u32,
+    tri_count: u32,
+    vert_start: u32,
+    vert_count: u32,
+}
+
+fn write_node(out: &mut Vec<u8>, name: &str, mesh: &Mesh, ranges: &[Range]) {
     let vc = mesh.vertex_count();
     let tc = mesh.triangle_count();
     let tans = tangents(mesh);
@@ -286,10 +319,12 @@ fn write_node(out: &mut Vec<u8>, part: &Part) {
     for i in &mesh.indices {
         put_u32(out, *i);
     }
-    put_u32(out, 1); // one submesh: the node is one piece
+    // One, whatever the group count is — `finish_gate.edf` writes 1 here and carries four
+    // groups.
+    put_u32(out, 1);
 
     let name_at = out.len();
-    put_name(out, &part.name);
+    put_name(out, name);
     debug_assert_eq!(out.len() - name_at, NODE_MAT_OFF);
 
     // Placed where it was authored.
@@ -301,15 +336,20 @@ fn write_node(out: &mut Vec<u8>, part: &Part) {
     for _ in 0..GROUP_GAP / 4 {
         put_u32(out, 0);
     }
-    // The group block: one group covering the whole node, and the bounds it covers.
-    put_u32(out, 1);
-    for _ in 0..3 {
-        put_u32(out, 0);
-    }
-    put_u32(out, tc as u32);
+
+    put_u32(out, ranges.len() as u32);
     put_u32(out, 0);
-    put_u32(out, vc as u32);
-    put_u32(out, vc as u32);
+    for (i, r) in ranges.iter().enumerate() {
+        put_u32(out, r.material);
+        put_u32(out, r.tri_start);
+        put_u32(out, r.tri_count);
+        put_u32(out, r.vert_start);
+        put_u32(out, r.vert_count);
+        // Zero on every group but the last, which carries the vertex the node ends at. Both
+        // worked examples do this and nothing here needs to know why.
+        let last = i + 1 == ranges.len();
+        put_u32(out, if last { r.vert_start + r.vert_count } else { 0 });
+    }
     put_u32(out, 0);
     let (lo, hi) = mesh.bounds();
     for v in lo.iter().chain(hi.iter()) {
@@ -443,6 +483,7 @@ mod tests {
         let mesh = cuboid(2.0, 3.0, 1.0);
         let (vc, tc) = (mesh.vertex_count(), mesh.triangle_count());
         let bytes = write(
+            "probe",
             &[Part { name: "post".into(), mesh: mesh.clone(), texture: 0 }],
             &[sheet("post_c", 64, [200, 180, 60, 255])],
         );
@@ -451,7 +492,7 @@ mod tests {
         let nodes = crate::edf::parse_world(&bytes);
         assert_eq!(nodes.len(), 1, "one part, one node");
         let n = &nodes[0];
-        assert_eq!(n.name, "post");
+        assert_eq!(n.name, "probe", "the node takes the model's name");
         assert_eq!(n.positions.len(), vc * 3);
         assert_eq!(n.normals.len(), vc * 3);
         assert_eq!(n.uvs.len(), vc * 2);
@@ -469,6 +510,7 @@ mod tests {
         // checks placed geometry against it — see `edf::header_aabb`.
         let mesh = moved(&cuboid(2.0, 3.0, 1.0), [5.0, 0.0, -4.0]);
         let bytes = write(
+            "probe",
             &[Part { name: "post".into(), mesh: mesh.clone(), texture: 0 }],
             &[sheet("post_c", 64, [1, 2, 3, 255])],
         );
@@ -484,6 +526,7 @@ mod tests {
     fn the_texture_comes_back_out_of_the_file() {
         let tex = sheet("bark_c_a", 64, [10, 120, 30, 255]);
         let bytes = write(
+            "probe",
             &[Part { name: "trunk".into(), mesh: card(1.0, 4.0), texture: 0 }],
             &[tex.clone()],
         );
@@ -496,22 +539,29 @@ mod tests {
     }
 
     #[test]
-    fn several_parts_each_bind_their_own_sheet() {
+    fn several_parts_are_one_node_of_several_groups() {
         let bytes = write(
+            "tree",
             &[
                 Part { name: "trunk".into(), mesh: cuboid(0.4, 4.0, 0.4), texture: 0 },
                 Part { name: "canopy".into(), mesh: crossed(5.0, 5.0, 2), texture: 1 },
             ],
             &[sheet("bark_c", 64, [90, 60, 40, 255]), sheet("leaf_c_a", 64, [40, 110, 40, 128])],
         );
+        // One node. Written as two, TerrainEd faults on a null write — see the module note.
         let nodes = crate::edf::parse_world(&bytes);
-        let names: Vec<&str> = nodes.iter().map(|n| n.name.as_str()).collect();
-        assert!(names.contains(&"trunk") && names.contains(&"canopy"), "{names:?}");
-        assert_eq!(crate::edf::embedded_textures(&bytes).len(), 2);
-        // Which material each node names — the binding a compiler will read.
-        let textures = crate::edf::embedded_textures(&bytes).len();
-        let table = crate::edf::node_material_table(&bytes, 0x1c + 4 + MAT_STRIDE * 2, textures);
+        assert_eq!(nodes.len(), 1, "several materials are one node, not several");
+        assert_eq!(nodes[0].name, "tree");
+
+        // Both sheets travel, and the node's material table names them in order.
+        let found = crate::edf::embedded_textures(&bytes);
+        assert_eq!(found.len(), 2);
+        let table = crate::edf::node_material_table(&bytes, 0x1c + 4 + MAT_STRIDE * 2, found.len());
         assert_eq!(table, vec![Some(0), Some(1)], "two materials, two sheets, in order");
+
+        // And the groups split the triangles between them the way the parts were given.
+        let (trunk_t, canopy_t) = (cuboid(0.4, 4.0, 0.4).triangle_count(), crossed(5.0, 5.0, 2).triangle_count());
+        assert_eq!(nodes[0].indices.len() / 3, trunk_t + canopy_t);
     }
 
     #[test]
@@ -522,6 +572,7 @@ mod tests {
         // this module builds crosses cards or boxes them, so nothing real sits below eight,
         // but a bare `card` node would vanish and it is better to have said so.
         let bytes = write(
+            "lone",
             &[Part { name: "lone".into(), mesh: card(1.0, 1.0), texture: 0 }],
             &[sheet("x_c", 64, [1, 1, 1, 255])],
         );
@@ -582,6 +633,7 @@ mod compiles {
         // where the scene block says and nowhere else.
         let (w, h) = (2.0f32, 4.0f32);
         let bytes = write(
+            "probe",
             &[Part { name: "probe".into(), mesh: cuboid(w, h, w), texture: 0 }],
             &[checks("probe_c", 64, [220, 40, 40, 255], [250, 250, 250, 255])],
         );
@@ -632,6 +684,165 @@ mod compiles {
             names.iter().any(|n| n.eq_ignore_ascii_case("probe_c")),
             "the sheet the model embedded is not in the map: {names:?}"
         );
+    }
+
+    /// The same, but a model of several parts wearing several sheets — which is what a
+    /// track's scenery is, and which the single-part proof above does not cover.
+    #[test]
+    #[ignore = "needs PiBoSo's compilers and a Wine prefix"]
+    fn terrained_bakes_a_model_of_several_parts() {
+        let dir = PathBuf::from(std::env::var("FROST_SCENE").expect("set FROST_SCENE"));
+        let tools = PathBuf::from(std::env::var("FROST_TOOLS").expect("set FROST_TOOLS"));
+        let terrained = crate::trackbuild::find(&tools)
+            .expect("terrained.exe under FROST_TOOLS")
+            .terrained;
+
+        let parts = vec![
+            Part { name: "posts".into(), mesh: cuboid(1.0, 4.0, 1.0), texture: 0 },
+            Part { name: "boards".into(), mesh: moved(&crossed(3.0, 2.0, 2), [6.0, 0.0, 0.0]), texture: 1 },
+            Part { name: "canopy".into(), mesh: moved(&crossed(4.0, 5.0, 3), [-6.0, 0.0, 0.0]), texture: 2 },
+        ];
+        let sheets = vec![
+            checks("posts_c", 64, [200, 60, 60, 255], [240, 240, 240, 255]),
+            checks("boards_c_a", 64, [40, 90, 200, 255], [255, 255, 255, 0]),
+            checks("canopy_c_a", 64, [40, 150, 60, 255], [255, 255, 255, 0]),
+        ];
+        let bytes = write("probe", &parts, &sheets);
+        std::fs::write(dir.join("probe.edf"), &bytes).unwrap();
+        println!("probe.edf: {} bytes, {} parts, {} sheets", bytes.len(), parts.len(), sheets.len());
+
+        let map = "out/multi.map";
+        let _ = std::fs::remove_file(dir.join(map));
+        let out = run(&terrained, &["track.hmf", map, "params.ini"], &dir);
+        println!("--- terrained ---\n{out}\n---");
+
+        assert!(dir.join(map).is_file(), "terrained wrote no {map}");
+        let mb = std::fs::read(dir.join(map)).unwrap();
+        let mesh = crate::map::parse(&mb).expect("the .map parses");
+        let names: Vec<String> = crate::map::survey(&mb).into_iter().map(|(n, ..)| n).collect();
+        println!(
+            "{} materials, {} triangles, sheets {names:?}",
+            mesh.materials,
+            mesh.triangle_count()
+        );
+        for want in ["posts_c", "boards_c_a", "canopy_c_a"] {
+            assert!(names.iter().any(|n| n.eq_ignore_ascii_case(want)), "{want} missing: {names:?}");
+        }
+    }
+
+    /// Which ingredient TerrainEd refuses, one at a time.
+    ///
+    /// A control it is known to accept, then one change each: a second group, a cut-out
+    /// sheet, cards instead of boxes. Cheap because the scene is 129 samples square; the
+    /// answer is which rows say `ok`.
+    #[test]
+    #[ignore = "needs PiBoSo's compilers and a Wine prefix"]
+    fn which_ingredient_terrained_refuses() {
+        let dir = PathBuf::from(std::env::var("FROST_SCENE").expect("set FROST_SCENE"));
+        let tools = PathBuf::from(std::env::var("FROST_TOOLS").expect("set FROST_TOOLS"));
+        let terrained = crate::trackbuild::find(&tools).expect("terrained").terrained;
+
+        let opaque = |n: &str| checks(n, 64, [210, 60, 50, 255], [240, 240, 240, 255]);
+        let cutout = |n: &str| checks(n, 64, [60, 150, 70, 255], [0, 0, 0, 0]);
+
+        let cases: Vec<(&str, Vec<Part>, Vec<Texture>)> = vec![
+            ("1 box, opaque (control)",
+             vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0 }],
+             vec![opaque("a_c")]),
+            ("2 boxes, 2 sheets",
+             vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0 },
+                  Part { name: "b".into(), mesh: moved(&cuboid(2.0, 3.0, 2.0), [6.0, 0.0, 0.0]), texture: 1 }],
+             vec![opaque("a_c"), opaque("b_c")]),
+            ("1 box, cut-out sheet",
+             vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0 }],
+             vec![cutout("a_c_a")]),
+            ("1 set of crossed cards",
+             vec![Part { name: "a".into(), mesh: crossed(4.0, 5.0, 3), texture: 0 }],
+             vec![cutout("a_c_a")]),
+            ("3 parts, mixed",
+             vec![Part { name: "a".into(), mesh: cuboid(1.0, 4.0, 1.0), texture: 0 },
+                  Part { name: "b".into(), mesh: moved(&crossed(3.0, 2.0, 2), [6.0, 0.0, 0.0]), texture: 1 },
+                  Part { name: "c".into(), mesh: moved(&crossed(4.0, 5.0, 3), [-6.0, 0.0, 0.0]), texture: 2 }],
+             vec![opaque("a_c"), cutout("b_c_a"), cutout("c_c_a")]),
+        ];
+
+        let mut verdict = Vec::new();
+        for (i, (label, parts, sheets)) in cases.iter().enumerate() {
+            let bytes = write("probe", parts, sheets);
+            std::fs::write(dir.join("probe.edf"), &bytes).unwrap();
+            let map = format!("out/case{i}.map");
+            let _ = std::fs::remove_file(dir.join(&map));
+            let out = run(&terrained, &["track.hmf", &map, "params.ini"], &dir);
+            let ok = dir.join(&map).is_file();
+            let tris = ok
+                .then(|| std::fs::read(dir.join(&map)).ok())
+                .flatten()
+                .and_then(|b| crate::map::parse(&b))
+                .map(|m| m.triangle_count())
+                .unwrap_or(0);
+            println!(
+                "{:<26} {:>10}  {:>5} tris  ({} B edf)  {}",
+                label,
+                if ok { "ok" } else { "REFUSED" },
+                tris,
+                bytes.len(),
+                out.lines().next().unwrap_or("")
+            );
+            verdict.push((label, ok));
+        }
+        println!();
+        for (l, ok) in &verdict {
+            println!("  {} {l}", if *ok { "ok " } else { "NO " });
+        }
+        assert!(verdict[0].1, "the control has to compile or nothing here means anything");
+    }
+
+    /// Write one probe model to `FROST_SCENE/probe.edf` and stop. Lets the compiler be driven
+    /// from outside, one case at a time, so a crash costs one run instead of the whole set.
+    #[test]
+    #[ignore = "writes a probe model — set FROST_SCENE and FROST_CASE"]
+    fn write_probe_case() {
+        let dir = PathBuf::from(std::env::var("FROST_SCENE").expect("set FROST_SCENE"));
+        let case: usize = std::env::var("FROST_CASE").unwrap_or_default().parse().unwrap_or(0);
+        let opaque = |n: &str| checks(n, 64, [210, 60, 50, 255], [240, 240, 240, 255]);
+        let cutout = |n: &str| checks(n, 64, [60, 150, 70, 255], [0, 0, 0, 0]);
+        let (label, parts, sheets): (&str, Vec<Part>, Vec<Texture>) = match case {
+            0 => ("1 box, opaque (control)",
+                  vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0 }],
+                  vec![opaque("a_c")]),
+            1 => ("2 boxes, 2 sheets",
+                  vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0 },
+                       Part { name: "b".into(), mesh: moved(&cuboid(2.0, 3.0, 2.0), [6.0, 0.0, 0.0]), texture: 1 }],
+                  vec![opaque("a_c"), opaque("b_c")]),
+            2 => ("1 box, cut-out sheet",
+                  vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0 }],
+                  vec![cutout("a_c_a")]),
+            3 => ("1 set of crossed cards",
+                  vec![Part { name: "a".into(), mesh: crossed(4.0, 5.0, 3), texture: 0 }],
+                  vec![cutout("a_c_a")]),
+            4 => ("2 boxes, 1 shared sheet",
+                  vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0 },
+                       Part { name: "b".into(), mesh: moved(&cuboid(2.0, 3.0, 2.0), [6.0, 0.0, 0.0]), texture: 0 }],
+                  vec![opaque("a_c")]),
+            5 => ("1 box, 200 copies",
+                  vec![Part { name: "a".into(), mesh: {
+                      let mut m = Mesh::default();
+                      for i in 0..200 {
+                          let (x, z) = ((i % 20) as f32 * 3.0, (i / 20) as f32 * 3.0);
+                          m.append(&moved(&cuboid(1.0, 2.0, 1.0), [20.0 + x, 0.0, 20.0 + z]));
+                      }
+                      m
+                  }, texture: 0 }],
+                  vec![opaque("a_c")]),
+            _ => ("3 parts, mixed",
+                  vec![Part { name: "a".into(), mesh: cuboid(1.0, 4.0, 1.0), texture: 0 },
+                       Part { name: "b".into(), mesh: moved(&crossed(3.0, 2.0, 2), [6.0, 0.0, 0.0]), texture: 1 },
+                       Part { name: "c".into(), mesh: moved(&crossed(4.0, 5.0, 3), [-6.0, 0.0, 0.0]), texture: 2 }],
+                  vec![opaque("a_c"), cutout("b_c_a"), cutout("c_c_a")]),
+        };
+        let bytes = write("probe", &parts, &sheets);
+        std::fs::write(dir.join("probe.edf"), &bytes).unwrap();
+        println!("case {case}: {label} — {} parts, {} sheets, {} B", parts.len(), sheets.len(), bytes.len());
     }
 
     fn run(exe: &Path, args: &[&str], dir: &Path) -> String {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -140,6 +140,7 @@ mod track;
 mod trackbuild;
 mod trackline;
 mod trackllm;
+mod trackobjects;
 mod trackprog;
 mod trackstats;
 mod tracksynth;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -143,6 +143,7 @@ mod trackline;
 mod trackllm;
 mod trackobjects;
 mod trackprog;
+mod trackscenery;
 mod trackstats;
 mod tracksynth;
 mod upload;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -13,6 +13,7 @@ mod cookie_session;
 mod downloads;
 mod dropzone;
 mod edf;
+mod edfwrite;
 mod feel;
 mod fileshare;
 mod firstpaint;

--- a/src-tauri/src/trackline.rs
+++ b/src-tauri/src/trackline.rs
@@ -77,6 +77,47 @@ impl Lap {
     }
 }
 
+/// A point on the lap: where it is, which way it faces, and how far round it sits.
+#[derive(Clone, Copy, Debug)]
+pub struct Station {
+    pub x: f32,
+    pub z: f32,
+    /// Radians, per [`crate::trackprog::heading_vector`].
+    pub heading: f32,
+    /// Metres round the lap.
+    pub at: f32,
+}
+
+impl Lap {
+    /// Walk the lap at roughly `step` metres.
+    ///
+    /// Each station is placed from its own segment's stated pose rather than integrated from
+    /// the one before, which is what keeps a two-kilometre walk from drifting.
+    pub fn stations(&self, step: f32) -> Vec<Station> {
+        let step = step.max(0.05);
+        let mut out = Vec::new();
+        for seg in &self.segments {
+            let steps = ((seg.length / step) as usize).max(1);
+            for k in 0..steps {
+                let d = k as f32 * seg.length / steps as f32;
+                let (x, z, heading) = if seg.radius == 0.0 {
+                    let (hx, hz) = crate::trackprog::heading_vector(seg.heading);
+                    (seg.x + d * hx, seg.z + d * hz, seg.heading)
+                } else {
+                    let h = seg.heading + d / seg.radius;
+                    (
+                        seg.x + seg.radius * (seg.heading.cos() - h.cos()),
+                        seg.z + seg.radius * (h.sin() - seg.heading.sin()),
+                        h,
+                    )
+                };
+                out.push(Station { x, z, heading, at: seg.at + d });
+            }
+        }
+        out
+    }
+}
+
 /// Read the centreline out of a height file's trailing block.
 ///
 /// The block's tail is fixed once the coverage masks are behind you, and the material table

--- a/src-tauri/src/trackobjects.rs
+++ b/src-tauri/src/trackobjects.rs
@@ -1,0 +1,656 @@
+//! What a published track stands beside its riding line, measured.
+//!
+//! The `.map` bakes every object into one mesh, and [`crate::map`] splits that back into
+//! connected islands. An island is not an object, though: the exporter duplicates vertices,
+//! so a track comes apart into a hundred and sixty thousand pieces of two or three triangles
+//! each — one card, one quad, one face. A tree is a handful of them in the same place.
+//!
+//! So the work is three joins and a clustering. The islands come from the `.map`; their sheet
+//! names come from the same file's texture table, which is the only statement a track makes
+//! about *what* a thing is; the centreline comes from the `.trh`'s trailing block, which
+//! [`crate::trackline`] reads. Islands of one class standing within a few metres of each
+//! other are one object, and against the lap every object has a distance round it and a
+//! lateral offset. That is what "where do objects go" means numerically.
+
+#![allow(dead_code)]
+
+use anyhow::{anyhow, Result};
+use std::path::Path;
+
+use crate::map;
+
+/// How close two islands of the same class have to be to count as one object, metres.
+///
+/// Three, because that is a tree: crossed cards sharing no vertex, standing on the same spot.
+/// It also strings a fence's panels into one run, which is the right answer for a fence — a
+/// fence is one object however many boards it is made of.
+const LINK_M: f32 = 3.0;
+
+/// Where a track's furniture ends and its landscape begins, metres from the centreline.
+///
+/// Not a round number picked for tidiness. Pooled over the corpus the two populations barely
+/// overlap: what lines a riding line sits at 5–45 m, and the backdrop ring — the distant
+/// treeline, the horizon fence, the far grandstand — sits at 100–700 m and stands 17 to 41 m
+/// tall. Measured together they average into a tree that is nowhere and forty feet high.
+const NEAR_M: f32 = 60.0;
+
+/// What a sheet name says a thing is.
+///
+/// Named from the vocabulary the corpus actually uses rather than from what a track *might*
+/// carry: twelve tracks between them name 60 sheets, and these are the groups they fall into.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Class {
+    Tree,
+    Fence,
+    Bale,
+    Banner,
+    Crowd,
+    Structure,
+    Pole,
+    Vehicle,
+    /// Dressing painted on the ground rather than standing on it — dirt, concrete, water,
+    /// the pit lane, a tunnel mouth. Not an object, and excluded from every count.
+    Ground,
+    Unknown,
+}
+
+impl Class {
+    /// Whether this is something placed rather than something painted.
+    pub fn is_object(self) -> bool {
+        !matches!(self, Class::Ground | Class::Unknown)
+    }
+
+    pub fn key(self) -> &'static str {
+        match self {
+            Class::Tree => "tree",
+            Class::Fence => "fence",
+            Class::Bale => "bale",
+            Class::Banner => "banner",
+            Class::Crowd => "crowd",
+            Class::Structure => "structure",
+            Class::Pole => "pole",
+            Class::Vehicle => "vehicle",
+            Class::Ground => "ground",
+            Class::Unknown => "unknown",
+        }
+    }
+}
+
+/// Read a sheet name as a class.
+///
+/// Order matters: `ck_bridge_grate_c_a` is ground before it is anything else, and
+/// `start_backdrop_c` is a banner rather than a building. Every rule here was written against
+/// a name a track in the corpus actually ships.
+pub fn classify(sheet: &str) -> Class {
+    let s = sheet.to_ascii_lowercase();
+    let any = |words: &[&str]| words.iter().any(|w| s.contains(w));
+
+    // Painted, not placed. First, because several of these also read as objects.
+    if any(&[
+        "dirt", "soil", "sand", "gravel", "mud", "concrete", "asphalt", "water", "rock",
+        "pitlane", "tunnel", "grate", "bridge", "road", "kerb", "curb", "terrain", "ground",
+    ]) {
+        return Class::Ground;
+    }
+    if any(&["tree", "bark", "leaf", "leafs", "leaves", "bush", "foliage", "hedge", "palm"]) {
+        return Class::Tree;
+    }
+    if any(&["fence", "net", "barrier", "railing", "hoarding"]) {
+        return Class::Fence;
+    }
+    if any(&["haybale", "bale", "hay", "straw", "tuff", "tyre", "tire"]) {
+        return Class::Bale;
+    }
+    if any(&[
+        "inflate", "inflatable", "backdrop", "banner", "flag", "sign", "board", "advert",
+        "sponsor", "logo", "arch",
+    ]) {
+        return Class::Banner;
+    }
+    if any(&["people", "person", "crowd", "spectator", "seat", "stand", "tribune"]) {
+        return Class::Crowd;
+    }
+    if any(&[
+        "vehicle", "trailer", "truck", "van", "car", "excavator", "tractor", "container",
+        "ambulance", "quad",
+    ]) {
+        return Class::Vehicle;
+    }
+    if any(&["pole", "post", "powerline", "pylon", "mast", "tower"]) {
+        return Class::Pole;
+    }
+    if any(&[
+        "tent", "building", "castle", "clubhouse", "roof", "wall", "shed", "hut", "cabin",
+        "office", "garage", "awning", "canopy", "metalsheet", "osb", "glass", "structure",
+        "objects", "trash", "strap", "tearoff", "machines", "vmx", "easy_up",
+    ]) {
+        return Class::Structure;
+    }
+    Class::Unknown
+}
+
+/// One object, placed against the lap.
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Placed {
+    pub class: Class,
+    /// The sheet most of it is painted with, lower-cased.
+    pub sheet: String,
+    /// How many islands it was clustered from.
+    pub pieces: u32,
+    pub tris: u32,
+    /// Metres, world frame.
+    pub centre: [f32; 3],
+    /// Bounding box extents, metres. `size[1]` is how tall it stands.
+    pub size: [f32; 3],
+    /// How far round the lap the nearest centreline point is, metres.
+    pub along_m: f32,
+    /// Lateral offset from the centreline, metres. Signed: positive is right of travel, the
+    /// side a positive radius turns towards everywhere else in the pipeline.
+    pub offset_m: f32,
+}
+
+/// The spread of one measurement, as the rest of the pipeline reports it.
+#[derive(Clone, Copy, Debug, Default, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Spread {
+    pub count: usize,
+    pub p10: f32,
+    pub p50: f32,
+    pub p90: f32,
+}
+
+fn spread(v: &mut [f32]) -> Spread {
+    if v.is_empty() {
+        return Spread::default();
+    }
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let q = |f: f32| v[(((v.len() - 1) as f32) * f).round() as usize];
+    Spread {
+        count: v.len(),
+        p10: q(0.1),
+        p50: q(0.5),
+        p90: q(0.9),
+    }
+}
+
+/// What one class amounts to on one track.
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClassStats {
+    pub class: Class,
+    /// True for the track's own furniture, false for the landscape beyond [`NEAR_M`].
+    pub near: bool,
+    pub objects: usize,
+    pub per_km: f32,
+    /// Distance from the centreline, unsigned.
+    pub offset_m: Spread,
+    /// How tall they stand.
+    pub height_m: Spread,
+    /// Longest footprint dimension — a fence run against a bale.
+    pub span_m: Spread,
+    /// Metres round the lap between one of these and the next. What a placement rule needs.
+    pub gap_m: Spread,
+    /// How much of the lap has one of these within 60 m of it, as a fraction. A fence that
+    /// follows the whole track reads near 1; a start structure reads near 0.
+    pub lap_covered: f32,
+}
+
+/// What one track carries.
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ObjectSurvey {
+    pub track: String,
+    pub lap_m: f32,
+    pub map_entry: String,
+    /// Islands the `.map` split into, before clustering.
+    pub islands: usize,
+    /// Whether the map's sheets bound to its materials at all. False means every object here
+    /// is `Unknown` and the track tells us nothing.
+    pub bound: bool,
+    /// `declared` where the sheet table bound the way the viewer binds it, `fallback` where
+    /// it refused and every record was taken in table order instead. A fallback track's
+    /// *offsets* are still its own; its *classes* may be a sheet out, so it is evidence with
+    /// a caveat rather than evidence.
+    pub binding: &'static str,
+    pub objects: Vec<Placed>,
+    pub classes: Vec<ClassStats>,
+    /// Sheet name against islands wearing it, commonest first. The vocabulary.
+    pub sheets: Vec<(String, usize)>,
+}
+
+/// Measure a track's objects against its own centreline.
+pub fn survey(path: &Path) -> Result<ObjectSurvey> {
+    let names = crate::track::entry_names(path)?;
+    let stem = path
+        .file_stem()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_ascii_lowercase();
+
+    // The lap, from the height file's trailing block.
+    let hf = crate::track::heightfield_entries(&names)
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow!("no heightfield in this track"))?;
+    let hb = crate::track::read_entry(path, &hf)?;
+    let layout = crate::heightfield::probe(&hb, None)
+        .ok_or_else(|| anyhow!("{hf} doesn't read as a terrain grid"))?;
+    let block_at =
+        layout.offset + layout.width as usize * layout.height as usize * layout.sample.size();
+    let lap = crate::trackline::read(hb.get(block_at..).unwrap_or(&[]))
+        .ok_or_else(|| anyhow!("{hf} carries no centreline"))?;
+
+    // The scenery.
+    let mut entry = String::new();
+    let mut mesh = None;
+    let mut sheets: Vec<(String, u32, u32)> = Vec::new();
+    let mut binding = "none";
+    for name in names.iter().filter(|n| {
+        Path::new(n)
+            .extension()
+            .map(|e| e.eq_ignore_ascii_case("map"))
+            .unwrap_or(false)
+    }) {
+        let Ok(bytes) = crate::track::read_entry(path, name) else {
+            continue;
+        };
+        if !map::is_map(&bytes) {
+            continue;
+        }
+        let Some(m) = map::parse(&bytes) else { continue };
+        let named = Path::new(name)
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_ascii_lowercase() == stem)
+            .unwrap_or(false);
+        if mesh.is_none() || named {
+            entry = name.clone();
+            // `declared` is the binding the viewer uses and it refuses a table it cannot
+            // trust. Where it refuses, every record is better than none for a survey: the
+            // names are still in the file, they just may not line up with the materials.
+            let declared = map::declared(&bytes);
+            binding = if declared.is_empty() { "fallback" } else { "declared" };
+            sheets = if declared.is_empty() {
+                map::primaries(&bytes)
+            } else {
+                declared
+            };
+            mesh = Some(m);
+        }
+        if named {
+            break;
+        }
+    }
+    let mesh = mesh.ok_or_else(|| anyhow!("no readable .map in {path:?}"))?;
+    let bound = !sheets.is_empty();
+
+    let sheet_of = |material: u32| -> &str {
+        sheets
+            .get(material as usize)
+            .map(|(n, ..)| n.as_str())
+            .unwrap_or("")
+    };
+
+    // Islands, named and classed.
+    struct Island {
+        class: Class,
+        sheet: String,
+        tris: u32,
+        min: [f32; 3],
+        max: [f32; 3],
+        cx: f32,
+        cz: f32,
+    }
+    let islands: Vec<Island> = mesh
+        .objects
+        .iter()
+        .map(|o| {
+            let sheet = sheet_of(o.material).to_ascii_lowercase();
+            Island {
+                class: classify(&sheet),
+                sheet,
+                tris: o.tri_count,
+                min: o.min,
+                max: o.max,
+                cx: (o.min[0] + o.max[0]) * 0.5,
+                cz: (o.min[2] + o.max[2]) * 0.5,
+            }
+        })
+        .collect();
+
+    // Cluster within a class: same kind of thing, standing within LINK_M of each other.
+    // Grid-hashed so this stays linear in the island count rather than quadratic.
+    let mut uf: Vec<usize> = (0..islands.len()).collect();
+    fn find(uf: &mut Vec<usize>, mut i: usize) -> usize {
+        while uf[i] != i {
+            uf[i] = uf[uf[i]];
+            i = uf[i];
+        }
+        i
+    }
+    let mut cells: std::collections::HashMap<(i32, i32, u8), Vec<usize>> =
+        std::collections::HashMap::new();
+    for (i, is) in islands.iter().enumerate() {
+        if !is.class.is_object() {
+            continue;
+        }
+        let key = (
+            (is.cx / LINK_M).floor() as i32,
+            (is.cz / LINK_M).floor() as i32,
+            is.class as u8,
+        );
+        cells.entry(key).or_default().push(i);
+    }
+    for (&(gx, gz, c), members) in &cells {
+        for dx in -1..=1 {
+            for dz in -1..=1 {
+                let Some(other) = cells.get(&(gx + dx, gz + dz, c)) else {
+                    continue;
+                };
+                for &i in members {
+                    for &j in other {
+                        if i >= j {
+                            continue;
+                        }
+                        let (a, b) = (&islands[i], &islands[j]);
+                        let (dx, dz) = (a.cx - b.cx, a.cz - b.cz);
+                        if dx * dx + dz * dz <= LINK_M * LINK_M {
+                            let (ra, rb) = (find(&mut uf, i), find(&mut uf, j));
+                            if ra != rb {
+                                uf[ra] = rb;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Roll the islands up into objects.
+    let mut by_root: std::collections::HashMap<usize, Vec<usize>> =
+        std::collections::HashMap::new();
+    for i in 0..islands.len() {
+        if !islands[i].class.is_object() {
+            continue;
+        }
+        let r = find(&mut uf, i);
+        by_root.entry(r).or_default().push(i);
+    }
+
+    let stations = lap.stations(1.0);
+    let mut objects: Vec<Placed> = by_root
+        .values()
+        .map(|members| {
+            let mut min = [f32::INFINITY; 3];
+            let mut max = [f32::NEG_INFINITY; 3];
+            let mut tris = 0u32;
+            let mut tally: std::collections::HashMap<&str, u32> =
+                std::collections::HashMap::new();
+            for &i in members {
+                let is = &islands[i];
+                for k in 0..3 {
+                    min[k] = min[k].min(is.min[k]);
+                    max[k] = max[k].max(is.max[k]);
+                }
+                tris += is.tris;
+                *tally.entry(is.sheet.as_str()).or_default() += is.tris;
+            }
+            let sheet = tally
+                .into_iter()
+                .max_by_key(|&(_, n)| n)
+                .map(|(s, _)| s.to_string())
+                .unwrap_or_default();
+            let centre = [
+                (min[0] + max[0]) * 0.5,
+                (min[1] + max[1]) * 0.5,
+                (min[2] + max[2]) * 0.5,
+            ];
+            let (along_m, offset_m) = nearest(&stations, centre[0], centre[2]);
+            Placed {
+                class: islands[members[0]].class,
+                sheet,
+                pieces: members.len() as u32,
+                tris,
+                centre,
+                size: [max[0] - min[0], max[1] - min[1], max[2] - min[2]],
+                along_m,
+                offset_m,
+            }
+        })
+        .collect();
+    objects.sort_by(|a, b| a.along_m.partial_cmp(&b.along_m).unwrap_or(std::cmp::Ordering::Equal));
+
+    let km = (lap.length / 1000.0).max(0.001);
+    let mut classes: Vec<ClassStats> = Vec::new();
+    for class in [
+        Class::Tree,
+        Class::Fence,
+        Class::Bale,
+        Class::Banner,
+        Class::Crowd,
+        Class::Structure,
+        Class::Pole,
+        Class::Vehicle,
+    ] {
+        for near in [true, false] {
+            let mine: Vec<&Placed> = objects
+                .iter()
+                .filter(|p| p.class == class && (p.offset_m.abs() <= NEAR_M) == near)
+                .collect();
+            if mine.is_empty() {
+                continue;
+            }
+            // How much of the lap has one of these beside it. Bucket at ten metres: an
+            // object covers the stretch it stands next to.
+            let buckets = ((lap.length / 10.0).ceil() as usize).max(1);
+            let mut seen = vec![false; buckets];
+            for p in &mine {
+                let b = ((p.along_m / 10.0) as usize).min(buckets - 1);
+                seen[b] = true;
+            }
+            // Spacing round the lap. `objects` is already sorted by `along_m`, and so is
+            // this filtered view of it, so consecutive differences are the gaps.
+            let mut gaps: Vec<f32> = mine
+                .windows(2)
+                .map(|w| w[1].along_m - w[0].along_m)
+                .filter(|g| *g > 0.0)
+                .collect();
+            classes.push(ClassStats {
+                class,
+                near,
+                objects: mine.len(),
+                per_km: mine.len() as f32 / km,
+                offset_m: spread(&mut mine.iter().map(|p| p.offset_m.abs()).collect::<Vec<_>>()),
+                height_m: spread(&mut mine.iter().map(|p| p.size[1]).collect::<Vec<_>>()),
+                span_m: spread(
+                    &mut mine
+                        .iter()
+                        .map(|p| p.size[0].max(p.size[2]))
+                        .collect::<Vec<_>>(),
+                ),
+                gap_m: spread(&mut gaps),
+                lap_covered: seen.iter().filter(|s| **s).count() as f32 / buckets as f32,
+            });
+        }
+    }
+
+    let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    for is in &islands {
+        *counts.entry(is.sheet.clone()).or_default() += 1;
+    }
+    let mut sheets: Vec<(String, usize)> = counts.into_iter().collect();
+    sheets.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+
+    Ok(ObjectSurvey {
+        track: path
+            .file_stem()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned(),
+        lap_m: lap.length,
+        map_entry: entry,
+        islands: mesh.objects.len(),
+        bound,
+        binding,
+        objects,
+        classes,
+        sheets,
+    })
+}
+
+/// Walk the lap and return `(distance round it, signed lateral offset)` for a world point.
+///
+/// Coarse on purpose — a metre a step over a two-kilometre lap, against an object that is
+/// metres across. Positive offset is to the **right** of travel, which is the side a positive
+/// radius turns towards everywhere else in the pipeline.
+fn nearest(stations: &[crate::trackline::Station], x: f32, z: f32) -> (f32, f32) {
+    let mut best = (0.0f32, f32::INFINITY, 0.0f32);
+    for p in stations {
+        let (dx, dz) = (x - p.x, z - p.z);
+        let d2 = dx * dx + dz * dz;
+        if d2 < best.1 {
+            let (rx, rz) = crate::trackprog::right_vector(p.heading);
+            best = (p.at, d2, dx * rx + dz * rz);
+        }
+    }
+    (best.0, best.2)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classes_read_the_corpus_vocabulary() {
+        // Every one of these is a sheet a track in `~/Projects/pkz` actually ships.
+        assert_eq!(classify("ck_tree_hawkstone_noleaf_atlas_c_a"), Class::Tree);
+        assert_eq!(classify("wood_leafs_c_a"), Class::Tree);
+        assert_eq!(classify("bark_qp_c"), Class::Tree);
+        assert_eq!(classify("ck_fence_01_c_a"), Class::Fence);
+        assert_eq!(classify("ck_orange_net_c_a"), Class::Fence);
+        assert_eq!(classify("ck_haybale_c_a"), Class::Bale);
+        assert_eq!(classify("inflate_tilable_c"), Class::Banner);
+        assert_eq!(classify("start_backdrop_c"), Class::Banner);
+        assert_eq!(classify("ck_cutout_people_atlas_c_a"), Class::Crowd);
+        assert_eq!(classify("ck_seat_red_c_a"), Class::Crowd);
+        assert_eq!(classify("big_tent_c"), Class::Structure);
+        assert_eq!(classify("clubhouse_c"), Class::Structure);
+        assert_eq!(classify("metal_pole_c"), Class::Pole);
+        assert_eq!(classify("flagpost_c"), Class::Pole);
+        assert_eq!(classify("semi_trailers_c"), Class::Vehicle);
+        // Painted, not placed — and these are the ones that read as objects if the ground
+        // rules don't come first.
+        assert_eq!(classify("ck_bridge_grate_c_a"), Class::Ground);
+        assert_eq!(classify("pitlane_c"), Class::Ground);
+        assert_eq!(classify("soil_dark_c"), Class::Ground);
+        assert_eq!(classify("water_c"), Class::Ground);
+    }
+
+    /// What published tracks stand beside their riding line:
+    ///
+    /// ```text
+    /// FROST_TRACKS=~/Projects/pkz/tracks cargo test -- --ignored --nocapture object_corpus
+    /// ```
+    #[test]
+    #[ignore = "needs real tracks — set FROST_TRACKS"]
+    fn object_corpus() {
+        let root = std::env::var("FROST_TRACKS").expect("set FROST_TRACKS to a tracks folder");
+        let mut paths: Vec<std::path::PathBuf> =
+            crate::linkwalk::walk_depth(Path::new(&root), 3)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .map(|e| e.path().to_path_buf())
+                .filter(|p| {
+                    p.extension()
+                        .map(|e| e.eq_ignore_ascii_case("pkz"))
+                        .unwrap_or(false)
+                })
+                .collect();
+        paths.sort();
+        assert!(!paths.is_empty(), "no .pkz tracks under {root}");
+
+        let mut all = Vec::new();
+        for p in &paths {
+            let name = p.file_stem().unwrap_or_default().to_string_lossy().into_owned();
+            match survey(p) {
+                Ok(s) => {
+                    if !s.bound {
+                        println!("\n{:<30} lap {:>5.0}m  binds no sheets — skipped", s.track, s.lap_m);
+                        continue;
+                    }
+                    println!(
+                        "\n{:<30} lap {:>5.0}m  {:>6} islands -> {:>5} objects  [{}]",
+                        s.track,
+                        s.lap_m,
+                        s.islands,
+                        s.objects.len(),
+                        s.binding,
+                    );
+                    for c in s.classes.iter().filter(|c| c.near) {
+                        println!(
+                            "  {:<10} {:>5} ({:>6.1}/km)  offset p10 {:>5.1} p50 {:>5.1} p90 {:>5.1} m  \
+                             tall p50 {:>4.1}  span p50 {:>5.1}  gap p50 {:>5.1} m  lap {:>3.0}%",
+                            c.class.key(), c.objects, c.per_km,
+                            c.offset_m.p10, c.offset_m.p50, c.offset_m.p90,
+                            c.height_m.p50, c.span_m.p50, c.gap_m.p50, c.lap_covered * 100.0,
+                        );
+                    }
+                    let far: Vec<&ClassStats> = s.classes.iter().filter(|c| !c.near).collect();
+                    if !far.is_empty() {
+                        let n: usize = far.iter().map(|c| c.objects).sum();
+                        println!(
+                            "  {:<10} {:>5} beyond {NEAR_M:.0} m — landscape, not furniture: {}",
+                            "backdrop", n,
+                            far.iter()
+                                .map(|c| format!("{} {}", c.objects, c.class.key()))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        );
+                    }
+                    all.push(s);
+                }
+                Err(e) => println!("{name:<30} skipped: {e:#}"),
+            }
+        }
+
+        println!("\n=== the track's own furniture, pooled over {} tracks ===", all.len());
+        println!(
+            "{:<10} {:>8}  {:>21}  {:>18}  {:>16}  {:>14}",
+            "", "tracks", "per km  p10/p50/p90", "offset p10/p50/p90", "gap p10/p50/p90", "tall p50",
+        );
+        for class in [
+            Class::Tree, Class::Fence, Class::Bale, Class::Banner,
+            Class::Crowd, Class::Structure, Class::Pole, Class::Vehicle,
+        ] {
+            let mine: Vec<&ClassStats> = all
+                .iter()
+                .flat_map(|s| s.classes.iter())
+                .filter(|c| c.near && c.class == class)
+                .collect();
+            if mine.is_empty() {
+                continue;
+            }
+            let mut per_km: Vec<f32> = mine.iter().map(|c| c.per_km).collect();
+            let mut off: Vec<f32> = mine.iter().map(|c| c.offset_m.p50).collect();
+            let mut gap: Vec<f32> = mine.iter().filter(|c| c.gap_m.count > 0).map(|c| c.gap_m.p50).collect();
+            let mut tall: Vec<f32> = mine.iter().map(|c| c.height_m.p50).collect();
+            let mut cover: Vec<f32> = mine.iter().map(|c| c.lap_covered).collect();
+            let (n, k, o, g, t, v) = (
+                mine.len(), spread(&mut per_km), spread(&mut off),
+                spread(&mut gap), spread(&mut tall), spread(&mut cover),
+            );
+            println!(
+                "{:<10} {n:>8}  {:>6.1} {:>6.1} {:>6.1}  {:>5.1} {:>5.1} {:>5.1} m  \
+                 {:>4.1} {:>4.1} {:>4.1} m  {:>4.1} m   lap {:>3.0}-{:.0}%",
+                class.key(), k.p10, k.p50, k.p90, o.p10, o.p50, o.p90,
+                g.p10, g.p50, g.p90, t.p50, v.p10 * 100.0, v.p90 * 100.0,
+            );
+        }
+
+        if let Ok(out) = std::env::var("FROST_OUT") {
+            std::fs::write(&out, serde_json::to_vec_pretty(&all).unwrap()).unwrap();
+            println!("wrote {out}");
+        }
+    }
+}

--- a/src-tauri/src/trackobjects.rs
+++ b/src-tauri/src/trackobjects.rs
@@ -102,6 +102,11 @@ pub fn classify(sheet: &str) -> Class {
     if any(&["haybale", "bale", "hay", "straw", "tuff", "tyre", "tire"]) {
         return Class::Bale;
     }
+    // Before the banner rule, because a `flagpost` is a pole that happens to fly a flag and
+    // the banner rule would take it on the word "flag" alone.
+    if any(&["pole", "post", "powerline", "pylon", "mast", "tower"]) {
+        return Class::Pole;
+    }
     if any(&[
         "inflate", "inflatable", "backdrop", "banner", "flag", "sign", "board", "advert",
         "sponsor", "logo", "arch",
@@ -116,9 +121,6 @@ pub fn classify(sheet: &str) -> Class {
         "ambulance", "quad",
     ]) {
         return Class::Vehicle;
-    }
-    if any(&["pole", "post", "powerline", "pylon", "mast", "tower"]) {
-        return Class::Pole;
     }
     if any(&[
         "tent", "building", "castle", "clubhouse", "roof", "wall", "shed", "hut", "cabin",

--- a/src-tauri/src/trackscenery.rs
+++ b/src-tauri/src/trackscenery.rs
@@ -410,8 +410,14 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
     while s < lap {
         let st = at(s);
         let (rx, rz) = crate::trackprog::right_vector(st.heading);
+        // Keyed on where round the lap we are, not on how many have been placed. Keyed on
+        // the count, every station drew the same three numbers — because the count only
+        // moves when a tree is accepted — so every station after the first proposed trees in
+        // the same three spots and the spacing rule threw them all away. One tree on the
+        // whole track, and it looked like the spacing rule was too strict.
+        let step = (s / TREE_SPACING_M) as u32;
         for k in 0..3u32 {
-            let i = (n as u32) * 7 + k;
+            let i = step * 7 + k;
             if rnd(seed ^ 0x41, i) > 0.45 {
                 continue;
             }
@@ -463,58 +469,46 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
     let _ = (fx, fz);
     tally.push(("gate", 1));
 
-    // One model, one node a kind. Empty kinds are dropped so nothing writes a node with no
-    // geometry in it.
-    let kinds: Vec<(&str, Mesh, usize)> = vec![
-        ("markers", markers, 0),
-        ("fence", fence, 1),
-        ("bales", bales, 2),
-        ("trees", trees, 3),
-        ("gate", gate, 4),
+    // One model a kind, each with its own single sheet. Not one model of five materials:
+    // TerrainEd faults on the second material in a model whatever the geometry — see
+    // `edfwrite`'s note and the case-by-case test behind it. PiBoSo's own example track is
+    // built the same way, three `scene` blocks for three objects.
+    //
+    // Empty kinds are dropped so nothing writes a node with no geometry in it, and anything
+    // under eight vertices would be invisible to our own reader besides.
+    let kinds: Vec<(&str, Mesh, Texture, bool)> = vec![
+        ("markers", markers, marker_sheet(), false),
+        ("fence", fence, fence_sheet(), false),
+        ("bales", bales, bale_sheet(), true),
+        ("trees", trees, leaf_sheet(), false),
+        ("gate", gate, gate_sheet(), true),
     ];
-    let sheets = vec![
-        marker_sheet(),
-        fence_sheet(),
-        bale_sheet(),
-        leaf_sheet(),
-        gate_sheet(),
-    ];
-    let parts: Vec<Part> = kinds
-        .into_iter()
-        .filter(|(_, m, _)| m.vertex_count() >= 8)
-        .map(|(name, mesh, texture)| Part { name: name.into(), mesh, texture })
-        .collect();
 
-    let bytes = edfwrite::write(&parts, &sheets);
-    let at_origin = Scene {
-        file: "scenery.edf".into(),
-        pos: [0.0, 0.0, 0.0],
-        rot: [0.0, 0.0, 0.0],
-    };
-
-    // Collision is a second model holding only what should stop a bike: the bales and the
-    // gate posts. Foliage and the marker line are cards — solid, they would be invisible
-    // walls, and a rider who clips a track-edge board should ride on.
-    let solid_parts: Vec<Part> = parts
-        .iter()
-        .filter(|p| p.name == "bales" || p.name == "gate")
-        .cloned()
-        .collect();
-    let mut files = vec![("scenery.edf".to_string(), bytes)];
+    let mut files = Vec::new();
+    let mut drawn = Vec::new();
     let mut solid = Vec::new();
-    if !solid_parts.is_empty() {
-        files.push((
-            "solids.edf".to_string(),
-            edfwrite::write(&solid_parts, &sheets),
-        ));
-        solid.push(Scene {
-            file: "solids.edf".into(),
-            pos: [0.0, 0.0, 0.0],
-            rot: [0.0, 0.0, 0.0],
-        });
+    for (name, mesh, sheet, is_solid) in kinds {
+        if mesh.vertex_count() < 8 {
+            continue;
+        }
+        let file = format!("{name}.edf");
+        let bytes = edfwrite::write(
+            name,
+            &[Part { name: name.into(), mesh, texture: 0 }],
+            &[sheet],
+        );
+        files.push((file.clone(), bytes));
+        let at = Scene { file, pos: [0.0, 0.0, 0.0], rot: [0.0, 0.0, 0.0] };
+        // Collision only for what should stop a bike. Foliage and the marker line are cards:
+        // solid, they would be invisible walls, and a rider who clips a track-edge board
+        // should ride on.
+        if is_solid {
+            solid.push(at.clone());
+        }
+        drawn.push(at);
     }
 
-    Scenery { files, drawn: vec![at_origin], solid, tally }
+    Scenery { files, drawn, solid, tally }
 }
 
 /// The `scene<N>` blocks, in the form TerrainEd reads them.
@@ -555,12 +549,28 @@ mod tests {
     }
 
     #[test]
+    fn a_lap_gets_a_treeline_and_not_one_tree() {
+        let (p, s) = demo();
+        let sc = build(&p, &s);
+        let trees = sc.tally.iter().find(|(k, _)| *k == "trees").unwrap().1;
+        // Corpus p50 is 118 near trees per km over the tracks that have them, and the loop is
+        // deliberately thinner than that. What this catches is the failure that actually
+        // happened: randomness keyed on the placed count, so every station drew the same
+        // numbers and the whole lap ended up with one tree.
+        let per_km = trees as f32 / (p.lap_length() / 1000.0);
+        assert!(per_km > 20.0, "{trees} trees is {per_km:.0}/km over {:.0} m", p.lap_length());
+    }
+
+    #[test]
     fn nothing_stands_on_the_riding_line() {
         let (p, s) = demo();
         let sc = build(&p, &s);
-        let bytes = &sc.files[0].1;
-        let nodes = crate::edf::parse_world(bytes);
-        assert!(!nodes.is_empty(), "the model has nodes");
+        let nodes: Vec<crate::edf::EdfNode> = sc
+            .files
+            .iter()
+            .flat_map(|(_, b)| crate::edf::parse_world(b))
+            .collect();
+        assert!(nodes.len() >= 4, "a kind a model: {}", nodes.len());
 
         // Every vertex, against the corridor the track was built with. The edge line sits
         // just outside the shoulder; nothing may sit inside the riding surface itself.
@@ -621,29 +631,35 @@ mod tests {
     }
 
     #[test]
-    fn the_blocks_read_the_way_terrained_writes_them() {
-        let s = blocks(&[Scene {
-            file: "scenery.edf".into(),
-            pos: [1.0, 2.0, 3.0],
-            rot: [0.0, 90.0, 0.0],
-        }]);
-        assert!(s.contains("scene0"));
-        assert!(s.contains("name = scenery.edf"));
-        assert!(s.contains("x = 1.000") && s.contains("y = 2.000") && s.contains("z = 3.000"));
-        assert!(s.contains("y = 90.000"));
-    }
-
-    #[test]
     fn collision_is_only_what_should_stop_a_bike() {
         let (p, s) = demo();
         let sc = build(&p, &s);
-        assert_eq!(sc.solid.len(), 1, "one collision model");
-        let names: Vec<String> = crate::edf::parse_world(&sc.files[1].1)
-            .into_iter()
-            .map(|n| n.name)
-            .collect();
-        assert!(names.iter().any(|n| n == "bales"), "{names:?}");
-        assert!(!names.iter().any(|n| n == "trees"), "foliage cards are not walls: {names:?}");
+        let named = |v: &[Scene]| -> Vec<String> { v.iter().map(|s| s.file.clone()).collect() };
+        let drawn = named(&sc.drawn);
+        let solid = named(&sc.solid);
+        assert!(drawn.contains(&"trees.edf".to_string()), "{drawn:?}");
+        assert!(drawn.contains(&"markers.edf".to_string()), "{drawn:?}");
+        // Only the things a bike should hit.
+        assert!(solid.contains(&"bales.edf".to_string()), "{solid:?}");
+        assert!(solid.contains(&"gate.edf".to_string()), "{solid:?}");
+        assert!(!solid.contains(&"trees.edf".to_string()), "foliage cards are not walls: {solid:?}");
+        assert!(!solid.contains(&"markers.edf".to_string()), "{solid:?}");
+        // And every placed model is one the export actually writes.
+        for f in solid.iter().chain(drawn.iter()) {
+            assert!(sc.files.iter().any(|(n, _)| n == f), "{f} is placed but never written");
+        }
+    }
+
+    #[test]
+    fn the_blocks_read_the_way_terrained_writes_them() {
+        let s = blocks(&[
+            Scene { file: "trees.edf".into(), pos: [1.0, 2.0, 3.0], rot: [0.0, 90.0, 0.0] },
+            Scene { file: "bales.edf".into(), pos: [0.0, 0.0, 0.0], rot: [0.0, 0.0, 0.0] },
+        ]);
+        assert!(s.contains("scene0") && s.contains("scene1"), "{s}");
+        assert!(s.contains("name = trees.edf") && s.contains("name = bales.edf"));
+        assert!(s.contains("x = 1.000") && s.contains("y = 2.000") && s.contains("z = 3.000"));
+        assert!(s.contains("y = 90.000"));
     }
 }
 
@@ -688,13 +704,7 @@ mod built {
 
         let tools = PathBuf::from(std::env::var("FROST_TOOLS").expect("set FROST_TOOLS"));
         let t = crate::trackbuild::find(&tools).expect("compilers under FROST_TOOLS");
-        let stem = dir
-            .join("track.hmf")
-            .exists()
-            .then(|| slug.iter().find_map(|f| f.strip_suffix(".map").map(|s| s.to_string())))
-            .flatten()
-            .unwrap_or_default();
-        let name = stem.split('/').next_back().unwrap_or("track").to_string();
+        let name = crate::tracksynth::slug(&p.name);
         println!("slug: {name}");
 
         let map_rel = format!("{name}/{name}.map");

--- a/src-tauri/src/trackscenery.rs
+++ b/src-tauri/src/trackscenery.rs
@@ -1,0 +1,842 @@
+//! What a generated track stands beside its riding line.
+//!
+//! `terrained.exe` places objects from `scene<N>` blocks in the `.hmf` and bakes their meshes
+//! into the `.map`; the same blocks in the `.tht` give them collision. So this module has two
+//! jobs: build the `.edf` models ([`crate::edfwrite`]) and decide where they go.
+//!
+//! Where they go is not invented. [`crate::trackobjects`] measured twelve published tracks and
+//! every figure below is one of its numbers — the offset from the centreline, the gap round
+//! the lap, the height. The single clearest of them is that **every track lines its riding
+//! line with something about a metre tall, 7.5 m out, one every three metres**, and on most of
+//! them it runs the whole lap. That is the edge a rider sees, and it is the first thing here.
+//!
+//! Everything of one kind is merged into **one node of one model**, placed once at the origin
+//! in world metres. That is how published tracks do it — their `main_track_objects_c` is a
+//! single baked mesh, which is why a `.map` comes apart into a hundred thousand islands and
+//! not a hundred thousand draw calls — and it means a lap's worth of markers costs one
+//! `scene` block rather than six hundred.
+
+#![allow(dead_code)]
+
+use crate::edfwrite::{self, Mesh, Part, Texture};
+use crate::trackprog::TrackProgram;
+use crate::tracksynth::Synth;
+
+/// Metres out from the centreline for the line of edge markers. The corpus median is 7.5;
+/// this keeps it just clear of the shoulder on a wide track.
+const MARKER_OFF_M: f32 = 7.5;
+/// Metres round the lap between markers. Corpus gap p50 is 3.1 m.
+const MARKER_GAP_M: f32 = 3.0;
+/// How tall a marker stands. Corpus p50 is 1.1 m.
+const MARKER_H_M: f32 = 1.1;
+
+/// The fence, at the corpus median of 19.2 m and 2.9 m tall.
+const FENCE_OFF_M: f32 = 19.2;
+const FENCE_H_M: f32 = 2.9;
+/// One panel, so the run is built from repeats the way a real fence is.
+const FENCE_PANEL_M: f32 = 2.5;
+
+/// Bales guard what a rider would otherwise hit. Corpus offset runs 10.9–34.6; the near end
+/// of that is where they do any good.
+const BALE_OFF_M: f32 = 11.0;
+const BALE_W_M: f32 = 1.2;
+const BALE_H_M: f32 = 1.0;
+const BALE_D_M: f32 = 0.8;
+
+/// Trees stand back. Corpus p50 offset 36.8 m, p50 gap 18.3 m, p50 height 3.9 m — those are
+/// the ones you ride past, not the backdrop ring beyond 60 m.
+const TREE_FROM_M: f32 = 26.0;
+const TREE_TO_M: f32 = 95.0;
+const TREE_SPACING_M: f32 = 13.0;
+const TREE_H_M: f32 = 6.5;
+
+/// Deterministic noise, so a track built twice is the same track.
+fn rnd(seed: u32, i: u32) -> f32 {
+    let mut h = seed ^ i.wrapping_mul(0x9E37_79B9);
+    h ^= h >> 16;
+    h = h.wrapping_mul(0x85EB_CA6B);
+    h ^= h >> 13;
+    h = h.wrapping_mul(0xC2B2_AE35);
+    h ^= h >> 16;
+    (h % 100_000) as f32 / 100_000.0
+}
+
+/// One model placed in the world.
+#[derive(Clone, Debug)]
+pub struct Scene {
+    /// The `.edf` beside the `.hmf`.
+    pub file: String,
+    pub pos: [f32; 3],
+    pub rot: [f32; 3],
+}
+
+/// What a track's scenery amounts to: the files to write, and the blocks that place them.
+pub struct Scenery {
+    /// `name.edf` against its bytes.
+    pub files: Vec<(String, Vec<u8>)>,
+    /// Placed in the `.hmf`, so drawn.
+    pub drawn: Vec<Scene>,
+    /// Placed in the `.tht` as well, so ridden into. Only what should stop a bike.
+    pub solid: Vec<Scene>,
+    /// What went where, for the log and for measuring the result back.
+    pub tally: Vec<(&'static str, usize)>,
+}
+
+/// Height of the built ground at a world point, bilinear.
+fn ground(syn: &Synth, x: f32, z: f32) -> f32 {
+    let (gx, gz) = (x / syn.mps, z / syn.mps);
+    let (x0, z0) = (gx.floor() as isize, gz.floor() as isize);
+    let (fx, fz) = (gx - x0 as f32, gz - z0 as f32);
+    let at = |ix: isize, iz: isize| -> f32 {
+        let ix = ix.clamp(0, syn.gw as isize - 1) as usize;
+        let iz = iz.clamp(0, syn.gh as isize - 1) as usize;
+        syn.heights[iz * syn.gw + ix]
+    };
+    let (a, b) = (at(x0, z0), at(x0 + 1, z0));
+    let (c, d) = (at(x0, z0 + 1), at(x0 + 1, z0 + 1));
+    (a + (b - a) * fx) * (1.0 - fz) + (c + (d - c) * fx) * fz
+}
+
+/// How far a point is from the nearest part of the riding line — any part of it, not the
+/// station it was placed from.
+///
+/// A lap folds back on itself. A tree put twenty-six metres to the side of one station lands
+/// a metre from another, and measured only against its own station it looks correctly placed
+/// right up until you ride into it. This is the check that catches that, and everything is
+/// held to it.
+fn clearance(coarse: &[crate::trackprog::Station], x: f32, z: f32) -> f32 {
+    coarse
+        .iter()
+        .map(|st| (st.x - x).powi(2) + (st.z - z).powi(2))
+        .fold(f32::INFINITY, f32::min)
+        .sqrt()
+}
+
+/// The lowest ground under a footprint `r` metres across.
+///
+/// A card is placed by one point but stands on a width of ground, and on anything sloping the
+/// far corner is the one that matters: sampling the centre alone buried a seven-metre tree
+/// card a metre into a hillside. Taking the minimum leaves a gap under the high side, which
+/// is what a real tree looks like anyway.
+fn ground_min(syn: &Synth, x: f32, z: f32, r: f32) -> f32 {
+    let mut lo = f32::INFINITY;
+    for (dx, dz) in [(0.0, 0.0), (-r, 0.0), (r, 0.0), (0.0, -r), (0.0, r), (-r, -r), (r, r), (-r, r), (r, -r)] {
+        lo = lo.min(ground(syn, x + dx, z + dz));
+    }
+    lo
+}
+
+/// The lowest and highest ground under a panel of length `len` centred on `(x, z)` and
+/// running along `deg`.
+///
+/// A disc of samples is the wrong shape for a fence panel: it is a line, and what buries it
+/// is the ground at its two ends. Sampled as a disc a panel across a two-metre step read as
+/// level and sank a metre into the bank.
+fn ground_span(syn: &Synth, x: f32, z: f32, deg: f32, len: f32) -> (f32, f32) {
+    let (s, c) = deg.to_radians().sin_cos();
+    let (mut lo, mut hi) = (f32::INFINITY, f32::NEG_INFINITY);
+    for k in 0..=8 {
+        let t = (k as f32 / 8.0 - 0.5) * len;
+        let g = ground(syn, x + c * t, z - s * t);
+        lo = lo.min(g);
+        hi = hi.max(g);
+    }
+    (lo, hi)
+}
+
+/// The lowest and highest ground under a rectangle `w` by `d`, turned to `deg`.
+fn ground_foot(syn: &Synth, x: f32, z: f32, deg: f32, w: f32, d: f32) -> (f32, f32) {
+    let (s, c) = deg.to_radians().sin_cos();
+    let (mut lo, mut hi) = (f32::INFINITY, f32::NEG_INFINITY);
+    for a in -1..=1 {
+        for b in -1..=1 {
+            let (u, v) = (a as f32 * w * 0.5, b as f32 * d * 0.5);
+            let g = ground(syn, x + c * u + s * v, z - s * u + c * v);
+            lo = lo.min(g);
+            hi = hi.max(g);
+        }
+    }
+    (lo, hi)
+}
+
+/// Whether a world point is inside the terrain square, with a margin.
+fn inside(prog: &TrackProgram, x: f32, z: f32, margin: f32) -> bool {
+    x > margin
+        && z > margin
+        && x < prog.terrain.size_x - margin
+        && z < prog.terrain.size_z - margin
+}
+
+// ---------------------------------------------------------------------------
+// Sheets
+// ---------------------------------------------------------------------------
+
+fn sheet(name: &str, dim: u32, f: impl Fn(f32, f32) -> [u8; 4]) -> Texture {
+    let mut rgba = Vec::with_capacity((dim * dim * 4) as usize);
+    for y in 0..dim {
+        for x in 0..dim {
+            let (u, v) = (x as f32 / dim as f32, y as f32 / dim as f32);
+            rgba.extend_from_slice(&f(u, v));
+        }
+    }
+    Texture { name: name.into(), width: dim, height: dim, rgba }
+}
+
+fn grain(u: f32, v: f32, seed: u32, scale: f32) -> f32 {
+    let i = ((u * scale) as u32) ^ (((v * scale) as u32) << 8);
+    rnd(seed, i)
+}
+
+/// The marker panel: a coloured board on a short post, which is what a track's edge line
+/// mostly is. Alpha cuts the board out of the sheet so the post reads as a post.
+fn marker_sheet() -> Texture {
+    sheet("marker_c_a", 64, |u, v| {
+        // Bottom fifth is the post, the rest the board.
+        if v > 0.8 {
+            if (u - 0.5).abs() < 0.06 {
+                [70, 70, 74, 255]
+            } else {
+                [0, 0, 0, 0]
+            }
+        } else if v > 0.06 && (0.04..0.96).contains(&u) {
+            let stripe = ((v * 5.0) as u32) % 2 == 0;
+            if stripe {
+                [206, 70, 32, 255]
+            } else {
+                [236, 236, 232, 255]
+            }
+        } else {
+            [0, 0, 0, 0]
+        }
+    })
+}
+
+/// Mesh fencing: a grid you can see through, which is the whole reason it is a cut-out.
+fn fence_sheet() -> Texture {
+    sheet("fence_c_a", 64, |u, v| {
+        let line = |t: f32| (t * 16.0).fract() < 0.22;
+        // Posts down the sides and a rail top and bottom keep the panel readable at distance.
+        let frame = v < 0.05 || v > 0.95 || u < 0.03 || u > 0.97;
+        if frame {
+            [120, 122, 126, 255]
+        } else if line(u) || line(v) {
+            [150, 152, 156, 210]
+        } else {
+            [0, 0, 0, 0]
+        }
+    })
+}
+
+fn bale_sheet() -> Texture {
+    sheet("bale_c", 64, |u, v| {
+        let g = grain(u, v, 0x51A7, 32.0);
+        let band = (v * 3.0).fract() < 0.12;
+        let base = if band { [180, 160, 60] } else { [214, 196, 96] };
+        [
+            (base[0] as f32 * (0.86 + 0.2 * g)) as u8,
+            (base[1] as f32 * (0.86 + 0.2 * g)) as u8,
+            (base[2] as f32 * (0.86 + 0.2 * g)) as u8,
+            255,
+        ]
+    })
+}
+
+/// Foliage, cut out of its sheet. A canopy that fills the quad reads as a green slab from
+/// every angle; the cut-out is what makes it a tree.
+fn leaf_sheet() -> Texture {
+    sheet("leaf_c_a", 128, |u, v| {
+        // A rough crown: dense in the middle, ragged at the edge, with a trunk below it.
+        let (cx, cy) = (u - 0.5, v - 0.38);
+        let r = (cx * cx + cy * cy * 1.35).sqrt();
+        let ragged = 0.36 + 0.09 * (grain(u, v, 0x2C41, 22.0) - 0.5) * 2.0;
+        if v > 0.72 {
+            if (u - 0.5).abs() < 0.035 {
+                let g = grain(u, v, 0x77B1, 40.0);
+                [(74.0 + 26.0 * g) as u8, (58.0 + 18.0 * g) as u8, (44.0 + 14.0 * g) as u8, 255]
+            } else {
+                [0, 0, 0, 0]
+            }
+        } else if r < ragged {
+            let g = grain(u, v, 0x3D19, 26.0);
+            let shade = 0.62 + 0.38 * g;
+            [
+                (58.0 * shade) as u8,
+                (104.0 * shade) as u8,
+                (46.0 * shade) as u8,
+                255,
+            ]
+        } else {
+            [0, 0, 0, 0]
+        }
+    })
+}
+
+fn gate_sheet() -> Texture {
+    sheet("gate_c", 64, |u, v| {
+        let g = grain(u, v, 0x9E11, 24.0);
+        if v < 0.28 {
+            [(30.0 + 30.0 * g) as u8, (60.0 + 40.0 * g) as u8, (120.0 + 40.0 * g) as u8, 255]
+        } else {
+            [(190.0 + 40.0 * g) as u8, (190.0 + 40.0 * g) as u8, (186.0 + 40.0 * g) as u8, 255]
+        }
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Placement
+// ---------------------------------------------------------------------------
+
+/// Build a track's scenery: the models, and where they stand.
+pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
+    let seed = prog.terrain.relief.seed;
+    let lap = prog.lap_length();
+    let half = prog.width * 0.5;
+    let stations = prog.stations(0.5);
+    // Every candidate is measured against the whole lap, not against the station it came
+    // from. Two metres a step is finer than anything being placed is wide.
+    let coarse = prog.stations(2.0);
+    let at = |s: f32| -> crate::trackprog::Station {
+        let i = ((s / 0.5) as usize).min(stations.len().saturating_sub(1));
+        stations[i]
+    };
+
+    let mut markers = Mesh::default();
+    let mut fence = Mesh::default();
+    let mut bales = Mesh::default();
+    let mut trees = Mesh::default();
+    let mut gate = Mesh::default();
+    let mut tally = Vec::new();
+
+    // 1. The edge line. Both sides, the whole lap. This is the thing every track has.
+    let marker_off = (half + 1.0).max(MARKER_OFF_M);
+    let mut n = 0usize;
+    let mut s = 0.0f32;
+    while s < lap {
+        let st = at(s);
+        let (rx, rz) = crate::trackprog::right_vector(st.heading);
+        for side in [-1.0f32, 1.0] {
+            let (x, z) = (st.x + rx * marker_off * side, st.z + rz * marker_off * side);
+            // Its own station is `marker_off` away, so anything nearer than that is another
+            // part of the lap and the marker would be standing on the track.
+            if !inside(prog, x, z, 2.0) || clearance(&coarse, x, z) < marker_off - 1.0 {
+                continue;
+            }
+            // A hand-planted line is not a ruler: a little jitter either way, and the boards
+            // face across the track rather than all one way.
+            let jitter = (rnd(seed ^ 0x11, n as u32) - 0.5) * 0.4;
+            let card = edfwrite::card(0.5, MARKER_H_M * (0.9 + 0.2 * rnd(seed ^ 0x12, n as u32)));
+            let deg = st.heading.to_degrees() + 90.0 + jitter * 20.0;
+            markers.append(&edfwrite::moved(
+                &edfwrite::turned(&card, deg),
+                [x, ground(syn, x, z) - 0.05, z],
+            ));
+            n += 1;
+        }
+        s += MARKER_GAP_M;
+    }
+    tally.push(("markers", n));
+
+    // 2. The fence, further out and continuous.
+    let mut n = 0usize;
+    let mut s = 0.0f32;
+    while s < lap {
+        let st = at(s);
+        let (rx, rz) = crate::trackprog::right_vector(st.heading);
+        for side in [-1.0f32, 1.0] {
+            let off = FENCE_OFF_M + (rnd(seed ^ 0x21, n as u32) - 0.5) * 2.0;
+            let (x, z) = (st.x + rx * off * side, st.z + rz * off * side);
+            if !inside(prog, x, z, 4.0) || clearance(&coarse, x, z) < half + 4.0 {
+                continue;
+            }
+            let deg = st.heading.to_degrees() + 90.0;
+            let (lo, hi) = ground_span(syn, x, z, deg, FENCE_PANEL_M);
+            // A fence is not built across a step. Where the ground under a panel moves more
+            // than this the run simply has a gap, which is what happens on a real one.
+            if hi - lo > 1.0 {
+                continue;
+            }
+            // Set on the mean of its two ends rather than on either. A panel is a flat board
+            // and the ground is not: put it on the low end and the high end buries it, put it
+            // on the high end and the low end leaves it in the air. Halfway is the bottom
+            // rail dipping in and out of the dirt, which is what a fence on rolling ground
+            // actually does.
+            let panel = edfwrite::card(FENCE_PANEL_M, FENCE_H_M);
+            fence.append(&edfwrite::moved(
+                &edfwrite::turned(&panel, deg),
+                [x, (lo + hi) * 0.5 - 0.05, z],
+            ));
+            n += 1;
+        }
+        s += FENCE_PANEL_M;
+    }
+    tally.push(("fence panels", n));
+
+    // 3. Bales where a rider leaves the track fastest: the outside of every corner.
+    let mut n = 0usize;
+    let mut s = 0.0f32;
+    while s < lap {
+        let st = at(s);
+        if st.curvature.abs() > 1.0 / 45.0 {
+            // Outside of the turn is away from the way it bends.
+            let side = -st.curvature.signum();
+            let (rx, rz) = crate::trackprog::right_vector(st.heading);
+            let off = BALE_OFF_M + (rnd(seed ^ 0x31, n as u32) - 0.5) * 2.0;
+            let (x, z) = (st.x + rx * off * side, st.z + rz * off * side);
+            if inside(prog, x, z, 3.0) && clearance(&coarse, x, z) > half + 2.0 {
+                let deg = st.heading.to_degrees() + 12.0 * (rnd(seed ^ 0x32, n as u32) - 0.5);
+                // A bale is a flat-bottomed box and the outside of a corner is the most
+                // sloped ground on the track. Where its own footprint is too far off level
+                // nobody would have stacked one there, so it isn't stacked there.
+                let (lo, hi) = ground_foot(syn, x, z, deg, BALE_W_M, BALE_D_M);
+                if hi - lo > 0.8 {
+                    s += 4.0;
+                    continue;
+                }
+                bales.append(&edfwrite::moved(
+                    &edfwrite::turned(&edfwrite::cuboid(BALE_W_M, BALE_H_M, BALE_D_M), deg),
+                    [x, (lo + hi) * 0.5, z],
+                ));
+                n += 1;
+            }
+        }
+        s += 4.0;
+    }
+    tally.push(("bales", n));
+
+    // 4. Trees, out past the fence, thinned so they don't line up with the lap.
+    let mut n = 0usize;
+    let mut placed: Vec<(f32, f32)> = Vec::new();
+    let mut s = 0.0f32;
+    while s < lap {
+        let st = at(s);
+        let (rx, rz) = crate::trackprog::right_vector(st.heading);
+        for k in 0..3u32 {
+            let i = (n as u32) * 7 + k;
+            if rnd(seed ^ 0x41, i) > 0.45 {
+                continue;
+            }
+            let side = if rnd(seed ^ 0x42, i) < 0.5 { -1.0 } else { 1.0 };
+            let off = TREE_FROM_M + (TREE_TO_M - TREE_FROM_M) * rnd(seed ^ 0x43, i);
+            let (x, z) = (st.x + rx * off * side, st.z + rz * off * side);
+            if !inside(prog, x, z, 6.0) || clearance(&coarse, x, z) < TREE_FROM_M - 6.0 {
+                continue;
+            }
+            // Nothing where the track is, and nothing on top of another tree.
+            if placed
+                .iter()
+                .any(|(px, pz)| (px - x).powi(2) + (pz - z).powi(2) < TREE_SPACING_M.powi(2))
+            {
+                continue;
+            }
+            placed.push((x, z));
+            let h = TREE_H_M * (0.7 + 0.6 * rnd(seed ^ 0x44, i));
+            let w = h * 0.75;
+            let tree = edfwrite::crossed(w, h, 3);
+            trees.append(&edfwrite::moved(
+                &edfwrite::turned(&tree, 360.0 * rnd(seed ^ 0x45, i)),
+                [x, ground_min(syn, x, z, w * 0.5) - 0.1, z],
+            ));
+            n += 1;
+        }
+        s += TREE_SPACING_M;
+    }
+    tally.push(("trees", n));
+
+    // 5. The start structure, over the gate row.
+    let st = at(2.0);
+    let (rx, rz) = crate::trackprog::right_vector(st.heading);
+    let (fx, fz) = crate::trackprog::heading_vector(st.heading);
+    // One foot for the whole structure: a gantry with a post at each end is level, and
+    // levelling it on the lower ground is what keeps the other post out of the air.
+    // Each post stands on its own ground — level them together and one is buried and the
+    // other in the air — and the beam clears the higher of the two.
+    let mut highest = f32::NEG_INFINITY;
+    for side in [-1.0f32, 1.0] {
+        let (x, z) = (st.x + rx * (half + 3.0) * side, st.z + rz * (half + 3.0) * side);
+        let foot = ground(syn, x, z);
+        highest = highest.max(foot);
+        gate.append(&edfwrite::moved(&edfwrite::cuboid(0.5, 5.0, 0.5), [x, foot, z]));
+    }
+    let span = (half + 3.0) * 2.0;
+    let beam = edfwrite::turned(&edfwrite::cuboid(span, 1.2, 0.3), st.heading.to_degrees() + 90.0);
+    gate.append(&edfwrite::moved(&beam, [st.x, highest + 4.6, st.z]));
+    let _ = (fx, fz);
+    tally.push(("gate", 1));
+
+    // One model, one node a kind. Empty kinds are dropped so nothing writes a node with no
+    // geometry in it.
+    let kinds: Vec<(&str, Mesh, usize)> = vec![
+        ("markers", markers, 0),
+        ("fence", fence, 1),
+        ("bales", bales, 2),
+        ("trees", trees, 3),
+        ("gate", gate, 4),
+    ];
+    let sheets = vec![
+        marker_sheet(),
+        fence_sheet(),
+        bale_sheet(),
+        leaf_sheet(),
+        gate_sheet(),
+    ];
+    let parts: Vec<Part> = kinds
+        .into_iter()
+        .filter(|(_, m, _)| m.vertex_count() >= 8)
+        .map(|(name, mesh, texture)| Part { name: name.into(), mesh, texture })
+        .collect();
+
+    let bytes = edfwrite::write(&parts, &sheets);
+    let at_origin = Scene {
+        file: "scenery.edf".into(),
+        pos: [0.0, 0.0, 0.0],
+        rot: [0.0, 0.0, 0.0],
+    };
+
+    // Collision is a second model holding only what should stop a bike: the bales and the
+    // gate posts. Foliage and the marker line are cards — solid, they would be invisible
+    // walls, and a rider who clips a track-edge board should ride on.
+    let solid_parts: Vec<Part> = parts
+        .iter()
+        .filter(|p| p.name == "bales" || p.name == "gate")
+        .cloned()
+        .collect();
+    let mut files = vec![("scenery.edf".to_string(), bytes)];
+    let mut solid = Vec::new();
+    if !solid_parts.is_empty() {
+        files.push((
+            "solids.edf".to_string(),
+            edfwrite::write(&solid_parts, &sheets),
+        ));
+        solid.push(Scene {
+            file: "solids.edf".into(),
+            pos: [0.0, 0.0, 0.0],
+            rot: [0.0, 0.0, 0.0],
+        });
+    }
+
+    Scenery { files, drawn: vec![at_origin], solid, tally }
+}
+
+/// The `scene<N>` blocks, in the form TerrainEd reads them.
+pub fn blocks(scenes: &[Scene]) -> String {
+    let mut s = String::new();
+    for (i, sc) in scenes.iter().enumerate() {
+        s.push_str(&format!(
+            "\nscene{i}\n{{\n\tname = {}\n\tpos\n\t{{\n\t\tx = {:.3}\n\t\ty = {:.3}\n\t\tz = {:.3}\n\t}}\n\
+             \trot\n\t{{\n\t\tx = {:.3}\n\t\ty = {:.3}\n\t\tz = {:.3}\n\t}}\n}}\n",
+            sc.file, sc.pos[0], sc.pos[1], sc.pos[2], sc.rot[0], sc.rot[1], sc.rot[2],
+        ));
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn demo() -> (TrackProgram, Synth) {
+        let p: TrackProgram = serde_json::from_str(crate::trackprog::EXAMPLE).unwrap();
+        let s = crate::tracksynth::synthesise(&p).unwrap();
+        (p, s)
+    }
+
+    #[test]
+    fn a_lap_gets_an_edge_line_the_whole_way_round() {
+        let (p, s) = demo();
+        let sc = build(&p, &s);
+        let markers = sc.tally.iter().find(|(k, _)| *k == "markers").unwrap().1;
+        // Both sides, one every three metres — the corpus figure.
+        let want = (p.lap_length() / MARKER_GAP_M * 2.0) as usize;
+        assert!(
+            markers > want * 8 / 10,
+            "{markers} markers for a {:.0} m lap, expected about {want}",
+            p.lap_length()
+        );
+    }
+
+    #[test]
+    fn nothing_stands_on_the_riding_line() {
+        let (p, s) = demo();
+        let sc = build(&p, &s);
+        let bytes = &sc.files[0].1;
+        let nodes = crate::edf::parse_world(bytes);
+        assert!(!nodes.is_empty(), "the model has nodes");
+
+        // Every vertex, against the corridor the track was built with. The edge line sits
+        // just outside the shoulder; nothing may sit inside the riding surface itself.
+        let stations = p.stations(1.0);
+        let half = p.width * 0.5;
+        // Anything a rider's head would pass under may cross the line — the start gantry is
+        // meant to. What matters is that nothing is in the way at riding height.
+        let ride_h = 3.0;
+        let mut worst = f32::INFINITY;
+        for n in &nodes {
+            for v in n.positions.chunks_exact(3) {
+                let g = ground(&s, v[0], v[2]);
+                if v[1] - g > ride_h {
+                    continue;
+                }
+                let d = stations
+                    .iter()
+                    .map(|st| ((st.x - v[0]).powi(2) + (st.z - v[2]).powi(2)).sqrt())
+                    .fold(f32::INFINITY, f32::min);
+                worst = worst.min(d);
+            }
+        }
+        assert!(
+            worst > half,
+            "something stands {worst:.1} m from the centreline, inside a {half:.1} m half-width"
+        );
+    }
+
+    #[test]
+    fn everything_stands_on_the_ground_it_was_placed_on() {
+        let (p, s) = demo();
+        let sc = build(&p, &s);
+        let nodes = crate::edf::parse_world(&sc.files[0].1);
+
+        // How far a thing's foot may sit under the surface, by kind. Not one number: a
+        // seven-metre foliage card is placed on the lowest ground it covers precisely so it
+        // never floats, and its far corner going under a rise is what that costs — and what
+        // you want, because a tree hovering over a bank is the thing you would notice. A
+        // fence panel or a gate post is built, flat-footed and man-high, and one sunk half a
+        // metre reads as broken.
+        let allowed = |name: &str| if name == "trees" { 1.5f32 } else { 0.6 };
+
+        let mut worst: (f32, String, [f32; 3]) = (0.0, String::new(), [0.0; 3]);
+        for n in &nodes {
+            let limit = allowed(&n.name);
+            for v in n.positions.chunks_exact(3) {
+                let under = ground(&s, v[0], v[2]) - v[1];
+                if under > limit && under - limit > worst.0 - allowed(&worst.1) {
+                    worst = (under, n.name.clone(), [v[0], v[1], v[2]]);
+                }
+            }
+        }
+        assert!(
+            worst.1.is_empty(),
+            "{} is buried {:.2} m at {:?}, over its {:.1} m allowance",
+            worst.1, worst.0, worst.2, allowed(&worst.1)
+        );
+    }
+
+    #[test]
+    fn the_blocks_read_the_way_terrained_writes_them() {
+        let s = blocks(&[Scene {
+            file: "scenery.edf".into(),
+            pos: [1.0, 2.0, 3.0],
+            rot: [0.0, 90.0, 0.0],
+        }]);
+        assert!(s.contains("scene0"));
+        assert!(s.contains("name = scenery.edf"));
+        assert!(s.contains("x = 1.000") && s.contains("y = 2.000") && s.contains("z = 3.000"));
+        assert!(s.contains("y = 90.000"));
+    }
+
+    #[test]
+    fn collision_is_only_what_should_stop_a_bike() {
+        let (p, s) = demo();
+        let sc = build(&p, &s);
+        assert_eq!(sc.solid.len(), 1, "one collision model");
+        let names: Vec<String> = crate::edf::parse_world(&sc.files[1].1)
+            .into_iter()
+            .map(|n| n.name)
+            .collect();
+        assert!(names.iter().any(|n| n == "bales"), "{names:?}");
+        assert!(!names.iter().any(|n| n == "trees"), "foliage cards are not walls: {names:?}");
+    }
+}
+
+#[cfg(test)]
+mod built {
+    use super::*;
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
+
+    fn u32b(v: usize) -> [u8; 4] {
+        (v as u32).to_le_bytes()
+    }
+
+    /// Build the demo track with its objects, compile it, package it, and dump what came out
+    /// in a form a renderer can draw.
+    ///
+    /// ```text
+    /// FROST_BUILD=/tmp/objtrack FROST_TOOLS=~/Downloads/mxb-trackbuild/tools \
+    /// FROST_PREFIX=~/Downloads/mxb-trackbuild/prefix FROST_WINE=".../wine" \
+    /// FROST_INSTALL="~/Documents/MX Bikes/mods/tracks" \
+    ///   cargo test -- --ignored --nocapture builds_a_track_with_objects
+    /// ```
+    #[test]
+    #[ignore = "writes and compiles a track — set FROST_BUILD"]
+    fn builds_a_track_with_objects() {
+        let dir = PathBuf::from(std::env::var("FROST_BUILD").expect("set FROST_BUILD"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let p: TrackProgram = serde_json::from_str(crate::trackprog::EXAMPLE).unwrap();
+        let syn = crate::tracksynth::synthesise(&p).unwrap();
+        let slug = crate::tracksynth::write_source(&p, &syn, &dir).unwrap();
+        println!("{}: {:.0} m lap, {} files", p.name, p.lap_length(), slug.len());
+
+        let sc = build(&p, &syn);
+        for (k, n) in &sc.tally {
+            println!("  {k:<14} {n}");
+        }
+        for (name, bytes) in &sc.files {
+            println!("  {name:<14} {} KB", bytes.len() / 1024);
+        }
+
+        let tools = PathBuf::from(std::env::var("FROST_TOOLS").expect("set FROST_TOOLS"));
+        let t = crate::trackbuild::find(&tools).expect("compilers under FROST_TOOLS");
+        let stem = dir
+            .join("track.hmf")
+            .exists()
+            .then(|| slug.iter().find_map(|f| f.strip_suffix(".map").map(|s| s.to_string())))
+            .flatten()
+            .unwrap_or_default();
+        let name = stem.split('/').next_back().unwrap_or("track").to_string();
+        println!("slug: {name}");
+
+        let map_rel = format!("{name}/{name}.map");
+        let trh_rel = format!("{name}/{name}.trh");
+        std::fs::create_dir_all(dir.join(&name)).ok();
+        for (label, args) in [
+            ("map", vec!["track.hmf", map_rel.as_str(), "params.ini"]),
+            ("trh", vec!["track.tht", trh_rel.as_str(), "trh_params.ini"]),
+        ] {
+            let out = run(&t.terrained, &args, &dir);
+            println!("--- {label} ---\n{out}");
+        }
+        if let Some(tracked) = &t.tracked {
+            let out = run(
+                tracked,
+                &["-merge", &trh_rel, "cl", "track.tcl", "sa", "track_start.tcl"],
+                &dir,
+            );
+            println!("--- centreline ---\n{out}");
+        }
+
+        let map_path = dir.join(&map_rel);
+        assert!(map_path.is_file(), "no {map_rel} was written");
+        let mb = std::fs::read(&map_path).unwrap();
+        let mesh = crate::map::parse(&mb).expect("the compiled .map parses");
+        let sheets = crate::map::declared(&mb);
+        println!(
+            "\ncompiled: {} materials, {} vertices, {} triangles, {} islands\nsheets: {:?}",
+            mesh.materials,
+            mesh.vertex_count(),
+            mesh.triangle_count(),
+            mesh.objects.len(),
+            sheets.iter().map(|(n, ..)| n).collect::<Vec<_>>()
+        );
+        assert!(mesh.triangle_count() > 1000, "the scenery didn't reach the map");
+
+        // Package, and install where the game lists it.
+        let pkz = dir.join(format!("{name}.pkz"));
+        let size = crate::trackbuild::package(&dir, &name, &pkz).unwrap();
+        println!("packaged {} KB", size / 1024);
+        if let Ok(to) = std::env::var("FROST_INSTALL") {
+            let at = crate::trackbuild::install(&pkz, Path::new(&to)).unwrap();
+            println!("installed {at:?}");
+        }
+
+        dump(&dir.join("scene.bin"), &p, &syn, &mesh, &mb);
+        println!("dumped {:?}", dir.join("scene.bin"));
+    }
+
+    /// Everything a renderer needs, in one file: the ground, the riding line, the scenery
+    /// mesh and the sheets it wears. Written so the picture is of what was *compiled*, not of
+    /// what we meant to compile.
+    fn dump(
+        to: &Path,
+        p: &TrackProgram,
+        syn: &Synth,
+        mesh: &crate::map::MapMesh,
+        map_bytes: &[u8],
+    ) {
+        let mut f = std::fs::File::create(to).unwrap();
+        let mut w = |b: &[u8]| f.write_all(b).unwrap();
+        w(b"SDMP");
+        w(&u32b(syn.gw));
+        w(&u32b(syn.gh));
+        w(&syn.mps.to_le_bytes());
+        w(&p.terrain.size_x.to_le_bytes());
+        for v in &syn.heights {
+            w(&v.to_le_bytes());
+        }
+        for c in &syn.corridor {
+            w(&[*c as u8]);
+        }
+
+        // Sheets, reduced so the dump stays small — enough to tell a leaf from a fence.
+        const DIM: u32 = 64;
+        let textures = crate::map::textures(map_bytes, 256);
+        let count = mesh.materials.max(1) as usize;
+        w(&u32b(count));
+        for m in 0..count {
+            let t = textures.iter().find(|t| t.material == m as u32);
+            w(&u32b(DIM as usize));
+            for y in 0..DIM {
+                for x in 0..DIM {
+                    let px = match t {
+                        Some(t) if t.width > 0 && t.height > 0 => {
+                            let sx = (x * t.width / DIM).min(t.width - 1) as usize;
+                            let sy = (y * t.height / DIM).min(t.height - 1) as usize;
+                            let i = (sy * t.width as usize + sx) * 4;
+                            [t.rgba[i], t.rgba[i + 1], t.rgba[i + 2], t.rgba[i + 3]]
+                        }
+                        _ => [170, 170, 170, 255],
+                    };
+                    w(&px);
+                }
+            }
+        }
+
+        w(&u32b(mesh.vertex_count()));
+        for v in &mesh.positions {
+            w(&v.to_le_bytes());
+        }
+        for v in &mesh.uvs {
+            w(&v.to_le_bytes());
+        }
+        // One material per triangle, from the group runs.
+        let tris = mesh.triangle_count();
+        let mut mat = vec![0u32; tris];
+        for g in &mesh.groups {
+            for t in g.tri_start as usize..(g.tri_start + g.tri_count) as usize {
+                if t < tris {
+                    mat[t] = g.material;
+                }
+            }
+        }
+        w(&u32b(tris));
+        for i in &mesh.indices {
+            w(&i.to_le_bytes());
+        }
+        for m in &mat {
+            w(&m.to_le_bytes());
+        }
+    }
+
+    fn run(exe: &Path, args: &[&str], dir: &Path) -> String {
+        let mut cmd = if cfg!(target_os = "windows") {
+            std::process::Command::new(exe)
+        } else {
+            let mut c = std::process::Command::new(
+                std::env::var("FROST_WINE").expect("set FROST_WINE"),
+            );
+            c.env("WINEPREFIX", std::env::var("FROST_PREFIX").expect("set FROST_PREFIX"));
+            c.env("WINEDEBUG", "-all");
+            c.arg(exe);
+            c
+        };
+        cmd.args(args).current_dir(dir);
+        let out = cmd.output().expect("running the compiler");
+        format!(
+            "exit {:?}\n{}{}",
+            out.status.code(),
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        )
+    }
+}

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -2003,9 +2003,19 @@ pub fn write_source(prog: &TrackProgram, syn: &Synth, dir: &Path) -> Result<Vec<
         put(&format!("maps/env/env_{face}.tga"), bytes, &mut wrote)?;
     }
 
+    // What stands beside the track: the models, and the blocks that place them. The `.hmf`
+    // draws them; the `.tht` gets only what should stop a bike, so a rider clips a foliage
+    // card and rides on but hits a bale.
+    let scenery = crate::trackscenery::build(prog, syn);
+    for (name, bytes) in &scenery.files {
+        put(name, bytes.clone(), &mut wrote)?;
+    }
+
     // PiBoSo's own source files are CRLF, so ours are.
-    put("track.hmf", crlf(&hmf(prog, syn)), &mut wrote)?;
-    put("track.tht", crlf(&tht(prog, syn)), &mut wrote)?;
+    let hmf_text = hmf(prog, syn) + &crate::trackscenery::blocks(&scenery.drawn);
+    let tht_text = tht(prog, syn) + &crate::trackscenery::blocks(&scenery.solid);
+    put("track.hmf", crlf(&hmf_text), &mut wrote)?;
+    put("track.tht", crlf(&tht_text), &mut wrote)?;
     put("params.ini", crlf(PARAMS_INI), &mut wrote)?;
     put("trh_params.ini", crlf(TRH_PARAMS_INI), &mut wrote)?;
     put("track.tcl", crlf(&tcl(prog)), &mut wrote)?;


### PR DESCRIPTION
A generated track now has things standing beside it: marker boards down both sides of the riding line, fencing behind them, bales on the outside of the corners, trees back in the field, and a gantry over the start. It compiles, packages and installs, and the pictures below are drawn from the compiled `.map` itself rather than from what we meant to build.

## Where things go is measured, not chosen

`trackobjects` reads twelve published tracks and joins three things that already existed — the `.map`'s connected islands, the sheet names from its own texture table, and the centreline `trackline` pulls out of the `.trh`. Against the lap every object gets a distance round it and a lateral offset.

Two corrections had to land before the numbers meant anything:

- **An island is not an object.** The exporter duplicates vertices, so a track comes apart into ~160k pieces of two or three triangles. Clustered at 3 m, Washougal's 235,653 islands become 4,395 objects.
- **The backdrop is not furniture.** Measured together, Netherlands reads 3,953 trees averaging 291 m from the centreline and 17.5 m tall — that is the distant treeline. Split at 60 m it reads 214 trees at 36.8 m plus 3,739 backdrop. The two populations barely overlap, which is what makes 60 m a measurement rather than a preference.

| | on | per km p50 | offset p50 | gap p50 | tall p50 |
|---|---|---|---|---|---|
| banner | 12 | 249.5 | 7.5 m | 3.1 m | 1.1 m |
| structure | 12 | 170.7 | 25.7 m | 3.0 m | 2.2 m |
| pole | 10 | 32.8 | 25.4 m | 8.3 m | 2.8 m |
| vehicle | 12 | 24.4 | 12.2 m | 8.0 m | 2.3 m |
| bale | 8 | 13.6 | 27.7 m | 8.0 m | 3.1 m |
| fence | 12 | 13.4 | 19.2 m | 6.2 m | 2.9 m |
| tree | 8 | 7.9 | 36.8 m | 18.3 m | 3.9 m |

The clearest of them: every track lines its riding line with something about a metre tall, 7.5 m out, one every three metres, and on most of them it runs the whole lap. That is the edge a rider sees, and we had none of it.

## Writing an `.edf`

`.edf` is the only mesh format `terrained.exe` will open — its own string table says so — and nothing here could write one. Reading `flagpoles.edf` against `edf.rs`'s own constants accounts for every byte, and what that reader calls the file header turns out to be the material table:

```
"EDF\0" | f32[6] bounds | u32 material count | 56 B a material
u32 vc | pos | uv0 | uv1 | ones | ones | normal | tangent      72 B a vertex
u32 tc | u32[tc*3] | u32 1 | char[104] name | f32[16] matrix
u32 group count, u32 0 | 24 B a group | u32 0 | f32[6] bounds
u32 texture count | char[104] name | w | h | 16 B | 0 | size | 8 B zeros | DEFLATE RGBA
```

The loop closes on macOS, which the terrain's never has: write the file, compile it under Wine, decode the `.map` with our own reader. A 2x4x2 box asked for at (40, 3, 50) comes back spanning 39-41, 3-7, 49-51.

## Four faults, all found rather than reasoned about

- **A lap folds back on itself.** A tree placed 26 m to the side of one station landed 0.9 m from another part of the track — correct against its own station right up until you ride into it. Everything is measured against the whole centreline now.
- **A multi-material model is one node of several groups, not several nodes.** `finish_gate.edf` settles it. A one-part model is byte-identical either way, which is why the first proof passed and the first real track faulted TerrainEd on a null write.
- **TerrainEd still refuses the second material** in a model, whatever the geometry. `which_ingredient_terrained_refuses` says so case by case: boxes, cut-out sheets, crossed cards, two groups sharing one sheet and two hundred boxes in one node all compile; two sheets does not. The cause is in the texture block, where real files put a trailer between records whose length varies (8, 24 and 40 bytes across the two examples) and nothing here knows what it says yet. So a kind gets its own `.edf` with one sheet — which is what PiBoSo's example track does with its three `scene` blocks.
- **A lap had one tree on it.** The scatter keyed its randomness on how many trees had been placed, and that count only moves when one is accepted, so every station drew the same three numbers and the spacing rule threw them all away.
- **Flat feet on sloping ground.** A fence panel sampled as a disc sank 2 m into a bank; panels are sampled along their own span now, set on the mean of their ends, and a run has a gap where the ground steps. Bales are not stacked at all where their footprint is more than 0.8 m off level, and a gantry levelled on one foot buried one post and left the other in the air.

## Also

- Fixed a real fault in `edf::embedded_textures`, which refused any name following an ASCII alphanumeric byte. That is right for a scan and wrong at a record boundary, where the preceding byte is the tail of a DEFLATE stream and is a letter about a quarter of the time — so the sheet after it was dropped silently. This affects real models, not only written ones.
- `scripts/track-render.py` draws a compiled track from the `scene.bin` the build test writes beside it. The corpus work found two placement faults that every measurement passed, so the picture is the check.
- Collision is only what should stop a bike. Bales and the gantry are in the `.tht`; marker boards and foliage cards are not, so clipping one costs nothing.

## Verified

`Corpus_National` builds, compiles (all three passes exit 0), packages to 65 MB and installs. The compiled `.map` carries 7,808 triangles across all five sheets. 1324 tests pass.

Nothing has been ridden — that still needs Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)