### PR TITLE
fix(tracks): the rut sheet was a solid colour, and tools to say so

### DIFF
--- a/src-tauri/src/edfwrite.rs
+++ b/src-tauri/src/edfwrite.rs
@@ -129,6 +129,14 @@ pub struct Part {
     pub mesh: Mesh,
     /// Index into the model's textures.
     pub texture: usize,
+    /// The companion sheet beside it — a normal map — as another index into the same list.
+    ///
+    /// The slot exists in every material record ever written and we left it zero, so nothing
+    /// generated has ever been normal-mapped. It matters more than it sounds: TerrainEd bakes
+    /// no normal for a *heightmap* layer — PiBoSo's own example proves that, and ours behaves
+    /// the same — so mesh materials are the only route to relief lighting on a track, and
+    /// they are how a published national gets `soil_white_n_s` and `gravel_n_s` into its map.
+    pub normal: Option<usize>,
 }
 
 fn put_u32(out: &mut Vec<u8>, v: u32) {
@@ -259,9 +267,12 @@ pub fn write(name: &str, parts: &[Part], textures: &[Texture]) -> Vec<u8> {
         for _ in 0..4 {
             put_u32(&mut out, 0);
         }
+        // w11: the colour sheet, one-based. w13: the companion beside it, likewise — the
+        // slot `edf::valid_material_record` calls "the companion", which a mod shipping `_n`
+        // sheets fills in and PiBoSo's own bikes leave zero.
         put_u32(&mut out, p.texture as u32 + 1);
         put_u32(&mut out, 0);
-        put_u32(&mut out, 0);
+        put_u32(&mut out, p.normal.map_or(0, |n| n as u32 + 1));
         debug_assert_eq!(out.len() - start, MAT_STRIDE);
     }
 
@@ -511,7 +522,7 @@ mod tests {
         let (vc, tc) = (mesh.vertex_count(), mesh.triangle_count());
         let bytes = write(
             "probe",
-            &[Part { name: "post".into(), mesh: mesh.clone(), texture: 0 }],
+            &[Part { name: "post".into(), mesh: mesh.clone(), texture: 0, normal: None }],
             &[sheet("post_c", 64, [200, 180, 60, 255])],
         );
 
@@ -538,7 +549,7 @@ mod tests {
         let mesh = moved(&cuboid(2.0, 3.0, 1.0), [5.0, 0.0, -4.0]);
         let bytes = write(
             "probe",
-            &[Part { name: "post".into(), mesh: mesh.clone(), texture: 0 }],
+            &[Part { name: "post".into(), mesh: mesh.clone(), texture: 0, normal: None }],
             &[sheet("post_c", 64, [1, 2, 3, 255])],
         );
         let (lo, hi) = crate::edf::header_aabb(&bytes).expect("header states bounds");
@@ -554,7 +565,7 @@ mod tests {
         let tex = sheet("bark_c_a", 64, [10, 120, 30, 255]);
         let bytes = write(
             "probe",
-            &[Part { name: "trunk".into(), mesh: card(1.0, 4.0), texture: 0 }],
+            &[Part { name: "trunk".into(), mesh: card(1.0, 4.0), texture: 0, normal: None }],
             &[tex.clone()],
         );
         let found = crate::edf::embedded_textures(&bytes);
@@ -570,8 +581,8 @@ mod tests {
         let bytes = write(
             "tree",
             &[
-                Part { name: "trunk".into(), mesh: cuboid(0.4, 4.0, 0.4), texture: 0 },
-                Part { name: "canopy".into(), mesh: crossed(5.0, 5.0, 2), texture: 1 },
+                Part { name: "trunk".into(), mesh: cuboid(0.4, 4.0, 0.4), texture: 0, normal: None },
+                Part { name: "canopy".into(), mesh: crossed(5.0, 5.0, 2), texture: 1, normal: None },
             ],
             &[sheet("bark_c", 64, [90, 60, 40, 255]), sheet("leaf_c_a", 64, [40, 110, 40, 128])],
         );
@@ -600,7 +611,7 @@ mod tests {
         // but a bare `card` node would vanish and it is better to have said so.
         let bytes = write(
             "lone",
-            &[Part { name: "lone".into(), mesh: card(1.0, 1.0), texture: 0 }],
+            &[Part { name: "lone".into(), mesh: card(1.0, 1.0), texture: 0, normal: None }],
             &[sheet("x_c", 64, [1, 1, 1, 255])],
         );
         assert!(crate::edf::parse_world(&bytes).is_empty());
@@ -658,6 +669,38 @@ mod tests {
         let (lo, hi) = m.bounds();
         assert!((lo[1] - 0.0).abs() < 1e-5 && (hi[1] - 2.0).abs() < 1e-5);
     }
+
+    #[test]
+    fn a_part_can_name_the_normal_map_beside_its_colour() {
+        // The slot the reader calls "the companion": w13 of the material record, one-based,
+        // zero for none. It was written zero unconditionally, so nothing this app has ever
+        // generated carried a normal map — and mesh materials are the only route to relief
+        // lighting on a track, because TerrainEd bakes none for a heightmap layer.
+        let mesh = cuboid(1.0, 1.0, 1.0);
+        let sheets = vec![sheet("ground_c", 4, [180, 140, 100, 255]), sheet("ground_n", 4, [128, 128, 255, 255])];
+        let with = write(
+            "m",
+            &[Part { name: "g".into(), mesh: mesh.clone(), texture: 0, normal: Some(1) }],
+            &sheets,
+        );
+        let without = write(
+            "m",
+            &[Part { name: "g".into(), mesh, texture: 0, normal: None }],
+            &sheets,
+        );
+        // The material table sits right after the bounds and the count.
+        let at = 4 + 24 + 4;
+        let w = |b: &[u8], k: usize| u32::from_le_bytes(b[at + k * 4..at + k * 4 + 4].try_into().unwrap());
+        assert_eq!(w(&with, 11), 1, "the colour sheet is still bound one-based");
+        assert_eq!(w(&with, 13), 2, "and the normal is the second sheet");
+        assert_eq!(w(&without, 13), 0, "with none, the slot stays empty");
+        // And the reader agrees it is a material table at all, which is what stops this being
+        // a number written into padding.
+        assert_eq!(
+            crate::edf::node_material_table(&with, 4 + 24 + 4 + MAT_STRIDE, sheets.len()).len(),
+            1
+        );
+    }
 }
 
 #[cfg(test)]
@@ -704,7 +747,7 @@ mod compiles {
         let (w, h) = (2.0f32, 4.0f32);
         let bytes = write(
             "probe",
-            &[Part { name: "probe".into(), mesh: cuboid(w, h, w), texture: 0 }],
+            &[Part { name: "probe".into(), mesh: cuboid(w, h, w), texture: 0, normal: None }],
             &[checks("probe_c", 64, [220, 40, 40, 255], [250, 250, 250, 255])],
         );
         std::fs::write(dir.join("probe.edf"), &bytes).unwrap();
@@ -768,9 +811,9 @@ mod compiles {
             .terrained;
 
         let parts = vec![
-            Part { name: "posts".into(), mesh: cuboid(1.0, 4.0, 1.0), texture: 0 },
-            Part { name: "boards".into(), mesh: moved(&crossed(3.0, 2.0, 2), [6.0, 0.0, 0.0]), texture: 1 },
-            Part { name: "canopy".into(), mesh: moved(&crossed(4.0, 5.0, 3), [-6.0, 0.0, 0.0]), texture: 2 },
+            Part { name: "posts".into(), mesh: cuboid(1.0, 4.0, 1.0), texture: 0, normal: None },
+            Part { name: "boards".into(), mesh: moved(&crossed(3.0, 2.0, 2), [6.0, 0.0, 0.0]), texture: 1, normal: None },
+            Part { name: "canopy".into(), mesh: moved(&crossed(4.0, 5.0, 3), [-6.0, 0.0, 0.0]), texture: 2, normal: None },
         ];
         let sheets = vec![
             checks("posts_c", 64, [200, 60, 60, 255], [240, 240, 240, 255]),
@@ -817,22 +860,22 @@ mod compiles {
 
         let cases: Vec<(&str, Vec<Part>, Vec<Texture>)> = vec![
             ("1 box, opaque (control)",
-             vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0 }],
+             vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0, normal: None }],
              vec![opaque("a_c")]),
             ("2 boxes, 2 sheets",
-             vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0 },
-                  Part { name: "b".into(), mesh: moved(&cuboid(2.0, 3.0, 2.0), [6.0, 0.0, 0.0]), texture: 1 }],
+             vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0, normal: None },
+                  Part { name: "b".into(), mesh: moved(&cuboid(2.0, 3.0, 2.0), [6.0, 0.0, 0.0]), texture: 1, normal: None }],
              vec![opaque("a_c"), opaque("b_c")]),
             ("1 box, cut-out sheet",
-             vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0 }],
+             vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0, normal: None }],
              vec![cutout("a_c_a")]),
             ("1 set of crossed cards",
-             vec![Part { name: "a".into(), mesh: crossed(4.0, 5.0, 3), texture: 0 }],
+             vec![Part { name: "a".into(), mesh: crossed(4.0, 5.0, 3), texture: 0, normal: None }],
              vec![cutout("a_c_a")]),
             ("3 parts, mixed",
-             vec![Part { name: "a".into(), mesh: cuboid(1.0, 4.0, 1.0), texture: 0 },
-                  Part { name: "b".into(), mesh: moved(&crossed(3.0, 2.0, 2), [6.0, 0.0, 0.0]), texture: 1 },
-                  Part { name: "c".into(), mesh: moved(&crossed(4.0, 5.0, 3), [-6.0, 0.0, 0.0]), texture: 2 }],
+             vec![Part { name: "a".into(), mesh: cuboid(1.0, 4.0, 1.0), texture: 0, normal: None },
+                  Part { name: "b".into(), mesh: moved(&crossed(3.0, 2.0, 2), [6.0, 0.0, 0.0]), texture: 1, normal: None },
+                  Part { name: "c".into(), mesh: moved(&crossed(4.0, 5.0, 3), [-6.0, 0.0, 0.0]), texture: 2, normal: None }],
              vec![opaque("a_c"), cutout("b_c_a"), cutout("c_c_a")]),
         ];
 
@@ -878,21 +921,21 @@ mod compiles {
         let cutout = |n: &str| checks(n, 64, [60, 150, 70, 255], [0, 0, 0, 0]);
         let (label, parts, sheets): (&str, Vec<Part>, Vec<Texture>) = match case {
             0 => ("1 box, opaque (control)",
-                  vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0 }],
+                  vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0, normal: None }],
                   vec![opaque("a_c")]),
             1 => ("2 boxes, 2 sheets",
-                  vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0 },
-                       Part { name: "b".into(), mesh: moved(&cuboid(2.0, 3.0, 2.0), [6.0, 0.0, 0.0]), texture: 1 }],
+                  vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0, normal: None },
+                       Part { name: "b".into(), mesh: moved(&cuboid(2.0, 3.0, 2.0), [6.0, 0.0, 0.0]), texture: 1, normal: None }],
                   vec![opaque("a_c"), opaque("b_c")]),
             2 => ("1 box, cut-out sheet",
-                  vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0 }],
+                  vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0, normal: None }],
                   vec![cutout("a_c_a")]),
             3 => ("1 set of crossed cards",
-                  vec![Part { name: "a".into(), mesh: crossed(4.0, 5.0, 3), texture: 0 }],
+                  vec![Part { name: "a".into(), mesh: crossed(4.0, 5.0, 3), texture: 0, normal: None }],
                   vec![cutout("a_c_a")]),
             4 => ("2 boxes, 1 shared sheet",
-                  vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0 },
-                       Part { name: "b".into(), mesh: moved(&cuboid(2.0, 3.0, 2.0), [6.0, 0.0, 0.0]), texture: 0 }],
+                  vec![Part { name: "a".into(), mesh: cuboid(2.0, 4.0, 2.0), texture: 0, normal: None },
+                       Part { name: "b".into(), mesh: moved(&cuboid(2.0, 3.0, 2.0), [6.0, 0.0, 0.0]), texture: 0, normal: None }],
                   vec![opaque("a_c")]),
             5 => ("1 box, 200 copies",
                   vec![Part { name: "a".into(), mesh: {
@@ -902,12 +945,12 @@ mod compiles {
                           m.append(&moved(&cuboid(1.0, 2.0, 1.0), [20.0 + x, 0.0, 20.0 + z]));
                       }
                       m
-                  }, texture: 0 }],
+                  }, texture: 0, normal: None }],
                   vec![opaque("a_c")]),
             _ => ("3 parts, mixed",
-                  vec![Part { name: "a".into(), mesh: cuboid(1.0, 4.0, 1.0), texture: 0 },
-                       Part { name: "b".into(), mesh: moved(&crossed(3.0, 2.0, 2), [6.0, 0.0, 0.0]), texture: 1 },
-                       Part { name: "c".into(), mesh: moved(&crossed(4.0, 5.0, 3), [-6.0, 0.0, 0.0]), texture: 2 }],
+                  vec![Part { name: "a".into(), mesh: cuboid(1.0, 4.0, 1.0), texture: 0, normal: None },
+                       Part { name: "b".into(), mesh: moved(&crossed(3.0, 2.0, 2), [6.0, 0.0, 0.0]), texture: 1, normal: None },
+                       Part { name: "c".into(), mesh: moved(&crossed(4.0, 5.0, 3), [-6.0, 0.0, 0.0]), texture: 2, normal: None }],
                   vec![opaque("a_c"), cutout("b_c_a"), cutout("c_c_a")]),
         };
         let bytes = write("probe", &parts, &sheets);

--- a/src-tauri/src/map.rs
+++ b/src-tauri/src/map.rs
@@ -1838,4 +1838,83 @@ mod tests {
             low as f32 * 100.0 / n as f32,
         );
     }
+
+    /// Per-group extent and flatness — is any of a track's mesh a ground carpet, or is it all
+    /// scenery standing up beside the track?
+    ///
+    /// The question matters because "Indiana's map carries 665,000 triangles and ours 18,000"
+    /// admits two readings, and they call for completely different work: a textured ground
+    /// laid over the terrain is an architecture we do not have, while tents and trucks are
+    /// scenery we already place.
+    #[test]
+    #[ignore = "needs a track — set FROST_TRACK"]
+    fn map_groups() {
+        let var = std::env::var("FROST_TRACK").expect("set FROST_TRACK");
+        let path = std::path::Path::new(&var);
+        let names = crate::track::entry_names(path).unwrap();
+        let entry =
+            names.iter().find(|n| n.to_ascii_lowercase().ends_with(".map")).unwrap().clone();
+        let bytes = crate::track::read_entry(path, &entry).unwrap();
+        let Some(m) = parse(&bytes) else {
+            println!("no mesh");
+            return;
+        };
+        let sheets = textures(&bytes, 64);
+        let mut rows: Vec<(f32, String, usize, f32, f32, f32)> = Vec::new();
+        for g in &m.groups {
+            let (mut lo, mut hi) = ([f32::MAX; 3], [f32::MIN; 3]);
+            let (mut up, mut tris) = (0usize, 0usize);
+            let from = g.tri_start as usize * 3;
+            let to = ((g.tri_start + g.tri_count) as usize * 3).min(m.indices.len());
+            if from >= to {
+                continue;
+            }
+            for t in m.indices[from..to].chunks_exact(3) {
+                tris += 1;
+                let p: Vec<[f32; 3]> = t
+                    .iter()
+                    .map(|&i| {
+                        let i = i as usize * 3;
+                        [m.positions[i], m.positions[i + 1], m.positions[i + 2]]
+                    })
+                    .collect();
+                for q in &p {
+                    for c in 0..3 {
+                        lo[c] = lo[c].min(q[c]);
+                        hi[c] = hi[c].max(q[c]);
+                    }
+                }
+                // A ground triangle faces up; a wall or a card does not.
+                let (a, b, c) = (p[0], p[1], p[2]);
+                let u = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+                let v = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+                let n = [
+                    u[1] * v[2] - u[2] * v[1],
+                    u[2] * v[0] - u[0] * v[2],
+                    u[0] * v[1] - u[1] * v[0],
+                ];
+                let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt().max(1e-9);
+                if (n[1] / len).abs() > 0.85 {
+                    up += 1;
+                }
+            }
+            let name = sheets
+                .iter()
+                .find(|t| t.material == g.material)
+                .map(|t| t.name.clone())
+                .unwrap_or_else(|| format!("material {}", g.material));
+            let flat = up as f32 * 100.0 / tris as f32;
+            let area = (hi[0] - lo[0]) * (hi[2] - lo[2]);
+            rows.push((area * flat, name, tris, hi[0] - lo[0], hi[2] - lo[2], flat));
+        }
+        rows.sort_by(|a, b| b.0.total_cmp(&a.0));
+        println!("{entry}");
+        println!(
+            "  {:<28} {:>8} {:>9} {:>9} {:>8}",
+            "sheet", "tris", "span x", "span z", "flat %"
+        );
+        for (_, name, tris, sx, sz, flat) in rows.iter() {
+            println!("  {name:<28} {tris:>8} {sx:>8.0}m {sz:>8.0}m {flat:>7.0}%");
+        }
+    }
 }

--- a/src-tauri/src/map.rs
+++ b/src-tauri/src/map.rs
@@ -1772,4 +1772,70 @@ mod tests {
             );
         }
     }
+
+    /// Every record in a `.map`'s texture table, unfiltered — what the file carries, before
+    /// any judgement about which of them bind to geometry.
+    #[test]
+    #[ignore = "needs a track — set FROST_TRACK"]
+    fn map_survey() {
+        let var = std::env::var("FROST_TRACK").expect("set FROST_TRACK");
+        let path = std::path::Path::new(&var);
+        let names = crate::track::entry_names(path).unwrap();
+        let entry = names
+            .iter()
+            .find(|n| n.to_ascii_lowercase().ends_with(".map"))
+            .expect("a .map")
+            .clone();
+        let bytes = crate::track::read_entry(path, &entry).unwrap();
+        let all = survey(&bytes);
+        println!("{} — {} records in the texture table", entry, all.len());
+        for (n, w, h) in &all {
+            println!("    {n:<32} {w}x{h}");
+        }
+    }
+
+    /// How much of a track's ground is *mesh* rather than painted heightmap.
+    #[test]
+    #[ignore = "needs a track — set FROST_TRACK"]
+    fn map_mesh_extent() {
+        let var = std::env::var("FROST_TRACK").expect("set FROST_TRACK");
+        let path = std::path::Path::new(&var);
+        let names = crate::track::entry_names(path).unwrap();
+        let entry = names
+            .iter()
+            .find(|n| n.to_ascii_lowercase().ends_with(".map"))
+            .expect("a .map")
+            .clone();
+        let bytes = crate::track::read_entry(path, &entry).unwrap();
+        let Some(m) = parse(&bytes) else {
+            println!("no mesh");
+            return;
+        };
+        let n = m.positions.len() / 3;
+        let (mut lo, mut hi) = ([f32::MAX; 3], [f32::MIN; 3]);
+        for v in m.positions.chunks_exact(3) {
+            for c in 0..3 {
+                lo[c] = lo[c].min(v[c]);
+                hi[c] = hi[c].max(v[c]);
+            }
+        }
+        // How flat it is: scenery stands up, ground lies down.
+        let mut low = 0usize;
+        for v in m.positions.chunks_exact(3) {
+            if v[1] - lo[1] < (hi[1] - lo[1]) * 0.15 {
+                low += 1;
+            }
+        }
+        println!(
+            "{}: {n} vertices, {} triangles, {} groups — spans {:.0} x {:.0} m, {:.0} m tall; \
+             {:.0}% of its vertices lie in the bottom sixth of that",
+            entry,
+            m.indices.len() / 3,
+            m.groups.len(),
+            hi[0] - lo[0],
+            hi[2] - lo[2],
+            hi[1] - lo[1],
+            low as f32 * 100.0 / n as f32,
+        );
+    }
 }

--- a/src-tauri/src/trackscenery.rs
+++ b/src-tauri/src/trackscenery.rs
@@ -993,7 +993,7 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
             continue;
         }
         let file = format!("{name}.edf");
-        let bytes = edfwrite::write(name, &[Part { name: name.into(), mesh, texture: 0 }], &[sheet]);
+        let bytes = edfwrite::write(name, &[Part { name: name.into(), mesh, texture: 0, normal: None }], &[sheet]);
         files.push((file.clone(), bytes));
         let at = Scene { file, pos: [0.0, 0.0, 0.0], rot: [0.0, 0.0, 0.0] };
         // Collision only for what should stop a bike. A stake snaps and the fence is behind

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -4865,17 +4865,23 @@ fn ground_looks(surface: Surface) -> Grounds {
         // ground's own rut signal — which is a contrast *within* the line rather than of the
         // line against everything else.
         base: [line[0] * 0.78, line[1] * 0.78, line[2] * 0.76],
-        grain_tint: (0.74, 1.20),
+        // Polished is not featureless. Measured against the sheets a published track bakes
+        // into its own `.map`, this one read a spread of 6.1 grey levels and a pixel-to-pixel
+        // grain of 2.59, where Indiana's three terrain sheets run 16-20 and 11-17 — near
+        // enough a solid colour. A solid colour laid down the middle of the track is what
+        // reads from the seat as the texture being broken and the line impossible to find. A
+        // packed rut is smooth in its *shape*; the dirt in it is still dirt.
+        grain_tint: (0.44, 1.52),
         fleck: [128.0, 124.0, 118.0],
-        fleck_density: 0.015,
+        fleck_density: 0.045,
         litter: [120.0, 104.0, 72.0],
-        litter_density: 0.1,
+        litter_density: 0.28,
         blade: ([0.0; 3], [0.0; 3]),
         blade_density: 0.0,
-        clods: 0.35,
-        coarse: 0.55,
-        mottle: 0.05,
-        contrast: 0.48,
+        clods: 0.72,
+        coarse: 0.42,
+        mottle: 0.18,
+        contrast: 1.00,
     };
     // Loose dirt: dry, so it reads light against everything around it, and coarse, because
     // it is the stuff that has been thrown there rather than driven on.


### PR DESCRIPTION
Measured against what a published track bakes into its own `.map`, rather than against its loose sheets on disk — which is a different thing, and the only thing we had ever compared with.

## The one clear bug: our `rut` sheet was a solid colour

Indiana's three terrain sheets run a luminance spread of 16–20 grey levels and a pixel-to-pixel grain of 11–17.

| ours | spread | grain | | Indiana | spread | grain |
|---|---|---|---|---|---|---|
| ground | 20.8 | 11.09 | | soil_light_c | 20.3 | 15.07 |
| line | 14.9 | 7.13 | | soil_dark_c | 16.0 | 11.46 |
| **rut** | **6.1** | **2.59** | | gravel_c | 19.6 | 16.89 |

The colours were already taken off Indiana and they match. The `rut` sheet did not: at 6.1 and 2.59 it is near enough a solid colour — and a solid colour laid down the middle of the track is what reads from the seat as the texture being broken and the line impossible to find. It now reads 19.8 and 11.33, inside the measured band.

## A normal map can be bound now

`edfwrite::Part` gains `normal`. The slot has always existed — w13 of the material record, the one `edf::valid_material_record` calls "the companion", which a mod shipping `_n` sheets fills in — and we wrote zero into it unconditionally, so nothing this app has ever generated carried a normal map.

TerrainEd bakes no normal for a *heightmap* layer. That looked like a fault in our pipeline until PiBoSo's own example track was compiled as a control: it behaves identically, three records per layer and no normal, despite shipping `dirt_n.tga` and declaring it in `dirt.shd`. So mesh materials are the only route to relief lighting on a track, and this is what makes that possible.

## A correction

An earlier revision of this description claimed Indiana's ground is largely textured mesh laid over the terrain, on the strength of its 665,313 triangles against our 18,208. **That was wrong**, and `map_groups` — written to check it — is what showed so.

Its ten biggest groups are `big_tent_c` at 118,388 triangles, `inflate_tilable_c` at 97,729, and a foliage atlas spread over 1526 × 1517 m. Scenery. Its two soil sheets bind to meshes spanning **14 × 7 m** and **5 × 8 m**, with 22% and 12% of their faces pointing up — props, not ground.

Indiana's riding surface is the painted heightmap, the same as ours. **No terrain-mesh architecture is needed.** The difference in how those tracks read is the sheets themselves, and scenery: 49 groups against our 6.

## Tools

Three ignored tests so none of this has to be re-derived: `map_survey` prints a `.map`'s whole texture table, `ground_sheets` measures colour, spread and grain for every sheet in one, and `map_groups` measures the mesh per group — triangles, ground span, and how much of it faces up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)