### PR TITLE
feat(nav): move Race mode under the Garage rail item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 - The 3D viewer shows paints at full resolution, so logos and lettering on bikes and gear
   read sharply.
+- Race mode is now a tab under Garage, next to Locker and Presets.
 
 ### Fixed
 - A server's track panel recognizes tracks you have installed as a `.pkz`, even when the

--- a/apps/manager/src/Components/Shell/nav.ts
+++ b/apps/manager/src/Components/Shell/nav.ts
@@ -54,10 +54,8 @@ export interface RailItem extends Gated {
 /**
  * The rail, left to right.
  *
- * Seven items is the ceiling before the row stops scanning, which is why Locker and Presets
- * share GARAGE: they act on the same two things — a bike, and the look on it. The slot that
- * freed is what carries Race mode, which decides what the game mounts at startup and was too
- * big to leave as an icon.
+ * Seven items is the ceiling before the row stops scanning, which is why Locker, Presets and
+ * Race mode share GARAGE: they all decide what you take onto the track.
  */
 export const RAIL: RailItem[] = [
   { id: "browse", label: "nav.browse", view: "browse" },
@@ -79,11 +77,11 @@ export const RAIL: RailItem[] = [
     tabs: [
       { view: "locker", label: "nav.locker", cap: "viewer" },
       { view: "presets", label: "nav.presets" },
+      { view: "manage", label: "nav.manage", cap: "manage" },
     ],
   },
   // Not a group any more: the tools are their own app, and this is the way to it.
   { id: "studio", label: "nav.studio", view: "studio" },
-  { id: "manage", label: "nav.manage", view: "manage", cap: "manage" },
   {
     id: "servers",
     label: "nav.servers",


### PR DESCRIPTION
- Race mode is now a third tab under **Garage** (Locker · Presets · Race mode) instead of its own rail item.
- Still gated on the `manage` capability.
- No DB changes. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)