### PR TITLE
fix(viewer): retire terrain cached before the row-order fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Picking a track's ground changes what it is made of, not its shape. Corners, berms and ruts
   stay as they are when you switch between soil, sand and grass.
 
+### Fixed
+- Objects in the 3D track view stand on the ground where the game puts them, on tracks you
+  opened in an earlier version too.
+
 ## 2026-09-09 — v0.14.0 — A new name, and a Studio of its own
 
 ### Added

--- a/crates/core/src/track.rs
+++ b/crates/core/src/track.rs
@@ -37,7 +37,9 @@ const MASTER_DIM: u32 = 2048;
 // holds the ground below a track standing as a wall around it.
 // v5: masters are kept at the source's own resolution; a v4 entry would pin a track to half
 // of it for as long as it stayed cached.
-const CACHE_DIR: &str = "track-terrain-v5";
+// v6: grids are read in file order, no longer flipped; a v5 entry holds the terrain mirrored
+// under its own scenery, so objects float and stand on the riding line.
+const CACHE_DIR: &str = "track-terrain-v6";
 
 /// How many cached masters to keep. Sixteen megabytes each at [`MASTER_DIM`], so this is kept
 /// small deliberately — the cache saves a second of archive reading, not a scarce resource.


### PR DESCRIPTION
Objects in the 3D track view floated and stood on the riding line, while in game they were placed correctly.

**Cause:** v0.13.5–v0.13.7 cached terrain masters under `track-terrain-v5` with the rows flipped. bedc6f20 switched to reading the heightfield in file order but kept the same cache generation, so any track opened in 0.13.x still loads its old mirrored grid under the right scenery.

**Fix:** bump `CACHE_DIR` to `track-terrain-v6`.

**Evidence:** probes against the viewer's own pipeline (`decode_master` → `terrain_blob`, `scenery::decode`):
- Read in file order, published tracks (OPMC, Abydos, Grays Harbor, MX191) put their objects on the ground; every flip is worse.
- On generated tracks, jump marks on the riding line sit −0.33 m (median) at the fine grid; banners and trees on the lap stand on it.

Test plan: `cargo test -p mxb-core --lib track::` → 25 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)