### PR TITLE
feat(tracks): a finish jump, where the lap ends and begins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 2026-09-06
 
+### Added
+- Generated tracks end the lap on a finish jump: a big tabletop on the main straight, with the
+  finish line past its landing and a gantry over it.
+
+## 2026-09-06
+
 ### Fixed
 - Sharing a track is quicker. The upload no longer waits on the host after the files are
   already up, and the app stays responsive while a share is being packed.

--- a/control-plane/src/trackgen.ts
+++ b/control-plane/src/trackgen.ts
@@ -226,17 +226,26 @@ what ten published circuits are made of:
                       then 18 m through 30° is ONE corner. Writing it as a single 165° arc of
                       constant radius is the clearest sign a lap was drawn rather than built.
   tightest radius     10.6-18.5 m at the median corner, down to 6.4 m at the hairpins.
-  straights           short. Indiana's run 21 m at the median and its longest is 62 m.
+  straights           short. Indiana's run 21 m at the median and its longest is 62 m. The
+                      main straight is the one exception: the start spur runs beside it and
+                      the finish jump stands on it.
   lap length          1800-2500 m.
 
 So: build each corner as a run of arcs, keep the straights short, and let the lap wander.
 Count the arcs before you send it — if straights outnumber corners you have written a shape.
 
 START THE LAP ON A STRAIGHT. A motocross start is forty gates in a line 48 m across, and the
-gate row, the finish line and the run at turn one all sit on the lap's opening straight — a lap
-that begins on a corner has its gates laid round a bend. So the FIRST segment is a straight of
-60-100 m, and the lap has to come back to it. That is the one long straight; the rest stay
-short. Leave it clear — no jumps in the first 40 m, riders are forty abreast there.
+gate row stands on its own spur beside the lap's opening straight, which is also where the
+finish line goes — a lap that begins on a corner has its gates laid round a bend. So the FIRST
+segment is a straight of 100-160 m, and the lap has to come back to it. That is the one long
+straight; the rest stay short.
+
+AND THAT STRAIGHT CARRIES THE FINISH JUMP. Every national ends the lap on one: the biggest
+tabletop on the track, 2.4-3.6 m tall, with the finish line painted past its landing. Put one
+there — leaving the first 18 m off the last corner clear so there is drive at it, and 10 m
+past the landing before the straight runs out. Leave it out and the app builds it anyway,
+taking the ground whatever you put there was standing on; what the app cannot do is lengthen
+the straight, so give it one long enough.
 
 THE LAP MUST STILL CLOSE, and a lap like this closes the same way: the signed angles sum to
 ±360° and the straights bring it home. A serpentine that turns 2400° in total and 360° net is

--- a/src-tauri/src/trackllm.rs
+++ b/src-tauri/src/trackllm.rs
@@ -516,7 +516,68 @@ fn repair(prog: &mut TrackProgram) -> Vec<String> {
         }
     }
 
-    // 6. Fit the height budget. It exists only because samples are quantised against it, and
+    // 6. Build the finish jump: the one on the main straight, where the lap ends and begins.
+    //
+    //    Every national has one and no model has ever written one, because it is not a thing
+    //    the brief asks for — it is a place on the lap. And where it goes is arithmetic: what
+    //    is left of the opening straight once the corner exit and the run-off are taken out,
+    //    and what the drive down it carries over the deck. So it is built here, at the biggest
+    //    size the straight will hold, and left alone when the lap already has one.
+    if let (Some((from, to)), None) = (prog.finish_window(), prog.finish_jump()) {
+        let speed = crate::trackspeed::of(prog);
+        let room = to - from;
+        // The speed halfway down the window, which is about where the lip ends up.
+        let lip_at = from + room * 0.5;
+        let mut built = None;
+        let mut height = crate::trackprog::FINISH_JUMP_M.1;
+        while height >= crate::trackprog::FINISH_JUMP_M.0 - 1e-3 {
+            let ramp = crate::trackprog::face_run(
+                height,
+                crate::trackprog::JUMP_FACE_DEG,
+                crate::trackprog::JUMP_FACE_MIN_M,
+            );
+            let deg = crate::trackprog::face_sweep(height, ramp).to_degrees();
+            // A deck no longer than the run at it carries: a tabletop nobody can get over the
+            // top of is a hill with a flat bit on it, and this is the one everybody lands on.
+            let deck = speed.carry(lip_at, deg).clamp(
+                crate::trackprog::TABLETOP_DECK_M,
+                crate::trackprog::FINISH_DECK_MAX_M,
+            );
+            let length = crate::trackprog::finish_jump_length(height, deck);
+            if length <= room {
+                built = Some((height, deck, length, from + (room - length) * 0.5));
+                break;
+            }
+            height -= 0.1;
+        }
+        if let Some((height, deck, length, at)) = built {
+            // Whatever stood on that ground goes. Two jumps blended into each other are one
+            // shape with a dip in it, and the finish jump is the one that stands.
+            let taken = prog
+                .features
+                .iter()
+                .filter(|f| f.at() + f.length() > at && f.at() < at + length)
+                .map(|f| f.name())
+                .collect::<Vec<_>>()
+                .join(", ");
+            prog.features
+                .retain(|f| f.at() + f.length() <= at || f.at() >= at + length);
+            prog.features.push(Feature::Tabletop { at, length, height });
+            prog.features.sort_by(|a, b| a.at().total_cmp(&b.at()));
+            done.push(format!(
+                "built the finish jump at {at:.0} m: a {height:.1} m tabletop {length:.0} m \
+                 across a {deck:.0} m deck, taken at {:.0} km/h{}",
+                speed.at(lip_at) * 3.6,
+                if taken.is_empty() {
+                    String::new()
+                } else {
+                    format!(" — it takes the ground the {taken} stood on")
+                }
+            ));
+        }
+    }
+
+    // 7. Fit the height budget. It exists only because samples are quantised against it, and
     //    it is a number the synthesiser already knows — there was never a reason to make the
     //    model guess it and then be told off for guessing wrong.
     if let Ok(fitted) = crate::tracksynth::with_fitted_budget(prog) {
@@ -709,6 +770,23 @@ pub fn review(prog: &TrackProgram) -> Review {
                 tracksynth::START_FAN_HALF_M * 2.0,
             ));
         }
+    }
+    // And whether the lap ends on a jump. `repair` builds one wherever there is room for it,
+    // so reaching here without one means there was none — which is the layout's business and
+    // not a number anything can fix.
+    if prog.finish_jump().is_none() {
+        let need = crate::trackprog::FINISH_RUNUP_M
+            + crate::trackprog::finish_jump_length(
+                crate::trackprog::FINISH_JUMP_M.0,
+                crate::trackprog::TABLETOP_DECK_M,
+            )
+            + crate::trackprog::FINISH_RUNOUT_M;
+        notes.push(format!(
+            "the lap has no finish jump: the main straight runs {opening:.0} m and one needs \
+             about {need:.0} m — the corner exit, the jump itself, and somewhere to land \
+             before the next corner. Make the opening straight that long and the finish jump \
+             gets built on it."
+        ));
     }
     if let Some((a, b, gap)) = self_crossing(prog) {
         // Named in the model's own terms. It wrote a list of segments, not a distance round
@@ -1412,11 +1490,117 @@ mod tests {
         p.features = vec![Feature::Double { at: hairpin_exit, height: 2.5, gap: 24.0, lip: 10.0 }];
         let done = repair(&mut p);
         assert!(done.iter().any(|d| d.contains("shrank")), "{done:?}");
-        let Feature::Double { gap, .. } = p.features[0] else { panic!("still a double") };
+        // By kind rather than by index: the lap gains a finish jump on its main straight, and
+        // the features are kept in the order they are ridden.
+        let Some(Feature::Double { gap, .. }) =
+            p.features.iter().find(|f| matches!(f, Feature::Double { .. }))
+        else {
+            panic!("still a double")
+        };
+        let gap = *gap;
         assert!(gap < 24.0, "the gap was not shrunk: {gap:.1} m");
         assert!(
             !review(&p).problems.iter().any(|c| c.contains("cannot be cleared")),
             "shrinking it did not settle the complaint"
         );
     }
+
+    /// A lap arrives with nothing on its main straight and leaves with the jump the finish
+    /// line is painted past.
+    #[test]
+    fn a_lap_is_given_the_jump_it_ends_on() {
+        let mut p = tweaked(|p| p.features.retain(|f| f.at() > 200.0));
+        assert!(p.finish_jump().is_none(), "the straight was cleared");
+        let done = repair(&mut p);
+        let f = p.finish_jump().expect("a lap ends on a jump").clone();
+        assert!(
+            matches!(f, Feature::Tabletop { .. }),
+            "the finish jump is a tabletop, not a {}: everybody lands on it",
+            f.name()
+        );
+        let (lo, hi) = crate::trackprog::FINISH_JUMP_M;
+        assert!(
+            f.height() >= lo && f.height() <= hi,
+            "it stands {:.1} m against {lo:.1}–{hi:.1}",
+            f.height()
+        );
+        // On the main straight, with drive at it and ground after it.
+        let (from, to) = p.finish_window().expect("the example has room for one");
+        assert!(
+            f.at() >= from && f.at() + f.length() <= to,
+            "it runs {:.0}–{:.0} m and the window is {from:.0}–{to:.0}",
+            f.at(),
+            f.at() + f.length()
+        );
+        // And in front of nobody who has just left the gate: the pack rides the spur and
+        // merges into turn one, which is past the far end of this.
+        let joins = p.start_line().expect("a start").joins_at;
+        assert!(
+            f.at() + f.length() <= joins,
+            "it ends at {:.0} m and the start merges in at {joins:.0}",
+            f.at() + f.length()
+        );
+        assert!(
+            done.iter().any(|l| l.contains("finish jump")),
+            "the repair said nothing about it: {done:?}"
+        );
+    }
+
+    /// The line goes where the rider comes down, not up the face of the jump.
+    #[test]
+    fn the_finish_line_is_painted_past_the_landing() {
+        let p = tweaked(|_| {});
+        let f = p.finish_jump().expect("the worked example ends on a jump");
+        let line = crate::tracksynth::finish_at(&p);
+        assert!(
+            line > f.at() + f.length(),
+            "the line is at {line:.0} m and the jump ends at {:.0}",
+            f.at() + f.length()
+        );
+        assert!(
+            line < p.opening_straight(),
+            "the line is at {line:.0} m and the main straight is {:.0} m long",
+            p.opening_straight()
+        );
+    }
+
+    /// Built once. `repair` runs on every attempt and on every edit in the studio, and a
+    /// finish jump that is rebuilt each time is a straight that loses a feature each time.
+    #[test]
+    fn the_finish_jump_is_built_once() {
+        let mut p = tweaked(|p| p.features.retain(|f| f.at() > 200.0));
+        repair(&mut p);
+        let (was, n) = (p.finish_jump().cloned(), p.features.len());
+        repair(&mut p);
+        assert_eq!(p.features.len(), n, "the second repair changed the features");
+        assert_eq!(
+            format!("{:?}", p.finish_jump()),
+            format!("{was:?}"),
+            "the second repair moved the finish jump"
+        );
+    }
+
+    /// A lap with no room for one says so rather than getting a jump squeezed onto a corner.
+    #[test]
+    fn a_lap_with_no_room_is_told_rather_than_given_one() {
+        // A paperclip: two hairpins fifty metres apart. Nothing on it is long enough to hold
+        // a corner exit, a jump and somewhere to land, and there is no longer straight for
+        // the repair to move the start onto either.
+        let mut p = hairpin_then_straight();
+        p.segments = vec![
+            Segment::Straight { length: 50.0, rise: 0.0 },
+            Segment::Arc { radius: 10.0, angle: 180.0, rise: 0.0 },
+            Segment::Straight { length: 50.0, rise: 0.0 },
+            Segment::Arc { radius: 10.0, angle: 180.0, rise: 0.0 },
+        ];
+        assert!(p.finish_window().is_none(), "there should be no room");
+        repair(&mut p);
+        assert!(p.finish_jump().is_none(), "a jump was built where there was no room");
+        assert!(
+            review(&p).notes.iter().any(|n| n.contains("no finish jump")),
+            "nothing was said about it: {:?}",
+            review(&p).notes
+        );
+    }
 }
+

--- a/src-tauri/src/trackprog.rs
+++ b/src-tauri/src/trackprog.rs
@@ -460,6 +460,45 @@ pub fn tabletop_faces(height: f32, length: f32) -> (f32, f32, f32) {
     (up, top, down)
 }
 
+/// How tall the finish jump is built, metres.
+///
+/// The jump the lap ends and begins on, and on a national it is one of the biggest on the
+/// track — a long tabletop on the main straight with the line painted past its landing. The
+/// range is the top of the published spread rather than the middle of it: this is the one
+/// jump a track is photographed on.
+pub const FINISH_JUMP_M: (f32, f32) = (2.4, 3.6);
+
+/// The longest deck a finish jump gets, metres. Published tabletop decks run six to twelve,
+/// and the finish one is at the long end because it is the one everybody lands on.
+pub const FINISH_DECK_MAX_M: f32 = 12.0;
+
+/// Bare ground off the last corner before the finish jump's face, metres. A takeoff at the
+/// corner exit is a takeoff nobody has any drive at.
+pub const FINISH_RUNUP_M: f32 = 18.0;
+
+/// Ground past the landing before the straight runs out, metres — where the line is painted
+/// and where a rider gets back on the brakes for the next corner.
+pub const FINISH_RUNOUT_M: f32 = 10.0;
+
+/// How far past the landing the line itself goes, metres. A finish line marks the ground a
+/// rider comes down on, so it sits just off the end of the ramp rather than on it.
+pub const FINISH_LINE_PAST_M: f32 = 4.0;
+
+/// The whole footprint of a finish jump of this height with this deck, metres.
+///
+/// A tabletop's ramps are the longer of an angle and a fraction of the stated length, so the
+/// length and the faces define each other. Solved by iterating: the fraction is 0.44 at
+/// worst, so it converges geometrically and eight passes is far past the millimetre.
+pub fn finish_jump_length(height: f32, deck: f32) -> f32 {
+    let deck = deck.max(TABLETOP_DECK_M);
+    let mut len = height.abs() + deck;
+    for _ in 0..8 {
+        let (up, _, down) = tabletop_faces(height, len);
+        len = up + deck + down;
+    }
+    len
+}
+
 /// The shortest straight a start will fit beside, metres.
 ///
 /// A motocross start is a gate row and a sprint at the first turn, all of it in a line,
@@ -755,10 +794,15 @@ impl Feature {
 /// a corner puts forty gates round a bend. Turned round to start there rather than redrawn —
 /// see [`TrackProgram::rotate_start`], and the printer beside its tests.
 ///
+/// The finish jump stands on that straight: a 3.6 m tabletop 49 m across, fifty metres of
+/// drive off the last corner, with the line painted past its landing. See
+/// [`TrackProgram::finish_window`] — a lap that arrives without one has one built.
+///
 /// 1905 m, 137 segments of which 109 are arcs, seventeen corners at a median 12.6 m through
-/// their tightest point — Indiana's is 10.6 — and 2651° of turning. Forty features, seven of them over 2.2 m and the
-/// rest small ground, which is the ratio Indiana has. It climbs 22 m round the lap, which is
-/// Indiana's 21.3 — half the published corpus is a hillside and a flat plot rides like one.
+/// their tightest point — Indiana's is 10.6 — and 2651° of turning. Thirty-seven features,
+/// eight of them over 2.2 m and the rest small ground, which is the ratio Indiana has. It
+/// climbs 22 m round the lap, which is Indiana's 21.3 — half the published corpus is a
+/// hillside and a flat plot rides like one.
 ///
 /// This is the schema's own test. It is parsed by the test suite, synthesised, and measured
 /// against published tracks, so it cannot drift away from what the code accepts.
@@ -913,8 +957,7 @@ pub const EXAMPLE: &str = r#"{
       ],
       "features": [
         { "kind": "roller", "at": 31.3, "length": 11.3, "height": 0.8 },
-        { "kind": "tabletop", "at": 64.5, "length": 33.0, "height": 1.5 },
-        { "kind": "stepUp", "at": 97.8, "length": 20.9, "height": 2.0 },
+        { "kind": "tabletop", "at": 52.3, "length": 48.5, "height": 3.6 },
         { "kind": "roller", "at": 131.0, "length": 14.4, "height": 0.75 },
         { "kind": "berm", "at": 265.5, "length": 8.0, "height": 1.7 },
         { "kind": "tabletop", "at": 295.7, "length": 30.0, "height": 1.5 },
@@ -1454,6 +1497,39 @@ impl TrackProgram {
         let mut segments = vec![Segment::Straight { length: START_SPRINT_M, rise: 0.0 }];
         segments.extend(merge.into_iter().filter(|s| s.length() > 0.5));
         Some(StartLine { start, segments, joins_at, side })
+    }
+
+    /// The stretch of the main straight a finish jump may stand on: metres round the lap,
+    /// from the corner exit to where the ground runs out.
+    ///
+    /// `None` when the lap has no start — a track whose gates end up on the racing line has
+    /// forty riders coming through here off a standing start, and nothing big belongs in
+    /// front of them. Otherwise it ends at the shorter of the straight's own end and where
+    /// the start spur merges back in, for the same reason.
+    pub fn finish_window(&self) -> Option<(f32, f32)> {
+        let run = self.opening_straight();
+        let line = self.start_line()?;
+        let mut to = run - FINISH_RUNOUT_M;
+        if line.joins_at < to {
+            to = line.joins_at - 5.0;
+        }
+        let from = FINISH_RUNUP_M;
+        (to - from >= finish_jump_length(FINISH_JUMP_M.0, TABLETOP_DECK_M)).then_some((from, to))
+    }
+
+    /// The finish jump, if the lap has one: the tallest jump standing in that window.
+    ///
+    /// Found rather than recorded. A jump is the finish jump because of where it is and how
+    /// big it is, and asking the ground is what keeps the answer true after an edit moves
+    /// something — there is no flag to go stale.
+    pub fn finish_jump(&self) -> Option<&Feature> {
+        let (from, to) = self.finish_window()?;
+        self.features
+            .iter()
+            .filter(|f| matches!(f, Feature::Tabletop { .. } | Feature::Double { .. }))
+            .filter(|f| f.height() >= FINISH_JUMP_M.0 - 0.1)
+            .filter(|f| f.at() >= from - 1.0 && f.at() + f.length() <= to + 1.0)
+            .max_by(|a, b| a.height().total_cmp(&b.height()))
     }
 
     /// Begin the lap at segment `index`: the same track, ridden from a different point on it.

--- a/src-tauri/src/trackscenery.rs
+++ b/src-tauri/src/trackscenery.rs
@@ -1373,6 +1373,32 @@ pub fn build(prog: &TrackProgram, syn: &Synth) -> Scenery {
     gate.append(&edfwrite::moved(&beam, [st.x, highest + 4.6, st.z]));
     tally.push(("gate", 1));
 
+    // And one over the finish line itself, which is where the finish jump lands. The same
+    // shape as the gate's, narrower — it spans the racing line rather than a row of forty
+    // gates — and taller, because what comes under it has just come off a three-metre
+    // tabletop.
+    {
+        let st = at(crate::tracksynth::finish_at(prog));
+        let (rx, rz) = crate::trackprog::right_vector(st.heading);
+        let span = half + 4.0;
+        let feet: Vec<(f32, f32)> = [-1.0f32, 1.0]
+            .iter()
+            .map(|side| (st.x + rx * span * side, st.z + rz * span * side))
+            .collect();
+        if feet.iter().all(|(x, z)| inside(prog, *x, *z, 2.0)) {
+            let mut highest = f32::NEG_INFINITY;
+            for (x, z) in &feet {
+                let foot = ground(syn, *x, *z);
+                highest = highest.max(foot);
+                gate.append(&edfwrite::moved(&edfwrite::cuboid(0.5, 6.0, 0.5), [*x, foot, *z]));
+            }
+            let beam =
+                edfwrite::turned(&edfwrite::cuboid(span * 2.0, 1.2, 0.3), across(st.heading));
+            gate.append(&edfwrite::moved(&beam, [st.x, highest + 5.6, st.z]));
+            tally.push(("finish gantry", 1));
+        }
+    }
+
     // One model a kind, each with its own single sheet. Not one model of several materials:
     // TerrainEd faults on the second material in a model whatever the geometry — see
     // `edfwrite`'s note and the case-by-case test behind it. PiBoSo's own example track is
@@ -1641,6 +1667,41 @@ mod tests {
         assert!(
             worst > half,
             "something stands {worst:.1} m from the centreline, inside a {half:.1} m half-width"
+        );
+    }
+
+    /// The finish line has a gantry over it, not only the gate row.
+    #[test]
+    fn a_gantry_stands_over_the_finish_line() {
+        let (p, s) = demo();
+        let sc = build(&p, &s);
+        assert_eq!(
+            sc.tally.iter().find(|(k, _)| *k == "finish gantry").map(|(_, v)| *v),
+            Some(1),
+            "no gantry over the finish line: {:?}",
+            sc.tally
+        );
+        let line = crate::tracksynth::finish_at(&p);
+        let st = p
+            .stations(0.5)
+            .into_iter()
+            .min_by(|a, b| (a.s - line).abs().total_cmp(&(b.s - line).abs()))
+            .expect("a station at the line");
+        let (fx, fz) = crate::trackprog::heading_vector(st.heading);
+        // A beam, over the line and over a rider's head. Measured along the lap rather than
+        // as a distance: the beam spans the track, so its nearest vertex is out at the post.
+        let clear = sc
+            .files
+            .iter()
+            .filter(|(f, _)| f == "gate.edf")
+            .flat_map(|(_, b)| crate::edf::parse_world(b))
+            .flat_map(|n| n.positions.chunks_exact(3).map(|v| [v[0], v[1], v[2]]).collect::<Vec<_>>())
+            .filter(|v| ((v[0] - st.x) * fx + (v[2] - st.z) * fz).abs() < 3.0)
+            .map(|v| v[1] - ground(&s, v[0], v[2]))
+            .fold(f32::MIN, f32::max);
+        assert!(
+            clear > 4.5,
+            "the highest thing over the finish line is {clear:.1} m up"
         );
     }
 

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -3271,8 +3271,16 @@ const GRID_LANE_M: f32 = 1.2;
 /// On the lap's opening straight, which is the main straight — riders cross it on every lap.
 /// The gate row is not here at all any more: it stands on the start straight, which is its
 /// own line beside the lap. See [`StartSpur`].
-fn finish_at(prog: &TrackProgram) -> f32 {
+///
+/// Past the finish jump's landing when the lap has one, because that is what a finish line
+/// marks: the ground a rider comes down on. Anywhere else and the line is painted up the face
+/// of the jump it belongs to.
+pub(crate) fn finish_at(prog: &TrackProgram) -> f32 {
     let run = prog.opening_straight();
+    if let Some(f) = prog.finish_jump() {
+        let past = f.at() + f.length() + crate::trackprog::FINISH_LINE_PAST_M;
+        return past.clamp(10.0, (run - 2.0).max(10.0));
+    }
     if run < 20.0 {
         return (prog.lap_length() * 0.06).clamp(10.0, 40.0);
     }
@@ -8861,6 +8869,54 @@ mod tests {
         }
     }
 
+    /// Look at the finish jump.
+    ///
+    /// ```text
+    /// FROST_SHOT=/tmp/shots cargo test -- --ignored --nocapture the_finish_jump_picture
+    /// ```
+    #[test]
+    #[ignore = "writes pictures to look at — set FROST_SHOT"]
+    fn the_finish_jump_picture() {
+        let dir = std::env::var("FROST_SHOT").expect("set FROST_SHOT");
+        let dir = Path::new(&dir);
+        std::fs::create_dir_all(dir).unwrap();
+        let p: TrackProgram = serde_json::from_str(crate::trackprog::EXAMPLE).unwrap();
+        let f = p.finish_jump().expect("a finish jump").clone();
+        let s = synthesise(&p).unwrap();
+        let mid = f.at() + f.length() * 0.5;
+        let k = s
+            .stations
+            .iter()
+            .enumerate()
+            .min_by(|a, b| (a.1.s - mid).abs().total_cmp(&(b.1.s - mid).abs()))
+            .unwrap()
+            .0;
+        let st = s.stations[k];
+        let look = Painted::of(&p, &s);
+        look.crop(&s, &dir.join("finishjump.ppm"), (st.x, st.z), 90.0, 900);
+        let span = (110.0 / s.mps) as usize;
+        preview_crop(
+            &s,
+            &dir.join("finishrelief.ppm"),
+            ((st.x / s.mps) as usize).saturating_sub(span / 2),
+            ((st.z / s.mps) as usize).saturating_sub(span / 2),
+            span,
+            span,
+        );
+        preview(&s, &dir.join("finishlap.ppm"));
+        println!("finish jump {:.1} m tall, {:.0}–{:.0} m round the lap, line at {:.0} m",
+            f.height(), f.at(), f.at() + f.length(), finish_at(&p));
+        // The main straight in elevation, a quarter-metre a sample: the one view a jump's
+        // shape can actually be read off.
+        let mut rows = String::new();
+        let mut u = 0.0f32;
+        while u <= p.opening_straight() {
+            rows.push_str(&format!("{u:.2} {:.3}\n", height_at_arc(&s, u)));
+            u += 0.25;
+        }
+        std::fs::write(dir.join("finishprofile.txt"), rows).unwrap();
+    }
+
     /// Our own 32-bit BGRA TGA, bottom-up, back into something a viewer opens.
     fn tga_to_ppm(tga: &[u8], dim: usize, out: &Path) {
         let px = &tga[18..18 + dim * dim * 4];
@@ -8907,6 +8963,58 @@ mod tests {
             }
         }
         let _ = std::fs::write(out, ppm);
+    }
+
+    /// The finish jump is on the ground, and the line is past it.
+    ///
+    /// The document is one thing and the terrain is another — a jump that exists only in the
+    /// feature list is a jump nobody rides. Measured against the two feet rather than against
+    /// a fixed height, because the worked example climbs 22 m round the lap and the ground
+    /// under a fifty-metre jump is not level.
+    #[test]
+    fn the_lap_ends_on_a_jump_that_is_really_there() {
+        let p: TrackProgram = serde_json::from_str(crate::trackprog::EXAMPLE).unwrap();
+        let f = p.finish_jump().expect("the worked example ends on a jump").clone();
+        let (at, len, height) = (f.at(), f.length(), f.height());
+        let s = synthesise(&p).unwrap();
+        let foot = (height_at_arc(&s, at - 3.0) + height_at_arc(&s, at + len + 3.0)) * 0.5;
+        let profile: Vec<f32> = (0..=(len as usize))
+            .map(|i| height_at_arc(&s, at + i as f32) - foot)
+            .collect();
+        let peak = profile.iter().copied().fold(f32::MIN, f32::max);
+        assert!(
+            peak > height * 0.8 && peak < height * 1.6,
+            "a {height:.1} m finish jump came out {peak:.2} m over its own feet: {:?}",
+            profile.iter().map(|h| (h * 10.0).round() / 10.0).collect::<Vec<_>>()
+        );
+        // And it has a top. A tabletop whose ramps meet at a point is a double, whatever the
+        // program calls it, and the finish jump is the one everybody has to land on. Judged as
+        // a grade against the ramp's own rather than against level: a jump is built on a pad
+        // that is cut roughly level and not perfectly, so a deck on a hillside slopes a little
+        // and should.
+        let (up, deck, _) = crate::trackprog::tabletop_faces(height, len);
+        assert!(deck >= crate::trackprog::TABLETOP_DECK_M, "the deck is {deck:.1} m");
+        let h = |u: f32| profile[(u.round() as usize).min(profile.len() - 1)];
+        let (a, b) = (up + deck * 0.2, up + deck * 0.8);
+        let flat = (h(b) - h(a)).abs() / (b - a);
+        let ramp = (h(up) - h(0.0)) / up;
+        assert!(
+            ramp > 0.2 && flat * 3.0 < ramp,
+            "the deck runs at {:.0}% and the ramp at {:.0}% — that is a point, not a top",
+            flat * 100.0,
+            ramp * 100.0
+        );
+        // The line is painted on the ground a rider comes down on, not up the face. Measured
+        // as how far below the deck it is: the lap climbs, so "level with the foot" is not a
+        // thing the ground does anywhere near a jump.
+        let line = finish_at(&p);
+        let below = (peak + foot) - height_at_arc(&s, line);
+        assert!(
+            line > at + len && below > height * 0.6,
+            "the finish line is at {line:.0} m, {below:.2} m under the deck of a {height:.1} m \
+             jump that ends at {:.0}",
+            at + len
+        );
     }
 
     fn height_at_arc(s: &Synth, at: f32) -> f32 {


### PR DESCRIPTION
Every national ends the lap on a jump and no generated track had one. The main straight carried whatever the model happened to put there, and the finish line was painted at a fixed 40% of it — often up the face of something.

## What a generated track gets now

The lap's main straight — the one the start spur runs beside — carries a finish jump: the biggest tabletop the straight will hold, 2.4–3.6 m tall with a 6–12 m deck, the finish line painted past its landing, and a gantry over it. On the worked example that comes out a 3.6 m tabletop, 49 m across a 12 m deck, taken at 71 km/h, with the line at 105 m.

## How it is decided

- **`trackprog`** — the numbers, and two accessors. `finish_window` is the stretch of the opening straight a finish jump may stand on: 18 m of drive off the last corner, 10 m of run-out, and it ends where the start spur merges back in, so a standing start never meets it. `finish_jump` finds one by where it is and how big it is rather than by a flag that goes stale under an edit.
- **`trackllm`** — `repair` steps the height down from 3.6 m until the footprint fits the window, sizes the deck to what `trackspeed` says the drive at it actually carries over the top, and takes the ground anything standing there was on. It leaves an existing one alone, so it is a no-op on a lap that already ends well. `review` says so, with the length the straight needs, when there is no room.
- **`tracksynth`** — `finish_at` puts the line past the landing instead of at a fixed fraction of the straight.
- **`trackscenery`** — a gantry over the finish line, beside the one over the gate row.
- **The worked example** carries its own finish jump, so repairing it changes nothing and the model has one to copy.
- **The prompt** asks for a 100–160 m main straight and says it carries the finish jump.

## Verified

1378 tests pass. Three are new:

- the jump is really in the terrain — measured off the built heightfield, it stands its height over its own two feet, and its deck is a *top* rather than a point (judged as a grade against the ramp's own, because a pad on a hillside slopes and should);
- the finish line lands past the landing and well below the deck;
- a gantry spans the line above riding height.

Profile of the example's main straight, sampled off the built terrain every metre from the jump's foot: 0.00 m at 49 m, rising to +5.98 at 78 (a 16 m face, ~26° at its steepest), a deck to 79, then down to +3.6 by 95. The whole straight climbs 16 m across 145 — that is the hillside the lap is cut into, not the jump.

## Worth knowing

The no-finish-jump case goes back to the model as a *note*, and notes block acceptance — so a lap whose longest straight is under about 58 m now costs a generation attempt instead of shipping without one. That threshold sits just under the 60 m a start line already needs, so in practice the two fail together.

No DB or schema changes: the jump is a `tabletop` feature, which the schema already had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)