### PR TITLE
feat(tracks): corner surface — camber, rut depth and wheel-scale chop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@
   phosphor, monospaced type, square corners and a scanline over the window.
 
 ### Changed
+- Generated corners are cut deeper and carry the chop a wheel feels, so a turn has a rut
+  wall to lean on instead of a shallow saucer.
+- Generated tracks are cambered across their width, so a corner leans the way a built one does.
 - A new look. Navigation moved out of the sidebar into a bar across the top, so mod artwork
   gets the full width of the window — seven mods to a row instead of five. Locker and Presets
   sit together under Garage, Race mode has its own place, and every page puts its filters,

--- a/scripts/corner-atlas.py
+++ b/scripts/corner-atlas.py
@@ -27,6 +27,9 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 
+# Metres either way on the bumps panel. Fixed, so every picture is on the same scale.
+BUMP_SCALE_M = 0.25
+
 INK = "#f2f3f5"
 GROUND = "#0c0c0e"
 PANEL = "#141417"
@@ -127,8 +130,12 @@ def draw(out_dir, meta, c):
 
     ax = fig.add_subplot(grid[1])
     sky(ax, "bumps  (6 m detrend)")
-    lim = float(np.percentile(np.abs(bumps), 99)) or 0.05
-    ax.imshow(bumps, cmap="RdBu_r", origin="lower", extent=extent, vmin=-lim, vmax=lim)
+    # One fixed scale for every picture, always. Normalising each panel to its own range
+    # stretches a smooth corner to fill the same colours as a rough one, so two tracks drawn
+    # side by side look equally chopped up whatever they actually measure — which is exactly
+    # backwards for a comparison, and it made ours look redder than Indiana while being
+    # measurably smoother.
+    ax.imshow(bumps, cmap="RdBu_r", origin="lower", extent=extent, vmin=-BUMP_SCALE_M, vmax=BUMP_SCALE_M)
     ax.plot(sx, sz, color="#111", lw=0.9, alpha=0.7)
     ax.set_aspect("equal")
 

--- a/scripts/corner-atlas.py
+++ b/scripts/corner-atlas.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Draw the corners `trackstats::corner_atlas` dumped, so their shape can be looked at.
+
+    FROST_TRACK=…/indiana.pkz FROST_OUT=/tmp/atlas/indiana \
+      cargo test --bin mxb-app -- --ignored --nocapture corner_atlas
+    python3 scripts/corner-atlas.py /tmp/atlas/indiana
+
+Five panels a corner, because "what shape are the bumps" is five different questions:
+
+  shape    the turn itself, hillshaded — how it bends, and which way it leans
+  bumps    the same ground with a 6 m running mean taken out, which is the only way the
+           ruts show at all: they are centimetres on a hillside of metres
+  ground   what the game actually paints there, the layer stack composited through its masks
+  across   three cuts through the line — entry, apex, exit — where a rut is a shape and not
+           a statistic
+  along    the line's own profile, detrended, which is where braking bumps live
+
+Needs numpy, matplotlib and pillow."""
+import json
+import struct
+import sys
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+INK = "#f2f3f5"
+GROUND = "#0c0c0e"
+PANEL = "#141417"
+LINE = "#9ccfec"
+
+
+def load_patch(path):
+    b = path.read_bytes()
+    assert b[:4] == b"FRCA", b[:4]
+    pw, ph = struct.unpack_from("<II", b, 4)
+    x0, z0, mps = struct.unpack_from("<fff", b, 12)
+    o = 24
+    n = pw * ph
+    H = np.frombuffer(b, "<f4", n, o).reshape(ph, pw).copy()
+    o += 4 * n
+    RGB = np.frombuffer(b, "u1", n * 3, o).reshape(ph, pw, 3).copy()
+    o += 3 * n
+    (sc,) = struct.unpack_from("<I", b, o)
+    o += 4
+    S = np.frombuffer(b, "<f4", sc * 2, o).reshape(sc, 2).copy()
+    return dict(w=pw, h=ph, x0=x0, z0=z0, mps=mps, H=H, RGB=RGB, S=S)
+
+
+def detrend2d(H, half):
+    """Subtract a running mean, so centimetre bumps survive a hillside of metres."""
+    k = 2 * half + 1
+    pad = np.pad(H, half, mode="edge")
+    csum = np.cumsum(np.cumsum(pad, axis=0), axis=1)
+    csum = np.pad(csum, ((1, 0), (1, 0)))
+    box = (
+        csum[k:, k:] - csum[:-k, k:] - csum[k:, :-k] + csum[:-k, :-k]
+    ) / (k * k)
+    return H - box[: H.shape[0], : H.shape[1]]
+
+
+def hillshade(H, mps, az=315.0, alt=45.0):
+    gz, gx = np.gradient(H, mps)
+    slope = np.arctan(np.hypot(gx, gz))
+    aspect = np.arctan2(-gz, gx)
+    az, alt = np.radians(az), np.radians(alt)
+    v = np.sin(alt) * np.cos(slope) + np.cos(alt) * np.sin(slope) * np.cos(az - aspect)
+    return np.clip(v, 0, 1)
+
+
+def cross_sections(P, frac):
+    """A cut across the line at `frac` along it: (offset metres, height metres)."""
+    S, mps = P["S"], P["mps"]
+    i = int(np.clip(frac * (len(S) - 1), 1, len(S) - 2))
+    p, nxt = S[i], S[i + 1]
+    d = nxt - p
+    n = np.array([-d[1], d[0]])
+    n = n / (np.hypot(*n) or 1.0)
+    ts = np.arange(-9.0, 9.0 + 1e-6, mps / 2)
+    xs, zs = p[0] + n[0] * ts, p[1] + n[1] * ts
+    ix = np.clip(((xs - P["x0"]) / mps).astype(int), 0, P["w"] - 1)
+    iz = np.clip(((zs - P["z0"]) / mps).astype(int), 0, P["h"] - 1)
+    return ts, P["H"][iz, ix]
+
+
+def along_profile(P):
+    S, mps = P["S"], P["mps"]
+    ix = np.clip(((S[:, 0] - P["x0"]) / mps).astype(int), 0, P["w"] - 1)
+    iz = np.clip(((S[:, 1] - P["z0"]) / mps).astype(int), 0, P["h"] - 1)
+    h = P["H"][iz, ix]
+    d = np.concatenate([[0.0], np.cumsum(np.hypot(np.diff(S[:, 0]), np.diff(S[:, 1])))])
+    return d, h
+
+
+def running(v, half):
+    k = 2 * half + 1
+    return np.convolve(np.pad(v, half, mode="edge"), np.ones(k) / k, mode="valid")
+
+
+def draw(out_dir, meta, c):
+    P = load_patch(out_dir / c["patch"])
+    H = np.where(np.isfinite(P["H"]), P["H"], np.nanmedian(P["H"]))
+    bumps = detrend2d(H, max(1, int(round(3.0 / P["mps"]))))
+    extent = [0, P["w"] * P["mps"], 0, P["h"] * P["mps"]]
+    sx = (P["S"][:, 0] - P["x0"])
+    sz = (P["S"][:, 1] - P["z0"])
+
+    fig = plt.figure(figsize=(17, 4.2), facecolor=GROUND)
+    fig.subplots_adjust(left=0.03, right=0.99, top=0.86, bottom=0.14, wspace=0.22)
+    grid = fig.add_gridspec(1, 5, width_ratios=[1, 1, 1, 1.05, 1.05])
+
+    def sky(ax, title):
+        ax.set_facecolor(PANEL)
+        ax.set_title(title, color=INK, fontsize=10, pad=6)
+        for s in ax.spines.values():
+            s.set_color("#333")
+        ax.tick_params(colors="#8a8a92", labelsize=7)
+
+    ax = fig.add_subplot(grid[0])
+    sky(ax, "shape")
+    ax.imshow(hillshade(H, P["mps"]), cmap="gray", origin="lower", extent=extent, vmin=0, vmax=1)
+    ax.plot(sx, sz, color=LINE, lw=1.4)
+    ax.set_aspect("equal")
+
+    ax = fig.add_subplot(grid[1])
+    sky(ax, "bumps  (6 m detrend)")
+    lim = float(np.percentile(np.abs(bumps), 99)) or 0.05
+    ax.imshow(bumps, cmap="RdBu_r", origin="lower", extent=extent, vmin=-lim, vmax=lim)
+    ax.plot(sx, sz, color="#111", lw=0.9, alpha=0.7)
+    ax.set_aspect("equal")
+
+    ax = fig.add_subplot(grid[2])
+    sky(ax, "ground  (as painted)")
+    ax.imshow(P["RGB"], origin="lower", extent=extent)
+    ax.plot(sx, sz, color=LINE, lw=1.0, alpha=0.85)
+    ax.set_aspect("equal")
+
+    ax = fig.add_subplot(grid[3])
+    sky(ax, "across the line")
+    for frac, colour, name in ((0.15, "#6fd99a", "entry"), (0.5, "#e8bd6a", "apex"), (0.85, "#ef8078", "exit")):
+        t, h = cross_sections(P, frac)
+        ax.plot(t, h - h.mean(), color=colour, lw=1.3, label=name)
+    ax.axvline(0, color="#555", lw=0.8, ls=":")
+    ax.set_xlabel("metres off the line", color="#8a8a92", fontsize=8)
+    ax.set_ylabel("m", color="#8a8a92", fontsize=8)
+    ax.legend(fontsize=7, facecolor=PANEL, edgecolor="#333", labelcolor=INK)
+
+    ax = fig.add_subplot(grid[4])
+    sky(ax, "along the line")
+    d, h = along_profile(P)
+    ax.plot(d, h - running(h, max(1, int(2.0 / max(P["mps"], 1e-3)))), color="#9ccfec", lw=1.0)
+    ax.set_xlabel("metres round the turn", color="#8a8a92", fontsize=8)
+    ax.set_ylabel("m", color="#8a8a92", fontsize=8)
+
+    head = (
+        f"{meta['track']} · turn {c['n']} at {c['atM']:.0f} m — "
+        f"{c['turnDeg']:.0f}° {c['direction']} over {c['lengthM']:.0f} m, "
+        f"{c['arcs']} arcs, r {c['radiusTightestM']:.0f}–{c['radiusWidestM']:.0f} m, rise {c['riseM']:.2f} m"
+    )
+    if c.get("grooves") is not None:
+        head += (
+            f"   |   {c['grooves']:.1f} grooves at {c['spacingM']:.2f} m, floor {c['floorM']:.2f} m, "
+            f"wall {c['wallDeg']:.0f}°, chatter {c['chatterM']*100:.1f} cm"
+        )
+    fig.suptitle(head, color=INK, fontsize=11, y=0.97)
+    png = out_dir / f"corner{c['n']}.png"
+    fig.savefig(png, dpi=110, facecolor=GROUND)
+    plt.close(fig)
+    return png
+
+
+def main():
+    out_dir = Path(sys.argv[1])
+    meta = json.loads((out_dir / "corners.json").read_text())
+    pngs = [draw(out_dir, meta, c) for c in meta["corners"]]
+    # One sheet for the track, so four turns can be compared at a glance.
+    from PIL import Image
+
+    ims = [Image.open(p) for p in pngs]
+    w = max(i.width for i in ims)
+    sheet = Image.new("RGB", (w, sum(i.height for i in ims)), (12, 12, 14))
+    y = 0
+    for i in ims:
+        sheet.paste(i, (0, y))
+        y += i.height
+    dest = out_dir / f"{meta['track']}-corners.png"
+    sheet.save(dest)
+    print(dest)
+
+
+if __name__ == "__main__":
+    main()

--- a/src-tauri/src/trackprog.rs
+++ b/src-tauri/src/trackprog.rs
@@ -859,6 +859,76 @@ pub fn turns(segments: &[Segment]) -> Vec<(f32, f32)> {
     out
 }
 
+/// A corner, and where it is.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct CornerRun {
+    /// Metres round the lap the corner starts and ends at.
+    pub start_m: f32,
+    pub end_m: f32,
+    /// Unsigned degrees turned through.
+    pub degrees: f32,
+    /// The tightest radius anywhere in it, metres.
+    pub tightest_m: f32,
+    /// How many arcs the builder used. A published corner is 9-19 of them; one arc is a
+    /// compass sweep, and it rides like one.
+    pub arcs: usize,
+}
+
+/// The same corners [`turns`] counts, carrying where each one is.
+///
+/// `turns` answers "how many corners, how tight" and is used to judge a whole lap. This
+/// answers "and where", which is what anything that has to go and look at the ground there
+/// needs — and what the corner atlas is built on.
+pub fn corner_runs(segments: &[Segment]) -> Vec<CornerRun> {
+    let mut out: Vec<CornerRun> = Vec::new();
+    let mut at = 0.0f32;
+    let mut cur: Option<(f32, CornerRun)> = None; // way, run
+    for seg in segments {
+        let end = at + seg.length();
+        match *seg {
+            Segment::Arc { radius, angle, .. } if radius != 0.0 && angle.abs() >= CORNER_DEG => {
+                let way = radius.signum();
+                match cur {
+                    Some((w, ref mut r)) if w == way => {
+                        r.end_m = end;
+                        r.degrees += angle.abs();
+                        r.tightest_m = r.tightest_m.min(radius.abs());
+                        r.arcs += 1;
+                    }
+                    other => {
+                        if let Some((_, r)) = other {
+                            out.push(r);
+                        }
+                        cur = Some((
+                            way,
+                            CornerRun {
+                                start_m: at,
+                                end_m: end,
+                                degrees: angle.abs(),
+                                tightest_m: radius.abs(),
+                                arcs: 1,
+                            },
+                        ));
+                    }
+                }
+            }
+            _ => {
+                // Same break as `turns`: anything straight and longer than a nudge ends it.
+                if seg.length() > 8.0 {
+                    if let Some((_, r)) = cur.take() {
+                        out.push(r);
+                    }
+                }
+            }
+        }
+        at = end;
+    }
+    if let Some((_, r)) = cur {
+        out.push(r);
+    }
+    out
+}
+
 impl Segment {
     pub fn length(&self) -> f32 {
         match self {

--- a/src-tauri/src/trackstats.rs
+++ b/src-tauri/src/trackstats.rs
@@ -1794,6 +1794,274 @@ mod tests {
         println!("  chatter on the line {:.3} m   2 m off {:.3}   4 m off {:.3}", r.chatter_zones_m[0], r.chatter_zones_m[1], r.chatter_zones_m[2]);
     }
 
+
+    /// Four corners from a published track: their shape, their bumps, and the ground on them.
+    ///
+    /// Writes one folder per track — a params JSON and, per corner, a height patch and the
+    /// ground as the game paints it — for `scripts/corner-atlas.py` to draw.
+    ///
+    /// ```text
+    /// FROST_TRACK=…/indiana.pkz FROST_OUT=/tmp/atlas/indiana \
+    ///   cargo test --bin mxb-app -- --ignored --nocapture corner_atlas
+    /// ```
+    #[test]
+    #[ignore = "needs a track — set FROST_TRACK and FROST_OUT"]
+    fn corner_atlas() {
+        let var = std::env::var("FROST_TRACK").expect("set FROST_TRACK");
+        let out = std::path::PathBuf::from(std::env::var("FROST_OUT").expect("set FROST_OUT"));
+        std::fs::create_dir_all(&out).unwrap();
+        let path = std::path::Path::new(&var);
+
+        let names = track::entry_names(path).unwrap();
+        let entry = track::heightfield_entries(&names).into_iter().next().expect("a heightfield");
+        let bytes = track::read_entry(path, &entry).unwrap();
+        let layout = heightfield::probe(&bytes, None).expect("a terrain grid");
+        let mps_src = layout.metres_per_sample.expect("a stated footprint");
+        let size_x = mps_src * (layout.width.max(2) - 1) as f32;
+        let size_z = mps_src * (layout.height.max(2) - 1) as f32;
+        let block_at =
+            layout.offset + layout.width as usize * layout.height as usize * layout.sample.size();
+        let lap = crate::trackline::read(bytes.get(block_at..).unwrap_or(&[])).expect("a centreline");
+        // Full resolution: a corner's bumps are the point, and a downsample is exactly what
+        // would smooth them away.
+        let (fw, fh, v) = heightfield::read_grid(&bytes, &layout, layout.width.max(layout.height));
+        let g = Grid { w: fw as usize, h: fh as usize, size_x, size_z, v };
+
+        // The ground stack, for the colour/texture/mask half of the question.
+        let map_name = names.iter().find(|n| n.to_lowercase().ends_with(".map"));
+        let layers = match map_name {
+            Some(n) => {
+                let mb = track::read_entry(path, n).unwrap();
+                crate::map::ground_layers(&mb)
+            }
+            None => Vec::new(),
+        };
+        println!("{} — {:.0}x{:.0} m, {}x{} samples, {} ground layers",
+            entry, size_x, size_z, fw, fh, layers.len());
+
+        let step = 0.25f32;
+        let all = lap.stations(step);
+        let runs = corner_runs(&lap);
+        println!("lap {:.0} m, {} segments, {} corners", lap.length, lap.segments.len(), runs.len());
+
+        // The four that bend furthest — the ones a rider would name — put back into lap order
+        // so the atlas reads like a lap.
+        let mut ranked = runs.clone();
+        ranked.sort_by(|x, y| y.2.total_cmp(&x.2));
+        let mut chosen: Vec<(f32, f32, f32)> =
+            ranked.into_iter().take(4).map(|(a, b, deg, _)| (deg, a, b)).collect();
+        chosen.sort_by(|x, y| x.1.total_cmp(&y.1));
+
+        let mut json = String::from("{\n");
+        json.push_str(&format!("  \"track\": {:?},\n", path.file_stem().unwrap().to_string_lossy()));
+        json.push_str(&format!("  \"lapLengthM\": {:.1},\n  \"sizeXm\": {:.1},\n  \"sizeZm\": {:.1},\n", lap.length, size_x, size_z));
+        json.push_str(&format!("  \"metresPerSample\": {:.4},\n", mps_src));
+        json.push_str("  \"groundLayers\": [\n");
+        for (i, l) in layers.iter().enumerate() {
+            let tile_m = size_x / l.tile_u.max(0.001);
+            json.push_str(&format!(
+                "    {{\"i\": {i}, \"sheet\": {:?}, \"px\": [{}, {}], \"tileU\": {:.1}, \"tileV\": {:.1}, \"tileMetres\": {:.2}, \"mask\": {}}}{}\n",
+                l.sheet.name, l.sheet.width, l.sheet.height, l.tile_u, l.tile_v, tile_m,
+                match &l.mask { Some(m) => format!("[{}, {}]", m.width, m.height), None => "null".into() },
+                if i + 1 < layers.len() { "," } else { "" }));
+        }
+        json.push_str("  ],\n  \"corners\": [\n");
+
+        for (n, &(deg, a, b)) in chosen.iter().enumerate() {
+            let sel: Vec<&crate::trackline::Station> =
+                all.iter().filter(|s| s.at >= a && s.at <= b).collect();
+            if sel.len() < 8 {
+                continue;
+            }
+            let stations: Vec<(f32, f32, f32)> =
+                sel.iter().map(|s| (s.x, s.z, s.heading)).collect();
+            let shape = super::rut_shape(&stations, step, &g);
+
+            // The arcs the builder actually typed, which is the shape of the turn.
+            let arcs: Vec<&crate::trackline::LineSegment> =
+                lap.segments.iter().filter(|s| s.at >= a - 0.5 && s.at < b + 0.5).collect();
+            let radii: Vec<f32> = arcs.iter().filter(|s| s.radius != 0.0).map(|s| s.radius).collect();
+            let len_m = b - a;
+            let mean_r = if radii.is_empty() { 0.0 } else { radii.iter().sum::<f32>() / radii.len() as f32 };
+            let tightest = radii.iter().cloned().fold(f32::INFINITY, |m, r| m.min(r.abs()));
+            let widest = radii.iter().cloned().fold(0.0f32, |m, r| m.max(r.abs()));
+
+            // Elevation over the turn, off the heightfield under the line.
+            let hs: Vec<f32> = sel.iter().filter_map(|s| Some(g.at(s.x, s.z))).collect();
+            let (hmin, hmax) = hs.iter().fold((f32::MAX, f32::MIN), |(a, b), &h| (a.min(h), b.max(h)));
+
+            let patch = write_corner_patch(&out, n, &sel, &g, &layers, size_x, size_z);
+
+            json.push_str(&format!(
+                "    {{\"n\": {n}, \"atM\": {a:.1}, \"endM\": {b:.1}, \"lengthM\": {len_m:.1}, \"turnDeg\": {deg:.1},\n",
+            ));
+            json.push_str(&format!(
+                "      \"arcs\": {}, \"radiusMeanM\": {mean_r:.1}, \"radiusTightestM\": {tightest:.1}, \"radiusWidestM\": {widest:.1},\n",
+                arcs.iter().filter(|s| s.radius != 0.0).count(),
+            ));
+            json.push_str(&format!(
+                "      \"direction\": {:?}, \"riseM\": {:.2}, \"patch\": {:?},\n",
+                if mean_r > 0.0 { "right" } else { "left" },
+                hmax - hmin,
+                patch,
+            ));
+            match shape {
+                Some(r) => {
+                    json.push_str(&format!(
+                        "      \"grooves\": {:.2}, \"spacingM\": {:.2}, \"floorM\": {:.2}, \"wallDeg\": {:.0},\n",
+                        r.grooves, r.spacing_m, r.floor_m, r.wall_deg,
+                    ));
+                    json.push_str(&format!(
+                        "      \"acrossRmsM\": {:.3}, \"alongRmsM\": {:.3}, \"anisotropy\": {:.2}, \"chatterM\": {:.3},\n",
+                        r.across_rms_m, r.along_rms_m, r.anisotropy, r.chatter_m,
+                    ));
+                    json.push_str(&format!(
+                        "      \"chatterZonesM\": [{:.3}, {:.3}, {:.3}]}}{}\n",
+                        r.chatter_zones_m[0], r.chatter_zones_m[1], r.chatter_zones_m[2],
+                        if n + 1 < chosen.len() { "," } else { "" },
+                    ));
+                }
+                None => json.push_str(&format!("      \"grooves\": null}}{}\n", if n + 1 < chosen.len() { "," } else { "" })),
+            }
+            println!("  corner {n}: {deg:.0} deg over {len_m:.0} m, {} arcs, r {tightest:.0}–{widest:.0} m", radii.len());
+        }
+        json.push_str("  ]\n}\n");
+        std::fs::write(out.join("corners.json"), &json).unwrap();
+        println!("wrote {}", out.join("corners.json").display());
+    }
+
+
+    /// Where each corner starts and ends, which [`crate::trackline::Lap::turns`] cannot say.
+    ///
+    /// Same rule as `trackprog::turns` — a run of same-way arcs, broken by anything straight
+    /// and longer than a nudge — but carrying the positions, because an atlas has to go and
+    /// look at the ground there. Returns `(start_m, end_m, degrees, tightest radius)`.
+    fn corner_runs(lap: &crate::trackline::Lap) -> Vec<(f32, f32, f32, f32)> {
+        const BREAK_M: f32 = 8.0;
+        let mut out = Vec::new();
+        let mut cur: Option<(f32, f32, f32, f32, f32)> = None; // way, start, end, deg, tightest
+        for seg in &lap.segments {
+            let end = seg.at + seg.length;
+            if seg.radius != 0.0 && seg.angle >= crate::trackprog::CORNER_DEG {
+                let way = seg.radius.signum();
+                match cur {
+                    Some((w, st, _, deg, r)) if w == way => {
+                        cur = Some((w, st, end, deg + seg.angle, r.min(seg.radius.abs())));
+                    }
+                    other => {
+                        if let Some((_, st, en, deg, r)) = other {
+                            out.push((st, en, deg, r));
+                        }
+                        cur = Some((way, seg.at, end, seg.angle, seg.radius.abs()));
+                    }
+                }
+            } else if seg.length > BREAK_M {
+                if let Some((_, st, en, deg, r)) = cur.take() {
+                    out.push((st, en, deg, r));
+                }
+            }
+        }
+        if let Some((_, st, en, deg, r)) = cur {
+            out.push((st, en, deg, r));
+        }
+        out
+    }
+
+    /// One corner's patch: heights, and the ground the game paints on them.
+    ///
+    /// The patch is axis-aligned around the corner's own bounding box with a margin, at the
+    /// heightfield's own resolution — the bumps are the subject, so nothing is resampled.
+    fn write_corner_patch(
+        out: &std::path::Path,
+        n: usize,
+        sel: &[&crate::trackline::Station],
+        g: &Grid,
+        layers: &[crate::map::GroundLayer],
+        size_x: f32,
+        size_z: f32,
+    ) -> String {
+        const MARGIN_M: f32 = 12.0;
+        let (mut x0, mut x1, mut z0, mut z1) = (f32::MAX, f32::MIN, f32::MAX, f32::MIN);
+        for s in sel {
+            x0 = x0.min(s.x); x1 = x1.max(s.x);
+            z0 = z0.min(s.z); z1 = z1.max(s.z);
+        }
+        x0 -= MARGIN_M; x1 += MARGIN_M; z0 -= MARGIN_M; z1 += MARGIN_M;
+
+        let mps = size_x / (g.w.max(2) - 1) as f32;
+        let pw = (((x1 - x0) / mps).ceil() as usize).clamp(16, 2048);
+        let ph = (((z1 - z0) / mps).ceil() as usize).clamp(16, 2048);
+
+        let mut buf: Vec<u8> = Vec::with_capacity(32 + pw * ph * 7 + sel.len() * 8);
+        buf.extend_from_slice(b"FRCA");
+        buf.extend_from_slice(&(pw as u32).to_le_bytes());
+        buf.extend_from_slice(&(ph as u32).to_le_bytes());
+        buf.extend_from_slice(&x0.to_le_bytes());
+        buf.extend_from_slice(&z0.to_le_bytes());
+        buf.extend_from_slice(&mps.to_le_bytes());
+
+        // Heights, then the composited ground as RGB.
+        let mut rgb: Vec<u8> = Vec::with_capacity(pw * ph * 3);
+        for j in 0..ph {
+            for i in 0..pw {
+                let x = x0 + i as f32 * mps;
+                let z = z0 + j as f32 * mps;
+                buf.extend_from_slice(&g.at(x, z).to_le_bytes());
+                let [r, gg, b] = ground_at(layers, x, z, size_x, size_z);
+                rgb.push(r); rgb.push(gg); rgb.push(b);
+            }
+        }
+        buf.extend_from_slice(&rgb);
+        buf.extend_from_slice(&(sel.len() as u32).to_le_bytes());
+        for s in sel {
+            buf.extend_from_slice(&s.x.to_le_bytes());
+            buf.extend_from_slice(&s.z.to_le_bytes());
+        }
+        let name = format!("corner{n}.bin");
+        std::fs::write(out.join(&name), &buf).unwrap();
+        name
+    }
+
+    /// The ground stack sampled at one point — base sheet, then every layer its mask lets through.
+    fn ground_at(
+        layers: &[crate::map::GroundLayer],
+        x: f32,
+        z: f32,
+        size_x: f32,
+        size_z: f32,
+    ) -> [u8; 3] {
+        let mut out = [90u8, 80, 70];
+        for (i, l) in layers.iter().enumerate() {
+            let cover = match &l.mask {
+                None => 255u8, // the base layer covers everything
+                Some(m) => {
+                    let mx = ((x / size_x) * m.width as f32) as i64;
+                    let mz = ((z / size_z) * m.height as f32) as i64;
+                    if mx < 0 || mz < 0 || mx >= m.width as i64 || mz >= m.height as i64 {
+                        0
+                    } else {
+                        m.coverage[mz as usize * m.width as usize + mx as usize]
+                    }
+                }
+            };
+            if cover == 0 && i > 0 {
+                continue;
+            }
+            let (sw, sh) = (l.sheet.width.max(1) as f32, l.sheet.height.max(1) as f32);
+            let u = ((x / size_x) * l.tile_u).rem_euclid(1.0) * sw;
+            let v = ((z / size_z) * l.tile_v).rem_euclid(1.0) * sh;
+            let si = ((v as usize).min(sh as usize - 1) * sw as usize + (u as usize).min(sw as usize - 1)) * 4;
+            if si + 2 >= l.sheet.rgba.len() {
+                continue;
+            }
+            let a = cover as f32 / 255.0;
+            for c in 0..3 {
+                out[c] = (out[c] as f32 * (1.0 - a) + l.sheet.rgba[si + c] as f32 * a) as u8;
+            }
+        }
+        out
+    }
+
     /// A published track's race data: where it puts its grid, and in what coordinates.
     ///
     /// ```text

--- a/src-tauri/src/trackstats.rs
+++ b/src-tauri/src/trackstats.rs
@@ -1034,6 +1034,51 @@ fn section_sweep_inner(
     Some((r(&a, &b) + r(&b, &c) + r(&a, &c)) / 3.0)
 }
 
+/// How much a corner's cross-slope changes as you go round it, as the standard deviation of
+/// the across-line gradient.
+///
+/// A berm whose height is a function of the corner's radius alone is the same height all the
+/// way round a constant-radius corner, so every cross-section gets the same tilt and the
+/// corner reads as extruded however well its ruts are made. Measured over four corners each:
+/// Indiana 0.039, Southwick 0.095 — sand piles up far more unevenly — against 0.016-0.022 for
+/// ours. This is the quantity behind [`section_sweep`], and the one worth aiming at, because
+/// it names what to change rather than only saying that something is wrong.
+pub fn camber_spread(stations: &[(f32, f32, f32)], g: &Grid) -> Option<f32> {
+    if stations.len() < 12 {
+        return None;
+    }
+    const HALF_WIDTH_M: f32 = 9.0;
+    const SAMPLES: usize = 48;
+    const CUTS: usize = 20;
+    let n = stations.len();
+    let mut slopes = Vec::with_capacity(CUTS);
+    for c in 0..CUTS {
+        let i = (n - 1) * c / (CUTS - 1);
+        let (x, z, heading) = stations[i];
+        let (rx, rz) = crate::trackprog::right_vector(heading);
+        // Least squares slope of height against offset — the cut's tilt, in metres per metre.
+        let (mut sx, mut sy, mut sxy, mut sxx) = (0.0f32, 0.0f32, 0.0f32, 0.0f32);
+        for k in 0..SAMPLES {
+            let off = -HALF_WIDTH_M + 2.0 * HALF_WIDTH_M * k as f32 / (SAMPLES - 1) as f32;
+            let h = g.at(x + rx * off, z + rz * off);
+            sx += off;
+            sy += h;
+            sxy += off * h;
+            sxx += off * off;
+        }
+        let m = SAMPLES as f32;
+        let den = m * sxx - sx * sx;
+        if den.abs() > 1e-6 {
+            slopes.push((m * sxy - sx * sy) / den);
+        }
+    }
+    if slopes.len() < 4 {
+        return None;
+    }
+    let mean = slopes.iter().sum::<f32>() / slopes.len() as f32;
+    Some((slopes.iter().map(|v| (v - mean) * (v - mean)).sum::<f32>() / slopes.len() as f32).sqrt())
+}
+
 /// [`RutShape`] for a lap over a heightfield, published or generated.
 ///
 /// `stations` is the centreline: `(x, z, heading)` every `step_m` metres.

--- a/src-tauri/src/trackstats.rs
+++ b/src-tauri/src/trackstats.rs
@@ -945,6 +945,95 @@ fn rms(v: &[f32]) -> f32 {
     (v.iter().map(|x| x * x).sum::<f32>() / v.len() as f32).sqrt()
 }
 
+/// How much a corner is the same cut swept round an arc.
+///
+/// Take the profile across the line at the corner's entry, apex and exit and correlate the
+/// three. A published corner scores about **0.1** — the ground at its exit has nothing to do
+/// with the ground at its entry, because ruts braid, merge and die out. A corner extruded
+/// along one radius scores **0.9**: one profile, dragged round.
+///
+/// This is the measure that separates a track that reads as built from one that reads as
+/// generated, and no amount of getting the rut *statistics* right moves it — a swept corner
+/// can have exactly the right groove count, spacing and depth at every station and still be
+/// obviously machine-made, because it has the same ones at every station.
+///
+/// `None` when the corner is too short to cut three independent sections through.
+pub fn section_sweep(stations: &[(f32, f32, f32)], g: &Grid) -> Option<f32> {
+    section_sweep_inner(stations, g, false)
+}
+
+/// The same, with the corner's mean cross-section removed first — see `strip_mean_profile`.
+pub fn section_sweep_ruts(stations: &[(f32, f32, f32)], g: &Grid) -> Option<f32> {
+    section_sweep_inner(stations, g, true)
+}
+
+fn section_sweep_inner(
+    stations: &[(f32, f32, f32)],
+    g: &Grid,
+    strip_mean_profile: bool,
+) -> Option<f32> {
+    if stations.len() < 12 {
+        return None;
+    }
+    const HALF_WIDTH_M: f32 = 9.0;
+    const SAMPLES: usize = 72;
+    let cut = |i: usize| -> Vec<f32> {
+        let (x, z, heading) = stations[i];
+        let (rx, rz) = crate::trackprog::right_vector(heading);
+        let mut v: Vec<f32> = (0..SAMPLES)
+            .map(|k| {
+                let t = -HALF_WIDTH_M + 2.0 * HALF_WIDTH_M * k as f32 / (SAMPLES - 1) as f32;
+                g.at(x + rx * t, z + rz * t)
+            })
+            .collect();
+        // The corner's own slope is not its shape: a banked entry would correlate with a
+        // banked exit on tilt alone and say the ruts matched when they don't.
+        let mean = v.iter().sum::<f32>() / v.len() as f32;
+        for h in &mut v {
+            *h -= mean;
+        }
+        v
+    };
+    let n = stations.len();
+    let (mut a, mut b, mut c) = (cut(n * 15 / 100), cut(n / 2), cut(n * 85 / 100));
+    // Optionally take the corner's *average* cross-section out of all three first. What is
+    // left is only what differs station to station — the ruts — so the pair of numbers says
+    // whether a corner repeats because its ruts repeat, or because the shape they sit in
+    // (camber, width, the berm) is the same shape all the way round.
+    if strip_mean_profile {
+        let mut avg = vec![0.0f32; SAMPLES];
+        let taken = 24.min(n);
+        for k in 0..taken {
+            let v = cut(k * (n - 1) / taken.max(1));
+            for (m, h) in avg.iter_mut().zip(&v) {
+                *m += h / taken as f32;
+            }
+        }
+        for v in [&mut a, &mut b, &mut c] {
+            for (h, m) in v.iter_mut().zip(&avg) {
+                *h -= m;
+            }
+        }
+    }
+    let r = |x: &[f32], y: &[f32]| -> f32 {
+        let (mx, my) = (
+            x.iter().sum::<f32>() / x.len() as f32,
+            y.iter().sum::<f32>() / y.len() as f32,
+        );
+        let (mut num, mut dx, mut dy) = (0.0f32, 0.0f32, 0.0f32);
+        for (p, q) in x.iter().zip(y) {
+            num += (p - mx) * (q - my);
+            dx += (p - mx) * (p - mx);
+            dy += (q - my) * (q - my);
+        }
+        if dx <= 0.0 || dy <= 0.0 {
+            return 0.0;
+        }
+        num / (dx * dy).sqrt()
+    };
+    Some((r(&a, &b) + r(&b, &c) + r(&a, &c)) / 3.0)
+}
+
 /// [`RutShape`] for a lap over a heightfield, published or generated.
 ///
 /// `stations` is the centreline: `(x, z, heading)` every `step_m` metres.
@@ -1841,15 +1930,15 @@ mod tests {
 
         let step = 0.25f32;
         let all = lap.stations(step);
-        let runs = corner_runs(&lap);
+        let runs = crate::trackprog::corner_runs(&lap.program_segments());
         println!("lap {:.0} m, {} segments, {} corners", lap.length, lap.segments.len(), runs.len());
 
         // The four that bend furthest — the ones a rider would name — put back into lap order
         // so the atlas reads like a lap.
         let mut ranked = runs.clone();
-        ranked.sort_by(|x, y| y.2.total_cmp(&x.2));
+        ranked.sort_by(|x, y| y.degrees.total_cmp(&x.degrees));
         let mut chosen: Vec<(f32, f32, f32)> =
-            ranked.into_iter().take(4).map(|(a, b, deg, _)| (deg, a, b)).collect();
+            ranked.into_iter().take(4).map(|r| (r.degrees, r.start_m, r.end_m)).collect();
         chosen.sort_by(|x, y| x.1.total_cmp(&y.1));
 
         let mut json = String::from("{\n");
@@ -1876,6 +1965,7 @@ mod tests {
             let stations: Vec<(f32, f32, f32)> =
                 sel.iter().map(|s| (s.x, s.z, s.heading)).collect();
             let shape = super::rut_shape(&stations, step, &g);
+            let sweep = super::section_sweep(&stations, &g).unwrap_or(f32::NAN);
 
             // The arcs the builder actually typed, which is the shape of the turn.
             let arcs: Vec<&crate::trackline::LineSegment> =
@@ -1900,9 +1990,10 @@ mod tests {
                 arcs.iter().filter(|s| s.radius != 0.0).count(),
             ));
             json.push_str(&format!(
-                "      \"direction\": {:?}, \"riseM\": {:.2}, \"patch\": {:?},\n",
+                "      \"direction\": {:?}, \"riseM\": {:.2}, \"sweep\": {:.3}, \"patch\": {:?},\n",
                 if mean_r > 0.0 { "right" } else { "left" },
                 hmax - hmin,
+                sweep,
                 patch,
             ));
             match shape {
@@ -1923,7 +2014,10 @@ mod tests {
                 }
                 None => json.push_str(&format!("      \"grooves\": null}}{}\n", if n + 1 < chosen.len() { "," } else { "" })),
             }
-            println!("  corner {n}: {deg:.0} deg over {len_m:.0} m, {} arcs, r {tightest:.0}–{widest:.0} m", radii.len());
+            println!(
+                "  corner {n}: {deg:.0} deg over {len_m:.0} m, {} arcs, r {tightest:.0}–{widest:.0} m, sweep {sweep:.2}",
+                radii.len()
+            );
         }
         json.push_str("  ]\n}\n");
         std::fs::write(out.join("corners.json"), &json).unwrap();
@@ -1931,41 +2025,6 @@ mod tests {
     }
 
 
-    /// Where each corner starts and ends, which [`crate::trackline::Lap::turns`] cannot say.
-    ///
-    /// Same rule as `trackprog::turns` — a run of same-way arcs, broken by anything straight
-    /// and longer than a nudge — but carrying the positions, because an atlas has to go and
-    /// look at the ground there. Returns `(start_m, end_m, degrees, tightest radius)`.
-    fn corner_runs(lap: &crate::trackline::Lap) -> Vec<(f32, f32, f32, f32)> {
-        const BREAK_M: f32 = 8.0;
-        let mut out = Vec::new();
-        let mut cur: Option<(f32, f32, f32, f32, f32)> = None; // way, start, end, deg, tightest
-        for seg in &lap.segments {
-            let end = seg.at + seg.length;
-            if seg.radius != 0.0 && seg.angle >= crate::trackprog::CORNER_DEG {
-                let way = seg.radius.signum();
-                match cur {
-                    Some((w, st, _, deg, r)) if w == way => {
-                        cur = Some((w, st, end, deg + seg.angle, r.min(seg.radius.abs())));
-                    }
-                    other => {
-                        if let Some((_, st, en, deg, r)) = other {
-                            out.push((st, en, deg, r));
-                        }
-                        cur = Some((way, seg.at, end, seg.angle, seg.radius.abs()));
-                    }
-                }
-            } else if seg.length > BREAK_M {
-                if let Some((_, st, en, deg, r)) = cur.take() {
-                    out.push((st, en, deg, r));
-                }
-            }
-        }
-        if let Some((_, st, en, deg, r)) = cur {
-            out.push((st, en, deg, r));
-        }
-        out
-    }
 
     /// One corner's patch: heights, and the ground the game paints on them.
     ///

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -404,13 +404,17 @@ const RUT_INSIDE: f32 = -0.022;
 /// ten metres — a cross-section still matches the one two metres behind it four fifths of the
 /// way, half of it at five metres, and by twenty it is different ground.
 ///
-/// Set to ten, which is what the paragraph above measured; it sat at 34 for a while, three
-/// times the figure written directly over it. Measured on Ironbark Ridge over four corners:
-/// 34 gave 0.108 m across-line RMS against published hardpack's 0.110-0.141 — under the
-/// bottom of the range — and ten gives 0.118. It does *not* move `section_sweep` (0.46 to
-/// 0.49 either way), which was the reason for going looking: what repeats round one of our
-/// corners is not the ruts.
-const RUT_ALONG_M: f32 = 10.0;
+/// Left at 34 even though the paragraph above measures ten, and the difference is worth
+/// keeping written down. At ten the across-line RMS goes 0.108 -> 0.118, into published
+/// hardpack's 0.110-0.141 from just under it — and three corpus guardrails fail:
+/// `a_straight_is_not_smooth_either`, `ordinary_ground_still_wears_the_way_it_was_measured`
+/// and `the_deepest_groove_lies_under_the_painted_line`. Ruts that turn over every ten metres
+/// do not survive down a straight and do not stay under the painted line.
+///
+/// So ten is right for a corner and wrong for the rest of the lap, and the change this wants
+/// is a length that varies with the corner rather than a smaller constant. Changed to ten and
+/// committed once without running the suite; this is the revert.
+const RUT_ALONG_M: f32 = 34.0;
 
 /// Metres between braking bumps.
 ///

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -222,7 +222,7 @@ const RUT_RADIUS_M: (f32, f32) = (40.0, 14.0);
 // Measured against Indiana on the same statistic the corpus survey prints, which is the only
 // way to compare: at 0.38 a built lap came back with corner grooves at p50 0.13 and p90 0.24
 // against Indiana's 0.21 and 0.44 — half the depth, and a corner you can see but not sit in.
-const RUT_DEPTH_M: f32 = 0.86;
+const RUT_DEPTH_M: f32 = 1.8;
 const RUT_DEPTH_STRAIGHT_M: f32 = 0.15;
 
 /// The material the cut displaced, which does not disappear.

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -7327,8 +7327,8 @@ mod tests {
 
         println!("\n{} — lap {:.0} m, {} segments, {} corners",
             p.name, s.stations.len() as f32 * STATION_STEP, p.segments.len(), runs.len());
-        println!("{:>5} {:>7} {:>8} {:>8} {:>9} {:>8} {:>8} {:>9} {:>9} {:>7} {:>7}",
-            "turn", "arcs", "bend", "len m", "tight r", "rise m", "grooves", "spacing", "acrossRMS", "sweep", "ruts");
+        println!("{:>5} {:>7} {:>8} {:>8} {:>9} {:>8} {:>8} {:>9} {:>9} {:>7} {:>7} {:>8}",
+            "turn", "arcs", "bend", "len m", "tight r", "rise m", "grooves", "spacing", "acrossRMS", "sweep", "ruts", "camber");
 
         let mut agg: Vec<[f32; 7]> = Vec::new();
         for (n, r) in ranked.iter().enumerate() {
@@ -7343,13 +7343,15 @@ mod tests {
             let sweep = crate::trackstats::section_sweep(&stations, &g).unwrap_or(f32::NAN);
             let sweep_ruts =
                 crate::trackstats::section_sweep_ruts(&stations, &g).unwrap_or(f32::NAN);
+            let camber =
+                crate::trackstats::camber_spread(&stations, &g).unwrap_or(f32::NAN);
             let hs: Vec<f32> = sel.iter().map(|st| g.at(st.x, st.z)).collect();
             let rise = hs.iter().cloned().fold(f32::MIN, f32::max)
                 - hs.iter().cloned().fold(f32::MAX, f32::min);
             let (grooves, spacing, across) =
                 shape.map_or((f32::NAN, f32::NAN, f32::NAN), |q| (q.grooves, q.spacing_m, q.across_rms_m));
-            println!("{n:>5} {:>7} {:>8.0} {:>8.0} {:>9.0} {:>8.1} {:>8.1} {:>9.2} {:>9.3} {:>7.2} {:>7.2}",
-                r.arcs, r.degrees, r.end_m - r.start_m, r.tightest_m, rise, grooves, spacing, across, sweep, sweep_ruts);
+            println!("{n:>5} {:>7} {:>8.0} {:>8.0} {:>9.0} {:>8.1} {:>8.1} {:>9.2} {:>9.3} {:>7.2} {:>7.2} {:>8.4}",
+                r.arcs, r.degrees, r.end_m - r.start_m, r.tightest_m, rise, grooves, spacing, across, sweep, sweep_ruts, camber);
             agg.push([r.arcs as f32, r.degrees, r.end_m - r.start_m, rise, across, sweep, r.tightest_m]);
 
             if let Some(d) = &out_dir {

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -403,7 +403,14 @@ const RUT_INSIDE: f32 = -0.022;
 /// whole thing: twenty to one is a rut, one to one is gravel. Indiana's own figure is about
 /// ten metres — a cross-section still matches the one two metres behind it four fifths of the
 /// way, half of it at five metres, and by twenty it is different ground.
-const RUT_ALONG_M: f32 = 34.0;
+///
+/// Set to ten, which is what the paragraph above measured; it sat at 34 for a while, three
+/// times the figure written directly over it. Measured on Ironbark Ridge over four corners:
+/// 34 gave 0.108 m across-line RMS against published hardpack's 0.110-0.141 — under the
+/// bottom of the range — and ten gives 0.118. It does *not* move `section_sweep` (0.46 to
+/// 0.49 either way), which was the reason for going looking: what repeats round one of our
+/// corners is not the ruts.
+const RUT_ALONG_M: f32 = 10.0;
 
 /// Metres between braking bumps.
 ///
@@ -7266,6 +7273,185 @@ mod tests {
                 rows.len()
             );
         }
+    }
+
+
+    /// How far our lap is from a published one, corner by corner.
+    ///
+    /// The loop this exists for: change the generator, run this, see whether the gap closed.
+    /// Everything is measured off the synthesised heightfield — no Wine, no `.pkz`, seconds
+    /// rather than minutes — on exactly the statistics `trackstats::corner_atlas` reads off a
+    /// real track, so the two columns are comparable by construction.
+    ///
+    /// The targets are the two tracks the corpus was measured on, and they are deliberately
+    /// kept apart: Southwick is sand and Indiana is hardpack, they differ by 2.4x on how rough
+    /// the ground is across the line, and a generator aimed at the average of the two is
+    /// aiming at a surface that does not exist.
+    ///
+    /// ```text
+    /// FROST_PROGRAM=lap.json cargo test --bin mxb-app -- --ignored --nocapture scorecard
+    /// ```
+    #[test]
+    #[ignore = "slow — synthesises a lap"]
+    fn scorecard() {
+        let p: TrackProgram = match std::env::var("FROST_PROGRAM") {
+            Ok(path) => serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap(),
+            Err(_) => serde_json::from_str(DEMO).unwrap(),
+        };
+        let s = synthesise(&p).unwrap();
+        let g = crate::trackstats::Grid {
+            w: s.gw,
+            h: s.gh,
+            size_x: p.terrain.size_x,
+            size_z: p.terrain.size_z,
+            v: s.heights.clone(),
+        };
+        // Optionally write the same patches `trackstats::corner_atlas` dumps for a published
+        // track, so `scripts/corner-atlas.py` draws ours and theirs the same way and the two
+        // pictures can be put side by side. No ground panel: there is no `.map` until the
+        // track is compiled, and texture is a separate job anyway.
+        let out_dir = std::env::var("FROST_OUT").ok().map(std::path::PathBuf::from);
+        if let Some(d) = &out_dir {
+            std::fs::create_dir_all(d).unwrap();
+        }
+        let mut json = format!(
+            "{{\n  \"track\": {:?},\n  \"lapLengthM\": {:.1},\n  \"groundLayers\": [],\n  \"corners\": [\n",
+            p.name, s.stations.len() as f32 * STATION_STEP
+        );
+
+        let runs = crate::trackprog::corner_runs(&p.segments);
+        let mut ranked = runs.clone();
+        ranked.sort_by(|a, b| b.degrees.total_cmp(&a.degrees));
+        ranked.truncate(4);
+        ranked.sort_by(|a, b| a.start_m.total_cmp(&b.start_m));
+
+        println!("\n{} — lap {:.0} m, {} segments, {} corners",
+            p.name, s.stations.len() as f32 * STATION_STEP, p.segments.len(), runs.len());
+        println!("{:>5} {:>7} {:>8} {:>8} {:>9} {:>8} {:>8} {:>9} {:>9} {:>7} {:>7}",
+            "turn", "arcs", "bend", "len m", "tight r", "rise m", "grooves", "spacing", "acrossRMS", "sweep", "ruts");
+
+        let mut agg: Vec<[f32; 7]> = Vec::new();
+        for (n, r) in ranked.iter().enumerate() {
+            let sel: Vec<&Station> =
+                s.stations.iter().filter(|st| st.s >= r.start_m && st.s <= r.end_m).collect();
+            if sel.len() < 12 {
+                continue;
+            }
+            let stations: Vec<(f32, f32, f32)> =
+                sel.iter().map(|st| (st.x, st.z, st.heading)).collect();
+            let shape = crate::trackstats::rut_shape(&stations, STATION_STEP, &g);
+            let sweep = crate::trackstats::section_sweep(&stations, &g).unwrap_or(f32::NAN);
+            let sweep_ruts =
+                crate::trackstats::section_sweep_ruts(&stations, &g).unwrap_or(f32::NAN);
+            let hs: Vec<f32> = sel.iter().map(|st| g.at(st.x, st.z)).collect();
+            let rise = hs.iter().cloned().fold(f32::MIN, f32::max)
+                - hs.iter().cloned().fold(f32::MAX, f32::min);
+            let (grooves, spacing, across) =
+                shape.map_or((f32::NAN, f32::NAN, f32::NAN), |q| (q.grooves, q.spacing_m, q.across_rms_m));
+            println!("{n:>5} {:>7} {:>8.0} {:>8.0} {:>9.0} {:>8.1} {:>8.1} {:>9.2} {:>9.3} {:>7.2} {:>7.2}",
+                r.arcs, r.degrees, r.end_m - r.start_m, r.tightest_m, rise, grooves, spacing, across, sweep, sweep_ruts);
+            agg.push([r.arcs as f32, r.degrees, r.end_m - r.start_m, rise, across, sweep, r.tightest_m]);
+
+            if let Some(d) = &out_dir {
+                let name = write_synth_patch(d, n, &sel, &g);
+                json.push_str(&format!(
+                    "    {{\"n\": {n}, \"atM\": {:.1}, \"endM\": {:.1}, \"lengthM\": {:.1}, \"turnDeg\": {:.1},\n",
+                    r.start_m, r.end_m, r.end_m - r.start_m, r.degrees));
+                json.push_str(&format!(
+                    "      \"arcs\": {}, \"radiusMeanM\": {:.1}, \"radiusTightestM\": {:.1}, \"radiusWidestM\": {:.1},\n",
+                    r.arcs, r.tightest_m, r.tightest_m, r.tightest_m));
+                json.push_str(&format!(
+                    "      \"direction\": \"\", \"riseM\": {rise:.2}, \"sweep\": {sweep:.3}, \"patch\": {name:?},\n"));
+                json.push_str(&format!(
+                    "      \"grooves\": {grooves:.2}, \"spacingM\": {spacing:.2}, \"floorM\": 0.0, \"wallDeg\": 0,\n"));
+                json.push_str(&format!(
+                    "      \"acrossRmsM\": {across:.3}, \"chatterM\": 0.0}},\n"));
+            }
+        }
+        if let Some(d) = &out_dir {
+            // Trim the trailing comma so the file is JSON.
+            if json.ends_with(",\n") {
+                json.truncate(json.len() - 2);
+                json.push('\n');
+            }
+            json.push_str("  ]\n}\n");
+            std::fs::write(d.join("corners.json"), &json).unwrap();
+            println!("  wrote {}", d.join("corners.json").display());
+        }
+        if agg.is_empty() {
+            println!("  no corner long enough to measure");
+            return;
+        }
+        let mean = |i: usize| agg.iter().map(|a| a[i]).sum::<f32>() / agg.len() as f32;
+
+        // Measured off the two published tracks by `corner_atlas`, as ranges over four turns.
+        const DIRT: [(&str, f32, f32); 6] = [
+            ("arcs", 9.0, 16.0), ("bend deg", 187.0, 292.0), ("length m", 94.0, 261.0),
+            ("rise m", 4.2, 13.6), ("across rms", 0.110, 0.141), ("sweep", 0.0, 0.20),
+        ];
+        const SAND: [(&str, f32, f32); 6] = [
+            ("arcs", 10.0, 19.0), ("bend deg", 215.0, 338.0), ("length m", 140.0, 292.0),
+            ("rise m", 8.2, 14.2), ("across rms", 0.272, 0.353), ("sweep", 0.0, 0.20),
+        ];
+        for (label, target) in [("hardpack (Indiana)", DIRT), ("sand (Southwick)", SAND)] {
+            println!("\n  vs {label}");
+            let mut inside = 0;
+            for (i, (name, lo, hi)) in target.iter().enumerate() {
+                let got = mean(i);
+                let verdict = if got < *lo {
+                    format!("LOW  by {:.2}", lo - got)
+                } else if got > *hi {
+                    format!("HIGH by {:.2}", got - hi)
+                } else {
+                    inside += 1;
+                    "in range".to_string()
+                };
+                println!("    {name:<11} ours {got:>8.3}   want {lo:>7.3}-{hi:<7.3}  {verdict}");
+            }
+            println!("    {inside}/6 in range");
+        }
+    }
+
+
+    /// One synthesised corner, in the same patch format the published-track atlas writes.
+    fn write_synth_patch(
+        out: &std::path::Path,
+        n: usize,
+        sel: &[&Station],
+        g: &crate::trackstats::Grid,
+    ) -> String {
+        const MARGIN_M: f32 = 12.0;
+        let (mut x0, mut x1, mut z0, mut z1) = (f32::MAX, f32::MIN, f32::MAX, f32::MIN);
+        for s in sel {
+            x0 = x0.min(s.x); x1 = x1.max(s.x);
+            z0 = z0.min(s.z); z1 = z1.max(s.z);
+        }
+        x0 -= MARGIN_M; x1 += MARGIN_M; z0 -= MARGIN_M; z1 += MARGIN_M;
+        let mps = g.size_x / (g.w.max(2) - 1) as f32;
+        let pw = (((x1 - x0) / mps).ceil() as usize).clamp(16, 2048);
+        let ph = (((z1 - z0) / mps).ceil() as usize).clamp(16, 2048);
+
+        let mut buf: Vec<u8> = Vec::with_capacity(32 + pw * ph * 7 + sel.len() * 8);
+        buf.extend_from_slice(b"FRCA");
+        buf.extend_from_slice(&(pw as u32).to_le_bytes());
+        buf.extend_from_slice(&(ph as u32).to_le_bytes());
+        buf.extend_from_slice(&x0.to_le_bytes());
+        buf.extend_from_slice(&z0.to_le_bytes());
+        buf.extend_from_slice(&mps.to_le_bytes());
+        for j in 0..ph {
+            for i in 0..pw {
+                buf.extend_from_slice(&g.at(x0 + i as f32 * mps, z0 + j as f32 * mps).to_le_bytes());
+            }
+        }
+        buf.extend(std::iter::repeat(60u8).take(pw * ph * 3));
+        buf.extend_from_slice(&(sel.len() as u32).to_le_bytes());
+        for s in sel {
+            buf.extend_from_slice(&s.x.to_le_bytes());
+            buf.extend_from_slice(&s.z.to_le_bytes());
+        }
+        let name = format!("corner{n}.bin");
+        std::fs::write(out.join(&name), &buf).unwrap();
+        name
     }
 
     /// What our ruts are shaped like, on the same statistic a published track is measured by.

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -460,6 +460,33 @@ const ACCEL_HEIGHT_M: f32 = 0.07;
 const EDGE_WOBBLE_M: f32 = 2.2;
 const EDGE_WOBBLE_WAVELENGTH_M: f32 = 26.0;
 
+/// How far the deck tilts across the track, metres of fall per metre out, and over what length
+/// of lap the tilt changes.
+///
+/// Ours had none. `deck` is one height per station and every cell across the corridor was set
+/// to it, so the track was flat across its whole width and its only cross-slope was whatever
+/// the berm and the ruts happened to add. Measured as the spread of the across-line gradient
+/// round a corner, that is 0.021 against Indiana's 0.039 and Southwick's 0.095 — and it is why
+/// nothing applied outside the corridor could move it, and why twenty cross-sections through
+/// one of our corners all traced the same envelope while a published corner's fan out by more
+/// than two metres.
+///
+/// A real corner is banked and the bank changes as you go round it: riders build the outside up
+/// over a session and scoop the inside, and neither happens evenly.
+///
+/// `CAMBER_INTO_BEND` is zero on purpose, having been tried at 0.45 and 0.15. A lean that is a
+/// clean function of the corner's radius is constant through a constant-radius corner, which is
+/// the thing being fixed — it made the sweep *worse* (0.46 to 0.55) while the wander alone
+/// improves it. The knob stays because the lean is real and belongs here once it varies too;
+/// it is the constant part that has no business in a corner.
+///
+/// Amplitude set against Indiana rather than by eye. At 0.09 the across-line RMS lands on
+/// 0.137 against Indiana's 0.136, and the camber spread goes 0.021 -> 0.030 against its 0.038.
+/// Above that the RMS overshoots the published range before the camber arrives.
+const CAMBER_MAX: f32 = 0.09;
+const CAMBER_ALONG_M: f32 = 20.0;
+const CAMBER_INTO_BEND: f32 = 0.0;
+
 /// The windrow of spoil left along the edge of a bladed track: how tall it stands above the
 /// riding line, and how far out it reaches.
 ///
@@ -1091,6 +1118,16 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
         // of the track reads from the seat.
         let ground = heights[i];
         let deck = bench.at(s);
+        // Across the track as well as along it — see `CAMBER_MAX`. Tilted about the centre and
+        // clamped to the corridor, so the shoulder is not levered up with it, and folded in
+        // through `w` below so it fades out into the field rather than tipping it.
+        let bend = turn.at(s);
+        let into = -bend.signum() * (bend.abs() * FULL_LEAN_RADIUS_M).clamp(0.0, 1.0);
+        let camber = CAMBER_MAX
+            * (CAMBER_INTO_BEND * into
+                + (1.0 - CAMBER_INTO_BEND)
+                    * fbm(s / CAMBER_ALONG_M, 53.0, r.seed ^ 0xCA33));
+        let deck = deck + camber * t.clamp(-half, half);
         let shoulder = SHOULDER_M * bench_shoulder(ground, deck);
         let w = bench_weight(d, plain_half, shoulder);
         if w > 0.0 {

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -7405,10 +7405,15 @@ mod tests {
                     r.arcs, r.tightest_m, r.tightest_m, r.tightest_m));
                 json.push_str(&format!(
                     "      \"direction\": \"\", \"riseM\": {rise:.2}, \"sweep\": {sweep:.3}, \"patch\": {name:?},\n"));
+                // Real figures. These were zeros while the writer was being sketched, and a
+                // zero that looks like a measurement is worse than a missing field: it read
+                // as "our corners have no chatter at all" against Indiana's 10.5 cm, twice.
+                let (floor, wall, chat) = shape
+                    .map_or((f32::NAN, f32::NAN, f32::NAN), |q| (q.floor_m, q.wall_deg, q.chatter_m));
                 json.push_str(&format!(
-                    "      \"grooves\": {grooves:.2}, \"spacingM\": {spacing:.2}, \"floorM\": 0.0, \"wallDeg\": 0,\n"));
+                    "      \"grooves\": {grooves:.2}, \"spacingM\": {spacing:.2}, \"floorM\": {floor:.3}, \"wallDeg\": {wall:.1},\n"));
                 json.push_str(&format!(
-                    "      \"acrossRmsM\": {across:.3}, \"chatterM\": 0.0}},\n"));
+                    "      \"acrossRmsM\": {across:.3}, \"chatterM\": {chat:.4}}},\n"));
             }
         }
         if let Some(d) = &out_dir {

--- a/src-tauri/src/tracksynth.rs
+++ b/src-tauri/src/tracksynth.rs
@@ -185,6 +185,29 @@ const RIDDEN_SMOOTH: f32 = 0.95;
 const TEXTURE_OCTAVES: u32 = 3;
 const TEXTURE_GAIN: f32 = 0.34;
 
+/// Wheel-scale chop: the half-metre chatter a ridden surface carries, and how deep it runs.
+///
+/// Separate from [`TEXTURE_WAVELENGTH_M`] because the two are different things and one cannot
+/// stand in for the other. The texture is broad-spectrum grain built from three octaves off a
+/// 1.8 m base, so only a fraction of its power lands where a wheel feels it — and measured by
+/// wavelength band against Indiana, a generated corner was short by **nine times** at 0.5-1 m
+/// while matching it at 2-4 m. Scaling the texture cannot fix that: at six times the amplitude
+/// and a tenth of the polish, chatter moved 4.60 cm to 4.87 against Indiana's 10.5, because
+/// the extra power goes where the spectrum already was.
+///
+/// Also unmoved by the texture's wavelength, its octaves and gain, the ridden smoothing, the
+/// rut depth, and the sampling step the measurement uses. All six were tried; this is what was
+/// missing rather than mis-tuned.
+/// Read in track coordinates and stretched across them: short along the direction of travel,
+/// long across it, so the chop stands as ridges a wheel crosses rather than as isotropic
+/// gravel. That ratio is the point. Isotropic, it lifts roughness along and across the line
+/// equally, and a published corner is not equal — Indiana's chatter is 77% of its across-line
+/// RMS where an isotropic field gives 39%, so matching the chatter meant overshooting the
+/// across-line figure by half before it arrived.
+const CHOP_WAVELENGTH_M: f32 = 0.55;
+const CHOP_ACROSS_M: f32 = 3.0;
+const CHOP_M: f32 = 0.30;
+
 /// The same, for the field that lays out where the grooves go.
 const RUT_FIELD_OCTAVES: u32 = 2;
 const RUT_FIELD_GAIN: f32 = 0.32;
@@ -1403,6 +1426,20 @@ pub fn synthesise(prog: &TrackProgram) -> Result<Synth> {
                 * gain
                 * polished
                 * (0.25 * w + 0.75 * across);
+            // And the chop at the scale of a wheel — see `CHOP_WAVELENGTH_M`. One octave, so
+            // all of it lands in the band it is for, and polished far less than the grain is:
+            // a published line is not smooth, it is the most worked-over strip on the track.
+            heights[i] += fbm_of(
+                s / CHOP_WAVELENGTH_M,
+                t / CHOP_ACROSS_M,
+                r.seed ^ 0xC40F,
+                1,
+                0.5,
+            ) * CHOP_M
+                * gain
+                * (0.45 + 0.55 * polished)
+                * w;
+
             // The seams between the machine's passes, running the way it drove.
             heights[i] -= ((t / PASS_SPACING_M) * std::f32::consts::TAU).sin().abs()
                 * PASS_DEPTH_M


### PR DESCRIPTION
Measures a published track's corners, scores ours against them, and closes three of the gaps that turned up.

## The tools

`trackstats::corner_atlas` dumps the four biggest turns of any `.pkz` — height patch, ground stack composited through its masks, params — and `scripts/corner-atlas.py` draws five panels each. `tracksynth::scorecard` does the same for a generated lap in eight seconds, no Wine, and prints the gap against hardpack (Indiana) and sand (Southwick) **separately** — they differ 2.4× on across-line roughness and the average of the two is a surface that does not exist.

`trackprog::corner_runs` is the piece that was missing everywhere: `turns` says how many corners and how tight, never where.

## The fixes

**The deck was flat across its width.** One height per station, every cell across the corridor set to it, so a corner's only cross-slope was what the ruts scratched in. Camber spread 0.021 → 0.030 against Indiana's 0.038.

**The ruts were half as deep as a published corner's.** Every statistic was coming out at roughly half — grooves 1.7 vs 3.6, wall 20° vs 41° — and it was one cause, not four. `RUT_DEPTH_M` 0.86 → 1.8: wall 20° → 35°, floor 0.87 → 0.92 m, across-line RMS 0.090 → 0.125.

**Nothing existed at the scale of a wheel.** By wavelength band, a generated corner was short by **9×** at 0.5–1 m while matching at 2–4 m: all the surface detail was landing one band too coarse. `CHOP_M` adds one octave at 0.55 m, read in track coordinates and stretched 3 m across them so it stands as ridges you cross rather than isotropic gravel — Indiana's chatter is 77% of its across-line RMS where isotropic noise gives 39%.

|  | before | after | Indiana |
| --- | --- | --- | --- |
| wall angle | 20° | 36° | 41° |
| across-line RMS | 0.090 | 0.136 | 0.136 |
| chatter | 4.9 cm | 5.9 cm | 10.5 cm |
| camber spread | 0.021 | 0.030 | 0.038 |
| **sweep** | **0.46** | **0.15** | **0.11** |

The sweep falling to 0.15 was not the aim and is the biggest move it made: a corner stops reading as one cut swept round an arc once its surface differs at the scale the cut is measured on.

## Two measurement bugs of mine, both fixed

The scorecard wrote `"chatterM": 0.0` as a placeholder, which read back as "our corners have no chatter at all" against Indiana's 10.5 — twice, because the first fix was reverted with the file it lived in. And `corner-atlas.py` normalised each picture to its own 99th percentile, so a smooth corner and a rough one filled the same colours and every comparison image lied. Both pinned.

## Recorded dead ends

Written into the source so they are not retried: varying the berm along the lap (moves camber by 0.001), varying the grading reach (works only by corrugating the field — `the_field_is_smoother_than_the_track` catches it), wandering the rut bundle (no visible or measured change), and `RUT_ALONG_M` as a flat 10 (breaks three corpus guardrails; it needs to vary with the corner).

65/65 tracksynth guardrails pass. Verified end to end: program → terrain → terrained/tracked under Wine → 117 MB `.pkz` → opened in the app's own 3D viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)