### PR TITLE
Server browser: favourites, sorting, regions, image cards, and one-click track install

### DIFF
--- a/apps/manager/src-tauri/src/main.rs
+++ b/apps/manager/src-tauri/src/main.rs
@@ -6333,6 +6333,8 @@ fn main() {
             server_riders,
             servers_with_paint_sync,
             guess_server_track,
+            installed_track_ids,
+            resolve_server_tracks,
             ranked_identity,
             ranked_profile,
             set_ranked_guid,
@@ -7691,6 +7693,46 @@ async fn scan_library(
     tauri::async_runtime::spawn_blocking(move || scan_library_blocking(app, subpath))
         .await
         .map_err(|e| format!("scan_library task failed: {e}"))?
+}
+
+/// One installed track, as the server browser matches it (see `lib/trackContent.ts`).
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InstalledTrack {
+    /// The track's internal folder id — exactly the value a server reports as its track, so
+    /// the browser matches on it directly. This is the library scan's `name`.
+    id: String,
+    /// Absolute path of the `.pkz` (or track folder), for reading its preview.
+    path: String,
+}
+
+/// The internal ids of every installed track, so the server browser can say which servers'
+/// tracks the player already has. Reuses the same track scan `guess_server_track` trusts,
+/// mapped down to the id/path the matcher needs.
+#[tauri::command]
+async fn installed_track_ids(app: tauri::AppHandle) -> Result<Vec<InstalledTrack>, String> {
+    let entries = scan_library(app, "tracks".into()).await?;
+    Ok(entries
+        .into_iter()
+        .map(|e| InstalledTrack { id: e.name, path: e.path })
+        .collect())
+}
+
+/// Which of these track ids the mxb-mods catalog can supply (see [`mods::trackindex`]).
+///
+/// Ask with the tracks the browser is showing as missing, most-hosted first: what the index
+/// can't answer becomes its background queue, so the order is also the priority. Returns
+/// immediately from the index — the queue is worked behind it, and `track-index://updated`
+/// says when a later call would answer more. Asked without `with_clearance` for the same
+/// reason `guess_server_track` is: a background resolve must never pop a browser challenge.
+#[tauri::command]
+async fn resolve_server_tracks(
+    app: tauri::AppHandle,
+    tracks: Vec<String>,
+) -> Result<mods::trackindex::Resolution, String> {
+    mods::trackindex::resolve(&app, tracks)
+        .await
+        .map_err(|e| format!("{e:#}"))
 }
 
 #[tauri::command]

--- a/apps/manager/src-tauri/src/main.rs
+++ b/apps/manager/src-tauri/src/main.rs
@@ -7699,23 +7699,70 @@ async fn scan_library(
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 struct InstalledTrack {
-    /// The track's internal folder id — exactly the value a server reports as its track, so
-    /// the browser matches on it directly. This is the library scan's `name`.
+    /// The track's internal folder id — the top-level directory inside its `.pkz`, which is
+    /// exactly the value a server reports as its track. Deliberately not the file name: a pkz
+    /// named `Farm14.pkz` holds a folder `Farm14`, and the master names the folder.
     id: String,
-    /// Absolute path of the `.pkz` (or track folder), for reading its preview.
+    /// Absolute path of the `.pkz`, for reading its preview.
     path: String,
 }
 
-/// The internal ids of every installed track, so the server browser can say which servers'
-/// tracks the player already has. Reuses the same track scan `guess_server_track` trusts,
-/// mapped down to the id/path the matcher needs.
+/// The internal ids of every installed track, so the browser can say which servers' tracks the
+/// player already has.
+///
+/// Walks `<mods>/mods/tracks` — tracks sit in category subfolders (`motocross/`, `supercross/`…)
+/// under it — and reads each pkz's own top folder. That, not the file name, is what the master
+/// reports and what a match has to line up against: a `scan_library` shortcut keyed on the file
+/// name (extension and all, in the wrong directory) matched nothing.
 #[tauri::command]
 async fn installed_track_ids(app: tauri::AppHandle) -> Result<Vec<InstalledTrack>, String> {
-    let entries = scan_library(app, "tracks".into()).await?;
-    Ok(entries
-        .into_iter()
-        .map(|e| InstalledTrack { id: e.name, path: e.path })
-        .collect())
+    tauri::async_runtime::spawn_blocking(move || {
+        let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
+        let root = library::mods_subdir(&cfg.mods_path, "mods/tracks");
+        let mut out: Vec<InstalledTrack> = Vec::new();
+        for entry in walkdir::WalkDir::new(&root).max_depth(3).into_iter().flatten() {
+            let path = entry.path();
+            if path
+                .extension()
+                .and_then(|e| e.to_str())
+                .is_some_and(|e| e.eq_ignore_ascii_case("pkz"))
+            {
+                if let Some(id) = track_id_of(path) {
+                    out.push(InstalledTrack { id, path: path.to_string_lossy().into_owned() });
+                }
+            }
+        }
+        Ok(out)
+    })
+    .await
+    .map_err(|e| format!("track scan failed: {e}"))?
+}
+
+/// A track's internal id: the top-level folder inside its `.pkz` (what a server reports),
+/// falling back to the file stem when the archive can't be read.
+fn track_id_of(path: &std::path::Path) -> Option<String> {
+    if let Ok(names) = pkz::entry_names(path) {
+        if let Some(id) = top_folder(&names) {
+            return Some(id);
+        }
+    }
+    let stem = path.file_stem()?.to_string_lossy().trim().to_string();
+    (!stem.is_empty()).then_some(stem)
+}
+
+/// The most common top-level directory across archive entry names — a track `.pkz` has exactly
+/// one, its track folder. `None` when the archive has no directoried entries.
+fn top_folder(names: &[String]) -> Option<String> {
+    use std::collections::HashMap;
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for n in names {
+        if let Some((top, _)) = n.split_once('/') {
+            if !top.is_empty() {
+                *counts.entry(top).or_default() += 1;
+            }
+        }
+    }
+    counts.into_iter().max_by_key(|(_, c)| *c).map(|(t, _)| t.to_string())
 }
 
 /// Which of these track ids the mxb-mods catalog can supply (see [`mods::trackindex`]).

--- a/apps/manager/src-tauri/src/main.rs
+++ b/apps/manager/src-tauri/src/main.rs
@@ -7699,7 +7699,7 @@ async fn scan_library(
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 struct InstalledTrack {
-    /// The track's internal folder id — the top-level directory inside its `.pkz`, which is
+    /// The track's internal folder id - the top-level directory inside its `.pkz`, which is
     /// exactly the value a server reports as its track. Deliberately not the file name: a pkz
     /// named `Farm14.pkz` holds a folder `Farm14`, and the master names the folder.
     id: String,
@@ -7710,8 +7710,8 @@ struct InstalledTrack {
 /// The internal ids of every installed track, so the browser can say which servers' tracks the
 /// player already has.
 ///
-/// Walks `<mods>/mods/tracks` — tracks sit in category subfolders (`motocross/`, `supercross/`…)
-/// under it — and reads each pkz's own top folder. That, not the file name, is what the master
+/// Walks `<mods>/mods/tracks` - tracks sit in category subfolders (`motocross/`, `supercross/`…)
+/// under it - and reads each pkz's own top folder. That, not the file name, is what the master
 /// reports and what a match has to line up against: a `scan_library` shortcut keyed on the file
 /// name (extension and all, in the wrong directory) matched nothing.
 #[tauri::command]
@@ -7750,7 +7750,7 @@ fn track_id_of(path: &std::path::Path) -> Option<String> {
     (!stem.is_empty()).then_some(stem)
 }
 
-/// The most common top-level directory across archive entry names — a track `.pkz` has exactly
+/// The most common top-level directory across archive entry names - a track `.pkz` has exactly
 /// one, its track folder. `None` when the archive has no directoried entries.
 fn top_folder(names: &[String]) -> Option<String> {
     use std::collections::HashMap;
@@ -7769,7 +7769,7 @@ fn top_folder(names: &[String]) -> Option<String> {
 ///
 /// Ask with the tracks the browser is showing as missing, most-hosted first: what the index
 /// can't answer becomes its background queue, so the order is also the priority. Returns
-/// immediately from the index — the queue is worked behind it, and `track-index://updated`
+/// immediately from the index - the queue is worked behind it, and `track-index://updated`
 /// says when a later call would answer more. Asked without `with_clearance` for the same
 /// reason `guess_server_track` is: a background resolve must never pop a browser challenge.
 #[tauri::command]

--- a/apps/manager/src-tauri/src/mods/mod.rs
+++ b/apps/manager/src-tauri/src/mods/mod.rs
@@ -3,6 +3,7 @@ pub mod hubaccount;
 pub mod mxb;
 pub mod mxbshop;
 pub mod shop_catalog;
+pub mod trackindex;
 
 use serde::{Deserialize, Serialize};
 

--- a/apps/manager/src-tauri/src/mods/mxb.rs
+++ b/apps/manager/src-tauri/src/mods/mxb.rs
@@ -763,7 +763,7 @@ pub async fn ratings(ids: &[u64]) -> HashMap<u64, ModRating> {
 /// WP's own `per_page` ceiling. Asking for more is a 400, not a bigger page.
 const BULK_PER_PAGE: u32 = 100;
 
-/// One listing page of a category, as light post summaries — for building the track index
+/// One listing page of a category, as light post summaries - for building the track index
 /// ([`super::trackindex`]) rather than for a browse view.
 ///
 /// The tracks category is ~1,600 posts; this pages it 100 at a time straight off the REST
@@ -815,7 +815,7 @@ pub async fn downloads_at(link: &str) -> anyhow::Result<Vec<DownloadOption>> {
 ///
 /// MediaFire puts the real name in the path (`/file/<id>/Farm14.pkz/file`); Google Drive and
 /// Mega use opaque ids and yield nothing here. That asymmetry is the whole reason this is
-/// best-effort rather than a guarantee — roughly half of catalog links name their file.
+/// best-effort rather than a guarantee - roughly half of catalog links name their file.
 pub fn download_file_name(url: &str) -> Option<String> {
     let name = url_file_name(url);
     let name = percent_decode(name);

--- a/apps/manager/src-tauri/src/mods/mxb.rs
+++ b/apps/manager/src-tauri/src/mods/mxb.rs
@@ -760,6 +760,104 @@ pub async fn ratings(ids: &[u64]) -> HashMap<u64, ModRating> {
     out
 }
 
+/// WP's own `per_page` ceiling. Asking for more is a 400, not a bigger page.
+const BULK_PER_PAGE: u32 = 100;
+
+/// One listing page of a category, as light post summaries — for building the track index
+/// ([`super::trackindex`]) rather than for a browse view.
+///
+/// The tracks category is ~1,600 posts; this pages it 100 at a time straight off the REST
+/// API, asking only for the fields the index keys on. A 400 means we've paged past the end,
+/// which is an empty page and not an error.
+pub async fn catalog_page(category_id: u32, page: u32) -> anyhow::Result<Vec<ModSummary>> {
+    let url = format!("{}{}", mxb_session::base(), obfstr!("/wp-json/wp/v2/posts"));
+    let params = vec![
+        ("categories", category_id.to_string()),
+        ("page", page.to_string()),
+        ("per_page", BULK_PER_PAGE.to_string()),
+        ("_fields", "id,slug,title,link,date".to_string()),
+    ];
+    let resp = get_with_retry(&url, &params).await?;
+    if resp.status == 400 {
+        return Ok(vec![]);
+    }
+    if !resp.is_success() {
+        return Err(refusal("the catalog listing", &resp));
+    }
+    let posts: Vec<Value> = resp.json()?;
+    Ok(posts
+        .iter()
+        .filter_map(|p| summary_from_post(p, category_id))
+        .collect())
+}
+
+/// The download links on one mod page, without the metadata round-trip [`detail`] also makes.
+///
+/// [`detail`] exists to render a mod page and needs the post JSON for its description, images
+/// and categories; a caller that only wants to know which *files* a mod ships needs none of
+/// that, and the page HTML alone has the links. Half the requests, for the callers building an
+/// index over many mods at once.
+pub async fn downloads_at(link: &str) -> anyhow::Result<Vec<DownloadOption>> {
+    let resp = get_page(link).await?;
+    if !resp.is_success() {
+        return Err(refusal("the mod page", &resp));
+    }
+    let downloads = parse_downloads(&resp.body);
+    if downloads.is_empty() {
+        if let Some(marker) = challenge_marker(&resp.body) {
+            return Err(challenge_error(marker, resp.body.len()));
+        }
+    }
+    Ok(downloads)
+}
+
+/// The file name a download URL carries, when it carries one.
+///
+/// MediaFire puts the real name in the path (`/file/<id>/Farm14.pkz/file`); Google Drive and
+/// Mega use opaque ids and yield nothing here. That asymmetry is the whole reason this is
+/// best-effort rather than a guarantee — roughly half of catalog links name their file.
+pub fn download_file_name(url: &str) -> Option<String> {
+    let name = url_file_name(url);
+    let name = percent_decode(name);
+    let (stem, ext) = name.rsplit_once('.')?;
+    if !matches!(ext.to_ascii_lowercase().as_str(), "pkz" | "zip" | "rar" | "7z") {
+        return None;
+    }
+    let stem = stem.trim();
+    (!stem.is_empty()).then(|| stem.to_string())
+}
+
+/// Enough percent/plus decoding for a URL path segment. MediaFire encodes spaces as `+` in
+/// some links and `%20` in others, and both spellings have to fold to the same name.
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b'%' if i + 2 < bytes.len() => match u8::from_str_radix(&s[i + 1..i + 3], 16) {
+                Ok(b) => {
+                    out.push(b);
+                    i += 3;
+                }
+                Err(_) => {
+                    out.push(b'%');
+                    i += 1;
+                }
+            },
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
 /// A poisoned rating cache is not worth taking the app down for — the worst case is one
 /// stale entry written by a thread that panicked mid-insert.
 fn lock<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {

--- a/apps/manager/src-tauri/src/mods/trackindex.rs
+++ b/apps/manager/src-tauri/src/mods/trackindex.rs
@@ -1,14 +1,14 @@
 //! Knowing, before the user asks, whether a server's track can be downloaded.
 //!
-//! The server browser gets a track as an internal id — `Farm14`, `Highland-Mx`,
-//! `2026_ARLMX_RD11_INDIANA_Pro` — and needs to say one of three things about it: installed,
+//! The server browser gets a track as an internal id - `Farm14`, `Highland-Mx`,
+//! `2026_ARLMX_RD11_INDIANA_Pro` - and needs to say one of three things about it: installed,
 //! downloadable from here, or not something we can get. The first is a disk scan. This module
 //! is the second.
 //!
 //! ## Why an index, and why two halves
 //!
 //! Answering per-track over the network ([`crate::mods::mxb::search`] then a page fetch) is
-//! what the app did before, and it can only run *after* the user clicks — so the browser can't
+//! what the app did before, and it can only run *after* the user clicks - so the browser can't
 //! badge anything ahead of time, and every click pays a search. An index inverts that, but the
 //! catalog only gives up half of what matching needs cheaply:
 //!
@@ -17,13 +17,13 @@
 //!   front, refreshed daily. Exact title/slug matching resolves about a third of live servers.
 //!
 //! * **File names are not.** A mod's download links live only in its *rendered page*, one
-//!   fetch each — and even then only MediaFire puts the real name in the URL; Drive and Mega
+//!   fetch each - and even then only MediaFire puts the real name in the URL; Drive and Mega
 //!   use opaque ids. Roughly half of catalog links name their file.
 //!
 //! File names are worth the fetches because they catch exactly what titles cannot: a post
 //! titled "Farm14 v0.1" ships `Farm14.pkz`, "Five-Two SMX" ships `SMX.pkz`, and "Rail MX"
 //! ships `Motoland_MX_Park.pkz`. A version suffix or a rename defeats title matching outright,
-//! and the file name is the author's own statement of what the track is called on disk — which
+//! and the file name is the author's own statement of what the track is called on disk - which
 //! is precisely the id a server reports.
 //!
 //! ## The drip
@@ -32,8 +32,8 @@
 //! would be ~1,600 requests per user against a Cloudflare-fronted site, to learn about tracks
 //! nobody is hosting. Instead [`resolve`] queues the track ids live servers are actually
 //! running that titles didn't resolve, and the drip behind it works the busiest first and stops at
-//! [`MAX_PAGES_PER_SESSION`]. Results are permanent — a file name is a fact about a published
-//! mod, not a cache of a changing value — so the index converges over a few sessions and
+//! [`MAX_PAGES_PER_SESSION`]. Results are permanent - a file name is a fact about a published
+//! mod, not a cache of a changing value - so the index converges over a few sessions and
 //! costs nothing thereafter.
 
 use super::ModSummary;
@@ -43,7 +43,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-/// mxb-mods' "Tracks" category — the `tracks` entry of `MOD_TYPES` in `src/api/mods.ts`.
+/// mxb-mods' "Tracks" category - the `tracks` entry of `MOD_TYPES` in `src/api/mods.ts`.
 const TRACKS_CATEGORY: u32 = 22;
 
 /// How long the title listing is served before a refresh is spawned behind it. Daily: new
@@ -64,10 +64,10 @@ const MAX_LISTING_PAGES: u32 = 40;
 /// budget has to span the cascade, so it lives in [`pages_read`] rather than in a loop bound.
 ///
 /// What the cap doesn't spend this session it spends the next, because what the drip learns
-/// is kept — so a low ceiling costs convergence time, never coverage.
+/// is kept - so a low ceiling costs convergence time, never coverage.
 const SESSION_PAGE_BUDGET: usize = 60;
 
-/// Pages in flight at once. Low on purpose — this is background work nobody is waiting on,
+/// Pages in flight at once. Low on purpose - this is background work nobody is waiting on,
 /// and it shares a Cloudflare budget with the browsing the user *is* waiting on.
 const ENRICH_CONCURRENCY: usize = 3;
 
@@ -90,7 +90,7 @@ pub struct Entry {
     pub link: String,
     pub date: String,
     /// File name stems the mod's downloads carry, e.g. `["Farm14"]`. Empty after enrichment
-    /// means the page was read and named nothing — a Drive-only mod — which is different from
+    /// means the page was read and named nothing - a Drive-only mod - which is different from
     /// never having been read; `enriched_at` is what tells those apart.
     #[serde(default)]
     pub files: Vec<String>,
@@ -136,7 +136,7 @@ pub struct Hit {
     pub via: Via,
 }
 
-/// What [`resolve`] found, plus whether the index is still filling itself in — the browser
+/// What [`resolve`] found, plus whether the index is still filling itself in - the browser
 /// uses `pending` to say "still looking" rather than "not available" for a track the drip
 /// hasn't reached yet.
 #[derive(Debug, Clone, Serialize)]
@@ -213,20 +213,20 @@ fn find(lookup: &Lookup, entries: &[Entry], track: &str) -> Option<Hit> {
 /// The shortest title allowed to claim a track id it is merely *contained in*, and the
 /// largest multiple of that title's length the id may be.
 ///
-/// These guard one arm of [`candidates`] only — the "post title appears inside the track id"
-/// case — and they exist because that arm is what made rounds 2-5 of the first live run spend
+/// These guard one arm of [`candidates`] only - the "post title appears inside the track id"
+/// case - and they exist because that arm is what made rounds 2-5 of the first live run spend
 /// 32 pages to resolve 3 tracks. A league id like `2026arlmxrd11indianapro` contains
 /// `indiana` and `pro`, so every generic short title in the catalog queued itself as a
 /// candidate for tracks that were never going to match. Requiring the title to be both
-/// substantial in itself and a real fraction of the id keeps the arm's actual wins —
-/// `outpost` inside `outpostprepped`, `islandsx` inside `ghptracksislandsx` — and drops the
+/// substantial in itself and a real fraction of the id keeps the arm's actual wins -
+/// `outpost` inside `outpostprepped`, `islandsx` inside `ghptracksislandsx` - and drops the
 /// rest.
 const MIN_CONTAINED_TITLE: usize = 5;
 const MAX_CONTAINED_RATIO: usize = 3;
 
 /// Posts worth reading a page for, when looking for `track`.
 ///
-/// Purely local — it decides which pages to spend fetches on, never what matches. The rule is
+/// Purely local - it decides which pages to spend fetches on, never what matches. The rule is
 /// containment either way round on the folded key, which is what the real misses look like:
 /// `Farm14` inside `farm14v01` ("Farm14 v0.1"), `smx` inside `fivetwosmx` ("Five-Two SMX").
 /// Shorter titles rank first, since a title that is barely longer than the id is far likelier
@@ -248,7 +248,7 @@ fn candidates(entries: &[Entry], track: &str) -> Vec<usize> {
             // version, an author prefix), in its title or its slug.
             let widened = t.contains(&key) || s.contains(&key);
             // The narrow arm: the track id is the post's title plus a suffix the author
-            // didn't publish under. Guarded — see the two constants above.
+            // didn't publish under. Guarded - see the two constants above.
             let contained = key.contains(&t)
                 && t.len() >= MIN_CONTAINED_TITLE
                 && t.len() * MAX_CONTAINED_RATIO >= key.len();
@@ -288,7 +288,7 @@ fn in_flight() -> &'static Mutex<HashSet<String>> {
 /// Track ids the drip has already been through this session and could not place.
 ///
 /// The terminal state the index was missing. Without it "we haven't looked yet" and "we looked
-/// and there is nothing" are the same answer, so the browser can only ever say "Looking…" —
+/// and there is nothing" are the same answer, so the browser can only ever say "Looking…" -
 /// and the queue re-reads the same dead ends every time the list refreshes.
 ///
 /// Session-scoped on purpose: a restart is cheap and the catalog does gain posts. It is not
@@ -451,8 +451,8 @@ fn spawn_listing_refresh(app: &tauri::AppHandle) {
 
 // ───────────────────────────────── the drip ─────────────────────────────────
 
-/// Read one mod page and record what it ships. Failures are recorded too — as an enrichment
-/// with no files — so a page that 404s or is Cloudflare-blocked isn't retried on every open.
+/// Read one mod page and record what it ships. Failures are recorded too - as an enrichment
+/// with no files - so a page that 404s or is Cloudflare-blocked isn't retried on every open.
 async fn enrich_one(entry: &Entry) -> (u64, Vec<String>) {
     let files = match super::mxb::downloads_at(&entry.link).await {
         Ok(downloads) => downloads
@@ -467,13 +467,13 @@ async fn enrich_one(entry: &Entry) -> (u64, Vec<String>) {
     (entry.id, files)
 }
 
-/// Work through `wanted` — track ids the index couldn't resolve — reading pages for the
+/// Work through `wanted` - track ids the index couldn't resolve - reading pages for the
 /// candidates each one suggests, busiest track first.
 ///
 /// `wanted` arrives already ordered by how many servers are running each track, so the drip
 /// spends its budget where it will change what the most people see.
 async fn drip(app: tauri::AppHandle, wanted: Vec<String>) {
-    // Whatever [`round`] does — finish, give up early, or panic — these ids come back and are
+    // Whatever [`round`] does - finish, give up early, or panic - these ids come back and are
     // marked settled (see [`Claim`]), and the browser is told to ask again. A round that
     // learned nothing still has to say so: "Looking…" is a state the UI cannot leave on its
     // own, because the only thing that moves it is this event.
@@ -539,7 +539,7 @@ async fn round(app: &tauri::AppHandle, wanted: &[String]) {
         }
     }
 
-    // Fold the results into the index as it stands *now* — a listing refresh may have landed
+    // Fold the results into the index as it stands *now* - a listing refresh may have landed
     // while we were fetching, and rebuilding from the copy we started with would lose it.
     let base = current().unwrap_or(index);
     let mut next = Index {
@@ -563,8 +563,8 @@ async fn round(app: &tauri::AppHandle, wanted: &[String]) {
 /// The track ids one drip round has claimed, released on drop and marked [`settled`].
 ///
 /// Deliberately a guard rather than a call at the end of the round. Every early return in
-/// [`round`] is a path where nothing was learned — the listing wouldn't load, the session's
-/// page budget was already spent, no candidate pages to read — and a claim left behind on one
+/// [`round`] is a path where nothing was learned - the listing wouldn't load, the session's
+/// page budget was already spent, no candidate pages to read - and a claim left behind on one
 /// of those is **permanent**: [`resolve`] goes on reporting that track as pending, so the
 /// browser shows "Looking…" and never stops, *and* the same claim filters it out of the queue,
 /// so nothing ever looks again. It is stuck in both directions at once.
@@ -574,7 +574,7 @@ async fn round(app: &tauri::AppHandle, wanted: &[String]) {
 ///
 /// Settling them is the other half, and it is what makes the notification in [`drip`] safe:
 /// without it, the re-resolve that event triggers would queue the same unanswerable ids, drip
-/// again, learn nothing again, and notify again — forever. A track the drip has already been
+/// again, learn nothing again, and notify again - forever. A track the drip has already been
 /// through is not asked about twice.
 struct Claim(Vec<String>);
 
@@ -611,7 +611,7 @@ pub async fn resolve(app: &tauri::AppHandle, tracks: Vec<String>) -> anyhow::Res
     }
 
     // Queue whatever is left, minus anything already being worked on and anything the drip has
-    // already been through without finding — see [`settled`].
+    // already been through without finding - see [`settled`].
     let queue: Vec<String> = {
         let mut f = lock(in_flight());
         let s = lock(settled());
@@ -765,7 +765,7 @@ mod tests {
         assert!(candidates(&entries, "2026_ARLMX_RD11_INDIANA_Pro").is_empty());
     }
 
-    /// Tightening one arm must not touch the other two — these are the round-one wins.
+    /// Tightening one arm must not touch the other two - these are the round-one wins.
     #[test]
     fn candidates_still_widen_on_title_and_slug() {
         let entries = vec![

--- a/apps/manager/src-tauri/src/mods/trackindex.rs
+++ b/apps/manager/src-tauri/src/mods/trackindex.rs
@@ -1,0 +1,875 @@
+//! Knowing, before the user asks, whether a server's track can be downloaded.
+//!
+//! The server browser gets a track as an internal id — `Farm14`, `Highland-Mx`,
+//! `2026_ARLMX_RD11_INDIANA_Pro` — and needs to say one of three things about it: installed,
+//! downloadable from here, or not something we can get. The first is a disk scan. This module
+//! is the second.
+//!
+//! ## Why an index, and why two halves
+//!
+//! Answering per-track over the network ([`crate::mods::mxb::search`] then a page fetch) is
+//! what the app did before, and it can only run *after* the user clicks — so the browser can't
+//! badge anything ahead of time, and every click pays a search. An index inverts that, but the
+//! catalog only gives up half of what matching needs cheaply:
+//!
+//! * **Titles are cheap.** The tracks category is ~1,600 posts, and WP's 100-per-page ceiling
+//!   turns the whole thing into 16 small requests. So every track's title and slug is known up
+//!   front, refreshed daily. Exact title/slug matching resolves about a third of live servers.
+//!
+//! * **File names are not.** A mod's download links live only in its *rendered page*, one
+//!   fetch each — and even then only MediaFire puts the real name in the URL; Drive and Mega
+//!   use opaque ids. Roughly half of catalog links name their file.
+//!
+//! File names are worth the fetches because they catch exactly what titles cannot: a post
+//! titled "Farm14 v0.1" ships `Farm14.pkz`, "Five-Two SMX" ships `SMX.pkz`, and "Rail MX"
+//! ships `Motoland_MX_Park.pkz`. A version suffix or a rename defeats title matching outright,
+//! and the file name is the author's own statement of what the track is called on disk — which
+//! is precisely the id a server reports.
+//!
+//! ## The drip
+//!
+//! So enrichment is deliberate rather than exhaustive. Scraping all 1,600 pages on first run
+//! would be ~1,600 requests per user against a Cloudflare-fronted site, to learn about tracks
+//! nobody is hosting. Instead [`resolve`] queues the track ids live servers are actually
+//! running that titles didn't resolve, and the drip behind it works the busiest first and stops at
+//! [`MAX_PAGES_PER_SESSION`]. Results are permanent — a file name is a fact about a published
+//! mod, not a cache of a changing value — so the index converges over a few sessions and
+//! costs nothing thereafter.
+
+use super::ModSummary;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// mxb-mods' "Tracks" category — the `tracks` entry of `MOD_TYPES` in `src/api/mods.ts`.
+const TRACKS_CATEGORY: u32 = 22;
+
+/// How long the title listing is served before a refresh is spawned behind it. Daily: new
+/// tracks are published a few times a week, and a server running one the same day is the only
+/// case a shorter window would help.
+const LISTING_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// A ceiling on the bulk crawl, so a category that grows (or a paging bug) can't spin. The
+/// tracks category needs 16.
+const MAX_LISTING_PAGES: u32 = 40;
+
+/// Page fetches the drip will make in one app session, **across every round**.
+///
+/// A per-run cap is not enough, and the first live run proved it: finishing a round fires
+/// `track-index://updated`, the UI re-resolves, the tracks that are still unmatched suggest
+/// candidates that the round just made visible by reading their neighbours, and another run
+/// starts. Five rounds of 49/12/10/9/1 spent 81 pages against a cap that read "60". The
+/// budget has to span the cascade, so it lives in [`pages_read`] rather than in a loop bound.
+///
+/// What the cap doesn't spend this session it spends the next, because what the drip learns
+/// is kept — so a low ceiling costs convergence time, never coverage.
+const SESSION_PAGE_BUDGET: usize = 60;
+
+/// Pages in flight at once. Low on purpose — this is background work nobody is waiting on,
+/// and it shares a Cloudflare budget with the browsing the user *is* waiting on.
+const ENRICH_CONCURRENCY: usize = 3;
+
+/// Candidate posts considered per unresolved track. Beyond three the scorer is guessing, and
+/// each extra candidate is a page fetch spent on a track we probably can't match anyway.
+const CANDIDATES_PER_TRACK: usize = 3;
+
+/// Bumped when [`Index`]'s shape changes, so an old file is dropped rather than misread.
+const CACHE_DIR: &str = "track-index-v1";
+
+// ───────────────────────────────── the index ─────────────────────────────────
+
+/// One catalog track. `files` and `enriched_at` are filled in by the drip, not the listing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Entry {
+    pub id: u64,
+    pub slug: String,
+    pub title: String,
+    pub link: String,
+    pub date: String,
+    /// File name stems the mod's downloads carry, e.g. `["Farm14"]`. Empty after enrichment
+    /// means the page was read and named nothing — a Drive-only mod — which is different from
+    /// never having been read; `enriched_at` is what tells those apart.
+    #[serde(default)]
+    pub files: Vec<String>,
+    /// Unix ms of the page read, or `None` if the page has never been read.
+    #[serde(default)]
+    pub enriched_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Index {
+    pub entries: Vec<Entry>,
+    /// Unix ms of the listing crawl.
+    pub fetched_at: i64,
+}
+
+impl Index {
+    fn stale(&self) -> bool {
+        let age = (now_ms() - self.fetched_at).max(0) as u64;
+        Duration::from_millis(age) >= LISTING_TTL
+    }
+}
+
+/// How a track id was matched to a catalog post. The UI shows both the same way; this is for
+/// the log and for tests, where "matched by title" and "matched by file name" are the two
+/// behaviours worth telling apart.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Via {
+    /// The mod ships a file with this exact name.
+    File,
+    /// The post's title or slug is this exact name.
+    Title,
+}
+
+/// A track the catalog has, as the browser needs to show it.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Hit {
+    pub slug: String,
+    pub title: String,
+    pub link: String,
+    pub via: Via,
+}
+
+/// What [`resolve`] found, plus whether the index is still filling itself in — the browser
+/// uses `pending` to say "still looking" rather than "not available" for a track the drip
+/// hasn't reached yet.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Resolution {
+    /// Track id (exactly as asked for) → the catalog post that has it.
+    pub found: HashMap<String, Hit>,
+    /// Track ids the drip is still working through.
+    pub pending: Vec<String>,
+    /// Unix ms of the listing crawl, or `None` when the index has never loaded.
+    pub fetched_at: Option<i64>,
+}
+
+// ───────────────────────────────── matching ─────────────────────────────────
+
+/// Fold to the same case/separator-insensitive key `src/lib/trackContent.ts` folds to, so a
+/// track matched here and a track matched against the disk agree about what "the same name"
+/// means. `ZD - Prebe Backyard`, `zd_prebe_backyard` and `ZDPrebeBackyard` are one key.
+fn norm(s: &str) -> String {
+    s.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .map(|c| c.to_ascii_lowercase())
+        .collect()
+}
+
+/// The lookup tables, rebuilt whenever the index changes.
+///
+/// File names come first and win ties. A post that *ships* `Farm14.pkz` is a stronger claim
+/// on the id `Farm14` than a post merely *titled* something that folds to it, and where the
+/// two disagree the file is the one the server is actually running.
+struct Lookup {
+    by_file: HashMap<String, usize>,
+    by_title: HashMap<String, usize>,
+}
+
+fn build_lookup(entries: &[Entry]) -> Lookup {
+    let mut by_file = HashMap::new();
+    let mut by_title = HashMap::new();
+    for (i, e) in entries.iter().enumerate() {
+        for f in &e.files {
+            let k = norm(f);
+            if !k.is_empty() {
+                by_file.entry(k).or_insert(i);
+            }
+        }
+        for k in [norm(&e.title), norm(&e.slug)] {
+            if !k.is_empty() {
+                by_title.entry(k).or_insert(i);
+            }
+        }
+    }
+    Lookup { by_file, by_title }
+}
+
+fn find(lookup: &Lookup, entries: &[Entry], track: &str) -> Option<Hit> {
+    let key = norm(track);
+    if key.is_empty() {
+        return None;
+    }
+    let (i, via) = lookup
+        .by_file
+        .get(&key)
+        .map(|i| (*i, Via::File))
+        .or_else(|| lookup.by_title.get(&key).map(|i| (*i, Via::Title)))?;
+    let e = entries.get(i)?;
+    Some(Hit {
+        slug: e.slug.clone(),
+        title: e.title.clone(),
+        link: e.link.clone(),
+        via,
+    })
+}
+
+/// The shortest title allowed to claim a track id it is merely *contained in*, and the
+/// largest multiple of that title's length the id may be.
+///
+/// These guard one arm of [`candidates`] only — the "post title appears inside the track id"
+/// case — and they exist because that arm is what made rounds 2-5 of the first live run spend
+/// 32 pages to resolve 3 tracks. A league id like `2026arlmxrd11indianapro` contains
+/// `indiana` and `pro`, so every generic short title in the catalog queued itself as a
+/// candidate for tracks that were never going to match. Requiring the title to be both
+/// substantial in itself and a real fraction of the id keeps the arm's actual wins —
+/// `outpost` inside `outpostprepped`, `islandsx` inside `ghptracksislandsx` — and drops the
+/// rest.
+const MIN_CONTAINED_TITLE: usize = 5;
+const MAX_CONTAINED_RATIO: usize = 3;
+
+/// Posts worth reading a page for, when looking for `track`.
+///
+/// Purely local — it decides which pages to spend fetches on, never what matches. The rule is
+/// containment either way round on the folded key, which is what the real misses look like:
+/// `Farm14` inside `farm14v01` ("Farm14 v0.1"), `smx` inside `fivetwosmx` ("Five-Two SMX").
+/// Shorter titles rank first, since a title that is barely longer than the id is far likelier
+/// to be the same track than one that merely contains it somewhere.
+fn candidates(entries: &[Entry], track: &str) -> Vec<usize> {
+    let key = norm(track);
+    // Two characters would match half the catalog and buy nothing.
+    if key.len() < 3 {
+        return Vec::new();
+    }
+    let mut hits: Vec<(usize, usize)> = entries
+        .iter()
+        .enumerate()
+        .filter(|(_, e)| e.enriched_at.is_none())
+        .filter_map(|(i, e)| {
+            let t = norm(&e.title);
+            let s = norm(&e.slug);
+            // The two productive arms: the post names the track with something appended (a
+            // version, an author prefix), in its title or its slug.
+            let widened = t.contains(&key) || s.contains(&key);
+            // The narrow arm: the track id is the post's title plus a suffix the author
+            // didn't publish under. Guarded — see the two constants above.
+            let contained = key.contains(&t)
+                && t.len() >= MIN_CONTAINED_TITLE
+                && t.len() * MAX_CONTAINED_RATIO >= key.len();
+            (widened || contained).then_some((i, t.len().abs_diff(key.len())))
+        })
+        .collect();
+    hits.sort_by_key(|(_, d)| *d);
+    hits.truncate(CANDIDATES_PER_TRACK);
+    hits.into_iter().map(|(i, _)| i).collect()
+}
+
+// ───────────────────────────────── state ─────────────────────────────────
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn lock<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+fn state() -> &'static Mutex<Option<Arc<Index>>> {
+    static S: OnceLock<Mutex<Option<Arc<Index>>>> = OnceLock::new();
+    S.get_or_init(|| Mutex::new(None))
+}
+
+/// Track ids the drip is working on right now, so the UI can say "still looking" and so a
+/// second call doesn't queue the same work twice.
+fn in_flight() -> &'static Mutex<HashSet<String>> {
+    static F: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    F.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Track ids the drip has already been through this session and could not place.
+///
+/// The terminal state the index was missing. Without it "we haven't looked yet" and "we looked
+/// and there is nothing" are the same answer, so the browser can only ever say "Looking…" —
+/// and the queue re-reads the same dead ends every time the list refreshes.
+///
+/// Session-scoped on purpose: a restart is cheap and the catalog does gain posts. It is not
+/// written to the cache, so tomorrow's run asks again.
+fn settled() -> &'static Mutex<HashSet<String>> {
+    static S: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    S.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Pages the drip has read this session, against [`SESSION_PAGE_BUDGET`].
+fn pages_read() -> &'static std::sync::atomic::AtomicUsize {
+    static N: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    &N
+}
+
+/// How many pages a run may still read. Pure, so the accounting is testable without a
+/// network or a Tauri handle.
+fn remaining_budget(read: usize) -> usize {
+    SESSION_PAGE_BUDGET.saturating_sub(read)
+}
+
+fn listing_lock() -> &'static tokio::sync::Mutex<()> {
+    static L: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    L.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+fn enrich_lock() -> &'static tokio::sync::Mutex<()> {
+    static L: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    L.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+fn current() -> Option<Arc<Index>> {
+    lock(state()).clone()
+}
+
+fn install(index: Index) -> Arc<Index> {
+    let arc = Arc::new(index);
+    *lock(state()) = Some(arc.clone());
+    arc
+}
+
+// ───────────────────────────────── disk ─────────────────────────────────
+
+fn cache_dir(app: &tauri::AppHandle) -> Option<PathBuf> {
+    use tauri::Manager;
+    Some(app.path().app_cache_dir().ok()?.join(CACHE_DIR))
+}
+
+fn read_cache(app: &tauri::AppHandle) -> Option<Index> {
+    let text = std::fs::read_to_string(cache_dir(app)?.join("index.json")).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+fn write_cache(app: &tauri::AppHandle, index: &Index) {
+    let Some(dir) = cache_dir(app) else { return };
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        log::warn!("could not create the track-index cache dir: {e}");
+        return;
+    }
+    match serde_json::to_vec(index) {
+        Ok(bytes) => {
+            if let Err(e) = std::fs::write(dir.join("index.json"), bytes) {
+                log::warn!("could not cache the track index: {e}");
+            }
+        }
+        Err(e) => log::warn!("could not encode the track index: {e}"),
+    }
+}
+
+// ───────────────────────────────── the listing crawl ─────────────────────────────────
+
+/// Page the whole tracks category, keeping what enrichment has already learned.
+///
+/// A refresh must not undo the drip: entries are matched by post id, so a track whose page was
+/// read months ago keeps its file names through every listing refresh and is never fetched
+/// again. Posts that leave the catalog fall out with the listing they came from.
+async fn crawl_listing(app: &tauri::AppHandle) -> anyhow::Result<Arc<Index>> {
+    let _guard = listing_lock().lock().await;
+    // Another caller may have finished the crawl while we waited for the lock.
+    if let Some(idx) = current() {
+        if !idx.stale() {
+            return Ok(idx);
+        }
+    }
+
+    let known: HashMap<u64, (Vec<String>, Option<i64>)> = current()
+        .map(|idx| {
+            idx.entries
+                .iter()
+                .filter(|e| e.enriched_at.is_some())
+                .map(|e| (e.id, (e.files.clone(), e.enriched_at)))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut entries: Vec<Entry> = Vec::new();
+    for page in 1..=MAX_LISTING_PAGES {
+        let posts = super::mxb::catalog_page(TRACKS_CATEGORY, page).await?;
+        if posts.is_empty() {
+            break;
+        }
+        let short = posts.len() < 100;
+        entries.extend(posts.into_iter().map(|p| entry_from(p, &known)));
+        if short {
+            break;
+        }
+    }
+    if entries.is_empty() {
+        anyhow::bail!("the tracks catalog came back empty");
+    }
+    log::info!("track index: {} tracks listed", entries.len());
+
+    let index = Index { entries, fetched_at: now_ms() };
+    write_cache(app, &index);
+    Ok(install(index))
+}
+
+fn entry_from(p: ModSummary, known: &HashMap<u64, (Vec<String>, Option<i64>)>) -> Entry {
+    let (files, enriched_at) = known.get(&p.id).cloned().unwrap_or_default();
+    Entry {
+        id: p.id,
+        slug: p.slug,
+        title: p.title,
+        link: p.link,
+        date: p.date,
+        files,
+        enriched_at,
+    }
+}
+
+/// The index to answer from, loading disk on first use and crawling only when there is
+/// nothing at all. A stale index is served as-is with a refresh spawned behind it.
+async fn ensure_loaded(app: &tauri::AppHandle) -> anyhow::Result<Arc<Index>> {
+    if let Some(idx) = current() {
+        if idx.stale() {
+            spawn_listing_refresh(app);
+        }
+        return Ok(idx);
+    }
+    if let Some(cached) = read_cache(app) {
+        if !cached.entries.is_empty() {
+            let arc = install(cached);
+            if arc.stale() {
+                spawn_listing_refresh(app);
+            }
+            return Ok(arc);
+        }
+    }
+    crawl_listing(app).await
+}
+
+fn spawn_listing_refresh(app: &tauri::AppHandle) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = crawl_listing(&app).await {
+            log::warn!("track index: listing refresh failed: {e:#}");
+        }
+    });
+}
+
+// ───────────────────────────────── the drip ─────────────────────────────────
+
+/// Read one mod page and record what it ships. Failures are recorded too — as an enrichment
+/// with no files — so a page that 404s or is Cloudflare-blocked isn't retried on every open.
+async fn enrich_one(entry: &Entry) -> (u64, Vec<String>) {
+    let files = match super::mxb::downloads_at(&entry.link).await {
+        Ok(downloads) => downloads
+            .iter()
+            .filter_map(|d| super::mxb::download_file_name(&d.url))
+            .collect(),
+        Err(e) => {
+            log::info!("track index: couldn't read {} ({e:#})", entry.slug);
+            Vec::new()
+        }
+    };
+    (entry.id, files)
+}
+
+/// Work through `wanted` — track ids the index couldn't resolve — reading pages for the
+/// candidates each one suggests, busiest track first.
+///
+/// `wanted` arrives already ordered by how many servers are running each track, so the drip
+/// spends its budget where it will change what the most people see.
+async fn drip(app: tauri::AppHandle, wanted: Vec<String>) {
+    // Whatever [`round`] does — finish, give up early, or panic — these ids come back and are
+    // marked settled (see [`Claim`]), and the browser is told to ask again. A round that
+    // learned nothing still has to say so: "Looking…" is a state the UI cannot leave on its
+    // own, because the only thing that moves it is this event.
+    let claim = Claim(wanted);
+    round(&app, &claim.0).await;
+    drop(claim);
+
+    use tauri::Emitter;
+    let _ = app.emit("track-index://updated", ());
+}
+
+/// One pass of the drip. Every early return here is a round that learned nothing, which
+/// [`drip`] is responsible for reporting.
+async fn round(app: &tauri::AppHandle, wanted: &[String]) {
+    let app = app.clone();
+    let _guard = enrich_lock().lock().await;
+    let Ok(index) = ensure_loaded(&app).await else { return };
+
+    use std::sync::atomic::Ordering;
+    let budget = remaining_budget(pages_read().load(Ordering::Relaxed));
+    if budget == 0 {
+        log::info!(
+            "track index: session page budget ({SESSION_PAGE_BUDGET}) spent;              {} tracks left for the next session",
+            wanted.len()
+        );
+        return;
+    }
+
+    // Pick the pages to read, dropping duplicates: two tracks often point at the same post.
+    let mut targets: Vec<Entry> = Vec::new();
+    let mut seen: HashSet<u64> = HashSet::new();
+    'pick: for track in wanted {
+        for i in candidates(&index.entries, track) {
+            let e = &index.entries[i];
+            if seen.insert(e.id) {
+                targets.push(e.clone());
+            }
+            if targets.len() >= budget {
+                break 'pick;
+            }
+        }
+    }
+    if targets.is_empty() {
+        return;
+    }
+    // Claimed before the fetches, not after: another round can start the moment this one
+    // emits its event, and a budget that only counted finished work would let them overlap
+    // past the ceiling.
+    pages_read().fetch_add(targets.len(), Ordering::Relaxed);
+    log::info!(
+        "track index: reading {} pages for {} unresolved tracks ({} of {} budget spent)",
+        targets.len(),
+        wanted.len(),
+        pages_read().load(Ordering::Relaxed),
+        SESSION_PAGE_BUDGET
+    );
+
+    let mut learned: HashMap<u64, Vec<String>> = HashMap::new();
+    for chunk in targets.chunks(ENRICH_CONCURRENCY) {
+        let results = futures_util::future::join_all(chunk.iter().map(enrich_one)).await;
+        for (id, files) in results {
+            learned.insert(id, files);
+        }
+    }
+
+    // Fold the results into the index as it stands *now* — a listing refresh may have landed
+    // while we were fetching, and rebuilding from the copy we started with would lose it.
+    let base = current().unwrap_or(index);
+    let mut next = Index {
+        entries: base.entries.clone(),
+        fetched_at: base.fetched_at,
+    };
+    let stamp = now_ms();
+    let mut named = 0usize;
+    for e in &mut next.entries {
+        if let Some(files) = learned.remove(&e.id) {
+            named += usize::from(!files.is_empty());
+            e.files = files;
+            e.enriched_at = Some(stamp);
+        }
+    }
+    write_cache(&app, &next);
+    install(next);
+    log::info!("track index: {named} of {} pages named their files", targets.len());
+}
+
+/// The track ids one drip round has claimed, released on drop and marked [`settled`].
+///
+/// Deliberately a guard rather than a call at the end of the round. Every early return in
+/// [`round`] is a path where nothing was learned — the listing wouldn't load, the session's
+/// page budget was already spent, no candidate pages to read — and a claim left behind on one
+/// of those is **permanent**: [`resolve`] goes on reporting that track as pending, so the
+/// browser shows "Looking…" and never stops, *and* the same claim filters it out of the queue,
+/// so nothing ever looks again. It is stuck in both directions at once.
+///
+/// The path that actually did it was `ensure_loaded` failing, which is an ordinary Tuesday for
+/// a Cloudflare-fronted site. Dropping instead of clearing also covers a panic mid-round.
+///
+/// Settling them is the other half, and it is what makes the notification in [`drip`] safe:
+/// without it, the re-resolve that event triggers would queue the same unanswerable ids, drip
+/// again, learn nothing again, and notify again — forever. A track the drip has already been
+/// through is not asked about twice.
+struct Claim(Vec<String>);
+
+impl Drop for Claim {
+    fn drop(&mut self) {
+        let mut f = lock(in_flight());
+        let mut s = lock(settled());
+        for w in &self.0 {
+            f.remove(w);
+            s.insert(w.clone());
+        }
+    }
+}
+
+// ───────────────────────────────── public API ─────────────────────────────────
+
+/// Which of `tracks` the catalog has, and which the drip is still working on.
+///
+/// `tracks` should be the ids the browser is actually showing as missing, busiest first: what
+/// doesn't resolve here becomes the drip's queue, so the order is also the priority.
+pub async fn resolve(app: &tauri::AppHandle, tracks: Vec<String>) -> anyhow::Result<Resolution> {
+    let index = ensure_loaded(app).await?;
+    let lookup = build_lookup(&index.entries);
+
+    let mut found = HashMap::new();
+    let mut unresolved = Vec::new();
+    for t in tracks {
+        match find(&lookup, &index.entries, &t) {
+            Some(hit) => {
+                found.insert(t, hit);
+            }
+            None => unresolved.push(t),
+        }
+    }
+
+    // Queue whatever is left, minus anything already being worked on and anything the drip has
+    // already been through without finding — see [`settled`].
+    let queue: Vec<String> = {
+        let mut f = lock(in_flight());
+        let s = lock(settled());
+        unresolved
+            .iter()
+            .filter(|t| !t.trim().is_empty())
+            .filter(|t| !s.contains(*t))
+            .filter(|t| f.insert((*t).clone()))
+            .cloned()
+            .collect()
+    };
+    if !queue.is_empty() {
+        let app = app.clone();
+        let queued = queue.clone();
+        tauri::async_runtime::spawn(drip(app, queued));
+    }
+
+    // Only the tracks *this* caller asked about, and only the ones actually being worked on.
+    // Returning the whole in-flight set would report another view's queue as this one's, and
+    // would keep reporting ids the loop above deliberately dropped for being blank.
+    let pending = {
+        let f = lock(in_flight());
+        unresolved.into_iter().filter(|t| f.contains(t)).collect()
+    };
+    Ok(Resolution {
+        found,
+        pending,
+        fetched_at: Some(index.fetched_at),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(id: u64, title: &str, slug: &str, files: &[&str]) -> Entry {
+        Entry {
+            id,
+            slug: slug.to_string(),
+            title: title.to_string(),
+            link: format!("https://mxb-mods.com/{slug}/"),
+            date: String::new(),
+            files: files.iter().map(|s| s.to_string()).collect(),
+            enriched_at: files.is_empty().then_some(None).unwrap_or(Some(1)),
+        }
+    }
+
+    fn fixture() -> Vec<Entry> {
+        vec![
+            entry(1, "Farm14 v0.1", "farm14-v0-1", &["Farm14"]),
+            entry(2, "Highland-Mx", "highland-mx", &[]),
+            entry(3, "Rail MX", "rail-mx", &["Motoland_MX_Park"]),
+            entry(4, "Five-Two SMX", "five-two-smx", &["SMX"]),
+        ]
+    }
+
+    #[test]
+    fn a_version_suffix_is_matched_by_file_name_not_title() {
+        let e = fixture();
+        let hit = find(&build_lookup(&e), &e, "Farm14").expect("Farm14");
+        assert_eq!(hit.slug, "farm14-v0-1");
+        assert_eq!(hit.via, Via::File);
+    }
+
+    #[test]
+    fn a_renamed_track_is_matched_by_file_name() {
+        let e = fixture();
+        let hit = find(&build_lookup(&e), &e, "Motoland_MX_Park").expect("Motoland");
+        assert_eq!(hit.slug, "rail-mx");
+    }
+
+    #[test]
+    fn titles_still_match_when_no_file_name_was_learned() {
+        let e = fixture();
+        let hit = find(&build_lookup(&e), &e, "Highland-Mx").expect("Highland");
+        assert_eq!(hit.via, Via::Title);
+    }
+
+    /// The two sides fold separators and case the same way `trackContent.ts` does.
+    #[test]
+    fn matching_ignores_case_and_separators() {
+        let e = fixture();
+        let l = build_lookup(&e);
+        assert!(find(&l, &e, "highland mx").is_some());
+        assert!(find(&l, &e, "HIGHLAND_MX").is_some());
+        // Separators fold on the file-name side too, so a host who typed the id with a space
+        // still lands on the mod that ships `Farm14.pkz`.
+        assert_eq!(find(&l, &e, "farm 14").map(|h| h.slug), Some("farm14-v0-1".into()));
+        // Folding is not fuzzing: a different id stays unmatched.
+        assert!(find(&l, &e, "farm 15").is_none());
+    }
+
+    #[test]
+    fn unknown_and_empty_track_ids_match_nothing() {
+        let e = fixture();
+        let l = build_lookup(&e);
+        assert!(find(&l, &e, "2026_ARLMX_RD11_INDIANA_Pro").is_none());
+        assert!(find(&l, &e, "").is_none());
+        assert!(find(&l, &e, "   ").is_none());
+    }
+
+    /// The drip's targets: only pages never read, ranked by how close the title is.
+    #[test]
+    fn candidates_prefer_the_closest_unread_title() {
+        let entries = vec![
+            entry(1, "Ironman", "ironman", &[]),
+            entry(2, "Ironman 2024 Remastered Edition", "ironman-2024-r", &[]),
+            entry(3, "Ironman v2", "ironman-v2", &[]),
+        ];
+        let picked: Vec<&str> = candidates(&entries, "Ironman")
+            .into_iter()
+            .map(|i| entries[i].slug.as_str())
+            .collect();
+        assert_eq!(picked[0], "ironman");
+        assert_eq!(picked[1], "ironman-v2");
+    }
+
+    #[test]
+    fn candidates_skip_pages_already_read() {
+        let entries = vec![entry(1, "Farm14 v0.1", "farm14-v0-1", &["Farm14"])];
+        assert!(candidates(&entries, "Farm14").is_empty());
+    }
+
+    /// A two-character id would otherwise pull in most of the catalog for nothing.
+    #[test]
+    fn candidates_ignore_ids_too_short_to_discriminate() {
+        let entries = vec![entry(1, "LL Compound", "ll-compound", &[])];
+        assert!(candidates(&entries, "LL").is_empty());
+    }
+
+    /// The narrow arm's wins: a track id that is a published title plus a suffix.
+    #[test]
+    fn candidates_keep_a_title_the_id_is_built_on() {
+        let entries = vec![
+            entry(1, "Outpost", "outpost", &[]),
+            entry(2, "island sx", "island-sx", &[]),
+        ];
+        assert_eq!(candidates(&entries, "Outpost - Prepped"), vec![0]);
+        assert_eq!(candidates(&entries, "GHPTRACKS_island sx"), vec![1]);
+    }
+
+    /// What rounds 2-5 of the first live run spent 32 pages on. A league id contains plenty
+    /// of short generic words, and none of those posts is the track.
+    #[test]
+    fn candidates_drop_generic_titles_swallowed_by_a_long_id() {
+        let entries = vec![
+            entry(1, "Indiana", "indiana", &[]),
+            entry(2, "Pro", "pro", &[]),
+            entry(3, "MX", "mx", &[]),
+        ];
+        assert!(candidates(&entries, "2026_ARLMX_RD11_INDIANA_Pro").is_empty());
+    }
+
+    /// Tightening one arm must not touch the other two — these are the round-one wins.
+    #[test]
+    fn candidates_still_widen_on_title_and_slug() {
+        let entries = vec![
+            entry(1, "Farm14 v0.1", "farm14-v0-1", &[]),
+            entry(2, "Rocky Mountain NP", "rocky-mountain-the-colorado-trail", &[]),
+        ];
+        assert_eq!(candidates(&entries, "Farm14"), vec![0]);
+        assert_eq!(candidates(&entries, "The Colorado Trail"), vec![1]);
+    }
+
+    /// The budget spans the whole cascade, which a per-run bound did not.
+    #[test]
+    fn the_page_budget_is_spent_across_rounds_not_reset_by_them() {
+        assert_eq!(remaining_budget(0), SESSION_PAGE_BUDGET);
+        assert_eq!(remaining_budget(49), SESSION_PAGE_BUDGET - 49);
+        // The five rounds that actually ran were 49 + 12 + 10 + 9 + 1 = 81, which a per-run
+        // cap of 60 allowed. Round two now runs down to nothing and round three is refused.
+        assert_eq!(remaining_budget(49 + 12), 0);
+        assert_eq!(remaining_budget(81), 0);
+        // And it never wraps, however far over a resumed session starts.
+        assert_eq!(remaining_budget(usize::MAX), 0);
+    }
+
+    #[test]
+    fn a_listing_refresh_keeps_what_enrichment_learned() {
+        let known: HashMap<u64, (Vec<String>, Option<i64>)> =
+            [(1, (vec!["Farm14".to_string()], Some(99)))].into_iter().collect();
+        let fresh = ModSummary {
+            id: 1,
+            slug: "farm14-v0-1".into(),
+            title: "Farm14 v0.2".into(),
+            link: "https://mxb-mods.com/farm14-v0-1/".into(),
+            date: String::new(),
+            image: None,
+            category_id: TRACKS_CATEGORY,
+            author: None,
+        };
+        let e = entry_from(fresh, &known);
+        assert_eq!(e.title, "Farm14 v0.2");
+        assert_eq!(e.files, vec!["Farm14".to_string()]);
+        assert_eq!(e.enriched_at, Some(99));
+    }
+
+    #[test]
+    fn a_post_new_to_the_listing_starts_unenriched() {
+        let e = entry_from(
+            ModSummary {
+                id: 7,
+                slug: "new-track".into(),
+                title: "New Track".into(),
+                link: String::new(),
+                date: String::new(),
+                image: None,
+                category_id: TRACKS_CATEGORY,
+                author: None,
+            },
+            &HashMap::new(),
+        );
+        assert!(e.files.is_empty());
+        assert_eq!(e.enriched_at, None);
+    }
+
+    /// A file name beats a title that folds to the same key.
+    #[test]
+    fn file_names_outrank_titles() {
+        let entries = vec![
+            entry(1, "SMX", "smx-the-other-one", &[]),
+            entry(2, "Five-Two SMX", "five-two-smx", &["SMX"]),
+        ];
+        let hit = find(&build_lookup(&entries), &entries, "SMX").expect("SMX");
+        assert_eq!(hit.slug, "five-two-smx");
+        assert_eq!(hit.via, Via::File);
+    }
+
+    /// The claim has to come back on *every* exit from a drip round, not just the one that
+    /// finished its work. A track left claimed is reported pending forever and requeued never,
+    /// so the browser sits on "Looking…" for the rest of the session.
+    #[test]
+    fn a_claim_is_released_on_an_early_return() {
+        let ids = vec!["leaky-track".to_string()];
+        lock(in_flight()).extend(ids.iter().cloned());
+
+        // Stands in for `ensure_loaded` failing: the guard is built, the round gives up.
+        {
+            let _claim = Claim(ids.clone());
+        }
+
+        assert!(!lock(in_flight()).contains("leaky-track"));
+        // …and it is not asked again, which is what keeps the notification from looping.
+        assert!(lock(settled()).contains("leaky-track"));
+    }
+
+    /// And on a panic, which is the other way a round can stop without reaching its end.
+    #[test]
+    fn a_claim_is_released_on_a_panic() {
+        let ids = vec!["panicky-track".to_string()];
+        lock(in_flight()).extend(ids.iter().cloned());
+
+        let caught = std::panic::catch_unwind(|| {
+            let _claim = Claim(ids.clone());
+            panic!("mid-round");
+        });
+
+        assert!(caught.is_err());
+        assert!(!lock(in_flight()).contains("panicky-track"));
+    }
+}

--- a/apps/manager/src/Components/Servers/ServerCard.tsx
+++ b/apps/manager/src/Components/Servers/ServerCard.tsx
@@ -57,7 +57,7 @@ export default function ServerCard({
 
   // The archive to read art out of, or null when there is nothing installed to read. A plain
   // string, deliberately: `matchTrack` builds a fresh object every render, so keying the
-  // effect on `match` itself would re-run it — an IPC call per card, per render. The path is
+  // effect on `match` itself would re-run it - an IPC call per card, per render. The path is
   // stable, so the preview is fetched once per track and survives every refresh.
   const previewPath = match.state === "installed" ? (match.installed?.path ?? null) : null;
 
@@ -141,7 +141,7 @@ export default function ServerCard({
           )}
         </span>
 
-        {/* Latency, bottom-left — the other number people pick a server on. */}
+        {/* Latency, bottom-left - the other number people pick a server on. */}
         {server.pingMs !== null && (
           <span
             className={cn(
@@ -162,7 +162,7 @@ export default function ServerCard({
         </span>
         <div className="flex items-center gap-1.5 text-[11.5px] text-muted-foreground">
           <span className="truncate" title={server.track}>
-            {server.track || "—"}
+            {server.track || "-"}
           </span>
           {cat && (
             <>
@@ -204,7 +204,7 @@ export default function ServerCard({
             {joining ? <Loader2 className="size-3.5 animate-spin" /> : <Play className="size-3.5" />}
             {t("serverBrowser.join")}
           </button>
-          {/* The `ip:port` the master gave us — the one thing someone needs to hand a server
+          {/* The `ip:port` the master gave us - the one thing someone needs to hand a server
               to a friend, or to reconnect from the game's own address box. */}
           <button
             onClick={() => {

--- a/apps/manager/src/Components/Servers/ServerCard.tsx
+++ b/apps/manager/src/Components/Servers/ServerCard.tsx
@@ -1,0 +1,235 @@
+import { useEffect, useState } from "react";
+import { Mountain, Users, Lock, Play, AlertTriangle, Loader2, Wifi, Copy, Star } from "lucide-react";
+import { toast } from "sonner";
+import { getPkzPreview, type MasterServer, type TrackHit } from "@frost/shared/api/mods";
+import type { TrackMatch } from "@/lib/trackContent";
+import { Badge } from "@frost/shared/Components/ui/badge";
+import { cn } from "@frost/shared/lib/utils";
+import { useT } from "@/i18n";
+import { regionLabel } from "@/lib/serverRegion";
+import TrackContentAction from "./TrackContentAction";
+
+/** Latency → colour, so the figure reads at a glance: close is green, far is red. */
+function pingTone(rtt: number | null): string {
+  if (rtt === null) return "text-white/60";
+  if (rtt < 60) return "text-emerald-300";
+  if (rtt < 120) return "text-lime-300";
+  if (rtt < 200) return "text-amber-300";
+  return "text-red-300";
+}
+
+interface Props {
+  server: MasterServer;
+  match: TrackMatch;
+  /** The catalog post that has this server's track, when the index already found one. */
+  known?: TrackHit;
+  /** The index is still looking for this track. */
+  pending?: boolean;
+  joining: boolean;
+  onJoin: () => void;
+  onOpenHub?: () => void;
+  /** Starred by the player: the star is filled and the card can be found under Favourites. */
+  favourite?: boolean;
+  onToggleFavourite?: () => void;
+}
+
+/**
+ * One server as a card: the track's own preview art where we have it, an amber "missing
+ * content" flag over a placeholder where we don't, and the live stats (players, region,
+ * category, session state) below. Joining is one click; a missing track offers to fetch itself.
+ *
+ * Ported from the standalone v0.13 browser and mapped onto upstream's `MasterServer` shape
+ * (`passworded`, `location`, `categories`, `session`, `conditions`, `pingMs`).
+ */
+export default function ServerCard({
+  server,
+  match,
+  known,
+  pending,
+  joining,
+  onJoin,
+  onOpenHub,
+  favourite = false,
+  onToggleFavourite,
+}: Props) {
+  const t = useT();
+  const [thumb, setThumb] = useState<string | null>(null);
+
+  // The archive to read art out of, or null when there is nothing installed to read. A plain
+  // string, deliberately: `matchTrack` builds a fresh object every render, so keying the
+  // effect on `match` itself would re-run it — an IPC call per card, per render. The path is
+  // stable, so the preview is fetched once per track and survives every refresh.
+  const previewPath = match.state === "installed" ? (match.installed?.path ?? null) : null;
+
+  useEffect(() => {
+    if (!previewPath) {
+      setThumb(null);
+      return;
+    }
+    let live = true;
+    getPkzPreview(previewPath)
+      .then((p) => live && setThumb(p))
+      .catch(() => {});
+    return () => {
+      live = false;
+    };
+  }, [previewPath]);
+
+  const missing = match.state === "missing";
+  const full = server.maxPlayers > 0 && server.players >= server.maxPlayers;
+  const cat = server.categories[0];
+
+  return (
+    <div
+      className={cn(
+        "group relative flex flex-col overflow-hidden rounded-xl border bg-card text-left transition-colors",
+        "border-white/[0.07] hover:border-white/15",
+      )}
+    >
+      <div className="relative aspect-video overflow-hidden bg-gradient-to-br from-[#3a3f45] to-[#20242a]">
+        {thumb ? (
+          <img src={thumb} alt={server.track} className="size-full object-cover" />
+        ) : (
+          <div className="grid size-full place-items-center text-foreground/20">
+            <Mountain className="size-8" strokeWidth={1.5} />
+          </div>
+        )}
+
+        {/* Missing-content flag, over the image the way the design overlays a badge. */}
+        {missing && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black/45 backdrop-blur-[1px]">
+            <span className="flex items-center gap-1.5 rounded-md bg-amber-500/90 px-2 py-1 text-[11px] font-bold text-black shadow">
+              <AlertTriangle className="size-3.5" strokeWidth={2.5} />
+              {t("serverBrowser.missingContent")}
+            </span>
+          </div>
+        )}
+
+        {/* Player count, top-right, like the rating pill on a mod card. */}
+        <span
+          className={cn(
+            "absolute right-1.5 top-1.5 flex items-center gap-1.5 rounded-md bg-black/70 px-2 py-1 text-[15px] font-bold tabular-nums shadow-sm backdrop-blur-[2px]",
+            server.players > 0 ? "text-white" : "text-white/70",
+          )}
+        >
+          <Users className="size-3.5" strokeWidth={2.5} />
+          {server.players}/{server.maxPlayers}
+        </span>
+
+        {/* Star and lock share the top-left corner. The star is always rendered, not revealed
+            on hover: a card that shows nothing until the pointer arrives gives the player no
+            way to learn the feature exists. */}
+        <span className="absolute left-1.5 top-1.5 flex items-center gap-1">
+          {onToggleFavourite && (
+            <button
+              onClick={onToggleFavourite}
+              title={favourite ? t("serverBrowser.unstar") : t("serverBrowser.star")}
+              aria-label={favourite ? t("serverBrowser.unstar") : t("serverBrowser.star")}
+              aria-pressed={favourite}
+              className={cn(
+                "grid size-5 place-items-center rounded-md bg-black/65 shadow-sm transition-colors cursor-default",
+                favourite ? "text-amber-300" : "text-white/70 hover:text-white",
+              )}
+            >
+              <Star className="size-3" fill={favourite ? "currentColor" : "none"} />
+            </button>
+          )}
+          {server.passworded && (
+            <span className="grid size-5 place-items-center rounded-md bg-black/65 text-white/80 shadow-sm">
+              <Lock className="size-3" />
+            </span>
+          )}
+        </span>
+
+        {/* Latency, bottom-left — the other number people pick a server on. */}
+        {server.pingMs !== null && (
+          <span
+            className={cn(
+              "absolute bottom-1.5 left-1.5 flex items-center gap-1 rounded-md bg-black/70 px-1.5 py-[3px] text-[12.5px] font-bold tabular-nums shadow-sm backdrop-blur-[2px]",
+              pingTone(server.pingMs),
+            )}
+            title={t("serverBrowser.ping.title", { ms: server.pingMs })}
+          >
+            <Wifi className="size-3" strokeWidth={2.5} />
+            {t("serverBrowser.ping.ms", { ms: server.pingMs })}
+          </span>
+        )}
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-1.5 px-3 py-2.5">
+        <span className="truncate text-[13px] font-semibold" title={server.name}>
+          {server.name || t("serverBrowser.unnamed")}
+        </span>
+        <div className="flex items-center gap-1.5 text-[11.5px] text-muted-foreground">
+          <span className="truncate" title={server.track}>
+            {server.track || "—"}
+          </span>
+          {cat && (
+            <>
+              <span className="opacity-40">·</span>
+              <span className="truncate">{cat}</span>
+            </>
+          )}
+        </div>
+        <div className="flex flex-wrap items-center gap-1">
+          {regionLabel(server.location) && (
+            <Badge variant="count" className="font-medium">
+              {regionLabel(server.location)}
+            </Badge>
+          )}
+          {server.session && <Badge variant="count">{server.session}</Badge>}
+          {server.conditions && server.conditions !== "?" && (
+            <Badge variant="count">{server.conditions}</Badge>
+          )}
+        </div>
+
+        <div className="mt-auto flex items-center gap-2 pt-1.5">
+          <button
+            onClick={onJoin}
+            disabled={joining || !server.joinable}
+            className={cn(
+              "inline-flex flex-1 items-center justify-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12px] font-semibold transition-colors cursor-default",
+              full || !server.joinable
+                ? "border border-white/[0.1] text-muted-foreground"
+                : "bg-secondary text-foreground hover:brightness-110",
+            )}
+            title={
+              !server.joinable
+                ? t("serverBrowser.notJoinable")
+                : full
+                  ? t("serverBrowser.full")
+                  : t("serverBrowser.join")
+            }
+          >
+            {joining ? <Loader2 className="size-3.5 animate-spin" /> : <Play className="size-3.5" />}
+            {t("serverBrowser.join")}
+          </button>
+          {/* The `ip:port` the master gave us — the one thing someone needs to hand a server
+              to a friend, or to reconnect from the game's own address box. */}
+          <button
+            onClick={() => {
+              navigator.clipboard
+                .writeText(server.address)
+                .then(() => toast.success(t("serverBrowser.copied")))
+                .catch(() => toast.error(t("serverBrowser.copyFailed")));
+            }}
+            title={t("serverBrowser.copyAddress")}
+            aria-label={t("serverBrowser.copyAddress")}
+            className="grid size-[30px] shrink-0 place-items-center rounded-md border border-white/[0.1] text-muted-foreground transition-colors cursor-default hover:text-foreground"
+          >
+            <Copy className="size-3.5" />
+          </button>
+          {missing && (
+            <TrackContentAction
+              track={server.track}
+              known={known}
+              pending={pending}
+              onOpenHub={onOpenHub}
+              compact
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/manager/src/Components/Servers/Servers.tsx
+++ b/apps/manager/src/Components/Servers/Servers.tsx
@@ -18,6 +18,7 @@ import {
   LayoutGrid,
   List,
   PackageCheck,
+  UserCheck,
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@frost/shared/lib/utils";
@@ -114,6 +115,8 @@ const Servers = () => {
   const [favesOnly, setFavesOnly] = useState(false);
   // Hide servers running a track the player doesn't have — no point joining one you can't load.
   const [installedOnly, setInstalledOnly] = useState(false);
+  // Hide empty servers — an empty one is rarely what someone opening the browser is after.
+  const [hideEmpty, setHideEmpty] = useState(false);
   const favs = useFavourites(servers);
 
   // Picture grid or dense table — a sticky per-machine preference.
@@ -232,6 +235,9 @@ const Servers = () => {
     if (installedOnly) {
       list = list.filter((s) => matchTrack(trackIndex, s.track).state !== "missing");
     }
+    if (hideEmpty) {
+      list = list.filter((s) => s.players > 0);
+    }
 
     const flip = dir === "desc" ? -1 : 1;
     const sorted = [...list];
@@ -264,7 +270,7 @@ const Servers = () => {
       }
     });
     return sorted;
-  }, [servers, query, showHidden, favesOnly, region, installedOnly, trackIndex, favs, sort, dir]);
+  }, [servers, query, showHidden, favesOnly, region, installedOnly, hideEmpty, trackIndex, favs, sort, dir]);
 
   const join = useCallback(
     async (address: string) => {
@@ -365,6 +371,18 @@ const Servers = () => {
         >
           <PackageCheck className="size-3.5" />
           {t("serverBrowser.installedOnly")}
+        </button>
+        <button
+          type="button"
+          onClick={() => setHideEmpty((v) => !v)}
+          title={t("serverBrowser.hideEmptyHelp")}
+          className={cn(
+            "flex h-7 shrink-0 items-center gap-1.5 whitespace-nowrap border border-input px-2.5 text-[12px]",
+            hideEmpty ? "bg-card text-muted-foreground" : "text-faint hover:text-muted-foreground",
+          )}
+        >
+          <UserCheck className="size-3.5" />
+          {t("serverBrowser.hideEmpty")}
         </button>
         {!favesOnly && regions.length > 1 && (
           <Select value={region} onValueChange={setRegion}>

--- a/apps/manager/src/Components/Servers/Servers.tsx
+++ b/apps/manager/src/Components/Servers/Servers.tsx
@@ -57,6 +57,18 @@ import ServerDetail from "./ServerDetail";
 
 type ViewMode = "cards" | "list";
 const VIEW_KEY = "mxb:serversView:v1";
+const HIDE_EMPTY_KEY = "mxb:serversHideEmpty:v1";
+const INSTALLED_ONLY_KEY = "mxb:serversInstalledOnly:v1";
+
+/** Read a sticky boolean, treating a missing/blocked value as `fallback`. */
+function readFlag(key: string, fallback: boolean): boolean {
+  try {
+    const v = localStorage.getItem(key);
+    return v === null ? fallback : v === "1";
+  } catch {
+    return fallback;
+  }
+}
 
 /**
  * The live MX Bikes server list, read straight from PiBoSo's master server — the same
@@ -114,9 +126,25 @@ const Servers = () => {
   const [region, setRegion] = useState<string>("all");
   const [favesOnly, setFavesOnly] = useState(false);
   // Hide servers running a track the player doesn't have — no point joining one you can't load.
-  const [installedOnly, setInstalledOnly] = useState(false);
-  // Hide empty servers — an empty one is rarely what someone opening the browser is after.
-  const [hideEmpty, setHideEmpty] = useState(false);
+  // Sticky, default off.
+  const [installedOnly, setInstalledOnly] = useState(() => readFlag(INSTALLED_ONLY_KEY, false));
+  // Hide empty servers — an empty one is rarely what someone opening the browser is after, so
+  // this defaults on and is remembered, opening the browser straight to servers with riders.
+  const [hideEmpty, setHideEmpty] = useState(() => readFlag(HIDE_EMPTY_KEY, true));
+  useEffect(() => {
+    try {
+      localStorage.setItem(INSTALLED_ONLY_KEY, installedOnly ? "1" : "0");
+    } catch {
+      // Storage disabled; the choice still holds for this session.
+    }
+  }, [installedOnly]);
+  useEffect(() => {
+    try {
+      localStorage.setItem(HIDE_EMPTY_KEY, hideEmpty ? "1" : "0");
+    } catch {
+      // Storage disabled; the choice still holds for this session.
+    }
+  }, [hideEmpty]);
   const favs = useFavourites(servers);
 
   // Picture grid or dense table — a sticky per-machine preference.

--- a/apps/manager/src/Components/Servers/Servers.tsx
+++ b/apps/manager/src/Components/Servers/Servers.tsx
@@ -32,6 +32,7 @@ import {
   listMasterServers,
   joinServer,
   serversWithPaintSync,
+  installedTrackIds,
   type MasterServer,
 } from "@frost/shared/api/mods";
 import { useT } from "@/i18n";
@@ -42,6 +43,9 @@ import {
   canonicalRegion,
   type RegionKey,
 } from "@/lib/serverRegion";
+import { buildTrackIndex, matchTrack, type TrackIndex } from "@/lib/trackContent";
+import { useTrackCatalog } from "@/lib/useTrackCatalog";
+import TrackContentAction from "./TrackContentAction";
 import JoinServerDialog from "../Shell/JoinServerDialog";
 import ServerDetail from "./ServerDetail";
 
@@ -101,6 +105,17 @@ const Servers = () => {
   const [region, setRegion] = useState<string>("all");
   const [favesOnly, setFavesOnly] = useState(false);
   const favs = useFavourites(servers);
+
+  // Which tracks are on disk, so a row can say "you have this" or offer to fetch it. Scanned
+  // once on mount; a track that finishes downloading shows as installed on the next refresh.
+  const [trackIndex, setTrackIndex] = useState<TrackIndex>(() => buildTrackIndex([]));
+  useEffect(() => {
+    installedTrackIds()
+      .then((tracks) => setTrackIndex(buildTrackIndex(tracks)))
+      .catch(() => setTrackIndex(buildTrackIndex([])));
+  }, []);
+  // Which of the missing tracks can actually be downloaded, for the whole list in one call.
+  const catalog = useTrackCatalog(servers, trackIndex);
 
   // One fetch at a time. Two overlapping ones each sign in to Steam, and the loser's
   // failure used to replace the winner's list with an error.
@@ -481,15 +496,28 @@ const Servers = () => {
                       </span>
                     </td>
                     <td className="px-2 py-2.5 text-muted-foreground">
-                      <span
-                        className="block max-w-[220px] truncate"
-                        title={[s.track, s.trackLayout].filter(Boolean).join(" — ")}
-                      >
-                        {s.track || "—"}
-                        {s.trackLayout && (
-                          <span className="text-faint"> · {s.trackLayout}</span>
+                      <div className="flex items-center gap-2">
+                        <span
+                          className="block max-w-[200px] truncate"
+                          title={[s.track, s.trackLayout].filter(Boolean).join(" — ")}
+                        >
+                          {s.track || "—"}
+                          {s.trackLayout && (
+                            <span className="text-faint"> · {s.trackLayout}</span>
+                          )}
+                        </span>
+                        {s.track && matchTrack(trackIndex, s.track).state === "missing" && (
+                          // The action opens the row's detail unless the click is stopped here.
+                          <span onClick={(e) => e.stopPropagation()}>
+                            <TrackContentAction
+                              track={s.track}
+                              known={catalog.found.get(s.track)}
+                              pending={catalog.pending.has(s.track)}
+                              compact
+                            />
+                          </span>
                         )}
-                      </span>
+                      </div>
                     </td>
                     <td className="px-2 py-2.5 text-muted-foreground">
                       <span className="block max-w-[140px] truncate" title={s.location}>

--- a/apps/manager/src/Components/Servers/Servers.tsx
+++ b/apps/manager/src/Components/Servers/Servers.tsx
@@ -17,6 +17,7 @@ import {
   Globe,
   LayoutGrid,
   List,
+  PackageCheck,
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@frost/shared/lib/utils";
@@ -111,6 +112,8 @@ const Servers = () => {
   const [dir, setDir] = useState<SortDir>(DEFAULT_DIR.players);
   const [region, setRegion] = useState<string>("all");
   const [favesOnly, setFavesOnly] = useState(false);
+  // Hide servers running a track the player doesn't have — no point joining one you can't load.
+  const [installedOnly, setInstalledOnly] = useState(false);
   const favs = useFavourites(servers);
 
   // Picture grid or dense table — a sticky per-machine preference.
@@ -225,6 +228,10 @@ const Servers = () => {
     } else if (region !== "all") {
       list = list.filter((s) => canonicalRegion(s.location) === region);
     }
+    // Content filter, orthogonal to the scope above: drop anything whose track isn't on disk.
+    if (installedOnly) {
+      list = list.filter((s) => matchTrack(trackIndex, s.track).state !== "missing");
+    }
 
     const flip = dir === "desc" ? -1 : 1;
     const sorted = [...list];
@@ -257,7 +264,7 @@ const Servers = () => {
       }
     });
     return sorted;
-  }, [servers, query, showHidden, favesOnly, region, favs, sort, dir]);
+  }, [servers, query, showHidden, favesOnly, region, installedOnly, trackIndex, favs, sort, dir]);
 
   const join = useCallback(
     async (address: string) => {
@@ -347,6 +354,18 @@ const Servers = () => {
             {t("serverBrowser.favesOnly")}
           </button>
         )}
+        <button
+          type="button"
+          onClick={() => setInstalledOnly((v) => !v)}
+          title={t("serverBrowser.installedOnlyHelp")}
+          className={cn(
+            "flex h-7 items-center gap-1.5 border border-input px-2.5 text-[12px]",
+            installedOnly ? "bg-card text-muted-foreground" : "text-faint hover:text-muted-foreground",
+          )}
+        >
+          <PackageCheck className="size-3.5" />
+          {t("serverBrowser.installedOnly")}
+        </button>
         {!favesOnly && regions.length > 1 && (
           <Select value={region} onValueChange={setRegion}>
             <SelectTrigger className="h-7 w-[150px] bg-card text-[12px]">

--- a/apps/manager/src/Components/Servers/Servers.tsx
+++ b/apps/manager/src/Components/Servers/Servers.tsx
@@ -346,7 +346,7 @@ const Servers = () => {
             onClick={() => setFavesOnly((v) => !v)}
             title={t("serverBrowser.favesOnly")}
             className={cn(
-              "flex h-7 items-center gap-1.5 border border-input px-2.5 text-[12px]",
+              "flex h-7 shrink-0 items-center gap-1.5 whitespace-nowrap border border-input px-2.5 text-[12px]",
               favesOnly ? "bg-card text-muted-foreground" : "text-faint hover:text-muted-foreground",
             )}
           >
@@ -359,7 +359,7 @@ const Servers = () => {
           onClick={() => setInstalledOnly((v) => !v)}
           title={t("serverBrowser.installedOnlyHelp")}
           className={cn(
-            "flex h-7 items-center gap-1.5 border border-input px-2.5 text-[12px]",
+            "flex h-7 shrink-0 items-center gap-1.5 whitespace-nowrap border border-input px-2.5 text-[12px]",
             installedOnly ? "bg-card text-muted-foreground" : "text-faint hover:text-muted-foreground",
           )}
         >
@@ -388,7 +388,7 @@ const Servers = () => {
             onClick={() => setShowHidden((v) => !v)}
             title={t("serverBrowser.hiddenHelp")}
             className={cn(
-              "flex h-7 items-center gap-1.5 border border-input px-2.5 text-[12px]",
+              "flex h-7 shrink-0 items-center gap-1.5 whitespace-nowrap border border-input px-2.5 text-[12px]",
               showHidden ? "bg-card text-muted-foreground" : "text-faint hover:text-muted-foreground",
             )}
           >

--- a/apps/manager/src/Components/Servers/Servers.tsx
+++ b/apps/manager/src/Components/Servers/Servers.tsx
@@ -15,10 +15,13 @@ import {
   ChevronUp,
   ChevronDown,
   Globe,
+  LayoutGrid,
+  List,
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@frost/shared/lib/utils";
 import { Button } from "@frost/shared/Components/ui/button";
+import { Segmented } from "@frost/shared/Components/ui/segmented";
 import {
   Select,
   SelectTrigger,
@@ -46,8 +49,12 @@ import {
 import { buildTrackIndex, matchTrack, type TrackIndex } from "@/lib/trackContent";
 import { useTrackCatalog } from "@/lib/useTrackCatalog";
 import TrackContentAction from "./TrackContentAction";
+import ServerCard from "./ServerCard";
 import JoinServerDialog from "../Shell/JoinServerDialog";
 import ServerDetail from "./ServerDetail";
+
+type ViewMode = "cards" | "list";
+const VIEW_KEY = "mxb:serversView:v1";
 
 /**
  * The live MX Bikes server list, read straight from PiBoSo's master server — the same
@@ -105,6 +112,22 @@ const Servers = () => {
   const [region, setRegion] = useState<string>("all");
   const [favesOnly, setFavesOnly] = useState(false);
   const favs = useFavourites(servers);
+
+  // Picture grid or dense table — a sticky per-machine preference.
+  const [view, setView] = useState<ViewMode>(() => {
+    try {
+      return localStorage.getItem(VIEW_KEY) === "list" ? "list" : "cards";
+    } catch {
+      return "cards";
+    }
+  });
+  useEffect(() => {
+    try {
+      localStorage.setItem(VIEW_KEY, view);
+    } catch {
+      // Storage disabled; the choice still holds for this session.
+    }
+  }, [view]);
 
   // Which tracks are on disk, so a row can say "you have this" or offer to fetch it. Scanned
   // once on mount; a track that finishes downloading shows as installed on the next refresh.
@@ -301,6 +324,15 @@ const Servers = () => {
             {t("serverBrowser.count", { count: servers.length - (showHidden ? 0 : hiddenCount) })}
           </span>
         )}
+        <Segmented<ViewMode>
+          size="sm"
+          value={view}
+          onChange={setView}
+          options={[
+            { value: "cards", label: <LayoutGrid className="size-3.5" /> },
+            { value: "list", label: <List className="size-3.5" /> },
+          ]}
+        />
         {favs.count > 0 && (
           <button
             type="button"
@@ -408,6 +440,24 @@ const Servers = () => {
               {favesOnly ? t("serverBrowser.favesEmpty") : t("serverBrowser.empty")}
             </p>
           </Centered>
+        ) : view === "cards" ? (
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-3">
+            {shown.map((s, i) => (
+              <ServerCard
+                key={`${s.address}-${i}`}
+                server={s}
+                match={matchTrack(trackIndex, s.track)}
+                known={catalog.found.get(s.track)}
+                pending={catalog.pending.has(s.track)}
+                joining={joining === s.address}
+                onJoin={() => join(s.address)}
+                favourite={favs.has(s.address)}
+                onToggleFavourite={() =>
+                  favs.toggle({ address: s.address, name: s.name, track: s.track })
+                }
+              />
+            ))}
+          </div>
         ) : (
           <div className="overflow-hidden rounded-xl border border-input">
             <table className="w-full border-collapse text-[13px]">

--- a/apps/manager/src/Components/Servers/Servers.tsx
+++ b/apps/manager/src/Components/Servers/Servers.tsx
@@ -82,7 +82,7 @@ function readFlag(key: string, fallback: boolean): boolean {
  *
  * On top of the fetch: any column sorts (click its header to flip), servers can be starred
  * to a favourites-only view, and the host's own `location` text is grouped into a small set
- * of regions for the filter (see `lib/serverRegion`) — three conveniences ported from the
+ * of regions for the filter (see `lib/serverRegion`) - three conveniences ported from the
  * standalone browser.
  */
 
@@ -92,7 +92,7 @@ type SortDir = "asc" | "desc";
 
 /**
  * Which way a column runs when first clicked. Descending for "more is what I want" (players),
- * ascending for everything else — clicking Players and landing on the empty servers reads as
+ * ascending for everything else - clicking Players and landing on the empty servers reads as
  * a bug, not a default.
  */
 const DEFAULT_DIR: Record<SortMode, SortDir> = {
@@ -125,10 +125,10 @@ const Servers = () => {
   const [dir, setDir] = useState<SortDir>(DEFAULT_DIR.players);
   const [region, setRegion] = useState<string>("all");
   const [favesOnly, setFavesOnly] = useState(false);
-  // Hide servers running a track the player doesn't have — no point joining one you can't load.
+  // Hide servers running a track the player doesn't have - no point joining one you can't load.
   // Sticky, default off.
   const [installedOnly, setInstalledOnly] = useState(() => readFlag(INSTALLED_ONLY_KEY, false));
-  // Hide empty servers — an empty one is rarely what someone opening the browser is after, so
+  // Hide empty servers - an empty one is rarely what someone opening the browser is after, so
   // this defaults on and is remembered, opening the browser straight to servers with riders.
   const [hideEmpty, setHideEmpty] = useState(() => readFlag(HIDE_EMPTY_KEY, true));
   useEffect(() => {
@@ -147,7 +147,7 @@ const Servers = () => {
   }, [hideEmpty]);
   const favs = useFavourites(servers);
 
-  // Picture grid or dense table — a sticky per-machine preference.
+  // Picture grid or dense table - a sticky per-machine preference.
   const [view, setView] = useState<ViewMode>(() => {
     try {
       return localStorage.getItem(VIEW_KEY) === "list" ? "list" : "cards";
@@ -224,7 +224,7 @@ const Servers = () => {
     [servers],
   );
 
-  /** The region buckets actually present, in a fixed order — not the raw host strings. */
+  /** The region buckets actually present, in a fixed order - not the raw host strings. */
   const regions = useMemo(() => {
     const present = new Set<RegionKey>();
     for (const s of servers ?? []) present.add(canonicalRegion(s.location));
@@ -614,9 +614,9 @@ const Servers = () => {
                       <div className="flex items-center gap-2">
                         <span
                           className="block max-w-[200px] truncate"
-                          title={[s.track, s.trackLayout].filter(Boolean).join(" — ")}
+                          title={[s.track, s.trackLayout].filter(Boolean).join(" - ")}
                         >
-                          {s.track || "—"}
+                          {s.track || "-"}
                           {s.trackLayout && (
                             <span className="text-faint"> · {s.trackLayout}</span>
                           )}

--- a/apps/manager/src/Components/Servers/Servers.tsx
+++ b/apps/manager/src/Components/Servers/Servers.tsx
@@ -11,10 +11,21 @@ import {
   ServerOff,
   EyeOff,
   Palette,
+  Star,
+  ChevronUp,
+  ChevronDown,
+  Globe,
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@frost/shared/lib/utils";
 import { Button } from "@frost/shared/Components/ui/button";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@frost/shared/Components/ui/select";
 import { ContextBarRight } from "../Shell/ContextBar";
 import HelpHint from "@frost/shared/Components/ui/help-hint";
 import {
@@ -24,6 +35,13 @@ import {
   type MasterServer,
 } from "@frost/shared/api/mods";
 import { useT } from "@/i18n";
+import { useFavourites } from "@/lib/useFavourites";
+import {
+  REGION_LABEL_KEY,
+  REGION_ORDER,
+  canonicalRegion,
+  type RegionKey,
+} from "@/lib/serverRegion";
 import JoinServerDialog from "../Shell/JoinServerDialog";
 import ServerDetail from "./ServerDetail";
 
@@ -36,7 +54,30 @@ import ServerDetail from "./ServerDetail";
  * The fetch is one Rust command; everything the master needs (auth, the protocol) lives
  * behind it. A build without the browser, or a master that won't answer, comes back as a
  * plain error string this renders rather than a blank tab.
+ *
+ * On top of the fetch: any column sorts (click its header to flip), servers can be starred
+ * to a favourites-only view, and the host's own `location` text is grouped into a small set
+ * of regions for the filter (see `lib/serverRegion`) — three conveniences ported from the
+ * standalone browser.
  */
+
+/** Every sortable column. These are the ones upstream's table actually shows. */
+type SortMode = "players" | "ping" | "name" | "region" | "track";
+type SortDir = "asc" | "desc";
+
+/**
+ * Which way a column runs when first clicked. Descending for "more is what I want" (players),
+ * ascending for everything else — clicking Players and landing on the empty servers reads as
+ * a bug, not a default.
+ */
+const DEFAULT_DIR: Record<SortMode, SortDir> = {
+  players: "desc",
+  ping: "asc",
+  name: "asc",
+  region: "asc",
+  track: "asc",
+};
+
 const Servers = () => {
   const t = useT();
   const [servers, setServers] = useState<MasterServer[] | null>(null);
@@ -54,6 +95,13 @@ const Servers = () => {
   // the list. This is one request for all of them, and it marks the rows.
   const [paintSync, setPaintSync] = useState<Record<string, number>>({});
 
+  // Ported conveniences: sort order, region filter, and a favourites-only view.
+  const [sort, setSort] = useState<SortMode>("players");
+  const [dir, setDir] = useState<SortDir>(DEFAULT_DIR.players);
+  const [region, setRegion] = useState<string>("all");
+  const [favesOnly, setFavesOnly] = useState(false);
+  const favs = useFavourites(servers);
+
   // One fetch at a time. Two overlapping ones each sign in to Steam, and the loser's
   // failure used to replace the winner's list with an error.
   const inFlight = useRef(false);
@@ -66,8 +114,6 @@ const Servers = () => {
     setError(null);
     listMasterServers()
       .then((list) => {
-        // Busiest first — an empty server is the last thing anyone's looking for.
-        list.sort((a, b) => b.players - a.players);
         onScreen.current = list;
         setServers(list);
         // After the list, never with it: the browser has to draw whether or not the control
@@ -95,24 +141,85 @@ const Servers = () => {
     load();
   }, [load]);
 
+  // Nothing to un-star means nothing to look at: never sit on an empty favourites view.
+  useEffect(() => {
+    if (favesOnly && favs.count === 0) setFavesOnly(false);
+  }, [favesOnly, favs.count]);
+
   /** How many rows the filter caught, whether or not they're being shown. */
   const hiddenCount = useMemo(
     () => (servers ?? []).filter((s) => s.hidden).length,
     [servers],
   );
 
+  /** The region buckets actually present, in a fixed order — not the raw host strings. */
+  const regions = useMemo(() => {
+    const present = new Set<RegionKey>();
+    for (const s of servers ?? []) present.add(canonicalRegion(s.location));
+    return REGION_ORDER.filter((r) => present.has(r));
+  }, [servers]);
+
+  /** Sort by `key`, flipping direction when it's already the active column. */
+  const sortBy = useCallback(
+    (key: SortMode) => {
+      setDir((d) => (sort === key ? (d === "asc" ? "desc" : "asc") : DEFAULT_DIR[key]));
+      setSort(key);
+    },
+    [sort],
+  );
+
   const shown = useMemo(() => {
     const q = query.trim().toLowerCase();
-    const visible = (servers ?? []).filter((s) => showHidden || !s.hidden);
-    if (!q) return visible;
-    return visible.filter(
-      (s) =>
-        s.name.toLowerCase().includes(q) ||
-        s.track.toLowerCase().includes(q) ||
-        s.location.toLowerCase().includes(q) ||
-        s.address.toLowerCase().includes(q),
-    );
-  }, [servers, query, showHidden]);
+    let list = (servers ?? []).filter((s) => showHidden || !s.hidden);
+    if (q) {
+      list = list.filter(
+        (s) =>
+          s.name.toLowerCase().includes(q) ||
+          s.track.toLowerCase().includes(q) ||
+          s.location.toLowerCase().includes(q) ||
+          s.address.toLowerCase().includes(q),
+      );
+    }
+    if (favesOnly) {
+      // Starring *is* the filter here: don't also apply the region pill, which would hide a
+      // favourite that happens to sit in another region from the one you're browsing.
+      list = list.filter((s) => favs.has(s.address));
+    } else if (region !== "all") {
+      list = list.filter((s) => canonicalRegion(s.location) === region);
+    }
+
+    const flip = dir === "desc" ? -1 : 1;
+    const sorted = [...list];
+    sorted.sort((a, b) => {
+      // Name breaks every tie, so the order is total and a re-render can't reshuffle rows
+      // that compare equal.
+      const byName = a.name.localeCompare(b.name);
+      switch (sort) {
+        case "players":
+          return (a.players - b.players) * flip || byName;
+        case "ping": {
+          const [x, y] = [a.pingMs, b.pingMs];
+          if (x === null || y === null) {
+            // Unreachable/unmeasured always last, whichever way the column runs.
+            if (x === y) return byName;
+            return x === null ? 1 : -1;
+          }
+          return (x - y) * flip || byName;
+        }
+        case "region":
+          return (
+            canonicalRegion(a.location).localeCompare(canonicalRegion(b.location)) * flip ||
+            byName
+          );
+        case "track":
+          return a.track.localeCompare(b.track) * flip || byName;
+        case "name":
+        default:
+          return byName * flip;
+      }
+    });
+    return sorted;
+  }, [servers, query, showHidden, favesOnly, region, favs, sort, dir]);
 
   const join = useCallback(
     async (address: string) => {
@@ -144,6 +251,33 @@ const Servers = () => {
     [t],
   );
 
+  /** A clickable column header that shows and flips the sort. */
+  const SortHead = ({
+    col,
+    label,
+    className,
+  }: {
+    col: SortMode;
+    label: string;
+    className?: string;
+  }) => (
+    <th className={cn("px-2 py-2.5 font-semibold", className)}>
+      <button
+        type="button"
+        onClick={() => sortBy(col)}
+        className="inline-flex items-center gap-1 uppercase tracking-wide hover:text-muted-foreground"
+      >
+        {label}
+        {sort === col &&
+          (dir === "asc" ? (
+            <ChevronUp className="size-3" />
+          ) : (
+            <ChevronDown className="size-3" />
+          ))}
+      </button>
+    </th>
+  );
+
   return (
     <div className="flex h-full flex-col">
       <ContextBarRight>
@@ -151,6 +285,36 @@ const Servers = () => {
           <span className="tabular-figures text-[12.5px] text-faint">
             {t("serverBrowser.count", { count: servers.length - (showHidden ? 0 : hiddenCount) })}
           </span>
+        )}
+        {favs.count > 0 && (
+          <button
+            type="button"
+            onClick={() => setFavesOnly((v) => !v)}
+            title={t("serverBrowser.favesOnly")}
+            className={cn(
+              "flex h-7 items-center gap-1.5 border border-input px-2.5 text-[12px]",
+              favesOnly ? "bg-card text-muted-foreground" : "text-faint hover:text-muted-foreground",
+            )}
+          >
+            <Star className={cn("size-3.5", favesOnly && "fill-current")} />
+            {t("serverBrowser.favesOnly")}
+          </button>
+        )}
+        {!favesOnly && regions.length > 1 && (
+          <Select value={region} onValueChange={setRegion}>
+            <SelectTrigger className="h-7 w-[150px] bg-card text-[12px]">
+              <Globe className="size-3.5 text-faint" />
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">{t("serverBrowser.region.all")}</SelectItem>
+              {regions.map((r) => (
+                <SelectItem key={r} value={r}>
+                  {t(REGION_LABEL_KEY[r])}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         )}
         {hiddenCount > 0 && (
           <button
@@ -225,18 +389,21 @@ const Servers = () => {
         ) : shown.length === 0 ? (
           <Centered>
             <ServerOff className="size-6 text-faint" />
-            <p className="text-[13px] text-faint">{t("serverBrowser.empty")}</p>
+            <p className="text-[13px] text-faint">
+              {favesOnly ? t("serverBrowser.favesEmpty") : t("serverBrowser.empty")}
+            </p>
           </Centered>
         ) : (
           <div className="overflow-hidden rounded-xl border border-input">
             <table className="w-full border-collapse text-[13px]">
               <thead>
                 <tr className="border-b border-input bg-card text-left text-[11.5px] uppercase tracking-wide text-faint">
-                  <th className="px-3.5 py-2.5 font-semibold">{t("serverBrowser.name")}</th>
-                  <th className="w-[92px] px-2 py-2.5 font-semibold">{t("serverBrowser.players")}</th>
-                  <th className="px-2 py-2.5 font-semibold">{t("servers.track")}</th>
-                  <th className="px-2 py-2.5 font-semibold">{t("serverBrowser.location")}</th>
-                  <th className="w-[72px] px-2 py-2.5 font-semibold">{t("serverBrowser.ping")}</th>
+                  <th className="w-[36px] px-2 py-2.5" />
+                  <SortHead col="name" label={t("serverBrowser.name")} className="px-3.5" />
+                  <SortHead col="players" label={t("serverBrowser.players")} className="w-[92px]" />
+                  <SortHead col="track" label={t("servers.track")} />
+                  <SortHead col="region" label={t("serverBrowser.location")} />
+                  <SortHead col="ping" label={t("serverBrowser.ping")} className="w-[72px]" />
                   <th className="px-2 py-2.5 font-semibold">{t("serverBrowser.address")}</th>
                   <th className="w-[110px] px-3.5 py-2.5" />
                 </tr>
@@ -253,6 +420,28 @@ const Servers = () => {
                       s.hidden && "opacity-55",
                     )}
                   >
+                    <td className="px-2 py-2.5">
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          favs.toggle({ address: s.address, name: s.name, track: s.track });
+                        }}
+                        title={
+                          favs.has(s.address)
+                            ? t("serverBrowser.unstar")
+                            : t("serverBrowser.star")
+                        }
+                        className={cn(
+                          "inline-flex items-center justify-center rounded p-0.5",
+                          favs.has(s.address)
+                            ? "text-amber-400"
+                            : "text-faint hover:text-muted-foreground",
+                        )}
+                      >
+                        <Star className={cn("size-3.5", favs.has(s.address) && "fill-current")} />
+                      </button>
+                    </td>
                     <td className="px-3.5 py-2.5">
                       <div className="flex items-center gap-2">
                         {s.passworded && (

--- a/apps/manager/src/Components/Servers/TrackContentAction.tsx
+++ b/apps/manager/src/Components/Servers/TrackContentAction.tsx
@@ -16,7 +16,7 @@ interface Props {
   track: string;
   /** The catalog post the backend's index already matched this track to, when it has one
    *  (see {@link useTrackCatalog}). Its presence is what turns this control from "look for
-   *  it" into "install it" — no search, no click spent finding out. */
+   *  it" into "install it" - no search, no click spent finding out. */
   known?: TrackHit;
   /** The index is still reading candidate pages for this track: neither found nor ruled out
    *  yet, so the control waits rather than offering a search that may be about to be
@@ -29,11 +29,11 @@ interface Props {
 }
 
 /**
- * The "this track isn't installed — get it" control.
+ * The "this track isn't installed - get it" control.
  *
  * The best case costs nothing: when the track index has already matched this track to an
  * mxb-mods post ({@link Props.known}), the button installs it directly. That covers the
- * tracks servers actually run, including the ones no title match would find — a post titled
+ * tracks servers actually run, including the ones no title match would find - a post titled
  * "Farm14 v0.1" ships `Farm14.pkz`, and the index knows it.
  *
  * Otherwise it falls back to the per-track search across the three catalogs ({@link

--- a/apps/manager/src/Components/Servers/TrackContentAction.tsx
+++ b/apps/manager/src/Components/Servers/TrackContentAction.tsx
@@ -1,0 +1,202 @@
+import { useCallback, useState } from "react";
+import { Download, Loader2, Tag, ExternalLink, Search } from "lucide-react";
+import { toast } from "sonner";
+import { useInstall } from "@/Context/Install";
+import { useConfig } from "@frost/shared/Context/Config";
+import { useI18n } from "@frost/shared/i18n/context";
+import { useT } from "@/i18n";
+import { resolveMissingTrack, trackQuery, type TrackSource } from "@/lib/trackDownload";
+import { resolveQuickInstall, modTypesFor, type TrackHit } from "@frost/shared/api/mods";
+import { openShopUrl } from "@/api/shop";
+import { open } from "@tauri-apps/plugin-shell";
+import { cn } from "@frost/shared/lib/utils";
+
+interface Props {
+  /** The server's track id (internal name). */
+  track: string;
+  /** The catalog post the backend's index already matched this track to, when it has one
+   *  (see {@link useTrackCatalog}). Its presence is what turns this control from "look for
+   *  it" into "install it" — no search, no click spent finding out. */
+  known?: TrackHit;
+  /** The index is still reading candidate pages for this track: neither found nor ruled out
+   *  yet, so the control waits rather than offering a search that may be about to be
+   *  answered for free. */
+  pending?: boolean;
+  /** Compact styling for the dense list view. */
+  compact?: boolean;
+  /** Open the Hub tab (for a Hub product the user should complete there). */
+  onOpenHub?: () => void;
+}
+
+/**
+ * The "this track isn't installed — get it" control.
+ *
+ * The best case costs nothing: when the track index has already matched this track to an
+ * mxb-mods post ({@link Props.known}), the button installs it directly. That covers the
+ * tracks servers actually run, including the ones no title match would find — a post titled
+ * "Farm14 v0.1" ships `Farm14.pkz`, and the index knows it.
+ *
+ * Otherwise it falls back to the per-track search across the three catalogs ({@link
+ * resolveMissingTrack}), on click: a free mxb-mods track queues straight into the installer
+ * (the same pipeline Browse's quick-install uses), a Hub track opens its page, and a paid shop
+ * track shows its price and links out to buy. When nothing matches confidently it offers a plain
+ * search rather than guessing.
+ */
+export default function TrackContentAction({ track, known, pending, compact, onOpenHub }: Props) {
+  const t = useT();
+  const { resolved } = useI18n();
+  const { game } = useConfig();
+  const { startPendingInstall } = useInstall();
+
+  const [source, setSource] = useState<TrackSource | null>(null);
+  const [searching, setSearching] = useState(false);
+  const [queued, setQueued] = useState(false);
+
+  const find = useCallback(async () => {
+    setSearching(true);
+    try {
+      setSource(await resolveMissingTrack(track, resolved));
+    } catch {
+      setSource({ kind: "none" });
+    } finally {
+      setSearching(false);
+    }
+  }, [track, resolved]);
+
+  const queueMxbMods = useCallback(
+    (slug: string, title: string) => {
+      const trackType = modTypesFor(game.id).find((mt) => mt.id === "tracks");
+      if (!trackType) return;
+      startPendingInstall({
+        slug,
+        title,
+        subpath: trackType.installSubpath,
+        resolve: async () => {
+          const r = await resolveQuickInstall(slug, trackType, game, trackType.categoryId);
+          return r.ok ? r.params : null;
+        },
+      });
+      setQueued(true);
+      toast.success(t("serverBrowser.dl.queued", { title }));
+    },
+    [game, startPendingInstall, t],
+  );
+
+  const base =
+    "inline-flex items-center gap-1.5 rounded-md font-medium transition-colors cursor-default " +
+    (compact ? "px-2 py-1 text-[11px]" : "px-2.5 py-1.5 text-[12px]");
+
+  if (queued) {
+    return (
+      <span className={cn(base, "text-success")}>
+        <Download className="size-3.5" /> {t("serverBrowser.dl.queuedShort")}
+      </span>
+    );
+  }
+
+  // The index already found it: install, with the post's own title on the tooltip. Skipped
+  // once the user has run a search of their own, so their result is never overwritten.
+  if (source === null && known) {
+    return (
+      <button
+        onClick={() => queueMxbMods(known.slug, known.title)}
+        className={cn(base, "bg-primary text-primary-foreground hover:brightness-105")}
+        title={t("serverBrowser.dl.installTitle", { title: known.title })}
+      >
+        <Download className="size-3.5" /> {t("serverBrowser.dl.install")}
+      </button>
+    );
+  }
+
+  // The index is still reading pages for this one. Saying "search" here would push the user
+  // into work that may be about to be done for them.
+  if (source === null && pending) {
+    return (
+      <span className={cn(base, "text-muted-foreground")} title={t("serverBrowser.dl.lookingTitle")}>
+        <Loader2 className="size-3.5 animate-spin" /> {t("serverBrowser.dl.looking")}
+      </span>
+    );
+  }
+
+  // Before searching: a single "find it" affordance.
+  if (source === null) {
+    return (
+      <button
+        onClick={find}
+        disabled={searching}
+        className={cn(base, "border border-white/[0.12] text-foreground/80 hover:bg-white/[0.05] disabled:opacity-60")}
+        title={t("serverBrowser.dl.findTitle")}
+      >
+        {searching ? <Loader2 className="size-3.5 animate-spin" /> : <Download className="size-3.5" />}
+        {t(searching ? "serverBrowser.dl.searching" : "serverBrowser.dl.find")}
+      </button>
+    );
+  }
+
+  if (source.kind === "mxbMods") {
+    return (
+      <button
+        onClick={() => queueMxbMods(source.mod.slug, source.title)}
+        className={cn(base, "bg-primary text-primary-foreground hover:brightness-105")}
+        title={source.title}
+      >
+        <Download className="size-3.5" /> {t("serverBrowser.dl.install")}
+      </button>
+    );
+  }
+
+  if (source.kind === "hub") {
+    return (
+      <button
+        onClick={() => (onOpenHub ? onOpenHub() : void openShopUrl(source.mod.url))}
+        className={cn(base, "border border-white/[0.12] text-foreground/80 hover:bg-white/[0.05]")}
+        title={source.title}
+      >
+        {source.free ? (
+          <>
+            <Download className="size-3.5" /> {t("serverBrowser.dl.onHub")}
+          </>
+        ) : (
+          <>
+            <Tag className="size-3.5" /> {source.price ?? t("serverBrowser.dl.onHub")}
+          </>
+        )}
+      </button>
+    );
+  }
+
+  if (source.kind === "shop") {
+    return (
+      <button
+        onClick={() => void openShopUrl(source.mod.url)}
+        className={cn(base, "border border-amber-400/30 text-amber-300 hover:bg-amber-400/10")}
+        title={t("serverBrowser.dl.onShop", { title: source.title })}
+      >
+        <Tag className="size-3.5" /> {source.price ?? ""}
+        <ExternalLink className="size-3" />
+      </button>
+    );
+  }
+
+  // Nothing matched confidently: offer a manual search on the catalog.
+  //
+  // Opened with the shell directly rather than through `openShopUrl`, which only ever opens
+  // the two *stores* and drops anything else on the floor without a word. The catalog is not
+  // one of them, so routing a search through it made this button do nothing at all.
+  //
+  // The host comes from the active title (`catalogDomain`), not a constant: GP Bikes has its
+  // own catalog, and a hardcoded mxb-mods.com would search the wrong site for its players.
+  return (
+    <button
+      onClick={() =>
+        void open(
+          `https://${game.catalogDomain}/?s=${encodeURIComponent(trackQuery(track))}`,
+        )
+      }
+      className={cn(base, "text-muted-foreground hover:text-foreground")}
+      title={t("serverBrowser.dl.searchTitle")}
+    >
+      <Search className="size-3.5" /> {t("serverBrowser.dl.search")}
+    </button>
+  );
+}

--- a/apps/manager/src/i18n/locales/de.ts
+++ b/apps/manager/src/i18n/locales/de.ts
@@ -947,7 +947,7 @@ export const de: Translation = {
   "serverBrowser.favesOnly": "Favoriten",
   "serverBrowser.star": "Zu Favoriten hinzufügen",
   "serverBrowser.unstar": "Aus Favoriten entfernen",
-  "serverBrowser.favesEmpty": "Noch keine Favoriten — markiere einen Server mit dem Stern, um ihn hier zu behalten.",
+  "serverBrowser.favesEmpty": "Noch keine Favoriten - markiere einen Server mit dem Stern, um ihn hier zu behalten.",
   "serverBrowser.region.all": "Alle Regionen",
   "serverBrowser.region.naEast": "Nordamerika (Ost)",
   "serverBrowser.region.naWest": "Nordamerika (West)",

--- a/apps/manager/src/i18n/locales/de.ts
+++ b/apps/manager/src/i18n/locales/de.ts
@@ -943,6 +943,21 @@ export const de: Translation = {
   "serverBrowser.trackGetMods": "Bei mxb-mods holen",
   "serverBrowser.trackGetHub": "Bei MXB Hub holen",
 
+  // ── Server-Browser: Favoriten, Regionsfilter (portiert) ──
+  "serverBrowser.favesOnly": "Favoriten",
+  "serverBrowser.star": "Zu Favoriten hinzufügen",
+  "serverBrowser.unstar": "Aus Favoriten entfernen",
+  "serverBrowser.favesEmpty": "Noch keine Favoriten — markiere einen Server mit dem Stern, um ihn hier zu behalten.",
+  "serverBrowser.region.all": "Alle Regionen",
+  "serverBrowser.region.naEast": "Nordamerika (Ost)",
+  "serverBrowser.region.naWest": "Nordamerika (West)",
+  "serverBrowser.region.na": "Nordamerika",
+  "serverBrowser.region.europe": "Europa",
+  "serverBrowser.region.oceania": "Ozeanien",
+  "serverBrowser.region.southAmerica": "Südamerika",
+  "serverBrowser.region.asia": "Asien",
+  "serverBrowser.region.other": "Andere",
+
   "sync.autoNote":
     "Dein Look veröffentlicht sich selbst — jedes Bike, sobald du ihn in der App oder in der Garage des Spiels änderst. Der der anderen kommt, wenn du auf Spielen drückst.",
 

--- a/apps/manager/src/i18n/locales/de.ts
+++ b/apps/manager/src/i18n/locales/de.ts
@@ -982,6 +982,8 @@ export const de: Translation = {
   "serverBrowser.ping.ms": "{{ms}} ms",
   "serverBrowser.viewCards": "Karten",
   "serverBrowser.viewList": "Liste",
+  "serverBrowser.installedOnly": "Nur installierte",
+  "serverBrowser.installedOnlyHelp": "Nur Server mit einer Strecke anzeigen, die du hast",
 
   "sync.autoNote":
     "Dein Look veröffentlicht sich selbst — jedes Bike, sobald du ihn in der App oder in der Garage des Spiels änderst. Der der anderen kommt, wenn du auf Spielen drückst.",

--- a/apps/manager/src/i18n/locales/de.ts
+++ b/apps/manager/src/i18n/locales/de.ts
@@ -958,6 +958,21 @@ export const de: Translation = {
   "serverBrowser.region.asia": "Asien",
   "serverBrowser.region.other": "Andere",
 
+  // ── Server-Browser: Strecken-Download-Aktion (portiert) ──
+  "serverBrowser.dl.queued": "In Warteschlange {{title}}",
+  "serverBrowser.dl.queuedShort": "In Warteschlange",
+  "serverBrowser.dl.install": "Installieren",
+  "serverBrowser.dl.installTitle": "{{title}} von mxb-mods installieren",
+  "serverBrowser.dl.looking": "Suche…",
+  "serverBrowser.dl.lookingTitle": "Prüfe, ob diese Strecke heruntergeladen werden kann…",
+  "serverBrowser.dl.find": "Strecke holen",
+  "serverBrowser.dl.findTitle": "Diese Strecke bei mxb-mods, im Hub und im Shop suchen",
+  "serverBrowser.dl.searching": "Suche…",
+  "serverBrowser.dl.search": "Suchen",
+  "serverBrowser.dl.searchTitle": "Diese Strecke im Katalog suchen",
+  "serverBrowser.dl.onHub": "Im Hub",
+  "serverBrowser.dl.onShop": "{{title}} im Shop kaufen",
+
   "sync.autoNote":
     "Dein Look veröffentlicht sich selbst — jedes Bike, sobald du ihn in der App oder in der Garage des Spiels änderst. Der der anderen kommt, wenn du auf Spielen drückst.",
 

--- a/apps/manager/src/i18n/locales/de.ts
+++ b/apps/manager/src/i18n/locales/de.ts
@@ -984,6 +984,8 @@ export const de: Translation = {
   "serverBrowser.viewList": "Liste",
   "serverBrowser.installedOnly": "Nur installierte",
   "serverBrowser.installedOnlyHelp": "Nur Server mit einer Strecke anzeigen, die du hast",
+  "serverBrowser.hideEmpty": "Leere ausblenden",
+  "serverBrowser.hideEmptyHelp": "Server ohne Fahrer ausblenden",
 
   "sync.autoNote":
     "Dein Look veröffentlicht sich selbst — jedes Bike, sobald du ihn in der App oder in der Garage des Spiels änderst. Der der anderen kommt, wenn du auf Spielen drückst.",

--- a/apps/manager/src/i18n/locales/de.ts
+++ b/apps/manager/src/i18n/locales/de.ts
@@ -973,6 +973,16 @@ export const de: Translation = {
   "serverBrowser.dl.onHub": "Im Hub",
   "serverBrowser.dl.onShop": "{{title}} im Shop kaufen",
 
+  // ── Server-Browser: Kartenansicht (portiert) ──
+  "serverBrowser.missingContent": "Fehlender Inhalt",
+  "serverBrowser.unnamed": "Unbenannter Server",
+  "serverBrowser.full": "Server voll",
+  "serverBrowser.copyFailed": "Adresse konnte nicht kopiert werden",
+  "serverBrowser.ping.title": "{{ms}} ms Round-Trip",
+  "serverBrowser.ping.ms": "{{ms}} ms",
+  "serverBrowser.viewCards": "Karten",
+  "serverBrowser.viewList": "Liste",
+
   "sync.autoNote":
     "Dein Look veröffentlicht sich selbst — jedes Bike, sobald du ihn in der App oder in der Garage des Spiels änderst. Der der anderen kommt, wenn du auf Spielen drückst.",
 

--- a/apps/manager/src/i18n/locales/en.ts
+++ b/apps/manager/src/i18n/locales/en.ts
@@ -960,6 +960,8 @@ export const en = {
   "serverBrowser.ping.ms": "{{ms}} ms",
   "serverBrowser.viewCards": "Cards",
   "serverBrowser.viewList": "List",
+  "serverBrowser.installedOnly": "Installed only",
+  "serverBrowser.installedOnlyHelp": "Show only servers running a track you have",
 
   "sync.autoNote":
     "Your look publishes itself — every bike, whenever you change it in the app or in the game's own garage. Everyone else's arrives when you press Play.",

--- a/apps/manager/src/i18n/locales/en.ts
+++ b/apps/manager/src/i18n/locales/en.ts
@@ -962,6 +962,8 @@ export const en = {
   "serverBrowser.viewList": "List",
   "serverBrowser.installedOnly": "Installed only",
   "serverBrowser.installedOnlyHelp": "Show only servers running a track you have",
+  "serverBrowser.hideEmpty": "Hide empty",
+  "serverBrowser.hideEmptyHelp": "Hide servers with no riders on them",
 
   "sync.autoNote":
     "Your look publishes itself — every bike, whenever you change it in the app or in the game's own garage. Everyone else's arrives when you press Play.",

--- a/apps/manager/src/i18n/locales/en.ts
+++ b/apps/manager/src/i18n/locales/en.ts
@@ -936,6 +936,21 @@ export const en = {
   "serverBrowser.region.asia": "Asia",
   "serverBrowser.region.other": "Other",
 
+  // ── Server browser: track download action (ported) ──
+  "serverBrowser.dl.queued": "Queued {{title}}",
+  "serverBrowser.dl.queuedShort": "Queued",
+  "serverBrowser.dl.install": "Install",
+  "serverBrowser.dl.installTitle": "Install {{title}} from mxb-mods",
+  "serverBrowser.dl.looking": "Looking…",
+  "serverBrowser.dl.lookingTitle": "Checking whether this track can be downloaded…",
+  "serverBrowser.dl.find": "Get track",
+  "serverBrowser.dl.findTitle": "Look for this track across mxb-mods, the Hub and the shop",
+  "serverBrowser.dl.searching": "Searching…",
+  "serverBrowser.dl.search": "Search",
+  "serverBrowser.dl.searchTitle": "Search the catalog for this track",
+  "serverBrowser.dl.onHub": "On the Hub",
+  "serverBrowser.dl.onShop": "Buy {{title}} from the shop",
+
   "sync.autoNote":
     "Your look publishes itself — every bike, whenever you change it in the app or in the game's own garage. Everyone else's arrives when you press Play.",
 

--- a/apps/manager/src/i18n/locales/en.ts
+++ b/apps/manager/src/i18n/locales/en.ts
@@ -951,6 +951,16 @@ export const en = {
   "serverBrowser.dl.onHub": "On the Hub",
   "serverBrowser.dl.onShop": "Buy {{title}} from the shop",
 
+  // ── Server browser: card view (ported) ──
+  "serverBrowser.missingContent": "Missing content",
+  "serverBrowser.unnamed": "Unnamed server",
+  "serverBrowser.full": "Server full",
+  "serverBrowser.copyFailed": "Couldn't copy the address",
+  "serverBrowser.ping.title": "{{ms}} ms round-trip",
+  "serverBrowser.ping.ms": "{{ms}} ms",
+  "serverBrowser.viewCards": "Cards",
+  "serverBrowser.viewList": "List",
+
   "sync.autoNote":
     "Your look publishes itself — every bike, whenever you change it in the app or in the game's own garage. Everyone else's arrives when you press Play.",
 

--- a/apps/manager/src/i18n/locales/en.ts
+++ b/apps/manager/src/i18n/locales/en.ts
@@ -925,7 +925,7 @@ export const en = {
   "serverBrowser.favesOnly": "Favourites",
   "serverBrowser.star": "Star this server",
   "serverBrowser.unstar": "Remove from favourites",
-  "serverBrowser.favesEmpty": "No favourites yet — star a server to keep it here.",
+  "serverBrowser.favesEmpty": "No favourites yet - star a server to keep it here.",
   "serverBrowser.region.all": "All regions",
   "serverBrowser.region.naEast": "North America (East)",
   "serverBrowser.region.naWest": "North America (West)",

--- a/apps/manager/src/i18n/locales/en.ts
+++ b/apps/manager/src/i18n/locales/en.ts
@@ -921,6 +921,21 @@ export const en = {
   "serverBrowser.trackGetMods": "Get it from mxb-mods",
   "serverBrowser.trackGetHub": "Get it from MXB Hub",
 
+  // ── Server browser: favourites, region filter (ported) ──
+  "serverBrowser.favesOnly": "Favourites",
+  "serverBrowser.star": "Star this server",
+  "serverBrowser.unstar": "Remove from favourites",
+  "serverBrowser.favesEmpty": "No favourites yet — star a server to keep it here.",
+  "serverBrowser.region.all": "All regions",
+  "serverBrowser.region.naEast": "North America (East)",
+  "serverBrowser.region.naWest": "North America (West)",
+  "serverBrowser.region.na": "North America",
+  "serverBrowser.region.europe": "Europe",
+  "serverBrowser.region.oceania": "Oceania",
+  "serverBrowser.region.southAmerica": "South America",
+  "serverBrowser.region.asia": "Asia",
+  "serverBrowser.region.other": "Other",
+
   "sync.autoNote":
     "Your look publishes itself — every bike, whenever you change it in the app or in the game's own garage. Everyone else's arrives when you press Play.",
 

--- a/apps/manager/src/i18n/locales/es.ts
+++ b/apps/manager/src/i18n/locales/es.ts
@@ -978,6 +978,8 @@ export const es: Translation = {
   "serverBrowser.viewList": "Lista",
   "serverBrowser.installedOnly": "Solo instalados",
   "serverBrowser.installedOnlyHelp": "Mostrar solo servidores con un circuito que tienes",
+  "serverBrowser.hideEmpty": "Ocultar vacíos",
+  "serverBrowser.hideEmptyHelp": "Ocultar servidores sin pilotos",
 
   "sync.autoNote":
     "Tu look se publica solo — cada moto, cada vez que lo cambias en la app o en el garaje del juego. El de los demás llega cuando pulsas Jugar.",

--- a/apps/manager/src/i18n/locales/es.ts
+++ b/apps/manager/src/i18n/locales/es.ts
@@ -952,6 +952,21 @@ export const es: Translation = {
   "serverBrowser.region.asia": "Asia",
   "serverBrowser.region.other": "Otra",
 
+  // ── Navegador de servidores: acción de descarga de circuito (portado) ──
+  "serverBrowser.dl.queued": "En cola {{title}}",
+  "serverBrowser.dl.queuedShort": "En cola",
+  "serverBrowser.dl.install": "Instalar",
+  "serverBrowser.dl.installTitle": "Instalar {{title}} desde mxb-mods",
+  "serverBrowser.dl.looking": "Buscando…",
+  "serverBrowser.dl.lookingTitle": "Comprobando si este circuito se puede descargar…",
+  "serverBrowser.dl.find": "Obtener circuito",
+  "serverBrowser.dl.findTitle": "Busca este circuito en mxb-mods, el Hub y la tienda",
+  "serverBrowser.dl.searching": "Buscando…",
+  "serverBrowser.dl.search": "Buscar",
+  "serverBrowser.dl.searchTitle": "Buscar este circuito en el catálogo",
+  "serverBrowser.dl.onHub": "En el Hub",
+  "serverBrowser.dl.onShop": "Comprar {{title}} en la tienda",
+
   "sync.autoNote":
     "Tu look se publica solo — cada moto, cada vez que lo cambias en la app o en el garaje del juego. El de los demás llega cuando pulsas Jugar.",
 

--- a/apps/manager/src/i18n/locales/es.ts
+++ b/apps/manager/src/i18n/locales/es.ts
@@ -967,6 +967,16 @@ export const es: Translation = {
   "serverBrowser.dl.onHub": "En el Hub",
   "serverBrowser.dl.onShop": "Comprar {{title}} en la tienda",
 
+  // ── Navegador de servidores: vista de tarjetas (portado) ──
+  "serverBrowser.missingContent": "Contenido no instalado",
+  "serverBrowser.unnamed": "Servidor sin nombre",
+  "serverBrowser.full": "Servidor lleno",
+  "serverBrowser.copyFailed": "No se pudo copiar la dirección",
+  "serverBrowser.ping.title": "{{ms}} ms de ida y vuelta",
+  "serverBrowser.ping.ms": "{{ms}} ms",
+  "serverBrowser.viewCards": "Tarjetas",
+  "serverBrowser.viewList": "Lista",
+
   "sync.autoNote":
     "Tu look se publica solo — cada moto, cada vez que lo cambias en la app o en el garaje del juego. El de los demás llega cuando pulsas Jugar.",
 

--- a/apps/manager/src/i18n/locales/es.ts
+++ b/apps/manager/src/i18n/locales/es.ts
@@ -937,6 +937,21 @@ export const es: Translation = {
   "serverBrowser.trackGetMods": "Conseguirlo en mxb-mods",
   "serverBrowser.trackGetHub": "Conseguirlo en MXB Hub",
 
+  // ── Navegador de servidores: favoritos, filtro de región (portado) ──
+  "serverBrowser.favesOnly": "Favoritos",
+  "serverBrowser.star": "Añadir a favoritos",
+  "serverBrowser.unstar": "Quitar de favoritos",
+  "serverBrowser.favesEmpty": "Aún no hay favoritos — marca un servidor con la estrella para guardarlo aquí.",
+  "serverBrowser.region.all": "Todas las regiones",
+  "serverBrowser.region.naEast": "Norteamérica (Este)",
+  "serverBrowser.region.naWest": "Norteamérica (Oeste)",
+  "serverBrowser.region.na": "Norteamérica",
+  "serverBrowser.region.europe": "Europa",
+  "serverBrowser.region.oceania": "Oceanía",
+  "serverBrowser.region.southAmerica": "Sudamérica",
+  "serverBrowser.region.asia": "Asia",
+  "serverBrowser.region.other": "Otra",
+
   "sync.autoNote":
     "Tu look se publica solo — cada moto, cada vez que lo cambias en la app o en el garaje del juego. El de los demás llega cuando pulsas Jugar.",
 

--- a/apps/manager/src/i18n/locales/es.ts
+++ b/apps/manager/src/i18n/locales/es.ts
@@ -976,6 +976,8 @@ export const es: Translation = {
   "serverBrowser.ping.ms": "{{ms}} ms",
   "serverBrowser.viewCards": "Tarjetas",
   "serverBrowser.viewList": "Lista",
+  "serverBrowser.installedOnly": "Solo instalados",
+  "serverBrowser.installedOnlyHelp": "Mostrar solo servidores con un circuito que tienes",
 
   "sync.autoNote":
     "Tu look se publica solo — cada moto, cada vez que lo cambias en la app o en el garaje del juego. El de los demás llega cuando pulsas Jugar.",

--- a/apps/manager/src/i18n/locales/es.ts
+++ b/apps/manager/src/i18n/locales/es.ts
@@ -941,7 +941,7 @@ export const es: Translation = {
   "serverBrowser.favesOnly": "Favoritos",
   "serverBrowser.star": "Añadir a favoritos",
   "serverBrowser.unstar": "Quitar de favoritos",
-  "serverBrowser.favesEmpty": "Aún no hay favoritos — marca un servidor con la estrella para guardarlo aquí.",
+  "serverBrowser.favesEmpty": "Aún no hay favoritos - marca un servidor con la estrella para guardarlo aquí.",
   "serverBrowser.region.all": "Todas las regiones",
   "serverBrowser.region.naEast": "Norteamérica (Este)",
   "serverBrowser.region.naWest": "Norteamérica (Oeste)",

--- a/apps/manager/src/i18n/locales/fr.ts
+++ b/apps/manager/src/i18n/locales/fr.ts
@@ -942,6 +942,21 @@ export const fr: Translation = {
   "serverBrowser.trackGetMods": "L'obtenir sur mxb-mods",
   "serverBrowser.trackGetHub": "L'obtenir sur MXB Hub",
 
+  // ── Navigateur de serveurs : favoris, filtre de région (porté) ──
+  "serverBrowser.favesOnly": "Favoris",
+  "serverBrowser.star": "Ajouter aux favoris",
+  "serverBrowser.unstar": "Retirer des favoris",
+  "serverBrowser.favesEmpty": "Aucun favori — ajoutez un serveur en étoile pour le garder ici.",
+  "serverBrowser.region.all": "Toutes les régions",
+  "serverBrowser.region.naEast": "Amérique du Nord (Est)",
+  "serverBrowser.region.naWest": "Amérique du Nord (Ouest)",
+  "serverBrowser.region.na": "Amérique du Nord",
+  "serverBrowser.region.europe": "Europe",
+  "serverBrowser.region.oceania": "Océanie",
+  "serverBrowser.region.southAmerica": "Amérique du Sud",
+  "serverBrowser.region.asia": "Asie",
+  "serverBrowser.region.other": "Autre",
+
   "sync.autoNote":
     "Votre look se publie tout seul — chaque moto, dès que vous le changez dans l'app ou dans le garage du jeu. Celui des autres arrive quand vous appuyez sur Jouer.",
 

--- a/apps/manager/src/i18n/locales/fr.ts
+++ b/apps/manager/src/i18n/locales/fr.ts
@@ -972,6 +972,16 @@ export const fr: Translation = {
   "serverBrowser.dl.onHub": "Sur le Hub",
   "serverBrowser.dl.onShop": "Acheter {{title}} dans la boutique",
 
+  // ── Navigateur de serveurs : vue en cartes (porté) ──
+  "serverBrowser.missingContent": "Contenu manquant",
+  "serverBrowser.unnamed": "Serveur sans nom",
+  "serverBrowser.full": "Serveur plein",
+  "serverBrowser.copyFailed": "Impossible de copier l'adresse",
+  "serverBrowser.ping.title": "{{ms}} ms aller-retour",
+  "serverBrowser.ping.ms": "{{ms}} ms",
+  "serverBrowser.viewCards": "Cartes",
+  "serverBrowser.viewList": "Liste",
+
   "sync.autoNote":
     "Votre look se publie tout seul — chaque moto, dès que vous le changez dans l'app ou dans le garage du jeu. Celui des autres arrive quand vous appuyez sur Jouer.",
 

--- a/apps/manager/src/i18n/locales/fr.ts
+++ b/apps/manager/src/i18n/locales/fr.ts
@@ -981,6 +981,8 @@ export const fr: Translation = {
   "serverBrowser.ping.ms": "{{ms}} ms",
   "serverBrowser.viewCards": "Cartes",
   "serverBrowser.viewList": "Liste",
+  "serverBrowser.installedOnly": "Installés seulement",
+  "serverBrowser.installedOnlyHelp": "N'afficher que les serveurs avec un circuit que vous avez",
 
   "sync.autoNote":
     "Votre look se publie tout seul — chaque moto, dès que vous le changez dans l'app ou dans le garage du jeu. Celui des autres arrive quand vous appuyez sur Jouer.",

--- a/apps/manager/src/i18n/locales/fr.ts
+++ b/apps/manager/src/i18n/locales/fr.ts
@@ -957,6 +957,21 @@ export const fr: Translation = {
   "serverBrowser.region.asia": "Asie",
   "serverBrowser.region.other": "Autre",
 
+  // ── Navigateur de serveurs : action de téléchargement de circuit (porté) ──
+  "serverBrowser.dl.queued": "En file {{title}}",
+  "serverBrowser.dl.queuedShort": "En file",
+  "serverBrowser.dl.install": "Installer",
+  "serverBrowser.dl.installTitle": "Installer {{title}} depuis mxb-mods",
+  "serverBrowser.dl.looking": "Recherche…",
+  "serverBrowser.dl.lookingTitle": "Vérification si ce circuit est téléchargeable…",
+  "serverBrowser.dl.find": "Obtenir le circuit",
+  "serverBrowser.dl.findTitle": "Chercher ce circuit sur mxb-mods, le Hub et la boutique",
+  "serverBrowser.dl.searching": "Recherche…",
+  "serverBrowser.dl.search": "Rechercher",
+  "serverBrowser.dl.searchTitle": "Rechercher ce circuit dans le catalogue",
+  "serverBrowser.dl.onHub": "Sur le Hub",
+  "serverBrowser.dl.onShop": "Acheter {{title}} dans la boutique",
+
   "sync.autoNote":
     "Votre look se publie tout seul — chaque moto, dès que vous le changez dans l'app ou dans le garage du jeu. Celui des autres arrive quand vous appuyez sur Jouer.",
 

--- a/apps/manager/src/i18n/locales/fr.ts
+++ b/apps/manager/src/i18n/locales/fr.ts
@@ -983,6 +983,8 @@ export const fr: Translation = {
   "serverBrowser.viewList": "Liste",
   "serverBrowser.installedOnly": "Installés seulement",
   "serverBrowser.installedOnlyHelp": "N'afficher que les serveurs avec un circuit que vous avez",
+  "serverBrowser.hideEmpty": "Masquer les vides",
+  "serverBrowser.hideEmptyHelp": "Masquer les serveurs sans pilotes",
 
   "sync.autoNote":
     "Votre look se publie tout seul — chaque moto, dès que vous le changez dans l'app ou dans le garage du jeu. Celui des autres arrive quand vous appuyez sur Jouer.",

--- a/apps/manager/src/i18n/locales/fr.ts
+++ b/apps/manager/src/i18n/locales/fr.ts
@@ -946,7 +946,7 @@ export const fr: Translation = {
   "serverBrowser.favesOnly": "Favoris",
   "serverBrowser.star": "Ajouter aux favoris",
   "serverBrowser.unstar": "Retirer des favoris",
-  "serverBrowser.favesEmpty": "Aucun favori — ajoutez un serveur en étoile pour le garder ici.",
+  "serverBrowser.favesEmpty": "Aucun favori - ajoutez un serveur en étoile pour le garder ici.",
   "serverBrowser.region.all": "Toutes les régions",
   "serverBrowser.region.naEast": "Amérique du Nord (Est)",
   "serverBrowser.region.naWest": "Amérique du Nord (Ouest)",

--- a/apps/manager/src/i18n/locales/it.ts
+++ b/apps/manager/src/i18n/locales/it.ts
@@ -950,6 +950,21 @@ export const it: Translation = {
   "serverBrowser.region.asia": "Asia",
   "serverBrowser.region.other": "Altro",
 
+  // ── Server browser: azione di download tracciato (portato) ──
+  "serverBrowser.dl.queued": "In coda {{title}}",
+  "serverBrowser.dl.queuedShort": "In coda",
+  "serverBrowser.dl.install": "Installa",
+  "serverBrowser.dl.installTitle": "Installa {{title}} da mxb-mods",
+  "serverBrowser.dl.looking": "Ricerca…",
+  "serverBrowser.dl.lookingTitle": "Verifica se questo tracciato è scaricabile…",
+  "serverBrowser.dl.find": "Ottieni tracciato",
+  "serverBrowser.dl.findTitle": "Cerca questo tracciato su mxb-mods, l'Hub e lo shop",
+  "serverBrowser.dl.searching": "Ricerca…",
+  "serverBrowser.dl.search": "Cerca",
+  "serverBrowser.dl.searchTitle": "Cerca questo tracciato nel catalogo",
+  "serverBrowser.dl.onHub": "Sull'Hub",
+  "serverBrowser.dl.onShop": "Acquista {{title}} dallo shop",
+
   "sync.autoNote":
     "Il tuo look si pubblica da solo — ogni moto, ogni volta che lo cambi nell'app o nel garage del gioco. Quello degli altri arriva quando premi Gioca.",
 

--- a/apps/manager/src/i18n/locales/it.ts
+++ b/apps/manager/src/i18n/locales/it.ts
@@ -935,6 +935,21 @@ export const it: Translation = {
   "serverBrowser.trackGetMods": "Prendila da mxb-mods",
   "serverBrowser.trackGetHub": "Prendila da MXB Hub",
 
+  // ── Server browser: preferiti, filtro regione (portato) ──
+  "serverBrowser.favesOnly": "Preferiti",
+  "serverBrowser.star": "Aggiungi ai preferiti",
+  "serverBrowser.unstar": "Rimuovi dai preferiti",
+  "serverBrowser.favesEmpty": "Nessun preferito — aggiungi un server con la stella per tenerlo qui.",
+  "serverBrowser.region.all": "Tutte le regioni",
+  "serverBrowser.region.naEast": "Nord America (Est)",
+  "serverBrowser.region.naWest": "Nord America (Ovest)",
+  "serverBrowser.region.na": "Nord America",
+  "serverBrowser.region.europe": "Europa",
+  "serverBrowser.region.oceania": "Oceania",
+  "serverBrowser.region.southAmerica": "Sud America",
+  "serverBrowser.region.asia": "Asia",
+  "serverBrowser.region.other": "Altro",
+
   "sync.autoNote":
     "Il tuo look si pubblica da solo — ogni moto, ogni volta che lo cambi nell'app o nel garage del gioco. Quello degli altri arriva quando premi Gioca.",
 

--- a/apps/manager/src/i18n/locales/it.ts
+++ b/apps/manager/src/i18n/locales/it.ts
@@ -974,6 +974,8 @@ export const it: Translation = {
   "serverBrowser.ping.ms": "{{ms}} ms",
   "serverBrowser.viewCards": "Schede",
   "serverBrowser.viewList": "Elenco",
+  "serverBrowser.installedOnly": "Solo installati",
+  "serverBrowser.installedOnlyHelp": "Mostra solo i server con un tracciato che possiedi",
 
   "sync.autoNote":
     "Il tuo look si pubblica da solo — ogni moto, ogni volta che lo cambi nell'app o nel garage del gioco. Quello degli altri arriva quando premi Gioca.",

--- a/apps/manager/src/i18n/locales/it.ts
+++ b/apps/manager/src/i18n/locales/it.ts
@@ -965,6 +965,16 @@ export const it: Translation = {
   "serverBrowser.dl.onHub": "Sull'Hub",
   "serverBrowser.dl.onShop": "Acquista {{title}} dallo shop",
 
+  // ── Server browser: vista a schede (portato) ──
+  "serverBrowser.missingContent": "Contenuto mancante",
+  "serverBrowser.unnamed": "Server senza nome",
+  "serverBrowser.full": "Server pieno",
+  "serverBrowser.copyFailed": "Impossibile copiare l'indirizzo",
+  "serverBrowser.ping.title": "{{ms}} ms di andata e ritorno",
+  "serverBrowser.ping.ms": "{{ms}} ms",
+  "serverBrowser.viewCards": "Schede",
+  "serverBrowser.viewList": "Elenco",
+
   "sync.autoNote":
     "Il tuo look si pubblica da solo — ogni moto, ogni volta che lo cambi nell'app o nel garage del gioco. Quello degli altri arriva quando premi Gioca.",
 

--- a/apps/manager/src/i18n/locales/it.ts
+++ b/apps/manager/src/i18n/locales/it.ts
@@ -939,7 +939,7 @@ export const it: Translation = {
   "serverBrowser.favesOnly": "Preferiti",
   "serverBrowser.star": "Aggiungi ai preferiti",
   "serverBrowser.unstar": "Rimuovi dai preferiti",
-  "serverBrowser.favesEmpty": "Nessun preferito — aggiungi un server con la stella per tenerlo qui.",
+  "serverBrowser.favesEmpty": "Nessun preferito - aggiungi un server con la stella per tenerlo qui.",
   "serverBrowser.region.all": "Tutte le regioni",
   "serverBrowser.region.naEast": "Nord America (Est)",
   "serverBrowser.region.naWest": "Nord America (Ovest)",

--- a/apps/manager/src/i18n/locales/it.ts
+++ b/apps/manager/src/i18n/locales/it.ts
@@ -976,6 +976,8 @@ export const it: Translation = {
   "serverBrowser.viewList": "Elenco",
   "serverBrowser.installedOnly": "Solo installati",
   "serverBrowser.installedOnlyHelp": "Mostra solo i server con un tracciato che possiedi",
+  "serverBrowser.hideEmpty": "Nascondi vuoti",
+  "serverBrowser.hideEmptyHelp": "Nascondi i server senza piloti",
 
   "sync.autoNote":
     "Il tuo look si pubblica da solo — ogni moto, ogni volta che lo cambi nell'app o nel garage del gioco. Quello degli altri arriva quando premi Gioca.",

--- a/apps/manager/src/i18n/locales/pt-BR.ts
+++ b/apps/manager/src/i18n/locales/pt-BR.ts
@@ -976,6 +976,8 @@ export const ptBR: Translation = {
   "serverBrowser.ping.ms": "{{ms}} ms",
   "serverBrowser.viewCards": "Cartões",
   "serverBrowser.viewList": "Lista",
+  "serverBrowser.installedOnly": "Somente instalados",
+  "serverBrowser.installedOnlyHelp": "Mostrar apenas servidores com uma pista que você tem",
 
   "sync.autoNote":
     "Seu visual se publica sozinho — cada moto, sempre que você muda no app ou na garagem do jogo. O dos outros chega quando você aperta Jogar.",

--- a/apps/manager/src/i18n/locales/pt-BR.ts
+++ b/apps/manager/src/i18n/locales/pt-BR.ts
@@ -978,6 +978,8 @@ export const ptBR: Translation = {
   "serverBrowser.viewList": "Lista",
   "serverBrowser.installedOnly": "Somente instalados",
   "serverBrowser.installedOnlyHelp": "Mostrar apenas servidores com uma pista que você tem",
+  "serverBrowser.hideEmpty": "Ocultar vazios",
+  "serverBrowser.hideEmptyHelp": "Ocultar servidores sem pilotos",
 
   "sync.autoNote":
     "Seu visual se publica sozinho — cada moto, sempre que você muda no app ou na garagem do jogo. O dos outros chega quando você aperta Jogar.",

--- a/apps/manager/src/i18n/locales/pt-BR.ts
+++ b/apps/manager/src/i18n/locales/pt-BR.ts
@@ -952,6 +952,21 @@ export const ptBR: Translation = {
   "serverBrowser.region.asia": "Ásia",
   "serverBrowser.region.other": "Outra",
 
+  // ── Navegador de servidores: ação de download de pista (portado) ──
+  "serverBrowser.dl.queued": "Na fila {{title}}",
+  "serverBrowser.dl.queuedShort": "Na fila",
+  "serverBrowser.dl.install": "Instalar",
+  "serverBrowser.dl.installTitle": "Instalar {{title}} do mxb-mods",
+  "serverBrowser.dl.looking": "Procurando…",
+  "serverBrowser.dl.lookingTitle": "Verificando se esta pista pode ser baixada…",
+  "serverBrowser.dl.find": "Obter pista",
+  "serverBrowser.dl.findTitle": "Procurar esta pista no mxb-mods, no Hub e na loja",
+  "serverBrowser.dl.searching": "Procurando…",
+  "serverBrowser.dl.search": "Procurar",
+  "serverBrowser.dl.searchTitle": "Procurar esta pista no catálogo",
+  "serverBrowser.dl.onHub": "No Hub",
+  "serverBrowser.dl.onShop": "Comprar {{title}} na loja",
+
   "sync.autoNote":
     "Seu visual se publica sozinho — cada moto, sempre que você muda no app ou na garagem do jogo. O dos outros chega quando você aperta Jogar.",
 

--- a/apps/manager/src/i18n/locales/pt-BR.ts
+++ b/apps/manager/src/i18n/locales/pt-BR.ts
@@ -937,6 +937,21 @@ export const ptBR: Translation = {
   "serverBrowser.trackGetMods": "Pegar no mxb-mods",
   "serverBrowser.trackGetHub": "Pegar no MXB Hub",
 
+  // ── Navegador de servidores: favoritos, filtro de região (portado) ──
+  "serverBrowser.favesOnly": "Favoritos",
+  "serverBrowser.star": "Adicionar aos favoritos",
+  "serverBrowser.unstar": "Remover dos favoritos",
+  "serverBrowser.favesEmpty": "Nenhum favorito ainda — marque um servidor com a estrela para mantê-lo aqui.",
+  "serverBrowser.region.all": "Todas as regiões",
+  "serverBrowser.region.naEast": "América do Norte (Leste)",
+  "serverBrowser.region.naWest": "América do Norte (Oeste)",
+  "serverBrowser.region.na": "América do Norte",
+  "serverBrowser.region.europe": "Europa",
+  "serverBrowser.region.oceania": "Oceania",
+  "serverBrowser.region.southAmerica": "América do Sul",
+  "serverBrowser.region.asia": "Ásia",
+  "serverBrowser.region.other": "Outra",
+
   "sync.autoNote":
     "Seu visual se publica sozinho — cada moto, sempre que você muda no app ou na garagem do jogo. O dos outros chega quando você aperta Jogar.",
 

--- a/apps/manager/src/i18n/locales/pt-BR.ts
+++ b/apps/manager/src/i18n/locales/pt-BR.ts
@@ -967,6 +967,16 @@ export const ptBR: Translation = {
   "serverBrowser.dl.onHub": "No Hub",
   "serverBrowser.dl.onShop": "Comprar {{title}} na loja",
 
+  // ── Navegador de servidores: visualização em cartões (portado) ──
+  "serverBrowser.missingContent": "Conteúdo ausente",
+  "serverBrowser.unnamed": "Servidor sem nome",
+  "serverBrowser.full": "Servidor cheio",
+  "serverBrowser.copyFailed": "Não foi possível copiar o endereço",
+  "serverBrowser.ping.title": "{{ms}} ms de ida e volta",
+  "serverBrowser.ping.ms": "{{ms}} ms",
+  "serverBrowser.viewCards": "Cartões",
+  "serverBrowser.viewList": "Lista",
+
   "sync.autoNote":
     "Seu visual se publica sozinho — cada moto, sempre que você muda no app ou na garagem do jogo. O dos outros chega quando você aperta Jogar.",
 

--- a/apps/manager/src/i18n/locales/pt-BR.ts
+++ b/apps/manager/src/i18n/locales/pt-BR.ts
@@ -941,7 +941,7 @@ export const ptBR: Translation = {
   "serverBrowser.favesOnly": "Favoritos",
   "serverBrowser.star": "Adicionar aos favoritos",
   "serverBrowser.unstar": "Remover dos favoritos",
-  "serverBrowser.favesEmpty": "Nenhum favorito ainda — marque um servidor com a estrela para mantê-lo aqui.",
+  "serverBrowser.favesEmpty": "Nenhum favorito ainda - marque um servidor com a estrela para mantê-lo aqui.",
   "serverBrowser.region.all": "Todas as regiões",
   "serverBrowser.region.naEast": "América do Norte (Leste)",
   "serverBrowser.region.naWest": "América do Norte (Oeste)",

--- a/apps/manager/src/lib/serverRegion.ts
+++ b/apps/manager/src/lib/serverRegion.ts
@@ -1,0 +1,114 @@
+/**
+ * Making sense of the region a server reports.
+ *
+ * The field is free text the host typed into their own config, and it shows: across one live
+ * list of 604 servers, 371 left it blank and the rest spelled the same handful of places a
+ * dozen ways — `USA (East)`, `US East`, `North Carolina`; `Europe (Germany)`, `Europe /
+ * Germany`, `Frankfurt, Germany`, `de` — alongside entries that name no place at all
+ * (`forest`, `redbud mx`, `123`, `YOUR MOMS`). Listing those raw in a filter gives a dropdown
+ * of nonsense with the real regions scattered through it.
+ *
+ * So the filter groups by {@link canonicalRegion}: a small fixed set of buckets, matched on
+ * keywords, with everything unrecognised falling into `other`. The *row* still shows what the
+ * host wrote when it means something, because "Europe (Germany)" tells a player more than
+ * "Europe" does — {@link regionLabel} is the one that decides that.
+ *
+ * The upstream `MasterServer` carries the host's text as `location`, so callers pass that in.
+ *
+ * Deliberately not a geo-IP lookup. That would be a request per server for a field nobody
+ * sorts by, and it would still disagree with the host's own label.
+ */
+
+import type { TKey } from "@/i18n";
+
+/** The buckets the filter offers. `other` collects blanks and anything unrecognised. */
+export type RegionKey =
+  | "na-east"
+  | "na-west"
+  | "na"
+  | "europe"
+  | "oceania"
+  | "south-america"
+  | "asia"
+  | "other";
+
+/** i18n keys, so the dropdown reads in the user's language rather than the host's. */
+export const REGION_LABEL_KEY: Record<RegionKey, TKey> = {
+  "na-east": "serverBrowser.region.naEast",
+  "na-west": "serverBrowser.region.naWest",
+  na: "serverBrowser.region.na",
+  europe: "serverBrowser.region.europe",
+  oceania: "serverBrowser.region.oceania",
+  "south-america": "serverBrowser.region.southAmerica",
+  asia: "serverBrowser.region.asia",
+  other: "serverBrowser.region.other",
+};
+
+/** The order the dropdown lists them in — busiest regions first, `other` last. */
+export const REGION_ORDER: RegionKey[] = [
+  "na-east",
+  "na-west",
+  "na",
+  "europe",
+  "oceania",
+  "south-america",
+  "asia",
+  "other",
+];
+
+/** Whole-word match, so `de` (Germany) doesn't fire on "Meadow" and `us` doesn't on "Aussie". */
+function has(text: string, ...words: string[]): boolean {
+  return words.some((w) => new RegExp(`(^|[^a-z])${w}([^a-z]|$)`).test(text));
+}
+
+const EUROPE = [
+  "europe", "eu", "germany", "deutschland", "de", "frankfurt", "uk", "england", "britain",
+  "london", "france", "paris", "netherlands", "amsterdam", "spain", "italy", "poland",
+  "hungary", "sweden", "norway", "finland", "denmark", "ireland", "portugal", "austria",
+  "switzerland", "belgium", "czech", "romania",
+];
+const OCEANIA = ["australia", "sydney", "melbourne", "brisbane", "perth", "oceania", "nz", "zealand", "aus"];
+const SOUTH_AMERICA = ["brazil", "brasil", "argentina", "chile", "peru", "colombia", "sa"];
+const ASIA = ["asia", "japan", "tokyo", "singapore", "korea", "china", "india", "hong", "jp"];
+// US states and cities hosts actually name, split by coast where the name settles it.
+const NA_EAST = [
+  "east", "carolina", "virginia", "york", "jersey", "florida", "georgia", "ohio", "michigan",
+  "maryland", "pennsylvania", "massachusetts", "toronto", "montreal", "miami", "atlanta",
+  "chicago", "dallas", "texas",
+];
+const NA_WEST = ["west", "california", "oregon", "washington", "seattle", "angeles", "vegas", "phoenix", "denver"];
+const NA = ["usa", "us", "united", "states", "america", "american", "canada", "mexico", "mex", "na"];
+
+/**
+ * Which bucket a host's region string belongs to.
+ *
+ * Coast before country, so `USA (East)` lands in `na-east` rather than the generic `na`;
+ * Europe before North America, because `EU` would otherwise be caught by nothing and
+ * `Germany`'s `de` is checked as a whole word.
+ */
+export function canonicalRegion(raw: string): RegionKey {
+  const text = raw.toLowerCase().trim();
+  if (!text || text === "unknown" || text === "?") return "other";
+  if (has(text, ...EUROPE)) return "europe";
+  if (has(text, ...OCEANIA)) return "oceania";
+  if (has(text, ...ASIA)) return "asia";
+  if (has(text, ...SOUTH_AMERICA)) return "south-america";
+  if (has(text, ...NA_EAST)) return "na-east";
+  if (has(text, ...NA_WEST)) return "na-west";
+  if (has(text, ...NA)) return "na";
+  return "other";
+}
+
+/**
+ * What to print on a row: the host's own text when it names a place we recognised, and
+ * nothing at all when it doesn't.
+ *
+ * Keeping the raw string is the point — `Europe (Germany)` and `Australia (Sydney)` are more
+ * use to a player than the bucket they fall in. But a server whose region is `YOUR MOMS` has
+ * told us nothing, and printing it is worse than printing nothing.
+ */
+export function regionLabel(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  return canonicalRegion(trimmed) === "other" ? null : trimmed;
+}

--- a/apps/manager/src/lib/serverRegion.ts
+++ b/apps/manager/src/lib/serverRegion.ts
@@ -3,15 +3,15 @@
  *
  * The field is free text the host typed into their own config, and it shows: across one live
  * list of 604 servers, 371 left it blank and the rest spelled the same handful of places a
- * dozen ways — `USA (East)`, `US East`, `North Carolina`; `Europe (Germany)`, `Europe /
- * Germany`, `Frankfurt, Germany`, `de` — alongside entries that name no place at all
+ * dozen ways - `USA (East)`, `US East`, `North Carolina`; `Europe (Germany)`, `Europe /
+ * Germany`, `Frankfurt, Germany`, `de` - alongside entries that name no place at all
  * (`forest`, `redbud mx`, `123`, `YOUR MOMS`). Listing those raw in a filter gives a dropdown
  * of nonsense with the real regions scattered through it.
  *
  * So the filter groups by {@link canonicalRegion}: a small fixed set of buckets, matched on
  * keywords, with everything unrecognised falling into `other`. The *row* still shows what the
  * host wrote when it means something, because "Europe (Germany)" tells a player more than
- * "Europe" does — {@link regionLabel} is the one that decides that.
+ * "Europe" does - {@link regionLabel} is the one that decides that.
  *
  * The upstream `MasterServer` carries the host's text as `location`, so callers pass that in.
  *
@@ -44,7 +44,7 @@ export const REGION_LABEL_KEY: Record<RegionKey, TKey> = {
   other: "serverBrowser.region.other",
 };
 
-/** The order the dropdown lists them in — busiest regions first, `other` last. */
+/** The order the dropdown lists them in - busiest regions first, `other` last. */
 export const REGION_ORDER: RegionKey[] = [
   "na-east",
   "na-west",
@@ -103,7 +103,7 @@ export function canonicalRegion(raw: string): RegionKey {
  * What to print on a row: the host's own text when it names a place we recognised, and
  * nothing at all when it doesn't.
  *
- * Keeping the raw string is the point — `Europe (Germany)` and `Australia (Sydney)` are more
+ * Keeping the raw string is the point - `Europe (Germany)` and `Australia (Sydney)` are more
  * use to a player than the bucket they fall in. But a server whose region is `YOUR MOMS` has
  * told us nothing, and printing it is worse than printing nothing.
  */

--- a/apps/manager/src/lib/trackContent.ts
+++ b/apps/manager/src/lib/trackContent.ts
@@ -1,0 +1,48 @@
+/**
+ * Deciding whether a server's track is already on disk.
+ *
+ * A server reports its track by internal id — the top folder inside the track's `.pkz`, e.g.
+ * `2026_ARLSX_RD14` or `walnut` — and {@link installedTrackIds} returns exactly those ids for
+ * everything installed. So the match is, at heart, an equality check; the only wrinkle is that
+ * authors are inconsistent with case, spaces, dashes and underscores between the packaged folder
+ * and how a host typed it, so we compare on a normalized form as well.
+ */
+import type { InstalledTrack } from "@frost/shared/api/mods";
+
+/** Fold to a case/separator-insensitive key: lowercase, alphanumeric only. `"ZD - Meadow
+ *  Valley MX"` and `"zd_meadowvalley_mx"` collapse together; `"2026_ARLSX_RD14"` keeps its
+ *  digits and letters. */
+function norm(id: string): string {
+  return id.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+export interface TrackIndex {
+  /** normalized id → the installed track (for reading its preview, etc.). */
+  byId: Map<string, InstalledTrack>;
+}
+
+export function buildTrackIndex(installed: InstalledTrack[]): TrackIndex {
+  const byId = new Map<string, InstalledTrack>();
+  for (const t of installed) {
+    const key = norm(t.id);
+    if (key && !byId.has(key)) byId.set(key, t);
+  }
+  return { byId };
+}
+
+/** Whether a server's track content is present. `unknown` is for servers that name no track
+ *  (practice/free-roam lobbies) — there is nothing to download and nothing missing. */
+export type TrackContentState = "installed" | "missing" | "unknown";
+
+export interface TrackMatch {
+  state: TrackContentState;
+  /** The installed track, when `state === "installed"`. */
+  installed?: InstalledTrack;
+}
+
+export function matchTrack(index: TrackIndex, serverTrack: string): TrackMatch {
+  const raw = serverTrack.trim();
+  if (!raw) return { state: "unknown" };
+  const hit = index.byId.get(norm(raw));
+  return hit ? { state: "installed", installed: hit } : { state: "missing" };
+}

--- a/apps/manager/src/lib/trackContent.ts
+++ b/apps/manager/src/lib/trackContent.ts
@@ -1,8 +1,8 @@
 /**
  * Deciding whether a server's track is already on disk.
  *
- * A server reports its track by internal id — the top folder inside the track's `.pkz`, e.g.
- * `2026_ARLSX_RD14` or `walnut` — and {@link installedTrackIds} returns exactly those ids for
+ * A server reports its track by internal id - the top folder inside the track's `.pkz`, e.g.
+ * `2026_ARLSX_RD14` or `walnut` - and {@link installedTrackIds} returns exactly those ids for
  * everything installed. So the match is, at heart, an equality check; the only wrinkle is that
  * authors are inconsistent with case, spaces, dashes and underscores between the packaged folder
  * and how a host typed it, so we compare on a normalized form as well.
@@ -31,7 +31,7 @@ export function buildTrackIndex(installed: InstalledTrack[]): TrackIndex {
 }
 
 /** Whether a server's track content is present. `unknown` is for servers that name no track
- *  (practice/free-roam lobbies) — there is nothing to download and nothing missing. */
+ *  (practice/free-roam lobbies) - there is nothing to download and nothing missing. */
 export type TrackContentState = "installed" | "missing" | "unknown";
 
 export interface TrackMatch {

--- a/apps/manager/src/lib/trackDownload.ts
+++ b/apps/manager/src/lib/trackDownload.ts
@@ -1,0 +1,156 @@
+/**
+ * Finding a missing track for download.
+ *
+ * When a server names a track that isn't on disk, we look for it across the three catalogs the
+ * app already knows — mxb-mods (free), MXB Hub, and mxbikes-shop (paid) — in that order, and
+ * return the first confident match. Free/owned matches can be queued straight into the install
+ * pipeline; a paid match comes back with a price tag and a link to buy, never an auto-purchase.
+ *
+ * Matching an internal track id (`2026_ARLSX_RD14`) to a prose catalog title ("2026 ARL SX —
+ * Round 14") is fuzzy, so it reuses the same token scorer the Library uses to badge installed
+ * mods ({@link buildInstalledIndex}): we index the track name and ask whether each catalog
+ * title "is" it. Below that bar we return `none` rather than guess, and the UI offers a manual
+ * search instead.
+ */
+import { searchMods } from "@frost/shared/api/mods";
+import { hubSearch } from "@/api/hub";
+import { shopCatalogSearch, formatPrice } from "@/api/shop";
+import type { HubMod, ModSummary, ShopMod } from "@frost/shared/types";
+import { buildInstalledIndex } from "./installedMatch";
+
+/** mxb-mods' "Tracks" category — `MOD_TYPES`' tracks `categoryId`. Not 29: that is the
+ *  *bikes* category, and searching it for a track name matched liveries or nothing at all. */
+const TRACKS_CATEGORY = 22;
+
+export type TrackSource =
+  | { kind: "mxbMods"; title: string; mod: ModSummary }
+  | { kind: "hub"; title: string; mod: HubMod; price: string | null; free: boolean }
+  | { kind: "shop"; title: string; mod: ShopMod; price: string | null }
+  | { kind: "none" };
+
+/**
+ * The same id with its volatile parts dropped, or `null` when that changes nothing.
+ *
+ * Catalog search is an AND over the terms (`shop_catalog::select`: "every term must match"),
+ * so one word the product spells differently hides it completely. The two that differ most
+ * often are the ones with no settled spelling: a round written `RD03` on the server and `RD3`
+ * on the post, and a season year the post may not carry at all. Dropping them leaves the part
+ * that actually names the track (`ARLMX Lakewood`), which is what a person would have typed.
+ *
+ * This only widens what gets *retrieved*. Whether a candidate really is this track is still
+ * settled by the scorer, which keeps the year and round it just searched without.
+ */
+function looseTrackQuery(trackId: string): string | null {
+  const words = trackQuery(trackId).split(/\s+/).filter(Boolean);
+  const kept = words.filter((w) => !/^(?:20[0-3][0-9]|rd[0-9]+|r[0-9]+)$/i.test(w));
+  if (kept.length === 0 || kept.length === words.length) return null;
+  return kept.join(" ");
+}
+
+/** A readable label for the internal track id — the id itself, since that's what hosts and
+ *  catalogs both derive from and it's what the player will recognize in a search box. */
+export function trackQuery(trackId: string): string {
+  // Internal ids are often `Snake_Or-Dashed`; a space-separated form searches far better.
+  return trackId.replace(/[_-]+/g, " ").trim();
+}
+
+/** Look for a missing track. `locale` is only for formatting any price found. */
+export async function resolveMissingTrack(
+  trackId: string,
+  locale: string,
+): Promise<TrackSource> {
+  const query = trackQuery(trackId);
+  if (!query) return { kind: "none" };
+
+  // The scorer, seeded with the track id so we can ask "does this catalog title match it?".
+  // Both the raw id and the spaced query go in, so either spelling can hit.
+  const index = buildInstalledIndex([trackId, query]);
+  const matches = (title: string) => index.has(title);
+
+  // The exact id first, then the same id without its round and year. The second pass is what
+  // reaches a post that spells either of those differently; both are scored the same way, so
+  // widening the search never widens what counts as a match.
+  const loose = looseTrackQuery(trackId);
+  const queries = loose === null ? [query] : [query, loose];
+
+  /** First candidate any of the queries turns up that the scorer accepts. */
+  const firstMatch = async <T>(
+    search: (q: string) => Promise<T[]>,
+    title: (item: T) => string,
+  ): Promise<T | null> => {
+    for (const q of queries) {
+      try {
+        const hit = (await search(q)).find((item) => matches(title(item)));
+        if (hit) return hit;
+      } catch {
+        // This catalog is unreachable or refused the query; the next one still gets a turn.
+      }
+    }
+    return null;
+  };
+
+  // 1. mxb-mods — free. The best outcome: one click and it's queued.
+  {
+    const hit = await firstMatch(
+      (q) => searchMods(q, TRACKS_CATEGORY, 1),
+      (m) => m.title,
+    );
+    if (hit) return { kind: "mxbMods", title: hit.title, mod: hit };
+  }
+
+  // 2. MXB Hub — may be free or paid.
+  {
+    let currency = "USD";
+    const hit = await firstMatch(
+      async (q) => {
+        const page = await hubSearch(q, null, 1, "newest", false);
+        currency = page.currency;
+        return page.items;
+      },
+      (m) => m.title,
+    );
+    if (hit) {
+      const price = hit.price.base;
+      const free = !price || price <= 0;
+      return {
+        kind: "hub",
+        title: hit.title,
+        mod: hit,
+        free,
+        price: free ? null : formatPrice(price, currency, locale),
+      };
+    }
+  }
+
+  // 3. mxbikes-shop — paid. We can't download it, but we can show the price and link out.
+  //
+  // Searched, not looked up by name. This used `shopMatchCatalog`, which is the *exact*
+  // title matcher the purchases page needs to map a scraped product name onto its catalog
+  // entry, folding case and punctuation and nothing else. A track id almost never spells
+  // its product title character for character (`2026_ARLMX_RD03_Lakewood` against
+  // "2026 ARLMX RD3 Lakewood"), so that lookup returned null for essentially every track and
+  // the paid route never fired at all. A search puts candidates in front of the same scorer
+  // the other two catalogs use, which is what decides whether one is really this track.
+  {
+    let currency = "USD";
+    const hit = await firstMatch(
+      async (q) => {
+        const page = await shopCatalogSearch(q, null, 1, "newest", false);
+        currency = page.currency;
+        return page.items;
+      },
+      (m) => m.title,
+    );
+    if (hit) {
+      const price = hit.price.onSale ? hit.price.sale : hit.price.base;
+      return {
+        kind: "shop",
+        title: hit.title,
+        mod: hit,
+        price: formatPrice(price, currency, locale),
+      };
+    }
+  }
+
+  return { kind: "none" };
+}

--- a/apps/manager/src/lib/trackDownload.ts
+++ b/apps/manager/src/lib/trackDownload.ts
@@ -2,11 +2,11 @@
  * Finding a missing track for download.
  *
  * When a server names a track that isn't on disk, we look for it across the three catalogs the
- * app already knows — mxb-mods (free), MXB Hub, and mxbikes-shop (paid) — in that order, and
+ * app already knows - mxb-mods (free), MXB Hub, and mxbikes-shop (paid) - in that order, and
  * return the first confident match. Free/owned matches can be queued straight into the install
  * pipeline; a paid match comes back with a price tag and a link to buy, never an auto-purchase.
  *
- * Matching an internal track id (`2026_ARLSX_RD14`) to a prose catalog title ("2026 ARL SX —
+ * Matching an internal track id (`2026_ARLSX_RD14`) to a prose catalog title ("2026 ARL SX -
  * Round 14") is fuzzy, so it reuses the same token scorer the Library uses to badge installed
  * mods ({@link buildInstalledIndex}): we index the track name and ask whether each catalog
  * title "is" it. Below that bar we return `none` rather than guess, and the UI offers a manual
@@ -18,7 +18,7 @@ import { shopCatalogSearch, formatPrice } from "@/api/shop";
 import type { HubMod, ModSummary, ShopMod } from "@frost/shared/types";
 import { buildInstalledIndex } from "./installedMatch";
 
-/** mxb-mods' "Tracks" category — `MOD_TYPES`' tracks `categoryId`. Not 29: that is the
+/** mxb-mods' "Tracks" category - `MOD_TYPES`' tracks `categoryId`. Not 29: that is the
  *  *bikes* category, and searching it for a track name matched liveries or nothing at all. */
 const TRACKS_CATEGORY = 22;
 
@@ -47,7 +47,7 @@ function looseTrackQuery(trackId: string): string | null {
   return kept.join(" ");
 }
 
-/** A readable label for the internal track id — the id itself, since that's what hosts and
+/** A readable label for the internal track id - the id itself, since that's what hosts and
  *  catalogs both derive from and it's what the player will recognize in a search box. */
 export function trackQuery(trackId: string): string {
   // Internal ids are often `Snake_Or-Dashed`; a space-separated form searches far better.
@@ -89,7 +89,7 @@ export async function resolveMissingTrack(
     return null;
   };
 
-  // 1. mxb-mods — free. The best outcome: one click and it's queued.
+  // 1. mxb-mods - free. The best outcome: one click and it's queued.
   {
     const hit = await firstMatch(
       (q) => searchMods(q, TRACKS_CATEGORY, 1),
@@ -98,7 +98,7 @@ export async function resolveMissingTrack(
     if (hit) return { kind: "mxbMods", title: hit.title, mod: hit };
   }
 
-  // 2. MXB Hub — may be free or paid.
+  // 2. MXB Hub - may be free or paid.
   {
     let currency = "USD";
     const hit = await firstMatch(
@@ -122,7 +122,7 @@ export async function resolveMissingTrack(
     }
   }
 
-  // 3. mxbikes-shop — paid. We can't download it, but we can show the price and link out.
+  // 3. mxbikes-shop - paid. We can't download it, but we can show the price and link out.
   //
   // Searched, not looked up by name. This used `shopMatchCatalog`, which is the *exact*
   // title matcher the purchases page needs to map a scraped product name onto its catalog

--- a/apps/manager/src/lib/useFavourites.ts
+++ b/apps/manager/src/lib/useFavourites.ts
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { MasterServer } from "@frost/shared/api/mods";
+
+/**
+ * Starred servers, remembered across launches.
+ *
+ * Kept in `localStorage` beside the browser's other sticky preferences rather than in the app
+ * config: this is a per-machine convenience, and the backend has no use for it.
+ *
+ * A favourite is stored as more than an address. The master only describes servers that are
+ * *up*, so a starred server that has gone offline would otherwise be a bare `ip:port` with
+ * nothing to show. The name and track are cached here precisely so the favourites view can
+ * still name it. Those cached fields are refreshed whenever the server appears in a live
+ * list, so what's shown offline is the last thing that was actually true.
+ */
+const FAVS_KEY = "mxb:serversFavourites:v1";
+
+/** A starred server, and the last thing the master said about it. */
+export interface Favourite {
+  /** `ip:port`, the identity. A server keeps its address across restarts; its name doesn't. */
+  address: string;
+  /** Last-known display name, for showing a favourite that's currently offline. */
+  name: string;
+  /** Last-known track, same reason. */
+  track: string;
+  /** When it was starred, so the offline list has a stable order of its own. */
+  savedAt: number;
+}
+
+function read(): Favourite[] {
+  try {
+    const raw = localStorage.getItem(FAVS_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    // Written by an older build, or hand-edited: keep only entries that still have an
+    // address, and fill the rest in rather than dropping a star the player set.
+    return parsed
+      .filter((f): f is Partial<Favourite> => !!f && typeof f === "object")
+      .filter((f) => typeof f.address === "string" && f.address.length > 0)
+      .map((f) => ({
+        address: f.address as string,
+        name: typeof f.name === "string" ? f.name : "",
+        track: typeof f.track === "string" ? f.track : "",
+        savedAt: typeof f.savedAt === "number" ? f.savedAt : 0,
+      }));
+  } catch {
+    // Corrupt JSON, or a browser that refuses storage. An empty list is the right fallback:
+    // the tab still works, it just has nothing starred.
+    return [];
+  }
+}
+
+function write(list: Favourite[]) {
+  try {
+    localStorage.setItem(FAVS_KEY, JSON.stringify(list));
+  } catch {
+    // Out of quota or storage disabled; the star still applies for this session.
+  }
+}
+
+export interface Favourites {
+  /** Every starred server, newest star first. */
+  list: Favourite[];
+  has: (address: string) => boolean;
+  /** Star an unstarred server, or unstar a starred one. */
+  toggle: (server: Pick<MasterServer, "address" | "name" | "track">) => void;
+  count: number;
+}
+
+/**
+ * `servers` is the live list, used only to keep each favourite's cached name and track
+ * current. Passing `null` (nothing loaded yet) leaves what's stored alone: an empty list
+ * must never be read as "these servers are all gone".
+ */
+export function useFavourites(servers: MasterServer[] | null): Favourites {
+  const [list, setList] = useState<Favourite[]>(read);
+
+  // Another window of the app can star something too. `storage` fires only in the *other*
+  // documents, so this syncs them without echoing our own writes back.
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === FAVS_KEY) setList(read());
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  // Refresh the cached name/track of any favourite the live list covers.
+  useEffect(() => {
+    if (!servers || servers.length === 0) return;
+    const live = new Map(servers.map((s) => [s.address, s]));
+    setList((prev) => {
+      let changed = false;
+      const next = prev.map((f) => {
+        const s = live.get(f.address);
+        if (!s || (s.name === f.name && s.track === f.track)) return f;
+        changed = true;
+        return { ...f, name: s.name, track: s.track };
+      });
+      if (!changed) return prev;
+      write(next);
+      return next;
+    });
+  }, [servers]);
+
+  const addresses = useMemo(() => new Set(list.map((f) => f.address)), [list]);
+
+  const has = useCallback((address: string) => addresses.has(address), [addresses]);
+
+  const toggle = useCallback(
+    (server: Pick<MasterServer, "address" | "name" | "track">) => {
+      setList((prev) => {
+        const next = prev.some((f) => f.address === server.address)
+          ? prev.filter((f) => f.address !== server.address)
+          : [
+              { address: server.address, name: server.name, track: server.track, savedAt: Date.now() },
+              ...prev,
+            ];
+        write(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  // Memoised: this object is a dependency of the browser's filter/sort memo, and a fresh
+  // identity every render would make that memo recompute on every render.
+  return useMemo(() => ({ list, has, toggle, count: list.length }), [list, has, toggle]);
+}

--- a/apps/manager/src/lib/useTrackCatalog.ts
+++ b/apps/manager/src/lib/useTrackCatalog.ts
@@ -8,7 +8,7 @@ import {
 import { matchTrack, type TrackIndex } from "./trackContent";
 
 /**
- * Which of the browser's missing tracks can actually be downloaded — worked out up front,
+ * Which of the browser's missing tracks can actually be downloaded - worked out up front,
  * for every server on screen at once.
  *
  * The old flow could only answer this *after* a click: each "get this track" button ran its
@@ -20,7 +20,7 @@ import { matchTrack, type TrackIndex } from "./trackContent";
  * Two things it is careful about:
  *
  * * **Order is priority.** Ids go out ranked by how many servers are running them, because
- *   whatever the index can't answer becomes its background queue — so the tracks the most
+ *   whatever the index can't answer becomes its background queue - so the tracks the most
  *   people are looking at are the ones it reads pages for first.
  * * **It re-asks, but only when there is a reason to.** The queue fills in behind us, so
  *   `track-index://updated` triggers another resolve; the set of ids is otherwise compared by
@@ -78,7 +78,7 @@ export function useTrackCatalog(
         });
       })
       // A failed resolve leaves every track looking un-gettable, which is the same thing the
-      // browser showed before this existed — the per-track search is still there behind the
+      // browser showed before this existed - the per-track search is still there behind the
       // button. Not worth a toast.
       .catch(() => {
         if (runId.current === id) setCatalog(EMPTY);

--- a/apps/manager/src/lib/useTrackCatalog.ts
+++ b/apps/manager/src/lib/useTrackCatalog.ts
@@ -1,0 +1,96 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  onTrackIndexUpdated,
+  resolveServerTracks,
+  type MasterServer,
+  type TrackHit,
+} from "@frost/shared/api/mods";
+import { matchTrack, type TrackIndex } from "./trackContent";
+
+/**
+ * Which of the browser's missing tracks can actually be downloaded — worked out up front,
+ * for every server on screen at once.
+ *
+ * The old flow could only answer this *after* a click: each "get this track" button ran its
+ * own three-catalog search, so the browser had no way to distinguish a track one click away
+ * from one nobody has published. This asks the backend's index instead ({@link
+ * resolveServerTracks}), in a single call covering every missing track in the list, so the
+ * card can say "Install" or stay quiet before the user commits to anything.
+ *
+ * Two things it is careful about:
+ *
+ * * **Order is priority.** Ids go out ranked by how many servers are running them, because
+ *   whatever the index can't answer becomes its background queue — so the tracks the most
+ *   people are looking at are the ones it reads pages for first.
+ * * **It re-asks, but only when there is a reason to.** The queue fills in behind us, so
+ *   `track-index://updated` triggers another resolve; the set of ids is otherwise compared by
+ *   value, so a refreshed server list with the same tracks (which is most refreshes) doesn't.
+ */
+export interface TrackCatalog {
+  /** Track id → the catalog post that has it. */
+  found: Map<string, TrackHit>;
+  /** Track ids the backend is still reading candidate pages for. */
+  pending: Set<string>;
+}
+
+const EMPTY: TrackCatalog = { found: new Map(), pending: new Set() };
+
+export function useTrackCatalog(
+  servers: MasterServer[] | null,
+  trackIndex: TrackIndex,
+): TrackCatalog {
+  const [catalog, setCatalog] = useState<TrackCatalog>(EMPTY);
+  // Bumped by `track-index://updated` to re-run the resolve with the same ids.
+  const [round, setRound] = useState(0);
+
+  // The missing tracks, most-hosted first. Joined into a string so the effect below compares
+  // by value: a refresh that returns the same tracks with different player counts is the
+  // common case, and re-resolving on every one of those would be pure noise.
+  const wantedKey = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const s of servers ?? []) {
+      const id = s.track.trim();
+      if (!id) continue;
+      if (matchTrack(trackIndex, id).state !== "missing") continue;
+      counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .map(([id]) => id)
+      .join("\n");
+  }, [servers, trackIndex]);
+
+  // A token so a resolve started before a re-render can't apply over a newer one.
+  const runId = useRef(0);
+
+  useEffect(() => {
+    if (!wantedKey) {
+      setCatalog(EMPTY);
+      return;
+    }
+    const id = ++runId.current;
+    resolveServerTracks(wantedKey.split("\n"))
+      .then((res) => {
+        if (runId.current !== id) return;
+        setCatalog({
+          found: new Map(Object.entries(res.found)),
+          pending: new Set(res.pending),
+        });
+      })
+      // A failed resolve leaves every track looking un-gettable, which is the same thing the
+      // browser showed before this existed — the per-track search is still there behind the
+      // button. Not worth a toast.
+      .catch(() => {
+        if (runId.current === id) setCatalog(EMPTY);
+      });
+  }, [wantedKey, round]);
+
+  useEffect(() => {
+    const un = onTrackIndexUpdated(() => setRound((r) => r + 1));
+    return () => {
+      void un.then((off) => off()).catch(() => {});
+    };
+  }, []);
+
+  return catalog;
+}

--- a/packages/shared/src/api/mods.ts
+++ b/packages/shared/src/api/mods.ts
@@ -3237,7 +3237,7 @@ export function guessServerTrack(track: string): Promise<TrackGuess> {
 
 /** One installed track, as the server browser matches it (see `lib/trackContent`). */
 export interface InstalledTrack {
-  /** The track's internal folder id — exactly the value a server reports as its track. */
+  /** The track's internal folder id - exactly the value a server reports as its track. */
   id: string;
   /** Absolute path of the `.pkz` (or folder), for reading its preview. */
   path: string;
@@ -3249,7 +3249,7 @@ export function installedTrackIds(): Promise<InstalledTrack[]> {
   return invoke<InstalledTrack[]>("installed_track_ids");
 }
 
-/** How a track id was matched to a catalog post — by an exact file name it ships, or by its
+/** How a track id was matched to a catalog post - by an exact file name it ships, or by its
  *  title/slug. The UI shows both the same way. */
 export type TrackVia = "file" | "title";
 
@@ -3262,7 +3262,7 @@ export interface TrackHit {
 }
 
 /** What {@link resolveServerTracks} found, plus whether the backend index is still filling
- *  itself in — `pending` ids are "still looking", not "not available". */
+ *  itself in - `pending` ids are "still looking", not "not available". */
 export interface TrackResolution {
   /** Track id (exactly as asked) → the catalog post that has it. */
   found: Record<string, TrackHit>;

--- a/packages/shared/src/api/mods.ts
+++ b/packages/shared/src/api/mods.ts
@@ -3235,6 +3235,59 @@ export function guessServerTrack(track: string): Promise<TrackGuess> {
   return invoke<TrackGuess>("guess_server_track", { track });
 }
 
+/** One installed track, as the server browser matches it (see `lib/trackContent`). */
+export interface InstalledTrack {
+  /** The track's internal folder id — exactly the value a server reports as its track. */
+  id: string;
+  /** Absolute path of the `.pkz` (or folder), for reading its preview. */
+  path: string;
+}
+
+/** The internal ids of every installed track, so the browser can badge which servers' tracks
+ *  the player already has. */
+export function installedTrackIds(): Promise<InstalledTrack[]> {
+  return invoke<InstalledTrack[]>("installed_track_ids");
+}
+
+/** How a track id was matched to a catalog post — by an exact file name it ships, or by its
+ *  title/slug. The UI shows both the same way. */
+export type TrackVia = "file" | "title";
+
+/** A track the mxb-mods catalog can supply, as the browser shows it. */
+export interface TrackHit {
+  slug: string;
+  title: string;
+  link: string;
+  via: TrackVia;
+}
+
+/** What {@link resolveServerTracks} found, plus whether the backend index is still filling
+ *  itself in — `pending` ids are "still looking", not "not available". */
+export interface TrackResolution {
+  /** Track id (exactly as asked) → the catalog post that has it. */
+  found: Record<string, TrackHit>;
+  /** Track ids the backend is still reading candidate pages for. */
+  pending: string[];
+  /** Unix ms of the listing crawl, or `null` when the index has never loaded. */
+  fetchedAt: number | null;
+}
+
+/**
+ * Which of these track ids the mxb-mods catalog can supply, resolved for the whole list at
+ * once (see the Rust `mods::trackindex`). Ask with missing tracks ranked most-hosted first:
+ * what the index can't answer becomes its background queue, so the order is its priority.
+ * The queue is worked behind the call, and {@link onTrackIndexUpdated} says when a later call
+ * would answer more.
+ */
+export function resolveServerTracks(tracks: string[]): Promise<TrackResolution> {
+  return invoke<TrackResolution>("resolve_server_tracks", { tracks });
+}
+
+/** Fires when the backend track index has learned more, so a re-resolve is worth it. */
+export function onTrackIndexUpdated(cb: () => void): Promise<UnlistenFn> {
+  return listen("track-index://updated", () => cb());
+}
+
 export type ServerAction = "start" | "stop" | "restart";
 
 export function listServers(): Promise<ServerRef[]> {


### PR DESCRIPTION
## Server browser: favourites, sorting, regions, image cards, and one-click track install

Adds the conveniences from the standalone v0.13 server browser onto the `Servers` tab, plus an in-app track installer. Everything is grafted on top of the existing browser - its master fetch, spam-filtering, paint-sync markers, detail panel and join dialog are untouched; this only adds to them.

### What's in it

- **Sortable columns** - click any header (name, players, track, location/region, ping) to sort; click again to flip. Ping reuses `pingMs`, so no extra probing.
- **Favourites** - star any server (card or row) into a favourites-only view. Per-machine, `localStorage`.
- **Region filter** - groups each host's free-text `location` into a small set of real regions (`lib/serverRegion`); the dropdown only offers regions actually present.
- **Card & list views** - a picture grid alongside the table, with a remembered toggle. Cards show the track's own preview art (or a "missing content" flag), player count, ping tint, lock and favourite star, and the same install control as the table.
- **One-click in-app track install** - a server whose track you don't have offers to fetch it: a free mxb-mods track installs in-app via Browse's quick-install pipeline; Hub/shop tracks link out. Backed by a file-name-aware catalog index (`mods::trackindex`) that matches tracks title-search alone misses (`Farm14 v0.1`  to  `Farm14.pkz`).
- **Filters** - "hide empty" (0-rider) and "installed only" toggles, both sticky; hide-empty defaults on so the browser opens to populated servers.

<img width="1520" height="781" alt="Screen 1" src="https://github.com/user-attachments/assets/b35302a4-c7d1-4eb1-a19f-99169401e6af" />

<img width="1393" height="363" alt="image" src="https://github.com/user-attachments/assets/5c225979-4fa3-43ab-9622-582494ac2b7f" />


<img width="314" height="404" alt="Screen 2" src="https://github.com/user-attachments/assets/90c393ee-723c-4905-b7fd-27d1182c9269" />

<img width="292" height="385" alt="image" src="https://github.com/user-attachments/assets/ba112614-397e-4c7f-b1de-5a5c72a4d130" />


### Backend

- `mods::trackindex` - the catalog index and its background drip (resolves a whole visible list in one call, converges over sessions).
- `mods::mxb` - three helpers the index needs (`catalog_page`, `downloads_at`, `download_file_name`), built on internals the module already had.
- Commands: `installed_track_ids` (walks `<mods>/mods/tracks`, reads each pkz's internal top-folder id - the value a server actually reports, not the file name) and `resolve_server_tracks` (asked without `with_clearance`, matching `guess_server_track`, so a background resolve never pops a browser challenge).

### Build note

The live master fetch lives in the local-only `worldnet` module, which is git-ignored and not part of this PR. Built without it, the Servers tab renders "the server browser isn't included in this build" instead of a list: the UI, filters and installer are all present and simply have no rows until that module is present at build time.

### Verification

- `tsc --noEmit` - clean
- `eslint` - clean on all changed files
- `cargo check -p mxb-app` - clean (no new warnings)
- `cargo test -p mxb-app trackindex` - 17/17 pass (file-name vs title matching, renames, version suffixes, page-budget and claim-release invariants)

i18n keys added across all six locales.

