### PR TITLE
feat(library): rescan when mods are dropped into the folder by hand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Changed
 - The 3D viewer shows paints at full resolution, so logos and lettering on bikes and gear
   read sharply.
+- The Library picks up tracks and other mods you add to the mods folder yourself, without
+  pressing Refresh.
 
 ### Fixed
 - A server's track panel recognizes tracks you have installed as a `.pkz`, even when the

--- a/apps/manager/src/Components/Library/Library.tsx
+++ b/apps/manager/src/Components/Library/Library.tsx
@@ -50,6 +50,8 @@ import {
   restoreLedgerEntry,
   downloadHistory,
   scanModelSwaps,
+  onFrostmodReload,
+  MODS_WATCH_SLUG,
   type ModType,
 } from "@frost/shared/api/mods";
 import type {
@@ -609,6 +611,19 @@ export default function Library({
     setLoading(false);
     if (!hit.fresh) void load({ quiet: true });
   }, [load, refreshKey, modType]);
+
+  // A mod dropped into the folder by hand, caught by the watcher: every remembered scan is
+  // stale, and the list on screen refreshes behind itself. In-app changes bump `refreshKey`.
+  useEffect(() => {
+    const un = onFrostmodReload((p) => {
+      if (p.slug !== MODS_WATCH_SLUG) return;
+      dropScans();
+      void load({ quiet: true });
+    });
+    return () => {
+      void un.then((f) => f());
+    };
+  }, [load]);
 
   // Model swaps, for the bikes tab only — one scan of the whole tree, indexed by bike
   // folder. Installing a mod or editing the folder changes what's swappable, so it rides

--- a/apps/manager/src/Components/Library/scanCache.ts
+++ b/apps/manager/src/Components/Library/scanCache.ts
@@ -8,7 +8,8 @@
  *
  * So a scan is remembered. A visit inside [`TTL_MS`] shows it and touches nothing; a later
  * one shows it *and* rescans behind it, replacing the list when the answer arrives. The app's
- * own installs and moves drop the cache outright, since those know the tree changed.
+ * own installs and moves drop the cache outright, since those know the tree changed, and so
+ * does the mods-folder watcher when something is dropped in by hand.
  *
  * `primeMetaCache` keeps archive metadata the same way, for the same reason.
  */


### PR DESCRIPTION
- Library now listens for the mods-folder watcher's `frostmod-reload` event (slug `__mods_watch__`), drops every cached scan and quietly rescans the list on screen.
- Hand-added tracks show up a few seconds after the copy settles, without pressing Refresh; switching tabs back picks them up too since the cache is cleared.
- In-app installs are ignored here — they already bump `refreshKey` and pause the watcher while they run.
- Relies on the auto-reload watcher (on by default); with it off the existing 30 s scan cache still applies.
- No DB changes. Typecheck and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)