### PR TITLE
Wine-host test: only holds on macOS

### DIFF
--- a/crates/core/src/winehost.rs
+++ b/crates/core/src/winehost.rs
@@ -590,7 +590,10 @@ mod tests {
     /// A bottle CrossOver or Whisky built is theirs. Running our own Wine in it would
     /// upgrade the prefix in place — someone's game broken by a track compile — so a
     /// prefix we can't drive properly is skipped for one of ours.
+    ///
+    /// macOS only: `bottle_roots` is empty elsewhere, so no prefix has a wrapper to leave it to.
     #[test]
+    #[cfg(target_os = "macos")]
     fn a_wrappers_bottle_is_left_to_its_wrapper() {
         let home = dirs_next::home_dir().expect("a home directory");
         let whisky = home.join("Library/Containers/com.isaacmarovitz.Whisky/Bottles/theirs");


### PR DESCRIPTION
## Why

`Rust (test)` has been failing on **both** ubuntu-latest and windows-latest since #542 merged, so `main` is red and no release can be cut off it.

One test, `winehost::tests::a_wrappers_bottle_is_left_to_its_wrapper`:

```
panicked at crates/core/src/winehost.rs:604:
  left: "/home/runner/Library/Containers/com.isaacmarovitz.Whisky/Bottles/theirs"
 right: "/data/ours"
```

The test asserts that a bottle built by CrossOver or Whisky is left alone and our own prefix used instead. That rule lives in `borrowable()` → `owner_of()` → `bottle_roots()`, and `bottle_roots()` is `#[cfg(target_os = "macos")]` — off macOS it returns an empty `Vec`. So on Linux and Windows the Whisky path has no recognised owner, counts as a bare prefix, and is borrowed. It passed on the author's Mac and could only ever fail in CI.

## What

Gate the test to macOS — the only platform the Wine-host path runs on at all (`tool_host` and `ensure_prefix` are both `allow(dead_code)` elsewhere). Test-only; no product change, so no changelog entry.

## Verification

- `cargo test -p mxb-core --lib winehost` on macOS — 17 passed, 0 failed, including the gated test.
- `cargo check -p mxb-core --lib --tests --target x86_64-pc-windows-gnu` — clean, so cfg-ing the test out leaves no unused imports on the platforms that were red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)