### PR TITLE
feat(studio): show which GUID a protected file is locked to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-09-10
+
+### Added
+- Protect in Frost's Studio shows who a file is already locked to. Add a protected file
+  and its row names the GUID it is bound to.
+
 ## 2026-09-09 — v0.14.0 — A new name, and a Studio of its own
 
 ### Added

--- a/apps/studio/src/Components/Studio/Protect/Protect.tsx
+++ b/apps/studio/src/Components/Studio/Protect/Protect.tsx
@@ -196,8 +196,14 @@ export default function Protect() {
                     )}
                   >
                     <span className="truncate font-mono">{it.rel}</span>
-                    <span className="flex-none tabular-figures text-[11px] text-muted-foreground">
-                      {it.skip ? t(SKIP_LABEL[it.skip]) : formatBytes(it.bytes)}
+                    <span className="flex-none select-text tabular-figures text-[11px] text-muted-foreground">
+                      {it.guid
+                        ? /^0+$/.test(it.guid)
+                          ? t("protect.lockedToNobody")
+                          : t("protect.lockedTo", { guid: it.guid })
+                        : it.skip
+                          ? t(SKIP_LABEL[it.skip])
+                          : formatBytes(it.bytes)}
                     </span>
                   </li>
                 ))}

--- a/apps/studio/src/i18n/locales/de.ts
+++ b/apps/studio/src/i18n/locales/de.ts
@@ -264,6 +264,8 @@ export const de: Translation = {
   "protect.skipJunk": "Übersprungen",
   "protect.skipEmpty": "Leer",
   "protect.skipProtected": "Bereits geschützt",
+  "protect.lockedTo": "Gesperrt für {{guid}}",
+  "protect.lockedToNobody": "Geschützt, keine GUID",
   "protect.guidsTitle": "Sperren auf",
   "protect.guidsDesc": "Eine GUID pro Zeile — pro GUID kommt ein Ordner heraus. Jede Kopie bekommt ihren eigenen Schlüssel, damit zwei Käufer nicht erkennen können, dass sie dieselbe Datei haben.",
   "protect.guidsPlaceholder": "FF0110000108D7CFE3",

--- a/apps/studio/src/i18n/locales/en.ts
+++ b/apps/studio/src/i18n/locales/en.ts
@@ -267,6 +267,8 @@ export const en = {
   "protect.skipJunk": "Skipped",
   "protect.skipEmpty": "Empty",
   "protect.skipProtected": "Already protected",
+  "protect.lockedTo": "Locked to {{guid}}",
+  "protect.lockedToNobody": "Protected, no GUID",
   "protect.guidsTitle": "Lock to",
   "protect.guidsDesc": "One GUID per line — one folder comes out per GUID. Every copy gets its own key, so two buyers can't tell they hold the same file.",
   "protect.guidsPlaceholder": "FF0110000108D7CFE3",

--- a/apps/studio/src/i18n/locales/es.ts
+++ b/apps/studio/src/i18n/locales/es.ts
@@ -264,6 +264,8 @@ export const es: Translation = {
   "protect.skipJunk": "Omitido",
   "protect.skipEmpty": "Vacío",
   "protect.skipProtected": "Ya protegido",
+  "protect.lockedTo": "Bloqueado para {{guid}}",
+  "protect.lockedToNobody": "Protegido, sin GUID",
   "protect.guidsTitle": "Bloquear para",
   "protect.guidsDesc": "Un GUID por línea — sale una carpeta por GUID. Cada copia lleva su propia clave, así que dos compradores no pueden saber que tienen el mismo archivo.",
   "protect.guidsPlaceholder": "FF0110000108D7CFE3",

--- a/apps/studio/src/i18n/locales/fr.ts
+++ b/apps/studio/src/i18n/locales/fr.ts
@@ -264,6 +264,8 @@ export const fr: Translation = {
   "protect.skipJunk": "Ignoré",
   "protect.skipEmpty": "Vide",
   "protect.skipProtected": "Déjà protégé",
+  "protect.lockedTo": "Verrouillé pour {{guid}}",
+  "protect.lockedToNobody": "Protégé, sans GUID",
   "protect.guidsTitle": "Verrouiller pour",
   "protect.guidsDesc": "Un GUID par ligne — un dossier par GUID en sortie. Chaque copie a sa propre clé, deux acheteurs ne peuvent donc pas voir qu'ils détiennent le même fichier.",
   "protect.guidsPlaceholder": "FF0110000108D7CFE3",

--- a/apps/studio/src/i18n/locales/it.ts
+++ b/apps/studio/src/i18n/locales/it.ts
@@ -264,6 +264,8 @@ export const it: Translation = {
   "protect.skipJunk": "Saltato",
   "protect.skipEmpty": "Vuoto",
   "protect.skipProtected": "Già protetto",
+  "protect.lockedTo": "Bloccato per {{guid}}",
+  "protect.lockedToNobody": "Protetto, senza GUID",
   "protect.guidsTitle": "Blocca per",
   "protect.guidsDesc": "Un GUID per riga — esce una cartella per GUID. Ogni copia riceve la propria chiave, così due acquirenti non possono accorgersi di avere lo stesso file.",
   "protect.guidsPlaceholder": "FF0110000108D7CFE3",

--- a/apps/studio/src/i18n/locales/pt-BR.ts
+++ b/apps/studio/src/i18n/locales/pt-BR.ts
@@ -263,6 +263,8 @@ export const ptBR: Translation = {
   "protect.skipJunk": "Ignorado",
   "protect.skipEmpty": "Vazio",
   "protect.skipProtected": "Já protegido",
+  "protect.lockedTo": "Bloqueado para {{guid}}",
+  "protect.lockedToNobody": "Protegido, sem GUID",
   "protect.guidsTitle": "Travar para",
   "protect.guidsDesc": "Um GUID por linha — sai uma pasta por GUID. Cada cópia leva a própria chave, então dois compradores não conseguem perceber que têm o mesmo arquivo.",
   "protect.guidsPlaceholder": "FF0110000108D7CFE3",

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1616,6 +1616,8 @@ export interface LockItem {
   kind: "archive" | "file";
   /** `null` when the file will be locked. */
   skip: "junk" | "empty" | "protected" | null;
+  /** The GUID an already-protected file is bound to; all zeros means bound to nobody. */
+  guid: string | null;
 }
 
 export interface LockOutcome {


### PR DESCRIPTION
Protect's file list now names the GUID on an already-protected file's row, where it used to say only "Already protected". An all-zero GUID reads as "Protected, no GUID".

- `LockItem` gains `guid: string | null`
- New strings in all six locales
- The value is filled by the optional locker module; a build without it shows the old label

Verified: the studio `tsc` is clean, and the locker's tests and a byte-exact check on real locked files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)