### PR TITLE
fix(tracks): a generated lap no longer runs out of room

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 2026-09-06
 
+### Fixed
+- Generating a track holds a full-length lap. A long circuit no longer runs out of room
+  part-way through being written, which is what turned a good design into "that didn't parse".
+
+## 2026-09-06
+
 ### Changed
 - The track creator is laid out the way you work: the lap as a numbered list on the left, a
   plan view of the circuit in the middle, and the numbers for whichever step you pick on the

--- a/control-plane/src/trackgen.ts
+++ b/control-plane/src/trackgen.ts
@@ -378,6 +378,20 @@ function ask(model: string) {
   };
 }
 
+/**
+ * How long the answer may be, in tokens.
+ *
+ * A published-length lap is 130 segments and forty features, and the thinking that lays it
+ * out is counted against the same ceiling. At 16000 the two together ran off the end: the
+ * program came back a truncated string and every attempt was spent on "that didn't parse",
+ * which reads as a model that cannot write JSON rather than one that was cut off.
+ *
+ * Raising it is what forces the streamed call above — the SDK will not take a non-streaming
+ * request whose ceiling could run past ten minutes. Not raised further than this because the
+ * app waits on one response and gives up at ten minutes.
+ */
+const MAX_ANSWER_TOKENS = 32000;
+
 /** Briefs longer than this are not briefs. */
 const MAX_BRIEF = 2000;
 
@@ -430,9 +444,12 @@ export async function generateTrack(request: Request, env: Env): Promise<Respons
   const client = new Anthropic({ apiKey: env.ANTHROPIC_API_KEY });
   try {
     const chosen = ask(env.TRACK_MODEL?.trim() || MODEL);
-    const response = await client.messages.parse({
+    // Streamed, and not for the progress: the SDK refuses a non-streaming request whose
+    // ceiling could take it past ten minutes, so `max_tokens` cannot be raised without this.
+    // The answer is still assembled here and returned whole — the app waits for one JSON body.
+    const stream = client.messages.stream({
       model: chosen.model,
-      max_tokens: 16000,
+      max_tokens: MAX_ANSWER_TOKENS,
       system: SYSTEM,
       messages,
       // Laying out a lap is arithmetic the model would have to do — except most of it is
@@ -443,6 +460,7 @@ export async function generateTrack(request: Request, env: Env): Promise<Respons
         ...(chosen.effort ? { effort: chosen.effort } : {}),
       },
     });
+    const response = await stream.finalMessage();
 
     if (response.stop_reason === "refusal") {
       return json(422, { error: "the model declined that brief" });

--- a/src-tauri/src/trackllm.rs
+++ b/src-tauri/src/trackllm.rs
@@ -1040,12 +1040,14 @@ impl Ask for ControlPlane {
             problems: attempt.problems.clone(),
         };
         // Generously long: the model thinks before it writes, and a lap is a few thousand
-        // tokens of output.
+        // tokens of output. Ten minutes rather than five because the answer's own ceiling was
+        // raised — a full-length lap plus the thinking that lays it out is most of 32k tokens,
+        // and a client that gives up at five minutes throws away attempts that were working.
         let res = reqwest::Client::new()
             .post(format!("{}/v1/track/generate", self.base.trim_end_matches('/')))
             .bearer_auth(&self.token)
             .json(&body)
-            .timeout(std::time::Duration::from_secs(300))
+            .timeout(std::time::Duration::from_secs(600))
             .send()
             .await
             .context("couldn't reach the track service")?;

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -8936,10 +8936,11 @@ mod tests {
         }
     }
 
-    /// Look at the finish jump.
+    /// Look at the finish jump — the worked example's, or any track program's.
     ///
     /// ```text
-    /// FROST_SHOT=/tmp/shots cargo test -- --ignored --nocapture the_finish_jump_picture
+    /// FROST_SHOT=/tmp/shots [FROST_PROGRAM=track/program.json] \
+    ///   cargo test -- --ignored --nocapture the_finish_jump_picture
     /// ```
     #[test]
     #[ignore = "writes pictures to look at — set FROST_SHOT"]
@@ -8947,7 +8948,11 @@ mod tests {
         let dir = std::env::var("FROST_SHOT").expect("set FROST_SHOT");
         let dir = Path::new(&dir);
         std::fs::create_dir_all(dir).unwrap();
-        let p: TrackProgram = serde_json::from_str(crate::trackprog::EXAMPLE).unwrap();
+        let json = match std::env::var("FROST_PROGRAM") {
+            Ok(path) => std::fs::read_to_string(path).expect("read the program"),
+            Err(_) => crate::trackprog::EXAMPLE.to_string(),
+        };
+        let p: TrackProgram = serde_json::from_str(&json).unwrap();
         let f = p.finish_jump().expect("a finish jump").clone();
         let s = synthesise(&p).unwrap();
         let mid = f.at() + f.length() * 0.5;


### PR DESCRIPTION
A full-length lap is 130 segments and forty features, and the thinking that lays it out is counted against the same ceiling. At `max_tokens: 16000` the two together overran, so the program came back as a truncated string — and every remaining attempt was spent on *"that didn't parse"*, which reads as a model that cannot write JSON rather than one that was cut off mid-sentence.

## The change

- **Ask for the program over a stream.** This is what unblocks the ceiling: the SDK refuses a non-streaming request whose `max_tokens` could take it past ten minutes (`Streaming is required for operations that may take longer than 10 minutes`), which is a 500 out of the worker, not a 400 you can read. The answer is still assembled with `finalMessage()` and returned whole, so the app sees no change in shape and `parsed_output` still carries the structured output.
- **32000 tokens for the answer**, named and explained rather than sitting inline.
- **The app waits ten minutes rather than five.** Measured attempts run 115–178 s each; the old 300 s timeout was close enough to throw away attempts that were working.
- **The finish-jump picture test takes `FROST_PROGRAM`**, so a generated track can be looked at the same way the worked example can.

## Verified

Against a live Sonnet 5 through a local `wrangler dev`, same brief throughout:

| | before | after |
|---|---|---|
| answers that parsed | truncated at attempt 8 | 5 of 5 came back whole |
| per attempt | — | 178 s, 122 s, 126 s, 116 s, 115 s |

1411 Rust tests and the control-plane suite pass.

## Not fixed here

The shipped model is still Haiku, which draws laps that cross themselves and turn ~900° against a published 1400–3600. That is the `TRACK_MODEL` decision the code already documents, not this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)