### PR TITLE
Calibrate the ground sheets against published tracks

### DIFF
--- a/src-tauri/src/map.rs
+++ b/src-tauri/src/map.rs
@@ -2692,6 +2692,78 @@ mod tests {
         println!("  {out}  {D}x{D}  {} layers", layers.len());
     }
 
+    /// A track's ground textures: what each sheet is, and how it lands on the ground.
+    ///
+    /// Texels per metre is the number that matters at riding distance — a big sheet tiled
+    /// coarsely reads no sharper than a small one tiled tight. Detail is the high-frequency
+    /// energy left after a blur, which is what stops a surface reading as a flat wash.
+    #[test]
+    #[ignore = "needs a real .map — set FROST_MAP"]
+    fn ground_texture_survey() {
+        let path = std::env::var("FROST_MAP").expect("set FROST_MAP");
+        let label = std::env::var("FROST_LABEL").unwrap_or_else(|_| "track".into());
+        let across: f32 = std::env::var("FROST_ACROSS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(525.0);
+        let b = std::fs::read(&path).expect("read the map");
+        let dir = std::env::var("FROST_DUMP").ok();
+        if let Some(d) = &dir {
+            std::fs::create_dir_all(d).unwrap();
+        }
+        println!(
+            "\n== {label} ==  site {across:.0} m\n{:<22} {:>9} {:>8} {:>9} {:>7} {:>7} {:>18}",
+            "layer", "sheet", "m/tile", "texel/m", "detail", "cover", "mean rgb"
+        );
+        for (i, l) in ground_layers(&b).iter().enumerate() {
+            let t = &l.sheet;
+            let n = (t.rgba.len() / 4).max(1);
+            let mut sum = [0f64; 3];
+            for p in t.rgba.chunks_exact(4) {
+                for k in 0..3 {
+                    sum[k] += p[k] as f64;
+                }
+            }
+            let mean = [sum[0] / n as f64, sum[1] / n as f64, sum[2] / n as f64];
+            // Detail: mean absolute difference between neighbouring texels, in luma. A wash
+            // scores near zero however bright it is.
+            let (w, h) = (t.width as usize, t.height as usize);
+            let luma = |i: usize| {
+                let p = &t.rgba[i * 4..];
+                p[0] as f64 * 0.299 + p[1] as f64 * 0.587 + p[2] as f64 * 0.114
+            };
+            let mut d = 0.0;
+            let mut c = 0usize;
+            for y in 0..h {
+                for x in 1..w {
+                    d += (luma(y * w + x) - luma(y * w + x - 1)).abs();
+                    c += 1;
+                }
+            }
+            let detail = if c > 0 { d / c as f64 } else { 0.0 };
+            let m_per_tile = across / l.tile_u.max(0.001);
+            // Texels per metre uses the sheet as stored here, which is the reduced one; the
+            // ratio between tracks is what this is for.
+            let texel_per_m = t.width as f32 / m_per_tile;
+            let cover = l.mask.as_ref().map_or(100.0, |m| {
+                m.coverage.iter().filter(|&&v| v > 8).count() as f64 * 100.0
+                    / m.coverage.len().max(1) as f64
+            });
+            println!(
+                "{:<22} {:>4}x{:<4} {:>8.2} {:>9.1} {:>7.2} {:>6.1}% {:>6.0},{:>4.0},{:>4.0}",
+                t.name, t.width, t.height, m_per_tile, texel_per_m, detail, cover,
+                mean[0], mean[1], mean[2]
+            );
+            if let Some(d) = &dir {
+                if let Some(img) =
+                    image::RgbaImage::from_raw(t.width, t.height, t.rgba.clone())
+                {
+                    let _ = img.save(format!("{d}/{label}_{i}_{}.png", t.name));
+                }
+            }
+        }
+    }
+
     /// Write a map's ground masks out as PNGs, one per layer.
     ///
     /// The masks are the only statement of where a track's paint goes, and whether they line

--- a/src-tauri/src/track.rs
+++ b/src-tauri/src/track.rs
@@ -301,7 +301,7 @@ pub fn load_master(app: &tauri::AppHandle, path: &str) -> Result<Master> {
 }
 
 /// The expensive path: inflate a heightfield, work out its layout, reduce it.
-fn decode_master(path: &Path) -> Result<Master> {
+pub(crate) fn decode_master(path: &Path) -> Result<Master> {
     let names = entry_names(path)?;
     let candidates = heightfield_entries(&names);
     if candidates.is_empty() {

--- a/src-tauri/src/trackline.rs
+++ b/src-tauri/src/trackline.rs
@@ -287,3 +287,272 @@ mod tests {
         assert!(read(&b).is_none());
     }
 }
+
+#[cfg(test)]
+mod corner_survey {
+    use super::*;
+    use std::path::Path;
+
+    /// Four corners of a real track, as pictures and as numbers.
+    ///
+    /// Corners come from the centreline the builder typed, which the `.trh` still carries, so
+    /// the radius and the angle are stated rather than inferred. The shape is then measured
+    /// off the heightfield around each one: how wide the worked ground is, how far the berm
+    /// stands over the apex, and how rough the surface is once the corner's own fall is taken
+    /// out.
+    ///
+    /// ```text
+    /// FROST_TRACK=… FROST_DUMP=/tmp/corners \
+    ///   cargo test --bin mxb-app -- --ignored --nocapture four_corners
+    /// ```
+    #[test]
+    #[ignore = "needs a real track — set FROST_TRACK and FROST_DUMP"]
+    fn four_corners() {
+        let path = std::env::var("FROST_TRACK").expect("set FROST_TRACK");
+        let dir = std::env::var("FROST_DUMP").expect("set FROST_DUMP");
+        let label = std::env::var("FROST_LABEL").unwrap_or_else(|_| "track".into());
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let m = crate::track::decode_master(Path::new(&path)).expect("terrain");
+        // The centreline sits in the trailing block, straight after the samples.
+        let names = crate::track::entry_names(Path::new(&path)).expect("entries");
+        let hf = crate::track::heightfield_entries(&names)
+            .into_iter()
+            .next()
+            .expect("a heightfield");
+        let hb = crate::track::read_entry(Path::new(&path), &hf).expect("read it");
+        let layout = crate::heightfield::probe(&hb, None).expect("a terrain grid");
+        let block_at =
+            layout.offset + layout.width as usize * layout.height as usize * layout.sample.size();
+        let lap = read(hb.get(block_at..).unwrap_or(&[])).expect("a centreline in the .trh");
+        let (gw, gh) = (m.info.width as usize, m.info.height as usize);
+        let mpp = m.info.metres_per_sample;
+        let half = gw as f32 * mpp * 0.5;
+        // The centreline is stated from a corner of the plot, not its centre: Indiana's x
+        // runs 22 to 470 across a 525 m site. Which way each axis then runs is not stated,
+        // so it is chosen by looking: the mapping that puts the lap on rutted ground wins,
+        // and the three that put it in a field are flat.
+        let (fx_dir, fz_dir) = pick_axes(&m, &lap, mpp, gw, gh);
+        let at = |x: f32, z: f32| -> f32 {
+            let sx = if fx_dir { x } else { gw as f32 * mpp - x };
+            let sz = if fz_dir { z } else { gh as f32 * mpp - z };
+            let gx = (sx / mpp).clamp(0.0, gw as f32 - 1.001);
+            let gz = (sz / mpp).clamp(0.0, gh as f32 - 1.001);
+            let (x0, z0) = (gx as usize, gz as usize);
+            let (fx, fz) = (gx - x0 as f32, gz - z0 as f32);
+            let h = |a: usize, b: usize| m.heights[b.min(gh - 1) * gw + a.min(gw - 1)];
+            let top = h(x0, z0) * (1.0 - fx) + h(x0 + 1, z0) * fx;
+            let bot = h(x0, z0 + 1) * (1.0 - fx) + h(x0 + 1, z0 + 1) * fx;
+            top * (1.0 - fz) + bot * fz
+        };
+
+        // The corners the file states, biggest turn first, spread round the lap.
+        let mut corners: Vec<&LineSegment> =
+            lap.segments.iter().filter(|s| s.is_corner()).collect();
+        corners.sort_by(|a, b| b.angle.total_cmp(&a.angle));
+        let mut picked: Vec<&LineSegment> = Vec::new();
+        for c in corners {
+            if picked.iter().all(|p| (p.at - c.at).abs() > lap.length * 0.12) {
+                picked.push(c);
+            }
+            if picked.len() == 4 {
+                break;
+            }
+        }
+
+        let (mut xlo, mut xhi, mut zlo, mut zhi) = (f32::MAX, f32::MIN, f32::MAX, f32::MIN);
+        for sgm in &lap.segments {
+            xlo = xlo.min(sgm.x); xhi = xhi.max(sgm.x);
+            zlo = zlo.min(sgm.z); zhi = zhi.max(sgm.z);
+        }
+        println!(
+            "  centreline x[{xlo:.0}, {xhi:.0}] z[{zlo:.0}, {zhi:.0}]   terrain half-extent {half:.0} m  ({} x {} @ {mpp:.3})",
+            gw, gh
+        );
+        println!("\n== {label}: {} corners on a {:.0} m lap ==", 
+            lap.segments.iter().filter(|s| s.is_corner()).count(), lap.length);
+        println!(
+            "{:<4} {:>7} {:>7} {:>8} {:>9} {:>8} {:>8} {:>8}",
+            "#", "radius", "angle", "arc_len", "worked_w", "berm", "camber", "rough"
+        );
+        for (i, c) in picked.iter().enumerate() {
+            let (fx, fz) = crate::trackprog::heading_vector(c.heading);
+            let (rx, rz) = crate::trackprog::right_vector(c.heading);
+            // Across the corner at its apex: sample out to 25 m each side.
+            // Half way round the arc, not half way along its chord: a 108 degree turn puts
+            // its apex nowhere near the start heading, and stepping straight lands in the
+            // field beside the track.
+            let half_ang = (c.angle * 0.5).to_radians() * c.radius.signum();
+            let mid_heading = c.heading + half_ang;
+            let (ax, az) = {
+                let r = c.radius.abs();
+                // Centre of the arc, then the point half way round it.
+                let (cx, cz) = (c.x + rx * r * c.radius.signum(), c.z + rz * r * c.radius.signum());
+                let (bx, bz) = (c.x - cx, c.z - cz);
+                let (s, co) = (half_ang.sin(), half_ang.cos());
+                (cx + bx * co - bz * s, cz + bx * s + bz * co)
+            };
+            let (px, pz) = (ax, az);
+            let (fx, fz) = crate::trackprog::heading_vector(mid_heading);
+            let (rx, rz) = crate::trackprog::right_vector(mid_heading);
+            let _ = (fx, fz);
+            const REACH: f32 = 25.0;
+            const N: usize = 201;
+            let profile: Vec<(f32, f32)> = (0..N)
+                .map(|k| {
+                    let d = (k as f32 / (N - 1) as f32 - 0.5) * 2.0 * REACH;
+                    (d, at(px + rx * d, pz + rz * d))
+                })
+                .collect();
+            let mid = profile[N / 2].1;
+            // Worked ground: how far out the surface stays within a hand's breadth of the
+            // apex's own plane before the field takes over.
+            let flat = |sign: f32| -> f32 {
+                let mut last = 0.0;
+                for (d, h) in &profile {
+                    if d.signum() != sign || d.abs() < 0.2 {
+                        continue;
+                    }
+                    if (h - mid).abs() < 1.2 {
+                        last = d.abs();
+                    } else if d.abs() > last + 3.0 {
+                        break;
+                    }
+                }
+                last
+            };
+            let worked = flat(-1.0) + flat(1.0);
+            // The berm: the most the ground stands above the apex on the outside of the turn.
+            let outside = if c.radius > 0.0 { -1.0 } else { 1.0 };
+            let berm = profile
+                .iter()
+                .filter(|(d, _)| d.signum() == outside && d.abs() <= 12.0)
+                .map(|(_, h)| h - mid)
+                .fold(f32::MIN, f32::max);
+            // Camber across the worked width, degrees.
+            let e = worked.max(2.0) * 0.5;
+            let camber = ((at(px + rx * e, pz + rz * e) - at(px - rx * e, pz - rz * e))
+                / (2.0 * e))
+                .atan()
+                .to_degrees();
+            // Roughness along the corner: chatter left after the corner's own fall is out.
+            let along: Vec<f32> = (0..=((c.length / 0.5) as usize).max(2))
+                .map(|k| {
+                    let d = k as f32 * 0.5;
+                    let ang = (d / c.radius.abs()).min(c.angle.to_radians());
+                    let hh = c.heading + ang * c.radius.signum();
+                    let (hx, hz) = crate::trackprog::heading_vector(hh);
+                    at(c.x + hx * d, c.z + hz * d)
+                })
+                .collect();
+            let rough = detrended_rms(&along);
+            println!(
+                "{:<4} {:>6.1}m {:>6.0}° {:>7.1}m {:>8.1}m {:>7.2}m {:>7.1}° {:>7.3}m",
+                i + 1,
+                c.radius.abs(),
+                c.angle,
+                c.length,
+                worked,
+                berm.max(0.0),
+                camber,
+                rough
+            );
+
+            // The picture: relief round the corner, with the centreline on it.
+            const PIX: usize = 300;
+            const SPAN: f32 = 70.0;
+            let mut img = vec![0u8; PIX * PIX * 3];
+            for py in 0..PIX {
+                for pxi in 0..PIX {
+                    let wx = px + (pxi as f32 / PIX as f32 - 0.5) * SPAN;
+                    let wz = pz + (py as f32 / PIX as f32 - 0.5) * SPAN;
+                    let s = SPAN / PIX as f32;
+                    let g = ((at(wx + s, wz) - at(wx - s, wz)).powi(2)
+                        + (at(wx, wz + s) - at(wx, wz - s)).powi(2))
+                    .sqrt();
+                    let v = (255.0 * (1.0 - (-g * 9.0).exp())).clamp(0.0, 255.0) as u8;
+                    let o = (py * PIX + pxi) * 3;
+                    img[o] = v;
+                    img[o + 1] = v;
+                    img[o + 2] = v;
+                }
+            }
+            for k in 0..=((c.length / 0.25) as usize) {
+                let d = k as f32 * 0.25;
+                let ang = (d / c.radius.abs()).min(c.angle.to_radians());
+                let hh = c.heading + ang * c.radius.signum();
+                let (hx, hz) = crate::trackprog::heading_vector(hh);
+                let (wx, wz) = (c.x + hx * d, c.z + hz * d);
+                let pxi = ((wx - px) / SPAN + 0.5) * PIX as f32;
+                let py = ((wz - pz) / SPAN + 0.5) * PIX as f32;
+                if (0.0..PIX as f32).contains(&pxi) && (0.0..PIX as f32).contains(&py) {
+                    let o = (py as usize * PIX + pxi as usize) * 3;
+                    img[o] = 255;
+                    img[o + 1] = 40;
+                    img[o + 2] = 40;
+                }
+            }
+            image::RgbImage::from_raw(PIX as u32, PIX as u32, img)
+                .unwrap()
+                .save(format!("{dir}/{label}_corner{}.png", i + 1))
+                .unwrap();
+        }
+    }
+
+    /// Which way each axis of the centreline runs against the grid.
+    ///
+    /// Scored by relief: a lap laid on the track crosses ruts and berms, and the same lap
+    /// laid in a field crosses almost nothing, so the spread of heights under it separates
+    /// the four readings cleanly.
+    fn pick_axes(
+        m: &crate::track::Master,
+        lap: &Lap,
+        mpp: f32,
+        gw: usize,
+        gh: usize,
+    ) -> (bool, bool) {
+        let mut best = (true, true);
+        let mut best_score = -1.0f64;
+        for fx in [true, false] {
+            for fz in [true, false] {
+                let mut vals = Vec::new();
+                for st in lap.stations(4.0) {
+                    let sx = if fx { st.x } else { gw as f32 * mpp - st.x };
+                    let sz = if fz { st.z } else { gh as f32 * mpp - st.z };
+                    let gx = (sx / mpp).clamp(0.0, gw as f32 - 1.0) as usize;
+                    let gz = (sz / mpp).clamp(0.0, gh as f32 - 1.0) as usize;
+                    vals.push(m.heights[gz * gw + gx] as f64);
+                }
+                if vals.len() < 8 {
+                    continue;
+                }
+                // Local spread along the lap: ruts and berms, not the site's overall fall.
+                let mut d = 0.0;
+                for w in vals.windows(2) {
+                    d += (w[1] - w[0]).abs();
+                }
+                let score = d / vals.len() as f64;
+                if score > best_score {
+                    best_score = score;
+                    best = (fx, fz);
+                }
+            }
+        }
+        best
+    }
+
+    /// RMS left after a straight line through the run is removed — the chatter, not the fall.
+    fn detrended_rms(v: &[f32]) -> f32 {
+        let n = v.len();
+        if n < 3 {
+            return 0.0;
+        }
+        let (a, b) = (v[0], v[n - 1]);
+        let mut s = 0.0f64;
+        for (i, h) in v.iter().enumerate() {
+            let want = a + (b - a) * i as f32 / (n - 1) as f32;
+            s += ((h - want) as f64).powi(2);
+        }
+        (s / n as f64).sqrt() as f32
+    }
+}

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -293,7 +293,12 @@ const RUT_WALL_HOLD: f32 = 1.8;
 /// than the dark soil of the line, so a rut read paler than its own line and disappeared, and
 /// the loose band was toned darker than a corridor that had become the field's own soil, so
 /// it read as blotches rather than as dust.
-const RUT_FLOOR_DARKEN: f32 = 0.42;
+// Measured against the sheets published tracks bake into their own `.map`: Indiana's darkest
+// ridden surface averages (49, 35, 23) and Southwick's (54, 36, 22). At 0.42 ours came out
+// (25, 19, 14) — half the luma of the darkest thing either of them lays on a track, and with
+// it a pixel-to-pixel grain of 1.6 against their 3.8-18. Dark and flat is the one combination
+// that reads as the texture having failed rather than as polished dirt.
+const RUT_FLOOR_DARKEN: f32 = 0.82;
 const LOOSE_DRY: f32 = 0.85;
 
 /// How much of its brightness the field's soil keeps.
@@ -559,15 +564,15 @@ const GROUND_TEXTURE_DIM: usize = 1024;
 /// 400 m track and a 900 m one get soil of the same grain. A fixed repetition count does not:
 /// the old 60 put a tile every 4.6 m on the example track and every 11.7 m on ours, which is
 /// most of why the ground looked out of scale.
-const TILE_FIELD_M: f32 = 4.5;
-const TILE_LINE_M: f32 = 3.2;
-const TILE_SHOULDER_M: f32 = 3.8;
+const TILE_FIELD_M: f32 = 3.0;
+const TILE_LINE_M: f32 = 3.0;
+const TILE_SHOULDER_M: f32 = 3.0;
 const TILE_GRASS_M: f32 = 2.8;
 /// The loose dirt tiles coarser than the line it sits on, so the two read as different ground
 /// and not as one sheet at two brightnesses.
-const TILE_LOOSE_M: f32 = 4.1;
+const TILE_LOOSE_M: f32 = 3.0;
 /// And the packed line finer, which is what being driven over does to it.
-const TILE_RUT_M: f32 = 2.4;
+const TILE_RUT_M: f32 = 2.8;
 
 /// The cube a wet layer reflects, per face. Small on purpose: it is seen smeared across a
 /// film of water and never in focus. The example track's own faces are 128 too.
@@ -5807,9 +5812,9 @@ fn ground_looks(surface: Surface) -> Grounds {
         // enough a solid colour. A solid colour laid down the middle of the track is what
         // reads from the seat as the texture being broken and the line impossible to find. A
         // packed rut is smooth in its *shape*; the dirt in it is still dirt.
-        grain_tint: (0.44, 1.52),
-        fleck: [128.0, 124.0, 118.0],
-        fleck_density: 0.045,
+        grain_tint: (0.34, 1.66),
+        fleck: [148.0, 142.0, 132.0],
+        fleck_density: 0.075,
         litter: [120.0, 104.0, 72.0],
         litter_density: 0.28,
         blade: ([0.0; 3], [0.0; 3]),
@@ -10723,6 +10728,75 @@ mod blank_repro {
         match crate::tracksynth::synthesise(&prog) {
             Ok(_) => println!("synthesise: OK"),
             Err(e) => println!("synthesise FAILED: {e:#}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod ground_sheets {
+    use super::*;
+
+    /// Our own ground sheets, measured the way a published track's are.
+    ///
+    /// Detail is the mean absolute luma step between neighbouring texels — what separates a
+    /// surface from a wash. Indiana's terrain sheets run 3.8 to 18.2 and Southwick's 3.9 to
+    /// 16.9, so anything far under that reads as flat from the seat however well toned it is.
+    #[test]
+    #[ignore = "prints a table — set FROST_DUMP to also write the sheets"]
+    fn our_ground_sheets() {
+        let dim = 256usize;
+        let dir = std::env::var("FROST_DUMP").ok();
+        if let Some(d) = &dir {
+            std::fs::create_dir_all(d).unwrap();
+        }
+        for surface in [Surface::Soil, Surface::Sand, Surface::Grass] {
+            let g = ground_looks(surface);
+            println!("\n== {surface:?} ==");
+            println!("{:<12} {:>8} {:>7} {:>20}", "sheet", "m/tile", "detail", "mean rgb");
+            for (name, look, tile) in [
+                ("ground", &g.field, TILE_FIELD_M),
+                ("shoulder", &g.shoulder, TILE_SHOULDER_M),
+                ("dirt", &g.ridden, TILE_LINE_M),
+                ("line", &g.line, TILE_LINE_M),
+                ("loose", &g.loose, TILE_LOOSE_M),
+                ("rut", &g.rut, TILE_RUT_M),
+                ("grass", &g.turf, TILE_GRASS_M),
+            ] {
+                let px = band_pixels(dim, look, 0x51D);
+                let luma = |i: usize| {
+                    px[i * 4] as f64 * 0.299 + px[i * 4 + 1] as f64 * 0.587
+                        + px[i * 4 + 2] as f64 * 0.114
+                };
+                let mut d = 0.0;
+                let mut c = 0usize;
+                for y in 0..dim {
+                    for x in 1..dim {
+                        d += (luma(y * dim + x) - luma(y * dim + x - 1)).abs();
+                        c += 1;
+                    }
+                }
+                let mut s = [0f64; 3];
+                for p in px.chunks_exact(4) {
+                    for k in 0..3 {
+                        s[k] += p[k] as f64;
+                    }
+                }
+                let n = (px.len() / 4) as f64;
+                println!(
+                    "{name:<12} {tile:>8.2} {:>7.2} {:>7.0},{:>4.0},{:>4.0}",
+                    d / c.max(1) as f64,
+                    s[0] / n,
+                    s[1] / n,
+                    s[2] / n
+                );
+                if let (Some(dd), Surface::Soil) = (&dir, surface) {
+                    if let Some(img) =
+                        image::RgbaImage::from_raw(dim as u32, dim as u32, px.clone())
+                    {
+                        let _ = img.save(format!("{dd}/ours_{name}.png"));
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Measured against what Indiana and Southwick bake into their own `.map`, with two new surveys reading both the same way.

## The rut floor

| | mean rgb | grain |
|---|---|---|
| ours, before | 25, 19, 14 | 1.6 |
| Indiana `soil_dark_c` | 49, 35, 23 | 8.7 |
| Southwick `sand_dark_c` | 54, 36, 22 | 3.9 |
| **ours, after** | **49, 38, 28** | **3.2** |

Half the luma of the darkest thing either of them lays on a track, and near flat with it. Dark *and* flat reads as the texture having failed rather than as polished dirt — and it sits on the racing line, which is where a rider looks.

## Tiling

Ours ran 2.4-4.5 m a tile across our own layers; both published tracks hold every layer inside 2.6-3.1 m. Ours is now 2.8-3.0, so sharpness does not jump from one band to the next.

## Tools kept

`ground_texture_survey` reads a published `.map`; `our_ground_sheets` reads the generator. Both ignored tests, both printing the same columns.

1499 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)