### PR TITLE
fix(servers): one Steam sign-in per run, reused by every refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   whichever step you have selected.
 
 ### Fixed
+- The Servers tab holds its Steam sign-in for the session, so refreshing the list keeps
+  working. A refresh that doesn't get through leaves the servers you already had on screen.
 - Starting a blank track works.
 - Giving a straight or a corner a rise now shapes a hill. The climb comes back down over the
   rest of the lap, so the circuit meets itself at the start line.

--- a/src-tauri/src/worldnet.rs
+++ b/src-tauri/src/worldnet.rs
@@ -38,6 +38,7 @@ use cipher::generic_array::GenericArray;
 use cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
 use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};
 use std::path::Path;
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 /// The 32-byte ASCII key the exe builds on the stack and hands to the Blowfish schedule.
@@ -232,7 +233,7 @@ fn fetch(masters: &[String], rider: &str, install: &Path) -> Result<Vec<WorldSer
     sock.set_read_timeout(Some(Duration::from_secs(3))).ok();
 
     // One ticket for the whole sweep — each one costs a Steam init and a callback pump.
-    let ticket = steam_ticket(install);
+    let ticket = signed_in(install);
     match &ticket {
         Ok(t) => log::info!("[worldnet] Steam ticket: {} bytes for {}", t.ticket.len(), t.steam_id),
         Err(e) => log::info!("[worldnet] no Steam ticket, browsing instead: {e}"),
@@ -436,9 +437,55 @@ fn hex(b: &[u8]) -> String {
 // unverifiable off Windows, so elsewhere it's a clear error and the browse path is what runs.
 
 /// What a Steam sign-in needs: the account, and the ticket that proves it.
+#[derive(Clone)]
 struct SteamAuth {
     steam_id: u64,
     ticket: Vec<u8>,
+}
+
+/// How long one sign-in is reused before Steam is asked for another. Steam mints at most one
+/// ticket a minute and hands the same one back in between, so asking more often buys nothing.
+const TICKET_TTL: Duration = Duration::from_secs(10 * 60);
+
+/// The sign-in this run is using.
+static SIGN_IN: Mutex<Option<(Instant, SteamAuth)>> = Mutex::new(None);
+
+/// The ticket to sign in with — this run's, until it ages out.
+///
+/// Asking Steam twice in one process does not work: `SteamAPI_Init` after a `SteamAPI_Shutdown`
+/// comes back with no `ISteamUser`, so the second refresh of a session used to fail with
+/// "Steam user interface unavailable." and empty the tab. The ticket is a sealed blob that
+/// outlives the API that issued it, so keep it rather than ask again.
+fn signed_in(install: &Path) -> Result<SteamAuth, String> {
+    let mut held = SIGN_IN.lock().unwrap_or_else(|p| p.into_inner());
+    reuse_or_fetch(&mut held, Instant::now(), || steam_ticket(install))
+}
+
+/// Reuse a ticket younger than [`TICKET_TTL`]; otherwise ask for a fresh one, and fall back to
+/// the one in hand when Steam won't issue another.
+fn reuse_or_fetch(
+    held: &mut Option<(Instant, SteamAuth)>,
+    now: Instant,
+    fresh: impl FnOnce() -> Result<SteamAuth, String>,
+) -> Result<SteamAuth, String> {
+    if let Some((issued, auth)) = held.as_ref() {
+        if now.saturating_duration_since(*issued) < TICKET_TTL {
+            return Ok(auth.clone());
+        }
+    }
+    match fresh() {
+        Ok(auth) => {
+            *held = Some((now, auth.clone()));
+            Ok(auth)
+        }
+        Err(e) => match held.as_ref() {
+            Some((_, auth)) => {
+                log::info!("[worldnet] Steam wouldn't issue another ticket ({e}); reusing this run's");
+                Ok(auth.clone())
+            }
+            None => Err(e),
+        },
+    }
 }
 
 #[cfg(windows)]
@@ -909,5 +956,54 @@ mod tests {
         assert_eq!(s.max_players, 20);
         assert!(s.passworded);
         assert_eq!(s.track, "mmx_supercross");
+    }
+
+    fn auth(id: u64) -> SteamAuth {
+        SteamAuth { steam_id: id, ticket: vec![1, 2, 3] }
+    }
+
+    /// The second refresh of a session must not ask Steam again — asking is what failed:
+    /// `SteamAPI_Init` after a shutdown has no `ISteamUser`, and the tab went empty.
+    #[test]
+    fn a_second_refresh_reuses_this_run_s_sign_in() {
+        let t0 = Instant::now();
+        let mut held = None;
+        reuse_or_fetch(&mut held, t0, || Ok(auth(7))).unwrap();
+
+        let mut asked = false;
+        let again = reuse_or_fetch(&mut held, t0 + Duration::from_secs(30), || {
+            asked = true;
+            Err("Steam user interface unavailable.".into())
+        })
+        .unwrap();
+        assert!(!asked, "Steam was asked a second time");
+        assert_eq!(again.steam_id, 7);
+    }
+
+    /// Past the TTL it asks again — and a refusal still leaves a working list, not an error.
+    #[test]
+    fn a_refusal_falls_back_to_the_ticket_in_hand() {
+        let t0 = Instant::now();
+        let mut held = None;
+        reuse_or_fetch(&mut held, t0, || Ok(auth(7))).unwrap();
+
+        let stale = t0 + TICKET_TTL + Duration::from_secs(1);
+        let out = reuse_or_fetch(&mut held, stale, || Err("Steam user interface unavailable.".into())).unwrap();
+        assert_eq!(out.steam_id, 7);
+
+        // A fresh one, when Steam does answer, replaces it.
+        let out = reuse_or_fetch(&mut held, stale, || Ok(auth(9))).unwrap();
+        assert_eq!(out.steam_id, 9);
+    }
+
+    /// With nothing in hand there is nothing to fall back to, and the Steam reason is what
+    /// the tab should say.
+    #[test]
+    fn the_first_failure_still_speaks() {
+        let mut held = None;
+        let e = reuse_or_fetch(&mut held, Instant::now(), || Err("Steam isn't running.".into()))
+            .map(|_| ())
+            .unwrap_err();
+        assert_eq!(e, "Steam isn't running.");
     }
 }

--- a/src/Components/Servers/Servers.tsx
+++ b/src/Components/Servers/Servers.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Search,
   RefreshCw,
@@ -42,20 +42,34 @@ const Servers = () => {
   const [joining, setJoining] = useState<string | null>(null);
   const [joinOpen, setJoinOpen] = useState(false);
 
+  // One fetch at a time. Two overlapping ones each sign in to Steam, and the loser's
+  // failure used to replace the winner's list with an error.
+  const inFlight = useRef(false);
+  // What the tab is showing, for the failure path — `load` holds no state of its own.
+  const onScreen = useRef<MasterServer[] | null>(null);
   const load = useCallback(() => {
+    if (inFlight.current) return;
+    inFlight.current = true;
     setLoading(true);
     setError(null);
     listMasterServers()
       .then((list) => {
         // Busiest first — an empty server is the last thing anyone's looking for.
         list.sort((a, b) => b.players - a.players);
+        onScreen.current = list;
         setServers(list);
       })
       .catch((e: unknown) => {
-        setServers([]);
-        setError(typeof e === "string" ? e : String(e));
+        const message = typeof e === "string" ? e : String(e);
+        setError(message);
+        // A failed refresh is not an empty list: keep what's on screen and say so instead.
+        if (onScreen.current?.length) toast.error(message);
+        else setServers([]);
       })
-      .finally(() => setLoading(false));
+      .finally(() => {
+        inFlight.current = false;
+        setLoading(false);
+      });
   }, []);
 
   useEffect(() => {
@@ -142,16 +156,13 @@ const Servers = () => {
 
       <JoinServerDialog open={joinOpen} onOpenChange={setJoinOpen} onJoined={load} />
 
-
-      <JoinServerDialog open={joinOpen} onOpenChange={setJoinOpen} onJoined={load} />
-
       <div className="min-h-0 flex-1 overflow-y-auto px-7 pb-6">
         {servers === null ? (
           <Centered>
             <Loader2 className="size-5 animate-spin text-faint" />
             <p className="text-[13px] text-faint">{t("serverBrowser.loading")}</p>
           </Centered>
-        ) : error ? (
+        ) : error && servers.length === 0 ? (
           <Centered>
             <ServerOff className="size-6 text-faint" />
             <p className="max-w-[420px] text-center text-[13px] text-muted-foreground">


### PR DESCRIPTION
## The report

A player sent a log bundle with "Steam user interface unavailable." Their `MXB App.log` has both of these, one second apart:

```
18:05:35 [worldnet] Steam ticket: 143 bytes for 765611991…
18:05:35 [worldnet] no Steam ticket, browsing instead: Steam user interface unavailable.
18:05:39 [worldnet] 9 server(s) from master.mx-bikes.com:54200
```

Two server-list fetches ran at startup. The first signed in and returned 9 servers. The second could not: `steam_ticket` does a full `SteamAPI_Init` → `RequestEncryptedAppTicket` → `SteamAPI_Shutdown` on **every** fetch, and a second init in the same process comes back with no `ISteamUser`. `interfaces()` returned `None`, that fetch fell through to the no-auth browse — which the public master ignores — and rejected. The tab renders the last error over the list that had already arrived, so the player saw the Steam message instead of the servers.

## The fix

- **One sign-in per run.** The ticket is held behind a mutex and reused for 10 minutes. It is a sealed blob that outlives the API that issued it, and Steam mints at most one a minute anyway, so asking again buys nothing.
- **A refusal falls back to the ticket in hand** rather than failing the refresh, since asking again is the operation that does not work.
- **Servers tab**: one fetch at a time, and a failed refresh keeps the servers already on screen (toast) instead of replacing them with an error screen. Removed a duplicated `JoinServerDialog` that was rendering twice.

Keeping Steam initialised for the app's lifetime is the other way out and is wrong — it would show the user as "Playing MX Bikes" the whole time the app is open.

## Verification

- `worldnet::` suite 11/11, including three new tests: reuse inside the TTL without asking Steam, fall-back to the held ticket when Steam refuses, and the first failure still reporting Steam's own reason.
- `cargo check --target x86_64-pc-windows-gnu` clean — the Steam code is `cfg(windows)` and a macOS build skips it.
- `tsc --noEmit` and eslint clean.

Runtime behaviour on Windows is unverified from here, as ever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)