### PR TITLE
feat(studio): find a Wine host for the compilers instead of asking for one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   and nothing to wait for — and you edit it like any other.
 
 ### Changed
+- Building a track on a Mac no longer asks you to put the game inside a Wine prefix. The
+  Studio finds its own way to run PiBoSo's compilers, and gets one if the Mac hasn't got it.
 - The app is now Frost's Mod Manager, with a new name and a new mark. Installing this
   version retires the old one for you: your settings, your disabled mods, your paint
   templates and your Launch at startup choice all carry over untouched. If you pinned the

--- a/apps/studio/src-tauri/Cargo.toml
+++ b/apps/studio/src-tauri/Cargo.toml
@@ -59,3 +59,9 @@ image = { version = "0.25", default-features = false, features = [
 [features]
 # Matches the manager's. `tauri build` turns it on; a dev run leaves it off.
 custom-protocol = ["tauri/custom-protocol"]
+
+[dev-dependencies]
+# Tauri's mock runtime. The content locker's tests run against a mock app, and without the
+# `test` feature the studio's tests don't build at all. Dev-only — dev-dependencies aren't
+# part of a normal build, so the shipped binary never gets it.
+tauri = { version = "2", features = ["test"] }

--- a/apps/studio/src-tauri/src/main.rs
+++ b/apps/studio/src-tauri/src/main.rs
@@ -24,6 +24,7 @@ mod trackshot;
 mod trackspeed;
 mod trackstats;
 mod tracksynth;
+mod winefetch;
 
 /// Sealing content to a buyer. Gitignored, like the module it builds on.
 #[cfg(sidecar)]
@@ -499,6 +500,31 @@ async fn ensure_track_tools(app: &tauri::AppHandle) -> Result<String, String> {
     Ok(got.path)
 }
 
+/// What the compilers will be run with, got ready if this machine isn't.
+///
+/// On Windows there is nothing to do. Anywhere else they are Windows binaries: this finds a
+/// Wine host — a bottle already here, or one of ours — and fetches a Wine build if the
+/// machine has none. Same bargain as [`ensure_track_tools`]: the setup belongs to the build,
+/// not to a step someone has to know to take first.
+async fn prepare_host(
+    app: &tauri::AppHandle,
+    cfg: &AppConfig,
+) -> Result<trackbuild::Host, String> {
+    let runner = winefetch::ensure_runner(app, cfg.wine_runner.clone()).await?;
+    let prefix = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("no data directory: {e}"))?
+        .join("wine")
+        .join("prefix");
+    let game = cfg.game_path.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        trackbuild::host(&game, &prefix, &runner).map_err(|e| format!("{e:#}"))
+    })
+    .await
+    .map_err(|e| format!("preparing the compilers failed: {e}"))?
+}
+
 /// How far a track build has got.
 ///
 /// A build is minutes of work with nothing to look at, so it reports where it is rather than
@@ -541,9 +567,18 @@ async fn build_track(
     install: bool,
 ) -> Result<BuildResult, String> {
     let prog = track_program(program)?;
+    let slug = tracksynth::slug(&prog.name);
+
+    // Getting the machine ready is on the bar rather than in front of it: the first build on
+    // a machine fetches the compilers, and on a Mac with no Wine it fetches that too and lays
+    // down a prefix. A window doing nothing for a minute reads as a build that hung.
+    let _ = app.emit(
+        BUILD_EVENT,
+        BuildProgress { slug: slug.clone(), at: trackbuild::PREPARING },
+    );
     let tools_at = ensure_track_tools(&app).await?;
     let cfg = config::load_or_detect(&app).unwrap_or_default();
-    let slug = tracksynth::slug(&prog.name);
+    let host = prepare_host(&app, &cfg).await?;
     // Somewhere of its own when nobody picked a folder, so building is one press.
     let root = match dir {
         Some(d) if !d.trim().is_empty() => std::path::PathBuf::from(d),
@@ -579,7 +614,7 @@ async fn build_track(
         std::fs::create_dir_all(&root).map_err(|e| format!("{}: {e}", root.display()))?;
         tracksynth::write_source(&prog, &syn, &root).map_err(|e| format!("{e:#}"))?;
 
-        let steps = trackbuild::compile(&tools, &root, &slug, &cfg.game_path, &mut |phase| {
+        let steps = trackbuild::compile(&tools, &root, &slug, &host, &mut |phase| {
             say(plan.start(phase))
         })
         .map_err(|e| format!("{e:#}"))?;

--- a/apps/studio/src-tauri/src/trackbuild.rs
+++ b/apps/studio/src-tauri/src/trackbuild.rs
@@ -98,6 +98,19 @@ pub struct Progress {
     pub expect: f32,
 }
 
+/// The bar while the machine is being got ready to compile — finding a Wine host, fetching
+/// one, laying down a prefix.
+///
+/// Ahead of the [`Plan`] rather than in it, and given a sliver of the bar rather than a
+/// share of the work: what it costs is a download and a first boot, which have nothing to do
+/// with how big the track is. Normally it is over in the time it takes to look at a folder.
+pub const PREPARING: Progress = Progress {
+    phase: "preparing",
+    from: 0.0,
+    to: 0.02,
+    expect: 45.0,
+};
+
 /// Seconds a phase takes per million terrain samples, as a first guess.
 ///
 /// Measured on 2026-09-06 against a generated 2049² track — 4.2 megasamples — with PiBoSo's
@@ -190,8 +203,8 @@ impl Plan {
 
 /// The three runs, in order. Stops at the first failure that makes the next one pointless.
 ///
-/// `game_path` is only used to find a Wine prefix on macOS — the compilers are Windows
-/// binaries and the prefix that runs the game is the one that has the runtime they need.
+/// `host` is what runs a Windows program on this machine — see [`host`], which resolves it
+/// once for the whole build.
 ///
 /// `starting` is called with each run's name just before it begins. It is the only sign of
 /// life there is while a build is going: see [`Progress`] for why the compilers' own output
@@ -200,7 +213,7 @@ pub fn compile(
     tools: &Tools,
     dir: &Path,
     slug: &str,
-    game_path: &str,
+    host: &Host,
     starting: &mut dyn FnMut(&'static str),
 ) -> Result<Vec<Step>> {
     if !dir.join("track.hmf").is_file() {
@@ -215,7 +228,7 @@ pub fn compile(
         &tools.terrained,
         &["track.hmf", &map, "params.ini"],
         dir,
-        game_path,
+        host,
         Some(&map),
     )?);
 
@@ -226,7 +239,7 @@ pub fn compile(
         &tools.terrained,
         &["track.tht", &trh, "trh_params.ini"],
         dir,
-        game_path,
+        host,
         Some(&trh),
     )?);
 
@@ -236,7 +249,7 @@ pub fn compile(
     if let (Some(tracked), true) = (&tools.tracked, dir.join(&trh).is_file()) {
         starting("centerline");
         let args = merge_args(&trh, dir.join("track_start.tcl").is_file());
-        steps.push(run("centerline", tracked, &args, dir, game_path, Some(&trh))?);
+        steps.push(run("centerline", tracked, &args, dir, host, Some(&trh))?);
     }
     Ok(steps)
 }
@@ -316,10 +329,10 @@ fn run(
     exe: &Path,
     args: &[&str],
     dir: &Path,
-    game_path: &str,
+    host: &Host,
     produces: Option<&str>,
 ) -> Result<Step> {
-    let mut cmd = command(exe, args, game_path)?;
+    let mut cmd = command(exe, args, host)?;
     cmd.current_dir(dir);
     let out = cmd
         .output()
@@ -344,39 +357,85 @@ fn run(
     })
 }
 
+/// How the compilers are run on this machine, resolved once for a whole build.
+///
+/// Nothing to hold on Windows, where they are simply run. Everywhere else they are Windows
+/// binaries and go through a Wine host.
+#[derive(Clone, Debug)]
+pub struct Host {
+    #[cfg(not(target_os = "windows"))]
+    wine: crate::winehost::Host,
+}
+
+impl Host {
+    /// What this ran through, for a log line. Empty on Windows, where there is no answer
+    /// more useful than "the machine".
+    pub fn via(&self) -> String {
+        #[cfg(target_os = "windows")]
+        return String::new();
+        #[cfg(not(target_os = "windows"))]
+        format!("{} at {}", self.wine.runner.via(), self.wine.prefix.display())
+    }
+}
+
+/// Windows runs Windows programs. There is nothing to find.
+#[cfg(target_os = "windows")]
+pub fn host(_game_path: &str, _own_prefix: &Path, _wine: &str) -> Result<Host> {
+    Ok(Host {})
+}
+
+/// Find a Wine host for the compilers, and make its prefix if it is ours and new.
+///
+/// The compilers are console programs: they read a `.hmf` and write a `.map`, they load
+/// nothing the game installed, and they do not touch a GPU. So any Wine prefix on the
+/// machine runs them, and where there is none, one of ours does — see
+/// [`crate::winehost::tool_host`] for the order. The game's path is still the first place
+/// looked, because a bottle that already runs MX Bikes is the safest bet, but it is no
+/// longer a requirement: this used to stop with "set the game path to a copy inside a Wine
+/// prefix", which asked someone to move their game to compile a track.
+///
+/// `wine` is an explicit runner — the Settings box, or one this app fetched. `FROST_WINE`
+/// does the same for the build harness, which drives a Wine that lives beside the compilers.
+#[cfg(not(target_os = "windows"))]
+pub fn host(game_path: &str, own_prefix: &Path, wine: &str) -> Result<Host> {
+    let over = match wine.trim() {
+        "" => std::env::var("FROST_WINE").unwrap_or_default(),
+        given => given.to_string(),
+    };
+    let Some(wine) = crate::winehost::tool_host(Path::new(game_path), own_prefix, &over) else {
+        bail!(
+            "the compilers are Windows programs, and there's no Wine on this machine to run \
+             them with. Install CrossOver, Whisky or Wine and the studio finds it by itself."
+        );
+    };
+    crate::winehost::ensure_prefix(&wine.runner, &wine.prefix)
+        .with_context(|| format!("preparing the Wine prefix at {:?}", wine.prefix))?;
+    Ok(Host { wine })
+}
+
 /// The command that runs a Windows executable here.
 #[cfg(target_os = "windows")]
-fn command(exe: &Path, args: &[&str], _game_path: &str) -> Result<std::process::Command> {
+fn command(exe: &Path, args: &[&str], _host: &Host) -> Result<std::process::Command> {
     let mut cmd = std::process::Command::new(exe);
     cmd.args(args);
     Ok(cmd)
 }
 
-/// On macOS the compilers are Windows binaries, so they go through the same Wine host the
-/// game does — and through the game's own prefix, which already has whatever runtime PiBoSo's
-/// tools were built against.
+/// Off Windows the compilers are Windows binaries, so they go through the host [`host`]
+/// resolved: a wrapper's bottle, or one of ours.
 #[cfg(not(target_os = "windows"))]
-fn command(exe: &Path, args: &[&str], game_path: &str) -> Result<std::process::Command> {
-    let Some((prefix, _)) = crate::winehost::split_prefix(Path::new(game_path)) else {
-        bail!(
-            "the compilers are Windows programs. Set the game path to a copy inside a Wine \
-             prefix — CrossOver, Whisky or plain Wine — and they'll run through that."
-        );
-    };
-    // `FROST_WINE` names a runner outside the places the resolver looks, which is how the
-    // build harness drives a Wine build that lives beside the compilers rather than installed.
-    // Empty unless set, so nothing changes for the app.
-    let over = std::env::var("FROST_WINE").unwrap_or_default();
-    let Some(runner) = crate::winehost::resolve(&over, Some(&prefix)) else {
-        bail!("found a Wine prefix at {prefix:?} but nothing that can run it");
-    };
+fn command(exe: &Path, args: &[&str], host: &Host) -> Result<std::process::Command> {
     let extra: Vec<String> = args.iter().map(|a| a.to_string()).collect();
-    let launch = crate::winehost::plan(&runner, &prefix, exe, &extra);
+    let launch = crate::winehost::plan(&host.wine.runner, &host.wine.prefix, exe, &extra);
     let mut cmd = std::process::Command::new(&launch.program);
     cmd.args(&launch.args);
     for (k, v) in &launch.env {
         cmd.env(k, v);
     }
+    // A fresh prefix would otherwise stop on a dialog offering to install Mono, which no
+    // compiler here needs and nobody is watching for.
+    cmd.env("WINEDEBUG", "-all");
+    cmd.env("WINEDLLOVERRIDES", "mscoree,mshtml=");
     Ok(cmd)
 }
 
@@ -530,7 +589,7 @@ mod tests {
             terrained: dir.join("terrained.exe"),
             tracked: None,
         };
-        let err = compile(&tools, &dir, "x", "", &mut |_| {}).unwrap_err().to_string();
+        let err = compile(&tools, &dir, "x", &nowhere(), &mut |_| {}).unwrap_err().to_string();
         assert!(err.contains("no track.hmf"), "{err}");
     }
 
@@ -547,19 +606,43 @@ mod tests {
             tracked: None,
         };
         let mut said = Vec::new();
-        let _ = compile(&tools, &dir, "x", "", &mut |phase| said.push(phase));
+        let _ = compile(&tools, &dir, "x", &nowhere(), &mut |phase| said.push(phase));
         assert_eq!(said.first(), Some(&"map"), "said {said:?}");
     }
 
-    /// Not on Windows, and not inside a Wine prefix, the failure has to name the reason
-    /// rather than surfacing whatever the OS says about an unrunnable file.
+    /// A host pointing at a Wine that isn't there. Enough to reach the compilers, which is
+    /// all a test that never means to run one needs.
+    #[cfg(not(target_os = "windows"))]
+    fn nowhere() -> Host {
+        Host {
+            wine: crate::winehost::Host {
+                runner: crate::winehost::Runner {
+                    program: PathBuf::from("/nowhere/wine"),
+                    kind: crate::winehost::RunnerKind::Wine { via: "Wine" },
+                },
+                prefix: PathBuf::from("/nowhere/prefix"),
+                fresh: false,
+            },
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    fn nowhere() -> Host {
+        Host {}
+    }
+
+    /// The one dead end left: a runner was named and it isn't there, so nothing on the
+    /// machine can run a Windows program. The message has to say that rather than surface
+    /// whatever the OS says about an unrunnable file — and it must not send anyone off to
+    /// move their game into a prefix, which is not what compiling needs.
     #[cfg(not(target_os = "windows"))]
     #[test]
-    fn without_a_prefix_it_explains_itself() {
-        let err = command(Path::new("/nowhere/terrained.exe"), &["a"], "/Applications/Game")
+    fn with_nothing_to_run_it_says_so() {
+        let err = host("", Path::new("/nowhere/prefix"), "/nowhere/wine")
             .unwrap_err()
             .to_string();
-        assert!(err.contains("Wine prefix"), "{err}");
+        assert!(err.contains("no Wine on this machine"), "{err}");
+        assert!(!err.contains("Set the game path"), "{err}");
     }
 }
 
@@ -578,14 +661,13 @@ mod build_one {
     /// FROST_PROGRAM=/tmp/prog.json FROST_OUT=/tmp/build \
     /// FROST_TOOLS=~/Downloads/mxb-trackbuild/tools \
     /// FROST_GAME="~/Downloads/mxb-trackbuild/prefix/drive_c/MX Bikes" \
-    /// FROST_PREFIX=~/Downloads/mxb-trackbuild/prefix \
     /// FROST_WINE="~/Downloads/mxb-trackbuild/Wine Devel.app/Contents/Resources/wine/bin/wine" \
-    ///   cargo test --bin mxb-app -- --ignored --nocapture build_a_track_to_pkz
+    ///   cargo test --bin frost-studio -- --ignored --nocapture build_a_track_to_pkz
     /// ```
     ///
-    /// `FROST_GAME` is not optional despite defaulting to empty: the prefix is found by
-    /// splitting the *game* path, so without it the compile stops on "the compilers are
-    /// Windows programs" however good the runner is. The folder need not hold a game.
+    /// Both of those are optional now: without `FROST_GAME` the host falls back to any
+    /// prefix on the machine and then to one of its own under `FROST_OUT`, and without
+    /// `FROST_WINE` it uses whatever Wine is installed.
     #[test]
     #[ignore = "needs PiBoSo's compilers and a Wine prefix"]
     fn build_a_track_to_pkz() {
@@ -631,7 +713,9 @@ mod build_one {
 
         let mut phase = |p: &'static str| println!("  .. {p}");
         let game = std::env::var("FROST_GAME").unwrap_or_default();
-        let steps = compile(&tools, &dir, &slug, &game, &mut phase).expect("compile");
+        let wine = host(&game, &out.join("wine-prefix"), "").expect("a Wine host");
+        println!("  running through {}", wine.via());
+        let steps = compile(&tools, &dir, &slug, &wine, &mut phase).expect("compile");
         for s in &steps {
             println!("  {} -> {}", s.name, if s.ok { "ok" } else { "FAILED" });
             if !s.ok {

--- a/apps/studio/src-tauri/src/winefetch.rs
+++ b/apps/studio/src-tauri/src/winefetch.rs
@@ -1,0 +1,148 @@
+//! Getting a Wine onto this Mac, so a track can be compiled with nothing installed first.
+//!
+//! The compilers are PiBoSo's Windows binaries and the app already fetches those rather than
+//! making anyone find them ([`crate::download_track_tools`]). What it did not do was find
+//! anything to *run* them with: on a Mac with no CrossOver, no Whisky and no Wine, the build
+//! stopped and told the person to go and set one up. This closes that — the last step of
+//! building a track that needed anything outside the app.
+//!
+//! Gcenx's build is the one used because it is what the track pipeline was proven on: a
+//! tarball, no installer, no sudo, no Homebrew. It is x86-64 and runs under Rosetta on Apple
+//! silicon, which for a console compiler costs nothing worth measuring.
+
+#[cfg(target_os = "macos")]
+use std::path::Path;
+use std::path::PathBuf;
+
+use tauri::Manager;
+
+/// The build that gets fetched. Pinned rather than asked of the GitHub API: a build is only
+/// interesting here if the compilers run under it, and this one is measured. Moving it up is
+/// this line and the folder name below. Unused on Windows, which runs the compilers itself.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+const URL: &str =
+    "https://github.com/Gcenx/macOS_Wine_builds/releases/download/11.16/wine-devel-11.16-osx64.tar.xz";
+
+/// Where the binary sits inside the tarball once it is unpacked.
+const INSIDE: &str = "Wine Devel.app/Contents/Resources/wine/bin/wine";
+
+/// Our copy of Wine, whether or not it has been fetched yet.
+pub fn ours(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    Ok(dir(app)?.join(INSIDE))
+}
+
+/// Where a fetched Wine is kept: beside the app's own data, not in Applications. Nothing is
+/// installed on this machine — deleting the folder undoes all of it.
+fn dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    Ok(app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("no data directory: {e}"))?
+        .join("wine"))
+}
+
+/// A Wine runner for the compilers: one that is installed, else ours, else fetched.
+///
+/// Returns what to hand [`crate::trackbuild::host`] as its runner: empty when the machine
+/// has its own and the resolver should pick, a path when the one to use is ours.
+///
+/// `configured` is the Settings box, and wins outright — someone who named a runner is not
+/// to be second-guessed, or quietly given a second Wine to go with the one they chose.
+pub async fn ensure_runner(app: &tauri::AppHandle, configured: String) -> Result<String, String> {
+    // Windows runs the compilers itself, and a Wine there would be nonsense.
+    if cfg!(target_os = "windows") || !configured.trim().is_empty() {
+        return Ok(configured);
+    }
+    // Anything already on the machine — CrossOver, Whisky, Homebrew, the game-porting
+    // toolkit. Nothing to fetch, and a wrapper's own Wine is better than ours for its bottles.
+    if mxb_core::winehost::resolve("", None).is_some() {
+        return Ok(String::new());
+    }
+    let ours = ours(app)?;
+    if ours.is_file() {
+        return Ok(ours.to_string_lossy().into_owned());
+    }
+    fetch(app).await
+}
+
+/// Download and unpack the Wine build. macOS only — see [`fetch`] for other systems.
+#[cfg(target_os = "macos")]
+async fn fetch(app: &tauri::AppHandle) -> Result<String, String> {
+    let into = dir(app)?;
+    let bytes = reqwest::Client::new()
+        .get(URL)
+        .send()
+        .await
+        .and_then(|r| r.error_for_status())
+        .map_err(|e| format!("couldn't reach {URL}: {e}"))?
+        .bytes()
+        .await
+        .map_err(|e| format!("the Wine download stopped early: {e}"))?;
+
+    let ours = tauri::async_runtime::spawn_blocking(move || unpack(&bytes, &into))
+        .await
+        .map_err(|e| format!("unpacking Wine failed: {e}"))??;
+    Ok(ours.to_string_lossy().into_owned())
+}
+
+/// Nothing to fetch anywhere else. Linux has Wine in every package manager and installing
+/// system software behind someone's back is not this app's business; Windows never asks.
+#[cfg(not(target_os = "macos"))]
+async fn fetch(_app: &tauri::AppHandle) -> Result<String, String> {
+    Err("no Wine here to run the compilers with — install it with your package manager \
+         (`wine` in every distribution) and this works with nothing else to set up."
+        .into())
+}
+
+/// Unpack the tarball into `into` and hand back the binary in it.
+///
+/// Through `tar` rather than a crate: the archive is `.tar.xz`, macOS's `tar` reads that
+/// natively, and it is one process against an xz decoder and a tar reader linked into the
+/// app for a file most people will never download.
+#[cfg(target_os = "macos")]
+fn unpack(bytes: &[u8], into: &Path) -> Result<PathBuf, String> {
+    std::fs::create_dir_all(into).map_err(|e| format!("{}: {e}", into.display()))?;
+    // Beside the destination rather than in the system temp folder, so an unpack that has to
+    // move files never crosses a device, and a half-finished download is cleaned up with the
+    // rest of the app's data.
+    let tarball = into.join("wine.tar.xz.part");
+    std::fs::write(&tarball, bytes).map_err(|e| format!("{}: {e}", tarball.display()))?;
+
+    let out = std::process::Command::new("/usr/bin/tar")
+        .arg("-xJf")
+        .arg(&tarball)
+        .arg("-C")
+        .arg(into)
+        .output()
+        .map_err(|e| format!("couldn't run tar: {e}"))?;
+    let _ = std::fs::remove_file(&tarball);
+    if !out.status.success() {
+        return Err(format!(
+            "that Wine download didn't unpack: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+
+    let wine = into.join(INSIDE);
+    if !wine.is_file() {
+        return Err(format!(
+            "Wine unpacked but there's no binary at {}",
+            wine.display()
+        ));
+    }
+    Ok(wine)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The pinned URL and the path inside the tarball have to agree about the build, or the
+    /// unpack succeeds and the binary is looked for in a folder that isn't there.
+    #[test]
+    fn the_url_and_the_path_inside_it_name_the_same_build() {
+        assert!(URL.ends_with(".tar.xz"), "{URL}");
+        assert!(URL.contains("wine-devel"), "{URL}");
+        assert!(INSIDE.starts_with("Wine Devel.app/"), "{INSIDE}");
+    }
+}

--- a/apps/studio/src/Components/Studio/TrackStudio/BuildCard.tsx
+++ b/apps/studio/src/Components/Studio/TrackStudio/BuildCard.tsx
@@ -74,8 +74,8 @@ export default function BuildCard() {
         </ul>
       )}
 
-      {/* A build that never reached a compiler — no Wine prefix, no tools — has no steps to
-          show, so its reason has nowhere else to go. */}
+      {/* A build that never reached a compiler — no tools, nothing to run them with — has
+          no steps to show, so its reason has nowhere else to go. */}
       {build.state === "failed" && build.steps.length === 0 && build.error && (
         <span className="line-clamp-4 text-[11px] leading-snug text-destructive">
           {build.error}

--- a/apps/studio/src/Context/TrackBuild.tsx
+++ b/apps/studio/src/Context/TrackBuild.tsx
@@ -35,6 +35,7 @@ import type { TKey } from "@/i18n";
 export type BuildState = BuildPhase | "done" | "failed";
 
 const RUNNING: BuildState[] = [
+  "preparing",
   "synthesising",
   "writing",
   "map",
@@ -55,6 +56,7 @@ export function isRunning(state: BuildState): boolean {
  * argument TerrainEd takes, and nobody waiting on a track wants to be told about a `.map`.
  */
 export const PHASE_KEY: Record<BuildState, TKey> = {
+  preparing: "track.phase.preparing",
   synthesising: "track.phase.synthesising",
   writing: "track.phase.writing",
   map: "track.phase.map",

--- a/apps/studio/src/api/trackgen.ts
+++ b/apps/studio/src/api/trackgen.ts
@@ -448,8 +448,9 @@ export interface BuildResult {
  * which is what makes building one press. `install` puts the finished `.pkz` in the mods
  * tree, where the game lists it.
  *
- * The compilers are PiBoSo's and Windows-only; on macOS they go through the same Wine prefix
- * the game does. Minutes, not seconds — TerrainEd bakes shadow maps over the whole terrain.
+ * The compilers are PiBoSo's and Windows-only; off Windows they go through a Wine host the
+ * app finds — or fetches — by itself, so there is nothing to install first. Minutes, not
+ * seconds — TerrainEd bakes shadow maps over the whole terrain.
  */
 export function buildTrack(
   program: TrackProgram,
@@ -461,6 +462,7 @@ export function buildTrack(
 
 /** The phases of a build, in the order they run. */
 export type BuildPhase =
+  | "preparing"
   | "synthesising"
   | "writing"
   | "map"

--- a/apps/studio/src/i18n/locales/de.ts
+++ b/apps/studio/src/i18n/locales/de.ts
@@ -432,6 +432,7 @@ export const de: Translation = {
   "protect.showFolder": "Ordner anzeigen",
   "track.gap": "Lücke",
   "track.deep": "tief",
+  "track.phase.preparing": "Compiler werden vorbereitet",
   "track.phase.synthesising": "Gelände wird geformt",
   "track.phase.writing": "Quelldateien werden geschrieben",
   "track.phase.map": "Grafik wird kompiliert",

--- a/apps/studio/src/i18n/locales/en.ts
+++ b/apps/studio/src/i18n/locales/en.ts
@@ -435,6 +435,7 @@ export const en = {
   "protect.showFolder": "Show folder",
   "track.gap": "gap",
   "track.deep": "deep",
+  "track.phase.preparing": "Getting the compilers ready",
   "track.phase.synthesising": "Shaping the ground",
   "track.phase.writing": "Writing the source",
   "track.phase.map": "Building the graphics",

--- a/apps/studio/src/i18n/locales/es.ts
+++ b/apps/studio/src/i18n/locales/es.ts
@@ -432,6 +432,7 @@ export const es: Translation = {
   "protect.showFolder": "Mostrar carpeta",
   "track.gap": "de hueco",
   "track.deep": "de profundidad",
+  "track.phase.preparing": "Preparando los compiladores",
   "track.phase.synthesising": "Modelando el terreno",
   "track.phase.writing": "Escribiendo las fuentes",
   "track.phase.map": "Compilando los gráficos",

--- a/apps/studio/src/i18n/locales/fr.ts
+++ b/apps/studio/src/i18n/locales/fr.ts
@@ -432,6 +432,7 @@ export const fr: Translation = {
   "protect.showFolder": "Afficher le dossier",
   "track.gap": "d'écart",
   "track.deep": "de profondeur",
+  "track.phase.preparing": "Préparation des compilateurs",
   "track.phase.synthesising": "Modelage du terrain",
   "track.phase.writing": "Écriture des sources",
   "track.phase.map": "Compilation des graphismes",

--- a/apps/studio/src/i18n/locales/it.ts
+++ b/apps/studio/src/i18n/locales/it.ts
@@ -432,6 +432,7 @@ export const it: Translation = {
   "protect.showFolder": "Mostra cartella",
   "track.gap": "di vuoto",
   "track.deep": "di profondità",
+  "track.phase.preparing": "Preparazione dei compilatori",
   "track.phase.synthesising": "Modellazione del terreno",
   "track.phase.writing": "Scrittura dei sorgenti",
   "track.phase.map": "Compilazione della grafica",

--- a/apps/studio/src/i18n/locales/pt-BR.ts
+++ b/apps/studio/src/i18n/locales/pt-BR.ts
@@ -430,6 +430,7 @@ export const ptBR: Translation = {
   "protect.showFolder": "Mostrar pasta",
   "track.gap": "de vão",
   "track.deep": "de profundidade",
+  "track.phase.preparing": "Preparando os compiladores",
   "track.phase.synthesising": "Modelando o terreno",
   "track.phase.writing": "Escrevendo os fontes",
   "track.phase.map": "Compilando os gráficos",

--- a/crates/core/src/winehost.rs
+++ b/crates/core/src/winehost.rs
@@ -418,6 +418,129 @@ pub fn describe(override_path: &str) -> HostInfo {
     }
 }
 
+/// A Wine host that can run a Windows program: what to launch it with, and where.
+///
+/// Resolved rather than asked for — see [`tool_host`].
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+#[derive(Debug, Clone)]
+pub struct Host {
+    pub runner: Runner,
+    pub prefix: PathBuf,
+    /// The prefix doesn't exist yet, so the first program run in it pays for creating it.
+    pub fresh: bool,
+}
+
+/// Find something on this machine that can run a Windows console program.
+///
+/// PiBoSo's track compilers need a Wine prefix, but not *the game's*: they are CPU-only,
+/// they load nothing the game installed, and the prefix is only somewhere for a Windows
+/// program to find a `C:`. So the game's bottle is the first choice rather than the
+/// requirement — asking someone to move their game inside a prefix to compile a track is
+/// asking them to do our work.
+///
+/// In order: the prefix the game sits in, any other prefix on this machine, and then `own`
+/// — ours, which [`ensure_prefix`] creates the first time it is used. `None` is the one
+/// answer a person has to act on: no Wine here at all.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub fn tool_host(game_path: &Path, own: &Path, override_path: &str) -> Option<Host> {
+    pick_host(game_path, own, bottles(), &|prefix| resolve(override_path, prefix))
+}
+
+/// [`tool_host`]'s order of preference, with the machine handed in so it can be tested on
+/// one that has no Wine on it.
+fn pick_host(
+    game_path: &Path,
+    own: &Path,
+    bottles: Vec<PathBuf>,
+    resolve: &dyn Fn(Option<&Path>) -> Option<Runner>,
+) -> Option<Host> {
+    // The game's own bottle is exempt from the check below: whatever runs the game is
+    // already running in there, and this is the same launch the Play button makes.
+    if let Some((prefix, _)) = split_prefix(game_path) {
+        if let Some(runner) = resolve(Some(&prefix)) {
+            return Some(Host { runner, prefix, fresh: false });
+        }
+    }
+    for prefix in bottles {
+        match resolve(Some(&prefix)) {
+            Some(runner) if borrowable(&prefix, &runner) => {
+                return Some(Host { runner, prefix, fresh: false })
+            }
+            _ => {}
+        }
+    }
+    let runner = resolve(None)?;
+    Some(Host { fresh: !is_prefix(own), runner, prefix: own.to_path_buf() })
+}
+
+/// May we run `runner` in someone else's `prefix`?
+///
+/// Only when the two belong together. A wrapper's bottle is built by its own Wine, and a
+/// different build launched against it upgrades the prefix in place — which is a stranger's
+/// game install broken by a track compile. A bare prefix (`~/.wine`, `$WINEPREFIX`) has no
+/// owner to disagree with, and our own is made below.
+fn borrowable(prefix: &Path, runner: &Runner) -> bool {
+    match owner_of(prefix) {
+        None | Some(Wrapper::Plain) => true,
+        Some(Wrapper::CrossOver) => runner.via() == "CrossOver",
+        Some(Wrapper::Whisky) => runner.via() == "Whisky",
+    }
+}
+
+/// How long a first `wineboot` is given before it is treated as stuck.
+const BOOT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// Lay down `prefix` if it isn't one yet.
+///
+/// `wineboot -i` is what writes `drive_c` and the registry. Doing it here rather than
+/// leaving it to the first real program keeps the wait somewhere the app can name, and
+/// keeps `wineboot`'s output out of a compiler's log.
+///
+/// Mono and Gecko are overridden off: a fresh prefix otherwise opens a dialog offering to
+/// download them, which on a machine with nobody watching is a build that never returns.
+/// Nothing we run in here is a .NET or a browser program.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub fn ensure_prefix(runner: &Runner, prefix: &Path) -> std::io::Result<()> {
+    // A wrapper's own bottle is made by the wrapper. Only ours is ever missing.
+    if is_prefix(prefix) || matches!(runner.kind, RunnerKind::CrossOver { .. }) {
+        return Ok(());
+    }
+    std::fs::create_dir_all(prefix)?;
+    let mut child = std::process::Command::new(&runner.program)
+        .args(["wineboot", "-i"])
+        .env("WINEPREFIX", prefix)
+        .env("WINEDEBUG", "-all")
+        .env("WINEDLLOVERRIDES", "mscoree,mshtml=")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()?;
+
+    let deadline = std::time::Instant::now() + BOOT_TIMEOUT;
+    loop {
+        if child.try_wait()?.is_some() {
+            break;
+        }
+        if std::time::Instant::now() > deadline {
+            let _ = child.kill();
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!("wineboot took longer than {}s in {prefix:?}", BOOT_TIMEOUT.as_secs()),
+            ));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+
+    // The exit status is not the test — some Wine builds boot a prefix and still exit
+    // non-zero — but a prefix with no `drive_c` is one nothing can run in.
+    if !is_prefix(prefix) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("{} made no drive_c in {prefix:?}", runner.via()),
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -427,6 +550,89 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    fn any_wine() -> Runner {
+        Runner {
+            program: PathBuf::from("/opt/wine"),
+            kind: RunnerKind::Wine { via: "Wine" },
+        }
+    }
+
+    /// The game's own bottle first: it is the one already proven to run Windows code here.
+    #[test]
+    fn the_games_prefix_is_the_first_choice() {
+        let host = pick_host(
+            Path::new("/b/MXB/drive_c/MX Bikes/mxbikes.exe"),
+            Path::new("/data/ours"),
+            vec![PathBuf::from("/b/Other")],
+            &|_| Some(any_wine()),
+        )
+        .expect("a runner was offered");
+        assert_eq!(host.prefix, PathBuf::from("/b/MXB"));
+        assert!(!host.fresh);
+    }
+
+    /// A game installed outside a prefix — a copy on the Desktop, a folder of files — used
+    /// to end the build. Any other bottle on the machine runs a console tool just as well.
+    #[test]
+    fn a_game_outside_a_prefix_borrows_another_bottle() {
+        let host = pick_host(
+            Path::new("/Applications/MX Bikes"),
+            Path::new("/data/ours"),
+            vec![PathBuf::from("/b/Whisky")],
+            &|_| Some(any_wine()),
+        )
+        .expect("a runner was offered");
+        assert_eq!(host.prefix, PathBuf::from("/b/Whisky"));
+    }
+
+    /// A bottle CrossOver or Whisky built is theirs. Running our own Wine in it would
+    /// upgrade the prefix in place — someone's game broken by a track compile — so a
+    /// prefix we can't drive properly is skipped for one of ours.
+    #[test]
+    fn a_wrappers_bottle_is_left_to_its_wrapper() {
+        let home = dirs_next::home_dir().expect("a home directory");
+        let whisky = home.join("Library/Containers/com.isaacmarovitz.Whisky/Bottles/theirs");
+        let host = pick_host(
+            Path::new(""),
+            Path::new("/data/ours"),
+            vec![whisky],
+            &|_| Some(any_wine()),
+        )
+        .expect("a runner was offered");
+        assert_eq!(host.prefix, PathBuf::from("/data/ours"));
+    }
+
+    /// Nothing on the machine but Wine itself: we make a prefix of our own rather than
+    /// asking anyone to make one.
+    #[test]
+    fn with_no_bottles_it_uses_its_own_prefix() {
+        let host = pick_host(
+            Path::new(""),
+            Path::new("/data/ours"),
+            vec![],
+            &|prefix| prefix.is_none().then(any_wine),
+        )
+        .expect("a runner was offered");
+        assert_eq!(host.prefix, PathBuf::from("/data/ours"));
+        assert!(host.fresh, "/data/ours doesn't exist, so it has to be created");
+    }
+
+    /// No Wine at all is the one case a person has to do something about.
+    #[test]
+    fn no_runner_anywhere_is_the_only_dead_end() {
+        assert!(pick_host(Path::new(""), Path::new("/data/ours"), vec![], &|_| None).is_none());
+    }
+
+    /// A prefix that is already there is not booted again — `fresh` is what decides, and a
+    /// second build must not pay for `wineboot`.
+    #[test]
+    fn an_existing_prefix_is_not_fresh() {
+        let dir = temp_dir("existing");
+        std::fs::create_dir_all(dir.join(DRIVE_C)).unwrap();
+        let host = pick_host(Path::new(""), &dir, vec![], &|_| Some(any_wine())).unwrap();
+        assert!(!host.fresh);
     }
 
     #[test]


### PR DESCRIPTION
Building a track on macOS stopped with:

> the compilers are Windows programs. Set the game path to a copy inside a Wine prefix — CrossOver, Whisky or plain Wine — and they'll run through that.

That asks someone to move their game install in order to compile a track, and the only lever it offers — the *game* path — has nothing to do with compiling. PiBoSo's compilers are console programs: they read a `.hmf`, write a `.map`, touch no GPU and load nothing the game installed. Any Wine prefix runs them.

## What it does now

`winehost::tool_host` picks, in order:

1. the prefix the game sits in (unchanged for anyone whose game is in a bottle),
2. any other bottle on the machine,
3. one of ours under the app's data folder, laid down with `wineboot -i`.

`winefetch` fetches Gcenx's macOS Wine build (pinned at 11.16) when the machine has none — the same bargain as `ensure_track_tools`, which already fetches the compilers rather than making anyone find them. Cached, so only the first build pays. Linux is pointed at its package manager; Windows never asks.

Two things worth a look:

- **A wrapper's bottle is left to its wrapper.** A bottle is only borrowed when the runner belongs to whoever built it — launching our Wine against someone's CrossOver or Whisky prefix upgrades it in place, which is their game install broken by a track compile.
- **Nothing can stop on a dialog.** A fresh prefix offers to install Mono and Gecko; both are overridden off, and `wineboot` runs under a five-minute cap so a wedged boot fails instead of hanging the build for ever.

Also here: the configured `wine_runner` is finally honoured (the studio read only `FROST_WINE`), a `preparing` phase on the build bar in six locales so a 190 MB download isn't a frozen window, and the `tauri = { features = ["test"] }` dev-dependency the studio has been missing since `sidecar_lock` moved into it — without which `cargo test` on that crate doesn't build at all.

## Verification

- `cargo check` for macOS and `x86_64-pc-windows-gnu`; `tsc --noEmit`; all winehost and trackbuild tests.
- New tests cover the fallback order, a game outside any prefix, a wrapper's bottle being skipped, and the one dead end left (nothing on the machine can run a Windows program) — including that its message no longer sends anyone off to move their game.
- The pinned Wine URL was streamed and the binary confirmed at exactly the path the code looks for it.
- A full end-to-end build with no game path set is still running at the time of writing; I'll report what it produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)