### PR TITLE
Render a track's ground as one composite PNG

### DIFF
--- a/src-tauri/src/map.rs
+++ b/src-tauri/src/map.rs
@@ -2632,6 +2632,66 @@ mod tests {
         assert_eq!(bindings(&flat, 4, 2), vec![(0, 0), (1, 1)]);
     }
 
+    /// Composite a track's ground the way the shader does, as one PNG.
+    ///
+    /// Base sheet, then each layer mixed in by its own mask, sampled straight. The sheets
+    /// tile a hundred-odd times across the ground, so at this size each one is its own mean
+    /// colour — which is what makes the placement of the paint readable rather than its grain.
+    #[test]
+    #[ignore = "writes a PNG — set FROST_MAP and FROST_PNG"]
+    fn dump_ground_composite() {
+        let path = std::env::var("FROST_MAP").expect("set FROST_MAP");
+        let out = std::env::var("FROST_PNG").expect("set FROST_PNG");
+        let b = std::fs::read(&path).expect("read the map");
+        let layers = ground_layers(&b);
+        assert!(!layers.is_empty(), "the map carries a ground stack");
+        const D: usize = 768;
+        let mean = |t: &MapTexture| -> [f64; 3] {
+            let mut s = [0f64; 3];
+            let n = (t.rgba.len() / 4).max(1);
+            for p in t.rgba.chunks_exact(4) {
+                for k in 0..3 {
+                    s[k] += p[k] as f64;
+                }
+            }
+            [s[0] / n as f64, s[1] / n as f64, s[2] / n as f64]
+        };
+        let mut px = vec![0f64; D * D * 3];
+        for (i, l) in layers.iter().enumerate() {
+            let c = mean(&l.sheet);
+            for y in 0..D {
+                for x in 0..D {
+                    let o = (y * D + x) * 3;
+                    let a = match &l.mask {
+                        Some(m) => {
+                            let mx = x * m.width as usize / D;
+                            let my = y * m.height as usize / D;
+                            m.coverage[my * m.width as usize + mx] as f64 / 255.0
+                        }
+                        None => 1.0,
+                    };
+                    let a = if i == 0 { 1.0 } else { a };
+                    for k in 0..3 {
+                        px[o + k] = px[o + k] * (1.0 - a) + c[k] * a;
+                    }
+                }
+            }
+        }
+        // Written with the last grid row first, so the picture reads the way the track does
+        // from above: the grid's y runs with world +Z, and a PNG's first row is its top.
+        let mut bytes: Vec<u8> = Vec::with_capacity(D * D * 3);
+        for y in (0..D).rev() {
+            for x in 0..D {
+                let o = (y * D + x) * 3;
+                for k in 0..3 {
+                    bytes.push(px[o + k].clamp(0.0, 255.0) as u8);
+                }
+            }
+        }
+        image::RgbImage::from_raw(D as u32, D as u32, bytes).unwrap().save(&out).unwrap();
+        println!("  {out}  {D}x{D}  {} layers", layers.len());
+    }
+
     /// Write a map's ground masks out as PNGs, one per layer.
     ///
     /// The masks are the only statement of where a track's paint goes, and whether they line


### PR DESCRIPTION
Diagnostic only.

`dump_ground_composite` composites the base sheet plus every masked layer the way the shader does, so the placement of a track ground is visible in one picture.

This is the tool that settled the mask alignment. The correlation and IoU metrics used before it ranked `fliplr` first on Blackpine, whose correct answer is `identity` and visibly exact — they were noise being read as signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)