### PR TITLE
fix(tracks): the start ends in turn one, and the track is legible again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## 2026-09-06
 
+### Changed
+- The start straight ends in turn one. It runs down the outside of the first corner and joins
+  the lap inside it, so the gate drop delivers you into the turn instead of onto a piece of
+  track with no clue which way it goes.
+- The riding line is lighter. Under the track's own sky a line at the colour a soil sheet
+  measures on its own was one you could not find; the gap to the field that makes a line
+  visible is still there, and the line now reads at speed.
+- The sky is a band round the horizon rather than a lid. A closed dome put the whole track in
+  its own shadow, which is what made the ground so dark.
+- Marker boards are thinner on the ground, blocks are plain white and laid in a line along the
+  outside of a corner rather than scattered, and a few trees stand in the infield.
+
+## 2026-09-06
+
 ### Added
 - A wood behind the track. The tracks people rate carry thousands of trees past 60 m and only
   a handful trackside, so that is what a built track gets now — a backdrop of mixed pine and

--- a/src-tauri/src/trackprog.rs
+++ b/src-tauri/src/trackprog.rs
@@ -334,6 +334,22 @@ pub const START_SPRINT_M: f32 = 70.0;
 /// about a fifth of the offset, which leaves one corner to do the rest.
 pub const START_CONVERGE_DEG: f32 = 10.0;
 
+/// Tighter than this and an arc is turn one rather than a bend the straight is drifting
+/// through. Published first corners run 10–46 m; this sits above them so it catches the whole
+/// corner rather than only its apex.
+pub const TURN_ONE_RADIUS_M: f32 = 60.0;
+
+/// Half the width of the start pad, metres: the gate row plus a margin.
+///
+/// Forty gates at 1.2 m is 48 m across, and the pad has to hold it. Stated here rather than
+/// in the synthesiser because the *layout* needs it — a start line whose centreline clears
+/// the lap by fifteen metres still lays its pad straight over it.
+pub const START_FAN_HALF_M: f32 = 27.0;
+
+/// How much a start line is expected to turn on its way onto the lap. Published ones sweep
+/// 100–180°, and what that buys is a pack that arrives *in* the corner.
+pub const TURN_ONE_SWEEP_DEG: f32 = 110.0;
+
 /// The tightest the merge back onto the lap may turn, metres. Published start lines join
 /// through 10–46 m radii; this is the floor, and a tight one keeps turn one close to the
 /// gates rather than a long sweep away from them.
@@ -1100,7 +1116,24 @@ impl TrackProgram {
             }
             worst
         };
-        let side = if room(1.0) >= room(-1.0) { 1.0 } else { -1.0 };
+        // Which side to stand on. The outside of turn one, so the sprint delivers the pack
+        // into the corner rather than across it — unless that side has no room, in which case
+        // room wins, because a start straight that doesn't fit isn't one.
+        let (room_r, room_l) = (room(1.0), room(-1.0));
+        let outside = st
+            .iter()
+            .find(|q| q.s > run * 0.8 && q.curvature.abs() > 1.0 / TURN_ONE_RADIUS_M)
+            .map(|q| -q.curvature.signum())
+            .unwrap_or(0.0);
+        let side = if outside != 0.0
+            && (if outside > 0.0 { room_r } else { room_l }) > START_OFFSET_M * 1.15
+        {
+            outside
+        } else if room_r >= room_l {
+            1.0
+        } else {
+            -1.0
+        };
 
         // The gate row: beside the lap's own start, far enough out that the lap never runs
         // through it.
@@ -1113,11 +1146,37 @@ impl TrackProgram {
             z: self.start.z + rz * side * START_OFFSET_M,
             angle: self.start.angle - side * START_CONVERGE_DEG,
         };
-        // Down the sprint, and then back onto the lap. Every candidate join is tried and the
-        // shortest kept — which lands on turn one, because that is what is nearest.
+        // Where turn one is: the first station past the opening straight that is properly
+        // turning, not drifting. Everything below is measured against it, because a start
+        // straight that lands on a straight is a start that leaves a rider guessing which way
+        // to go — what a real one does is deliver the pack into the first corner.
+        let tight = |q: &Station| q.curvature.abs() > 1.0 / TURN_ONE_RADIUS_M;
+        let corner_at = st
+            .iter()
+            .find(|q| q.s > run * 0.8 && tight(q))
+            .map(|q| q.s)
+            .unwrap_or(run);
+        // And how far it runs. The start joins *inside* turn one rather than at its mouth:
+        // that is what published start lines do — Indiana's own turns through 46 m, then 10,
+        // then 17 before it meets the racing line — and it is what turns the pack instead of
+        // handing it a fork.
+        let corner_end = st
+            .iter()
+            .find(|q| q.s > corner_at + 12.0 && !tight(q))
+            .map(|q| q.s)
+            .unwrap_or(corner_at + 60.0);
+        let land_at = corner_at + (corner_end - corner_at).min(30.0) * 0.35;
+
+        // Down the sprint, and then into it.
+        //
+        // Three goes, each asking for less: land inside turn one without the pad crossing the
+        // lap; failing that, land anywhere it can without crossing; failing that, take the
+        // shortest merge there is. A track whose ground will not hold the ideal start still
+        // gets one, and it is the same search each time.
         let after = end_pose(start, &[Segment::Straight { length: START_SPRINT_M, rise: 0.0 }]);
+        let search = |aim_at_the_corner: bool, keep_clear: bool| -> Option<(f32, Vec<Segment>, f32)> {
         let mut best: Option<(f32, Vec<Segment>, f32)> = None;
-        for q in st.iter().filter(|q| q.s >= run * 0.5 && q.s <= run + 400.0) {
+        for q in st.iter().filter(|q| q.s >= run * 0.5 && q.s <= corner_end + 120.0) {
             let onto = Start { x: q.x, z: q.z, angle: q.heading.to_degrees() };
             // A corner, not a dog-leg: two arcs that meet tangentially, which is the shape
             // every published start line joins the lap with. The Dubins path is the fallback
@@ -1138,24 +1197,112 @@ impl TrackProgram {
             if turned > 200.0 {
                 continue;
             }
-            // Straight in a merge is a start straight that has not ended, so it costs double.
+            // Anything in a merge that isn't turning is a start straight that has not ended —
+            // a straight, or an arc so open it rides as one. Both cost the same.
             let straight: f32 = merge
                 .iter()
-                .filter(|s| matches!(s, Segment::Straight { .. }))
+                .filter(|s| match s {
+                    Segment::Straight { .. } => true,
+                    Segment::Arc { radius, .. } => radius.abs() > TURN_ONE_RADIUS_M * 2.5,
+                })
                 .map(|s| s.length())
                 .sum();
             // And the sooner it is back on the lap the better: a merge that picks a join a
             // hundred metres further round is a gentle sweep that reads as more straight.
             // Published start lines turn 100–180° through 10–46 m radii and are done with it.
+            // And it lands in the corner. A join onto straight track is cheap to build and
+            // reads as a slip road: the pack arrives on the racing line with nothing telling
+            // it where the track goes. Joining where the lap is already turning is what makes
+            // the start straight end in turn one, which is what every real one does.
+            // Two things it is scored on beyond its length: landing well inside turn one, and
+            // turning like one. Published merges turn 100–180° all told; a merge that turns
+            // twenty is a slip road, whatever else is right about it.
+            let into_the_turn = if aim_at_the_corner { (q.s - land_at).abs() } else { 0.0 };
+            // One-way, and the same way as the corner it lands in. An S — right then left —
+            // is what you get joining straight track from a parallel offset, and it rides as
+            // a chicane on the way to a fork. A published start turns *with* turn one and
+            // hands the pack to it already leant over.
+            let ways: Vec<f32> = merge
+                .iter()
+                .filter_map(|s| match s {
+                    Segment::Arc { radius, angle, .. } if angle.abs() > 8.0 => {
+                        Some(radius.signum())
+                    }
+                    _ => None,
+                })
+                .collect();
+            let s_shaped = ways.windows(2).any(|w| w[0] != w[1]);
+            let with_the_corner = match (ways.last(), q.curvature) {
+                (Some(way), k) if k.abs() > 1.0 / TURN_ONE_RADIUS_M => *way == k.signum(),
+                _ => true,
+            };
+            // It may not cross the lap to get there. Reaching a corner two hundred metres round
+            // by sweeping over the main straight is a start straight that runs through the
+            // track — which is the thing this whole spur exists to avoid.
+            let path = TrackProgram {
+                start: after,
+                segments: merge.clone(),
+                features: Vec::new(),
+                elevation: Vec::new(),
+                ..self.clone()
+            };
+            let mut crosses = false;
+            for a in path.stations(3.0) {
+                for b in &st {
+                    let apart = (b.s - q.s).abs().min(self.lap_length() - (b.s - q.s).abs());
+                    // Near the join the two are meant to be together: a start straight and the
+                    // approach it merges into share their ground for the last stretch, which
+                    // is what makes one surface out of two at turn one. What the rule is for
+                    // is the pad lying across a *different* part of the lap.
+                    if apart < 90.0 {
+                        continue;
+                    }
+                    // Nor is the opening straight a thing to cross: the start runs beside it
+                    // by construction, forty metres out, and the pad reaching towards it is
+                    // the whole idea. What matters is the rest of the lap.
+                    if b.s <= run + 10.0 {
+                        continue;
+                    }
+                    // Against the *pad*, not the centreline: the start is 54 m across at the
+                    // gates and still twenty by the middle of the merge, and a line that
+                    // clears the lap by fifteen metres lays its pad straight over it.
+                    let taper = (a.s / (START_SPRINT_M * 0.9).max(1.0)).clamp(0.0, 1.0);
+                    let pad = START_FAN_HALF_M + (self.width * 0.5 - START_FAN_HALF_M) * taper;
+                    // The riding line has to stay outside the pad — that is what "crossing"
+                    // means here. Anything more generous is unsatisfiable on a lap that folds
+                    // back on itself every eighty metres.
+                    let want = pad + 2.0;
+                    if (b.x - a.x).powi(2) + (b.z - a.z).powi(2) < want * want {
+                        crosses = true;
+                        break;
+                    }
+                }
+                if crosses {
+                    break;
+                }
+            }
+            if crosses && keep_clear {
+                continue;
+            }
+            // Landing in the corner is what this is for, so it outweighs everything else. The
+            // straight in a merge still costs — a start straight that has not ended reads as
+            // one — but only enough to break a tie: Indiana runs 90 m of straight before its
+            // own corner, and a gentle approach into turn one is exactly right.
             let cost: f32 = merge.iter().map(|s| s.length()).sum::<f32>()
-                + turned * 0.35
-                + straight * 2.0
-                + (q.s - run).max(0.0) * 1.2;
+                + straight * 0.6
+                + into_the_turn * 3.0
+                + (TURN_ONE_SWEEP_DEG - turned).max(0.0) * 0.9
+                + if s_shaped { 90.0 } else { 0.0 }
+                + if with_the_corner { 0.0 } else { 90.0 };
             if best.as_ref().map(|b| cost < b.0).unwrap_or(true) {
                 best = Some((cost, merge, q.s));
             }
         }
-        let (_, merge, joins_at) = best?;
+        best
+        };
+        let (_, merge, joins_at) = search(true, true)
+            .or_else(|| search(false, true))
+            .or_else(|| search(false, false))?;
         let mut segments = vec![Segment::Straight { length: START_SPRINT_M, rise: 0.0 }];
         segments.extend(merge.into_iter().filter(|s| s.length() > 0.5));
         Some(StartLine { start, segments, joins_at, side })

--- a/src-tauri/src/trackscenery.rs
+++ b/src-tauri/src/trackscenery.rs
@@ -31,7 +31,7 @@ const STAKE_OFF_M: f32 = 7.5;
 /// of a baked mesh rather than one object — so a banner made of four quads counted as four
 /// banners three metres apart. Read literally it put 1272 boards round a lap and the track
 /// looked fenced in by its own edge marking.
-const STAKE_GAP_M: f32 = 6.0;
+const STAKE_GAP_M: f32 = 9.0;
 const STAKE_H_M: f32 = 1.15;
 /// A stake is a stake: thin enough that what you see is a line of points, not a wall.
 const STAKE_W_M: f32 = 0.07;
@@ -82,6 +82,10 @@ const TREE_TO_M: f32 = 58.0;
 const TREE_SPACING_M: f32 = 45.0;
 const TREE_H_M: f32 = 8.0;
 
+/// How high the sky band reaches, in degrees above the horizon — below the sun, which stands
+/// at 54°. See `dome_mesh`.
+const SKY_TOP_DEG: f32 = 34.0;
+
 /// How far apart the poles and the parked vans go, from the per-kilometre counts above.
 const POLE_GAP_M: f32 = 50.0;
 const POLE_H_M: f32 = 7.5;
@@ -90,6 +94,11 @@ const VAN_GAP_M: f32 = 40.0;
 /// The backdrop: where the wood starts, and how thickly it stands out to the edge of the plot.
 const WOOD_FROM_M: f32 = 64.0;
 const WOOD_STEP_M: f32 = 9.0;
+
+/// How close to the track a tree may stand when it is inside the lap rather than behind it,
+/// and how few of the candidates there are taken.
+const INFIELD_TREE_FROM_M: f32 = 30.0;
+const INFIELD_TREE_SHARE: f32 = 0.16;
 
 /// How much of the wood is pine. A wood of one tree is wallpaper; the venues this is measured
 /// against are half conifer, and the silhouette is most of what says where you are.
@@ -361,29 +370,30 @@ fn gate_sheet() -> Texture {
 ///
 /// UVs put the trunk in the left half of the sheet and the foliage in the right; see
 /// [`tree_sheet`].
-/// The sky, as a dome over the whole plot.
+/// The sky, as a band round the horizon rather than a lid over the plot.
 ///
-/// Every track people rate ships one — Mt Morris carries `dome_R26.edf` inside its own `.pkz`
-/// — and a track without one gets whatever the game draws by default, which is the same sky
-/// on every generated track. It is drawn from the inside: a hemisphere whose faces point in,
-/// big enough that the plot sits well within it.
+/// A closed dome is what a track ships — Mt Morris carries `dome_R26.edf` — but a closed dome
+/// built here came out *dark*: TerrainEd bakes shadow volumes from every scene in the file,
+/// the sun stands 54° up, and a lid over the whole plot puts the entire track in its shadow.
+/// The riding line went from dark brown to unreadable.
+///
+/// Open above [`SKY_TOP_DEG`] and the sun comes through, while the part a rider actually sees
+/// — the horizon and a little way up from it — is still the track's own. Looking straight up
+/// gets the game's sky, which is no loss on a bike.
 fn dome_mesh(radius: f32) -> Mesh {
-    const RINGS: usize = 8;
+    const RINGS: usize = 5;
     const SIDES: usize = 24;
     let mut m = Mesh::default();
+    let top = SKY_TOP_DEG.to_radians().tan();
     let mut ring_at = |mesh: &mut Mesh, t: f32| -> u32 {
         let start = mesh.vertex_count() as u32;
-        // `t` runs 0 at the horizon to 1 at the zenith, eased so the ring spacing tightens
-        // where the eye is — near the horizon.
-        let phi = t * std::f32::consts::FRAC_PI_2;
-        let (y, r) = (radius * phi.sin() * 0.55, radius * phi.cos());
+        let y = radius * top * t;
         for k in 0..=SIDES {
             let a = std::f32::consts::TAU * k as f32 / SIDES as f32;
-            let (x, z) = (a.sin() * r, a.cos() * r);
+            let (x, z) = (a.sin() * radius, a.cos() * radius);
             mesh.positions.extend_from_slice(&[x, y, z]);
-            // Facing inwards: this is a lid, and it is looked at from underneath.
-            let l = (x * x + y * y + z * z).sqrt().max(1e-4);
-            mesh.normals.extend_from_slice(&[-x / l, -y / l, -z / l]);
+            let l = (x * x + z * z).sqrt().max(1e-4);
+            mesh.normals.extend_from_slice(&[-x / l, 0.0, -z / l]);
             mesh.uvs.extend_from_slice(&[k as f32 / SIDES as f32 * 4.0, 1.0 - t]);
         }
         start
@@ -394,7 +404,6 @@ fn dome_mesh(radius: f32) -> Mesh {
         for k in 0..SIDES as u32 {
             let (a, b) = (lo + k, lo + k + 1);
             let (c, d) = (hi + k, hi + k + 1);
-            // Wound so the inside is the front face.
             m.indices.extend_from_slice(&[a, c, b]);
             m.indices.extend_from_slice(&[b, c, d]);
         }
@@ -703,17 +712,19 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
         if st.curvature.abs() > 1.0 / 45.0 {
             let side = -st.curvature.signum();
             let (rx, rz) = crate::trackprog::right_vector(st.heading);
-            let key = (s / 4.0) as u32;
-            let off = BALE_OFF_M + (rnd(seed ^ 0x31, key) - 0.5) * 2.0;
+            // A fixed offset and no jitter: a row of blocks is a *row*, and a row that
+            // wanders reads as rubbish left at the edge of a corner rather than as something
+            // somebody laid out.
+            let off = BALE_OFF_M;
             let (x, z) = (st.x + rx * off * side, st.z + rz * off * side);
             if inside(prog, x, z, 3.0)
                 && clearance(&coarse, x, z) > half + 2.0
                 && clear_of_the_start(x, z)
             {
-                let deg = along(st.heading) + 10.0 * (rnd(seed ^ 0x32, key) - 0.5);
+                let deg = along(st.heading);
                 let (lo, hi) = ground_foot(syn, x, z, deg, BALE_W_M, BALE_D_M);
                 if hi - lo > 0.8 {
-                    s += 4.0;
+                    s += BALE_W_M + 0.35;
                     continue;
                 }
                 bales.append(&edfwrite::moved(
@@ -723,7 +734,7 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
                 n += 1;
             }
         }
-        s += 4.0;
+        s += BALE_W_M + 0.35;
     }
     tally.push(("bales", n));
 
@@ -790,8 +801,18 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
             if rnd(seed ^ 0x63, key) > 0.62 || !inside(prog, x, z, 4.0) {
                 continue;
             }
-            // Everything on the venue side of the wood belongs to somebody else.
-            if clearance(&coarse, x, z) < WOOD_FROM_M || !clear_of_the_start(x, z) {
+            if !clear_of_the_start(x, z) {
+                continue;
+            }
+            // The wood proper stands past everything else. Inside that — the infield, and the
+            // pockets the lap folds round — a *few* trees, thinned right down: they are what
+            // stops the middle of a track being a bare field, and any more would be a hedge
+            // across the view of the next corner.
+            let room = clearance(&coarse, x, z);
+            if room < INFIELD_TREE_FROM_M {
+                continue;
+            }
+            if room < WOOD_FROM_M && rnd(seed ^ 0x66, key) > INFIELD_TREE_SHARE {
                 continue;
             }
             let h = TREE_H_M * (0.75 + 0.7 * rnd(seed ^ 0x64, key));
@@ -855,7 +876,7 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
     // 7. The sky over all of it.
     let (sx, sz) = (prog.terrain.size_x, prog.terrain.size_z);
     let sky = edfwrite::moved(
-        &dome_mesh(sx.max(sz) * 1.35),
+        &dome_mesh(sx.max(sz) * 0.95),
         [sx * 0.5, ground(syn, sx * 0.5, sz * 0.5) - 2.0, sz * 0.5],
     );
     tally.push(("sky", 1));

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -4398,9 +4398,15 @@ fn ground_looks(surface: Surface) -> Grounds {
     // line, and the gap between them is far wider than any two colours anyone would guess.
     // These are the numbers *before* shading, which lands around three quarters of them.
     let (base, line): ([f32; 3], [f32; 3]) = match surface {
-        Surface::Soil => ([179.0, 140.0, 104.0], [56.0, 40.0, 27.0]),
-        Surface::Sand => ([214.0, 193.0, 152.0], [166.0, 142.0, 105.0]),
-        Surface::Grass => ([174.0, 142.0, 100.0], [55.0, 40.0, 27.0]),
+        // The line is lighter than Indiana's own (50, 36, 24) on purpose. That figure is what
+        // a sheet averages under a photographer's light; in the game, with the track's sky
+        // over it and its own shadows on it, a line that dark stops reading as a line at all —
+        // ridden, you cannot see where the groove is. Lifted until it does, and no further:
+        // the gap to the field is what makes a racing line visible, and that gap is still
+        // more than a hundred levels.
+        Surface::Soil => ([179.0, 140.0, 104.0], [86.0, 63.0, 44.0]),
+        Surface::Sand => ([214.0, 193.0, 152.0], [176.0, 152.0, 114.0]),
+        Surface::Grass => ([174.0, 142.0, 100.0], [84.0, 62.0, 43.0]),
     };
     let field = GroundLook {
         base,
@@ -4472,7 +4478,7 @@ fn ground_looks(surface: Surface) -> Grounds {
     // off `ridden` in tone, because two shades of the same brown at riding speed is one
     // shade.
     let rut = GroundLook {
-        base: [line[0] * 0.72, line[1] * 0.72, line[2] * 0.70],
+        base: [line[0] * 0.78, line[1] * 0.78, line[2] * 0.76],
         grain_tint: (0.74, 1.20),
         fleck: [128.0, 124.0, 118.0],
         fleck_density: 0.015,
@@ -6556,7 +6562,8 @@ mod tests {
             let _ = crate::trackllm::repair_for_tests(&mut p);
             let s = synthesise(&p).unwrap();
             match (&s.spur, p.start_line()) {
-                (Some(spur), Some(line)) => { for (i, sg) in line.segments.iter().enumerate() {
+                (Some(spur), Some(line)) => {
+                for (i, sg) in line.segments.iter().enumerate() {
                     match sg {
                         crate::trackprog::Segment::Straight { length, .. } =>
                             println!("    {i}: straight {length:.0} m"),
@@ -6764,19 +6771,26 @@ mod tests {
                 (sum[2] / (dim * dim) as f64) as f32,
             ]
         };
-        for (what, got, want) in [
-            ("the field", mean(&field), [172.0, 134.0, 99.0]),
-            ("the riding line", mean(&ridden), [50.0, 36.0, 24.0]),
-        ] {
-            for c in 0..3 {
-                assert!(
-                    (got[c] - want[c]).abs() < 14.0,
-                    "{what} came out {:?}, and the published sheet it is calibrated \
-                     against is {want:?}",
-                    got.map(|v| v.round())
-                );
-            }
+        // The field is Indiana's, level for level. The riding line is deliberately lighter
+        // than its (50, 36, 24): that figure is what a sheet averages on its own, and in the
+        // game — under the track's own sky, with its own shadows on it — a line that dark is
+        // one a rider cannot find. What has to survive is the *gap*, because the gap is what
+        // makes a racing line visible from the seat.
+        for c in 0..3 {
+            assert!(
+                (mean(&field)[c] - [172.0, 134.0, 99.0][c]).abs() < 14.0,
+                "the field came out {:?}, and Indiana's sheet is [172, 134, 99]",
+                mean(&field).map(|v| v.round())
+            );
         }
+        let (f, r) = (mean(&field), mean(&ridden));
+        let gap = (f[0] - r[0] + f[1] - r[1] + f[2] - r[2]) / 3.0;
+        assert!(
+            (60.0..130.0).contains(&gap),
+            "the line stands {gap:.0} levels off the field: {:?} against {:?}",
+            r.map(|v| v.round()),
+            f.map(|v| v.round())
+        );
     }
 
 
@@ -6793,7 +6807,10 @@ mod tests {
         let g = ground_looks(Surface::Soil);
         for (what, look, most) in [
             ("the field", &g.field, 34.0),
-            ("the riding line", &g.ridden, 26.0),
+            // The line's bound is above the field's own 26 because the sheet is lighter than
+            // Indiana's: the same relative grain lands in more grey levels on a brighter
+            // base, and the grain is what stops a track reading as painted plastic.
+            ("the riding line", &g.ridden, 30.0),
             ("the shoulder", &g.shoulder, 34.0),
             ("the loose dirt", &g.loose, 34.0),
         ] {


### PR DESCRIPTION
All off riding the built track.

- **The start straight ends in turn one.** It joined wherever the merge was cheapest, which was onto straight track — the pack arrived on the racing line with nothing saying where the track went. The first corner is now found explicitly, the start stands on its outside, and landing *inside* it outweighs every other term in the search. What unblocked it was the crossing rule: the pad may share ground with the approach it merges into, and with the opening straight it runs beside by construction; only lying across a *different* part of the lap counts as crossing.
- **The sky was making everything dark.** TerrainEd bakes shadow volumes from every scene in the file and the sun stands 54° up, so a closed dome put the whole track in its own shadow. It is a band to 34° now — the horizon is the track's own, the sun comes through, the ground is lit.
- **The riding line is lighter.** Indiana's sheet averages (50, 36, 24); that is what a sheet measures on its own, and in the game, under the track's sky and its own shadows, a line that dark is one a rider cannot find. The gap to the field — the thing that actually makes a line visible — is still ~90 levels, and the test holds that rather than the absolute darkness.
- **Blocks are plain white, laid end to end along the outside of a corner** instead of scattered with a random offset and heading.
- **Fewer marker boards**, and a few trees inside the lap rather than only behind it.

Full suite 1330 passed / 0 failed; the track builds through PiBoSo's compilers with all of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)