### PR TITLE
fix(tracks): no vans in the way, banners back, flags at the crest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 ## 2026-09-06
 
 ### Changed
+- The parked vans are gone. They stood close enough to the riding line to be something a rider
+  runs into.
+- The banners are back.
+- Jump posts stand at the top of the takeoff face rather than at its foot: the post grows with
+  the jump, so the flag sits at the crest.
+- No gap between the start straight and the lap. The tracks this is measured against are flat
+  ground from the gate row right up to the racing line, and the two are one surface.
+
+## 2026-09-06
+
+### Changed
 - The printed banners are gone.
 - A third as many blocks round a corner, and each one now has a dark foot under its white body
   so it reads as a block rather than a paper cube.

--- a/src-tauri/src/trackscenery.rs
+++ b/src-tauri/src/trackscenery.rs
@@ -479,14 +479,14 @@ fn bare(m: &Mesh) -> Mesh {
 ///
 /// A post and not a board: every track marks its jumps, and what it marks them with is a
 /// stake — a rider coming at a blind crest reads the line of colour, not a sign.
-fn jumpmark_mesh() -> Mesh {
-    let mut m = edfwrite::cuboid(JUMPMARK_W_M, JUMPMARK_H_M, JUMPMARK_W_M);
+fn jumpmark_mesh(h: f32) -> Mesh {
+    let mut m = edfwrite::cuboid(JUMPMARK_W_M, h, JUMPMARK_W_M);
     // A pennant at the top: a triangle off one side of the post, doubled so it reads from
     // both. It is the flag a rider picks up out of the corner of an eye, not the post.
-    let (w, h) = (JUMPMARK_FLAG_M, JUMPMARK_FLAG_M * 0.62);
-    let y = JUMPMARK_H_M * 0.5 - h * 0.5;
+    let (w, flag_h) = (JUMPMARK_FLAG_M, JUMPMARK_FLAG_M * 0.62);
+    let y = h * 0.5 - flag_h * 0.5;
     let mut flag = Mesh::default();
-    for (px, py) in [(0.0, y + h * 0.5), (0.0, y - h * 0.5), (w, y)] {
+    for (px, py) in [(0.0, y + flag_h * 0.5), (0.0, y - flag_h * 0.5), (w, y)] {
         flag.positions.extend_from_slice(&[px, py, 0.0]);
         flag.normals.extend_from_slice(&[0.0, 0.0, 1.0]);
         flag.uvs.extend_from_slice(&[px / w, 0.5 - py * 0.1]);
@@ -747,9 +747,32 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
     }
     tally.push(("stakes", n));
 
-    // 2. No banners. White panels with a red block and a blue one: they read as nothing in
-    //    particular from a bike, and there is nothing they could be advertising. Gone.
-    let _ = &mut banners;
+    // 2. Banners: few, big, and facing the rider.
+    let mut n = 0usize;
+    let mut s = BANNER_GAP_M * 0.5;
+    while s < lap {
+        let st = at(s);
+        let (rx, rz) = crate::trackprog::right_vector(st.heading);
+        let key = (s / BANNER_GAP_M) as u32;
+        let side = if rnd(seed ^ 0x51, key) < 0.5 { -1.0f32 } else { 1.0 };
+        let off = BANNER_OFF_M.max(half + 2.5);
+        let (x, z) = (st.x + rx * off * side, st.z + rz * off * side);
+        if inside(prog, x, z, 3.0)
+            && clearance(&coarse, x, z) > off - 1.0
+            && clear_of_the_start(x, z)
+        {
+            let (lo, hi) = ground_span(syn, x, z, along(st.heading), BANNER_W_M);
+            if hi - lo < 1.0 {
+                banners.append(&edfwrite::moved(
+                    &edfwrite::turned(&banner_mesh(), along(st.heading)),
+                    [x, (lo + hi) * 0.5 - 0.05, z],
+                ));
+                n += 1;
+            }
+        }
+        s += BANNER_GAP_M;
+    }
+    tally.push(("banners", n));
 
 
 
@@ -832,13 +855,18 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
         let st = at(crest % lap);
         let (rx, rz) = crate::trackprog::right_vector(st.heading);
         for side in [-1.0f32, 1.0] {
-            let off = half + 0.8;
+            let off = half + 0.4;
             let (x, z) = (st.x + rx * off * side, st.z + rz * off * side);
             if !inside(prog, x, z, 2.0) || !clear_of_the_start(x, z) {
                 continue;
             }
+            // Tall enough to reach the top of the face. A jump's shape fades out across the
+            // width of the track, so the ground a post stands on at the edge is the *foot* of
+            // the jump — and a flag down there is a flag on the run-up, which is what it
+            // looked like. The post grows with the jump so the pennant sits at the crest.
+            let h = JUMPMARK_H_M + height.abs() * 0.9;
             jumpmarks.append(&edfwrite::moved(
-                &edfwrite::turned(&jumpmark_mesh(), along(st.heading)),
+                &edfwrite::turned(&jumpmark_mesh(h), along(st.heading)),
                 [x, ground(syn, x, z) - 0.05, z],
             ));
             n += 1;
@@ -956,30 +984,11 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
     }
     tally.push(("poles", n));
 
-    let mut n = 0usize;
-    let mut s = VAN_GAP_M * 0.5;
-    while s < lap {
-        let st = at(s);
-        let (rx, rz) = crate::trackprog::right_vector(st.heading);
-        let key = (s / VAN_GAP_M) as u32;
-        let side = if rnd(seed ^ 0x81, key) < 0.5 { -1.0f32 } else { 1.0 };
-        let off = 15.0 + 12.0 * rnd(seed ^ 0x82, key);
-        let (x, z) = (st.x + rx * off * side, st.z + rz * off * side);
-        if inside(prog, x, z, 6.0) && clearance(&coarse, x, z) > off - 2.0 && clear_of_the_start(x, z)
-        {
-            // Parked on level ground, or it stands on one wheel.
-            let (lo, hi) = ground_span(syn, x, z, along(st.heading), 6.0);
-            if hi - lo < 0.8 {
-                vans.append(&edfwrite::moved(
-                    &edfwrite::turned(&van_mesh(), along(st.heading) + 90.0 * rnd(seed ^ 0x83, key)),
-                    [x, lo - 0.1, z],
-                ));
-                n += 1;
-            }
-        }
-        s += VAN_GAP_M;
-    }
-    tally.push(("vans", n));
+    // No parked vans. They are what a paddock is full of, but ours stood close enough to the
+    // riding line to be something a rider hits — a white box with a stripe down it, solid, in
+    // the way. Out until they can be put somewhere that is actually a paddock.
+    let _ = &mut vans;
+
 
     // 7. The sky over all of it.
     let (sx, sz) = (prog.terrain.size_x, prog.terrain.size_z);
@@ -1024,12 +1033,12 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
     // built the same way, three `scene` blocks for three objects.
     let kinds: Vec<(&str, Mesh, Texture, bool)> = vec![
         ("stakes", stakes, stake_sheet(), false),
+        ("banners", banners, banner_sheet(), true),
         ("bales", bales, bale_sheet(), true),
         // Not solid: clipping a marker board should cost a rider nothing.
         ("jumpmarks", jumpmarks, jumpmark_sheet(), false),
         ("trees", trees, tree_sheet(), true),
         ("poles", poles, pole_sheet(), false),
-        ("vans", vans, van_sheet(), true),
         // The sky is drawn and nothing else: a dome you can ride into is not a sky.
         ("sky", sky, dome_sheet(), false),
         ("gate", gate, gate_sheet(), true),

--- a/src-tauri/src/trackstats.rs
+++ b/src-tauri/src/trackstats.rs
@@ -1439,6 +1439,133 @@ mod tests {
         }
     }
 
+    /// The ground across a published start straight: how wide the flat pad is, and whether it
+    /// runs into the lap or stops short of it.
+    ///
+    /// ```text
+    /// FROST_TRACK=…/track.pkz cargo test -- --ignored --nocapture published_start_ground
+    /// ```
+    #[test]
+    #[ignore = "needs a track — set FROST_TRACK"]
+    fn published_start_ground() {
+        let var = std::env::var("FROST_TRACK").expect("set FROST_TRACK");
+        let path = std::path::Path::new(&var);
+        let names = crate::track::entry_names(path).unwrap();
+        let entry = crate::track::heightfield_entries(&names).into_iter().next().unwrap();
+        let bytes = crate::track::read_entry(path, &entry).unwrap();
+        let layout = crate::heightfield::probe(&bytes, None).unwrap();
+        let mps = layout.metres_per_sample.expect("a track in metres");
+        let (gw, gh, heights) =
+            crate::heightfield::read_grid(&bytes, &layout, layout.width.max(layout.height));
+        let (gw, gh) = (gw as usize, gh as usize);
+        let at = |x: f32, z: f32| -> f32 {
+            let (ix, iz) = ((x / mps) as usize, (z / mps) as usize);
+            heights[iz.min(gh - 1) * gw + ix.min(gw - 1)]
+        };
+
+        // The lap, and the start line beside it.
+        let block_at =
+            layout.offset + layout.width as usize * layout.height as usize * layout.sample.size();
+        let block = &bytes[block_at..];
+        let lap = crate::trackline::read(block).expect("a lap");
+        let prog = crate::trackprog::TrackProgram {
+            name: String::new(), author: String::new(), location: String::new(),
+            terrain: crate::trackprog::Terrain {
+                size_x: mps * (gw - 1) as f32, size_z: mps * (gh - 1) as f32,
+                samples: 513, scale: 100.0,
+                relief: Default::default(), surface: Default::default(),
+                wear: Default::default(),
+            },
+            start: crate::trackprog::Start { x: lap.start.0, z: lap.start.1, angle: lap.heading },
+            segments: lap.program_segments(), width: 12.0, features: Vec::new(),
+            blend: 1.2, elevation: Vec::new(),
+        };
+        let lap_st = prog.stations(1.0);
+
+        // Find the start line the way `second_line` does.
+        let table = crate::track::material_table_offset(block).unwrap();
+        let u32_at = |o: usize| u32::from_le_bytes(block[o..o + 4].try_into().unwrap());
+        let f32_at = |o: usize| f32::from_le_bytes(block[o..o + 4].try_into().unwrap());
+        let materials = u32_at(table) as usize;
+        let after = table + 4 + materials * 52 + 4 + u32_at(table + 4 + materials * 52) as usize * 60;
+        let mut line: Option<(f32, f32, f32, Vec<(f32, f32, f32)>)> = None;
+        let mut k = after;
+        while k + 16 < block.len() {
+            let (x, z, ang) = (f32_at(k), f32_at(k + 4), f32_at(k + 8));
+            let n = u32_at(k + 12) as usize;
+            let sane = (0.0..4000.0).contains(&x) && (0.0..4000.0).contains(&z)
+                && ang.abs() <= 720.0 && n > 0 && n < 64 && k + 16 + n * 60 <= block.len();
+            if sane {
+                let (mut total, mut ok, mut segs) = (0.0f32, true, Vec::new());
+                for i in 0..n {
+                    let o = k + 16 + i * 60;
+                    let (len, r, a, s0) = (f32_at(o + 4), f32_at(o + 8), f32_at(o + 12), f32_at(o + 20));
+                    if !(0.0..2000.0).contains(&len) || (s0 - total).abs() > 0.5 {
+                        ok = false;
+                        break;
+                    }
+                    total += len;
+                    segs.push((len, r, a));
+                }
+                if ok && total > 20.0 {
+                    line = Some((x, z, ang, segs));
+                    break;
+                }
+            }
+            k += 4;
+        }
+        let Some((sx, sz, sang, segs)) = line else {
+            println!("  no start line");
+            return;
+        };
+        let walk = crate::trackprog::TrackProgram {
+            start: crate::trackprog::Start { x: sx, z: sz, angle: sang },
+            segments: segs
+                .iter()
+                .map(|(len, r, a)| {
+                    if *r == 0.0 || *a == 0.0 {
+                        crate::trackprog::Segment::Straight { length: *len, rise: 0.0 }
+                    } else {
+                        crate::trackprog::Segment::Arc { radius: *r, angle: a.abs(), rise: 0.0 }
+                    }
+                })
+                .collect(),
+            ..prog.clone()
+        };
+
+        println!("  along  flat±   to the lap   step at the join");
+        for q in walk.stations(1.0).iter().step_by(10) {
+            let (rx, rz) = crate::trackprog::right_vector(q.heading);
+            // How far the ground stays flat either side: walk out until it tilts hard.
+            let mut reach = [0.0f32; 2];
+            for (i, side) in [-1.0f32, 1.0].into_iter().enumerate() {
+                let mut last = at(q.x, q.z);
+                for m in 1..60 {
+                    let t = m as f32;
+                    let (x, z) = (q.x + rx * t * side, q.z + rz * t * side);
+                    if x < 1.0 || z < 1.0 || x > prog.terrain.size_x - 1.0 || z > prog.terrain.size_z - 1.0 {
+                        break;
+                    }
+                    let h = at(x, z);
+                    if (h - last).abs() > 0.55 {
+                        break;
+                    }
+                    last = h;
+                    reach[i] = t;
+                }
+            }
+            let (near, _) = lap_st.iter().fold((f32::MAX, 0.0f32), |b, p| {
+                let d = ((p.x - q.x).powi(2) + (p.z - q.z).powi(2)).sqrt();
+                if d < b.0 { (d, p.s) } else { b }
+            });
+            println!(
+                "  {:>5.0}m  {:>4.0}/{:<4.0} {:>8.0} m   {}",
+                q.s, reach[0], reach[1], near,
+                if near < reach[0].max(reach[1]) + 2.0 { "flat right up to it" } else { "" },
+            );
+        }
+    }
+
     /// A published track's race data: where it puts its grid, and in what coordinates.
     ///
     /// ```text

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -1217,25 +1217,14 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
             // line the ground was benched by a different rule, and the two rules do not meet.
             let spur_e = d - wide;
             let lap_e = dist[i] - widths.at(arc[i]);
-            // The strip of ground between the start and the lap, kept clear until they meet
-            // — see `Synth::outside`, which every mask reads and which has to agree with this
-            // or the ground is benched into one apron and painted as two.
             let lap_e = dist[i] - widths.at(arc[i]);
-            if lap_e <= START_GAP_M && !spur.merging(s) {
-                continue;
-            }
-            // The pad's hold on the ground fades out across that strip rather than stopping
-            // at the edge of it, or the gap is a wall instead of a gap.
-            let hold = if spur.merging(s) { 0.0 } else { START_GAP_M };
             // Track surface wherever the start covers it, whatever the ground under it is
             // doing: this is the same width the `.trh` and the `.map` paint, and a corridor
             // that disagreed with them measured eight metres narrower than the file it wrote.
             if d <= wide && back > 0.0 {
                 corridor[i] = true;
             }
-            let claim = smoothstep(((lap_e - spur_e) / SHOULDER_M).clamp(0.0, 1.0))
-                * smoothstep(((lap_e - hold) / SHOULDER_M).clamp(0.0, 1.0))
-                * back;
+            let claim = smoothstep(((lap_e - spur_e) / SHOULDER_M).clamp(0.0, 1.0)) * back;
             if claim <= 0.0 {
                 continue;
             }
@@ -3139,10 +3128,6 @@ const TIE_FAR_M: f32 = 70.0;
 /// to be one.
 const MERGE_JOIN_M: f32 = 45.0;
 
-/// How much unridden ground is left between the start straight and the lap, metres, before
-/// the two meet.
-const START_GAP_M: f32 = 5.0;
-
 /// How much ground the pad keeps behind the gate row, metres — where a real start has its
 /// bank and its scoring tower.
 const BACK_OF_THE_GATE_M: f32 = 8.0;
@@ -3519,13 +3504,11 @@ impl Synth {
         let mut e = lap;
         if let Some(spur) = &self.spur {
             let d = self.spur_dist[i];
-            // A strip of ground between the two, right up until they meet. Ridden, the start
-            // straight and the lap are two pieces of track that touch once — at turn one —
-            // and a rider on a flying lap should have no way onto the other one. Without this
-            // the pad's edge runs into the lap's for a hundred metres and the two are one
-            // apron you can wander across.
-            let apart = lap > START_GAP_M || spur.merging(self.spur_arc[i]);
-            if d.is_finite() && apart {
+            // No gap between the two. Measured off Mt Morris, whose start pad is flat ground
+            // from its gate row right up to the racing line the whole way along: a start
+            // straight and the lap it feeds are one surface, and a strip of field between
+            // them is a ditch a rider drops into on the way to turn one.
+            if d.is_finite() {
                 e = e.min(d - spur.at(self.spur_arc[i]));
             }
         }


### PR DESCRIPTION
- **The parked vans are out.** A white box with a stripe down it, solid, fifteen metres off the racing line, is a thing a rider hits — and on a lap that folds back on itself they ended up beside the track rather than in a paddock.
- **The banners are back.**
- **The jump post grows with the jump.** A feature's shape fades out across the width of the track, so a post planted at the edge stands on the *foot* of the jump and its flag ends up down on the run-up. It is sized to the jump now, so the pennant sits at the top of the takeoff face, and it still stays off the riding line.
- **No gap between the start straight and the lap.** Measured off Mt Morris — its start pad is flat ground from the gate row right up to the racing line the whole way along, and the two meet 70 m in. A strip of field between them is a ditch on the way to turn one.

Full suite 1353 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)