### PR TITLE
feat(viewer): draw a track's ground the way the game draws it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ docs/secure-content/
 
 # CI-only checkout of the private sidecar module (see .github/workflows/release.yml)
 /.sidecar-src/
+
+# The compiled UI-driving harness; build it with swiftc from the .swift beside it.
+docs/guides/tools/uidrive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 - Tracks in the 3D viewer are drawn with the ground the game draws: each layer's own sheet,
   tiled the way the track states, through the track's own masks. Published tracks used to come
   out one flat brown, because the colour was taken from the surface data a track uses for grip
-  rather than from what it is painted with.
+  rather than from what it is painted with. Indiana now shows its dirt, its ruts and the
+  gravel round the paddock.
 
 ## 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 2026-09-06
 
+### Changed
+- Tracks in the 3D viewer are drawn with the ground the game draws: each layer's own sheet,
+  tiled the way the track states, through the track's own masks. Published tracks used to come
+  out one flat brown, because the colour was taken from the surface data a track uses for grip
+  rather than from what it is painted with.
+
+## 2026-09-06
+
 ### Added
 - The Servers tab lists every server on the master list, and measures the real ping to each
   one instead of leaving the column blank.

--- a/docs/guides/tools/uidrive.swift
+++ b/docs/guides/tools/uidrive.swift
@@ -1,0 +1,164 @@
+// Drives a Tauri window on macOS with raw CGEvents.
+//
+// System Events' `click at` fails against a WKWebView with -25208: that path goes through the
+// Accessibility API, which the web view does not implement. CGEvents posted to the HID tap go
+// to whatever is under the point instead, and drive the app completely.
+//
+// Every point here is *window-relative*, and the window's origin is read fresh on each call.
+// A CGEvent goes wherever it lands, and this is the user's own desktop — a point read off a
+// full-screen capture once landed in their chat client and pulled a private channel forward.
+//
+// Build:  swiftc -O -o uidrive uidrive.swift
+
+import Cocoa
+
+let app = "mxb-app"
+/// Which instance to drive. This machine routinely has two of them up — one per checkout —
+/// and a CGEvent goes wherever it lands, so the window is picked by process id rather than by
+/// name whenever MXB_PID is set.
+let wantPid = ProcessInfo.processInfo.environment["MXB_PID"].flatMap { Int32($0) }
+
+func frontWindow() -> CGRect? {
+    guard let list = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] else {
+        return nil
+    }
+    for w in list {
+        if let want = wantPid {
+            guard let pid = w[kCGWindowOwnerPID as String] as? Int32, pid == want else { continue }
+        } else {
+            guard let owner = w[kCGWindowOwnerName as String] as? String, owner.lowercased().contains(app.lowercased()) else { continue }
+        }
+        guard let b = w[kCGWindowBounds as String] as? [String: Any],
+              let x = b["X"] as? CGFloat, let y = b["Y"] as? CGFloat,
+              let width = b["Width"] as? CGFloat, let height = b["Height"] as? CGFloat,
+              width > 200, height > 200 else { continue }
+        return CGRect(x: x, y: y, width: width, height: height)
+    }
+    return nil
+}
+
+func focus() {
+    if let want = wantPid, let a = NSRunningApplication(processIdentifier: want) {
+        a.activate(options: [.activateAllWindows])
+        usleep(400_000)
+        return
+    }
+    for a in NSWorkspace.shared.runningApplications where (a.localizedName ?? "").lowercased().contains(app.lowercased()) {
+        a.activate(options: [.activateAllWindows])
+    }
+    usleep(400_000)
+}
+
+/// Window-relative point to screen point. Read after focusing, never cached.
+func screenPoint(_ x: CGFloat, _ y: CGFloat) -> CGPoint? {
+    guard let r = frontWindow() else { return nil }
+    guard x >= 0, y >= 0, x <= r.width, y <= r.height else {
+        FileHandle.standardError.write("point \(x),\(y) is outside the window \(r.width)x\(r.height)\n".data(using: .utf8)!)
+        return nil
+    }
+    return CGPoint(x: r.origin.x + x, y: r.origin.y + y)
+}
+
+func post(_ type: CGEventType, _ p: CGPoint, _ button: CGMouseButton = .left, clicks: Int64 = 1) {
+    guard let e = CGEvent(mouseEventSource: nil, mouseType: type, mouseCursorPosition: p, mouseButton: button) else { return }
+    e.setIntegerValueField(.mouseEventClickState, value: clicks)
+    e.post(tap: .cghidEventTap)
+}
+
+func click(_ x: CGFloat, _ y: CGFloat, clicks: Int64 = 1) {
+    guard let p = screenPoint(x, y) else { exit(2) }
+    post(.mouseMoved, p)
+    usleep(80_000)
+    for _ in 0..<clicks {
+        post(.leftMouseDown, p, .left, clicks: clicks)
+        usleep(40_000)
+        post(.leftMouseUp, p, .left, clicks: clicks)
+        usleep(60_000)
+    }
+}
+
+func drag(_ x1: CGFloat, _ y1: CGFloat, _ x2: CGFloat, _ y2: CGFloat) {
+    guard let a = screenPoint(x1, y1), let b = screenPoint(x2, y2) else { exit(2) }
+    post(.mouseMoved, a); usleep(60_000)
+    post(.leftMouseDown, a); usleep(60_000)
+    let steps = 24
+    for i in 1...steps {
+        let t = CGFloat(i) / CGFloat(steps)
+        post(.leftMouseDragged, CGPoint(x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t))
+        usleep(12_000)
+    }
+    post(.leftMouseUp, b); usleep(60_000)
+}
+
+func scroll(_ x: CGFloat, _ y: CGFloat, _ amount: Int32) {
+    guard let p = screenPoint(x, y) else { exit(2) }
+    post(.mouseMoved, p); usleep(60_000)
+    // Scrolled in steps: the viewer's zoom is per-event, so one large delta moves less than
+    // many small ones and stops short of the dirt.
+    let step: Int32 = amount > 0 ? 3 : -3
+    for _ in 0..<(abs(amount) / 3) {
+        if let e = CGEvent(scrollWheelEvent2Source: nil, units: .line, wheelCount: 1, wheel1: step, wheel2: 0, wheel3: 0) {
+            e.location = p
+            e.post(tap: .cghidEventTap)
+        }
+        usleep(40_000)
+    }
+}
+
+func type(_ s: String) {
+    for ch in s {
+        guard let d = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true),
+              let u = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false) else { continue }
+        var chars = Array(String(ch).utf16)
+        d.keyboardSetUnicodeString(stringLength: chars.count, unicodeString: &chars)
+        u.keyboardSetUnicodeString(stringLength: chars.count, unicodeString: &chars)
+        d.post(tap: .cghidEventTap); usleep(20_000)
+        u.post(tap: .cghidEventTap); usleep(30_000)
+    }
+}
+
+func key(_ code: CGKeyCode) {
+    CGEvent(keyboardEventSource: nil, virtualKey: code, keyDown: true)?.post(tap: .cghidEventTap)
+    usleep(40_000)
+    CGEvent(keyboardEventSource: nil, virtualKey: code, keyDown: false)?.post(tap: .cghidEventTap)
+    usleep(60_000)
+}
+
+let args = CommandLine.arguments
+guard args.count >= 2 else {
+    print("usage: uidrive geometry|focus|click X Y|double X Y|drag X1 Y1 X2 Y2|scroll X Y N|type TEXT|esc|enter")
+    exit(1)
+}
+let n = { (i: Int) -> CGFloat in CGFloat(Double(args[i]) ?? 0) }
+
+switch args[1] {
+case "list":
+    guard let l = CGWindowListCopyWindowInfo([.excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] else { exit(3) }
+    for w in l {
+        let owner = w[kCGWindowOwnerName as String] as? String ?? "?"
+        let pid = w[kCGWindowOwnerPID as String] as? Int32 ?? -1
+        let b = w[kCGWindowBounds as String] as? [String: Any] ?? [:]
+        let ww = b["Width"] as? CGFloat ?? 0, hh = b["Height"] as? CGFloat ?? 0
+        let id = w[kCGWindowNumber as String] as? Int ?? -1
+        let on = (w[kCGWindowIsOnscreen as String] as? Bool) ?? false
+        let layer = w[kCGWindowLayer as String] as? Int ?? -99
+        let xx = b["X"] as? CGFloat ?? 0, yy = b["Y"] as? CGFloat ?? 0
+        if wantPid == nil || (w[kCGWindowOwnerPID as String] as? Int32) == wantPid {
+            print("\(pid)\t\(id)\tlayer=\(layer)\ton=\(on)\t\(owner)\t\(Int(ww))x\(Int(hh))@\(Int(xx)),\(Int(yy))")
+        }
+    }
+case "geometry":
+    focus()
+    _ = frontWindow()          // an unfocused app answers with nothing; ask twice
+    guard let r = frontWindow() else { print("no window"); exit(3) }
+    print("\(Int(r.origin.x)) \(Int(r.origin.y)) \(Int(r.width)) \(Int(r.height))")
+case "focus": focus()
+case "click": focus(); click(n(2), n(3))
+case "double": focus(); click(n(2), n(3), clicks: 2)
+case "drag": focus(); drag(n(2), n(3), n(4), n(5))
+case "scroll": focus(); scroll(n(2), n(3), Int32(args[4]) ?? 0)
+case "type": focus(); type(args[2])
+case "esc": focus(); key(53)
+case "enter": focus(); key(36)
+default: print("unknown: \(args[1])"); exit(1)
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1693,6 +1693,27 @@ async fn load_track_ground(
     .map_err(|e| format!("load_track_ground task failed: {e}"))
 }
 
+/// The ground a track is painted with, layer by layer — what the game puts under the bike.
+///
+/// Separate from `load_track_ground`, which hands back a single sheet to tile everywhere. This
+/// is the stack itself: each layer's sheet, how far it tiles, and the mask that cuts it into
+/// the one below.
+#[tauri::command]
+async fn load_track_ground_layers(
+    app: tauri::AppHandle,
+    path: String,
+) -> Result<tauri::ipc::Response, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let blob = scenery::load_ground_layers(&app, &path).unwrap_or_else(|e| {
+            log::debug!("[scenery] ground layers for {path}: {e:#}");
+            Vec::new()
+        });
+        tauri::ipc::Response::new(blob)
+    })
+    .await
+    .map_err(|e| format!("load_track_ground_layers task failed: {e}"))
+}
+
 /// The models a track ships that a prop can be placed by name.
 #[tauri::command]
 async fn read_track_placeable(path: String) -> Result<Vec<String>, String> {
@@ -10253,6 +10274,7 @@ fn main() {
             load_track_prop,
             load_track_backdrop,
             load_track_ground,
+            load_track_ground_layers,
             diagnose_track,
             unpack_paint,
             texture_bytes,

--- a/src-tauri/src/map.rs
+++ b/src-tauri/src/map.rs
@@ -934,7 +934,7 @@ fn name_words(name: &str) -> Vec<String> {
 
 /// Whether the name says this record is a normal map. Written every way going: `Dirt2_n`,
 /// `soil_white_n_s`, `sand-dark-normal`.
-fn is_normal_name(name: &str) -> bool {
+pub(crate) fn is_normal_name(name: &str) -> bool {
     name_words(name)
         .iter()
         .any(|w| matches!(w.as_str(), "n" | "nrm" | "norm" | "normal" | "nor"))
@@ -1289,12 +1289,511 @@ pub fn surfaces_blob(textures: &[MapTexture]) -> Vec<u8> {
     out
 }
 
+
+// ---------------------------------------------------------------------------
+// The ground the game draws
+// ---------------------------------------------------------------------------
+
+/// One painted layer of a track's ground.
+///
+/// This is what the game puts under the bike, and it is not what the `.trh` coverage masks
+/// describe — those are the *physics* surfaces, a friction table keyed by
+/// `asphalt/grass/sand/kerb/soil/concrete`, and on a published track they are all but unused:
+/// Indiana paints one 256×256 patch of `concrete` across a 2049² grid and nothing else. Drawn
+/// from those, a real track is a flat brown slab.
+///
+/// The paint lives here instead: a stack of layers, each a tiling sheet with its own mask,
+/// composited in order. The first covers everything and carries no mask; the rest cut into it.
+#[derive(Clone, Debug)]
+pub struct GroundLayer {
+    /// The sheet, reduced for tiling rather than for extent.
+    pub sheet: MapTexture,
+    /// How many times the sheet repeats across the ground, per axis. Read rather than
+    /// assumed: Indiana's base is 200 and its dark soil 180, which over 525 m is about
+    /// 2.6 and 2.9 metres a tile — close enough to the viewer's old hardcoded 4 m to look
+    /// plausible and far enough to read as the wrong ground.
+    pub tile_u: f32,
+    pub tile_v: f32,
+    /// Coverage, one byte a texel, laid across the whole ground. `None` on the base layer.
+    ///
+    /// Coarse on purpose — Indiana's are 256² against a 2049² heightfield — which is why the
+    /// whole stack is a few hundred kilobytes rather than the hundreds of megabytes the sheets
+    /// themselves come to.
+    pub mask: Option<GroundMask>,
+}
+
+#[derive(Clone, Debug)]
+pub struct GroundMask {
+    pub width: u32,
+    pub height: u32,
+    /// `width * height`, one byte a texel.
+    pub coverage: Vec<u8>,
+}
+
+/// How far a layer's sheet is reduced. It tiles, so it needs frequency rather than extent —
+/// the same reasoning as [`ground_sheet`], and it keeps a six-layer stack inside a few
+/// megabytes rather than the ninety a map's own 1024² sheets would cost.
+const LAYER_SHEET_DIM: u32 = 256;
+
+/// A sheet record, at either of the two widths the format uses.
+///
+/// A layer's colour sheet carries a zero word between its name and its width; the normal map
+/// hanging off it does not. Rather than tell them apart by which slot they sit in — the
+/// secondary's header is a variable run of words, and two samples were not enough to pin it —
+/// each offset is tried and the record has to prove itself: a NUL-padded ASCII name, power-of
+/// -two dimensions, a zero where the sub-record count goes, and a length that stays in the
+/// file.
+fn layer_sheet_at(b: &[u8], o: usize) -> Option<(String, u32, u32, usize, usize)> {
+    if o + 148 > b.len() {
+        return None;
+    }
+    let name = b.get(o..o + 100)?;
+    let end = name.iter().position(|c| *c == 0)?;
+    if end == 0 || !name[..end].iter().all(|c| c.is_ascii_graphic()) {
+        return None;
+    }
+    if !name[end..].iter().all(|c| *c == 0) {
+        return None;
+    }
+    let pow2 = |v: u32| (4..=8192).contains(&v) && v.is_power_of_two();
+    for w_off in [104usize, 100] {
+        if w_off == 104 && u32le(b, o + 100) != 0 {
+            continue;
+        }
+        let (w, h) = (u32le(b, o + w_off), u32le(b, o + w_off + 4));
+        if !pow2(w) || !pow2(h) {
+            continue;
+        }
+        // The 16-byte content hash, then a zero where sub-records would be counted.
+        let he = o + w_off + 8 + 16;
+        if he + 8 > b.len() || u32le(b, he) != 0 {
+            continue;
+        }
+        let len = u32le(b, he + 4) as usize;
+        // The length counts the eight bytes that follow it.
+        if len < 8 || he + 8 + len + 4 > b.len() {
+            continue;
+        }
+        let data = he + 16;
+        return Some((
+            String::from_utf8_lossy(&name[..end]).into_owned(),
+            w,
+            h,
+            data,
+            data + len - 8,
+        ));
+    }
+    None
+}
+
+/// A mask record: `u32 w, u32 h, u32 len`, eight bytes, then DEFLATE over one byte a texel.
+///
+/// Proved by inflating rather than by its header alone — it has to come out at exactly `w * h`
+/// bytes. Nothing else in a map does that, so this cannot pick up a sheet or a run of geometry.
+fn layer_mask_at(b: &[u8], o: usize) -> Option<(GroundMask, usize)> {
+    if o + 20 > b.len() {
+        return None;
+    }
+    let (w, h, len) = (u32le(b, o), u32le(b, o + 4), u32le(b, o + 8) as usize);
+    let ok = |v: u32| (16..=8192).contains(&v) && v.is_power_of_two();
+    if !ok(w) || !ok(h) || len < 16 {
+        return None;
+    }
+    let data = o + 20;
+    let take = len - 8;
+    if data + take > b.len() {
+        return None;
+    }
+    let want = w as usize * h as usize;
+    if take > want {
+        return None;
+    }
+    let mut out = Vec::with_capacity(want);
+    let mut dec = flate2::bufread::DeflateDecoder::new(&b[data..data + take]);
+    use std::io::Read;
+    let mut buf = [0u8; 1 << 16];
+    loop {
+        match dec.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                out.extend_from_slice(&buf[..n]);
+                if out.len() > want {
+                    return None;
+                }
+            }
+            Err(_) => return None,
+        }
+    }
+    if out.len() != want {
+        return None;
+    }
+    // Bottom-up, like every other sheet the compilers write — see the flip in [`ground_sheet`].
+    // Left as it lies, a mask puts the riding line on the wrong side of the track.
+    let row = w as usize;
+    for y in 0..(h as usize) / 2 {
+        let (top, bottom) = (y * row, (h as usize - 1 - y) * row);
+        for x in 0..row {
+            out.swap(top + x, bottom + x);
+        }
+    }
+    Some((
+        GroundMask {
+            width: w,
+            height: h,
+            coverage: out,
+        },
+        data + take,
+    ))
+}
+
+/// Whether a name marks a normal map rather than a colour sheet.
+///
+/// Wider than [`is_normal_name`], which splits on separators and so reads `dirtnorm` and
+/// `grassnorm` — Smokey Pines' two — as words of their own. A normal map drawn as ground is a
+/// lilac sheet, so the test errs toward calling one.
+fn is_layer_normal(name: &str) -> bool {
+    let n = name.to_ascii_lowercase();
+    is_normal_name(&n)
+        || n.ends_with("norm")
+        || n.ends_with("_n")
+        || n.ends_with("_n_s")
+        || n.ends_with("nrm")
+}
+
+/// How many bytes of material a layer states before its sheet: fourteen floats.
+const LAYER_MATERIAL: usize = 56;
+
+/// How far past a sheet the walk will look for the trailer that closes its layer.
+///
+/// Far enough to step over a normal map's payload — a 1024² sheet is a megabyte or two — and
+/// bounded so a walk that has lost the stack gives up rather than reading the rest of the file.
+const TRAILER_REACH: usize = 8 << 20;
+
+/// What closes a layer: how its sheet tiles, and the mask that cuts it into the one below.
+struct Trailer {
+    tile_u: f32,
+    tile_v: f32,
+    mask: Option<GroundMask>,
+    /// Where the next layer's material record begins.
+    next: usize,
+}
+
+/// Find the trailer that follows a layer's sheet.
+///
+/// Searched for rather than read at a fixed offset, because what sits between the sheet and
+/// the trailer is a normal map whose own header is a variable run of words — two samples were
+/// not enough to pin it, and a walk that assumes one is wrong on the tracks that carry the
+/// other. The trailer proves itself instead: two plausible tiling floats, a flag that is zero
+/// or one, and — where it is one — a mask that inflates to exactly its stated size.
+fn trailer_after(b: &[u8], from: usize, limit: usize) -> Option<Trailer> {
+    let sane = |v: f32| v.is_finite() && (0.01..=100_000.0).contains(&v);
+    let mut o = from;
+    while o + 20 < limit.min(b.len()) {
+        let (tu, tv) = (f32le(b, o), f32le(b, o + 4));
+        if sane(tu) && sane(tv) {
+            match u32le(b, o + 8) {
+                // A masked layer: the mask is proof enough on its own.
+                1 => {
+                    if let Some((mask, after)) = layer_mask_at(b, o + 12) {
+                        return Some(Trailer {
+                            tile_u: tu,
+                            tile_v: tv,
+                            mask: Some(mask),
+                            next: after + 4,
+                        });
+                    }
+                }
+                // The base layer carries no mask, so there is nothing to prove it by except
+                // what comes next: the following layer's material and sheet have to parse.
+                0 => {
+                    let next = o + 16;
+                    if next + 60 < b.len()
+                        && (1..=4).contains(&u32le(b, next + LAYER_MATERIAL))
+                        && layer_sheet_at(b, next + LAYER_MATERIAL + 4).is_some()
+                    {
+                        return Some(Trailer {
+                            tile_u: tu,
+                            tile_v: tv,
+                            mask: None,
+                            next,
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+        o += 4;
+    }
+    None
+}
+
+/// Walk the layer stack from `start`, which is a layer's material record.
+///
+/// `decode` is false while the stack's phase is still being searched for: the walk is the same
+/// but no sheet is inflated, because hundreds of candidate starts each decoding a megabyte of
+/// pixels to be thrown away is most of a minute of work.
+fn march_layers(b: &[u8], start: usize, decode: bool) -> Vec<GroundLayer> {
+    let mut out = Vec::new();
+    let mut o = start;
+    while out.len() < 64 && o + 60 < b.len() {
+        if !(1..=4).contains(&u32le(b, o + LAYER_MATERIAL)) {
+            break;
+        }
+        let Some((name, w, h, data, end)) = layer_sheet_at(b, o + LAYER_MATERIAL + 4) else {
+            break;
+        };
+        let Some(t) = trailer_after(b, end, end + TRAILER_REACH) else {
+            break;
+        };
+        // A normal map opens no layer of its own; it hangs off the colour sheet above it.
+        if !is_layer_normal(&name) {
+            let sheet = if decode {
+                match inflate(b, data, end - data, w, h) {
+                    Some(mut rgba) => {
+                        flip_rows(&mut rgba, w, h);
+                        let (rgba, rw, rh) = reduce(rgba, w, h, LAYER_SHEET_DIM);
+                        Some((rgba, rw, rh))
+                    }
+                    None => None,
+                }
+            } else {
+                Some((Vec::new(), w, h))
+            };
+            if let Some((rgba, rw, rh)) = sheet {
+                out.push(GroundLayer {
+                    sheet: MapTexture {
+                        material: out.len() as u32,
+                        name,
+                        width: rw,
+                        height: rh,
+                        alpha: false,
+                        rgba,
+                    },
+                    tile_u: t.tile_u,
+                    tile_v: t.tile_v,
+                    mask: t.mask,
+                });
+            }
+        }
+        o = t.next;
+    }
+    out
+}
+
+/// The ground a track is painted with, layer by layer.
+///
+/// This is what the game puts under the bike. It is a march through the records rather than a
+/// scan for them, because the stack only means anything in order — but a march has to start in
+/// phase, and nothing in the file announces where the stack begins. So the phase is *found*:
+/// every sheet record in the map is tried as the stack's first, and the one that walks furthest
+/// wins. A march that starts in the wrong place fails within a layer or two, because a layer
+/// only closes on a mask that inflates to exactly its stated size.
+///
+/// Sheets are not inflated while the phase is being searched for — only the winning march
+/// decodes anything. A map carries well over a hundred textures that are banners and foliage.
+pub fn ground_layers(b: &[u8]) -> Vec<GroundLayer> {
+    // Every sheet record is a candidate first layer; its material record sits 60 bytes back.
+    let mut starts: Vec<usize> = Vec::new();
+    let mut o = 0usize;
+    while o + 160 < b.len() {
+        if b[o].is_ascii_graphic()
+            && b[o + 99] == 0
+            && o >= LAYER_MATERIAL + 4
+            && (1..=4).contains(&u32le(b, o - 4))
+            && layer_sheet_at(b, o).is_some()
+        {
+            starts.push(o - LAYER_MATERIAL - 4);
+        }
+        o += 4;
+    }
+
+    // The march that reads the most layers is the stack. Ties go to the earliest, which is the
+    // one that starts at the base rather than part way down it.
+    let mut best: Option<(usize, usize)> = None; // (layers, start)
+    for s in starts {
+        let n = march_layers(b, s, false).len();
+        if n > best.map_or(0, |(m, _)| m) {
+            best = Some((n, s));
+        }
+    }
+    match best {
+        Some((_, s)) => march_layers(b, s, true),
+        None => Vec::new(),
+    }
+}
+
+/// The two tiling floats a layer keeps between the end of its sheet and the next record.
+///
+/// Scanned for rather than read at a fixed offset, because what sits between them and the
+/// sheet is a normal map of unknown length. They are the pair immediately before a flag word.
+fn tiling_before(b: &[u8], from: usize, to: usize) -> Option<(f32, f32)> {
+    let mut o = from;
+    let mut found = None;
+    while o + 12 <= to.min(b.len()) {
+        let flag = u32le(b, o + 8);
+        if flag <= 1 {
+            let (u, v) = (f32le(b, o), f32le(b, o + 4));
+            if (0.01..=100_000.0).contains(&u) && (0.01..=100_000.0).contains(&v) {
+                found = Some((u, v));
+            }
+        }
+        o += 4;
+    }
+    found
+}
+
+/// The ground stack, packed for the front end.
+///
+/// One table of fixed-width entries and then the pixels, so the whole stack crosses the bridge
+/// as one buffer rather than as a JSON object per layer with a megabyte of numbers in it.
+pub fn ground_layers_blob(layers: &[GroundLayer]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(
+        GROUND_LAYERS_HEADER
+            + layers.len() * GROUND_LAYER_ENTRY
+            + layers
+                .iter()
+                .map(|l| l.sheet.rgba.len() + l.mask.as_ref().map_or(0, |m| m.coverage.len()))
+                .sum::<usize>(),
+    );
+    out.extend_from_slice(b"FGLY");
+    out.extend_from_slice(&1u16.to_le_bytes());
+    out.extend_from_slice(&0u16.to_le_bytes());
+    out.extend_from_slice(&(layers.len() as u32).to_le_bytes());
+    out.extend_from_slice(&0u32.to_le_bytes());
+    for l in layers {
+        out.extend_from_slice(&l.sheet.width.to_le_bytes());
+        out.extend_from_slice(&l.sheet.height.to_le_bytes());
+        out.extend_from_slice(&(l.sheet.rgba.len() as u32).to_le_bytes());
+        out.extend_from_slice(&l.tile_u.to_le_bytes());
+        out.extend_from_slice(&l.tile_v.to_le_bytes());
+        let (mw, mh, ml) = l
+            .mask
+            .as_ref()
+            .map_or((0, 0, 0), |m| (m.width, m.height, m.coverage.len() as u32));
+        out.extend_from_slice(&mw.to_le_bytes());
+        out.extend_from_slice(&mh.to_le_bytes());
+        out.extend_from_slice(&ml.to_le_bytes());
+    }
+    for l in layers {
+        out.extend_from_slice(&l.sheet.rgba);
+    }
+    for l in layers {
+        if let Some(m) = &l.mask {
+            out.extend_from_slice(&m.coverage);
+        }
+    }
+    out
+}
+
+/// Bytes before the layer table.
+pub const GROUND_LAYERS_HEADER: usize = 16;
+/// Bytes per layer in that table.
+pub const GROUND_LAYER_ENTRY: usize = 32;
+
 /// Bytes before the surface table. Four-byte aligned, same reasoning as [`SCENERY_HEADER`].
 pub const SURFACES_HEADER: usize = 16;
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build a layer stack the way a compiled map holds one, so the walk can be tested
+    /// without a three-hundred-megabyte track on disk.
+    fn synth_stack(layers: &[(&str, f32, Option<u32>)]) -> Vec<u8> {
+        use flate2::{write::DeflateEncoder, Compression};
+        use std::io::Write;
+        let mut b = vec![0u8; 64]; // something in front, so offset zero is never the answer
+        for (name, tile, mask) in layers {
+            b.extend_from_slice(&[0u8; LAYER_MATERIAL]);
+            b.extend_from_slice(&1u32.to_le_bytes()); // one sheet
+            let mut nm = vec![0u8; 100];
+            nm[..name.len()].copy_from_slice(name.as_bytes());
+            b.extend_from_slice(&nm);
+            b.extend_from_slice(&0u32.to_le_bytes());
+            b.extend_from_slice(&8u32.to_le_bytes()); // 8x8 sheet
+            b.extend_from_slice(&8u32.to_le_bytes());
+            b.extend_from_slice(&[0u8; 16]); // hash
+            b.extend_from_slice(&0u32.to_le_bytes()); // no sub-records
+            let px = vec![128u8; 8 * 8 * 4];
+            let mut e = DeflateEncoder::new(Vec::new(), Compression::fast());
+            e.write_all(&px).unwrap();
+            let z = e.finish().unwrap();
+            b.extend_from_slice(&((z.len() + 8) as u32).to_le_bytes());
+            b.extend_from_slice(&[0u8; 8]);
+            b.extend_from_slice(&z);
+            b.extend_from_slice(&0u32.to_le_bytes()); // no secondary map
+            b.extend_from_slice(&tile.to_le_bytes());
+            b.extend_from_slice(&tile.to_le_bytes());
+            match mask {
+                Some(d) => {
+                    b.extend_from_slice(&1u32.to_le_bytes());
+                    b.extend_from_slice(&d.to_le_bytes());
+                    b.extend_from_slice(&d.to_le_bytes());
+                    let cov = vec![200u8; (*d as usize) * (*d as usize)];
+                    let mut e = DeflateEncoder::new(Vec::new(), Compression::fast());
+                    e.write_all(&cov).unwrap();
+                    let z = e.finish().unwrap();
+                    b.extend_from_slice(&((z.len() + 8) as u32).to_le_bytes());
+                    b.extend_from_slice(&[0u8; 8]);
+                    b.extend_from_slice(&z);
+                }
+                None => b.extend_from_slice(&0u32.to_le_bytes()),
+            }
+            b.extend_from_slice(&0u32.to_le_bytes()); // the word that closes a layer
+        }
+        b.extend_from_slice(&[0u8; 256]);
+        b
+    }
+
+    #[test]
+    fn reads_a_layer_stack_in_order() {
+        let b = synth_stack(&[
+            ("base_c", 200.0, None),
+            ("line_c", 180.0, Some(64)),
+            ("grass_c", 150.0, Some(32)),
+        ]);
+        let ls = ground_layers(&b);
+        assert_eq!(
+            ls.iter().map(|l| l.sheet.name.as_str()).collect::<Vec<_>>(),
+            ["base_c", "line_c", "grass_c"],
+            "the stack has to come back in the order it is painted"
+        );
+        // The base covers everything, so it states no mask; the rest cut into it.
+        assert!(ls[0].mask.is_none());
+        assert_eq!(ls[1].mask.as_ref().unwrap().width, 64);
+        assert_eq!(ls[2].mask.as_ref().unwrap().width, 32);
+        // Tiling is read, not assumed — the viewer used to hardcode four metres for every one.
+        assert_eq!(ls[0].tile_u, 200.0);
+        assert_eq!(ls[1].tile_u, 180.0);
+        assert_eq!(ls[2].tile_u, 150.0);
+        assert_eq!(ls[1].mask.as_ref().unwrap().coverage.len(), 64 * 64);
+    }
+
+    /// A normal map hangs off the colour sheet above it and is not a layer of its own. Drawn
+    /// as ground it is a lilac sheet.
+    #[test]
+    fn a_normal_map_opens_no_layer() {
+        let b = synth_stack(&[
+            ("base_c", 200.0, None),
+            ("line_n_s", 180.0, Some(32)),
+            ("grassnorm", 150.0, Some(32)),
+        ]);
+        let names: Vec<_> = ground_layers(&b)
+            .iter()
+            .map(|l| l.sheet.name.clone())
+            .collect();
+        assert_eq!(names, ["base_c"], "only the colour sheet is ground");
+    }
+
+    /// Nothing in a map announces where the ground begins, so the walk finds its own phase.
+    /// A map with no stack in it at all must come back empty rather than reading its scenery
+    /// as ground — a banner tiled across the terrain is worse than no change at all.
+    #[test]
+    fn a_map_with_no_ground_reads_none() {
+        assert!(ground_layers(&[0u8; 4096]).is_empty());
+        let noise: Vec<u8> = (0..40_000u32).map(|i| (i.wrapping_mul(2_654_435_761) >> 13) as u8).collect();
+        assert!(ground_layers(&noise).is_empty());
+    }
 
     /// Ground words used to be looked for anywhere in a name, which is how Abydos's
     /// `logo-dirtmaster` came to be its dirt and I40's `banner_lucasoil` its soil. Both are

--- a/src-tauri/src/scenery.rs
+++ b/src-tauri/src/scenery.rs
@@ -31,6 +31,9 @@ const SURFACE_CACHE: &str = "track-surfaces-v4";
 /// surfaces' hundreds of megabytes, and finding them means reading the archive a third time.
 const GROUND_CACHE: &str = "track-ground-v2";
 
+/// The ground stack, cached as the blob the front end receives.
+const GROUND_LAYERS_CACHE: &str = "track-ground-layers-v1";
+
 /// How many decoded scenery meshes to keep. Smaller than the terrain's: one of these is
 /// about 30 MB, against 16 for a terrain master.
 const CACHE_KEEP: usize = 4;
@@ -868,6 +871,50 @@ pub fn load_ground(app: &tauri::AppHandle, path: &str) -> Result<Vec<MapTexture>
         prune_cache(app, GROUND_CACHE);
     }
     Ok(sheets)
+}
+
+/// The ground a track is painted with, cached like its surfaces.
+///
+/// Two or three hundred kilobytes once reduced — small next to the surfaces, and worth caching
+/// for the same reason: getting at it means pulling a several-hundred-megabyte `.map` out of an
+/// archive, which is most of a second.
+pub fn load_ground_layers(app: &tauri::AppHandle, path: &str) -> Result<Vec<u8>> {
+    let key = cache_key(path)?;
+    if let Some(hit) = cache_file(app, &key, GROUND_LAYERS_CACHE).and_then(|f| std::fs::read(f).ok())
+    {
+        if hit.len() >= map::GROUND_LAYERS_HEADER && hit.starts_with(b"FGLY") {
+            return Ok(hit);
+        }
+    }
+    let blob = map::ground_layers_blob(&read_ground_layers(path)?);
+    if let Some(f) = cache_file(app, &key, GROUND_LAYERS_CACHE) {
+        if let Some(parent) = f.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::write(&f, &blob);
+        prune_cache(app, GROUND_LAYERS_CACHE);
+    }
+    Ok(blob)
+}
+
+/// The uncached read: the expensive half, and the one the tests come in through.
+fn read_ground_layers(path: &str) -> Result<Vec<map::GroundLayer>> {
+    let p = Path::new(path);
+    let names = crate::track::entry_names(p)?;
+    let stem = track_stem(p);
+    for entry in entries_with_ext(&names, "map", &stem) {
+        let Ok(bytes) = crate::track::read_entry(p, &entry) else {
+            continue;
+        };
+        if !map::is_map(&bytes) {
+            continue;
+        }
+        let layers = map::ground_layers(&bytes);
+        if !layers.is_empty() {
+            return Ok(layers);
+        }
+    }
+    Ok(Vec::new())
 }
 
 /// A track's surfaces, cached apart from its mesh.

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -672,6 +672,19 @@ const GROUND_TILE_METRES = 4;
 /** How far the grain is allowed to swing the ground's brightness. */
 const GROUND_STRENGTH = 0.5;
 
+/**
+ * What the ground stack's average is lifted to, as linear albedo.
+ *
+ * A track's sheets are not albedo maps. They are photographs of dirt taken under their own
+ * light, and several are very dark on purpose — Indiana's base is luma 47 and the dark soil
+ * over it 35, which is 0.02 linear. Handed to a lit material raw, the whole track renders
+ * black. So the stack is scaled to put its *average* here and its layers keep their distances
+ * from each other, which is where the picture is: what the eye reads at any distance is the
+ * masks, not the grain. The same reasoning as `groundMean` on the single-sheet path below,
+ * which divides by the sheet's mean for exactly this reason.
+ */
+const STACK_TARGET_ALBEDO = 0.19;
+
 function TerrainMesh({
   terrain,
   overview,
@@ -794,6 +807,37 @@ function TerrainMesh({
     });
   }, [layers]);
 
+  // The stack's own average, weighted by how much of the ground each layer actually covers —
+  // a layer masked to a tenth of the map should not pull the whole track's brightness to it.
+  const stackGamma = useMemo(() => {
+    if (layers.length === 0) return 1;
+    let total = 0;
+    let weight = 0;
+    for (const l of layers) {
+      const px = l.sheet.pixels;
+      let lum = 0;
+      let n = 0;
+      for (let i = 0; i < px.length; i += 64) {
+        // Linearised before averaging: the mean of a sheet's sRGB bytes is not the mean of
+        // the light it stands for, and it is the light the material is handed.
+        for (let k = 0; k < 3; k += 1) lum += ((px[i + k] / 255) ** 2.2) * [0.299, 0.587, 0.114][k];
+        n += 1;
+      }
+      if (n === 0) continue;
+      const cover = l.mask
+        ? l.mask.coverage.reduce((a, v, i) => (i % 16 === 0 ? a + v / 255 : a), 0) /
+          Math.ceil(l.mask.coverage.length / 16)
+        : 1;
+      total += (lum / n) * cover;
+      weight += cover;
+    }
+    const mean = total / weight;
+    if (weight === 0 || !(mean > 0) || mean >= 1) return 1;
+    // The exponent that puts the stack's mean on the target. Clamped so a stack that is
+    // already about right is left alone and one sheet read wrong cannot flatten the rest.
+    return Math.min(Math.max(Math.log(STACK_TARGET_ALBEDO) / Math.log(mean), 0.3), 1);
+  }, [layers]);
+
   useEffect(
     () => () =>
       stack.forEach((l) => {
@@ -872,7 +916,7 @@ function TerrainMesh({
       <meshStandardMaterial
         key={`${texture ? "textured" : "plain"}-${detail ? "grain" : "flat"}-${
           relief ? "relief" : "smooth"
-        }-${repeat}-stack${stack.length}`}
+        }-${repeat}-stack${stack.length}-${stackGamma.toFixed(2)}`}
         color={stacked ? "#ffffff" : tint}
         map={stacked ? undefined : (texture ?? undefined)}
         normalMap={relief ?? undefined}
@@ -890,6 +934,7 @@ function TerrainMesh({
             // *physics* surfaces, and published tracks barely paint them. Indiana states one
             // 256x256 patch of concrete over a 2049-square grid, so drawn that way it is a
             // flat brown slab.
+            shader.uniforms.stackGamma = { value: stackGamma };
             stack.forEach((l, i) => {
               shader.uniforms[`stackSheet${i}`] = { value: l.sheet };
               shader.uniforms[`stackTile${i}`] = {
@@ -935,6 +980,7 @@ function TerrainMesh({
                 "#include <common>",
                 `#include <common>
                  varying vec2 vGroundUv;
+                 uniform float stackGamma;
                  ${decls}`,
               )
               .replace(
@@ -946,7 +992,7 @@ function TerrainMesh({
                    // Multiplied rather than assigned: what is already in diffuseColor is the
                    // cavity shading the relief is read by, and dropping it flattens every
                    // rut and berm the track has.
-                   diffuseColor.rgb *= ground;
+                   diffuseColor.rgb *= pow(ground, vec3(stackGamma));
                  }`,
               );
             return;

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import type {
   TrackBackdrop,
   TrackGround,
+  TrackGroundLayer,
   TrackMeshArrays,
   TrackOverview,
   TrackPlacement,
@@ -675,15 +676,22 @@ function TerrainMesh({
   terrain,
   overview,
   ground,
+  layers,
 }: {
   terrain: TrackTerrain;
   overview: TrackOverview | null;
   /** A tiling sheet of the track's own ground, multiplied in for close-up detail. */
   ground: TrackGround | null;
+  /** The ground the game draws: the track's own sheets, through the track's own masks. */
+  layers: TrackGroundLayer[];
 }) {
+  // The stack is the ground when a track states one. Everything below — the surface picture
+  // built from the physics masks, the single sheet tiled everywhere, the elevation ramp — is
+  // what to draw when it doesn't.
+  const stacked = layers.length > 0;
   // A track with no surface data of its own still has ground: its sheet says what colour that
   // is, so the elevation ramp is only reached for when a track states neither.
-  const tinted = overview != null || ground != null;
+  const tinted = overview != null || ground != null || stacked;
   const geometry = useMemo(() => buildGeometry(terrain, tinted), [terrain, tinted]);
 
   // Built once per picture and handed to the GPU as-is. `sRGB` because it's artwork rather
@@ -745,6 +753,54 @@ function TerrainMesh({
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [ground, repeat],
+  );
+
+  // The stack, as the GPU takes it: a sheet per layer wrapped for tiling, and its mask laid
+  // once across the whole ground. Masks are read as a single channel — they are coverage, not
+  // colour — which is a quarter of the memory of the same map as RGBA.
+  const stack = useMemo(() => {
+    return layers.map((l) => {
+      const sheet = new THREE.DataTexture(
+        l.sheet.pixels,
+        l.sheet.width,
+        l.sheet.height,
+        THREE.RGBAFormat,
+      );
+      sheet.wrapS = THREE.RepeatWrapping;
+      sheet.wrapT = THREE.RepeatWrapping;
+      sheet.minFilter = THREE.LinearMipmapLinearFilter;
+      sheet.magFilter = THREE.LinearFilter;
+      sheet.generateMipmaps = true;
+      sheet.anisotropy = 8;
+      sheet.needsUpdate = true;
+      let mask: THREE.DataTexture | null = null;
+      if (l.mask) {
+        mask = new THREE.DataTexture(
+          l.mask.coverage,
+          l.mask.width,
+          l.mask.height,
+          THREE.RedFormat,
+        );
+        // Clamped, never wrapped: a mask covers the ground once, and a repeat would tile the
+        // riding line across the whole map.
+        mask.wrapS = THREE.ClampToEdgeWrapping;
+        mask.wrapT = THREE.ClampToEdgeWrapping;
+        mask.minFilter = THREE.LinearMipmapLinearFilter;
+        mask.magFilter = THREE.LinearFilter;
+        mask.generateMipmaps = true;
+        mask.needsUpdate = true;
+      }
+      return { sheet, mask, tileU: l.tileU, tileV: l.tileV };
+    });
+  }, [layers]);
+
+  useEffect(
+    () => () =>
+      stack.forEach((l) => {
+        l.sheet.dispose();
+        l.mask?.dispose();
+      }),
+    [stack],
   );
 
   // The sheet's own average brightness. Dividing by it is what makes this a *detail* layer:
@@ -816,9 +872,9 @@ function TerrainMesh({
       <meshStandardMaterial
         key={`${texture ? "textured" : "plain"}-${detail ? "grain" : "flat"}-${
           relief ? "relief" : "smooth"
-        }-${repeat}`}
-        color={tint}
-        map={texture ?? undefined}
+        }-${repeat}-stack${stack.length}`}
+        color={stacked ? "#ffffff" : tint}
+        map={stacked ? undefined : (texture ?? undefined)}
         normalMap={relief ?? undefined}
         // Gentle: this is one ground sheet standing in for every surface a track has, so it
         // should suggest a texture underfoot rather than emboss the whole place.
@@ -827,6 +883,74 @@ function TerrainMesh({
         roughness={0.95}
         metalness={0}
         onBeforeCompile={(shader) => {
+          if (stacked) {
+            // The ground the game draws: the base sheet, then every layer above it mixed in
+            // by its own mask. This is what a track is actually painted with — the surface
+            // picture this replaces is built from the `.trh` coverage masks, which are the
+            // *physics* surfaces, and published tracks barely paint them. Indiana states one
+            // 256x256 patch of concrete over a 2049-square grid, so drawn that way it is a
+            // flat brown slab.
+            stack.forEach((l, i) => {
+              shader.uniforms[`stackSheet${i}`] = { value: l.sheet };
+              shader.uniforms[`stackTile${i}`] = {
+                value: new THREE.Vector2(l.tileU, l.tileV),
+              };
+              if (l.mask) shader.uniforms[`stackMask${i}`] = { value: l.mask };
+            });
+            shader.vertexShader = shader.vertexShader
+              .replace(
+                "#include <common>",
+                `#include <common>
+                 varying vec2 vGroundUv;`,
+              )
+              .replace(
+                "#include <begin_vertex>",
+                `#include <begin_vertex>
+                 vGroundUv = uv;`,
+              );
+            const decls = stack
+              .map(
+                (l, i) =>
+                  `uniform sampler2D stackSheet${i};
+                   uniform vec2 stackTile${i};` +
+                  (l.mask ? `\nuniform sampler2D stackMask${i};` : ""),
+              )
+              .join("\n");
+            // Each sheet is sampled at its own tiling — read from the track, not assumed. The
+            // viewer used to tile one sheet every four metres for every surface; Indiana's
+            // base repeats 200 times across 525 m and its dark soil 180, which is 2.6 m
+            // against 2.9 m. Wrong tiling reads as the wrong ground.
+            const blend = stack
+              .map((l, i) => {
+                const sample = `pow(texture2D(stackSheet${i}, vGroundUv * stackTile${i}).rgb, vec3(2.2))`;
+                // Sheets are handed over as raw bytes rather than tagged sRGB, so the decode
+                // is done here — three.js only converts the slots it compiled itself.
+                return i === 0 || !l.mask
+                  ? `  ground = ${sample};`
+                  : `  ground = mix(ground, ${sample}, texture2D(stackMask${i}, vGroundUv).r);`;
+              })
+              .join("\n");
+            shader.fragmentShader = shader.fragmentShader
+              .replace(
+                "#include <common>",
+                `#include <common>
+                 varying vec2 vGroundUv;
+                 ${decls}`,
+              )
+              .replace(
+                "#include <color_fragment>",
+                `#include <color_fragment>
+                 {
+                   vec3 ground = vec3(0.5);
+                 ${blend}
+                   // Multiplied rather than assigned: what is already in diffuseColor is the
+                   // cavity shading the relief is read by, and dropping it flattens every
+                   // rut and berm the track has.
+                   diffuseColor.rgb *= ground;
+                 }`,
+              );
+            return;
+          }
           if (!detail) return;
           shader.uniforms.groundMap = { value: detail };
           shader.uniforms.groundRepeat = { value: repeat };
@@ -1198,6 +1322,13 @@ interface TrackViewerProps {
   backdrop?: TrackBackdrop | null;
   /** A tiling sheet of the track's own ground, for detail closer than its data carries. */
   ground?: TrackGround | null;
+  /**
+   * The ground the game draws: the track's own sheets through the track's own masks.
+   *
+   * When a track states a stack this replaces the surface picture entirely — that picture is
+   * built from the `.trh` coverage masks, which are the physics surfaces rather than the paint.
+   */
+  groundLayers?: TrackGroundLayer[];
   /** Told what a click on the scenery landed on, and when the selection clears. */
   onPick?: (piece: PickedPiece | null) => void;
   /**
@@ -1229,6 +1360,7 @@ export function TrackViewer({
   showObjects = true,
   backdrop = null,
   ground = null,
+  groundLayers = [],
   onPick,
   focus = null,
   highlight = null,
@@ -1313,7 +1445,12 @@ export function TrackViewer({
           />
           <directionalLight position={[-6, 3, -5]} intensity={0.4} />
           {terrain && (
-            <TerrainMesh terrain={terrain} overview={overview} ground={ground} />
+            <TerrainMesh
+              terrain={terrain}
+              overview={overview}
+              ground={ground}
+              layers={groundLayers}
+            />
           )}
           {terrain && showObjects && scenery && (
             <SceneryMesh

--- a/src/Components/Viewer/TrackViewerDialog.tsx
+++ b/src/Components/Viewer/TrackViewerDialog.tsx
@@ -8,6 +8,7 @@ import {
   loadTrackOverview,
   loadTrackBackdrop,
   loadTrackGround,
+  loadTrackGroundLayers,
   loadTrackScenery,
   loadTrackSurfaces,
   loadTrackTerrain,
@@ -20,6 +21,7 @@ import type {
   TrackPlacement,
   TrackBackdrop,
   TrackGround,
+  TrackGroundLayer,
   TrackScenery,
   TrackSceneryTexture,
   TrackTerrain,
@@ -69,6 +71,7 @@ export function TrackViewerDialog({
   const [surfaces, setSurfaces] = useState<TrackSceneryTexture[]>([]);
   const [backdrop, setBackdrop] = useState<TrackBackdrop | null>(null);
   const [ground, setGround] = useState<TrackGround | null>(null);
+  const [groundLayers, setGroundLayers] = useState<TrackGroundLayer[]>([]);
   const [placements, setPlacements] = useState<TrackPlacement[]>([]);
   // On by default: the scenery is the difference between a shape and a place, and a track
   // that carries none simply has nothing to switch off.
@@ -100,6 +103,7 @@ export function TrackViewerDialog({
     setSurfaces([]);
     setBackdrop(null);
     setGround(null);
+    setGroundLayers([]);
     setPicked(null);
     setSceneryError(null);
     setPlacements([]);
@@ -130,6 +134,12 @@ export function TrackViewerDialog({
     // terrain is up.
     loadTrackGround(path)
       .then((g) => alive && setGround(g))
+      .catch(() => {});
+
+    // The ground the game draws. A few hundred kilobytes once reduced, and it replaces the
+    // surface picture rather than adding to it, so it is worth having as early as possible.
+    loadTrackGroundLayers(path)
+      .then((l) => alive && setGroundLayers(l))
       .catch(() => {});
 
     void (async () => {
@@ -291,6 +301,7 @@ export function TrackViewerDialog({
               surfaces={surfaces}
               backdrop={backdrop}
               ground={ground}
+              groundLayers={groundLayers}
               placements={placements}
               showObjects={showObjects}
               onPick={setPicked}

--- a/src/api/tracks.ts
+++ b/src/api/tracks.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type {
   TrackBackdrop,
   TrackGround,
+  TrackGroundLayer,
   TrackInfo,
   TrackMeshArrays,
   TrackOverview,
@@ -338,6 +339,64 @@ export async function loadTrackGround(path: string): Promise<TrackGround | null>
   if (sheets.length === 0) return null;
   // The colour first, then its relief where the track ships one.
   return { colour: sheets[0], normal: sheets[1] ?? null };
+}
+
+/** Header bytes before the layer table. Mirrors `map::GROUND_LAYERS_HEADER`. */
+const GROUND_LAYERS_HEADER = 16;
+/** Bytes per layer in that table. Mirrors `map::GROUND_LAYER_ENTRY`. */
+const GROUND_LAYER_ENTRY = 32;
+/** "FGLY", little-endian. */
+const GROUND_LAYERS_MAGIC = 0x594c4746;
+
+/**
+ * The ground a track is painted with, layer by layer.
+ *
+ * Empty when the track's `.map` states no stack the walk could read, in which case the viewer
+ * falls back to the single tiled sheet and the surface picture.
+ */
+export async function loadTrackGroundLayers(path: string): Promise<TrackGroundLayer[]> {
+  const buf = await invoke<ArrayBuffer>("load_track_ground_layers", { path });
+  if (buf.byteLength === 0) return [];
+  const view = new DataView(buf);
+  if (buf.byteLength < GROUND_LAYERS_HEADER || view.getUint32(0, true) !== GROUND_LAYERS_MAGIC) {
+    throw new Error("track ground layers are not in the expected format");
+  }
+  const count = view.getUint32(8, true);
+  const table = GROUND_LAYERS_HEADER;
+  const entries = [];
+  for (let i = 0; i < count; i += 1) {
+    const o = table + i * GROUND_LAYER_ENTRY;
+    entries.push({
+      width: view.getUint32(o, true),
+      height: view.getUint32(o + 4, true),
+      bytes: view.getUint32(o + 8, true),
+      tileU: view.getFloat32(o + 12, true),
+      tileV: view.getFloat32(o + 16, true),
+      maskW: view.getUint32(o + 20, true),
+      maskH: view.getUint32(o + 24, true),
+      maskBytes: view.getUint32(o + 28, true),
+    });
+  }
+  // The sheets follow the table back to back, then every mask in the same order.
+  let at = table + count * GROUND_LAYER_ENTRY;
+  const sheets = entries.map((e) => {
+    const pixels = new Uint8Array(buf, at, e.bytes);
+    at += e.bytes;
+    return pixels;
+  });
+  return entries.map((e, i) => {
+    const mask =
+      e.maskBytes > 0
+        ? { width: e.maskW, height: e.maskH, coverage: new Uint8Array(buf, at, e.maskBytes) }
+        : null;
+    at += e.maskBytes;
+    return {
+      sheet: { width: e.width, height: e.height, pixels: sheets[i] },
+      tileU: e.tileU,
+      tileV: e.tileV,
+      mask,
+    };
+  });
 }
 
 /** The models a track ships that a prop can be placed by name. */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -747,6 +747,23 @@ export interface TrackGround {
   normal: TrackSceneryTexture | null;
 }
 
+/**
+ * One painted layer of the ground the game draws.
+ *
+ * Not the same thing as the `.trh` coverage masks the overview picture is built from — those
+ * are the *physics* surfaces, a friction table, and published tracks barely paint them. This
+ * is the paint: a stack of tiling sheets, each cut into the one below by its own mask.
+ */
+export interface TrackGroundLayer {
+  /** The sheet, tiled across the ground. */
+  sheet: { width: number; height: number; pixels: Uint8Array<ArrayBuffer> };
+  /** How many times it repeats across the whole ground, per axis. Read from the track. */
+  tileU: number;
+  tileV: number;
+  /** Coverage, one byte a texel. `null` on the base layer, which covers everything. */
+  mask: { width: number; height: number; coverage: Uint8Array<ArrayBuffer> } | null;
+}
+
 /** What a track pins to a point but ships no mesh for. Mirrors `scenery::Placement`. */
 export interface TrackPlacement {
   /** A key, not prose — the UI translates it. */


### PR DESCRIPTION
## The fault

The viewer coloured terrain from the `.trh` coverage masks. **Those are the physics surfaces** — a material table of `asphalt/grass/sand/kerb/soil/concrete` carrying nine floats of friction each — and published tracks barely paint them:

| track | what the `.trh` actually paints |
|---|---|
| Indiana | **one 256×256 patch of `concrete`** over a 2049² grid |
| Briarcliff | two masks |
| I40 | mostly id 10, repeated |

Run through `surface_colour()`'s seven hand-picked RGBs, that is why a real track rendered as one flat brown slab with a blob on it.

The paint is somewhere else entirely, and nothing in the app had ever read it: the **`.map`'s trailing layer stack**. Each layer is a sheet, how far it tiles, and a mask cutting it into the layer below. We already *write* this format in `tracksynth::map` — traced against the game's own loader — but had never written a reader.

## The change

- **`map::ground_layers`** walks the stack; `load_track_ground_layers` caches it beside the surfaces. A few hundred KB once reduced — the masks are coarse, 256²–1024² against a 2049² heightfield.
- **The terrain shader** composites the stack in order, each sheet at **its own tiling**.
- Where a track states no stack, the viewer draws exactly what it drew before.

What Indiana actually carries:

| layer | tiling | mask | cover |
|---|---|---|---|
| `sand_bottom` (base) | 200×200 | — | 100% |
| `soil_dark_c` | 180×180 | 256² | 99.5% |
| `gravel_c` | 100×200 | 512² | 36.5% |

Its ground is 525 m, so 200 tiles is **2.6 m** a tile. The viewer tiled every sheet of every track at a hardcoded 4 m.

## Why a march, not a scan

The stack only means anything in order, but nothing announces where it begins — so the phase is *found*: every sheet record is tried as the first layer, and the march that reads furthest wins. A march starting in the wrong place dies within a layer or two, because **a layer only closes on a mask that inflates to exactly its stated size**.

Five other approaches were tried and measurably regressed — mask-owner pairing, contiguous-run grouping, material-record filtering, a fixed 12-zero anchor, and a chained scan. Each read Indiana's `trex_c` or I40's `MetalRoof` as ground. This one stops early rather than inventing a layer, which is the failure mode you want: a banner tiled across the terrain is worse than no change.

## Known limits

**8 of 23 installed tracks read a stack, and Indiana reads 3 of its 6 layers.** The march stops where a layer carries a normal map, whose header is a variable run of words I could not pin from two samples. That is the next thing to fix, and it is why this is scoped as a floor rather than a finish.

## Verification

- 1439 Rust tests pass, 3 new: order and tiling round-trip through a synthetic stack; a normal map opens no layer; a map with no ground reads none rather than reading its scenery.
- Reader exercised against all 23 installed tracks; typecheck and lint clean.
- **Not yet seen in the running app** — the dev instance's window sat on another Space behind a fullscreen app, and I would not switch Spaces to grab it. The shader is unproven on screen.

Also restores `docs/guides/tools/uidrive.swift`, the CGEvent harness for driving the app on macOS; it was absent from `main` and had to be rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)