### PR TITLE
feat(tracks): a venue round the track, and a start you can ride

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## 2026-09-06
 
+### Added
+- A wood behind the track. The tracks people rate carry thousands of trees past 60 m and only
+  a handful trackside, so that is what a built track gets now — a backdrop of mixed pine and
+  broadleaf out to the edge of the ground, with a few standing closer in.
+- Poles and parked vans down both sides, at the spacing the same tracks use, and a sky of the
+  track's own instead of the game's default one.
+- The start pad is ridden ground: the same surface texture the rest of the track has, and the
+  comb of grooves forty bikes leave pulling out of forty stalls.
+
+### Changed
+- The ground round a track is grass in patches over bare worked dirt rather than one flat
+  green field.
+- Marker blocks are white.
+- Nothing is planted on the start straight any more, and the fence is gone for now — it ran
+  along the lap and closed the start off.
+
+### Fixed
+- The start straight ends where the gates are. Its surface ran on behind the row for as far
+  as the ground went.
+- The picture a track is listed by shows the colours it will actually have. It was mixing
+  each band's base colour rather than the sheet made from it, which turned a green field into
+  a desert.
+
+## 2026-09-06
+
 ### Changed
 - The start on a track you build is its own straight beside the circuit now, the way a real
   one is: the gate row stands 40 m off the lap, sprints 85 m, and turns in to join the track

--- a/src-tauri/src/trackscenery.rs
+++ b/src-tauri/src/trackscenery.rs
@@ -44,6 +44,9 @@ const BANNER_H_M: f32 = 1.2;
 /// How far off the ground the panel is slung.
 const BANNER_LIFT_M: f32 = 0.35;
 
+/// How far off the edge of the start straight anything trackside has to stand.
+const OFF_THE_START_M: f32 = 2.5;
+
 /// The fence, at the corpus median of 19.2 m and 2.9 m tall.
 const FENCE_OFF_M: f32 = 19.2;
 const FENCE_H_M: f32 = 2.9;
@@ -57,12 +60,40 @@ const BALE_W_M: f32 = 1.2;
 const BALE_H_M: f32 = 1.0;
 const BALE_D_M: f32 = 0.8;
 
-/// Trees stand back. Corpus p50 offset 36.8 m, p50 gap 18.3 m, p50 height 3.9 m — those are
-/// the ones you ride past, not the backdrop ring beyond 60 m.
-const TREE_FROM_M: f32 = 26.0;
-const TREE_TO_M: f32 = 95.0;
-const TREE_SPACING_M: f32 = 13.0;
-const TREE_H_M: f32 = 6.5;
+/// What the tracks people rate actually carry, per kilometre of lap, and how far off the
+/// racing line they put it. Measured with `trackobjects` over Rancho, Lakewood, Mt Morris and
+/// Southwick:
+///
+/// ```text
+///   structure  234-324 /km  at  4-6 m    the marker boards down both sides
+///   fence       35-58  /km  at  8-18 m
+///   bale        13-14  /km  at  8-15 m
+///   banner      12-22  /km  at 20-37 m
+///   pole        17-135 /km  at 18-26 m
+///   vehicle     22-36  /km  at 15-25 m
+///   tree         2-5   /km  at 50-55 m
+/// ```
+///
+/// Trackside trees are *rare* — five a kilometre at Lakewood. What that track has instead is
+/// **15,341 trees beyond 60 m**: the wood is a backdrop, not furniture, and a track with a few
+/// dozen trees dotted along it reads as a field with sticks in it.
+const TREE_FROM_M: f32 = 34.0;
+const TREE_TO_M: f32 = 58.0;
+const TREE_SPACING_M: f32 = 45.0;
+const TREE_H_M: f32 = 8.0;
+
+/// How far apart the poles and the parked vans go, from the per-kilometre counts above.
+const POLE_GAP_M: f32 = 50.0;
+const POLE_H_M: f32 = 7.5;
+const VAN_GAP_M: f32 = 40.0;
+
+/// The backdrop: where the wood starts, and how thickly it stands out to the edge of the plot.
+const WOOD_FROM_M: f32 = 64.0;
+const WOOD_STEP_M: f32 = 9.0;
+
+/// How much of the wood is pine. A wood of one tree is wallpaper; the venues this is measured
+/// against are half conifer, and the silhouette is most of what says where you are.
+const PINE_SHARE: f32 = 0.55;
 
 /// Which way to turn a mesh so its own X axis runs along a heading.
 ///
@@ -274,7 +305,9 @@ fn bale_sheet() -> Texture {
     sheet("bale_c", 64, |u, v| {
         let g = grain(u, v, 0x51A7, 32.0);
         let band = (v * 3.0).fract() < 0.12;
-        let base = if band { [180, 160, 60] } else { [214, 196, 96] };
+        // White, the way a modern track's blocks are: hay-coloured ones read as a yellow lump
+        // from any distance, and what a rider actually picks a corner out by is the white.
+        let base = if band { [206, 208, 210] } else { [238, 240, 242] };
         [
             (base[0] as f32 * (0.86 + 0.2 * g)) as u8,
             (base[1] as f32 * (0.86 + 0.2 * g)) as u8,
@@ -328,6 +361,173 @@ fn gate_sheet() -> Texture {
 ///
 /// UVs put the trunk in the left half of the sheet and the foliage in the right; see
 /// [`tree_sheet`].
+/// The sky, as a dome over the whole plot.
+///
+/// Every track people rate ships one — Mt Morris carries `dome_R26.edf` inside its own `.pkz`
+/// — and a track without one gets whatever the game draws by default, which is the same sky
+/// on every generated track. It is drawn from the inside: a hemisphere whose faces point in,
+/// big enough that the plot sits well within it.
+fn dome_mesh(radius: f32) -> Mesh {
+    const RINGS: usize = 8;
+    const SIDES: usize = 24;
+    let mut m = Mesh::default();
+    let mut ring_at = |mesh: &mut Mesh, t: f32| -> u32 {
+        let start = mesh.vertex_count() as u32;
+        // `t` runs 0 at the horizon to 1 at the zenith, eased so the ring spacing tightens
+        // where the eye is — near the horizon.
+        let phi = t * std::f32::consts::FRAC_PI_2;
+        let (y, r) = (radius * phi.sin() * 0.55, radius * phi.cos());
+        for k in 0..=SIDES {
+            let a = std::f32::consts::TAU * k as f32 / SIDES as f32;
+            let (x, z) = (a.sin() * r, a.cos() * r);
+            mesh.positions.extend_from_slice(&[x, y, z]);
+            // Facing inwards: this is a lid, and it is looked at from underneath.
+            let l = (x * x + y * y + z * z).sqrt().max(1e-4);
+            mesh.normals.extend_from_slice(&[-x / l, -y / l, -z / l]);
+            mesh.uvs.extend_from_slice(&[k as f32 / SIDES as f32 * 4.0, 1.0 - t]);
+        }
+        start
+    };
+    let mut lo = ring_at(&mut m, 0.0);
+    for i in 1..=RINGS {
+        let hi = ring_at(&mut m, i as f32 / RINGS as f32);
+        for k in 0..SIDES as u32 {
+            let (a, b) = (lo + k, lo + k + 1);
+            let (c, d) = (hi + k, hi + k + 1);
+            // Wound so the inside is the front face.
+            m.indices.extend_from_slice(&[a, c, b]);
+            m.indices.extend_from_slice(&[b, c, d]);
+        }
+        lo = hi;
+    }
+    m
+}
+
+/// The sky's own sheet: blue overhead, pale at the horizon, with cloud banded across it.
+fn dome_sheet() -> Texture {
+    sheet("sky_c", 256, |u, v| {
+        // v is 0 at the zenith and 1 at the horizon — see `dome_mesh`'s uvs.
+        let up = 1.0 - v;
+        let base = [
+            60.0 + 130.0 * (1.0 - up).powf(1.6),
+            110.0 + 120.0 * (1.0 - up).powf(1.4),
+            180.0 + 55.0 * (1.0 - up).powf(1.2),
+        ];
+        // Cloud: two scales of noise, thresholded so it comes out as banks rather than fog,
+        // and thinned towards the top where a flat sheet would read as a ceiling.
+        let n = 0.6 * grain(u * 3.0, v * 6.0, 0x9A11, 5.0) + 0.4 * grain(u * 9.0, v * 14.0, 0x9A12, 11.0);
+        let cloud = ((n - 0.52) * 3.4).clamp(0.0, 1.0) * (0.35 + 0.65 * (1.0 - up));
+        let c = |i: usize| (base[i] * (1.0 - cloud) + 246.0 * cloud).clamp(0.0, 255.0) as u8;
+        [c(0), c(1), c(2), 255]
+    })
+}
+
+/// A pole: a post with a crossbar near the top. Power, floodlight or flag — at the distance
+/// these stand it is a vertical, and what it does is break up the skyline.
+fn pole_mesh(h: f32) -> Mesh {
+    let mut m = edfwrite::cuboid(0.22, h, 0.22);
+    m.append(&edfwrite::moved(&edfwrite::cuboid(1.8, 0.14, 0.14), [0.0, h * 0.86, 0.0]));
+    m
+}
+
+/// A box van, parked. Two boxes and nothing else: at twenty metres it is a white slab with a
+/// dark cab, and every paddock on every track is full of them.
+fn van_mesh() -> Mesh {
+    let mut m = edfwrite::moved(&edfwrite::cuboid(6.0, 2.5, 2.4), [0.0, 1.55, 0.0]);
+    m.append(&edfwrite::moved(&edfwrite::cuboid(2.1, 1.7, 2.3), [-3.6, 1.15, 0.0]));
+    m
+}
+
+fn pole_sheet() -> Texture {
+    sheet("pole_c", 32, |u, v| {
+        let g = grain(u, v * 0.3, 0x71B3, 24.0);
+        let s = 0.82 + 0.24 * g;
+        [(142.0 * s) as u8, (140.0 * s) as u8, (134.0 * s) as u8, 255]
+    })
+}
+
+/// A van's paint: white with a band of colour through it, which is what a team truck is
+/// without being anybody's actual livery.
+fn van_sheet() -> Texture {
+    sheet("van_c", 64, |u, v| {
+        let g = grain(u, v, 0x24C9, 28.0);
+        let base = if (0.30..0.46).contains(&v) {
+            [190.0, 54.0, 44.0]
+        } else if v < 0.18 {
+            [56.0, 58.0, 62.0]
+        } else {
+            [236.0, 238.0, 240.0]
+        };
+        let s = 0.90 + 0.12 * g;
+        [(base[0] * s) as u8, (base[1] * s) as u8, (base[2] * s) as u8, 255]
+    })
+}
+
+/// A tree of one kind or the other, so the wood comes out mixed.
+fn stand(h: f32, seed: u32, key: u32) -> Mesh {
+    if rnd(seed ^ 0x46, key) < PINE_SHARE {
+        pine_mesh(h * 1.25, seed, key)
+    } else {
+        tree_mesh(h, seed, key)
+    }
+}
+
+/// A conifer: a straight trunk and three skirts of needles narrowing to a point.
+///
+/// Its own mesh rather than a taller broadleaf, because at a distance a tree is a silhouette
+/// and nothing else — a ridge of pines behind a track is most of what tells you where it is.
+fn pine_mesh(h: f32, seed: u32, i: u32) -> Mesh {
+    const SIDES: usize = 6;
+    let mut m = Mesh::default();
+    let trunk_h = h * 0.22;
+    let r_trunk = (h * 0.028).max(0.05);
+
+    let ring = |mesh: &mut Mesh, y: f32, r: f32, v: f32| -> u32 {
+        let start = mesh.vertex_count() as u32;
+        for s in 0..SIDES {
+            let a = std::f32::consts::TAU * s as f32 / SIDES as f32;
+            let (sx, sz) = (a.sin() * r, a.cos() * r);
+            mesh.positions.extend_from_slice(&[sx, y, sz]);
+            let l = (sx * sx + sz * sz).sqrt().max(1e-4);
+            mesh.normals.extend_from_slice(&[sx / l, 0.0, sz / l]);
+            mesh.uvs.extend_from_slice(&[0.06 + 0.10 * (s as f32 / SIDES as f32), v]);
+        }
+        start
+    };
+    let mut band = |mesh: &mut Mesh, lo: u32, hi: u32| {
+        for s in 0..SIDES as u32 {
+            let n = (s + 1) % SIDES as u32;
+            mesh.indices.extend_from_slice(&[lo + s, lo + n, hi + s]);
+            mesh.indices.extend_from_slice(&[hi + s, lo + n, hi + n]);
+            mesh.indices.extend_from_slice(&[hi + s, lo + n, lo + s]);
+            mesh.indices.extend_from_slice(&[hi + n, lo + n, hi + s]);
+        }
+    };
+    let base = ring(&mut m, 0.0, r_trunk, 0.02);
+    let top = ring(&mut m, trunk_h, r_trunk * 0.8, 0.22);
+    band(&mut m, base, top);
+
+    // Three skirts, each narrower and higher than the last.
+    let spread = 0.85 + 0.30 * rnd(seed ^ 0xC1, i);
+    for k in 0..3u32 {
+        let f = k as f32 / 3.0;
+        let y0 = trunk_h + (h - trunk_h) * f * 0.62;
+        let y1 = y0 + (h - y0) * 0.78;
+        let r = (h * 0.30 * (1.0 - f * 0.55) * spread).max(0.3);
+        let skirt = ring(&mut m, y0, r, 0.45 + 0.15 * f);
+        let tip = m.vertex_count() as u32;
+        m.positions.extend_from_slice(&[0.0, y1, 0.0]);
+        m.normals.extend_from_slice(&[0.0, 1.0, 0.0]);
+        m.uvs.extend_from_slice(&[0.62, 0.95]);
+        for sd in 0..SIDES as u32 {
+            let n = (sd + 1) % SIDES as u32;
+            m.indices.extend_from_slice(&[skirt + sd, skirt + n, tip]);
+            m.indices.extend_from_slice(&[tip, skirt + n, skirt + sd]);
+        }
+    }
+    m
+}
+
 fn tree_mesh(h: f32, seed: u32, i: u32) -> Mesh {
     const SIDES: usize = 7;
     let mut m = Mesh::default();
@@ -414,11 +614,20 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
     // from. Two metres a step is finer than anything being placed is wide.
     let coarse = prog.stations(2.0);
 
+    // Nothing is planted on the start straight. It is track — forty riders leave the gate
+    // across the whole width of it — and the scenery is laid out from the lap, which knows
+    // nothing about a spur running beside it.
+    let clear_of_the_start = |x: f32, z: f32| -> bool {
+        syn.outside_the_start(x, z).map(|e| e > OFF_THE_START_M).unwrap_or(true)
+    };
+
     let mut stakes = Mesh::default();
     let mut banners = Mesh::default();
     let mut fence = Mesh::default();
     let mut bales = Mesh::default();
     let mut trees = Mesh::default();
+    let mut poles = Mesh::default();
+    let mut vans = Mesh::default();
     let mut gate = Mesh::default();
     let mut tally = Vec::new();
 
@@ -432,7 +641,10 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
         let (rx, rz) = crate::trackprog::right_vector(st.heading);
         for side in [-1.0f32, 1.0] {
             let (x, z) = (st.x + rx * stake_off * side, st.z + rz * stake_off * side);
-            if !inside(prog, x, z, 2.0) || clearance(&coarse, x, z) < stake_off - 1.0 {
+            if !inside(prog, x, z, 2.0)
+                || clearance(&coarse, x, z) < stake_off - 1.0
+                || !clear_of_the_start(x, z)
+            {
                 continue;
             }
             let key = (s / STAKE_GAP_M) as u32 * 2 + (side > 0.0) as u32;
@@ -458,7 +670,10 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
         let side = if rnd(seed ^ 0x51, key) < 0.5 { -1.0f32 } else { 1.0 };
         let off = BANNER_OFF_M.max(half + 2.5);
         let (x, z) = (st.x + rx * off * side, st.z + rz * off * side);
-        if inside(prog, x, z, 3.0) && clearance(&coarse, x, z) > off - 1.0 {
+        if inside(prog, x, z, 3.0)
+            && clearance(&coarse, x, z) > off - 1.0
+            && clear_of_the_start(x, z)
+        {
             let (lo, hi) = ground_span(syn, x, z, along(st.heading), BANNER_W_M);
             if hi - lo < 1.0 {
                 banners.append(&edfwrite::moved(
@@ -472,63 +687,12 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
     }
     tally.push(("banners", n));
 
-    // 3. The fence, walked along its *own* line rather than along the centreline.
-    //
-    // Stepping the centreline and offsetting each step spaces panels by the centreline's arc
-    // length, and the offset line's is longer on the outside of a corner and shorter on the
-    // inside — so the run gapped through every turn one way and piled up the other. Walking
-    // the offset polyline and laying a panel every panel-length of *it* is what makes a fence
-    // a fence.
-    let mut n = 0usize;
-    let mut fence_at: Vec<(f32, f32)> = Vec::new();
-    for side in [-1.0f32, 1.0] {
-        let line: Vec<(f32, f32)> = stations
-            .iter()
-            .map(|st| {
-                let (rx, rz) = crate::trackprog::right_vector(st.heading);
-                let off = FENCE_OFF_M + 1.2 * (rnd(seed ^ 0x21, (st.s * 0.05) as u32) - 0.5);
-                (st.x + rx * off * side, st.z + rz * off * side)
-            })
-            .collect();
-        let mut run = 0.0f32;
-        let mut last = line[0];
-        for w in line.windows(2) {
-            run += ((w[1].0 - w[0].0).powi(2) + (w[1].1 - w[0].1).powi(2)).sqrt();
-            if run < FENCE_PANEL_M {
-                continue;
-            }
-            run = 0.0;
-            let (x, z) = ((last.0 + w[1].0) * 0.5, (last.1 + w[1].1) * 0.5);
-            let deg = (w[1].0 - last.0).atan2(w[1].1 - last.1).to_degrees() + 90.0;
-            last = w[1];
-            if !inside(prog, x, z, 4.0) || clearance(&coarse, x, z) < half + 4.0 {
-                continue;
-            }
-            let (lo, hi) = ground_span(syn, x, z, deg, FENCE_PANEL_M);
-            if hi - lo > 1.2 {
-                continue;
-            }
-            // Where the lap folds back the two sides' fences meet, and a panel from one run
-            // lands inside a panel from the other. Spacing along a run does not catch that
-            // because the runs are walked separately.
-            let too_near = (FENCE_PANEL_M * 0.55).powi(2);
-            if fence_at
-                .iter()
-                .any(|(px, pz)| (px - x).powi(2) + (pz - z).powi(2) < too_near)
-            {
-                continue;
-            }
-            fence_at.push((x, z));
-            // Double-sided: a fence you can only see from behind is not a fence.
-            let panel = edfwrite::double_sided(&edfwrite::card(FENCE_PANEL_M, FENCE_H_M));
-            fence.append(&edfwrite::moved(
-                &edfwrite::turned(&panel, deg),
-                [x, (lo + hi) * 0.5 - 0.05, z],
-            ));
-            n += 1;
-        }
-    }
-    tally.push(("fence panels", n));
+    // 3. No fence. It ran along the lap and closed the start straight off — the spur runs
+    //    beside the circuit and a fence between the two is a wall across where the field
+    //    leaves the gate. Dropped everywhere for now rather than routed round the start,
+    //    which is the smaller change and the one that can be judged from a bike.
+    let _ = &mut fence;
+
 
     // 4. Bales where a rider leaves the track fastest: the outside of every corner. Their
     // long side runs along the track edge, which is what `along` is for.
@@ -542,7 +706,10 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
             let key = (s / 4.0) as u32;
             let off = BALE_OFF_M + (rnd(seed ^ 0x31, key) - 0.5) * 2.0;
             let (x, z) = (st.x + rx * off * side, st.z + rz * off * side);
-            if inside(prog, x, z, 3.0) && clearance(&coarse, x, z) > half + 2.0 {
+            if inside(prog, x, z, 3.0)
+                && clearance(&coarse, x, z) > half + 2.0
+                && clear_of_the_start(x, z)
+            {
                 let deg = along(st.heading) + 10.0 * (rnd(seed ^ 0x32, key) - 0.5);
                 let (lo, hi) = ground_foot(syn, x, z, deg, BALE_W_M, BALE_D_M);
                 if hi - lo > 0.8 {
@@ -581,7 +748,10 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
             let side = if rnd(seed ^ 0x42, i) < 0.5 { -1.0 } else { 1.0 };
             let off = TREE_FROM_M + (TREE_TO_M - TREE_FROM_M) * rnd(seed ^ 0x43, i);
             let (x, z) = (st.x + rx * off * side, st.z + rz * off * side);
-            if !inside(prog, x, z, 6.0) || clearance(&coarse, x, z) < TREE_FROM_M - 6.0 {
+            if !inside(prog, x, z, 6.0)
+                || clearance(&coarse, x, z) < TREE_FROM_M - 6.0
+                || !clear_of_the_start(x, z)
+            {
                 continue;
             }
             // Nothing where the track is, and nothing on top of another tree.
@@ -594,7 +764,7 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
             placed.push((x, z));
             let h = TREE_H_M * (0.7 + 0.6 * rnd(seed ^ 0x44, i));
             trees.append(&edfwrite::moved(
-                &edfwrite::turned(&tree_mesh(h, seed, i), 360.0 * rnd(seed ^ 0x45, i)),
+                &edfwrite::turned(&stand(h, seed, i), 360.0 * rnd(seed ^ 0x45, i)),
                 [x, ground_min(syn, x, z, h * 0.2) - 0.05, z],
             ));
             n += 1;
@@ -602,6 +772,93 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
         s += TREE_SPACING_M;
     }
     tally.push(("trees", n));
+
+    // 5b. The wood behind them, which is the part that makes a place: a grid of trees from
+    //     past the furniture out to the edge of the plot, thinned by noise so it reads as a
+    //     wood rather than as an orchard, and kept off everything else.
+    let mut n = 0usize;
+    let (sx, sz) = (prog.terrain.size_x, prog.terrain.size_z);
+    let mut gz = WOOD_STEP_M * 0.5;
+    while gz < sz {
+        let mut gx = WOOD_STEP_M * 0.5;
+        while gx < sx {
+            let key = (gz / WOOD_STEP_M) as u32 * 4096 + (gx / WOOD_STEP_M) as u32;
+            // Jittered off the grid, or the wood comes out in rows.
+            let x = gx + (rnd(seed ^ 0x61, key) - 0.5) * WOOD_STEP_M * 0.9;
+            let z = gz + (rnd(seed ^ 0x62, key) - 0.5) * WOOD_STEP_M * 0.9;
+            gx += WOOD_STEP_M;
+            if rnd(seed ^ 0x63, key) > 0.62 || !inside(prog, x, z, 4.0) {
+                continue;
+            }
+            // Everything on the venue side of the wood belongs to somebody else.
+            if clearance(&coarse, x, z) < WOOD_FROM_M || !clear_of_the_start(x, z) {
+                continue;
+            }
+            let h = TREE_H_M * (0.75 + 0.7 * rnd(seed ^ 0x64, key));
+            trees.append(&edfwrite::moved(
+                &edfwrite::turned(&stand(h, seed, key), 360.0 * rnd(seed ^ 0x65, key)),
+                [x, ground_min(syn, x, z, h * 0.2) - 0.05, z],
+            ));
+            n += 1;
+        }
+        gz += WOOD_STEP_M;
+    }
+    tally.push(("wood", n));
+
+    // 6. Poles and vans — twenty and twenty-five a kilometre on the tracks measured, standing
+    //    18–26 m and 15–25 m off the line. Neither is scenery you look at; together they are
+    //    what stops the ground beside a track reading as an empty field.
+    let mut n = 0usize;
+    let mut s = 0.0f32;
+    while s < lap {
+        let st = at(s);
+        let (rx, rz) = crate::trackprog::right_vector(st.heading);
+        let key = (s / POLE_GAP_M) as u32;
+        let side = if rnd(seed ^ 0x71, key) < 0.5 { -1.0f32 } else { 1.0 };
+        let off = 18.0 + 8.0 * rnd(seed ^ 0x72, key);
+        let (x, z) = (st.x + rx * off * side, st.z + rz * off * side);
+        if inside(prog, x, z, 3.0) && clearance(&coarse, x, z) > off - 2.0 && clear_of_the_start(x, z)
+        {
+            let h = POLE_H_M * (0.85 + 0.4 * rnd(seed ^ 0x73, key));
+            poles.append(&edfwrite::moved(&pole_mesh(h), [x, ground(syn, x, z) - 0.1, z]));
+            n += 1;
+        }
+        s += POLE_GAP_M;
+    }
+    tally.push(("poles", n));
+
+    let mut n = 0usize;
+    let mut s = VAN_GAP_M * 0.5;
+    while s < lap {
+        let st = at(s);
+        let (rx, rz) = crate::trackprog::right_vector(st.heading);
+        let key = (s / VAN_GAP_M) as u32;
+        let side = if rnd(seed ^ 0x81, key) < 0.5 { -1.0f32 } else { 1.0 };
+        let off = 15.0 + 12.0 * rnd(seed ^ 0x82, key);
+        let (x, z) = (st.x + rx * off * side, st.z + rz * off * side);
+        if inside(prog, x, z, 6.0) && clearance(&coarse, x, z) > off - 2.0 && clear_of_the_start(x, z)
+        {
+            // Parked on level ground, or it stands on one wheel.
+            let (lo, hi) = ground_span(syn, x, z, along(st.heading), 6.0);
+            if hi - lo < 0.8 {
+                vans.append(&edfwrite::moved(
+                    &edfwrite::turned(&van_mesh(), along(st.heading) + 90.0 * rnd(seed ^ 0x83, key)),
+                    [x, lo - 0.1, z],
+                ));
+                n += 1;
+            }
+        }
+        s += VAN_GAP_M;
+    }
+    tally.push(("vans", n));
+
+    // 7. The sky over all of it.
+    let (sx, sz) = (prog.terrain.size_x, prog.terrain.size_z);
+    let sky = edfwrite::moved(
+        &dome_mesh(sx.max(sz) * 1.35),
+        [sx * 0.5, ground(syn, sx * 0.5, sz * 0.5) - 2.0, sz * 0.5],
+    );
+    tally.push(("sky", 1));
 
     // 6. The start gantry, over the gate row — which is on the start straight, off to the
     //    side of the lap, not on the lap itself. It spans the whole row, and the row is 54 m
@@ -639,9 +896,12 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
     let kinds: Vec<(&str, Mesh, Texture, bool)> = vec![
         ("stakes", stakes, stake_sheet(), false),
         ("banners", banners, banner_sheet(), true),
-        ("fence", fence, fence_sheet(), false),
         ("bales", bales, bale_sheet(), true),
         ("trees", trees, tree_sheet(), true),
+        ("poles", poles, pole_sheet(), false),
+        ("vans", vans, van_sheet(), true),
+        // The sky is drawn and nothing else: a dome you can ride into is not a sky.
+        ("sky", sky, dome_sheet(), false),
         ("gate", gate, gate_sheet(), true),
     ];
 
@@ -717,16 +977,23 @@ mod tests {
     }
 
     #[test]
-    fn a_lap_gets_a_treeline_and_not_one_tree() {
+    fn a_lap_gets_a_wood_behind_it_and_not_one_tree() {
         let (p, s) = demo();
         let sc = build(&p, &s);
-        let trees = sc.tally.iter().find(|(k, _)| *k == "trees").unwrap().1;
-        // Corpus p50 is 118 near trees per km over the tracks that have them, and the loop is
-        // deliberately thinner than that. What this catches is the failure that actually
-        // happened: randomness keyed on the placed count, so every station drew the same
-        // numbers and the whole lap ended up with one tree.
-        let per_km = trees as f32 / (p.lap_length() / 1000.0);
-        assert!(per_km > 20.0, "{trees} trees is {per_km:.0}/km over {:.0} m", p.lap_length());
+        let count = |k: &str| sc.tally.iter().find(|(n, _)| *n == k).map(|(_, v)| *v).unwrap_or(0);
+        let km = p.lap_length() / 1000.0;
+
+        // Trackside trees are rare on the tracks this is measured against — 2.4–5 a kilometre
+        // — and what makes those places is the wood behind them.
+        let near = count("trees") as f32 / km;
+        assert!(near > 1.0 && near < 12.0, "{near:.1} trees/km trackside");
+
+        // The wood itself. Lakewood stands fifteen thousand; a 500 m plot has room for
+        // hundreds, and the failure this catches is the one that happened — randomness keyed
+        // on the placed count, so every station drew the same numbers and the whole lap ended
+        // up with a single tree.
+        let wood = count("wood");
+        assert!(wood > 200, "the backdrop is {wood} trees");
     }
 
     #[test]
@@ -826,7 +1093,8 @@ mod tests {
         let named = |v: &[Scene]| -> Vec<String> { v.iter().map(|s| s.file.clone()).collect() };
         let drawn = named(&sc.drawn);
         let solid = named(&sc.solid);
-        for want in ["stakes.edf", "banners.edf", "fence.edf", "bales.edf", "trees.edf", "gate.edf"] {
+        // No fence: it ran along the lap and closed the start straight off. See `build`.
+        for want in ["stakes.edf", "banners.edf", "bales.edf", "trees.edf", "gate.edf"] {
             assert!(drawn.contains(&want.to_string()), "{want} not drawn: {drawn:?}");
         }
         // A tree, a bale and the gantry stop a bike.
@@ -836,7 +1104,7 @@ mod tests {
         // A stake snaps rather than stopping you, and the fence run has gaps where the ground
         // steps — as collision that is a wall with holes in it, which is worse than no wall.
         assert!(!solid.contains(&"stakes.edf".to_string()), "{solid:?}");
-        assert!(!solid.contains(&"fence.edf".to_string()), "{solid:?}");
+        assert!(!drawn.contains(&"fence.edf".to_string()), "the fence is dropped: {drawn:?}");
         // And every placed model is one the export actually writes.
         for f in solid.iter().chain(drawn.iter()) {
             assert!(sc.files.iter().any(|(n, _)| n == f), "{f} is placed but never written");
@@ -854,43 +1122,6 @@ mod tests {
         assert!(s.contains("x = 1.000") && s.contains("y = 2.000") && s.contains("z = 3.000"));
         assert!(s.contains("y = 90.000"));
     }
-
-    #[test]
-    fn a_fence_run_is_spaced_along_its_own_line() {
-        // Stepping the centreline and offsetting each step spaces panels by the *centreline's*
-        // arc length, so a run gaps through every corner one way and piles up the other. Walk
-        // the offset line instead and consecutive panels are a panel-length apart wherever
-        // they are, corner or straight.
-        let (p, s) = demo();
-        let sc = build(&p, &s);
-        let (_, bytes) = sc.files.iter().find(|(n, _)| n == "fence.edf").expect("a fence");
-        let nodes = crate::edf::parse_world(bytes);
-        let mut centres: Vec<[f32; 2]> = Vec::new();
-        for n in &nodes {
-            // Each panel is 8 vertices: a card and its double. Take each panel's own centre.
-            for chunk in n.positions.chunks_exact(24) {
-                let (mut x, mut z) = (0.0f32, 0.0f32);
-                for v in chunk.chunks_exact(3) {
-                    x += v[0] / 8.0;
-                    z += v[2] / 8.0;
-                }
-                centres.push([x, z]);
-            }
-        }
-        assert!(centres.len() > 100, "only {} panels", centres.len());
-        // Neighbours within a run sit about a panel apart; nothing sits on top of anything.
-        let mut overlapping = 0;
-        for i in 0..centres.len() {
-            for j in i + 1..centres.len() {
-                let d = (centres[i][0] - centres[j][0]).powi(2)
-                    + (centres[i][1] - centres[j][1]).powi(2);
-                if d < (FENCE_PANEL_M * 0.55).powi(2) {
-                    overlapping += 1;
-                }
-            }
-        }
-        assert_eq!(overlapping, 0, "{overlapping} fence panels sit on top of each other");
-    }
 }
 
 #[cfg(test)]
@@ -903,15 +1134,6 @@ mod built {
         (v as u32).to_le_bytes()
     }
 
-    /// Build the demo track with its objects, compile it, package it, and dump what came out
-    /// in a form a renderer can draw.
-    ///
-    /// ```text
-    /// FROST_BUILD=/tmp/objtrack FROST_TOOLS=~/Downloads/mxb-trackbuild/tools \
-    /// FROST_PREFIX=~/Downloads/mxb-trackbuild/prefix FROST_WINE=".../wine" \
-    /// FROST_INSTALL="~/Documents/MX Bikes/mods/tracks" \
-    ///   cargo test -- --ignored --nocapture builds_a_track_with_objects
-    /// ```
     #[test]
     #[ignore = "writes and compiles a track — set FROST_BUILD"]
     fn builds_a_track_with_objects() {

--- a/src-tauri/src/trackstats.rs
+++ b/src-tauri/src/trackstats.rs
@@ -1427,6 +1427,17 @@ mod tests {
         }
     }
 
+    /// Everything a published track ships, by name and size — what files it carries at all.
+    #[test]
+    #[ignore = "needs a track — set FROST_TRACK"]
+    fn published_files() {
+        let var = std::env::var("FROST_TRACK").expect("set FROST_TRACK");
+        let path = std::path::Path::new(&var);
+        for n in crate::track::entry_names(path).unwrap() {
+            println!("  {n}");
+        }
+    }
+
     /// A published track's race data: where it puts its grid, and in what coordinates.
     ///
     /// ```text

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -1036,7 +1036,7 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
         let (_, which) = nearest_station(&spur.stations, gw, gh, mps_x, mps_z);
         for i in 0..gw * gh {
             let (wx, wz) = ((i % gw) as f32 * mps_x, (i / gw) as f32 * mps_z);
-            let (mut d, s, _) = local_frame(&spur.stations, which[i] as usize, wx, wz);
+            let (mut d, s, t) = local_frame(&spur.stations, which[i] as usize, wx, wz);
             // Behind the gate row the frame runs out and every distance becomes radial, which
             // rounds the back of the pad off into a lollipop. A start has a straight back edge
             // — the bank the gates are set against — so back there the width is measured
@@ -1052,6 +1052,13 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
                     back = smoothstep(
                         ((BACK_OF_THE_GATE_M - behind) / BACK_OF_THE_GATE_M).clamp(0.0, 1.0),
                     );
+                    // And it ends there. Everything that paints the ground reads `spur_dist`,
+                    // and a station's frame runs on for ever — so without this the start is
+                    // surfaced as track for as far behind the gate row as the grid goes, which
+                    // from the gate is a wide slab running off into nothing.
+                    if behind > BACK_OF_THE_GATE_M {
+                        d = f32::MAX;
+                    }
                 }
             }
             spur_dist[i] = d;
@@ -1086,6 +1093,34 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
                 * if ground > deck { CUT_SHOULDER } else { FILL_SHOULDER };
             let w = bench_weight(d, wide, shoulder) * claim;
             heights[i] = ground * (1.0 - w) + deck * w;
+
+            if d > wide {
+                continue;
+            }
+            // Ridden ground. The pad is track, and a track with no texture on it is a slab —
+            // the same fine roughness the lap gets, tapered across the width the way it is
+            // there, because the middle of a start is used and its far corners are not.
+            let across = 1.0 - (d / wide.max(1e-3)).min(1.0).powi(2);
+            if r.texture > 0.0 {
+                heights[i] += fbm(
+                    wx / TEXTURE_WAVELENGTH_M,
+                    wz / TEXTURE_WAVELENGTH_M,
+                    r.seed ^ 0x5EED,
+                ) * r.texture
+                    * (0.25 + 0.75 * across)
+                    * claim;
+            }
+            // And the grooves the gate leaves: forty bikes pulling out of forty stalls dig
+            // forty lines, deepest a few metres off the row and gone by the time the pack has
+            // spread. The one piece of ground on a track whose ruts are laid out in a comb.
+            let from_gate = s - spur.gate_at();
+            let row = GRID_STALLS as f32 * GRID_LANE_M * 0.5;
+            if from_gate > -1.0 && from_gate < GATE_RUT_M && t.abs() < row {
+                let along = smoothstep(1.0 - (from_gate.max(0.0) / GATE_RUT_M));
+                let lane = (t / GRID_LANE_M) * std::f32::consts::TAU;
+                let groove = 0.5 - 0.5 * lane.cos();
+                heights[i] -= GATE_RUT_DEPTH_M * along * groove * claim;
+            }
         }
     }
 
@@ -2119,7 +2154,8 @@ pub fn write_source(prog: &TrackProgram, syn: &Synth, dir: &Path) -> Result<Vec<
         )
     });
     let grass = mask_outside(syn, MASK_DIM, half, |e, x, z| {
-        255 - soft_edge(SHOULDER_M + edge_noise(x, z, seed ^ 0x6EE2, 3.2, 1.2), 6.0, e)
+        let past = 255 - soft_edge(SHOULDER_M + edge_noise(x, z, seed ^ 0x6EE2, 3.2, 1.2), 6.0, e);
+        (past as f32 * turf_cover(x, z, seed)) as u8
     });
     // Off-track starts where the graded shoulder ends: the rider is on the track, or in the
     // field, with the shoulder belonging to neither. This one decides where the game says a
@@ -2689,6 +2725,13 @@ pub struct StartSpur {
     len: f32,
 }
 
+/// How far past the gate row its grooves run, and how deep they are at their deepest.
+///
+/// A start is the one place on a track where the ruts are a comb: every rider pulls out of
+/// their own stall in a line, and the lines stay parallel until the pack starts to spread.
+const GATE_RUT_M: f32 = 35.0;
+const GATE_RUT_DEPTH_M: f32 = 0.09;
+
 /// How much of the start straight's last stretch is already the width of the lap it joins.
 const MERGE_TAIL_M: f32 = 12.0;
 
@@ -3077,6 +3120,20 @@ impl Synth {
         e
     }
 
+    /// How far outside the start straight's edge a point in the world is — negative on it,
+    /// `None` where the track has no start straight.
+    ///
+    /// For anything that has to keep off the start: the pad is track, and a fence post or a
+    /// hay bale standing on it is standing where forty riders are about to be.
+    pub fn outside_the_start(&self, x: f32, z: f32) -> Option<f32> {
+        let spur = self.spur.as_ref()?;
+        let gx = (x / self.mps).round().clamp(0.0, (self.gw - 1) as f32) as usize;
+        let gy = (z / self.mps).round().clamp(0.0, (self.gh - 1) as f32) as usize;
+        let i = gy * self.gw + gx;
+        let d = self.spur_dist[i];
+        d.is_finite().then(|| d - spur.at(self.spur_arc[i]))
+    }
+
     /// Whether a cell is on the start straight rather than on the lap.
     pub fn on_the_start(&self, i: usize, half: f32) -> bool {
         match &self.spur {
@@ -3313,8 +3370,8 @@ fn map(prog: &TrackProgram, syn: &Synth) -> Vec<u8> {
                     BandMask::Everywhere => unreachable!(),
                     BandMask::Rut => rut_mask(syn, half, seed, mw, mh),
                     BandMask::Loose => loose_mask(syn, half, seed, mw, mh),
-                    BandMask::Beyond => mask_rect_outside(syn, mw, mh, half, |e, _, _| {
-                        u8::from(e > SHOULDER_M) * 255
+                    BandMask::Beyond => mask_rect_outside(syn, mw, mh, half, |e, x, z| {
+                        (u8::from(e > SHOULDER_M) as f32 * 255.0 * turf_cover(x, z, seed)) as u8
                     }),
                     BandMask::Out(extra) => mask_rect_outside(syn, mw, mh, half, |e, _, _| {
                         u8::from(e <= extra) * 255
@@ -3556,6 +3613,26 @@ fn mask_rect(syn: &Synth, mw: usize, mh: usize, f: impl Fn(f32, f32, f32, f32) -
         }
     }
     out
+}
+
+/// How big the patches of grass in the field are, metres.
+const TURF_PATCH_M: f32 = 55.0;
+
+/// How much turf covers the field at a point: 1 where grass has taken, 0 where the ground is
+/// bare.
+///
+/// The field used to be one flat sheet of grass from the shoulder to the fence, which is a
+/// lawn — and no venue is a lawn. Two scales of noise, thresholded, so what comes out is
+/// patches of grass in worked ground with bare tracks between them, which is what the ground
+/// round a motocross track actually looks like.
+fn turf_cover(x: f32, z: f32, seed: u32) -> f32 {
+    let broad = fbm(x / TURF_PATCH_M, z / TURF_PATCH_M, seed ^ 0x3C71);
+    let fine = fbm(x / (TURF_PATCH_M * 0.28), z / (TURF_PATCH_M * 0.28), seed ^ 0x3C72);
+    let n = broad * 0.72 + fine * 0.28;
+    // `fbm` runs either side of zero, so the threshold does too: bare where the field dips
+    // well below it, full turf where it rises, and a soft edge in between. About two thirds
+    // of the ground comes out grassed, which is what a venue looks like from the air.
+    smoothstep(((n + 0.25) * 2.5).clamp(0.0, 1.0))
 }
 
 /// A mask of the track's edge — the lap's and the start straight's together.
@@ -4595,12 +4672,19 @@ fn ground_sheet(prog: &TrackProgram, syn: &Synth, dim: usize) -> Vec<[f32; 3]> {
     let half = prog.width * 0.5;
     let mut px = vec![[0.0f32; 3]; dim * dim];
     for l in layers(prog) {
+        // What this band's sheet actually averages, generated the way the shipped one is.
+        //
+        // It used to take the look's own `base` and a flat 0.78 for the shading, which is a
+        // guess about a sheet the code can simply make: the ground sheet averages 0.98 of its
+        // base and the turf 0.55 of its own, because a sheet of grass is mostly blades. That
+        // gap is why a track that comes out green in the game was a desert in its picture.
+        let mean = sheet_mean(&l.look, seed ^ l.salt);
         let cover = match l.band {
             BandMask::Everywhere => vec![255u8; dim * dim],
             BandMask::Rut => rut_mask(syn, half, seed, dim, dim),
             BandMask::Loose => loose_mask(syn, half, seed, dim, dim),
-            BandMask::Beyond => mask_rect_outside(syn, dim, dim, half, |e, _, _| {
-                u8::from(e > SHOULDER_M) * 255
+            BandMask::Beyond => mask_rect_outside(syn, dim, dim, half, |e, x, z| {
+                (u8::from(e > SHOULDER_M) as f32 * 255.0 * turf_cover(x, z, seed)) as u8
             }),
             BandMask::Out(extra) => mask_rect_outside(syn, dim, dim, half, |e, _, _| {
                 u8::from(e <= extra) * 255
@@ -4618,10 +4702,10 @@ fn ground_sheet(prog: &TrackProgram, syn: &Synth, dim: usize) -> Vec<[f32; 3]> {
                 // The same patching `ground_pixels` gives the sheets, at the only scale a
                 // picture this size can hold it: without it the ground is flat colour and the
                 // track reads as a drawing again.
-                let k = SHEET_SHADE * (1.0 + l.look.mottle * fbm(wx * 0.06, wz * 0.06, seed ^ l.salt));
+                let k = 1.0 + l.look.mottle * fbm(wx * 0.06, wz * 0.06, seed ^ l.salt);
                 let at = y * dim + x;
                 for c in 0..3 {
-                    px[at][c] += (l.look.base[c] * k - px[at][c]) * a;
+                    px[at][c] += (mean[c] * k - px[at][c]) * a;
                 }
             }
         }
@@ -4635,6 +4719,22 @@ fn ground_sheet(prog: &TrackProgram, syn: &Synth, dim: usize) -> Vec<[f32; 3]> {
 /// comes out lands around three quarters of the colour that went in. The picture composites
 /// the base colours directly, so it has to take the same cut or every band in it is brighter
 /// than the ground it is a picture of.
+/// The average colour of a band's sheet, made the way the shipped one is made.
+///
+/// Small on purpose — 32 px is 1024 samples of the same generator, which settles the mean of
+/// anything the sheet does — and cheap enough to call per band per picture.
+fn sheet_mean(look: &GroundLook, salt: u32) -> [f32; 3] {
+    let px = ground_pixels(32, look, salt);
+    let mut sum = [0.0f32; 3];
+    let n = (px.len() / 4).max(1);
+    for p in px.chunks_exact(4) {
+        sum[0] += p[0] as f32;
+        sum[1] += p[1] as f32;
+        sum[2] += p[2] as f32;
+    }
+    [sum[0] / n as f32, sum[1] / n as f32, sum[2] / n as f32]
+}
+
 const SHEET_SHADE: f32 = 0.78;
 
 /// Uncompressed 32-bit BGRA, the mask in the alpha channel — the shape the official example's
@@ -6978,7 +7078,7 @@ mod tests {
                         BandMask::Loose => Some(loose_mask(syn, half, seed, mw, mh)),
                         BandMask::Beyond => Some(mask_rect_outside(
                             syn, mw, mh, half,
-                            |e, _, _| u8::from(e > SHOULDER_M) * 255,
+                            |e, x, z| (u8::from(e > SHOULDER_M) as f32 * 255.0 * turf_cover(x, z, seed)) as u8,
                         )),
                         BandMask::Out(extra) => Some(mask_rect_outside(
                             syn, mw, mh, half,


### PR DESCRIPTION
Off riding the built track, and off measuring the four tracks in the "high level" folder with `trackobjects`.

## What the rated tracks carry

Per kilometre of lap, and how far off the racing line:

| | per km | offset (p50) |
|---|---|---|
| structure (marker boards) | 234–324 | 4–6 m |
| fence | 35–58 | 8–18 m |
| bale | 13–14 | 8–15 m |
| banner | 12–22 | 20–37 m |
| pole | 17–135 | 18–26 m |
| vehicle | 22–36 | 15–25 m |
| tree | 2–5 | 50–55 m |

Trackside trees are *rare*. What Lakewood has instead is **15,341 trees beyond 60 m** — the wood is the backdrop, not the furniture, which is why a track with a few dozen trees dotted along it reads as a field with sticks in it.

## What this does

- **A wood behind the track**: mixed pine and broadleaf from 64 m out to the edge of the plot, several hundred on a 500 m ground, thinned by noise so it reads as a wood and not an orchard. Trackside trees drop to the corpus figure. `pine_mesh` is its own silhouette.
- **Poles and parked vans** at those counts and offsets.
- **A sky dome**, because every one of those tracks ships its own (`dome_R26.edf` at Mt Morris) and a track without one gets the game's default sky.
- **The field is grass in patches over bare worked ground** rather than a lawn — one `turf_cover` shared by the export and both previews.
- **White marker blocks.**
- **Nothing planted on the start straight**, and the fence dropped for now: it followed the lap and closed the start off.
- **The start pad is ridden ground** — the track's own surface texture, plus the comb of grooves forty bikes leave pulling out of forty stalls.
- **The pad's surface ends at the back of the gate row.** Everything that paints the ground reads `spur_dist`, and a station's frame runs on for ever, so the start was being surfaced for as far behind the gates as the grid went — a slab running off into nothing.
- **The track picture shows the colours the track will have.** It composited each band's base colour against a flat 0.78 for shading; the sheet actually made from that base averages 0.98 of it for ground and 0.55 for turf. A track that is green in the game came out a desert in its own picture. It reads the sheets now.

Full suite 1330 passed / 0 failed, and the track builds through PiBoSo's compilers with all of it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)