### PR TITLE
feat(ranked): scroll the results on their own, and give the tab a look

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   Global, MX and SX, plus your last 50 races with the track, your position and the points.
 - Nothing to sign in to or set up — the app works out your MX Bikes GUID from Steam. If you
   bought MX Bikes direct you can enter your GUID, and the same box looks up anyone else.
+- The tab wears your MXB Ranked achievement banner, your rank's colour on the standings, and
+  gold, silver and bronze on your podium finishes. Your rank stays on screen while the results
+  scroll on their own.
 
 ## 2026-09-07
 

--- a/src-tauri/src/ranked.rs
+++ b/src-tauri/src/ranked.rs
@@ -93,6 +93,11 @@ pub struct RankedProfile {
     pub season: String,
     pub cards: Vec<RankCard>,
     pub races: Vec<RaceRow>,
+    /// The rider's own achievement banner on mxb-ranked, absolute. Empty when they have none.
+    ///
+    /// Earned artwork, and different for every rider — which is the one thing on the page that
+    /// is *theirs* rather than a number about them, so it is worth carrying across.
+    pub banner: String,
     /// The profile on their site, for the "open on mxb-ranked" link.
     pub url: String,
 }
@@ -243,6 +248,21 @@ pub fn parse(html: &str, guid: &str) -> RankedProfile {
     let season = Selector::parse(r#"[aria-label="Selected Season"]"#).unwrap();
     out.season = doc.select(&season).map(text).find(|t| !t.is_empty()).unwrap_or_default();
 
+    // The banner is a CSS background rather than an <img>, so it is read off the style.
+    let banner = Selector::parse(r#"[style*="Achievements"]"#).unwrap();
+    out.banner = doc
+        .select(&banner)
+        .next()
+        .and_then(|el| el.value().attr("style"))
+        .and_then(|style| {
+            let (_, rest) = style.split_once("url(")?;
+            let (inner, _) = rest.split_once(')')?;
+            Some(inner.trim().trim_matches(['\'', '"']).to_string())
+        })
+        .filter(|u| !u.is_empty())
+        .map(|u| if u.starts_with("http") { u } else { format!("{BASE}/{}", u.trim_start_matches('/')) })
+        .unwrap_or_default();
+
     out.cards = parse_cards(&doc);
     out.races = parse_races(&doc);
     out
@@ -374,6 +394,10 @@ mod tests {
         assert_eq!(p.global_penalty_points, "2.697");
         assert_eq!(p.season, "Season 7");
         assert_eq!(p.url, "https://mxb-ranked.com/Rider/FF011000010178A758");
+        assert_eq!(
+            p.banner,
+            "https://mxb-ranked.com/images/Achievements/2A73E25E-BA3C-429E-A57E-1F94C485F235.jpg"
+        );
     }
 
     #[test]

--- a/src/Components/Ranked/Ranked.tsx
+++ b/src/Components/Ranked/Ranked.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
 import { cn } from "@/lib/utils";
 import { Button } from "@/Components/ui/button";
+import CachedImg from "@/Components/ui/cached-img";
 import { ContextBarRight } from "../Shell/ContextBar";
 import {
   rankedIdentity,
@@ -142,7 +143,7 @@ const Ranked = () => {
         onSave={saveGuid}
       />
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-7 pb-6">
+      <div className="flex min-h-0 flex-1 flex-col px-7 pb-6">
         {identity && !identity.guid ? (
           <Centered>
             <Trophy className="size-6 text-faint" />
@@ -192,6 +193,67 @@ const flagOf = (code: string) => {
   );
 };
 
+/**
+ * How much of a rank's own colour to use where.
+ *
+ * MXB Ranked gives every rank a colour — silver, gold, bronze — and on a screen that is
+ * otherwise near-black by design it is the only colour carrying meaning rather than
+ * decoration. Used at three strengths: solid on the plate, a line down the card, and a wash
+ * faint enough to sit under white text. A rank we get no colour for falls back to the app's
+ * own accent, because one grey card beside three coloured ones reads as a fault.
+ */
+const tint = (color: string, alpha: number) => {
+  const c = /^#([0-9a-f]{6})$/i.exec(color.trim());
+  if (!c) return `color-mix(in srgb, var(--primary) ${alpha * 100}%, transparent)`;
+  const n = parseInt(c[1], 16);
+  return `rgba(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}, ${alpha})`;
+};
+const solid = (color: string) =>
+  /^#([0-9a-f]{6})$/i.test(color.trim()) ? color : "var(--primary)";
+
+/** The behaviour grade, best to worst. Their site colours it; it doesn't tell us with what. */
+const RATING_COLOR: Record<string, string> = {
+  A: "var(--success)",
+  B: "var(--success)",
+  C: "var(--warning)",
+  D: "var(--destructive)",
+  E: "var(--destructive)",
+};
+
+/** A podium finish is what you look for in a results list, so it gets the medal's colour. */
+const PODIUM = ["#FFD700", "#C0C0C0", "#cd7f32"];
+const podiumColor = (position: string) => {
+  const place = Number(position.split("/")[0]?.trim());
+  return Number.isFinite(place) && place >= 1 && place <= 3 ? PODIUM[place - 1] : "";
+};
+
+/**
+ * A rank badge as a number plate — the shape the whole app is built from (`.u-skew`, and the
+ * cut corner on the cards). A rank is the one number a rider would put on a plate, so it is
+ * the one place in the app where the motif is literal rather than decorative.
+ */
+const Plate = ({
+  children,
+  color,
+  className,
+  title,
+}: {
+  children: React.ReactNode;
+  color: string;
+  className?: string;
+  title?: string;
+}) => (
+  <span
+    title={title}
+    className={cn("u-skew grid place-items-center px-2", className)}
+    style={{ background: solid(color) }}
+  >
+    <span className="u-unskew block font-cond font-bold leading-none tracking-[0.04em] text-[#0d1216]">
+      {children}
+    </span>
+  </span>
+);
+
 const Profile = ({
   profile,
   identity,
@@ -201,73 +263,129 @@ const Profile = ({
 }) => {
   const t = useT();
   const flag = flagOf(profile.country);
+  // The best of the three standings leads: it is the number a rider would give if you asked
+  // them what rank they are.
+  const headline = profile.cards.find((c) => c.discipline === "Global") ?? profile.cards[0];
 
   return (
-    <div className="flex flex-col gap-4 pt-1">
-      <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-input bg-card px-4 py-3">
-        <div className="flex items-center gap-3">
-          {flag && <span className="text-[20px] leading-none">{flag}</span>}
-          <div>
-            <h2 className="text-[16px] font-semibold">{profile.name || profile.guid}</h2>
-            <p className="text-[11.5px] text-faint">
-              {profile.guid}
-              {profile.memberSince && ` · ${t("ranked.since", { date: profile.memberSince })}`}
-              {/* Whose profile this is, because a typed GUID is easy to get subtly wrong and
-                  somebody else's season looks exactly like a bad one of your own. */}
-              {identity?.source === "manual" && ` · ${t("ranked.manualGuid")}`}
-            </p>
-          </div>
-        </div>
-        <div className="flex items-center gap-5">
-          {profile.exp && (
-            <Stat label={t("ranked.exp")} value={profile.exp} />
-          )}
-          {profile.rating && (
-            <Stat label={t("ranked.riderRating")} value={profile.rating} />
-          )}
-          {profile.penaltyPoints && (
-            <Stat
-              label={t("ranked.penaltyPoints")}
-              value={profile.penaltyPoints}
-              // The number means nothing without the field it is measured against.
-              hint={
-                profile.globalPenaltyPoints
-                  ? t("ranked.globalAvg", { value: profile.globalPenaltyPoints })
-                  : undefined
-              }
+    // Only the results scroll. The rider and their standings stay put, so "how am I doing" is
+    // never something you have to scroll back up for.
+    <div className="flex min-h-0 flex-1 flex-col gap-3 pt-1">
+      <div
+        className="u-notch relative shrink-0 overflow-hidden bg-card"
+        // A line of the rank's colour along the foot, tying the banner to the cards below.
+        style={
+          headline ? { boxShadow: `inset 0 -2px 0 ${tint(headline.color, 0.55)}` } : undefined
+        }
+      >
+        {/* The rider's own achievement artwork — earned, different for everyone, and the one
+            thing on their profile that isn't a number about them. Behind the text, with a
+            wash over it so the name stays readable whatever the picture turns out to be. */}
+        {profile.banner && (
+          <>
+            <CachedImg
+              src={profile.banner}
+              alt=""
+              aria-hidden
+              className="absolute inset-0 size-full object-cover"
             />
-          )}
+            {/* Solid behind the name, clearing to the artwork on the right. The picture is
+                the point; the gradient only exists so the text on top of it stays readable. */}
+            <div className="absolute inset-0 bg-gradient-to-r from-card via-card/85 to-card/20" />
+          </>
+        )}
+        <div className="relative flex min-h-[92px] flex-wrap items-center justify-between gap-4 px-5 py-4">
+          <div className="flex items-center gap-4">
+            {headline && (
+              <Plate color={headline.color} className="h-[46px] w-[58px]" title={headline.rankName}>
+                <span className="block text-[19px]">{headline.badge}</span>
+                <span className="mt-0.5 block text-[10px] tracking-[0.08em] opacity-75">
+                  {headline.mxp}
+                </span>
+              </Plate>
+            )}
+            <div>
+              <div className="flex items-center gap-2.5">
+                {flag && <span className="text-[18px] leading-none">{flag}</span>}
+                <h2 className="font-cond text-[26px] font-bold uppercase leading-none tracking-[0.02em]">
+                  {profile.name || profile.guid}
+                </h2>
+                {headline?.rankName && (
+                  <span
+                    className="font-cond text-[13px] font-semibold uppercase tracking-[0.1em]"
+                    style={{ color: solid(headline.color) }}
+                  >
+                    {headline.rankName}
+                  </span>
+                )}
+              </div>
+              <p className="mt-1.5 text-[11.5px] text-faint">
+                {profile.guid}
+                {profile.memberSince && ` · ${t("ranked.since", { date: profile.memberSince })}`}
+                {/* Whose profile this is, because a typed GUID is easy to get subtly wrong and
+                    somebody else's season looks exactly like a bad one of your own. */}
+                {identity?.source === "manual" && ` · ${t("ranked.manualGuid")}`}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-7 pr-2">
+            {profile.exp && <Stat label={t("ranked.exp")} value={profile.exp} />}
+            {profile.rating && (
+              <Stat
+                label={t("ranked.riderRating")}
+                value={profile.rating}
+                color={RATING_COLOR[profile.rating.toUpperCase()]}
+              />
+            )}
+            {profile.penaltyPoints && (
+              <Stat
+                label={t("ranked.penaltyPoints")}
+                value={profile.penaltyPoints}
+                // The number means nothing without the field it is measured against.
+                hint={
+                  profile.globalPenaltyPoints
+                    ? t("ranked.globalAvg", { value: profile.globalPenaltyPoints })
+                    : undefined
+                }
+              />
+            )}
+          </div>
         </div>
       </div>
 
       {profile.cards.length > 0 && (
-        <div className="flex flex-wrap gap-3">
+        <div className="grid shrink-0 gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {profile.cards.map((c) => (
             <div
               key={c.discipline}
-              className="min-w-[240px] flex-1 overflow-hidden rounded-xl border border-input"
+              className="u-notch overflow-hidden bg-card"
+              style={{
+                // The rank's colour washed off the top-left and drawn down the edge — enough
+                // to tell three cards apart across the room, without tinting the surface.
+                background: `linear-gradient(135deg, ${tint(c.color, 0.14)} 0%, transparent 55%), var(--card)`,
+                boxShadow: `inset 2px 0 0 ${solid(c.color)}`,
+              }}
+              title={c.rankName}
             >
-              <div
-                className="flex items-center justify-between px-3.5 py-2.5 text-black"
-                // The rank's own colour, straight off their card, so the two read as the
-                // same thing rather than as our idea of what Silver looks like.
-                style={c.color ? { background: c.color } : undefined}
-                title={c.rankName}
-              >
+              <div className="flex items-center justify-between gap-3 px-4 pt-3.5">
                 <div>
-                  <p className="text-[13px] font-semibold">{c.discipline}</p>
-                  <p className="text-[11.5px] opacity-80">
+                  <p className="font-cond text-[17px] font-bold uppercase leading-none tracking-[0.06em]">
+                    {c.discipline}
+                  </p>
+                  <p className="mt-1 text-[11.5px] text-faint">
                     {t("ranked.rank", { rank: c.rank })}
                   </p>
                 </div>
-                <div className="flex items-center gap-2.5">
-                  <span className="border border-black/20 px-1.5 py-px text-[11.5px] font-semibold">
-                    {c.badge}
+                <div className="flex items-center gap-3">
+                  <Plate color={c.color} className="h-[30px] w-[38px]">
+                    <span className="block text-[13px]">{c.badge}</span>
+                  </Plate>
+                  <span className="font-cond text-[27px] font-bold leading-none tabular-nums">
+                    {c.mxp}
                   </span>
-                  <span className="text-[17px] font-semibold tabular-nums">{c.mxp}</span>
                 </div>
               </div>
-              <dl className="grid grid-cols-2 gap-x-4 gap-y-1 bg-card px-3.5 py-2.5 text-[12.5px]">
+              <dl className="grid grid-cols-2 gap-x-5 gap-y-1 px-4 pb-3.5 pt-3 text-[12.5px]">
                 <Row label={t("ranked.races")} value={c.races} />
                 <Row label={t("ranked.avgPosition")} value={c.avgPosition} />
                 <Row label={t("ranked.wins")} value={c.wins} />
@@ -282,56 +400,97 @@ const Profile = ({
       )}
 
       {profile.races.length > 0 && (
-        <div className="overflow-hidden rounded-xl border border-input">
-          <table className="w-full border-collapse text-[13px]">
+        // `min-h-0` is what actually makes this scroll instead of stretching the page: a flex
+        // child refuses to shrink below its content without it.
+        <div className="min-h-0 flex-1 overflow-auto border border-input">
+          {/* `separate` rather than `collapse`, so the sticky header keeps its own bottom
+              border — a collapsed border belongs to the table and scrolls away with it. */}
+          <table className="w-full border-separate border-spacing-0 text-[13px]">
             <thead>
-              <tr className="border-b border-input bg-card text-left text-[11.5px] uppercase tracking-wide text-faint">
-                <th className="px-3.5 py-2.5 font-semibold">{t("ranked.track")}</th>
-                <th className="px-2 py-2.5 font-semibold">{t("ranked.server")}</th>
-                <th className="w-[70px] px-2 py-2.5 font-semibold">{t("ranked.position")}</th>
-                <th className="px-2 py-2.5 font-semibold">{t("ranked.bike")}</th>
-                <th className="w-[70px] px-2 py-2.5 font-semibold">{t("ranked.mxp")}</th>
-                <th className="w-[80px] px-2 py-2.5 font-semibold">{t("ranked.penalty")}</th>
-                <th className="w-[110px] px-3.5 py-2.5 font-semibold">{t("ranked.finished")}</th>
+              <tr className="text-left text-[11px] uppercase tracking-[0.08em] text-faint">
+                {(
+                  [
+                    ["ranked.track", "px-3.5"],
+                    ["ranked.server", "px-2"],
+                    ["ranked.position", "w-[76px] px-2"],
+                    ["ranked.bike", "px-2"],
+                    ["ranked.mxp", "w-[76px] px-2"],
+                    ["ranked.penalty", "w-[84px] px-2"],
+                    ["ranked.finished", "w-[112px] px-3.5"],
+                  ] as const
+                ).map(([key, width]) => (
+                  <th
+                    key={key}
+                    className={cn(
+                      "sticky top-0 z-10 border-b border-input bg-card py-2.5 font-cond font-semibold",
+                      width,
+                    )}
+                  >
+                    {t(key)}
+                  </th>
+                ))}
               </tr>
             </thead>
             <tbody>
-              {profile.races.map((r, i) => (
-                <tr
-                  key={`${r.finishedAt}-${i}`}
-                  className="border-b border-input/60 last:border-0 hover:bg-foreground/[0.03]"
-                >
-                  <td className="max-w-[260px] truncate px-3.5 py-2.5 font-medium" title={r.track}>
-                    {r.track}
-                  </td>
-                  <td className="max-w-[280px] truncate px-2 py-2.5 text-muted-foreground" title={r.server}>
-                    {r.server}
-                  </td>
-                  <td className="px-2 py-2.5 tabular-nums">{r.position}</td>
-                  <td className="max-w-[180px] truncate px-2 py-2.5 text-muted-foreground" title={r.bike}>
-                    {r.bike}
-                  </td>
-                  <td className="px-2 py-2.5">
-                    <span
-                      className={cn(
-                        "inline-flex items-center gap-1 tabular-nums",
-                        r.mxpDir === "up" && "text-success",
-                        r.mxpDir === "down" && "text-destructive",
-                      )}
+              {profile.races.map((r, i) => {
+                const medal = podiumColor(r.position);
+                return (
+                  <tr key={`${r.finishedAt}-${i}`} className="group hover:bg-foreground/[0.04]">
+                    <td className="max-w-[260px] truncate border-b border-input/50 px-3.5 py-2.5 font-medium group-last:border-0">
+                      {/* A bar in the medal's colour, so scanning the list picks out the good
+                          days without reading a single number. */}
+                      <span
+                        className="mr-2.5 inline-block h-3.5 w-[3px] translate-y-[2px] u-skew"
+                        style={{ background: medal || "transparent" }}
+                      />
+                      <span title={r.track}>{r.track}</span>
+                    </td>
+                    <td
+                      className="max-w-[240px] truncate border-b border-input/50 px-2 py-2.5 text-muted-foreground group-last:border-0"
+                      title={r.server}
                     >
-                      {r.mxpDir === "up" && <ArrowUp className="size-3" />}
-                      {r.mxpDir === "down" && <ArrowDown className="size-3" />}
-                      {r.mxp}
-                    </span>
-                  </td>
-                  <td className="px-2 py-2.5 tabular-nums text-muted-foreground">
-                    {r.penaltyPoints}
-                  </td>
-                  <td className="px-3.5 py-2.5 text-faint" title={r.finishedAt}>
-                    {r.finished}
-                  </td>
-                </tr>
-              ))}
+                      {/* The lobby, without the "MXB-Ranked.com |" every row shares and the
+                          "| NA | #102801" nobody reads. */}
+                      {lobbyName(r.server)}
+                    </td>
+                    <td
+                      className="border-b border-input/50 px-2 py-2.5 font-cond text-[15px] font-bold tabular-nums group-last:border-0"
+                      style={medal ? { color: medal } : undefined}
+                    >
+                      {r.position}
+                    </td>
+                    <td
+                      className="max-w-[170px] truncate border-b border-input/50 px-2 py-2.5 text-muted-foreground group-last:border-0"
+                      title={r.bike}
+                    >
+                      {r.bike}
+                    </td>
+                    <td className="border-b border-input/50 px-2 py-2.5 group-last:border-0">
+                      <span
+                        className={cn(
+                          "inline-flex items-center gap-1 tabular-nums",
+                          r.mxpDir === "up" && "text-success",
+                          r.mxpDir === "down" && "text-destructive",
+                          !r.mxpDir && "text-faint",
+                        )}
+                      >
+                        {r.mxpDir === "up" && <ArrowUp className="size-3" />}
+                        {r.mxpDir === "down" && <ArrowDown className="size-3" />}
+                        {r.mxp}
+                      </span>
+                    </td>
+                    <td className="border-b border-input/50 px-2 py-2.5 tabular-nums text-muted-foreground group-last:border-0">
+                      {r.penaltyPoints}
+                    </td>
+                    <td
+                      className="border-b border-input/50 px-3.5 py-2.5 text-faint group-last:border-0"
+                      title={r.finishedAt}
+                    >
+                      {r.finished}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>
@@ -340,10 +499,38 @@ const Profile = ({
   );
 };
 
-const Stat = ({ label, value, hint }: { label: string; value: string; hint?: string }) => (
+/**
+ * The lobby's own name out of the full server string.
+ *
+ * Every row reads "MXB-Ranked.com | MX Freebies | 250 | G+ | NA | #99684": a prefix shared by
+ * every row, then the lobby, then a region and a session number. The whole thing stays in the
+ * tooltip; the column shows the part that differs.
+ */
+const lobbyName = (server: string) => {
+  const parts = server
+    .split("|")
+    .map((p) => p.trim())
+    .filter((p) => p && !/^#/.test(p) && !/^mxb-ranked\.com$/i.test(p));
+  return parts.join(" | ") || server;
+};
+
+const Stat = ({
+  label,
+  value,
+  hint,
+  color,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+  /** Set where the value is a grade rather than a measurement, so it reads at a glance. */
+  color?: string;
+}) => (
   <div className="text-right" title={hint}>
     <p className="text-[11.5px] uppercase tracking-wide text-faint">{label}</p>
-    <p className="text-[15px] font-semibold tabular-nums">{value}</p>
+    <p className="text-[17px] font-semibold tabular-nums" style={color ? { color } : undefined}>
+      {value}
+    </p>
   </div>
 );
 

--- a/src/api/ranked.ts
+++ b/src/api/ranked.ts
@@ -55,6 +55,8 @@ export interface RankedProfile {
   season: string;
   cards: RankCard[];
   races: RaceRow[];
+  /** The rider's own achievement banner on mxb-ranked, absolute. Empty when they have none. */
+  banner: string;
   url: string;
 }
 


### PR DESCRIPTION
Two things: the table scrolls by itself now, and the tab has a look.

## The results scroll, not the page

The rider, their rank and the three standings stay put; only the last 50 races move, under a pinned header.

Measured rather than eyeballed — I rendered the real component against a captured profile and had the harness report what actually scrolls:

| | before | after |
| --- | --- | --- |
| page overflow | 1688px | **0px** |
| table scrollable | 0px | **1938px** |

The header is still pinned with the table scrolled to the bottom.

## "Too black and white and all look the same"

Fair. It was grey text on a near-black ground with every row identical. The fix was to stop inventing and use what the app already has — `src/index.css` says the geometry comes from a motocross number plate: `.u-skew`, the cut corner in `.u-notch`, and radius 0. I had been reaching for `rounded-xl`.

- **The rider's achievement banner** sits behind the header. It's earned, and different for every rider — the one thing on a profile that isn't a number about them. Read out of the page's `background-image`; riders without one just get the plain card.
- **A rank's own colour** — silver, gold, bronze — drives its plate, the line down its card and a wash across it, so the three standings are told apart at a glance instead of read.
- **Podium finishes** carry the medal's colour in the position column, with a slim skewed bar beside the track, so scanning the list finds the good days without reading a number.
- **Condensed type** for the name, the disciplines and the MXP, matching everything else plate-shaped in the app.

The rank colours aren't decoration — they come from MXB Ranked itself, which is the only place on this screen where colour already carries meaning.

## Notes

- One new parsed field (`banner`), covered by the fixture test. 7 ranked tests pass; `tsc` and eslint clean.
- Verification was an isolated render of the real component with the Tauri calls stubbed, since another session held the dev port. Worth recording: Tailwind only scans `src/**`, so classes written in a harness outside it are never generated — my first harness silently applied no layout at all and told me the fix had failed when it hadn't been under test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)