### PR TITLE
fix(ci): name studio release assets with tauri-action's real input

### DIFF
--- a/.github/workflows/release-studio.yml
+++ b/.github/workflows/release-studio.yml
@@ -118,7 +118,7 @@ jobs:
           releaseName: "Frost's Studio ${{ steps.tag.outputs.name }}"
           # Named here rather than renamed afterwards: this applies before latest.json is
           # written, so the manifest and the assets cannot disagree.
-          releaseAssetNamePattern: "Frost-Studio-[version]-[arch][ext]"
+          assetNamePattern: "Frost-Studio-[version]-[arch][ext]"
           releaseDraft: false
           prerelease: ${{ github.ref_type != 'tag' || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') }}
           args: ${{ matrix.args }}


### PR DESCRIPTION
The studio release workflow set `releaseAssetNamePattern`, which tauri-action@v0 doesn't recognise. The v0.1.0 run warned (`Unexpected input(s) 'releaseAssetNamePattern'`) and uploaded files under the CLI's default names, like `Frost.Studio_0.1.0_x64-setup.exe`.

The input is actually called `assetNamePattern`. `[ext]` carries the leading dot and the `.sig` suffix, so every file still gets a unique name (`.dmg`, `.app.tar.gz`, `.deb`, `.rpm`, `.AppImage`, `.exe`, plus their signatures). The pattern is applied before `latest.json` is written, so the manifest points at the new names.

v0.1.0 keeps its existing names. Renaming them by hand would break its `latest.json`.

No CHANGELOG entry, because the changelog is player-facing and this only changes CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)