### PR TITLE
feat(servers): keep the server list live while the game runs, and filter the spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## 2026-09-07
 
+### Added
+- The server list keeps working while MX Bikes is running. It asks each server directly rather
+  than the master list, so nothing competes with the game for your account.
+- Servers advertising cheats are hidden, by the same rules FrostMod uses in the game. The tab
+  says how many it hid and lets you look at them.
+- A server's details show who is on it: everyone in the session when it is the server you are
+  riding, and the riders using paint sync anywhere else.
+- A server's details name the track it is running, show its picture when you already have it,
+  and point you at the shop or MXB Hub when you don't.
+
+### Changed
+- Opening a server asks it for fresh numbers, so the riders, the session and the track are what
+  they are now rather than what they were when the list loaded.
+
 ### Fixed
 - Trackside scenery in the 3D viewer no longer stands in slabs of flat grey. A track whose
   textures the viewer can't read now leaves its banners and foliage out rather than drawing

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -300,6 +300,7 @@ async function route(request: Request, env: Env): Promise<Response> {
   if (method === "PUT" && path === "/v1/loadout") return putLoadout(request, account, env);
   if (method === "PUT" && path === "/v1/loadouts") return putLoadouts(request, account, env);
   if (method === "GET" && path === "/v1/roster") return roster(url, account, env);
+  if (method === "GET" && path === "/v1/presence") return whoIsOn(url, env);
 
   const openPaint = /^\/v1\/paints\/([0-9a-f]{64})$/.exec(path);
   if (openPaint) {
@@ -1889,6 +1890,54 @@ async function roster(url: URL, account: Account, env: Env): Promise<Response> {
     });
   }
   return json(200, { server: serverId, riders: [...riders.values()] });
+}
+
+/**
+ * Who the app can see on a server, by name alone.
+ *
+ * The server browser wants to put faces to a rider count, and `/v1/roster` cannot do it: it
+ * joins through `loadout_paints`, so a rider who has never published a paint is invisible to
+ * it, and it hauls back every paint row for everyone to answer a question about names. This
+ * reads `presence` and nothing else.
+ *
+ * **It takes more than one key on purpose.** The same server is recorded under two different
+ * keys depending on how the app found out where it was: a rider who joined through the app
+ * reports the address key (`server_key_for`), while a rider whose session was detected by
+ * FrostMod reports the folded server *name*, because a name is the only thing every rider in a
+ * session can compute. Asking under one key would show half a grid and look like the other
+ * half had left.
+ *
+ * Deliberately not a "who is on every server" endpoint. That would be one query returning the
+ * whole platform's whereabouts to anyone who asked, and the browser only ever needs the server
+ * whose panel is open.
+ */
+async function whoIsOn(url: URL, env: Env): Promise<Response> {
+  const keys = url.searchParams
+    .getAll("server")
+    .flatMap((v) => v.split(","))
+    .map((v) => v.trim())
+    .filter((v) => isServerKey(v));
+  // Bounded because it becomes an IN list; two is the real-world case and the rest is slack.
+  const wanted = [...new Set(keys)].slice(0, 8);
+  if (wanted.length === 0) return json(400, { error: "a server id is required" });
+
+  const placeholders = wanted.map(() => "?").join(", ");
+  const rows = await env.DB.prepare(
+    "SELECT a.rider_name, a.guid FROM accounts a" +
+      " JOIN presence pr ON pr.account_id = a.id" +
+      ` WHERE pr.server_id IN (${placeholders}) AND pr.updated_at > ?` +
+      " ORDER BY a.rider_name",
+  )
+    .bind(...wanted, Date.now() - PRESENCE_TTL_MS)
+    .all<{ rider_name: string; guid: string | null }>();
+
+  // One rider, one entry, however many of the keys they are recorded under.
+  const seen = new Map<string, { riderName: string; guid: string | null }>();
+  for (const r of rows.results) {
+    const key = r.guid ?? `name:${r.rider_name.toLowerCase()}`;
+    if (!seen.has(key)) seen.set(key, { riderName: r.rider_name, guid: r.guid });
+  }
+  return json(200, { riders: [...seen.values()] });
 }
 
 /** Read a column we wrote as JSON. A row that somehow isn't parseable is an empty list, not

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -128,6 +128,8 @@ mod presets;
 mod paintsync;
 mod reshade;
 mod scenery;
+mod serverbook;
+mod serverfilter;
 mod servers;
 mod sessionwatch;
 mod shop_catalog_session;
@@ -7736,7 +7738,7 @@ fn join_server(app: tauri::AppHandle, address: String) -> Result<gameproc::Launc
 /// from the master-server list; a superset of [`paintsync::RegisteredServer`] so the tab's
 /// Join button reuses [`join_server`]. The struct carries no protocol detail — that all lives
 /// behind `cfg(worldnet)` — so it stays in the public tree and the command compiles either way.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WorldServer {
     /// Display name the operator gave the server.
@@ -7777,6 +7779,181 @@ pub struct WorldServer {
     pub force_cockpit: bool,
     pub no_aids: bool,
     pub limited_tyre_sets: bool,
+    /// Why the spam filter would hide this row, or empty to show it. The row is sent either
+    /// way: the tab shows a count of what was hidden and can reveal it, and someone who thinks
+    /// a rule is wrong has to be able to see what it caught. See [`serverfilter`].
+    pub hidden: String,
+}
+
+/// Who the app can name on a server, and where the names came from.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerRiders {
+    pub riders: Vec<String>,
+    /// `"session"` when it is the game's own roster for the server you are on — every rider,
+    /// named by the server. `"app"` when it is the riders whose own apps reported themselves
+    /// there, which is a subset and has to be labelled as one.
+    pub source: String,
+}
+
+/// The riders on a server, as far as anything can honestly say.
+///
+/// MX Bikes will not tell a stranger who is on a server. `GETINFO` answers with a rider count
+/// and a seat count and nothing else, and the roster message is only ever built inside a live
+/// session — so a full list for a server you are not on does not exist to be fetched.
+///
+/// That leaves two real answers, and the panel says which one it is showing. If you are on the
+/// server, FrostMod is in the session and hands over the actual grid. Otherwise the control
+/// plane knows where each rider's *app* said it was, which names the players who run MXB App
+/// and nobody else.
+#[tauri::command]
+async fn server_riders(
+    app: tauri::AppHandle,
+    address: String,
+    name: String,
+) -> Result<ServerRiders, String> {
+    // The game's own roster, when this is the server under us. `room_key` folds both sides so
+    // capitalisation or a stray space can't make a server fail to match itself.
+    if let Some(session) = live_session() {
+        if session.on_a_server()
+            && voice::session::room_key(&session.server_name) == voice::session::room_key(&name)
+        {
+            let riders = session.riders.into_iter().map(|r| r.name).collect();
+            return Ok(ServerRiders { riders, source: "session".into() });
+        }
+    }
+
+    let cfg = config::load_or_detect(&app).unwrap_or_default();
+    let token = Some(cfg.cp_token.as_str()).filter(|t| !t.trim().is_empty());
+
+    // Both key forms, because presence is recorded under whichever one the reporting app had:
+    // the address for a rider who joined through the app, the folded server name for one whose
+    // session FrostMod detected. See `paintsync::who_is_on`.
+    let mut keys = Vec::new();
+    if !address.trim().is_empty() {
+        let registry = paintsync::registry(token).await.unwrap_or_default();
+        keys.push(paintsync::server_key_for(&registry, &address));
+    }
+    let named = voice::session::room_key(&name);
+    if !named.is_empty() && !keys.contains(&named) {
+        keys.push(named);
+    }
+    if keys.is_empty() {
+        return Ok(ServerRiders::default());
+    }
+
+    let riders = paintsync::who_is_on(token, &keys).await.map_err(|e| format!("{e:#}"))?;
+    Ok(ServerRiders { riders, source: "app".into() })
+}
+
+/// What track a server is running, matched against what the player has and what they could get.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrackGuess {
+    /// The internal id the server published, e.g. `mmx_supercross`.
+    pub id: String,
+    /// The installed track's file or folder name, empty when it isn't installed.
+    pub installed: String,
+    /// The installed track's own preview image, as a data URL.
+    pub preview: String,
+    /// Where a copy could come from when it isn't installed: `"shop"`, `"hub"`, or empty.
+    pub source: String,
+    pub product_id: u64,
+    pub product_name: String,
+    pub product_url: String,
+    pub product_image: String,
+    /// False when the name only resembles the track rather than matching it. The panel says
+    /// "we think" for these, because an internal id is not a product title and a fold of one
+    /// onto the other is a guess however good it looks.
+    pub exact: bool,
+}
+
+/// Work out which track a server means.
+///
+/// The server publishes an internal id — `mmx_supercross` — and nothing else. That is not a
+/// product title, not a folder name, and not something a player can search for, which is why
+/// the tab has always shown it raw and left everyone to guess.
+///
+/// Three answers in order of how much they are worth: the track is installed and the panel can
+/// show its own preview; there is an exact catalogue match and the panel can offer it; the name
+/// merely resembles something, which is offered as a guess and labelled as one.
+#[tauri::command]
+async fn guess_server_track(app: tauri::AppHandle, track: String) -> Result<TrackGuess, String> {
+    let id = track.trim().to_string();
+    let mut guess = TrackGuess { id: id.clone(), ..Default::default() };
+    if id.is_empty() {
+        return Ok(guess);
+    }
+
+    // Installed wins outright: nothing to buy, and the track's own artwork beats a shop photo.
+    if let Ok(entries) = scan_library(app.clone(), "tracks".into()).await {
+        let want = fold_name(&id);
+        if let Some(hit) = entries.iter().find(|e| fold_name(&e.name) == want) {
+            guess.installed = hit.name.clone();
+            guess.exact = true;
+            guess.preview = pkz::read_preview(std::path::Path::new(&hit.path))
+                .ok()
+                .flatten()
+                .unwrap_or_default();
+            return Ok(guess);
+        }
+    }
+
+    // The shop's own matcher, which is the fold the Browse grid already trusts to decide
+    // whether something is installed — reused here rather than a second opinion about names.
+    if let Ok(hits) = mods::shop_catalog::match_products(&app, &[id.clone()]).await {
+        if let Some(hit) = hits.into_iter().flatten().next() {
+            return Ok(shop_guess(guess, hit, true));
+        }
+    }
+    // Nothing matched outright, so fall back to searching for it. The id is snake_case and a
+    // product title is not, so the underscores become spaces before either catalogue sees it.
+    let words = id.replace('_', " ");
+    if let Ok(page) =
+        mods::shop_catalog::search(&app, &words, None, 1, mods::shop_catalog::ShopSort::default(), false).await
+    {
+        if let Some(hit) = page.items.into_iter().next() {
+            return Ok(shop_guess(guess, hit, false));
+        }
+    }
+
+    // Nothing in the shop; the hub is the other half of where tracks come from. Asked directly
+    // rather than through `with_hub_clearance`: that answers the robot challenge by opening a
+    // browser, and this runs from opening a panel. A browser window appearing because someone
+    // clicked a server row would be an ambush, so a challenge here simply means no guess.
+    if let Ok(page) = mods::hub::search(&words, None, 1, mods::hub::HubSort::default(), false).await {
+        if let Some(hit) = page.items.into_iter().next() {
+            guess.source = "hub".into();
+            guess.product_id = hit.id;
+            guess.product_name = hit.title;
+            guess.product_url = hit.url.unwrap_or_default();
+            guess.product_image = hit.image.unwrap_or_default();
+        }
+    }
+    Ok(guess)
+}
+
+fn shop_guess(mut guess: TrackGuess, hit: mods::shop_catalog::ShopMod, exact: bool) -> TrackGuess {
+    guess.source = "shop".into();
+    guess.product_id = hit.id;
+    guess.product_name = hit.title;
+    guess.product_url = hit.url.unwrap_or_default();
+    guess.product_image = hit.image.unwrap_or_default();
+    guess.exact = exact;
+    guess
+}
+
+/// Lowercase and reduce everything that isn't alphanumeric to a single space, so an internal
+/// id (`mmx_supercross`) and a folder or product name ("MMX Supercross") fold together. The
+/// same rule the shop catalogue matches on, so the two agree about what counts as the same
+/// name.
+fn fold_name(raw: &str) -> String {
+    raw.chars()
+        .map(|c| if c.is_alphanumeric() { c.to_ascii_lowercase() } else { ' ' })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// The live MX Bikes server list, as the game's WORLD browser sees it.
@@ -7794,6 +7971,24 @@ async fn list_master_servers(app: tauri::AppHandle) -> Result<Vec<WorldServer>, 
     #[cfg(not(worldnet))]
     {
         let _ = app;
+        Err("The server browser isn't included in this build.".into())
+    }
+}
+
+/// Ask one server about itself, right now.
+///
+/// The detail panel used to format whatever the list happened to hold, which on a busy evening
+/// is minutes old — the rider count, the session and the track are all things that move while
+/// somebody reads the row. `GETINFO` costs one datagram and no account, so the panel asks.
+#[tauri::command]
+async fn probe_server(address: String) -> Result<WorldServer, String> {
+    #[cfg(worldnet)]
+    {
+        worldnet::probe_server(address).await
+    }
+    #[cfg(not(worldnet))]
+    {
+        let _ = address;
         Err("The server browser isn't included in this build.".into())
     }
 }
@@ -10406,6 +10601,9 @@ fn main() {
             launch_game,
             join_server,
             list_master_servers,
+            probe_server,
+            server_riders,
+            guess_server_track,
             experimental_state,
             enroll_account,
             // Paid plugins: the catalogue, redeeming a key, and getting a bundle on disk.

--- a/src-tauri/src/paintsync.rs
+++ b/src-tauri/src/paintsync.rs
@@ -477,6 +477,38 @@ pub async fn report_presence(token: &str, server_id: &str) -> anyhow::Result<()>
     Ok(())
 }
 
+/// The riders the control plane can see on a server, by name.
+///
+/// The counterpart of [`report_presence`]: every rider's app says where it is, and this asks
+/// who said a given server. It is the only way the browser can name anybody — MX Bikes never
+/// tells a stranger who is on a server, so a rider the app can name is precisely a rider whose
+/// own app reported them.
+///
+/// **Both keys are sent**, because the same server is recorded under two of them: the address
+/// key for a rider who joined through the app, and the folded server name for one whose
+/// session FrostMod detected. Asking under one would show half a grid.
+///
+/// Best-effort: a control plane that can't be reached means a rider count with no names beside
+/// it, which is the honest answer anyway.
+pub async fn who_is_on(token: Option<&str>, keys: &[String]) -> anyhow::Result<Vec<String>> {
+    #[derive(Deserialize)]
+    struct Rider {
+        #[serde(rename = "riderName")]
+        rider_name: String,
+    }
+    #[derive(Deserialize)]
+    struct Resp {
+        riders: Vec<Rider>,
+    }
+    let query: Vec<(&str, &str)> = keys.iter().map(|k| ("server", k.as_str())).collect();
+    let mut req = client()?.get(format!("{}/v1/presence", control_plane())).query(&query);
+    if let Some(t) = token {
+        req = req.bearer_auth(t);
+    }
+    let resp: Resp = req.send().await?.error_for_status()?.json().await?;
+    Ok(resp.riders.into_iter().map(|r| r.rider_name).collect())
+}
+
 /// A server in the control plane's registry, as `GET /v1/servers` returns it.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/serverbook.rs
+++ b/src-tauri/src/serverbook.rs
@@ -1,0 +1,278 @@
+//! Every server we have ever been told about, so the browser doesn't need the master to work.
+//!
+//! The master server is the only thing that can *discover* a server, and asking it costs the
+//! player's Steam account — a `LOGIN` carrying an encrypted app ticket. The game spends that
+//! same account whenever it is running, which is why the tab used to go dark mid-session.
+//!
+//! But discovery is the only part that needs the master. A server answers `GETINFO` to anyone
+//! who asks, with no challenge, no password and no ticket, and the reply carries everything the
+//! list shows: name, riders, seats, password, the whole event blob. So the addresses are worth
+//! keeping: with a book of them the app can rebuild the entire list by asking the servers
+//! themselves, and never touch the account the game is using.
+//!
+//! The book is written after every successful master sweep and is otherwise append-and-age:
+//! a server that stops answering keeps its row for a while, because "the host rebooted" and
+//! "the host is gone" look identical for the first few minutes and only one of them is worth
+//! forgetting.
+
+use crate::WorldServer;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// One remembered server. Only the fields the master is the sole source of — everything else
+/// comes back live from the server itself, so storing it would just be a staler copy.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase", default)]
+pub struct Entry {
+    /// `ip:port` — the key, and the only field that is truly required.
+    pub address: String,
+    /// Last name the master gave it. A `GETINFO` reply carries a name too, so this is really
+    /// just what the row says before the probe comes back.
+    pub name: String,
+    /// The address the server reports for itself; kept because the master is the only place it
+    /// appears and the detail panel shows it.
+    pub lan_address: String,
+    /// Operator free text, `[connection] location`. Never sent by `GETINFO`.
+    pub location: String,
+    /// Licence class the server requires. Also master-only.
+    pub rating: String,
+    /// Whether the game could reach the address at all.
+    pub joinable: bool,
+    /// Milliseconds since the epoch, from the last sweep that saw it.
+    pub last_seen: u64,
+}
+
+/// How long a server that has stopped appearing is kept.
+///
+/// Long enough that a host taken down for a weekend comes back to its own row, short enough
+/// that the book doesn't become a list of everything that ever existed — every entry costs a
+/// datagram on every probe-only refresh, so this is a real budget and not just tidiness.
+pub const KEEP: std::time::Duration = std::time::Duration::from_secs(30 * 24 * 60 * 60);
+
+/// The most addresses the book will hold. A cap the master can't push past, because the
+/// refresh that reads this book sends one datagram per row and a runaway file would turn a
+/// tab refresh into a port scan.
+pub const MAX_ENTRIES: usize = 2000;
+
+fn path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    use tauri::Manager;
+    Ok(app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("no data directory: {e}"))?
+        .join("servers.json"))
+}
+
+/// Read the book. A missing or damaged file is an empty book, never an error: the browser's
+/// answer to "I have no addresses" is to ask the master, which is what it would do anyway.
+pub fn load(app: &tauri::AppHandle) -> Vec<Entry> {
+    let Ok(p) = path(app) else { return Vec::new() };
+    read(&p)
+}
+
+fn read(p: &Path) -> Vec<Entry> {
+    let Ok(text) = std::fs::read_to_string(p) else { return Vec::new() };
+    match serde_json::from_str::<Vec<Entry>>(&text) {
+        Ok(entries) => entries,
+        Err(e) => {
+            log::warn!("[serverbook] {} isn't readable ({e}); starting a fresh book", p.display());
+            Vec::new()
+        }
+    }
+}
+
+/// Fold a fresh master sweep into the book and write it back.
+///
+/// Best-effort: a book we couldn't write is a slower refresh next time, not a failed one, so
+/// nothing here is allowed to fail a list the player is already looking at.
+pub fn remember(app: &tauri::AppHandle, servers: &[WorldServer], now: u64) {
+    let Ok(p) = path(app) else { return };
+    let merged = merge(read(&p), servers, now);
+    if let Some(dir) = p.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    match serde_json::to_string_pretty(&merged) {
+        Ok(text) => {
+            if let Err(e) = std::fs::write(&p, text) {
+                log::warn!("[serverbook] couldn't write {}: {e}", p.display());
+            }
+        }
+        Err(e) => log::warn!("[serverbook] couldn't serialize the book: {e}"),
+    }
+}
+
+/// The merge itself, with no I/O in it so the ageing and the cap can be tested directly.
+///
+/// A server that appears in the sweep is refreshed and re-stamped; one that doesn't keeps the
+/// stamp it had, and ages out on its own. Newest-seen first, so the cap drops the coldest
+/// addresses rather than an arbitrary slice.
+pub fn merge(existing: Vec<Entry>, servers: &[WorldServer], now: u64) -> Vec<Entry> {
+    let cutoff = now.saturating_sub(KEEP.as_millis() as u64);
+    let mut book: Vec<Entry> = existing.into_iter().filter(|e| e.last_seen >= cutoff).collect();
+
+    for s in servers {
+        if s.address.trim().is_empty() {
+            continue;
+        }
+        let fresh = Entry {
+            address: s.address.clone(),
+            name: s.name.clone(),
+            lan_address: s.lan_address.clone(),
+            location: s.location.clone(),
+            rating: s.rating.clone(),
+            joinable: s.joinable,
+            last_seen: now,
+        };
+        match book.iter_mut().find(|e| e.address == s.address) {
+            Some(e) => *e = fresh,
+            None => book.push(fresh),
+        }
+    }
+
+    book.sort_by(|a, b| b.last_seen.cmp(&a.last_seen).then_with(|| a.address.cmp(&b.address)));
+    book.truncate(MAX_ENTRIES);
+    book
+}
+
+/// Turn the book back into rows to probe.
+///
+/// Every field the master owns is restored and everything else left at its default, because
+/// the probe is about to overwrite it. A row that never gets an answer is dropped by the
+/// caller — showing a remembered name beside a rider count from last week would be worse than
+/// showing nothing.
+pub fn rows(book: &[Entry]) -> Vec<WorldServer> {
+    book.iter()
+        .map(|e| WorldServer {
+            name: e.name.clone(),
+            address: e.address.clone(),
+            joinable: e.joinable,
+            lan_address: e.lan_address.clone(),
+            location: e.location.clone(),
+            rating: e.rating.clone(),
+            ..Default::default()
+        })
+        .collect()
+}
+
+/// Milliseconds since the epoch; 0 from a clock we can't read, which ages everything out
+/// rather than keeping it forever.
+pub fn now_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn server(address: &str, name: &str) -> WorldServer {
+        WorldServer {
+            name: name.into(),
+            address: address.into(),
+            joinable: true,
+            location: "EU".into(),
+            rating: "B".into(),
+            ..Default::default()
+        }
+    }
+
+    const DAY: u64 = 24 * 60 * 60 * 1000;
+
+    #[test]
+    fn a_sweep_becomes_a_book() {
+        let book = merge(vec![], &[server("198.51.100.1:54210", "One")], 1_000);
+        assert_eq!(book.len(), 1);
+        assert_eq!(book[0].address, "198.51.100.1:54210");
+        assert_eq!(book[0].location, "EU");
+        assert_eq!(book[0].last_seen, 1_000);
+    }
+
+    /// The book is the union, not the last sweep: a server the master happened not to list this
+    /// time is exactly the one a probe-only refresh still wants to ask.
+    #[test]
+    fn a_server_missing_from_this_sweep_is_kept() {
+        let first = merge(vec![], &[server("198.51.100.1:54210", "One")], DAY);
+        let second = merge(first, &[server("198.51.100.2:54210", "Two")], 2 * DAY);
+        assert_eq!(second.len(), 2);
+        assert!(second.iter().any(|e| e.address == "198.51.100.1:54210"));
+    }
+
+    #[test]
+    fn a_returning_server_is_refreshed_not_duplicated() {
+        let first = merge(vec![], &[server("198.51.100.1:54210", "Old name")], DAY);
+        let second = merge(first, &[server("198.51.100.1:54210", "New name")], 2 * DAY);
+        assert_eq!(second.len(), 1);
+        assert_eq!(second[0].name, "New name");
+        assert_eq!(second[0].last_seen, 2 * DAY);
+    }
+
+    /// Every row costs a datagram on every probe-only refresh, so a host that disappeared
+    /// months ago has to stop being asked.
+    #[test]
+    fn a_long_gone_server_ages_out() {
+        let old = merge(vec![], &[server("198.51.100.1:54210", "Gone")], DAY);
+        let now = DAY + KEEP.as_millis() as u64 + 1;
+        let book = merge(old, &[], now);
+        assert!(book.is_empty());
+    }
+
+    #[test]
+    fn a_server_seen_yesterday_survives() {
+        let old = merge(vec![], &[server("198.51.100.1:54210", "Here")], DAY);
+        let book = merge(old, &[], 2 * DAY);
+        assert_eq!(book.len(), 1);
+    }
+
+    /// The cap has to drop the coldest addresses; dropping the freshest would mean the servers
+    /// people are actually on are the ones that stop being remembered.
+    #[test]
+    fn the_cap_drops_the_coldest_first() {
+        let mut book: Vec<Entry> = (0..MAX_ENTRIES)
+            .map(|i| Entry {
+                address: format!("198.51.100.1:{}", 10_000 + i),
+                last_seen: 10 * DAY,
+                ..Default::default()
+            })
+            .collect();
+        book.push(Entry { address: "cold:1".into(), last_seen: 2 * DAY, ..Default::default() });
+
+        let merged = merge(book, &[server("hot:1", "Hot")], 11 * DAY);
+        assert_eq!(merged.len(), MAX_ENTRIES);
+        assert_eq!(merged[0].address, "hot:1", "the newest sighting leads");
+        assert!(!merged.iter().any(|e| e.address == "cold:1"), "the coldest row is what goes");
+    }
+
+    /// A record with no address can't be probed and can't be joined, so it has no business in
+    /// a book whose whole purpose is addresses.
+    #[test]
+    fn a_record_with_no_address_is_not_remembered() {
+        let book = merge(vec![], &[server("", "Nameless"), server("  ", "Blank")], 1_000);
+        assert!(book.is_empty());
+    }
+
+    /// What the probe-only refresh starts from: the master's fields restored, everything the
+    /// server itself will answer left empty.
+    #[test]
+    fn rows_restore_what_only_the_master_knows() {
+        let book = merge(vec![], &[server("198.51.100.1:54210", "One")], 1_000);
+        let rows = rows(&book);
+        assert_eq!(rows[0].location, "EU");
+        assert_eq!(rows[0].rating, "B");
+        assert!(rows[0].joinable);
+        assert_eq!(rows[0].players, 0, "the probe fills this in, the book must not pretend to");
+        assert_eq!(rows[0].ping_ms, None);
+    }
+
+    /// A book that has been hand-edited into nonsense must not take the tab down with it.
+    #[test]
+    fn a_damaged_book_reads_as_an_empty_one() {
+        let dir = std::env::temp_dir().join(format!("serverbook-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let p = dir.join("servers.json");
+        std::fs::write(&p, "{ not json at all").unwrap();
+        assert!(read(&p).is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/src/serverfilter.rs
+++ b/src-tauri/src/serverfilter.rs
@@ -1,0 +1,467 @@
+//! Hiding the spam and cheat servers, by the same rules FrostMod already hides them in-game.
+//!
+//! The master lists whatever registers with it, and a good part of that is advertising: names
+//! shouting about cheats that can't be joined, and clusters of them from one host. FrostMod
+//! solved this on the game's own browser (`serverfilter.cpp`) by splicing its list-populate
+//! loop; the app's browser needs the same answer, and a player who has tuned the rules in one
+//! should not have to tune them again in the other.
+//!
+//! So this is a port, not a second design: the same minimal YAML, the same keys, the same
+//! order of tests, and the same defaults. It reads FrostMod's own
+//! `frostmod_serverfilter.yaml` when there is one, which is what makes the two agree.
+//!
+//! It does have to be its own parser rather than a `serde_yaml` dependency. FrostMod hand-rolls
+//! the reader in C++, and the point here is to read *that* file the way *it* does — an
+//! off-the-shelf YAML parser would be stricter about some lines and looser about others, and
+//! the two browsers would quietly disagree about a rule the player wrote once.
+//!
+//! **It is also more capable than the original, because the app has more to work with.**
+//! `SB_SuppressRow` builds its candidate from the game's in-memory row, which carries no
+//! address and no password flag, so `maxPerIP` and `hideLocked` are unreachable in the DLL
+//! however the file is written. Here both fields come off the master record, so both rules run.
+
+use crate::WorldServer;
+use regex::Regex;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// FrostMod's shipped defaults, verbatim from `kDefaultConfig` in `serverfilter.cpp`.
+///
+/// Carried as the file's own text rather than as constructed rules so that "what the app
+/// filters with" and "what FrostMod writes on first run" are the same bytes, and a drift
+/// between them is a failing test rather than a difference nobody notices.
+const DEFAULT_CONFIG: &str = "\
+# frostmod-filter v4
+# FrostMod server filter - hide spam/ad servers from the online browser.
+# Hidden if the name contains any 'names' entry or matches any 'regex'.
+hideUnjoinable: false   # ping '---' - unreliable at list time, keep off
+hideEmpty: false        # hide 0-player servers (many legit ones are just empty)
+hideLocked: false       # hide password-locked servers
+maxPerIP: 0             # 0 = off; else hide servers past N from one IP per refresh
+names:                  # case-insensitive substrings
+  - che4ts
+  - kaizo
+  - kalz0
+regex:                  # ECMAScript regex; single-quote to keep backslashes literal
+  - '(che[a4]ts|k[a4][il1]z[o0]|\\.pr0\\b)'
+";
+
+/// The file FrostMod writes beside its DLL, and the one we read if it's there.
+pub const CONFIG_NAME: &str = "frostmod_serverfilter.yaml";
+
+/// What the rules can be asked about one server.
+#[derive(Debug, Default, Clone)]
+pub struct Candidate {
+    pub name: String,
+    /// Host part of the address, for `maxPerIP`. Empty disables that rule for this row.
+    pub ip: String,
+    pub players: u32,
+    pub passworded: bool,
+    /// The server didn't answer its own `GETINFO`. Unlike in the game — where every row reads
+    /// `---` until the pings resolve, which is why FrostMod keeps this off — the probe here has
+    /// already run by the time a rule sees the row, so the answer means something.
+    pub unjoinable: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct Rules {
+    name_contains: Vec<String>,
+    /// Source text beside the compiled form: a reason a player can match against their own file
+    /// is worth more than "a regex matched".
+    regexes: Vec<(String, Regex)>,
+    max_per_ip: u32,
+    hide_locked: bool,
+    hide_empty: bool,
+    hide_unjoinable: bool,
+    /// Lines the parser couldn't use, surfaced so a typo in the file is visible in the log
+    /// rather than silently costing a rule.
+    pub complaints: Vec<String>,
+}
+
+impl Rules {
+    /// The shipped defaults, for when there is no file to read.
+    pub fn defaults() -> Rules {
+        Rules::parse(DEFAULT_CONFIG)
+    }
+
+    /// FrostMod's file if it has one, otherwise the defaults.
+    ///
+    /// Deliberately never writes the file. FrostMod owns it — it versions it, backs up an
+    /// out-of-date one and rewrites it — and two programs writing one config is how a player's
+    /// edits get lost.
+    pub fn load(dir: &Path) -> Rules {
+        match std::fs::read_to_string(dir.join(CONFIG_NAME)) {
+            Ok(text) => {
+                let rules = Rules::parse(&text);
+                log::info!(
+                    "[serverfilter] {} name rule(s), {} regex(es) from FrostMod's own {CONFIG_NAME}",
+                    rules.name_contains.len(),
+                    rules.regexes.len()
+                );
+                for c in &rules.complaints {
+                    log::warn!("[serverfilter] {c}");
+                }
+                rules
+            }
+            Err(_) => Rules::defaults(),
+        }
+    }
+
+    /// The minimal YAML FrostMod writes: `key: value` scalars, and `key:` followed by `  - item`
+    /// block lists for `names` / `regex`. `#` starts a comment, matching is case-insensitive,
+    /// and an unreadable line is a complaint rather than a failure — half a ruleset still hides
+    /// half the spam, where refusing the file hides none of it.
+    pub fn parse(text: &str) -> Rules {
+        #[derive(PartialEq, Clone, Copy)]
+        enum List {
+            None,
+            Names,
+            Regex,
+        }
+        let mut r = Rules::default();
+        let mut cur = List::None;
+
+        for raw in text.lines() {
+            let line = raw.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+
+            if let Some(item) = line.strip_prefix('-') {
+                let v = unquote(item.trim());
+                if v.is_empty() {
+                    continue;
+                }
+                match cur {
+                    List::Names => r.name_contains.push(v.to_lowercase()),
+                    List::Regex => r.push_regex(&v),
+                    List::None => r.complaints.push(format!("'- {v}' has no list key above it; ignored")),
+                }
+                continue;
+            }
+
+            let Some((key, value)) = line.split_once(':') else {
+                r.complaints.push(format!("ignoring line: {line}"));
+                continue;
+            };
+            let value = value.trim();
+            cur = List::None;
+            match key.trim().to_lowercase().as_str() {
+                "names" => cur = List::Names,
+                "regex" | "regexes" => cur = List::Regex,
+                "hideunjoinable" => r.hide_unjoinable = truthy(value),
+                "hideempty" => r.hide_empty = truthy(value),
+                "hidelocked" => r.hide_locked = truthy(value),
+                "maxperip" => r.max_per_ip = strip_comment(value).parse().unwrap_or(0),
+                other => r.complaints.push(format!("ignoring unknown key: {other}")),
+            }
+
+            // An inline scalar beside the list key (`names: foo`) counts too, the way it does
+            // in the C++ — a convenience that exists in the wild because the file invites it.
+            if cur != List::None && !value.is_empty() && !value.starts_with('#') {
+                let v = unquote(value);
+                match cur {
+                    List::Names => r.name_contains.push(v.to_lowercase()),
+                    List::Regex => r.push_regex(&v),
+                    List::None => unreachable!("guarded above"),
+                }
+            }
+        }
+        r
+    }
+
+    /// Compile one pattern, case-insensitively, and keep its source beside it.
+    ///
+    /// FrostMod's are ECMAScript and these are Rust's, which is a real difference: a rule using
+    /// a backreference or a lookaround compiles there and not here. That is a complaint and a
+    /// skipped rule, never a refused file — the other rules are still worth running.
+    fn push_regex(&mut self, src: &str) {
+        match Regex::new(&format!("(?i){src}")) {
+            Ok(re) => self.regexes.push((src.to_string(), re)),
+            Err(e) => self.complaints.push(format!("bad regex '{src}' skipped ({e})")),
+        }
+    }
+
+    /// Why this server should be hidden, or `None` to show it.
+    ///
+    /// Test order is `serverfilter.cpp`'s, so that a server hidden in the game is hidden here
+    /// for the same stated reason. `seen` carries the per-IP tally across one list; a fresh map
+    /// per call is what makes the answer depend on the list rather than on how recently the
+    /// last refresh happened, which is the one thing here that is deliberately *not* a port.
+    pub fn hide(&self, c: &Candidate, seen: &mut HashMap<String, u32>) -> Option<String> {
+        if self.hide_unjoinable && c.unjoinable {
+            return Some("didn't answer".into());
+        }
+
+        let name = c.name.to_lowercase();
+        if let Some(sub) = self.name_contains.iter().find(|s| name.contains(s.as_str())) {
+            return Some(format!("name contains '{sub}'"));
+        }
+        if let Some((src, _)) = self.regexes.iter().find(|(_, re)| re.is_match(&c.name)) {
+            return Some(format!("name matches /{src}/"));
+        }
+        if self.hide_locked && c.passworded {
+            return Some("password-locked".into());
+        }
+        if self.hide_empty && c.players == 0 {
+            return Some("empty".into());
+        }
+        if self.max_per_ip > 0 && !c.ip.is_empty() {
+            let n = seen.entry(c.ip.clone()).or_insert(0);
+            *n += 1;
+            if *n > self.max_per_ip {
+                return Some(format!("more than {} from {}", self.max_per_ip, c.ip));
+            }
+        }
+        None
+    }
+}
+
+/// Mark every server the rules would hide, leaving the list otherwise intact.
+///
+/// Nothing is dropped: the tab shows a count of what was hidden and can reveal it, and a
+/// player who thinks a rule is wrong needs to be able to see the row it caught. Dropping here
+/// would mean a refetch to change your mind.
+///
+/// Sorted busiest-first before the tally so `maxPerIP` keeps a host's *busiest* servers rather
+/// than whichever ones the master happened to send first. The tab sorts the same way, so this
+/// costs nothing and makes the rule mean something stable across refreshes.
+pub fn mark(rules: &Rules, servers: &mut [WorldServer]) -> usize {
+    servers.sort_by(|a, b| b.players.cmp(&a.players));
+    let mut seen = HashMap::new();
+    let mut hidden = 0;
+    for s in servers.iter_mut() {
+        let c = Candidate {
+            name: s.name.clone(),
+            ip: host_of(&s.address),
+            players: s.players,
+            passworded: s.passworded,
+            unjoinable: s.ping_ms.is_none(),
+        };
+        s.hidden = rules.hide(&c, &mut seen).unwrap_or_default();
+        if !s.hidden.is_empty() {
+            hidden += 1;
+        }
+    }
+    hidden
+}
+
+/// The host out of an `ip:port`, so a filter counts servers per machine. An IPv6 address is
+/// bracketed, and a row that isn't an address at all simply opts out of the per-IP rule.
+fn host_of(address: &str) -> String {
+    let a = address.trim();
+    if let Some(rest) = a.strip_prefix('[') {
+        return rest.split(']').next().unwrap_or("").to_string();
+    }
+    match a.rsplit_once(':') {
+        Some((host, _)) => host.to_string(),
+        None => a.to_string(),
+    }
+}
+
+/// Strip one pair of surrounding quotes, as a YAML scalar may carry.
+fn unquote(v: &str) -> String {
+    let v = v.trim();
+    let mut c = v.chars();
+    match (c.next(), v.chars().last()) {
+        (Some(q @ ('\'' | '"')), Some(last)) if last == q && v.len() >= 2 => {
+            v[q.len_utf8()..v.len() - last.len_utf8()].to_string()
+        }
+        _ => v.to_string(),
+    }
+}
+
+/// Drop a trailing ` # comment` from a scalar. Only after whitespace, so a `#` inside a value
+/// survives.
+fn strip_comment(v: &str) -> &str {
+    let b = v.as_bytes();
+    for i in 1..b.len() {
+        if b[i] == b'#' && (b[i - 1] == b' ' || b[i - 1] == b'\t') {
+            return v[..i].trim();
+        }
+    }
+    v.trim()
+}
+
+fn truthy(v: &str) -> bool {
+    matches!(strip_comment(v).to_lowercase().as_str(), "true" | "1" | "yes" | "on")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(name: &str) -> Candidate {
+        Candidate { name: name.into(), ..Default::default() }
+    }
+
+    fn hidden(rules: &Rules, c: &Candidate) -> Option<String> {
+        rules.hide(c, &mut HashMap::new())
+    }
+
+    /// The whole point of the port: the names FrostMod hides in the game are hidden here, with
+    /// no file to read and nothing for the player to set up.
+    #[test]
+    fn the_shipped_defaults_catch_the_spam_they_were_written_for() {
+        let r = Rules::defaults();
+        for name in ["CHE4TS.PR0 free mods", "kaizo racing", "Kalz0 Server #3", "cheats zone", "ka1z0 pub"] {
+            assert!(hidden(&r, &candidate(name)).is_some(), "{name} should be hidden");
+        }
+    }
+
+    /// A filter that hid real servers would be worse than no filter — this is the half that
+    /// matters when someone reports "my server vanished".
+    #[test]
+    fn it_leaves_ordinary_servers_alone() {
+        let r = Rules::defaults();
+        for name in ["MXB-Central EU", "Sunday Night Supercross", "Frost's Server", "A1 Practice"] {
+            assert_eq!(hidden(&r, &candidate(name)), None, "{name} must be shown");
+        }
+    }
+
+    /// Matching is case-insensitive on both paths, which is most of what makes a substring rule
+    /// worth writing at all.
+    #[test]
+    fn matching_ignores_case_on_both_paths() {
+        let r = Rules::parse("names:\n  - spam\nregex:\n  - 'wid[g]et'\n");
+        assert!(hidden(&r, &candidate("SPAM central")).is_some());
+        assert!(hidden(&r, &candidate("WIDGET works")).is_some());
+    }
+
+    /// The two rules the DLL cannot run, because its candidate has neither field.
+    #[test]
+    fn hide_locked_and_hide_empty_are_reachable_here() {
+        let r = Rules::parse("hideLocked: true\nhideEmpty: true\n");
+        let locked = Candidate { name: "x".into(), passworded: true, players: 4, ..Default::default() };
+        let empty = Candidate { name: "y".into(), players: 0, ..Default::default() };
+        assert_eq!(hidden(&r, &locked).as_deref(), Some("password-locked"));
+        assert_eq!(hidden(&r, &empty).as_deref(), Some("empty"));
+    }
+
+    /// `maxPerIP` counts within one list, so the same list always gives the same answer —
+    /// unlike the DLL's version, which resets on a gap between rows and so depends on timing.
+    #[test]
+    fn max_per_ip_keeps_the_first_n_from_a_host() {
+        let r = Rules::parse("maxPerIP: 2\n");
+        let mut seen = HashMap::new();
+        let one = |ip: &str| Candidate { name: "s".into(), ip: ip.into(), ..Default::default() };
+        assert_eq!(r.hide(&one("198.51.100.7"), &mut seen), None);
+        assert_eq!(r.hide(&one("198.51.100.7"), &mut seen), None);
+        assert!(r.hide(&one("198.51.100.7"), &mut seen).is_some(), "the third is past the cap");
+        assert_eq!(r.hide(&one("203.0.113.9"), &mut seen), None, "a different host has its own tally");
+    }
+
+    /// A row with no usable address opts out rather than sharing an empty-string bucket with
+    /// every other unparseable row — which would hide all but the first of them.
+    #[test]
+    fn a_row_without_an_address_is_not_counted_against_a_host() {
+        let r = Rules::parse("maxPerIP: 1\n");
+        let mut seen = HashMap::new();
+        let no_ip = Candidate { name: "s".into(), ..Default::default() };
+        assert_eq!(r.hide(&no_ip, &mut seen), None);
+        assert_eq!(r.hide(&no_ip, &mut seen), None);
+    }
+
+    #[test]
+    fn takes_the_host_out_of_an_address() {
+        assert_eq!(host_of("198.51.100.7:54210"), "198.51.100.7");
+        assert_eq!(host_of("[2001:db8::1]:54210"), "2001:db8::1");
+        assert_eq!(host_of("mx.example.com:54210"), "mx.example.com");
+    }
+
+    /// Every scalar in the shipped file carries a trailing comment; reading `false   # ...` as
+    /// a value would turn all four switches on.
+    #[test]
+    fn a_trailing_comment_is_not_part_of_the_value() {
+        let r = Rules::parse(DEFAULT_CONFIG);
+        assert!(!r.hide_empty && !r.hide_locked && !r.hide_unjoinable);
+        assert_eq!(r.max_per_ip, 0);
+    }
+
+    /// Single quotes are what keep a regex's backslashes intact in the file, so they must not
+    /// survive into the pattern.
+    #[test]
+    fn quotes_come_off_a_scalar() {
+        assert_eq!(unquote("'che4ts'"), "che4ts");
+        assert_eq!(unquote("\"kaizo\""), "kaizo");
+        assert_eq!(unquote("bare"), "bare");
+        assert_eq!(unquote("'unbalanced"), "'unbalanced");
+    }
+
+    /// The defaults must actually parse into rules — an empty ruleset would silently filter
+    /// nothing and look exactly like a working filter with nothing to catch.
+    #[test]
+    fn the_defaults_are_not_an_empty_ruleset() {
+        let r = Rules::defaults();
+        assert_eq!(r.name_contains.len(), 3, "{:?}", r.name_contains);
+        assert_eq!(r.regexes.len(), 1);
+        assert!(r.complaints.is_empty(), "{:?}", r.complaints);
+    }
+
+    /// A rule the Rust engine can't compile costs that rule and nothing else. ECMAScript has
+    /// lookarounds and this doesn't, so a player who wrote one in FrostMod's file will hit it.
+    #[test]
+    fn an_uncompilable_regex_costs_only_itself() {
+        let r = Rules::parse("names:\n  - spam\nregex:\n  - '(?<=x)y'\n");
+        assert_eq!(r.regexes.len(), 0);
+        assert_eq!(r.complaints.len(), 1, "the skipped rule should be visible: {:?}", r.complaints);
+        assert!(hidden(&r, &candidate("SPAM")).is_some(), "the other rules still run");
+    }
+
+    /// A file written by hand, with the inline form the C++ also accepts.
+    #[test]
+    fn an_inline_scalar_beside_a_list_key_counts() {
+        let r = Rules::parse("names: junk\n");
+        assert!(hidden(&r, &candidate("JUNK server")).is_some());
+    }
+
+    /// A list item before any list key is a mistake worth reporting, not a rule.
+    #[test]
+    fn an_orphan_list_item_is_a_complaint() {
+        let r = Rules::parse("  - stray\n");
+        assert!(r.name_contains.is_empty());
+        assert_eq!(r.complaints.len(), 1);
+    }
+
+    /// Nothing is dropped and the count is what the tab shows on its chip.
+    #[test]
+    fn marking_keeps_every_row_and_counts_the_hidden_ones() {
+        let mut list = vec![
+            world("Kaizo Cheats", "198.51.100.1:54210", 0),
+            world("MXB-Central EU", "198.51.100.2:54210", 12),
+        ];
+        let n = mark(&Rules::defaults(), &mut list);
+        assert_eq!(n, 1);
+        assert_eq!(list.len(), 2, "a hidden row is still there to be revealed");
+        assert_eq!(list[0].name, "MXB-Central EU", "busiest first");
+        assert!(list[0].hidden.is_empty());
+        assert!(!list[1].hidden.is_empty());
+    }
+
+    fn world(name: &str, address: &str, players: u32) -> WorldServer {
+        WorldServer {
+            name: name.into(),
+            address: address.into(),
+            joinable: true,
+            lan_address: String::new(),
+            players,
+            max_players: 20,
+            ping_ms: Some(30),
+            passworded: false,
+            location: String::new(),
+            rating: String::new(),
+            track: String::new(),
+            track_layout: String::new(),
+            categories: vec![],
+            bikes: vec![],
+            session: String::new(),
+            race_length: String::new(),
+            conditions: String::new(),
+            realistic_weather: false,
+            force_cockpit: false,
+            no_aids: false,
+            limited_tyre_sets: false,
+            hidden: String::new(),
+        }
+    }
+}

--- a/src-tauri/src/worldnet.rs
+++ b/src-tauri/src/worldnet.rs
@@ -258,6 +258,16 @@ fn decode_addr(b: &[u8]) -> Option<Addr> {
 
 /// The command entry point: resolve the masters, ask each until one answers, return what the
 /// tab shows. Runs the blocking socket work off the async runtime.
+///
+/// **The master is not always ours to ask.** Signing in to it spends the player's Steam
+/// account, and MX Bikes spends the same account the moment it is running — so while the game
+/// is up the app stays off the master entirely and rebuilds the list by asking the servers
+/// themselves. `GETINFO` needs no account, no ticket and no challenge, so a refresh mid-session
+/// costs nothing that the game is using. See [`crate::serverbook`] for where the addresses to
+/// ask come from.
+///
+/// The same path is the fallback whenever the master fails for any other reason: a remembered
+/// list, refreshed live from each server, beats an error message.
 pub async fn list_servers(app: tauri::AppHandle) -> Result<Vec<WorldServer>, String> {
     let cfg = crate::config::load_or_detect(&app).unwrap_or_default();
     let masters = crate::config::master_servers(&cfg);
@@ -269,9 +279,86 @@ pub async fn list_servers(app: tauri::AppHandle) -> Result<Vec<WorldServer>, Str
         cfg.cp_rider_name.trim().to_string()
     };
     let install = std::path::PathBuf::from(cfg.install_dir());
-    tauri::async_runtime::spawn_blocking(move || fetch(&masters, &rider, &install))
-        .await
-        .map_err(|e| format!("server-list task failed: {e}"))?
+    let remembered = crate::serverbook::rows(&crate::serverbook::load(&app));
+    let playing = crate::gameproc::is_game_running();
+
+    let (mut list, from_master) = tauri::async_runtime::spawn_blocking(move || {
+        if playing {
+            log::info!(
+                "[worldnet] MX Bikes is running — asking {} remembered server(s) directly and \
+                 leaving the master login to the game",
+                remembered.len()
+            );
+            return from_book(remembered).map(|l| (l, false));
+        }
+        match fetch(&masters, &rider, &install) {
+            Ok(list) => Ok((list, true)),
+            // A master that won't answer is exactly when a book of addresses earns its keep.
+            Err(e) => match from_book(remembered) {
+                Ok(list) => {
+                    log::warn!("[worldnet] the master didn't answer ({e}); used the remembered list");
+                    Ok((list, false))
+                }
+                Err(_) => Err(e),
+            },
+        }
+    })
+    .await
+    .map_err(|e| format!("server-list task failed: {e}"))??;
+
+    // Only a real sweep can teach the book an address it doesn't have; a probe of the book can
+    // only ever confirm what taught it.
+    if from_master {
+        crate::serverbook::remember(&app, &list, crate::serverbook::now_millis());
+    }
+
+    let rules = crate::serverfilter::Rules::load(&crate::frostmod_manage::frostmod_dir(&app));
+    let hidden = crate::serverfilter::mark(&rules, &mut list);
+    log::info!("[worldnet] {} server(s), {hidden} hidden by the filter", list.len());
+    Ok(list)
+}
+
+/// Rebuild the list from remembered addresses alone, by asking each server about itself.
+///
+/// A row that doesn't answer is dropped rather than shown from memory: a remembered name beside
+/// a rider count from last week is worse than an absent row, because it looks current. Rows the
+/// game could never reach are dropped for the same reason — they can't be probed, so there is
+/// nothing to say about them that is true right now.
+fn from_book(mut rows: Vec<WorldServer>) -> Result<Vec<WorldServer>, String> {
+    if rows.is_empty() {
+        return Err("There are no remembered servers yet — open the browser once with MX Bikes \
+                    closed and the list will keep working from then on."
+            .into());
+    }
+    let budget = book_budget(rows.len());
+    probe_within(&mut rows, budget);
+    rows.retain(|s| s.ping_ms.is_some());
+    if rows.is_empty() {
+        return Err("None of the remembered servers answered.".into());
+    }
+    Ok(rows)
+}
+
+/// How long to wait on a whole book. The probe is one datagram out per server and the replies
+/// come back in parallel, so this is about the slowest useful round trip plus room for a large
+/// book's send loop — not about the number of servers.
+fn book_budget(n: usize) -> Duration {
+    (PROBE_BUDGET + Duration::from_millis(n as u64)).min(Duration::from_secs(10))
+}
+
+/// Ask one server about itself. What the detail panel opens with, so a row the list built
+/// minutes ago isn't what a player reads before deciding to join.
+pub async fn probe_server(address: String) -> Result<WorldServer, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let mut one = vec![WorldServer { address, joinable: true, ..Default::default() }];
+        probe_within(&mut one, PROBE_BUDGET);
+        match one.pop() {
+            Some(s) if s.ping_ms.is_some() => Ok(s),
+            _ => Err("That server didn't answer.".into()),
+        }
+    })
+    .await
+    .map_err(|e| format!("probe task failed: {e}"))?
 }
 
 /// Try each master: the Steam-ticket `LOGIN` the game uses, then a no-auth browse.
@@ -475,6 +562,7 @@ fn parse_list(r: &mut Reader, out: &mut Vec<WorldServer>, want: usize) -> Page {
             force_cockpit: event.force_cockpit,
             no_aids: event.no_aids,
             limited_tyre_sets: event.limited_tyre_sets,
+            hidden: String::new(),
         });
     }
     if more {
@@ -619,6 +707,12 @@ const PROBE_BUDGET: Duration = Duration::from_secs(3);
 /// Best-effort throughout: a server that stays quiet keeps the row the master gave it and
 /// simply shows no ping. Live answers win over the master's copy, which can be a minute stale.
 fn probe(servers: &mut [WorldServer]) {
+    probe_within(servers, PROBE_BUDGET)
+}
+
+/// [`probe`], with the budget named by the caller. A whole address book takes longer to hear
+/// back from than the tail of one master sweep, and a single server takes no time at all.
+fn probe_within(servers: &mut [WorldServer], budget: Duration) {
     let Ok(sock) = UdpSocket::bind("0.0.0.0:0") else {
         return;
     };
@@ -643,7 +737,7 @@ fn probe(servers: &mut [WorldServer]) {
         sock.send_to(&encrypt(w.finish()), addr).ok();
     }
 
-    let deadline = start + PROBE_BUDGET;
+    let deadline = start + budget;
     let mut buf = [0u8; 4096];
     while !waiting.is_empty() && Instant::now() < deadline {
         let Ok((n, from)) = sock.recv_from(&mut buf) else {
@@ -655,6 +749,12 @@ fn probe(servers: &mut [WorldServer]) {
         if let Some(info) = parse_serverinfo(&decrypt(&buf[..n.min(MAX_REPLY)])) {
             let s = &mut servers[i];
             s.ping_ms = Some(stamp().saturating_sub(info.echo).max(0) as u32);
+            // The server's own name over the master's forwarded copy — an operator who renamed
+            // it half an hour ago shows as renamed, and a row probed with no name at all (the
+            // detail panel's single-server refresh) gets one.
+            if !info.name.is_empty() {
+                s.name = info.name;
+            }
             s.players = info.players as u32;
             s.max_players = info.max_players as u32;
             s.passworded = info.passworded;
@@ -681,6 +781,7 @@ fn probe(servers: &mut [WorldServer]) {
 /// A `SERVERINFO` reply, as the client reads it back (`0x1402a7ead`).
 struct ServerInfo {
     echo: i32,
+    name: String,
     players: u8,
     max_players: u8,
     passworded: bool,
@@ -696,7 +797,7 @@ fn parse_serverinfo(clear: &[u8]) -> Option<ServerInfo> {
         return None;
     }
     let echo = r.i32_le()?;
-    let _name = r.field();
+    let name = r.field().trim().to_string();
     let max_players = r.u8()?;
     let players = r.u8()?;
     let passworded = r.u8()? != 0;
@@ -704,7 +805,7 @@ fn parse_serverinfo(clear: &[u8]) -> Option<ServerInfo> {
     let _id = r.i32_le();
     let blob_len = r.i16_le().unwrap_or(0).max(0) as usize;
     let blob = r.raw(blob_len).map(|b| &b[..b.len().min(MAX_BLOB)]).unwrap_or_default();
-    Some(ServerInfo { echo, players, max_players, passworded, event: Event::parse(blob) })
+    Some(ServerInfo { echo, name, players, max_players, passworded, event: Event::parse(blob) })
 }
 
 /// The authenticated login the game uses before joining. Succeeds when the master replies
@@ -1505,6 +1606,92 @@ mod tests {
         // A fresh one, when Steam does answer, replaces it.
         let out = reuse_or_fetch(&mut held, stale, || Ok(auth(9))).unwrap();
         assert_eq!(out.steam_id, 9);
+    }
+
+    /// The probe-only refresh, end to end against a server that actually answers.
+    ///
+    /// This is the path the tab runs on while MX Bikes is up, so it is worth exercising for
+    /// real rather than by parsing a handmade buffer: a socket, the request the game sends,
+    /// the cipher in both directions, and the reply parsed back into a row. A regression in
+    /// any one of those is the difference between a live list and an empty tab.
+    #[test]
+    fn a_remembered_server_is_refreshed_by_asking_it() {
+        // Stand in for a dedicated server: read one GETINFO, answer one SERVERINFO.
+        let server = UdpSocket::bind("127.0.0.1:0").expect("a loopback socket");
+        let addr = server.local_addr().unwrap();
+        server.set_read_timeout(Some(Duration::from_secs(5))).ok();
+
+        let listening = std::thread::spawn(move || {
+            let mut buf = [0u8; 4096];
+            let (n, from) = server.recv_from(&mut buf).expect("the probe's request");
+            let asked = decrypt(&buf[..n]);
+
+            // What the game sends, and what a server checks before answering at all.
+            let mut r = Reader::new(&asked);
+            assert_eq!(r.i32_le(), Some(CONNECTIONLESS));
+            assert_eq!(r.i32_le(), Some(GETINFO));
+            assert_eq!(r.i32_le(), Some(client_version() as i32));
+            let stamp = r.i32_le().expect("a client timestamp to echo");
+
+            let mut w = Writer::default();
+            w.i32le(SERVERINFO).i32le(stamp);
+            w.raw(b"Frost's Server\0");
+            w.raw(&[20, 7, 1]); // max, then players, then passworded — this message's order
+            w.raw(b"USA\0");
+            w.raw(&0i32.to_le_bytes());
+            let blob = race_blob();
+            w.raw(&(blob.len() as i16).to_le_bytes()).raw(&blob);
+            server.send_to(&encrypt(w.finish()), from).ok();
+        });
+
+        // A row as the address book hands one over: an address, and nothing else worth trusting.
+        let mut rows = vec![WorldServer {
+            name: "stale name".into(),
+            address: addr.to_string(),
+            joinable: true,
+            ..Default::default()
+        }];
+        probe_within(&mut rows, Duration::from_secs(5));
+        listening.join().expect("the stand-in server");
+
+        let s = &rows[0];
+        assert!(s.ping_ms.is_some(), "a server that answered has a measured ping");
+        assert_eq!(s.players, 7);
+        assert_eq!(s.max_players, 20);
+        assert!(s.passworded);
+        assert_eq!(s.name, "Frost's Server", "the server's own name replaces the remembered one");
+        assert_eq!(s.track, "mmx_supercross", "the event blob is read from the live reply");
+    }
+
+    /// A remembered address that has gone quiet must not be listed. Showing a name beside a
+    /// rider count from last week reads as current, which is worse than an absent row.
+    #[test]
+    fn a_server_that_doesnt_answer_is_dropped_from_a_book_only_refresh() {
+        // Port 1 on loopback: nothing is listening, and nothing will start.
+        let err = from_book(vec![WorldServer {
+            name: "gone".into(),
+            address: "127.0.0.1:1".into(),
+            joinable: true,
+            ..Default::default()
+        }])
+        .unwrap_err();
+        assert!(err.contains("answered"), "unhelpful: {err}");
+    }
+
+    /// With no book at all the tab has to say what would fill it, not just fail.
+    #[test]
+    fn an_empty_book_explains_itself() {
+        let err = from_book(vec![]).unwrap_err();
+        assert!(err.contains("MX Bikes closed"), "unhelpful: {err}");
+    }
+
+    /// The budget grows with the book but stays bounded — a refresh is something a player is
+    /// watching, and a large book must not turn it into a minute of spinner.
+    #[test]
+    fn the_probe_budget_is_bounded() {
+        assert!(book_budget(0) >= PROBE_BUDGET);
+        assert!(book_budget(10_000) <= Duration::from_secs(10));
+        assert!(book_budget(500) > book_budget(5), "a bigger book waits longer");
     }
 
     /// With nothing in hand there is nothing to fall back to, and the Steam reason is what

--- a/src/Components/Servers/ServerDetail.tsx
+++ b/src/Components/Servers/ServerDetail.tsx
@@ -1,4 +1,6 @@
-import { Lock, Plug, Loader2, Signal, Users } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Lock, Plug, Loader2, Signal, Users, Download, MapPin, CheckCircle2 } from "lucide-react";
+import { open as openUrl } from "@tauri-apps/plugin-shell";
 import { Button } from "@/Components/ui/button";
 import {
   Dialog,
@@ -7,7 +9,14 @@ import {
   DialogTitle,
 } from "@/Components/ui/dialog";
 import { useT } from "../../i18n/context";
-import type { MasterServer } from "../../api/mods";
+import {
+  probeServer,
+  serverRiders,
+  guessServerTrack,
+  type MasterServer,
+  type ServerRiders,
+  type TrackGuess,
+} from "../../api/mods";
 
 /**
  * Everything one server publishes about itself.
@@ -17,6 +26,10 @@ import type { MasterServer } from "../../api/mods";
  * event blob holds the track, the session and the rules, and `location` and the licence
  * class sit beside it. It lands here rather than in the row because it is what you read
  * once, before deciding to join, not what you compare fifty rows on.
+ *
+ * Three things arrive after opening, because none of them is worth fetching for every row in
+ * a list: the server's own live answer, who the app can name on it, and which track the
+ * internal id it publishes actually refers to.
  */
 
 /** One label/value line. Values that came back empty are dropped by {@link Facts}. */
@@ -42,6 +55,135 @@ const Facts = ({ title, facts }: { title: string; facts: Fact[] }) => {
   );
 };
 
+/**
+ * Who is on the server.
+ *
+ * The count is the server's own and is always right. The names are not the same thing and
+ * must not look like they are: MX Bikes tells a stranger how many riders are on and nothing
+ * else, so unless this is the server under you, the names are the riders whose own copy of
+ * MXB App said they were here. That is a subset, and the label says so.
+ */
+const Riders = ({
+  players,
+  maxPlayers,
+  riders,
+  loading,
+}: {
+  players: number;
+  maxPlayers: number;
+  riders: ServerRiders | null;
+  loading: boolean;
+}) => {
+  const t = useT();
+  const names = riders?.riders ?? [];
+  return (
+    <section className="space-y-2">
+      <h3 className="flex items-center gap-2 text-[11.5px] font-semibold uppercase tracking-wide text-faint">
+        {t("serverBrowser.ridersTitle")}
+        {loading && <Loader2 className="size-3 animate-spin" />}
+      </h3>
+      <p className="text-[13px]">
+        {t("serverBrowser.ridersCount", { players, maxPlayers })}
+        {names.length > 0 && (
+          <span className="text-muted-foreground">
+            {" · "}
+            {riders?.source === "session"
+              ? t("serverBrowser.ridersFromSession")
+              : t("serverBrowser.ridersFromApp", { count: names.length })}
+          </span>
+        )}
+      </p>
+      {names.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5">
+          {names.map((n) => (
+            <span
+              key={n}
+              className="border border-input bg-card px-2 py-0.5 text-[12px] text-muted-foreground"
+            >
+              {n}
+            </span>
+          ))}
+        </div>
+      ) : (
+        !loading &&
+        players > 0 && (
+          <p className="text-[12px] text-faint">{t("serverBrowser.ridersUnknown")}</p>
+        )
+      )}
+    </section>
+  );
+};
+
+/**
+ * Which track this actually is.
+ *
+ * A server publishes an internal id — `mmx_supercross` — which is not a title, not a folder
+ * name and not something anyone can search for. Installed is the best answer and shows the
+ * track's own artwork; otherwise this offers where to get it, and says plainly when the name
+ * only resembles a product rather than matching it.
+ */
+const Track = ({ guess, loading }: { guess: TrackGuess | null; loading: boolean }) => {
+  const t = useT();
+  if (loading) {
+    return (
+      <p className="flex items-center gap-2 text-[12.5px] text-faint">
+        <Loader2 className="size-3.5 animate-spin" />
+        {t("serverBrowser.trackChecking")}
+      </p>
+    );
+  }
+  if (!guess || (!guess.installed && !guess.source)) return null;
+
+  const art = guess.preview || guess.productImage;
+  return (
+    <section className="space-y-2">
+      <h3 className="text-[11.5px] font-semibold uppercase tracking-wide text-faint">
+        {t("serverBrowser.trackTitle")}
+      </h3>
+      <div className="flex items-start gap-3">
+        {art && (
+          <img
+            src={art}
+            alt=""
+            className="h-[72px] w-[128px] shrink-0 border border-input object-cover"
+          />
+        )}
+        <div className="min-w-0 flex-1 space-y-1.5">
+          {guess.installed ? (
+            <p className="flex items-center gap-1.5 text-[13px]">
+              <CheckCircle2 className="size-3.5 shrink-0 text-faint" />
+              <span className="truncate">
+                {t("serverBrowser.trackInstalled", { name: guess.installed })}
+              </span>
+            </p>
+          ) : (
+            <>
+              <p className="text-[13px]">
+                <MapPin className="mr-1.5 inline size-3.5 text-faint" />
+                {guess.exact
+                  ? guess.productName
+                  : t("serverBrowser.trackMaybe", { name: guess.productName })}
+              </p>
+              {guess.productUrl && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void openUrl(guess.productUrl)}
+                >
+                  <Download className="size-3.5" />
+                  {guess.source === "hub"
+                    ? t("serverBrowser.trackGetHub")
+                    : t("serverBrowser.trackGetShop")}
+                </Button>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+};
+
 const ServerDetail = ({
   server,
   onOpenChange,
@@ -54,8 +196,59 @@ const ServerDetail = ({
   joining: string | null;
 }) => {
   const t = useT();
+  // What the row carried, replaced by the server's own answer once it arrives. Held here
+  // rather than pushed back into the list: the list refreshes on its own schedule, and one
+  // row updating under a player's cursor while they read it would be worse than stale.
+  const [live, setLive] = useState<MasterServer | null>(null);
+  const [riders, setRiders] = useState<ServerRiders | null>(null);
+  const [ridersLoading, setRidersLoading] = useState(false);
+  const [guess, setGuess] = useState<TrackGuess | null>(null);
+  const [guessing, setGuessing] = useState(false);
+
+  const address = server?.address ?? "";
+  const name = server?.name ?? "";
+  const track = live?.track || server?.track || "";
+
+  // Ask the server about itself, and ask who is on it. `cancelled` is what keeps a slow
+  // answer for the last server out of the panel for the next one.
+  useEffect(() => {
+    if (!address) return;
+    let cancelled = false;
+    setLive(null);
+    setRiders(null);
+    setRidersLoading(true);
+    probeServer(address)
+      .then((s) => !cancelled && setLive(s))
+      .catch(() => {});
+    serverRiders(address, name)
+      .then((r) => !cancelled && setRiders(r))
+      .catch(() => {})
+      .finally(() => !cancelled && setRidersLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [address, name]);
+
+  // Separate from the probe because it keys on the track, which the probe can change: a
+  // server that rolled over to the next track while the panel was open re-identifies it.
+  useEffect(() => {
+    if (!track) {
+      setGuess(null);
+      return;
+    }
+    let cancelled = false;
+    setGuessing(true);
+    guessServerTrack(track)
+      .then((g) => !cancelled && setGuess(g))
+      .catch(() => {})
+      .finally(() => !cancelled && setGuessing(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [track]);
+
   if (!server) return null;
-  const s = server;
+  const s = live ?? server;
 
   const yes = t("serverBrowser.yes");
   const flag = (on: boolean) => (on ? yes : "");
@@ -86,6 +279,15 @@ const ServerDetail = ({
         </DialogHeader>
 
         <div className="max-h-[60vh] space-y-5 overflow-y-auto pr-1">
+          <Riders
+            players={s.players}
+            maxPlayers={s.maxPlayers}
+            riders={riders}
+            loading={ridersLoading}
+          />
+
+          <Track guess={guess} loading={guessing} />
+
           <Facts
             title={t("serverBrowser.running")}
             facts={[

--- a/src/Components/Servers/Servers.tsx
+++ b/src/Components/Servers/Servers.tsx
@@ -9,6 +9,7 @@ import {
   Copy,
   Plug,
   ServerOff,
+  EyeOff,
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
@@ -43,6 +44,9 @@ const Servers = () => {
   const [joining, setJoining] = useState<string | null>(null);
   const [joinOpen, setJoinOpen] = useState(false);
   const [detail, setDetail] = useState<MasterServer | null>(null);
+  // Spam and cheat-advertising servers are marked by the backend, not dropped, so this can
+  // reveal them. Off by default: the whole point is not to have to read past them.
+  const [showHidden, setShowHidden] = useState(false);
 
   // One fetch at a time. Two overlapping ones each sign in to Steam, and the loser's
   // failure used to replace the winner's list with an error.
@@ -78,17 +82,24 @@ const Servers = () => {
     load();
   }, [load]);
 
+  /** How many rows the filter caught, whether or not they're being shown. */
+  const hiddenCount = useMemo(
+    () => (servers ?? []).filter((s) => s.hidden).length,
+    [servers],
+  );
+
   const shown = useMemo(() => {
     const q = query.trim().toLowerCase();
-    if (!q || !servers) return servers ?? [];
-    return servers.filter(
+    const visible = (servers ?? []).filter((s) => showHidden || !s.hidden);
+    if (!q) return visible;
+    return visible.filter(
       (s) =>
         s.name.toLowerCase().includes(q) ||
         s.track.toLowerCase().includes(q) ||
         s.location.toLowerCase().includes(q) ||
         s.address.toLowerCase().includes(q),
     );
-  }, [servers, query]);
+  }, [servers, query, showHidden]);
 
   const join = useCallback(
     async (address: string) => {
@@ -125,8 +136,24 @@ const Servers = () => {
       <ContextBarRight>
         {servers && servers.length > 0 && (
           <span className="tabular-figures text-[12.5px] text-faint">
-            {t("serverBrowser.count", { count: servers.length })}
+            {t("serverBrowser.count", { count: servers.length - (showHidden ? 0 : hiddenCount) })}
           </span>
+        )}
+        {hiddenCount > 0 && (
+          <button
+            type="button"
+            onClick={() => setShowHidden((v) => !v)}
+            title={t("serverBrowser.hiddenHelp")}
+            className={cn(
+              "flex h-7 items-center gap-1.5 border border-input px-2.5 text-[12px]",
+              showHidden ? "bg-card text-muted-foreground" : "text-faint hover:text-muted-foreground",
+            )}
+          >
+            <EyeOff className="size-3.5" />
+            {showHidden
+              ? t("serverBrowser.hideFiltered")
+              : t("serverBrowser.hiddenCount", { count: hiddenCount })}
+          </button>
         )}
         <div className="flex h-7 w-[220px] items-center gap-2 border border-input bg-card px-2.5">
           <Search className="size-3.5 text-faint" />
@@ -206,7 +233,12 @@ const Servers = () => {
                   <tr
                     key={`${s.address}-${i}`}
                     onClick={() => setDetail(s)}
-                    className="cursor-pointer border-b border-input/60 last:border-0 hover:bg-foreground/[0.03]"
+                    className={cn(
+                      "cursor-pointer border-b border-input/60 last:border-0 hover:bg-foreground/[0.03]",
+                      // Revealed rows stay legible but visibly demoted, so nobody mistakes one
+                      // for an ordinary result they just hadn't scrolled to.
+                      s.hidden && "opacity-55",
+                    )}
                   >
                     <td className="px-3.5 py-2.5">
                       <div className="flex items-center gap-2">
@@ -219,6 +251,14 @@ const Servers = () => {
                         <span className="truncate font-medium" title={s.name}>
                           {s.name}
                         </span>
+                        {s.hidden && (
+                          <span
+                            className="shrink-0 border border-input px-1.5 py-px text-[10.5px] uppercase tracking-wide text-faint"
+                            title={t("serverBrowser.hiddenBecause", { reason: s.hidden })}
+                          >
+                            {t("serverBrowser.filtered")}
+                          </span>
+                        )}
                       </div>
                     </td>
                     <td className="px-2 py-2.5 tabular-nums text-muted-foreground">

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -3017,6 +3017,9 @@ export interface MasterServer {
   forceCockpit: boolean;
   noAids: boolean;
   limitedTyreSets: boolean;
+  /** Why the spam filter would hide this row, or `""` to show it. Rows arrive either way so
+   *  the tab can say how many it hid and let you look at them. */
+  hidden: string;
 }
 
 /**
@@ -3026,6 +3029,61 @@ export interface MasterServer {
  */
 export function listMasterServers(): Promise<MasterServer[]> {
   return invoke<MasterServer[]>("list_master_servers");
+}
+
+/**
+ * Ask one server about itself, right now.
+ *
+ * The list can be minutes old by the time somebody clicks a row, and the rider count, the
+ * session and the track all move in that time. This costs one datagram and no sign-in.
+ */
+export function probeServer(address: string): Promise<MasterServer> {
+  return invoke<MasterServer>("probe_server", { address });
+}
+
+/** Who the app can name on a server, and how it knows. */
+export interface ServerRiders {
+  riders: string[];
+  /** `"session"` is the game's own grid, for the server you're on — everyone.
+   *  `"app"` is the riders whose own apps reported being there, which is a subset. */
+  source: "session" | "app" | "";
+}
+
+/**
+ * The riders on a server, as far as anything can honestly say.
+ *
+ * MX Bikes never tells a stranger who is on a server, so a full list only exists for the
+ * server you are on. Everywhere else this names the players running MXB App and nobody else —
+ * which is why {@link ServerRiders.source} has to be shown beside it.
+ */
+export function serverRiders(address: string, name: string): Promise<ServerRiders> {
+  return invoke<ServerRiders>("server_riders", { address, name });
+}
+
+/** What track a server is running, matched against what you have and what you could get. */
+export interface TrackGuess {
+  /** The internal id the server published, e.g. `mmx_supercross`. */
+  id: string;
+  /** The installed track's file or folder name; `""` when it isn't installed. */
+  installed: string;
+  /** The installed track's own preview image, as a data URL. */
+  preview: string;
+  /** Where a copy could come from: `"shop"`, `"hub"`, or `""` when nothing matched. */
+  source: "shop" | "hub" | "";
+  productId: number;
+  productName: string;
+  productUrl: string;
+  productImage: string;
+  /** False when the name only resembles the track — show it as a guess. */
+  exact: boolean;
+}
+
+/**
+ * Work out which track a server means. The server publishes an internal id and nothing else,
+ * which is not a product title and not something anyone can search for.
+ */
+export function guessServerTrack(track: string): Promise<TrackGuess> {
+  return invoke<TrackGuess>("guess_server_track", { track });
 }
 
 export type ServerAction = "start" | "stop" | "restart";

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1106,6 +1106,24 @@ export const de: Translation = {
   "serverBrowser.any": "Beliebig",
   "serverBrowser.yes": "Ja",
   "serverBrowser.notJoinable": "MX Bikes kann die Adresse dieses Servers nicht ansteuern.",
+  "serverBrowser.filtered": "Gefiltert",
+  "serverBrowser.hiddenCount": "{{count}} ausgeblendet",
+  "serverBrowser.hideFiltered": "Wieder ausblenden",
+  "serverBrowser.hiddenBecause": "Ausgeblendet: {{reason}}",
+  "serverBrowser.hiddenHelp":
+    "Server, die mit Cheats werben, und anderer Spam werden nach FrostMods eigenen Regeln ausgeblendet. Klicke, um sie trotzdem anzusehen.",
+  "serverBrowser.ridersTitle": "Fahrer",
+  "serverBrowser.ridersCount": "{{players}} von {{maxPlayers}} Fahrern",
+  "serverBrowser.ridersFromSession": "deine Session",
+  "serverBrowser.ridersFromApp": "{{count}} mit Paint-Sync",
+  "serverBrowser.ridersUnknown":
+    "MX Bikes verrät der App nur, wie viele Fahrer auf einem Server sind. Namen kommen von den Spielern, die MXB App nutzen.",
+  "serverBrowser.trackTitle": "Strecke",
+  "serverBrowser.trackChecking": "Ermittle, welche Strecke das ist…",
+  "serverBrowser.trackInstalled": "Du hast diese Strecke — {{name}}",
+  "serverBrowser.trackMaybe": "Wir vermuten, das ist {{name}}",
+  "serverBrowser.trackGetShop": "Im Shop holen",
+  "serverBrowser.trackGetHub": "Bei MXB Hub holen",
 
   "sync.autoNote":
     "Dein Look veröffentlicht sich selbst — jedes Bike, sobald du ihn in der App oder in der Garage des Spiels änderst. Der der anderen kommt, wenn du auf Spielen drückst.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1084,6 +1084,24 @@ export const en = {
   "serverBrowser.any": "Any",
   "serverBrowser.yes": "Yes",
   "serverBrowser.notJoinable": "MX Bikes can't be pointed at this server's address.",
+  "serverBrowser.filtered": "Filtered",
+  "serverBrowser.hiddenCount": "{{count}} hidden",
+  "serverBrowser.hideFiltered": "Hide them again",
+  "serverBrowser.hiddenBecause": "Hidden: {{reason}}",
+  "serverBrowser.hiddenHelp":
+    "Servers advertising cheats, and other spam, are hidden using FrostMod's own rules. Click to look at them anyway.",
+  "serverBrowser.ridersTitle": "Riders",
+  "serverBrowser.ridersCount": "{{players}} of {{maxPlayers}} riders",
+  "serverBrowser.ridersFromSession": "your session",
+  "serverBrowser.ridersFromApp": "{{count}} using paint sync",
+  "serverBrowser.ridersUnknown":
+    "MX Bikes only tells the app how many riders are on a server. Names come from the players who run MXB App.",
+  "serverBrowser.trackTitle": "Track",
+  "serverBrowser.trackChecking": "Working out which track this is…",
+  "serverBrowser.trackInstalled": "You have this track — {{name}}",
+  "serverBrowser.trackMaybe": "We think this is {{name}}",
+  "serverBrowser.trackGetShop": "Get it from the shop",
+  "serverBrowser.trackGetHub": "Get it from MXB Hub",
 
   "sync.autoNote":
     "Your look publishes itself — every bike, whenever you change it in the app or in the game's own garage. Everyone else's arrives when you press Play.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1099,6 +1099,24 @@ export const es: Translation = {
   "serverBrowser.any": "Cualquiera",
   "serverBrowser.yes": "Sí",
   "serverBrowser.notJoinable": "MX Bikes no puede conectarse a la dirección de este servidor.",
+  "serverBrowser.filtered": "Filtrado",
+  "serverBrowser.hiddenCount": "{{count}} ocultos",
+  "serverBrowser.hideFiltered": "Volver a ocultar",
+  "serverBrowser.hiddenBecause": "Oculto: {{reason}}",
+  "serverBrowser.hiddenHelp":
+    "Los servidores que anuncian trucos, y otro spam, se ocultan con las reglas del propio FrostMod. Haz clic para verlos de todos modos.",
+  "serverBrowser.ridersTitle": "Pilotos",
+  "serverBrowser.ridersCount": "{{players}} de {{maxPlayers}} pilotos",
+  "serverBrowser.ridersFromSession": "tu sesión",
+  "serverBrowser.ridersFromApp": "{{count}} con sincronización de pinturas",
+  "serverBrowser.ridersUnknown":
+    "MX Bikes solo le dice a la app cuántos pilotos hay en un servidor. Los nombres vienen de los jugadores que usan MXB App.",
+  "serverBrowser.trackTitle": "Circuito",
+  "serverBrowser.trackChecking": "Averiguando qué circuito es…",
+  "serverBrowser.trackInstalled": "Ya tienes este circuito — {{name}}",
+  "serverBrowser.trackMaybe": "Creemos que es {{name}}",
+  "serverBrowser.trackGetShop": "Conseguirlo en la tienda",
+  "serverBrowser.trackGetHub": "Conseguirlo en MXB Hub",
 
   "sync.autoNote":
     "Tu look se publica solo — cada moto, cada vez que lo cambias en la app o en el garaje del juego. El de los demás llega cuando pulsas Jugar.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1104,6 +1104,24 @@ export const fr: Translation = {
   "serverBrowser.any": "Toutes",
   "serverBrowser.yes": "Oui",
   "serverBrowser.notJoinable": "MX Bikes ne peut pas se connecter à l'adresse de ce serveur.",
+  "serverBrowser.filtered": "Filtré",
+  "serverBrowser.hiddenCount": "{{count}} masqués",
+  "serverBrowser.hideFiltered": "Masquer à nouveau",
+  "serverBrowser.hiddenBecause": "Masqué : {{reason}}",
+  "serverBrowser.hiddenHelp":
+    "Les serveurs qui font la publicité de triches, et les autres spams, sont masqués selon les règles de FrostMod. Cliquez pour les afficher quand même.",
+  "serverBrowser.ridersTitle": "Pilotes",
+  "serverBrowser.ridersCount": "{{players}} pilotes sur {{maxPlayers}}",
+  "serverBrowser.ridersFromSession": "votre session",
+  "serverBrowser.ridersFromApp": "{{count}} avec la synchro des peintures",
+  "serverBrowser.ridersUnknown":
+    "MX Bikes indique seulement à l'app combien de pilotes sont sur un serveur. Les noms viennent des joueurs qui utilisent MXB App.",
+  "serverBrowser.trackTitle": "Circuit",
+  "serverBrowser.trackChecking": "Identification du circuit…",
+  "serverBrowser.trackInstalled": "Vous avez ce circuit — {{name}}",
+  "serverBrowser.trackMaybe": "Nous pensons qu'il s'agit de {{name}}",
+  "serverBrowser.trackGetShop": "L'obtenir sur la boutique",
+  "serverBrowser.trackGetHub": "L'obtenir sur MXB Hub",
 
   "sync.autoNote":
     "Votre look se publie tout seul — chaque moto, dès que vous le changez dans l'app ou dans le garage du jeu. Celui des autres arrive quand vous appuyez sur Jouer.",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1097,6 +1097,24 @@ export const it: Translation = {
   "serverBrowser.any": "Qualsiasi",
   "serverBrowser.yes": "Sì",
   "serverBrowser.notJoinable": "MX Bikes non può essere indirizzato a questo server.",
+  "serverBrowser.filtered": "Filtrato",
+  "serverBrowser.hiddenCount": "{{count}} nascosti",
+  "serverBrowser.hideFiltered": "Nascondili di nuovo",
+  "serverBrowser.hiddenBecause": "Nascosto: {{reason}}",
+  "serverBrowser.hiddenHelp":
+    "I server che pubblicizzano cheat, e altro spam, vengono nascosti con le regole di FrostMod. Fai clic per vederli comunque.",
+  "serverBrowser.ridersTitle": "Piloti",
+  "serverBrowser.ridersCount": "{{players}} di {{maxPlayers}} piloti",
+  "serverBrowser.ridersFromSession": "la tua sessione",
+  "serverBrowser.ridersFromApp": "{{count}} con la sincronizzazione delle livree",
+  "serverBrowser.ridersUnknown":
+    "MX Bikes dice all'app solo quanti piloti ci sono su un server. I nomi arrivano dai giocatori che usano MXB App.",
+  "serverBrowser.trackTitle": "Pista",
+  "serverBrowser.trackChecking": "Sto capendo di quale pista si tratta…",
+  "serverBrowser.trackInstalled": "Hai questa pista — {{name}}",
+  "serverBrowser.trackMaybe": "Pensiamo sia {{name}}",
+  "serverBrowser.trackGetShop": "Prendila dallo shop",
+  "serverBrowser.trackGetHub": "Prendila da MXB Hub",
 
   "sync.autoNote":
     "Il tuo look si pubblica da solo — ogni moto, ogni volta che lo cambi nell'app o nel garage del gioco. Quello degli altri arriva quando premi Gioca.",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1099,6 +1099,24 @@ export const ptBR: Translation = {
   "serverBrowser.any": "Qualquer",
   "serverBrowser.yes": "Sim",
   "serverBrowser.notJoinable": "O MX Bikes não consegue se conectar ao endereço deste servidor.",
+  "serverBrowser.filtered": "Filtrado",
+  "serverBrowser.hiddenCount": "{{count}} ocultos",
+  "serverBrowser.hideFiltered": "Ocultar de novo",
+  "serverBrowser.hiddenBecause": "Oculto: {{reason}}",
+  "serverBrowser.hiddenHelp":
+    "Servidores que anunciam cheats, e outros spams, ficam ocultos pelas regras do próprio FrostMod. Clique para vê-los mesmo assim.",
+  "serverBrowser.ridersTitle": "Pilotos",
+  "serverBrowser.ridersCount": "{{players}} de {{maxPlayers}} pilotos",
+  "serverBrowser.ridersFromSession": "sua sessão",
+  "serverBrowser.ridersFromApp": "{{count}} usando sincronização de pinturas",
+  "serverBrowser.ridersUnknown":
+    "O MX Bikes só informa ao app quantos pilotos estão em um servidor. Os nomes vêm dos jogadores que usam o MXB App.",
+  "serverBrowser.trackTitle": "Pista",
+  "serverBrowser.trackChecking": "Descobrindo qual pista é essa…",
+  "serverBrowser.trackInstalled": "Você tem esta pista — {{name}}",
+  "serverBrowser.trackMaybe": "Achamos que é {{name}}",
+  "serverBrowser.trackGetShop": "Pegar na loja",
+  "serverBrowser.trackGetHub": "Pegar no MXB Hub",
 
   "sync.autoNote":
     "Seu visual se publica sozinho — cada moto, sempre que você muda no app ou na garagem do jogo. O dos outros chega quando você aperta Jogar.",


### PR DESCRIPTION
## The problem

The Servers tab went dark whenever MX Bikes was up. The list is gated behind a master-server `LOGIN` that spends the player's Steam account — and the game spends the same account the moment it is running.

## The fix

**Discovery is the only part that needs the master.** A server answers `GETINFO` to anyone who asks — no challenge, no password, no Steam ticket — and the reply carries everything the list shows: name, riders, seats, password, the whole event blob. So remember the addresses, and ask the servers themselves.

- **`serverbook.rs`** — every server a master sweep returns is persisted. Aged out at 30 days and capped at 2000, because every row costs a datagram on every probe-only refresh.
- **`worldnet.rs`** — skips Steam and the master entirely while the game is running, and uses the same path as the fallback whenever the master fails for any other reason. A remembered row that doesn't answer is dropped rather than shown from memory: a name beside a rider count from last week reads as current, which is worse than an absent row.

## The filter

**`serverfilter.rs`** ports FrostMod's rule engine and reads FrostMod's *own* `frostmod_serverfilter.yaml`, so one file tunes both browsers. It never writes that file — FrostMod owns and versions it, and two programs writing one config is how a player's edits get lost.

It is its own parser rather than a `serde_yaml` dependency on purpose: the point is to read *that* file the way *it* does, and an off-the-shelf parser would be stricter about some lines and looser about others.

**It is also strictly more capable than the original.** `SB_SuppressRow` builds its candidate from the game's in-memory row, which carries no address and no password flag — so `maxPerIP` and `hideLocked` are unreachable in the DLL however the file is written. Both fields come off the master record here, so both rules run.

Rows are marked, never dropped: the tab says how many it hid and can reveal them, because someone who thinks a rule is wrong has to be able to see what it caught.

## Server detail

- **Probes on open**, so the riders, the session and the track are what they are now.
- **Riders** — FrostMod's real grid when it is the server you are on; otherwise a new slim `GET /v1/presence` that reads presence alone. `/v1/roster` could not do this: it joins through `loadout_paints`, so a rider who never published a paint is invisible to it.
  It takes **both key forms**, which fixes a latent split: presence is recorded under the address key for a rider who joined through the app, and under the folded server *name* for one whose session FrostMod detected. Asking under one showed half a grid and looked like the other half had left.
- **Track** — the server publishes an internal id (`mmx_supercross`), which is not a title, not a folder name, and not something anyone can search for. Resolved against the library first (showing the track's own artwork), then the shop matcher, then the hub. The hub is asked directly rather than through `with_hub_clearance`: that answers the robot challenge by opening a browser, and a browser appearing because someone clicked a server row would be an ambush.

## Verification

1470 Rust tests, 274 control-plane tests, `tsc`, eslint, `vite build`, and `cargo check --target x86_64-pc-windows-gnu` all clean.

**Proven with a real socket, not just compiled.** `a_remembered_server_is_refreshed_by_asking_it` stands up a UDP server, reads the `GETINFO` the probe sends, checks the version gate the way a real server does, and answers a `SERVERINFO` — so the socket, the Blowfish in both directions and the reply parse are exercised end to end. That is the exact path the tab runs on while the game is up.

## Not verified, and limits by design

- **Untested premise:** whether the master genuinely refuses a second sign-in from an account the game already holds. The design does not depend on the answer — it stays off the master while the game is running either way.
- **Needs a control-plane deploy** before names appear in a shipped build; the panel shows a rider count until then.
- The book only learns addresses from a master sweep, so a server first appearing while the game is running is invisible until the next sweep.
- An IPv6-only row can't be probed, so it drops out of a book-only refresh rather than being listed with numbers nobody can check.
- Rider names are only ever the players running MXB App, unless it is the server under you. MX Bikes never sends a roster to a stranger — `CLIENTS_LIST` is built only inside a live session. The panel labels which of the two it is showing.

## Follow-ups, their own PRs

- The FrostMod `recvfrom` relay, to discover servers first seen while the game is running — plus the `frostmod_cmd_result.json` response path the command channel still lacks.
- The fake-join spike (`GETCHALLENGE` → `CONNECTION` → `CLIENTS_LIST`): real names, but it takes a slot on someone else's server, so it gets measured before any UI touches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)