### PR TITLE
fix(tracks): the walk and the layout drifted from the corpus bounds

### DIFF
--- a/scripts/track-layout.py
+++ b/scripts/track-layout.py
@@ -313,10 +313,14 @@ def faces(height):
     """How much run a jump's own faces take, metres — the app's `tabletop_faces`, here.
 
     The face is an arc tangent to the ground, so its run is the height over the tangent of
-    *half* the angle: a 4 m lip at 27 degrees is sixteen metres of ground before the deck
-    starts, and its landing at 19 is twenty-four more.
+    *half* the angle: a 4 m lip at 38 degrees is 11.6 m of ground before the deck starts, and
+    its landing at 19 is 23.9 more.
+
+    These MIRROR `trackprog::JUMP_FACE_DEG` and `JUMP_LANDING_DEG` and nothing enforces it —
+    the 27 here was left behind when the face angle moved, which made every jump this script
+    laid a third longer than the app builds it.
     """
-    up = max(height / math.tan(math.radians(27.0 * 0.5)), 9.0)
+    up = max(height / math.tan(math.radians(38.0 * 0.5)), 9.0)
     down = max(height / math.tan(math.radians(19.0 * 0.5)), 9.0)
     return up + down
 
@@ -367,7 +371,10 @@ def features(rng, segs):
             # The deck is what was asked to grow, not the height: a table built to five and a
             # half metres over its run-in reads as a wall however long its top is. These come
             # out about a quarter taller than they are stated, so state them lower.
-            height = round(rng.uniform(2.8, 3.7), 2)
+            # Capped at three metres: Motorcycling Australia and Motorcycling New Zealand both
+            # write "jumps must not exceed 3m in height", and `corpus::FEATURE_HEIGHT_M` holds
+            # a program to it. 3.7 put eleven jumps a lap outside it.
+            height = round(rng.uniform(2.4, 3.0), 2)
             deck = rng.uniform(16.0, 27.0)
             length = round(min(deck + faces(height), room), 1)
             out.append({"kind": "tabletop", "at": round(pos, 1), "length": length,
@@ -380,13 +387,14 @@ def features(rng, segs):
             # A triple: one take-off, a landing, and a second lower one short of it for
             # anyone not committing — "make a second smaller landing like a triple knowing I
             # would jump it".
-            h = rng.uniform(2.8, 3.7)
+            # Same 3 m ceiling as the tabletop above, and for the same reason.
+            h = rng.uniform(2.4, 3.0)
             dip = rng.uniform(0.30, 0.40)
             # Drawn in metres and normalised afterwards, so the take-off gets the same run a
             # tabletop of this height gets. Drawn as fractions it had 3.6 m of lip in 8.5 m of
             # ground — a 23 degree chord, which any curve through it rides steeper still, and
             # from the seat that is a wall.
-            up = max(h / math.tan(math.radians(27.0 * 0.5)), 9.0)
+            up = max(h / math.tan(math.radians(38.0 * 0.5)), 9.0)
             down = max(h / math.tan(math.radians(19.0 * 0.5)), 9.0)
             near = up + 4.0 + down * 0.55
             marks = [(0.0, 0.0),

--- a/scripts/track-walk.py
+++ b/scripts/track-walk.py
@@ -256,7 +256,21 @@ def grow(rng, plot, width, want_m):
         # What a rider could be given next: a run, or a turn of one of three tightnesses
         # either way. Runs are what carry the lap across the ground; turns are what keep it
         # inside the plot.
-        moves = [{"kind": "straight", "length": rng.uniform(35.0, 80.0), "rise": 0.0}]
+        # A straight, unless the lap is already on one long enough. Consecutive straights are
+        # colinear, so the app's `straight_runs` reads a row of them as ONE straight — and a
+        # row of 35-80 m moves reached 248 m against the 125 m cap (`corpus::STRAIGHT_M`, the
+        # FFM's limit and the only one any federation writes). Indiana's longest is 62 m.
+        running = 0.0
+        for prev in reversed(segs):
+            if prev["kind"] != "straight":
+                break
+            running += prev["length"]
+        moves = []
+        room_on_the_straight = 125.0 - running
+        if room_on_the_straight > 35.0:
+            moves.append({"kind": "straight",
+                          "length": rng.uniform(35.0, min(80.0, room_on_the_straight)),
+                          "rise": 0.0})
         # The lap's own wander, and most of what it is made of. A published track is a chain
         # of arcs — Indiana runs 109 of them against 11 straights — but they average twenty
         # degrees apiece, not a hundred. Without this move every piece of the lap was a real
@@ -352,9 +366,42 @@ def grow(rng, plot, width, want_m):
                         ok = False
                         break
                     p = advance(p, seg)
+                # And no straight anywhere on the finished lap may run past the cap.
+                #
+                # Checked on the WHOLE lap rather than on the way home, because two things
+                # make a long straight and neither is one segment: consecutive straights are
+                # colinear, so the app's `straight_runs` reads a row of them as one — and a
+                # Dubins path is arc-straight-arc, so its straight sits in the MIDDLE and a
+                # look at the last segment never sees it. That is what left a 244 m straight
+                # on a lap whose every move was capped at 80. The limit is the FFM's 125 m,
+                # the only straight-length rule any federation writes; Indiana's longest is 62.
+                if ok and longest_straight(segs + home, opening) > 125.0:
+                    continue
                 if ok and all(s["kind"] != "arc" or s["angle"] < 200.0 for s in home):
                     return segs + home, start
     return None
+
+
+def longest_straight(segs, opening):
+    """The longest unbroken straight a rider meets, metres — merged the way the app merges.
+
+    Mirrors `Station::straight_runs`: consecutive straights are one straight, and so is the
+    pair either side of the finish line, because a lap that ends on a straight and begins on
+    one runs through the line without a corner in it.
+    """
+    runs, run = [], 0.0
+    for s in segs:
+        if s["kind"] == "straight":
+            run += s["length"]
+        else:
+            if run:
+                runs.append(run)
+            run = 0.0
+    trailing = run
+    # Through the line: whatever the lap ends on, plus the opening straight it rejoins.
+    if trailing:
+        runs.append(trailing + opening["length"])
+    return max(runs) if runs else 0.0
 
 
 def closes_to(segs, start):


### PR DESCRIPTION
The layout walker from #487 and the corpus bounds from #485 landed in parallel and disagree. Running a walked lap through `review` — which is what those checks are for — found three faults.

**A stale mirrored constant.** `track-layout.py` hardcodes the jump face angle in two places, and both still said **27°**. `trackprog::JUMP_FACE_DEG` is 38 now, so every jump the script laid was about a third longer than the app actually builds it. Nothing enforces the mirror between the Python and the Rust; the comment now says so out loud.

**Two independent height ranges over the ceiling.** `uniform(2.8, 3.7)` appears in both the tabletop branch and the whale-tail branch, against a 3.0 m ceiling that Motorcycling Australia and New Zealand both write and `corpus::FEATURE_HEIGHT_M` holds a program to. Eleven jumps a lap were outside it.

**A 248 m straight against a 125 m cap** — and this one was worth chasing, because two separate mechanisms make it and *neither is a single segment*:

- consecutive straights are colinear, so the app's `straight_runs` reads a row of 35–80 m moves as **one** straight;
- a Dubins path is arc-straight-arc, so its straight sits in the **middle**, where my first attempt at this check — which looked at the last segment — never saw it.

`longest_straight()` now merges the way the app merges, including the pair either side of the finish line, and the walk refuses a way home that would break the cap.

## Result

Seed 49 builds and comes back **`review: nothing to say`**:

| | |
|---|---|
| lap | 2215 m |
| segments | 54, of which 47 arcs (**87%**) |
| total turning | 2564° |
| features | 36, tallest 3.0 m |
| longest straight | 93 m |
| riding line | 14.7 m |

Compiled under Wine (203,948 vertices, 174,411 triangles) and rendered. Every figure sits inside the published band in `docs/tracks/real-track-corpus.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)