### PR TITLE
fix(ui): put the gap back between a button's icon and its label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   they are now rather than what they were when the list loaded.
 
 ### Fixed
+- Buttons that pair an icon with a label — Refresh across the app, and the rest of the plain
+  buttons — put a space back between the two instead of running them together.
 - Trackside scenery wears its own textures. Tents, inflatable gates, haybales, fences and
   crowd stands each take the sheet that belongs to them instead of the one next to it.
 - Tracks that name their textures plainly, without PiBoSo's suffixes, are drawn painted rather

--- a/src/Components/ui/button.tsx
+++ b/src/Components/ui/button.tsx
@@ -16,7 +16,7 @@ export const CHIP = "bg-foreground/[0.10] text-foreground hover:bg-foreground/[0
 const SKEWED = new Set(["default", "secondary", "outline", "destructive"]);
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap font-cond font-semibold uppercase tracking-[0.14em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-default select-none",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap font-cond font-semibold uppercase tracking-[0.14em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-default select-none",
   {
     variants: {
       variant: {


### PR DESCRIPTION
The Refresh button reads as `⟳REFRESH` — icon flush against the word — anywhere it is drawn as a plain (ghost) button: Presets, the Supporters card, and every other icon+label ghost, chip or link button in the app.

**Cause.** `buttonVariants`' base class has no `gap-*`. The only `gap-2` sits on the `u-unskew` wrapper, and that wrapper is rendered only for the leaning variants (`default`, `secondary`, `outline`, `destructive`). Every other variant puts its children straight into the button, with nothing between the svg and the text node.

**Fix.** `gap-2` moves onto the base string. The skewed variants are unchanged — their only child is the wrapper, which still carries its own gap.

**Verified** by extracting the class strings out of `button.tsx` and rendering both the old and new base against the built stylesheet (`dist/assets/index-*.css`), so Tailwind's real output and specificity are part of the test. Before: ghost icon touching the label. After: 8px, matching outline. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)