### PR TITLE
feat(studio): show which bikes a model swap lines up with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 - Protect in Frost's Studio shows who a file is already locked to. Add a protected file
   and its row names the GUID it is bound to.
+- The Studio's Rider screen shows which bikes a model swap lines up with: every bike that
+  shares its frame's mount points, like a KTM swap fitting the Husqvarna and GasGas too.
 
 ## 2026-09-09 — v0.14.0 — A new name, and a Studio of its own
 

--- a/apps/studio/src-tauri/src/main.rs
+++ b/apps/studio/src-tauri/src/main.rs
@@ -36,7 +36,7 @@ use mxb_core::config::AppConfig;
 use tauri::{Emitter, Manager};
 
 pub(crate) use mxb_core::{
-    bikefiles, presets, cloudfiles, config, edf, game, heightfield, library, linkwalk, map, paint, pkz, texstore, track, usage, viewer, winehost,
+    bikefiles, presets, cloudfiles, config, edf, game, heightfield, library, linkwalk, map, modelswap, paint, pkz, texstore, track, usage, viewer, winehost,
 };
 #[cfg(sidecar)]
 pub(crate) use mxb_core::sidecar;
@@ -58,6 +58,7 @@ fn main() {
             log_client,
             set_preview_tyres,
             scan_model_swaps,
+            model_swap_lineup,
             designer_recents,
             psd_watch,
             psd_unwatch,
@@ -1839,13 +1840,10 @@ fn set_guid(app: tauri::AppHandle, guid: String) -> Result<(), String> {
     config::save(&app, &cfg).map_err(|e| format!("{e:#}"))
 }
 
-/// Draw a bike for the shared viewer.
+/// Draw a bike as one of its model swaps, for the shared viewer.
 ///
-/// The viewer asks for "this bike as variant X" because in the mod manager a bike can have
-/// model swaps parked beside it, and Stock is one variant among several. Nothing here parks
-/// anything: the studio paints the bike that is installed, so the variant is always Stock and
-/// the honest answer is the bike itself. Resolving a real swap needs `modelswap`, which is
-/// the manager's — a studio that could answer for it would be a studio that could disagree.
+/// Same resolution as the manager's, from the same `modelswap` in core. Nothing on disk
+/// moves: `preview_set` only works out which files the variant would put on the bike.
 #[tauri::command]
 async fn preview_model_swap(
     app: tauri::AppHandle,
@@ -1853,11 +1851,13 @@ async fn preview_model_swap(
     variant: String,
     tyres: Option<String>,
 ) -> Result<mxb_core::viewer::BikeModel, String> {
-    let _ = variant;
     tauri::async_runtime::spawn_blocking(move || {
         let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
-        let dir = library::mods_subdir(&cfg.mods_path, "mods/bikes").join(&bike);
-        viewer::load_bike_model_blocking(dir.to_string_lossy().into_owned(), tyres)
+        let set = modelswap::preview_set(&cfg.mods_path, &bike, &variant)
+            .map_err(|e| format!("{e:#}"))?;
+        let label = format!("{bike} · {variant}");
+        let tyre_dir = library::mods_subdir(&cfg.mods_path, "mods/tyres");
+        viewer::load_preview_blocking(&set, &label, tyre_dir, tyres)
     })
     .await
     .map_err(|e| format!("preview_model_swap task failed: {e}"))?
@@ -1884,15 +1884,28 @@ fn set_preview_tyres(app: tauri::AppHandle, tyres: String) -> Result<(), String>
     config::save(&app, &cfg).map_err(|e| format!("{e:#}"))
 }
 
-/// The model swaps parked beside a bike — always none here.
-///
-/// Parking a mesh so the game loads a different one is the mod manager's Locker, and doing
-/// it needs `modelswap`, which is its module. The shared viewer asks every host this so it
-/// can offer a variant picker; the honest answer from the studio is that there are none, and
-/// the picker then does not appear.
+/// The model swaps parked beside each bike. Read-only: applying one stays the manager's
+/// Locker. The studio lists them so the Rider screen can offer and preview them.
 #[tauri::command]
-fn scan_model_swaps(_mods_path: String) -> Vec<serde_json::Value> {
-    Vec::new()
+async fn scan_model_swaps(app: tauri::AppHandle) -> Result<Vec<modelswap::BikeModels>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
+        Ok(modelswap::scan_model_swaps(&cfg.mods_path))
+    })
+    .await
+    .map_err(|e| format!("scan_model_swaps task failed: {e}"))?
+}
+
+/// The bikes a model swap parked under `bike` lines up with — every bike whose `.geom`
+/// mount points match `bike`'s. See `modelswap::lined_up_bikes`.
+#[tauri::command]
+async fn model_swap_lineup(app: tauri::AppHandle, bike: String) -> Result<Vec<String>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let cfg = config::load(&app).map_err(|e| format!("{e:#}"))?;
+        Ok(modelswap::lined_up_bikes(&cfg.mods_path, &bike))
+    })
+    .await
+    .map_err(|e| format!("model_swap_lineup task failed: {e}"))?
 }
 
 

--- a/apps/studio/src/Components/Rider/RiderStudio.tsx
+++ b/apps/studio/src/Components/Rider/RiderStudio.tsx
@@ -11,6 +11,7 @@ import {
   presetsSave,
   scanGearRepairs,
   repairGear,
+  modelSwapLineup,
   type GearRepair,
 } from "@frost/shared/api/mods";
 import { ViewerPanel } from "@frost/shared/Components/Viewer/ViewerPanel";
@@ -152,6 +153,21 @@ export default function RiderStudio() {
       .catch(() => setRepairs([]));
   }, []);
 
+  // The bikes a swap on this bike lines up with — the ones sharing its .geom mount points.
+  const hasSwaps = !!(bike && scans?.modelSwaps[bike]?.length);
+  const [lineup, setLineup] = useState<string[] | null>(null);
+  useEffect(() => {
+    setLineup(null);
+    if (!hasSwaps) return;
+    let alive = true;
+    void modelSwapLineup(bike)
+      .then((b) => alive && setLineup(b))
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, [bike, hasSwaps]);
+
   const onRepair = useCallback(
     async (r: GearRepair) => {
       setRepairing(r.id);
@@ -193,6 +209,16 @@ export default function RiderStudio() {
   );
   const bikeVariant =
     loadout.modelSwap || (offersStock ? "Stock" : pickedModel(bike, loadout, scans));
+  const lineupNames = lineup?.map((b) => b.replace(/^MX[0-9E]OEM_/i, "").replace(/_/g, " "));
+  const lineupHint =
+    lineupNames &&
+    (lineupNames.length ? (
+      <span className="line-clamp-3" title={lineupNames.join(", ")}>
+        {t("rider.swapLinesUp", { bikes: lineupNames.join(", ") })}
+      </span>
+    ) : (
+      t("rider.swapLinesUpNone")
+    ));
   const showBike = bikePreview && !!bike;
   // A bike handed over by Presets comes from the profile's own list, which the target scan
   // should already cover — but if it doesn't, keep it pickable rather than showing an empty
@@ -326,6 +352,7 @@ export default function RiderStudio() {
                     value={loadout[slot.key]}
                     options={optionsFor(slot, bike, scans)}
                     missing={missingFor(slot, bike, scans)}
+                    hint={slot.key === "modelSwap" ? lineupHint : undefined}
                     compact
                     onChange={(v) => setSlot(slot.key, v)}
                   />

--- a/apps/studio/src/i18n/locales/de.ts
+++ b/apps/studio/src/i18n/locales/de.ts
@@ -42,6 +42,8 @@ export const de: Translation = {
     "Kleide das Fahrermodell ein — Helm, Brille, Outfit und Stiefel zusammen.",
   "rider.namePlaceholder": "Diesem Fahrer einen Namen geben…",
   "rider.showOnModel": "Am Modell zeigen",
+  "rider.swapLinesUp": "Passt auf {{bikes}}",
+  "rider.swapLinesUpNone": "Passt auf kein anderes installiertes Bike",
   "rider.repairTitle": "Ein {{area}}-Mod wurde lose installiert",
   "rider.repairBody":
     "Seine Dateien liegen direkt in {{area}} statt in einem Ordner — weder das Spiel noch diese App können ihn so laden. In „{{model}}“ zusammenfassen?",

--- a/apps/studio/src/i18n/locales/en.ts
+++ b/apps/studio/src/i18n/locales/en.ts
@@ -46,6 +46,8 @@ export const en = {
     "Dress the player model — helmet, goggles, outfit and boots together.",
   "rider.namePlaceholder": "Name this rider…",
   "rider.showOnModel": "Show on model",
+  "rider.swapLinesUp": "Lines up with {{bikes}}",
+  "rider.swapLinesUpNone": "Lines up with no other installed bike",
   "rider.repairTitle": "A {{area}} mod was installed loose",
   "rider.repairBody":
     "Its files sit directly in {{area}} instead of in a folder, so neither the game nor this app can load it. Gather them into “{{model}}”?",

--- a/apps/studio/src/i18n/locales/es.ts
+++ b/apps/studio/src/i18n/locales/es.ts
@@ -42,6 +42,8 @@ export const es: Translation = {
     "Viste al modelo del piloto — casco, gafas, equipación y botas a la vez.",
   "rider.namePlaceholder": "Pon nombre a este piloto…",
   "rider.showOnModel": "Mostrar en el modelo",
+  "rider.swapLinesUp": "Encaja en {{bikes}}",
+  "rider.swapLinesUpNone": "No encaja en ninguna otra moto instalada",
   "rider.repairTitle": "Un mod de {{area}} se instaló suelto",
   "rider.repairBody":
     "Sus archivos están directamente en {{area}} en vez de en una carpeta, así que ni el juego ni esta app pueden cargarlo. ¿Recogerlos en “{{model}}”?",

--- a/apps/studio/src/i18n/locales/fr.ts
+++ b/apps/studio/src/i18n/locales/fr.ts
@@ -42,6 +42,8 @@ export const fr: Translation = {
     "Habillez le modèle du pilote — casque, masque, tenue et bottes d'un seul coup.",
   "rider.namePlaceholder": "Nommez ce pilote…",
   "rider.showOnModel": "Afficher sur le modèle",
+  "rider.swapLinesUp": "S'aligne sur {{bikes}}",
+  "rider.swapLinesUpNone": "Ne s'aligne sur aucune autre moto installée",
   "rider.repairTitle": "Un mod {{area}} a été installé en vrac",
   "rider.repairBody":
     "Ses fichiers sont directement dans {{area}} au lieu d'un dossier, donc ni le jeu ni cette app ne peuvent le charger. Les rassembler dans « {{model}} » ?",

--- a/apps/studio/src/i18n/locales/it.ts
+++ b/apps/studio/src/i18n/locales/it.ts
@@ -42,6 +42,8 @@ export const it: Translation = {
     "Vesti il modello del pilota — casco, maschera, completo e stivali insieme.",
   "rider.namePlaceholder": "Dai un nome a questo pilota…",
   "rider.showOnModel": "Mostra sul modello",
+  "rider.swapLinesUp": "Si allinea con {{bikes}}",
+  "rider.swapLinesUpNone": "Non si allinea con nessun’altra moto installata",
   "rider.repairTitle": "Un mod in {{area}} è stato installato sparso",
   "rider.repairBody":
     "I suoi file stanno direttamente in {{area}} invece che in una cartella, quindi né il gioco né questa app possono caricarlo. Raccoglierli in “{{model}}”?",

--- a/apps/studio/src/i18n/locales/pt-BR.ts
+++ b/apps/studio/src/i18n/locales/pt-BR.ts
@@ -42,6 +42,8 @@ export const ptBR: Translation = {
     "Vista o modelo do piloto — capacete, óculos, uniforme e botas de uma vez.",
   "rider.namePlaceholder": "Dê um nome a este piloto…",
   "rider.showOnModel": "Mostrar no modelo",
+  "rider.swapLinesUp": "Encaixa em {{bikes}}",
+  "rider.swapLinesUpNone": "Não encaixa em nenhuma outra moto instalada",
   "rider.repairTitle": "Um mod de {{area}} foi instalado solto",
   "rider.repairBody":
     "Os arquivos dele estão direto em {{area}} em vez de numa pasta, então nem o jogo nem este app conseguem carregá-lo. Juntar tudo em “{{model}}”?",

--- a/crates/core/src/modelswap.rs
+++ b/crates/core/src/modelswap.rs
@@ -879,6 +879,61 @@ pub fn bike_folders(mods_path: &str) -> Vec<String> {
     out
 }
 
+/// The `.geom` points a model's parts hang off: steering head, swingarm pivot, fork, axles.
+const LINEUP_MOUNTS: [&str; 8] = [
+    "chassis_steer",
+    "chassis_rsusp_min",
+    "steer_joint",
+    "rsusp_joint",
+    "front_upper",
+    "fwheel",
+    "rwheel_min",
+    "rwheel_max",
+];
+
+/// How far two bikes' mounts may differ and still be one frame. On the OEM set KTM,
+/// Husqvarna and GasGas agree within 4.3 mm; the next bike is 34 mm off.
+const LINEUP_TOLERANCE: f32 = 0.010;
+
+/// A bike's `.geom` mount points — loose beside it, else inside its `.pkz`.
+fn bike_geom(mods_path: &str, bike: &str) -> Option<std::collections::HashMap<String, [f32; 3]>> {
+    let root = bikes_root(mods_path);
+    let is_geom = |n: &str| n.to_ascii_lowercase().ends_with(".geom");
+    if let Ok(rd) = fs::read_dir(root.join(bike)) {
+        for e in rd.flatten() {
+            if e.file_name().to_str().is_some_and(is_geom) {
+                if let Ok(b) = fs::read(e.path()) {
+                    return Some(crate::edf::parse_geom(&b));
+                }
+            }
+        }
+    }
+    let files = crate::pkz::read_selected(&root.join(format!("{bike}.pkz")), is_geom).ok()?;
+    files.first().map(|(_, b)| crate::edf::parse_geom(b))
+}
+
+/// The other bikes a model built for `bike` lines up with: every bike whose `.geom` puts
+/// the same mounts in the same place, so the model's parts land where they belong.
+pub fn lined_up_bikes(mods_path: &str, bike: &str) -> Vec<String> {
+    let Some(host) = bike_geom(mods_path, bike) else {
+        return Vec::new();
+    };
+    let same_frame = |g: &std::collections::HashMap<String, [f32; 3]>| {
+        LINEUP_MOUNTS.iter().all(|k| match (host.get(*k), g.get(*k)) {
+            (Some(a), Some(b)) => {
+                let d = (0..3).map(|i| (a[i] - b[i]).powi(2)).sum::<f32>().sqrt();
+                d <= LINEUP_TOLERANCE
+            }
+            _ => false,
+        })
+    };
+    bike_folders(mods_path)
+        .into_iter()
+        .filter(|b| !b.eq_ignore_ascii_case(bike))
+        .filter(|b| bike_geom(mods_path, b).is_some_and(|g| same_frame(&g)))
+        .collect()
+}
+
 /// Why a variant can't be moved or deleted, or `None` when it can.
 ///
 /// The active set is the one case that matters: its files are loose at the bike root, not in
@@ -1428,6 +1483,29 @@ mod tests {
     }
     fn shelved_liveries(mp: &str, bike: &str) -> Vec<String> {
         liveries_in(&shelf_dir(mp, bike))
+    }
+
+    #[test]
+    fn a_model_lines_up_with_bikes_sharing_its_mounts() {
+        let root = tmp("lineup");
+        let mp = root.to_str().unwrap();
+        let geom = |shift: f32| {
+            let mut g = String::new();
+            for (i, k) in LINEUP_MOUNTS.iter().enumerate() {
+                g.push_str(&format!("{k} = 0, {}, {}\n", i as f32 * 0.1 + shift, -0.2));
+            }
+            g
+        };
+        for (bike, shift) in [("KTM", 0.0), ("GasGas", 0.004), ("Honda", 0.034)] {
+            fs::create_dir_all(bike_dir(mp, bike)).unwrap();
+            fs::write(bike_dir(mp, bike).join("bike.geom"), geom(shift)).unwrap();
+        }
+        // A bike with no .geom at all can't be said to line up with anything.
+        fs::create_dir_all(bike_dir(mp, "Bare")).unwrap();
+
+        assert_eq!(lined_up_bikes(mp, "KTM"), ["GasGas"]);
+        assert!(lined_up_bikes(mp, "Bare").is_empty());
+        let _ = fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/packages/shared/src/api/mods.ts
+++ b/packages/shared/src/api/mods.ts
@@ -587,6 +587,11 @@ export function previewModelSwap(
   }).then(reviveMesh);
 }
 
+/** The other bikes a model swap parked under `bike` lines up with — same `.geom` mounts. */
+export function modelSwapLineup(bike: string): Promise<string[]> {
+  return invoke<string[]>("model_swap_lineup", { bike });
+}
+
 /**
  * Every livery the bike has, wherever it currently sits — including the ones shelved
  * because the model that claims them isn't on the bike. The assignment picker needs all of


### PR DESCRIPTION
## What
Frost's Studio's Rider screen now shows, under the model-swap slot, which bikes a swap lines up with — every installed bike whose `.geom` mount points (steer head, swingarm pivot, fork, axles) sit within 10 mm of the host bike's.

## Why .geom
Measured on the OEM set: all 2023 KTMs 0.0 mm, Husqvarna FC/TC 2.4 mm, GasGas MC 4.3 mm, next bike (Stark VARG) 34 mm. Two cheaper signals were tried and rejected: `gfx.cfg` grip/chain/exhaust points are boilerplate (a KTM swap ranked Yamaha closer than its own family), and per-part mesh bounding boxes are dominated by bodywork.

## Changes
- core: `modelswap::lined_up_bikes`, reading only the `.geom` out of each `.pkz` (~1.3 s for 53 bikes); unit test
- studio: `scan_model_swaps` / `preview_model_swap` were stubs — now core's read-only modelswap, so the Rider screen lists and previews swaps
- studio: `model_swap_lineup` command and the "Lines up with …" hint, in all six locales
- No DB changes

## Verified
- `cargo test -p mxb-core modelswap::` 61 passed; studio `cargo check` clean; studio + manager `tsc` clean
- Real mods folder: KTM 250 SX-F → 15 KTM/Husqvarna/GasGas bikes; CRF450R → CRF250R; a bike with no `.geom` → none

🤖 Generated with [Claude Code](https://claude.com/claude-code)