### PR TITLE
fix(share): stop waiting on a host that has already taken the upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## 2026-09-06
 
 ### Fixed
+- Sharing a track is quicker. The upload no longer waits on the host after the files are
+  already up, and the app stays responsive while a share is being packed.
+
+## 2026-09-06
+
+### Fixed
 - The Servers tab lists the live MX Bikes servers. The app signs in to the master server the
   same way the game does, through your Steam copy of MX Bikes.
 

--- a/src-tauri/src/fileshare.rs
+++ b/src-tauri/src/fileshare.rs
@@ -282,9 +282,22 @@ pub async fn create(
     entries.push(bundle::ZipEntry { rel: "share.json".to_string(), src: manifest });
 
     let zip_path = work.join(format!("{}.zip", archive_stem(&items)));
-    bundle::zip_entries(&entries, &zip_path)?;
+    // Off the runtime: packing a track copies eighty-odd megabytes through a blocking read
+    // and write, and doing that on a runtime thread freezes every other async task in the
+    // app — the upload that follows included. `file_share_plan` beside it already does this.
+    let packed = std::time::Instant::now();
+    let zp = zip_path.clone();
+    tauri::async_runtime::spawn_blocking(move || bundle::zip_entries(&entries, &zp))
+        .await
+        .map_err(|e| anyhow::anyhow!("packing the share failed: {e}"))??;
 
     let size = bundle::file_size(&zip_path);
+    log::info!(
+        "share: packed {} into {} in {:.1}s",
+        bundle::human_size(size),
+        zip_path.display(),
+        packed.elapsed().as_secs_f32()
+    );
     let total = bundle::human_size(size);
     bundle::emit(app, EVENT, "uploading", Some(format!("Uploading {total}…")));
     let client = install::build_client()?;

--- a/src-tauri/src/upload.rs
+++ b/src-tauri/src/upload.rs
@@ -78,9 +78,28 @@ pub async fn upload_file(
     // shares the same track twice gets the same broken bundle twice.
     let mut last: Option<anyhow::Error> = None;
     for part_bytes in PART_STEPS {
+        let started = std::time::Instant::now();
         match upload_sliced(client, file, size, part_bytes, &on_part).await {
-            Ok(up) => return Ok(up),
-            Err(Short(e)) => last = Some(e),
+            Ok(up) => {
+                log::info!(
+                    "share: uploaded {} in {} part(s) of {} in {:.1}s",
+                    crate::bundle::human_size(size),
+                    up.parts.len(),
+                    crate::bundle::human_size(part_bytes),
+                    started.elapsed().as_secs_f32()
+                );
+                return Ok(up);
+            }
+            Err(Short(e)) => {
+                // Worth a line of its own: a recut sends the whole file again, so this is
+                // the difference between a twenty-second share and a three-minute one.
+                log::warn!(
+                    "share: a {} cut came back short after {:.1}s — recutting: {e:#}",
+                    crate::bundle::human_size(part_bytes),
+                    started.elapsed().as_secs_f32()
+                );
+                last = Some(e);
+            }
             Err(Fatal(e)) => return Err(e),
         }
     }
@@ -133,13 +152,27 @@ async fn upload_sliced(
                 format!("{stem}.part{}of{}.zip", i + 1, n)
             };
             let done = &done;
+            let src = file.to_path_buf();
             async move {
-                // Its own handle per slice: the reads are interleaved now, so a shared cursor
-                // would have them seeking over each other.
-                let bytes = read_slice_at(file, offset, len)
-                    .with_context(|| format!("reading {}", file.display()))
-                    .map_err(Fatal)?;
+                // Its own handle per slice, and off the runtime: the reads are interleaved
+                // now, so a shared cursor would have them seeking over each other — and a
+                // blocking 24 MiB read on a runtime thread stalls the slices beside it.
+                let started = std::time::Instant::now();
+                let bytes = tokio::task::spawn_blocking({
+                    let src = src.clone();
+                    move || read_slice_at(&src, offset, len)
+                })
+                .await
+                .map_err(|e| Fatal(anyhow::anyhow!("reading {} failed: {e}", src.display())))?
+                .with_context(|| format!("reading {}", src.display()))
+                .map_err(Fatal)?;
                 let url = catbox_upload(client, endpoint(), &name, &bytes, len).await?;
+                log::info!(
+                    "share: part {} of {n} ({}) took {:.1}s",
+                    i + 1,
+                    crate::bundle::human_size(len),
+                    started.elapsed().as_secs_f32()
+                );
                 let behind = done.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
                 on_part((behind + 1).min(n), n);
                 Ok::<(String, u64), UploadFail>((url, len))
@@ -247,15 +280,26 @@ pub(crate) async fn hosted_len(client: &Client, url: &str) -> Option<u64> {
 /// has the room it always had.
 const SETTLE_WAITS: [u64; 7] = [1, 2, 3, 3, 4, 4, 5];
 
+/// How many times running the host may decline to answer before we stop asking.
+///
+/// A `None` is not a short part — it is the host not saying, and [`catbox_upload`] accepts
+/// the part on `None` however long we wait for it. So sitting out the whole ladder on an
+/// unanswerable probe bought nothing and cost twenty-two seconds a part, which on a
+/// four-part track is most of a minute of an upload that had already finished. Two, not one:
+/// a 404 straight after the POST is catbox still registering the file, and that one clears.
+const NONE_PROBES: usize = 2;
+
 /// What the host is holding, once it has stopped growing — or the last thing it said.
 async fn settled_len(client: &Client, url: &str, expect: u64) -> Option<u64> {
     let mut last = hosted_len(client, url).await;
+    let mut unanswered = usize::from(last.is_none());
     for wait in SETTLE_WAITS {
-        if last == Some(expect) {
+        if last == Some(expect) || unanswered >= NONE_PROBES {
             return last;
         }
         tokio::time::sleep(std::time::Duration::from_secs(wait)).await;
         last = hosted_len(client, url).await;
+        unanswered = if last.is_none() { unanswered + 1 } else { 0 };
     }
     last
 }
@@ -447,6 +491,60 @@ mod tests {
                 return;
             }
         }
+    }
+
+    /// The same stand-in, but it keeps answering — the last reply repeats — and says how
+    /// many times it was asked. Counting the asks is the whole point: what went wrong with
+    /// the settle ladder was never a wrong answer, it was how long it kept asking for one.
+    fn serve_counting(
+        replies: Vec<&'static str>,
+    ) -> (String, std::sync::Arc<std::sync::atomic::AtomicUsize>) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let hits = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let seen = hits.clone();
+        std::thread::spawn(move || loop {
+            let Ok((mut sock, _)) = listener.accept() else { return };
+            let i = seen.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            drain_request(&mut sock);
+            let _ = sock.write_all(replies[i.min(replies.len() - 1)].as_bytes());
+            let _ = sock.flush();
+        });
+        (format!("http://127.0.0.1:{port}/part.zip"), hits)
+    }
+
+    /// What a host holding `total` bytes answers a `Range: bytes=0-0` with.
+    fn ranged(total: u64) -> &'static str {
+        Box::leak(
+            format!(
+                "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes 0-0/{total}\r\n\
+                 Content-Length: 1\r\nConnection: close\r\n\r\nx"
+            )
+            .into_boxed_str(),
+        )
+    }
+
+    /// A host that will not say what it is holding is not a host holding a short part, and
+    /// [`catbox_upload`] takes the part either way. So the ladder must stop asking rather
+    /// than sit out all seven waits to reach the answer it had at the second one — on a
+    /// four-part track that dead wait was most of a minute of an upload already finished.
+    #[tokio::test(start_paused = true)]
+    async fn an_unanswerable_probe_stops_asking() {
+        let missing: &'static str = Box::leak(reply("404 Not Found", "nope").into_boxed_str());
+        let (url, hits) = serve_counting(vec![missing]);
+        let client = Client::builder().build().unwrap();
+        assert_eq!(settled_len(&client, &url, 100).await, None);
+        assert_eq!(hits.load(std::sync::atomic::Ordering::Relaxed), NONE_PROBES);
+    }
+
+    /// The other direction, and the reason the ladder exists: a host that *is* answering,
+    /// with a part it is still writing, gets waited on until the number stops moving.
+    #[tokio::test(start_paused = true)]
+    async fn a_part_still_being_written_is_waited_out() {
+        let (url, hits) = serve_counting(vec![ranged(50), ranged(50), ranged(100)]);
+        let client = Client::builder().build().unwrap();
+        assert_eq!(settled_len(&client, &url, 100).await, Some(100));
+        assert_eq!(hits.load(std::sync::atomic::Ordering::Relaxed), 3);
     }
 
     fn reply(status: &str, body: &str) -> String {


### PR DESCRIPTION
Sharing an 85 MB track took a minute or more. It should take about thirteen seconds, and the extra was the app waiting on a question it had already given up on.

## What I measured

The real upload path against live catbox, with an 85 MB track (`Corpus_National.pkz`):

- **13 s** of upload, four parts, all stored to the byte.
- The `.pkz` is already deflate inside (174 MB → 85 MB), so the outer zip storing it raw is right — there is nothing left to compress.
- catbox ingests at ~2.7–6 MB/s from here, and three parts at once was no faster than one. That is the floor.

## The dead wait

`settled_len` checks that a part really stored, on a ladder of `1+2+3+3+4+4+5` = 22 s, exiting as soon as the host reports the expected size. It did not exit when the host would not answer at all: `None` never equals `Some(expect)`, so every wait ran. And `catbox_upload` accepts the part on `None` anyway —

```rust
Some(got) if got != expect => { ...retry... }
_ => return Ok(body),   // None lands here
```

— so those 22 s bought nothing. `hosted_len` returns `None` on any non-success status, which includes a 404 while catbox is still registering the file just posted. Four parts over two waves is up to 44 s of dead waiting on an upload that had already finished. 13 + 44 is the reported minute.

Now: two unanswered probes and it stops asking. A host that *is* answering, with a part it is still writing, is still waited out — that is what the ladder is for, and both directions have a test.

## Two others found on the way

- `fileshare::create` ran the blocking 85 MB zip straight on the async runtime, stalling every other task in the app while a share packed. `file_share_plan` immediately beside it already spawns for exactly this reason. Same for the 24 MiB slice reads, which were blocking the slices uploading next to them.
- Nothing in the share path logged anything, so "it's slow" had no number behind it. Per-part timings and the total now go to the log, plus a warning when a short part sends the whole file up again under a different cut — that re-slice is the genuine multi-minute path and it was invisible.

## Verification

- 8 upload tests, 12 fileshare tests pass, including two new ones covering both sides of the settle change.
- Live round trip re-run after the change: 13 s, four parts, all intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)