### PR TITLE
feat(browse): choose which download to take when a mod offers several

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   it. The dot says whether it is running and whether it actually reached the game.
 - Interface size in Settings, from 90% to 160%. It scales the whole interface, not just the
   text, for a large or high-resolution monitor.
+- Two download preferences in Settings. "Prefer dedicated-server files" takes the server
+  build wherever a mod ships one, so a server machine can quick-install a whole selection
+  without opening each mod. "Preferred download host" takes MediaFire, or whichever host you
+  pick, ahead of the others when a mod is mirrored on several.
 - Random track in the Track Studio. It draws a whole track from a number — no brief to write
   and nothing to wait for — and you edit it like any other.
 

--- a/apps/manager/src/Components/Settings/Settings.tsx
+++ b/apps/manager/src/Components/Settings/Settings.tsx
@@ -98,6 +98,12 @@ import {
 import { Trans, APP_NAME } from "@/i18n";
 import { useI18n, type LocalePref, type TKey } from "@/i18n";
 import { getLocale, LOCALE_OPTIONS } from "@/i18n";
+import {
+  KNOWN_HOSTS,
+  readDownloadPrefs,
+  writeDownloadPrefs,
+  type DownloadPrefs,
+} from "@frost/shared/lib/downloadPrefs";
 import { useFrostmod } from "../../Context/FrostmodContext";
 import { prettyHotkey } from "../../lib/hotkey";
 import { formatBytes, formatDateShort } from "@frost/shared/lib/mods";
@@ -302,6 +308,12 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
   // bottle on macOS. The app starts FrostMod in whichever prefix holds the game.
   const hasFrostmod = isWindows || platform === "linux" || isMac;
   const { theme, setTheme, colorway, setColorway, scale, setScale } = useTheme();
+  // Which download to take when a mod offers several — see `lib/downloadPrefs`.
+  const [dlPrefs, setDlPrefsState] = useState<DownloadPrefs>(readDownloadPrefs);
+  const setDlPrefs = useCallback((next: DownloadPrefs) => {
+    writeDownloadPrefs(next);
+    setDlPrefsState(next);
+  }, []);
   const { running, reload, status, installing, checking, statusError, install, start, stop, refreshStatus, missingRuntime, installRuntime, installingRuntime, repairRuntimes, repairingRuntimes, strayMsvcr90, clearingStray, clearStrayMsvcr90 } =
     useFrostmod();
   const { check: checkForUpdates } = useUpdate();
@@ -1280,6 +1292,47 @@ export default function Settings({ initialSection, onShowWhatsNew }: SettingsPro
               checked={paintSyncEnabled}
               onChange={togglePaintSync}
             />
+            <div className="h-px bg-border" />
+            {/* Which file to take when a mod ships the same thing twice. Both of these are
+                one-click-install problems: without them a dedicated-server rig picks the
+                server build by hand on every mod, and a Drive link that answers "too many
+                downloads" has to be stepped past by hand too. */}
+            <ToggleRow
+              label={t("settings.preferServer")}
+              desc={t("settings.preferServerDesc")}
+              checked={dlPrefs.preferServer}
+              onChange={(v) => setDlPrefs({ ...dlPrefs, preferServer: v })}
+            />
+            <div className="h-px bg-border" />
+            <div className="flex items-center justify-between gap-4 py-3">
+              <div className="min-w-0">
+                <div className="text-[12.5px] text-foreground/85">
+                  {t("settings.preferredHost")}
+                </div>
+                <p className="mt-0.5 text-[11px] text-muted-foreground">
+                  {t("settings.preferredHostDesc")}
+                </p>
+              </div>
+              <Select
+                value={dlPrefs.preferredHost || "none"}
+                onValueChange={(v) =>
+                  setDlPrefs({ ...dlPrefs, preferredHost: v === "none" ? "" : v })
+                }
+              >
+                <SelectTrigger className="h-8 w-[180px] flex-none">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">{t("settings.preferredHostNone")}</SelectItem>
+                  {KNOWN_HOSTS.map((h) => (
+                    <SelectItem key={h.id} value={h.id}>
+                      {h.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
             {secureAvailable && (
               <>
                 <div className="h-px bg-border" />

--- a/apps/manager/src/i18n/locales/de.ts
+++ b/apps/manager/src/i18n/locales/de.ts
@@ -607,6 +607,11 @@ export const de: Translation = {
   "settings.colorwayRetro": "Retro",
   "settings.language": "Sprache",
   "settings.languageSystem": "System",
+  "settings.preferServer": "Dateien für dedizierte Server bevorzugen",
+  "settings.preferServerDesc": "Die Dedicated-Server-Version nehmen, wenn ein Mod eine anbietet. Für einen Rechner, der einen Server betreibt statt zu spielen.",
+  "settings.preferredHost": "Bevorzugter Download-Anbieter",
+  "settings.preferredHostDesc": "Wenn ein Mod bei mehreren Anbietern liegt, diesen zuerst nehmen.",
+  "settings.preferredHostNone": "Keine Präferenz",
   "settings.runInBackground": "Im Hintergrund weiterlaufen",
   "settings.runInBackgroundDesc":
     "Beim Schließen des Fensters läuft {{app}} im Infobereich weiter, damit FrostMod verbunden bleibt. Beenden über das Symbol im Infobereich.",

--- a/apps/manager/src/i18n/locales/en.ts
+++ b/apps/manager/src/i18n/locales/en.ts
@@ -593,6 +593,11 @@ export const en = {
   "settings.colorwayRetro": "Retro",
   "settings.language": "Language",
   "settings.languageSystem": "System",
+  "settings.preferServer": "Prefer dedicated-server files",
+  "settings.preferServerDesc": "Take the dedicated-server build where a mod ships one. For a machine running a server rather than playing.",
+  "settings.preferredHost": "Preferred download host",
+  "settings.preferredHostDesc": "Where a mod is mirrored on several hosts, take this one first.",
+  "settings.preferredHostNone": "No preference",
   "settings.runInBackground": "Keep running in the background",
   "settings.runInBackgroundDesc":
     "Closing the window hides {{app}} to the tray so FrostMod stays connected. Quit from the tray icon.",

--- a/apps/manager/src/i18n/locales/es.ts
+++ b/apps/manager/src/i18n/locales/es.ts
@@ -600,6 +600,11 @@ export const es: Translation = {
   "settings.colorwayRetro": "Retro",
   "settings.language": "Idioma",
   "settings.languageSystem": "Sistema",
+  "settings.preferServer": "Preferir archivos de servidor dedicado",
+  "settings.preferServerDesc": "Tomar la versión de servidor dedicado cuando un mod la ofrezca. Para una máquina que aloja un servidor en lugar de jugar.",
+  "settings.preferredHost": "Servidor de descarga preferido",
+  "settings.preferredHostDesc": "Cuando un mod está en varios servidores, tomar este primero.",
+  "settings.preferredHostNone": "Sin preferencia",
   "settings.runInBackground": "Seguir en segundo plano",
   "settings.runInBackgroundDesc":
     "Cerrar la ventana deja {{app}} en la bandeja del sistema para que FrostMod siga conectado. Sal desde el icono de la bandeja.",

--- a/apps/manager/src/i18n/locales/fr.ts
+++ b/apps/manager/src/i18n/locales/fr.ts
@@ -604,6 +604,11 @@ export const fr: Translation = {
   "settings.colorwayRetro": "Rétro",
   "settings.language": "Langue",
   "settings.languageSystem": "Système",
+  "settings.preferServer": "Préférer les fichiers serveur dédié",
+  "settings.preferServerDesc": "Prendre la version serveur dédié quand un mod en propose une. Pour une machine qui héberge un serveur plutôt que pour jouer.",
+  "settings.preferredHost": "Hébergeur préféré",
+  "settings.preferredHostDesc": "Quand un mod est disponible sur plusieurs hébergeurs, prendre celui-ci en premier.",
+  "settings.preferredHostNone": "Aucune préférence",
   "settings.runInBackground": "Continuer en arrière-plan",
   "settings.runInBackgroundDesc":
     "Fermer la fenêtre place {{app}} dans la barre d'état pour que FrostMod reste connecté. Quittez depuis l'icône de la barre.",

--- a/apps/manager/src/i18n/locales/it.ts
+++ b/apps/manager/src/i18n/locales/it.ts
@@ -599,6 +599,11 @@ export const it: Translation = {
   "settings.colorwayRetro": "Retrò",
   "settings.language": "Lingua",
   "settings.languageSystem": "Sistema",
+  "settings.preferServer": "Preferisci i file per server dedicato",
+  "settings.preferServerDesc": "Prendere la versione per server dedicato quando un mod la offre. Per una macchina che ospita un server invece di giocare.",
+  "settings.preferredHost": "Host di download preferito",
+  "settings.preferredHostDesc": "Quando un mod è su più host, prendere prima questo.",
+  "settings.preferredHostNone": "Nessuna preferenza",
   "settings.runInBackground": "Continua in background",
   "settings.runInBackgroundDesc":
     "Chiudendo la finestra, {{app}} resta nella barra di sistema così FrostMod rimane collegato. Esci dall'icona nella barra.",

--- a/apps/manager/src/i18n/locales/pt-BR.ts
+++ b/apps/manager/src/i18n/locales/pt-BR.ts
@@ -602,6 +602,11 @@ export const ptBR: Translation = {
   "settings.colorwayRetro": "Retrô",
   "settings.language": "Idioma",
   "settings.languageSystem": "Sistema",
+  "settings.preferServer": "Preferir arquivos de servidor dedicado",
+  "settings.preferServerDesc": "Pegar a versão de servidor dedicado quando um mod oferecer uma. Para uma máquina que hospeda um servidor em vez de jogar.",
+  "settings.preferredHost": "Host de download preferido",
+  "settings.preferredHostDesc": "Quando um mod está em vários hosts, pegar este primeiro.",
+  "settings.preferredHostNone": "Sem preferência",
   "settings.runInBackground": "Continuar em segundo plano",
   "settings.runInBackgroundDesc":
     "Fechar a janela deixa o {{app}} na bandeja do sistema para o FrostMod continuar conectado. Saia pelo ícone da bandeja.",

--- a/packages/shared/src/api/mods.ts
+++ b/packages/shared/src/api/mods.ts
@@ -65,6 +65,7 @@ import type {
   LockProgress,
 } from "../types";
 import type { BaseTKey } from "../i18n/core";
+import { isHost, readDownloadPrefs, type DownloadPrefs } from "../lib/downloadPrefs";
 
 /** Results per page (mirrors `PER_PAGE` in the Rust backend). */
 export const SEARCH_PAGE_SIZE = 24;
@@ -1683,12 +1684,28 @@ export function isBlockedDownload(opt: { url: string; host: string }): boolean {
  * off the page, and a server build the parser missed was silently preselected instead.
  * Ranked below even a browser-only mirror, since that at least installs something playable.
  */
-export function sortMirrors(detail: ModDetail): DownloadOption[] {
+export function sortMirrors(
+  detail: ModDetail,
+  prefs: DownloadPrefs = readDownloadPrefs(),
+): DownloadOption[] {
   return [...(detail.downloads ?? [])].sort((a, b) => {
-    if (a.isServer !== b.isServer) return Number(a.isServer) - Number(b.isServer);
+    // Server builds last, unless someone has said they want them — a dedicated-server rig
+    // installs nothing else, and picking it by hand on every mod is the thing being fixed.
+    if (a.isServer !== b.isServer) {
+      const rank = (m: DownloadOption) =>
+        prefs.preferServer ? Number(!m.isServer) : Number(m.isServer);
+      return rank(a) - rank(b);
+    }
     const ab = isBlockedDownload(a) ? 1 : 0;
     const bb = isBlockedDownload(b) ? 1 : 0;
     if (ab !== bb) return ab - bb;
+    // Then the preferred host, above even the author's own "Default" — a Drive link that
+    // answers "too many downloads" is marked default just as often as one that works.
+    if (prefs.preferredHost) {
+      const ah = isHost(a, prefs.preferredHost) ? 0 : 1;
+      const bh = isHost(b, prefs.preferredHost) ? 0 : 1;
+      if (ah !== bh) return ah - bh;
+    }
     return Number(b.isDefault) - Number(a.isDefault);
   });
 }
@@ -1702,7 +1719,14 @@ export function playableMirrors(mirrors: DownloadOption[]): DownloadOption[] {
  * Which of `mirrors` (in {@link sortMirrors} order) a picker should start on: the best
  * playable file, never a server build while anything else is on offer.
  */
-export function defaultMirrorIndex(mirrors: DownloadOption[]): number {
+export function defaultMirrorIndex(
+  mirrors: DownloadOption[],
+  prefs: DownloadPrefs = readDownloadPrefs(),
+): number {
+  if (prefs.preferServer) {
+    const server = mirrors.findIndex((m) => m.isServer);
+    if (server >= 0) return server;
+  }
   const i = mirrors.findIndex((m) => !m.isServer);
   return i >= 0 ? i : 0;
 }
@@ -1940,14 +1964,17 @@ export async function resolveQuickInstall(
   game: GameInfo,
   categoryId: number | null | undefined,
 ): Promise<QuickInstallResult> {
+  const prefs = readDownloadPrefs();
   const detail = await getModDetail(slug);
-  const mirrors = sortMirrors(detail);
-  const primary = mirrors[defaultMirrorIndex(mirrors)];
+  const mirrors = sortMirrors(detail, prefs);
+  const primary = mirrors[defaultMirrorIndex(mirrors, prefs)];
   if (!primary) return { ok: false, reason: "none", title: detail.title };
   // One click can't ask which build was meant, and a dedicated-server file installed by
   // mistake looks installed while the game shows nothing. Send them to the mod's page,
-  // where every download is spelled out.
-  if (primary.isServer) return { ok: false, reason: "serverOnly", title: detail.title };
+  // where every download is spelled out — unless they have said server builds are what
+  // they want, which is exactly the answer this refusal could not guess.
+  if (primary.isServer && !prefs.preferServer)
+    return { ok: false, reason: "serverOnly", title: detail.title };
   if (isBlockedDownload(primary))
     return { ok: false, reason: "blocked", title: detail.title, host: primary.host };
 

--- a/packages/shared/src/lib/downloadPrefs.ts
+++ b/packages/shared/src/lib/downloadPrefs.ts
@@ -1,0 +1,93 @@
+/**
+ * Which download to take when a mod offers several.
+ *
+ * A mod on mxb-mods often ships the same file on two or three hosts, and sometimes a
+ * dedicated-server build beside the playable one. The app already ranks them — server builds
+ * last, hosts we can't fetch unattended below the rest — but that ranking is fixed, and two
+ * people want opposite things from it:
+ *
+ * - someone running a dedicated server wants the server build *every time*, and today has to
+ *   open each mod and pick it by hand, because quick install refuses a server-only mod
+ *   outright rather than guess;
+ * - a Google Drive link that has been shared widely returns "too many downloads", so the
+ *   MediaFire copy beside it is the one that actually works — and today that is a manual
+ *   pick on every mod too.
+ *
+ * Both are one stored preference, applied wherever a mirror gets chosen.
+ */
+
+/** What the user wants taken when there is a choice. */
+export interface DownloadPrefs {
+  /**
+   * Prefer the dedicated-server build where a mod offers one.
+   *
+   * Off by default: a server file installs cleanly and then the game shows nothing, so it is
+   * the wrong guess for almost everyone. On, it also lets quick install take a server-only
+   * mod rather than refusing it.
+   */
+  preferServer: boolean;
+  /** {@link KNOWN_HOSTS} id to prefer, or `""` for no preference. */
+  preferredHost: string;
+}
+
+export const DEFAULT_DOWNLOAD_PREFS: DownloadPrefs = {
+  preferServer: false,
+  preferredHost: "",
+};
+
+/**
+ * The hosts worth naming, and the fragments that identify one.
+ *
+ * `DownloadOption.host` is a label scraped off the page, not a domain — "Media Fire" and
+ * "drive.google.com" are both real values — so matching normalises away everything but
+ * letters and digits and then looks for a fragment.
+ */
+export const KNOWN_HOSTS: { id: string; label: string; match: string[] }[] = [
+  { id: "mediafire", label: "MediaFire", match: ["mediafire"] },
+  { id: "gdrive", label: "Google Drive", match: ["googledrive", "drivegoogle", "docsgoogle"] },
+  { id: "mega", label: "MEGA", match: ["meganz", "megaio"] },
+  { id: "dropbox", label: "Dropbox", match: ["dropbox"] },
+  { id: "onedrive", label: "OneDrive", match: ["onedrive", "1drv"] },
+  { id: "discord", label: "Discord", match: ["discord"] },
+  { id: "github", label: "GitHub", match: ["github"] },
+];
+
+const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+/** Whether a download sits on the named {@link KNOWN_HOSTS} entry. */
+export function isHost(opt: { url: string; host: string }, id: string): boolean {
+  const known = KNOWN_HOSTS.find((h) => h.id === id);
+  if (!known) return false;
+  const hay = norm(`${opt.host} ${opt.url}`);
+  return known.match.some((m) => hay.includes(m));
+}
+
+const KEY = "frost-download-prefs";
+
+export function readDownloadPrefs(): DownloadPrefs {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return DEFAULT_DOWNLOAD_PREFS;
+    const v = JSON.parse(raw) as Partial<DownloadPrefs>;
+    return {
+      preferServer: v.preferServer === true,
+      preferredHost:
+        typeof v.preferredHost === "string" &&
+        KNOWN_HOSTS.some((h) => h.id === v.preferredHost)
+          ? v.preferredHost
+          : "",
+    };
+  } catch {
+    // A browser with storage blocked, or someone's hand-edited JSON. The defaults are the
+    // behaviour the app had before this existed, so falling back to them is always safe.
+    return DEFAULT_DOWNLOAD_PREFS;
+  }
+}
+
+export function writeDownloadPrefs(prefs: DownloadPrefs) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(prefs));
+  } catch {
+    /* storage blocked — the pick just won't outlive the session */
+  }
+}


### PR DESCRIPTION
User report: *"I use it on both my gaming rig and my dedicated server… if I want to download all the KMX tracks on the server rig, currently I would go into each individual track and download the server version… Or if someone hosts on Google Drive and MediaFire, the Google Drive link usually has too many downloads so you have to go in and manually select MediaFire."*

Two settings, both applied wherever a mirror gets chosen — including quick install and bulk select, which is where the pain actually is.

## Prefer dedicated-server files

Takes the server build wherever a mod ships one, and — the part that matters — **stops quick install refusing a server-only mod**. That refusal was deliberate:

> One click can't ask which build was meant, and a dedicated-server file installed by mistake looks installed while the game shows nothing.

Which was right while nothing could answer the question. Now it can be told once, so a server machine can select twenty tracks and let them all install.

Off by default; nothing changes for anyone who doesn't turn it on.

## Preferred download host

Ranks a chosen host first where a mod is mirrored on several. It sorts **above the author's own "Default" flag**, because a Drive link that answers *too many downloads* is marked default just as often as one that works.

Matching normalises to letters and digits before looking for a fragment: `DownloadOption.host` is a label scraped off the page, and "Media Fire" and "drive.google.com" are both real values in the wild.

Stored in local storage rather than app config, so the gaming rig and the server can be set differently — which is exactly this user's setup.

## Verification

Drove the real `sortMirrors`/`defaultMirrorIndex` over a mod carrying a Drive default, a MediaFire mirror, a Drive server build and a Proton link:

```
default            : gdrive | mediafire | proton | gdrive(srv)  ->  gdrive
prefer mediafire   : mediafire | gdrive | proton | gdrive(srv)  ->  mediafire
prefer server      : gdrive(srv) | gdrive | mediafire | proton  ->  gdrive(srv)
server + mediafire : gdrive(srv) | mediafire | gdrive | proton  ->  gdrive(srv)
```

**Default ordering is unchanged** with no preference set, which is the regression that mattered. Server preference outranks host preference, which is right for a server rig.

There is no frontend test runner in this repo, so that is a harness run, not a committed test — worth knowing if you'd like vitest added.

Typecheck, lint and the production build pass. Not driven in the running app: another session holds the dev port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)