### PR TITLE
fix(scripts): root `bun run tauri dev` recursed for ever

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
     "apps/studio"
   ],
   "scripts": {
-    "dev": "npm run dev -w apps/manager",
-    "start-dev": "npm run start-dev -w apps/manager",
-    "build-prod": "npm run build-prod -w apps/manager",
-    "tauri": "npm run tauri -w apps/manager",
+    "dev": "cd apps/manager && npm run dev",
+    "start-dev": "cd apps/manager && npm run start-dev",
+    "build-prod": "cd apps/manager && npm run build-prod",
+    "tauri": "cd apps/manager && npm run tauri",
     "build": "npm run build --workspaces --if-present",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "lint": "eslint .",
-    "dev:studio": "npm run dev -w apps/studio",
-    "tauri:studio": "npm run tauri -w apps/studio"
+    "dev:studio": "cd apps/studio && npm run dev",
+    "tauri:studio": "cd apps/studio && npm run tauri"
   },
   "overrides": {
     "postcss": "^8.5.25"


### PR DESCRIPTION
## Summary
- The monorepo refactor (aa633cf1) made the root scripts delegate with `npm run <script> -w apps/manager`. Bun rewrites `npm run` inside scripts to `bun run`, which does not know npm's `-w` workspace flag, so `bun run tauri dev` at the repo root resolved `tauri` to the root script again and re-spawned itself without end (`bun run tauri -w apps/manager -w apps/manager -w apps/manager … dev`).
- Root scripts now delegate with `cd apps/<app> && npm run <script>`, which resolves the app's own script under both npm and bun. The studio scripts get the same treatment.

## Test plan
- [x] `bun run tauri --version` and `bun run tauri:studio --version` at the root print `tauri-cli 2.11.4` instead of recursing
- [x] `bun run tauri dev` from `apps/manager` was already fine and is unchanged (builds and paints the Browse tab on macOS)
- [x] `package.json` still parses; no changelog entry, developer tooling only

🤖 Generated with [Claude Code](https://claude.com/claude-code)