### PR TITLE
fix(release): keep the sidecar checkout out of the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,16 @@
 #
 # `server-agent` is deliberately NOT a member: it ships to an EC2 box and wants its own
 # `opt-level = "z"`, and a workspace member cannot carry its own `[profile.*]`.
+#
+# `.sidecar-src` is the release workflow's checkout of the private crate. It lands inside this
+# directory, so once the repo root became a workspace Cargo started claiming its manifest and
+# refusing to build it — "current package believes it's in a workspace when it's not", which
+# failed the Windows leg of v0.14.0-beta.1 at the secure-content DLL. It is gitignored and
+# only ever exists in CI, so it can never be a member; excluding it is what tells Cargo that.
 [workspace]
 resolver = "2"
 members = ["crates/core", "apps/manager/src-tauri", "apps/studio/src-tauri"]
-exclude = ["server-agent"]
+exclude = ["server-agent", ".sidecar-src"]
 
 # The profiles live here because Cargo IGNORES `[profile.*]` in a non-root workspace member —
 # it warns, in the middle of a long build log, and otherwise silently gives you the defaults.


### PR DESCRIPTION
The Windows leg of the `v0.14.0-beta.1` release build failed at **Build secure-content DLL** ([run](https://github.com/Frostn1/mxb-app/actions/runs/34425890015)). Linux and macOS passed — they don't build the DLL — so `finalize` and `notify` were skipped and nothing published.

```
error: current package believes it's in a workspace when it's not:
current:   D:\a\mxb-app\mxb-app\.sidecar-src\secure\Cargo.toml
workspace: D:\a\mxb-app\mxb-app\Cargo.toml
```

## Cause

The release workflow checks the private crate out to `.sidecar-src` at the repo root and builds the DLL straight from it:

```yaml
run: cargo build --release --manifest-path .sidecar-src/secure/Cargo.toml --target x86_64-pc-windows-msvc
```

That was fine while the repo root held no manifest — the workspace was `src-tauri/Cargo.toml`, one level down. The monorepo move put a `[workspace]` at the root, and a workspace claims **every** manifest beneath its directory; a package it claims but doesn't list as a member is a hard error.

Nothing about the sidecar changed. It is a latent break the migration left behind, and it can only ever appear in a real release build — the sidecar checkout needs a deploy key, so no PR CI run and no local build ever exercises that step. Tagging a beta first is what surfaced it.

## Fix

`.sidecar-src` is gitignored and only exists inside a CI run, so it can never be a workspace member. Excluding it is what tells Cargo so — the same remedy already applied to `server-agent` on the line above.

## Verification

Not asserted — reproduced. Planting a dummy crate at `.sidecar-src/secure` and building it by manifest path gives the identical error against `main`:

```
error: current package believes it's in a workspace when it's not:
current:   .../wt-track/.sidecar-src/secure/Cargo.toml
workspace: .../wt-track/Cargo.toml
```

and with this change:

```
   Compiling secure-probe v0.1.0 (.../wt-track/.sidecar-src/secure)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.55s
```

`cargo metadata --no-deps` still resolves the workspace unchanged.

Once this is in, `v0.14.0-beta.2` gets tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)