### PR TITLE
fix(viewer): inflate a bike's paints only when one is shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 - The 3D viewer shows paints at full resolution, so logos and lettering on bikes and gear
   read sharply.
+- Bikes with many paints open faster in the 3D viewer and use far less memory.
 
 ### Fixed
 - A server's track panel recognizes tracks you have installed as a `.pkz`, even when the

--- a/crates/core/src/paint.rs
+++ b/crates/core/src/paint.rs
@@ -141,26 +141,7 @@ pub fn decode_where(
         .enumerate()
         .filter(|(_, h)| want(&h.name))
         .map(|(i, h)| {
-            let expected = texture_bytes(h.width, h.height)?;
-            let mut rgba = Vec::with_capacity(expected.min(MAX_RESERVE));
-            // Stop one byte past what the header promised. Deflate expands ~1000:1, so a
-            // mis-framed payload inflates until it runs the machine out of memory otherwise —
-            // and the length check below turns the overrun into an error either way.
-            DeflateDecoder::new(&buf[h.data])
-                .take(expected as u64 + 1)
-                .read_to_end(&mut rgba)
-                .with_context(|| format!("inflate texture {i} '{}'", h.name))?;
-
-            if rgba.len() != expected {
-                bail!(
-                    "texture {i} '{}': inflated {} bytes, expected {expected} ({}x{} RGBA)",
-                    h.name,
-                    rgba.len(),
-                    h.width,
-                    h.height
-                );
-            }
-
+            let rgba = inflate_plane(buf, &h).with_context(|| format!("texture {i}"))?;
             Ok(PntTexture {
                 name: h.name,
                 width: h.width,
@@ -169,6 +150,30 @@ pub fn decode_where(
             })
         })
         .collect()
+}
+
+/// One plane's pixels, inflated and checked against the size its header states.
+fn inflate_plane(buf: &[u8], h: &ImageHeader) -> Result<Vec<u8>> {
+    let expected = texture_bytes(h.width, h.height)?;
+    let mut rgba = Vec::with_capacity(expected.min(MAX_RESERVE));
+    // Stop one byte past what the header promised. Deflate expands ~1000:1, so a
+    // mis-framed payload inflates until it runs the machine out of memory otherwise —
+    // and the length check below turns the overrun into an error either way.
+    DeflateDecoder::new(&buf[h.data.clone()])
+        .take(expected as u64 + 1)
+        .read_to_end(&mut rgba)
+        .with_context(|| format!("inflate '{}'", h.name))?;
+
+    if rgba.len() != expected {
+        bail!(
+            "'{}': inflated {} bytes, expected {expected} ({}x{} RGBA)",
+            h.name,
+            rgba.len(),
+            h.width,
+            h.height
+        );
+    }
+    Ok(rgba)
 }
 
 /// The texture names a `.pnt` supplies, read from the headers alone.
@@ -258,6 +263,30 @@ pub fn decode_any_where(
         return decode_where(&plain, want);
     }
     decode_where(buf, want)
+}
+
+/// [`decode_any`] into the texture store without inflating: each sheet is inflated when the
+/// viewer fetches it. A bike offers every paint it has and shows one, and holding them all
+/// inflated at full size ran past a gigabyte.
+pub fn store_lazy_any(buf: &[u8]) -> Result<Vec<PaintTexture>> {
+    let plain = if is_plain(buf) { None } else { crate::pkz::read_sidecar_blob(buf) };
+    let buf: std::sync::Arc<[u8]> = match plain {
+        Some(p) => p.into(),
+        None => buf.into(),
+    };
+    Ok(image_headers(&buf)?
+        .into_iter()
+        .map(|h| {
+            let (width, height) = capped_size(&h.name, h.width, h.height);
+            let name = h.name.clone();
+            let src = buf.clone();
+            let token = crate::texstore::put_lazy(h.data.len(), move || {
+                let rgba = inflate_plane(&src, &h).map_err(|e| log::warn!("{e:#}")).ok()?;
+                Some(cap_pixels(&h.name, h.width, h.height, rgba).2)
+            });
+            PaintTexture { name, width, height, token }
+        })
+        .collect())
 }
 
 /// Whether `buf` is a paint stored in the open format this module also writes.
@@ -376,6 +405,29 @@ fn max_edge(name: &str) -> u32 {
     }
 }
 
+/// The size a sheet reaches the viewer at: its own, shrunk to fit [`max_edge`].
+fn capped_size(name: &str, width: u32, height: u32) -> (u32, u32) {
+    let (cap, long) = (max_edge(name) as u64, width.max(height) as u64);
+    if long <= cap {
+        return (width, height);
+    }
+    let scale = |d: u32| ((d as u64 * cap + long / 2) / long).max(1) as u32;
+    (scale(width), scale(height))
+}
+
+/// `rgba` resized to [`capped_size`] — or as it is when it fits, or isn't `w*h*4`, which the
+/// viewer then renders grey.
+fn cap_pixels(name: &str, width: u32, height: u32, rgba: Vec<u8>) -> (u32, u32, Vec<u8>) {
+    let (w, h) = capped_size(name, width, height);
+    if (w, h) == (width, height) || rgba.len() != (width as usize) * (height as usize) * 4 {
+        return (width, height, rgba);
+    }
+    match image::RgbaImage::from_raw(width, height, rgba) {
+        Some(img) => (w, h, image::imageops::thumbnail(&img, w, h).into_raw()),
+        None => (width, height, Vec::new()), // unreachable: the length is checked above
+    }
+}
+
 pub fn extract_edf_textures(edf: &[u8]) -> Vec<PaintTexture> {
     extract_edf_textures_where(edf, |_| true)
 }
@@ -413,13 +465,8 @@ pub fn extract_edf_normal_maps(edf: &[u8], want: impl Fn(&str) -> bool) -> Vec<P
 /// Shared with [`extract_edf_textures_where`] so the two can't come to different views about
 /// how much memory a sheet is allowed to occupy.
 fn store_capped(name: &str, width: u32, height: u32, rgba: Vec<u8>) -> Option<PaintTexture> {
-    let cap = max_edge(name);
-    if width.max(height) <= cap {
-        return Some(store_rgba(name, width, height, rgba));
-    }
-    let img = image::DynamicImage::ImageRgba8(image::RgbaImage::from_raw(width, height, rgba)?);
-    let scaled = img.thumbnail(cap, cap);
-    Some(store_rgba(name, scaled.width(), scaled.height(), scaled.to_rgba8().into_raw()))
+    let (w, h, rgba) = cap_pixels(name, width, height, rgba);
+    Some(store_rgba(name, w, h, rgba))
 }
 
 pub fn extract_edf_textures_where(
@@ -462,24 +509,8 @@ pub fn into_texture(t: PntTexture) -> PaintTexture {
         height,
         rgba,
     } = t;
-    // `from_raw` takes the buffer and hands back nothing when it isn't `w*h*4`, so the length
-    // is checked here instead — a truncated plane then goes through verbatim, exactly as
-    // before, and the viewer renders it grey.
-    let cap = max_edge(&name);
-    if width.max(height) > cap && rgba.len() == (width as usize) * (height as usize) * 4 {
-        if let Some(img) = image::RgbaImage::from_raw(width, height, rgba) {
-            let scaled = image::DynamicImage::ImageRgba8(img).thumbnail(cap, cap);
-            return store_rgba(
-                &name,
-                scaled.width(),
-                scaled.height(),
-                scaled.to_rgba8().into_raw(),
-            );
-        }
-        // Unreachable — the only thing `from_raw` rejects is the length checked above.
-        return store_rgba(&name, width, height, Vec::new());
-    }
-    store_rgba(&name, width, height, rgba)
+    let (w, h, rgba) = cap_pixels(&name, width, height, rgba);
+    store_rgba(&name, w, h, rgba)
 }
 
 pub fn decode_image(name: &str, bytes: &[u8]) -> Option<PaintTexture> {
@@ -789,6 +820,19 @@ mod tests {
         short.rgba.truncate(4);
         assert!(encode("p", &[short]).is_err(), "pixels that don't fill the dimensions");
         assert!(encode("p", &[tex("livery", 0, 4)]).is_err(), "a zero dimension");
+    }
+
+    /// The lazy path is the eager one deferred: same names, sizes and pixels.
+    #[test]
+    fn lazy_paints_serve_the_same_pixels() {
+        let bytes = encode("p", &[tex("livery", 4, 4), tex("livery_n", 2, 2)]).unwrap();
+        let lazy = store_lazy_any(&bytes).unwrap();
+        let eager: Vec<_> = decode(&bytes).unwrap().into_iter().map(into_texture).collect();
+        assert_eq!(lazy.len(), eager.len());
+        for (l, e) in lazy.iter().zip(&eager) {
+            assert_eq!((&l.name, l.width, l.height), (&e.name, e.width, e.height));
+            assert_eq!(crate::texstore::get(&l.token), crate::texstore::get(&e.token));
+        }
     }
 
     #[test]

--- a/crates/core/src/texstore.rs
+++ b/crates/core/src/texstore.rs
@@ -32,9 +32,26 @@ const MISSING_RGBA: [u8; 4] = [0xb7, 0xbc, 0xc4, 0xff];
 /// here — the `PaintTexture` the frontend already holds is their single source of truth.
 type Blob = Vec<u8>;
 
+type Inflate = Arc<dyn Fn() -> Option<Blob> + Send + Sync>;
+
+/// A texture's pixels, held — or, see [`put_lazy`], made each time they are fetched.
+enum Entry {
+    Ready(Arc<Blob>),
+    Lazy { inflate: Inflate, bytes: usize },
+}
+
+impl Entry {
+    fn bytes(&self) -> usize {
+        match self {
+            Entry::Ready(b) => b.len(),
+            Entry::Lazy { bytes, .. } => *bytes,
+        }
+    }
+}
+
 #[derive(Default)]
 struct Store {
-    blobs: HashMap<String, Arc<Blob>>,
+    blobs: HashMap<String, Entry>,
     /// Insertion order, for the cap below.
     order: VecDeque<String>,
     bytes: usize,
@@ -52,13 +69,22 @@ fn next_token() -> String {
 
 /// Take ownership of a texture's pixels and return the token that names them.
 pub fn put(rgba: Vec<u8>) -> String {
+    insert(Entry::Ready(Arc::new(rgba)))
+}
+
+/// A token whose pixels `inflate` makes on every fetch, holding only what it captures —
+/// `bytes` of it, for the cap. For a paint the viewer may never show.
+pub fn put_lazy(bytes: usize, inflate: impl Fn() -> Option<Blob> + Send + Sync + 'static) -> String {
+    insert(Entry::Lazy { inflate: Arc::new(inflate), bytes })
+}
+
+fn insert(entry: Entry) -> String {
     let token = next_token();
-    let size = rgba.len();
     let Ok(mut s) = store().lock() else {
         return token; // poisoned — the token resolves to grey, which beats panicking
     };
-    s.bytes += size;
-    s.blobs.insert(token.clone(), Arc::new(rgba));
+    s.bytes += entry.bytes();
+    s.blobs.insert(token.clone(), entry);
     s.order.push_back(token.clone());
 
     while s.bytes > CAP_BYTES {
@@ -66,7 +92,7 @@ pub fn put(rgba: Vec<u8>) -> String {
             break;
         };
         if let Some(b) = s.blobs.remove(&oldest) {
-            s.bytes -= b.len();
+            s.bytes -= b.bytes();
             log::warn!(
                 "texture store over {CAP_BYTES} bytes — dropped {oldest}; a viewer still \
                  holding it will show grey"
@@ -77,7 +103,17 @@ pub fn put(rgba: Vec<u8>) -> String {
 }
 
 pub fn get(token: &str) -> Option<Arc<Blob>> {
-    store().lock().ok()?.blobs.get(token).cloned()
+    let inflate = match store().lock().ok()?.blobs.get(token)? {
+        Entry::Ready(b) => return Some(b.clone()),
+        Entry::Lazy { inflate, .. } => inflate.clone(),
+    };
+    // Outside the lock, so inflating a 4096² sheet doesn't stall every other fetch.
+    inflate().map(Arc::new)
+}
+
+/// Whether every one of `tokens` still names pixels — false once the cap has reaped any.
+pub fn all_resident(tokens: &[String]) -> bool {
+    store().lock().is_ok_and(|s| tokens.iter().all(|t| s.blobs.contains_key(t)))
 }
 
 /// Drop the pixels behind `tokens`, called when whatever owned them is evicted.
@@ -88,7 +124,7 @@ pub fn release(tokens: &[String]) {
     let s = &mut *guard;
     for t in tokens {
         if let Some(b) = s.blobs.remove(t) {
-            s.bytes -= b.len();
+            s.bytes -= b.bytes();
         }
     }
     let blobs = &s.blobs;
@@ -99,7 +135,8 @@ pub fn release(tokens: &[String]) {
 /// buffer that doesn't match the texture's declared size as "no texture" and renders grey.
 pub fn bytes_or_missing(token: &str) -> Vec<u8> {
     match get(token) {
-        Some(b) => b.as_ref().clone(),
+        // A lazy sheet's pixels are ours alone — move them rather than copy 67 MB.
+        Some(b) => Arc::try_unwrap(b).unwrap_or_else(|b| b.as_ref().clone()),
         None => {
             log::warn!("texture {token} is no longer resident — serving grey");
             MISSING_RGBA.to_vec()
@@ -122,6 +159,24 @@ mod tests {
         let token = put(px.clone());
         assert_eq!(*get(&token).expect("token resolves"), px);
         assert_eq!(bytes_or_missing(&token), px);
+    }
+
+    #[test]
+    fn lazy_tokens_inflate_on_fetch_and_count_what_they_hold() {
+        let before = resident_bytes();
+        let token = put_lazy(10, || Some(vec![1u8, 2, 3, 4]));
+        assert_eq!(resident_bytes(), before + 10);
+        assert_eq!(bytes_or_missing(&token), vec![1u8, 2, 3, 4]);
+        release(std::slice::from_ref(&token));
+        assert_eq!(resident_bytes(), before);
+    }
+
+    #[test]
+    fn residency_notices_a_reaped_token() {
+        let (a, b) = (put(vec![1u8; 4]), put(vec![2u8; 4]));
+        assert!(all_resident(&[a.clone(), b.clone()]));
+        release(std::slice::from_ref(&b));
+        assert!(!all_resident(&[a, b]));
     }
 
     #[test]

--- a/crates/core/src/viewer.rs
+++ b/crates/core/src/viewer.rs
@@ -150,9 +150,14 @@ pub fn bike_cache() -> &'static std::sync::Mutex<lru::Lru<BikeModel>> {
 }
 
 /// The cached bike under `key`, if it's still resident. Taken and released in one step so
-/// no caller holds the cache lock while it waits on [`gate::enter`].
+/// no caller holds the cache lock while it waits on [`gate::enter`]. A hit whose pixels the
+/// texture store has since reaped is a miss: served, it would draw the bike grey.
 pub fn cached_bike(key: &str) -> Option<BikeModel> {
-    bike_cache().lock().ok().and_then(|mut c| c.get(key).cloned())
+    bike_cache()
+        .lock()
+        .ok()
+        .and_then(|mut c| c.get(key).cloned())
+        .filter(|m| texstore::all_resident(&m.tokens()))
 }
 
 pub fn mtime_nanos(path: &std::path::Path) -> u128 {
@@ -576,12 +581,13 @@ pub fn build_bike_model(
     let mut paints: Vec<(BikePaint, bool)> = pnt_jobs
         .par_iter()
         .filter_map(|(name, data, shipped, path)| {
-            paint::decode_any(data).ok().map(|pnt| {
+            // Uninflated: the viewer fetches the sheets of the paint it shows, not all of them.
+            paint::store_lazy_any(data).ok().map(|textures| {
                 (
                     BikePaint {
                         name: name.clone(),
                         path: path.map(str::to_string),
-                        textures: pnt.into_par_iter().map(paint::into_texture).collect(),
+                        textures,
                         changes_preview: false, // resolved below, once bindings are known
                     },
                     *shipped,
@@ -4234,6 +4240,21 @@ mod viewer_tests {
         let mut own: Vec<&str> = m.base.iter().map(|t| t.name.as_str()).collect();
         own.sort_unstable();
         eprintln!("the model's own textures: {}", own.join(", "));
+        // Every paint is offered, one is shown: the store must hold the list cheaply, and a
+        // bike's own sheets must still be there once all of its paints are in.
+        let base_bytes: u64 = m.base.iter().map(|t| t.width as u64 * t.height as u64 * 4).sum();
+        eprintln!(
+            "texture store: {:.1} MB resident, {:.1} MB of it the model's own sheets",
+            crate::texstore::resident_bytes() as f64 / (1024.0 * 1024.0),
+            base_bytes as f64 / (1024.0 * 1024.0)
+        );
+        for t in &m.base {
+            eprintln!("  base '{}' {}x{}", t.name, t.width, t.height);
+        }
+        for t in m.base.iter().chain(&m.paints[0].textures) {
+            let px = crate::texstore::get(&t.token).expect("token resolves");
+            assert_eq!(px.len() as u32, t.width * t.height * 4, "'{}' at its stated size", t.name);
+        }
         assert!(!m.nodes.is_empty(), "decoded the mesh");
         let have: std::collections::HashSet<String> = m.paints[0]
             .textures
@@ -5299,7 +5320,11 @@ fn paint_cache() -> &'static std::sync::Mutex<lru::Lru<Vec<paint::PaintTexture>>
 
 /// As [`cached_bike`], for the paints: looked up and released without holding the lock.
 pub fn cached_paint(key: &str) -> Option<Vec<paint::PaintTexture>> {
-    paint_cache().lock().ok().and_then(|mut c| c.get(key).cloned())
+    paint_cache()
+        .lock()
+        .ok()
+        .and_then(|mut c| c.get(key).cloned())
+        .filter(|t| texstore::all_resident(&t.iter().map(|x| x.token.clone()).collect::<Vec<_>>()))
 }
 
 pub fn unpack_paint_blocking(path: String) -> Result<Vec<paint::PaintTexture>, String> {


### PR DESCRIPTION
## Why
After #554 the KTM 250 SX-F's stock paint drew white. A bike load inflated every paint it offers; at full resolution that reached 1023 MB, the texture store hit its 1 GiB cap, and it evicted the bike's own stock sheets (log: `texture t54 is no longer resident — serving grey`).

## What
- `paint::store_lazy_any`: a bike's paints go into the texture store uninflated; a sheet is inflated when the viewer fetches its token. The viewer only ever fetches the paint it shows.
- `texstore`: `Entry::Lazy` + `put_lazy`; `get` inflates outside the lock. `all_resident` lets a cache hit notice reaped pixels.
- `cached_bike` / `cached_paint`: a hit whose pixels were reaped is a miss and is rebuilt, not served grey.
- `capped_size` / `cap_pixels`: one sizing rule for eager and lazy paths, so declared size always matches served pixels.

## Verified
- `cargo test -p mxb-core --lib` — 458 passed (new: lazy == eager pixels, lazy accounting, residency check).
- Real KTM 250 SX-F `.pkz`: every base and stock sheet resolves at its stated size; store holds 428 MB (was 1023 MB with evictions).
- `cargo check -p mxb-app` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)