### PR TITLE
fix(viewer): stop the 3D bike view banding its own bodywork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-09-09
+
+### Fixed
+- The 3D bike view no longer draws faint diagonal banding across the bodywork.
+
 ## 2026-09-08
 
 ### Changed

--- a/packages/shared/src/Components/Viewer/ModelViewer.tsx
+++ b/packages/shared/src/Components/Viewer/ModelViewer.tsx
@@ -2281,7 +2281,17 @@ export function ModelViewer({
             position={look.key.at}
             intensity={look.key.intensity}
             castShadow
-            shadow-mapSize={[1024, 1024]}
+            shadow-mapSize={[2048, 2048]}
+            // Without a bias the bodywork shadows ITSELF: every shadow-map texel
+            // that quantises just under the surface reads as occluded, and the
+            // result is regular evenly-spaced stripes across the panels — shadow
+            // acne. It reads as a defect in the paint, but it is there on the
+            // stock bike and survives turning off both the normal map and the
+            // specular lobe, because it is the shadow pass drawing it.
+            // normalBias is what clears acne on curved panels; the small
+            // negative depth bias handles faces nearly parallel to the light.
+            shadow-normalBias={0.03}
+            shadow-bias={-0.0004}
           />
           <directionalLight position={[-4, 2, -3]} intensity={look.back} />
           {/* Front fill from the camera side so the front of the kit isn't in shadow. */}


### PR DESCRIPTION
The 3D bike view drew faint regular diagonal stripes across the bodywork.

## What it was

Shadow acne. The Canvas has `shadows` on and the key `directionalLight` casts
them, but no bias was set — so shadow-map texels that quantise just under the
surface read as occluded and stripe the panels they belong to.

## How it was narrowed down

It read as a paint defect, so that is where the hunt started. It is not:

- present on the **stock** paint, with no custom sheet involved;
- unchanged with the **normal map disabled** entirely;
- unchanged with the **specular lobe removed** (`metalness 0`, `roughness 1`);
- **absent from an offline renderer** using the same geometry and the same
  sheets — which has no shadow pass, and is what pointed at one.

Measured off a screenshot the ridges are ~37 screen px apart at −42° and about
3.5% contrast: far too coarse for texture aliasing, and independent of anything
in the sheets.

## The fix

`shadow-normalBias={0.03}` — the standard remedy for acne on curved panels —
plus a small negative `shadow-bias` for faces nearly parallel to the light, and
the shadow map raised from 1024² to 2048².

Confirmed fixed in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)