### PR TITLE
fix(build): stop `tauri dev` rebuilding in a loop

### DIFF
--- a/src-tauri/.taurignore
+++ b/src-tauri/.taurignore
@@ -1,0 +1,3 @@
+# build.rs stages the injected client DLL here on every build. The dev watcher would see
+# that write as a change, restart the app, and stage it again — an endless rebuild loop.
+resources/*.dll

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -55,7 +55,7 @@ fn stage_secure_dll() {
     // (1) Beside the exe. OUT_DIR is `<target>/<profile>/build/<crate>-<hash>/out`; up three.
     let out_dir = std::env::var("OUT_DIR").unwrap_or_default();
     if let Some(target_dir) = Path::new(&out_dir).ancestors().nth(3) {
-        if let Err(e) = std::fs::copy(src, target_dir.join("mxbsecure.dll")) {
+        if let Err(e) = copy_if_changed(src, &target_dir.join("mxbsecure.dll")) {
             println!("cargo::warning=could not stage mxbsecure.dll beside the exe: {e}");
         }
     }
@@ -63,10 +63,22 @@ fn stage_secure_dll() {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
     let res_dir = Path::new(&manifest_dir).join("resources");
     if std::fs::create_dir_all(&res_dir).is_ok() {
-        if let Err(e) = std::fs::copy(src, res_dir.join("mxbsecure.dll")) {
+        if let Err(e) = copy_if_changed(src, &res_dir.join("mxbsecure.dll")) {
             println!("cargo::warning=could not stage mxbsecure.dll into resources: {e}");
         }
     }
+}
+
+/// Copy only when the destination differs. Rewriting identical bytes still moves the file's
+/// mtime, and `tauri dev` watches `src-tauri/`: the touch restarts the app, which runs this
+/// again, which touches it again — the dev server rebuilds forever without ever launching.
+fn copy_if_changed(src: &Path, dst: &Path) -> std::io::Result<()> {
+    if let (Ok(from), Ok(to)) = (std::fs::read(src), std::fs::read(dst)) {
+        if from == to {
+            return Ok(());
+        }
+    }
+    std::fs::copy(src, dst).map(|_| ())
 }
 
 /// Bake in the git tag this build came from, when there is one.


### PR DESCRIPTION
## The loop

On a checkout that has the private `src/mxbsecure.dll`, `npm run tauri dev` never launches:

```
Compiling mxb-app v0.13.6 (C:\Users\hagai\mxb-app\src-tauri)
     Info File src-tauri\resources\mxbsecure.dll changed. Rebuilding application...
```

`stage_secure_dll` copies that DLL into `src-tauri/resources/` on every build script run, and the
dev watcher watches `src-tauri/`. `fs::copy` moves the destination's mtime even when the bytes are
identical, so the build's own write looked like an edit — restart, rerun the build script, write
again. It only bites where the private module is synced, which is why CI and a public checkout
never saw it.

## The fix

- Copy only when the destination differs. A build that changes nothing leaves the file untouched.
- `src-tauri/.taurignore` for `resources/*.dll`, so staged build output can't restart the watcher
  even when it legitimately changes.

Nothing about what ships changes: the release workflow's `resources/*.dll` glob and the
beside-the-exe copy behave exactly as before.

## Verified

Extracted the build script (`tauri_build::build()` stubbed), compiled it, and ran it three times
against a fixture DLL:

| run | `resources/mxbsecure.dll` mtime |
| --- | --- |
| first | `1788724086.953046504` |
| second, source untouched | `1788724086.953046504` — no write |
| third, after editing the source | `1788724088.339092810`, contents `DLLv2` |

So an unchanged source no longer touches the file, and a real DLL update still restages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)