### PR TITLE
feat(track): hold generated tracks to what real ones measure

### DIFF
--- a/control-plane/src/trackgen.ts
+++ b/control-plane/src/trackgen.ts
@@ -230,6 +230,9 @@ what ten published circuits are made of:
                       main straight is the one exception: the start spur runs beside it and
                       the finish jump stands on it.
   lap length          1800-2500 m.
+  average speed       the lap must come out between 45 and 65 km/h averaged over it. Every
+                      federation caps it at 65, and 386 official MXGP races run a median of
+                      50.6 — a lap that averages more is one long straight.
 
 So: build each corner as a run of arcs, keep the straights short, and let the lap wander.
 Count the arcs before you send it — if straights outnumber corners you have written a shape.
@@ -237,11 +240,15 @@ Count the arcs before you send it — if straights outnumber corners you have wr
 START THE LAP ON A STRAIGHT. A motocross start is forty gates in a line 48 m across, and the
 gate row stands on its own spur beside the lap's opening straight, which is also where the
 finish line goes — a lap that begins on a corner has its gates laid round a bend. So the FIRST
-segment is a straight of 100-160 m, and the lap has to come back to it. That is the one long
+segment is a straight of 100-125 m, and the lap has to come back to it. That is the one long
 straight; the rest stay short.
 
+NO STRAIGHT MAY EXCEED 125 m — or 140 m where a jump stands in its first fifteen metres. The
+FFM is the only federation that writes a straight-length limit and that is it. A longer
+straight arrives at its next corner faster than the corner was built for.
+
 AND THAT STRAIGHT CARRIES THE FINISH JUMP. Every national ends the lap on one: the biggest
-tabletop on the track, 2.4-3.6 m tall, with the finish line painted past its landing. Put one
+tabletop on the track, 2.4-3.0 m tall, with the finish line painted past its landing. Put one
 there — leaving the first 18 m off the last corner clear so there is drive at it, and 10 m
 past the landing before the straight runs out. Leave it out and the app builds it anyway,
 taking the ground whatever you put there was standing on; what the app cannot do is lengthen
@@ -310,10 +317,14 @@ explicitly asks otherwise:
                       stand over a metre. Six or eight big ones of 2.5–4 m, and the rest
                       rollers of 0.4–0.9 m. A lap of thirty identical 1.5 m tabletops is
                       wrong in both directions at once.
-  a jump's height     0.4–0.9 m for a roller, 1.0–2.0 m for an ordinary jump, 2.5–4.0 m for
+  a jump's height     0.4–0.9 m for a roller, 1.0–2.0 m for an ordinary jump, 2.5–3.0 m for
                       the handful that matter (it measures about 0.75x that against the
-                      landscape). Published lips top out at 3.0–5.9 m.
-  jump spacing        20–50 m between takeoffs
+                      landscape). NOTHING MAY STAND OVER 3.0 m: Motorcycling Australia and
+                      Motorcycling New Zealand both write "jumps must not exceed 3m in
+                      height", and no federation anywhere allows more.
+  jump spacing        20–50 m between takeoffs, and NEVER less than 20 m of clear ground in
+                      front of a jump — a written standard, and why a rhythm section is a run
+                      of small jumps rather than a heap of big ones.
   jumps and speed     A JUMP IS ONLY AS BIG AS THE RUN AT IT. This is checked and it is the
                       most common thing to get wrong after closure. A rider leaves a hairpin
                       at about 33 km/h and needs 60–80 m of straight to reach 90. So: a big
@@ -325,7 +336,8 @@ explicitly asks otherwise:
                       back as a problem with the number.
   after a corner      small first, then bigger. That progression is what a rhythm section is,
                       and it falls out of the speed rather than being a style.
-  whoop spacing       4–6 m crest to crest
+  whoop spacing       4–6 m crest to crest, and 0.6–0.9 m TALL. Dirt Wurx cut them at 13–14
+                      feet and three feet high; the regulated ceiling is 0.6 m.
   corner radius       7–30 m at the tightest point of a corner; 40 m and up barely turns
   steepest ground     27–41°
 

--- a/src-tauri/src/trackllm.rs
+++ b/src-tauri/src/trackllm.rs
@@ -50,9 +50,47 @@ pub mod corpus {
     pub const LIPS_PER_KM: (f32, f32) = (12.0, 45.0);
     /// One jump's height above the ground it sits on, as the program states it.
     ///
-    /// Up to five metres because published ones are: measured lips top out at 3.0–5.9 m per
-    /// track, and a lap whose biggest jump is 1.6 m has no big jump on it.
-    pub const FEATURE_HEIGHT_M: (f32, f32) = (0.3, 5.0);
+    /// Three metres, which is the regulated ceiling: Motorcycling Australia §6.7.1(a) and
+    /// Motorcycling New Zealand §3.9.2(b) both say "jumps must not exceed 3m in height", and
+    /// no federation anywhere allows more. It was five, on the grounds that measured lips top
+    /// out at 3.0–5.9 m per published track — but that figure is a *prominence* against a 60 m
+    /// mean, which the same survey warns reads a 3.6 m table as 1.9 m and picks up the
+    /// hillside on a wider baseline. The regulated 3 m and the program's `height` are the same
+    /// quantity — the obstacle standing off the ground — and the measured lip is not.
+    /// See `docs/tracks/real-track-corpus.md` §1.2 and §8.2.
+    pub const FEATURE_HEIGHT_M: (f32, f32) = (0.3, 3.0);
+
+    /// How tall one whoop stands.
+    ///
+    /// The best-sourced obstacle in motocross and it was unconstrained here. Dirt Wurx build
+    /// them at 3 ft — "The Whoops – Typical height is 3 feet" — and MA and MNZ both cap a whoop
+    /// at 600 mm. The band spans the two: a regulated set and a supercross-built one.
+    pub const WHOOP_HEIGHT_M: (f32, f32) = (0.3, 0.9);
+
+    /// The least clear ground a jump may have in front of it, metres.
+    ///
+    /// A written standard rather than a judgement: MA §14.4.3(d) asks for "at least 20 metres
+    /// of run-up preceding each Jump". It is a floor and the speed check is the ceiling — the
+    /// same clause elsewhere says approach length "should be limited to control approach
+    /// speed", so a jump wants enough run to be cleared and no more.
+    pub const RUN_UP_M: f32 = 20.0;
+
+    /// The longest a straight may be, metres.
+    ///
+    /// The FFM is the only federation that states one: a straight "must not exceed 125 metres,
+    /// or 140 if there is an obstacle in the first 15 metres". Ours ran to 160 on the opening
+    /// straight. The allowance is kept because our own opening straight carries the finish
+    /// jump, which is exactly the obstacle the rule has in mind.
+    pub const STRAIGHT_M: f32 = 125.0;
+    pub const STRAIGHT_WITH_OBSTACLE_M: f32 = 140.0;
+
+    /// What a lap averages once a rider is round it, km/h.
+    ///
+    /// Measured over 386 official MXGP race classifications, 2014–2026: median 50.6, and a dry
+    /// working band of 45–54. The ceiling is the regulation — FIM 4.1 §5, MA §6.6.1 and MNZ
+    /// §3.8 all cap a lap's average at 65 km/h — and the floor is a mud race. A track whose
+    /// modelled average lands outside this is not one anybody would licence.
+    pub const LAP_AVG_KMH: (f32, f32) = (40.0, 65.0);
     /// Between the crests of a whoop section.
     pub const WHOOP_SPACING_M: (f32, f32) = (2.5, 8.0);
     /// A corner tight enough to need a berm, and one loose enough not to be a corner.
@@ -919,6 +957,69 @@ pub fn review(prog: &TrackProgram) -> Review {
         between("feature density", per_km, corpus::LIPS_PER_KM, " per km", &mut notes);
     }
 
+    // Straights, against the only length limit any federation states. The FFM allows the
+    // longer one when an obstacle stands in the first fifteen metres, which our opening
+    // straight has — it carries the finish jump — so a straight is measured against whichever
+    // applies to it.
+    for (_, at, len) in prog.straight_runs() {
+        let obstacle = prog
+            .features
+            .iter()
+            .any(|f| f.at() >= at - 1.0 && f.at() <= at + 15.0);
+        let cap = if obstacle {
+            corpus::STRAIGHT_WITH_OBSTACLE_M
+        } else {
+            corpus::STRAIGHT_M
+        };
+        if len > cap {
+            out.push(format!(
+                "the straight at {at:.0} m runs {len:.0} m; a straight may not exceed \
+                 {cap:.0} m{}",
+                if obstacle {
+                    " even with an obstacle on it"
+                } else {
+                    " — or 140 m with a jump in its first 15 m"
+                }
+            ));
+        }
+    }
+
+    // Clear ground in front of each jump. A written standard, and the other half of the speed
+    // check below: a jump wants enough run to be cleared and no more.
+    {
+        let mut jumps: Vec<(f32, f32, &'static str)> = prog
+            .features
+            .iter()
+            .filter(|f| {
+                matches!(
+                    f,
+                    Feature::Tabletop { .. } | Feature::Double { .. } | Feature::StepUp { .. }
+                )
+            })
+            .map(|f| (f.at(), f.at() + f.length(), f.name()))
+            .collect();
+        jumps.sort_by(|a, b| a.0.total_cmp(&b.0));
+        for i in 0..jumps.len() {
+            let (at, _, name) = jumps[i];
+            // What stands before it, wrapping round the lap so the first jump is measured
+            // against the last one rather than against the start line.
+            let before = if i == 0 {
+                jumps.last().map(|j| j.1 - prog.lap_length())
+            } else {
+                Some(jumps[i - 1].1)
+            };
+            let Some(before) = before else { continue };
+            let run = at - before;
+            if run < corpus::RUN_UP_M && jumps.len() > 1 {
+                out.push(format!(
+                    "the {name} at {at:.0} m has {run:.0} m of clear ground in front of it; a \
+                     jump needs at least {:.0} m of run-up",
+                    corpus::RUN_UP_M
+                ));
+            }
+        }
+    }
+
     // Per-feature, where the complaint can name the thing that's wrong.
     let turn = prog.stations(1.0);
     let speed = crate::trackspeed::of(prog);
@@ -982,12 +1083,21 @@ pub fn review(prog: &TrackProgram) -> Review {
                 corpus::FEATURE_HEIGHT_M.1
             ));
         }
-        if let Feature::Whoops { at, spacing, .. } = f {
+        if let Feature::Whoops { at, spacing, height, .. } = f {
             if *spacing < corpus::WHOOP_SPACING_M.0 || *spacing > corpus::WHOOP_SPACING_M.1 {
                 out.push(format!(
                     "the whoops at {at:.0} m are {spacing:.1} m apart; whoops run {:.1}–{:.1} m",
                     corpus::WHOOP_SPACING_M.0,
                     corpus::WHOOP_SPACING_M.1
+                ));
+            }
+            let wh = height.abs();
+            if wh < corpus::WHOOP_HEIGHT_M.0 || wh > corpus::WHOOP_HEIGHT_M.1 {
+                out.push(format!(
+                    "the whoops at {at:.0} m stand {wh:.2} m; a whoop is {:.1}–{:.1} m — the \
+                     regulated ceiling is 0.6 and a supercross one is built at 0.9",
+                    corpus::WHOOP_HEIGHT_M.0,
+                    corpus::WHOOP_HEIGHT_M.1
                 ));
             }
         }
@@ -1011,6 +1121,23 @@ pub fn review(prog: &TrackProgram) -> Review {
                      banks the outside of a corner.{nearest}"
                 ));
             }
+        }
+    }
+
+    // What the lap averages, which is the one thing every federation regulates about how a
+    // track rides. The model already knows: a rider's speed round the lap, integrated as the
+    // time it takes them.
+    {
+        let step = 1.0f32;
+        let mut time = 0.0f32;
+        let mut at = 0.0f32;
+        while at < prog.lap_length() {
+            time += step / speed.at(at).max(1.0);
+            at += step;
+        }
+        if time > 1.0 {
+            let kmh = prog.lap_length() / time * 3.6;
+            between("the lap's average speed", kmh, corpus::LAP_AVG_KMH, " km/h", &mut notes);
         }
     }
 

--- a/src-tauri/src/trackprog.rs
+++ b/src-tauri/src/trackprog.rs
@@ -277,7 +277,46 @@ impl Segment {
 /// the median face against Indiana's 12.0, which is what "the jumps are too big" turns out to
 /// mean: not their height, which already matches, but that every one of them is as abrupt as
 /// the worst one on a real track.
-pub const JUMP_FACE_DEG: f32 = 27.0;
+/// Thirty-eight, and it is a ceiling that now rarely binds — which is the point.
+///
+/// Twenty-seven was read off the *terrain* statistic: Indiana's faces measure 27.4° at the
+/// ninetieth percentile, sampled off the ground. That is not the same quantity as the angle a
+/// builder builds to, and taking it as one made every big face too long. Sized by the half
+/// angle, a 27° lip puts a 12.5 m ramp under a 3 m jump — a mean gradient of 13.5°, where
+/// every real source puts a built take-off between 2:1 and 3:1, or 26.6° down to 18.4° of
+/// mean. See `docs/tracks/real-track-corpus.md` §4.1: the ratio a builder quotes describes the
+/// *mean* of a concave face, and its lip runs about 1.8x steeper.
+///
+/// At 38 the angle stops lengthening faces past [`JUMP_FACE_MIN_M`] for anything under about
+/// 3.1 m, so the floor governs the whole realistic range and the angle is what the comment on
+/// [`TABLETOP_DECK_M`] always said it should be: a ceiling for the tall ones, not a target for
+/// all of them. A 3 m jump comes out on the floor at 9 m — 18.4° of mean, which is 3:1 exactly.
+///
+/// The tension worth knowing: our lip is now geometrically steeper than the 27.4° Indiana
+/// *measures*, because a windowed terrain slope under-reads a real lip. If a generated lap
+/// starts measuring past Indiana at the ninetieth, this is the number that did it.
+pub const JUMP_FACE_DEG: f32 = 38.0;
+
+// A straight lip is NOT built here, and the reason is geometric rather than an oversight.
+//
+// The terrain-park literature builds the last ~2 m of a take-off straight, so the ground is
+// not still turning under the wheel at the moment of release — Petrone's constant-EFH jump
+// states it outright. Adding that here was tried and backed out.
+//
+// [`DoubleShape::height_at`] trims the crown off the top of a face and rescales what is left,
+// and that trick is exact *only* because the face is a pure arc: a chord cut off an arc keeps
+// rise and run in the same `tan(sweep/2)` ratio, so the trimmed face is still the face `up`
+// describes and the crown still meets it tangentially. Splice a straight into the top and the
+// identity fails — `sin(u)·tan(u) != 1 − cos(u)` — so the crown joins a face that is no longer
+// at the crown's own angle and the ramp comes out steeper than it states. Measured: a 4 m jump
+// over a 12 m gap stood at 39.1° against a stated 38.
+//
+// Doing it properly means rebuilding the crown construction so it does not lean on
+// self-similarity. That is worth doing and it is not a one-line change. Note the crown already
+// rounds the crest over `0.9·h` of radius, which on a 4 m jump is more ground than the 2 m
+// straight would have occupied — so the release is less abrupt than the bare arc suggests.
+// See `docs/tracks/real-track-corpus.md` §6.2.
+
 
 /// The gentlest face — the one a landing gets. Published landings measure 19.0° at the
 /// ninetieth against a takeoff's 27.0: a built takeoff is short because that is what throws
@@ -365,6 +404,7 @@ pub fn face_arc(t: f32, sweep: f32) -> f32 {
     let phi = (t * sin_s).clamp(-1.0, 1.0).asin();
     (1.0 - phi.cos()) / (1.0 - cos_s)
 }
+
 
 /// How far a face has to run to reach `height` without standing steeper than `deg` at its lip.
 ///
@@ -658,7 +698,7 @@ pub fn tabletop_faces(height: f32, length: f32) -> (f32, f32, f32) {
 /// track — a long tabletop on the main straight with the line painted past its landing. The
 /// range is the top of the published spread rather than the middle of it: this is the one
 /// jump a track is photographed on.
-pub const FINISH_JUMP_M: (f32, f32) = (2.4, 3.6);
+pub const FINISH_JUMP_M: (f32, f32) = (2.4, 3.0);
 
 /// The longest deck a finish jump gets, metres. Published tabletop decks run six to twelve,
 /// and the finish one is at the long end because it is the one everybody lands on.
@@ -712,7 +752,7 @@ pub const START_OFFSET_M: f32 = 40.0;
 /// told. Shorter than the middle of that on purpose: ridden, 85 m of sprint and 90 m of
 /// turn-in is a long way to the first corner, and the whole point of a start straight is that
 /// it ends at one.
-pub const START_SPRINT_M: f32 = 70.0;
+pub const START_SPRINT_M: f32 = 80.0;
 
 /// How far the start straight is angled towards the lap, degrees. Over the sprint it closes
 /// about a fifth of the offset, which leaves one corner to do the rest.
@@ -1009,7 +1049,7 @@ pub const EXAMPLE: &str = r#"{
       },
       "start": { "x": 337.80, "z": 97.64, "angle": 272.27 },
       "segments": [
-        { "kind": "straight", "length": 145.1504 },
+        { "kind": "straight", "length": 125 },
         { "kind": "arc", "radius": 63.4878, "angle": 8.1222 },
         { "kind": "arc", "radius": 24.3538, "angle": 16.4685 },
         { "kind": "arc", "radius": 14.1670, "angle": 28.3103 },
@@ -1035,7 +1075,7 @@ pub const EXAMPLE: &str = r#"{
         { "kind": "arc", "radius": -11.7162, "angle": 144.0096 },
         { "kind": "arc", "radius": -43.0843, "angle": 15.9680 },
         { "kind": "arc", "radius": -64.3372, "angle": 9.7961 },
-        { "kind": "straight", "length": 62.0060 },
+        { "kind": "straight", "length": 82.1895 },
         { "kind": "arc", "radius": 132.9446, "angle": 0.4310 },
         { "kind": "arc", "radius": 38.3394, "angle": 11.9555 },
         { "kind": "arc", "radius": 16.8713, "angle": 30.5645 },
@@ -1126,7 +1166,7 @@ pub const EXAMPLE: &str = r#"{
         { "kind": "arc", "radius": -32.8954, "angle": 13.9340 },
         { "kind": "straight", "length": 11.1325 },
         { "kind": "arc", "radius": 125.4045, "angle": 0.9138 },
-        { "kind": "straight", "length": 90.3427 },
+        { "kind": "straight", "length": 91.4006 },
         { "kind": "arc", "radius": -29.7662, "angle": 15.3989 },
         { "kind": "arc", "radius": -12.1796, "angle": 32.9296 },
         { "kind": "arc", "radius": -14.3360, "angle": 35.9696 },
@@ -1149,42 +1189,42 @@ pub const EXAMPLE: &str = r#"{
       ],
       "features": [
         { "kind": "roller", "at": 31.3, "length": 11.3, "height": 0.8 },
-        { "kind": "tabletop", "at": 52.3, "length": 48.5, "height": 3.6 },
-        { "kind": "roller", "at": 131.0, "length": 14.4, "height": 0.75 },
-        { "kind": "berm", "at": 265.5, "length": 8.0, "height": 1.7 },
-        { "kind": "tabletop", "at": 295.7, "length": 30.0, "height": 1.5 },
-        { "kind": "roller", "at": 408.7, "length": 11.1, "height": 0.79 },
-        { "kind": "tabletop", "at": 481.6, "length": 21.0, "height": 3.4 },
-        { "kind": "roller", "at": 540.0, "length": 11.6, "height": 0.8 },
-        { "kind": "roller", "at": 565.0, "length": 12.0, "height": 0.6 },
-        { "kind": "tabletop", "at": 600.0, "length": 22.0, "height": 3.6 },
-        { "kind": "stepUp", "at": 655.0, "length": 19.3, "height": 2.2 },
-        { "kind": "whoops", "at": 690.0, "count": 7, "spacing": 4.2, "height": 0.57 },
-        { "kind": "roller", "at": 725.0, "length": 13.0, "height": 0.8 },
-        { "kind": "roller", "at": 800.0, "length": 14.0, "height": 0.8 },
-        { "kind": "roller", "at": 845.0, "length": 15.0, "height": 0.85 },
-        { "kind": "tabletop", "at": 870.0, "length": 30.0, "height": 1.6 },
-        { "kind": "stepUp", "at": 925.7, "length": 25.2, "height": 1.9 },
-        { "kind": "roller", "at": 990.6, "length": 14.8, "height": 0.6 },
-        { "kind": "tabletop", "at": 1064.9, "length": 20.0, "height": 2.5 },
-        { "kind": "roller", "at": 1110.0, "length": 14.4, "height": 0.82 },
-        { "kind": "roller", "at": 1135.0, "length": 13.2, "height": 0.58 },
-        { "kind": "tabletop", "at": 1183.2, "length": 24.0, "height": 1.3 },
-        { "kind": "tabletop", "at": 1253.9, "length": 22.0, "height": 3.6 },
-        { "kind": "roller", "at": 1310.0, "length": 14.6, "height": 0.64 },
-        { "kind": "tabletop", "at": 1340.3, "length": 26.0, "height": 1.5 },
-        { "kind": "roller", "at": 1383.5, "length": 15.0, "height": 0.85 },
-        { "kind": "roller", "at": 1426.7, "length": 11.5, "height": 0.77 },
-        { "kind": "tabletop", "at": 1450.0, "length": 20.0, "height": 3.1 },
-        { "kind": "whoops", "at": 1524.5, "count": 7, "spacing": 5.0, "height": 0.75 },
-        { "kind": "tabletop", "at": 1566.5, "length": 30.0, "height": 1.6 },
-        { "kind": "tabletop", "at": 1634.9, "length": 20.0, "height": 2.5 },
-        { "kind": "roller", "at": 1685.0, "length": 13.0, "height": 0.65 },
-        { "kind": "double", "at": 1706.0, "height": 1.3, "gap": 2.0, "lip": 5.5 },
-        { "kind": "roller", "at": 1766.8, "length": 14.3, "height": 0.79 },
-        { "kind": "roller", "at": 1790.0, "length": 15.0, "height": 0.7 },
-        { "kind": "berm", "at": 1830.0, "length": 15.0, "height": 1.7 },
-        { "kind": "tabletop", "at": 1874.0, "length": 27.0, "height": 1.1 }
+        { "kind": "tabletop", "at": 52.3, "length": 48.5, "height": 3 },
+        { "kind": "roller", "at": 131, "length": 14.4, "height": 0.75 },
+        { "kind": "berm", "at": 245.3496, "length": 8.0, "height": 1.7 },
+        { "kind": "tabletop", "at": 275.5496, "length": 30.0, "height": 1.5 },
+        { "kind": "roller", "at": 388.5496, "length": 11.1, "height": 0.79 },
+        { "kind": "tabletop", "at": 461.4496, "length": 21.0, "height": 3 },
+        { "kind": "roller", "at": 540.0331, "length": 11.6, "height": 0.8 },
+        { "kind": "roller", "at": 565.0331, "length": 12.0, "height": 0.6 },
+        { "kind": "tabletop", "at": 600.0331, "length": 22.0, "height": 3 },
+        { "kind": "stepUp", "at": 655.0331, "length": 19.3, "height": 2.2 },
+        { "kind": "whoops", "at": 690.0331, "count": 7, "spacing": 4.2, "height": 0.57 },
+        { "kind": "roller", "at": 725.0331, "length": 13.0, "height": 0.8 },
+        { "kind": "roller", "at": 800.0331, "length": 14.0, "height": 0.8 },
+        { "kind": "roller", "at": 845.0331, "length": 15.0, "height": 0.85 },
+        { "kind": "tabletop", "at": 870.0331, "length": 30.0, "height": 1.6 },
+        { "kind": "stepUp", "at": 925.7331, "length": 25.2, "height": 1.9 },
+        { "kind": "roller", "at": 990.6331, "length": 14.8, "height": 0.6 },
+        { "kind": "tabletop", "at": 1064.9331, "length": 20.0, "height": 2.5 },
+        { "kind": "roller", "at": 1110.0331, "length": 14.4, "height": 0.82 },
+        { "kind": "roller", "at": 1135.0331, "length": 13.2, "height": 0.58 },
+        { "kind": "tabletop", "at": 1183.2331, "length": 24.0, "height": 1.3 },
+        { "kind": "tabletop", "at": 1253.9331, "length": 22.0, "height": 3 },
+        { "kind": "roller", "at": 1310.0331, "length": 14.6, "height": 0.64 },
+        { "kind": "tabletop", "at": 1340.3331, "length": 26.0, "height": 1.5 },
+        { "kind": "roller", "at": 1383.5331, "length": 15.0, "height": 0.85 },
+        { "kind": "roller", "at": 1426.7331, "length": 11.5, "height": 0.77 },
+        { "kind": "tabletop", "at": 1450.0331, "length": 20.0, "height": 3 },
+        { "kind": "whoops", "at": 1524.5331, "count": 7, "spacing": 5.0, "height": 0.75 },
+        { "kind": "tabletop", "at": 1566.5331, "length": 30.0, "height": 1.6 },
+        { "kind": "tabletop", "at": 1634.9331, "length": 20.0, "height": 2.5 },
+        { "kind": "roller", "at": 1685.0331, "length": 13.0, "height": 0.65 },
+        { "kind": "double", "at": 1706.0331, "height": 1.3, "gap": 2.0, "lip": 5.5 },
+        { "kind": "roller", "at": 1767.891, "length": 14.3, "height": 0.79 },
+        { "kind": "roller", "at": 1791.091, "length": 15.0, "height": 0.7 },
+        { "kind": "berm", "at": 1831.091, "length": 15.0, "height": 1.7 },
+        { "kind": "tabletop", "at": 1875.091, "length": 27.0, "height": 1.1 }
       ]
     }"#;
 

--- a/src-tauri/src/trackspeed.rs
+++ b/src-tauri/src/trackspeed.rs
@@ -68,11 +68,22 @@ const P_SPEC: f32 = 22.0;
 /// Brakes, m/s². Limited by the same ground that limits everything else.
 const A_BRAKE: f32 = 6.0;
 
-/// The fastest anything goes on a national, m/s — about 79 km/h.
+/// The fastest anything goes, m/s — 77 km/h.
 ///
-/// Measured off lap times rather than picked: a 2 km national lap runs about two minutes,
-/// which is a 60 km/h average, and a lap whose *average* is 60 does not have a 100 km/h top.
-const V_MAX: f32 = 20.0;
+/// This used to be reasoned from "a 2 km national lap runs about two minutes, which is a
+/// 60 km/h average". That average was wrong, and it was the load-bearing number: across 386
+/// official MXGP race classifications, 2014–2026, the median winner's race average is
+/// **50.6 km/h** and the dry band is 45–54. Sixty is the fastest single lap in twelve seasons.
+///
+/// The top itself is now measured rather than inferred. Nobody publishes a top speed for a
+/// motocross bike — not the manufacturers, not Cycle World, not MXA — but Dirt Rider had LAPD
+/// officers radar a supercross test track, and the fastest thing on it was the start at
+/// 48 mph. That is 21.4 m/s, and it is the only instrumented number of its kind.
+///
+/// Note it went *up* while the lap got slower: a lap's average is held down by its corners,
+/// which [`A_LAT`] already had right — the same radar put a bowl turn's apex at 27.4 km/h and
+/// this model puts a 13 m corner at 27.5. See `docs/tracks/real-track-corpus.md` §2.3.
+const V_MAX: f32 = 21.4;
 
 /// The slowest a corner is ever taken, m/s. A first-gear pivot turn is still moving.
 const V_MIN: f32 = 3.0;

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -305,9 +305,12 @@ const RUT_CORRIDOR_FADE_M: f32 = 1.6;
 /// How wide the ridden line is either side of the racing line, how much wider it gets through
 /// a corner, and how far its own edge fades.
 ///
-/// Measured off what a corner looks like rather than picked: riders take a straight in a file
-/// about three metres wide and a corner across most of it.
-const LINE_HALF_WIDTH_M: f32 = 2.1;
+/// Three metres either side, which is the narrowest *riding width* any federation licenses: FIM
+/// article 4.2 §5 and Motorcycling New Zealand both say 6 m, and Motorcycling Australia asks 7.
+/// This was 2.1 — a 4.2 m file, under every one of them. Note the number this is not: our
+/// `width` is the graded corridor at 10–17 m, and the regulated 6 m is the surface riders use,
+/// which is this. See `docs/tracks/real-track-corpus.md` §8.1.
+const LINE_HALF_WIDTH_M: f32 = 3.0;
 const LINE_CORNER_SPREAD: f32 = 0.85;
 const LINE_FADE_M: f32 = 0.8;
 


### PR DESCRIPTION
Acts on the corpus in `docs/tracks/real-track-corpus.md` (#478). **Eight of its nine findings ship here.** The ninth is recorded in the code with the reason it is not done, rather than quietly dropped.

## Geometry

- **`JUMP_FACE_DEG` 27 → 38.** This is the headline. Twenty-seven was read off the *terrain* statistic — Indiana measures 27.4° at the ninetieth percentile — and then used as the angle a builder builds to. Those are not the same quantity, and the mistake put a **12.5 m ramp under a 3 m jump: a 13.5° mean gradient, where every real source says 18.4–26.6°**. At 38 the angle stops lengthening faces past the 9 m floor below about 3.1 m, so the floor governs the whole realistic range and the angle becomes the ceiling the code always described it as. A 3 m jump now lands on the floor at 9 m — 3:1 exactly.
- **`LINE_HALF_WIDTH_M` 2.1 → 3.0.** The ridden file was 4.2 m against a 6 m regulated minimum riding width. Note this is *not* `width`, which is the graded corridor — conflating the two is trap §8.1 in the corpus.
- **`FINISH_JUMP_M`** tops out at 3.0 rather than 3.6, consistent with the new height ceiling.
- **`START_SPRINT_M` 70 → 80**, the bottom of FIM's and FFM's recommended range rather than the bottom of MA's absolute one.

## Validator — five new or moved bounds

| | Was | Now | Source |
|---|---|---|---|
| `FEATURE_HEIGHT_M` ceiling | 5.0 | **3.0** | MA §6.7.1(a), MNZ §3.9.2(b) |
| `WHOOP_HEIGHT_M` | unconstrained | **0.3–0.9** | Dirt Wurx build at 3 ft; regulated ceiling 0.6 m |
| `RUN_UP_M` | — | **20 m** clear in front of every jump | MA §14.4.3(d) |
| `STRAIGHT_M` | — | **125 m** (140 with a jump in the first 15 m) | FFM, the only such rule anywhere |
| `LAP_AVG_KMH` | — | **40–65** | every federation caps at 65; 386 MXGP races median 50.6 |

The 5.0 m height ceiling was justified by measured lips of 3.0–5.9 m, but that figure is a *prominence against a 60 m mean* — the same survey warns it reads a 3.6 m table as 1.9 m. The regulated 3 m and the program's `height` are the same quantity; the measured lip is not.

## Speed

**`V_MAX` 20 → 21.4 m/s.** It was inferred from "a 2 km lap in two minutes, so a 60 km/h average" — that average was wrong and load-bearing. Across 386 official MXGP classifications the median is 50.6 km/h and 60 is the *fastest lap ever recorded*. The top is now the one instrumented figure that exists: a radared supercross start at 48 mph. `A_LAT` is deliberately untouched — the same radar confirms it at a bowl turn's apex (27.4 km/h measured, 27.5 modelled).

## Not done, deliberately

**The straight lip.** A pure arc is steepest at the instant of release, and the terrain-park literature builds the last ~2 m straight. I implemented it and backed it out: `DoubleShape::height_at` trims the crown off a face and rescales what is left, which is exact **only** because a chord cut off an arc keeps rise and run in the same `tan(sweep/2)` ratio. A straight breaks that identity — `sin(u)·tan(u) ≠ 1 − cos(u)` — so the crown joins a face that is no longer at the crown's own angle. Measured: **a 4 m jump over a 12 m gap stood at 39.1° against a stated 38.** Rebuilding the crown construction so it doesn't lean on self-similarity is real work, not a constant. The reasoning is left in the code where the change would go.

## The worked example

`EXAMPLE` genuinely violated three of the new bounds, which is the checks working. It is edited to comply: the opening straight comes down from 145 m to the 125 m cap, with **two other straights solved so the lap still closes to 0.014 m**, features shifted with them, and five heights clamped to 3.0. Layout preserved, so the diff is readable.

## Verification

- **1484 Rust tests pass, 0 failures.** Including `a_jump_face_is_steepest_at_its_lip` and `a_double_turns_rather_than_folding`, which are what caught the straight-lip problem.
- **297 control-plane tests pass**, including the schema-drift test that keeps `trackgen.ts` and `trackprog.rs` in step.
- The model's prompt carries every new bound, so generation targets them rather than being rejected by them.

## Note for review

No CHANGELOG entry — nothing here is player-visible on its own; it changes what the generator will produce next time it runs. Worth a look: whether the 3.0 m ceiling is right for an explicit supercross brief, where real tracks do exceed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)