### PR TITLE
fix(viewer): scenery sheets keep their stored row order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
 - The riding surface carries a relief map baked from the track's own ground, so ruts, bumps and
   tyre lines catch the light in game the way they do in the studio's 3D view.
 
+### Fixed
+- Trees, signs and other scenery in the 3D track view stand the right way up.
+
 ## 2026-09-11
 
 ### Added

--- a/apps/studio/src-tauri/src/trackobjects.rs
+++ b/apps/studio/src-tauri/src/trackobjects.rs
@@ -704,8 +704,8 @@ mod edge_marking {
         let tex = map::textures(&bytes, 512);
         println!("{entry}: {} islands, {} sheets", mesh.objects.len(), sheets.len());
 
-        // Mean colour of a material over the UV box one piece uses. Sheets come back already
-        // row-flipped, so V maps straight to a row.
+        // Mean colour of a material over the UV box one piece uses. Sheets come back in stored
+        // row order, so V maps straight to a row.
         let colour = |mat: u32, u0: f32, u1: f32, v0: f32, v1: f32| -> Option<[f32; 3]> {
             let t = tex.iter().find(|t| t.material == mat)?;
             if t.width == 0 || t.height == 0 {
@@ -717,7 +717,7 @@ mod edge_marking {
                 for j in 0..12 {
                     let u = u0 + (u1 - u0) * i as f32 / 11.0;
                     let v = v0 + (v1 - v0) * j as f32 / 11.0;
-                    let o = ((px(1.0 - v, t.height) * t.width + px(u, t.width)) * 4) as usize;
+                    let o = ((px(v, t.height) * t.width + px(u, t.width)) * 4) as usize;
                     if t.rgba[o + 3] < 32 {
                         continue;
                     }

--- a/apps/studio/src-tauri/src/trackprops.rs
+++ b/apps/studio/src-tauri/src/trackprops.rs
@@ -696,10 +696,8 @@ fn short(sheet: &str) -> String {
 ///
 /// Two things worth stating, because both are silent when wrong.
 ///
-/// **Orientation.** [`map::textures`] flips rows on the way out, because a viewer wants row 0
-/// at the top. A lifted prop keeps the donor's own UVs, which address the sheet the way the
-/// `.map` stored it, so the flip has to be undone or every wordmark ships upside-down — the
-/// same trap [`crate::tracksynth`]'s generated sheets hit from the other side.
+/// **Orientation.** [`map::textures`] hands rows back as the `.map` stored them, which is how a
+/// lifted prop's own UVs address them. Flip one and every wordmark and tree ships upside down.
 ///
 /// **Size.** Indiana's venue sheets are 72 MB inflated and seven of them are most of it:
 /// `semi_trailers_c` is 4096² for two trailers. `max_dim` is the knob that makes a library
@@ -714,23 +712,7 @@ pub fn sheets_for(donor: &Donor, lib: &mut PropLibrary, max_dim: u32) {
         if !want.contains(&name) || !seen.insert(name.clone()) {
             continue;
         }
-        let mut rgba = t.rgba;
-        flip_rows(&mut rgba, t.width, t.height);
-        lib.sheets.push((name, t.width, t.height, rgba));
-    }
-}
-
-/// Turn an RGBA image upside-down, in place.
-fn flip_rows(rgba: &mut [u8], w: u32, h: u32) {
-    let stride = w as usize * 4;
-    if stride == 0 || rgba.len() < stride * h as usize {
-        return;
-    }
-    for y in 0..(h as usize / 2) {
-        let (a, b) = (y * stride, (h as usize - 1 - y) * stride);
-        for i in 0..stride {
-            rgba.swap(a + i, b + i);
-        }
+        lib.sheets.push((name, t.width, t.height, t.rgba));
     }
 }
 

--- a/crates/core/src/map.rs
+++ b/crates/core/src/map.rs
@@ -760,11 +760,8 @@ fn inflate(b: &[u8], data_off: usize, data_len: usize, w: u32, h: u32) -> Option
     (buf.len() == expected).then_some(buf)
 }
 
-/// Turn a sheet the right way up.
-///
-/// PiBoSo stores these bottom-up, the same way it stores a `.pnt`: a card's UVs put V zero at
-/// the foot of the thing drawn, while the file's first row of pixels is its top. Left alone,
-/// every tree in a track hangs from its canopy.
+/// Reverse a sheet's rows. The ground sheets and layers are read this way; scenery sheets are
+/// not, because the game samples a scenery sheet's first stored row at V zero.
 fn flip_rows(rgba: &mut [u8], w: u32, h: u32) {
     let stride = w as usize * 4;
     let (mut top, mut bottom) = (0usize, h as usize - 1);
@@ -1302,7 +1299,8 @@ pub fn textures(b: &[u8], max_dim: u32) -> Vec<MapTexture> {
             // channel is the fact, and a sheet that is half see-through is a cut-out whatever
             // it is called.
             let alpha = cutout_fraction(&rgba) > CUTOUT_FRACTION;
-            flip_rows(&mut rgba, w, h);
+            // Rows as stored. The game samples the first stored row at V zero — a tree card's
+            // trunk — and so does a `DataTexture`; reversing them hung every tree by its crown.
             let (mut rgba, w, h) = reduce(rgba, w, h, max_dim.max(1));
             // After the reduce, and so before the only mips left to make are the GPU's.
             // `reduce` already weights colour by alpha, so an opaque texel keeps its leaf
@@ -1984,7 +1982,33 @@ mod tests {
                     println!("  BLANK mat {m} tris {}", tris[m]);
                 }
             }
+            // Per material: does v rise or fall with height inside each object? Tells which way
+            // up a card's sheet is addressed, without knowing the picture.
+            let mut acc = vec![(0f64, 0f64, 0f64, 0f64, 0f64, 0f64); count];
+            for o in &mesh.objects {
+                let span = (o.max[1] - o.min[1]).max(1e-3);
+                for t in o.tri_start..o.tri_start + o.tri_count {
+                    for k in 0..3 {
+                        let vi = mesh.indices[t as usize * 3 + k] as usize;
+                        let y = ((mesh.positions[vi * 3 + 1] - o.min[1]) / span) as f64;
+                        let v = mesh.uvs[vi * 2 + 1] as f64;
+                        if let Some(a) = acc.get_mut(o.material as usize) {
+                            *a = (a.0 + 1.0, a.1 + y, a.2 + v, a.3 + y * y, a.4 + v * v, a.5 + y * v);
+                        }
+                    }
+                }
+            }
+            let corr: Vec<f64> = acc
+                .iter()
+                .map(|&(n, sy, sv, syy, svv, syv)| {
+                    let cov = syv / n - (sy / n) * (sv / n);
+                    let vy = syy / n - (sy / n).powi(2);
+                    let vv = svv / n - (sv / n).powi(2);
+                    if n < 3.0 || vy <= 0.0 || vv <= 0.0 { 0.0 } else { cov / (vy * vv).sqrt() }
+                })
+                .collect();
             for (m, (n, w, h)) in declared(&b).into_iter().enumerate() {
+                println!("  vcorr mat {m:3} {:+.2} {n}", corr.get(m).copied().unwrap_or(0.0));
                 let w0 = u32le(&b, MATERIALS_AT + m * MATERIAL_RECORD);
                 println!(
                     "  bound mat {m:3} w0 {w0} tris {:7} -> {n} {w}x{h}",

--- a/crates/core/src/scenery.rs
+++ b/crates/core/src/scenery.rs
@@ -34,7 +34,8 @@ use crate::map::{self, Group, MapMesh, MapTexture};
 // v7 entries carry the word-11 guess, which put every tree on our own tracks on its
 // neighbour's sheet; the key is the track's bytes, so without the bump they stay.
 const MESH_CACHE: &str = "track-scenery-v8";
-const SURFACE_CACHE: &str = "track-surfaces-v8";
+// v9: sheets keep their stored row order, so every cached sheet is upside down.
+const SURFACE_CACHE: &str = "track-surfaces-v9";
 /// The ground sheet and its normal map, cached apart again — two 512×512 sheets against the
 /// surfaces' hundreds of megabytes, and finding them means reading the archive a third time.
 // v3: 8192-wide sheets are read now, so the pick has records to consider that v2 never saw.


### PR DESCRIPTION
The 3D view reversed every scenery sheet's rows (map::textures), then sampled it with the .map's own UVs, so every tree card hung by its crown, Indiana's included. The game samples a sheet's first stored row at v = 0 (a tree card's trunk: height and v correlate +0.99 on Indiana's talltrees), and so does a three.js DataTexture. Rows now go through as stored; the two places that undid the flip (trackprops::sheets_for, the edge_marking sampler) no longer do, and the surface cache moves to v9.

Lifted props were never wrong in game: their pixels and UVs match Indiana's in the compiled map.

Tested: mxb-core 457, studio 226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)