### PR TITLE
chore(release): v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2026-09-09
+## 2026-09-09 — v0.14.0 — Frost's Mod Manager, and a Studio of its own
 
 ### Added
 - FrostMod's status sits in the top bar, on every screen, with Start, Stop and Reload behind

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,5 @@
 # Changelog
 
-## 2026-09-08
-
-### Changed
-- Frost's Studio has a look of its own, and it is light. A dark surround pushes every colour
-  you are judging lighter than it really is, which is the wrong way round for an app you pick
-  paint in.
-- The Designer uses the whole window. The sheet runs edge to edge, the setup row moved into
-  the bar at the top, and the panels sit flat against the sides instead of boxing the work in.
-- The tools are named down the left rather than drawn as icons.
-- Frost's Studio has its own mark: the snowflake, split into two paints.
-
-## 2026-09-07
 ## 2026-09-09
 
 ### Added
@@ -27,15 +15,46 @@
   and nothing to wait for — and you edit it like any other.
 
 ### Changed
+- The app is now Frost's Mod Manager, with a new name and a new mark. Installing this
+  version retires the old one for you: your settings, your disabled mods, your paint
+  templates and your Launch at startup choice all carry over untouched. If you pinned the
+  old app to your taskbar or Start menu, pin it again from the new one.
+- The paint Designer, Paint Studio, Track Studio, the Rider and the content tools are now
+  Frost's Studio, an app of their own. The Studio tab points you at it: it opens the app if
+  you have it, and gets it for you if you don't. Your paints, tracks and presets are
+  untouched — both apps read the same folders.
+- Frost's Studio has a look of its own, and it is light. A dark surround pushes every colour
+  you are judging lighter than it really is, which is the wrong way round for an app you pick
+  paint in.
+- The Designer uses the whole window. The sheet runs edge to edge, the setup row moved into
+  the bar at the top, and the panels sit flat against the sides instead of boxing the work in.
+- The tools are named down the left rather than drawn as icons.
+- Frost's Studio has its own mark: the snowflake, split into two paints.
 - The Servers tab knows the tracks that come with MX Bikes. A server on Forest Raceway, Nevada
   or Holjes now says you have it, with the track's own picture, instead of pointing you at a
   download.
 - It looks on mxb-mods for a track it doesn't recognise, ahead of the paid catalogues, and only
   offers something whose name actually matches the track the server named.
+- Opening a server asks it for fresh numbers, so the riders, the session and the track are what
+  they are now rather than what they were when the list loaded.
 - A new base track. It is a walked lap now, and it measures like a published national: 1966 m,
   nineteen corners, and the corner shape and spacing read off Indiana and Southwick.
 - Straw bales stand off the track edge rather than a fixed distance from the line, so tracks
   wider than 14 m get them.
+
+### Fixed
+- Trackside scenery in the 3D viewer no longer stands in slabs of flat grey. A track whose
+  textures the viewer can't read now leaves its banners and foliage out rather than drawing
+  them blank.
+- Trees keep their colour when you pull the camera back, instead of going black across the
+  paddock.
+- The black shapes standing over some tracks are gone. They were shadows, drawn as if they
+  were solid.
+- More tracks show their real ground in the 3D viewer. A track's normal maps are stored a
+  little differently from its colour sheets, and reading them the same way stopped the viewer
+  part way through a track's ground.
+- The Settings descriptions for the profiles folder and the game install folder name the
+  game you are set up for.
 
 ## 2026-09-08 — v0.13.7 — Servers, live share codes and a new 3D view
 
@@ -74,32 +93,6 @@
 - Seven colorways in Settings — Frost is still the default; Ember, Moss, Violet, Rose and
   Slate move the whole window, not just the buttons. Plus Retro, which goes further: amber
   phosphor, monospaced type, square corners and a scanline over the window.
-
-### Changed
-- The paint Designer, Paint Studio, Track Studio, the Rider and the content tools are now
-  Frost's Studio, an app of their own. The Studio tab points you at it: it opens the app if
-  you have it, and gets it for you if you don't. Your paints, tracks and presets are
-  untouched — both apps read the same folders.
-- Opening a server asks it for fresh numbers, so the riders, the session and the track are what
-  they are now rather than what they were when the list loaded.
-- The app is now Frost's Mod Manager, with a new name and a new mark. Installing this
-  version retires the old one for you: your settings, your disabled mods, your paint
-  templates and your Launch at startup choice all carry over untouched. If you pinned the
-  old app to your taskbar or Start menu, pin it again from the new one.
-
-### Fixed
-- Trackside scenery in the 3D viewer no longer stands in slabs of flat grey. A track whose
-  textures the viewer can't read now leaves its banners and foliage out rather than drawing
-  them blank.
-- Trees keep their colour when you pull the camera back, instead of going black across the
-  paddock.
-- The black shapes standing over some tracks are gone. They were shadows, drawn as if they
-  were solid.
-- More tracks show their real ground in the 3D viewer. A track's normal maps are stored a
-  little differently from its colour sheets, and reading them the same way stopped the viewer
-  part way through a track's ground.
-- The Settings descriptions for the profiles folder and the game install folder name the
-  game you are set up for.
 
 ## 2026-09-06
 

--- a/apps/manager/src/Components/Showcase/releases.ts
+++ b/apps/manager/src/Components/Showcase/releases.ts
@@ -82,6 +82,21 @@ export interface Release {
 
 export const RELEASES: Release[] = [
   {
+    version: "0.14.0",
+    hero: {
+      icon: Sparkles,
+      title: "showcase.v0140.hero.title",
+      body: "showcase.v0140.hero.body",
+    },
+    highlights: [
+      { icon: Palette, text: "showcase.v0140.studio" },
+      { icon: Zap, text: "showcase.v0140.frostmod" },
+      { icon: Mountain, text: "showcase.v0140.stocktracks" },
+      { icon: Download, text: "showcase.v0140.downloads" },
+      { icon: Maximize2, text: "showcase.v0140.uiscale" },
+    ],
+  },
+  {
     version: "0.13.7",
     hero: {
       icon: Globe,

--- a/apps/manager/src/i18n/locales/de.ts
+++ b/apps/manager/src/i18n/locales/de.ts
@@ -1484,6 +1484,20 @@ export const de: Translation = {
   "showcase.supporters.title_one": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.title_other": "Ermöglicht durch {{count}} Unterstützer",
   "showcase.supporters.more": "+{{count}} weitere",
+  "showcase.v0140.hero.title":
+    "Frost's Mod Manager, und ein eigenes Studio",
+  "showcase.v0140.hero.body":
+    "Die App hat einen neuen Namen und ein neues Zeichen. Diese Version löst die alte für dich ab — deine Einstellungen, deaktivierten Mods, Paint-Vorlagen und die Autostart-Option werden unverändert übernommen. Wenn du die alte App an die Taskleiste oder das Startmenü angeheftet hast, hefte sie von der neuen aus erneut an.",
+  "showcase.v0140.studio":
+    "Designer, Paint- und Track-Studio, der Fahrer und die Content-Tools sind jetzt Frost's Studio, eine eigene App. Der Studio-Tab öffnet sie oder holt sie für dich. Beide Apps lesen dieselben Ordner, es wird nichts verschoben.",
+  "showcase.v0140.frostmod":
+    "FrostMods Status sitzt auf jedem Bildschirm in der oberen Leiste, mit Start, Stopp und Neu laden dahinter. Der Punkt zeigt, ob es läuft und ob es das Spiel wirklich erreicht hat.",
+  "showcase.v0140.stocktracks":
+    "Der Server-Tab kennt die Strecken, die MX Bikes mitbringt. Bei einem Server auf Forest Raceway oder Nevada heißt es jetzt, dass du sie hast — mit dem Bild der Strecke — und für die anderen wird auf mxb-mods gesucht.",
+  "showcase.v0140.downloads":
+    "Zwei Download-Einstellungen. Nimm die Dedicated-Server-Datei, wo ein Mod eine mitliefert, und deinen bevorzugten Host, wenn ein Mod mehrfach gespiegelt ist.",
+  "showcase.v0140.uiscale":
+    "Oberflächengröße in den Einstellungen, von 90% bis 160%. Skaliert die ganze Oberfläche, nicht nur den Text — für große oder hochauflösende Monitore.",
   "showcase.v0137.hero.title":
     "Jeder MX-Bikes-Server, live, während du fährst",
   "showcase.v0137.hero.body":

--- a/apps/manager/src/i18n/locales/en.ts
+++ b/apps/manager/src/i18n/locales/en.ts
@@ -1444,6 +1444,20 @@ export const en = {
   "showcase.supporters.title_one": "Made possible by {{count}} supporter",
   "showcase.supporters.title_other": "Made possible by {{count}} supporters",
   "showcase.supporters.more": "+{{count}} more",
+  "showcase.v0140.hero.title":
+    "Frost's Mod Manager, and a Studio of its own",
+  "showcase.v0140.hero.body":
+    "The app has a new name and a new mark. Installing this version retires the old one for you — your settings, your disabled mods, your paint templates and your Launch at startup choice all carry over untouched. If you pinned the old app to your taskbar or Start menu, pin it again from the new one.",
+  "showcase.v0140.studio":
+    "The Designer, the Paint and Track Studios, the Rider and the content tools are now Frost's Studio, an app of their own. The Studio tab opens it, or gets it for you. Both apps read the same folders, so nothing moves.",
+  "showcase.v0140.frostmod":
+    "FrostMod's status sits in the top bar on every screen, with Start, Stop and Reload behind it. The dot says whether it is running and whether it actually reached the game.",
+  "showcase.v0140.stocktracks":
+    "The Servers tab knows the tracks that come with MX Bikes. A server on Forest Raceway or Nevada says you have it, with the track's own picture, and it looks on mxb-mods for the ones you don't.",
+  "showcase.v0140.downloads":
+    "Two download preferences. Take the dedicated-server file wherever a mod ships one, and take your preferred host when a mod is mirrored on several.",
+  "showcase.v0140.uiscale":
+    "Interface size in Settings, from 90% to 160%. It scales the whole interface, not just the text, for a large or high-resolution monitor.",
   "showcase.v0137.hero.title":
     "Every MX Bikes server, live, while you ride",
   "showcase.v0137.hero.body":

--- a/apps/manager/src/i18n/locales/es.ts
+++ b/apps/manager/src/i18n/locales/es.ts
@@ -1472,6 +1472,20 @@ export const es: Translation = {
   "showcase.supporters.title_one": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.title_other": "Posible gracias a {{count}} mecenas",
   "showcase.supporters.more": "+{{count}} más",
+  "showcase.v0140.hero.title":
+    "Frost's Mod Manager, y un Studio propio",
+  "showcase.v0140.hero.body":
+    "La aplicación tiene un nombre nuevo y una marca nueva. Instalar esta versión retira la anterior por ti: tus ajustes, tus mods desactivados, tus plantillas de pintura y tu opción de inicio automático se mantienen intactos. Si tenías la aplicación anterior anclada a la barra de tareas o al menú Inicio, ánclala de nuevo desde la nueva.",
+  "showcase.v0140.studio":
+    "El Diseñador, los Studios de pintura y circuitos, el Piloto y las herramientas de contenido son ahora Frost's Studio, una aplicación propia. La pestaña Studio la abre, o la consigue por ti. Ambas leen las mismas carpetas, así que nada se mueve.",
+  "showcase.v0140.frostmod":
+    "El estado de FrostMod está en la barra superior, en todas las pantallas, con Iniciar, Detener y Recargar detrás. El punto dice si está en marcha y si realmente llegó al juego.",
+  "showcase.v0140.stocktracks":
+    "La pestaña Servidores conoce los circuitos que vienen con MX Bikes. Un servidor en Forest Raceway o Nevada ya dice que lo tienes, con la imagen del propio circuito, y busca en mxb-mods los que no tienes.",
+  "showcase.v0140.downloads":
+    "Dos preferencias de descarga. Coge el archivo de servidor dedicado cuando un mod lo incluya, y tu host preferido cuando esté replicado en varios.",
+  "showcase.v0140.uiscale":
+    "Tamaño de la interfaz en Ajustes, del 90% al 160%. Escala toda la interfaz, no solo el texto, para monitores grandes o de alta resolución.",
   "showcase.v0137.hero.title":
     "Todos los servidores de MX Bikes, en directo, mientras ruedas",
   "showcase.v0137.hero.body":

--- a/apps/manager/src/i18n/locales/fr.ts
+++ b/apps/manager/src/i18n/locales/fr.ts
@@ -1476,6 +1476,20 @@ export const fr: Translation = {
   "showcase.supporters.title_one": "Rendu possible par {{count}} soutien",
   "showcase.supporters.title_other": "Rendu possible par {{count}} soutiens",
   "showcase.supporters.more": "+{{count}} autres",
+  "showcase.v0140.hero.title":
+    "Frost's Mod Manager, et un Studio à part",
+  "showcase.v0140.hero.body":
+    "L'application a un nouveau nom et une nouvelle marque. Installer cette version retire l'ancienne pour vous : vos réglages, vos mods désactivés, vos modèles de peinture et votre choix de lancement au démarrage sont repris tels quels. Si vous aviez épinglé l'ancienne application à la barre des tâches ou au menu Démarrer, épinglez-la de nouveau depuis la nouvelle.",
+  "showcase.v0140.studio":
+    "Le Designer, les Studios de peinture et de circuits, le Pilote et les outils de contenu sont maintenant Frost's Studio, une application à part. L'onglet Studio l'ouvre, ou vous la procure. Les deux lisent les mêmes dossiers : rien ne bouge.",
+  "showcase.v0140.frostmod":
+    "L'état de FrostMod est dans la barre du haut, sur tous les écrans, avec Démarrer, Arrêter et Recharger derrière. Le point indique s'il tourne et s'il a vraiment atteint le jeu.",
+  "showcase.v0140.stocktracks":
+    "L'onglet Serveurs connaît les circuits fournis avec MX Bikes. Un serveur sur Forest Raceway ou Nevada indique que vous l'avez, avec l'image du circuit, et cherche sur mxb-mods ceux que vous n'avez pas.",
+  "showcase.v0140.downloads":
+    "Deux préférences de téléchargement. Prendre le fichier serveur dédié quand un mod en propose un, et votre hébergeur préféré quand un mod est disponible sur plusieurs.",
+  "showcase.v0140.uiscale":
+    "Taille de l'interface dans les Réglages, de 90% à 160%. Elle met à l'échelle toute l'interface, pas seulement le texte, pour un grand écran ou un écran haute résolution.",
   "showcase.v0137.hero.title":
     "Tous les serveurs MX Bikes, en direct, pendant que tu roules",
   "showcase.v0137.hero.body":

--- a/apps/manager/src/i18n/locales/it.ts
+++ b/apps/manager/src/i18n/locales/it.ts
@@ -1467,6 +1467,20 @@ export const it: Translation = {
   "showcase.supporters.title_one": "Reso possibile da {{count}} sostenitore",
   "showcase.supporters.title_other": "Reso possibile da {{count}} sostenitori",
   "showcase.supporters.more": "+{{count}} altri",
+  "showcase.v0140.hero.title":
+    "Frost's Mod Manager, e uno Studio tutto suo",
+  "showcase.v0140.hero.body":
+    "L'app ha un nome nuovo e un marchio nuovo. Installare questa versione ritira la precedente per te: impostazioni, mod disattivate, modelli di verniciatura e la scelta di avvio automatico passano intatti. Se avevi la vecchia app fissata alla barra delle applicazioni o al menu Start, fissala di nuovo dalla nuova.",
+  "showcase.v0140.studio":
+    "Il Designer, i Studio di verniciatura e piste, il Pilota e gli strumenti per i contenuti sono ora Frost's Studio, un'app a sé. La scheda Studio la apre, o te la procura. Entrambe leggono le stesse cartelle, quindi non si sposta nulla.",
+  "showcase.v0140.frostmod":
+    "Lo stato di FrostMod sta nella barra in alto, su ogni schermata, con Avvia, Ferma e Ricarica dietro. Il punto dice se è in esecuzione e se ha davvero raggiunto il gioco.",
+  "showcase.v0140.stocktracks":
+    "La scheda Server conosce le piste incluse in MX Bikes. Un server su Forest Raceway o Nevada ora dice che ce l'hai, con l'immagine della pista, e cerca su mxb-mods quelle che non hai.",
+  "showcase.v0140.downloads":
+    "Due preferenze di download. Prendi il file per server dedicato quando una mod lo include, e l'host che preferisci quando una mod è su più mirror.",
+  "showcase.v0140.uiscale":
+    "Dimensione dell'interfaccia nelle Impostazioni, dal 90% al 160%. Scala tutta l'interfaccia, non solo il testo, per monitor grandi o ad alta risoluzione.",
   "showcase.v0137.hero.title":
     "Ogni server MX Bikes, in diretta, mentre giri",
   "showcase.v0137.hero.body":

--- a/apps/manager/src/i18n/locales/pt-BR.ts
+++ b/apps/manager/src/i18n/locales/pt-BR.ts
@@ -1466,6 +1466,20 @@ export const ptBR: Translation = {
   "showcase.supporters.title_one": "Possível graças a {{count}} apoiador",
   "showcase.supporters.title_other": "Possível graças a {{count}} apoiadores",
   "showcase.supporters.more": "+{{count}} outros",
+  "showcase.v0140.hero.title":
+    "Frost's Mod Manager, e um Studio só dele",
+  "showcase.v0140.hero.body":
+    "O app tem um nome novo e uma marca nova. Instalar esta versão aposenta a anterior para você: suas configurações, seus mods desativados, seus modelos de pintura e sua opção de iniciar com o sistema passam intactos. Se você fixou o app antigo na barra de tarefas ou no menu Iniciar, fixe de novo a partir do novo.",
+  "showcase.v0140.studio":
+    "O Designer, os Studios de pintura e de pistas, o Piloto e as ferramentas de conteúdo agora são o Frost's Studio, um app próprio. A aba Studio abre ele, ou baixa pra você. Os dois leem as mesmas pastas, então nada sai do lugar.",
+  "showcase.v0140.frostmod":
+    "O status do FrostMod fica na barra de cima, em todas as telas, com Iniciar, Parar e Recarregar atrás. O ponto diz se está rodando e se realmente chegou ao jogo.",
+  "showcase.v0140.stocktracks":
+    "A aba Servidores conhece as pistas que vêm com o MX Bikes. Um servidor em Forest Raceway ou Nevada agora diz que você tem, com a imagem da própria pista, e procura no mxb-mods as que você não tem.",
+  "showcase.v0140.downloads":
+    "Duas preferências de download. Pegue o arquivo de servidor dedicado quando um mod trouxer um, e o host que você preferir quando um mod estiver em vários.",
+  "showcase.v0140.uiscale":
+    "Tamanho da interface nas Configurações, de 90% a 160%. Escala a interface toda, não só o texto, para um monitor grande ou de alta resolução.",
   "showcase.v0137.hero.title":
     "Todos os servidores de MX Bikes, ao vivo, enquanto você pilota",
   "showcase.v0137.hero.body":


### PR DESCRIPTION
Release prep for **v0.14.0**, to be tagged first as `v0.14.0-beta.1` (a pre-release: same three-platform build, but off `releases/latest`, so the in-app updater doesn't offer it, and it posts to the beta Discord channel).

## Why a beta first

What's unreleased is not a patch. The app is **renamed to Frost's Mod Manager**, and the Designer, Paint Studio, Track Studio, Rider and content tools have **split out into a second app, Frost's Studio**. That restructure landed today across roughly a dozen PRs from parallel sessions. Worth riding before every player is prompted to install a renamed app.

## The changelog needed consolidating first

Three unreleased date headings sat above `v0.13.7` — `## 2026-09-08`, an **empty** `## 2026-09-07`, and `## 2026-09-09` — out of date order.

Worse, **eight entries had been written into the already-released v0.13.7 section**: branches cut before that release was consolidated landed their changelog entries into what had since become the released section. Verified against the tag (`git show v0.13.7:CHANGELOG.md`) rather than by eye — the entire `### Changed` and `### Fixed` blocks of that section post-date it, while its `### Added` is genuinely what shipped:

- the rename to Frost's Mod Manager
- the Studio app split
- the four 3D-viewer fixes, and the Settings-description wording
- "opening a server asks it for fresh numbers"

All moved into the unreleased section; `v0.13.7` keeps only its `Added`. `Changed` now leads with the rename and the split, which is what a player actually notices.

## Also here

- The unreleased heading gets its version marker, so `scripts/changelog-section.sh` finds the section — without it the release publishes with download guidance and no notes, and Discord says only "A new version is out". Verified: `changelog-section.sh v0.14.0-beta.1 --heading` prints, and the body is 53 lines (a suffixed tag correctly falls back to the `v0.14.0` section).
- **A Showcase entry for 0.14.0**, with its strings in all six locales. The newest entry in `releases.ts` was still 0.13.7, and nothing catches that — the release would have shipped announcing nothing. Hero is the rename; highlights are the Studio split, FrostMod in the top bar, the stock-track fix, download preferences and interface size.
- No version bumps: every manifest (`package.json` ×2, `tauri.conf.json`, both `Cargo.toml`, `Cargo.lock`) already reads 0.14.0.

`npm run typecheck -w apps/manager` passes, which is what catches a locale string missing from any of the six.

🤖 Generated with [Claude Code](https://claude.com/claude-code)