### PR TITLE
fix(release): the Discord announcement dies on the app's apostrophe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2026-09-09 — v0.14.0 — Frost's Mod Manager, and a Studio of its own
+## 2026-09-09 — v0.14.0 — A new name, and a Studio of its own
 
 ### Added
 - FrostMod's status sits in the top bar, on every screen, with Start, Stop and Reload behind

--- a/scripts/notify-discord.sh
+++ b/scripts/notify-discord.sh
@@ -39,7 +39,13 @@ if [ -z "$TAG" ]; then
 fi
 
 REPO="${REPO:-${GITHUB_REPOSITORY:-Frostn1/mxb-app}}"
-APP_NAME="${APP_NAME:-Frost's Mod Manager}"
+# Not `${APP_NAME:-Frost's Mod Manager}`: inside `${...}` bash honours that apostrophe as an
+# opening quote, scans the rest of the file for its partner and dies with
+# `unexpected EOF while looking for matching \''` — pointing at whatever line it gave up on,
+# nowhere near this one. The name grew its apostrophe in the rename, and this ran on every
+# release from then on, so v0.14.0-beta.3 published its assets and then announced nothing.
+APP_NAME="${APP_NAME-}"
+[ -n "$APP_NAME" ] || APP_NAME="Frost's Mod Manager"
 
 # A suffixed tag (`v0.8.0-beta.2`) is a beta build of the version it names — the same test
 # release.yml uses to publish it as a pre-release, and release-notes.sh to head the release


### PR DESCRIPTION
`v0.14.0-beta.3` **built on all three platforms and published its assets** — the release page is complete. Then `notify` failed and it announced nothing:

```
scripts/notify-discord.sh: command substitution: line 88: unexpected EOF while looking for matching `''
```

## Line 88 is innocent

The fault is **line 42**:

```sh
APP_NAME="${APP_NAME:-Frost's Mod Manager}"
```

Inside `${...}`, bash honours that apostrophe as an opening quote. It scans the rest of the file for a partner, reaches the `awk -F'—' '…'` block at line 81, and gives up past the end of it — which is why the error points at line 88, forty lines from the actual bug.

The app name only grew an apostrophe **in the rename**. This has been broken for every release since.

## Why nothing caught it

`bash -n` passes. Bash defers parsing a command substitution's body until the substitution actually *runs*, so a static syntax check cannot see it — and the only place it runs is a release build, after the assets are already published.

That is the third release-only failure in this line, after the sidecar workspace error and the NSIS `MANUFACTURER` define.

## Fix

```sh
APP_NAME="${APP_NAME-}"
[ -n "$APP_NAME" ] || APP_NAME="Frost's Mod Manager"
```

Same `:-` semantics (unset **or** empty takes the default), and an override is still honoured — both checked. `"${APP_NAME:-"Frost's…"}"` also works, but reads like a typo; this reads like what it is. A comment records why the obvious form can't be used.

Swept the rest of `scripts/` and the workflows: this is the only `${…:-…}` default containing a quote.

## Verification

Reproduced locally under bash 5 with `curl` stubbed so nothing could post — the identical error. With the fix, the script's own `--print` renders the entire payload: title, beta note, the full changelog section and every download link.

## Also here

The section is retitled to **"A new name, and a Studio of its own"**. As it stood the Discord title read:

> 🧪 Beta — Frost's Mod Manager v0.14.0-beta.3 — **Frost's Mod Manager**, and a Studio of its own

Now:

> 🧪 Beta — Frost's Mod Manager v0.14.0-beta.3 — A new name, and a Studio of its own

## Note

`v0.14.0-beta.3` itself is fine and needs no rebuild — it is published, with assets, correctly marked as a pre-release. Only its announcement was lost. Once this merges the next tag announces properly; the beta.3 post can be sent by hand from the merged script if it's worth having.

🤖 Generated with [Claude Code](https://claude.com/claude-code)