### PR TITLE
fix(tracks): shape the ruts the way a published track's are

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 ## 2026-09-06
 
 ### Changed
+- Ruts are shaped the way a ridden track's are: fewer grooves, further apart, with flatter
+  bottoms, and smooth along their length instead of chopped up at every scale. A lap holds
+  a line rather than shaking the bike over it.
 - A generated track has a riding line in it. The corridor is worked dirt with a darker line
   worn through it and tyre marks in the ruts, instead of one dark ribbon from edge to edge.
 - Generated tracks are painted with real ground. The soil, the riding line, the packed bottom

--- a/src-tauri/src/trackstats.rs
+++ b/src-tauri/src/trackstats.rs
@@ -875,6 +875,175 @@ struct Cross {
     p: Vec<f32>,
 }
 
+/// What a rut is shaped like, as distinct from how deep it is.
+///
+/// Depth was already measured and it is not what tells a real corner from a generated one.
+/// Three things do:
+///
+/// - **Anisotropy.** A rut is a groove somebody drove down: sharp across, smooth along. Noise
+///   is rough both ways. This is the ratio of the two, and it is the number that says whether
+///   the ground was ridden or shaken.
+/// - **Floor.** A worn groove is flat-bottomed — a tyre's width of it sits within a fifth of
+///   its own depth. A sine wave has no floor at all.
+/// - **Wall.** How steeply the ground climbs out of one, in degrees.
+///
+/// Measured on a band `RIDDEN_HALF_M` either side of the line, detrended over six metres so
+/// the track's own shape drops out and only what is cut into it is left.
+#[derive(Debug, Clone, Copy)]
+pub struct RutShape {
+    /// Roughness across the line, RMS metres after the six-metre detrend.
+    pub across_rms_m: f32,
+    /// And along it, the same way.
+    pub along_rms_m: f32,
+    /// `across / along`. One is noise; a ridden surface is well above it.
+    pub anisotropy: f32,
+    /// How much of a groove's width sits within a fifth of its depth, metres.
+    pub floor_m: f32,
+    /// The steepest wall out of a groove, degrees.
+    pub wall_deg: f32,
+    /// Grooves per cross-section, and how far apart they are.
+    pub grooves: f32,
+    pub spacing_m: f32,
+    /// Roughness along the line at the scale a wheel feels rather than a lap: RMS metres
+    /// after a one-metre detrend. Long undulations drop out; chatter does not.
+    pub chatter_m: f32,
+    /// The same, by how far off the line it is: on it (within a metre), two metres off, and
+    /// four. A real track is polished where the wheels go and chopped up either side, and one
+    /// number for the whole width cannot tell that from a lap that is rough everywhere.
+    pub chatter_zones_m: [f32; 3],
+}
+
+/// Detrend a series against a running mean `half` samples either side, wrapping.
+fn detrend(v: &[f32], half: usize) -> Vec<f32> {
+    let n = v.len();
+    if n == 0 {
+        return Vec::new();
+    }
+    (0..n)
+        .map(|i| {
+            let mut sum = 0.0;
+            let mut count = 0.0;
+            for k in 0..=2 * half {
+                let j = (i + n + k - half.min(i + n)) % n;
+                sum += v[j];
+                count += 1.0;
+            }
+            v[i] - sum / count
+        })
+        .collect()
+}
+
+fn rms(v: &[f32]) -> f32 {
+    if v.is_empty() {
+        return 0.0;
+    }
+    (v.iter().map(|x| x * x).sum::<f32>() / v.len() as f32).sqrt()
+}
+
+/// [`RutShape`] for a lap over a heightfield, published or generated.
+///
+/// `stations` is the centreline: `(x, z, heading)` every `step_m` metres.
+pub fn rut_shape(stations: &[(f32, f32, f32)], step_m: f32, g: &Grid) -> Option<RutShape> {
+    if stations.len() < 64 {
+        return None;
+    }
+    let lat = RIDDEN_LATERAL_M;
+    let n = (2.0 * RIDDEN_HALF_M / lat) as usize + 1;
+    let u_at = |i: usize| i as f32 * lat - RIDDEN_HALF_M;
+    // Heights across the line at every station, and the same grid read the other way.
+    let rows: Vec<Vec<f32>> = stations
+        .iter()
+        .map(|&(x, z, h)| {
+            let (rx, rz) = crate::trackprog::right_vector(h);
+            (0..n).map(|i| g.at(x + u_at(i) * rx, z + u_at(i) * rz)).collect()
+        })
+        .collect();
+
+    // Across: detrend each row over six metres of *width*.
+    let half_across = ((3.0 / lat) as usize).max(1);
+    let mut across: Vec<f32> = Vec::new();
+    let mut floors: Vec<f32> = Vec::new();
+    let mut walls: Vec<f32> = Vec::new();
+    let mut counts: Vec<f32> = Vec::new();
+    let mut gaps: Vec<f32> = Vec::new();
+    for row in &rows {
+        let d = detrend(row, half_across);
+        across.extend(d.iter().copied());
+        // Grooves: runs below a fifth of the section's own deepest cut.
+        let deepest = -d.iter().copied().fold(f32::INFINITY, f32::min);
+        if deepest < 0.02 {
+            continue;
+        }
+        let cut = -0.2 * deepest;
+        let (mut run, mut last_centre, mut found) = (0usize, None::<f32>, 0usize);
+        for i in 0..d.len() {
+            if d[i] <= cut {
+                run += 1;
+            } else if run > 0 {
+                found += 1;
+                floors.push(run as f32 * lat);
+                let centre = (i as f32 - run as f32 * 0.5) * lat - RIDDEN_HALF_M;
+                if let Some(prev) = last_centre {
+                    gaps.push(centre - prev);
+                }
+                last_centre = Some(centre);
+                run = 0;
+            }
+        }
+        counts.push(found as f32);
+        for i in 1..d.len() {
+            walls.push(((d[i] - d[i - 1]).abs() / lat).atan().to_degrees());
+        }
+    }
+
+    // Along: the same detrend down each lateral offset, over six metres of *track*.
+    let half_along = ((3.0 / step_m) as usize).max(1);
+    let half_chatter = ((0.5 / step_m) as usize).max(1);
+    let mut along: Vec<f32> = Vec::new();
+    let mut chatter: Vec<f32> = Vec::new();
+    let mut zones: [Vec<f32>; 3] = [Vec::new(), Vec::new(), Vec::new()];
+    for i in 0..n {
+        let col: Vec<f32> = rows.iter().map(|r| r[i]).collect();
+        along.extend(detrend(&col, half_along));
+        let fine = detrend(&col, half_chatter);
+        let u = u_at(i).abs();
+        // On the line, two metres off it, four metres off it.
+        let zone = if u <= 1.0 {
+            Some(0)
+        } else if (1.5..2.5).contains(&u) {
+            Some(1)
+        } else if (3.5..4.5).contains(&u) {
+            Some(2)
+        } else {
+            None
+        };
+        if let Some(z) = zone {
+            zones[z].extend(fine.iter().copied());
+        }
+        chatter.extend(fine);
+    }
+
+    let mut walls_sorted = walls;
+    walls_sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let wall_deg = walls_sorted
+        .get((walls_sorted.len() as f32 * 0.98) as usize)
+        .copied()
+        .unwrap_or(0.0);
+    let mean = |v: &[f32]| if v.is_empty() { 0.0 } else { v.iter().sum::<f32>() / v.len() as f32 };
+    let (a, b) = (rms(&across), rms(&along));
+    Some(RutShape {
+        across_rms_m: a,
+        along_rms_m: b,
+        anisotropy: if b > 1e-6 { a / b } else { 0.0 },
+        floor_m: mean(&floors),
+        wall_deg,
+        grooves: mean(&counts),
+        spacing_m: mean(&gaps),
+        chatter_m: rms(&chatter),
+        chatter_zones_m: [rms(&zones[0]), rms(&zones[1]), rms(&zones[2])],
+    })
+}
+
 pub fn ridden(lap: &crate::trackline::Lap, g: &Grid) -> Option<RiddenStats> {
     let n = (2.0 * RIDDEN_REACH_M / RIDDEN_LATERAL_M) as usize + 1;
     let u_at = |i: usize| i as f32 * RIDDEN_LATERAL_M - RIDDEN_REACH_M;
@@ -1564,6 +1733,42 @@ mod tests {
                 if near < reach[0].max(reach[1]) + 2.0 { "flat right up to it" } else { "" },
             );
         }
+    }
+
+    /// What a published track's ruts are shaped like.
+    ///
+    /// ```text
+    /// FROST_TRACK=…/indiana.pkz cargo test --bin mxb-app -- --ignored --nocapture rut_shape_of
+    /// ```
+    #[test]
+    #[ignore = "needs a track — set FROST_TRACK"]
+    fn rut_shape_of() {
+        let var = std::env::var("FROST_TRACK").expect("set FROST_TRACK");
+        let path = std::path::Path::new(&var);
+        let names = track::entry_names(path).unwrap();
+        let entry = track::heightfield_entries(&names)
+            .into_iter()
+            .next()
+            .expect("a heightfield");
+        let bytes = track::read_entry(path, &entry).unwrap();
+        let layout = heightfield::probe(&bytes, None).expect("a terrain grid");
+        let mps_src = layout.metres_per_sample.expect("a stated footprint");
+        let size_x = mps_src * (layout.width.max(2) - 1) as f32;
+        let size_z = mps_src * (layout.height.max(2) - 1) as f32;
+        let block_at =
+            layout.offset + layout.width as usize * layout.height as usize * layout.sample.size();
+        let block = bytes.get(block_at..).unwrap_or(&[]);
+        let lap = crate::trackline::read(block).expect("a centreline");
+        let (fw, fh, v) = heightfield::read_grid(&bytes, &layout, layout.width.max(layout.height));
+        let g = &Grid { w: fw as usize, h: fh as usize, size_x, size_z, v };
+        let step = 0.5f32;
+        let stations: Vec<(f32, f32, f32)> =
+            lap.stations(step).into_iter().map(|st| (st.x, st.z, st.heading)).collect();
+        let r = super::rut_shape(&stations, step, g).expect("a rut shape");
+        println!("  {} stations over {:.0} m", stations.len(), stations.len() as f32 * step);
+        println!("  across {:.3} m rms   along {:.3} m rms   anisotropy {:.2}", r.across_rms_m, r.along_rms_m, r.anisotropy);
+        println!("  floor {:.2} m   wall {:.0} deg   {:.1} grooves at {:.2} m   chatter {:.3} m", r.floor_m, r.wall_deg, r.grooves, r.spacing_m, r.chatter_m);
+        println!("  chatter on the line {:.3} m   2 m off {:.3}   4 m off {:.3}", r.chatter_zones_m[0], r.chatter_zones_m[1], r.chatter_zones_m[2]);
     }
 
     /// A published track's race data: where it puts its grid, and in what coordinates.

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -114,6 +114,29 @@ const PASS_DEPTH_M: f32 = 0.022;
 /// at the scale of a jump.
 const TEXTURE_WAVELENGTH_M: f32 = 1.8;
 
+/// And how far down the scales that texture carries.
+///
+/// Four octaves at a half gain put a fifth of the surface's energy below half a metre, and
+/// measured as roughness after a one-metre detrend that is a lap running 0.012 m against
+/// Indiana's 0.007 — half again as rough as a real track at the scale a wheel bounces on,
+/// everywhere across the width. Worked ground is lumpy at the scale of a clod and smooth
+/// under that; it is not fractal all the way down.
+/// How far along the track the ridden ground is averaged, in how many taps, and how much of
+/// the result is taken.
+///
+/// Half a metre either way: long enough to take out what a wheel would bounce on, short
+/// enough to leave a braking bump — those run at two metres and up — most of its height.
+const RIDDEN_SMOOTH_M: f32 = 0.5;
+const RIDDEN_SMOOTH_TAPS: u32 = 3;
+const RIDDEN_SMOOTH: f32 = 0.85;
+
+const TEXTURE_OCTAVES: u32 = 3;
+const TEXTURE_GAIN: f32 = 0.34;
+
+/// The same, for the field that lays out where the grooves go.
+const RUT_FIELD_OCTAVES: u32 = 2;
+const RUT_FIELD_GAIN: f32 = 0.32;
+
 /// How much the riding line's width wanders, as a fraction. A track of exactly constant
 /// width reads as machine-made from the first glance — real ones pinch into corners and open
 /// out on the straights.
@@ -905,6 +928,10 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
     // 3. Bench the corridor in, then build on it.
     let mut corridor = vec![false; gw * gh];
     let mut rut = vec![0.0f32; gw * gh];
+    // How ridden each cell is, and which way the track runs there — read by the pass that
+    // smooths the ground along its own direction.
+    let mut ridden_at = vec![0.0f32; gw * gh];
+    let mut heading_at = vec![0.0f32; gw * gh];
     let mut arc = vec![0.0f32; gw * gh];
     for i in 0..gw * gh {
         let (d, s, t) = local_frame(
@@ -1104,8 +1131,20 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
             let off = t - mid;
             if off.abs() <= reach || carved > 0.0 {
                 let fade = 1.0 - (off.abs() / reach).min(1.0).powi(2);
-                let field =
-                    |at: f32| fbm(at / feel.rut_spacing, s / RUT_ALONG_M, r.seed ^ 0x2117);
+                // Two octaves, not four. A groove field summed over four octaves carries as
+                // much shape at a third of the spacing as at the spacing itself, so a corner
+                // came out with half again as many grooves as a real one, packed 2.0 m apart
+                // against Indiana's 2.5, each with a floor a fifth narrower. A rut is one
+                // wavelength with a bottom on it — see `RUT_EDGE` — not a spectrum.
+                let field = |at: f32| {
+                    fbm_of(
+                        at / feel.rut_spacing,
+                        s / RUT_ALONG_M,
+                        r.seed ^ 0x2117,
+                        RUT_FIELD_OCTAVES,
+                        RUT_FIELD_GAIN,
+                    )
+                };
                 // Ground, wall, floor — see `RUT_EDGE`. Saturating the field rather than
                 // scaling it is what gives a groove a bottom to sit on and leaves the ground
                 // between two of them flat.
@@ -1152,6 +1191,8 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
         // seams between one station's territory and the next. Out at the centre of a corner's
         // arc those seams are metres wide and the jump draws a crease across the infield.
         let w = bench_weight(d, half, SPOIL_WIDTH_M);
+        ridden_at[i] = w;
+        heading_at[i] = stations[station[i] as usize].heading;
         // Worn hardest where the wheels are. Riders use the middle of a track and the edges
         // barely at all, so the ridden texture tapers across it rather than covering the
         // corridor evenly — which is what it did, and it is measurable: Indiana's surface
@@ -1167,10 +1208,12 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
         if r.texture > 0.0 && w > 0.0 {
             let (wx, wz) = ((i % gw) as f32 * mps_x, (i / gw) as f32 * mps_z);
             let gain = chop.rough.at(s);
-            heights[i] += fbm(
+            heights[i] += fbm_of(
                 wx / TEXTURE_WAVELENGTH_M,
                 wz / TEXTURE_WAVELENGTH_M,
                 r.seed ^ 0x5EED,
+                TEXTURE_OCTAVES,
+                TEXTURE_GAIN,
             ) * r.texture
                 * gain
                 * polished
@@ -1196,6 +1239,45 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
                 let ripple = ((s / feel.accel.0 + drift) * std::f32::consts::TAU).sin();
                 heights[i] += ripple * feel.accel.1 * 0.5 * out * across * polished;
             }
+        }
+    }
+
+    // 3b. Smooth the ridden ground along the way it was ridden.
+    //
+    // A rut is a groove somebody drove down: sharp across, smooth along. Everything above
+    // builds it out of fields that are equally rough in both directions, and the difference
+    // is measurable — Indiana's ground carries 0.007 m of roughness after a one-metre
+    // detrend and ours carried 0.012, half again as much, at exactly the scale a wheel
+    // bounces on. Two thirds of that came from the rut carving and the ridden texture, and
+    // neither can simply be turned down: they are also what makes the groove.
+    //
+    // So it is taken out where it does not belong rather than never put in. Averaging along
+    // the track direction leaves anything that runs *with* the track — a groove, a berm, the
+    // line — untouched, and takes the edge off anything that does not.
+    //
+    // Braking chop runs across the track and so is attenuated by this; `RIDDEN_SMOOTH_M` is
+    // kept under a quarter of the shortest chop wavelength for that reason.
+    {
+        let src = heights.clone();
+        let taps = RIDDEN_SMOOTH_TAPS as i32;
+        for i in 0..gw * gh {
+            let w = ridden_at[i];
+            if w <= 0.0 {
+                continue;
+            }
+            let (fx, fz) = crate::trackprog::heading_vector(heading_at[i]);
+            let (cx, cz) = ((i % gw) as f32 * mps_x, (i / gw) as f32 * mps_z);
+            let mut sum = 0.0;
+            let mut norm = 0.0;
+            for k in -taps..=taps {
+                let d = k as f32 * RIDDEN_SMOOTH_M / taps as f32;
+                let g = sample_smooth(&src, gw, gh, (cx + fx * d) / mps_x, (cz + fz * d) / mps_z);
+                let weight = 1.0 - (k.abs() as f32 / (taps + 1) as f32);
+                sum += g * weight;
+                norm += weight;
+            }
+            let smoothed = sum / norm.max(1e-6);
+            heights[i] += (smoothed - heights[i]) * w * RIDDEN_SMOOTH;
         }
     }
 
@@ -6083,6 +6165,47 @@ pub fn slug(name: &str) -> String {
 mod tests {
     use super::*;
     use crate::trackprog::{Relief, Start, Terrain};
+
+    /// What our ruts are shaped like, on the same statistic a published track is measured by.
+    ///
+    /// ```text
+    /// cargo test --bin mxb-app -- --ignored --nocapture our_rut_shape
+    /// ```
+    /// Indiana, for comparison: across 0.115 m rms, along 0.068, anisotropy 1.70, floor
+    /// 0.99 m, wall 35 deg, 2.9 grooves at 2.48 m.
+    #[test]
+    #[ignore = "slow — synthesises a lap"]
+    fn our_rut_shape() {
+        let p: TrackProgram = match std::env::var("FROST_PROGRAM") {
+            Ok(path) => serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap(),
+            Err(_) => serde_json::from_str(DEMO).unwrap(),
+        };
+        let s = synthesise(&p).unwrap();
+        let g = crate::trackstats::Grid {
+            w: s.gw,
+            h: s.gh,
+            size_x: p.terrain.size_x,
+            size_z: p.terrain.size_z,
+            v: s.heights.clone(),
+        };
+        let step = STATION_STEP;
+        let stations: Vec<(f32, f32, f32)> =
+            s.stations.iter().map(|st| (st.x, st.z, st.heading)).collect();
+        let r = crate::trackstats::rut_shape(&stations, step, &g).expect("a rut shape");
+        println!("  {} stations over {:.0} m", stations.len(), stations.len() as f32 * step);
+        println!(
+            "  across {:.3} m rms   along {:.3} m rms   anisotropy {:.2}",
+            r.across_rms_m, r.along_rms_m, r.anisotropy
+        );
+        println!(
+            "  floor {:.2} m   wall {:.0} deg   {:.1} grooves at {:.2} m   chatter {:.3} m",
+            r.floor_m, r.wall_deg, r.grooves, r.spacing_m, r.chatter_m
+        );
+        println!(
+            "  chatter on the line {:.3} m   2 m off {:.3}   4 m off {:.3}",
+            r.chatter_zones_m[0], r.chatter_zones_m[1], r.chatter_zones_m[2]
+        );
+    }
 
     /// Pull a published track's ground sheets out of its `.map`, as PNGs.
     ///


### PR DESCRIPTION
"Too rough" turned out to be measurable.

`trackstats::rut_shape` measures what a lap's grooves are shaped like, on any track — published or generated: roughness across the line against roughness along it (a rut is sharp across and smooth along; noise is rough both ways), the width of a groove's flat floor, its wall angle, the count and spacing, and roughness after a one-metre detrend — the scale a wheel bounces on.

| | across | along | aniso | floor | grooves | chatter |
| --- | --- | --- | --- | --- | --- | --- |
| Indiana | 0.115 | 0.068 | 1.70 | 0.99 m | 2.9 at 2.48 m | **0.007** |
| ours, before | 0.104 | 0.068 | 1.52 | 0.80 m | 3.5 at 2.04 m | **0.012** |
| ours, now | 0.104 | 0.066 | 1.57 | 0.90 m | 3.2 at 2.23 m | **0.009** |

Indiana is uniformly smooth at the sub-metre scale — 0.008 on the line, 0.007 two metres off, 0.006 at four — so this is not a polish-distribution difference. Ours was half again as rough everywhere.

## What changed

- **The ridden ground is averaged along the track's own direction**, half a metre either way, weighted by how ridden the cell is. Anything running with the track — a groove, a berm, the line — is untouched; anything that does not gets its edge taken off. Isolating the terms first showed the base landscape already sits at Indiana's roughness and that the rut carving and the ridden texture each add as much again, so neither could simply be turned down: they are also what makes the groove.
- **The surface texture and the groove field roll off sooner** — three and two octaves rather than four. A groove field summed to four octaves carries as much shape at a third of the spacing as at the spacing itself, which is where the extra grooves and the fifth-narrower floors came from.

Braking chop runs across the track and so is attenuated by the smoothing — about a tenth of its height. `RIDDEN_SMOOTH_M` is kept under a quarter of the shortest chop wavelength for that reason.

`rut_shape_of` (published, `FROST_TRACK`) and `our_rut_shape` (generated) print the table above, so the next argument about this is settled with numbers.

1366 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)