### PR TITLE
The mask follows the heightfield flip

### DIFF
--- a/src/Components/Viewer/TrackViewer.tsx
+++ b/src/Components/Viewer/TrackViewer.tsx
@@ -1005,7 +1005,7 @@ function TerrainMesh({
                    // chance. The lesson worth keeping: this correction is a reflection, and
                    // no rotation ever fixes a reflection — turning it only moved the error
                    // around.
-                   vec2 maskUv = vGroundUv;
+                   vec2 maskUv = vec2(vGroundUv.x, 1.0 - vGroundUv.y);
                    vec3 ground = vec3(0.5);
                  ${blend}
                    // Multiplied rather than assigned: what is already in diffuseColor is the


### PR DESCRIPTION
Reading the heightfield bottom-up (#512) moved the grid under the paint. The mask is sampled with the terrain uv, so it has to turn with it — on its own, #512 pulled the two apart.

```glsl
vec2 maskUv = vec2(vGroundUv.x, 1.0 - vGroundUv.y);
```

Checked as a pair against the relief on Blackpine — where we author both the mask and the heightfield from the same geometry, so alignment is not a matter of opinion — and on Indiana and Southwick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)