### PR TITLE
fix(installer): stop defining MANUFACTURER in the installer hooks

### DIFF
--- a/apps/manager/src-tauri/installer-hooks.nsh
+++ b/apps/manager/src-tauri/installer-hooks.nsh
@@ -67,15 +67,21 @@
   Pop $0 ; 0 = closed it, 128 = wasn't running. Either is the state we want.
 !macroend
 
-; The manufacturer key the previous product name was filed under. The bundler defines
-; MANUFACTURER from tauri.conf.json's `publisher` before including this file; the guard is
-; there so a future template that stops doing so fails visibly at the registry read rather
-; than silently expanding to an empty path and matching the wrong key.
-!ifndef MANUFACTURER
-  !define MANUFACTURER "Frost"
-!endif
+; The manufacturer key the previous product name was filed under.
+;
+; MANUFACTURER is emphatically NOT available here, and must not be defined here either. The
+; bundler's template includes this file (line 29) *before* it runs its own
+; `!define MANUFACTURER` (line 34) — so a `!ifndef MANUFACTURER / !define` guard does fire,
+; and then makes the template's own line a fatal `!define: "MANUFACTURER" already defined!`.
+; That failed the Windows leg of v0.14.0-beta.1 and beta.2 at `makensis`, after a clean
+; fifteen-minute compile, and it can only ever show up in a real release build.
+;
+; Hence a name of our own for the legacy paths. `${MANUFACTURER}` is still usable *inside* a
+; macro below, because a macro body is expanded where it is inserted — which is after the
+; template has defined it.
+!define LEGACY_MANUFACTURER   "Frost"
 !define LEGACY_PRODUCTNAME    "MXB App"
-!define LEGACY_MANUPRODUCTKEY "Software\${MANUFACTURER}\${LEGACY_PRODUCTNAME}"
+!define LEGACY_MANUPRODUCTKEY "Software\${LEGACY_MANUFACTURER}\${LEGACY_PRODUCTNAME}"
 !define LEGACY_UNINSTKEY      "Software\Microsoft\Windows\CurrentVersion\Uninstall\${LEGACY_PRODUCTNAME}"
 
 ; Retire the install the rename orphaned.


### PR DESCRIPTION
Second release-only failure in the v0.14.0 line. The Windows leg of both `v0.14.0-beta.1` and `v0.14.0-beta.2` died at `makensis`, **after a clean fifteen-minute compile and a successfully built exe**:

```
!define: "MANUFACTURER" already defined!
Error in script "target\release\nsis\x64\installer.nsi" on line 35 -- aborting creation process
failed to bundle project: `Failed to bundle app with makensis`
```

## Cause

`installer-hooks.nsh` guarded its fallback like this, with the reasoning stated in the comment:

```nsis
; The bundler defines MANUFACTURER from tauri.conf.json's `publisher` before including
; this file; the guard is there so a future template that stops doing so fails visibly…
!ifndef MANUFACTURER
  !define MANUFACTURER "Frost"
!endif
```

**The bundler does the opposite.** From `tauri-bundler`'s `installer.nsi` template:

```
line 29:  !include "{{installer_hooks}}"
line 34:  !define MANUFACTURER "{{manufacturer}}"
```

The hooks are included *first*. So the guard finds `MANUFACTURER` genuinely undefined, defines it, and the template's own line then aborts the build. The guard wasn't protection against a future template — it was the failure, and it fires on every release.

## Fix

`LEGACY_MANUFACTURER`, a name of ours, for the legacy registry paths. `${MANUFACTURER}` inside `RetireLegacyInstall` is left alone and is still correct: a macro body is expanded where it is *inserted*, which is well after line 34.

## Verification

`makensis` runs on macOS, so this was reproduced rather than reasoned about. The harness mimics the template's include order and inserts all three `NSIS_HOOK_*` entry points, which transitively expand every other macro in the file.

`main`'s version:

```
!define: "MANUFACTURER" already defined!
Error in script "real2.nsi" on line 8 -- aborting creation process
```

This branch's version:

```
Output: ".../real.exe"
Total size:  51536 / 71452 bytes (72.1%)
```

Zero errors — a complete installer, with every hook macro expanded.

## Worth considering separately

Both beta failures were invisible to PR CI: one needed the sidecar deploy key, this one needs the NSIS bundling step. A Linux CI job that `apt-get install nsis` and compiles `installer-hooks.nsh` through a harness like the above would have caught this one in seconds instead of after two ~15-minute release builds. Not in this PR — happy to open it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)