### PR TITLE
Sample a ground mask straight

### DIFF
--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -1005,7 +1005,7 @@ function TerrainMesh({
                    // chance. The lesson worth keeping: this correction is a reflection, and
                    // no rotation ever fixes a reflection — turning it only moved the error
                    // around.
-                   vec2 maskUv = vec2(vGroundUv.x, 1.0 - vGroundUv.y);
+                   vec2 maskUv = vGroundUv;
                    vec3 ground = vec3(0.5);
                  ${blend}
                    // Multiplied rather than assigned: what is already in diffuseColor is the


### PR DESCRIPTION
Southwick renders its paint mirrored where Indiana is correct, from one code path.

## Ruled out

- **Mask records** — byte-identical shape in both: `tile_u, tile_v, flag=1, w, h, len, 2, 0`. No orientation flag in or around them.
- **Terrain decode** — same `TRH\0` header, both 2049², decode diff empty apart from numbers.
- **Layer walk** — traced both. Every layer finds its trailer, every mask attaches with a sane gap. Southwick two unmasked base layers are genuine (flag=0), not a missed mask.

## The hypothesis

The orientation is the same for both and Indiana cannot show it. Indiana masks cover 99.7%, 60%, 42% and 26% of the ground — diffuse soil and patchy grass, where a flip is near invisible. Southwick paints an 11.9% asphalt road, where a flip is obvious.

So the flip was likely always wrong, and only Southwick had the contrast to say so.

**Needs checking on both tracks**: Southwick should now be correct, and Indiana should be unchanged or better.

`tsc` and `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)