### PR TITLE
fix(scripts): the studio couldn't start if its dev port was taken

### DIFF
--- a/apps/manager/package.json
+++ b/apps/manager/package.json
@@ -4,7 +4,7 @@
   "version": "0.14.0",
   "type": "module",
   "scripts": {
-    "predev": "node ../../scripts/free-dev-port.mjs",
+    "predev": "node ../../scripts/free-dev-port.mjs MXB_DEV_PORT 1420",
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
+    "predev": "node ../../scripts/free-dev-port.mjs FROST_STUDIO_DEV_PORT 1430",
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",

--- a/scripts/free-dev-port.mjs
+++ b/scripts/free-dev-port.mjs
@@ -5,8 +5,12 @@
 // die. This clears it so `tauri dev` reliably starts on the first try.
 import { execSync } from "node:child_process";
 
-// Kept in step with `vite.config.ts`, which reads the same variable.
-const PORT = Number(process.env.MXB_DEV_PORT) || 1420;
+// Which app's port to free is passed in, because each app has its own: the
+// manager on 1420, the studio on 1430. Args are `<env var name> <default>`
+// rather than a shell expansion so the script behaves the same on Windows.
+// Kept in step with each app's `vite.config.ts`, which reads the same variable.
+const [ENV_NAME = "MXB_DEV_PORT", FALLBACK = "1420"] = process.argv.slice(2);
+const PORT = Number(process.env[ENV_NAME]) || Number(FALLBACK);
 
 function pidsOnPort(port) {
   try {


### PR DESCRIPTION
## Summary
- `bun run tauri:studio dev` failed with `Error: Port 1430 is already in use`. `apps/studio/vite.config.ts` sets `strictPort`, so vite never falls back, and a vite left behind by an earlier run or another checkout blocks the studio permanently.
- The manager has had a `predev` hook freeing port 1420 since that script was added. The studio never got one.
- `scripts/free-dev-port.mjs` now takes `<env var name> <default>` as arguments, so each app frees its own port. Arguments rather than a shell expansion, so it works the same under Windows `cmd`. With no arguments it still defaults to `MXB_DEV_PORT`/1420.

## Test plan
- [x] With a squatter on 1430, `npm run dev` in `apps/studio` prints `[predev] freed port 1430` and vite comes up on 1430
- [x] `FROST_STUDIO_DEV_PORT=14399` frees 14399 instead, so the env override still wins
- [x] Bare `node scripts/free-dev-port.mjs` with no arguments still frees 1420
- [x] Both `package.json` files still parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)