### PR TITLE
Mirror a ground mask in u, and stop flipping it in v

### DIFF
--- a/src-tauri/src/map.rs
+++ b/src-tauri/src/map.rs
@@ -1633,15 +1633,15 @@ fn layer_mask_at(b: &[u8], o: usize) -> Option<(GroundMask, usize)> {
     if out.len() != want {
         return None;
     }
-    // Bottom-up, like every other sheet the compilers write — see the flip in [`ground_sheet`].
-    // Left as it lies, a mask puts the riding line on the wrong side of the track.
-    let row = w as usize;
-    for y in 0..(h as usize) / 2 {
-        let (top, bottom) = (y * row, (h as usize - 1 - y) * row);
-        for x in 0..row {
-            out.swap(top + x, bottom + x);
-        }
-    }
+    // Kept as it lies. The *sheets* a compiler writes are bottom-up and are flipped on the
+    // way in, and a coverage mask looks like it should follow them — but it does not, and
+    // flipping it here put the paint across the track: grass over the riding line, dirt out
+    // in the field.
+    //
+    // Settled on screen over four passes, because nothing in the file states where a mask
+    // sits in the world and so there is no ground truth in the data to measure against. What
+    // finally fixed it was noticing the correction is a *reflection*: a quarter turn leaves
+    // it mirrored and a half turn leaves it reversed, so no amount of rotating ever lands it.
     Some((
         GroundMask {
             width: w,

--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -987,25 +987,24 @@ function TerrainMesh({
                 "#include <color_fragment>",
                 `#include <color_fragment>
                  {
-                   // A layer's mask is laid out the obvious way — across by world X, down by
-                   // world Z — and the only thing between it and the terrain's uv is that
-                   // the mesh negates X. buildTerrainGeometry places a vertex at
-                   // originX minus x * step, because the game's frame is left-handed and
-                   // three.js's is not, so u runs the opposite way to the world it came
-                   // from. Undo that one mirror and the paint lands on the track.
+                   // One mirror, in u only.
                    //
-                   // Nothing here is a rotation, though it took turning it every which way
-                   // to find that out: a mirror is a reflection, and no amount of rotating
-                   // fixes a reflection. Untransposed the paint sits square with the site
-                   // but across the track — grass over the riding line, dirt in the field.
+                   // A coverage mask is stored the same way up as the terrain grid, so v is
+                   // left alone — unlike the layer *sheets*, which are bottom-up and get
+                   // flipped as they are read. That difference is the trap: the mask looks
+                   // like it should follow the sheets and does not.
                    //
-                   // Settled on screen. Nothing in the file states where a mask sits in the
-                   // world, so there is no ground truth in the data to measure against, and
-                   // every overlay metric tried sat within noise of chance — the masks cover
-                   // a third to two thirds of the ground, so agreement means little.
+                   // u is mirrored because the mesh is. buildTerrainGeometry places a vertex
+                   // at originX minus x * step, since the game's frame is left-handed and
+                   // three.js's is not, so u runs the opposite way to the world the mask was
+                   // painted in.
                    //
-                   // The sheets themselves are left alone: they tile ~200 times across the
-                   // ground, so their orientation is not something an eye can find.
+                   // Settled on screen over five passes. Nothing in the file states where a
+                   // mask sits in the world, so there is no ground truth in the data to
+                   // measure against, and every overlay metric tried sat within noise of
+                   // chance. The lesson worth keeping: this correction is a reflection, and
+                   // no rotation ever fixes a reflection — turning it only moved the error
+                   // around.
                    vec2 maskUv = vec2(1.0 - vGroundUv.x, vGroundUv.y);
                    vec3 ground = vec3(0.5);
                  ${blend}


### PR DESCRIPTION
Two separate mistakes were cancelling into a third, which is why turning it never landed.

```glsl
vec2 maskUv = vec2(1.0 - vGroundUv.x, vGroundUv.y);
```

## What was actually wrong

**v was being flipped and should not have been.** `layer_mask_at` flipped each coverage mask on the way in, on the reasonable assumption that it is bottom-up like everything else a compiler writes. The layer *sheets* are bottom-up and are flipped; the masks are not. That flip is removed.

**u needs mirroring, because the mesh is mirrored.** `buildTerrainGeometry` places a vertex at `originX - x * step`, since the game's frame is left-handed and three.js's is not — so `u` runs the opposite way to the world the mask was painted in.

Each of those alone leaves the paint wrong, and together they had been cancelling into a diagonal error that looked like a rotation. It isn't one.

## Combinations tried, against the raw stored mask

| sampled as | result |
|---|---|
| `(u, 1-v)` | original — paint across the track |
| `(v, u)` | mirrored |
| `(v, 1-u)` | mirrored |
| `(1-u, 1-v)` | wrong way |
| `(u, v)` | aligned but mirrored |
| **`(1-u, v)`** | **this change** |

## Confidence

Settled on screen over five passes. Nothing in the file states where a mask sits in the world, so there is no ground truth in the data — every overlay metric tried against a rut map from the heightfield sat within noise of chance, because the masks cover a third to two thirds of the ground.

The difference here is that both halves now have a cause rather than a result: the sheet/mask distinction is visible in the reader, and the u mirror follows directly from the mesh's X negation.

**The lesson worth keeping:** the correction is a reflection, and no rotation fixes a reflection. Turning it only moved the error around.

Bumps the ground-layers cache to v3 — a v2 entry holds the mask flipped.

1491 Rust tests pass; `tsc`, eslint and `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)