### PR TITLE
Bind each material to the sheet the map names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,10 @@
   they are now rather than what they were when the list loaded.
 
 ### Fixed
-- Trackside scenery wears its own textures. Tents, inflatable gates, haybales, fences and
-  crowd stands each take the sheet that belongs to them instead of the one next to it.
+- Trackside scenery wears its own textures. Every object now takes the sheet the track itself
+  says it wears, rather than one worked out from the order they are stored in — so banners
+  show their sponsors, the inflatable gates are back to full colour, and the treeline is
+  leaves instead of bark.
 - Tracks that name their textures plainly, without PiBoSo's suffixes, are drawn painted rather
   than grey. Two of the tracks checked had no readable name at all and now come out fully
   textured.

--- a/src-tauri/src/map.rs
+++ b/src-tauri/src/map.rs
@@ -41,6 +41,13 @@ const MAGIC: &[u8; 4] = b"MP2\0";
 /// Where the material records start, and how big one is. Geometry follows the last of them.
 const MATERIALS_AT: usize = 0x0C;
 const MATERIAL_RECORD: usize = 56;
+/// Which word of a material record holds the index of the sheet that paints it.
+///
+/// The one field in the file that states the binding outright. Everything before this read
+/// the sheets positionally and guessed, which is off by one for most of Indiana and by two
+/// for its trees: material 45 takes sheet 0 and material 38 takes sheet 40, skipping 39, so
+/// the order is genuinely the file's rather than an offset anyone could have inferred.
+const MATERIAL_TEX_WORD: usize = 11;
 
 /// Bytes per vertex, and where each attribute's array begins within the block — every one
 /// of them a count of vertices from the block's start, not a stride.
@@ -907,15 +914,15 @@ pub fn declared(b: &[u8]) -> Vec<(String, u32, u32)> {
     let Some((from, count)) = texture_table(b) else {
         return Vec::new();
     };
-    // The same walk `textures` makes, so a slot and the sheet that fills it agree.
+    // The same binding `textures` makes, so a slot and the sheet that fills it agree.
     let painting = painting_records(colour_records(b, from));
     if !covers(painting.len(), count) {
         return Vec::new();
     }
-    painting
+    bindings(b, count, painting.len())
         .into_iter()
-        .take(count)
-        .map(|(n, w, h, ..)| (n, w, h))
+        .filter_map(|(_, sheet)| painting.get(sheet))
+        .map(|(n, w, h, ..)| (n.clone(), *w, *h))
         .collect()
 }
 
@@ -1250,7 +1257,41 @@ pub fn bound_count(b: &[u8]) -> usize {
     if !binds(b) {
         return 0;
     }
-    painting_records(colour_records(b, from)).len().min(count)
+    bindings(b, count, painting_records(colour_records(b, from)).len()).len()
+}
+
+/// Which sheet paints each material, as `(material, sheet)` pairs.
+///
+/// Read out of the material records rather than guessed: see [`MATERIAL_TEX_WORD`]. Checked
+/// against 12 published tracks from 4 authors, every one of which reads as a legal index into
+/// the sheets, and on Indiana it is off by one from the positional walk for most materials
+/// and by two for its trees — which is the difference between a banner showing its sponsor
+/// and showing the 80%-transparent sheet of the object beside it.
+///
+/// Falls back to the positional walk when the field doesn't read as an index, so a map built
+/// by something that leaves it empty is no worse off than before.
+fn bindings(b: &[u8], materials: usize, sheets: usize) -> Vec<(usize, usize)> {
+    let mut out = Vec::with_capacity(materials);
+    let mut distinct = std::collections::HashSet::new();
+    for m in 0..materials {
+        let at = MATERIALS_AT + m * MATERIAL_RECORD + MATERIAL_TEX_WORD * 4;
+        if at + 4 > b.len() {
+            out.clear();
+            break;
+        }
+        let sheet = u32le(b, at) as usize;
+        if sheet >= sheets {
+            out.clear();
+            break;
+        }
+        distinct.insert(sheet);
+        out.push((m, sheet));
+    }
+    // A column holding one value throughout is a constant, not an index.
+    if out.len() == materials && distinct.len() > 1 {
+        return out;
+    }
+    (0..materials.min(sheets)).map(|i| (i, i)).collect()
 }
 
 pub fn textures(b: &[u8], max_dim: u32) -> Vec<MapTexture> {
@@ -1261,13 +1302,16 @@ pub fn textures(b: &[u8], max_dim: u32) -> Vec<MapTexture> {
     if !covers(painting.len(), count) {
         return Vec::new();
     }
-    // Anything past the material count is the terrain's own sheets, which trail the scenery's.
-    painting
+    // Each material names its own sheet, so nothing here is positional. One sheet may paint
+    // several materials, and it is inflated once per material that asks for it — the sheets
+    // are reduced immediately and a map rarely shares more than a handful.
+    let bound = bindings(b, count, painting.len());
+    bound
         .into_iter()
-        .take(count)
-        .enumerate()
-        .filter_map(|(i, (name, w, h, off, len))| {
+        .filter_map(|(material, sheet)| {
+            let (name, w, h, off, len) = painting.get(sheet)?.clone();
             let mut rgba = inflate(b, off, len, w, h)?;
+            let i = material;
             // Read from the pixels, not the name: `_c_a` is the convention, but the alpha
             // channel is the fact, and a sheet that is half see-through is a cut-out whatever
             // it is called.
@@ -2526,6 +2570,115 @@ mod tests {
         assert_eq!(kept, ["a_c", "b_c", "c_c"]);
     }
 
+    /// A material names its own sheet, and the walk that guessed is only the fallback.
+    ///
+    /// Built as Indiana's records are: the index is not the material's own number, it is not
+    /// a fixed offset from it, and it does not stay in order — Indiana's material 45 takes
+    /// sheet 0 and its 38 takes sheet 40, skipping 39. Nothing positional reproduces that.
+    #[test]
+    fn a_material_names_the_sheet_that_paints_it() {
+        // Four materials, and a header long enough to hold their records.
+        let mut b = vec![0u8; MATERIALS_AT + 4 * MATERIAL_RECORD];
+        let put = |b: &mut Vec<u8>, m: usize, sheet: u32| {
+            let at = MATERIALS_AT + m * MATERIAL_RECORD + MATERIAL_TEX_WORD * 4;
+            b[at..at + 4].copy_from_slice(&sheet.to_le_bytes());
+        };
+        // Out of order, and one sheet shared by two materials — both of which a positional
+        // walk gets wrong by construction.
+        put(&mut b, 0, 3);
+        put(&mut b, 1, 0);
+        put(&mut b, 2, 2);
+        put(&mut b, 3, 2);
+        assert_eq!(bindings(&b, 4, 4), vec![(0, 3), (1, 0), (2, 2), (3, 2)]);
+
+        // An index past the end of the sheets is not an index, so the walk takes over.
+        let mut bad = b.clone();
+        put(&mut bad, 2, 99);
+        assert_eq!(bindings(&bad, 4, 4), vec![(0, 0), (1, 1), (2, 2), (3, 3)]);
+
+        // Neither is a column holding one value throughout.
+        let mut flat = vec![0u8; MATERIALS_AT + 4 * MATERIAL_RECORD];
+        for m in 0..4 {
+            put(&mut flat, m, 1);
+        }
+        assert_eq!(bindings(&flat, 4, 4), vec![(0, 0), (1, 1), (2, 2), (3, 3)]);
+
+        // And the fallback never invents a sheet a map doesn't carry.
+        assert_eq!(bindings(&flat, 4, 2), vec![(0, 0), (1, 1)]);
+    }
+
+    /// What is actually inside a material record.
+    ///
+    /// The parse has always stepped straight over these 56 bytes, and the whole binding
+    /// problem — which sheet paints which material — is guesswork *because* of that. If one
+    /// of these fourteen words is a texture index, the guessing ends.
+    ///
+    /// ```text
+    /// FROST_MAP="…/track.map" \
+    ///   cargo test --bin mxb-app -- --ignored --nocapture inside_a_material_record
+    /// ```
+    #[test]
+    #[ignore = "needs a real .map — set FROST_MAP"]
+    fn inside_a_material_record() {
+        let path = std::env::var("FROST_MAP").expect("set FROST_MAP");
+        let b = std::fs::read(&path).expect("read the map");
+        let n = material_count(&b).expect("a material count");
+        let sheets = painting_records(colour_records(&b, texture_table(&b).unwrap().0));
+        println!("  {n} materials, {} painting records", sheets.len());
+
+        const WORDS: usize = MATERIAL_RECORD / 4;
+        // A column that is always a small number in range is what a texture index looks like.
+        let mut in_range = [true; WORDS];
+        let mut distinct: Vec<std::collections::HashSet<u32>> = vec![Default::default(); WORDS];
+        for m in 0..n {
+            let at = MATERIALS_AT + m * MATERIAL_RECORD;
+            let mut row = String::new();
+            for w in 0..WORDS {
+                let v = u32le(&b, at + w * 4);
+                distinct[w].insert(v);
+                if v as usize >= sheets.len() {
+                    in_range[w] = false;
+                }
+                let f = f32::from_le_bytes([
+                    b[at + w * 4],
+                    b[at + w * 4 + 1],
+                    b[at + w * 4 + 2],
+                    b[at + w * 4 + 3],
+                ]);
+                // Floats are colours and factors; integers are the interesting ones.
+                row += &if f != 0.0 && f.is_finite() && f.abs() < 1e6 && f.fract() != 0.0 {
+                    format!("{f:>10.3}")
+                } else {
+                    format!("{v:>10}")
+                };
+            }
+            if m < 24 {
+                println!("  m{m:<3}{row}");
+            }
+        }
+        println!();
+        for w in 0..WORDS {
+            println!(
+                "  word {w:<2} distinct={:<4} always_in_sheet_range={}",
+                distinct[w].len(),
+                in_range[w]
+            );
+        }
+
+        // The candidate: one distinct value per material, every one a legal sheet index.
+        let idx = (0..WORDS)
+            .find(|&w| in_range[w] && distinct[w].len() == n && n > 1)
+            .expect("a word that indexes the sheets one-to-one");
+        println!("\n  word {idx} reads as the texture index:");
+        for m in 0..n {
+            let v = u32le(&b, MATERIALS_AT + m * MATERIAL_RECORD + idx * 4) as usize;
+            println!(
+                "  mat{m:<3} -> sheet {v:<3} {}",
+                sheets.get(v).map(|(s, ..)| s.as_str()).unwrap_or("??")
+            );
+        }
+    }
+
     /// How many colour maps each rule finds, against how many materials the map declares.
     ///
     /// The positional binding needs one colour map per material, in order. Too few and the
@@ -2579,13 +2732,38 @@ mod tests {
                     !secondary && seen.insert(l)
                 })
                 .count();
+            // Does word 11 of every material record read as a legal, one-per-material index
+            // into the painting records? That is what makes it the binding rather than a
+            // coincidence, and it has to hold on every track before it can be trusted.
+            // In range is the test; distinct is not. One sheet often paints several
+            // materials — a fence and its gate wear the same picture — so demanding a
+            // one-to-one map wrongly rejected the two largest tracks here.
+            let sheets = not_secondary;
+            let mut seen = std::collections::HashSet::new();
+            let mut legal = count > 0;
+            for m in 0..count {
+                let at = MATERIALS_AT + m * MATERIAL_RECORD + MATERIAL_TEX_WORD * 4;
+                if at + 4 > bytes.len() {
+                    legal = false;
+                    break;
+                }
+                let v = u32le(&bytes, at) as usize;
+                if v >= sheets {
+                    legal = false;
+                    break;
+                }
+                seen.insert(v);
+            }
+            // A column of the same value is a constant, not an index.
+            legal = legal && seen.len() > 1;
             println!(
-                "{:<44} {:>7} {:>7} {:>7} {:>7}{}",
+                "{:<44} {:>7} {:>7} {:>7} {:>7}   w11={}{}",
                 p.file_stem().unwrap_or_default().to_string_lossy(),
                 all.len(),
                 count,
                 named,
                 not_secondary,
+                if legal { "INDEX" } else { "no" },
                 if named < count { "   <- SLIDES" } else { "" }
             );
         }

--- a/src-tauri/src/scenery.rs
+++ b/src-tauri/src/scenery.rs
@@ -27,9 +27,11 @@ use crate::map::{self, Group, MapMesh, MapTexture};
 // second having been decoded at all.
 // v6: a sheet is bound unless it is demonstrably a companion map, so materials no longer
 // slide onto their neighbour's picture and the sheets a track names plainly now bind at all.
-// Every v5 entry holds the old binding, which is the wrong colour on the wrong object.
-const MESH_CACHE: &str = "track-scenery-v6";
-const SURFACE_CACHE: &str = "track-surfaces-v6";
+// v7: the binding is read out of the material records rather than walked positionally, which
+// moves most of a track's materials by one and its trees by two. Every earlier entry holds a
+// guess, and the guess put an 80%-transparent sheet on Indiana's banners.
+const MESH_CACHE: &str = "track-scenery-v7";
+const SURFACE_CACHE: &str = "track-surfaces-v7";
 /// The ground sheet and its normal map, cached apart again — two 512×512 sheets against the
 /// surfaces' hundreds of megabytes, and finding them means reading the archive a third time.
 // v3: 8192-wide sheets are read now, so the pick has records to consider that v2 never saw.
@@ -2104,6 +2106,111 @@ overcast\n{\nsky = my_own_dome.edf\n}\n";
     #[test]
     #[ignore = "needs a real track — set FROST_TRACK"]
     fn decode_a_real_track() {
+        real_track_report();
+    }
+
+    /// What each material actually wears, against how much of the track it covers.
+    ///
+    /// A material drawn over thousands of triangles in a sheet whose opaque pixels average
+    /// near black is a black object on screen, and this is the one view that puts those two
+    /// facts side by side.
+    ///
+    /// ```text
+    /// FROST_TRACK="…/track.pkz" \
+    ///   cargo test --bin mxb-app -- --ignored --nocapture what_each_material_wears
+    /// ```
+    #[test]
+    #[ignore = "needs a real track — set FROST_TRACK"]
+    fn what_each_material_wears() {
+        let path = std::env::var("FROST_TRACK").expect("set FROST_TRACK");
+        let s = decode(Path::new(&path), true).expect("decode the scenery");
+        let tex = &s.textures;
+
+        let mut tris = vec![0u32; s.info.materials.max(1) as usize + 8];
+        // Per material, the box its triangles occupy — a banner run is long, thin and low,
+        // a treeline is tall, and that is what says which material is the thing on screen.
+        let mut box_of = vec![([f32::MAX; 3], [f32::MIN; 3]); s.info.materials.max(1) as usize + 8];
+        for g in &s.mesh.groups {
+            let Some(slot) = tris.get_mut(g.material as usize) else {
+                continue;
+            };
+            *slot += g.tri_count;
+            let bb = &mut box_of[g.material as usize];
+            for t in g.tri_start..g.tri_start + g.tri_count {
+                for k in 0..3 {
+                    let Some(&idx) = s.mesh.indices.get(t as usize * 3 + k) else {
+                        continue;
+                    };
+                    for axis in 0..3 {
+                        let Some(&v) = s.mesh.positions.get(idx as usize * 3 + axis) else {
+                            continue;
+                        };
+                        bb.0[axis] = bb.0[axis].min(v);
+                        bb.1[axis] = bb.1[axis].max(v);
+                    }
+                }
+            }
+        }
+        println!(
+            "{:<4} {:<30} {:>8} {:>6} {:>6} {:>4}  {:>20}",
+            "mat", "sheet", "tris", "luma", "opq", "cut", "extent x/y/z (m)"
+        );
+        for (i, t) in tex.iter().enumerate() {
+            // Only the texels an alpha test would keep: the rest is the black behind a cut,
+            // and averaging it in calls every cut-out dark whether it draws dark or not.
+            let (mut sum, mut n) = (0f64, 0u64);
+            for p in t.rgba.chunks_exact(4) {
+                if p[3] < 128 {
+                    continue;
+                }
+                sum += p[0] as f64 * 0.299 + p[1] as f64 * 0.587 + p[2] as f64 * 0.114;
+                n += 1;
+            }
+            let luma = if n > 0 { sum / n as f64 } else { 0.0 };
+            let opaque = n as f64 * 100.0 / (t.rgba.len() / 4).max(1) as f64;
+            let count = tris.get(t.material as usize).copied().unwrap_or(0);
+            let bb = box_of[t.material as usize];
+            let ext = if bb.0[0] <= bb.1[0] {
+                format!(
+                    "{:.0}x{:.0}x{:.0}",
+                    bb.1[0] - bb.0[0],
+                    bb.1[1] - bb.0[1],
+                    bb.1[2] - bb.0[2]
+                )
+            } else {
+                "-".into()
+            };
+            println!(
+                "{:<4} {:<30} {:>8} {:>6.1} {:>5.1}% {:>4}  {:>20}{}",
+                t.material,
+                t.name,
+                count,
+                luma,
+                opaque,
+                if t.alpha { "cut" } else { "-" },
+                ext,
+                // What the viewer's own guard calls a shadow, and what reads as black.
+                if luma < 4.0 {
+                    "   <- SHADOW-DROPPED"
+                } else if luma < 24.0 && count > 200 {
+                    "   <- DARK"
+                } else {
+                    ""
+                },
+            );
+            let _ = i;
+        }
+        let painted: std::collections::HashSet<u32> = tex.iter().map(|t| t.material).collect();
+        let bare: Vec<(usize, u32)> = (0..s.info.materials as usize)
+            .filter(|m| !painted.contains(&(*m as u32)))
+            .map(|m| (m, tris.get(m).copied().unwrap_or(0)))
+            .filter(|(_, c)| *c > 0)
+            .collect();
+        println!("  {} materials, {} painted", s.info.materials, tex.len());
+        println!("  unpainted but drawn: {bare:?}");
+    }
+
+    fn real_track_report() {
         let path = std::env::var("FROST_TRACK").expect("set FROST_TRACK to a track .pkz/folder");
         let s = decode(Path::new(&path), true).expect("decode the scenery");
         let (lo, hi) = s.mesh.bounds();


### PR DESCRIPTION
Follow-up to #481. The banners were still black, and the trees still wrong — because the binding was still a guess.

## The finding

The `.map` header is `material_count` followed by `material_count x 56-byte material records`. **The parse has always stepped straight over those records.** Word 11 of each one is the index of the sheet that paints that material.

That is why every attempt at this has been guesswork: the sheet order is not the material order.

On Indiana:

```
mat0  -> sheet 1   metal_beams_02_c_a
mat1  -> sheet 2   main_track_objects_c   <- the sponsor atlas
...
mat38 -> sheet 40  CK_fence_c_a           <- skips 39
mat43 -> sheet 45  CK_TREE_Ironman        <- trees, off by two positionally
mat45 -> sheet 0   pitlane_c              <- wraps back to the start
```

`mat45 -> 0` and `mat38 -> 40` are the proof: no offset, and no ordering anyone could infer, reproduces that.

## Why the banners were black

Material 1 wears the sponsor atlas. Positionally it was handed `metal_beams_02_c_a` — a cut-out that is **80% transparent**. That is the black slab in the screenshot.

The inflatable arches (97,729 triangles, 36 m tall) were on `inflate_tilable_c`, a 32x32 sheet at **luma 28**. They now wear their own branded 1024² sheet at **luma 95**.

The 1.5 km treeline was wearing `bark_QP_c`. It now wears `leafs_twigs_QP_c_a` — leaves, not bark.

## Validation

| | result |
|---|---|
| Tracks where word 11 reads as a legal index into that map's own sheets | **12 of 12** (4 authors) |
| Indiana materials bound | 49/49 |

Coherence improves independently of the sheet names: `big_tent_c` drops from an implausible 118,388 triangles to 7,948, and `metal_pole_c` — poles, which genuinely are everywhere — picks up the large count instead.

Falls back to the positional walk when the field is absent, out of range, or constant, so a map built by something that leaves it empty is no worse off than before.

`declared()`, `textures()` and `bound_count()` all share the one binding, so a material slot and the sheet that fills it cannot disagree.

## Caches

Scenery and surfaces bumped to v7. An earlier entry holds the old guess and no amount of rebuilding dislodges it — that is why the previous fix appeared to do nothing.

## Verification

- 1485 Rust tests pass, 0 fail. New test pins the real behaviour: out-of-order indices, a sheet shared by two materials, and all three fallback conditions.
- Two new diagnostics kept: `what_each_material_wears` (tris, luma, opacity and bounding box per material — this is what found it) and `inside_a_material_record`.
- Four tracks spot-checked for regressions, all decode clean.

Also repairs `decode_a_real_track`, whose `#[test]` attributes I orphaned in the previous commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)