### PR TITLE
The ground mask needs one mirror, not a turn

### DIFF
--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -987,26 +987,26 @@ function TerrainMesh({
                 "#include <color_fragment>",
                 `#include <color_fragment>
                  {
-                   // A layer's mask is stored *transposed* against the grid the terrain is
-                   // built on — its rows run where the terrain's columns do. Untransposed,
-                   // the paint sits square with the site but across the track: grass over
-                   // the riding line, dirt out in the field.
+                   // A layer's mask is laid out the obvious way — across by world X, down by
+                   // world Z — and the only thing between it and the terrain's uv is that
+                   // the mesh negates X. buildTerrainGeometry places a vertex at
+                   // originX minus x * step, because the game's frame is left-handed and
+                   // three.js's is not, so u runs the opposite way to the world it came
+                   // from. Undo that one mirror and the paint lands on the track.
                    //
-                   // A transpose, not a rotation, which is why turning it never quite
-                   // worked. A quarter turn leaves it mirrored and a half turn leaves it
-                   // reversed; only swapping the two coordinates puts the paint on the
-                   // track. That is what row-major against column-major looks like from
-                   // this side, and it costs one swizzle.
+                   // Nothing here is a rotation, though it took turning it every which way
+                   // to find that out: a mirror is a reflection, and no amount of rotating
+                   // fixes a reflection. Untransposed the paint sits square with the site
+                   // but across the track — grass over the riding line, dirt in the field.
                    //
-                   // Settled on screen. Every overlay metric tried here sat within noise of
-                   // chance — the masks cover a third to two thirds of the ground, so
-                   // agreement means little — and nothing in the file states where a mask
-                   // sits in the world, so there is no ground truth in the data to check
-                   // against.
+                   // Settled on screen. Nothing in the file states where a mask sits in the
+                   // world, so there is no ground truth in the data to measure against, and
+                   // every overlay metric tried sat within noise of chance — the masks cover
+                   // a third to two thirds of the ground, so agreement means little.
                    //
                    // The sheets themselves are left alone: they tile ~200 times across the
                    // ground, so their orientation is not something an eye can find.
-                   vec2 maskUv = vec2(vGroundUv.y, vGroundUv.x);
+                   vec2 maskUv = vec2(1.0 - vGroundUv.x, vGroundUv.y);
                    vec3 ground = vec3(0.5);
                  ${blend}
                    // Multiplied rather than assigned: what is already in diffuseColor is the


### PR DESCRIPTION
Final step of #492 / #493. Transpose plus a 90° clockwise turn composes to a **pure horizontal mirror**:

```glsl
vec2 maskUv = vec2(1.0 - vGroundUv.x, vGroundUv.y);
```

## Why this one has a reason behind it

Unlike the intermediate guesses, this has an independent derivation from the geometry.

A mask is laid out the obvious way — across by world X, down by world Z. The only thing between it and the terrain's uv is that **the mesh negates X**: `buildTerrainGeometry` places a vertex at `originX - x * step`, because the game's frame is left-handed and three.js's is not. So `u` runs the opposite way to the world the mask came from, and undoing that single mirror lands the paint on the track.

That is exactly the mapping the geometry implies, and it is the one I derived early on and then talked myself out of when I assumed a rotation was needed.

Nothing here is a rotation. It took turning it every which way to establish that: a mirror is a reflection, and no rotation fixes a reflection — a quarter turn leaves it mirrored, a half turn leaves it reversed.

## Confidence

Settled on screen over four passes. Nothing in the file states where a mask sits in the world, so there is no ground truth in the data to measure against — every overlay metric tried against a rut map from the heightfield sat within noise of chance, because the masks cover a third to two thirds of the ground.

The difference now is that the answer also falls out of the mesh's own X negation, which is a reason rather than a result.

`tsc`, eslint and `vite build` clean — the last of those because the shader lives in a template literal and a stray backtick in a comment broke it once during this change. No cache bump: render-time transform, cached bytes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)