### PR TITLE
feat(servers): mark the rows with riders on paint sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   says how many it hid and lets you look at them.
 - A server's details show who is on it: everyone in the session when it is the server you are
   riding, and the riders using paint sync anywhere else.
+- The server list marks the rows with riders on paint sync, so you can see where your paints
+  will actually show up without opening each server.
 - A server's details name the track it is running, show its picture when you already have it,
   and point you at the shop or MXB Hub when you don't.
 - Share codes that keep updating. Turn on "Keep it updated" when you share and you get a

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -323,6 +323,7 @@ async function route(request: Request, env: Env): Promise<Response> {
   if (method === "PUT" && path === "/v1/loadouts") return putLoadouts(request, account, env);
   if (method === "GET" && path === "/v1/roster") return roster(url, account, env);
   if (method === "GET" && path === "/v1/presence") return whoIsOn(url, env);
+  if (method === "GET" && path === "/v1/presence/counts") return presenceCounts(env);
 
   const openPaint = /^\/v1\/paints\/([0-9a-f]{64})$/.exec(path);
   if (openPaint) {
@@ -1960,6 +1961,40 @@ async function whoIsOn(url: URL, env: Env): Promise<Response> {
     if (!seen.has(key)) seen.set(key, { riderName: r.rider_name, guid: r.guid });
   }
   return json(200, { riders: [...seen.values()] });
+}
+
+/**
+ * How many riders are on each server, without saying who any of them is.
+ *
+ * The server browser wants to mark the rows worth joining before anyone clicks one, and
+ * `whoIsOn` cannot answer that: it is one request per server, so a list of eighty rows would
+ * be eighty requests to draw eighty badges.
+ *
+ * `whoIsOn` declines to answer "who is on every server" and still does — that would hand the
+ * whole platform's whereabouts to anyone who asked. A count is a different question. Nobody
+ * is named, nobody is locatable, and the answer is the same one the row already shows in
+ * another form. What it adds is which of those riders the app can actually sync with.
+ *
+ * A rider is in `presence` precisely because their app is publishing and pulling, so this
+ * count *is* the answer to "will paint sync do anything on this server". The result is only
+ * as long as the number of servers being played on right now — presence rows age out after
+ * `PRESENCE_TTL_MS` — so this stays small without a limit clause.
+ */
+async function presenceCounts(env: Env): Promise<Response> {
+  // Counted the same way `whoIsOn` de-duplicates: one rider recorded under both key forms of
+  // the same server would otherwise be two people standing on it.
+  const rows = await env.DB.prepare(
+    "SELECT pr.server_id, COUNT(DISTINCT COALESCE(a.guid, 'name:' || lower(a.rider_name)))" +
+      " AS riders FROM presence pr" +
+      " JOIN accounts a ON a.id = pr.account_id" +
+      " WHERE pr.updated_at > ? GROUP BY pr.server_id",
+  )
+    .bind(Date.now() - PRESENCE_TTL_MS)
+    .all<{ server_id: string; riders: number }>();
+
+  const servers: Record<string, number> = {};
+  for (const r of rows.results) if (r.riders > 0) servers[r.server_id] = r.riders;
+  return json(200, { servers });
 }
 
 /** Read a column we wrote as JSON. A row that somehow isn't parseable is an empty list, not

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7847,6 +7847,73 @@ async fn server_riders(
     Ok(ServerRiders { riders, source: "app".into() })
 }
 
+/// One row of the server browser, as much of it as naming a server takes.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerRow {
+    pub name: String,
+    pub address: String,
+}
+
+/// How many riders on each of these servers are running paint sync, by address.
+///
+/// The detail panel asks [`server_riders`] who is on one server; a browser row only needs to
+/// know whether joining would put the player among people they can actually sync with, and
+/// asking that server-by-server would be one request per row. This is the whole list in one
+/// request — plus the registry, which is what turns an address into the key a rider who
+/// joined through the app was recorded under.
+///
+/// A row with nobody on it is absent rather than zero: the badge is a thing that is there or
+/// isn't, and a map of mostly-zeroes is a bigger answer than the question deserves.
+///
+/// Best-effort throughout. A control plane that can't be reached means no badges, which is
+/// the same as the browser has always looked — never an error over the list itself.
+#[tauri::command]
+async fn servers_with_paint_sync(
+    app: tauri::AppHandle,
+    servers: Vec<ServerRow>,
+) -> Result<std::collections::HashMap<String, u32>, String> {
+    let cfg = config::load_or_detect(&app).unwrap_or_default();
+    let token = Some(cfg.cp_token.as_str()).filter(|t| !t.trim().is_empty());
+    let counts = paintsync::presence_counts(token).await.map_err(|e| format!("{e:#}"))?;
+    if counts.is_empty() {
+        return Ok(Default::default());
+    }
+    // Only worth fetching once there is something to map onto, and only for the address key:
+    // a server nobody registered is keyed by its own address either way.
+    let registry = paintsync::registry(token).await.unwrap_or_default();
+
+    Ok(match_presence(&counts, &registry, &servers))
+}
+
+/// Resolve each browser row to the number of synced riders standing on it.
+///
+/// Split out from the command because this is the whole of the thinking: a server is recorded
+/// under two different keys depending on how the reporting app found out where it was, so a
+/// row has to be looked up twice and the answers reconciled.
+///
+/// **The larger of the two, never the sum.** Both keys can hold the same rider — their app
+/// reported the address, the rider beside them reported the folded name — and nothing here can
+/// tell a second rider from the same one counted twice. Adding them would show four riders on
+/// a server holding two, which is worse than showing two on a server holding three.
+fn match_presence(
+    counts: &std::collections::HashMap<String, u32>,
+    registry: &[paintsync::RegisteredServer],
+    servers: &[ServerRow],
+) -> std::collections::HashMap<String, u32> {
+    let mut present = std::collections::HashMap::new();
+    for row in servers {
+        let by_address = counts.get(&paintsync::server_key_for(registry, &row.address));
+        let by_name = counts.get(&voice::session::room_key(&row.name));
+        let riders = by_address.into_iter().chain(by_name).copied().max().unwrap_or(0);
+        // Absent rather than zero: the badge is a thing that is there or isn't.
+        if riders > 0 {
+            present.insert(row.address.clone(), riders);
+        }
+    }
+    present
+}
+
 /// What track a server is running, matched against what the player has and what they could get.
 #[derive(Debug, Clone, Default, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -10722,6 +10789,7 @@ fn main() {
             list_master_servers,
             probe_server,
             server_riders,
+            servers_with_paint_sync,
             guess_server_track,
             experimental_state,
             enroll_account,
@@ -14176,3 +14244,72 @@ mod track_install_tests {
     }
 }
 
+
+/// The server browser's paint-sync badge.
+///
+/// Presence is keyed two ways for one server, so every one of these is about a row being
+/// looked up twice and the two answers reconciled into one number.
+#[cfg(test)]
+mod paint_sync_badge_tests {
+    use super::*;
+
+    fn counts(pairs: &[(&str, u32)]) -> std::collections::HashMap<String, u32> {
+        pairs.iter().map(|(k, n)| ((*k).to_string(), *n)).collect()
+    }
+
+    fn row(name: &str, address: &str) -> ServerRow {
+        ServerRow { name: name.into(), address: address.into() }
+    }
+
+    /// A community server nobody registered: its riders are recorded under the folded name,
+    /// because that is the only key every rider in the session can compute.
+    #[test]
+    fn a_server_is_found_by_its_folded_name() {
+        let counts = counts(&[("mxb hub public", 4)]);
+        let got = match_presence(&counts, &[], &[row("MXB  Hub   Public", "1.2.3.4:54210")]);
+        assert_eq!(got.get("1.2.3.4:54210"), Some(&4), "{got:?}");
+    }
+
+    /// A rider who joined through the app reports the address, not the name — so a row whose
+    /// name we have never seen still has to resolve.
+    #[test]
+    fn a_server_is_found_by_its_address() {
+        let counts = counts(&[("1.2.3.4:54210", 2)]);
+        let got = match_presence(&counts, &[], &[row("Something Else Entirely", "1.2.3.4:54210")]);
+        assert_eq!(got.get("1.2.3.4:54210"), Some(&2), "{got:?}");
+    }
+
+    /// Both keys holding riders is the ordinary case in a mixed session, and the two sets
+    /// overlap by an unknowable amount. Summing them would put four riders on a server that
+    /// might hold two.
+    #[test]
+    fn two_keys_are_the_larger_not_the_sum() {
+        let counts = counts(&[("1.2.3.4:54210", 2), ("night league", 3)]);
+        let got = match_presence(&counts, &[], &[row("Night League", "1.2.3.4:54210")]);
+        assert_eq!(got.get("1.2.3.4:54210"), Some(&3), "{got:?}");
+    }
+
+    /// A registered server's riders are recorded under its registry id, which is neither its
+    /// address nor its name — that is what the registry is fetched for.
+    #[test]
+    fn a_registered_server_resolves_through_its_id() {
+        let registry = vec![paintsync::RegisteredServer {
+            id: "mxb-eu-1".into(),
+            name: "MXB EU 1".into(),
+            region: "eu".into(),
+            address: "5.6.7.8:54210".into(),
+        }];
+        let counts = counts(&[("mxb-eu-1", 6)]);
+        let got = match_presence(&counts, &registry, &[row("MXB EU 1", "5.6.7.8:54210")]);
+        assert_eq!(got.get("5.6.7.8:54210"), Some(&6), "{got:?}");
+    }
+
+    /// An empty entry is not a badge that says nothing, it is no badge. The frontend keys on
+    /// presence in the map, so a zero here would draw one.
+    #[test]
+    fn a_server_with_nobody_on_it_is_absent() {
+        let counts = counts(&[("somewhere else", 3)]);
+        let got = match_presence(&counts, &[], &[row("Quiet Server", "9.9.9.9:54210")]);
+        assert!(got.is_empty(), "{got:?}");
+    }
+}

--- a/src-tauri/src/paintsync.rs
+++ b/src-tauri/src/paintsync.rs
@@ -509,6 +509,31 @@ pub async fn who_is_on(token: Option<&str>, keys: &[String]) -> anyhow::Result<V
     Ok(resp.riders.into_iter().map(|r| r.rider_name).collect())
 }
 
+/// How many riders are on each server, keyed the way presence is recorded.
+///
+/// The counterpart of [`who_is_on`] for the server *list* rather than one server's panel.
+/// That one names people and costs a request per server, which is the wrong shape for a
+/// browser drawing a badge on every row — so this is counts only, every server at once, one
+/// request for the whole list.
+///
+/// Keys come back exactly as they were written, meaning both forms of the same server may
+/// appear: see [`server_key_for`] for why there are two. Resolving a row to a number is the
+/// caller's job, because only the caller knows which rows it is asking about.
+pub async fn presence_counts(
+    token: Option<&str>,
+) -> anyhow::Result<std::collections::HashMap<String, u32>> {
+    #[derive(Deserialize)]
+    struct Resp {
+        servers: std::collections::HashMap<String, u32>,
+    }
+    let mut req = client()?.get(format!("{}/v1/presence/counts", control_plane()));
+    if let Some(t) = token {
+        req = req.bearer_auth(t);
+    }
+    let resp: Resp = req.send().await?.error_for_status()?.json().await?;
+    Ok(resp.servers)
+}
+
 /// A server in the control plane's registry, as `GET /v1/servers` returns it.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/Components/Servers/Servers.tsx
+++ b/src/Components/Servers/Servers.tsx
@@ -10,6 +10,7 @@ import {
   Plug,
   ServerOff,
   EyeOff,
+  Palette,
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
@@ -19,6 +20,7 @@ import HelpHint from "@/Components/ui/help-hint";
 import {
   listMasterServers,
   joinServer,
+  serversWithPaintSync,
   type MasterServer,
 } from "../../api/mods";
 import { useT } from "../../i18n/context";
@@ -47,6 +49,10 @@ const Servers = () => {
   // Spam and cheat-advertising servers are marked by the backend, not dropped, so this can
   // reveal them. Off by default: the whole point is not to have to read past them.
   const [showHidden, setShowHidden] = useState(false);
+  // Riders running paint sync, by address. Which rows are worth joining used to mean opening
+  // each one and reading its Riders panel — a request per server to answer a question about
+  // the list. This is one request for all of them, and it marks the rows.
+  const [paintSync, setPaintSync] = useState<Record<string, number>>({});
 
   // One fetch at a time. Two overlapping ones each sign in to Steam, and the loser's
   // failure used to replace the winner's list with an error.
@@ -64,6 +70,13 @@ const Servers = () => {
         list.sort((a, b) => b.players - a.players);
         onScreen.current = list;
         setServers(list);
+        // After the list, never with it: the browser has to draw whether or not the control
+        // plane answers, and badges arriving a moment later is the right trade for that.
+        serversWithPaintSync(
+          list.map((s) => ({ name: s.name, address: s.address })),
+        )
+          .then(setPaintSync)
+          .catch(() => setPaintSync({}));
       })
       .catch((e: unknown) => {
         const message = typeof e === "string" ? e : String(e);
@@ -257,6 +270,17 @@ const Servers = () => {
                             title={t("serverBrowser.hiddenBecause", { reason: s.hidden })}
                           >
                             {t("serverBrowser.filtered")}
+                          </span>
+                        )}
+                        {(paintSync[s.address] ?? 0) > 0 && (
+                          <span
+                            className="inline-flex shrink-0 items-center gap-1 border border-success/40 bg-success/10 px-1.5 py-px text-[10.5px] tabular-nums text-success"
+                            title={t("serverBrowser.paintSyncHere", {
+                              count: paintSync[s.address],
+                            })}
+                          >
+                            <Palette className="size-3" />
+                            {paintSync[s.address]}
                           </span>
                         )}
                       </div>

--- a/src/api/mods.ts
+++ b/src/api/mods.ts
@@ -3128,6 +3128,22 @@ export function serverRiders(address: string, name: string): Promise<ServerRider
   return invoke<ServerRiders>("server_riders", { address, name });
 }
 
+/**
+ * How many riders on each of these servers are running paint sync, keyed by address.
+ *
+ * Servers with nobody on them are left out rather than sent back as zero — the browser draws
+ * a badge or it doesn't, and there is no row that wants to say "0 riders synced".
+ *
+ * One request for the whole list, which is why this takes the list rather than being called
+ * per row: {@link serverRiders} names the people on one server and is what the detail panel
+ * asks once a row is open.
+ */
+export function serversWithPaintSync(
+  servers: { name: string; address: string }[],
+): Promise<Record<string, number>> {
+  return invoke<Record<string, number>>("servers_with_paint_sync", { servers });
+}
+
 /** What track a server is running, matched against what you have and what you could get. */
 export interface TrackGuess {
   /** The internal id the server published, e.g. `mmx_supercross`. */

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1106,6 +1106,10 @@ export const de: Translation = {
   "serverBrowser.any": "Beliebig",
   "serverBrowser.yes": "Ja",
   "serverBrowser.notJoinable": "MX Bikes kann die Adresse dieses Servers nicht ansteuern.",
+  "serverBrowser.paintSyncHere_one":
+    "{{count}} Fahrer auf diesem Server nutzt Paint-Sync — du siehst sein echtes Design.",
+  "serverBrowser.paintSyncHere_other":
+    "{{count}} Fahrer auf diesem Server nutzen Paint-Sync — du siehst ihre echten Designs.",
   "serverBrowser.filtered": "Gefiltert",
   "serverBrowser.hiddenCount": "{{count}} ausgeblendet",
   "serverBrowser.hideFiltered": "Wieder ausblenden",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1084,6 +1084,10 @@ export const en = {
   "serverBrowser.any": "Any",
   "serverBrowser.yes": "Yes",
   "serverBrowser.notJoinable": "MX Bikes can't be pointed at this server's address.",
+  "serverBrowser.paintSyncHere_one":
+    "{{count}} rider on this server is running paint sync — you'll see the livery they actually built.",
+  "serverBrowser.paintSyncHere_other":
+    "{{count}} riders on this server are running paint sync — you'll see the liveries they actually built.",
   "serverBrowser.filtered": "Filtered",
   "serverBrowser.hiddenCount": "{{count}} hidden",
   "serverBrowser.hideFiltered": "Hide them again",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1099,6 +1099,10 @@ export const es: Translation = {
   "serverBrowser.any": "Cualquiera",
   "serverBrowser.yes": "Sí",
   "serverBrowser.notJoinable": "MX Bikes no puede conectarse a la dirección de este servidor.",
+  "serverBrowser.paintSyncHere_one":
+    "{{count}} piloto en este servidor usa la sincronización de pinturas: verás su diseño real.",
+  "serverBrowser.paintSyncHere_other":
+    "{{count}} pilotos en este servidor usan la sincronización de pinturas: verás sus diseños reales.",
   "serverBrowser.filtered": "Filtrado",
   "serverBrowser.hiddenCount": "{{count}} ocultos",
   "serverBrowser.hideFiltered": "Volver a ocultar",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1104,6 +1104,10 @@ export const fr: Translation = {
   "serverBrowser.any": "Toutes",
   "serverBrowser.yes": "Oui",
   "serverBrowser.notJoinable": "MX Bikes ne peut pas se connecter à l'adresse de ce serveur.",
+  "serverBrowser.paintSyncHere_one":
+    "{{count}} pilote sur ce serveur utilise la synchro des peintures — vous verrez sa vraie livrée.",
+  "serverBrowser.paintSyncHere_other":
+    "{{count}} pilotes sur ce serveur utilisent la synchro des peintures — vous verrez leurs vraies livrées.",
   "serverBrowser.filtered": "Filtré",
   "serverBrowser.hiddenCount": "{{count}} masqués",
   "serverBrowser.hideFiltered": "Masquer à nouveau",

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -1097,6 +1097,10 @@ export const it: Translation = {
   "serverBrowser.any": "Qualsiasi",
   "serverBrowser.yes": "Sì",
   "serverBrowser.notJoinable": "MX Bikes non può essere indirizzato a questo server.",
+  "serverBrowser.paintSyncHere_one":
+    "{{count}} pilota su questo server usa la sincronizzazione delle grafiche: vedrai la sua livrea reale.",
+  "serverBrowser.paintSyncHere_other":
+    "{{count}} piloti su questo server usano la sincronizzazione delle grafiche: vedrai le loro livree reali.",
   "serverBrowser.filtered": "Filtrato",
   "serverBrowser.hiddenCount": "{{count}} nascosti",
   "serverBrowser.hideFiltered": "Nascondili di nuovo",

--- a/src/i18n/locales/pt-BR.ts
+++ b/src/i18n/locales/pt-BR.ts
@@ -1099,6 +1099,10 @@ export const ptBR: Translation = {
   "serverBrowser.any": "Qualquer",
   "serverBrowser.yes": "Sim",
   "serverBrowser.notJoinable": "O MX Bikes não consegue se conectar ao endereço deste servidor.",
+  "serverBrowser.paintSyncHere_one":
+    "{{count}} piloto neste servidor usa a sincronização de pinturas — você verá a pintura real dele.",
+  "serverBrowser.paintSyncHere_other":
+    "{{count}} pilotos neste servidor usam a sincronização de pinturas — você verá as pinturas reais deles.",
   "serverBrowser.filtered": "Filtrado",
   "serverBrowser.hiddenCount": "{{count}} ocultos",
   "serverBrowser.hideFiltered": "Ocultar de novo",


### PR DESCRIPTION
The server browser could only answer "will my paints actually show up here" by opening a
server and reading its Riders panel. That is one request per server to answer a question
about the whole list, so nobody does it — you join, and find out.

Now the row says so.

## What it does

A small green count beside the server name: how many riders on that server are running paint
sync right now. Absent when nobody is, so it reads as a mark rather than a column of zeros.

## How

**`GET /v1/presence/counts`** (new, authenticated like the rest of `/v1/presence`) —
per-server counts, no names.

`whoIsOn`'s doc comment explicitly declined to become a "who is on every server" endpoint,
because that would hand the whole platform's whereabouts to anyone who asked. That objection
is about naming people. A count names nobody, isn't locatable, and is the same fact the row
already shows in another form — what it adds is which of those riders you can sync with. The
new handler says so where the old one says the opposite, so the next person reading them sees
a distinction rather than a contradiction.

Counted with `COUNT(DISTINCT COALESCE(guid, 'name:' || lower(rider_name)))`, the same
de-duplication `whoIsOn` does in JS. No schema change: `presence` already carries this and is
indexed on `(server_id, updated_at)`. Rows age out at `PRESENCE_TTL_MS`, so the response is
only as long as the number of servers being played on.

**`servers_with_paint_sync`** — one request for the list, plus the registry.

The interesting part is that a server is recorded under *two* keys depending on how the
reporting app found out where it was: the address key for a rider who joined through the app,
the folded server name for one whose session FrostMod detected. So every row is looked up
twice, and the two answers reconciled by **taking the larger, never the sum** — both keys can
hold the same rider, and nothing at this end can tell a duplicate from a second person.
Summing would show 4 on a server holding 2, which is a worse error than showing 2 on a server
holding 3.

Pulled out as `match_presence` so that reconciliation is testable on its own; five tests cover
name-keyed, address-keyed, registry-id-keyed, the two-key overlap, and the empty case.

**Frontend** — fetched after the list lands, never with it, and a failure is silently no
badges. The browser has to draw whether or not the control plane answers.

## Deploying

The badge is dark until the worker is deployed — the endpoint is new. Everything else degrades
to today's behaviour (404 → no badges), so the app half is safe to ship ahead of it. See the
control-plane deploy note.

## Verified

- `cargo test --bin mxb-app` — 1490 passed, 0 failed (5 new)
- `control-plane` — 297 passed, 0 failed
- `tsc --noEmit`, `eslint`, `vite build` all clean
- Badge rendered through the built stylesheet in a mock of the real row markup, alongside the
  lock and Filtered pills, to check it doesn't crowd the name

🤖 Generated with [Claude Code](https://claude.com/claude-code)
