### PR TITLE
feat(settings): an interface size, for a big monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 - FrostMod's status sits in the top bar, on every screen, with Start, Stop and Reload behind
   it. The dot says whether it is running and whether it actually reached the game.
+- Interface size in Settings, from 90% to 160%. It scales the whole interface, not just the
+  text, for a large or high-resolution monitor.
 - Random track in the Track Studio. It draws a whole track from a number — no brief to write
   and nothing to wait for — and you edit it like any other.
 

--- a/apps/manager/src-tauri/capabilities/default.json
+++ b/apps/manager/src-tauri/capabilities/default.json
@@ -12,6 +12,7 @@
     "core:window:allow-unmaximize",
     "core:window:allow-toggle-maximize",
     "core:window:allow-close",
+    "core:webview:allow-set-webview-zoom",
     "dialog:default",
     "dialog:allow-open",
     "dialog:allow-save",

--- a/apps/manager/src/Components/Settings/Settings.tsx
+++ b/apps/manager/src/Components/Settings/Settings.tsx
@@ -90,7 +90,9 @@ import SupportersCard from "./SupportersCard";
 import {
   COLORWAYS,
   COLORWAY_SWATCH,
+  UI_SCALES,
   useTheme,
+  type UiScale,
   type Colorway,
   type ThemeMode,
 } from "../../Context/Theme";
@@ -300,7 +302,7 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
   // everywhere it runs: natively on Windows, under Proton on Linux, in a CrossOver/Whisky
   // bottle on macOS. The app starts FrostMod in whichever prefix holds the game.
   const hasFrostmod = isWindows || platform === "linux" || isMac;
-  const { theme, setTheme, colorway, setColorway } = useTheme();
+  const { theme, setTheme, colorway, setColorway, scale, setScale } = useTheme();
   const { running, reload, status, installing, checking, statusError, install, start, stop, refreshStatus, missingRuntime, installRuntime, installingRuntime, repairRuntimes, repairingRuntimes, strayMsvcr90, clearingStray, clearStrayMsvcr90 } =
     useFrostmod();
   const { check: checkForUpdates } = useUpdate();
@@ -1728,6 +1730,30 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
                   {t(COLORWAY_LABEL[colorway])}
                 </span>
               </div>
+            </div>
+
+            {/* The webview's own zoom, so it moves type, spacing and icons together.
+                Scaling the root font instead would leave the app's 778 pixel-valued
+                type sizes exactly where they were. */}
+            <div className="mt-3 flex items-center justify-between">
+              <span className="text-[12.5px] text-foreground/85">
+                {t("settings.uiScale")}
+              </span>
+              <Select
+                value={String(scale)}
+                onValueChange={(v) => setScale(Number(v) as UiScale)}
+              >
+                <SelectTrigger className="h-8 w-[180px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {UI_SCALES.map((factor) => (
+                    <SelectItem key={factor} value={String(factor)}>
+                      {Math.round(factor * 100)}%
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
 
             {/* A Select, not a Segmented control — seven options don't fit the

--- a/apps/manager/src/Context/Theme.tsx
+++ b/apps/manager/src/Context/Theme.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 
 export type ThemeMode = "light" | "dark" | "system";
 
@@ -25,6 +26,18 @@ export const COLORWAYS = [
   "retro",
 ] as const;
 export type Colorway = (typeof COLORWAYS)[number];
+
+/**
+ * How big the interface is drawn, as a multiplier.
+ *
+ * This is the webview's own zoom, not a font size. The app writes 778 type sizes as
+ * arbitrary pixel values (`text-[13px]`), so scaling the root font would move the rem-based
+ * spacing and leave nearly all of the text where it was. Zoom scales the rendered page
+ * whole — type, spacing, icons and borders together — which is what "the font is too small
+ * on 1440p" is actually asking for.
+ */
+export const UI_SCALES = [0.9, 1, 1.1, 1.25, 1.4, 1.6] as const;
+export type UiScale = (typeof UI_SCALES)[number];
 
 /** `[accent, chrome]` — what a colorway's swatch is drawn from. */
 export const COLORWAY_SWATCH: Record<Colorway, [string, string]> = {
@@ -46,12 +59,19 @@ interface ThemeContextValue {
   /** The palette applied on top of light/dark. */
   colorway: Colorway;
   setColorway: (colorway: Colorway) => void;
+  /** How big the interface is drawn. 1 is the design size. */
+  scale: UiScale;
+  setScale: (scale: UiScale) => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 
 const STORAGE_KEY = "frost-theme";
 const COLORWAY_KEY = "frost-colorway";
+const SCALE_KEY = "frost-ui-scale";
+
+/** The in-game overlay loads the same bundle with `?overlay=1` — see `main.tsx`. */
+const IS_OVERLAY = new URLSearchParams(window.location.search).has("overlay");
 
 function readStored(): ThemeMode {
   const v = localStorage.getItem(STORAGE_KEY);
@@ -65,6 +85,11 @@ function readStoredColorway(): Colorway {
   return COLORWAYS.includes(v as Colorway) ? (v as Colorway) : "frost";
 }
 
+function readStoredScale(): UiScale {
+  const v = Number(localStorage.getItem(SCALE_KEY));
+  return (UI_SCALES as readonly number[]).includes(v) ? (v as UiScale) : 1;
+}
+
 function systemPrefersDark() {
   return window.matchMedia("(prefers-color-scheme: dark)").matches;
 }
@@ -72,6 +97,7 @@ function systemPrefersDark() {
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setThemeState] = useState<ThemeMode>(readStored);
   const [colorway, setColorwayState] = useState<Colorway>(readStoredColorway);
+  const [scale, setScaleState] = useState<UiScale>(readStoredScale);
   const [systemDark, setSystemDark] = useState(systemPrefersDark);
 
   // Track OS theme changes for `system`.
@@ -88,6 +114,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     const onStorage = (e: StorageEvent) => {
       if (e.key === STORAGE_KEY) setThemeState(readStored());
       if (e.key === COLORWAY_KEY) setColorwayState(readStoredColorway());
+      if (e.key === SCALE_KEY) setScaleState(readStoredScale());
     };
     window.addEventListener("storage", onStorage);
     return () => window.removeEventListener("storage", onStorage);
@@ -110,6 +137,16 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     document.documentElement.dataset.colorway = colorway;
   }, [colorway]);
 
+  // Zoom is per-webview and does not persist across launches, so it is applied on mount as
+  // well as on change. Never to the overlay: it is sized against the game's screen, not the
+  // desk this window sits on, and scaling it would push it over what it is meant to annotate.
+  useEffect(() => {
+    if (IS_OVERLAY) return;
+    getCurrentWebview()
+      .setZoom(scale)
+      .catch((e) => console.warn("could not set the interface scale", e));
+  }, [scale]);
+
   const setTheme = (mode: ThemeMode) => {
     localStorage.setItem(STORAGE_KEY, mode);
     setThemeState(mode);
@@ -120,9 +157,14 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     setColorwayState(next);
   };
 
+  const setScale = (next: UiScale) => {
+    localStorage.setItem(SCALE_KEY, String(next));
+    setScaleState(next);
+  };
+
   const value = useMemo(
-    () => ({ theme, resolved, setTheme, colorway, setColorway }),
-    [theme, resolved, colorway],
+    () => ({ theme, resolved, setTheme, colorway, setColorway, scale, setScale }),
+    [theme, resolved, colorway, scale],
   );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;

--- a/apps/manager/src/i18n/locales/de.ts
+++ b/apps/manager/src/i18n/locales/de.ts
@@ -599,6 +599,7 @@ export const de: Translation = {
   "settings.themeDark": "Dunkel",
   "settings.themeSystem": "System",
   "settings.colorway": "Farbwelt",
+  "settings.uiScale": "Oberflächengröße",
   "settings.colorwayFrost": "Frost",
   "settings.colorwayEmber": "Glut",
   "settings.colorwayMoss": "Moos",

--- a/apps/manager/src/i18n/locales/en.ts
+++ b/apps/manager/src/i18n/locales/en.ts
@@ -585,6 +585,7 @@ export const en = {
   "settings.themeDark": "Dark",
   "settings.themeSystem": "System",
   "settings.colorway": "Colorway",
+  "settings.uiScale": "Interface size",
   "settings.colorwayFrost": "Frost",
   "settings.colorwayEmber": "Ember",
   "settings.colorwayMoss": "Moss",

--- a/apps/manager/src/i18n/locales/es.ts
+++ b/apps/manager/src/i18n/locales/es.ts
@@ -592,6 +592,7 @@ export const es: Translation = {
   "settings.themeDark": "Oscuro",
   "settings.themeSystem": "Sistema",
   "settings.colorway": "Paleta",
+  "settings.uiScale": "Tamaño de la interfaz",
   "settings.colorwayFrost": "Escarcha",
   "settings.colorwayEmber": "Brasa",
   "settings.colorwayMoss": "Musgo",

--- a/apps/manager/src/i18n/locales/fr.ts
+++ b/apps/manager/src/i18n/locales/fr.ts
@@ -596,6 +596,7 @@ export const fr: Translation = {
   "settings.themeDark": "Sombre",
   "settings.themeSystem": "Système",
   "settings.colorway": "Palette",
+  "settings.uiScale": "Taille de l'interface",
   "settings.colorwayFrost": "Givre",
   "settings.colorwayEmber": "Braise",
   "settings.colorwayMoss": "Mousse",

--- a/apps/manager/src/i18n/locales/it.ts
+++ b/apps/manager/src/i18n/locales/it.ts
@@ -591,6 +591,7 @@ export const it: Translation = {
   "settings.themeDark": "Scuro",
   "settings.themeSystem": "Sistema",
   "settings.colorway": "Palette",
+  "settings.uiScale": "Dimensione dell'interfaccia",
   "settings.colorwayFrost": "Gelo",
   "settings.colorwayEmber": "Brace",
   "settings.colorwayMoss": "Muschio",

--- a/apps/manager/src/i18n/locales/pt-BR.ts
+++ b/apps/manager/src/i18n/locales/pt-BR.ts
@@ -594,6 +594,7 @@ export const ptBR: Translation = {
   "settings.themeDark": "Escuro",
   "settings.themeSystem": "Sistema",
   "settings.colorway": "Paleta",
+  "settings.uiScale": "Tamanho da interface",
   "settings.colorwayFrost": "Gelo",
   "settings.colorwayEmber": "Brasa",
   "settings.colorwayMoss": "Musgo",


### PR DESCRIPTION
User report: *"I would love to see a resizable font adjustment as the font is a tad too small for 1440p monitor at least."*

**Interface size** in Settings, 90% to 160%, beside the theme and the colorway and persisted the same way.

## Why zoom rather than a font size

The obvious implementation — a `--ui-scale` token driving the root font size — does not work in this codebase. It writes **778 type sizes as arbitrary pixel values** (`text-[13px]`, `text-[14.5px]`). Scaling the root font would move the rem-based Tailwind spacing and leave nearly all of the text exactly where it was, which reads as a broken layout rather than a bigger UI.

The webview's own zoom scales the rendered page whole — type, spacing, icons, borders — which is what the request actually asks for.

## Details worth knowing

- **Never applied to the overlay.** The in-game overlay is a second webview on the same origin (`?overlay=1`). It is sized against the game's screen, not the desk this window sits on, so scaling it would push it over the thing it annotates.
- **Zoom does not survive a relaunch**, so it is applied on mount as well as on change.
- **`core:webview:allow-set-webview-zoom`** is granted to the main window. The identifier is checked against `gen/schemas/desktop-schema.json` rather than typed from memory — a wrong one fails the Rust build, not the typecheck.
- `settings.uiScale` added to all six locales, since `Translation` is `Record<keyof typeof en, string>`.

## Verification

Typecheck, lint and the production build pass.

**Not seen running.** Another session holds :1420, which the debug binary bakes in, and the app renders blank outside Tauri. The zoom call itself is one line against a documented API, but the step sizes are a judgement call best made looking at it — if 160% is not enough at 1440p, the array in `Theme.tsx` is the only thing to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)